### PR TITLE
fix(models): validate Alibaba coding-endpoint switches via catalog when /models 404s (#12272)

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2190,6 +2190,47 @@ def validate_requested_model(
         except Exception:
             pass  # Fall through to generic warning
 
+    # Alibaba (DashScope) coding endpoint
+    # (``https://coding.dashscope.aliyuncs.com/v1``) does not expose
+    # ``/models`` — the request returns HTTP 404 and ``fetch_api_models``
+    # yields ``None``, same as any unreachable endpoint.  Before this
+    # fall-through was added the generic "couldn't reach" branch below
+    # hard-rejected every ``/model`` switch for DashScope coding users,
+    # even for model IDs we statically know about (qwen3-coder-plus,
+    # kimi-k2.5, glm-5, …).  Fall back to the curated catalog so the
+    # switch still works; warn when the ID isn't in our catalog.  See
+    # #12272.
+    if normalized == "alibaba":
+        try:
+            catalog = provider_model_ids("alibaba")
+        except Exception:
+            catalog = []
+        if catalog:
+            catalog_set = set(catalog)
+            if requested in catalog_set or requested_for_lookup in catalog_set:
+                return {
+                    "accepted": True,
+                    "persist": True,
+                    "recognized": True,
+                    "message": None,
+                }
+            suggestions = get_close_matches(requested, catalog, n=3, cutoff=0.4)
+            suggestion_text = ""
+            if suggestions:
+                suggestion_text = "\n  Similar models: " + ", ".join(f"`{s}`" for s in suggestions)
+            return {
+                "accepted": True,
+                "persist": True,
+                "recognized": False,
+                "message": (
+                    f"Note: `{requested}` was not found in the Alibaba (DashScope) "
+                    f"catalog; the coding endpoint doesn't expose `/models`, so the "
+                    f"switch will proceed and the model name will be validated on "
+                    f"first request."
+                    f"{suggestion_text}"
+                ),
+            }
+
     provider_label = _PROVIDER_LABELS.get(normalized, normalized)
     return {
         "accepted": False,

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -540,3 +540,167 @@ class TestValidateCodexAutoCorrection:
         assert result["recognized"] is False
         assert result.get("corrected_model") is None
         assert "not found" in result["message"]
+
+
+# ---------------------------------------------------------------------------
+# Regression coverage for #12272:  Alibaba (DashScope) coding endpoint
+# (``https://coding.dashscope.aliyuncs.com/v1``) does not expose /models
+# — it returns HTTP 404 and ``fetch_api_models`` yields ``None``.  Before
+# this branch was added, ``validate_requested_model`` hard-rejected every
+# ``/model`` switch for DashScope coding users.  These tests pin the new
+# curated-catalog fall-through.
+# ---------------------------------------------------------------------------
+
+
+class TestValidateAlibabaCodingEndpoint:
+    """The coding endpoint returns 404 on ``/models``; we must fall back
+    to the curated catalog so switches still work."""
+
+    _ALIBABA_CATALOG = [
+        "qwen3-coder-plus",
+        "qwen3-coder-next",
+        "qwen3.5-plus",
+        "kimi-k2.5",
+        "glm-5",
+        "MiniMax-M2.5",
+    ]
+
+    def _validate_no_api(self, model, catalog=None):
+        """Call validate_requested_model with /models returning None
+        (the 404 case) and provider_model_ids returning our catalog."""
+        probe_payload = {
+            "models": None,
+            "probed_url": "https://coding.dashscope.aliyuncs.com/v1/models",
+            "resolved_base_url": "https://coding.dashscope.aliyuncs.com/v1",
+            "suggested_base_url": None,
+            "used_fallback": False,
+        }
+        with patch("hermes_cli.models.fetch_api_models", return_value=None), \
+             patch("hermes_cli.models.probe_api_models", return_value=probe_payload), \
+             patch(
+                 "hermes_cli.models.provider_model_ids",
+                 return_value=self._ALIBABA_CATALOG if catalog is None else catalog,
+             ):
+            return validate_requested_model(
+                model,
+                "alibaba",
+                api_key="fake-dashscope-key",
+                base_url="https://coding.dashscope.aliyuncs.com/v1",
+            )
+
+    def test_known_qwen_model_accepted(self):
+        """Reporter's scenario: a model in our catalog is accepted even
+        when the API /models endpoint 404s."""
+        result = self._validate_no_api("qwen3-coder-plus")
+        assert result["accepted"] is True
+        assert result["persist"] is True
+        assert result["recognized"] is True
+        assert result["message"] is None
+
+    def test_known_third_party_model_accepted(self):
+        """Third-party models served on the coding endpoint (glm-5,
+        kimi-k2.5, MiniMax-M2.5) are also in the catalog."""
+        for model in ("glm-5", "kimi-k2.5", "MiniMax-M2.5"):
+            result = self._validate_no_api(model)
+            assert result["accepted"] is True, (
+                f"{model} should be accepted via catalog fall-through"
+            )
+            assert result["recognized"] is True
+
+    def test_unknown_model_accepted_with_warning(self):
+        """Models not in the catalog still proceed (the endpoint may
+        have models the static list doesn't know about), but the caller
+        is warned."""
+        result = self._validate_no_api("qwen-hypothetical-future-model")
+        assert result["accepted"] is True
+        assert result["persist"] is True
+        assert result["recognized"] is False
+        assert "Alibaba" in result["message"]
+        assert "coding endpoint" in result["message"]
+
+    def test_unknown_model_includes_suggestions(self):
+        """Typo → suggestions close to known catalog names."""
+        result = self._validate_no_api("qwen3-coder-plu")  # typo
+        assert result["accepted"] is True
+        assert "Similar models" in result["message"]
+        assert "qwen3-coder-plus" in result["message"]
+
+    def test_empty_catalog_falls_through_to_generic_reject(self):
+        """Defensive: if ``provider_model_ids`` somehow returns an empty
+        list (e.g. catalog module import failure), we don't silently
+        accept unknown models — fall through to the generic reject
+        behaviour so the user sees the original error."""
+        result = self._validate_no_api("qwen3-coder-plus", catalog=[])
+        assert result["accepted"] is False
+        assert "Alibaba Cloud" in result["message"]
+
+    def test_catalog_lookup_exception_falls_through(self):
+        """If ``provider_model_ids`` raises, behave as if no catalog was
+        available — fall through to the generic reject."""
+        probe_payload = {
+            "models": None,
+            "probed_url": "https://coding.dashscope.aliyuncs.com/v1/models",
+            "resolved_base_url": "https://coding.dashscope.aliyuncs.com/v1",
+            "suggested_base_url": None,
+            "used_fallback": False,
+        }
+        with patch("hermes_cli.models.fetch_api_models", return_value=None), \
+             patch("hermes_cli.models.probe_api_models", return_value=probe_payload), \
+             patch(
+                 "hermes_cli.models.provider_model_ids",
+                 side_effect=RuntimeError("catalog unavailable"),
+             ):
+            result = validate_requested_model(
+                "qwen3-coder-plus",
+                "alibaba",
+                api_key="fake-dashscope-key",
+                base_url="https://coding.dashscope.aliyuncs.com/v1",
+            )
+        assert result["accepted"] is False
+
+    # --- preserved behaviour canaries ----------------------------------
+
+    def test_live_api_path_unchanged_when_endpoint_supports_models(self):
+        """The classic DashScope endpoint (compatible-mode) DOES expose
+        /models.  When ``fetch_api_models`` returns a list, the existing
+        live-API path must still be used — we must not short-circuit
+        every Alibaba request to the catalog."""
+        api_list = ["qwen3-coder-plus", "qwen-turbo"]
+        probe_payload = {
+            "models": api_list,
+            "probed_url": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/models",
+            "resolved_base_url": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+            "suggested_base_url": None,
+            "used_fallback": False,
+        }
+        with patch("hermes_cli.models.fetch_api_models", return_value=api_list), \
+             patch("hermes_cli.models.probe_api_models", return_value=probe_payload):
+            result = validate_requested_model(
+                "qwen3-coder-plus",
+                "alibaba",
+                api_key="fake-classic-key",
+                base_url="https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
+            )
+        assert result["accepted"] is True
+        assert result["recognized"] is True
+
+    def test_other_providers_still_hard_reject_when_api_unreachable(self):
+        """Narrow-scope canary: the catalog fall-through must fire only
+        for ``alibaba``.  Other providers (e.g. zai) still hit the
+        generic reject when their /models endpoint is unreachable."""
+        probe_payload = {
+            "models": None,
+            "probed_url": "https://example.com/v1/models",
+            "resolved_base_url": "https://example.com/v1",
+            "suggested_base_url": None,
+            "used_fallback": False,
+        }
+        with patch("hermes_cli.models.fetch_api_models", return_value=None), \
+             patch("hermes_cli.models.probe_api_models", return_value=probe_payload):
+            result = validate_requested_model(
+                "glm-5",
+                "zai",
+                api_key="fake",
+                base_url="https://example.com/v1",
+            )
+        assert result["accepted"] is False


### PR DESCRIPTION
Fixes #12272.

## TL;DR

`validate_requested_model` probes the provider's `/models` endpoint to confirm a requested model exists. The **DashScope coding endpoint** (`https://coding.dashscope.aliyuncs.com/v1`) does not expose `/models` — it returns **HTTP 404**, so `fetch_api_models` yields `None`.

Before this fix, the "couldn't reach API" branch hard-rejected every `/model` switch for DashScope coding users — including models Hermes statically knows about (`qwen3-coder-plus`, `kimi-k2.5`, `glm-5`, `MiniMax-M2.5`).

Fix: mirror the existing Bedrock pattern — when `api_models is None` and `normalized == "alibaba"`, fall back to the curated `provider_model_ids("alibaba")` catalog. Accept known models quietly; accept unknown models with a warning; fall through to the generic reject if the catalog itself is unavailable.

## Regression window

The "couldn't reach → hard reject" branch was introduced by commit `aeb53131f` (Apr 13, 2026) to prevent "fake model" typos. This fix re-enables switch-ability for the DashScope coding endpoint without reverting `aeb53131f`'s guard for other providers.

## Root cause

`hermes_cli/models.py:2155` (pre-fix):

```python
# api_models is None — couldn't reach API.  Accept and persist,
# but warn so typos don't silently break things.

# Bedrock: use our own discovery instead of HTTP /models endpoint.
if normalized == "bedrock":
    ...

# ← No alibaba case here → generic reject fires for DashScope coding

provider_label = _PROVIDER_LABELS.get(normalized, normalized)
return {
    "accepted": False,
    "persist": False,
    "recognized": False,
    "message": (
        f"Could not reach the {provider_label} API to validate `{requested}`. "
        f"If the service isn't down, this model may not be valid."
    ),
}
```

## Fix

```python
if normalized == "alibaba":
    try:
        catalog = provider_model_ids("alibaba")
    except Exception:
        catalog = []
    if catalog:
        if requested in set(catalog) or requested_for_lookup in set(catalog):
            return {"accepted": True, "persist": True, "recognized": True, "message": None}
        suggestions = get_close_matches(requested, catalog, n=3, cutoff=0.4)
        return {
            "accepted": True,
            "persist": True,
            "recognized": False,
            "message": f"Note: `{requested}` was not found in the Alibaba (DashScope) "
                       f"catalog; the coding endpoint doesn't expose `/models`, …",
        }
    # empty catalog or lookup failed → fall through to generic reject
```

## Behaviour matrix

| Scenario | Endpoint | `api_models` | Before | After |
| --- | --- | --- | --- | --- |
| Switch to `qwen3-coder-plus` on coding | 404s on `/models` | `None` | **REJECT** (bug) | accept (quiet) |
| Switch to `glm-5` on coding (third-party via DashScope) | 404s on `/models` | `None` | **REJECT** (bug) | accept (quiet) |
| Switch to unknown model on coding | 404s on `/models` | `None` | reject with "couldn't reach" | accept with `Similar models:` suggestions |
| Switch on classic endpoint | supports `/models` | `["qwen3-…", …]` | accept via live list | **unchanged** |
| Switch on other provider whose API is unreachable | timeout | `None` | reject with "couldn't reach" | **unchanged** (narrow-scope guard) |
| Catalog module raises | — | `None` | reject | fall through to reject (defensive) |

## Narrow scope — explicitly not changed

* **Classic DashScope endpoint** (`dashscope-intl.aliyuncs.com/compatible-mode/v1`). Still probes the live `/models` endpoint — pinned by `test_live_api_path_unchanged_when_endpoint_supports_models`.
* **Other providers' hard-reject behaviour**. The `if normalized == "alibaba"` is deliberately narrow. Pinned by `test_other_providers_still_hard_reject_when_api_unreachable` (zai canary).
* **The `aeb53131f` "fake models" guard**. Intact for every path that doesn't match `alibaba`.
* **`provider: custom` with a DashScope coding base URL**. Custom provider has its own validation path via `TestCustomProviderBaseUrlSuggestion`; out of scope.

## Regression coverage

`tests/hermes_cli/test_model_validation.py::TestValidateAlibabaCodingEndpoint` — 8 cases:

- **4 new-behaviour tests** (fail on main):
  - `test_known_qwen_model_accepted` (reporter's exact repro)
  - `test_known_third_party_model_accepted` (`glm-5`, `kimi-k2.5`, `MiniMax-M2.5`)
  - `test_unknown_model_accepted_with_warning`
  - `test_unknown_model_includes_suggestions`
- **2 defensive-fallback pins**:
  - `test_empty_catalog_falls_through_to_generic_reject`
  - `test_catalog_lookup_exception_falls_through`
- **2 preserved-behaviour canaries** (pass on both main and branch):
  - `test_live_api_path_unchanged_when_endpoint_supports_models`
  - `test_other_providers_still_hard_reject_when_api_unreachable`

**4 of 8 fail on clean `origin/main` (`6fb69229`)** with `assert False is True` on `result["accepted"]` — the exact reporter symptom.

## Validation

```bash
source venv/bin/activate
python -m pytest tests/hermes_cli/test_model_validation.py::TestValidateAlibabaCodingEndpoint -q
# 8 passed
```

Broader model-switch / normalize suites:

```bash
python -m pytest \
  tests/hermes_cli/test_model_validation.py \
  tests/hermes_cli/test_model_switch_custom_providers.py \
  tests/hermes_cli/test_model_switch_variant_tags.py \
  tests/hermes_cli/test_user_providers_model_switch.py \
  tests/hermes_cli/test_model_normalize.py -q
# 147 passed, 0 failures
```

## Pre-empted review questions

**Q. Why not always fall back to the catalog for every provider?**
Because `aeb53131f` was deliberate — the "fake model" guard was added to catch user typos that would otherwise silently burn API quota on nonexistent models. The fix is narrowed to `alibaba` because the coding endpoint *structurally* doesn't expose `/models` (it's not a transient network error), so the catalog is the only validation signal available. Other providers should still fail loudly when their API is genuinely unreachable.

**Q. What about users on the classic DashScope endpoint?**
They follow the live `/models` path at `models.py:2114`, which runs *before* my fallback. No change. Pinned by a dedicated test.

**Q. What if the catalog drifts out of sync with what DashScope actually serves?**
That's already the tradeoff of using any static catalog — same for `bedrock`, `openai-codex`, `nous`, `copilot`. Unknown models are still accepted (with a warning) so users who want to use newer models than the catalog knows about still get the switch. They just see "not found in catalog" as a heads-up.

**Q. Auto-correction for typos (`qwen3-coder-plu` → `qwen3-coder-plus`)?**
Not in this PR — matches Bedrock's current behaviour (suggest-only, don't auto-correct on the fallback path). Auto-correction is only done when `/models` returns a list. Scope creep otherwise.

---

<sub>Co-authored via LLM assistance; I've reviewed every line and am responsible for correctness.</sub>
