### PR TITLE
fix(gateway): preserve pending steer fallback

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9903,6 +9903,8 @@ class GatewayRunner:
                 elif pending_event:
                     pending = pending_event.text or _build_media_placeholder(pending_event)
                     logger.debug("Processing queued message after agent completion: '%s...'", pending[:40])
+                elif result.get("pending_steer"):
+                    pending = result.get("pending_steer")
 
             # Safety net: if the pending text is a slash command (e.g. "/stop",
             # "/new"), discard it — commands should never be passed to the agent


### PR DESCRIPTION
## Summary
- route leftover pending_steer from finished gateway agent runs into the existing pending follow-up path
- preserve late /steer messages when no tool result remains to receive them

## Validation
- python3 -m py_compile gateway/run.py
- git diff --check

Note: scripts/run_tests.sh tests/gateway/test_steer_command.py could not run because the discovered venv at /home/jayne/.hermes/hermes-agent/venv lacks pip while the wrapper attempted to install pytest-split.