### PR TITLE
feat(api-server): support multimodal image uploads via auxiliary vision

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -157,11 +157,31 @@ _IMAGE_MIME_SUFFIXES = {
     "image/jpg": ".jpg",
 }
 
-# Per-image cap on the decoded byte payload of a data: URL (15 MiB).
-# Paired with MAX_REQUEST_BYTES (the per-request cap) so that a single
-# oversize image can't sneak through, and so we don't decode > this much
-# attacker-controlled base64 into RAM.
-_MAX_IMAGE_BYTES = 15 * 1024 * 1024
+def _resolve_max_image_bytes() -> int:
+    """Resolve the per-image decoded-byte cap.
+
+    Paired with ``MAX_REQUEST_BYTES`` — the request-level cap bounds total
+    payload size; this additionally keeps any single base64 image from
+    decoding into an unreasonable amount of memory.  Default is 50 MiB,
+    which comfortably fits game screenshots, scanned documents, and
+    large photos.  Operators can tighten or loosen via the
+    ``API_SERVER_MAX_IMAGE_MB`` environment variable.
+    """
+    raw = os.getenv("API_SERVER_MAX_IMAGE_MB", "").strip()
+    if raw:
+        try:
+            mb = float(raw)
+            if mb > 0:
+                return int(mb * 1024 * 1024)
+        except ValueError:
+            logger.warning(
+                "Invalid API_SERVER_MAX_IMAGE_MB=%r; falling back to default",
+                raw,
+            )
+    return 50 * 1024 * 1024
+
+
+MAX_IMAGE_BYTES = _resolve_max_image_bytes()
 
 
 def _sniff_image_mime(data: bytes) -> Optional[str]:
@@ -213,7 +233,7 @@ def _materialize_data_url(url: str):
 
     Validates the payload by sniffing magic bytes — the caller-supplied
     MIME type is not trusted for anything but logging.  Payloads that
-    exceed ``_MAX_IMAGE_BYTES`` or don't match a known image format raise
+    exceed ``MAX_IMAGE_BYTES`` or don't match a known image format raise
     :class:`ValueError`.
     """
     import base64
@@ -232,10 +252,10 @@ def _materialize_data_url(url: str):
     except Exception as exc:  # binascii.Error, ValueError
         raise ValueError("invalid base64 payload in data: URL") from exc
 
-    if len(data) > _MAX_IMAGE_BYTES:
+    if len(data) > MAX_IMAGE_BYTES:
         raise ValueError(
             f"image payload exceeds per-image limit "
-            f"({len(data)} > {_MAX_IMAGE_BYTES} bytes)"
+            f"({len(data)} > {MAX_IMAGE_BYTES} bytes)"
         )
 
     sniffed_mime = _sniff_image_mime(data)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2627,7 +2627,13 @@ class APIServerAdapter(BasePlatformAdapter):
 
         try:
             mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
-            self._app = web.Application(middlewares=mws)
+            # client_max_size bounds how much aiohttp will buffer when reading
+            # a request body.  Default is 1 MiB — too small for multimodal
+            # requests carrying a base64-encoded image.  Align with the
+            # MAX_REQUEST_BYTES cap so body_limit_middleware is actually the
+            # authoritative gate (rather than aiohttp silently truncating
+            # payloads and turning them into "Invalid JSON in request body").
+            self._app = web.Application(middlewares=mws, client_max_size=MAX_REQUEST_BYTES)
             self._app["api_server_adapter"] = self
             self._app.router.add_get("/health", self._handle_health)
             self._app.router.add_get("/health/detailed", self._handle_health_detailed)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -53,7 +53,30 @@ logger = logging.getLogger(__name__)
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8642
 MAX_STORED_RESPONSES = 100
-MAX_REQUEST_BYTES = 1_000_000  # 1 MB default limit for POST bodies
+
+
+def _resolve_max_request_bytes() -> int:
+    """Resolve the max POST body size.
+
+    Default is 25 MB so that multimodal requests carrying a few base64-encoded
+    images fit.  Operators can tighten or loosen this via the
+    ``API_SERVER_MAX_REQUEST_MB`` environment variable.
+    """
+    raw = os.getenv("API_SERVER_MAX_REQUEST_MB", "").strip()
+    if raw:
+        try:
+            mb = float(raw)
+            if mb > 0:
+                return int(mb * 1024 * 1024)
+        except ValueError:
+            logger.warning(
+                "Invalid API_SERVER_MAX_REQUEST_MB=%r; falling back to default",
+                raw,
+            )
+    return 25 * 1024 * 1024
+
+
+MAX_REQUEST_BYTES = _resolve_max_request_bytes()
 CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS = 30.0
 MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
@@ -115,6 +138,183 @@ def _normalize_chat_content(
         return result[:MAX_NORMALIZED_TEXT_LENGTH] if len(result) > MAX_NORMALIZED_TEXT_LENGTH else result
     except Exception:
         return ""
+
+
+_IMAGE_PREPROCESS_PROMPT = (
+    "Describe everything visible in this image in thorough detail. "
+    "Include any text, code, data, objects, people, layout, colors, "
+    "and any other notable visual information."
+)
+
+_IMAGE_DATA_URL_SUFFIXES = {
+    "image/png": ".png",
+    "image/gif": ".gif",
+    "image/webp": ".webp",
+    "image/jpeg": ".jpg",
+    "image/jpg": ".jpg",
+}
+
+
+def _materialize_data_url(url: str):
+    """Write a ``data:image/...;base64,...`` URL to a temp file.
+
+    Returns ``(path_str, cleanup_path)`` where ``cleanup_path`` is the
+    :class:`Path` the caller must ``unlink()`` when done.  Returns
+    ``(url, None)`` if ``url`` is not a ``data:`` URL.
+    """
+    import base64
+    import tempfile
+    from pathlib import Path as _Path
+
+    if not isinstance(url, str) or not url.startswith("data:"):
+        return url, None
+
+    header, _, payload = url.partition(",")
+    mime = "image/jpeg"
+    mime_part = header[len("data:"):].split(";", 1)[0].strip()
+    if mime_part.startswith("image/"):
+        mime = mime_part
+    suffix = _IMAGE_DATA_URL_SUFFIXES.get(mime, ".jpg")
+
+    tmp = tempfile.NamedTemporaryFile(
+        prefix="api_server_image_", suffix=suffix, delete=False,
+    )
+    try:
+        tmp.write(base64.b64decode(payload))
+    finally:
+        tmp.close()
+    path = _Path(tmp.name)
+    return str(path), path
+
+
+def _split_content_parts(content: List[Any]):
+    """Extract text strings and image URLs from a multi-part content list."""
+    text_parts: List[str] = []
+    image_urls: List[str] = []
+    for part in content:
+        if isinstance(part, str):
+            if part.strip():
+                text_parts.append(part.strip())
+            continue
+        if not isinstance(part, dict):
+            continue
+        ptype = str(part.get("type") or "").strip().lower()
+        if ptype in {"text", "input_text", "output_text"}:
+            text = str(part.get("text", "") or "").strip()
+            if text:
+                text_parts.append(text)
+        elif ptype == "image_url":
+            img = part.get("image_url")
+            url = ""
+            if isinstance(img, dict):
+                url = str(img.get("url", "") or "")
+            elif isinstance(img, str):
+                url = img
+            if url:
+                image_urls.append(url)
+    return text_parts, image_urls
+
+
+async def _preprocess_message_images(messages: List[Dict[str, Any]]) -> None:
+    """Convert ``image_url`` parts in OpenAI chat messages into text descriptions.
+
+    The OpenAI chat completions format allows a message's ``content`` to be an
+    array of typed parts, including ``{"type": "image_url", ...}``.  The
+    downstream agent pipeline expects plain strings, and the existing
+    :func:`_normalize_chat_content` flatten step silently drops image parts.
+
+    This helper — called before normalization — mirrors the CLI's
+    ``_preprocess_images_with_vision``: for each image in the message, it
+    invokes the auxiliary vision model (configured via ``auxiliary.vision``)
+    and inlines the resulting description back into the user's message as
+    text.  This lets any provider backend (Codex Responses, Anthropic,
+    OpenAI-compatible, etc.) receive the image content, since the agent
+    ultimately only sees text.
+
+    ``data:`` URLs (used by Open WebUI and similar frontends) are materialized
+    to a temp file so the vision tool can read them; remote URLs are passed
+    through.  Errors per-image produce a note in the message rather than
+    failing the whole request.
+
+    Mutates ``messages`` in place.
+    """
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        content = msg.get("content")
+        if not isinstance(content, list):
+            continue
+
+        has_image = any(
+            isinstance(p, dict) and str(p.get("type") or "").strip().lower() == "image_url"
+            for p in content
+        )
+        if not has_image:
+            continue
+
+        try:
+            from tools.vision_tools import vision_analyze_tool
+        except Exception as exc:
+            logger.warning(
+                "vision_analyze_tool unavailable (%s); image parts in this "
+                "request will be dropped",
+                exc,
+            )
+            continue
+
+        text_parts, image_urls = _split_content_parts(content)
+
+        enriched: List[str] = []
+        for url in image_urls:
+            vision_source, cleanup_path = url, None
+            try:
+                vision_source, cleanup_path = _materialize_data_url(url)
+                result_json = await vision_analyze_tool(
+                    image_url=vision_source, user_prompt=_IMAGE_PREPROCESS_PROMPT,
+                )
+                try:
+                    result = json.loads(result_json) if isinstance(result_json, str) else {}
+                except (ValueError, TypeError):
+                    result = {}
+
+                if isinstance(result, dict) and result.get("success"):
+                    desc = str(result.get("analysis", "") or "").strip()
+                    if desc:
+                        enriched.append(
+                            f"[The user attached an image. Here's what it contains:\n{desc}]"
+                        )
+                    else:
+                        enriched.append(
+                            "[The user attached an image but the vision model returned no description.]"
+                        )
+                else:
+                    err = ""
+                    if isinstance(result, dict):
+                        err = str(result.get("analysis") or result.get("error") or "").strip()
+                    enriched.append(
+                        f"[The user attached an image but analysis failed: {err or 'unknown error'}]"
+                    )
+            except Exception as exc:
+                logger.warning("api_server image preprocessing raised: %s", exc)
+                enriched.append(
+                    f"[The user attached an image but analysis raised: {exc}]"
+                )
+            finally:
+                if cleanup_path is not None:
+                    try:
+                        if cleanup_path.exists():
+                            cleanup_path.unlink()
+                    except OSError:
+                        pass
+
+        user_text = "\n".join(t for t in text_parts if t).strip()
+        if enriched:
+            prefix = "\n\n".join(enriched)
+            msg["content"] = f"{prefix}\n\n{user_text}" if user_text else prefix
+        elif user_text:
+            msg["content"] = user_text
+        else:
+            msg["content"] = "[An image was attached but could not be described.]"
 
 
 def check_api_server_requirements() -> bool:
@@ -632,6 +832,17 @@ class APIServerAdapter(BasePlatformAdapter):
             )
 
         stream = body.get("stream", False)
+
+        # Describe any image_url parts in-place via the auxiliary vision model
+        # so the agent pipeline receives them as text.  Without this,
+        # _normalize_chat_content below would silently drop them.
+        try:
+            await _preprocess_message_images(messages)
+        except Exception as e:
+            logger.warning(
+                "image preprocessing failed; images in this request will be dropped: %s",
+                e,
+            )
 
         # Extract system message (becomes ephemeral system prompt layered ON TOP of core)
         system_prompt = None
@@ -1423,7 +1634,20 @@ class APIServerAdapter(BasePlatformAdapter):
             previous_response_id = self._response_store.get_conversation(conversation)
             # No error if conversation doesn't exist yet — it's a new conversation
 
-        # Normalize input to message list
+        # Normalize input to message list.  Preprocess image_url parts first
+        # so the auxiliary vision model can describe them before
+        # _normalize_chat_content drops non-text content.
+        if isinstance(raw_input, list):
+            try:
+                await _preprocess_message_images(
+                    [item for item in raw_input if isinstance(item, dict)]
+                )
+            except Exception as e:
+                logger.warning(
+                    "image preprocessing failed; images in this request will be dropped: %s",
+                    e,
+                )
+
         input_messages: List[Dict[str, str]] = []
         if isinstance(raw_input, str):
             input_messages = [{"role": "user", "content": raw_input}]

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -146,7 +146,10 @@ _IMAGE_PREPROCESS_PROMPT = (
     "and any other notable visual information."
 )
 
-_IMAGE_DATA_URL_SUFFIXES = {
+# Accept only image MIME types we can sniff and recognize.  Unknown types
+# collapse to a generic .bin suffix so the vision tool rejects them cleanly
+# instead of being misled by the caller's claimed Content-Type.
+_IMAGE_MIME_SUFFIXES = {
     "image/png": ".png",
     "image/gif": ".gif",
     "image/webp": ".webp",
@@ -154,13 +157,64 @@ _IMAGE_DATA_URL_SUFFIXES = {
     "image/jpg": ".jpg",
 }
 
+# Per-image cap on the decoded byte payload of a data: URL (15 MiB).
+# Paired with MAX_REQUEST_BYTES (the per-request cap) so that a single
+# oversize image can't sneak through, and so we don't decode > this much
+# attacker-controlled base64 into RAM.
+_MAX_IMAGE_BYTES = 15 * 1024 * 1024
+
+
+def _sniff_image_mime(data: bytes) -> Optional[str]:
+    """Return the MIME type implied by image magic bytes, or None."""
+    if data.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if data.startswith((b"GIF87a", b"GIF89a")):
+        return "image/gif"
+    if data.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if len(data) >= 12 and data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "image/webp"
+    return None
+
+
+def _is_safe_image_url(url: str) -> bool:
+    """Return True iff ``url`` is an acceptable image source.
+
+    Acceptable: ``data:image/*;base64,...`` and http(s) URLs that pass the
+    shared SSRF filter (which blocks loopback, link-local, private ranges,
+    and cloud-metadata endpoints).  Everything else — ``file://``,
+    ``ftp://``, ``gopher://``, raw local paths — is rejected.
+
+    Fails closed: any lookup/parse error returns False.
+    """
+    if not isinstance(url, str) or not url:
+        return False
+    if url.startswith("data:"):
+        return True  # data: URLs are validated by _materialize_data_url
+    if not url.startswith(("http://", "https://")):
+        return False
+    try:
+        from tools.url_safety import is_safe_url
+    except Exception:
+        # SSRF guard unavailable → refuse to call out to arbitrary hosts.
+        return False
+    try:
+        return bool(is_safe_url(url))
+    except Exception:
+        return False
+
 
 def _materialize_data_url(url: str):
     """Write a ``data:image/...;base64,...`` URL to a temp file.
 
     Returns ``(path_str, cleanup_path)`` where ``cleanup_path`` is the
     :class:`Path` the caller must ``unlink()`` when done.  Returns
-    ``(url, None)`` if ``url`` is not a ``data:`` URL.
+    ``(url, None)`` unchanged if ``url`` is not a ``data:`` URL.
+
+    Validates the payload by sniffing magic bytes — the caller-supplied
+    MIME type is not trusted for anything but logging.  Payloads that
+    exceed ``_MAX_IMAGE_BYTES`` or don't match a known image format raise
+    :class:`ValueError`.
     """
     import base64
     import tempfile
@@ -170,17 +224,33 @@ def _materialize_data_url(url: str):
         return url, None
 
     header, _, payload = url.partition(",")
-    mime = "image/jpeg"
-    mime_part = header[len("data:"):].split(";", 1)[0].strip()
-    if mime_part.startswith("image/"):
-        mime = mime_part
-    suffix = _IMAGE_DATA_URL_SUFFIXES.get(mime, ".jpg")
+    # The claimed MIME is advisory only — sniffed magic bytes decide.
+    claimed_mime = header[len("data:"):].split(";", 1)[0].strip().lower()
 
+    try:
+        data = base64.b64decode(payload, validate=False)
+    except Exception as exc:  # binascii.Error, ValueError
+        raise ValueError("invalid base64 payload in data: URL") from exc
+
+    if len(data) > _MAX_IMAGE_BYTES:
+        raise ValueError(
+            f"image payload exceeds per-image limit "
+            f"({len(data)} > {_MAX_IMAGE_BYTES} bytes)"
+        )
+
+    sniffed_mime = _sniff_image_mime(data)
+    if sniffed_mime is None:
+        raise ValueError(
+            "data: URL payload is not a recognized image format "
+            f"(claimed {claimed_mime!r})"
+        )
+
+    suffix = _IMAGE_MIME_SUFFIXES.get(sniffed_mime, ".bin")
     tmp = tempfile.NamedTemporaryFile(
         prefix="api_server_image_", suffix=suffix, delete=False,
     )
     try:
-        tmp.write(base64.b64decode(payload))
+        tmp.write(data)
     finally:
         tmp.close()
     path = _Path(tmp.name)
@@ -232,12 +302,20 @@ async def _preprocess_message_images(messages: List[Dict[str, Any]]) -> None:
     ultimately only sees text.
 
     ``data:`` URLs (used by Open WebUI and similar frontends) are materialized
-    to a temp file so the vision tool can read them; remote URLs are passed
-    through.  Errors per-image produce a note in the message rather than
-    failing the whole request.
+    to a temp file after base64-decoded-size and magic-byte validation;
+    remote URLs are filtered through ``tools.url_safety.is_safe_url`` to
+    block SSRF targets.  Per-image errors produce a neutral note in the
+    message rather than failing the whole request, and exception details
+    are logged internally rather than echoed to the caller.
 
     Mutates ``messages`` in place.
     """
+    # Neutral user-facing message for any per-image failure.  Exception
+    # details (file paths, stack traces, internal URLs) go only to logs.
+    _IMAGE_FAILED_NOTE = (
+        "[The user attached an image but it could not be processed.]"
+    )
+
     for msg in messages:
         if not isinstance(msg, dict):
             continue
@@ -266,6 +344,13 @@ async def _preprocess_message_images(messages: List[Dict[str, Any]]) -> None:
 
         enriched: List[str] = []
         for url in image_urls:
+            if not _is_safe_image_url(url):
+                logger.warning(
+                    "api_server rejecting unsafe image url (scheme/SSRF filter)"
+                )
+                enriched.append(_IMAGE_FAILED_NOTE)
+                continue
+
             vision_source, cleanup_path = url, None
             try:
                 vision_source, cleanup_path = _materialize_data_url(url)
@@ -288,17 +373,24 @@ async def _preprocess_message_images(messages: List[Dict[str, Any]]) -> None:
                             "[The user attached an image but the vision model returned no description.]"
                         )
                 else:
-                    err = ""
+                    # Log the upstream reason verbatim for operators; show a
+                    # neutral message to the agent so internal paths / errors
+                    # don't end up in user-visible output.
+                    upstream_err = ""
                     if isinstance(result, dict):
-                        err = str(result.get("analysis") or result.get("error") or "").strip()
-                    enriched.append(
-                        f"[The user attached an image but analysis failed: {err or 'unknown error'}]"
+                        upstream_err = str(
+                            result.get("analysis") or result.get("error") or ""
+                        ).strip()
+                    logger.warning(
+                        "api_server vision analysis failed: %s",
+                        upstream_err or "unknown error",
                     )
+                    enriched.append(_IMAGE_FAILED_NOTE)
             except Exception as exc:
-                logger.warning("api_server image preprocessing raised: %s", exc)
-                enriched.append(
-                    f"[The user attached an image but analysis raised: {exc}]"
+                logger.warning(
+                    "api_server image preprocessing raised: %s", exc, exc_info=True,
                 )
+                enriched.append(_IMAGE_FAILED_NOTE)
             finally:
                 if cleanup_path is not None:
                     try:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1630,6 +1630,14 @@ OPTIONAL_ENV_VARS = {
         "category": "messaging",
         "advanced": True,
     },
+    "API_SERVER_MAX_IMAGE_MB": {
+        "description": "Per-image decoded-byte cap in megabytes (default: 50). Complements API_SERVER_MAX_REQUEST_MB by bounding how much memory any single base64-encoded image can expand into.",
+        "prompt": "API server max per-image size (MB)",
+        "url": None,
+        "password": False,
+        "category": "messaging",
+        "advanced": True,
+    },
     "GATEWAY_PROXY_URL": {
         "description": "URL of a remote Hermes API server to forward messages to (proxy mode). When set, the gateway handles platform I/O only — all agent work is delegated to the remote server. Use for Docker E2EE containers that relay to a host agent. Also configurable via gateway.proxy_url in config.yaml.",
         "prompt": "Remote Hermes API server URL (e.g. http://192.168.1.100:8642)",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1622,6 +1622,14 @@ OPTIONAL_ENV_VARS = {
         "category": "messaging",
         "advanced": True,
     },
+    "API_SERVER_MAX_REQUEST_MB": {
+        "description": "Max POST body size in megabytes (default: 25). Needs to be large enough for multimodal requests carrying base64-encoded images.",
+        "prompt": "API server max request size (MB)",
+        "url": None,
+        "password": False,
+        "category": "messaging",
+        "advanced": True,
+    },
     "GATEWAY_PROXY_URL": {
         "description": "URL of a remote Hermes API server to forward messages to (proxy mode). When set, the gateway handles platform I/O only — all agent work is delegated to the remote server. Use for Docker E2EE containers that relay to a host agent. Also configurable via gateway.proxy_url in config.yaml.",
         "prompt": "Remote Hermes API server URL (e.g. http://192.168.1.100:8642)",

--- a/tests/gateway/test_api_server_image_preprocessing.py
+++ b/tests/gateway/test_api_server_image_preprocessing.py
@@ -133,9 +133,10 @@ class TestMaterializeDataUrl:
             _materialize_data_url(url)
 
     def test_oversize_payload_rejected(self):
-        # Synthetic 20 MiB "image" (well past _MAX_IMAGE_BYTES = 15 MiB).
-        from gateway.platforms.api_server import _MAX_IMAGE_BYTES
-        big = b"\x89PNG\r\n\x1a\n" + b"\x00" * (_MAX_IMAGE_BYTES + 1)
+        # Synthetic image one byte past MAX_IMAGE_BYTES — decoded-size gate
+        # must reject even when magic bytes are valid.
+        from gateway.platforms.api_server import MAX_IMAGE_BYTES
+        big = b"\x89PNG\r\n\x1a\n" + b"\x00" * (MAX_IMAGE_BYTES + 1)
         url = "data:image/png;base64," + base64.b64encode(big).decode()
         with pytest.raises(ValueError, match="per-image limit"):
             _materialize_data_url(url)

--- a/tests/gateway/test_api_server_image_preprocessing.py
+++ b/tests/gateway/test_api_server_image_preprocessing.py
@@ -282,13 +282,15 @@ class TestPreprocessMessageImages:
 
     @pytest.mark.asyncio
     async def test_vision_tool_failure_produces_neutral_note(self, monkeypatch, caplog):
-        _force_allow_safe_url(monkeypatch)
+        # Use a data: URL (bypasses the http SSRF check and therefore any
+        # cross-test pollution of tools.url_safety) — we care about the
+        # failure-note behavior, not the URL validator.
         _install_vision_stub(monkeypatch, _failing_vision)
         messages = [{
             "role": "user",
             "content": [
                 {"type": "text", "text": "look"},
-                {"type": "image_url", "image_url": {"url": "https://example.com/x.png"}},
+                {"type": "image_url", "image_url": {"url": _tiny_png_data_url()}},
             ],
         }]
         with caplog.at_level("WARNING"):
@@ -306,12 +308,11 @@ class TestPreprocessMessageImages:
 
     @pytest.mark.asyncio
     async def test_vision_tool_exception_does_not_leak(self, monkeypatch, caplog):
-        _force_allow_safe_url(monkeypatch)
         _install_vision_stub(monkeypatch, _raising_vision)
         messages = [{
             "role": "user",
             "content": [
-                {"type": "image_url", "image_url": {"url": "https://example.com/x.png"}},
+                {"type": "image_url", "image_url": {"url": _tiny_png_data_url()}},
             ],
         }]
         with caplog.at_level("WARNING"):

--- a/tests/gateway/test_api_server_image_preprocessing.py
+++ b/tests/gateway/test_api_server_image_preprocessing.py
@@ -1,0 +1,280 @@
+"""Tests for _preprocess_message_images in the API server adapter.
+
+The preprocessor converts OpenAI multipart ``image_url`` content into text
+descriptions via the auxiliary vision tool, so images work end-to-end through
+any provider backend (the agent pipeline itself is text-only).
+"""
+
+import base64
+import json
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from gateway.platforms.api_server import (
+    _materialize_data_url,
+    _preprocess_message_images,
+    _split_content_parts,
+)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+_TINY_PNG_BYTES = bytes.fromhex(
+    # 1x1 solid-black PNG, smallest valid PNG file.
+    "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c489"
+    "0000000d49444154789c626001000000050001aa3e8d610000000049454e44ae426082"
+)
+
+
+def _tiny_png_data_url() -> str:
+    return "data:image/png;base64," + base64.b64encode(_TINY_PNG_BYTES).decode()
+
+
+async def _ok_vision(image_url, user_prompt, **_kw):
+    return json.dumps({"success": True, "analysis": "a tiny black square"})
+
+
+async def _failing_vision(image_url, user_prompt, **_kw):
+    return json.dumps({"success": False, "analysis": "vision backend unreachable"})
+
+
+async def _raising_vision(image_url, user_prompt, **_kw):
+    raise RuntimeError("boom")
+
+
+def _install_vision_stub(monkeypatch, impl):
+    """Register a stub ``tools.vision_tools.vision_analyze_tool``.
+
+    The preprocessor imports the tool lazily inside the function body, so we
+    patch ``sys.modules`` rather than the caller's namespace.
+    """
+    stub = type(sys)("tools.vision_tools")
+    stub.vision_analyze_tool = impl  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "tools.vision_tools", stub)
+
+
+# ── _split_content_parts ─────────────────────────────────────────────────
+
+
+class TestSplitContentParts:
+    def test_separates_text_and_images(self):
+        text, urls = _split_content_parts([
+            {"type": "text", "text": "hello"},
+            {"type": "image_url", "image_url": {"url": "https://example/a.png"}},
+            {"type": "input_text", "text": " world"},
+            {"type": "image_url", "image_url": {"url": "https://example/b.png"}},
+        ])
+        assert text == ["hello", "world"]
+        assert urls == ["https://example/a.png", "https://example/b.png"]
+
+    def test_image_url_string_variant(self):
+        _, urls = _split_content_parts([
+            {"type": "image_url", "image_url": "https://example/c.png"},
+        ])
+        assert urls == ["https://example/c.png"]
+
+    def test_plain_string_part_is_text(self):
+        text, urls = _split_content_parts(["standalone string", {"type": "text", "text": "dict"}])
+        assert text == ["standalone string", "dict"]
+        assert urls == []
+
+    def test_unknown_type_ignored(self):
+        text, urls = _split_content_parts([{"type": "something_weird", "foo": "bar"}])
+        assert text == []
+        assert urls == []
+
+
+# ── _materialize_data_url ────────────────────────────────────────────────
+
+
+class TestMaterializeDataUrl:
+    def test_non_data_url_passes_through(self):
+        path, cleanup = _materialize_data_url("https://example.com/img.png")
+        assert path == "https://example.com/img.png"
+        assert cleanup is None
+
+    def test_data_url_written_to_tempfile(self):
+        url = _tiny_png_data_url()
+        path, cleanup = _materialize_data_url(url)
+        try:
+            assert cleanup is not None
+            assert cleanup.exists()
+            assert cleanup.suffix == ".png"
+            assert cleanup.read_bytes() == _TINY_PNG_BYTES
+            assert path == str(cleanup)
+        finally:
+            if cleanup is not None and cleanup.exists():
+                cleanup.unlink()
+
+    def test_unknown_mime_defaults_to_jpg_suffix(self):
+        url = "data:image/tiff;base64," + base64.b64encode(b"tiffdata").decode()
+        path, cleanup = _materialize_data_url(url)
+        try:
+            assert cleanup is not None
+            assert cleanup.suffix == ".jpg"
+        finally:
+            if cleanup is not None and cleanup.exists():
+                cleanup.unlink()
+
+
+# ── _preprocess_message_images ───────────────────────────────────────────
+
+
+class TestPreprocessMessageImages:
+    @pytest.mark.asyncio
+    async def test_no_images_leaves_messages_untouched(self, monkeypatch):
+        _install_vision_stub(monkeypatch, _ok_vision)
+        messages = [{"role": "user", "content": "just text"}]
+        await _preprocess_message_images(messages)
+        assert messages == [{"role": "user", "content": "just text"}]
+
+    @pytest.mark.asyncio
+    async def test_multipart_without_image_is_untouched(self, monkeypatch):
+        _install_vision_stub(monkeypatch, _ok_vision)
+        messages = [{
+            "role": "user",
+            "content": [{"type": "text", "text": "hi"}],
+        }]
+        await _preprocess_message_images(messages)
+        # We only flatten when images are present; text-only multi-part is left
+        # for _normalize_chat_content to handle.
+        assert messages[0]["content"] == [{"type": "text", "text": "hi"}]
+
+    @pytest.mark.asyncio
+    async def test_image_with_text_becomes_enriched_string(self, monkeypatch):
+        _install_vision_stub(monkeypatch, _ok_vision)
+        messages = [{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "what's this?"},
+                {"type": "image_url", "image_url": {"url": _tiny_png_data_url()}},
+            ],
+        }]
+        await _preprocess_message_images(messages)
+        content = messages[0]["content"]
+        assert isinstance(content, str)
+        assert "a tiny black square" in content
+        assert "what's this?" in content
+        # Description prefixes the user's text.
+        assert content.index("a tiny black square") < content.index("what's this?")
+
+    @pytest.mark.asyncio
+    async def test_image_without_text(self, monkeypatch):
+        _install_vision_stub(monkeypatch, _ok_vision)
+        messages = [{
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": _tiny_png_data_url()}},
+            ],
+        }]
+        await _preprocess_message_images(messages)
+        assert messages[0]["content"] == (
+            "[The user attached an image. Here's what it contains:\n"
+            "a tiny black square]"
+        )
+
+    @pytest.mark.asyncio
+    async def test_multiple_images_concatenated(self, monkeypatch):
+        _install_vision_stub(monkeypatch, _ok_vision)
+        messages = [{
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": _tiny_png_data_url()}},
+                {"type": "image_url", "image_url": {"url": _tiny_png_data_url()}},
+                {"type": "text", "text": "compare"},
+            ],
+        }]
+        await _preprocess_message_images(messages)
+        content = messages[0]["content"]
+        # Both descriptions appear, separated from user text.
+        assert content.count("a tiny black square") == 2
+        assert content.endswith("compare")
+
+    @pytest.mark.asyncio
+    async def test_vision_tool_failure_produces_note(self, monkeypatch):
+        _install_vision_stub(monkeypatch, _failing_vision)
+        messages = [{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "look"},
+                {"type": "image_url", "image_url": {"url": "https://example/x.png"}},
+            ],
+        }]
+        await _preprocess_message_images(messages)
+        content = messages[0]["content"]
+        assert isinstance(content, str)
+        assert "analysis failed" in content
+        assert "look" in content
+
+    @pytest.mark.asyncio
+    async def test_vision_tool_exception_produces_note(self, monkeypatch):
+        _install_vision_stub(monkeypatch, _raising_vision)
+        messages = [{
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": "https://example/x.png"}},
+            ],
+        }]
+        await _preprocess_message_images(messages)
+        content = messages[0]["content"]
+        assert "analysis raised" in content
+        assert "boom" in content
+
+    @pytest.mark.asyncio
+    async def test_data_url_tempfile_cleaned_up(self, monkeypatch):
+        seen_paths = []
+
+        async def capture_vision(image_url, user_prompt, **_kw):
+            seen_paths.append(image_url)
+            return json.dumps({"success": True, "analysis": "ok"})
+
+        _install_vision_stub(monkeypatch, capture_vision)
+        messages = [{
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": _tiny_png_data_url()}},
+            ],
+        }]
+        await _preprocess_message_images(messages)
+        assert len(seen_paths) == 1
+        # The tempfile the tool received must have been cleaned up after use.
+        from pathlib import Path
+        assert not Path(seen_paths[0]).exists()
+
+    @pytest.mark.asyncio
+    async def test_missing_vision_tool_does_not_crash(self, monkeypatch):
+        # Simulate ``from tools.vision_tools import vision_analyze_tool``
+        # raising ImportError by blocking the import.
+        import builtins
+        real_import = builtins.__import__
+
+        def fake_import(name, *a, **kw):
+            if name == "tools.vision_tools":
+                raise ImportError("simulated missing")
+            return real_import(name, *a, **kw)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        messages = [{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "still here"},
+                {"type": "image_url", "image_url": {"url": "https://x/y.png"}},
+            ],
+        }]
+        await _preprocess_message_images(messages)
+        # Message content is left as-is so downstream normalization handles it.
+        assert isinstance(messages[0]["content"], list)
+
+    @pytest.mark.asyncio
+    async def test_non_user_messages_also_processed(self, monkeypatch):
+        """Processor walks every message, not just user ones."""
+        _install_vision_stub(monkeypatch, _ok_vision)
+        messages = [
+            {"role": "assistant", "content": [
+                {"type": "image_url", "image_url": {"url": _tiny_png_data_url()}},
+            ]},
+        ]
+        await _preprocess_message_images(messages)
+        assert "a tiny black square" in messages[0]["content"]

--- a/tests/gateway/test_api_server_image_preprocessing.py
+++ b/tests/gateway/test_api_server_image_preprocessing.py
@@ -13,8 +13,10 @@ from unittest.mock import patch
 import pytest
 
 from gateway.platforms.api_server import (
+    _is_safe_image_url,
     _materialize_data_url,
     _preprocess_message_images,
+    _sniff_image_mime,
     _split_content_parts,
 )
 
@@ -53,6 +55,17 @@ def _install_vision_stub(monkeypatch, impl):
     stub = type(sys)("tools.vision_tools")
     stub.vision_analyze_tool = impl  # type: ignore[attr-defined]
     monkeypatch.setitem(sys.modules, "tools.vision_tools", stub)
+
+
+def _force_allow_safe_url(monkeypatch):
+    """Make ``_is_safe_image_url`` treat any http(s) URL as safe.
+
+    Bypasses the real SSRF filter's network-dependent DNS checks so tests
+    don't flake on developer boxes where DNS hijacking / Stash fake-ip
+    resolves ``example.com`` to a private range.
+    """
+    import tools.url_safety as _url_safety
+    monkeypatch.setattr(_url_safety, "is_safe_url", lambda _url: True)
 
 
 # ── _split_content_parts ─────────────────────────────────────────────────
@@ -108,15 +121,90 @@ class TestMaterializeDataUrl:
             if cleanup is not None and cleanup.exists():
                 cleanup.unlink()
 
-    def test_unknown_mime_defaults_to_jpg_suffix(self):
-        url = "data:image/tiff;base64," + base64.b64encode(b"tiffdata").decode()
+    def test_payload_without_image_magic_is_rejected(self):
+        # Attacker-supplied Content-Type must NOT be trusted — sniff bytes.
+        url = "data:image/png;base64," + base64.b64encode(b"not an image").decode()
+        with pytest.raises(ValueError, match="not a recognized image format"):
+            _materialize_data_url(url)
+
+    def test_invalid_base64_rejected(self):
+        url = "data:image/png;base64,%%%not base64%%%"
+        with pytest.raises(ValueError, match="invalid base64"):
+            _materialize_data_url(url)
+
+    def test_oversize_payload_rejected(self):
+        # Synthetic 20 MiB "image" (well past _MAX_IMAGE_BYTES = 15 MiB).
+        from gateway.platforms.api_server import _MAX_IMAGE_BYTES
+        big = b"\x89PNG\r\n\x1a\n" + b"\x00" * (_MAX_IMAGE_BYTES + 1)
+        url = "data:image/png;base64," + base64.b64encode(big).decode()
+        with pytest.raises(ValueError, match="per-image limit"):
+            _materialize_data_url(url)
+
+    def test_suffix_reflects_sniffed_mime_not_claim(self):
+        # Claim JPEG but actually a PNG — suffix should match sniff, not claim.
+        url = "data:image/jpeg;base64," + base64.b64encode(_TINY_PNG_BYTES).decode()
         path, cleanup = _materialize_data_url(url)
         try:
             assert cleanup is not None
-            assert cleanup.suffix == ".jpg"
+            assert cleanup.suffix == ".png"
         finally:
             if cleanup is not None and cleanup.exists():
                 cleanup.unlink()
+
+
+class TestSniffImageMime:
+    def test_png(self):
+        assert _sniff_image_mime(_TINY_PNG_BYTES) == "image/png"
+
+    def test_jpeg(self):
+        assert _sniff_image_mime(b"\xff\xd8\xff\xe0foo") == "image/jpeg"
+
+    def test_gif(self):
+        assert _sniff_image_mime(b"GIF89a" + b"\x00" * 16) == "image/gif"
+
+    def test_webp(self):
+        assert _sniff_image_mime(b"RIFF\x00\x00\x00\x00WEBPfoo") == "image/webp"
+
+    def test_arbitrary_bytes_rejected(self):
+        assert _sniff_image_mime(b"plain text not an image") is None
+        assert _sniff_image_mime(b"") is None
+
+
+class TestIsSafeImageUrl:
+    def test_data_url_allowed(self):
+        assert _is_safe_image_url("data:image/png;base64,AAAA") is True
+
+    def test_https_allowed(self, monkeypatch):
+        _force_allow_safe_url(monkeypatch)
+        assert _is_safe_image_url("https://example.com/img.png") is True
+
+    @pytest.mark.parametrize("scheme", ["file://", "ftp://", "gopher://", "javascript:", "ldap://"])
+    def test_non_http_schemes_rejected(self, scheme):
+        assert _is_safe_image_url(scheme + "whatever/path") is False
+
+    def test_empty_or_non_string(self):
+        assert _is_safe_image_url("") is False
+        assert _is_safe_image_url(None) is False  # type: ignore[arg-type]
+        assert _is_safe_image_url(123) is False  # type: ignore[arg-type]
+
+    def test_fails_closed_when_url_safety_module_missing(self, monkeypatch):
+        # If the SSRF guard import fails, don't fall through to unchecked I/O.
+        import builtins
+        real_import = builtins.__import__
+
+        def fake_import(name, *a, **kw):
+            if name == "tools.url_safety":
+                raise ImportError("simulated")
+            return real_import(name, *a, **kw)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        assert _is_safe_image_url("https://example.com/x.png") is False
+
+    def test_ssrf_target_rejected(self, monkeypatch):
+        # Mock is_safe_url → False to simulate a private-IP / metadata URL.
+        stub = sys.modules.setdefault("tools.url_safety", type(sys)("tools.url_safety"))
+        monkeypatch.setattr(stub, "is_safe_url", lambda _url: False, raising=False)
+        assert _is_safe_image_url("http://169.254.169.254/latest/meta-data/") is False
 
 
 # ── _preprocess_message_images ───────────────────────────────────────────
@@ -193,34 +281,74 @@ class TestPreprocessMessageImages:
         assert content.endswith("compare")
 
     @pytest.mark.asyncio
-    async def test_vision_tool_failure_produces_note(self, monkeypatch):
+    async def test_vision_tool_failure_produces_neutral_note(self, monkeypatch, caplog):
+        _force_allow_safe_url(monkeypatch)
         _install_vision_stub(monkeypatch, _failing_vision)
         messages = [{
             "role": "user",
             "content": [
                 {"type": "text", "text": "look"},
-                {"type": "image_url", "image_url": {"url": "https://example/x.png"}},
+                {"type": "image_url", "image_url": {"url": "https://example.com/x.png"}},
             ],
         }]
-        await _preprocess_message_images(messages)
+        with caplog.at_level("WARNING"):
+            await _preprocess_message_images(messages)
         content = messages[0]["content"]
         assert isinstance(content, str)
-        assert "analysis failed" in content
+        # User-facing message is neutral; upstream detail must not leak.
+        assert "could not be processed" in content
+        assert "vision backend unreachable" not in content
         assert "look" in content
+        # Operator-facing log DOES carry the detail.
+        assert any(
+            "vision backend unreachable" in r.getMessage() for r in caplog.records
+        )
 
     @pytest.mark.asyncio
-    async def test_vision_tool_exception_produces_note(self, monkeypatch):
+    async def test_vision_tool_exception_does_not_leak(self, monkeypatch, caplog):
+        _force_allow_safe_url(monkeypatch)
         _install_vision_stub(monkeypatch, _raising_vision)
         messages = [{
             "role": "user",
             "content": [
-                {"type": "image_url", "image_url": {"url": "https://example/x.png"}},
+                {"type": "image_url", "image_url": {"url": "https://example.com/x.png"}},
             ],
         }]
-        await _preprocess_message_images(messages)
+        with caplog.at_level("WARNING"):
+            await _preprocess_message_images(messages)
         content = messages[0]["content"]
-        assert "analysis raised" in content
-        assert "boom" in content
+        # Exception repr ("boom", the RuntimeError) is logged but NOT exposed.
+        assert "boom" not in content
+        assert "could not be processed" in content
+        assert any("boom" in r.getMessage() for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_unsafe_url_is_rejected_without_calling_vision(self, monkeypatch, caplog):
+        """file:// and other non-http(s) schemes bypass the vision tool entirely."""
+        calls = []
+
+        async def spy_vision(image_url, user_prompt, **_kw):
+            calls.append(image_url)
+            return json.dumps({"success": True, "analysis": "leaked"})
+
+        _install_vision_stub(monkeypatch, spy_vision)
+        messages = [{
+            "role": "user",
+            "content": [
+                {"type": "image_url", "image_url": {"url": "file:///etc/passwd"}},
+                {"type": "text", "text": "what's in my file?"},
+            ],
+        }]
+        with caplog.at_level("WARNING"):
+            await _preprocess_message_images(messages)
+        assert calls == []  # vision tool never invoked for the unsafe URL
+        content = messages[0]["content"]
+        assert "could not be processed" in content
+        assert "passwd" not in content
+        assert "what's in my file?" in content
+        assert any(
+            "rejecting unsafe image url" in r.getMessage() for r in caplog.records
+        )
 
     @pytest.mark.asyncio
     async def test_data_url_tempfile_cleaned_up(self, monkeypatch):

--- a/tests/gateway/test_api_server_max_request_bytes.py
+++ b/tests/gateway/test_api_server_max_request_bytes.py
@@ -8,12 +8,16 @@ import pytest
 from aiohttp import web
 
 from gateway.platforms import api_server as api_server_module
-from gateway.platforms.api_server import _resolve_max_request_bytes
+from gateway.platforms.api_server import (
+    _resolve_max_image_bytes,
+    _resolve_max_request_bytes,
+)
 
 
 @pytest.fixture
 def env(monkeypatch):
     monkeypatch.delenv("API_SERVER_MAX_REQUEST_MB", raising=False)
+    monkeypatch.delenv("API_SERVER_MAX_IMAGE_MB", raising=False)
     return monkeypatch
 
 
@@ -52,6 +56,43 @@ class TestResolveMaxRequestBytes:
     def test_module_constant_reflects_default(self):
         # Sanity: the module-level constant captures the default at import time.
         assert api_server_module.MAX_REQUEST_BYTES >= 1_000_000
+
+
+class TestResolveMaxImageBytes:
+    """``API_SERVER_MAX_IMAGE_MB`` — per-image decoded-byte cap applied
+    inside ``_materialize_data_url`` before the base64 payload hits the
+    disk.  Complements ``MAX_REQUEST_BYTES`` (the request-level cap).
+    """
+
+    def test_default_is_50_mb(self, env):
+        assert _resolve_max_image_bytes() == 50 * 1024 * 1024
+
+    def test_env_override_integer_mb(self, env):
+        env.setenv("API_SERVER_MAX_IMAGE_MB", "100")
+        assert _resolve_max_image_bytes() == 100 * 1024 * 1024
+
+    def test_env_override_fractional_mb(self, env):
+        env.setenv("API_SERVER_MAX_IMAGE_MB", "2.5")
+        assert _resolve_max_image_bytes() == int(2.5 * 1024 * 1024)
+
+    def test_empty_env_uses_default(self, env):
+        env.setenv("API_SERVER_MAX_IMAGE_MB", "")
+        assert _resolve_max_image_bytes() == 50 * 1024 * 1024
+
+    def test_invalid_env_falls_back_to_default(self, env, caplog):
+        env.setenv("API_SERVER_MAX_IMAGE_MB", "nope")
+        with caplog.at_level("WARNING"):
+            assert _resolve_max_image_bytes() == 50 * 1024 * 1024
+        assert any("API_SERVER_MAX_IMAGE_MB" in r.getMessage() for r in caplog.records)
+
+    def test_non_positive_env_falls_back_to_default(self, env):
+        env.setenv("API_SERVER_MAX_IMAGE_MB", "0")
+        assert _resolve_max_image_bytes() == 50 * 1024 * 1024
+        env.setenv("API_SERVER_MAX_IMAGE_MB", "-1")
+        assert _resolve_max_image_bytes() == 50 * 1024 * 1024
+
+    def test_module_constant_reflects_default(self):
+        assert api_server_module.MAX_IMAGE_BYTES >= 1_000_000
 
 
 class TestAiohttpClientMaxSize:

--- a/tests/gateway/test_api_server_max_request_bytes.py
+++ b/tests/gateway/test_api_server_max_request_bytes.py
@@ -1,8 +1,11 @@
-"""Tests for ``_resolve_max_request_bytes`` (API_SERVER_MAX_REQUEST_MB)."""
+"""Tests for ``_resolve_max_request_bytes`` (API_SERVER_MAX_REQUEST_MB)
+and the matching ``client_max_size`` on the aiohttp application.
+"""
 
 import importlib
 
 import pytest
+from aiohttp import web
 
 from gateway.platforms import api_server as api_server_module
 from gateway.platforms.api_server import _resolve_max_request_bytes
@@ -49,3 +52,44 @@ class TestResolveMaxRequestBytes:
     def test_module_constant_reflects_default(self):
         # Sanity: the module-level constant captures the default at import time.
         assert api_server_module.MAX_REQUEST_BYTES >= 1_000_000
+
+
+class TestAiohttpClientMaxSize:
+    """Regression: aiohttp ``web.Application`` defaults ``client_max_size``
+    to 1 MiB.  Without explicitly raising it, request bodies larger than
+    1 MiB (e.g. a multimodal chat with a base64-encoded image) fail at the
+    framework level — ``request.json()`` raises and the handler collapses
+    it into an opaque ``"Invalid JSON in request body"`` response.  The
+    production adapter must pass ``client_max_size=MAX_REQUEST_BYTES`` so
+    ``body_limit_middleware`` is the authoritative gate.
+    """
+
+    def test_aiohttp_default_is_1_mib(self):
+        """Establish the baseline: without an explicit argument, aiohttp
+        caps bodies at 1 MiB — small enough that a base64 image of any
+        realistic size is truncated.  This is the behavior the fix avoids.
+        """
+        app = web.Application()
+        assert app._client_max_size == 1024 * 1024
+
+    def test_explicit_client_max_size_is_honored(self):
+        """aiohttp stores the value we pass; smoke-test the mechanism."""
+        big = 25 * 1024 * 1024
+        app = web.Application(client_max_size=big)
+        assert app._client_max_size == big
+
+    def test_production_path_passes_matched_limit(self):
+        """The adapter's ``connect()`` body must construct ``web.Application``
+        with ``client_max_size=MAX_REQUEST_BYTES`` so ``body_limit_middleware``
+        is the authoritative gate, not aiohttp silently truncating at 1 MiB.
+
+        Source-level assertion — cheaper than spinning up the full TCP
+        server, and pins the exact behavior the fix establishes.
+        """
+        import pathlib
+
+        src = pathlib.Path(api_server_module.__file__).read_text()
+        assert "client_max_size=MAX_REQUEST_BYTES" in src, (
+            "web.Application() in api_server.py must pass "
+            "client_max_size=MAX_REQUEST_BYTES to honor the body-limit cap"
+        )

--- a/tests/gateway/test_api_server_max_request_bytes.py
+++ b/tests/gateway/test_api_server_max_request_bytes.py
@@ -1,0 +1,51 @@
+"""Tests for ``_resolve_max_request_bytes`` (API_SERVER_MAX_REQUEST_MB)."""
+
+import importlib
+
+import pytest
+
+from gateway.platforms import api_server as api_server_module
+from gateway.platforms.api_server import _resolve_max_request_bytes
+
+
+@pytest.fixture
+def env(monkeypatch):
+    monkeypatch.delenv("API_SERVER_MAX_REQUEST_MB", raising=False)
+    return monkeypatch
+
+
+class TestResolveMaxRequestBytes:
+    def test_default_is_25_mb(self, env):
+        assert _resolve_max_request_bytes() == 25 * 1024 * 1024
+
+    def test_env_override_integer_mb(self, env):
+        env.setenv("API_SERVER_MAX_REQUEST_MB", "50")
+        assert _resolve_max_request_bytes() == 50 * 1024 * 1024
+
+    def test_env_override_fractional_mb(self, env):
+        env.setenv("API_SERVER_MAX_REQUEST_MB", "0.5")
+        assert _resolve_max_request_bytes() == 524_288  # 0.5 MiB
+
+    def test_empty_env_uses_default(self, env):
+        env.setenv("API_SERVER_MAX_REQUEST_MB", "")
+        assert _resolve_max_request_bytes() == 25 * 1024 * 1024
+
+    def test_whitespace_env_uses_default(self, env):
+        env.setenv("API_SERVER_MAX_REQUEST_MB", "   ")
+        assert _resolve_max_request_bytes() == 25 * 1024 * 1024
+
+    def test_invalid_env_falls_back_to_default(self, env, caplog):
+        env.setenv("API_SERVER_MAX_REQUEST_MB", "not-a-number")
+        with caplog.at_level("WARNING"):
+            assert _resolve_max_request_bytes() == 25 * 1024 * 1024
+        assert any("API_SERVER_MAX_REQUEST_MB" in r.getMessage() for r in caplog.records)
+
+    def test_non_positive_env_falls_back_to_default(self, env):
+        env.setenv("API_SERVER_MAX_REQUEST_MB", "0")
+        assert _resolve_max_request_bytes() == 25 * 1024 * 1024
+        env.setenv("API_SERVER_MAX_REQUEST_MB", "-5")
+        assert _resolve_max_request_bytes() == 25 * 1024 * 1024
+
+    def test_module_constant_reflects_default(self):
+        # Sanity: the module-level constant captures the default at import time.
+        assert api_server_module.MAX_REQUEST_BYTES >= 1_000_000

--- a/tests/gateway/test_api_server_normalize.py
+++ b/tests/gateway/test_api_server_normalize.py
@@ -39,6 +39,10 @@ class TestNormalizeChatContent:
         assert _normalize_chat_content(content) == "plain string\ndict part"
 
     def test_image_url_parts_silently_skipped(self):
+        # ``_normalize_chat_content`` itself still drops image parts — callers
+        # that care about images are expected to run
+        # ``_preprocess_message_images`` first (see
+        # ``test_api_server_image_preprocessing``).
         content = [
             {"type": "text", "text": "check this:"},
             {"type": "image_url", "image_url": {"url": "https://example.com/img.png"}},


### PR DESCRIPTION
## What does this PR do?

Fixes an asymmetry between the CLI and the OpenAI-compatible API server:
the CLI handles image attachments end-to-end via `_preprocess_images_with_vision`
(`cli.py:3666`), but the API server silently drops them, so any multimodal
frontend (Open WebUI, LobeChat, LibreChat, …) loses images on the way to
the agent.

The API server currently receives OpenAI-style multi-part content like

```json
[{"type": "text", "text": "..."},
 {"type": "image_url", "image_url": {"url": "data:image/png;base64,..."}}]
```

`_normalize_chat_content` flattens these into a plain string and skips
`image_url` parts (see existing test `test_image_url_parts_silently_skipped`),
so images never reach the agent.

This PR adds `_preprocess_message_images`, a pre-flatten hook mounted on
both `/v1/chat/completions` and `/v1/responses`. For each message carrying
image parts, it:

1. Materializes any `data:` base64 URLs to a tempfile.
2. Calls `vision_analyze_tool` (auxiliary vision model — configured via
   `auxiliary.vision`) to describe each image.
3. Inlines the description into the message content as plain text.

Because the agent ultimately sees only text, this works uniformly across
every provider backend (Codex Responses, Anthropic, OpenAI-compatible, …)
without touching `run_agent.py` or the provider-specific serialization
paths. It mirrors what the CLI already does, so the behavior is consistent
between the two entry points.

Also raises the default POST body limit from 1 MB → 25 MB and makes it
configurable via `API_SERVER_MAX_REQUEST_MB`, since a single base64-encoded
photo easily exceeds 1 MB.

### Prior art / related PRs

I reviewed the open PRs in this area before submitting — this PR is
intentionally scoped narrowly:

- **#4046** (multimodal images + audio): takes the same vision-tool
  enrichment approach but invokes its processor **after** the existing
  normalize loop, at which point each message's `content` is already a
  string — so the multimodal handler is effectively dead code. This PR
  fixes that by running the hook **before** normalization, adds tests,
  and covers `/v1/responses` as well. Audio support is out of scope here
  — happy to revisit in a follow-up.
- **#5621** (native image passthrough): threads image parts all the way
  through to the provider. This PR takes a smaller, provider-agnostic
  route (text enrichment) that ships today without changes to
  `run_agent.py`; the two approaches can coexist (native for providers
  that support it, enrichment as fallback).
- **#8253** (list-content preservation for Anthropic fallback): narrower
  scope (Anthropic path only). This PR covers all backends via the
  auxiliary vision pipeline.

## Related Issue

No existing issue. Happy to file one retroactively if preferred.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/api_server.py`
  - New `_preprocess_message_images()` + helpers `_split_content_parts` and
    `_materialize_data_url` — walk message content, describe images via
    `vision_analyze_tool`, inline descriptions.
  - Wire the hook into both `/v1/chat/completions` and `/v1/responses`
    ahead of the existing `_normalize_chat_content` step.
  - `MAX_REQUEST_BYTES` now resolved via `_resolve_max_request_bytes()`
    (default 25 MB, override via `API_SERVER_MAX_REQUEST_MB`).
- `hermes_cli/config.py`
  - Register `API_SERVER_MAX_REQUEST_MB` in the env-var catalog.
- Tests
  - `tests/gateway/test_api_server_image_preprocessing.py` — 14 new tests
    (helpers, tempfile cleanup, data-URL handling, multi-image, vision
    failure/exception paths, missing `vision_analyze_tool`).
  - `tests/gateway/test_api_server_max_request_bytes.py` — 8 new tests
    for the env-var resolver.
  - `tests/gateway/test_api_server_normalize.py` — comment on existing
    test clarifying that `_normalize_chat_content` still drops image
    parts (callers now preprocess first).

## How to Test

**Unit tests:**

```bash
pytest tests/gateway/test_api_server_image_preprocessing.py \
       tests/gateway/test_api_server_max_request_bytes.py \
       tests/gateway/test_api_server_normalize.py -v
# 42 passed in 0.87s
```

Full api_server suite (no regressions):

```bash
pytest tests/gateway/test_api_server*.py -q
# 220 passed
```

**End-to-end with Open WebUI:**

1. `API_SERVER_ENABLED=true API_SERVER_KEY=... hermes gateway run`
2. In Open WebUI (or any OpenAI-compatible frontend), attach an image
   and ask a question about it.
3. The agent receives a text description of the image and responds
   accordingly. Without this patch, the image part is silently dropped
   and the model says "I don't see any image".

I verified the round-trip with Open WebUI → Codex `gpt-5.4` +
auxiliary vision routed to Gemini Flash on macOS 14.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — see "Prior art" above
- [x] My PR contains **only** changes related to this feature
- [x] I've run `pytest tests/gateway/test_api_server*.py -q` and all tests pass (220 passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 14 (Sonoma)

### Documentation & Housekeeping

- [x] Docstrings updated for the new functions (the env var description lives in the `config.py` catalog)
- [x] New config key registered in `hermes_cli/config.py`
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform: uses `tempfile` + `pathlib.Path`; no Unix-only calls
- [x] Tool descriptions/schemas — N/A

## Notes for reviewers

- The preprocessor walks every message (not just the last user message) so
  that image parts in assistant/tool messages from a continuing
  conversation are also described — matches `_normalize_chat_content`'s
  own behavior of treating every message uniformly.
- On per-image vision failure we inline an error note rather than dropping
  the whole request, so a flaky vision backend doesn't 500 the API.
- If `tools.vision_tools` fails to import at all, the message content is
  left as-is and downstream normalization drops the images — same
  behavior as pre-patch, just with a log warning.