### PR TITLE
fix(tui): disambiguate /model picker rows when provider display names collide

### DIFF
--- a/ui-tui/src/__tests__/providers.test.ts
+++ b/ui-tui/src/__tests__/providers.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+
+import { providerDisplayNames } from '../domain/providers.js'
+
+describe('providerDisplayNames', () => {
+  it('returns bare names when all are unique', () => {
+    expect(providerDisplayNames([{ name: 'Anthropic', slug: 'anthropic' }, { name: 'OpenAI', slug: 'openai' }])).toEqual(
+      ['Anthropic', 'OpenAI']
+    )
+  })
+
+  it('appends slug to every collision so the disambiguation is symmetric', () => {
+    expect(
+      providerDisplayNames([
+        { name: 'Kimi For Coding', slug: 'kimi-coding' },
+        { name: 'Kimi For Coding', slug: 'kimi-coding-cn' }
+      ])
+    ).toEqual(['Kimi For Coding (kimi-coding)', 'Kimi For Coding (kimi-coding-cn)'])
+  })
+
+  it('only disambiguates the colliding group', () => {
+    expect(
+      providerDisplayNames([
+        { name: 'Anthropic', slug: 'anthropic' },
+        { name: 'Foo', slug: 'foo-a' },
+        { name: 'Foo', slug: 'foo-b' }
+      ])
+    ).toEqual(['Anthropic', 'Foo (foo-a)', 'Foo (foo-b)'])
+  })
+
+  it('falls back to plain name if slug is empty', () => {
+    expect(
+      providerDisplayNames([
+        { name: 'Foo', slug: '' },
+        { name: 'Foo', slug: '' }
+      ])
+    ).toEqual(['Foo', 'Foo'])
+  })
+
+  it('skips disambiguation when slug equals name', () => {
+    expect(
+      providerDisplayNames([
+        { name: 'foo', slug: 'foo' },
+        { name: 'foo', slug: 'foo' }
+      ])
+    ).toEqual(['foo', 'foo'])
+  })
+
+  it('handles empty input', () => {
+    expect(providerDisplayNames([])).toEqual([])
+  })
+
+  it('preserves order', () => {
+    const input = [
+      { name: 'Z', slug: 'z' },
+      { name: 'A', slug: 'a1' },
+      { name: 'A', slug: 'a2' }
+    ]
+
+    expect(providerDisplayNames(input)).toEqual(['Z', 'A (a1)', 'A (a2)'])
+  })
+})

--- a/ui-tui/src/components/modelPicker.tsx
+++ b/ui-tui/src/components/modelPicker.tsx
@@ -1,6 +1,7 @@
 import { Box, Text, useInput } from '@hermes/ink'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
+import { providerDisplayNames } from '../domain/providers.js'
 import type { GatewayClient } from '../gatewayClient.js'
 import type { ModelOptionProvider, ModelOptionsResponse } from '../gatewayTypes.js'
 import { asRpcResult, rpcErrorMessage } from '../lib/rpc.js'
@@ -59,6 +60,7 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
 
   const provider = providers[providerIdx]
   const models = provider?.models ?? []
+  const names = useMemo(() => providerDisplayNames(providers), [providers])
 
   useInput((ch, key) => {
     if (key.escape) {
@@ -160,7 +162,7 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
 
   if (stage === 'provider') {
     const rows = providers.map(
-      p => `${p.is_current ? '*' : ' '} ${p.name} · ${p.total_models ?? p.models?.length ?? 0} models`
+      (p, i) => `${p.is_current ? '*' : ' '} ${names[i]} · ${p.total_models ?? p.models?.length ?? 0} models`
     )
 
     const { items, off } = visibleItems(rows, providerIdx)
@@ -201,7 +203,7 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
         Select Model
       </Text>
 
-      <Text color={t.color.dim}>{provider?.name || '(unknown provider)'}</Text>
+      <Text color={t.color.dim}>{names[providerIdx] || '(unknown provider)'}</Text>
       {!models.length ? <Text color={t.color.dim}>no models listed for this provider</Text> : null}
       {provider?.warning ? <Text color={t.color.label}>warning: {provider.warning}</Text> : null}
       {off > 0 && <Text color={t.color.dim}> ↑ {off} more</Text>}

--- a/ui-tui/src/domain/providers.ts
+++ b/ui-tui/src/domain/providers.ts
@@ -1,0 +1,17 @@
+export const providerDisplayNames = (providers: readonly { name: string; slug: string }[]): string[] => {
+  const counts = new Map<string, number>()
+
+  for (const p of providers) {
+    counts.set(p.name, (counts.get(p.name) ?? 0) + 1)
+  }
+
+  return providers.map(p => {
+    const dup = (counts.get(p.name) ?? 0) > 1
+
+    if (!dup || !p.slug || p.slug === p.name) {
+      return p.name
+    }
+
+    return `${p.name} (${p.slug})`
+  })
+}


### PR DESCRIPTION
## What does this PR do?

Defensive UX fix in the TS Ink `/model` picker: when two providers render with the same display name (e.g. `kimi-coding` and `kimi-coding-cn` both → "Kimi For Coding"), both rows now get their slug appended — `Kimi For Coding (kimi-coding)` vs `Kimi For Coding (kimi-coding-cn)` — so users can actually distinguish them. Same disambiguation is applied to the header of the "Select Model" stage so the selected provider label stays unambiguous. No-op when names are already unique.

The Python backend already dedupes Kimi-style aliases by skipping one (#10599 landed that for #10526), but that's "first-with-credentials wins" — a user with both sets of credentials only sees one. User-defined providers from `config.yaml`, `CANONICAL_PROVIDERS` overlays, and any future backend regression can still surface as two rows with identical labels. This is a tiny client-side safety net that makes the picker resilient instead of trusting the gateway to be perfect.

## Related Issue

Refs #10526

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `ui-tui/src/domain/providers.ts` — new pure helper `providerDisplayNames(providers)`. Single pass to count name occurrences, second pass to append `(slug)` to members of any group with count > 1. Falls back to the plain name when slug is empty or equal to the display name.
- `ui-tui/src/components/modelPicker.tsx` — compute disambiguated names once via `useMemo`, use them for both the provider-list rows and the selected-provider header on the model-selection stage.
- `ui-tui/src/__tests__/providers.test.ts` — 7 unit tests: unique names untouched, collisions disambiguated symmetrically, non-colliding groups unaffected, empty-slug fallback, slug-equals-name edge case, empty input, order preservation.

## How to Test

1. `cd ui-tui && npm install && npm run test` — 80 tests pass (7 new).
2. `npm run type-check` — clean.
3. `npm run lint` — no new errors on touched files.
4. Manual: if you have credentials for both `kimi-coding` and `kimi-coding-cn` configured, run `/model` and confirm the picker shows `Kimi For Coding (kimi-coding)` and `Kimi For Coding (kimi-coding-cn)` instead of two identical rows. With only one set of credentials, the backend dedupe still wins and the single row shows just `Kimi For Coding` (no slug suffix since there's no collision).

Tested on: Ubuntu 24.04 (WSL2), Node v22.22.2.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` — N/A, TS-only change; `npm run test` in `ui-tui/` passes (80/80)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04 (WSL2)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (internal TUI render helper)
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — pure string logic, no platform-specific code
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

Before (per #10526):

```
╭─ ⚙ Model Picker — Select Provider ─────────────╮
│                                                │
│ * Kimi For Coding · 6 models                   │
│   Kimi For Coding · 4 models                   │
│                                                │
╰────────────────────────────────────────────────╯
```

After:

```
╭─ ⚙ Model Picker — Select Provider ─────────────╮
│                                                │
│ * Kimi For Coding (kimi-coding) · 6 models     │
│   Kimi For Coding (kimi-coding-cn) · 4 models  │
│                                                │
╰────────────────────────────────────────────────╯
```