### PR TITLE
fix: cross-channel send_message failures (Telegram proxy + WeChat event loop)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -112,9 +112,9 @@ def is_network_accessible(host: str) -> bool:
 def _detect_macos_system_proxy() -> str | None:
     """Read the macOS system HTTP(S) proxy via ``scutil --proxy``.
 
-    Returns an ``http://host:port`` URL string if an HTTP or HTTPS proxy is
-    enabled, otherwise *None*.  Falls back silently on non-macOS or on any
-    subprocess error.
+    Returns a proxy URL string (``http://host:port`` or ``socks5://host:port``)
+    if an HTTP, HTTPS, or SOCKS proxy is enabled, otherwise *None*.  Falls back
+    silently on non-macOS or on any subprocess error.
     """
     if sys.platform != "darwin":
         return None
@@ -132,7 +132,17 @@ def _detect_macos_system_proxy() -> str | None:
             key, _, val = line.partition(" : ")
             props[key.strip()] = val.strip()
 
-    # Prefer HTTPS, fall back to HTTP
+    # SOCKS proxy
+    if props.get("SOCKSEnable") == "1":
+        host = props.get("SOCKSProxy")
+        port = props.get("SOCKSPort")
+        if host and port:
+            return f"socks5://{host}:{port}"
+
+    # HTTPS proxy (returns http:// scheme intentionally — HTTP CONNECT
+    # tunnelling works for both HTTP and HTTPS destinations, and most
+    # HTTP client libraries expect the proxy URL to use the http scheme
+    # regardless of the target protocol.)
     for enable_key, host_key, port_key in (
         ("HTTPSEnable", "HTTPSProxy", "HTTPSPort"),
         ("HTTPEnable", "HTTPProxy", "HTTPPort"),

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1081,6 +1081,8 @@ class TelegramAdapter(BasePlatformAdapter):
         chat_id: str,
         message_id: str,
         content: str,
+        *,
+        finalize: bool = False,
     ) -> SendResult:
         """Edit a previously sent Telegram message."""
         if not self._bot:

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1982,7 +1982,20 @@ async def send_weixin_direct(
 
     live_adapter = _LIVE_ADAPTERS.get(resolved_token)
     send_session = getattr(live_adapter, '_send_session', None)
-    if live_adapter is not None and send_session is not None and not send_session.closed:
+    # When called via _run_async from a different async context (e.g. cross-channel
+    # Telegram→WeChat), the live adapter's aiohttp session is bound to the gateway's
+    # main event loop.  Using it from the new thread's loop causes
+    # "Timeout context manager should be used inside a task".
+    _loop_compat = True
+    if send_session is not None and not send_session.closed:
+        try:
+            _conn = getattr(send_session, '_connector', None)
+            _sess_loop = getattr(_conn, '_loop', None)
+            if _sess_loop is not None and _sess_loop is not asyncio.get_running_loop():
+                _loop_compat = False
+        except RuntimeError:
+            pass  # no running loop — fine, single-threaded path
+    if live_adapter is not None and send_session is not None and not send_session.closed and _loop_compat:
         last_result: Optional[SendResult] = None
         cleaned = live_adapter.format_message(message)
         if cleaned:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2452,23 +2452,21 @@ class GatewayRunner:
 
             # Write a clean-shutdown marker so the next startup knows this
             # wasn't a crash.  suspend_recently_active() only needs to run
-            # after unexpected exits.  However, if the drain timed out and
-            # agents were force-interrupted, their sessions may be in an
-            # incomplete state (trailing tool response, no final assistant
-            # message).  Skip the marker in that case so the next startup
-            # suspends those sessions — giving users a clean slate instead
-            # of resuming a half-finished tool loop.
-            if not timed_out:
-                try:
-                    (_hermes_home / ".clean_shutdown").touch()
-                except Exception:
-                    pass
-            else:
-                logger.info(
-                    "Skipping .clean_shutdown marker — drain timed out with "
-                    "interrupted agents; next startup will suspend recently "
-                    "active sessions."
-                )
+            # after unexpected exits.
+            #
+            # Even when drain timed out, we still write the marker because:
+            # 1. The interrupt signal has been sent — agents will handle it
+            #    cleanly on their next iteration (they check _interrupt_requested
+            #    before committing tool results or making new API calls).
+            # 2. The 3-restart stuck-loop detection (#7536) below already
+            #    suspends sessions that genuinely cannot exit, providing a
+            #    safety net against infinite restart cycles.
+            # 3. Without the marker, EVERY restart loses the active
+            #    conversation — far worse than resuming an interrupted one.
+            try:
+                (_hermes_home / ".clean_shutdown").touch()
+            except Exception:
+                pass
 
             # Track sessions that were active at shutdown for stuck-loop
             # detection (#7536).  On each restart, the counter increments

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -587,7 +587,14 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                 formatted = message
             send_parse_mode = ParseMode.MARKDOWN_V2
 
-        bot = Bot(token=token)
+        from gateway.platforms.base import resolve_proxy_url
+        proxy_url = resolve_proxy_url("TELEGRAM_PROXY")
+        if proxy_url:
+            from telegram.request import HTTPXRequest
+            bot = Bot(token=token, request=HTTPXRequest(proxy=proxy_url))
+            logger.info("[send_message/telegram] Proxy detected: %s", proxy_url)
+        else:
+            bot = Bot(token=token)
         int_chat_id = int(chat_id)
         media_files = media_files or []
         thread_kwargs = {}


### PR DESCRIPTION
## Problem

This PR addresses four issues:

1. **Cross-channel WeChat → Telegram**: `Telegram send failed: Timed out`
2. **Cross-channel Telegram → WeChat**: `Timeout context manager should be used inside a task`
3. **Session continuity on restart**: Every `gateway restart` loses the active conversation
4. **Proxy auto-detection**: macOS system proxy doesn't detect SOCKS proxies

## Root Causes & Fixes

### 1. `_send_telegram()` missing proxy support (`send_message_tool.py`)

The `send_message` tool's `_send_telegram()` created `Bot(token=token)` without proxy configuration, bypassing `TELEGRAM_PROXY`. The gateway adapter correctly uses the proxy, but the tool's direct send path didn't.

**Fix**: Added `resolve_proxy_url("TELEGRAM_PROXY")` + `HTTPXRequest(proxy=...)`, matching the gateway adapter's pattern.

### 2. `send_weixin_direct()` event loop mismatch (`weixin.py`)

When `send_weixin_direct()` is called via `_run_async()` from a different async context (e.g. cross-channel Telegram→WeChat), `_run_async` spawns a new thread with `asyncio.run()` creating a fresh event loop. The code tries to reuse a `live_adapter` from `_LIVE_ADAPTERS`, but that adapter's aiohttp session is bound to the gateway's main event loop. Using it from the new loop causes aiohttp's timeout context manager to fail.

**Fix**: Added event loop compatibility check. If the live adapter's aiohttp session connector loop doesn't match the current running loop, skip adapter reuse and fall through to the existing fresh-session fallback path.

### 3. `edit_message()` missing `finalize` kwarg (`telegram.py`)

The gateway calls `TelegramAdapter.edit_message(..., finalize=...)` but the method signature didn't accept this keyword argument, causing `TypeError`.

**Fix**: Added `finalize: bool = False` parameter.

### 4. Session continuity on restart (`gateway/run.py`)

When `gateway restart` is called, `_drain_active_agents()` waits up to 60s for running agents to finish. The current agent can't self-terminate mid-response, so drain times out. The code then skips writing the `.clean_shutdown` marker, causing the next startup to call `suspend_recently_active()` — suspending all sessions and losing the conversation.

**Fix**: Always write the `.clean_shutdown` marker, even on drain timeout. The interrupt signal has been sent and agents handle it cleanly on their next iteration. The existing 3-restart stuck-loop detection (#7536) already suspends truly stuck sessions as a safety net. Losing every conversation on restart is far worse than resuming an interrupted one.

### 5. SOCKS proxy auto-detection (`gateway/platforms/base.py`)

`_detect_macos_system_proxy()` only checked HTTP/HTTPS proxy settings from `scutil --proxy`, ignoring SOCKS proxies. Many users (especially behind GFW) use SOCKS5 proxies (V2rayU, Clash, Shadowrocket).

**Fix**: Added SOCKS proxy detection (`SOCKSEnable`/`SOCKSProxy`/`SOCKSPort`) returning `socks5://` URLs. Added explanatory comment for why `http://` scheme is used for HTTPS proxies (HTTP CONNECT tunnelling). Env vars (`ALL_PROXY`, `TELEGRAM_PROXY` etc.) remain the recommended way to configure any proxy scheme.

## Testing

- ✅ WeChat → Telegram: message delivered
- ✅ Telegram → WeChat: message delivered
- ✅ Gateway restart + message continues same session
- ✅ No new errors in gateway logs
