### PR TITLE
feat(cli): improve transcript visibility and resume history

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -309,7 +309,7 @@ def load_cli_config() -> Dict[str, Any]:
 
         "display": {
             "compact": False,
-            "resume_display": "full",
+            "resume_display": "history",
             "show_reasoning": False,
             "streaming": True,
             "busy_input_mode": "interrupt",
@@ -1676,8 +1676,8 @@ class HermesCLI:
         # YAML 1.1 parses bare `off` as boolean False — normalise to string.
         _raw_tp = CLI_CONFIG["display"].get("tool_progress", "all")
         self.tool_progress_mode = "off" if _raw_tp is False else str(_raw_tp)
-        # resume_display: "full" (show history) | "minimal" (one-liner only)
-        self.resume_display = CLI_CONFIG["display"].get("resume_display", "full")
+        # resume_display: "full"/"history" (full visible chat) | "summary" (compact recap) | "minimal" (one-liner only)
+        self.resume_display = CLI_CONFIG["display"].get("resume_display", "history")
         # bell_on_complete: play terminal bell (\a) when agent finishes a response
         self.bell_on_complete = CLI_CONFIG["display"].get("bell_on_complete", False)
         # show_reasoning: display model thinking/reasoning before the response
@@ -2404,6 +2404,85 @@ class HermesCLI:
         self._reasoning_preview_buf = buf.lstrip() if flush_text else buf
         if flush_text:
             self._emit_reasoning_preview(flush_text)
+
+    def _format_submitted_user_message_preview(self, user_input: str) -> str:
+        """Format the submitted user-message scrollback preview."""
+        lines = user_input.split("\n")
+        if len(lines) <= 1:
+            return f"[bold {_accent_hex()}]●[/] [bold]{_escape(user_input)}[/]"
+
+        first_lines = 5
+        last_lines = 1
+        head = lines[:first_lines]
+        remaining_after_head = max(0, len(lines) - len(head))
+        tail_count = min(last_lines, remaining_after_head)
+        tail = lines[-tail_count:] if tail_count else []
+
+        hidden_middle_count = len(lines) - len(head) - len(tail)
+        if hidden_middle_count < 0:
+            hidden_middle_count = 0
+            tail = []
+
+        preview_lines = [
+            f"[bold {_accent_hex()}]●[/] [bold]{_escape(head[0])}[/]"
+        ]
+        preview_lines.extend(f"[bold]{_escape(line)}[/]" for line in head[1:])
+
+        if hidden_middle_count > 0:
+            noun = "line" if hidden_middle_count == 1 else "lines"
+            preview_lines.append(f"[dim]... (+{hidden_middle_count} more {noun})[/]")
+
+        preview_lines.extend(f"[bold]{_escape(line)}[/]" for line in tail)
+        return "\n".join(preview_lines)
+
+    def _expand_paste_references(self, text: str | None) -> str:
+        """Expand [Pasted text #N -> file] placeholders into file contents."""
+        if not isinstance(text, str) or "[Pasted text #" not in text:
+            return text or ""
+        import re as _re
+
+        paste_ref_re = _re.compile(r'\[Pasted text #\d+: \d+ lines \u2192 (.+?)\]')
+
+        def _expand_ref(match):
+            path = Path(match.group(1))
+            return path.read_text(encoding="utf-8") if path.exists() else match.group(0)
+
+        return paste_ref_re.sub(_expand_ref, text)
+
+    def _print_user_message_preview(self, user_input: str) -> None:
+        """Render a user message using the normal chat scrollback style."""
+        ChatConsole().print(f"[{_accent_hex()}]{'─' * 40}[/]")
+        text = str(user_input or "")
+        if "\n" in text:
+            ChatConsole().print(self._format_submitted_user_message_preview(text))
+        else:
+            ChatConsole().print(f"[bold {_accent_hex()}]●[/] [bold]{_escape(text)}[/]")
+
+    def _print_assistant_response_panel(self, response: str, *, title_suffix: str = "") -> None:
+        """Render assistant text using the normal final-response panel style."""
+        try:
+            from hermes_cli.skin_engine import get_active_skin
+            skin = get_active_skin()
+            label = skin.get_branding("response_label", "⚕ Hermes")
+            resp_color = skin.get_color("response_border", "#CD7F32")
+            resp_text = skin.get_color("banner_text", "#FFF8DC")
+        except Exception:
+            label = "⚕ Hermes"
+            resp_color = "#CD7F32"
+            resp_text = "#FFF8DC"
+
+        if title_suffix:
+            label = f"{label} {title_suffix}"
+
+        ChatConsole().print(Panel(
+            _rich_text_from_ansi(response),
+            title=f"[{resp_color} bold]{label}[/]",
+            title_align="left",
+            border_style=resp_color,
+            style=resp_text,
+            box=rich_box.HORIZONTALS,
+            padding=(1, 4),
+        ))
 
     def _stream_reasoning_delta(self, text: str) -> None:
         """Stream reasoning/thinking tokens into a dim box above the response.
@@ -3160,8 +3239,50 @@ class HermesCLI:
         if not self.conversation_history:
             return
 
-        # Check config: resume_display setting
-        if self.resume_display == "minimal":
+        normalized_resume_display = str(self.resume_display).strip().lower()
+        if normalized_resume_display == "minimal":
+            return
+
+        show_full_history = normalized_resume_display in {"history", "full"}
+
+        def _iter_visible_resume_messages():
+            for msg in self.conversation_history:
+                role = msg.get("role", "")
+                content = msg.get("content")
+                tool_calls = msg.get("tool_calls") or []
+                if role == "system" or role == "tool":
+                    continue
+                if role == "user":
+                    text = "" if content is None else str(content)
+                    if isinstance(content, list):
+                        parts = []
+                        for part in content:
+                            if isinstance(part, dict) and part.get("type") == "text":
+                                parts.append(part.get("text", ""))
+                            elif isinstance(part, dict) and part.get("type") == "image_url":
+                                parts.append("[image]")
+                        text = " ".join(parts)
+                    if text:
+                        yield ("user", self._expand_paste_references(text))
+                    continue
+                if role == "assistant":
+                    text = "" if content is None else str(content)
+                    text = _strip_reasoning_tags(text)
+                    if tool_calls:
+                        continue
+                    if text and text.strip() and text.strip() != "(empty)":
+                        yield ("assistant", text)
+
+        if show_full_history:
+            first = True
+            for role, text in _iter_visible_resume_messages():
+                if not first:
+                    print()
+                first = False
+                if role == "user":
+                    self._print_user_message_preview(text)
+                else:
+                    self._print_assistant_response_panel(text, title_suffix="(resumed)")
             return
 
         MAX_DISPLAY_EXCHANGES = 10   # max user+assistant pairs to show
@@ -3180,7 +3301,7 @@ class HermesCLI:
 
             if role == "system":
                 continue
-            if role == "tool":
+            if role == "tool" and not show_full_history:
                 continue
 
             if role == "user":
@@ -3194,7 +3315,7 @@ class HermesCLI:
                         elif isinstance(part, dict) and part.get("type") == "image_url":
                             parts.append("[image]")
                     text = " ".join(parts)
-                if len(text) > MAX_USER_LEN:
+                if MAX_USER_LEN is not None and len(text) > MAX_USER_LEN:
                     text = text[:MAX_USER_LEN] + "..."
                 entries.append(("user", text))
 
@@ -3206,9 +3327,9 @@ class HermesCLI:
                 if text:
                     full_parts.append(text)
                     lines = text.splitlines()
-                    if len(lines) > MAX_ASST_LINES:
+                    if MAX_ASST_LINES is not None and len(lines) > MAX_ASST_LINES:
                         text = "\n".join(lines[:MAX_ASST_LINES]) + " ..."
-                    if len(text) > MAX_ASST_LEN:
+                    if MAX_ASST_LEN is not None and len(text) > MAX_ASST_LEN:
                         text = text[:MAX_ASST_LEN] + "..."
                     parts.append(text)
                 if tool_calls:
@@ -3239,7 +3360,7 @@ class HermesCLI:
 
         # Determine if we need to truncate
         skipped = 0
-        if len(entries) > MAX_DISPLAY_EXCHANGES * 2:
+        if MAX_DISPLAY_EXCHANGES is not None and len(entries) > MAX_DISPLAY_EXCHANGES * 2:
             skipped = len(entries) - MAX_DISPLAY_EXCHANGES * 2
             entries = entries[skipped:]
 
@@ -3306,6 +3427,13 @@ class HermesCLI:
             style=_history_text_c,
         )
         self.console.print(panel)
+
+    def _print_clarify_transcript(self, question: str, answer: str) -> None:
+        """Render a clarify prompt and chosen answer into scrollback."""
+        print()
+        ChatConsole().print(f"[{_accent_hex()}]{'─' * 40}[/]")
+        ChatConsole().print(f"[bold {_accent_hex()}]?[/] [bold]{_escape(question)}[/]")
+        ChatConsole().print(f"[dim]↳ {_escape(answer)}[/]")
 
     def _try_attach_clipboard_image(self) -> bool:
         """Check clipboard for an image and attach it if found.
@@ -7432,6 +7560,7 @@ class HermesCLI:
         response_queue = queue.Queue()
         is_open_ended = not choices
 
+        self._capture_modal_input_snapshot()
         self._clarify_state = {
             "question": question,
             "choices": choices if not is_open_ended else [],
@@ -7458,7 +7587,12 @@ class HermesCLI:
         while True:
             try:
                 result = response_queue.get(timeout=1)
+                self._clarify_state = None
+                self._clarify_freetext = False
                 self._clarify_deadline = 0
+                self._restore_modal_input_snapshot()
+                self._invalidate()
+                self._print_clarify_transcript(question, result)
                 return result
             except queue.Empty:
                 remaining = self._clarify_deadline - _time.monotonic()
@@ -7477,6 +7611,7 @@ class HermesCLI:
         self._clarify_state = None
         self._clarify_freetext = False
         self._clarify_deadline = 0
+        self._restore_modal_input_snapshot()
         self._invalidate()
         _cprint(f"\n{_DIM}(clarify timed out after {timeout}s — agent will decide){_RST}")
         return (

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -553,7 +553,7 @@ DEFAULT_CONFIG = {
     "display": {
         "compact": False,
         "personality": "kawaii",
-        "resume_display": "full",
+        "resume_display": "history",
         "busy_input_mode": "interrupt",
         "bell_on_complete": False,
         "show_reasoning": False,
@@ -3378,6 +3378,7 @@ def show_config():
     print(color("◆ Display", Colors.CYAN, Colors.BOLD))
     display = config.get('display', {})
     print(f"  Personality:  {display.get('personality', 'kawaii')}")
+    print(f"  Resume:       {display.get('resume_display', 'full')}")
     print(f"  Reasoning:    {'on' if display.get('show_reasoning', False) else 'off'}")
     print(f"  Bell:         {'on' if display.get('bell_on_complete', False) else 'off'}")
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -178,7 +178,7 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
     "display.resume_display": {
         "type": "select",
         "description": "How resumed sessions display history",
-        "options": ["minimal", "full", "off"],
+        "options": ["minimal", "summary", "full", "history"],
     },
     "display.busy_input_mode": {
         "type": "select",

--- a/tests/cli/test_cli_clarify_history.py
+++ b/tests/cli/test_cli_clarify_history.py
@@ -1,0 +1,117 @@
+import threading
+import time
+from unittest.mock import patch
+
+from cli import HermesCLI
+
+
+class _FakeBuffer:
+    def __init__(self, text="", cursor_position=None):
+        self.text = text
+        self.cursor_position = len(text) if cursor_position is None else cursor_position
+        self.reset_called = False
+
+    def reset(self):
+        self.text = ""
+        self.cursor_position = 0
+        self.reset_called = True
+
+
+class _FakeApp:
+    def __init__(self, text="draft text"):
+        self.current_buffer = _FakeBuffer(text=text)
+        self.invalidated = 0
+
+    def invalidate(self):
+        self.invalidated += 1
+
+
+class _FakeChatConsole:
+    def __init__(self, sink):
+        self._sink = sink
+
+    def print(self, message):
+        self._sink.append(message)
+
+
+def _make_cli_stub(with_app=True):
+    cli = HermesCLI.__new__(HermesCLI)
+    cli._app = _FakeApp() if with_app else None
+    cli._modal_input_snapshot = None
+    cli._clarify_state = None
+    cli._clarify_freetext = False
+    cli._clarify_deadline = 0
+    cli._last_invalidate = 0.0
+    cli._invalidate = lambda *args, **kwargs: None
+    return cli
+
+
+def test_clarify_callback_restores_draft_and_prints_choice_to_scrollback():
+    cli = _make_cli_stub(with_app=True)
+    printed = []
+    results = []
+
+    with patch("cli.ChatConsole", side_effect=lambda: _FakeChatConsole(printed)), patch("builtins.print"):
+        worker = threading.Thread(
+            target=lambda: results.append(cli._clarify_callback("How should I proceed?", ["rebase", "merge"]))
+        )
+        worker.start()
+
+        deadline = time.time() + 2
+        while cli._clarify_state is None and time.time() < deadline:
+            time.sleep(0.01)
+
+        assert cli._clarify_state is not None
+        assert cli._app.current_buffer.reset_called is True
+        assert cli._app.current_buffer.text == ""
+
+        cli._clarify_state["response_queue"].put("merge")
+        worker.join(timeout=2)
+
+    assert results == ["merge"]
+    assert cli._app.current_buffer.text == "draft text"
+    assert any("How should I proceed?" in line for line in printed)
+    assert any("merge" in line for line in printed)
+
+
+def test_clarify_callback_prints_open_ended_answer_to_scrollback():
+    cli = _make_cli_stub(with_app=False)
+    printed = []
+    results = []
+
+    with patch("cli.ChatConsole", side_effect=lambda: _FakeChatConsole(printed)), patch("builtins.print"):
+        worker = threading.Thread(
+            target=lambda: results.append(cli._clarify_callback("What changed?", []))
+        )
+        worker.start()
+
+        deadline = time.time() + 2
+        while cli._clarify_state is None and time.time() < deadline:
+            time.sleep(0.01)
+
+        assert cli._clarify_state is not None
+        assert cli._clarify_freetext is True
+
+        cli._clarify_state["response_queue"].put("I chose the first option")
+        worker.join(timeout=2)
+
+    assert results == ["I chose the first option"]
+    assert any("What changed?" in line for line in printed)
+    assert any("I chose the first option" in line for line in printed)
+
+
+def test_clarify_timeout_restores_draft_without_printing_answer():
+    cli = _make_cli_stub(with_app=True)
+    printed = []
+
+    with patch("cli.ChatConsole", side_effect=lambda: _FakeChatConsole(printed)), patch("builtins.print"), patch(
+        "cli._cprint"
+    ) as mock_cprint, patch("cli.queue.Queue.get", side_effect=__import__("queue").Empty), patch(
+        "cli.CLI_CONFIG", {"clarify": {"timeout": 1}}
+    ), patch("time.monotonic", side_effect=[0, 0, 2]):
+        result = cli._clarify_callback("Still there?", ["yes", "no"])
+
+    assert "did not provide a response" in result
+    assert cli._app.current_buffer.text == "draft text"
+    assert not printed
+    assert mock_cprint.called

--- a/tests/cli/test_resume_display.py
+++ b/tests/cli/test_resume_display.py
@@ -26,7 +26,7 @@ def _make_cli(config_overrides=None, env_overrides=None, **kwargs):
             "base_url": "https://openrouter.ai/api/v1",
             "provider": "auto",
         },
-        "display": {"compact": False, "tool_progress": "all", "resume_display": "full"},
+        "display": {"compact": False, "tool_progress": "all", "resume_display": "summary"},
         "agent": {},
         "terminal": {"env_type": "local"},
     }
@@ -120,10 +120,16 @@ class TestDisplayResumedHistory:
     """_display_resumed_history() renders a Rich panel with conversation recap."""
 
     def _capture_display(self, cli_obj):
-        """Run _display_resumed_history and capture the Rich console output."""
+        """Run _display_resumed_history and capture the rendered output."""
         buf = StringIO()
         cli_obj.console.file = buf
-        cli_obj._display_resumed_history()
+
+        class _TestChatConsole:
+            def print(self, *args, **kwargs):
+                cli_obj.console.print(*args, **kwargs)
+
+        with patch("cli.ChatConsole", _TestChatConsole):
+            cli_obj._display_resumed_history()
         return buf.getvalue()
 
     def test_simple_history_shows_user_and_assistant(self):
@@ -280,11 +286,40 @@ class TestDisplayResumedHistory:
         assert output.strip() == ""
 
     def test_panel_has_title(self):
-        cli = _make_cli()
+        cli = _make_cli(config_overrides={"display": {"resume_display": "summary"}})
         cli.conversation_history = _simple_history()
         output = self._capture_display(cli)
 
         assert "Previous Conversation" in output
+
+    def test_full_mode_replays_normal_chat_style_instead_of_summary_panel(self):
+        cli = _make_cli(config_overrides={"display": {"resume_display": "full"}})
+        cli.conversation_history = _simple_history()
+        output = self._capture_display(cli)
+
+        assert "Previous Conversation" not in output
+        assert "⚕ Hermes" in output
+        assert "────────────────────────────────────────" in output
+
+    def test_history_mode_shows_full_history_without_exchange_truncation(self):
+        cli = _make_cli(config_overrides={"display": {"resume_display": "history"}})
+        cli.conversation_history = _large_history(n_exchanges=15)
+        output = self._capture_display(cli)
+
+        assert "Question #1" in output
+        assert "Question #15" in output
+        assert "earlier messages" not in output
+
+    def test_full_mode_skips_tool_results_and_tool_only_assistant_turns(self):
+        cli = _make_cli(config_overrides={"display": {"resume_display": "full"}})
+        cli.conversation_history = _tool_call_history()
+        output = self._capture_display(cli)
+
+        assert "web_search" not in output
+        assert "python tutorials" not in output
+        assert "Found 5 results" not in output
+        assert "Page content" not in output
+        assert "Here are some great Python tutorials I found." in output
 
     def test_assistant_with_no_content_no_tools_skipped(self):
         """Assistant messages with no visible output (e.g. pure reasoning)
@@ -509,7 +544,7 @@ class TestResumeDisplayConfig:
         from hermes_cli.config import DEFAULT_CONFIG
         display = DEFAULT_CONFIG.get("display", {})
         assert "resume_display" in display
-        assert display["resume_display"] == "full"
+        assert display["resume_display"] == "history"
 
     def test_cli_defaults_have_resume_display(self):
         """cli.py load_cli_config defaults include resume_display."""
@@ -523,4 +558,4 @@ class TestResumeDisplayConfig:
             config = load_cli_config()
 
         display = config.get("display", {})
-        assert display.get("resume_display") == "full"
+        assert display.get("resume_display") == "history"


### PR DESCRIPTION
## What does this PR do?

Improves CLI transcript visibility around resumed sessions and clarify prompts. Resume history now supports richer display modes, and clarify responses are echoed back into scrollback so the conversation transcript reflects the user’s actual choice.

## Related Issue

Fixes #TBD

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added richer resume-history handling in `cli.py`.
- Added clarify transcript echoing in `cli.py`.
- Updated resume-display defaults/schema handling in `hermes_cli/config.py` and `hermes_cli/web_server.py`.
- Added coverage in `tests/cli/test_cli_clarify_history.py` and `tests/cli/test_resume_display.py`.

## How to Test

1. Run `source /Volumes/Shared/turbo/hermes-agent/venv/bin/activate && scripts/run_tests.sh`.
2. Run `scripts/run_tests.sh tests/cli/test_cli_clarify_history.py tests/cli/test_resume_display.py -q`.
3. Resume a prior session and verify `summary` vs `history` rendering.
4. Trigger a clarify prompt and verify the selected answer is echoed into scrollback.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Full suite on branch `feat/transcript-visibility` (`d9e817f7506d`): `35 failed, 12914 passed, 38 skipped`.
- Clean `upstream/main` baseline on this machine: `34 failed, 12909 passed, 38 skipped`.
- The branch still has a small net regression versus baseline; see `tests-feat-transcript-visibility-d9e817f7506d.delta.txt`.
