### PR TITLE
fix(gateway/macos): kill orphan gateway processes on launchd restart; add macOS cmdline fallback

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -100,15 +100,27 @@ def _get_process_start_time(pid: int) -> Optional[int]:
 
 def _read_process_cmdline(pid: int) -> Optional[str]:
     """Return the process command line as a space-separated string."""
+    # Linux: /proc/<pid>/cmdline
     cmdline_path = Path(f"/proc/{pid}/cmdline")
     try:
         raw = cmdline_path.read_bytes()
+        if raw:
+            return raw.replace(b"\x00", b" ").decode("utf-8", errors="ignore").strip()
     except (FileNotFoundError, PermissionError, OSError):
-        return None
+        pass
 
-    if not raw:
-        return None
-    return raw.replace(b"\x00", b" ").decode("utf-8", errors="ignore").strip()
+    # macOS / BSD fallback
+    try:
+        result = subprocess.run(
+            ["ps", "-o", "command=", "-p", str(pid)],
+            capture_output=True, text=True, timeout=3,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip() or None
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        pass
+
+    return None
 
 
 def _looks_like_gateway_process(pid: int) -> bool:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1901,6 +1901,33 @@ def _wait_for_gateway_exit(timeout: float = 10.0, force_after: float | None = 5.
     return True
 
 
+def _kill_orphan_gateway_pids() -> None:
+    """Kill gateway processes not tracked by the service manager.
+
+    launchctl kickstart -k only kills the launchd-managed process.  Any
+    gateway started manually (or left behind by a previous failed restart)
+    will survive and hold platform locks, blocking the new instance.
+    """
+    import time as _time
+    service_pids = _get_service_pids()
+    orphan_pids = find_gateway_pids(exclude_pids=service_pids | {os.getpid()})
+    if not orphan_pids:
+        return
+    for orphan_pid in orphan_pids:
+        try:
+            terminate_pid(orphan_pid, force=False)
+        except (ProcessLookupError, PermissionError, OSError):
+            pass
+    _time.sleep(1)
+    for orphan_pid in orphan_pids:
+        try:
+            os.kill(orphan_pid, 0)
+            terminate_pid(orphan_pid, force=True)
+        except (ProcessLookupError, PermissionError, OSError):
+            pass
+    print(f"↻ Cleaned up {len(orphan_pids)} orphan gateway process(es): {orphan_pids}")
+
+
 def launchd_restart():
     label = get_launchd_label()
     target = f"{_launchd_domain()}/{label}"
@@ -1911,6 +1938,7 @@ def launchd_restart():
         pid = get_running_pid()
         if pid is not None and _request_gateway_self_restart(pid):
             print("✓ Service restart requested")
+            _kill_orphan_gateway_pids()
             return
         if pid is not None:
             try:
@@ -1921,6 +1949,7 @@ def launchd_restart():
                 exited = _wait_for_gateway_exit(timeout=drain_timeout, force_after=None)
                 if not exited:
                     print(f"⚠ Gateway drain timed out after {drain_timeout:.0f}s — forcing launchd restart")
+        _kill_orphan_gateway_pids()
         subprocess.run(["launchctl", "kickstart", "-k", target], check=True, timeout=90)
         print("✓ Service restarted")
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION
## Problem

On macOS, after `hermes gateway restart`, platform channels (e.g. Weixin/WeChat) stop responding. Logs show:

```
ERROR gateway.platforms.base: [Weixin] Weixin bot token already in use (PID XXXXX). Stop the other gateway first.
WARNING gateway.run: ✗ weixin failed to connect
```

## Root Cause

### 1. `launchd_restart()` leaves orphan gateway processes alive

`launchd_restart()` only kills the PID recorded in `gateway.pid`. When that file is stale (points to a dead PID), the Python kill step is skipped entirely. `launchctl kickstart -k` then only kills the single launchd-tracked process — any manually-started or previously-orphaned gateway process survives and continues holding the platform token lock (e.g. `weixin-bot-token`). The new gateway fails to acquire that lock and the platform doesn't connect.

`find_gateway_pids()` already exists and can locate all gateway processes via `ps`, but `launchd_restart()` never calls it.

### 2. `_read_process_cmdline()` always returns `None` on macOS

The function reads `/proc/<pid>/cmdline`, which is Linux-only. On macOS/Darwin, this always fails silently, making `_looks_like_gateway_process()` always return `False`. This disables the cmdline-based process identity check in `acquire_scoped_lock()` on macOS — the only remaining check is `os.kill(pid, 0)`, which can't distinguish a recycled PID from a live gateway.

## Fix

### `hermes_cli/gateway.py`

Add `_kill_orphan_gateway_pids()`: calls `find_gateway_pids(exclude_pids=service_pids)` to locate all gateway processes not tracked by launchd, SIGTERMs them, then escalates to SIGKILL after 1 s. Called from `launchd_restart()` before `kickstart -k` and also on the SIGUSR1 self-restart path.

### `gateway/status.py`

Add a `ps(1)` fallback to `_read_process_cmdline()` so cmdline resolution works on macOS/BSD when `/proc` is unavailable.

## Related Issues

- Relates to #5109 — launchd gateway refresh can start a second local gateway on macOS
- Relates to #11718 — `gateway run --replace` race condition: multiple instances run simultaneously

## Testing

Reproduced on macOS 15.4 (Darwin 25.4.0) with launchd-managed gateway:
1. Run `hermes gateway restart` while a manually-started gateway holds the Weixin lock
2. **Before fix**: new gateway logs "Weixin bot token already in use" and Weixin goes silent
3. **After fix**: orphan is killed before `kickstart -k`, new gateway acquires lock successfully