### PR TITLE
fix(mattermost): prefer metadata thread root over stale reply_to

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -183,12 +183,20 @@ class MattermostAdapter(BasePlatformAdapter):
         reply_to: Optional[str],
         metadata: Optional[Dict[str, Any]],
     ) -> Optional[str]:
-        """Resolve the Mattermost root_id from reply_to or metadata."""
+        """Resolve the Mattermost root_id from metadata or reply_to.
+
+        ``metadata["thread_id"]`` is the thread root recorded when the
+        inbound post was received, so it wins over ``reply_to``, which may
+        point at an arbitrary reply inside the thread (or at a post in a
+        different thread entirely for delayed/progress deliveries).
+        """
         if self._reply_mode != "thread":
             return None
-        candidate = reply_to
-        if not candidate and isinstance(metadata, dict):
+        candidate = None
+        if isinstance(metadata, dict):
             candidate = metadata.get("thread_id") or metadata.get("root_id")
+        if not candidate:
+            candidate = reply_to
         if not candidate:
             return None
         return await self._resolve_root_id(str(candidate))

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -394,6 +394,44 @@ class TestMattermostSend:
         assert payload["root_id"] == "root_post_123"
 
     @pytest.mark.asyncio
+    async def test_send_prefers_metadata_thread_id_over_conflicting_reply_to(self):
+        """metadata['thread_id'] is authoritative when reply_to disagrees."""
+        self.adapter._reply_mode = "thread"
+        self.adapter._api_get = AsyncMock(return_value={"id": "root_post_123", "root_id": ""})
+        self.adapter._api_post = AsyncMock(return_value={"id": "reply_post"})
+
+        result = await self.adapter.send(
+            "channel_1",
+            "Answer",
+            reply_to="other_thread_post_999",
+            metadata={"thread_id": "root_post_123"},
+        )
+
+        assert result.success is True
+        payload = self.adapter._api_post.call_args_list[0][0][1]
+        assert payload["root_id"] == "root_post_123"
+        # The stale reply_to must never reach the resolver.
+        self.adapter._api_get.assert_awaited_once_with("posts/root_post_123")
+
+    @pytest.mark.asyncio
+    async def test_send_falls_back_to_reply_to_without_metadata_thread_id(self):
+        """reply_to still drives threading when metadata carries no root."""
+        self.adapter._reply_mode = "thread"
+        self.adapter._api_get = AsyncMock(return_value={"id": "root_post_456", "root_id": ""})
+        self.adapter._api_post = AsyncMock(return_value={"id": "reply_post"})
+
+        result = await self.adapter.send(
+            "channel_1",
+            "Answer",
+            reply_to="root_post_456",
+            metadata={"some_other_key": "value"},
+        )
+
+        assert result.success is True
+        payload = self.adapter._api_post.call_args_list[0][0][1]
+        assert payload["root_id"] == "root_post_456"
+
+    @pytest.mark.asyncio
     async def test_progress_send_with_invalid_thread_root_never_falls_back_flat(self):
         """Tool/status/progress bubbles must stay quiet when the thread is broken."""
         self.adapter._reply_mode = "thread"


### PR DESCRIPTION
Reworked per the hermes-sweeper review to the narrow salvageable scope.

## What changed

Rebased onto current `main` (`d83e85850`) and reduced to the single outbound fix. The adapter path migration to `plugins/platforms/mattermost/adapter.py` (`af973e407`) is picked up, so the branch no longer conflicts.

**Dropped** — inbound channel-thread isolation, which landed on main in `5a0e0d35b` with coverage at `tests/gateway/test_mattermost.py:1029-1085`. The DM guard at `adapter.py:869-876` is untouched, so DM sessions keep their existing behavior and the `test_mattermost_dm_post_does_not_seed_thread_root` regression still passes.

**Kept** — the outbound metadata-precedence case in `_thread_root_for_send()` (`adapter.py:181-194`), where main still prefers `reply_to` over metadata.

## The remaining bug

`_thread_root_for_send()` reads `reply_to` first and consults `metadata["thread_id"]` only when `reply_to` is empty. When both are present and disagree — delayed or progress deliveries where `reply_to` points at a post in a different thread — the message is posted under the wrong root.

`metadata["thread_id"]` is the thread root recorded when the inbound post was received, so this makes it authoritative and falls back to `reply_to` only when metadata carries no root. The fallback path is unchanged for ordinary replies.

## Tests

Two added, per the review request:

- `test_send_prefers_metadata_thread_id_over_conflicting_reply_to` — conflicting `reply_to` + `metadata["thread_id"]`. Also asserts the stale `reply_to` never reaches `_resolve_root_id()`, which drops an API round-trip on this path.
- `test_send_falls_back_to_reply_to_without_metadata_thread_id` — guards the fallback.

Verified the first test fails on unpatched `main` with `assert 'other_thread_post_999' == 'root_post_123'`, and passes with the change.

```
uv run --with pytest==9.0.2 --with pytest-asyncio==1.3.0 --with pytest-timeout==2.4.0 --with aiohttp==3.13.2 pytest tests/gateway/test_mattermost.py -q -o addopts=
65 passed
```

Also clean: `python3 -m py_compile` on both files, `git diff --check`.

Diff is +49/−3 across 2 files. The previous branch tip is preserved at `imapotato123:backup/pr12299-pre-rework` if any of the dropped work is wanted later.