### PR TITLE
fix(send_message): support current gateway session target

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -273,6 +273,83 @@ class TestSendMessageTool:
             media_files=[],
         )
 
+    def test_current_discord_target_uses_active_session_chat_and_thread(self):
+        discord_cfg = SimpleNamespace(enabled=True, token="***", extra={})
+        config = SimpleNamespace(
+            platforms={Platform.DISCORD: discord_cfg},
+            get_home_channel=lambda _platform: None,
+        )
+
+        with patch.dict(
+            os.environ,
+            {
+                "HERMES_SESSION_PLATFORM": "discord",
+                "HERMES_SESSION_CHAT_ID": "123456789012345678",
+                "HERMES_SESSION_THREAD_ID": "987654321098765432",
+            },
+            clear=False,
+        ), \
+             patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "discord:current",
+                        "message": "batch 1",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        send_mock.assert_awaited_once_with(
+            Platform.DISCORD,
+            discord_cfg,
+            "123456789012345678",
+            "batch 1",
+            thread_id="987654321098765432",
+            media_files=[],
+        )
+        mirror_mock.assert_called_once_with(
+            "discord",
+            "123456789012345678",
+            "batch 1",
+            source_label="discord",
+            thread_id="987654321098765432",
+        )
+
+    def test_current_target_errors_without_active_session_chat(self):
+        discord_cfg = SimpleNamespace(enabled=True, token="***", extra={})
+        config = SimpleNamespace(
+            platforms={Platform.DISCORD: discord_cfg},
+            get_home_channel=lambda _platform: None,
+        )
+
+        with patch.dict(
+            os.environ,
+            {
+                "HERMES_SESSION_PLATFORM": "discord",
+            },
+            clear=False,
+        ), \
+             patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False):
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "discord:current",
+                        "message": "batch 1",
+                    }
+                )
+            )
+
+        assert "error" in result
+        assert "active session chat_id" in result["error"].lower()
+
     def test_media_only_message_uses_placeholder_for_mirroring(self):
         config, telegram_cfg = _make_config()
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -113,7 +113,7 @@ SEND_MESSAGE_SCHEMA = {
             },
             "target": {
                 "type": "string",
-                "description": "Delivery target. Format: 'platform' (uses home channel), 'platform:#channel-name', 'platform:chat_id', or 'platform:chat_id:thread_id' for Telegram topics and Discord threads. Examples: 'telegram', 'telegram:-1001234567890:17585', 'discord:999888777:555444333', 'discord:#bot-home', 'slack:#engineering', 'signal:+155****4567', 'matrix:!roomid:server.org', 'matrix:@user:server.org'"
+                "description": "Delivery target. Format: 'platform' (uses home channel), 'platform:current' (uses the active gateway session channel/thread), 'platform:#channel-name', 'platform:chat_id', or 'platform:chat_id:thread_id' for Telegram topics and Discord threads. Examples: 'telegram', 'telegram:current', 'telegram:-1001234567890:17585', 'discord:current', 'discord:999888777:555444333', 'discord:#bot-home', 'slack:#engineering', 'signal:+155****4567', 'matrix:!roomid:server.org', 'matrix:@user:server.org'"
             },
             "message": {
                 "type": "string",
@@ -157,7 +157,14 @@ def _handle_send(args):
     chat_id = None
     thread_id = None
 
-    if target_ref:
+    if target_ref and target_ref.lower() in {"current", "__session__"}:
+        session_error = _resolve_current_session_target(platform_name)
+        if "error" in session_error:
+            return json.dumps(session_error)
+        chat_id = session_error["chat_id"]
+        thread_id = session_error.get("thread_id")
+        is_explicit = True
+    elif target_ref:
         chat_id, thread_id, is_explicit = _parse_target_ref(platform_name, target_ref)
     else:
         is_explicit = False
@@ -286,7 +293,7 @@ def _handle_send(args):
             try:
                 from gateway.mirror import mirror_to_session
                 from gateway.session_context import get_session_env
-                source_label = get_session_env("HERMES_SESSION_PLATFORM", "cli")
+                source_label = get_session_env("HERMES_SESSION_PLATFORM", "cli") or "cli"
                 if mirror_to_session(platform_name, chat_id, mirror_text, source_label=source_label, thread_id=thread_id):
                     result["mirrored"] = True
             except Exception:
@@ -297,6 +304,31 @@ def _handle_send(args):
         return json.dumps(result)
     except Exception as e:
         return json.dumps(_error(f"Send failed: {e}"))
+
+
+def _resolve_current_session_target(platform_name: str) -> dict:
+    """Resolve platform:current / platform:__session__ to the active session target."""
+    from gateway.session_context import get_session_env
+
+    session_platform = get_session_env("HERMES_SESSION_PLATFORM", "").strip().lower()
+    chat_id = get_session_env("HERMES_SESSION_CHAT_ID", "").strip()
+    thread_id = get_session_env("HERMES_SESSION_THREAD_ID", "").strip() or None
+
+    if session_platform and session_platform != platform_name:
+        return _error(
+            f"Current session target is for {session_platform}, not {platform_name}. "
+            f"Use '{session_platform}:current' or an explicit {platform_name} target instead."
+        )
+
+    if not chat_id:
+        return _error(
+            "No active session chat_id available. Use an explicit channel target instead."
+        )
+
+    return {
+        "chat_id": chat_id,
+        "thread_id": thread_id,
+    }
 
 
 def _parse_target_ref(platform_name: str, target_ref: str):


### PR DESCRIPTION
## Summary
- add `platform:current` / `platform:__session__` support to `send_message`
- resolve the active gateway session `chat_id` and `thread_id` from session context
- return a clear error when no active session target exists or when the requested platform mismatches the current session
- preserve `cli` as the mirror source fallback when the session platform label is empty

## Testing
- `pytest tests/tools/test_send_message_tool.py::TestSendMessageTool::test_current_discord_target_uses_active_session_chat_and_thread tests/tools/test_send_message_tool.py::TestSendMessageTool::test_current_target_errors_without_active_session_chat tests/tools/test_send_message_tool.py::TestSendMessageTool::test_cron_different_target_still_sends tests/tools/test_send_message_tool.py::TestSendMessageTool::test_cron_same_chat_different_thread_still_sends tests/tools/test_send_message_tool.py::TestSendMessageTool::test_sends_to_explicit_telegram_topic_target tests/tools/test_send_message_tool.py::TestSendMessageTool::test_media_only_message_uses_placeholder_for_mirroring -q`
- `python -m py_compile tools/send_message_tool.py tests/tools/test_send_message_tool.py`

Closes #5472