### PR TITLE
fix(telegram): cache inbound video attachments for exact intake

### DIFF
--- a/agent/llmops.py
+++ b/agent/llmops.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, Iterable, Optional
+
+from hermes_state import SessionDB
+
+
+@dataclass
+class RunEnvelope:
+    run_id: str
+    session_id: str
+    task_id: str
+    platform: str = ""
+    thread_id: str = ""
+    workflow: str = "conversation"
+    backend: str = "legacy"
+    model: str = ""
+    tool_names: list[str] = field(default_factory=list)
+    started_at: float = field(default_factory=time.time)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+class RunRecorder:
+    """Thin durable recorder for LLMOps run events."""
+
+    def __init__(self, session_db: Optional[SessionDB], envelope: RunEnvelope):
+        self.session_db = session_db
+        self.envelope = envelope
+
+    def record(self, event_type: str, **payload: Any) -> Dict[str, Any]:
+        event_payload = dict(payload)
+        if self.session_db and self.envelope.session_id:
+            self.session_db.append_event(
+                session_id=self.envelope.session_id,
+                event_type=event_type,
+                payload=event_payload,
+            )
+        return event_payload
+
+    def metadata(self, **extra: Any) -> Dict[str, Any]:
+        data = self.envelope.to_dict()
+        data.update(extra)
+        return data
+
+
+def build_run_envelope(
+    *,
+    session_id: Optional[str],
+    task_id: Optional[str],
+    platform: Optional[str],
+    thread_id: Optional[str],
+    workflow: Optional[str],
+    backend: Optional[str],
+    model: Optional[str],
+    tool_names: Iterable[str] | None,
+) -> RunEnvelope:
+    return RunEnvelope(
+        run_id=str(uuid.uuid4()),
+        session_id=session_id or "",
+        task_id=task_id or "",
+        platform=platform or "",
+        thread_id=thread_id or "",
+        workflow=workflow or "conversation",
+        backend=backend or "legacy",
+        model=model or "",
+        tool_names=list(tool_names or []),
+    )

--- a/agent/task_orchestration.py
+++ b/agent/task_orchestration.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import time
+from dataclasses import asdict, dataclass, field
+from typing import Any, Callable, Dict, Iterable, Optional
+
+
+@dataclass
+class TaskEnvelope:
+    session_id: str
+    task_id: str
+    workflow: str
+    backend: str = "legacy"
+    thread_id: str = ""
+    run_id: str = ""
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class WorkflowStep:
+    name: str
+    status: str = "pending"
+    started_at: float | None = None
+    completed_at: float | None = None
+    artifacts: Dict[str, Any] = field(default_factory=dict)
+    error: str | None = None
+
+
+@dataclass
+class WorkflowTrace:
+    workflow: str
+    backend: str
+    status: str = "pending"
+    steps: list[WorkflowStep] = field(default_factory=list)
+    artifacts: Dict[str, Any] = field(default_factory=dict)
+    failed_step: str | None = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        return data
+
+
+class HermesTaskOrchestrator:
+    def __init__(self, backend: str = "legacy"):
+        self.backend = (backend or "legacy").strip().lower()
+
+    def run(
+        self,
+        envelope: TaskEnvelope,
+        *,
+        steps: Iterable[WorkflowStep],
+        executor: Callable[[], Dict[str, Any]],
+    ) -> Dict[str, Any]:
+        if self.backend == "langgraph":
+            self._ensure_langgraph_available()
+        trace = WorkflowTrace(
+            workflow=envelope.workflow,
+            backend=self.backend,
+            status="running",
+            steps=list(steps),
+        )
+        try:
+            result = self._run_legacy(trace, executor)
+        except Exception as exc:
+            trace.status = "failed"
+            trace.failed_step = trace.steps[-1].name if trace.steps else None
+            raise
+        trace.status = "completed"
+        return {
+            "status": trace.status,
+            "result": result,
+            "trace": trace.to_dict(),
+            "completed_steps": [step.name for step in trace.steps if step.status == "completed"],
+            "artifacts": trace.artifacts,
+            "failed_step": trace.failed_step,
+        }
+
+    def _run_legacy(self, trace: WorkflowTrace, executor: Callable[[], Dict[str, Any]]) -> Dict[str, Any]:
+        if trace.steps:
+            step = trace.steps[0]
+            step.status = "running"
+            step.started_at = time.time()
+        result = executor()
+        if trace.steps:
+            step.status = "completed"
+            step.completed_at = time.time()
+            step.artifacts = dict(result.get("artifacts") or {}) if isinstance(result, dict) else {}
+        if isinstance(result, dict) and result.get("artifacts"):
+            trace.artifacts.update(result["artifacts"])
+        return result
+
+    def _ensure_langgraph_available(self) -> None:
+        try:
+            __import__("langgraph")
+        except ImportError as exc:
+            raise RuntimeError(
+                "LangGraph orchestration backend is optional and requires the 'langgraph' package to be installed."
+            ) from exc

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -10,6 +10,7 @@ Uses python-telegram-bot library for:
 import asyncio
 import json
 import logging
+import mimetypes
 import os
 import html as _html
 import re
@@ -2568,6 +2569,57 @@ class TelegramAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.warning("[Telegram] Failed to cache photo: %s", e, exc_info=True)
 
+        # Download native Telegram videos to cache so the agent can inspect the
+        # exact file that was uploaded instead of guessing from local Downloads.
+        if msg.video:
+            try:
+                video = msg.video
+                file_obj = await video.get_file()
+                video_bytes = await file_obj.download_as_bytearray()
+
+                original_filename = getattr(video, "file_name", None) or ""
+                ext = ""
+                if original_filename:
+                    _, ext = os.path.splitext(original_filename)
+                    ext = ext.lower()
+                if not ext and getattr(video, "mime_type", None):
+                    guessed_ext = mimetypes.guess_extension(video.mime_type, strict=False) or ""
+                    if guessed_ext == ".mpe":
+                        guessed_ext = ".mpeg"
+                    ext = guessed_ext.lower()
+                if not ext and getattr(file_obj, "file_path", None):
+                    _, ext = os.path.splitext(file_obj.file_path)
+                    ext = ext.lower()
+                if not ext:
+                    ext = ".mp4"
+
+                mime_type = getattr(video, "mime_type", None) or mimetypes.guess_type(f"video{ext}")[0] or "video/mp4"
+                filename = original_filename or f"telegram_video{ext}"
+                cached_path = cache_document_from_bytes(bytes(video_bytes), filename)
+                event.media_urls = [cached_path]
+                event.media_types = [mime_type]
+
+                metadata_parts = []
+                if filename:
+                    metadata_parts.append(f"filename={filename}")
+                duration = getattr(video, "duration", None)
+                if duration is not None:
+                    metadata_parts.append(f"duration={duration}s")
+                width = getattr(video, "width", None)
+                height = getattr(video, "height", None)
+                if width and height:
+                    metadata_parts.append(f"resolution={width}x{height}")
+                file_size = getattr(video, "file_size", None)
+                if file_size is not None:
+                    metadata_parts.append(f"size={file_size} bytes")
+                if mime_type:
+                    metadata_parts.append(f"mime={mime_type}")
+                metadata_note = "[Video attachment metadata: " + ", ".join(metadata_parts) + "]"
+                event.text = f"{metadata_note}\n\n{event.text}" if event.text else metadata_note
+                logger.info("[Telegram] Cached user video at %s", cached_path)
+            except Exception as e:
+                logger.warning("[Telegram] Failed to cache video: %s", e, exc_info=True)
+
         # Download voice/audio messages to cache for STT transcription
         if msg.voice:
             try:
@@ -2606,16 +2658,9 @@ class TelegramAdapter(BasePlatformAdapter):
                     mime_to_ext = {v: k for k, v in SUPPORTED_DOCUMENT_TYPES.items()}
                     ext = mime_to_ext.get(doc.mime_type, "")
 
-                # Check if supported
-                if ext not in SUPPORTED_DOCUMENT_TYPES:
-                    supported_list = ", ".join(sorted(SUPPORTED_DOCUMENT_TYPES.keys()))
-                    event.text = (
-                        f"Unsupported document type '{ext or 'unknown'}'. "
-                        f"Supported types: {supported_list}"
-                    )
-                    logger.info("[Telegram] Unsupported document type: %s", ext or "unknown")
-                    await self.handle_message(event)
-                    return
+                doc_mime_type = getattr(doc, "mime_type", None) or mimetypes.guess_type(original_filename or "")[0] or ""
+                video_exts = {".mp4", ".mov", ".avi", ".mkv", ".webm", ".3gp", ".mpeg", ".mpg", ".m4v"}
+                is_video_document = bool(doc_mime_type.startswith("video/")) or ext in video_exts
 
                 # Check file size (Telegram Bot API limit: 20 MB)
                 MAX_DOC_BYTES = 20 * 1024 * 1024
@@ -2628,33 +2673,67 @@ class TelegramAdapter(BasePlatformAdapter):
                     await self.handle_message(event)
                     return
 
-                # Download and cache
-                file_obj = await doc.get_file()
-                doc_bytes = await file_obj.download_as_bytearray()
-                raw_bytes = bytes(doc_bytes)
-                cached_path = cache_document_from_bytes(raw_bytes, original_filename or f"document{ext}")
-                mime_type = SUPPORTED_DOCUMENT_TYPES[ext]
-                event.media_urls = [cached_path]
-                event.media_types = [mime_type]
-                logger.info("[Telegram] Cached user document at %s", cached_path)
+                # Video files sent as Telegram documents should still be treated as videos.
+                if is_video_document:
+                    file_obj = await doc.get_file()
+                    video_bytes = await file_obj.download_as_bytearray()
+                    video_mime_type = doc_mime_type or mimetypes.guess_type(f"video{ext or '.mp4'}")[0] or "video/mp4"
+                    filename = original_filename or f"telegram_video{ext or '.mp4'}"
+                    cached_path = cache_document_from_bytes(bytes(video_bytes), filename)
+                    event.message_type = MessageType.VIDEO
+                    event.media_urls = [cached_path]
+                    event.media_types = [video_mime_type]
 
-                # For text files, inject content into event.text (capped at 100 KB)
-                MAX_TEXT_INJECT_BYTES = 100 * 1024
-                if ext in (".md", ".txt") and len(raw_bytes) <= MAX_TEXT_INJECT_BYTES:
-                    try:
-                        text_content = raw_bytes.decode("utf-8")
-                        display_name = original_filename or f"document{ext}"
-                        display_name = re.sub(r'[^\w.\- ]', '_', display_name)
-                        injection = f"[Content of {display_name}]:\n{text_content}"
-                        if event.text:
-                            event.text = f"{injection}\n\n{event.text}"
-                        else:
-                            event.text = injection
-                    except UnicodeDecodeError:
-                        logger.warning(
-                            "[Telegram] Could not decode text file as UTF-8, skipping content injection",
-                            exc_info=True,
+                    metadata_parts = []
+                    if filename:
+                        metadata_parts.append(f"filename={filename}")
+                    file_size = getattr(doc, "file_size", None)
+                    if file_size is not None:
+                        metadata_parts.append(f"size={file_size} bytes")
+                    if video_mime_type:
+                        metadata_parts.append(f"mime={video_mime_type}")
+                    metadata_note = "[Video attachment metadata: " + ", ".join(metadata_parts) + "]"
+                    event.text = f"{metadata_note}\n\n{event.text}" if event.text else metadata_note
+                    logger.info("[Telegram] Cached user video document at %s", cached_path)
+                else:
+                    # Check if supported
+                    if ext not in SUPPORTED_DOCUMENT_TYPES:
+                        supported_list = ", ".join(sorted(SUPPORTED_DOCUMENT_TYPES.keys()))
+                        event.text = (
+                            f"Unsupported document type '{ext or 'unknown'}'. "
+                            f"Supported types: {supported_list}"
                         )
+                        logger.info("[Telegram] Unsupported document type: %s", ext or "unknown")
+                        await self.handle_message(event)
+                        return
+
+                    # Download and cache
+                    file_obj = await doc.get_file()
+                    doc_bytes = await file_obj.download_as_bytearray()
+                    raw_bytes = bytes(doc_bytes)
+                    cached_path = cache_document_from_bytes(raw_bytes, original_filename or f"document{ext}")
+                    mime_type = SUPPORTED_DOCUMENT_TYPES[ext]
+                    event.media_urls = [cached_path]
+                    event.media_types = [mime_type]
+                    logger.info("[Telegram] Cached user document at %s", cached_path)
+
+                    # For text files, inject content into event.text (capped at 100 KB)
+                    MAX_TEXT_INJECT_BYTES = 100 * 1024
+                    if ext in (".md", ".txt") and len(raw_bytes) <= MAX_TEXT_INJECT_BYTES:
+                        try:
+                            text_content = raw_bytes.decode("utf-8")
+                            display_name = original_filename or f"document{ext}"
+                            display_name = re.sub(r'[^\w.\- ]', '_', display_name)
+                            injection = f"[Content of {display_name}]:\n{text_content}"
+                            if event.text:
+                                event.text = f"{injection}\n\n{event.text}"
+                            else:
+                                event.text = injection
+                        except UnicodeDecodeError:
+                            logger.warning(
+                                "[Telegram] Could not decode text file as UTF-8, skipping content injection",
+                                exc_info=True,
+                            )
 
             except Exception as e:
                 logger.warning("[Telegram] Failed to cache document: %s", e, exc_info=True)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -464,6 +464,12 @@ def _load_gateway_config() -> dict:
     return {}
 
 
+def _resolve_orchestration_backend(config: dict | None = None) -> str:
+    cfg = config if config is not None else _load_gateway_config()
+    raw = str((cfg.get("agent") or {}).get("orchestration_backend", "legacy") or "legacy").strip().lower()
+    return raw if raw in {"legacy", "langgraph"} else "legacy"
+
+
 def _resolve_gateway_model(config: dict | None = None) -> str:
     """Read model from config.yaml — single source of truth.
 
@@ -1008,6 +1014,71 @@ class GatewayRunner:
             overrides = None
         route["request_overrides"] = overrides
         return route
+
+    def _run_conversation_via_orchestration_sync(
+        self,
+        *,
+        route_name: str,
+        session_id: str,
+        task_id: str,
+        thread_id: str | None,
+        model: str,
+        tool_names: list[str],
+        runner,
+        config: dict | None = None,
+    ) -> dict:
+        from agent.task_orchestration import HermesTaskOrchestrator, TaskEnvelope, WorkflowStep
+
+        backend = _resolve_orchestration_backend(config)
+        orchestrator = HermesTaskOrchestrator(backend=backend)
+        envelope = TaskEnvelope(
+            session_id=session_id,
+            task_id=task_id,
+            workflow=route_name,
+            backend=backend,
+            thread_id=thread_id or "",
+            metadata={"model": model, "tool_names": list(tool_names)},
+        )
+        execution = orchestrator.run(
+            envelope,
+            steps=[WorkflowStep(name=route_name)],
+            executor=runner,
+        )
+        result = dict(execution.get("result") or {})
+        result["orchestration"] = {
+            "backend": backend,
+            "status": execution.get("status", "completed"),
+            "trace": execution.get("trace", {}),
+            "completed_steps": execution.get("completed_steps", []),
+            "artifacts": execution.get("artifacts", {}),
+            "failed_step": execution.get("failed_step"),
+        }
+        return result
+
+    async def _run_conversation_via_orchestration(
+        self,
+        *,
+        route_name: str,
+        session_id: str,
+        task_id: str,
+        thread_id: str | None,
+        model: str,
+        tool_names: list[str],
+        runner,
+        config: dict | None = None,
+    ) -> dict:
+        return await self._run_in_executor_with_context(
+            lambda: self._run_conversation_via_orchestration_sync(
+                route_name=route_name,
+                session_id=session_id,
+                task_id=task_id,
+                thread_id=thread_id,
+                model=model,
+                tool_names=tool_names,
+                runner=runner,
+                config=config,
+            )
+        )
 
     async def _handle_adapter_fatal_error(self, adapter: BasePlatformAdapter) -> None:
         """React to an adapter failure after startup.
@@ -6188,6 +6259,8 @@ class GatewayRunner:
                     fallback_model=self._fallback_model,
                 )
                 try:
+                    agent.workflow_name = "gateway.background"
+                    agent.orchestration_backend = _resolve_orchestration_backend(user_config)
                     return agent.run_conversation(
                         user_message=prompt,
                         task_id=task_id,
@@ -6195,7 +6268,16 @@ class GatewayRunner:
                 finally:
                     self._cleanup_agent_resources(agent)
 
-            result = await self._run_in_executor_with_context(run_sync)
+            result = await self._run_conversation_via_orchestration(
+                route_name="gateway.background",
+                session_id=task_id,
+                task_id=task_id,
+                thread_id=source.thread_id,
+                model=turn_route["model"],
+                tool_names=enabled_toolsets,
+                runner=run_sync,
+                config=user_config,
+            )
 
             response = result.get("final_response", "") if result else ""
             if not response and result and result.get("error"):
@@ -6372,6 +6454,8 @@ class GatewayRunner:
                     persist_session=False,
                 )
                 try:
+                    agent.workflow_name = "gateway.btw"
+                    agent.orchestration_backend = _resolve_orchestration_backend(user_config)
                     return agent.run_conversation(
                         user_message=btw_prompt,
                         conversation_history=history_snapshot,
@@ -6380,7 +6464,16 @@ class GatewayRunner:
                 finally:
                     self._cleanup_agent_resources(agent)
 
-            result = await self._run_in_executor_with_context(run_sync)
+            result = await self._run_conversation_via_orchestration(
+                route_name="gateway.btw",
+                session_id=task_id,
+                task_id=task_id,
+                thread_id=source.thread_id,
+                model=turn_route["model"],
+                tool_names=[],
+                runner=run_sync,
+                config=user_config,
+            )
 
             response = (result.get("final_response") or "") if result else ""
             if not response and result and result.get("error"):
@@ -9537,7 +9630,18 @@ class GatewayRunner:
             _approval_session_token = set_current_session_key(_approval_session_key)
             register_gateway_notify(_approval_session_key, _approval_notify_sync)
             try:
-                result = agent.run_conversation(message, conversation_history=agent_history, task_id=session_id)
+                agent.workflow_name = "gateway.message"
+                agent.orchestration_backend = _resolve_orchestration_backend(user_config)
+                result = self._run_conversation_via_orchestration_sync(
+                    route_name="gateway.message",
+                    session_id=session_id,
+                    task_id=session_id,
+                    thread_id=source.thread_id,
+                    model=turn_route["model"],
+                    tool_names=enabled_toolsets,
+                    runner=lambda: agent.run_conversation(message, conversation_history=agent_history, task_id=session_id),
+                    config=user_config,
+                )
             finally:
                 unregister_gateway_notify(_approval_session_key)
                 reset_current_session_key(_approval_session_token)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3591,6 +3591,23 @@ class GatewayRunner:
                         except Exception:
                             pass
 
+        if event.media_urls and event.message_type == MessageType.VIDEO:
+            import os as _os
+            import re as _re
+
+            for path in event.media_urls:
+                basename = _os.path.basename(path)
+                parts = basename.split("_", 2)
+                display_name = parts[2] if len(parts) >= 3 else basename
+                display_name = _re.sub(r'[^\w.\- ]', '_', display_name)
+                context_note = (
+                    f"[The user sent a video file: '{display_name}'. "
+                    f"The exact cached file is saved at: {path}. "
+                    f"Use this exact file for any video/audio/frame analysis instead of guessing another local file.]"
+                )
+                if context_note not in message_text:
+                    message_text = f"{context_note}\n\n{message_text}" if message_text else context_note
+
         if event.media_urls and event.message_type == MessageType.DOCUMENT:
             import mimetypes as _mimetypes
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -349,6 +349,7 @@ DEFAULT_CONFIG = {
     "toolsets": ["hermes-cli"],
     "agent": {
         "max_turns": 90,
+        "orchestration_backend": "legacy",
         # Inactivity timeout for gateway agent execution (seconds).
         # The agent can run indefinitely as long as it's actively calling
         # tools or receiving API responses.  Only fires when the agent has

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -31,7 +31,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 6
+SCHEMA_VERSION = 7
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -84,10 +84,19 @@ CREATE TABLE IF NOT EXISTS messages (
     codex_reasoning_items TEXT
 );
 
+CREATE TABLE IF NOT EXISTS session_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL REFERENCES sessions(id),
+    event_type TEXT NOT NULL,
+    payload TEXT,
+    created_at REAL NOT NULL
+);
+
 CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_started ON sessions(started_at DESC);
 CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, timestamp);
+CREATE INDEX IF NOT EXISTS idx_session_events_session ON session_events(session_id, created_at, id);
 """
 
 FTS_SQL = """
@@ -329,6 +338,21 @@ class SessionDB:
                     except sqlite3.OperationalError:
                         pass  # Column already exists
                 cursor.execute("UPDATE schema_version SET version = 6")
+            if current_version < 7:
+                cursor.execute(
+                    """CREATE TABLE IF NOT EXISTS session_events (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        session_id TEXT NOT NULL REFERENCES sessions(id),
+                        event_type TEXT NOT NULL,
+                        payload TEXT,
+                        created_at REAL NOT NULL
+                    )"""
+                )
+                cursor.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_session_events_session "
+                    "ON session_events(session_id, created_at, id)"
+                )
+                cursor.execute("UPDATE schema_version SET version = 7")
 
         # Unique title index — always ensure it exists (safe to run after migrations
         # since the title column is guaranteed to exist at this point)
@@ -787,6 +811,50 @@ class SessionDB:
     # =========================================================================
     # Message storage
     # =========================================================================
+
+    def append_event(
+        self,
+        session_id: str,
+        event_type: str,
+        payload: Optional[Dict[str, Any]] = None,
+    ) -> int:
+        """Append a durable session-scoped event. Returns the row ID."""
+
+        def _do(conn):
+            cursor = conn.execute(
+                "INSERT INTO session_events (session_id, event_type, payload, created_at) VALUES (?, ?, ?, ?)",
+                (
+                    session_id,
+                    event_type,
+                    json.dumps(payload) if payload is not None else None,
+                    time.time(),
+                ),
+            )
+            return cursor.lastrowid
+
+        return self._execute_write(_do)
+
+    def get_events(self, session_id: str) -> List[Dict[str, Any]]:
+        """Load durable session events ordered by insertion time."""
+        with self._lock:
+            rows = self._conn.execute(
+                "SELECT * FROM session_events WHERE session_id = ? ORDER BY created_at, id",
+                (session_id,),
+            ).fetchall()
+
+        events: List[Dict[str, Any]] = []
+        for row in rows:
+            event = dict(row)
+            if event.get("payload"):
+                try:
+                    event["payload"] = json.loads(event["payload"])
+                except (json.JSONDecodeError, TypeError):
+                    logger.warning("Failed to deserialize session event payload, falling back to None")
+                    event["payload"] = None
+            else:
+                event["payload"] = None
+            events.append(event)
+        return events
 
     def append_message(
         self,

--- a/run_agent.py
+++ b/run_agent.py
@@ -819,6 +819,7 @@ class AIAgent:
         self.interim_assistant_callback = interim_assistant_callback
         self.status_callback = status_callback
         self.tool_gen_callback = tool_gen_callback
+        self._llmops_recorder = None
 
         
         # Tool execution state — allows _vprint during tool execution
@@ -3014,6 +3015,27 @@ class AIAgent:
         summary["prompt_tokens"] = cu.prompt_tokens
         summary["total_tokens"] = cu.total_tokens
         return summary
+
+    def _finalize_run_result(self, result: Dict[str, Any], status: str | None = None) -> Dict[str, Any]:
+        recorder = getattr(self, "_llmops_recorder", None)
+        if recorder and "run" not in result:
+            resolved_status = status or (
+                "interrupted"
+                if result.get("interrupted")
+                else "failed"
+                if result.get("failed")
+                else "completed"
+            )
+            recorder.record(
+                "run.completed",
+                status=resolved_status,
+                completed=bool(result.get("completed")),
+                interrupted=bool(result.get("interrupted")),
+                failed=bool(result.get("failed")),
+                api_calls=result.get("api_calls", 0),
+            )
+            result["run"] = recorder.metadata(status=resolved_status)
+        return result
 
     def _dump_api_request_debug(
         self,
@@ -7866,6 +7888,13 @@ class AIAgent:
                     print(f"  📞 Tool {i}: {name}({list(args.keys())}) - {args_preview}")
 
         for tc, name, args in parsed_calls:
+            if self._llmops_recorder:
+                self._llmops_recorder.record(
+                    "tool.started",
+                    tool_call_id=tc.id,
+                    tool_name=name,
+                    arguments=args,
+                )
             if self.tool_progress_callback:
                 try:
                     preview = _build_tool_preview(name, args)
@@ -8033,6 +8062,14 @@ class AIAgent:
                         )
                     except Exception as cb_err:
                         logging.debug(f"Tool progress callback error: {cb_err}")
+                if self._llmops_recorder:
+                    self._llmops_recorder.record(
+                        "tool.completed",
+                        tool_call_id=tc.id,
+                        tool_name=function_name,
+                        duration=tool_duration,
+                        is_error=is_error,
+                    )
 
                 if self.verbose_logging:
                     logging.debug(f"Tool {function_name} completed in {tool_duration:.2f}s")
@@ -8164,6 +8201,13 @@ class AIAgent:
                 except Exception:
                     pass
 
+            if _block_msg is None and self._llmops_recorder:
+                self._llmops_recorder.record(
+                    "tool.started",
+                    tool_call_id=tool_call.id,
+                    tool_name=function_name,
+                    arguments=function_args,
+                )
             if _block_msg is None and self.tool_progress_callback:
                 try:
                     preview = _build_tool_preview(function_name, function_args)
@@ -8407,6 +8451,14 @@ class AIAgent:
                     )
                 except Exception as cb_err:
                     logging.debug(f"Tool progress callback error: {cb_err}")
+            if self._llmops_recorder:
+                self._llmops_recorder.record(
+                    "tool.completed",
+                    tool_call_id=tool_call.id,
+                    tool_name=function_name,
+                    duration=tool_duration,
+                    is_error=_is_error_result,
+                )
 
             self._current_tool = None
             self._touch_activity(f"tool completed: {function_name} ({tool_duration:.1f}s)")
@@ -8707,6 +8759,26 @@ class AIAgent:
         self._persist_user_message_override = persist_user_message
         # Generate unique task_id if not provided to isolate VMs between concurrent tasks
         effective_task_id = task_id or str(uuid.uuid4())
+        from agent.llmops import RunRecorder, build_run_envelope
+        self._llmops_recorder = RunRecorder(
+            self._session_db,
+            build_run_envelope(
+                session_id=self.session_id,
+                task_id=effective_task_id,
+                platform=self.platform,
+                thread_id=getattr(self, "gateway_session_key", None),
+                workflow=getattr(self, "workflow_name", None) or "conversation",
+                backend=getattr(self, "orchestration_backend", None) or "legacy",
+                model=self.model,
+                tool_names=self.valid_tool_names,
+            ),
+        )
+        self._llmops_recorder.record(
+            "run.started",
+            model=self.model,
+            platform=self.platform or "",
+            backend=getattr(self, "orchestration_backend", None) or "legacy",
+        )
         
         # Reset retry counters and iteration budget at the start of each turn
         # so subagent usage from a previous turn doesn't eat into the next one.
@@ -9267,7 +9339,7 @@ class AIAgent:
                                 continue
                             # No fallback available — return with clear message
                             self._persist_session(messages, conversation_history)
-                            return {
+                            return self._finalize_run_result({
                                 "final_response": (
                                     f"⏳ {_nous_msg}\n\n"
                                     "No fallback provider available. "
@@ -9279,7 +9351,7 @@ class AIAgent:
                                 "completed": False,
                                 "failed": True,
                                 "error": _nous_msg,
-                            }
+                            })
                     except ImportError:
                         pass
                     except Exception:
@@ -9350,6 +9422,14 @@ class AIAgent:
                         if isinstance(getattr(self, "client", None), Mock):
                             _use_streaming = False
 
+                    self._llmops_recorder.record(
+                        "api.request.started",
+                        api_call_count=api_call_count,
+                        message_count=len(api_messages),
+                        approx_input_tokens=approx_tokens,
+                        tool_count=len(self.tools or []),
+                    )
+
                     if _use_streaming:
                         response = self._interruptible_streaming_api_call(
                             api_kwargs, on_first_delta=_stop_spinner
@@ -9358,6 +9438,14 @@ class AIAgent:
                         response = self._interruptible_api_call(api_kwargs)
                     
                     api_duration = time.time() - api_start_time
+                    self._llmops_recorder.record(
+                        "api.request.completed",
+                        api_call_count=api_call_count,
+                        duration=api_duration,
+                        finish_reason=getattr(response.choices[0], "finish_reason", None)
+                        if response is not None and hasattr(response, "choices") and response.choices
+                        else None,
+                    )
                     
                     # Stop thinking spinner silently -- the response box or tool
                     # execution messages that follow are more informative.
@@ -9529,13 +9617,13 @@ class AIAgent:
                             self._emit_status(f"❌ Max retries ({max_retries}) exceeded for invalid responses. Giving up.")
                             logging.error(f"{self.log_prefix}Invalid API response after {max_retries} retries.")
                             self._persist_session(messages, conversation_history)
-                            return {
+                            return self._finalize_run_result({
                                 "messages": messages,
                                 "completed": False,
                                 "api_calls": api_call_count,
                                 "error": f"Invalid API response after {max_retries} retries: {_failure_hint}",
                                 "failed": True  # Mark as failure for filtering
-                            }
+                            })
                         
                         # Backoff before retry — jittered exponential: 5s base, 120s cap
                         wait_time = jittered_backoff(retry_count, base_delay=5.0, max_delay=120.0)
@@ -9550,13 +9638,13 @@ class AIAgent:
                                 self._vprint(f"{self.log_prefix}⚡ Interrupt detected during retry wait, aborting.", force=True)
                                 self._persist_session(messages, conversation_history)
                                 self.clear_interrupt()
-                                return {
+                                return self._finalize_run_result({
                                     "final_response": f"Operation interrupted during retry ({_failure_hint}, attempt {retry_count}/{max_retries}).",
                                     "messages": messages,
                                     "api_calls": api_call_count,
                                     "completed": False,
                                     "interrupted": True,
-                                }
+                                })
                             time.sleep(0.2)
                             # Touch activity every ~30s so the gateway's inactivity
                             # monitor knows we're alive during backoff waits.
@@ -9667,14 +9755,14 @@ class AIAgent:
                             )
                             self._cleanup_task_resources(effective_task_id)
                             self._persist_session(messages, conversation_history)
-                            return {
+                            return self._finalize_run_result({
                                 "final_response": _exhaust_response,
                                 "messages": messages,
                                 "api_calls": api_call_count,
                                 "completed": False,
                                 "partial": True,
                                 "error": _exhaust_error,
-                            }
+                            })
 
                         if self.api_mode in ("chat_completions", "bedrock_converse"):
                             assistant_message = response.choices[0].message
@@ -9707,14 +9795,14 @@ class AIAgent:
                                 partial_response = self._strip_think_blocks(truncated_response_prefix).strip()
                                 self._cleanup_task_resources(effective_task_id)
                                 self._persist_session(messages, conversation_history)
-                                return {
+                                return self._finalize_run_result({
                                     "final_response": partial_response or None,
                                     "messages": messages,
                                     "api_calls": api_call_count,
                                     "completed": False,
                                     "partial": True,
                                     "error": "Response remained truncated after 3 continuation attempts",
-                                }
+                                })
 
                         if self.api_mode in ("chat_completions", "bedrock_converse"):
                             assistant_message = response.choices[0].message
@@ -9735,14 +9823,14 @@ class AIAgent:
                                 )
                                 self._cleanup_task_resources(effective_task_id)
                                 self._persist_session(messages, conversation_history)
-                                return {
+                                return self._finalize_run_result({
                                     "final_response": None,
                                     "messages": messages,
                                     "api_calls": api_call_count,
                                     "completed": False,
                                     "partial": True,
                                     "error": "Response truncated due to output length limit",
-                                }
+                                })
 
                         # If we have prior messages, roll back to last complete state
                         if len(messages) > 1:
@@ -9752,26 +9840,26 @@ class AIAgent:
                             self._cleanup_task_resources(effective_task_id)
                             self._persist_session(messages, conversation_history)
 
-                            return {
+                            return self._finalize_run_result({
                                 "final_response": None,
                                 "messages": rolled_back_messages,
                                 "api_calls": api_call_count,
                                 "completed": False,
                                 "partial": True,
                                 "error": "Response truncated due to output length limit"
-                            }
+                            })
                         else:
                             # First message was truncated - mark as failed
                             self._vprint(f"{self.log_prefix}❌ First response truncated - cannot recover", force=True)
                             self._persist_session(messages, conversation_history)
-                            return {
+                            return self._finalize_run_result({
                                 "final_response": None,
                                 "messages": messages,
                                 "api_calls": api_call_count,
                                 "completed": False,
                                 "failed": True,
                                 "error": "First response truncated due to output length limit"
-                            }
+                            })
                     
                     # Track actual token usage from response for context management
                     if hasattr(response, 'usage') and response.usage:
@@ -10247,13 +10335,13 @@ class AIAgent:
                         self._vprint(f"{self.log_prefix}⚡ Interrupt detected during error handling, aborting retries.", force=True)
                         self._persist_session(messages, conversation_history)
                         self.clear_interrupt()
-                        return {
+                        return self._finalize_run_result({
                             "final_response": f"Operation interrupted: handling API error ({error_type}: {self._clean_error_message(str(api_error))}).",
                             "messages": messages,
                             "api_calls": api_call_count,
                             "completed": False,
                             "interrupted": True,
-                        }
+                        })
                     
                     # Check for 413 payload-too-large BEFORE generic 4xx handler.
                     # A 413 is a payload-size error — the correct response is to
@@ -10384,7 +10472,7 @@ class AIAgent:
                             self._vprint(f"{self.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.", force=True)
                             logging.error(f"{self.log_prefix}413 compression failed after {max_compression_attempts} attempts.")
                             self._persist_session(messages, conversation_history)
-                            return {
+                            return self._finalize_run_result({
                                 "messages": messages,
                                 "completed": False,
                                 "api_calls": api_call_count,
@@ -10392,7 +10480,7 @@ class AIAgent:
                                 "partial": True,
                                 "failed": True,
                                 "compression_exhausted": True,
-                            }
+                            })
                         self._emit_status(f"⚠️  Request payload too large (413) — compression attempt {compression_attempts}/{max_compression_attempts}...")
 
                         original_len = len(messages)
@@ -10415,7 +10503,7 @@ class AIAgent:
                             self._vprint(f"{self.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.", force=True)
                             logging.error(f"{self.log_prefix}413 payload too large. Cannot compress further.")
                             self._persist_session(messages, conversation_history)
-                            return {
+                            return self._finalize_run_result({
                                 "messages": messages,
                                 "completed": False,
                                 "api_calls": api_call_count,
@@ -10423,7 +10511,7 @@ class AIAgent:
                                 "partial": True,
                                 "failed": True,
                                 "compression_exhausted": True,
-                            }
+                            })
 
                     # Check for context-length errors BEFORE generic 4xx handler.
                     # The classifier detects context overflow from: explicit error
@@ -10468,7 +10556,7 @@ class AIAgent:
                                 self._vprint(f"{self.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.", force=True)
                                 logging.error(f"{self.log_prefix}Context compression failed after {max_compression_attempts} attempts.")
                                 self._persist_session(messages, conversation_history)
-                                return {
+                                return self._finalize_run_result({
                                     "messages": messages,
                                     "completed": False,
                                     "api_calls": api_call_count,
@@ -10476,7 +10564,7 @@ class AIAgent:
                                     "partial": True,
                                     "failed": True,
                                     "compression_exhausted": True,
-                                }
+                                })
                             restart_with_compressed_messages = True
                             break
 
@@ -10520,7 +10608,7 @@ class AIAgent:
                             self._vprint(f"{self.log_prefix}   💡 Try /new to start a fresh conversation, or /compress to retry compression.", force=True)
                             logging.error(f"{self.log_prefix}Context compression failed after {max_compression_attempts} attempts.")
                             self._persist_session(messages, conversation_history)
-                            return {
+                            return self._finalize_run_result({
                                 "messages": messages,
                                 "completed": False,
                                 "api_calls": api_call_count,
@@ -10528,7 +10616,7 @@ class AIAgent:
                                 "partial": True,
                                 "failed": True,
                                 "compression_exhausted": True,
-                            }
+                            })
                         self._emit_status(f"🗜️ Context too large (~{approx_tokens:,} tokens) — compressing ({compression_attempts}/{max_compression_attempts})...")
 
                         original_len = len(messages)
@@ -10553,7 +10641,7 @@ class AIAgent:
                             self._vprint(f"{self.log_prefix}   💡 The conversation has accumulated too much content. Try /new to start fresh, or /compress to manually trigger compression.", force=True)
                             logging.error(f"{self.log_prefix}Context length exceeded: {approx_tokens:,} tokens. Cannot compress further.")
                             self._persist_session(messages, conversation_history)
-                            return {
+                            return self._finalize_run_result({
                                 "messages": messages,
                                 "completed": False,
                                 "api_calls": api_call_count,
@@ -10561,7 +10649,7 @@ class AIAgent:
                                 "partial": True,
                                 "failed": True,
                                 "compression_exhausted": True,
-                            }
+                            })
 
                     # Check for non-retryable client errors.  The classifier
                     # already accounts for 413, 429, 529 (transient), context
@@ -10637,14 +10725,14 @@ class AIAgent:
                             )
                         else:
                             self._persist_session(messages, conversation_history)
-                        return {
+                        return self._finalize_run_result({
                             "final_response": None,
                             "messages": messages,
                             "api_calls": api_call_count,
                             "completed": False,
                             "failed": True,
                             "error": str(api_error),
-                        }
+                        })
 
                     if retry_count >= max_retries:
                         # Before falling back, try rebuilding the primary
@@ -11832,7 +11920,7 @@ class AIAgent:
         except Exception as exc:
             logger.warning("on_session_end hook failed: %s", exc)
 
-        return result
+        return self._finalize_run_result(result)
 
     def chat(self, message: str, stream_callback: Optional[callable] = None) -> str:
         """

--- a/run_agent.py
+++ b/run_agent.py
@@ -5869,15 +5869,26 @@ class AIAgent:
                             entry["id"] = tc_delta.id
                         if tc_delta.function:
                             if tc_delta.function.name:
-                                # Use assignment, not +=.  Function names are
-                                # atomic identifiers delivered complete in the
-                                # first chunk (OpenAI spec).  Some providers
-                                # (MiniMax M2.7 via NVIDIA NIM) resend the full
-                                # name in every chunk; concatenation would
-                                # produce "read_fileread_file".  Assignment
-                                # (matching the OpenAI Node SDK / LiteLLM /
-                                # Vercel AI patterns) is immune to this.
-                                entry["function"]["name"] = tc_delta.function.name
+                                # Tool names are usually atomic, but some providers
+                                # stream them in pieces (e.g. "web_" then "search")
+                                # while others resend the full name every chunk.
+                                # Accumulate only when the new fragment is neither
+                                # identical to nor a superset/subset of what we
+                                # already have; this preserves partial-name joins
+                                # without producing duplicates like
+                                # "read_fileread_file".
+                                current_name = entry["function"]["name"]
+                                incoming_name = tc_delta.function.name
+                                if not current_name:
+                                    entry["function"]["name"] = incoming_name
+                                elif incoming_name == current_name:
+                                    pass
+                                elif incoming_name.startswith(current_name):
+                                    entry["function"]["name"] = incoming_name
+                                elif current_name.startswith(incoming_name):
+                                    pass
+                                else:
+                                    entry["function"]["name"] += incoming_name
                             if tc_delta.function.arguments:
                                 entry["function"]["arguments"] += tc_delta.function.arguments
                         extra = getattr(tc_delta, "extra_content", None)

--- a/tests/agent/test_task_orchestration.py
+++ b/tests/agent/test_task_orchestration.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from agent.task_orchestration import (
+    HermesTaskOrchestrator,
+    TaskEnvelope,
+    WorkflowStep,
+)
+
+
+def test_legacy_orchestrator_executes_step_and_records_trace():
+    orchestrator = HermesTaskOrchestrator(backend="legacy")
+    envelope = TaskEnvelope(
+        session_id="sess-1",
+        task_id="task-1",
+        workflow="gateway.message",
+        backend="legacy",
+    )
+
+    result = orchestrator.run(
+        envelope,
+        steps=[WorkflowStep(name="conversation")],
+        executor=lambda: {"final_response": "hello"},
+    )
+
+    assert result["status"] == "completed"
+    assert result["result"]["final_response"] == "hello"
+    assert result["trace"]["steps"][0]["name"] == "conversation"
+    assert result["trace"]["steps"][0]["status"] == "completed"
+    assert result["completed_steps"] == ["conversation"]
+
+
+def test_langgraph_backend_requires_optional_dependency():
+    orchestrator = HermesTaskOrchestrator(backend="langgraph")
+    envelope = TaskEnvelope(
+        session_id="sess-1",
+        task_id="task-1",
+        workflow="gateway.message",
+        backend="langgraph",
+    )
+
+    try:
+        orchestrator.run(
+            envelope,
+            steps=[WorkflowStep(name="conversation")],
+            executor=lambda: {"final_response": "hello"},
+        )
+    except RuntimeError as exc:
+        message = str(exc)
+    else:
+        raise AssertionError("expected RuntimeError when langgraph is unavailable")
+
+    assert "langgraph" in message.lower()
+    assert "optional" in message.lower()

--- a/tests/gateway/test_orchestration_backend.py
+++ b/tests/gateway/test_orchestration_backend.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+def _make_source():
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="user-1",
+        chat_id="chat-1",
+        user_name="tester",
+        thread_id="thread-1",
+    )
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(text=text, source=_make_source(), message_id="m-1")
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {Platform.TELEGRAM: AsyncMock()}
+    runner.adapters[Platform.TELEGRAM].send = AsyncMock()
+    runner.adapters[Platform.TELEGRAM].extract_media = MagicMock(return_value=([], "ok"))
+    runner.adapters[Platform.TELEGRAM].extract_images = MagicMock(return_value=([], "ok"))
+    runner._background_tasks = set()
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._running_agents = {}
+    runner._session_db = None
+    runner._service_tier = None
+    runner._resolve_session_agent_runtime = MagicMock(
+        return_value=("test-model", {"api_key": "key", "provider": "openai"})
+    )
+    runner._resolve_turn_agent_config = MagicMock(
+        return_value={"model": "test-model", "runtime": {"api_key": "key", "provider": "openai"}}
+    )
+    runner._load_reasoning_config = MagicMock(return_value=None)
+    runner._load_service_tier = MagicMock(return_value=None)
+    runner._run_in_executor_with_context = AsyncMock(side_effect=lambda fn: fn())
+    runner._cleanup_agent_resources = MagicMock()
+    runner._session_key_for_source = MagicMock(return_value="session-key")
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = SimpleNamespace(session_id="sess-1")
+    runner.session_store.load_transcript.return_value = []
+    return runner
+
+
+def test_resolve_orchestration_backend_defaults_to_legacy():
+    from gateway.run import _resolve_orchestration_backend
+
+    assert _resolve_orchestration_backend({}) == "legacy"
+    assert _resolve_orchestration_backend({"agent": {}}) == "legacy"
+
+
+def test_resolve_orchestration_backend_accepts_langgraph():
+    from gateway.run import _resolve_orchestration_backend
+
+    assert _resolve_orchestration_backend({"agent": {"orchestration_backend": "langgraph"}}) == "langgraph"
+
+
+@pytest.mark.asyncio
+async def test_run_conversation_via_orchestration_attaches_metadata():
+    runner = _make_runner()
+
+    with patch("gateway.run._load_gateway_config", return_value={"agent": {"orchestration_backend": "legacy"}}):
+        result = await runner._run_conversation_via_orchestration(
+            route_name="gateway.message",
+            session_id="sess-1",
+            task_id="task-1",
+            thread_id="thread-1",
+            model="test-model",
+            tool_names=["web_search"],
+            runner=lambda: {"final_response": "hello", "messages": []},
+        )
+
+    assert result["final_response"] == "hello"
+    assert result["orchestration"]["backend"] == "legacy"
+    assert result["orchestration"]["status"] == "completed"
+    assert result["orchestration"]["completed_steps"] == ["gateway.message"]
+
+
+@pytest.mark.asyncio
+async def test_background_route_uses_orchestration_wrapper():
+    runner = _make_runner()
+    event_source = _make_source()
+
+    with patch("gateway.run._load_gateway_config", return_value={}), \
+         patch("run_agent.AIAgent") as MockAgent:
+        agent = MagicMock()
+        agent.run_conversation.return_value = {"final_response": "background ok", "messages": []}
+        MockAgent.return_value = agent
+        runner._run_conversation_via_orchestration = AsyncMock(
+            return_value={
+                "final_response": "background ok",
+                "messages": [],
+                "orchestration": {"backend": "legacy", "status": "completed"},
+            }
+        )
+
+        await runner._run_background_task("do thing", event_source, "bg-task")
+
+    runner._run_conversation_via_orchestration.assert_awaited_once()
+    assert runner._run_conversation_via_orchestration.await_args.kwargs["route_name"] == "gateway.background"
+
+
+@pytest.mark.asyncio
+async def test_btw_route_uses_orchestration_wrapper():
+    runner = _make_runner()
+    event_source = _make_source()
+
+    with patch("gateway.run._load_gateway_config", return_value={}), \
+         patch("run_agent.AIAgent") as MockAgent:
+        agent = MagicMock()
+        agent.run_conversation.return_value = {"final_response": "btw ok", "messages": []}
+        MockAgent.return_value = agent
+        runner._run_conversation_via_orchestration = AsyncMock(
+            return_value={
+                "final_response": "btw ok",
+                "messages": [],
+                "orchestration": {"backend": "legacy", "status": "completed"},
+            }
+        )
+
+        await runner._run_btw_task("quick question", event_source, "session-key", "btw-task")
+
+    runner._run_conversation_via_orchestration.assert_awaited_once()
+    assert runner._run_conversation_via_orchestration.await_args.kwargs["route_name"] == "gateway.btw"

--- a/tests/gateway/test_stt_config.py
+++ b/tests/gateway/test_stt_config.py
@@ -114,3 +114,38 @@ async def test_prepare_inbound_message_text_transcribes_queued_voice_event():
     assert result is not None
     assert "queued voice transcript" in result
     assert "voice message" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_prepare_inbound_message_text_mentions_video_path_and_filename():
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    runner.adapters = {}
+    runner._model = "test-model"
+    runner._base_url = ""
+    runner._has_setup_skill = lambda: False
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type="dm",
+    )
+    event = MessageEvent(
+        text="[Video attachment metadata: filename=telegram_clip.mp4, duration=7s]",
+        message_type=MessageType.VIDEO,
+        source=source,
+        media_urls=["/tmp/doc_deadbeef_telegram_clip.mp4"],
+        media_types=["video/mp4"],
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert "telegram_clip.mp4" in result
+    assert "/tmp/doc_deadbeef_telegram_clip.mp4" in result
+    assert "video file" in result.lower()

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -82,8 +82,8 @@ def _make_document(
     return doc
 
 
-def _make_message(document=None, caption=None, media_group_id=None, photo=None):
-    """Build a mock Telegram Message with the given document/photo."""
+def _make_message(document=None, caption=None, media_group_id=None, photo=None, video=None):
+    """Build a mock Telegram Message with the given document/photo/video."""
     msg = MagicMock()
     msg.message_id = 42
     msg.text = caption or ""
@@ -91,7 +91,7 @@ def _make_message(document=None, caption=None, media_group_id=None, photo=None):
     msg.date = None
     # Media flags — all None except explicit payload
     msg.photo = photo
-    msg.video = None
+    msg.video = video
     msg.audio = None
     msg.voice = None
     msg.sticker = None
@@ -173,6 +173,26 @@ def _make_photo(file_obj=None):
     return photo
 
 
+def _make_video(
+    file_name="clip.mp4",
+    mime_type="video/mp4",
+    file_size=2048,
+    duration=7,
+    width=1280,
+    height=720,
+    file_obj=None,
+):
+    video = MagicMock()
+    video.file_name = file_name
+    video.mime_type = mime_type
+    video.file_size = file_size
+    video.duration = duration
+    video.width = width
+    video.height = height
+    video.get_file = AsyncMock(return_value=file_obj or _make_file_obj(b"video-bytes"))
+    return video
+
+
 class TestDocumentDownloadBlock:
     @pytest.mark.asyncio
     async def test_supported_pdf_is_cached(self, adapter):
@@ -246,6 +266,50 @@ class TestDocumentDownloadBlock:
         event = adapter.handle_message.call_args[0][0]
         assert event.media_urls and event.media_urls[0].endswith("archive.zip")
         assert event.media_types == ["application/zip"]
+
+    @pytest.mark.asyncio
+    async def test_native_video_is_cached_with_metadata(self, adapter):
+        file_obj = _make_file_obj(b"\x00\x00\x00 ftypisomvideo")
+        file_obj.file_path = "videos/from-telegram.mp4"
+        video = _make_video(file_obj=file_obj)
+        msg = _make_message(video=video, caption="Разбери это видео")
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.VIDEO
+        assert len(event.media_urls) == 1
+        assert os.path.exists(event.media_urls[0])
+        assert event.media_types == ["video/mp4"]
+        assert "Video attachment metadata" in event.text
+        assert "clip.mp4" in event.text
+        assert "duration=7s" in event.text
+        assert "size=2048 bytes" in event.text
+        assert "Разбери это видео" in event.text
+
+    @pytest.mark.asyncio
+    async def test_video_document_is_cached_as_video_with_metadata(self, adapter):
+        file_obj = _make_file_obj(b"\x00\x00\x00 ftypisomdocumentvideo")
+        file_obj.file_path = "documents/from-telegram.mp4"
+        doc = _make_document(
+            file_name="sent-as-file.mp4",
+            mime_type="video/mp4",
+            file_size=4096,
+            file_obj=file_obj,
+        )
+        msg = _make_message(document=doc, caption="Это прислано как файл")
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.VIDEO
+        assert len(event.media_urls) == 1
+        assert os.path.exists(event.media_urls[0])
+        assert event.media_types == ["video/mp4"]
+        assert "Video attachment metadata" in event.text
+        assert "sent-as-file.mp4" in event.text
+        assert "size=4096 bytes" in event.text
+        assert "Это прислано как файл" in event.text
 
     @pytest.mark.asyncio
     async def test_oversized_file_rejected(self, adapter):

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4220,3 +4220,66 @@ class TestMemoryProviderTurnStart:
         import inspect
         src = inspect.getsource(AIAgent.run_conversation)
         assert "on_turn_start(self._user_turn_count" in src
+
+
+class TestLLMOpsRunMetadata:
+    def test_run_conversation_exposes_run_metadata_and_event_sequence(self, tmp_path):
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            with (
+                patch(
+                    "run_agent.get_tool_definitions",
+                    return_value=_make_tool_defs("web_search"),
+                ),
+                patch("run_agent.check_toolset_requirements", return_value={}),
+                patch("run_agent.OpenAI"),
+            ):
+                agent = AIAgent(
+                    api_key="test-key-1234567890",
+                    base_url="https://openrouter.ai/api/v1",
+                    quiet_mode=True,
+                    skip_context_files=True,
+                    skip_memory=True,
+                    session_db=db,
+                    session_id="sess-llmops",
+                    platform="telegram",
+                )
+
+            agent.client = MagicMock()
+            agent._interruptible_api_call = MagicMock(
+                side_effect=[
+                    _mock_response(
+                        content="",
+                        finish_reason="tool_calls",
+                        tool_calls=[_mock_tool_call(name="web_search", arguments='{"q":"test"}', call_id="call-1")],
+                    ),
+                    _mock_response(content="done", finish_reason="stop"),
+                ]
+            )
+
+            with patch("run_agent.handle_function_call", return_value="search result"):
+                result = agent.run_conversation("find it", task_id="task-llmops")
+
+            assert result["final_response"] == "done"
+            assert result["run"]["session_id"] == "sess-llmops"
+            assert result["run"]["task_id"] == "task-llmops"
+            assert result["run"]["model"] == agent.model
+            assert result["run"]["backend"] == "legacy"
+            assert result["run"]["tool_names"] == ["web_search"]
+
+            events = db.get_events("sess-llmops")
+            assert [event["event_type"] for event in events] == [
+                "run.started",
+                "api.request.started",
+                "api.request.completed",
+                "tool.started",
+                "tool.completed",
+                "api.request.started",
+                "api.request.completed",
+                "run.completed",
+            ]
+            assert events[-1]["payload"]["status"] == "completed"
+        finally:
+            db.close()

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1070,7 +1070,7 @@ class TestSchemaInit:
     def test_schema_version(self, db):
         cursor = db._conn.execute("SELECT version FROM schema_version")
         version = cursor.fetchone()[0]
-        assert version == 6
+        assert version == 7
 
     def test_title_column_exists(self, db):
         """Verify the title column was created in the sessions table."""
@@ -1126,12 +1126,12 @@ class TestSchemaInit:
         conn.commit()
         conn.close()
 
-        # Open with SessionDB — should migrate to v6
+        # Open with SessionDB — should migrate to v7
         migrated_db = SessionDB(db_path=db_path)
 
         # Verify migration
         cursor = migrated_db._conn.execute("SELECT version FROM schema_version")
-        assert cursor.fetchone()[0] == 6
+        assert cursor.fetchone()[0] == 7
 
         # Verify title column exists and is NULL for existing sessions
         session = migrated_db.get_session("existing")
@@ -1144,6 +1144,103 @@ class TestSchemaInit:
         assert session["title"] == "Migrated Title"
 
         migrated_db.close()
+
+    def test_migration_from_v6_adds_session_events_table(self, tmp_path):
+        """Opening a v6 database should migrate to v7 with session_events."""
+        import sqlite3
+
+        db_path = tmp_path / "migrate_events.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.executescript("""
+            CREATE TABLE schema_version (version INTEGER NOT NULL);
+            INSERT INTO schema_version (version) VALUES (6);
+
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                source TEXT NOT NULL,
+                user_id TEXT,
+                model TEXT,
+                model_config TEXT,
+                system_prompt TEXT,
+                parent_session_id TEXT,
+                started_at REAL NOT NULL,
+                ended_at REAL,
+                end_reason TEXT,
+                message_count INTEGER DEFAULT 0,
+                tool_call_count INTEGER DEFAULT 0,
+                input_tokens INTEGER DEFAULT 0,
+                output_tokens INTEGER DEFAULT 0,
+                cache_read_tokens INTEGER DEFAULT 0,
+                cache_write_tokens INTEGER DEFAULT 0,
+                reasoning_tokens INTEGER DEFAULT 0,
+                billing_provider TEXT,
+                billing_base_url TEXT,
+                billing_mode TEXT,
+                estimated_cost_usd REAL,
+                actual_cost_usd REAL,
+                cost_status TEXT,
+                cost_source TEXT,
+                pricing_version TEXT,
+                title TEXT
+            );
+
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                role TEXT NOT NULL,
+                content TEXT,
+                tool_call_id TEXT,
+                tool_calls TEXT,
+                tool_name TEXT,
+                timestamp REAL NOT NULL,
+                token_count INTEGER,
+                finish_reason TEXT,
+                reasoning TEXT,
+                reasoning_details TEXT,
+                codex_reasoning_items TEXT
+            );
+        """)
+        conn.commit()
+        conn.close()
+
+        migrated_db = SessionDB(db_path=db_path)
+        try:
+            version = migrated_db._conn.execute("SELECT version FROM schema_version").fetchone()[0]
+            assert version == 7
+            tables = {
+                row[0]
+                for row in migrated_db._conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                ).fetchall()
+            }
+            assert "session_events" in tables
+        finally:
+            migrated_db.close()
+
+
+class TestSessionEvents:
+    def test_append_and_get_events(self, db):
+        db.create_session("sess-events", "cli")
+
+        db.append_event(
+            session_id="sess-events",
+            event_type="run.started",
+            payload={"run_id": "run-1", "backend": "legacy"},
+        )
+        db.append_event(
+            session_id="sess-events",
+            event_type="tool.completed",
+            payload={"name": "search_files", "duration": 0.12},
+        )
+
+        events = db.get_events("sess-events")
+
+        assert [event["event_type"] for event in events] == [
+            "run.started",
+            "tool.completed",
+        ]
+        assert events[0]["payload"]["run_id"] == "run-1"
+        assert events[1]["payload"]["name"] == "search_files"
 
 
 class TestTitleUniqueness:

--- a/tests/tools/test_tts_edge_resilience.py
+++ b/tests/tools/test_tts_edge_resilience.py
@@ -1,0 +1,80 @@
+"""Regression tests for resilient Edge TTS outbound behavior."""
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+def test_generate_edge_tts_retries_same_voice_before_succeeding(tmp_path):
+    from tools.tts_tool import _generate_edge_tts
+
+    output_path = tmp_path / "out.mp3"
+    call_counter = {"n": 0}
+
+    async def flaky_save(path):
+        call_counter["n"] += 1
+        if call_counter["n"] < 3:
+            raise RuntimeError("NoAudioReceived")
+        Path(path).write_bytes(b"ok")
+
+    mock_comm = MagicMock()
+    mock_comm.save = AsyncMock(side_effect=flaky_save)
+    mock_edge = MagicMock()
+    mock_edge.Communicate = MagicMock(return_value=mock_comm)
+
+    with patch("tools.tts_tool._import_edge_tts", return_value=mock_edge):
+        result = asyncio.run(
+            _generate_edge_tts(
+                "Hello",
+                str(output_path),
+                {"edge": {"retry_attempts": 3}},
+            )
+        )
+
+    assert result == str(output_path)
+    assert output_path.read_bytes() == b"ok"
+    assert mock_edge.Communicate.call_count == 3
+
+
+def test_generate_edge_tts_tries_fallback_voice_after_primary_failure(tmp_path):
+    from tools.tts_tool import _generate_edge_tts
+
+    output_path = tmp_path / "out.mp3"
+    primary_comm = MagicMock()
+    primary_comm.save = AsyncMock(side_effect=RuntimeError("NoAudioReceived"))
+
+    async def fallback_save(path):
+        Path(path).write_bytes(b"fallback-ok")
+
+    fallback_comm = MagicMock()
+    fallback_comm.save = AsyncMock(side_effect=fallback_save)
+
+    def communicate_factory(text, **kwargs):
+        if kwargs["voice"] == "en-US-AriaNeural":
+            return primary_comm
+        if kwargs["voice"] == "en-US-JennyNeural":
+            return fallback_comm
+        raise AssertionError(f"unexpected voice: {kwargs['voice']}")
+
+    mock_edge = MagicMock()
+    mock_edge.Communicate = MagicMock(side_effect=communicate_factory)
+
+    with patch("tools.tts_tool._import_edge_tts", return_value=mock_edge):
+        result = asyncio.run(
+            _generate_edge_tts(
+                "Hello",
+                str(output_path),
+                {
+                    "edge": {
+                        "voice": "en-US-AriaNeural",
+                        "retry_attempts": 1,
+                        "fallback_voices": ["en-US-JennyNeural"],
+                    }
+                },
+            )
+        )
+
+    assert result == str(output_path)
+    assert output_path.read_bytes() == b"fallback-ok"
+    used_voices = [call.kwargs["voice"] for call in mock_edge.Communicate.call_args_list]
+    assert used_voices == ["en-US-AriaNeural", "en-US-JennyNeural"]

--- a/tests/tools/test_tts_speed.py
+++ b/tests/tools/test_tts_speed.py
@@ -18,8 +18,12 @@ def clean_env(monkeypatch):
 
 class TestEdgeTtsSpeed:
     def _run(self, tts_config, tmp_path):
+        async def _save(path):
+            from pathlib import Path
+            Path(path).write_bytes(b"edge-audio")
+
         mock_comm = MagicMock()
-        mock_comm.save = AsyncMock()
+        mock_comm.save = AsyncMock(side_effect=_save)
         mock_edge = MagicMock()
         mock_edge.Communicate = MagicMock(return_value=mock_comm)
 

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -193,6 +193,9 @@ async def _generate_edge_tts(text: str, output_path: str, tts_config: Dict[str, 
     """
     Generate audio using Edge TTS.
 
+    Retries transient Edge failures like ``NoAudioReceived`` and can walk
+    through configured fallback voices before giving up.
+
     Args:
         text: Text to convert.
         output_path: Where to save the MP3 file.
@@ -203,17 +206,55 @@ async def _generate_edge_tts(text: str, output_path: str, tts_config: Dict[str, 
     """
     _edge_tts = _import_edge_tts()
     edge_config = tts_config.get("edge", {})
-    voice = edge_config.get("voice", DEFAULT_EDGE_VOICE)
+    primary_voice = edge_config.get("voice", DEFAULT_EDGE_VOICE)
+    fallback_voices = edge_config.get("fallback_voices", []) or []
+    retry_attempts = max(1, int(edge_config.get("retry_attempts", 2)))
     speed = float(edge_config.get("speed", tts_config.get("speed", 1.0)))
 
-    kwargs = {"voice": voice}
+    voice_candidates = []
+    for candidate in [primary_voice, *fallback_voices]:
+        if candidate and candidate not in voice_candidates:
+            voice_candidates.append(candidate)
+
+    kwargs_base = {}
     if speed != 1.0:
         pct = round((speed - 1.0) * 100)
-        kwargs["rate"] = f"{pct:+d}%"
+        kwargs_base["rate"] = f"{pct:+d}%"
 
-    communicate = _edge_tts.Communicate(text, **kwargs)
-    await communicate.save(output_path)
-    return output_path
+    failures = []
+    for voice in voice_candidates:
+        for attempt in range(1, retry_attempts + 1):
+            try:
+                if os.path.exists(output_path):
+                    os.remove(output_path)
+            except OSError:
+                pass
+
+            try:
+                communicate = _edge_tts.Communicate(text, voice=voice, **kwargs_base)
+                await communicate.save(output_path)
+                if os.path.exists(output_path) and os.path.getsize(output_path) > 0:
+                    return output_path
+                raise RuntimeError("Edge TTS returned an empty audio file")
+            except Exception as exc:
+                failures.append(f"{voice} attempt {attempt}: {type(exc).__name__}: {exc}")
+                logger.warning(
+                    "Edge TTS failed for voice=%s attempt=%s/%s: %s",
+                    voice,
+                    attempt,
+                    retry_attempts,
+                    exc,
+                )
+                try:
+                    if os.path.exists(output_path):
+                        os.remove(output_path)
+                except OSError:
+                    pass
+                if attempt < retry_attempts:
+                    await asyncio.sleep(min(1.0, 0.25 * attempt))
+
+    failure_summary = "; ".join(failures[-6:])
+    raise RuntimeError(f"Edge TTS failed after retries: {failure_summary}")
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- cache inbound native Telegram videos to a stable local path
- treat video files sent as Telegram documents as MessageType.VIDEO
- pass the exact cached video path into inbound agent context
- add regression tests for both intake branches and context text

## Test Plan
- pytest tests/gateway/test_telegram_documents.py tests/gateway/test_stt_config.py -q