### PR TITLE
fix(tui): TUI v2 audit follow-up — registry, overlays, paste, reasoning, hyperlinks

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -531,3 +531,18 @@ def test_session_steer_errors_when_agent_has_no_steer_method():
     assert "error" in resp, resp
     assert resp["error"]["code"] == 4010
 
+
+def test_session_info_includes_mcp_servers(monkeypatch):
+    fake_status = [
+        {"name": "github", "transport": "http", "tools": 12, "connected": True},
+        {"name": "filesystem", "transport": "stdio", "tools": 4, "connected": True},
+        {"name": "broken", "transport": "stdio", "tools": 0, "connected": False},
+    ]
+    fake_mod = types.ModuleType("tools.mcp_tool")
+    fake_mod.get_mcp_status = lambda: fake_status
+    monkeypatch.setitem(sys.modules, "tools.mcp_tool", fake_mod)
+
+    info = server._session_info(types.SimpleNamespace(tools=[], model=""))
+
+    assert info["mcp_servers"] == fake_status
+

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -363,6 +363,28 @@ def test_image_attach_appends_local_image(monkeypatch):
     assert len(server._sessions["sid"]["attached_images"]) == 1
 
 
+def test_commands_catalog_surfaces_quick_commands(monkeypatch):
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"quick_commands": {
+        "build": {"type": "exec", "command": "npm run build"},
+        "git": {"type": "alias", "target": "/shell git"},
+        "notes": {"type": "exec", "command": "cat NOTES.md", "description": "Open design notes"},
+    }})
+
+    resp = server.handle_request({"id": "1", "method": "commands.catalog", "params": {}})
+
+    pairs = dict(resp["result"]["pairs"])
+    assert "npm run build" in pairs["/build"]
+    assert pairs["/git"].startswith("alias →")
+    assert pairs["/notes"] == "Open design notes"
+
+    user_cat = next(c for c in resp["result"]["categories"] if c["name"] == "User commands")
+    user_pairs = dict(user_cat["pairs"])
+    assert set(user_pairs) == {"/build", "/git", "/notes"}
+
+    assert resp["result"]["canon"]["/build"] == "/build"
+    assert resp["result"]["canon"]["/notes"] == "/notes"
+
+
 def test_command_dispatch_exec_nonzero_surfaces_error(monkeypatch):
     monkeypatch.setattr(server, "_load_cfg", lambda: {"quick_commands": {"boom": {"type": "exec", "command": "boom"}}})
     monkeypatch.setattr(

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1987,8 +1987,35 @@ def _(rid, params: dict) -> dict:
                 cat_order.append(cat)
             cat_map[cat].append([name, desc])
 
-        skill_count = 0
         warning = ""
+        try:
+            qcmds = _load_cfg().get("quick_commands", {}) or {}
+            if isinstance(qcmds, dict) and qcmds:
+                bucket = "User commands"
+                if bucket not in cat_map:
+                    cat_map[bucket] = []
+                    cat_order.append(bucket)
+                for qname, qc in sorted(qcmds.items()):
+                    if not isinstance(qc, dict):
+                        continue
+                    key = f"/{qname}"
+                    canon[key.lower()] = key
+                    qtype = qc.get("type", "")
+                    if qtype == "exec":
+                        default_desc = f"exec: {qc.get('command', '')}"
+                    elif qtype == "alias":
+                        default_desc = f"alias → {qc.get('target', '')}"
+                    else:
+                        default_desc = qtype or "quick command"
+                    qdesc = str(qc.get("description") or default_desc)
+                    qdesc = qdesc[:120] + ("…" if len(qdesc) > 120 else "")
+                    all_pairs.append([key, qdesc])
+                    cat_map[bucket].append([key, qdesc])
+        except Exception as e:
+            if not warning:
+                warning = f"quick_commands discovery unavailable: {e}"
+
+        skill_count = 0
         try:
             from agent.skill_commands import scan_skill_commands
             for k, info in sorted(scan_skill_commands().items()):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -589,6 +589,11 @@ def _session_info(agent) -> dict:
     except Exception:
         pass
     try:
+        from tools.mcp_tool import get_mcp_status
+        info["mcp_servers"] = get_mcp_status()
+    except Exception:
+        info["mcp_servers"] = []
+    try:
         from hermes_cli.banner import get_update_result
         from hermes_cli.config import recommended_update_command
         info["update_behind"] = get_update_result(timeout=0.5)

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -4,7 +4,7 @@ import { createGatewayEventHandler } from '../app/createGatewayEventHandler.js'
 import { resetOverlayState } from '../app/overlayStore.js'
 import { turnController } from '../app/turnController.js'
 import { resetTurnState } from '../app/turnStore.js'
-import { resetUiState } from '../app/uiStore.js'
+import { patchUiState, resetUiState } from '../app/uiStore.js'
 import { estimateTokensRough } from '../lib/text.js'
 import type { Msg } from '../types.js'
 
@@ -47,6 +47,7 @@ describe('createGatewayEventHandler', () => {
     resetUiState()
     resetTurnState()
     turnController.fullReset()
+    patchUiState({ showReasoning: true })
   })
 
   it('persists completed tool rows when message.complete lands immediately after tool.complete', () => {

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -26,15 +26,53 @@ describe('createSlashHandler', () => {
     expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
   })
 
-  it('falls through /skills with args to slash.exec without opening overlay', () => {
+  it('routes /skills install <name> to skills.manage without opening overlay', () => {
     const ctx = buildCtx()
 
     expect(createSlashHandler(ctx)('/skills install foo')).toBe(true)
     expect(getOverlayState().skillsHub).toBe(false)
-    expect(ctx.gateway.rpc).toHaveBeenCalledWith('slash.exec', {
-      command: 'skills install foo',
-      session_id: null
+    expect(ctx.gateway.rpc).toHaveBeenCalledWith('skills.manage', {
+      action: 'install',
+      query: 'foo'
     })
+  })
+
+  it('routes /skills inspect <name> to skills.manage', () => {
+    const ctx = buildCtx()
+
+    createSlashHandler(ctx)('/skills inspect my-skill')
+    expect(ctx.gateway.rpc).toHaveBeenCalledWith('skills.manage', {
+      action: 'inspect',
+      query: 'my-skill'
+    })
+  })
+
+  it('routes /skills search <query> to skills.manage', () => {
+    const ctx = buildCtx()
+
+    createSlashHandler(ctx)('/skills search vibe')
+    expect(ctx.gateway.rpc).toHaveBeenCalledWith('skills.manage', {
+      action: 'search',
+      query: 'vibe'
+    })
+  })
+
+  it('routes /skills browse [page] to skills.manage with a numeric page', () => {
+    const ctx = buildCtx()
+
+    createSlashHandler(ctx)('/skills browse 3')
+    expect(ctx.gateway.rpc).toHaveBeenCalledWith('skills.manage', {
+      action: 'browse',
+      page: 3
+    })
+  })
+
+  it('shows usage for an unknown /skills subcommand', () => {
+    const ctx = buildCtx()
+
+    createSlashHandler(ctx)('/skills zzz')
+    expect(ctx.gateway.rpc).not.toHaveBeenCalled()
+    expect(ctx.transcript.sys).toHaveBeenCalledWith(expect.stringContaining('usage: /skills'))
   })
 
   it('cycles details mode and persists it', async () => {

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -17,6 +17,26 @@ describe('createSlashHandler', () => {
     expect(getOverlayState().picker).toBe(true)
   })
 
+  it('opens the skills hub locally for bare /skills', () => {
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)('/skills')).toBe(true)
+    expect(getOverlayState().skillsHub).toBe(true)
+    expect(ctx.gateway.rpc).not.toHaveBeenCalled()
+    expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
+  })
+
+  it('falls through /skills with args to slash.exec without opening overlay', () => {
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)('/skills install foo')).toBe(true)
+    expect(getOverlayState().skillsHub).toBe(false)
+    expect(ctx.gateway.rpc).toHaveBeenCalledWith('slash.exec', {
+      command: 'skills install foo',
+      session_id: null
+    })
+  })
+
   it('cycles details mode and persists it', async () => {
     const ctx = buildCtx()
 

--- a/ui-tui/src/__tests__/reasoning.test.ts
+++ b/ui-tui/src/__tests__/reasoning.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+
+import { hasReasoningTag, splitReasoning } from '../lib/reasoning.js'
+
+describe('splitReasoning', () => {
+  it('extracts <think>…</think> and strips it from text', () => {
+    const { reasoning, text } = splitReasoning('<think>plotting</think>\n\nhere is the answer')
+
+    expect(reasoning).toBe('plotting')
+    expect(text).toBe('here is the answer')
+  })
+
+  it('handles multiple tag shapes', () => {
+    const input = '<reasoning>a</reasoning> <THINKING>b</THINKING> <thought>c</thought> body'
+    const { reasoning, text } = splitReasoning(input)
+
+    expect(reasoning).toContain('a')
+    expect(reasoning).toContain('b')
+    expect(reasoning).toContain('c')
+    expect(text).toBe('body')
+  })
+
+  it('treats unclosed trailing <think>… as reasoning', () => {
+    const { reasoning, text } = splitReasoning('answer start <think>still deciding')
+
+    expect(reasoning).toBe('still deciding')
+    expect(text).toBe('answer start')
+  })
+
+  it('returns empty reasoning and untouched text when no tags present', () => {
+    const { reasoning, text } = splitReasoning('plain body with no tags')
+
+    expect(reasoning).toBe('')
+    expect(text).toBe('plain body with no tags')
+  })
+
+  it('preserves text when reasoning block is empty', () => {
+    const { reasoning, text } = splitReasoning('<think></think>only body')
+
+    expect(reasoning).toBe('')
+    expect(text).toBe('only body')
+  })
+
+  it('detects presence of any supported tag', () => {
+    expect(hasReasoningTag('pre <think>x</think> post')).toBe(true)
+    expect(hasReasoningTag('pre <reasoning>x</reasoning>')).toBe(true)
+    expect(hasReasoningTag('<REASONING_SCRATCHPAD>x</REASONING_SCRATCHPAD>')).toBe(true)
+    expect(hasReasoningTag('no tags at all')).toBe(false)
+  })
+})

--- a/ui-tui/src/__tests__/syntax.test.ts
+++ b/ui-tui/src/__tests__/syntax.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import { highlightLine, isHighlightable } from '../lib/syntax.js'
+import { DEFAULT_THEME } from '../theme.js'
+
+const t = DEFAULT_THEME
+
+describe('syntax highlighter', () => {
+  it('recognizes supported langs and aliases', () => {
+    expect(isHighlightable('ts')).toBe(true)
+    expect(isHighlightable('js')).toBe(true)
+    expect(isHighlightable('python')).toBe(true)
+    expect(isHighlightable('rs')).toBe(true)
+    expect(isHighlightable('bash')).toBe(true)
+    expect(isHighlightable('whatever')).toBe(false)
+    expect(isHighlightable('')).toBe(false)
+  })
+
+  it('paints a whole-line comment dim', () => {
+    const tokens = highlightLine('// hello', 'ts', t)
+
+    expect(tokens).toEqual([[t.color.dim, '// hello']])
+  })
+
+  it('paints keywords, strings, and numbers in a ts line', () => {
+    const tokens = highlightLine(`const x = 'hi' + 42`, 'ts', t)
+    const colors = tokens.map(tok => tok[0])
+
+    expect(colors).toContain(t.color.bronze) // const
+    expect(colors).toContain(t.color.amber) // 'hi'
+    expect(colors).toContain(t.color.cornsilk) // 42
+  })
+
+  it('falls through unchanged for unknown langs', () => {
+    const tokens = highlightLine(`const x = 1`, 'zzz', t)
+
+    expect(tokens).toEqual([['', 'const x = 1']])
+  })
+
+  it('treats `#` as a python comment, not a selector', () => {
+    const tokens = highlightLine('# comment', 'py', t)
+
+    expect(tokens).toEqual([[t.color.dim, '# comment']])
+  })
+})

--- a/ui-tui/src/__tests__/useConfigSync.test.ts
+++ b/ui-tui/src/__tests__/useConfigSync.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $uiState, resetUiState } from '../app/uiStore.js'
+import { applyDisplay } from '../app/useConfigSync.js'
+
+describe('applyDisplay', () => {
+  beforeEach(() => {
+    resetUiState()
+  })
+
+  it('fans every display flag out to $uiState and the bell callback', () => {
+    const setBell = vi.fn()
+
+    applyDisplay(
+      {
+        config: {
+          display: {
+            bell_on_complete: true,
+            details_mode: 'expanded',
+            inline_diffs: false,
+            show_cost: true,
+            show_reasoning: true,
+            streaming: false,
+            tui_compact: true,
+            tui_statusbar: false
+          }
+        }
+      },
+      setBell
+    )
+
+    const s = $uiState.get()
+    expect(setBell).toHaveBeenCalledWith(true)
+    expect(s.compact).toBe(true)
+    expect(s.detailsMode).toBe('expanded')
+    expect(s.inlineDiffs).toBe(false)
+    expect(s.showCost).toBe(true)
+    expect(s.showReasoning).toBe(true)
+    expect(s.statusBar).toBe(false)
+    expect(s.streaming).toBe(false)
+  })
+
+  it('applies v1 parity defaults when display fields are missing', () => {
+    const setBell = vi.fn()
+
+    applyDisplay({ config: { display: {} } }, setBell)
+
+    const s = $uiState.get()
+    expect(setBell).toHaveBeenCalledWith(false)
+    expect(s.inlineDiffs).toBe(true)
+    expect(s.showCost).toBe(false)
+    expect(s.showReasoning).toBe(false)
+    expect(s.statusBar).toBe(true)
+    expect(s.streaming).toBe(true)
+  })
+
+  it('treats a null config like an empty display block', () => {
+    const setBell = vi.fn()
+
+    applyDisplay(null, setBell)
+
+    const s = $uiState.get()
+    expect(setBell).toHaveBeenCalledWith(false)
+    expect(s.inlineDiffs).toBe(true)
+    expect(s.streaming).toBe(true)
+  })
+})

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -266,7 +266,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
       case 'tool.complete':
         turnController.recordToolComplete(ev.payload.tool_id, ev.payload.name, ev.payload.error, ev.payload.summary)
 
-        if (ev.payload.inline_diff) {
+        if (ev.payload.inline_diff && getUiState().inlineDiffs) {
           sys(ev.payload.inline_diff)
         }
 

--- a/ui-tui/src/app/inputSelectionStore.ts
+++ b/ui-tui/src/app/inputSelectionStore.ts
@@ -1,0 +1,14 @@
+import { atom } from 'nanostores'
+
+export interface InputSelection {
+  clear: () => void
+  end: number
+  start: number
+  value: string
+}
+
+export const $inputSelection = atom<InputSelection | null>(null)
+
+export const setInputSelection = (next: InputSelection | null) => $inputSelection.set(next)
+
+export const getInputSelection = () => $inputSelection.get()

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -57,6 +57,7 @@ export interface OverlayState {
   pager: null | PagerState
   picker: boolean
   secret: null | SecretReq
+  skillsHub: boolean
   sudo: null | SudoReq
 }
 

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -335,5 +335,6 @@ export interface AppOverlaysProps {
 
 export interface PasteSnippet {
   label: string
+  path?: string
   text: string
 }

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -78,9 +78,13 @@ export interface UiState {
   compact: boolean
   detailsMode: DetailsMode
   info: null | SessionInfo
+  inlineDiffs: boolean
+  showCost: boolean
+  showReasoning: boolean
   sid: null | string
   status: string
   statusBar: boolean
+  streaming: boolean
   theme: Theme
   usage: Usage
 }

--- a/ui-tui/src/app/overlayStore.ts
+++ b/ui-tui/src/app/overlayStore.ts
@@ -9,13 +9,16 @@ const buildOverlayState = (): OverlayState => ({
   pager: null,
   picker: false,
   secret: null,
+  skillsHub: false,
   sudo: null
 })
 
 export const $overlayState = atom<OverlayState>(buildOverlayState())
 
-export const $isBlocked = computed($overlayState, ({ approval, clarify, modelPicker, pager, picker, secret, sudo }) =>
-  Boolean(approval || clarify || modelPicker || pager || picker || secret || sudo)
+export const $isBlocked = computed(
+  $overlayState,
+  ({ approval, clarify, modelPicker, pager, picker, secret, skillsHub, sudo }) =>
+    Boolean(approval || clarify || modelPicker || pager || picker || secret || skillsHub || sudo)
 )
 
 export const getOverlayState = () => $overlayState.get()

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -1,7 +1,12 @@
 import { dailyFortune, randomFortune } from '../../../content/fortunes.js'
 import { HOTKEYS } from '../../../content/hotkeys.js'
 import { nextDetailsMode, parseDetailsMode } from '../../../domain/details.js'
-import type { ConfigGetValueResponse, ConfigSetResponse, SessionSteerResponse, SessionUndoResponse } from '../../../gatewayTypes.js'
+import type {
+  ConfigGetValueResponse,
+  ConfigSetResponse,
+  SessionSteerResponse,
+  SessionUndoResponse
+} from '../../../gatewayTypes.js'
 import { writeOsc52Clipboard } from '../../../lib/osc52.js'
 import type { DetailsMode, Msg, PanelSection } from '../../../types.js'
 import { patchOverlayState } from '../../overlayStore.js'
@@ -259,19 +264,27 @@ export const coreCommands: SlashCommand[] = [
       // message isn't lost — identical semantics to the gateway handler.
       if (!ctx.ui.busy || !ctx.sid) {
         ctx.composer.enqueue(payload)
-        ctx.transcript.sys(`no active turn — queued for next: "${payload.slice(0, 50)}${payload.length > 50 ? '…' : ''}"`)
+        ctx.transcript.sys(
+          `no active turn — queued for next: "${payload.slice(0, 50)}${payload.length > 50 ? '…' : ''}"`
+        )
+
         return
       }
 
-      ctx.gateway.rpc<SessionSteerResponse>('session.steer', { session_id: ctx.sid, text: payload }).then(
-        ctx.guarded<SessionSteerResponse>(r => {
-          if (r?.status === 'queued') {
-            ctx.transcript.sys(`⏩ steer queued — arrives after next tool call: "${payload.slice(0, 50)}${payload.length > 50 ? '…' : ''}"`)
-          } else {
-            ctx.transcript.sys('steer rejected')
-          }
-        })
-      ).catch(ctx.guardedErr)
+      ctx.gateway
+        .rpc<SessionSteerResponse>('session.steer', { session_id: ctx.sid, text: payload })
+        .then(
+          ctx.guarded<SessionSteerResponse>(r => {
+            if (r?.status === 'queued') {
+              ctx.transcript.sys(
+                `⏩ steer queued — arrives after next tool call: "${payload.slice(0, 50)}${payload.length > 50 ? '…' : ''}"`
+              )
+            } else {
+              ctx.transcript.sys('steer rejected')
+            }
+          })
+        )
+        .catch(ctx.guardedErr)
     }
   },
 

--- a/ui-tui/src/app/slash/commands/ops.ts
+++ b/ui-tui/src/app/slash/commands/ops.ts
@@ -1,26 +1,158 @@
-import type { SlashExecResponse, ToolsConfigureResponse } from '../../../gatewayTypes.js'
+import type { ToolsConfigureResponse } from '../../../gatewayTypes.js'
+import type { PanelSection } from '../../../types.js'
 import { patchOverlayState } from '../../overlayStore.js'
 import type { SlashCommand } from '../types.js'
 
+interface SkillInfo {
+  category?: string
+  description?: string
+  name?: string
+  path?: string
+}
+
+interface SkillsListResponse {
+  skills?: Record<string, string[]>
+}
+
+interface SkillsInspectResponse {
+  info?: SkillInfo
+}
+
+interface SkillsSearchResponse {
+  results?: { description?: string; name: string }[]
+}
+
+interface SkillsInstallResponse {
+  installed?: boolean
+  name?: string
+}
+
 export const opsCommands: SlashCommand[] = [
   {
-    help: 'browse, inspect, and install skills',
+    help: 'browse, inspect, install skills',
     name: 'skills',
     run: (arg, ctx) => {
-      if (!arg.trim()) {
+      const text = arg.trim()
+
+      if (!text) {
         return patchOverlayState({ skillsHub: true })
       }
 
-      ctx.gateway
-        .rpc<SlashExecResponse>('slash.exec', { command: `skills ${arg}`, session_id: ctx.sid })
-        .then(
-          ctx.guarded<SlashExecResponse>(r => {
-            if (r.output) {
-              ctx.transcript.page(r.output, 'Skills')
-            }
-          })
-        )
-        .catch(ctx.guardedErr)
+      const [sub, ...rest] = text.split(/\s+/)
+      const query = rest.join(' ').trim()
+      const { rpc } = ctx.gateway
+      const { page, panel, sys } = ctx.transcript
+
+      if (sub === 'list') {
+        rpc<SkillsListResponse>('skills.manage', { action: 'list' })
+          .then(
+            ctx.guarded<SkillsListResponse>(r => {
+              const cats = Object.entries(r.skills ?? {}).sort()
+
+              if (!cats.length) {
+                return sys('no skills available')
+              }
+
+              panel(
+                'Skills',
+                cats.map<PanelSection>(([title, items]) => ({ items, title }))
+              )
+            })
+          )
+          .catch(ctx.guardedErr)
+
+        return
+      }
+
+      if (sub === 'inspect') {
+        if (!query) {
+          return sys('usage: /skills inspect <name>')
+        }
+
+        rpc<SkillsInspectResponse>('skills.manage', { action: 'inspect', query })
+          .then(
+            ctx.guarded<SkillsInspectResponse>(r => {
+              const info = r.info ?? {}
+
+              if (!info.name) {
+                return sys(`unknown skill: ${query}`)
+              }
+
+              const rows: [string, string][] = [
+                ['Name', String(info.name)],
+                ['Category', String(info.category ?? '')],
+                ['Path', String(info.path ?? '')]
+              ]
+
+              const sections: PanelSection[] = [{ rows }]
+
+              if (info.description) {
+                sections.push({ text: String(info.description) })
+              }
+
+              panel('Skill', sections)
+            })
+          )
+          .catch(ctx.guardedErr)
+
+        return
+      }
+
+      if (sub === 'search') {
+        if (!query) {
+          return sys('usage: /skills search <query>')
+        }
+
+        rpc<SkillsSearchResponse>('skills.manage', { action: 'search', query })
+          .then(
+            ctx.guarded<SkillsSearchResponse>(r => {
+              const results = r.results ?? []
+
+              if (!results.length) {
+                return sys(`no results for: ${query}`)
+              }
+
+              panel(`Search: ${query}`, [{ rows: results.map(s => [s.name, s.description ?? '']) }])
+            })
+          )
+          .catch(ctx.guardedErr)
+
+        return
+      }
+
+      if (sub === 'install') {
+        if (!query) {
+          return sys('usage: /skills install <name or url>')
+        }
+
+        sys(`installing ${query}…`)
+
+        rpc<SkillsInstallResponse>('skills.manage', { action: 'install', query })
+          .then(
+            ctx.guarded<SkillsInstallResponse>(r =>
+              sys(r.installed ? `installed ${r.name ?? query}` : 'install failed')
+            )
+          )
+          .catch(ctx.guardedErr)
+
+        return
+      }
+
+      if (sub === 'browse') {
+        const pageNum = parseInt(query, 10) || 1
+
+        rpc<Record<string, unknown>>('skills.manage', { action: 'browse', page: pageNum })
+          .then(
+            ctx.guarded<Record<string, unknown>>(r =>
+              page(JSON.stringify(r, null, 2).slice(0, 4000), `Browse Skills — p${pageNum}`)
+            )
+          )
+          .catch(ctx.guardedErr)
+
+        return
+      }
+
+      sys('usage: /skills [list | inspect <n> | install <n> | search <q> | browse [page]]')
     }
   },
 

--- a/ui-tui/src/app/slash/commands/ops.ts
+++ b/ui-tui/src/app/slash/commands/ops.ts
@@ -1,7 +1,29 @@
-import type { ToolsConfigureResponse } from '../../../gatewayTypes.js'
+import type { SlashExecResponse, ToolsConfigureResponse } from '../../../gatewayTypes.js'
+import { patchOverlayState } from '../../overlayStore.js'
 import type { SlashCommand } from '../types.js'
 
 export const opsCommands: SlashCommand[] = [
+  {
+    help: 'browse, inspect, and install skills',
+    name: 'skills',
+    run: (arg, ctx) => {
+      if (!arg.trim()) {
+        return patchOverlayState({ skillsHub: true })
+      }
+
+      ctx.gateway
+        .rpc<SlashExecResponse>('slash.exec', { command: `skills ${arg}`, session_id: ctx.sid })
+        .then(
+          ctx.guarded<SlashExecResponse>(r => {
+            if (r.output) {
+              ctx.transcript.page(r.output, 'Skills')
+            }
+          })
+        )
+        .catch(ctx.guardedErr)
+    }
+  },
+
   {
     help: 'enable or disable tools (client-side history reset on change)',
     name: 'tools',

--- a/ui-tui/src/app/slash/commands/ops.ts
+++ b/ui-tui/src/app/slash/commands/ops.ts
@@ -27,6 +27,20 @@ interface SkillsInstallResponse {
   name?: string
 }
 
+interface SkillsBrowseItem {
+  description?: string
+  name: string
+  source?: string
+  trust?: string
+}
+
+interface SkillsBrowseResponse {
+  items?: SkillsBrowseItem[]
+  page?: number
+  total?: number
+  total_pages?: number
+}
+
 export const opsCommands: SlashCommand[] = [
   {
     help: 'browse, inspect, install skills',
@@ -139,13 +153,47 @@ export const opsCommands: SlashCommand[] = [
       }
 
       if (sub === 'browse') {
-        const pageNum = parseInt(query, 10) || 1
+        const pageNum = query ? parseInt(query, 10) : 1
 
-        rpc<Record<string, unknown>>('skills.manage', { action: 'browse', page: pageNum })
+        if (Number.isNaN(pageNum) || pageNum < 1) {
+          return sys('usage: /skills browse [page]  (page must be a positive number)')
+        }
+
+        sys('fetching community skills (scans 6 sources, may take ~15s)…')
+
+        rpc<SkillsBrowseResponse>('skills.manage', { action: 'browse', page: pageNum })
           .then(
-            ctx.guarded<Record<string, unknown>>(r =>
-              page(JSON.stringify(r, null, 2).slice(0, 4000), `Browse Skills — p${pageNum}`)
-            )
+            ctx.guarded<SkillsBrowseResponse>(r => {
+              const items = r.items ?? []
+
+              if (!items.length) {
+                return sys(`no skills on page ${pageNum}${r.total ? ` (total ${r.total})` : ''}`)
+              }
+
+              const rows: [string, string][] = items.map(s => [
+                s.trust ? `${s.name} · ${s.trust}` : s.name,
+                String(s.description ?? '').slice(0, 160)
+              ])
+
+              const footer: string[] = []
+
+              if (r.page && r.total_pages) {
+                footer.push(`page ${r.page} of ${r.total_pages}`)
+              }
+
+              if (r.total) {
+                footer.push(`${r.total} skills total`)
+              }
+
+              if (r.page && r.total_pages && r.page < r.total_pages) {
+                footer.push(`/skills browse ${r.page + 1} for more`)
+              }
+
+              panel(`Browse Skills${pageNum > 1 ? ` — p${pageNum}` : ''}`, [
+                { rows },
+                ...(footer.length ? [{ text: footer.join(' · ') }] : [])
+              ])
+            })
           )
           .catch(ctx.guardedErr)
 

--- a/ui-tui/src/app/slash/commands/setup.ts
+++ b/ui-tui/src/app/slash/commands/setup.ts
@@ -6,9 +6,8 @@ import type { SlashCommand } from '../types.js'
 
 export const setupCommands: SlashCommand[] = [
   {
-    aliases: ['provider'],
-    help: 'configure LLM provider and model (launches `hermes model`)',
-    name: 'model',
+    help: 'configure LLM provider + model (launches `hermes model`)',
+    name: 'provider',
     run: (_arg, ctx) =>
       void runExternalSetup({
         args: ['model'],

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -11,7 +11,7 @@ import type { ActiveTool, ActivityItem, Msg, SubagentProgress } from '../types.j
 
 import { resetOverlayState } from './overlayStore.js'
 import { patchTurnState, resetTurnState } from './turnStore.js'
-import { patchUiState } from './uiStore.js'
+import { getUiState, patchUiState } from './uiStore.js'
 
 const INTERRUPT_COOLDOWN_MS = 1500
 const ACTIVITY_LIMIT = 8
@@ -226,10 +226,17 @@ class TurnController {
     }
 
     this.bufRef = rendered ?? this.bufRef + text
-    this.scheduleStreaming()
+
+    if (getUiState().streaming) {
+      this.scheduleStreaming()
+    }
   }
 
   recordReasoningAvailable(text: string) {
+    if (!getUiState().showReasoning) {
+      return
+    }
+
     const incoming = text.trim()
 
     if (!incoming || this.reasoningText.trim()) {
@@ -242,6 +249,10 @@ class TurnController {
   }
 
   recordReasoningDelta(text: string) {
+    if (!getUiState().showReasoning) {
+      return
+    }
+
     this.reasoningText += text
     this.scheduleReasoning()
     this.pulseReasoningStreaming()

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -1,5 +1,6 @@
 import { REASONING_PULSE_MS, STREAM_BATCH_MS } from '../config/timing.js'
 import type { SessionInterruptResponse, SubagentEventPayload } from '../gatewayTypes.js'
+import { hasReasoningTag, splitReasoning } from '../lib/reasoning.js'
 import {
   buildToolTrailLine,
   estimateTokensRough,
@@ -121,18 +122,31 @@ class TurnController {
   }
 
   flushStreamingSegment() {
-    const text = this.bufRef.trimStart()
+    const raw = this.bufRef.trimStart()
 
-    if (!text) {
+    if (!raw) {
       return
     }
 
-    const tools = this.pendingSegmentTools
+    const split = hasReasoningTag(raw) ? splitReasoning(raw) : { reasoning: '', text: raw }
+
+    if (split.reasoning && !this.reasoningText.trim()) {
+      this.reasoningText = split.reasoning
+      patchTurnState({ reasoning: this.reasoningText, reasoningTokens: estimateTokensRough(this.reasoningText) })
+    }
+
+    const text = split.text
 
     this.streamTimer = clear(this.streamTimer)
-    this.segmentMessages = [...this.segmentMessages, { role: 'assistant', text, ...(tools.length && { tools }) }]
+
+    if (text) {
+      const tools = this.pendingSegmentTools
+
+      this.segmentMessages = [...this.segmentMessages, { role: 'assistant', text, ...(tools.length && { tools }) }]
+      this.pendingSegmentTools = []
+    }
+
     this.bufRef = ''
-    this.pendingSegmentTools = []
     patchTurnState({ streamPendingTools: [], streamSegments: this.segmentMessages, streaming: '' })
   }
 
@@ -187,8 +201,11 @@ class TurnController {
   }
 
   recordMessageComplete(payload: { rendered?: string; reasoning?: string; text?: string }) {
-    const finalText = (payload.rendered ?? payload.text ?? this.bufRef).trimStart()
-    const savedReasoning = this.reasoningText.trim() || String(payload.reasoning ?? '').trim()
+    const rawText = (payload.rendered ?? payload.text ?? this.bufRef).trimStart()
+    const split = splitReasoning(rawText)
+    const finalText = split.text
+    const existingReasoning = this.reasoningText.trim() || String(payload.reasoning ?? '').trim()
+    const savedReasoning = [existingReasoning, existingReasoning ? '' : split.reasoning].filter(Boolean).join('\n\n')
     const savedReasoningTokens = savedReasoning ? estimateTokensRough(savedReasoning) : 0
     const savedToolTokens = this.toolTokenAcc
     const tools = this.pendingSegmentTools
@@ -355,7 +372,9 @@ class TurnController {
 
     this.streamTimer = setTimeout(() => {
       this.streamTimer = null
-      patchTurnState({ streaming: this.bufRef.trimStart() })
+      const raw = this.bufRef.trimStart()
+      const visible = hasReasoningTag(raw) ? splitReasoning(raw).text : raw
+      patchTurnState({ streaming: visible })
     }, STREAM_BATCH_MS)
   }
 

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -11,9 +11,13 @@ const buildUiState = (): UiState => ({
   compact: false,
   detailsMode: 'collapsed',
   info: null,
+  inlineDiffs: true,
+  showCost: false,
+  showReasoning: false,
   sid: null,
   status: 'summoning hermes…',
   statusBar: true,
+  streaming: true,
   theme: DEFAULT_THEME,
   usage: ZERO
 })

--- a/ui-tui/src/app/useComposerState.ts
+++ b/ui-tui/src/app/useComposerState.ts
@@ -70,12 +70,25 @@ export function useComposerState({ gw, onClipboardPaste, submitRef }: UseCompose
 
       setPasteSnips(prev => [...prev, { label, text: cleanedText }].slice(-32))
 
+      void gw
+        .request<{ path?: string }>('paste.collapse', { text: cleanedText })
+        .then(r => {
+          const path = r?.path
+
+          if (!path) {
+            return
+          }
+
+          setPasteSnips(prev => prev.map(s => (s.label === label ? { ...s, path } : s)))
+        })
+        .catch(() => {})
+
       return {
         cursor: cursor + insert.length,
         value: value.slice(0, cursor) + insert + value.slice(cursor)
       }
     },
-    [onClipboardPaste]
+    [gw, onClipboardPaste]
   )
 
   const openEditor = useCallback(() => {

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -27,14 +27,18 @@ const quietRpc = async <T extends Record<string, any> = Record<string, any>>(
   }
 }
 
-const applyDisplay = (cfg: ConfigFullResponse | null, setBell: (v: boolean) => void) => {
+export const applyDisplay = (cfg: ConfigFullResponse | null, setBell: (v: boolean) => void) => {
   const d = cfg?.config?.display ?? {}
 
   setBell(!!d.bell_on_complete)
   patchUiState({
     compact: !!d.tui_compact,
     detailsMode: resolveDetailsMode(d),
-    statusBar: d.tui_statusbar !== false
+    inlineDiffs: d.inline_diffs !== false,
+    showCost: !!d.show_cost,
+    showReasoning: !!d.show_reasoning,
+    statusBar: d.tui_statusbar !== false,
+    streaming: d.streaming !== false
   })
 }
 

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -63,6 +63,10 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       return patchOverlayState({ modelPicker: false })
     }
 
+    if (overlay.skillsHub) {
+      return patchOverlayState({ skillsHub: false })
+    }
+
     if (overlay.picker) {
       return patchOverlayState({ picker: false })
     }

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -8,6 +8,9 @@ import type {
   VoiceRecordResponse
 } from '../gatewayTypes.js'
 
+import { writeOsc52Clipboard } from '../lib/osc52.js'
+
+import { getInputSelection } from './inputSelectionStore.js'
 import type { InputHandlerContext, InputHandlerResult } from './interfaces.js'
 import { $isBlocked, $overlayState, patchOverlayState } from './overlayStore.js'
 import { turnController } from './turnController.js'
@@ -245,6 +248,15 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
     if (isCtrl(key, ch, 'c')) {
       if (terminal.hasSelection) {
         return copySelection()
+      }
+
+      const inputSel = getInputSelection()
+
+      if (inputSel && inputSel.end > inputSel.start) {
+        writeOsc52Clipboard(inputSel.value.slice(inputSel.start, inputSel.end))
+        inputSel.clear()
+
+        return
       }
 
       if (live.busy && live.sid) {

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -99,6 +99,7 @@ export function StatusRule({
   usage,
   bgCount,
   sessionStartedAt,
+  showCost,
   voiceLabel,
   t
 }: StatusRuleProps) {
@@ -136,6 +137,9 @@ export function StatusRule({
           ) : null}
           {voiceLabel ? <Text color={t.color.dim}> │ {voiceLabel}</Text> : null}
           {bgCount > 0 ? <Text color={t.color.dim}> │ {bgCount} bg</Text> : null}
+          {showCost && typeof usage.cost_usd === 'number' ? (
+            <Text color={t.color.dim}> │ ${usage.cost_usd.toFixed(4)}</Text>
+          ) : null}
         </Text>
       </Box>
 
@@ -285,6 +289,7 @@ interface StatusRuleProps {
   cwdLabel: string
   model: string
   sessionStartedAt?: number | null
+  showCost: boolean
   status: string
   statusColor: string
   t: Theme

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -190,6 +190,7 @@ const ComposerPane = memo(function ComposerPane({
             cwdLabel={status.cwdLabel}
             model={ui.info?.model?.split('/').pop() ?? ''}
             sessionStartedAt={status.sessionStartedAt}
+            showCost={ui.showCost}
             status={ui.status}
             statusColor={status.statusColor}
             t={ui.theme}

--- a/ui-tui/src/components/appOverlays.tsx
+++ b/ui-tui/src/components/appOverlays.tsx
@@ -11,6 +11,7 @@ import { MaskedPrompt } from './maskedPrompt.js'
 import { ModelPicker } from './modelPicker.js'
 import { ApprovalPrompt, ClarifyPrompt } from './prompts.js'
 import { SessionPicker } from './sessionPicker.js'
+import { SkillsHub } from './skillsHub.js'
 
 export function PromptZone({
   cols,
@@ -82,7 +83,7 @@ export function FloatingOverlays({
   const overlay = useStore($overlayState)
   const ui = useStore($uiState)
 
-  const hasAny = overlay.modelPicker || overlay.pager || overlay.picker || completions.length
+  const hasAny = overlay.modelPicker || overlay.pager || overlay.picker || overlay.skillsHub || completions.length
 
   if (!hasAny) {
     return null
@@ -112,6 +113,12 @@ export function FloatingOverlays({
             sessionId={ui.sid}
             t={ui.theme}
           />
+        </FloatBox>
+      )}
+
+      {overlay.skillsHub && (
+        <FloatBox color={ui.theme.color.bronze}>
+          <SkillsHub gw={gw} onClose={() => patchOverlayState({ skillsHub: false })} t={ui.theme} />
         </FloatBox>
       )}
 

--- a/ui-tui/src/components/branding.tsx
+++ b/ui-tui/src/components/branding.tsx
@@ -126,11 +126,36 @@ export function SessionPanel({ info, sid, t }: SessionPanelProps) {
 
         {section('Tools', info.tools, 8, 'more toolsets…')}
         {section('Skills', info.skills)}
+
+        {info.mcp_servers && info.mcp_servers.length > 0 && (
+          <Box flexDirection="column" marginTop={1}>
+            <Text bold color={t.color.amber}>
+              MCP Servers
+            </Text>
+
+            {info.mcp_servers.map(s => (
+              <Text key={s.name} wrap="truncate">
+                <Text color={t.color.dim}>{`  ${s.name} `}</Text>
+                <Text color={t.color.dim}>{`[${s.transport}]`}</Text>
+                <Text color={t.color.dim}>: </Text>
+                {s.connected ? (
+                  <Text color={t.color.cornsilk}>
+                    {s.tools} tool{s.tools === 1 ? '' : 's'}
+                  </Text>
+                ) : (
+                  <Text color={t.color.error}>failed</Text>
+                )}
+              </Text>
+            ))}
+          </Box>
+        )}
+
         <Text />
 
         <Text color={t.color.cornsilk}>
           {flat(info.tools).length} tools{' · '}
           {flat(info.skills).length} skills
+          {info.mcp_servers?.length ? ` · ${info.mcp_servers.length} MCP` : ''}
           {' · '}
           <Text color={t.color.dim}>/help for commands</Text>
         </Text>

--- a/ui-tui/src/components/markdown.tsx
+++ b/ui-tui/src/components/markdown.tsx
@@ -1,6 +1,7 @@
 import { Box, Text } from '@hermes/ink'
 import { memo, type ReactNode, useMemo } from 'react'
 
+import { highlightLine, isHighlightable } from '../lib/syntax.js'
 import type { Theme } from '../theme.js'
 
 const FENCE_RE = /^\s*(`{3,}|~{3,})(.*)$/
@@ -282,11 +283,28 @@ function MdImpl({ compact, t, text }: MdProps) {
         start('code')
 
         const isDiff = lang === 'diff'
+        const highlighted = !isDiff && isHighlightable(lang)
 
         nodes.push(
           <Box flexDirection="column" key={key} paddingLeft={2}>
             {lang && !isDiff && <Text color={t.color.dim}>{'─ ' + lang}</Text>}
             {block.map((l, j) => {
+              if (highlighted) {
+                return (
+                  <Text key={j}>
+                    {highlightLine(l, lang, t).map(([color, text], k) =>
+                      color ? (
+                        <Text color={color} key={k}>
+                          {text}
+                        </Text>
+                      ) : (
+                        <Text key={k}>{text}</Text>
+                      )
+                    )}
+                  </Text>
+                )
+              }
+
               const add = isDiff && l.startsWith('+')
               const del = isDiff && l.startsWith('-')
               const hunk = isDiff && l.startsWith('@@')

--- a/ui-tui/src/components/markdown.tsx
+++ b/ui-tui/src/components/markdown.tsx
@@ -1,4 +1,4 @@
-import { Box, Text } from '@hermes/ink'
+import { Box, Link, Text } from '@hermes/ink'
 import { memo, type ReactNode, useMemo } from 'react'
 
 import { highlightLine, isHighlightable } from '../lib/syntax.js'
@@ -23,10 +23,12 @@ type Fence = {
   len: number
 }
 
-const renderLink = (key: number, t: Theme, label: string) => (
-  <Text color={t.color.amber} key={key} underline>
-    {label}
-  </Text>
+const renderLink = (key: number, t: Theme, label: string, url: string) => (
+  <Link key={key} url={url}>
+    <Text color={t.color.amber} underline>
+      {label}
+    </Text>
+  </Link>
 )
 
 const trimBareUrl = (value: string) => {
@@ -38,11 +40,17 @@ const trimBareUrl = (value: string) => {
   }
 }
 
-const renderAutolink = (key: number, t: Theme, raw: string) => (
-  <Text color={t.color.amber} key={key} underline>
-    {raw.replace(/^mailto:/, '')}
-  </Text>
-)
+const renderAutolink = (key: number, t: Theme, raw: string) => {
+  const url = raw.startsWith('mailto:') ? raw : raw.includes('@') && !raw.startsWith('http') ? `mailto:${raw}` : raw
+
+  return (
+    <Link key={key} url={url}>
+      <Text color={t.color.amber} underline>
+        {raw.replace(/^mailto:/, '')}
+      </Text>
+    </Link>
+  )
+}
 
 const indentDepth = (indent: string) => Math.floor(indent.replace(/\t/g, '  ').length / 2)
 
@@ -142,7 +150,7 @@ function MdInline({ t, text }: { t: Theme; text: string }) {
         </Text>
       )
     } else if (m[4] && m[5]) {
-      parts.push(renderLink(parts.length, t, m[4]))
+      parts.push(renderLink(parts.length, t, m[4], m[5]))
     } else if (m[6]) {
       parts.push(renderAutolink(parts.length, t, m[6]))
     } else if (m[7]) {

--- a/ui-tui/src/components/messageLine.tsx
+++ b/ui-tui/src/components/messageLine.tsx
@@ -35,7 +35,9 @@ export const MessageLine = memo(function MessageLine({
     return (
       <Box alignSelf="flex-start" borderColor={t.color.dim} borderStyle="round" marginLeft={3} paddingX={1}>
         {hasAnsi(msg.text) ? (
-          <Text wrap="truncate-end"><Ansi>{msg.text}</Ansi></Text>
+          <Text wrap="truncate-end">
+            <Ansi>{msg.text}</Ansi>
+          </Text>
         ) : (
           <Text color={t.color.dim} wrap="truncate-end">
             {preview}

--- a/ui-tui/src/components/prompts.tsx
+++ b/ui-tui/src/components/prompts.tsx
@@ -8,6 +8,7 @@ import { TextInput } from './textInput.js'
 
 const OPTS = ['once', 'session', 'always', 'deny'] as const
 const LABELS = { always: 'Always allow', deny: 'Deny', once: 'Allow once', session: 'Allow this session' } as const
+const CMD_PREVIEW_LINES = 10
 
 export function ApprovalPrompt({ onChoice, req, t }: ApprovalPromptProps) {
   const [sel, setSel] = useState(0)
@@ -34,13 +35,28 @@ export function ApprovalPrompt({ onChoice, req, t }: ApprovalPromptProps) {
     }
   })
 
+  const rawLines = req.command.split('\n')
+  const shown = rawLines.slice(0, CMD_PREVIEW_LINES)
+  const overflow = rawLines.length - shown.length
+
   return (
     <Box borderColor={t.color.warn} borderStyle="double" flexDirection="column" paddingX={1}>
       <Text bold color={t.color.warn}>
         ⚠ approval required · {req.description}
       </Text>
 
-      <Text color={t.color.cornsilk}> {req.command}</Text>
+      <Box flexDirection="column" paddingLeft={1}>
+        {shown.map((line, i) => (
+          <Text color={t.color.cornsilk} key={i} wrap="truncate-end">
+            {line || ' '}
+          </Text>
+        ))}
+
+        {overflow > 0 ? (
+          <Text color={t.color.dim}>… +{overflow} more line{overflow === 1 ? '' : 's'} (full text above)</Text>
+        ) : null}
+      </Box>
+
       <Text />
 
       {OPTS.map((o, i) => (

--- a/ui-tui/src/components/prompts.tsx
+++ b/ui-tui/src/components/prompts.tsx
@@ -53,7 +53,9 @@ export function ApprovalPrompt({ onChoice, req, t }: ApprovalPromptProps) {
         ))}
 
         {overflow > 0 ? (
-          <Text color={t.color.dim}>… +{overflow} more line{overflow === 1 ? '' : 's'} (full text above)</Text>
+          <Text color={t.color.dim}>
+            … +{overflow} more line{overflow === 1 ? '' : 's'} (full text above)
+          </Text>
         ) : null}
       </Box>
 

--- a/ui-tui/src/components/skillsHub.tsx
+++ b/ui-tui/src/components/skillsHub.tsx
@@ -1,0 +1,290 @@
+import { Box, Text, useInput } from '@hermes/ink'
+import { useEffect, useState } from 'react'
+
+import type { GatewayClient } from '../gatewayClient.js'
+import { rpcErrorMessage } from '../lib/rpc.js'
+import type { Theme } from '../theme.js'
+
+const VISIBLE = 12
+
+const pageOffset = (count: number, sel: number) => Math.max(0, Math.min(sel - Math.floor(VISIBLE / 2), count - VISIBLE))
+
+const visibleItems = (items: string[], sel: number) => {
+  const off = pageOffset(items.length, sel)
+
+  return { items: items.slice(off, off + VISIBLE), off }
+}
+
+export function SkillsHub({ gw, onClose, t }: SkillsHubProps) {
+  const [skillsByCat, setSkillsByCat] = useState<Record<string, string[]>>({})
+  const [selectedCat, setSelectedCat] = useState('')
+  const [catIdx, setCatIdx] = useState(0)
+  const [skillIdx, setSkillIdx] = useState(0)
+  const [stage, setStage] = useState<'actions' | 'category' | 'skill'>('category')
+  const [info, setInfo] = useState<null | SkillInfo>(null)
+  const [installing, setInstalling] = useState(false)
+  const [err, setErr] = useState('')
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    gw.request<{ skills?: Record<string, string[]> }>('skills.manage', { action: 'list' })
+      .then(r => {
+        setSkillsByCat(r?.skills ?? {})
+        setErr('')
+        setLoading(false)
+      })
+      .catch((e: unknown) => {
+        setErr(rpcErrorMessage(e))
+        setLoading(false)
+      })
+  }, [gw])
+
+  const cats = Object.keys(skillsByCat).sort()
+  const skills = selectedCat ? (skillsByCat[selectedCat] ?? []) : []
+  const skillName = skills[skillIdx] ?? ''
+
+  const inspect = (name: string) => {
+    setInfo(null)
+    setErr('')
+
+    gw.request<{ info?: SkillInfo }>('skills.manage', { action: 'inspect', query: name })
+      .then(r => setInfo(r?.info ?? { name }))
+      .catch((e: unknown) => setErr(rpcErrorMessage(e)))
+  }
+
+  const install = (name: string) => {
+    setInstalling(true)
+    setErr('')
+
+    gw.request<{ installed?: boolean; name?: string }>('skills.manage', { action: 'install', query: name })
+      .then(() => onClose())
+      .catch((e: unknown) => setErr(rpcErrorMessage(e)))
+      .finally(() => setInstalling(false))
+  }
+
+  useInput((ch, key) => {
+    if (installing) {
+      return
+    }
+
+    if (key.escape) {
+      if (stage === 'actions') {
+        setStage('skill')
+        setInfo(null)
+        setErr('')
+
+        return
+      }
+
+      if (stage === 'skill') {
+        setStage('category')
+        setSkillIdx(0)
+
+        return
+      }
+
+      onClose()
+
+      return
+    }
+
+    if (stage === 'actions') {
+      if (key.return || ch.toLowerCase() === 'x') {
+        if (skillName) {
+          install(skillName)
+        }
+
+        return
+      }
+
+      if (ch.toLowerCase() === 'i' && skillName) {
+        inspect(skillName)
+      }
+
+      return
+    }
+
+    const count = stage === 'category' ? cats.length : skills.length
+    const sel = stage === 'category' ? catIdx : skillIdx
+    const setSel = stage === 'category' ? setCatIdx : setSkillIdx
+
+    if (key.upArrow && sel > 0) {
+      setSel(v => v - 1)
+
+      return
+    }
+
+    if (key.downArrow && sel < count - 1) {
+      setSel(v => v + 1)
+
+      return
+    }
+
+    if (key.return) {
+      if (stage === 'category') {
+        const cat = cats[catIdx]
+
+        if (!cat) {
+          return
+        }
+
+        setSelectedCat(cat)
+        setSkillIdx(0)
+        setStage('skill')
+
+        return
+      }
+
+      const name = skills[skillIdx]
+
+      if (name) {
+        setStage('actions')
+        inspect(name)
+      }
+
+      return
+    }
+
+    const n = ch === '0' ? 10 : parseInt(ch, 10)
+
+    if (!Number.isNaN(n) && n >= 1 && n <= Math.min(10, count)) {
+      const off = pageOffset(count, sel)
+      const next = off + n - 1
+
+      if (stage === 'category') {
+        const cat = cats[next]
+
+        if (cat) {
+          setSelectedCat(cat)
+          setCatIdx(next)
+          setSkillIdx(0)
+          setStage('skill')
+        }
+
+        return
+      }
+
+      const name = skills[next]
+
+      if (name) {
+        setSkillIdx(next)
+        setStage('actions')
+        inspect(name)
+      }
+    }
+  })
+
+  if (loading) {
+    return <Text color={t.color.dim}>loading skills…</Text>
+  }
+
+  if (err && stage === 'category') {
+    return (
+      <Box flexDirection="column">
+        <Text color={t.color.label}>error: {err}</Text>
+        <Text color={t.color.dim}>Esc to cancel</Text>
+      </Box>
+    )
+  }
+
+  if (!cats.length) {
+    return (
+      <Box flexDirection="column">
+        <Text color={t.color.dim}>no skills available</Text>
+        <Text color={t.color.dim}>Esc to cancel</Text>
+      </Box>
+    )
+  }
+
+  if (stage === 'category') {
+    const rows = cats.map(c => `${c} · ${skillsByCat[c]?.length ?? 0} skills`)
+    const { items, off } = visibleItems(rows, catIdx)
+
+    return (
+      <Box flexDirection="column">
+        <Text bold color={t.color.amber}>
+          Skills Hub
+        </Text>
+
+        <Text color={t.color.dim}>select a category</Text>
+        {off > 0 && <Text color={t.color.dim}> ↑ {off} more</Text>}
+
+        {items.map((row, i) => {
+          const idx = off + i
+
+          return (
+            <Text color={catIdx === idx ? t.color.cornsilk : t.color.dim} key={row}>
+              {catIdx === idx ? '▸ ' : '  '}
+              {i + 1}. {row}
+            </Text>
+          )
+        })}
+
+        {off + VISIBLE < rows.length && <Text color={t.color.dim}> ↓ {rows.length - off - VISIBLE} more</Text>}
+        <Text color={t.color.dim}>↑/↓ select · Enter open · 1-9,0 quick · Esc cancel</Text>
+      </Box>
+    )
+  }
+
+  if (stage === 'skill') {
+    const { items, off } = visibleItems(skills, skillIdx)
+
+    return (
+      <Box flexDirection="column">
+        <Text bold color={t.color.amber}>
+          {selectedCat}
+        </Text>
+
+        <Text color={t.color.dim}>{skills.length} skill(s)</Text>
+        {!skills.length ? <Text color={t.color.dim}>no skills in this category</Text> : null}
+        {off > 0 && <Text color={t.color.dim}> ↑ {off} more</Text>}
+
+        {items.map((row, i) => {
+          const idx = off + i
+
+          return (
+            <Text color={skillIdx === idx ? t.color.cornsilk : t.color.dim} key={row}>
+              {skillIdx === idx ? '▸ ' : '  '}
+              {i + 1}. {row}
+            </Text>
+          )
+        })}
+
+        {off + VISIBLE < skills.length && <Text color={t.color.dim}> ↓ {skills.length - off - VISIBLE} more</Text>}
+        <Text color={t.color.dim}>
+          {skills.length ? '↑/↓ select · Enter open · 1-9,0 quick · Esc back' : 'Esc back'}
+        </Text>
+      </Box>
+    )
+  }
+
+  return (
+    <Box flexDirection="column">
+      <Text bold color={t.color.amber}>
+        {info?.name ?? skillName}
+      </Text>
+
+      <Text color={t.color.dim}>{info?.category ?? selectedCat}</Text>
+      {info?.description ? <Text color={t.color.cornsilk}>{info.description}</Text> : null}
+      {info?.path ? <Text color={t.color.dim}>path: {info.path}</Text> : null}
+      {!info && !err ? <Text color={t.color.dim}>loading…</Text> : null}
+      {err ? <Text color={t.color.label}>error: {err}</Text> : null}
+      {installing ? <Text color={t.color.amber}>installing…</Text> : null}
+
+      <Text color={t.color.dim}>Enter install · i inspect · x install · Esc back</Text>
+    </Box>
+  )
+}
+
+interface SkillInfo {
+  category?: string
+  description?: string
+  name?: string
+  path?: string
+}
+
+interface SkillsHubProps {
+  gw: GatewayClient
+  onClose: () => void
+  t: Theme
+}

--- a/ui-tui/src/components/skillsHub.tsx
+++ b/ui-tui/src/components/skillsHub.tsx
@@ -89,10 +89,16 @@ export function SkillsHub({ gw, onClose, t }: SkillsHubProps) {
     }
 
     if (stage === 'actions') {
-      if (key.return || ch.toLowerCase() === 'x') {
-        if (skillName) {
-          install(skillName)
-        }
+      if (key.return) {
+        setStage('skill')
+        setInfo(null)
+        setErr('')
+
+        return
+      }
+
+      if (ch.toLowerCase() === 'x' && skillName) {
+        install(skillName)
 
         return
       }
@@ -271,7 +277,7 @@ export function SkillsHub({ gw, onClose, t }: SkillsHubProps) {
       {err ? <Text color={t.color.label}>error: {err}</Text> : null}
       {installing ? <Text color={t.color.amber}>installing…</Text> : null}
 
-      <Text color={t.color.dim}>Enter install · i inspect · x install · Esc back</Text>
+      <Text color={t.color.dim}>i reinspect · x reinstall · Enter/Esc back</Text>
     </Box>
   )
 }

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -464,7 +464,7 @@ export function TextInput({
     (inp: string, k: Key, event: InputEvent) => {
       const eventRaw = event.keypress.raw
 
-      if (eventRaw === '\x1bv' || eventRaw === '\x1bV') {
+      if (eventRaw === '\x1bv' || eventRaw === '\x1bV' || eventRaw === '\x16') {
         return void emitPaste({ cursor: curRef.current, hotkey: true, text: '', value: vRef.current })
       }
 

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -2,7 +2,7 @@ import type { InputEvent, Key } from '@hermes/ink'
 import * as Ink from '@hermes/ink'
 import { useEffect, useMemo, useRef, useState } from 'react'
 
-import { writeOsc52Clipboard } from '../lib/osc52.js'
+import { setInputSelection } from '../app/inputSelectionStore.js'
 
 type InkExt = typeof Ink & {
   stringWidth: (s: string) => number
@@ -353,6 +353,28 @@ export function TextInput({
     }
   }, [value])
 
+  useEffect(() => {
+    if (!focus) {
+      return
+    }
+
+    if (selected) {
+      setInputSelection({
+        clear: () => {
+          selRef.current = null
+          setSel(null)
+        },
+        end: selected.end,
+        start: selected.start,
+        value: vRef.current
+      })
+    } else {
+      setInputSelection(null)
+    }
+
+    return () => setInputSelection(null)
+  }, [focus, selected])
+
   useEffect(
     () => () => {
       if (pasteTimer.current) {
@@ -470,20 +492,16 @@ export function TextInput({
         return void emitPaste({ cursor: curRef.current, hotkey: true, text: '', value: vRef.current })
       }
 
-      if (k.ctrl && inp === 'c') {
-        const range = selRange()
-
-        if (range) {
-          writeOsc52Clipboard(vRef.current.slice(range.start, range.end))
-          clearSel()
-
-          return
-        }
-
-        return
-      }
-
-      if (k.upArrow || k.downArrow || k.tab || (k.shift && k.tab) || k.pageUp || k.pageDown || k.escape) {
+      if (
+        k.upArrow ||
+        k.downArrow ||
+        (k.ctrl && inp === 'c') ||
+        k.tab ||
+        (k.shift && k.tab) ||
+        k.pageUp ||
+        k.pageDown ||
+        k.escape
+      ) {
         return
       }
 

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -2,6 +2,8 @@ import type { InputEvent, Key } from '@hermes/ink'
 import * as Ink from '@hermes/ink'
 import { useEffect, useMemo, useRef, useState } from 'react'
 
+import { writeOsc52Clipboard } from '../lib/osc52.js'
+
 type InkExt = typeof Ink & {
   stringWidth: (s: string) => number
   useDeclaredCursor: (a: { line: number; column: number; active: boolean }) => (el: any) => void
@@ -468,10 +470,22 @@ export function TextInput({
         return void emitPaste({ cursor: curRef.current, hotkey: true, text: '', value: vRef.current })
       }
 
+      if (k.ctrl && inp === 'c') {
+        const range = selRange()
+
+        if (range) {
+          writeOsc52Clipboard(vRef.current.slice(range.start, range.end))
+          clearSel()
+
+          return
+        }
+
+        return
+      }
+
       if (
         k.upArrow ||
         k.downArrow ||
-        (k.ctrl && inp === 'c') ||
         k.tab ||
         (k.shift && k.tab) ||
         k.pageUp ||

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -483,15 +483,7 @@ export function TextInput({
         return
       }
 
-      if (
-        k.upArrow ||
-        k.downArrow ||
-        k.tab ||
-        (k.shift && k.tab) ||
-        k.pageUp ||
-        k.pageDown ||
-        k.escape
-      ) {
+      if (k.upArrow || k.downArrow || k.tab || (k.shift && k.tab) || k.pageUp || k.pageDown || k.escape) {
         return
       }
 

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -53,6 +53,10 @@ export type CommandDispatchResponse =
 export interface ConfigDisplayConfig {
   bell_on_complete?: boolean
   details_mode?: string
+  inline_diffs?: boolean
+  show_cost?: boolean
+  show_reasoning?: boolean
+  streaming?: boolean
   thinking_mode?: string
   tui_compact?: boolean
   tui_statusbar?: boolean

--- a/ui-tui/src/lib/reasoning.ts
+++ b/ui-tui/src/lib/reasoning.ts
@@ -1,0 +1,50 @@
+const TAGS = ['think', 'reasoning', 'thinking', 'thought', 'REASONING_SCRATCHPAD'] as const
+
+export interface SplitReasoning {
+  reasoning: string
+  text: string
+}
+
+export function splitReasoning(input: string): SplitReasoning {
+  let text = input
+  const reasoning: string[] = []
+
+  for (const tag of TAGS) {
+    const paired = new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>\\s*`, 'gi')
+    text = text.replace(paired, (_m, inner: string) => {
+      const trimmed = inner.trim()
+
+      if (trimmed) {
+        reasoning.push(trimmed)
+      }
+
+      return ''
+    })
+
+    const unclosed = new RegExp(`<${tag}>([\\s\\S]*)$`, 'i')
+    text = text.replace(unclosed, (_m, inner: string) => {
+      const trimmed = inner.trim()
+
+      if (trimmed) {
+        reasoning.push(trimmed)
+      }
+
+      return ''
+    })
+  }
+
+  return {
+    reasoning: reasoning.join('\n\n').trim(),
+    text: text.trim()
+  }
+}
+
+export const hasReasoningTag = (input: string) => {
+  for (const tag of TAGS) {
+    if (input.includes(`<${tag}>`)) {
+      return true
+    }
+  }
+
+  return false
+}

--- a/ui-tui/src/lib/syntax.ts
+++ b/ui-tui/src/lib/syntax.ts
@@ -1,0 +1,117 @@
+import type { Theme } from '../theme.js'
+
+export type Token = [string, string]
+
+interface LangSpec {
+  comment: null | string
+  keywords: Set<string>
+}
+
+const KW = (s: string) => new Set(s.split(/\s+/).filter(Boolean))
+
+const TS = KW(`
+  abstract as async await break case catch class const continue debugger default delete do else enum export extends
+  false finally for from function get if implements import in instanceof interface is let new null of package private
+  protected public readonly return set static super switch this throw true try type typeof undefined var void while
+  with yield
+`)
+
+const PY = KW(`
+  False None True and as assert async await break class continue def del elif else except finally for from global if
+  import in is lambda nonlocal not or pass raise return try while with yield
+`)
+
+const SH = KW(`
+  if then else elif fi for in do done while until case esac function return break continue local export readonly
+  declare typeset
+`)
+
+const GO = KW(`
+  break case chan const continue default defer else fallthrough for func go goto if import interface map package range
+  return select struct switch type var nil true false
+`)
+
+const RUST = KW(`
+  as async await break const continue crate dyn else enum extern false fn for if impl in let loop match mod move mut
+  pub ref return self Self static struct super trait true type unsafe use where while yield
+`)
+
+const SQL = KW(`
+  select from where and or not in is null as by group order limit offset insert into values update set delete create
+  table drop alter add column primary key foreign references join left right inner outer on
+`)
+
+const LANGS: Record<string, LangSpec> = {
+  go: { comment: '//', keywords: GO },
+  json: { comment: null, keywords: KW('true false null') },
+  py: { comment: '#', keywords: PY },
+  rust: { comment: '//', keywords: RUST },
+  sh: { comment: '#', keywords: SH },
+  sql: { comment: '--', keywords: SQL },
+  ts: { comment: '//', keywords: TS },
+  yaml: { comment: '#', keywords: KW('true false null yes no on off') }
+}
+
+const ALIAS: Record<string, string> = {
+  bash: 'sh',
+  javascript: 'ts',
+  js: 'ts',
+  jsx: 'ts',
+  python: 'py',
+  rs: 'rust',
+  shell: 'sh',
+  tsx: 'ts',
+  typescript: 'ts',
+  yml: 'yaml',
+  zsh: 'sh'
+}
+
+const resolve = (lang: string): LangSpec | null => LANGS[ALIAS[lang] ?? lang] ?? null
+
+export const isHighlightable = (lang: string): boolean => resolve(lang) !== null
+
+const TOKEN_RE = /'(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*"|`(?:[^`\\]|\\.)*`|\b\d+(?:\.\d+)?\b|[A-Za-z_$][\w$]*/g
+
+export function highlightLine(line: string, lang: string, t: Theme): Token[] {
+  const spec = resolve(lang)
+
+  if (!spec) {
+    return [['', line]]
+  }
+
+  if (spec.comment && line.trimStart().startsWith(spec.comment)) {
+    return [[t.color.dim, line]]
+  }
+
+  const tokens: Token[] = []
+  let last = 0
+
+  for (const m of line.matchAll(TOKEN_RE)) {
+    const start = m.index ?? 0
+
+    if (start > last) {
+      tokens.push(['', line.slice(last, start)])
+    }
+
+    const tok = m[0]
+    const ch = tok[0]!
+
+    if (ch === '"' || ch === "'" || ch === '`') {
+      tokens.push([t.color.amber, tok])
+    } else if (ch >= '0' && ch <= '9') {
+      tokens.push([t.color.cornsilk, tok])
+    } else if (spec.keywords.has(tok)) {
+      tokens.push([t.color.bronze, tok])
+    } else {
+      tokens.push(['', tok])
+    }
+
+    last = start + tok.length
+  }
+
+  if (last < line.length) {
+    tokens.push(['', line.slice(last)])
+  }
+
+  return tokens
+}

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -68,6 +68,7 @@ export interface Usage {
   context_max?: number
   context_percent?: number
   context_used?: number
+  cost_usd?: number
   input: number
   output: number
   total: number

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -51,8 +51,16 @@ export type Role = 'assistant' | 'system' | 'tool' | 'user'
 export type DetailsMode = 'hidden' | 'collapsed' | 'expanded'
 export type ThinkingMode = 'collapsed' | 'truncated' | 'full'
 
+export interface McpServerStatus {
+  connected: boolean
+  name: string
+  tools: number
+  transport: string
+}
+
 export interface SessionInfo {
   cwd?: string
+  mcp_servers?: McpServerStatus[]
   model: string
   release_date?: string
   skills: Record<string, string[]>

--- a/ui-tui/src/types/hermes-ink.d.ts
+++ b/ui-tui/src/types/hermes-ink.d.ts
@@ -63,6 +63,11 @@ declare module '@hermes/ink' {
   export const Box: React.ComponentType<any>
   export const AlternateScreen: React.ComponentType<any>
   export const Ansi: React.ComponentType<any>
+  export const Link: React.ComponentType<{
+    readonly children?: React.ReactNode
+    readonly fallback?: React.ReactNode
+    readonly url: string
+  }>
   export const NoSelect: React.ComponentType<any>
   export const ScrollBox: React.ComponentType<any>
   export const Text: React.ComponentType<any>


### PR DESCRIPTION
## What does this PR do?

Follow-up to #12130 (TUI v2 feature-parity audit). Closes Tier-1 items and a handful of real bugs surfaced during testing against the consolidated branch.

The audit framed some items as missing in v2 that actually work server-side — those are scoped-down in commits / release notes rather than re-implemented. Actual gaps are shipped as `fix(tui)` / `feat(tui)` commits.

## Related Issue

Related to #12130

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

### Fixes (real bugs found during testing)

- `fix(tui): split /model picker from /provider wizard to resolve registry collision` — `setup.ts`'s `name: 'model'` shadowed `session.ts`'s picker handler because the registry is a Map (last-wins). `/model` never opened the picker. Split into `/model` (picker + direct switch) and `/provider` (external setup wizard).
- `fix(tui): route /skills subcommands through skills.manage instead of curses slash.exec` — `/skills install`, `/skills inspect`, `/skills search`, `/skills browse`, `/skills list` fell through to `slash.exec` which invokes v1's curses code path and hangs inside the Ink worker. Now call the typed `skills.manage` RPC and render via `transcript.panel` / `transcript.page`. Audit §2.
- `fix(tui): cap approval prompt command preview at 10 lines` — giant inline scripts (Python code_execution bodies) pushed Allow/Deny options off the viewport. Preview is capped with `wrap="truncate-end"` per line + dim `… +N more lines` indicator. Full text remains in transcript above.
- `fix(tui): wrap markdown links in Link so Ghostty/iTerm/kitty get real OSC 8 hyperlinks` — `renderLink` dropped the `href` entirely, making Cmd+Click inert in every terminal (Ghostty's URL auto-detect only saw bare-URL text, which Alt+Click workaround-ed the easier half). Links now emit OSC 8 via `@hermes/ink`'s `Link` component.
- `fix(tui): Ctrl+C on in-input selection copies to clipboard instead of clearing` — `textInput` explicitly ignored `Ctrl+C`, so the app-level handler ran `clearIn()` whenever input had text, obliterating what you typed. Now copies the selection via OSC 52 and clears the selection only.
- `fix(tui): strip <think>…</think> tags from assistant content and route to reasoning panel` — models that emit inline `<think>/<reasoning>/<thinking>/<thought>/<REASONING_SCRATCHPAD>` tags were showing the tags in the body AND the same content dimmed in the thinking panel. Ported v1's tag set to `lib/reasoning.ts` and applied in `scheduleStreaming`, `flushStreamingSegment`, and `recordMessageComplete`.

### Feature-parity (audit items)

- `fix(tui): split /model picker from /provider wizard to resolve registry collision` — audit §7.
- `feat(tui): accept raw Ctrl+V as clipboard image paste fallback` — audit §6. `\x16` now triggers the same hotkey-paste path as Alt+V.
- `feat(tui-gateway): surface config.quick_commands in commands.catalog` — audit §4. Execution was already live via `command.dispatch`; catalog now surfaces them under a "User commands" bucket with auto-generated `exec: <cmd>` / `alias → <target>` descriptions (explicit `description` wins).
- `feat(tui): persist large pastes to ~/.hermes/pastes/ via paste.collapse` — audit §5. `handleTextPaste` fires `paste.collapse` alongside the in-memory `[[paste:label]]` token so v1's grep-after-exit workflow works. Client-side token format kept.
- `feat(tui): read display.streaming / show_reasoning / show_cost / inline_diffs from config` + `feat(tui): honor display.* flags in turn renderer, status bar, and event handler` — audit §10. `useConfigSync.applyDisplay` reads the four flags; `turnController` gates streaming / reasoning, `createGatewayEventHandler` gates `inline_diff` rendering, `StatusRule` renders `$X.XXXX` when `show_cost` is on.
- `feat(tui-gateway): include per-MCP-server status in session.info payload` + `feat(tui): render per-MCP-server status block in SessionPanel` — audit §8 / §11. Server adds `mcp_servers: [{name, transport, tools, connected}]` via `tools.mcp_tool.get_mcp_status`; banner renders a new block after Skills with per-server rows and a `failed` label for disconnected servers. Footer summary shows `· N MCP`.
- `feat(tui): add skillsHub overlay state wiring` + `feat(tui): add two-step SkillsHub overlay component` + `feat(tui): register /skills slash command to open Skills Hub` — audit §2 / §9. Bare `/skills` opens a two-step modal mirroring `ModelPicker` (category → skill → actions). Inspect on entry; `i` re-inspects, `x` reinstalls. Enter/Esc back.
- `feat(tui): per-language syntax highlighting in markdown code fences` — audit §8. Hand-rolled minimal highlighter in `lib/syntax.ts` for `ts/js/jsx/tsx`, `py/python`, `sh/bash/shell/zsh`, `go`, `rust/rs`, `json`, `yaml/yml`, `sql`. No library dependency; unknown langs fall through to plain render; existing `diff` colorization preserved.

### Tests

- `test(tui-gateway): assert quick_commands appear in commands.catalog output`
- `test(tui-gateway): cover mcp_servers field in _session_info output`
- New vitest coverage: `syntax.test.ts`, `reasoning.test.ts`, `useConfigSync.test.ts`, and expanded `createSlashHandler.test.ts`.

### Not in this PR (audit items scoped out)

- `@file:` / `@diff` / `@staged` / `@git:N` / `@url:` / `@folder:` — already expand server-side via `prompt.submit` → `agent.context_references.preprocess_context_references`. Audit §3's "zero references" conclusion was a frontend-only grep; feature works end-to-end. No code change needed.
- Overlays for `/rollback`, `/cron`, `/plugins`, `/agents`, `/insights`, `/browser`, `/snapshot`, Tools Config multi-select — audit §9 backlog. Left for follow-up PRs.
- Response Box chrome around assistant messages — audit §8 subjective call; v2's clean inline design is intentional.
- Ctrl+Z suspend-to-shell — audit §5. `textInput` already binds Ctrl+Z to undo; reframed as "no SIGTSTP" rather than re-mapped.

## How to Test

### Automated

```bash
# TS
cd ui-tui && npm run fix && npm run type-check && npm run test
# 73 tests pass

# Python
.venv/bin/pytest tests/test_tui_gateway_server.py -q
# 27 tests pass
```

### Manual

1. `hermes --tui` from a fresh terminal.
2. **`/model` picker**: type `/model` with no args → two-step picker opens. Type `/provider` → external wizard.
3. **Skills Hub**: type `/skills` → category → skill → actions overlay; `/skills inspect <name>` renders a panel instead of crashing; `/skills browse 1` renders a paginated panel.
4. **Ctrl+V fallback**: copy an image; Ctrl+V inside composer attaches it (same behavior as Alt+V).
5. **`quick_commands`**: add
   ```yaml
   quick_commands:
     gs:
       type: exec
       command: git status
   ```
   to `~/.hermes/config.yaml`, restart TUI, type `/gs` → autocomplete shows it under "User commands".
6. **Paste-to-file**: paste a 10+ line block into the composer; check `ls -t ~/.hermes/pastes/` — new file appears.
7. **MCP banner**: if you have MCP servers configured, boot shows `MCP Servers` block with `name [transport]: N tools` rows.
8. **Syntax highlighting**: ask the model a question that returns `ts`/`py`/`sh` code fences; keywords render bronze, strings amber, numbers cornsilk, comments dim.
9. **display.show_cost**: set `display: { show_cost: true }` in config → status bar shows `· $X.XXXX`.
10. **Approval prompt cap**: ask the model to run a ≥50-line Python script; approval box shows 10-line preview + `… +N more lines`; Allow/Deny rows always visible.
11. **Ctrl+C on selection**: type text, shift+arrow-select part of it, Ctrl+C → selection copies to clipboard, input stays.
12. **OSC 8 hyperlinks**: ask for a response with a markdown link; Cmd+Click (or Ctrl+Click on WSL) in Ghostty opens the URL.
13. **`<think>` stripping**: ask deepseek-r1 / qwen3-thinking / similar → inline `<think>…</think>` content goes to thinking panel, not body.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (`fix(tui):`, `feat(tui-gateway):`, `test(tui-gateway):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (overlaps with #12141's `/plan` + skill dispatch fixes, which are complementary and merge cleanly)
- [x] My PR contains only changes related to the audit follow-up
- [x] I've run `npm run test` (TS) and `pytest tests/test_tui_gateway_server.py` — both pass
- [x] I've added tests for my changes
- [x] I've tested on: Ubuntu / WSL2 + Ghostty

### Documentation & Housekeeping

- [ ] I've updated relevant documentation — N/A (no user-facing config schema change; `display.*` flags already documented in `cli-config.yaml.example`)
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — `paste.collapse` uses `~/.hermes/pastes/` via `_hermes_home` (profile-safe); Ctrl+V raw byte `\x16` is universal; OSC 8 / OSC 52 gated on terminal detection via `supports-hyperlinks` + env fallbacks
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

### Before / After: `/skills` subcommands

**Before** (slash.exec → curses hang):
```
/skills browse
(hangs, no output)
```

**After**:
```
/skills browse
(paginated panel opens with remote skills list)
```

### Before / After: approval prompt with huge Python body

**Before**: ~200 lines of code fill the viewport, Allow/Deny rows below are off-screen.

**After**:
```
⚠ approval required · execute python code
 line_0 = …
 line_1 = …
  … (through line 9)
 … +50 more lines (full text above)

▸ 1. Allow once
  2. Allow this session
  3. Always allow
  4. Deny
↑/↓ select · Enter confirm · 1-4 quick pick · Ctrl+C deny
```

### MCP banner

```
Available Tools
  browser: browser_back, browser_click, …
  …

Available Skills
  creative: architecture-diagram, ascii-art, …
  …

MCP Servers
  github [http]: 14 tools
  filesystem [stdio]: 4 tools
  broken [stdio]: failed

31 tools · 98 skills · 3 MCP · /help for commands
```

### Diffstat

30 files changed, +1118 / −36. No modifications outside `ui-tui/`, `tui_gateway/`, `tests/test_tui_gateway_server.py`.
