### PR TITLE
fix(agent): silence quiet_mode in python library use

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1941,13 +1941,16 @@ class AIAgent:
     def _should_emit_quiet_tool_messages(self) -> bool:
         """Return True when quiet-mode tool summaries should print directly.
 
-        When the caller provides ``tool_progress_callback`` (for example the CLI
-        TUI or a gateway progress renderer), that callback owns progress display.
-        Emitting quiet-mode summary lines here duplicates progress and leaks tool
-        previews into flows that are expected to stay silent, such as
-        ``hermes chat -q``.
+        Quiet mode is used by both the interactive CLI and embedded/library
+        callers. The CLI may still want compact progress hints when no callback
+        owns rendering. Embedded/library callers, on the other hand, expect
+        quiet mode to be truly silent.
         """
-        return self.quiet_mode and not self.tool_progress_callback
+        return (
+            self.quiet_mode
+            and not self.tool_progress_callback
+            and getattr(self, "platform", "") == "cli"
+        )
 
     def _emit_status(self, message: str) -> None:
         """Emit a lifecycle status message to both CLI and gateway channels.
@@ -11163,7 +11166,7 @@ class AIAgent:
                         self._last_content_tools_all_housekeeping = _all_housekeeping
                         if _all_housekeeping and self._has_stream_consumers():
                             self._mute_post_response = True
-                        elif self.quiet_mode:
+                        elif self.quiet_mode and getattr(self, "platform", "") == "cli":
                             clean = self._strip_think_blocks(turn_content).strip()
                             if clean:
                                 relayed = False

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1196,6 +1196,7 @@ class TestExecuteToolCalls:
         tc = _mock_tool_call(name="web_search", arguments='{"q":"test"}', call_id="c1")
         mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
         messages = []
+        agent.platform = "cli"
         agent.tool_progress_callback = None
 
         with patch("run_agent.handle_function_call", return_value="search result"), \
@@ -1204,6 +1205,21 @@ class TestExecuteToolCalls:
 
         mock_print.assert_called_once()
         assert "search" in str(mock_print.call_args.args[0]).lower()
+        assert len(messages) == 1
+        assert messages[0]["role"] == "tool"
+
+    def test_quiet_tool_output_suppressed_without_progress_callback_for_non_cli_agent(self, agent):
+        tc = _mock_tool_call(name="web_search", arguments='{"q":"test"}', call_id="c1")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        messages = []
+        agent.platform = None
+        agent.tool_progress_callback = None
+
+        with patch("run_agent.handle_function_call", return_value="search result"), \
+             patch.object(agent, "_safe_print") as mock_print:
+            agent._execute_tool_calls(mock_msg, messages, "task-1")
+
+        mock_print.assert_not_called()
         assert len(messages) == 1
         assert messages[0]["role"] == "tool"
 
@@ -1786,6 +1802,30 @@ class TestRunConversation:
         assert all(call["session_id"] == agent.session_id for call in pre_request_calls)
         assert all("message_count" in c and "messages" not in c for c in pre_request_calls)
         assert all("usage" in c and "response" not in c for c in post_request_calls)
+
+    def test_content_with_tool_calls_stays_silent_for_non_cli_quiet_mode(self, agent):
+        self._setup_agent(agent)
+        agent.platform = None
+        tc = _mock_tool_call(name="web_search", arguments="{}", call_id="c1")
+        resp1 = _mock_response(
+            content="I'll search for that.",
+            finish_reason="tool_calls",
+            tool_calls=[tc],
+        )
+        resp2 = _mock_response(content="Done searching", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [resp1, resp2]
+
+        with (
+            patch("run_agent.handle_function_call", return_value="search result"),
+            patch.object(agent, "_safe_print") as mock_print,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("search something")
+
+        assert result["final_response"] == "Done searching"
+        mock_print.assert_not_called()
 
     def test_interrupt_breaks_loop(self, agent):
         self._setup_agent(agent)


### PR DESCRIPTION
## What does this PR do?

Makes `AIAgent(..., quiet_mode=True)` actually stay quiet for embedded/library use instead of still printing compact tool summaries and assistant snippets during tool-calling turns.

Right now the Python library docs tell users to set `quiet_mode=True` when embedding Hermes, but the runtime still leaks progress output in non-CLI code paths. This patch makes the runtime match that contract.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Restricted quiet-mode direct progress printing in `run_agent.py` so compact tool summaries only emit for the interactive CLI path.
- Stopped the non-CLI quiet-mode path from printing the `┊ 💬 ...` assistant snippet when a turn contains both content and tool calls.
- Updated `tests/run_agent/test_run_agent.py` to preserve the existing CLI behavior while adding regression coverage for embedded/non-CLI silence.

## How to Test

1. Run:

   `scripts/run_tests.sh tests/run_agent/test_run_agent.py::TestExecuteToolCalls::test_quiet_tool_output_prints_without_progress_callback tests/run_agent/test_run_agent.py::TestExecuteToolCalls::test_quiet_tool_output_suppressed_without_progress_callback_for_non_cli_agent tests/run_agent/test_run_agent.py::TestRunConversation::test_content_with_tool_calls_stays_silent_for_non_cli_quiet_mode tests/run_agent/test_run_agent.py::TestExecuteToolCalls::test_vprint_suppressed_in_parseable_quiet_mode tests/run_agent/test_run_agent.py::TestExecuteToolCalls::test_run_conversation_suppresses_retry_noise_in_parseable_quiet_mode -q`

2. Confirm the targeted quiet-mode regressions pass.
3. In a Python script, create `AIAgent(..., quiet_mode=True)` and verify tool-calling turns no longer print progress snippets to stdout.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 under WSL2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted run:

`5 passed, 4 warnings in 7.03s`

Full suite with the CI-shaped wrapper (`scripts/run_tests.sh tests/ -q`, 4 workers):

`20 failed, 12943 passed, 36 skipped, 186 warnings in 284.81s (0:04:44)`

One of those full-suite failures is the existing `tests/run_agent/test_run_agent.py::TestStreamingApiCall::test_tool_call_accumulation` baseline on current upstream. This change does not touch the streaming tool-call accumulator path.
