### PR TITLE
fix: handle stream=True in CopilotACPClient to prevent TypeError

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -305,6 +305,7 @@ class CopilotACPClient:
         timeout: float | None = None,
         tools: list[dict[str, Any]] | None = None,
         tool_choice: Any = None,
+        stream: bool = False,
         **_: Any,
     ) -> Any:
         prompt_text = _format_messages_as_prompt(
@@ -342,6 +343,35 @@ class CopilotACPClient:
             total_tokens=0,
             prompt_tokens_details=SimpleNamespace(cached_tokens=0),
         )
+        finish_reason = "tool_calls" if tool_calls else "stop"
+        model_name = model or "copilot-acp"
+
+        if stream:
+            # Return a single-chunk iterable in OpenAI streaming delta format.
+            stream_tool_calls = None
+            if tool_calls:
+                stream_tool_calls = [
+                    SimpleNamespace(
+                        index=i,
+                        id=tc.id,
+                        type="function",
+                        function=SimpleNamespace(
+                            name=tc.function.name,
+                            arguments=tc.function.arguments,
+                        ),
+                    )
+                    for i, tc in enumerate(tool_calls)
+                ]
+            delta = SimpleNamespace(
+                content=cleaned_text,
+                tool_calls=stream_tool_calls,
+                reasoning=reasoning_text or None,
+                reasoning_content=reasoning_text or None,
+            )
+            stream_choice = SimpleNamespace(delta=delta, finish_reason=finish_reason)
+            chunk = SimpleNamespace(choices=[stream_choice], usage=usage, model=model_name)
+            return [chunk]
+
         assistant_message = SimpleNamespace(
             content=cleaned_text,
             tool_calls=tool_calls,
@@ -349,12 +379,11 @@ class CopilotACPClient:
             reasoning_content=reasoning_text or None,
             reasoning_details=None,
         )
-        finish_reason = "tool_calls" if tool_calls else "stop"
         choice = SimpleNamespace(message=assistant_message, finish_reason=finish_reason)
         return SimpleNamespace(
             choices=[choice],
             usage=usage,
-            model=model or "copilot-acp",
+            model=model_name,
         )
 
     def _run_prompt(self, prompt_text: str, *, timeout_seconds: float) -> tuple[str, str]:


### PR DESCRIPTION
## Problem

When connecting to GitHub Copilot via the `copilot-acp` provider, the agent fails immediately with:

```
TypeError: 'types.SimpleNamespace' object is not iterable
```

## Root Cause

`run_agent.py` always calls `chat.completions.create(stream=True, ...)` and iterates the result with `for chunk in stream:`. However, `CopilotACPClient._create_chat_completion()` was silently absorbing the `stream` parameter via `**_` and returning a plain `SimpleNamespace` object — which is not iterable.

## Fix

Explicitly accept `stream: bool = False` in `_create_chat_completion`. When `stream=True`, return a single-element list containing a chunk in the OpenAI streaming **delta** format (`delta.content`, `delta.tool_calls`, etc.) instead of the non-streaming `message` format.

The non-streaming return path is unchanged.