### PR TITLE
fix(mattermost): start fresh session for each top-level channel message

### DIFF
--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -263,15 +263,19 @@ class MattermostAdapter(BasePlatformAdapter):
         formatted = self.format_message(content)
         chunks = self.truncate_message(formatted, MAX_POST_LENGTH)
 
+        # Thread support: prefer explicit reply_to, fall back to metadata thread_id
+        effective_root_id = reply_to
+        if not effective_root_id and metadata and metadata.get("thread_id"):
+            effective_root_id = metadata["thread_id"]
+
         last_id = None
         for chunk in chunks:
             payload: Dict[str, Any] = {
                 "channel_id": chat_id,
                 "message": chunk,
             }
-            # Thread support: reply_to is the root post ID.
-            if reply_to and self._reply_mode == "thread":
-                payload["root_id"] = reply_to
+            if effective_root_id and self._reply_mode == "thread":
+                payload["root_id"] = effective_root_id
 
             data = await self._api_post("posts", payload)
             if not data or "id" not in data:
@@ -654,7 +658,19 @@ class MattermostAdapter(BasePlatformAdapter):
         sender_name = data.get("sender_name", "").lstrip("@") or sender_id
 
         # Thread support: if the post is in a thread, use root_id.
-        thread_id = post.get("root_id") or None
+        # When reply_mode is "thread", top-level messages (no root_id) use
+        # the post's own id so each starts a fresh session — matching Slack
+        # channel behavior (slack.py:1022).  Replies in the resulting thread
+        # carry root_id == this post's id, so they join the same session key.
+        # When reply_mode is "off", replies are flat (no threads), so we must
+        # fall back to None to preserve the single channel-level session.
+        root_id = post.get("root_id") or None
+        if root_id:
+            thread_id = root_id
+        elif self._reply_mode == "thread":
+            thread_id = post.get("id")
+        else:
+            thread_id = None
 
         # Determine message type.
         file_ids = post.get("file_ids") or []


### PR DESCRIPTION
## Summary

- Top-level Mattermost messages (no `root_id`) all shared a single channel-level session key, causing context to accumulate indefinitely. Users could not start a fresh conversation without restarting the gateway.
- When `reply_mode` is `thread`, use the post's own `id` as `thread_id` for top-level messages so each gets its own session. Replies in the resulting thread carry `root_id` matching the original post, joining the same session automatically.
- When `reply_mode` is `off`, preserve the existing channel-level session — since all messages are top-level, per-message sessions would break multi-turn conversations.

## Context

The Slack adapter already implements this pattern (`slack.py:1022`) where channels use `event.thread_ts or ts` as the session key. This brings the Mattermost adapter to parity.

## Test plan

- [ ] Verify `reply_mode: thread` — new top-level message starts fresh session, thread replies continue it
- [ ] Verify `reply_mode: off` — behavior unchanged, channel shares one session
- [ ] Verify thread replies with `root_id` join the correct parent session

🤖 Generated with [Claude Code](https://claude.com/claude-code)