### PR TITLE
fix(auxiliary): vision auto-routing fails for aggregator providers wrapping dedicated vision models

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1882,7 +1882,16 @@ def resolve_vision_provider_client(
         main_provider = _read_main_provider()
         main_model = _read_main_model()
         if main_provider and main_provider not in ("auto", ""):
-            vision_model = _PROVIDER_VISION_MODELS.get(main_provider, main_model)
+            # _PROVIDER_VISION_MODELS keys are model-level providers (e.g.
+            # "xiaomi", "zai"), not API providers (e.g. "nous", "openrouter").
+            # When main_provider is an aggregator that wraps a model with a
+            # dedicated vision variant, extract the model's provider prefix
+            # and look up the override by that first.
+            _model_prefix = main_model.split("/")[0] if "/" in main_model else ""
+            vision_model = _PROVIDER_VISION_MODELS.get(
+                _model_prefix,
+                _PROVIDER_VISION_MODELS.get(main_provider, main_model),
+            )
             rpc_client, rpc_model = resolve_provider_client(
                 main_provider, vision_model,
                 api_mode=resolved_api_mode)


### PR DESCRIPTION
## Problem

When \`main_provider\` is an aggregator (e.g. \`"nous"\`) that wraps models from a different manufacturer (e.g. \`xiaomi/mimo-v2-pro\`), the vision auto-routing lookup fails because \_PROVIDER\_VISION\_MODELS keys are model-level providers (\`"xiaomi"\`, \`"zai"\`), not API providers (\`"nous"\`).

This causes vision tasks to use \`xiaomi/mimo-v2-pro\` (text-only, no vision support) instead of \`xiaomi/mimo-v2-omni\` (multimodal), breaking image recognition for all Nous Portal users on \`auto\` vision routing.

## Root Cause

Line 1885 in \`agent/auxiliary_client.py\`:
```python
vision_model = _PROVIDER_VISION_MODELS.get(main_provider, main_model)
```

\`main_provider\` is \`"nous"\`, but the dict only has \`"xiaomi"\` and \`"zai"\` as keys. The lookup misses and falls back to \`main_model = "xiaomi/mimo-v2-pro"\`.

## Fix

Extract the model provider prefix (e.g. \`"xiaomi"\` from \`"xiaomi/mimo-v2-pro"\`) and look up \`\_PROVIDER\_VISION\_MODELS\` by that first:

```python
_model_prefix = main_model.split("/")[0] if "/" in main_model else ""
vision_model = _PROVIDER_VISION_MODELS.get(
    _model_prefix,
    _PROVIDER_VISION_MODELS.get(main_provider, main_model),
)
```

## Reproduction

- \`config.yaml\`: \`model.provider: nous\`, \`model.default: xiaomi/mimo-v2-pro\`
- \`config.yaml\`: \`auxiliary.vision.provider: auto\`
- Expected: vision uses \`xiaomi/mimo-v2-omni\`
- Actual (before fix): vision uses \`xiaomi/mimo-v2-pro\` → 400 error (not vision-capable)

## Regression

Introduced by commit a155b4a1 (PR #11900) which changed \`auto\` routing to prefer main provider for all users, but the vision model override lookup was not updated to handle aggregator providers wrapping models from different manufacturers.