### PR TITLE
fix(memory): supermemory forget returns 404 — document ID passed to memories endpoint

### DIFF
--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -333,8 +333,8 @@ class _SupermemoryClient:
         return {"static": static, "dynamic": dynamic, "search_results": search_results}
 
     def forget_memory(self, memory_id: str, *, container_tag: Optional[str] = None) -> None:
-        tag = container_tag or self._container_tag
-        self._client.memories.forget(container_tag=tag, id=memory_id)
+        """Delete by document ID — add_memory returns document IDs, not memory IDs."""
+        self._client.documents.delete(memory_id)
 
     def forget_by_query(self, query: str, *, container_tag: Optional[str] = None) -> dict:
         results = self.search_memories(query, limit=5, container_tag=container_tag)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -95,6 +95,7 @@ AUTHOR_MAP = {
     "hakanerten02@hotmail.com": "teyrebaz33",
     "ruzzgarcn@gmail.com": "Ruzzgar",
     "alireza78.crypto@gmail.com": "alireza78a",
+    "roque@priveperfumeshn.com": "priveperfumes",
     "brooklyn.bb.nicholson@gmail.com": "brooklynnicholson",
     "4317663+helix4u@users.noreply.github.com": "helix4u",
     "331214+counterposition@users.noreply.github.com": "counterposition",

--- a/tests/plugins/memory/test_supermemory_provider.py
+++ b/tests/plugins/memory/test_supermemory_provider.py
@@ -409,3 +409,44 @@ def test_get_config_schema_minimal():
     assert len(schema) == 1
     assert schema[0]["key"] == "api_key"
     assert schema[0]["secret"] is True
+
+
+# -- Document ID regression tests -------------------------------------------
+
+
+def test_forget_by_id_uses_documents_delete(provider):
+    """forget by ID routes to documents.delete since store returns document IDs."""
+    store_result = json.loads(
+        provider.handle_tool_call("supermemory_store", {"content": "test memory"})
+    )
+    forget_result = json.loads(
+        provider.handle_tool_call("supermemory_forget", {"id": store_result["id"]})
+    )
+    assert forget_result["forgotten"] is True
+    assert store_result["id"] in provider._client.forgotten_ids
+
+
+def test_store_then_forget_round_trip(provider):
+    """Store returns an ID, forget accepts that same ID."""
+    store = json.loads(
+        provider.handle_tool_call("supermemory_store", {"content": "round trip"})
+    )
+    forget = json.loads(
+        provider.handle_tool_call("supermemory_forget", {"id": store["id"]})
+    )
+    assert forget["forgotten"] is True
+
+
+def test_forget_by_query_still_uses_memory_search(provider):
+    """forget_by_query searches memories first, so it uses memory IDs from search."""
+    provider._client.search_results = [
+        {"id": "memory_abc", "memory": "test", "similarity": 0.95}
+    ]
+    provider._client.forget_by_query_response = {
+        "success": True, "message": "Forgot", "id": "memory_abc",
+    }
+    result = json.loads(
+        provider.handle_tool_call("supermemory_forget", {"query": "test"})
+    )
+    assert result["success"] is True
+    assert result["id"] == "memory_abc"


### PR DESCRIPTION
## Bug

`supermemory_forget` with an ID always returns **404** because the plugin passes a document ID to the memories endpoint, which uses a different ID space.

## Root cause

Supermemory has two distinct ID spaces:

| Operation | Endpoint | Returns |
|---|---|---|
| **Store** (`add_memory`) | `POST /v3/documents` | **Document ID** |
| **Forget** (`forget_memory`) | `DELETE /v4/memories` | Expects **Memory ID** |

When you store a memory, the SDK returns a document ID (e.g. `PykWVARbQJtVt28CAmp1NF`). When you try to forget it, the plugin passes that same ID to `memories.forget()`, which 404s because it expects a memory ID (e.g. `QeqnQqbaZjHnPuP7pmewd7`) — the ID of the extracted knowledge unit, not the raw document.

This is the documented architecture: documents are raw input, memories are intelligent knowledge units extracted from documents. They have separate IDs.

## Fix

Changed `forget_memory()` to use `documents.delete(memory_id)` (`DELETE /v3/documents/{id}`) instead of `memories.forget()` — since the IDs it receives come from `documents.add()`.

The `forget_by_query` path is unaffected — it searches first (getting memory IDs from search results) and then calls `forget_memory` with whatever ID search returned.

## How to test

```python
# Before fix: 404
client = Supermemory(api_key="...")
doc = client.documents.add(content="test", container_tags=["test"])
# doc.id is a document ID
client.memories.forget(container_tag="test", id=doc.id)  # → 404!

# After fix: works
# forget_memory now calls client.documents.delete(doc.id)  # → 204
```

Or run the test suite:

```bash
pytest tests/plugins/memory/test_supermemory_provider.py -v
```

## Test coverage

3 new tests:
- `test_forget_by_id_uses_documents_delete` — regression test for the 404 bug
- `test_store_then_forget_round_trip` — store then forget by returned ID succeeds
- `test_forget_by_query_still_uses_memory_search` — forget_by_query still works via memory IDs

All 32 tests pass (29 existing + 3 new).

## Platforms tested

- Linux (aarch64), Python 3.11