### PR TITLE
fix(honcho): inherit apiKey from default 'hermes' host block for sub-profiles

### DIFF
--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -349,6 +349,13 @@ class HonchoClientConfig:
             host_block.get("apiKey")
             or raw.get("apiKey")
             or os.environ.get("HONCHO_API_KEY")
+            # Sub-profiles (hermes.bob, hermes.ares, etc.) don't have their own
+            # apiKey — inherit from the default 'hermes' host block.
+            or (
+                (raw.get("hosts") or {}).get("hermes", {}).get("apiKey")
+                if resolved_host != HOST
+                else None
+            )
         )
 
         environment = (


### PR DESCRIPTION
## Problem

Sub-profiles (hermes.bob, hermes.ares, hermes.trinity, etc.) don't have their own `apiKey` in the Honcho config — only the default `hermes` host block has it. When resolving API key for non-default hosts, `from_global_config()` only checked:

1. `hosts.<host>.apiKey` — doesn't exist for sub-profiles
2. `apiKey` (root level) — doesn't exist
3. `` env var — not set

This caused all sub-profiles to report `Not connected (no API key or base URL)` in `hermes honcho status --target-profile <profile>`, and tools like the Hermes Control Interface showed them as disconnected.

## Fix

Added a 4th fallback in `client.py`'s `from_global_config()`: if the resolved host isn't the default `hermes`, inherit the apiKey from the `hermes` host block.

## Testing

All 5 profiles now connect OK:

```
hermes    -> OK
bob       -> OK
trinity   -> OK
stan      -> OK
ares      -> OK
```

No regression on default profile — apiKey still resolves from `hosts.hermes.apiKey` as before.