### PR TITLE
fix(windows): handle OSError from os.kill() for non-existent PIDs

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10363,7 +10363,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 try:
                     os.kill(existing_pid, 0)
                     _time.sleep(0.5)
-                except (ProcessLookupError, PermissionError):
+                except (ProcessLookupError, PermissionError, OSError):
                     break  # Process is gone
             else:
                 # Still alive after 10s — force kill

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -341,7 +341,7 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
         if not stale:
             try:
                 os.kill(existing_pid, 0)
-            except (ProcessLookupError, PermissionError):
+            except (ProcessLookupError, PermissionError, OSError):
                 stale = True
             else:
                 current_start = _get_process_start_time(existing_pid)
@@ -576,7 +576,7 @@ def get_running_pid(
 
     try:
         os.kill(pid, 0)  # signal 0 = existence check, no actual signal sent
-    except (ProcessLookupError, PermissionError):
+    except (ProcessLookupError, PermissionError, OSError):
         _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale)
         return None
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -257,7 +257,7 @@ class ProcessRegistry:
         try:
             os.kill(pid, 0)
             return True
-        except (ProcessLookupError, PermissionError):
+        except (ProcessLookupError, PermissionError, OSError):
             return False
 
     def _refresh_detached_session(self, session: Optional[ProcessSession]) -> Optional[ProcessSession]:


### PR DESCRIPTION
Fixes #12359

## Problem

On Windows, `os.kill(pid, 0)` raises `OSError: [WinError 87] ERROR_INVALID_PARAMETER` when the target PID does not exist — unlike POSIX where it raises `ProcessLookupError`. The existing liveness checks only caught `(ProcessLookupError, PermissionError)`, so a stale `gateway.pid` file left behind after a crash/reboot would cause `hermes gateway run` to crash immediately instead of cleaning up and starting fresh.

The same pattern surfaced in three additional call sites that share the same POSIX-only assumption.

## Solution

Add `OSError` to the exception tuple at all four affected `os.kill(pid, 0)` liveness checks, treating it identically to `ProcessLookupError` (i.e. "process is gone, clean up"):

- `gateway/status.py` — `get_running_pid()` (line 578) and `acquire_scoped_lock()` (line 343)
- `tools/process_registry.py` — `_is_host_pid_alive()` (line 258)
- `gateway/run.py` — `--replace` wait loop (line 10364)

Each change is a one-line addition. Since `ProcessLookupError` is already a subclass of `OSError`, existing POSIX behavior is unchanged; only the Windows code path is affected.

## Testing

Verified locally on Windows 11 (Python 3.11.15, Hermes v0.10.0) with a stale `gateway.pid` — gateway now starts cleanly after applying these changes.