### PR TITLE
fix(agent): honor HTTPS_PROXY when using custom httpx transport

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4714,8 +4714,11 @@ class AIAgent:
                 elif hasattr(_socket, "TCP_KEEPALIVE"):
                     # macOS (uses TCP_KEEPALIVE instead of TCP_KEEPIDLE)
                     _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPALIVE, 30))
+                import os as _os
+                _proxy = (_os.getenv("HTTPS_PROXY") or _os.getenv("https_proxy")
+                          or _os.getenv("HTTP_PROXY") or _os.getenv("http_proxy"))
                 client_kwargs["http_client"] = _httpx.Client(
-                    transport=_httpx.HTTPTransport(socket_options=_sock_opts),
+                    transport=_httpx.HTTPTransport(socket_options=_sock_opts, proxy=_proxy),
                 )
             except Exception:
                 pass  # Fall through to default transport if socket opts fail


### PR DESCRIPTION
## Problem

`_create_openai_client` builds a custom `httpx.Client` with a pre-configured `HTTPTransport(socket_options=...)` to enable TCP keepalive. Passing a pre-built transport to `httpx.Client` disables httpx's automatic proxy discovery from `HTTPS_PROXY` / `HTTP_PROXY` env vars — the agent then ignores the user's proxy and attempts a direct connection.

## Repro

On WSL2 with a Clash/V2Ray global-TUN proxy (`HTTPS_PROXY=http://127.0.0.1:7897`):

- `curl` against the provider → ~5s, 200 OK
- Plain `openai.OpenAI(...).chat.completions.create(...)` with the *default* client → works fine
- `hermes` chat or gateway → every attempt hangs ~90s and fails `APITimeoutError`, 3 retries exhausted, eventually gives up

## Fix

Forward `HTTPS_PROXY` / `HTTP_PROXY` (case-insensitive) to `HTTPTransport(proxy=...)` when we build the transport ourselves. This restores parity with the default httpx behavior while keeping the TCP keepalive socket options intact.

## Verification

Same WSL environment, same model (qwen3-coder-plus on Alibaba DashScope) — time-to-first-token dropped from >90s (timeout) to ~3.6s.