### PR TITLE
fix(models,cli,gateway): alias kimi-for-coding to kimi-coding with guard and rollback warnings

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -67,6 +67,7 @@ _PROVIDER_ALIASES = {
     "zhipu": "zai",
     "kimi": "kimi-coding",
     "moonshot": "kimi-coding",
+    "kimi-for-coding": "kimi-coding",
     "kimi-cn": "kimi-coding-cn",
     "moonshot-cn": "kimi-coding-cn",
     "minimax-china": "minimax-cn",

--- a/cli.py
+++ b/cli.py
@@ -4652,6 +4652,14 @@ class HermesCLI:
             return
 
         old_model = self.model
+        old_provider = self.provider
+        old_requested_provider = self.requested_provider
+        old_api_key = self.api_key
+        old_explicit_api_key = getattr(self, "_explicit_api_key", "")
+        old_base_url = self.base_url
+        old_explicit_base_url = getattr(self, "_explicit_base_url", "")
+        old_api_mode = self.api_mode
+
         self.model = result.new_model
         self.provider = result.target_provider
         self.requested_provider = result.target_provider
@@ -4674,7 +4682,18 @@ class HermesCLI:
                     api_mode=result.api_mode,
                 )
             except Exception as exc:
-                _cprint(f"  ⚠ Agent swap failed ({exc}); change applied to next session.")
+                # Roll back CLI state so we don't claim success while the
+                # agent is still on the old model.
+                self.model = old_model
+                self.provider = old_provider
+                self.requested_provider = old_requested_provider
+                self.api_key = old_api_key
+                self._explicit_api_key = old_explicit_api_key
+                self.base_url = old_base_url
+                self._explicit_base_url = old_explicit_base_url
+                self.api_mode = old_api_mode
+                _cprint(f"  ⚠ Switch failed: {exc}. Using {old_model}.")
+                return
 
         self._pending_model_switch_note = (
             f"[Note: model was just switched from {old_model} to {result.new_model} "
@@ -4872,6 +4891,14 @@ class HermesCLI:
         # Update requested_provider so _ensure_runtime_credentials() doesn't
         # overwrite the switch on the next turn (it re-resolves from this).
         old_model = self.model
+        old_provider = self.provider
+        old_requested_provider = self.requested_provider
+        old_api_key = self.api_key
+        old_explicit_api_key = getattr(self, "_explicit_api_key", "")
+        old_base_url = self.base_url
+        old_explicit_base_url = getattr(self, "_explicit_base_url", "")
+        old_api_mode = self.api_mode
+
         self.model = result.new_model
         self.provider = result.target_provider
         self.requested_provider = result.target_provider
@@ -4895,7 +4922,18 @@ class HermesCLI:
                     api_mode=result.api_mode,
                 )
             except Exception as exc:
-                _cprint(f"  ⚠ Agent swap failed ({exc}); change applied to next session.")
+                # Roll back CLI state so we don't claim success while the
+                # agent is still on the old model.
+                self.model = old_model
+                self.provider = old_provider
+                self.requested_provider = old_requested_provider
+                self.api_key = old_api_key
+                self._explicit_api_key = old_explicit_api_key
+                self.base_url = old_base_url
+                self._explicit_base_url = old_explicit_base_url
+                self.api_mode = old_api_mode
+                _cprint(f"  ⚠ Switch failed: {exc}. Using {old_model}.")
+                return
 
         # Store a note to prepend to the next user message so the model
         # knows a switch occurred (avoids injecting system messages mid-history

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5118,6 +5118,7 @@ class GatewayRunner:
                         if _cache_lock and _cache is not None:
                             with _cache_lock:
                                 cached_entry = _cache.get(_session_key)
+                        agent_swap_ok = True
                         if cached_entry and cached_entry[0] is not None:
                             try:
                                 cached_entry[0].switch_model(
@@ -5128,7 +5129,13 @@ class GatewayRunner:
                                     api_mode=result.api_mode,
                                 )
                             except Exception as exc:
-                                logger.warning("Picker model switch failed for cached agent: %s", exc)
+                                agent_swap_ok = False
+                                logger.warning(
+                                    "Picker model switch failed for cached agent: %s", exc
+                                )
+
+                        if not agent_swap_ok:
+                            return f"\u26a0 Switch failed. Still using `{_cur_model}`."
 
                         # Store model note + session override
                         if not hasattr(_self, "_pending_model_notes"):
@@ -5233,6 +5240,7 @@ class GatewayRunner:
             with _cache_lock:
                 cached_entry = _cache.get(session_key)
 
+        agent_swap_ok = True
         if cached_entry and cached_entry[0] is not None:
             try:
                 cached_entry[0].switch_model(
@@ -5243,7 +5251,11 @@ class GatewayRunner:
                     api_mode=result.api_mode,
                 )
             except Exception as exc:
+                agent_swap_ok = False
                 logger.warning("In-place model switch failed for cached agent: %s", exc)
+
+        if not agent_swap_ok:
+            return f"\u26a0 Switch failed. Still using `{current_model}`."
 
         # Store a note to prepend to the next user message so the model
         # knows about the switch (avoids system messages mid-history).

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -592,6 +592,7 @@ _PROVIDER_ALIASES = {
     "google-ai-studio": "gemini",
     "kimi": "kimi-coding",
     "moonshot": "kimi-coding",
+    "kimi-for-coding": "kimi-coding",
     "kimi-cn": "kimi-coding-cn",
     "moonshot-cn": "kimi-coding-cn",
     "arcee-ai": "arcee",
@@ -1056,13 +1057,24 @@ def detect_provider_for_model(
 
     name_lower = name.lower()
 
+    # --- Guard: if input is an exact model name in any provider's catalog,
+    # don't let step 0 treat it as a provider alias. Prevents e.g.
+    # `/model kimi-for-coding` from being misresolved to the default model
+    # of the `kimi-coding` provider because that model name happens to be
+    # in the provider alias table.
+    _is_exact_model_name = False
+    for _pid, _models in _PROVIDER_MODELS.items():
+        if any(name_lower == _m.lower() for _m in _models):
+            _is_exact_model_name = True
+            break
+
     # --- Step 0: bare provider name typed as model ---
     # If someone types `/model nous` or `/model anthropic`, treat it as a
     # provider switch and pick the first model from that provider's catalog.
     # Skip "custom" and "openrouter" — custom has no model catalog, and
     # openrouter requires an explicit model name to be useful.
     resolved_provider = _PROVIDER_ALIASES.get(name_lower, name_lower)
-    if resolved_provider not in {"custom", "openrouter"}:
+    if not _is_exact_model_name and resolved_provider not in {"custom", "openrouter"}:
         default_models = _PROVIDER_MODELS.get(resolved_provider, [])
         if (
             resolved_provider in _PROVIDER_LABELS

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -268,6 +268,7 @@ AUTHOR_MAP = {
     "junminliu@gmail.com": "JimLiu",
     "jarvischer@gmail.com": "maxchernin",
     "levantam.98.2324@gmail.com": "LVT382009",
+    "juancrfig@gmail.com": "juancrfig",
 }
 
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -978,3 +978,24 @@ class TestAnthropicCompatImageConversion:
         }]
         result = _convert_openai_images_to_anthropic(messages)
         assert result[0]["content"][0]["source"]["media_type"] == "image/jpeg"
+
+
+# -- Provider alias normalization --------------------------------------------
+
+class TestNormalizeAuxProvider:
+    def test_kimi_for_coding_alias(self):
+        from agent.auxiliary_client import _normalize_aux_provider
+        assert _normalize_aux_provider("kimi-for-coding") == "kimi-coding"
+
+    def test_kimi_alias(self):
+        from agent.auxiliary_client import _normalize_aux_provider
+        assert _normalize_aux_provider("kimi") == "kimi-coding"
+
+    def test_moonshot_alias(self):
+        from agent.auxiliary_client import _normalize_aux_provider
+        assert _normalize_aux_provider("moonshot") == "kimi-coding"
+
+    def test_no_alias_unchanged(self):
+        from agent.auxiliary_client import _normalize_aux_provider
+        assert _normalize_aux_provider("openrouter") == "openrouter"
+        assert _normalize_aux_provider("anthropic") == "anthropic"

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from hermes_cli.models import (
     copilot_model_api_mode,
+    detect_provider_for_model,
     fetch_github_model_catalog,
     curated_models_for_provider,
     fetch_api_models,
@@ -154,6 +155,7 @@ class TestNormalizeProvider:
         assert normalize_provider("glm") == "zai"
         assert normalize_provider("kimi") == "kimi-coding"
         assert normalize_provider("moonshot") == "kimi-coding"
+        assert normalize_provider("kimi-for-coding") == "kimi-coding"
         assert normalize_provider("github-copilot") == "copilot"
 
     def test_case_insensitive(self):
@@ -540,3 +542,35 @@ class TestValidateCodexAutoCorrection:
         assert result["recognized"] is False
         assert result.get("corrected_model") is None
         assert "not found" in result["message"]
+
+
+# -- detect_provider_for_model -----------------------------------------------
+
+class TestDetectProviderForModel:
+    def test_kimi_for_coding_from_openrouter(self):
+        """kimi-for-coding typed from openrouter should switch to kimi-coding provider."""
+        result = detect_provider_for_model("kimi-for-coding", "openrouter")
+        assert result is not None
+        assert result[0] == "kimi-coding"
+        assert result[1] == "kimi-for-coding"
+
+    def test_kimi_for_coding_already_on_kimi_coding(self):
+        """kimi-for-coding when already on kimi-coding should return None."""
+        result = detect_provider_for_model("kimi-for-coding", "kimi-coding")
+        assert result is None
+
+    def test_kimi_for_coding_not_replaced_with_default_model(self):
+        """The guard should prevent step 0 from replacing kimi-for-coding with the default model."""
+        result = detect_provider_for_model("kimi-for-coding", "nous")
+        assert result is not None
+        assert result[0] == "kimi-coding"
+        # Must preserve the exact model name, not swap to the provider's default
+        assert result[1] == "kimi-for-coding"
+        assert result[1] != "kimi-k2.5"
+
+    def test_bare_provider_alias_still_works(self):
+        """Typing a bare provider alias like 'kimi' should still switch to default model."""
+        result = detect_provider_for_model("kimi", "openrouter")
+        assert result is not None
+        assert result[0] == "kimi-coding"
+        assert result[1] == "kimi-k2.5"


### PR DESCRIPTION
## What does this PR do?

Fixes the `/model kimi-for-coding` command silently failing by addressing three layers of the provider resolution chain:

1. **CLI model detection** — "kimi-for-coding" was not recognized as a valid model because `detect_provider_for_model()` had no alias mapping for it. Worse, since the model name collided with a potential provider alias pattern, Step 0 of the detection logic would incorrectly treat it as a bare provider switch and replace it with the default model ("kimi-k2.5").

2. **Agent provider routing** — `auxiliary_client.py` also lacked the alias, so even if the CLI had resolved it, the agent would route to a non-existent provider.

3. **Silent failure UX** — When `agent.switch_model()` failed (due to the above), the CLI and gateway reported success while the agent continued using the old model, silently burning API credits on the wrong provider.

This PR adds:
- The "kimi-for-coding" -> "kimi-coding" alias in both CLI and agent alias tables
- A guard in `detect_provider_for_model()` that skips Step 0 (bare-provider-alias detection) when the input is an exact model name present in any provider's catalog, preventing alias-model name collisions
- Defensive rollback + warning in CLI and gateway when `agent.switch_model()` fails, so the user knows the switch did not happen

## Related Issue

Fixes #12296

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `hermes_cli/models.py`:
  - Add "kimi-for-coding": "kimi-coding" to `_PROVIDER_ALIASES`
  - Add guard in `detect_provider_for_model()` to check if input exists as an exact model name before treating it as a bare provider alias
- `agent/auxiliary_client.py`:
  - Add "kimi-for-coding": "kimi-coding" to `_PROVIDER_ALIASES`
- `hermes_cli/cli.py`:
  - Store old model/provider before swap attempt
  - Rollback and emit warning if `agent.switch_model()` returns False
- `gateway/run.py`:
  - Same rollback/warning pattern for TUI picker and `/model` slash command
- `tests/hermes_cli/test_model_validation.py`:
  - Add `TestDetectProviderForModel` with 4 test cases covering the alias, the guard, and bare-provider-alias backwards compatibility
- `tests/agent/test_auxiliary_client.py`:
  - Add `TestNormalizeAuxProvider` with 4 test cases for alias normalization

## How to Test

1. Run targeted tests:
   ```bash
   pytest tests/hermes_cli/test_model_validation.py tests/agent/test_auxiliary_client.py -q
   ```
   Expected: 90+ tests pass.

2. Run broader CLI + agent test suite:
   ```bash
   pytest tests/hermes_cli/ tests/agent/ tests/run_agent/ -q --tb=short
   ```
   Expected: ~4488 pass, 7 unrelated pre-existing failures (test_claw.py, test_web_server.py, test_concurrent_interrupt.py, test_run_agent.py::test_tool_call_accumulation).

3. Manual verification (requires a Kimi API key):
   ```bash
   hermes chat -q "/model kimi-for-coding"
   ```
   Should report success and show the new model in the prompt. Previously this would silently stay on the old model.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls)
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've considered cross-platform impact — N/A (pure Python string matching, no platform-specific code)
