### PR TITLE
fix: honcho multi-profile isolation — unique workspace per profile

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2799,24 +2799,40 @@ def load_config() -> Dict[str, Any]:
     """Load configuration from ~/.hermes/config.yaml."""
     ensure_hermes_home()
     config_path = get_config_path()
-    
+
     config = copy.deepcopy(DEFAULT_CONFIG)
-    
+
+    user_config = {}
+    config_loaded = False
+
     if config_path.exists():
         try:
             with open(config_path, encoding="utf-8") as f:
                 user_config = yaml.safe_load(f) or {}
-
-            if "max_turns" in user_config:
-                agent_user_config = dict(user_config.get("agent") or {})
-                if agent_user_config.get("max_turns") is None:
-                    agent_user_config["max_turns"] = user_config["max_turns"]
-                user_config["agent"] = agent_user_config
-                user_config.pop("max_turns", None)
-
-            config = _deep_merge(config, user_config)
+            config_loaded = True
         except Exception as e:
             print(f"Warning: Failed to load config: {e}")
+
+    # If the profile has no config.yaml, fall back to the root Hermes config.
+    # This lets non-default profiles inherit settings like memory.provider
+    # without needing their own config.yaml.
+    if not config_loaded:
+        root_config_path = Path.home() / ".hermes" / "config.yaml"
+        if root_config_path != config_path and root_config_path.exists():
+            try:
+                with open(root_config_path, encoding="utf-8") as f:
+                    user_config = yaml.safe_load(f) or {}
+            except Exception as e:
+                print(f"Warning: Failed to load root config: {e}")
+
+    if "max_turns" in user_config:
+        agent_user_config = dict(user_config.get("agent") or {})
+        if agent_user_config.get("max_turns") is None:
+            agent_user_config["max_turns"] = user_config["max_turns"]
+        user_config["agent"] = agent_user_config
+        user_config.pop("max_turns", None)
+
+    config = _deep_merge(config, user_config)
 
     normalized = _normalize_root_model_keys(_normalize_max_turns_config(config))
     expanded = _expand_env_vars(normalized)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6029,15 +6029,15 @@ def cmd_profile(args):
                 else:
                     print(f"Cloned config, .env, SOUL.md from {source_label}.")
 
-            # Auto-clone Honcho config for the new profile (only with --clone/--clone-all)
-            if clone or clone_all:
-                try:
-                    from plugins.memory.honcho.cli import clone_honcho_for_profile
+            # Auto-clone Honcho config for every new profile so each user gets
+            # their own isolated Honcho workspace (even without --clone).
+            try:
+                from plugins.memory.honcho.cli import clone_honcho_for_profile
 
-                    if clone_honcho_for_profile(name):
-                        print(f"Honcho config cloned (peer: {name})")
-                except Exception:
-                    pass  # Honcho plugin not installed or not configured
+                if clone_honcho_for_profile(name):
+                    print(f"Honcho workspace initialized (workspace: {name}-workspace)")
+            except Exception:
+                pass  # Honcho plugin not installed or not configured
 
             # Seed bundled skills (skip if --clone-all already copied them)
             if not clone_all:

--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -54,16 +54,32 @@ def clone_honcho_for_profile(profile_name: str) -> bool:
     if peer_name:
         new_block["peerName"] = peer_name
 
-    # AI peer is profile-specific; workspace is shared so all profiles
-    # see the same user context, sessions, and project history.
+    # AI peer is profile-specific; workspace is also profile-specific
+    # so each user has completely isolated memory on Honcho Cloud.
     # Use the bare profile name as the peer identity (not the host key)
     # because Honcho's peer ID pattern is ^[a-zA-Z0-9_-]+$ (no dots).
     new_block["aiPeer"] = profile_name
-    new_block["workspace"] = default_block.get("workspace") or cfg.get("workspace") or HOST
+    new_block["workspace"] = f"{profile_name}-workspace"
     new_block["enabled"] = default_block.get("enabled", True)
 
     cfg.setdefault("hosts", {})[new_host] = new_block
-    _write_config(cfg)
+
+    # Write to the profile's local honcho.json so it is fully self-contained.
+    # If the profile dir already has a honcho.json, write there. Otherwise
+    # write to root (for the case where the profile dir doesn't exist yet).
+    # During normal `hermes profile create` the profile dir is created first,
+    # so the profile-local path wins in practice.
+    profile_home = get_hermes_home()
+    root_home = Path.home() / ".hermes"
+    profile_honcho = profile_home / "honcho.json"
+    write_path: Path
+    if profile_home != root_home:
+        # Profile-specific HERMES_HOME — write to the profile-local path
+        write_path = profile_honcho
+    else:
+        # Default profile — write to root
+        write_path = Path.home() / ".hermes" / "honcho.json"
+    _write_config(cfg, write_path)
 
     # Eagerly create the peer in Honcho so it exists before first message
     _ensure_peer_exists(new_host)


### PR DESCRIPTION
## Summary

Three changes that make Honcho memory fully isolated per Hermes profile — each user gets their own Honcho Cloud workspace with no shared state.

### Fix 1 — `hermes_cli/config.py`: config.yaml fallback for non-default profiles

When a profile has no `config.yaml`, `load_config()` now falls back to `~/.hermes/config.yaml`. This means profiles like `alice` inherit `memory.provider: honcho` automatically without needing their own config.

### Fix 2a — `plugins/memory/honcho/cli.py`: unique workspace per profile

Changed `clone_honcho_for_profile()` to set `workspace: {profile_name}-workspace` instead of inheriting the default `hermes` workspace. Each user gets a truly isolated Honcho Cloud workspace.

### Fix 2b — `hermes_cli/main.py`: honcho setup for ALL new profiles

Moved `clone_honcho_for_profile()` outside the `if clone:` block so it runs automatically on every `hermes profile create`. No `--clone` flag needed — every new user gets their own workspace automatically.

### Fix 2c — `plugins/memory/honcho/cli.py`: profile-local honcho.json write

`clone_honcho_for_profile()` now writes to `$HERMES_HOME/honcho.json` (profile-local path) instead of always writing to root. Each profile's Honcho config is fully self-contained.

## What this enables

```bash
hermes profile create alice   # → creates alice profile + alice-workspace
hermes profile create bob     # → creates bob profile + bob-workspace
# Each user's Honcho memory is completely isolated.
```

## Testing

Verified with `hermes -p alice honcho` and `hermes -p bob honcho` — each shows a unique `Workspace:` field.
```

---

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

