### PR TITLE
fix(skill-config): expand ~ against subprocess HOME, not Python process HOME (#12260)

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -12,7 +12,7 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
-from hermes_constants import get_config_path, get_skills_dir
+from hermes_constants import get_config_path, get_skills_dir, get_subprocess_home
 
 logger = logging.getLogger(__name__)
 
@@ -382,6 +382,37 @@ def _resolve_dotpath(config: Dict[str, Any], dotted_key: str):
     return current
 
 
+def _expanduser_for_subprocess(path: str) -> str:
+    """Expand ``~`` in a path using the Hermes subprocess HOME when active.
+
+    Skill config values are surfaced in the agent's prompt and then acted on
+    by subprocess tools (Bash, background processes, external launchers)
+    whose ``HOME`` is set to ``{HERMES_HOME}/home`` — *not* the Python
+    process's own ``HOME`` (which in Docker may be ``/opt/data`` or
+    ``/root``).  Using :func:`os.path.expanduser` here produced a path that
+    pointed somewhere the subprocess tools wouldn't find — see #12260.
+
+    Behaviour:
+      * If :func:`hermes_constants.get_subprocess_home` is active
+        (``{HERMES_HOME}/home`` exists on disk), expand ``~`` and ``~/…``
+        against that directory.
+      * ``~user`` forms are still resolved via :func:`os.path.expanduser`
+        (they name a specific OS user and are independent of Hermes).
+      * When no subprocess HOME is active, behaviour is identical to the
+        original :func:`os.path.expanduser` call.
+    """
+    subprocess_home = get_subprocess_home()
+    if subprocess_home is None:
+        return os.path.expanduser(path)
+    if path == "~":
+        return subprocess_home
+    if path.startswith("~/"):
+        # Explicit posix join — path[2:] has no leading slash.
+        return os.path.join(subprocess_home, path[2:])
+    # ``~user`` or embedded ``~`` — defer to the OS user database.
+    return os.path.expanduser(path)
+
+
 def resolve_skill_config_values(
     config_vars: List[Dict[str, Any]],
 ) -> Dict[str, Any]:
@@ -390,7 +421,11 @@ def resolve_skill_config_values(
     Skill config is stored under ``skills.config.<key>`` in config.yaml.
     Returns a dict mapping **logical** keys (as declared by skills) to their
     current values (or the declared default if the key isn't set).
-    Path values are expanded via ``os.path.expanduser``.
+
+    Path values are expanded via :func:`_expanduser_for_subprocess` so that
+    ``~/…`` defaults resolve to the same ``HOME`` that Hermes-spawned
+    subprocess tools will see — ``{HERMES_HOME}/home`` when that directory
+    exists, otherwise the Python process's own ``HOME``.  See #12260.
     """
     config_path = get_config_path()
     config: Dict[str, Any] = {}
@@ -411,9 +446,9 @@ def resolve_skill_config_values(
         if value is None or (isinstance(value, str) and not value.strip()):
             value = var.get("default", "")
 
-        # Expand ~ in path-like values
+        # Expand ~ in path-like values — subprocess HOME wins when active.
         if isinstance(value, str) and ("~" in value or "${" in value):
-            value = os.path.expanduser(os.path.expandvars(value))
+            value = _expanduser_for_subprocess(os.path.expandvars(value))
 
         resolved[logical_key] = value
 

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -382,7 +382,13 @@ def _resolve_dotpath(config: Dict[str, Any], dotted_key: str):
     return current
 
 
-def _expanduser_for_subprocess(path: str) -> str:
+_TILDE_PREFIXES: Tuple[str, ...] = ("~/", "~\\")
+
+
+def _expanduser_for_subprocess(
+    path: str,
+    subprocess_home: Optional[str] = None,
+) -> str:
     """Expand ``~`` in a path using the Hermes subprocess HOME when active.
 
     Skill config values are surfaced in the agent's prompt and then acted on
@@ -394,21 +400,34 @@ def _expanduser_for_subprocess(path: str) -> str:
 
     Behaviour:
       * If :func:`hermes_constants.get_subprocess_home` is active
-        (``{HERMES_HOME}/home`` exists on disk), expand ``~`` and ``~/…``
-        against that directory.
+        (``{HERMES_HOME}/home`` exists on disk), expand ``~``, ``~/…`` and
+        ``~\\…`` (Windows) against that directory.  Leading path separators
+        on the remainder (``~//foo``, ``~\\\\foo``) are stripped so the
+        result always lives under the subprocess HOME — mirroring what
+        :func:`os.path.expanduser` does for the same inputs.
       * ``~user`` forms are still resolved via :func:`os.path.expanduser`
         (they name a specific OS user and are independent of Hermes).
-      * When no subprocess HOME is active, behaviour is identical to the
-        original :func:`os.path.expanduser` call.
+      * When no subprocess HOME is active (or the caller already resolved
+        ``None``), behaviour is identical to the original
+        :func:`os.path.expanduser` call.
+
+    ``subprocess_home`` may be passed in to avoid repeated
+    :func:`get_subprocess_home` lookups when this helper is called in a
+    loop (see :func:`resolve_skill_config_values`).
     """
-    subprocess_home = get_subprocess_home()
+    if subprocess_home is None:
+        subprocess_home = get_subprocess_home()
     if subprocess_home is None:
         return os.path.expanduser(path)
     if path == "~":
         return subprocess_home
-    if path.startswith("~/"):
-        # Explicit posix join — path[2:] has no leading slash.
-        return os.path.join(subprocess_home, path[2:])
+    for prefix in _TILDE_PREFIXES:
+        if path.startswith(prefix):
+            # Strip the leading ``~`` and *all* leading separators so
+            # ``~//foo`` or ``~\\foo`` join under the subprocess HOME
+            # instead of returning an accidentally-absolute path.
+            remainder = path[len(prefix) - 1:].lstrip("/\\")
+            return os.path.join(subprocess_home, remainder)
     # ``~user`` or embedded ``~`` — defer to the OS user database.
     return os.path.expanduser(path)
 
@@ -437,6 +456,12 @@ def resolve_skill_config_values(
         except Exception:
             pass
 
+    # Resolve the subprocess HOME once up-front so we don't re-``stat``
+    # ``{HERMES_HOME}/home`` for every config var.  ``None`` means no
+    # subprocess HOME is active and the helper will fall through to
+    # ``os.path.expanduser``.
+    subprocess_home = get_subprocess_home()
+
     resolved: Dict[str, Any] = {}
     for var in config_vars:
         logical_key = var["key"]
@@ -448,7 +473,10 @@ def resolve_skill_config_values(
 
         # Expand ~ in path-like values — subprocess HOME wins when active.
         if isinstance(value, str) and ("~" in value or "${" in value):
-            value = _expanduser_for_subprocess(os.path.expandvars(value))
+            value = _expanduser_for_subprocess(
+                os.path.expandvars(value),
+                subprocess_home=subprocess_home,
+            )
 
         resolved[logical_key] = value
 

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -374,7 +374,13 @@ def _resolve_dotpath(config: Dict[str, Any], dotted_key: str):
     return current
 
 
-def _expanduser_for_subprocess(path: str) -> str:
+_TILDE_PREFIXES: Tuple[str, ...] = ("~/", "~\\")
+
+
+def _expanduser_for_subprocess(
+    path: str,
+    subprocess_home: Optional[str] = None,
+) -> str:
     """Expand ``~`` in a path using the Hermes subprocess HOME when active.
 
     Skill config values are surfaced in the agent's prompt and then acted on
@@ -386,21 +392,34 @@ def _expanduser_for_subprocess(path: str) -> str:
 
     Behaviour:
       * If :func:`hermes_constants.get_subprocess_home` is active
-        (``{HERMES_HOME}/home`` exists on disk), expand ``~`` and ``~/…``
-        against that directory.
+        (``{HERMES_HOME}/home`` exists on disk), expand ``~``, ``~/…`` and
+        ``~\\…`` (Windows) against that directory.  Leading path separators
+        on the remainder (``~//foo``, ``~\\\\foo``) are stripped so the
+        result always lives under the subprocess HOME — mirroring what
+        :func:`os.path.expanduser` does for the same inputs.
       * ``~user`` forms are still resolved via :func:`os.path.expanduser`
         (they name a specific OS user and are independent of Hermes).
-      * When no subprocess HOME is active, behaviour is identical to the
-        original :func:`os.path.expanduser` call.
+      * When no subprocess HOME is active (or the caller already resolved
+        ``None``), behaviour is identical to the original
+        :func:`os.path.expanduser` call.
+
+    ``subprocess_home`` may be passed in to avoid repeated
+    :func:`get_subprocess_home` lookups when this helper is called in a
+    loop (see :func:`resolve_skill_config_values`).
     """
-    subprocess_home = get_subprocess_home()
+    if subprocess_home is None:
+        subprocess_home = get_subprocess_home()
     if subprocess_home is None:
         return os.path.expanduser(path)
     if path == "~":
         return subprocess_home
-    if path.startswith("~/"):
-        # Explicit posix join — path[2:] has no leading slash.
-        return os.path.join(subprocess_home, path[2:])
+    for prefix in _TILDE_PREFIXES:
+        if path.startswith(prefix):
+            # Strip the leading ``~`` and *all* leading separators so
+            # ``~//foo`` or ``~\\foo`` join under the subprocess HOME
+            # instead of returning an accidentally-absolute path.
+            remainder = path[len(prefix) - 1:].lstrip("/\\")
+            return os.path.join(subprocess_home, remainder)
     # ``~user`` or embedded ``~`` — defer to the OS user database.
     return os.path.expanduser(path)
 
@@ -429,6 +448,12 @@ def resolve_skill_config_values(
         except Exception:
             pass
 
+    # Resolve the subprocess HOME once up-front so we don't re-``stat``
+    # ``{HERMES_HOME}/home`` for every config var.  ``None`` means no
+    # subprocess HOME is active and the helper will fall through to
+    # ``os.path.expanduser``.
+    subprocess_home = get_subprocess_home()
+
     resolved: Dict[str, Any] = {}
     for var in config_vars:
         logical_key = var["key"]
@@ -440,7 +465,10 @@ def resolve_skill_config_values(
 
         # Expand ~ in path-like values — subprocess HOME wins when active.
         if isinstance(value, str) and ("~" in value or "${" in value):
-            value = _expanduser_for_subprocess(os.path.expandvars(value))
+            value = _expanduser_for_subprocess(
+                os.path.expandvars(value),
+                subprocess_home=subprocess_home,
+            )
 
         resolved[logical_key] = value
 

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -12,7 +12,7 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
-from hermes_constants import get_config_path, get_skills_dir
+from hermes_constants import get_config_path, get_skills_dir, get_subprocess_home
 
 logger = logging.getLogger(__name__)
 
@@ -374,6 +374,37 @@ def _resolve_dotpath(config: Dict[str, Any], dotted_key: str):
     return current
 
 
+def _expanduser_for_subprocess(path: str) -> str:
+    """Expand ``~`` in a path using the Hermes subprocess HOME when active.
+
+    Skill config values are surfaced in the agent's prompt and then acted on
+    by subprocess tools (Bash, background processes, external launchers)
+    whose ``HOME`` is set to ``{HERMES_HOME}/home`` — *not* the Python
+    process's own ``HOME`` (which in Docker may be ``/opt/data`` or
+    ``/root``).  Using :func:`os.path.expanduser` here produced a path that
+    pointed somewhere the subprocess tools wouldn't find — see #12260.
+
+    Behaviour:
+      * If :func:`hermes_constants.get_subprocess_home` is active
+        (``{HERMES_HOME}/home`` exists on disk), expand ``~`` and ``~/…``
+        against that directory.
+      * ``~user`` forms are still resolved via :func:`os.path.expanduser`
+        (they name a specific OS user and are independent of Hermes).
+      * When no subprocess HOME is active, behaviour is identical to the
+        original :func:`os.path.expanduser` call.
+    """
+    subprocess_home = get_subprocess_home()
+    if subprocess_home is None:
+        return os.path.expanduser(path)
+    if path == "~":
+        return subprocess_home
+    if path.startswith("~/"):
+        # Explicit posix join — path[2:] has no leading slash.
+        return os.path.join(subprocess_home, path[2:])
+    # ``~user`` or embedded ``~`` — defer to the OS user database.
+    return os.path.expanduser(path)
+
+
 def resolve_skill_config_values(
     config_vars: List[Dict[str, Any]],
 ) -> Dict[str, Any]:
@@ -382,7 +413,11 @@ def resolve_skill_config_values(
     Skill config is stored under ``skills.config.<key>`` in config.yaml.
     Returns a dict mapping **logical** keys (as declared by skills) to their
     current values (or the declared default if the key isn't set).
-    Path values are expanded via ``os.path.expanduser``.
+
+    Path values are expanded via :func:`_expanduser_for_subprocess` so that
+    ``~/…`` defaults resolve to the same ``HOME`` that Hermes-spawned
+    subprocess tools will see — ``{HERMES_HOME}/home`` when that directory
+    exists, otherwise the Python process's own ``HOME``.  See #12260.
     """
     config_path = get_config_path()
     config: Dict[str, Any] = {}
@@ -403,9 +438,9 @@ def resolve_skill_config_values(
         if value is None or (isinstance(value, str) and not value.strip()):
             value = var.get("default", "")
 
-        # Expand ~ in path-like values
+        # Expand ~ in path-like values — subprocess HOME wins when active.
         if isinstance(value, str) and ("~" in value or "${" in value):
-            value = os.path.expanduser(os.path.expandvars(value))
+            value = _expanduser_for_subprocess(os.path.expandvars(value))
 
         resolved[logical_key] = value
 

--- a/tests/agent/test_skill_config_subprocess_home.py
+++ b/tests/agent/test_skill_config_subprocess_home.py
@@ -1,0 +1,216 @@
+"""Regression coverage for #12260.
+
+``agent.skill_utils.resolve_skill_config_values`` is what surfaces skill
+config values into the agent's prompt.  Subprocess tools (Bash, background
+launchers, terminal) later act on those values — and those subprocesses
+run with ``HOME={HERMES_HOME}/home`` when that directory exists (see
+``hermes_constants.get_subprocess_home``), *not* the Python process's
+own ``HOME``.
+
+Before the fix, ``~/wiki`` in a skill default expanded via
+``os.path.expanduser`` against the Python-process ``HOME``, producing a
+path that subprocess tools couldn't find.  After the fix, the expansion
+honours the subprocess HOME when active, and falls through to the
+original behaviour when no subprocess HOME is set (``~/.hermes/home``
+doesn't exist).
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from agent.skill_utils import (
+    SKILL_CONFIG_PREFIX,
+    _expanduser_for_subprocess,
+    resolve_skill_config_values,
+)
+
+
+# ---------------------------------------------------------------------------
+# _expanduser_for_subprocess — unit coverage
+# ---------------------------------------------------------------------------
+
+
+class TestExpanduserForSubprocess:
+    def test_tilde_slash_uses_subprocess_home_when_active(self):
+        with patch(
+            "agent.skill_utils.get_subprocess_home",
+            return_value="/opt/data/home",
+        ):
+            assert _expanduser_for_subprocess("~/wiki") == "/opt/data/home/wiki"
+
+    def test_bare_tilde_uses_subprocess_home_when_active(self):
+        with patch(
+            "agent.skill_utils.get_subprocess_home",
+            return_value="/opt/data/home",
+        ):
+            assert _expanduser_for_subprocess("~") == "/opt/data/home"
+
+    def test_nested_tilde_path_uses_subprocess_home(self):
+        with patch(
+            "agent.skill_utils.get_subprocess_home",
+            return_value="/opt/data/home",
+        ):
+            assert (
+                _expanduser_for_subprocess("~/cache/notes")
+                == "/opt/data/home/cache/notes"
+            )
+
+    def test_absolute_path_unaffected(self):
+        with patch(
+            "agent.skill_utils.get_subprocess_home",
+            return_value="/opt/data/home",
+        ):
+            assert _expanduser_for_subprocess("/var/data/wiki") == "/var/data/wiki"
+
+    def test_tilde_user_falls_through_to_os_expanduser(self):
+        """``~user`` addresses a specific OS user and must defer to the
+        passwd database; subprocess HOME shouldn't hijack it."""
+        with patch(
+            "agent.skill_utils.get_subprocess_home",
+            return_value="/opt/data/home",
+        ):
+            # Expand against a username that we know exists on the test host —
+            # ``root`` is universal on POSIX runners.  We only assert the
+            # result is *not* prefixed with our subprocess HOME, because the
+            # actual expansion depends on /etc/passwd on the runner.
+            result = _expanduser_for_subprocess("~root/conf")
+            assert not result.startswith("/opt/data/home")
+
+    def test_no_subprocess_home_falls_back_to_os_expanduser(self, monkeypatch):
+        """When ``get_subprocess_home()`` returns ``None``, behaviour must be
+        identical to ``os.path.expanduser`` — no change for users whose
+        ``{HERMES_HOME}/home`` doesn't exist."""
+        with patch("agent.skill_utils.get_subprocess_home", return_value=None):
+            monkeypatch.setenv("HOME", "/home/alice")
+            assert _expanduser_for_subprocess("~/wiki") == "/home/alice/wiki"
+            assert _expanduser_for_subprocess("~") == "/home/alice"
+            assert _expanduser_for_subprocess("/abs/path") == "/abs/path"
+
+
+# ---------------------------------------------------------------------------
+# resolve_skill_config_values — end-to-end through the skill config surface
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def hermes_home_with_subprocess_home(tmp_path):
+    """Create a HERMES_HOME with a ``home/`` subdirectory (activates
+    ``get_subprocess_home``)."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "home").mkdir()  # <-- triggers get_subprocess_home activation
+    (home / "config.yaml").write_text("skills:\n  config: {}\n")
+    return home
+
+
+@pytest.fixture
+def hermes_home_without_subprocess_home(tmp_path):
+    """Create a HERMES_HOME with NO ``home/`` subdirectory (subprocess HOME
+    falls back to the Python process HOME)."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text("skills:\n  config: {}\n")
+    return home
+
+
+class TestResolveSkillConfigValuesHOME:
+    def test_tilde_default_resolves_to_subprocess_home(
+        self, hermes_home_with_subprocess_home
+    ):
+        """Reporter's scenario: ``default: ~/wiki`` must surface
+        ``{HERMES_HOME}/home/wiki`` when the subprocess HOME is active."""
+        with patch.dict(
+            os.environ,
+            {"HERMES_HOME": str(hermes_home_with_subprocess_home)},
+        ):
+            result = resolve_skill_config_values(
+                [{"key": "wiki.path", "default": "~/wiki"}]
+            )
+        expected = str(hermes_home_with_subprocess_home / "home" / "wiki")
+        assert result == {"wiki.path": expected}
+
+    def test_tilde_default_falls_back_without_subprocess_home(
+        self, hermes_home_without_subprocess_home, monkeypatch
+    ):
+        """Without ``{HERMES_HOME}/home`` on disk, behaviour matches the
+        pre-fix ``os.path.expanduser`` output — nobody regresses."""
+        monkeypatch.setenv("HOME", "/home/alice")
+        with patch.dict(
+            os.environ,
+            {"HERMES_HOME": str(hermes_home_without_subprocess_home),
+             "HOME": "/home/alice"},
+        ):
+            result = resolve_skill_config_values(
+                [{"key": "wiki.path", "default": "~/wiki"}]
+            )
+        assert result == {"wiki.path": "/home/alice/wiki"}
+
+    def test_explicit_config_value_also_expanded(
+        self, hermes_home_with_subprocess_home
+    ):
+        """User-supplied ``skills.config.wiki.path: ~/notes`` in config.yaml
+        must also flow through the subprocess-HOME expansion."""
+        (hermes_home_with_subprocess_home / "config.yaml").write_text(
+            "skills:\n  config:\n    wiki:\n      path: ~/notes\n"
+        )
+        with patch.dict(
+            os.environ,
+            {"HERMES_HOME": str(hermes_home_with_subprocess_home)},
+        ):
+            result = resolve_skill_config_values(
+                [{"key": "wiki.path", "default": "~/wiki"}]
+            )
+        expected = str(hermes_home_with_subprocess_home / "home" / "notes")
+        assert result == {"wiki.path": expected}
+
+    def test_absolute_default_unchanged(self, hermes_home_with_subprocess_home):
+        """Non-tilde defaults are passed through untouched — no false
+        positives for absolute paths."""
+        with patch.dict(
+            os.environ,
+            {"HERMES_HOME": str(hermes_home_with_subprocess_home)},
+        ):
+            result = resolve_skill_config_values(
+                [{"key": "tool.dir", "default": "/opt/preconfigured/tool"}]
+            )
+        assert result == {"tool.dir": "/opt/preconfigured/tool"}
+
+    def test_envvar_default_still_expanded(self, hermes_home_with_subprocess_home):
+        """``${VAR}`` expansion is preserved alongside the new ``~``
+        semantics.  Regression guard for the os.path.expandvars chain."""
+        with patch.dict(
+            os.environ,
+            {"HERMES_HOME": str(hermes_home_with_subprocess_home),
+             "MY_SKILL_DIR": "~/custom"},
+        ):
+            result = resolve_skill_config_values(
+                [{"key": "tool.dir", "default": "${MY_SKILL_DIR}/bin"}]
+            )
+        expected = str(hermes_home_with_subprocess_home / "home" / "custom" / "bin")
+        assert result == {"tool.dir": expected}
+
+    def test_non_string_value_unaffected(self, hermes_home_with_subprocess_home):
+        """Dict/list values stored under skills.config must not be mangled
+        by the expansion step."""
+        (hermes_home_with_subprocess_home / "config.yaml").write_text(
+            "skills:\n  config:\n    tool:\n      flags: [a, b]\n"
+        )
+        with patch.dict(
+            os.environ,
+            {"HERMES_HOME": str(hermes_home_with_subprocess_home)},
+        ):
+            result = resolve_skill_config_values([{"key": "tool.flags"}])
+        assert result == {"tool.flags": ["a", "b"]}
+
+    def test_missing_default_uses_empty_string(
+        self, hermes_home_with_subprocess_home
+    ):
+        """No default + no config value → empty string (unchanged)."""
+        with patch.dict(
+            os.environ,
+            {"HERMES_HOME": str(hermes_home_with_subprocess_home)},
+        ):
+            result = resolve_skill_config_values([{"key": "unset.key"}])
+        assert result == {"unset.key": ""}

--- a/tests/agent/test_skill_config_subprocess_home.py
+++ b/tests/agent/test_skill_config_subprocess_home.py
@@ -21,7 +21,6 @@ from unittest.mock import patch
 import pytest
 
 from agent.skill_utils import (
-    SKILL_CONFIG_PREFIX,
     _expanduser_for_subprocess,
     resolve_skill_config_values,
 )
@@ -87,6 +86,49 @@ class TestExpanduserForSubprocess:
             assert _expanduser_for_subprocess("~/wiki") == "/home/alice/wiki"
             assert _expanduser_for_subprocess("~") == "/home/alice"
             assert _expanduser_for_subprocess("/abs/path") == "/abs/path"
+
+    # -- Edge cases flagged by Copilot on PR #12284 ---------------------
+
+    def test_double_slash_after_tilde_stays_under_subprocess_home(self):
+        """``~//foo`` must NOT bypass the subprocess HOME via ``os.path.join``
+        treating the ``/foo`` remainder as absolute.  Mirrors the behaviour
+        of ``os.path.expanduser`` which strips repeated separators."""
+        result = _expanduser_for_subprocess(
+            "~//foo/bar", subprocess_home="/opt/data/home"
+        )
+        assert result == "/opt/data/home/foo/bar"
+
+    def test_tilde_backslash_on_windows_style_paths(self):
+        """``~\\wiki`` (Windows-style) must also expand under the subprocess
+        HOME, not fall through to the Python process HOME."""
+        result = _expanduser_for_subprocess(
+            "~\\wiki", subprocess_home="/opt/data/home"
+        )
+        # os.path.join normalises on the running platform; we just check
+        # the result lives under the subprocess HOME.
+        assert result.startswith("/opt/data/home")
+        assert "wiki" in result
+
+    def test_mixed_separators_after_tilde(self):
+        """``~\\\\foo`` (escaped backslash + repeat) must still join under
+        the subprocess HOME, not return an absolute ``/foo``."""
+        result = _expanduser_for_subprocess(
+            "~\\\\foo", subprocess_home="/opt/data/home"
+        )
+        assert result.startswith("/opt/data/home")
+
+    def test_subprocess_home_argument_short_circuits_lookup(self):
+        """Passing ``subprocess_home=`` bypasses
+        :func:`get_subprocess_home` — callers in loops can resolve once
+        and reuse (avoids repeated ``os.path.isdir`` stat calls)."""
+        with patch(
+            "agent.skill_utils.get_subprocess_home",
+            side_effect=AssertionError("should not be called"),
+        ):
+            result = _expanduser_for_subprocess(
+                "~/x", subprocess_home="/opt/data/home"
+            )
+        assert result == "/opt/data/home/x"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #12260.

## TL;DR

`agent.skill_utils.resolve_skill_config_values` expanded `~` in skill config defaults using `os.path.expanduser` — which resolves against the **Python process's** `HOME`. Hermes independently sets a different `HOME` (`{HERMES_HOME}/home/` via `get_subprocess_home`) for every subprocess it spawns.

A skill declaring `default: "~/wiki"` therefore surfaced `/opt/data/wiki` in the prompt, but subprocess tools (Bash, `wiki init`, …) resolved `~` to `/opt/data/home/wiki`. Files written by one tool weren't findable by the next.

Fix: expand `~` against the subprocess HOME when active, fall through to `os.path.expanduser` otherwise.

## Root cause

`agent/skill_utils.py:407-408` (pre-fix):

```python
if isinstance(value, str) and ("~" in value or "${" in value):
    value = os.path.expanduser(os.path.expandvars(value))
```

`hermes_constants.get_subprocess_home` returns `{HERMES_HOME}/home` when that directory exists and explicitly states in its docstring:

> The Python process's own `os.environ["HOME"]` and `Path.home()` are **never** modified — only subprocess environments should inject this value.

So the skill-config surface, which is consumed by subprocess-facing tools, was silently pointing at the wrong HOME.

## Fix

New helper `_expanduser_for_subprocess(path)`:

```python
def _expanduser_for_subprocess(path: str) -> str:
    subprocess_home = get_subprocess_home()
    if subprocess_home is None:
        return os.path.expanduser(path)
    if path == "~":
        return subprocess_home
    if path.startswith("~/"):
        return os.path.join(subprocess_home, path[2:])
    # ~user → passwd database, independent of Hermes
    return os.path.expanduser(path)
```

`resolve_skill_config_values` calls it instead of `os.path.expanduser` directly. Nothing else changes.

## Behaviour matrix

| Input | `get_subprocess_home()` | Before | After |
| --- | --- | --- | --- |
| `~/wiki` | `/opt/data/home` (active) | `/opt/data/wiki` (**wrong**) | `/opt/data/home/wiki` |
| `~` | `/opt/data/home` (active) | `/opt/data` (**wrong**) | `/opt/data/home` |
| `~/a/b/c` | `/opt/data/home` (active) | `/opt/data/a/b/c` (**wrong**) | `/opt/data/home/a/b/c` |
| `/abs/path` | `/opt/data/home` (active) | `/abs/path` | **unchanged** |
| `~root/conf` | `/opt/data/home` (active) | `/root/conf` (passwd lookup) | `/root/conf` (**unchanged** — not hijacked) |
| `~/wiki` | `None` (no subprocess home) | `/home/alice/wiki` | **unchanged** |
| `${VAR}/bin` where VAR=`~/custom` | `/opt/data/home` (active) | `/root/custom/bin` | `/opt/data/home/custom/bin` |

## Narrow scope — explicitly not changed

* **Other `os.path.expanduser` call sites.** Only the skill-config surface feeds subprocess-facing prompts. `get_external_skills_dirs` at `skill_utils.py:212` reads directories for the **Python process** to load skills from — expanding against the process HOME is correct there, and untouched.
* **Subprocess HOME activation logic.** Unchanged — still triggered by `{HERMES_HOME}/home/` existing on disk.
* **`${VAR}` env expansion.** Still runs via `os.path.expandvars` before `~` expansion; unchanged semantics.
* **`~user` forms** (`~alice/foo`, `~root/conf`). Still defer to `os.path.expanduser`'s passwd-database lookup — those name a specific OS user independent of Hermes, so the subprocess HOME should not hijack them. Pinned by a dedicated test.

## Regression coverage

`tests/agent/test_skill_config_subprocess_home.py` (new, 13 cases):

- **`TestExpanduserForSubprocess` (6 unit tests)** — `~/x`, bare `~`, nested `~/a/b/c`, absolute paths, `~user` passwd fall-through, and the no-subprocess-home `os.path.expanduser` fallback.
- **`TestResolveSkillConfigValuesHOME` (7 end-to-end tests)** through the public API — reporter scenario, no-subprocess-home fallback, explicit config value expansion, absolute default unchanged, `${VAR}` interaction, non-string value pass-through, and an empty-default canary.

Bug also verified to reproduce on clean `origin/main` (`6fb69229`) via direct Python repro:

```
Got:      {'wiki.path': '/home/testuser/wiki'}
Expected: {'wiki.path': '<HERMES_HOME>/home/wiki'}
BUG REPRO: True
```

## Validation

```bash
source venv/bin/activate
python -m pytest tests/agent/test_skill_config_subprocess_home.py -q
# 13 passed
```

Broader agent + skills suites under `-n auto`:

```bash
python -m pytest tests/agent/ tests/hermes_cli/test_skills_config.py \
    tests/hermes_cli/test_chat_skills_flag.py tests/hermes_cli/test_skills_hub.py \
    tests/hermes_cli/test_banner_skills.py tests/cli/test_cli_preloaded_skills.py \
    tests/tools/test_skill_manager_tool.py tests/tools/test_skills_tool.py -q -n auto
# 1566 passed, 1 skipped, 0 failures
```

## Pre-empted review questions

**Q. Should this behaviour apply everywhere the agent expands `~`, not just skill config?**
Out of scope for this PR. `resolve_skill_config_values` is the specific surface the reporter identified and it has a clean subprocess-facing contract. A broader audit of `os.path.expanduser` usage (auth file paths, external skills dirs, etc.) is a separate, larger change with different trade-offs per call site.

**Q. What if a skill author genuinely wants the Python process HOME (e.g. for a Python-only tool)?**
They can either pass an absolute path, or use an explicit `${HOME}` that will be `os.path.expandvars`'d (expanding against the Python process env). Most skill defaults want "where the subprocess tools work" — this PR makes that the default.

**Q. Concurrency?**
`get_subprocess_home()` is a read-only lookup of an env var + a `os.path.isdir` check. No mutation, no locks. Called per skill-config resolution, not per message.

**Q. What about Windows?**
`os.path.join` handles both separator flavours; `os.path.expanduser` on Windows uses `USERPROFILE`. Both fall-through branches are preserved. No Windows-specific change.

---

<sub>Co-authored via LLM assistance; I've reviewed every line and am responsible for correctness.</sub>
