### PR TITLE
fix(anthropic_adapter): preserve dots in Bedrock Claude inference-profile IDs

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -831,10 +831,22 @@ def normalize_model_name(model: str, preserve_dots: bool = False) -> str:
     - Converts dots to hyphens in version numbers (OpenRouter uses dots,
       Anthropic uses hyphens: claude-opus-4.6 → claude-opus-4-6), unless
       preserve_dots is True (e.g. for Alibaba/DashScope: qwen3.5-plus).
+    - Bedrock cross-region inference-profile IDs for Claude
+      (us.anthropic.claude-*, global.anthropic.claude-*, eu./ap./jp.)
+      keep their dotted regional prefix regardless of preserve_dots;
+      collapsing the dots produces an id the AnthropicBedrock SDK rejects
+      with HTTP 400 "The provided model identifier is invalid."
     """
     lower = model.lower()
     if lower.startswith("anthropic/"):
         model = model[len("anthropic/"):]
+        lower = model.lower()
+    # Bedrock cross-region inference-profile Claude IDs must keep their dots.
+    if (
+        any(lower.startswith(p) for p in ("us.", "global.", "eu.", "ap.", "jp."))
+        and "anthropic.claude" in lower
+    ):
+        return model
     if not preserve_dots:
         # OpenRouter uses dots for version separators (claude-opus-4.6),
         # Anthropic uses hyphens (claude-opus-4-6). Convert dots to hyphens.

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -481,6 +481,56 @@ class TestNormalizeModelName:
         assert normalize_model_name("anthropic/qwen3.5-plus", preserve_dots=True) == "qwen3.5-plus"
         assert normalize_model_name("qwen3.5-flash", preserve_dots=True) == "qwen3.5-flash"
 
+    def test_preserve_dots_for_bedrock_inference_profile_claude(self):
+        """Bedrock cross-region inference-profile Claude IDs (us.anthropic.claude-*,
+        global.anthropic.claude-*, eu./ap./jp.) keep their dotted regional prefix.
+        Collapsing the dots produces an id the AnthropicBedrock SDK rejects with
+        HTTP 400 'The provided model identifier is invalid.'"""
+        # us. cross-region profile
+        assert (
+            normalize_model_name("us.anthropic.claude-sonnet-4-5-20250929-v1:0")
+            == "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+        )
+        assert (
+            normalize_model_name("us.anthropic.claude-opus-4-6-v1:0")
+            == "us.anthropic.claude-opus-4-6-v1:0"
+        )
+        # global. cross-region profile
+        assert (
+            normalize_model_name("global.anthropic.claude-opus-4-6-v1:0")
+            == "global.anthropic.claude-opus-4-6-v1:0"
+        )
+        # Other regional prefixes
+        assert (
+            normalize_model_name("eu.anthropic.claude-sonnet-4-5-20250929-v1:0")
+            == "eu.anthropic.claude-sonnet-4-5-20250929-v1:0"
+        )
+        assert (
+            normalize_model_name("ap.anthropic.claude-sonnet-4-5-20250929-v1:0")
+            == "ap.anthropic.claude-sonnet-4-5-20250929-v1:0"
+        )
+        assert (
+            normalize_model_name("jp.anthropic.claude-sonnet-4-5-20250929-v1:0")
+            == "jp.anthropic.claude-sonnet-4-5-20250929-v1:0"
+        )
+        # anthropic/ prefix stripped first, then the dotted id is preserved
+        assert (
+            normalize_model_name("anthropic/us.anthropic.claude-sonnet-4-5-20250929-v1:0")
+            == "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+        )
+        # preserve_dots=False still preserves the inference-profile id
+        assert (
+            normalize_model_name(
+                "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+                preserve_dots=False,
+            )
+            == "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+        )
+        # Non-Claude Bedrock ids (e.g. Amazon Nova) route through the Converse
+        # API and are not Anthropic inference profiles; the guard must not
+        # match them.
+        assert normalize_model_name("us.amazon.nova-pro-v1:0") == "us-amazon-nova-pro-v1:0"
+
 
 # ---------------------------------------------------------------------------
 # Tool conversion


### PR DESCRIPTION
Closes #12295.

## Problem

AWS Bedrock cross-region inference-profile Claude IDs carry a dotted regional prefix — `us.anthropic.claude-sonnet-4-5-20250929-v1:0`, `global.anthropic.claude-opus-4-6-v1:0`, etc. They are passed verbatim to the `AnthropicBedrock` SDK in the `bedrock` provider path (`is_anthropic_bedrock_model` → `anthropic_messages`).

Today `normalize_model_name` unconditionally replaces `.` with `-` when `preserve_dots=False`, and `run_agent._anthropic_preserve_dots()` only returns True for Alibaba / MiniMax / OpenCode / ZAI / DashScope — **not `bedrock`**. So every Bedrock call is shipped to the SDK with a hyphen-collapsed id:

\`\`\`
us.anthropic.claude-sonnet-4-5-20250929-v1:0
    --> us-anthropic-claude-sonnet-4-5-20250929-v1:0   # wrong
\`\`\`

Bedrock rejects the hyphenated form with `BadRequestError [HTTP 400]: The provided model identifier is invalid.`, which surfaces to users as a plain 400 from Hermes.

## Reproduction

Inside a Bedrock-configured Hermes task, both behaviors are directly observable (the **dotted** id works, the **hyphen-collapsed** id returns exactly the production error):

\`\`\`python
from anthropic import AnthropicBedrock
c = AnthropicBedrock(aws_region="us-east-1")

c.messages.create(
    model="us.anthropic.claude-sonnet-4-5-20250929-v1:0",
    max_tokens=16,
    messages=[{"role":"user","content":"ping"}],
)
# -> 200 OK, TextBlock('pong')

c.messages.create(
    model="us-anthropic-claude-sonnet-4-5-20250929-v1:0",
    max_tokens=16,
    messages=[{"role":"user","content":"ping"}],
)
# -> anthropic.BadRequestError: 400 The provided model identifier is invalid.
\`\`\`

And in pure Python against the current `main`:

\`\`\`python
>>> from agent.anthropic_adapter import normalize_model_name
>>> normalize_model_name("us.anthropic.claude-sonnet-4-5-20250929-v1:0")
'us-anthropic-claude-sonnet-4-5-20250929-v1:0'    # wrong
\`\`\`

## Fix

Guard the dot-collapsing inside \`normalize_model_name\` itself. Ids whose lowercase form starts with one of \`us./global./eu./ap./jp.\` and contains \`anthropic.claude\` keep their dots regardless of \`preserve_dots\`.

This is preferred over adding \`bedrock\` to \`_anthropic_preserve_dots()\` because:

1. It protects **every** call site, including any future paths that forget to plumb the flag.
2. The "don't mangle this id" property is intrinsic to the id's shape, not the provider routing choice.
3. It has no effect on non-Claude Bedrock ids (e.g. \`us.amazon.nova-pro-v1:0\`): those route through the Converse API and don't go through this function, and the guard specifically requires \`anthropic.claude\`.

\`anthropic/\` prefix handling is preserved: if the caller passes \`anthropic/us.anthropic.claude-...\`, the prefix is still stripped and **then** the dotted inference-profile id is preserved.

## Tests

New test \`TestNormalizeModelName::test_preserve_dots_for_bedrock_inference_profile_claude\` in \`tests/agent/test_anthropic_adapter.py\` covers:

- \`us./global./eu./ap./jp.\` Claude inference profiles.
- The \`anthropic/\` prefix stripped → dotted id preserved case.
- Explicit \`preserve_dots=False\` still preserves the Bedrock id.
- \`us.amazon.nova-pro-v1:0\` **still** gets its dots collapsed (the guard must not match non-Anthropic Bedrock ids).

\`\`\`
$ python3 -m pytest tests/agent/test_anthropic_adapter.py::TestNormalizeModelName -v
============================= test session starts ==============================
...
tests/agent/test_anthropic_adapter.py::TestNormalizeModelName::test_strips_anthropic_prefix PASSED
tests/agent/test_anthropic_adapter.py::TestNormalizeModelName::test_leaves_bare_name PASSED
tests/agent/test_anthropic_adapter.py::TestNormalizeModelName::test_converts_dots_to_hyphens PASSED
tests/agent/test_anthropic_adapter.py::TestNormalizeModelName::test_already_hyphenated_unchanged PASSED
tests/agent/test_anthropic_adapter.py::TestNormalizeModelName::test_preserve_dots_for_alibaba_dashscope PASSED
tests/agent/test_anthropic_adapter.py::TestNormalizeModelName::test_preserve_dots_for_bedrock_inference_profile_claude PASSED
============================== 6 passed in 0.19s ===============================
\`\`\`

## Context

We hit this in production on a Bedrock-only deployment (Slack bot, HTTP 400 on every Claude call even though SSM held the correct dotted profile id). We're shipping a downstream monkey-patch with the same semantics as this PR so our gateway keeps working; I'd love to drop the patch once this lands.

Made with [Cursor](https://cursor.com)