### PR TITLE
fix: use subprocess HOME for ~ expansion in skill config values

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -12,9 +12,21 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
-from hermes_constants import get_config_path, get_skills_dir
+from hermes_constants import get_config_path, get_skills_dir, get_subprocess_home
 
 logger = logging.getLogger(__name__)
+
+
+def _expand_home(path: str) -> str:
+    """Expand ``~`` using the subprocess HOME when available.
+
+    Falls back to ``os.path.expanduser`` when ``get_subprocess_home()``
+    returns ``None``.
+    """
+    sub_home = get_subprocess_home()
+    if sub_home and path.startswith("~"):
+        return sub_home + path[1:]
+    return os.path.expanduser(path)
 
 # ── Platform mapping ──────────────────────────────────────────────────────
 
@@ -209,7 +221,7 @@ def get_external_skills_dirs() -> List[Path]:
         if not entry:
             continue
         # Expand ~ and environment variables
-        expanded = os.path.expanduser(os.path.expandvars(entry))
+        expanded = _expand_home(os.path.expandvars(entry))
         p = Path(expanded).resolve()
         if p == local_skills:
             continue
@@ -382,7 +394,7 @@ def resolve_skill_config_values(
     Skill config is stored under ``skills.config.<key>`` in config.yaml.
     Returns a dict mapping **logical** keys (as declared by skills) to their
     current values (or the declared default if the key isn't set).
-    Path values are expanded via ``os.path.expanduser``.
+    Path values are expanded via the subprocess HOME (``get_subprocess_home``).
     """
     config_path = get_config_path()
     config: Dict[str, Any] = {}
@@ -405,7 +417,7 @@ def resolve_skill_config_values(
 
         # Expand ~ in path-like values
         if isinstance(value, str) and ("~" in value or "${" in value):
-            value = os.path.expanduser(os.path.expandvars(value))
+            value = _expand_home(os.path.expandvars(value))
 
         resolved[logical_key] = value
 

--- a/tests/skills/test_skill_config_home_expansion.py
+++ b/tests/skills/test_skill_config_home_expansion.py
@@ -1,0 +1,43 @@
+"""Tests that skill config ~ expansion uses subprocess HOME, not process HOME."""
+
+from unittest.mock import patch
+
+from agent.skill_utils import _expand_home, resolve_skill_config_values
+
+
+class TestExpandHome:
+    def test_uses_subprocess_home_when_available(self):
+        with patch("agent.skill_utils.get_subprocess_home", return_value="/hermes/home"):
+            assert _expand_home("~/foo/bar") == "/hermes/home/foo/bar"
+
+    def test_falls_back_to_expanduser_when_no_subprocess_home(self):
+        with patch("agent.skill_utils.get_subprocess_home", return_value=None):
+            result = _expand_home("~/foo")
+            assert "~" not in result
+            assert result.endswith("/foo")
+
+    def test_no_tilde_unchanged(self):
+        with patch("agent.skill_utils.get_subprocess_home", return_value="/hermes/home"):
+            assert _expand_home("/absolute/path") == "/absolute/path"
+
+
+class TestResolveSkillConfigValues:
+    def test_tilde_in_default_expands_to_subprocess_home(self, tmp_path):
+        config_vars = [{"key": "output_dir", "default": "~/outputs"}]
+        with (
+            patch("agent.skill_utils.get_config_path", return_value=tmp_path / "config.yaml"),
+            patch("agent.skill_utils.get_subprocess_home", return_value="/hermes/home"),
+        ):
+            result = resolve_skill_config_values(config_vars)
+            assert result["output_dir"] == "/hermes/home/outputs"
+
+    def test_tilde_in_stored_value_expands_to_subprocess_home(self, tmp_path):
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("skills:\n  config:\n    data_dir: ~/data\n")
+        config_vars = [{"key": "data_dir", "default": ""}]
+        with (
+            patch("agent.skill_utils.get_config_path", return_value=config_file),
+            patch("agent.skill_utils.get_subprocess_home", return_value="/sub/home"),
+        ):
+            result = resolve_skill_config_values(config_vars)
+            assert result["data_dir"] == "/sub/home/data"


### PR DESCRIPTION
Fixes #12260

`resolve_skill_config_values()` used `os.path.expanduser()` to expand `~` in skill config defaults, which resolves against the Python process's HOME (e.g. `/opt/data` in containers) rather than the subprocess HOME.

**Changes:**
- Added `_expand_home()` helper that uses `get_subprocess_home()` from `hermes_constants`
- Updated both call sites in `resolve_skill_config_values()` (skill dirs + config values)
- Falls back to `os.path.expanduser()` when `get_subprocess_home()` returns `None`
- Added 5 tests covering the helper and integration with `resolve_skill_config_values()`