### PR TITLE
fix(skills): fall back to directory name for non-ASCII skill command slugs

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -257,7 +257,26 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     cmd_name = _SKILL_INVALID_CHARS.sub('', cmd_name)
                     cmd_name = _SKILL_MULTI_HYPHEN.sub('-', cmd_name).strip('-')
                     if not cmd_name:
-                        continue
+                        # Name contains only non-ASCII characters (e.g. Chinese).
+                        # Fall back to the skill directory name so the command
+                        # is still registered and can be invoked.
+                        dir_slug = skill_md.parent.name.lower().replace(' ', '-').replace('_', '-')
+                        dir_slug = _SKILL_INVALID_CHARS.sub('', dir_slug)
+                        dir_slug = _SKILL_MULTI_HYPHEN.sub('-', dir_slug).strip('-')
+                        if not dir_slug:
+                            logger.warning(
+                                "Skill at %s: name %r produces an empty slug and"
+                                " the directory name also yields no valid slug —"
+                                " skipping.",
+                                skill_md, name,
+                            )
+                            continue
+                        logger.warning(
+                            "Skill at %s: name %r contains non-ASCII characters;"
+                            " registering as /%s (derived from directory name).",
+                            skill_md, name, dir_slug,
+                        )
+                        cmd_name = dir_slug
                     _skill_commands[f"/{cmd_name}"] = {
                         "name": name,
                         "description": description or f"Invoke the {name} skill",


### PR DESCRIPTION
Fixes #12351

## Problem

Skills whose `name` field in `SKILL.md` frontmatter contains only non-ASCII characters (e.g. Chinese: `小说拆条`) were silently skipped and never registered as slash commands.

The root cause is in `scan_skill_commands()` (`agent/skill_commands.py`):

```python
cmd_name = name.lower().replace(' ', '-').replace('_', '-')
cmd_name = _SKILL_INVALID_CHARS.sub('', cmd_name)  # strips all non-[a-z0-9-]
cmd_name = _SKILL_MULTI_HYPHEN.sub('-', cmd_name).strip('-')
if not cmd_name:
    continue  # ← silently dropped
```

`_SKILL_INVALID_CHARS = re.compile(r'[^a-z0-9-]')` removes every character of a Chinese name, producing an empty string, which the guard then silently skips.

## Solution

When the name produces an empty slug, fall back to the skill's **directory name** (which is typically ASCII-safe since filesystem names rarely contain non-ASCII characters). A `logger.warning` is emitted so the user can see the effective command name. If both the name and directory produce empty slugs, the skill is skipped with a warning instead of silently.

```python
if not cmd_name:
    dir_slug = ... # normalize skill_md.parent.name the same way
    if not dir_slug:
        logger.warning("... no valid slug — skipping.")
        continue
    logger.warning("... registering as /%s (derived from directory name).", dir_slug)
    cmd_name = dir_slug
```

This approach keeps slash commands ASCII-only (required by Telegram and other messaging platforms) while ensuring non-ASCII named skills are still reachable.

## Testing

- Skills with Chinese names are now registered using their directory name as the command slug
- A warning is logged at startup indicating the effective command name
- Skills where both name and directory produce empty slugs are skipped with an explicit warning (not silently)
- Existing ASCII-named skills are unaffected