### PR TITLE
test: isolate scheduler tick lock in cron tests

### DIFF
--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -12,6 +12,15 @@ from tools.env_passthrough import clear_env_passthrough
 from tools.credential_files import clear_credential_files
 
 
+@pytest.fixture(autouse=True)
+def isolated_tick_lock(tmp_path, monkeypatch):
+    """Keep scheduler tests from contending with any live cron tick lock."""
+    import cron.scheduler as scheduler
+
+    monkeypatch.setattr(scheduler, "_LOCK_DIR", tmp_path)
+    monkeypatch.setattr(scheduler, "_LOCK_FILE", tmp_path / ".tick.lock")
+
+
 class TestResolveOrigin:
     def test_full_origin(self):
         job = {


### PR DESCRIPTION
## Summary
- add an autouse pytest fixture that redirects `cron.scheduler`'s file lock into each test's tmp directory
- keep `tests/cron/test_scheduler.py` from colliding with any live `~/.hermes/cron/.tick.lock` holder on the machine running the suite
- restore the cron scheduler assertions that were falsely returning `0` executions on current `main`

## Root cause
`tick()` acquires a global lock at `~/.hermes/cron/.tick.lock` before it touches any mocked scheduler helpers. Most of the cron scheduler tests patch `get_due_jobs`, `run_job`, and `mark_job_run`, but they do not isolate `_LOCK_DIR` / `_LOCK_FILE`. On a live Hermes host that means the suite can lose the lock before any mocked calls run, so the tests fail as if no jobs executed.

## Validation
- `cd /tmp/hermes-cron-test-lock-clean && pytest tests/cron/test_scheduler.py::TestRunJobSessionPersistence::test_tick_marks_empty_response_as_error tests/cron/test_scheduler.py::TestSilentDelivery::test_failed_job_always_delivers tests/cron/test_scheduler.py::TestSilentDelivery::test_output_saved_even_when_delivery_suppressed tests/cron/test_scheduler.py::TestSilentDelivery::test_silent_response_suppresses_delivery -q`
- `cd /tmp/hermes-cron-test-lock-clean && pytest tests/cron/test_scheduler.py -q`
- `cd /tmp/hermes-cron-test-lock-clean && git diff --check`
