### PR TITLE
fix(cli): scope backup and import to active profile home

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -21,7 +21,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from hermes_constants import get_default_hermes_root, get_hermes_home, display_hermes_home
+from hermes_constants import get_hermes_home, display_hermes_home
 
 logger = logging.getLogger(__name__)
 
@@ -113,7 +113,7 @@ def _format_size(nbytes: int) -> str:
 
 def run_backup(args) -> None:
     """Create a zip backup of the Hermes home directory."""
-    hermes_root = get_default_hermes_root()
+    hermes_root = get_hermes_home()
 
     if not hermes_root.is_dir():
         print(f"Error: Hermes home directory not found at {hermes_root}")
@@ -302,7 +302,7 @@ def run_import(args) -> None:
         print(f"Error: Not a valid zip file: {zip_path}")
         sys.exit(1)
 
-    hermes_root = get_default_hermes_root()
+    hermes_root = get_hermes_home()
 
     with zipfile.ZipFile(zip_path, "r") as zf:
         # Validate

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -233,6 +233,29 @@ class TestBackup:
         zips = list(tmp_path.glob("hermes-backup-*.zip"))
         assert len(zips) == 1
 
+    def test_backup_uses_active_profile_home(self, tmp_path, monkeypatch):
+        """Backup scopes to the active profile instead of the root ~/.hermes."""
+        root_home = tmp_path / ".hermes"
+        profile_home = root_home / "profiles" / "coder"
+        profile_home.mkdir(parents=True)
+
+        (root_home / "config.yaml").write_text("model: root\n")
+        (profile_home / "config.yaml").write_text("model: profile\n")
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        out_zip = tmp_path / "profile-backup.zip"
+        args = Namespace(output=str(out_zip))
+
+        from hermes_cli.backup import run_backup
+        run_backup(args)
+
+        with zipfile.ZipFile(out_zip, "r") as zf:
+            config_text = zf.read("config.yaml").decode().replace("\r\n", "\n")
+            assert config_text == "model: profile\n"
+            assert "profiles/coder/config.yaml" not in zf.namelist()
+
 
 # ---------------------------------------------------------------------------
 # _validate_backup_zip tests
@@ -446,6 +469,33 @@ class TestImport:
         from hermes_cli.backup import run_import
         with pytest.raises(SystemExit):
             run_import(args)
+
+    def test_import_uses_active_profile_home(self, tmp_path, monkeypatch):
+        """Import restores into the active profile instead of the root ~/.hermes."""
+        root_home = tmp_path / ".hermes"
+        profile_home = root_home / "profiles" / "coder"
+        profile_home.mkdir(parents=True)
+
+        (root_home / "config.yaml").write_text("model: root\n")
+        (profile_home / "config.yaml").write_text("model: existing-profile\n")
+
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+        zip_path = tmp_path / "profile-import.zip"
+        self._make_backup_zip(zip_path, {
+            "config.yaml": "model: imported-profile\n",
+            "skills/my-skill/SKILL.md": "# Imported Skill\n",
+        })
+
+        args = Namespace(zipfile=str(zip_path), force=True)
+
+        from hermes_cli.backup import run_import
+        run_import(args)
+
+        assert (profile_home / "config.yaml").read_text() == "model: imported-profile\n"
+        assert (profile_home / "skills" / "my-skill" / "SKILL.md").read_text() == "# Imported Skill\n"
+        assert (root_home / "config.yaml").read_text() == "model: root\n"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix `hermes backup` and `hermes import` so they operate on the active `HERMES_HOME` instead of always targeting the root Hermes directory.

Before this change, running backup/import from a named profile could still read from or write to the root `~/.hermes`, which broke profile isolation and made the user-facing target path misleading.

## What Changed

- Switched `run_backup()` to use `get_hermes_home()`
- Switched `run_import()` to use `get_hermes_home()`
- Added regression coverage for profile-scoped backup behavior
- Added regression coverage for profile-scoped import behavior
- Normalized newline handling in the zip-content assertion so the new backup test passes on Windows and Unix

## Reproduction

1. Set `HERMES_HOME` to a named profile such as `~/.hermes/profiles/coder`
2. Put different `config.yaml` contents in the root Hermes home and the active profile
3. Run `hermes backup` or `hermes import`
4. Before this fix, the command could operate on the root home instead of the active profile

## Expected Behavior

- `hermes backup` should archive the active profile home
- `hermes import` should restore into the active profile home
- Root `~/.hermes` should remain untouched unless it is the active `HERMES_HOME`

## Tests

Added:
- `test_backup_uses_active_profile_home`
- `test_import_uses_active_profile_home`

Also kept existing related coverage:
- `test_restores_files`
- `test_backup_then_import`


