### PR TITLE
feat(tui): append git branch to cwd label in status bar

### DIFF
--- a/ui-tui/src/__tests__/paths.test.ts
+++ b/ui-tui/src/__tests__/paths.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { fmtCwdBranch, shortCwd } from '../domain/paths.js'
+
+describe('shortCwd', () => {
+  const origHome = process.env.HOME
+
+  beforeEach(() => {
+    process.env.HOME = '/Users/bb'
+  })
+
+  afterEach(() => {
+    process.env.HOME = origHome
+  })
+
+  it('collapses HOME to ~', () => {
+    expect(shortCwd('/Users/bb/proj/repo')).toBe('~/proj/repo')
+  })
+
+  it('leaves non-HOME paths alone', () => {
+    expect(shortCwd('/tmp/work')).toBe('/tmp/work')
+  })
+
+  it('truncates long paths from the left with ellipsis', () => {
+    const out = shortCwd('/var/long/deeply/nested/workspace/here', 10)
+    expect(out.startsWith('…')).toBe(true)
+    expect(out.length).toBe(10)
+    expect('/var/long/deeply/nested/workspace/here'.endsWith(out.slice(1))).toBe(true)
+  })
+
+  it('keeps paths shorter than max intact', () => {
+    expect(shortCwd('/a/b', 10)).toBe('/a/b')
+  })
+})
+
+describe('fmtCwdBranch', () => {
+  const origHome = process.env.HOME
+
+  beforeEach(() => {
+    process.env.HOME = '/Users/bb'
+  })
+
+  afterEach(() => {
+    process.env.HOME = origHome
+  })
+
+  it('returns bare cwd when branch is null', () => {
+    expect(fmtCwdBranch('/Users/bb/proj', null)).toBe('~/proj')
+  })
+
+  it('returns bare cwd when branch is empty', () => {
+    expect(fmtCwdBranch('/Users/bb/proj', '')).toBe('~/proj')
+  })
+
+  it('appends branch in parens', () => {
+    expect(fmtCwdBranch('/Users/bb/proj', 'main')).toBe('~/proj (main)')
+  })
+
+  it('truncates the path to keep the branch tag readable', () => {
+    const out = fmtCwdBranch('/Users/bb/very/deeply/nested/project/folder', 'feature-branch', 30)
+    expect(out).toMatch(/ \(feature-branch\)$/)
+    expect(out.length).toBeLessThanOrEqual(30)
+  })
+
+  it('truncates very long branch names from the right', () => {
+    const out = fmtCwdBranch('/Users/bb/p', 'a-very-long-feature-branch-name')
+    expect(out).toMatch(/^~\/p \(…/)
+    expect(out).toContain(')')
+  })
+})

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -5,7 +5,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { STARTUP_RESUME_ID } from '../config/env.js'
 import { MAX_HISTORY, WHEEL_SCROLL_STEP } from '../config/limits.js'
 import { imageTokenMeta } from '../domain/messages.js'
-import { shortCwd } from '../domain/paths.js'
+import { fmtCwdBranch } from '../domain/paths.js'
 import { type GatewayClient } from '../gatewayClient.js'
 import type {
   ClarifyRespondResponse,
@@ -13,6 +13,7 @@ import type {
   GatewayEvent,
   TerminalResizeResponse
 } from '../gatewayTypes.js'
+import { useGitBranch } from '../hooks/useGitBranch.js'
 import { useVirtualHistory } from '../hooks/useVirtualHistory.js'
 import { asRpcResult, rpcErrorMessage } from '../lib/rpc.js'
 import { buildToolTrailLine, sameToolTrailGroup, toolTrailLabel } from '../lib/text.js'
@@ -620,9 +621,12 @@ export function useMainApp(gw: GatewayClient) {
     [turn, showProgressArea]
   )
 
+  const cwd = ui.info?.cwd || process.env.HERMES_CWD || process.cwd()
+  const gitBranch = useGitBranch(cwd)
+
   const appStatus = useMemo(
     () => ({
-      cwdLabel: shortCwd(ui.info?.cwd || process.env.HERMES_CWD || process.cwd()),
+      cwdLabel: fmtCwdBranch(cwd, gitBranch),
       goodVibesTick,
       sessionStartedAt: ui.sid ? sessionStartedAt : null,
       showStickyPrompt: !!stickyPrompt,
@@ -630,7 +634,7 @@ export function useMainApp(gw: GatewayClient) {
       stickyPrompt,
       voiceLabel: voiceRecording ? 'REC' : voiceProcessing ? 'STT' : `voice ${voiceEnabled ? 'on' : 'off'}`
     }),
-    [goodVibesTick, sessionStartedAt, stickyPrompt, ui, voiceEnabled, voiceProcessing, voiceRecording]
+    [cwd, gitBranch, goodVibesTick, sessionStartedAt, stickyPrompt, ui, voiceEnabled, voiceProcessing, voiceRecording]
   )
 
   const appTranscript = useMemo(

--- a/ui-tui/src/domain/paths.ts
+++ b/ui-tui/src/domain/paths.ts
@@ -4,3 +4,14 @@ export const shortCwd = (cwd: string, max = 28) => {
 
   return p.length <= max ? p : `…${p.slice(-(max - 1))}`
 }
+
+export const fmtCwdBranch = (cwd: string, branch: null | string, max = 40) => {
+  if (!branch) {
+    return shortCwd(cwd, max)
+  }
+
+  const b = branch.length > 16 ? `…${branch.slice(-15)}` : branch
+  const tag = ` (${b})`
+
+  return `${shortCwd(cwd, Math.max(8, max - tag.length))}${tag}`
+}

--- a/ui-tui/src/hooks/useGitBranch.ts
+++ b/ui-tui/src/hooks/useGitBranch.ts
@@ -1,0 +1,72 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+import { useEffect, useState } from 'react'
+
+const TTL_MS = 15_000
+const TIMEOUT_MS = 500
+
+const pexec = promisify(execFile)
+const cache = new Map<string, { at: number; branch: null | string }>()
+const inflight = new Map<string, Promise<null | string>>()
+
+const resolveBranch = async (cwd: string): Promise<null | string> => {
+  try {
+    const { stdout } = await pexec('git', ['-C', cwd, 'rev-parse', '--abbrev-ref', 'HEAD'], { timeout: TIMEOUT_MS })
+    const b = stdout.trim()
+
+    return !b || b === 'HEAD' ? null : b
+  } catch {
+    return null
+  }
+}
+
+const fetchBranch = (cwd: string): Promise<null | string> => {
+  const pending = inflight.get(cwd)
+
+  if (pending) {
+    return pending
+  }
+
+  const p = resolveBranch(cwd).finally(() => inflight.delete(cwd))
+  inflight.set(cwd, p)
+
+  return p
+}
+
+export function useGitBranch(cwd: string): null | string {
+  const [branch, setBranch] = useState<null | string>(() => cache.get(cwd)?.branch ?? null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    const tick = async () => {
+      const hit = cache.get(cwd)
+
+      if (hit && Date.now() - hit.at < TTL_MS) {
+        if (!cancelled) {
+          setBranch(hit.branch)
+        }
+
+        return
+      }
+
+      const b = await fetchBranch(cwd)
+      cache.set(cwd, { at: Date.now(), branch: b })
+
+      if (!cancelled) {
+        setBranch(b)
+      }
+    }
+
+    void tick()
+    const id = setInterval(() => void tick(), TTL_MS)
+
+    return () => {
+      cancelled = true
+      clearInterval(id)
+    }
+  }, [cwd])
+
+  return branch
+}


### PR DESCRIPTION
## What does this PR do?

Shows the active git branch next to the workspace path in the TUI (`ui-tui`) status bar — `~/hermes-agent (main)` instead of just `~/hermes-agent`. When you switch branches in another pane, the footer catches up within a few seconds. Silent no-op when git isn't available or you're outside a repo.

This is the ui-tui counterpart to #12277 (which targets the Python `cli.py` / `hermes status` command). That PR doesn't touch the TS Ink renderer, so the footer there was still showing just the short cwd.

## Related Issue

Fixes #12267 (TUI portion — Python side is addressed by #12277)

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `ui-tui/src/domain/paths.ts` — add `fmtCwdBranch(cwd, branch, max=40)` that composes `~/repo (main)`, shrinking the path budget when branch names are long so the total stays inside `max`. Long branch names are truncated from the right with `…`.
- `ui-tui/src/hooks/useGitBranch.ts` — new hook. Runs `git -C <cwd> rev-parse --abbrev-ref HEAD` via async `execFile` with a 500ms timeout. Module-level cache + inflight dedupe so concurrent renders share one git call. 15s TTL + `setInterval` refresh so a branch switch in another pane propagates without relaunching Hermes. Returns `null` on error, detached HEAD, or non-repo.
- `ui-tui/src/app/useMainApp.ts` — pull `cwd` up, call `useGitBranch(cwd)`, feed `fmtCwdBranch(cwd, gitBranch)` into `appStatus.cwdLabel`. No change to `StatusRule` / `appChrome.tsx` — the existing `leftWidth = cols - cwdLabel.length - 3` budget already adapts since the full label length is used.
- `ui-tui/src/__tests__/paths.test.ts` — 9 new tests covering `shortCwd` (HOME collapse, passthrough, truncation, bounds) and `fmtCwdBranch` (null/empty branch, tag append, path shrinks to protect tag, long-branch truncation).

## How to Test

1. `cd ui-tui && npm install && npm run test` — 82 tests pass (9 new).
2. `npm run type-check` — clean.
3. `npm run lint` — no new errors on touched files. (One pre-existing import-sort error in `src/app/useInputHandlers.ts` from an earlier commit; untouched here.)
4. Manual: `hermes chat` inside a git repo, confirm the footer reads e.g. `~/hermes-agent (main)`. `git checkout -b foo` in another terminal; within ~15s the footer updates to `(foo)`. `cd /tmp && hermes chat` — footer shows just `/tmp`, no branch tag.

Tested on: Ubuntu 24.04 (WSL2), Node v22.22.2.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (#12277 covers only the Python side)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` — N/A, TS-only change; `npm run test` in `ui-tui/` passes (82/82)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04 (WSL2)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (internal TUI helper)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — git lookup uses async `execFile` with a 500ms timeout and swallows all errors, so Windows / no-git / permission-denied environments degrade silently
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

(Local TUI screenshot will follow — status footer now reads `─ ~/hermes-agent (bb/tui-status-git-branch)` on the right.)