### PR TITLE
fix(memory): add 404 error handling to supermemory forget

### DIFF
--- a/plugins/memory/supermemory/__init__.py
+++ b/plugins/memory/supermemory/__init__.py
@@ -334,7 +334,13 @@ class _SupermemoryClient:
 
     def forget_memory(self, memory_id: str, *, container_tag: Optional[str] = None) -> None:
         tag = container_tag or self._container_tag
-        self._client.memories.forget(container_tag=tag, id=memory_id)
+        try:
+            self._client.memories.forget(container_tag=tag, id=memory_id)
+        except Exception as exc:
+            exc_name = type(exc).__name__
+            if "NotFound" in exc_name:
+                raise ValueError(f"Memory {memory_id} not found — it may have already been deleted.") from exc
+            raise
 
     def forget_by_query(self, query: str, *, container_tag: Optional[str] = None) -> dict:
         results = self.search_memories(query, limit=5, container_tag=container_tag)

--- a/tests/plugins/memory/test_supermemory_provider.py
+++ b/tests/plugins/memory/test_supermemory_provider.py
@@ -409,3 +409,31 @@ def test_get_config_schema_minimal():
     assert len(schema) == 1
     assert schema[0]["key"] == "api_key"
     assert schema[0]["secret"] is True
+
+
+# -- Forget error handling tests ---------------------------------------------
+
+
+def test_forget_tool_returns_clear_error_on_not_found(provider, monkeypatch):
+    """404 from the API surfaces a human-readable error."""
+
+    def raise_not_found(memory_id, *, container_tag=None):
+        raise ValueError(f"Memory {memory_id} not found — it may have already been deleted.")
+
+    monkeypatch.setattr(provider._client, "forget_memory", raise_not_found)
+    result = json.loads(provider.handle_tool_call("supermemory_forget", {"id": "gone_id"}))
+    assert "error" in result
+    assert "not found" in result["error"].lower()
+    assert "gone_id" in result["error"]
+
+
+def test_forget_tool_surfaces_other_errors(provider, monkeypatch):
+    """Non-404 errors are still surfaced as tool errors."""
+
+    def raise_auth(memory_id, *, container_tag=None):
+        raise PermissionError("Invalid API key")
+
+    monkeypatch.setattr(provider._client, "forget_memory", raise_auth)
+    result = json.loads(provider.handle_tool_call("supermemory_forget", {"id": "m1"}))
+    assert "error" in result
+    assert "Invalid API key" in result["error"]


### PR DESCRIPTION
Follow-up to #12341 per security review suggestion.

## What

Adds explicit NotFoundError handling in `forget_memory()` so 404s surface a clear message with the memory ID instead of a raw exception.

## Why

The security reviewer noted: *"No explicit 404 error handling added — fix avoids 404 by using correct endpoint. Consider adding error handling for edge cases in follow-up."*

Edge cases where 404 can still occur:
- Memory already deleted
- Stale ID from a previous session
- Race condition between store and forget

## Changes

- `forget_memory()`: catches NotFoundError, raises ValueError with memory ID
- 2 new tests: 404 returns clear error, non-404 errors still surface

## Tests

```bash
pytest tests/plugins/memory/test_supermemory_provider.py -v
# 31 passed
```