### PR TITLE
discord drops some direct bot mentions

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -671,7 +671,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     if allow_bots == "none":
                         return
                     elif allow_bots == "mentions":
-                        if not self._client.user or self._client.user not in message.mentions:
+                        if not adapter_self._self_is_explicitly_mentioned(message):
                             return
                     # "all" falls through; bot is permitted — skip the
                     # human-user allowlist below (bots aren't in it).
@@ -690,10 +690,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 # with bot-aware filtering that works correctly when multiple
                 # agents share a channel.
                 if not isinstance(message.channel, discord.DMChannel) and message.mentions:
-                    _self_mentioned = (
-                        self._client.user is not None
-                        and self._client.user in message.mentions
-                    )
+                    _self_mentioned = adapter_self._self_is_explicitly_mentioned(message)
                     _other_bots_mentioned = any(
                         m.bot and m != self._client.user
                         for m in message.mentions
@@ -2532,6 +2529,22 @@ class DiscordAdapter(BasePlatformAdapter):
             return {part.strip() for part in raw.split(",") if part.strip()}
         return set()
 
+    def _raw_mentioned_user_ids(self, message: Any) -> set[str]:
+        """Extract Discord user mentions directly from raw message content."""
+        content = getattr(message, "content", "") or ""
+        return {
+            match.group(1)
+            for match in re.finditer(r"<@!?(\d+)>", content)
+        }
+
+    def _self_is_explicitly_mentioned(self, message: Any) -> bool:
+        """Return True when this bot is explicitly mentioned in the message."""
+        if not self._client or not self._client.user:
+            return False
+        if self._client.user in getattr(message, "mentions", []):
+            return True
+        return str(self._client.user.id) in self._raw_mentioned_user_ids(message)
+
     def _thread_parent_channel(self, channel: Any) -> Any:
         """Return the parent text channel when invoked from a thread."""
         return getattr(channel, "parent", None) or channel
@@ -3041,10 +3054,19 @@ class DiscordAdapter(BasePlatformAdapter):
             # Skip the mention check if the message is in a thread where
             # the bot has previously participated (auto-created or replied in).
             in_bot_thread = is_thread and thread_id in self._threads
+            self_explicitly_mentioned = self._self_is_explicitly_mentioned(message)
 
             if require_mention and not is_free_channel and not in_bot_thread:
-                if self._client.user not in message.mentions and not mention_prefix:
+                if not self_explicitly_mentioned:
                     return
+
+            clean_content = normalized_content
+            if self_explicitly_mentioned and not mention_prefix:
+                clean_content = clean_content.replace(f"<@{self._client.user.id}>", "").strip()
+                clean_content = clean_content.replace(f"<@!{self._client.user.id}>", "").strip()
+        else:
+            self_explicitly_mentioned = False
+            clean_content = normalized_content
         # Auto-thread: when enabled, automatically create a thread for every
         # @mention in a text channel so each conversation is isolated (like Slack).
         # Messages already inside threads or DMs are unaffected.
@@ -3206,15 +3228,30 @@ class DiscordAdapter(BasePlatformAdapter):
                                 att.filename, e, exc_info=True,
                             )
 
-        # Use normalized_content (saved before auto-threading) instead of message.content,
-        # to detect /slash commands in channel messages.
-        event_text = normalized_content
+        # Use pre-auto-thread normalized content so raw mentions and mention-only
+        # messages are handled consistently even if create_thread() mutates message.content.
+        event_text = clean_content
         if pending_text_injection:
             event_text = f"{pending_text_injection}\n\n{event_text}" if event_text else pending_text_injection
 
         # Defense-in-depth: prevent empty user messages from entering session
         # (can happen when user sends @mention-only with no other text)
         if not event_text or not event_text.strip():
+            if (
+                self_explicitly_mentioned
+                and not media_urls
+                and not pending_text_injection
+            ):
+                stripped = re.sub(r"<@[!&]?\d+>", "", raw_content)
+                stripped = re.sub(r"<#\d+>", "", stripped)
+                stripped = re.sub(r"\s+", " ", stripped).strip()
+                if not stripped:
+                    logger.info(
+                        "[Discord] Ignoring mention-only message from %s in %s",
+                        getattr(message.author, "display_name", getattr(message.author, "name", "unknown")),
+                        getattr(effective_channel, "id", "unknown"),
+                    )
+                    return
             event_text = "(The user sent a message with no text content)"
 
         _chan = message.channel

--- a/tests/gateway/test_discord_bot_filter.py
+++ b/tests/gateway/test_discord_bot_filter.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import os
+import re
 import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -41,6 +42,17 @@ def _make_message(*, author=None, content="hello", mentions=None, is_dm=False):
 class TestDiscordBotFilter(unittest.TestCase):
     """Test the DISCORD_ALLOW_BOTS filtering logic."""
 
+    @staticmethod
+    def _self_is_explicitly_mentioned(message, client_user):
+        if not client_user:
+            return False
+        if client_user in message.mentions:
+            return True
+        return str(client_user.id) in {
+            match.group(1)
+            for match in re.finditer(r"<@!?(\d+)>", getattr(message, "content", "") or "")
+        }
+
     def _run_filter(self, message, allow_bots="none", client_user=None):
         """Simulate the on_message filter logic and return whether message was accepted."""
         # Replicate the exact filter logic from discord.py on_message
@@ -52,7 +64,7 @@ class TestDiscordBotFilter(unittest.TestCase):
             if allow == "none":
                 return False
             elif allow == "mentions":
-                if not client_user or client_user not in message.mentions:
+                if not self._self_is_explicitly_mentioned(message, client_user):
                     return False
             # "all" falls through
         
@@ -96,6 +108,13 @@ class TestDiscordBotFilter(unittest.TestCase):
         our_user = _make_author(is_self=True)
         bot = _make_author(bot=True)
         msg = _make_message(author=bot, mentions=[our_user])
+        self.assertTrue(self._run_filter(msg, "mentions", our_user))
+
+    def test_allow_bots_mentions_accepts_with_raw_content_mention(self):
+        """Raw Discord mention syntax should count even if message.mentions is empty."""
+        our_user = _make_author(is_self=True)
+        bot = _make_author(bot=True)
+        msg = _make_message(author=bot, content=f"<@!{our_user.id}> relay", mentions=[])
         self.assertTrue(self._run_filter(msg, "mentions", our_user))
 
     def test_default_is_none(self):

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -257,6 +257,59 @@ async def test_discord_accepts_and_strips_bot_mentions_when_required(adapter, mo
 
 
 @pytest.mark.asyncio
+async def test_discord_accepts_raw_bot_mentions_when_required(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    bot_user = adapter._client.user
+    message = make_message(
+        channel=FakeTextChannel(channel_id=322),
+        content=f"<@!{bot_user.id}> hello from raw mention",
+        mentions=[],
+    )
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.text == "hello from raw mention"
+
+
+@pytest.mark.asyncio
+async def test_discord_ignores_bare_bot_mentions_without_text(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    bot_user = adapter._client.user
+    message = make_message(
+        channel=FakeTextChannel(channel_id=323),
+        content=f"<@{bot_user.id}>",
+        mentions=[],
+    )
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_discord_ignores_bare_bot_mentions_without_text_when_mentions_list_is_populated(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    bot_user = adapter._client.user
+    message = make_message(
+        channel=FakeTextChannel(channel_id=324),
+        content=f"<@{bot_user.id}>",
+        mentions=[bot_user],
+    )
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_discord_dms_ignore_mention_requirement(adapter, monkeypatch):
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
     monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)


### PR DESCRIPTION
Some direct bot mentions were getting missed in Discord, and bare @bot pings could turn into fake empty-text user turns.

What was happening:
- a few mention checks were relying on `message.mentions` alone
- that misses some raw Discord mention forms like `<@!ID>`
- in `_handle_message`, mention stripping was mutating `message.content` in place
- that made it harder to tell the difference between a real empty message and a bare ping
- result was weird behavior where `@Bot` by itself could still kick off a thinking/reply cycle

What changed:
- added a helper that treats a bot as mentioned if it's either in `message.mentions` or directly present in raw content as `<@ID>` / `<@!ID>`
- used that same check in the places that gate bot-message handling and mention-required handling
- stopped mutating `message.content` in place and used cleaned local content instead
- bare mention-only pings now get dropped instead of becoming fake empty-text turns

Tests:
- raw direct bot mention still works when `message.mentions` is empty
- bare `@Bot` gets ignored
- bot-message mention gating still works with raw mention syntax
