### PR TITLE
fix(hermes_cli): dedup providers across user_providers and custom_providers

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1039,6 +1039,9 @@ def list_authenticated_providers(
         for ep_name, ep_cfg in user_providers.items():
             if not isinstance(ep_cfg, dict):
                 continue
+            # Skip if a built-in / canonical / hermes overlay already claimed this slug (#12293).
+            if ep_name.lower() in seen_slugs:
+                continue
             display_name = ep_cfg.get("name", "") or ep_name
             api_url = ep_cfg.get("api", "") or ep_cfg.get("url", "") or ""
             default_model = ep_cfg.get("default_model", "")
@@ -1066,6 +1069,9 @@ def list_authenticated_providers(
                 "source": "user-config",
                 "api_url": api_url,
             })
+            # Register this user-defined slug so Section 4 (custom_providers)
+            # will not emit a second row for the same provider (#12293).
+            seen_slugs.add(ep_name.lower())
 
     # --- 4. Saved custom providers from config ---
     # Each ``custom_providers`` entry represents one model under a named
@@ -1105,7 +1111,16 @@ def list_authenticated_providers(
                 groups[slug]["models"].append(default_model)
 
         for slug, grp in groups.items():
-            if slug.lower() in seen_slugs:
+            # Match against the prefixed slug, the bare display name, and
+            # the hyphenated display name — any of the three forms may have
+            # been registered by an earlier section (#12293).
+            display_lower = grp["name"].strip().lower()
+            display_hyphen = display_lower.replace(" ", "-")
+            if (
+                slug.lower() in seen_slugs
+                or display_lower in seen_slugs
+                or display_hyphen in seen_slugs
+            ):
                 continue
             results.append({
                 "slug": slug,
@@ -1118,6 +1133,8 @@ def list_authenticated_providers(
                 "api_url": grp["api_url"],
             })
             seen_slugs.add(slug.lower())
+            seen_slugs.add(display_lower)
+            seen_slugs.add(display_hyphen)
 
     # Sort: current provider first, then by model count descending
     results.sort(key=lambda r: (not r["is_current"], -r["total_models"]))

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -156,3 +156,64 @@ def test_list_deduplicates_same_model_in_group(monkeypatch):
     assert len(my_rows) == 1
     assert my_rows[0]["models"] == ["llama3", "mistral"]
     assert my_rows[0]["total_models"] == 2
+
+
+def test_user_provider_and_custom_provider_same_name_emit_once(monkeypatch):
+    """#12293: defining the same provider under BOTH `providers:` (user-defined)
+    and `custom_providers:` in config.yaml should emit one row, not two."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    providers = list_authenticated_providers(
+        current_provider="openrouter",
+        user_providers={
+            "api.us-west-2.modal.direct": {
+                "name": "api.us-west-2.modal.direct",
+                "api": "https://api.us-west-2.modal.direct/v1",
+                "default_model": "claude-sonnet-4-5",
+            }
+        },
+        custom_providers=[
+            {
+                "name": "api.us-west-2.modal.direct",
+                "base_url": "https://api.us-west-2.modal.direct/v1",
+                "model": "claude-sonnet-4-5",
+            }
+        ],
+        max_models=50,
+    )
+
+    matching = [
+        p for p in providers
+        if p["name"] == "api.us-west-2.modal.direct"
+        or p["slug"] == "api.us-west-2.modal.direct"
+        or p["slug"] == "custom:api.us-west-2.modal.direct"
+    ]
+    assert len(matching) == 1, f"expected 1 row, got {len(matching)}: {matching}"
+
+
+def test_user_provider_registered_before_custom_wins_and_dedups(monkeypatch):
+    """When a user_provider runs first, the later custom_providers entry
+    must see the name in seen_slugs and be skipped (#12293)."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    providers = list_authenticated_providers(
+        current_provider="openrouter",
+        user_providers={
+            "my-local": {
+                "name": "My Local",
+                "api": "http://localhost:4141/v1",
+                "default_model": "local-default",
+            }
+        },
+        custom_providers=[
+            # Different display name but same resolved target — should still dedupe
+            # when the prefixed custom:my-local slug matches a bare my-local already seen.
+            {"name": "my-local", "base_url": "http://localhost:4141/v1", "model": "local-default"},
+        ],
+        max_models=50,
+    )
+
+    my_local_rows = [p for p in providers if "my-local" in p["slug"].lower()]
+    assert len(my_local_rows) == 1


### PR DESCRIPTION
## Problem

\`list_authenticated_providers()\` in \`hermes_cli/model_switch.py\` maintains a \`seen_slugs\` set to prevent duplicate \`/model\` rows. Section 1 (built-in) and Section 2 (canonical) correctly register their slugs. But:

- **Section 3** (\`providers:\` user-defined endpoints at line 1037) never registered its slugs in \`seen_slugs\`, so a later section could emit a second row for the same provider.
- **Section 4** (\`custom_providers:\` at line 1070) only checked the \`custom:\`-prefixed slug against \`seen_slugs\`. If Section 3 had already emitted the same provider under its bare name, Section 4's check at \`custom:<name>\` wouldn't match, so a duplicate row was emitted.

Reported in #12293 by @wl-lgtm — in their repro, one provider defined in \`~/.hermes/config.yaml\` under both \`providers:\` and \`custom_providers:\` appeared twice in the \`/model\` picker.

## Fix

- Section 3 now checks \`seen_slugs\` before emitting and registers \`ep_name.lower()\` after emitting.
- Section 4 now checks against three forms — the prefixed slug, the bare display name lowercased, and the hyphenated display name — and registers all three on success. This covers the naming variants Section 3 / Section 2 / the overlay mapping may have used.

Scope is intentionally tight: only the dedup path in \`list_authenticated_providers\`. No changes to \`custom_provider_slug\`, \`resolve_provider_full\`, or the runtime resolution path.

## Testing

- 2 new regression tests in \`tests/hermes_cli/test_model_switch_custom_providers.py\`:
  - \`test_user_provider_and_custom_provider_same_name_emit_once\` — the exact repro from #12293
  - \`test_user_provider_registered_before_custom_wins_and_dedups\` — guards against future slug-format churn
- Full \`test_model_switch_custom_providers.py\` + related model_switch suites pass (26/26).

Fixes #12293