### PR TITLE
fix(discord): decouple free-response from auto-threading

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3014,7 +3014,7 @@ class DiscordAdapter(BasePlatformAdapter):
         if not is_thread and not isinstance(message.channel, discord.DMChannel):
             no_thread_channels_raw = os.getenv("DISCORD_NO_THREAD_CHANNELS", "")
             no_thread_channels = {ch.strip() for ch in no_thread_channels_raw.split(",") if ch.strip()}
-            skip_thread = bool(channel_ids & no_thread_channels) or is_free_channel
+            skip_thread = bool(channel_ids & no_thread_channels)
             auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in ("true", "1", "yes")
             is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
             if auto_thread and not skip_thread and not is_voice_linked_channel and not is_reply_message:

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -427,15 +427,36 @@ async def test_discord_voice_linked_channel_skips_mention_requirement_and_auto_t
 
 
 @pytest.mark.asyncio
-async def test_discord_free_channel_skips_auto_thread(adapter, monkeypatch):
-    """Free-response channels must NOT auto-create threads — bot replies inline.
-
-    Without this, every message in a free-response channel would spin off a
-    thread (since the channel bypasses the @mention gate), defeating the
-    lightweight-chat purpose of free-response mode.
-    """
+async def test_discord_free_channel_still_auto_threads(adapter, monkeypatch):
+    """Free-response channels bypass mentions without implicitly disabling threads."""
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
     monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "789")
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)  # default true
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+
+    fake_thread = FakeThread(channel_id=999, name="auto-thread")
+    adapter._auto_create_thread = AsyncMock(return_value=fake_thread)
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=789),
+        content="free chat message",
+    )
+
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_awaited_once()
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_type == "thread"
+    assert event.source.thread_id == "999"
+
+
+@pytest.mark.asyncio
+async def test_discord_free_channel_no_thread_override_stays_inline(adapter, monkeypatch):
+    """DISCORD_NO_THREAD_CHANNELS should keep free-response channels inline."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "789")
+    monkeypatch.setenv("DISCORD_NO_THREAD_CHANNELS", "789")
     monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)  # default true
 
     adapter._auto_create_thread = AsyncMock()

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -207,11 +207,11 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `DISCORD_HOME_CHANNEL` | Default Discord channel for cron delivery |
 | `DISCORD_HOME_CHANNEL_NAME` | Display name for the Discord home channel |
 | `DISCORD_REQUIRE_MENTION` | Require an @mention before responding in server channels |
-| `DISCORD_FREE_RESPONSE_CHANNELS` | Comma-separated channel IDs where mention is not required |
-| `DISCORD_AUTO_THREAD` | Auto-thread long replies when supported |
+| `DISCORD_FREE_RESPONSE_CHANNELS` | Comma-separated channel IDs where mention is not required; does not disable auto-threading |
+| `DISCORD_AUTO_THREAD` | Auto-thread eligible top-level channel messages when supported |
 | `DISCORD_REACTIONS` | Enable emoji reactions on messages during processing (default: `true`) |
 | `DISCORD_IGNORED_CHANNELS` | Comma-separated channel IDs where the bot never responds |
-| `DISCORD_NO_THREAD_CHANNELS` | Comma-separated channel IDs where bot responds without auto-threading |
+| `DISCORD_NO_THREAD_CHANNELS` | Comma-separated channel IDs where bot responds without auto-threading, including mention-free channels |
 | `DISCORD_REPLY_TO_MODE` | Reply-reference behavior: `off`, `first` (default), or `all` |
 | `DISCORD_ALLOW_MENTION_EVERYONE` | Allow the bot to ping `@everyone`/`@here` (default: `false`). See [Mention Control](../user-guide/messaging/discord.md#mention-control). |
 | `DISCORD_ALLOW_MENTION_ROLES` | Allow the bot to ping `@role` mentions (default: `false`). |

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -16,13 +16,13 @@ Before setup, here's the part most people want to know: how Hermes behaves once 
 |---------|----------|
 | **DMs** | Hermes responds to every message. No `@mention` needed. Each DM has its own session. |
 | **Server channels** | By default, Hermes only responds when you `@mention` it. If you post in a channel without mentioning it, Hermes ignores the message. |
-| **Free-response channels** | You can make specific channels mention-free with `DISCORD_FREE_RESPONSE_CHANNELS`, or disable mentions globally with `DISCORD_REQUIRE_MENTION=false`. Messages in these channels are answered inline — auto-threading is skipped so the channel stays a lightweight chat. |
+| **Free-response channels** | You can make specific channels mention-free with `DISCORD_FREE_RESPONSE_CHANNELS`, or disable mentions globally with `DISCORD_REQUIRE_MENTION=false`. This only changes mention gating; auto-threading still follows `DISCORD_AUTO_THREAD` and `DISCORD_NO_THREAD_CHANNELS`. |
 | **Threads** | Hermes replies in the same thread. Mention rules still apply unless that thread or its parent channel is configured as free-response. Threads stay isolated from the parent channel for session history. |
 | **Shared channels with multiple users** | By default, Hermes isolates session history per user inside the channel for safety and clarity. Two people talking in the same channel do not share one transcript unless you explicitly disable that. |
 | **Messages mentioning other users** | When `DISCORD_IGNORE_NO_MENTION` is `true` (the default), Hermes stays silent if a message @mentions other users but does **not** mention the bot. This prevents the bot from jumping into conversations directed at other people. Set to `false` if you want the bot to respond to all messages regardless of who is mentioned. This only applies in server channels, not DMs. |
 
 :::tip
-If you want a normal bot-help channel where people can talk to Hermes without tagging it every time, add that channel to `DISCORD_FREE_RESPONSE_CHANNELS`.
+If you want a normal bot-help channel where people can talk to Hermes without tagging it every time, add that channel to `DISCORD_FREE_RESPONSE_CHANNELS`. If you also want replies to stay inline instead of auto-threading, add the same channel to `DISCORD_NO_THREAD_CHANNELS`.
 :::
 
 ### Discord Gateway Model
@@ -276,14 +276,14 @@ Discord behavior is controlled through two files: **`~/.hermes/.env`** for crede
 | `DISCORD_HOME_CHANNEL` | No | — | Channel ID where the bot sends proactive messages (cron output, reminders, notifications). |
 | `DISCORD_HOME_CHANNEL_NAME` | No | `"Home"` | Display name for the home channel in logs and status output. |
 | `DISCORD_REQUIRE_MENTION` | No | `true` | When `true`, the bot only responds in server channels when `@mentioned`. Set to `false` to respond to all messages in every channel. |
-| `DISCORD_FREE_RESPONSE_CHANNELS` | No | — | Comma-separated channel IDs where the bot responds without requiring an `@mention`, even when `DISCORD_REQUIRE_MENTION` is `true`. |
+| `DISCORD_FREE_RESPONSE_CHANNELS` | No | — | Comma-separated channel IDs where the bot responds without requiring an `@mention`, even when `DISCORD_REQUIRE_MENTION` is `true`. This does not disable auto-threading by itself. |
 | `DISCORD_IGNORE_NO_MENTION` | No | `true` | When `true`, the bot stays silent if a message `@mentions` other users but does **not** mention the bot. Prevents the bot from jumping into conversations directed at other people. Only applies in server channels, not DMs. |
-| `DISCORD_AUTO_THREAD` | No | `true` | When `true`, automatically creates a new thread for every `@mention` in a text channel, so each conversation is isolated (similar to Slack behavior). Messages already inside threads or DMs are unaffected. |
+| `DISCORD_AUTO_THREAD` | No | `true` | When `true`, automatically creates a new thread for eligible top-level text-channel messages so each conversation is isolated (similar to Slack behavior). Messages already inside threads or DMs are unaffected. Use `DISCORD_NO_THREAD_CHANNELS` to keep specific channels inline. |
 | `DISCORD_ALLOW_BOTS` | No | `"none"` | Controls how the bot handles messages from other Discord bots. `"none"` — ignore all other bots. `"mentions"` — only accept bot messages that `@mention` Hermes. `"all"` — accept all bot messages. |
 | `DISCORD_REACTIONS` | No | `true` | When `true`, the bot adds emoji reactions to messages during processing (👀 when starting, ✅ on success, ❌ on error). Set to `false` to disable reactions entirely. |
 | `DISCORD_IGNORED_CHANNELS` | No | — | Comma-separated channel IDs where the bot **never** responds, even when `@mentioned`. Takes priority over all other channel settings. |
 | `DISCORD_ALLOWED_CHANNELS` | No | — | Comma-separated channel IDs. When set, the bot **only** responds in these channels (plus DMs if allowed). Overrides `config.yaml` `discord.allowed_channels`. Combine with `DISCORD_IGNORED_CHANNELS` to express allow/deny rules. |
-| `DISCORD_NO_THREAD_CHANNELS` | No | — | Comma-separated channel IDs where the bot responds directly in the channel instead of creating a thread. Only relevant when `DISCORD_AUTO_THREAD` is `true`. |
+| `DISCORD_NO_THREAD_CHANNELS` | No | — | Comma-separated channel IDs where the bot responds directly in the channel instead of creating a thread. Only relevant when `DISCORD_AUTO_THREAD` is `true`. Use this when a channel should be mention-free via `DISCORD_FREE_RESPONSE_CHANNELS` but still stay inline. |
 | `DISCORD_REPLY_TO_MODE` | No | `"first"` | Controls reply-reference behavior: `"off"` — never reply to the original message, `"first"` — reply-reference on the first message chunk only (default), `"all"` — reply-reference on every chunk. |
 | `DISCORD_ALLOW_MENTION_EVERYONE` | No | `false` | When `false` (default), the bot cannot ping `@everyone` or `@here` even if its response contains those tokens. Set to `true` to opt back in. See [Mention Control](#mention-control) below. |
 | `DISCORD_ALLOW_MENTION_ROLES` | No | `false` | When `false` (default), the bot cannot ping `@role` mentions. Set to `true` to allow. |


### PR DESCRIPTION
## Summary

This PR decouples Discord free-response behavior from auto-thread suppression.

Today, channels listed in `DISCORD_FREE_RESPONSE_CHANNELS` implicitly skip auto-threading because `is_free_channel` is folded into `skip_thread`. That makes it impossible to configure a channel that is both:

- mention-free
- auto-threaded

This PR restores the more explicit configuration model already described in the Discord docs:

- `DISCORD_FREE_RESPONSE_CHANNELS` controls mention policy
- `DISCORD_AUTO_THREAD` controls global auto-threading
- `DISCORD_NO_THREAD_CHANNELS` controls per-channel inline replies

## Root Cause

The coupling was introduced in `93fe4b35` (`fix(discord): free-response channels skip auto-threading`), which was salvaged from the earlier `#9650` work.

That change added `is_free_channel` to the auto-thread suppression path:

- before: `skip_thread = bool(channel_ids & no_thread_channels)`
- after: `skip_thread = bool(channel_ids & no_thread_channels) or is_free_channel`

As a result, `DISCORD_FREE_RESPONSE_CHANNELS` stopped being only a mention-policy control and started acting like a hidden threading override.

## Why This Change Is Correct

The official Discord docs already describe these as separate controls:

- `DISCORD_FREE_RESPONSE_CHANNELS`: channels where Hermes responds without requiring an `@mention`
- `DISCORD_AUTO_THREAD`: global auto-thread toggle
- `DISCORD_NO_THREAD_CHANNELS`: channels where Hermes replies inline instead of creating a thread

In other words, Hermes already has two explicit threading knobs:
`DISCORD_AUTO_THREAD` and `DISCORD_NO_THREAD_CHANNELS`.

Using `DISCORD_FREE_RESPONSE_CHANNELS` as an implicit third threading control makes the configuration model harder to reason about and prevents a valid setup: a mention-free channel that still gets isolated threaded conversations.

## Behavior After This PR

- Free-response channels still bypass the `@mention` requirement.
- Auto-threading still applies when `DISCORD_AUTO_THREAD=true`.
- If a free-response channel should stay inline, it must be listed in `DISCORD_NO_THREAD_CHANNELS`.
- Existing DM, thread, and reply-message behavior stays unchanged.

## Changes

- remove the implicit `is_free_channel` -> `skip_thread` coupling in the Discord adapter
- replace the existing regression test with coverage for:
  - free-response channel still auto-threads by default
  - `DISCORD_NO_THREAD_CHANNELS` keeps a free-response channel inline
- update Discord docs to clarify:
  - free-response is mention policy
  - `DISCORD_AUTO_THREAD` + `DISCORD_NO_THREAD_CHANNELS` are the threading controls
  - migration path for operators who relied on the previous inline behavior

## Migration Note

This is a behavior change for deployments that relied on the recently-merged
"free-response channels skip auto-threading" logic.

If you currently use `DISCORD_FREE_RESPONSE_CHANNELS` and expect those channels to remain inline, add the same channel IDs to `DISCORD_NO_THREAD_CHANNELS`.

## Verification

Ran:

```bash
pytest -o addopts="" tests/gateway/test_discord_free_response.py tests/gateway/test_discord_channel_controls.py -q
```

Result:

- `35 passed`
