### PR TITLE
fix: Kimi provider slug mismatch (#12296)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -66,6 +66,7 @@ _PROVIDER_ALIASES = {
     "z.ai": "zai",
     "zhipu": "zai",
     "kimi": "kimi-coding",
+    "kimi-for-coding": "kimi-coding",
     "moonshot": "kimi-coding",
     "kimi-cn": "kimi-coding-cn",
     "moonshot-cn": "kimi-coding-cn",


### PR DESCRIPTION
Fixes #12296

When switching to "Kimi For Coding" model, the provider slug `kimi-for-coding` (from models.dev) wasn't mapped in `_PROVIDER_ALIASES` in `resolve_provider_client()`. The function logged `unknown provider 'kimi-for-coding'` and silently fell back to the default model.

Fix: Added `"kimi-for-coding": "kimi-coding"` to `_PROVIDER_ALIASES` dict.