### PR TITLE
fix(cli): make multiline input height and paste collapse configurable

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -74,6 +74,7 @@ _COMMAND_SPINNER_FRAMES = ("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧
 # User-managed env files should override stale shell exports on restart.
 from hermes_constants import get_hermes_home, display_hermes_home
 from hermes_cli.env_loader import load_hermes_dotenv
+from utils import is_truthy_value
 
 _hermes_home = get_hermes_home()
 _project_env = Path(__file__).parent / '.env'
@@ -347,6 +348,8 @@ def load_cli_config() -> Dict[str, Any]:
             "show_reasoning": False,
             "streaming": True,
             "busy_input_mode": "interrupt",
+            "collapse_large_pastes": True,
+            "input_max_lines": 8,
 
             "skin": "default",
         },
@@ -1719,6 +1722,15 @@ class HermesCLI:
         # busy_input_mode: "interrupt" (Enter interrupts current run) or "queue" (Enter queues for next turn)
         _bim = CLI_CONFIG["display"].get("busy_input_mode", "interrupt")
         self.busy_input_mode = "queue" if str(_bim).strip().lower() == "queue" else "interrupt"
+        self.collapse_large_pastes = is_truthy_value(
+            CLI_CONFIG["display"].get("collapse_large_pastes", True),
+            default=True,
+        )
+        try:
+            self.input_max_lines = int(CLI_CONFIG["display"].get("input_max_lines", 8))
+        except (TypeError, ValueError):
+            self.input_max_lines = 8
+        self.input_max_lines = max(1, self.input_max_lines)
 
         self.verbose = verbose if verbose is not None else (self.tool_progress_mode == "verbose")
         
@@ -2093,6 +2105,34 @@ class HermesCLI:
         if position == "top":
             return 1
         return 0 if self._use_minimal_tui_chrome(width=width) else 1
+
+    def _cap_input_visual_lines(self, visual_lines: int) -> int:
+        """Clamp rendered input height to the configured multiline limit."""
+        try:
+            limit = int(getattr(self, "input_max_lines", 8))
+        except (TypeError, ValueError):
+            limit = 8
+        limit = max(1, limit)
+        return min(max(int(visual_lines), 1), limit)
+
+    def _should_collapse_paste(
+        self,
+        text: str,
+        *,
+        existing_buffer_text: str = "",
+        is_paste: bool = True,
+        newline_count: Optional[int] = None,
+    ) -> bool:
+        """Return True when a large pasted text block should collapse to a file reference."""
+        if not getattr(self, "collapse_large_pastes", True):
+            return False
+        if not is_paste:
+            return False
+        if (existing_buffer_text or "").strip().startswith("/"):
+            return False
+        if newline_count is None:
+            newline_count = (text or "").count("\n")
+        return max(int(newline_count), 0) >= 5
 
     def _agent_spacer_height(self, width: Optional[int] = None) -> int:
         """Return the spacer height shown above the status bar while the agent runs."""
@@ -9164,7 +9204,11 @@ class HermesCLI:
                 pasted_text = _sanitize_surrogates(pasted_text)
                 line_count = pasted_text.count('\n')
                 buf = event.current_buffer
-                if line_count >= 5 and not buf.text.strip().startswith('/'):
+                if self._should_collapse_paste(
+                    pasted_text,
+                    existing_buffer_text=buf.text,
+                    is_paste=True,
+                ):
                     _paste_counter[0] += 1
                     paste_dir = _hermes_home / "pastes"
                     paste_dir.mkdir(parents=True, exist_ok=True)
@@ -9225,7 +9269,7 @@ class HermesCLI:
             command_filter=cli_ref._command_available,
         )
         input_area = TextArea(
-            height=Dimension(min=1, max=8, preferred=1),
+            height=Dimension(min=1, max=self.input_max_lines, preferred=1),
             prompt=get_prompt,
             style='class:input-area',
             multiline=True,
@@ -9257,14 +9301,13 @@ class HermesCLI:
                     available_width = 40
                 visual_lines = 0
                 for line in doc.lines:
-                    # Each logical line takes at least 1 visual row; long lines wrap.
                     # Use prompt_toolkit's cell width so CJK wide characters count as 2.
                     line_width = get_cwidth(line)
                     if line_width <= 0:
                         visual_lines += 1
                     else:
                         visual_lines += max(1, -(-line_width // available_width))  # ceil division
-                return min(max(visual_lines, 1), 8)
+                return self._cap_input_visual_lines(visual_lines)
             except Exception:
                 return 1
 
@@ -9274,6 +9317,7 @@ class HermesCLI:
         _paste_counter = [0]
         _prev_text_len = [0]
         _prev_newline_count = [0]
+        _prev_buffer_text = [""]
         _paste_just_collapsed = [False]
 
         def _on_text_changed(buf):
@@ -9292,6 +9336,8 @@ class HermesCLI:
                event so it never triggers this.
             """
             text = buf.text
+            previous_text = _prev_buffer_text[0]
+            _prev_buffer_text[0] = text
             chars_added = len(text) - _prev_text_len[0]
             _prev_text_len[0] = len(text)
             if _paste_just_collapsed[0]:
@@ -9302,7 +9348,12 @@ class HermesCLI:
             newlines_added = line_count - _prev_newline_count[0]
             _prev_newline_count[0] = line_count
             is_paste = chars_added > 1 or newlines_added >= 4
-            if line_count >= 5 and is_paste and not text.startswith('/'):
+            if self._should_collapse_paste(
+                text,
+                existing_buffer_text=previous_text,
+                is_paste=is_paste,
+                newline_count=newlines_added,
+            ):
                 _paste_counter[0] += 1
                 # Save to temp file
                 paste_dir = _hermes_home / "pastes"

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -149,6 +149,46 @@ class TestBusyInputMode:
         assert cli._pending_input.empty()
 
 
+class TestInputDisplayConfig:
+    def test_input_max_lines_and_collapse_large_pastes_are_loaded_from_config(self):
+        cli = _make_cli(config_overrides={
+            "display": {
+                "input_max_lines": 40,
+                "collapse_large_pastes": False,
+            }
+        })
+
+        assert cli.input_max_lines == 40
+        assert cli.collapse_large_pastes is False
+
+    def test_string_false_disables_large_paste_collapse(self):
+        cli = _make_cli(config_overrides={
+            "display": {
+                "collapse_large_pastes": "false",
+            }
+        })
+
+        assert cli.collapse_large_pastes is False
+
+    def test_invalid_input_max_lines_falls_back_to_default(self):
+        cli = _make_cli(config_overrides={
+            "display": {
+                "input_max_lines": "bogus",
+            }
+        })
+
+        assert cli.input_max_lines == 8
+
+    def test_input_max_lines_is_clamped_to_at_least_one(self):
+        cli = _make_cli(config_overrides={
+            "display": {
+                "input_max_lines": 0,
+            }
+        })
+
+        assert cli.input_max_lines == 1
+
+
 class TestSingleQueryState:
     def test_voice_and_interrupt_state_initialized_before_run(self):
         """Single-query mode calls chat() without going through run()."""

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -166,6 +166,43 @@ class TestCLIStatusBar:
             assert _input_height() == 2
         mock_shutil.assert_not_called()
 
+    def test_cap_input_visual_lines_uses_configured_limit(self):
+        cli_obj = _make_cli()
+        cli_obj.input_max_lines = 40
+
+        assert cli_obj._cap_input_visual_lines(100) == 40
+        assert cli_obj._cap_input_visual_lines(0) == 1
+
+    def test_should_collapse_paste_respects_config_flag(self):
+        cli_obj = _make_cli()
+        cli_obj.collapse_large_pastes = False
+
+        assert cli_obj._should_collapse_paste(
+            "a\nb\nc\nd\ne",
+            existing_buffer_text="",
+            is_paste=True,
+        ) is False
+
+    def test_small_paste_into_existing_multiline_buffer_does_not_collapse(self):
+        cli_obj = _make_cli()
+
+        assert cli_obj._should_collapse_paste(
+            "line1\nline2\nline3\nline4\nline5\nline6x",
+            existing_buffer_text="line1\nline2\nline3\nline4\nline5\nline6",
+            is_paste=True,
+            newline_count=0,
+        ) is False
+
+    def test_newline_delta_controls_fallback_paste_collapse(self):
+        cli_obj = _make_cli()
+
+        assert cli_obj._should_collapse_paste(
+            "line1\nline2\nline3\nline4\nline5\nline6",
+            existing_buffer_text="prefix",
+            is_paste=True,
+            newline_count=5,
+        ) is True
+
     def test_build_status_bar_text_no_cost_in_status_bar(self):
         cli_obj = _attach_agent(
             _make_cli(),


### PR DESCRIPTION
## Summary
- add `display.input_max_lines` so the prompt_toolkit input box can grow past the hard-coded 8-line cap
- add `display.collapse_large_pastes` so users can keep large pasted text editable in the input buffer instead of collapsing it into a temp-file placeholder
- keep the fallback paste-collapse path based on newly added lines, and add regression tests for config parsing and multiline paste behavior

## Why
The current CLI hard-codes an 8-line input box and always collapses large pasted blocks. That makes long multi-line prompts harder to inspect/edit in-place, especially when pasting notes, code, logs, or structured prompts. This change keeps the existing defaults, but lets users opt into a taller input area and disable paste collapsing entirely.

## Test Plan
- `source .venv/bin/activate && python -m pytest tests/cli/test_cli_init.py tests/cli/test_cli_status_bar.py -o 'addopts=' -q`
