### PR TITLE
feat(cli): add workspace folder and git branch to status bar

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -16,6 +16,7 @@ Usage:
 import logging
 import os
 import shutil
+import subprocess
 import sys
 import json
 import re
@@ -695,6 +696,122 @@ def _run_cleanup():
 
 # Tracks the active worktree for cleanup on exit
 _active_worktree: Optional[Dict[str, str]] = None
+
+
+_BRANCH_CACHE_TTL_SECONDS = 2.0
+_cached_workspace_branch: tuple[str, float, Optional[str]] | None = None
+
+
+def _shorten_status_path(path: Path, max_width: int = 34) -> str:
+    """Return a compact, user-facing path for status displays."""
+    try:
+        resolved = path.expanduser().resolve()
+    except Exception:
+        resolved = path.expanduser()
+
+    display = resolved.name or str(resolved)
+    if len(display) <= max_width:
+        return display
+
+    try:
+        home = Path.home().resolve()
+        rel = resolved.relative_to(home)
+        display = str(Path("~") / rel)
+        if len(display) <= max_width:
+            return display
+    except Exception:
+        pass
+
+    parts = resolved.parts
+    if len(parts) >= 2:
+        tail = Path(*parts[-2:])
+        tail_text = f".../{tail}"
+        if len(tail_text) <= max_width:
+            return tail_text
+    if max_width <= 3:
+        return "." * max_width
+    return f"{display[: max_width - 3]}..."
+
+
+def _resolve_git_branch(resolved: Path) -> Optional[str]:
+    """Best-effort short git branch name for a resolved workspace path."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=str(resolved),
+            capture_output=True,
+            text=True,
+            timeout=1,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+    if result.returncode != 0:
+        return None
+
+    branch = (result.stdout or "").strip()
+    if not branch or branch == "HEAD":
+        return None
+    return branch
+
+
+def _get_cached_git_branch(resolved: Path) -> Optional[str]:
+    """Return a cached branch for the resolved workspace path."""
+    global _cached_workspace_branch
+
+    key = str(resolved)
+    now = time.monotonic()
+    if _cached_workspace_branch is not None:
+        cached_key, cached_at, cached_branch = _cached_workspace_branch
+        if cached_key == key and (now - cached_at) < _BRANCH_CACHE_TTL_SECONDS:
+            return cached_branch
+
+    branch = _resolve_git_branch(resolved)
+    _cached_workspace_branch = (key, now, branch)
+    return branch
+
+
+def _select_status_context_labels(
+    width: int,
+    workspace_label: Optional[str],
+    branch_label: Optional[str],
+) -> list[str]:
+    """Choose workspace/branch labels that fit the available status-bar space."""
+    workspace = (workspace_label or "").strip()
+    branch = (branch_label or "").strip()
+    if width >= 120:
+        labels = []
+        if workspace:
+            labels.append(workspace)
+        if branch:
+            labels.append(branch)
+        return labels
+    if width >= 90:
+        if workspace and branch:
+            return [workspace if len(workspace) <= len(branch) else branch]
+        if workspace:
+            return [workspace]
+        if branch:
+            return [branch]
+    return []
+
+
+def _inject_workspace_context(snapshot: Dict[str, Any]) -> Dict[str, Any]:
+    """Best-effort workspace folder and git branch for the status bar.
+
+    Called on every status-bar snapshot — must not fail or block.
+    """
+    workspace = os.getenv("TERMINAL_CWD") or os.getcwd()
+    try:
+        resolved = Path(workspace).expanduser().resolve()
+    except Exception:
+        resolved = Path(workspace).expanduser()
+
+    snapshot["workspace_short"] = _shorten_status_path(resolved)
+    snapshot["git_branch"] = _get_cached_git_branch(resolved)
+
+    return snapshot
 
 
 def _git_repo_root() -> Optional[str]:
@@ -1963,10 +2080,12 @@ class HermesCLI:
             "session_total_tokens": 0,
             "session_api_calls": 0,
             "compressions": 0,
+            "workspace_short": None,
+            "git_branch": None,
         }
 
         if not agent:
-            return snapshot
+            return _inject_workspace_context(snapshot)
 
         snapshot["session_input_tokens"] = getattr(agent, "session_input_tokens", 0) or 0
         snapshot["session_output_tokens"] = getattr(agent, "session_output_tokens", 0) or 0
@@ -1987,7 +2106,7 @@ class HermesCLI:
             if context_length:
                 snapshot["context_percent"] = max(0, min(100, round((context_tokens / context_length) * 100)))
 
-        return snapshot
+        return _inject_workspace_context(snapshot)
 
     @staticmethod
     def _status_bar_display_width(text: str) -> int:
@@ -2101,7 +2220,12 @@ class HermesCLI:
         return [("class:voice-status", f" 🎤 Voice mode{tts}{cont}  —  Ctrl+B to record ")]
 
     def _build_status_bar_text(self, width: Optional[int] = None) -> str:
-        """Return a compact one-line session status string for the TUI footer."""
+        """Return the full status bar text for width-sensitive layouts.
+
+        The TUI status bar is rendered as a single line. To avoid wrapping or
+        duplicate rows on narrow terminals, this helper mirrors the fragment
+        logic and trims the assembled text to fit the current width.
+        """
         try:
             snapshot = self._get_status_bar_snapshot()
             if width is None:
@@ -2126,6 +2250,10 @@ class HermesCLI:
                 context_label = "ctx --"
 
             parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label]
+            ws = snapshot.get("workspace_short")
+            br = snapshot.get("git_branch")
+            status_labels = _select_status_context_labels(width, ws, br)
+            parts.extend(status_labels)
             parts.append(duration_label)
             return self._trim_status_bar_text(" │ ".join(parts), width)
         except Exception:
@@ -2174,11 +2302,17 @@ class HermesCLI:
                         context_label = "ctx --"
 
                     bar_style = self._status_bar_context_style(percent)
+                    workspace_label = snapshot.get("workspace_short") or ""
+                    branch_label = snapshot.get("git_branch") or ""
+                    context_parts = [f"⚕ {snapshot['model_short']}", context_label]
+                    if workspace_label:
+                        context_parts.append(workspace_label)
+                    if branch_label:
+                        context_parts.append(branch_label)
+                    context_line = " │ ".join(context_parts)
                     frags = [
-                        ("class:status-bar", " ⚕ "),
-                        ("class:status-bar-strong", snapshot["model_short"]),
-                        ("class:status-bar-dim", " │ "),
-                        ("class:status-bar-dim", context_label),
+                        ("class:status-bar", " "),
+                        ("class:status-bar-strong", context_line),
                         ("class:status-bar-dim", " │ "),
                         (bar_style, self._build_context_bar(percent)),
                         ("class:status-bar-dim", " "),

--- a/cli.py
+++ b/cli.py
@@ -698,7 +698,12 @@ def _run_cleanup():
 _active_worktree: Optional[Dict[str, str]] = None
 
 
+# Cache branch lookups briefly to keep the status bar fresh without
+# repeatedly spawning git subprocesses during rapid UI updates.
 _BRANCH_CACHE_TTL_SECONDS = 2.0
+# When trimming status-bar paths, we fall back to an all-dots string when the
+# available width is too small to fit the ellipsis marker ("...") plus a prefix.
+MIN_ELLIPSIS_WIDTH = 3
 _cached_workspace_branch: tuple[str, float, Optional[str]] | None = None
 
 
@@ -728,9 +733,9 @@ def _shorten_status_path(path: Path, max_width: int = 34) -> str:
         tail_text = f".../{tail}"
         if len(tail_text) <= max_width:
             return tail_text
-    if max_width <= 3:
+    if max_width <= MIN_ELLIPSIS_WIDTH:
         return "." * max_width
-    return f"{display[: max_width - 3]}..."
+    return f"{display[: max_width - MIN_ELLIPSIS_WIDTH]}..."
 
 
 def _resolve_git_branch(resolved: Path) -> Optional[str]:

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -79,6 +79,38 @@ def _effective_provider_label() -> str:
     return provider_label(effective)
 
 
+def _status_current_folder() -> str:
+    """Resolve the current terminal working folder shown in CLI status."""
+    cwd_value = os.getenv("TERMINAL_CWD") or os.getcwd()
+    try:
+        return str(Path(cwd_value).expanduser().resolve())
+    except Exception:
+        return str(Path(cwd_value).expanduser())
+
+
+def _status_git_branch(current_folder: str) -> str | None:
+    """Best-effort short git branch name for the current folder."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=current_folder,
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+    if result.returncode != 0:
+        return None
+
+    branch = (result.stdout or "").strip()
+    if not branch or branch == "HEAD":
+        return None
+    return branch
+
+
 from hermes_constants import is_termux as _is_termux
 
 
@@ -108,8 +140,13 @@ def show_status(args):
     except Exception:
         config = {}
 
+    current_folder = _status_current_folder()
+    git_branch = _status_git_branch(current_folder)
+
     print(f"  Model:        {_configured_model_label(config)}")
     print(f"  Provider:     {_effective_provider_label()}")
+    print(f"  Current Folder: {current_folder}")
+    print(f"  Git Branch:   {git_branch or '(not a git repo)'}")
     
     # =========================================================================
     # API Keys

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -415,3 +415,70 @@ class TestStatusBarWidthSource:
         mock_get_app.assert_not_called()
         mock_shutil.assert_not_called()
         assert len(text) > 0
+
+
+class TestStatusBarWorkspaceContext:
+    """Tests for workspace folder and git branch in the TUI status bar."""
+
+    def _make_cli_with_workspace(self, monkeypatch, tmp_path, *, branch=None):
+        import subprocess as sp
+        import cli as cli_mod
+
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        monkeypatch.setenv("TERMINAL_CWD", str(workspace))
+
+        def fake_run(cmd, cwd=None, capture_output=False, text=False, timeout=None, check=False):
+            if cmd == ["git", "rev-parse", "--abbrev-ref", "HEAD"]:
+                if branch is None:
+                    return sp.CompletedProcess(cmd, 128, stdout="", stderr="fatal: not a git repo")
+                return sp.CompletedProcess(cmd, 0, stdout=f"{branch}\n", stderr="")
+            raise AssertionError(f"Unexpected command: {cmd}")
+
+        monkeypatch.setattr(cli_mod, "subprocess", sp)
+        monkeypatch.setattr(sp, "run", fake_run)
+
+        cli_obj = _make_cli()
+        return cli_obj, workspace
+
+    def test_snapshot_includes_workspace_folder(self, monkeypatch, tmp_path):
+        cli_obj, workspace = self._make_cli_with_workspace(monkeypatch, tmp_path, branch="feature/x")
+
+        snapshot = cli_obj._get_status_bar_snapshot()
+        assert "workspace_short" in snapshot
+        assert snapshot["workspace_short"] == workspace.name
+
+    def test_snapshot_includes_git_branch(self, monkeypatch, tmp_path):
+        cli_obj, _ = self._make_cli_with_workspace(monkeypatch, tmp_path, branch="main")
+
+        snapshot = cli_obj._get_status_bar_snapshot()
+        assert "git_branch" in snapshot
+        assert snapshot["git_branch"] == "main"
+
+    def test_snapshot_reports_none_git_branch_when_not_a_repo(self, monkeypatch, tmp_path):
+        cli_obj, _ = self._make_cli_with_workspace(monkeypatch, tmp_path, branch=None)
+
+        snapshot = cli_obj._get_status_bar_snapshot()
+        assert snapshot["git_branch"] is None
+
+    def test_status_bar_text_includes_workspace_and_branch_on_wide_terminal(self, monkeypatch, tmp_path):
+        cli_obj, workspace = self._make_cli_with_workspace(monkeypatch, tmp_path, branch="feature/auth")
+
+        text = cli_obj._build_status_bar_text(width=140)
+        assert workspace.name in text
+        assert "feature/auth" in text
+
+    def test_status_bar_text_prefers_workspace_only_on_tighter_width(self, monkeypatch, tmp_path):
+        cli_obj, workspace = self._make_cli_with_workspace(monkeypatch, tmp_path, branch="feature/auth")
+
+        text = cli_obj._build_status_bar_text(width=100)
+        assert workspace.name in text or "..." in text
+        assert "feature/auth" not in text
+
+    def test_status_bar_text_hides_workspace_and_branch_when_very_narrow(self, monkeypatch, tmp_path):
+        cli_obj, workspace = self._make_cli_with_workspace(monkeypatch, tmp_path, branch="feature/auth")
+
+        text = cli_obj._build_status_bar_text(width=88)
+        assert workspace.name not in text
+        assert "feature/auth" not in text
+

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+import subprocess
 
 from hermes_cli.status import show_status
 
@@ -31,10 +32,12 @@ def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys,
     monkeypatch.setattr(auth_mod, "get_codex_auth_status", lambda: {}, raising=False)
     monkeypatch.setattr(gateway_mod, "find_gateway_pids", lambda exclude_pids=None: [], raising=False)
 
-    def _unexpected_systemctl(*args, **kwargs):
+    def _fake_run(cmd, cwd=None, capture_output=False, text=False, timeout=None, check=False):
+        if cmd == ["git", "rev-parse", "--abbrev-ref", "HEAD"]:
+            return subprocess.CompletedProcess(cmd, 128, stdout="", stderr="fatal: not a git repository")
         raise AssertionError("systemctl should not be called in the Termux status view")
 
-    monkeypatch.setattr(status_mod.subprocess, "run", _unexpected_systemctl)
+    monkeypatch.setattr(status_mod.subprocess, "run", _fake_run)
 
     status_mod.show_status(SimpleNamespace(all=False, deep=False))
 
@@ -42,3 +45,66 @@ def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys,
     assert "Manager:      Termux / manual process" in output
     assert "Start with:   hermes gateway" in output
     assert "systemd (user)" not in output
+
+
+def test_show_status_includes_current_folder_and_git_branch(monkeypatch, capsys, tmp_path):
+    from hermes_cli import status as status_mod
+    import hermes_cli.auth as auth_mod
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("TERMINAL_CWD", str(workspace))
+    monkeypatch.setattr(status_mod, "get_env_path", lambda: tmp_path / ".env", raising=False)
+    monkeypatch.setattr(status_mod, "get_hermes_home", lambda: tmp_path, raising=False)
+    monkeypatch.setattr(status_mod, "load_config", lambda: {"model": "openai/gpt-5.4"}, raising=False)
+    monkeypatch.setattr(status_mod, "resolve_requested_provider", lambda requested=None: "openai", raising=False)
+    monkeypatch.setattr(status_mod, "resolve_provider", lambda requested=None, **kwargs: "openai", raising=False)
+    monkeypatch.setattr(status_mod, "provider_label", lambda provider: "OpenAI", raising=False)
+    monkeypatch.setattr(auth_mod, "get_nous_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_codex_auth_status", lambda: {}, raising=False)
+
+    def fake_run(cmd, cwd=None, capture_output=False, text=False, timeout=None, check=False):
+        assert cmd == ["git", "rev-parse", "--abbrev-ref", "HEAD"]
+        assert cwd == str(workspace.resolve())
+        return subprocess.CompletedProcess(cmd, 0, stdout="feature/cli-status\n", stderr="")
+
+    monkeypatch.setattr(status_mod.subprocess, "run", fake_run)
+
+    status_mod.show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert f"Current Folder: {workspace.resolve()}" in output
+    assert "Git Branch:   feature/cli-status" in output
+
+
+def test_show_status_reports_non_git_folder_when_branch_lookup_fails(monkeypatch, capsys, tmp_path):
+    from hermes_cli import status as status_mod
+    import hermes_cli.auth as auth_mod
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("TERMINAL_CWD", str(workspace))
+    monkeypatch.setattr(status_mod, "get_env_path", lambda: tmp_path / ".env", raising=False)
+    monkeypatch.setattr(status_mod, "get_hermes_home", lambda: tmp_path, raising=False)
+    monkeypatch.setattr(status_mod, "load_config", lambda: {"model": "openai/gpt-5.4"}, raising=False)
+    monkeypatch.setattr(status_mod, "resolve_requested_provider", lambda requested=None: "openai", raising=False)
+    monkeypatch.setattr(status_mod, "resolve_provider", lambda requested=None, **kwargs: "openai", raising=False)
+    monkeypatch.setattr(status_mod, "provider_label", lambda provider: "OpenAI", raising=False)
+    monkeypatch.setattr(auth_mod, "get_nous_auth_status", lambda: {}, raising=False)
+    monkeypatch.setattr(auth_mod, "get_codex_auth_status", lambda: {}, raising=False)
+
+    def fake_run(cmd, cwd=None, capture_output=False, text=False, timeout=None, check=False):
+        assert cmd == ["git", "rev-parse", "--abbrev-ref", "HEAD"]
+        return subprocess.CompletedProcess(cmd, 128, stdout="", stderr="fatal: not a git repository")
+
+    monkeypatch.setattr(status_mod.subprocess, "run", fake_run)
+
+    status_mod.show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert f"Current Folder: {workspace.resolve()}" in output
+    assert "Git Branch:   (not a git repo)" in output


### PR DESCRIPTION
## What does this PR do?

This PR enhances the Hermes CLI status experience by adding workspace context (current folder + current git branch) to both the TUI status bar and the `hermes status` command output. It also adds width-aware rendering logic so the status bar remains readable on narrow terminals (avoiding wrapping / duplicate rows).


## Related Issue

Fixes #12267 (workspace folder + git branch context in status UI)


## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)


## Changes Made

- Updated TUI status bar snapshot to include workspace context:
  - `cli.py`
    - Adds `workspace_short` and `git_branch` fields to `_get_status_bar_snapshot()`
    - Adds short path formatting and a small TTL cache for git branch lookup
    - Updates status bar text rendering to be width-sensitive and avoid wrapping on narrow terminals

- Updated `hermes status` command output to display workspace context:
  - `hermes_cli/status.py`
    - Adds “Current Folder” and “Git Branch” lines (or “(not a git repo)” when not available)

- Added tests for the new status fields and layout behavior:
  - `tests/cli/test_cli_status_bar.py`
  - `tests/hermes_cli/test_status.py`


## How to Test

1. Run: `hermes status`
2. In the TUI, observe the footer/status bar while switching directories (inside and outside a git repo).
3. Resize the terminal to a narrow width and verify the status bar remains single-line / readable (workspace/branch labels should adapt).


## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

<img width="1113" height="1073" alt="image" src="https://github.com/user-attachments/assets/6554d961-e250-4994-bb33-62126796735f" />
