### PR TITLE
fix(feishu): accept finalize kwarg in edit_message

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1423,8 +1423,15 @@ class FeishuAdapter(BasePlatformAdapter):
         chat_id: str,
         message_id: str,
         content: str,
+        *,
+        finalize: bool = False,
     ) -> SendResult:
-        """Edit a previously sent Feishu text/post message."""
+        """Edit a previously sent Feishu text/post message.
+
+        ``finalize`` is accepted for compatibility with the shared gateway
+        streaming interface but intentionally ignored because Feishu's normal
+        message-edit API does not need an explicit end-of-stream signal.
+        """
         if not self._client:
             return SendResult(success=False, error="Not connected")
 


### PR DESCRIPTION
## Summary
- make `FeishuAdapter.edit_message()` accept `finalize: bool = False`
- document that Feishu ignores `finalize` because normal message edits do not need an explicit end-of-stream signal
- preserve existing Feishu message update behavior

## Root cause
`GatewayStreamConsumer` now calls the shared adapter interface as:

```python
adapter.edit_message(..., finalize=finalize)
```

That matches `BasePlatformAdapter.edit_message()`, but `FeishuAdapter.edit_message()` still had the old signature and raised:

```text
FeishuAdapter.edit_message() got an unexpected keyword argument 'finalize'
```

This broke streamed edits and filled logs with repeated errors during Feishu replies.

## Fix
Accept the keyword-only `finalize` parameter for API compatibility and intentionally ignore it.

Feishu's normal message edit API does not require a distinct finalize step, so this is a compatibility fix only — no behavior change for successful edits.

## Validation
- confirmed `BasePlatformAdapter.edit_message()` defines `finalize`
- confirmed `GatewayStreamConsumer` passes `finalize=...`
- confirmed `FeishuAdapter.edit_message()` on `main` lacked the parameter
- patched Feishu locally on branch `fix/feishu-finalize-edit-message`

## Additional audit
Checked the WeCom adapters while here:
- `gateway/platforms/wecom.py` (`WeComAdapter`) does **not** override `edit_message()`, so it inherits the compatible base signature and is **not affected** by this specific bug
- `gateway/platforms/wecom_callback.py` also does **not** override `edit_message()` and is **not affected**
