### PR TITLE
fix(models): alibaba coding plan /model validation + provider_label scope bug

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2155,6 +2155,8 @@ def validate_requested_model(
     # api_models is None — couldn't reach API.  Accept and persist,
     # but warn so typos don't silently break things.
 
+    provider_label = _PROVIDER_LABELS.get(normalized, normalized)
+
     # Bedrock: use our own discovery instead of HTTP /models endpoint.
     # Bedrock's bedrock-runtime URL doesn't support /models — it uses the
     # AWS SDK control plane (ListFoundationModels + ListInferenceProfiles).
@@ -2190,7 +2192,34 @@ def validate_requested_model(
         except Exception:
             pass  # Fall through to generic warning
 
-    provider_label = _PROVIDER_LABELS.get(normalized, normalized)
+    # DashScope coding endpoint does not expose a /models endpoint (returns
+    # 404).  For alibaba, fall back to the models.dev catalog instead of
+    # hard-rejecting — otherwise /model Qwen will always fail for coding-plan
+    # users who set providers.alibaba.base_url to the coding endpoint.
+    if normalized == "alibaba":
+        known = provider_model_ids("alibaba")
+        if requested in known:
+            return {
+                "accepted": True,
+                "persist": True,
+                "recognized": True,
+                "message": None,
+            }
+        suggestions = get_close_matches(requested, known, n=3, cutoff=0.5)
+        suggestion_text = ""
+        if suggestions:
+            suggestion_text = "\n  Similar models: " + ", ".join(f"`{s}`" for s in suggestions)
+        return {
+            "accepted": True,
+            "persist": True,
+            "recognized": False,
+            "message": (
+                f"Note: `{requested}` was not found in the models.dev catalog for "
+                f"{provider_label}, but it may still work on your coding plan."
+                f"{suggestion_text}"
+            ),
+        }
+
     return {
         "accepted": False,
         "persist": False,


### PR DESCRIPTION
## Problem

`/model qwen3.6-plus` fails for Alibaba/DashScope coding plan users with:

```
Error: Could not validate qwen3.6-plus: cannot access local variable 'provider_label' where it is not associated with a value
```

## Root Cause

Two issues in `hermes_cli/models.py` `validate_requested_model()`:

1. **`provider_label` UnboundLocalError**: The variable was defined only in the generic fallback branch (line 2223), but referenced earlier in provider-specific branches (alibaba, bedrock) that `return` before reaching it. This caused `UnboundLocalError` for any provider whose special branch executed before the generic one.

2. **Alibaba coding endpoint hard-rejection**: The DashScope coding endpoint (`coding.dashscope.aliyuncs.com/v1`) does not support the `/models` endpoint (returns 404). Without a catalog fallback, all `/model` commands for alibaba provider were hard-rejected with "Could not reach the API".

## Fix

1. **Move `provider_label` assignment** before all provider-specific branches, so it's available regardless of which path is taken.

2. **Add alibaba catalog fallback**: When the `/models` endpoint is unreachable, fall back to checking against the models.dev catalog for known alibaba models. If the model is in the catalog, accept it. If not, still accept with a warning (coding plan may include uncataloged models).

## Impact

- Fixes `/model` command for all DashScope coding plan users
- Prevents `UnboundLocalError` for any provider with a special validation branch
- No behavior change for providers with working `/models` endpoints

## Testing

Verified on local instance with `providers.alibaba.base_url` set to `coding.dashscope.aliyuncs.com/v1`:
- `/model qwen3.6-plus` succeeds with catalog match warning
- Model actually works for chat completions after switch