### PR TITLE
fix: preserve dots in Bedrock inference-profile IDs (#12295)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6423,11 +6423,12 @@ class AIAgent:
         Alibaba/DashScope keeps dots (e.g. qwen3.5-plus).
         MiniMax keeps dots (e.g. MiniMax-M2.7).
         OpenCode Go/Zen keeps dots for non-Claude models (e.g. minimax-m2.5-free).
-        ZAI/Zhipu keeps dots (e.g. glm-4.7, glm-5.1)."""
-        if (getattr(self, "provider", "") or "").lower() in {"alibaba", "minimax", "minimax-cn", "opencode-go", "opencode-zen", "zai"}:
+        ZAI/Zhipu keeps dots (e.g. glm-4.7, glm-5.1).
+        AWS Bedrock inference-profile IDs contain dots (e.g. us.anthropic.claude-sonnet-4-5-20250929-v1:0)."""
+        if (getattr(self, "provider", "") or "").lower() in {"alibaba", "bedrock", "minimax", "minimax-cn", "opencode-go", "opencode-zen", "zai"}:
             return True
         base = (getattr(self, "base_url", "") or "").lower()
-        return "dashscope" in base or "aliyuncs" in base or "minimax" in base or "opencode.ai/zen/" in base or "bigmodel.cn" in base
+        return "dashscope" in base or "aliyuncs" in base or "minimax" in base or "opencode.ai/zen/" in base or "bigmodel.cn" in base or "bedrock-runtime" in base
 
     def _is_qwen_portal(self) -> bool:
         """Return True when the base URL targets Qwen Portal."""

--- a/tests/agent/test_minimax_provider.py
+++ b/tests/agent/test_minimax_provider.py
@@ -345,6 +345,30 @@ class TestMinimaxPreserveDots:
         # Without preserve_dots, dots become hyphens (broken for MiniMax)
         assert normalize_model_name("MiniMax-M2.7", preserve_dots=False) == "MiniMax-M2-7"
 
+    def test_bedrock_provider_preserves_dots(self):
+        """Bedrock inference-profile IDs contain dots that must not be collapsed."""
+        from types import SimpleNamespace
+        agent = SimpleNamespace(provider="bedrock", base_url="")
+        from run_agent import AIAgent
+        assert AIAgent._anthropic_preserve_dots(agent) is True
+
+    def test_bedrock_url_preserves_dots(self):
+        """Bedrock base URLs (bedrock-runtime) should also preserve dots."""
+        from types import SimpleNamespace
+        agent = SimpleNamespace(provider="custom", base_url="https://bedrock-runtime.us-east-1.amazonaws.com")
+        from run_agent import AIAgent
+        assert AIAgent._anthropic_preserve_dots(agent) is True
+
+    def test_normalize_preserves_bedrock_inference_profile_dots(self):
+        from agent.anthropic_adapter import normalize_model_name
+        # A real Bedrock inference-profile ID must retain its dots
+        assert normalize_model_name("us.anthropic.claude-sonnet-4-5-20250929-v1:0", preserve_dots=True) == "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+
+    def test_normalize_bedrock_dots_broken_without_preserve(self):
+        from agent.anthropic_adapter import normalize_model_name
+        # Without preserve_dots the ID is mangled — this is the bug we are fixing
+        assert normalize_model_name("us.anthropic.claude-sonnet-4-5-20250929-v1:0", preserve_dots=False) == "us-anthropic-claude-sonnet-4-5-20250929-v1:0"
+
 
 class TestMinimaxSwitchModelCredentialGuard:
     """Verify switch_model() does not leak Anthropic credentials to MiniMax.


### PR DESCRIPTION
Fixes #12295

`_anthropic_preserve_dots()` didn't include 'bedrock' in the providers that preserve dots. AWS Bedrock inference-profile IDs like `us.anthropic.claude-sonnet-4-5-20250929-v1:0` were mangled to `us-anthropic-claude-sonnet-4-5-20250929-v1:0`, causing HTTP 400.

Changes:
- Added `"bedrock"` to provider set in `_anthropic_preserve_dots()`
- Added `"bedrock-runtime"` to base_url fallback check
- Added 4 unit tests for Bedrock dot preservation