### PR TITLE
feat: integrate Codex app-server bridge with Hermes loop

### DIFF
--- a/agent/codex_app_server_bridge.py
+++ b/agent/codex_app_server_bridge.py
@@ -1,0 +1,737 @@
+"""Process-local bridge for Codex app-server JSON-RPC events."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import asdict, dataclass
+import json
+import os
+import subprocess
+import threading
+import time
+from typing import Any, Callable
+
+from hermes_cli import __version__ as HERMES_VERSION
+
+
+IDLE = "idle"
+RUNNING = "running"
+WAITING_FOR_INPUT = "waiting_for_input"
+DIFF_UPDATED = "diff_updated"
+COMPLETED = "completed"
+FAILED = "failed"
+
+TERMINAL_STATUSES = {COMPLETED, FAILED}
+
+STARTING = "starting"
+READY = "ready"
+STOPPED = "stopped"
+ERROR = "error"
+
+CODEX_APP_SERVER_COMMAND = ("codex", "app-server", "--listen", "stdio://")
+INITIALIZE_METHOD = "initialize"
+START_THREAD_METHOD = "thread/start"
+START_TURN_METHOD = "turn/start"
+
+DEFAULT_INITIALIZE_TIMEOUT_SECONDS = 5.0
+DEFAULT_REQUEST_TIMEOUT_SECONDS = 30.0
+STOP_TIMEOUT_SECONDS = 2.0
+
+
+class CodexAppServerBridgeError(RuntimeError):
+    """Base exception for bridge transport/request failures."""
+
+
+class CodexAppServerTimeoutError(CodexAppServerBridgeError):
+    """Raised when a JSON-RPC request does not receive a response in time."""
+
+
+@dataclass
+class BridgeEvent:
+    """A normalized app-server notification while preserving raw details."""
+
+    raw_method: str
+    normalized_status: str
+    payload: dict[str, Any]
+    received_at: float
+    raw_message: dict[str, Any] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class BridgeTurnState:
+    """Current process-local view of a Codex app-server turn."""
+
+    bridge_status: str = IDLE
+    normalized_status: str = IDLE
+    thread_id: str | None = None
+    turn_id: str | None = None
+    last_event_at: float | None = None
+    last_error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class CodexAppServerBridge:
+    """Small stdio JSON-RPC bridge with notification state tracking."""
+
+    def __init__(
+        self,
+        *,
+        recent_events_limit: int = 200,
+        clock: Callable[[], float] = time.time,
+        command: tuple[str, ...] | list[str] | None = None,
+        popen_factory: Callable[..., Any] = subprocess.Popen,
+    ) -> None:
+        self.state = BridgeTurnState()
+        self._recent_events: deque[BridgeEvent] = deque(maxlen=recent_events_limit)
+        self._pending_responses: dict[Any, dict[str, Any]] = {}
+        self._request_id = 0
+        self._clock = clock
+        self._command = tuple(command or CODEX_APP_SERVER_COMMAND)
+        self._popen_factory = popen_factory
+        self._process: Any | None = None
+        self._reader_thread: threading.Thread | None = None
+        self._stop_reader = threading.Event()
+        self._lock = threading.RLock()
+        self._write_lock = threading.Lock()
+        self._last_completion_event: dict[str, Any] | None = None
+        self._enqueued_completion_sessions: set[str] = set()
+        self._route_metadata: dict[str, str] = {}
+
+    def start(self, *, timeout: float = DEFAULT_INITIALIZE_TIMEOUT_SECONDS) -> dict[str, Any]:
+        """Start ``codex app-server --listen stdio://`` and initialize it."""
+        with self._lock:
+            if self.state.bridge_status == READY and self._process_is_running_locked():
+                return self.get_status()
+
+            self.state.bridge_status = STARTING
+            self.state.last_error = None
+            self._stop_reader.clear()
+
+        try:
+            process = self._popen_factory(
+                list(self._command),
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                bufsize=1,
+            )
+        except Exception as exc:
+            self._set_transport_error(f"Failed to start Codex app-server: {exc}")
+            raise CodexAppServerBridgeError(str(exc)) from exc
+
+        if process.stdin is None or process.stdout is None:
+            self._process = process
+            self.stop()
+            self._set_transport_error("Codex app-server did not expose stdio pipes")
+            raise CodexAppServerBridgeError("Codex app-server did not expose stdio pipes")
+
+        with self._lock:
+            self._process = process
+            self._reader_thread = threading.Thread(
+                target=self._reader_loop,
+                name="codex-app-server-reader",
+                daemon=True,
+            )
+            self._reader_thread.start()
+
+        try:
+            initialize_result = self.initialize(timeout=timeout)
+        except Exception as exc:
+            self.stop()
+            self._set_transport_error(f"Codex app-server initialize failed: {exc}")
+            raise
+
+        with self._lock:
+            self.state.bridge_status = READY
+            self.state.last_error = None
+
+        status = self.get_status()
+        status["initialize_result"] = initialize_result
+        return status
+
+    def initialize(self, *, timeout: float = DEFAULT_INITIALIZE_TIMEOUT_SECONDS) -> Any:
+        """Send the JSON-RPC initialize request and wait for its response."""
+        return self.send_request(
+            INITIALIZE_METHOD,
+            {"clientInfo": {"name": "hermes-agent", "version": HERMES_VERSION}},
+            timeout=timeout,
+        )
+
+    def set_route_metadata(self, **metadata: str | None) -> None:
+        """Remember the originating session so completion events can be routed safely."""
+        filtered = {
+            key: str(value)
+            for key, value in metadata.items()
+            if value not in (None, "")
+        }
+        with self._lock:
+            self._route_metadata = filtered
+
+    def stop(self) -> dict[str, Any]:
+        """Stop the reader and terminate the owned subprocess."""
+        with self._lock:
+            process = self._process
+            reader_thread = self._reader_thread
+            self._stop_reader.set()
+
+        if process is not None:
+            self._close_pipe(getattr(process, "stdin", None))
+            self._close_pipe(getattr(process, "stdout", None))
+            try:
+                if process.poll() is None:
+                    process.terminate()
+                    try:
+                        process.wait(timeout=STOP_TIMEOUT_SECONDS)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                        process.wait(timeout=STOP_TIMEOUT_SECONDS)
+            except Exception:
+                pass
+
+        if reader_thread is not None and reader_thread.is_alive():
+            reader_thread.join(timeout=STOP_TIMEOUT_SECONDS)
+
+        with self._lock:
+            self._process = None
+            self._reader_thread = None
+            for pending in self._pending_responses.values():
+                pending["error"] = {"message": "bridge stopped"}
+                pending["event"].set()
+            self._pending_responses.clear()
+            self.state.bridge_status = STOPPED
+        return self.get_status()
+
+    def send_request(
+        self,
+        method: str,
+        params: dict[str, Any] | None = None,
+        *,
+        timeout: float = DEFAULT_REQUEST_TIMEOUT_SECONDS,
+    ) -> Any:
+        """Send a JSON-RPC request and wait for the correlated response."""
+        if not method:
+            raise ValueError("method is required")
+
+        with self._lock:
+            process = self._process
+            if process is None or getattr(process, "stdin", None) is None:
+                raise CodexAppServerBridgeError("Codex app-server bridge is not started")
+            if process.poll() is not None:
+                raise CodexAppServerBridgeError("Codex app-server process is not running")
+
+        request_id = self._next_request_id()
+        pending = self._register_pending_request(request_id)
+        message = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+            "params": params or {},
+        }
+
+        try:
+            self._write_json(message)
+        except Exception as exc:
+            with self._lock:
+                self._pending_responses.pop(request_id, None)
+            self._set_transport_error(f"Failed to write JSON-RPC request: {exc}")
+            raise CodexAppServerBridgeError(str(exc)) from exc
+
+        if not pending["event"].wait(timeout=max(0.0, float(timeout))):
+            with self._lock:
+                self._pending_responses.pop(request_id, None)
+            raise CodexAppServerTimeoutError(
+                f"Timed out waiting for Codex app-server response to {method}"
+            )
+
+        with self._lock:
+            self._pending_responses.pop(request_id, None)
+            error = pending.get("error")
+            result = pending.get("result")
+
+        if error:
+            message = self._format_response_error(error)
+            self._set_transport_error(message)
+            raise CodexAppServerBridgeError(message)
+
+        return result
+
+    def start_turn(
+        self,
+        *,
+        repo_path: str,
+        prompt: str,
+        timeout: float = DEFAULT_REQUEST_TIMEOUT_SECONDS,
+    ) -> dict[str, Any]:
+        """Start a repo-rooted app-server thread, then start a prompt turn."""
+        repo_path = os.fspath(repo_path)
+        if not repo_path:
+            raise ValueError("repo_path is required")
+        if not prompt or not str(prompt).strip():
+            raise ValueError("prompt is required")
+
+        thread_result = self.send_request(
+            START_THREAD_METHOD,
+            {"cwd": repo_path},
+            timeout=timeout,
+        )
+        thread_id = self._extract_id(
+            thread_result,
+            "thread_id",
+            "threadId",
+            "id",
+            "thread.id",
+        )
+        if not thread_id:
+            raise CodexAppServerBridgeError("thread/start response did not include a thread id")
+
+        turn_result = self.send_request(
+            START_TURN_METHOD,
+            {
+                "threadId": thread_id,
+                "input": [
+                    {
+                        "type": "text",
+                        "text": str(prompt),
+                    }
+                ],
+            },
+            timeout=timeout,
+        )
+        turn_id = self._extract_id(turn_result, "turn_id", "turnId", "id", "turn.id")
+
+        with self._lock:
+            if thread_id:
+                self.state.thread_id = thread_id
+            if turn_id:
+                self.state.turn_id = turn_id
+            self.state.normalized_status = RUNNING
+            self.state.last_error = None
+            identifier = self.state.turn_id or self.state.thread_id
+            if identifier:
+                self._enqueued_completion_sessions.discard(f"codex_turn_{identifier}")
+
+        return {
+            "thread_result": thread_result,
+            "turn_result": turn_result,
+            "thread_id": thread_id,
+            "turn_id": turn_id,
+            "methods": {
+                "start_thread": START_THREAD_METHOD,
+                "start_turn": START_TURN_METHOD,
+            },
+            "status": self.get_status(),
+        }
+
+    def _next_request_id(self) -> int:
+        with self._lock:
+            self._request_id += 1
+            return self._request_id
+
+    def _register_pending_request(self, request_id: Any | None = None) -> dict[str, Any]:
+        """Create a tiny in-memory response slot for a JSON-RPC request."""
+        if request_id is None:
+            request_id = self._next_request_id()
+        pending = {
+            "id": request_id,
+            "event": threading.Event(),
+            "response": None,
+            "result": None,
+            "error": None,
+        }
+        with self._lock:
+            self._pending_responses[request_id] = pending
+        return pending
+
+    def _handle_incoming_line(self, line: str) -> dict[str, Any] | BridgeEvent | None:
+        """Parse one newline-delimited JSON-RPC message.
+
+        Malformed JSON and unsupported message shapes are converted into safe
+        failed/unknown events instead of escaping exceptions into reader loops.
+        """
+        raw = line.strip()
+        if not raw:
+            return None
+
+        try:
+            message = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            return self._record_event(
+                raw_method="jsonrpc.parse_error",
+                normalized_status=FAILED,
+                payload={"line": raw, "error": str(exc)},
+                raw_message=None,
+            )
+
+        if not isinstance(message, dict):
+            return self._record_event(
+                raw_method="jsonrpc.invalid_message",
+                normalized_status=FAILED,
+                payload={"message": message},
+                raw_message={"message": message},
+            )
+
+        if "id" in message and ("result" in message or "error" in message):
+            return self._handle_response(message)
+
+        if "id" in message and "method" in message:
+            return self._handle_server_request(message)
+
+        if "method" in message:
+            return self._handle_notification(message)
+
+        return self._record_event(
+            raw_method="jsonrpc.unknown_message",
+            normalized_status=self.state.normalized_status,
+            payload=message,
+            raw_message=message,
+        )
+
+    def _handle_response(self, message: dict[str, Any]) -> dict[str, Any]:
+        """Correlate a JSON-RPC response to an in-memory pending request."""
+        request_id = message.get("id")
+        with self._lock:
+            pending = self._pending_responses.get(request_id)
+            if pending is None:
+                return {
+                    "matched": False,
+                    "id": request_id,
+                    "response": message,
+                }
+
+            pending["response"] = message
+            pending["result"] = message.get("result")
+            pending["error"] = message.get("error")
+            pending["event"].set()
+            return {
+                "matched": True,
+                "id": request_id,
+                "result": pending["result"],
+                "error": pending["error"],
+            }
+
+    def _handle_notification(self, message: dict[str, Any]) -> BridgeEvent:
+        """Normalize and store a JSON-RPC notification."""
+        method = str(message.get("method", ""))
+        params = message.get("params", {})
+        payload = params if isinstance(params, dict) else {"params": params}
+        normalized_status = self._normalize_notification(method, payload)
+        return self._record_event(
+            raw_method=method,
+            normalized_status=normalized_status,
+            payload=payload,
+            raw_message=message,
+        )
+
+    def _handle_server_request(self, message: dict[str, Any]) -> BridgeEvent:
+        """Fail fast on server->client requests the bridge does not implement."""
+        request_id = message.get("id")
+        method = str(message.get("method", ""))
+        params = message.get("params", {})
+        payload = params if isinstance(params, dict) else {"params": params}
+        self._update_ids(payload)
+        error_message = (
+            f"Unsupported Codex app-server request: {method}. "
+            "Hermes bridge does not handle approval/input requests yet."
+        )
+        self._send_error_response(request_id, error_message)
+        event = self._record_event(
+            raw_method=method,
+            normalized_status=FAILED,
+            payload={
+                "error": {"message": error_message},
+                "server_request": payload,
+                "request_id": request_id,
+            },
+            raw_message=message,
+        )
+        with self._lock:
+            self.state.bridge_status = ERROR
+            for pending in self._pending_responses.values():
+                pending["error"] = {"message": error_message}
+                pending["event"].set()
+        return event
+
+    def get_status(self) -> dict[str, Any]:
+        with self._lock:
+            status = self.state.to_dict()
+            status["recent_event_count"] = len(self._recent_events)
+            status["process_running"] = self._process_is_running_locked()
+            status["reader_alive"] = (
+                self._reader_thread is not None and self._reader_thread.is_alive()
+            )
+            return status
+
+    def get_recent_events(self, limit: int | None = None) -> list[dict[str, Any]]:
+        with self._lock:
+            events = list(self._recent_events)
+        if limit is not None:
+            events = events[-max(0, int(limit)) :]
+        return [event.to_dict() for event in events]
+
+    def build_completion_event(self, event: BridgeEvent | None = None) -> dict[str, Any]:
+        """Build a Hermes completion-queue-compatible payload."""
+        with self._lock:
+            normalized_status = (
+                event.normalized_status if event is not None else self.state.normalized_status
+            )
+            identifier = self.state.turn_id or self.state.thread_id or "unknown"
+            last_error = self.state.last_error
+            route_metadata = dict(self._route_metadata)
+
+        failed = normalized_status == FAILED
+        exit_code = 1 if failed else 0
+        output = (
+            f"Codex turn failed via app-server: {last_error or 'unknown error'}"
+            if failed
+            else "Codex turn completed via app-server"
+        )
+        payload = {
+            "type": "completion",
+            "session_id": f"codex_turn_{identifier}",
+            "command": "codex app-server turn",
+            "exit_code": exit_code,
+            "output": output,
+        }
+        payload.update(route_metadata)
+        return payload
+
+    def get_last_completion_event(self) -> dict[str, Any] | None:
+        with self._lock:
+            if self._last_completion_event is None:
+                return None
+            return dict(self._last_completion_event)
+
+    def _record_event(
+        self,
+        *,
+        raw_method: str,
+        normalized_status: str,
+        payload: dict[str, Any],
+        raw_message: dict[str, Any] | None,
+    ) -> BridgeEvent:
+        now = float(self._clock())
+        event = BridgeEvent(
+            raw_method=raw_method,
+            normalized_status=normalized_status,
+            payload=dict(payload),
+            received_at=now,
+            raw_message=raw_message,
+        )
+
+        with self._lock:
+            previous_status = self.state.normalized_status
+            self._recent_events.append(event)
+            self.state.last_event_at = now
+            self._update_ids(payload)
+
+            if normalized_status != previous_status:
+                self.state.normalized_status = normalized_status
+            if normalized_status == FAILED:
+                self.state.last_error = self._extract_error(payload)
+            elif normalized_status == COMPLETED:
+                self.state.last_error = None
+
+            completion_event = None
+            if normalized_status in TERMINAL_STATUSES:
+                completion_event = self.build_completion_event(event)
+                if completion_event["session_id"] in self._enqueued_completion_sessions:
+                    completion_event = None
+                else:
+                    self._enqueued_completion_sessions.add(completion_event["session_id"])
+                    self._last_completion_event = dict(completion_event)
+
+        if completion_event is not None:
+            self._enqueue_completion_event(completion_event)
+
+        return event
+
+    @staticmethod
+    def _enqueue_completion_event(event: dict[str, Any]) -> None:
+        from tools.process_registry import process_registry
+
+        process_registry.completion_queue.put(dict(event))
+
+    def _reader_loop(self) -> None:
+        while not self._stop_reader.is_set():
+            with self._lock:
+                process = self._process
+                stdout = getattr(process, "stdout", None) if process is not None else None
+            if stdout is None:
+                return
+            try:
+                line = stdout.readline()
+            except ValueError:
+                return
+            except Exception as exc:
+                if not self._stop_reader.is_set():
+                    self._set_transport_error(f"Codex app-server reader failed: {exc}")
+                return
+            if line == "":
+                if not self._stop_reader.is_set():
+                    self._set_transport_error("Codex app-server stdout closed")
+                return
+            self._handle_incoming_line(line)
+
+    def _write_json(self, message: dict[str, Any]) -> None:
+        line = json.dumps(message, ensure_ascii=False) + "\n"
+        with self._lock:
+            process = self._process
+            stdin = getattr(process, "stdin", None) if process is not None else None
+        if stdin is None:
+            raise CodexAppServerBridgeError("Codex app-server stdin is closed")
+        with self._write_lock:
+            stdin.write(line)
+            stdin.flush()
+
+    def _send_error_response(self, request_id: Any, message: str) -> None:
+        if request_id is None:
+            return
+        try:
+            self._write_json(
+                {
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "error": {
+                        "code": -32000,
+                        "message": message,
+                    },
+                }
+            )
+        except Exception:
+            # Best-effort only — the bridge should still surface the failure locally.
+            return
+
+    def _process_is_running_locked(self) -> bool:
+        return self._process is not None and self._process.poll() is None
+
+    def _set_transport_error(self, message: str) -> None:
+        with self._lock:
+            self.state.bridge_status = ERROR
+            self.state.normalized_status = FAILED
+            self.state.last_error = message
+
+    @staticmethod
+    def _close_pipe(pipe: Any) -> None:
+        if pipe is not None:
+            try:
+                pipe.close()
+            except Exception:
+                pass
+
+    @staticmethod
+    def _format_response_error(error: Any) -> str:
+        if isinstance(error, dict):
+            message = error.get("message") or error.get("detail") or error.get("code")
+            if message is not None:
+                return str(message)
+            return json.dumps(error, ensure_ascii=False)
+        return str(error)
+
+    @staticmethod
+    def _extract_id(result: Any, *keys: str) -> str | None:
+        if not isinstance(result, dict):
+            return None
+        for key in keys:
+            if "." in key:
+                parts = key.split(".")
+                value: Any = result
+                for part in parts:
+                    if not isinstance(value, dict):
+                        value = None
+                        break
+                    value = value.get(part)
+            else:
+                value = result.get(key)
+            if value is not None and value != "":
+                return str(value)
+        return None
+
+    def _normalize_notification(self, method: str, payload: dict[str, Any]) -> str:
+        method_l = method.lower()
+        status = _lower_string(payload.get("status"))
+        event_type = _lower_string(payload.get("type"))
+        combined = " ".join(part for part in (method_l, status, event_type) if part)
+
+        if _contains_any(combined, ("error", "failed", "failure", "exception", "crash")):
+            return FAILED
+        if _contains_any(combined, ("complete", "completed", "success", "succeeded", "finished", "done")):
+            return COMPLETED
+        if _contains_any(
+            combined,
+            ("waiting", "input", "approval", "permission", "confirm", "requires_action"),
+        ):
+            return WAITING_FOR_INPUT
+        if _contains_any(combined, ("diff", "patch", "file", "fs", "workspace")):
+            return DIFF_UPDATED
+        if _contains_any(
+            combined,
+            ("delta", "message", "agent", "progress", "started", "start", "running", "turn"),
+        ):
+            return RUNNING
+        if any(key in payload for key in ("diff", "patch", "files", "file_changes")):
+            return DIFF_UPDATED
+        if "error" in payload:
+            return FAILED
+        return self.state.normalized_status
+
+    def _update_ids(self, payload: dict[str, Any]) -> None:
+        thread_id = _first_string(
+            payload.get("thread_id"),
+            payload.get("threadId"),
+            _nested_string(payload, "thread", "id"),
+            _nested_string(payload, "conversation", "id"),
+        )
+        turn_id = _first_string(
+            payload.get("turn_id"),
+            payload.get("turnId"),
+            _nested_string(payload, "turn", "id"),
+        )
+        if thread_id:
+            self.state.thread_id = thread_id
+        if turn_id:
+            self.state.turn_id = turn_id
+
+    def _extract_error(self, payload: dict[str, Any]) -> str | None:
+        error = payload.get("error")
+        if isinstance(error, dict):
+            message = error.get("message") or error.get("detail") or error.get("code")
+            return str(message) if message is not None else json.dumps(error, ensure_ascii=False)
+        if error is not None:
+            return str(error)
+        for key in ("message", "detail", "reason"):
+            value = payload.get(key)
+            if value is not None:
+                return str(value)
+        return None
+
+
+def _contains_any(value: str, needles: tuple[str, ...]) -> bool:
+    return any(needle in value for needle in needles)
+
+
+def _lower_string(value: Any) -> str:
+    return value.lower() if isinstance(value, str) else ""
+
+
+def _nested_string(payload: dict[str, Any], outer: str, inner: str) -> str | None:
+    value = payload.get(outer)
+    if isinstance(value, dict):
+        nested = value.get(inner)
+        if nested is not None:
+            return str(nested)
+    return None
+
+
+def _first_string(*values: Any) -> str | None:
+    for value in values:
+        if value is not None and value != "":
+            return str(value)
+    return None

--- a/cli.py
+++ b/cli.py
@@ -1182,6 +1182,7 @@ def _format_process_notification(evt: dict) -> "str | None":
     evt_type = evt.get("type", "completion")
     _sid = evt.get("session_id", "unknown")
     _cmd = evt.get("command", "unknown")
+    _is_codex_turn = isinstance(_sid, str) and _sid.startswith("codex_turn_")
 
     if evt_type == "watch_disabled":
         return f"[SYSTEM: {evt.get('message', '')}]"
@@ -1204,6 +1205,16 @@ def _format_process_notification(evt: dict) -> "str | None":
     # Default: completion event
     _exit = evt.get("exit_code", "?")
     _out = evt.get("output", "")
+    if _is_codex_turn:
+        _state = "completed" if _exit == 0 else "failed"
+        return (
+            f"[SYSTEM: Codex app-server turn {_state} "
+            f"(exit code {_exit}).\n"
+            f"Session: {_sid}\n"
+            f"Command: {_cmd}\n"
+            f"Output:\n{_out}\n"
+            f"Verify git diff and run relevant tests before declaring success.]"
+        )
     return (
         f"[SYSTEM: Background process {_sid} completed "
         f"(exit code {_exit}).\n"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -483,10 +483,11 @@ def _resolve_hermes_bin() -> Optional[list[str]]:
 
 
 def _format_gateway_process_notification(evt: dict) -> "str | None":
-    """Format a watch pattern event from completion_queue into a [SYSTEM:] message."""
+    """Format a completion_queue event into a [SYSTEM:] message."""
     evt_type = evt.get("type", "completion")
     _sid = evt.get("session_id", "unknown")
     _cmd = evt.get("command", "unknown")
+    _is_codex_turn = isinstance(_sid, str) and _sid.startswith("codex_turn_")
 
     if evt_type == "watch_disabled":
         return f"[SYSTEM: {evt.get('message', '')}]"
@@ -505,6 +506,19 @@ def _format_gateway_process_notification(evt: dict) -> "str | None":
             text += f"\n({_sup} earlier matches were suppressed by rate limit)"
         text += "]"
         return text
+
+    if evt_type == "completion" and _is_codex_turn:
+        _exit = evt.get("exit_code", "?")
+        _out = evt.get("output", "")
+        _state = "completed" if _exit == 0 else "failed"
+        return (
+            f"[SYSTEM: Codex app-server turn {_state} "
+            f"(exit code {_exit}).\n"
+            f"Session: {_sid}\n"
+            f"Command: {_cmd}\n"
+            f"Output:\n{_out}\n"
+            f"Verify git diff and run relevant tests before declaring success.]"
+        )
 
     return None
 
@@ -3664,24 +3678,27 @@ class GatewayRunner:
             except Exception as e:
                 logger.error("Process watcher setup error: %s", e)
 
-            # Drain watch pattern notifications that arrived during the agent run.
-            # Watch events and completions share the same queue; completions are
-            # already handled by the per-process watcher task above, so we only
-            # inject watch-type events here.
+            # Drain notifications that arrived during the agent run. Watch events
+            # and Codex bridge completions are injected here; ordinary background
+            # process completions are handled by the per-process watcher task.
             try:
                 from tools.process_registry import process_registry as _pr
                 _watch_events = []
                 while not _pr.completion_queue.empty():
                     evt = _pr.completion_queue.get_nowait()
                     evt_type = evt.get("type", "completion")
-                    if evt_type in ("watch_match", "watch_disabled"):
+                    session_id = evt.get("session_id", "")
+                    is_codex_turn = isinstance(session_id, str) and session_id.startswith("codex_turn_")
+                    if evt_type in ("watch_match", "watch_disabled") or (
+                        evt_type == "completion" and is_codex_turn
+                    ):
                         _watch_events.append(evt)
                     # else: completion events are handled by the watcher task
                 for evt in _watch_events:
                     synth_text = _format_gateway_process_notification(evt)
                     if synth_text:
                         try:
-                            await self._inject_watch_notification(synth_text, event)
+                            await self._inject_watch_notification(synth_text, event, evt)
                         except Exception as e2:
                             logger.error("Watch notification injection error: %s", e2)
             except Exception as e:
@@ -7153,16 +7170,46 @@ class GatewayRunner:
             return prefix
         return user_text
 
-    async def _inject_watch_notification(self, synth_text: str, original_event) -> None:
-        """Inject a watch-pattern notification as a synthetic message event.
+    async def _inject_watch_notification(self, synth_text: str, original_event, routing_event: dict | None = None) -> None:
+        """Inject a completion/watch notification as a synthetic message event.
 
-        Uses the source from the original user event to route the notification
-        back to the correct chat/adapter.
+        Prefer explicit routing metadata embedded in the queued event when present
+        (used by Codex app-server completions). Otherwise fall back to the source
+        from the original user event.
         """
-        source = getattr(original_event, "source", None)
-        if not source:
-            return
-        platform_name = source.platform.value if hasattr(source.platform, "value") else str(source.platform)
+        source = None
+        platform_name = ""
+        chat_id = ""
+        thread_id = ""
+        user_id = None
+        user_name = None
+        chat_name = None
+        if routing_event:
+            platform_name = routing_event.get("platform", "") or ""
+            chat_id = routing_event.get("chat_id", "") or ""
+            thread_id = routing_event.get("thread_id", "") or ""
+            user_id = routing_event.get("user_id") or None
+            user_name = routing_event.get("user_name") or None
+            chat_name = routing_event.get("chat_name") or None
+            if platform_name and chat_id:
+                try:
+                    from gateway.session import SessionSource
+                    from gateway.config import Platform
+                    source = SessionSource(
+                        platform=Platform(platform_name),
+                        chat_id=chat_id,
+                        chat_name=chat_name,
+                        thread_id=thread_id or None,
+                        user_id=user_id,
+                        user_name=user_name,
+                    )
+                except Exception:
+                    source = None
+        if source is None:
+            source = getattr(original_event, "source", None)
+            if not source:
+                return
+            platform_name = source.platform.value if hasattr(source.platform, "value") else str(source.platform)
         adapter = None
         for p, a in self.adapters.items():
             if p.value == platform_name:

--- a/model_tools.py
+++ b/model_tools.py
@@ -156,6 +156,7 @@ def _discover_tools():
         "tools.delegate_tool",
         "tools.process_registry",
         "tools.send_message_tool",
+        "tools.codex_app_server_tool",
         # "tools.honcho_tools",  # Removed — Honcho is now a memory provider plugin
         "tools.homeassistant_tool",
     ]

--- a/tests/agent/test_codex_app_server_bridge.py
+++ b/tests/agent/test_codex_app_server_bridge.py
@@ -1,0 +1,429 @@
+import json
+import queue
+import time
+
+import pytest
+
+from agent.codex_app_server_bridge import (
+    COMPLETED,
+    DIFF_UPDATED,
+    FAILED,
+    RUNNING,
+    START_THREAD_METHOD,
+    START_TURN_METHOD,
+    CodexAppServerTimeoutError,
+    CodexAppServerBridge,
+)
+from hermes_cli import __version__ as HERMES_VERSION
+from tools.process_registry import process_registry
+
+
+class FakeStdout:
+    def __init__(self):
+        self._lines = queue.Queue()
+        self.closed = False
+
+    def push_json(self, message):
+        self._lines.put(json.dumps(message) + "\n")
+
+    def readline(self):
+        while not self.closed:
+            try:
+                line = self._lines.get(timeout=0.01)
+            except queue.Empty:
+                continue
+            if line is None:
+                return ""
+            return line
+        return ""
+
+    def close(self):
+        self.closed = True
+        self._lines.put(None)
+
+
+class FakeStdin:
+    def __init__(self, stdout, *, auto_respond=True):
+        self.stdout = stdout
+        self.auto_respond = auto_respond
+        self.writes = []
+        self.closed = False
+
+    def write(self, line):
+        self.writes.append(line)
+        if not self.auto_respond:
+            return
+        message = json.loads(line)
+        method = message.get("method")
+        if method is None:
+            return
+        if method == "initialize":
+            result = {"server": "fake-codex"}
+        elif method == START_THREAD_METHOD:
+            result = {"thread": {"id": "thread-123"}}
+        elif method == START_TURN_METHOD:
+            result = {"turn": {"id": "turn-456"}}
+        else:
+            result = {"ok": True}
+        self.stdout.push_json({"jsonrpc": "2.0", "id": message["id"], "result": result})
+
+    def flush(self):
+        pass
+
+    def close(self):
+        self.closed = True
+
+
+class FakeProcess:
+    def __init__(self, *, auto_respond=True):
+        self.stdout = FakeStdout()
+        self.stdin = FakeStdin(self.stdout, auto_respond=auto_respond)
+        self.returncode = None
+        self.terminated = False
+        self.killed = False
+
+    def poll(self):
+        return self.returncode
+
+    def terminate(self):
+        self.terminated = True
+        self.returncode = -15
+        self.stdout.close()
+
+    def kill(self):
+        self.killed = True
+        self.returncode = -9
+        self.stdout.close()
+
+    def wait(self, timeout=None):
+        deadline = time.time() + (timeout or 0)
+        while self.returncode is None and (timeout is None or time.time() < deadline):
+            time.sleep(0.001)
+        if self.returncode is None:
+            raise TimeoutError()
+        return self.returncode
+
+
+def _drain_completion_queue():
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+
+
+@pytest.fixture(autouse=True)
+def clean_completion_queue():
+    _drain_completion_queue()
+    yield
+    _drain_completion_queue()
+
+
+def test_response_correlation_works_for_matching_request_id():
+    bridge = CodexAppServerBridge()
+    request_id = bridge._next_request_id()
+    pending = bridge._register_pending_request(request_id)
+
+    result = bridge._handle_incoming_line(
+        json.dumps({"jsonrpc": "2.0", "id": request_id, "result": {"ok": True}})
+    )
+
+    assert result["matched"] is True
+    assert result["id"] == request_id
+    assert pending["event"].is_set()
+    assert pending["result"] == {"ok": True}
+    assert pending["error"] is None
+
+
+def test_start_bootstraps_subprocess_and_waits_for_initialize():
+    created = []
+
+    def popen_factory(args, **kwargs):
+        process = FakeProcess()
+        created.append((args, kwargs, process))
+        return process
+
+    bridge = CodexAppServerBridge(popen_factory=popen_factory)
+
+    status = bridge.start(timeout=1)
+
+    assert status["bridge_status"] == "ready"
+    assert status["initialize_result"] == {"server": "fake-codex"}
+    assert created[0][0] == ["codex", "app-server", "--listen", "stdio://"]
+    assert created[0][1]["text"] is True
+    initialize_request = json.loads(created[0][2].stdin.writes[0])
+    assert initialize_request["method"] == "initialize"
+    assert initialize_request["params"] == {
+        "clientInfo": {
+            "name": "hermes-agent",
+            "version": HERMES_VERSION,
+        }
+    }
+
+    stopped = bridge.stop()
+    assert stopped["bridge_status"] == "stopped"
+    assert created[0][2].terminated is True
+
+
+def test_start_marks_error_when_initialize_times_out():
+    created = []
+
+    def popen_factory(args, **kwargs):
+        process = FakeProcess(auto_respond=False)
+        created.append(process)
+        return process
+
+    bridge = CodexAppServerBridge(popen_factory=popen_factory)
+
+    try:
+        bridge.start(timeout=0.02)
+    except CodexAppServerTimeoutError as exc:
+        assert "initialize" in str(exc)
+    else:
+        raise AssertionError("expected initialize timeout")
+
+    status = bridge.get_status()
+    assert status["bridge_status"] == "error"
+    assert status["normalized_status"] == FAILED
+    assert "initialize failed" in status["last_error"]
+    assert created[0].terminated is True
+
+
+def test_start_turn_sends_schema_thread_and_turn_requests():
+    created = []
+
+    def popen_factory(args, **kwargs):
+        process = FakeProcess()
+        created.append(process)
+        return process
+
+    bridge = CodexAppServerBridge(popen_factory=popen_factory)
+    bridge.start(timeout=1)
+
+    result = bridge.start_turn(
+        repo_path="/tmp/example-repo",
+        prompt="make the change",
+        timeout=1,
+    )
+
+    assert result["thread_id"] == "thread-123"
+    assert result["turn_id"] == "turn-456"
+    assert result["methods"] == {
+        "start_thread": "thread/start",
+        "start_turn": "turn/start",
+    }
+
+    writes = [json.loads(line) for line in created[0].stdin.writes]
+    assert writes[1]["method"] == "thread/start"
+    assert writes[1]["params"] == {"cwd": "/tmp/example-repo"}
+    assert writes[2]["method"] == "turn/start"
+    assert writes[2]["params"] == {
+        "threadId": "thread-123",
+        "input": [
+            {
+                "type": "text",
+                "text": "make the change",
+            }
+        ],
+    }
+    assert bridge.get_status()["normalized_status"] == RUNNING
+    assert bridge.get_status()["bridge_status"] == "ready"
+    bridge.stop()
+
+
+def test_server_request_fails_fast_and_replies_with_error():
+    created = []
+
+    def popen_factory(args, **kwargs):
+        process = FakeProcess()
+        created.append(process)
+        return process
+
+    bridge = CodexAppServerBridge(popen_factory=popen_factory)
+    bridge.start(timeout=1)
+    bridge.state.turn_id = "turn-req-1"
+    pending = bridge._register_pending_request(1234)
+
+    event = bridge._handle_incoming_line(
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 99,
+                "method": "approval/request",
+                "params": {"reason": "need approval"},
+            }
+        )
+    )
+
+    assert event.normalized_status == FAILED
+    assert bridge.get_status()["bridge_status"] == "error"
+    assert "Unsupported Codex app-server request: approval/request" in bridge.get_status()["last_error"]
+    assert pending["event"].is_set()
+    assert pending["error"] == {
+        "message": (
+            "Unsupported Codex app-server request: approval/request. "
+            "Hermes bridge does not handle approval/input requests yet."
+        )
+    }
+
+    queued = process_registry.completion_queue.get_nowait()
+    assert queued["session_id"] == "codex_turn_turn-req-1"
+    assert queued["exit_code"] == 1
+
+    writes = [json.loads(line) for line in created[0].stdin.writes]
+    assert writes[-1] == {
+        "jsonrpc": "2.0",
+        "id": 99,
+        "error": {
+            "code": -32000,
+            "message": (
+                "Unsupported Codex app-server request: approval/request. "
+                "Hermes bridge does not handle approval/input requests yet."
+            ),
+        },
+    }
+
+    bridge.stop()
+
+
+def test_notification_normalization_updates_state_and_stores_recent_events():
+    bridge = CodexAppServerBridge(clock=lambda: 123.0)
+
+    event = bridge._handle_incoming_line(
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "method": "codex/turn/delta",
+                "params": {"thread_id": "thread-1", "turn_id": "turn-1", "text": "hi"},
+            }
+        )
+    )
+
+    assert event.raw_method == "codex/turn/delta"
+    assert event.normalized_status == RUNNING
+    assert bridge.get_status()["normalized_status"] == RUNNING
+    assert bridge.get_status()["thread_id"] == "thread-1"
+    assert bridge.get_status()["turn_id"] == "turn-1"
+
+    diff_event = bridge._handle_incoming_line(
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "method": "codex/diff_updated",
+                "params": {"files": ["agent/example.py"]},
+            }
+        )
+    )
+
+    recent_events = bridge.get_recent_events()
+    assert diff_event.normalized_status == DIFF_UPDATED
+    assert bridge.get_status()["normalized_status"] == DIFF_UPDATED
+    assert [event["raw_method"] for event in recent_events] == [
+        "codex/turn/delta",
+        "codex/diff_updated",
+    ]
+    assert recent_events[-1]["payload"] == {"files": ["agent/example.py"]}
+    assert recent_events[-1]["received_at"] == 123.0
+
+
+def test_completion_notification_yields_completed_status():
+    bridge = CodexAppServerBridge()
+
+    event = bridge._handle_notification(
+        {
+            "jsonrpc": "2.0",
+            "method": "codex/turn/completed",
+            "params": {"turn_id": "turn-2"},
+        }
+    )
+
+    assert event.normalized_status == COMPLETED
+    assert bridge.get_status()["normalized_status"] == COMPLETED
+    assert bridge.get_last_completion_event()["exit_code"] == 0
+    queued = process_registry.completion_queue.get_nowait()
+    assert queued == {
+        "type": "completion",
+        "session_id": "codex_turn_turn-2",
+        "command": "codex app-server turn",
+        "exit_code": 0,
+        "output": "Codex turn completed via app-server",
+    }
+
+
+def test_error_notification_yields_failed_status():
+    bridge = CodexAppServerBridge()
+
+    event = bridge._handle_notification(
+        {
+            "jsonrpc": "2.0",
+            "method": "codex/error",
+            "params": {"turn_id": "turn-3", "error": {"message": "boom"}},
+        }
+    )
+
+    assert event.normalized_status == FAILED
+    assert bridge.get_status()["normalized_status"] == FAILED
+    assert bridge.get_status()["last_error"] == "boom"
+    assert bridge.get_last_completion_event()["exit_code"] == 1
+    queued = process_registry.completion_queue.get_nowait()
+    assert queued["session_id"] == "codex_turn_turn-3"
+    assert queued["command"] == "codex app-server turn"
+    assert queued["exit_code"] == 1
+    assert queued["output"] == "Codex turn failed via app-server: boom"
+
+
+def test_repeated_terminal_notification_enqueues_once():
+    bridge = CodexAppServerBridge()
+
+    notification = {
+        "jsonrpc": "2.0",
+        "method": "codex/turn/completed",
+        "params": {"turn_id": "turn-dupe"},
+    }
+    bridge._handle_notification(notification)
+    bridge._handle_notification(notification)
+
+    assert process_registry.completion_queue.qsize() == 1
+    queued = process_registry.completion_queue.get_nowait()
+    assert queued["session_id"] == "codex_turn_turn-dupe"
+
+
+def test_unknown_notification_methods_are_stored_safely_without_failure():
+    bridge = CodexAppServerBridge()
+
+    event = bridge._handle_incoming_line(
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "method": "codex/unexpected_new_event",
+                "params": {"shape": {"can": "drift"}},
+            }
+        )
+    )
+
+    assert event.raw_method == "codex/unexpected_new_event"
+    assert event.normalized_status == "idle"
+    assert bridge.get_status()["normalized_status"] == "idle"
+    assert bridge.get_recent_events()[0]["payload"] == {"shape": {"can": "drift"}}
+
+
+def test_synthetic_completion_event_payload_has_expected_minimal_keys():
+    bridge = CodexAppServerBridge()
+    bridge.set_route_metadata(platform="local", chat_id="cli", user_id="user-1")
+    bridge._handle_notification(
+        {
+            "jsonrpc": "2.0",
+            "method": "codex/turn/completed",
+            "params": {"turn_id": "turn-4"},
+        }
+    )
+
+    payload = bridge.build_completion_event()
+
+    assert payload == {
+        "type": "completion",
+        "session_id": "codex_turn_turn-4",
+        "command": "codex app-server turn",
+        "exit_code": 0,
+        "output": "Codex turn completed via app-server",
+        "platform": "local",
+        "chat_id": "cli",
+        "user_id": "user-1",
+    }

--- a/tests/test_codex_app_server_notifications.py
+++ b/tests/test_codex_app_server_notifications.py
@@ -1,0 +1,97 @@
+import asyncio
+import sys
+import types
+
+
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+sys.modules.setdefault("fal_client", types.SimpleNamespace())
+
+from cli import _format_process_notification
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner, _format_gateway_process_notification
+from gateway.session import SessionSource
+
+
+def _codex_completion(exit_code=0):
+    return {
+        "type": "completion",
+        "session_id": "codex_turn_turn-123",
+        "command": "codex app-server turn",
+        "exit_code": exit_code,
+        "output": "Codex turn completed via app-server",
+    }
+
+
+def test_cli_formats_codex_completion_as_codex_turn_notification():
+    text = _format_process_notification(_codex_completion())
+
+    assert "Codex app-server turn completed" in text
+    assert "Session: codex_turn_turn-123" in text
+    assert "Verify git diff and run relevant tests" in text
+
+
+def test_gateway_formats_codex_completion_as_codex_turn_notification():
+    text = _format_gateway_process_notification(_codex_completion(exit_code=1))
+
+    assert "Codex app-server turn failed" in text
+    assert "Session: codex_turn_turn-123" in text
+    assert "Verify git diff and run relevant tests" in text
+
+
+def test_gateway_leaves_regular_completion_to_process_watcher():
+    text = _format_gateway_process_notification(
+        {
+            "type": "completion",
+            "session_id": "proc_123",
+            "command": "pytest",
+            "exit_code": 0,
+            "output": "ok",
+        }
+    )
+
+    assert text is None
+
+
+def test_gateway_inject_watch_notification_prefers_routing_event_metadata():
+    class FakeAdapter:
+        def __init__(self):
+            self.events = []
+
+        async def handle_message(self, event):
+            self.events.append(event)
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    adapter = FakeAdapter()
+    runner.adapters = {Platform.LOCAL: adapter}
+
+    original_event = MessageEvent(
+        text="original",
+        message_type=MessageType.TEXT,
+        source=SessionSource(platform=Platform.LOCAL, chat_id="original-chat", user_id="u1"),
+    )
+
+    routing_event = {
+        "platform": "local",
+        "chat_id": "target-chat",
+        "thread_id": "thread-42",
+        "user_id": "user-42",
+        "user_name": "Dongwoo",
+        "chat_name": "CLI",
+    }
+
+    asyncio.run(
+        runner._inject_watch_notification(
+            "[SYSTEM: Codex app-server turn completed]",
+            original_event,
+            routing_event,
+        )
+    )
+
+    assert len(adapter.events) == 1
+    injected = adapter.events[0]
+    assert injected.internal is True
+    assert injected.source.chat_id == "target-chat"
+    assert injected.source.thread_id == "thread-42"
+    assert injected.source.user_id == "user-42"

--- a/tests/tools/test_codex_app_server_tool.py
+++ b/tests/tools/test_codex_app_server_tool.py
@@ -1,0 +1,161 @@
+import json
+
+import pytest
+
+import tools.codex_app_server_tool as tool
+
+
+class FakeBridge:
+    def __init__(self):
+        self.started = False
+        self.stopped = False
+        self.turns = []
+
+    def start(self, *, timeout):
+        self.started = True
+        return {"bridge_status": "ready", "timeout": timeout}
+
+    def stop(self):
+        self.stopped = True
+        return {"bridge_status": "stopped"}
+
+    def get_status(self):
+        return {"bridge_status": "ready", "normalized_status": "idle"}
+
+    def get_recent_events(self, limit):
+        return [{"raw_method": "codex/example", "limit": limit}]
+
+    def start_turn(self, *, repo_path, prompt, timeout):
+        self.turns.append((repo_path, prompt, timeout))
+        return {
+            "thread_id": "thread-1",
+            "turn_id": "turn-1",
+            "status": {"normalized_status": "running"},
+        }
+
+
+@pytest.fixture(autouse=True)
+def reset_bridge_singleton():
+    tool._set_bridge_for_tests(None)
+    yield
+    tool._set_bridge_for_tests(None)
+
+
+def test_unknown_action_returns_json_error():
+    result = json.loads(tool.codex_app_server_tool(action="bogus"))
+
+    assert "error" in result
+    assert "Unknown action" in result["error"]
+
+
+def test_start_bridge_returns_success_status(monkeypatch):
+    fake = FakeBridge()
+    monkeypatch.setattr(tool, "CodexAppServerBridge", lambda: fake)
+
+    result = json.loads(tool.codex_app_server_tool(action="start_bridge", timeout_seconds=1.5))
+
+    assert result == {
+        "success": True,
+        "action": "start_bridge",
+        "status": {"bridge_status": "ready", "timeout": 1.5},
+    }
+    assert fake.started is True
+
+
+def test_status_without_bridge_is_stopped_shape():
+    result = json.loads(tool.codex_app_server_tool(action="status"))
+
+    assert result["success"] is True
+    assert result["action"] == "status"
+    assert result["status"] == {"bridge_status": "stopped"}
+    assert result["methods"] == {
+        "start_thread": "thread/start",
+        "start_turn": "turn/start",
+    }
+
+
+def test_events_returns_limited_recent_events():
+    fake = FakeBridge()
+    tool._set_bridge_for_tests(fake)
+
+    result = json.loads(tool.codex_app_server_tool(action="events", limit=7))
+
+    assert result["success"] is True
+    assert result["count"] == 1
+    assert result["events"] == [{"raw_method": "codex/example", "limit": 7}]
+
+
+def test_start_turn_validates_required_fields():
+    tool._set_bridge_for_tests(FakeBridge())
+
+    missing_repo = json.loads(tool.codex_app_server_tool(action="start_turn", prompt="hi"))
+    missing_prompt = json.loads(tool.codex_app_server_tool(action="start_turn", repo_path="/tmp/repo"))
+
+    assert missing_repo["error"] == "repo_path is required for start_turn"
+    assert missing_prompt["error"] == "prompt is required for start_turn"
+
+
+def test_start_turn_requires_started_bridge():
+    result = json.loads(
+        tool.codex_app_server_tool(
+            action="start_turn",
+            repo_path="/tmp/repo",
+            prompt="hi",
+        )
+    )
+
+    assert result["error"] == "Bridge is not started. Call start_bridge first."
+
+
+def test_start_turn_returns_bridge_result():
+    fake = FakeBridge()
+    tool._set_bridge_for_tests(fake)
+
+    result = json.loads(
+        tool.codex_app_server_tool(
+            action="start_turn",
+            repo_path="/tmp/repo",
+            prompt="hi",
+            timeout_seconds=2,
+        )
+    )
+
+    assert result["success"] is True
+    assert result["action"] == "start_turn"
+    assert result["thread_id"] == "thread-1"
+    assert result["turn_id"] == "turn-1"
+    assert result["result"]["thread_id"] == "thread-1"
+    assert result["result"]["turn_id"] == "turn-1"
+    assert fake.turns == [("/tmp/repo", "hi", 2.0)]
+
+
+def test_start_job_starts_bridge_and_turn_in_one_call(monkeypatch):
+    fake = FakeBridge()
+    monkeypatch.setattr(tool, "CodexAppServerBridge", lambda: fake)
+
+    result = json.loads(
+        tool.codex_app_server_tool(
+            action="start_job",
+            repo_path="/tmp/repo",
+            prompt="do the work",
+            timeout_seconds=3,
+        )
+    )
+
+    assert result["success"] is True
+    assert result["action"] == "start_job"
+    assert result["thread_id"] == "thread-1"
+    assert result["turn_id"] == "turn-1"
+    assert result["status"] == {"normalized_status": "running"}
+    assert result["bridge_start_status"] == {"bridge_status": "ready", "timeout": 3.0}
+    assert result["result"]["thread_id"] == "thread-1"
+    assert fake.started is True
+    assert fake.turns == [("/tmp/repo", "do the work", 3.0)]
+
+
+def test_start_job_validates_required_fields():
+    missing_repo = json.loads(tool.codex_app_server_tool(action="start_job", prompt="hi"))
+    missing_prompt = json.loads(tool.codex_app_server_tool(action="start_job", repo_path="/tmp/repo"))
+
+    assert missing_repo["error"] == "repo_path is required for start_job"
+    assert missing_prompt["error"] == "prompt is required for start_job"

--- a/tools/codex_app_server_tool.py
+++ b/tools/codex_app_server_tool.py
@@ -1,0 +1,251 @@
+"""Minimal tool wrapper for the process-local Codex app-server bridge."""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+from gateway.session_context import get_session_env
+from agent.codex_app_server_bridge import (
+    DEFAULT_INITIALIZE_TIMEOUT_SECONDS,
+    DEFAULT_REQUEST_TIMEOUT_SECONDS,
+    START_THREAD_METHOD,
+    START_TURN_METHOD,
+    CodexAppServerBridge,
+    CodexAppServerBridgeError,
+    CodexAppServerTimeoutError,
+)
+from tools.registry import registry, tool_error, tool_result
+
+
+_ACTIONS = ("start_bridge", "stop_bridge", "start_turn", "start_job", "status", "events")
+_bridges: dict[str, CodexAppServerBridge] = {}
+_bridge_lock = threading.RLock()
+
+
+def _session_bridge_key() -> str:
+    session_key = get_session_env("HERMES_SESSION_KEY", "")
+    if session_key:
+        return session_key
+    platform = get_session_env("HERMES_SESSION_PLATFORM", "") or "local"
+    chat_id = get_session_env("HERMES_SESSION_CHAT_ID", "") or "local"
+    thread_id = get_session_env("HERMES_SESSION_THREAD_ID", "")
+    return f"{platform}:{chat_id}:{thread_id}"
+
+
+def _current_route_metadata() -> dict[str, str]:
+    metadata = {
+        "platform": get_session_env("HERMES_SESSION_PLATFORM", ""),
+        "chat_id": get_session_env("HERMES_SESSION_CHAT_ID", ""),
+        "chat_name": get_session_env("HERMES_SESSION_CHAT_NAME", ""),
+        "thread_id": get_session_env("HERMES_SESSION_THREAD_ID", ""),
+        "user_id": get_session_env("HERMES_SESSION_USER_ID", ""),
+        "user_name": get_session_env("HERMES_SESSION_USER_NAME", ""),
+        "session_key": _session_bridge_key(),
+    }
+    return {key: value for key, value in metadata.items() if value}
+
+
+def _get_bridge() -> CodexAppServerBridge:
+    key = _session_bridge_key()
+    with _bridge_lock:
+        bridge = _bridges.get(key)
+        if bridge is None:
+            bridge = CodexAppServerBridge()
+            _bridges[key] = bridge
+        if hasattr(bridge, "set_route_metadata"):
+            bridge.set_route_metadata(**_current_route_metadata())
+        return bridge
+
+
+def _current_bridge() -> CodexAppServerBridge | None:
+    key = _session_bridge_key()
+    with _bridge_lock:
+        bridge = _bridges.get(key)
+        if bridge is not None and hasattr(bridge, "set_route_metadata"):
+            bridge.set_route_metadata(**_current_route_metadata())
+        return bridge
+
+
+def _clear_bridge() -> None:
+    key = _session_bridge_key()
+    with _bridge_lock:
+        _bridges.pop(key, None)
+
+
+def _set_bridge_for_tests(bridge: CodexAppServerBridge | None) -> None:
+    key = _session_bridge_key()
+    with _bridge_lock:
+        if bridge is None:
+            _bridges.pop(key, None)
+        else:
+            _bridges[key] = bridge
+
+
+def _coerce_timeout(value: Any, default: float) -> float:
+    if value is None or value == "":
+        return default
+    try:
+        timeout = float(value)
+    except (TypeError, ValueError):
+        raise ValueError("timeout_seconds must be a number")
+    if timeout <= 0:
+        raise ValueError("timeout_seconds must be greater than 0")
+    return min(timeout, 300.0)
+
+
+def _coerce_limit(value: Any) -> int:
+    if value is None or value == "":
+        return 20
+    try:
+        limit = int(value)
+    except (TypeError, ValueError):
+        raise ValueError("limit must be an integer")
+    return max(0, min(limit, 200))
+
+
+def codex_app_server_tool(
+    *,
+    action: str,
+    repo_path: str | None = None,
+    prompt: str | None = None,
+    limit: int | None = None,
+    timeout_seconds: float | None = None,
+) -> str:
+    """Dispatch a small set of Codex app-server bridge actions."""
+    action = (action or "").strip()
+    if action not in _ACTIONS:
+        return tool_error(f"Unknown action: {action}. Use one of: {', '.join(_ACTIONS)}")
+
+    try:
+        if action == "start_bridge":
+            timeout = _coerce_timeout(timeout_seconds, DEFAULT_INITIALIZE_TIMEOUT_SECONDS)
+            bridge = _get_bridge()
+            return tool_result(
+                success=True,
+                action=action,
+                status=bridge.start(timeout=timeout),
+            )
+
+        if action == "stop_bridge":
+            bridge = _current_bridge()
+            if bridge is None:
+                return tool_result(
+                    success=True,
+                    action=action,
+                    status={"bridge_status": "stopped"},
+                )
+            status = bridge.stop()
+            _clear_bridge()
+            return tool_result(success=True, action=action, status=status)
+
+        if action == "status":
+            bridge = _current_bridge()
+            status = bridge.get_status() if bridge is not None else {"bridge_status": "stopped"}
+            return tool_result(
+                success=True,
+                action=action,
+                status=status,
+                methods={
+                    "start_thread": START_THREAD_METHOD,
+                    "start_turn": START_TURN_METHOD,
+                },
+            )
+
+        if action == "events":
+            bridge = _current_bridge()
+            event_limit = _coerce_limit(limit)
+            events = bridge.get_recent_events(event_limit) if bridge is not None else []
+            return tool_result(
+                success=True,
+                action=action,
+                events=events,
+                count=len(events),
+            )
+
+        if action in ("start_turn", "start_job"):
+            if not repo_path:
+                return tool_error(f"repo_path is required for {action}")
+            if not prompt or not str(prompt).strip():
+                return tool_error(f"prompt is required for {action}")
+            bridge = _get_bridge() if action == "start_job" else _current_bridge()
+            if bridge is None:
+                return tool_error("Bridge is not started. Call start_bridge first.")
+            timeout = _coerce_timeout(timeout_seconds, DEFAULT_REQUEST_TIMEOUT_SECONDS)
+            start_status = None
+            if action == "start_job":
+                start_status = bridge.start(timeout=timeout)
+            result = bridge.start_turn(repo_path=repo_path, prompt=prompt, timeout=timeout)
+            response = {
+                "thread_id": result.get("thread_id"),
+                "turn_id": result.get("turn_id"),
+                "status": result.get("status"),
+                "result": result,
+            }
+            if start_status is not None:
+                response["bridge_start_status"] = start_status
+            return tool_result(success=True, action=action, **response)
+
+    except (ValueError, CodexAppServerTimeoutError, CodexAppServerBridgeError) as exc:
+        return tool_error(str(exc))
+
+    return tool_error(f"Unhandled action: {action}")
+
+
+def _handle_codex_app_server(args: dict[str, Any], **_: Any) -> str:
+    return codex_app_server_tool(
+        action=args.get("action", ""),
+        repo_path=args.get("repo_path"),
+        prompt=args.get("prompt"),
+        limit=args.get("limit"),
+        timeout_seconds=args.get("timeout_seconds"),
+    )
+
+
+CODEX_APP_SERVER_SCHEMA = {
+    "name": "codex_app_server",
+    "description": (
+        "Start and inspect a process-local Codex app-server monitor. Supports "
+        "starting/stopping the bridge, starting a turn, starting a job, status, "
+        "and recent events. Does not handle approvals, websocket listeners, or dashboards."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": list(_ACTIONS),
+                "description": "Bridge action to perform.",
+            },
+            "repo_path": {
+                "type": "string",
+                "description": "Repository path for action='start_turn' or action='start_job'.",
+            },
+            "prompt": {
+                "type": "string",
+                "description": "Prompt for action='start_turn' or action='start_job'.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum recent events to return for action='events'.",
+                "minimum": 0,
+                "maximum": 200,
+            },
+            "timeout_seconds": {
+                "type": "number",
+                "description": "Request timeout for bridge startup or turn-start requests.",
+                "minimum": 0.001,
+                "maximum": 300,
+            },
+        },
+        "required": ["action"],
+    },
+}
+
+
+registry.register(
+    name="codex_app_server",
+    toolset="codex_monitor",
+    schema=CODEX_APP_SERVER_SCHEMA,
+    handler=_handle_codex_app_server,
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -125,6 +125,12 @@ TOOLSETS = {
         "tools": ["cronjob"],
         "includes": []
     },
+
+    "codex_monitor": {
+        "description": "Process-local Codex app-server completion monitor",
+        "tools": ["codex_app_server"],
+        "includes": []
+    },
     
     "messaging": {
         "description": "Cross-platform messaging: send messages to Telegram, Discord, Slack, SMS, etc.",


### PR DESCRIPTION
## Summary
- add a Codex app-server stdio bridge plus a `codex_monitor` tool wrapper for bridge lifecycle, turn execution, and status/event inspection
- integrate Codex app-server completion events into the Hermes CLI and gateway notification loop
- isolate bridge state per session and fail fast on unsupported server requests while preserving existing completion routing behavior

## Testing
- `source venv/bin/activate && python -m pytest tests/agent/test_codex_app_server_bridge.py tests/tools/test_codex_app_server_tool.py tests/test_codex_app_server_notifications.py tests/tools/test_notify_on_complete.py tests/cron/test_codex_execution_paths.py -q`
- `47 passed in 7.37s`
