### PR TITLE
feat: Lazy skill loading — skills.loading config option

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -583,8 +583,13 @@ def _skill_should_show(
 def build_skills_system_prompt(
     available_tools: "set[str] | None" = None,
     available_toolsets: "set[str] | None" = None,
+    lazy: bool = False,
 ) -> str:
     """Build a compact skill index for the system prompt.
+
+    When *lazy* is ``True``, the full skill listing is omitted from the prompt.
+    Instead a short hint tells the agent to call ``skills_list`` on demand.  This
+    saves ~1,500–2,000 system-prompt tokens when many skills are installed.
 
     Two-layer cache:
       1. In-process LRU dict keyed by (skills_dir, tools, toolsets)
@@ -603,6 +608,17 @@ def build_skills_system_prompt(
 
     if not skills_dir.exists() and not external_dirs:
         return ""
+
+    # ── Lazy loading: short hint instead of full listing ────────────────
+    if lazy:
+        return (
+            "## Skills (on-demand)\n"
+            "A skills catalog is available. Call skills_list() when you think a "
+            "specialized skill might help with your task, then load it with "
+            "skill_view(name). If a skill has issues, fix it with "
+            "skill_manage(action='patch'). After difficult/iterative tasks, "
+            "offer to save as a skill."
+        )
 
     # ── Layer 1: in-process LRU cache ─────────────────────────────────
     # Include the resolved platform so per-platform disabled-skill lists

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -689,6 +689,9 @@ DEFAULT_CONFIG = {
     # always goes to ~/.hermes/skills/.
     "skills": {
         "external_dirs": [],   # e.g. ["~/.agents/skills", "/shared/team-skills"]
+        # "eager" (default): inject full skill listing into system prompt every turn.
+        # "lazy": omit listing from system prompt; agent calls skills_list() on demand.
+        "loading": "eager",
     },
 
     # Honcho AI-native memory -- reads ~/.honcho/config.json as single source of truth.

--- a/run_agent.py
+++ b/run_agent.py
@@ -1405,6 +1405,7 @@ class AIAgent:
         try:
             skills_config = _agent_cfg.get("skills", {})
             self._skill_nudge_interval = int(skills_config.get("creation_nudge_interval", 10))
+            self._skills_loading = str(skills_config.get("loading", "eager")).lower()
         except Exception:
             pass
 
@@ -3772,6 +3773,7 @@ class AIAgent:
             skills_prompt = build_skills_system_prompt(
                 available_tools=self.valid_tool_names,
                 available_toolsets=avail_toolsets,
+                lazy=getattr(self, "_skills_loading", "eager") == "lazy",
             )
         else:
             skills_prompt = ""


### PR DESCRIPTION
## Summary

Implements **lazy skill loading** as proposed in #2045.

### Problem
When many skills are installed, all skill names + descriptions are injected into `<available_skills>` in the system prompt at every session start. With 87 bundled skills, this block alone consumes ~1,500–2,000 tokens — re-sent with every API call. For messaging platform users (Discord/Telegram) paying per-token through proxies without prompt caching, this adds up fast.

### Solution
Add a `skills.loading` config option:

```yaml
skills:
  loading: lazy    # "eager" (default) or "lazy"
```

**When `lazy`:**
- The full skill listing is **NOT** injected into the system prompt
- Instead, a short hint tells the agent to call `skills_list()` on demand
- Agent calls `skill_view(name)` as normal after discovering relevant skills
- Saves ~1,500–2,000 system-prompt tokens per turn

**When `eager` (default):**
- Current behavior — full listing in system prompt (backward compatible)

### Changes (3 files, +21 lines)

| File | Change |
|------|--------|
| `hermes_cli/config.py` | Add `skills.loading: "eager"` default |
| `agent/prompt_builder.py` | Add `lazy` param + on-demand hint branch |
| `run_agent.py` | Read config, pass `lazy` flag to prompt builder |

### Token savings estimate

| Setup | System prompt tokens | Working headroom (200k) |
|-------|---------------------|------------------------|
| 87 skills always loaded | ~8,500 | ~191k |
| Lazy loading | ~6,500 (-2,000) | ~193k |

Closes #2045