### PR TITLE
fix: allow home channel from config.yaml to be recognized

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -744,6 +744,10 @@ def load_gateway_config() -> GatewayConfig:
 
     config = GatewayConfig.from_dict(gw_data)
 
+    # Apply home_channel settings from config.yaml top-level keys (e.g., SLACK_HOME_CHANNEL)
+    # This supports home channels set via /sethome. Env vars take precedence (applied later).
+    _apply_config_home_channels(config, yaml_cfg if 'yaml_cfg' in dir() else {})
+
     # Override with environment variables
     _apply_env_overrides(config)
     
@@ -820,6 +824,61 @@ def _validate_gateway_config(config: "GatewayConfig") -> None:
                     platform.value, env_name, token.strip()[:6] + "...",
                 )
                 pconfig.enabled = False
+
+
+def _apply_config_home_channels(config: GatewayConfig, yaml_cfg: dict) -> None:
+    """Apply home channel settings from config.yaml top-level keys (e.g., SLACK_HOME_CHANNEL).
+
+    This supports home channels set via /sethome. Environment variables take precedence
+    and will override these values in _apply_env_overrides.
+    """
+    if not isinstance(yaml_cfg, dict):
+        return
+
+    # Map of platform enum → (home_channel_key, home_channel_name_key)
+    home_channel_map = {
+        Platform.TELEGRAM: ("TELEGRAM_HOME_CHANNEL", "TELEGRAM_HOME_CHANNEL_NAME"),
+        Platform.DISCORD: ("DISCORD_HOME_CHANNEL", "DISCORD_HOME_CHANNEL_NAME"),
+        Platform.SLACK: ("SLACK_HOME_CHANNEL", "SLACK_HOME_CHANNEL_NAME"),
+        Platform.SIGNAL: ("SIGNAL_HOME_CHANNEL", "SIGNAL_HOME_CHANNEL_NAME"),
+        Platform.MATTERMOST: ("MATTERMOST_HOME_CHANNEL", "MATTERMOST_HOME_CHANNEL_NAME"),
+        Platform.MATRIX: ("MATRIX_HOME_ROOM", "MATRIX_HOME_ROOM_NAME"),
+        Platform.EMAIL: ("EMAIL_HOME_ADDRESS", "EMAIL_HOME_ADDRESS_NAME"),
+        Platform.SMS: ("SMS_HOME_CHANNEL", "SMS_HOME_CHANNEL_NAME"),
+        Platform.HOMEASSISTANT: ("HOMEASSISTANT_HOME_CHANNEL", "HOMEASSISTANT_HOME_CHANNEL_NAME"),
+    }
+
+    for platform, (key, name_key) in home_channel_map.items():
+        chat_id = yaml_cfg.get(key)
+        if chat_id:
+            if platform not in config.platforms:
+                config.platforms[platform] = PlatformConfig()
+            config.platforms[platform].home_channel = HomeChannel(
+                platform=platform,
+                chat_id=str(chat_id),
+                name=yaml_cfg.get(name_key, "Home"),
+            )
+
+    # Also check for legacy `gateway.home_channel` - use as fallback for slack if set
+    # and no platform-specific home channel is configured
+    gateway_cfg = yaml_cfg.get("gateway")
+    if isinstance(gateway_cfg, dict):
+        legacy_home = gateway_cfg.get("home_channel")
+        if legacy_home:
+            # Only use if slack doesn't already have a home channel
+            if Platform.SLACK in config.platforms and not config.platforms[Platform.SLACK].home_channel:
+                config.platforms[Platform.SLACK].home_channel = HomeChannel(
+                    platform=Platform.SLACK,
+                    chat_id=str(legacy_home),
+                    name="Home",
+                )
+            elif Platform.SLACK not in config.platforms:
+                config.platforms[Platform.SLACK] = PlatformConfig()
+                config.platforms[Platform.SLACK].home_channel = HomeChannel(
+                    platform=Platform.SLACK,
+                    chat_id=str(legacy_home),
+                    name="Home",
+                )
 
 
 def _apply_env_overrides(config: GatewayConfig) -> None:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4051,7 +4051,11 @@ class GatewayRunner:
         if not history and source.platform and source.platform != Platform.LOCAL and source.platform != Platform.WEBHOOK:
             platform_name = source.platform.value
             env_key = f"{platform_name.upper()}_HOME_CHANNEL"
-            if not os.getenv(env_key):
+            # Check both env var and loaded config (home channel may be set via /sethome in config.yaml)
+            has_home_channel = bool(os.getenv(env_key))
+            if not has_home_channel and source.platform in self.config.platforms:
+                has_home_channel = bool(self.config.platforms[source.platform].home_channel)
+            if not has_home_channel:
                 adapter = self.adapters.get(source.platform)
                 if adapter:
                     await adapter.send(
@@ -5546,6 +5550,14 @@ class GatewayRunner:
             atomic_yaml_write(config_path, user_config)
             # Also set in the current environment so it takes effect immediately
             os.environ[env_key] = str(chat_id)
+            # Also update the in-memory config so the check sees it without restart
+            if source.platform and source.platform in self.config.platforms:
+                from gateway.config import HomeChannel, Platform
+                self.config.platforms[source.platform].home_channel = HomeChannel(
+                    platform=source.platform,
+                    chat_id=str(chat_id),
+                    name=chat_name or str(chat_id),
+                )
         except Exception as e:
             return f"Failed to save home channel: {e}"
         


### PR DESCRIPTION
## Summary
The _handle_home_channel_check() in run.py only looked at environment variables via os.getenv(), missing home channels set via /sethome in config.yaml.

## Problem
When users ran `/sethome` to set their home channel, the value was saved to config.yaml as a top-level key (e.g., `SLACK_HOME_CHANNEL`). However, on subsequent runs, the `_handle_home_channel_check` function only checked `os.getenv()`, which doesn't see values from the loaded config. This caused users to receive repeated "home not set" notifications despite having configured it.

## Changes Made
1. **gateway/run.py**: Updated `_handle_home_channel_check` to also check `config.platforms[platform].home_channel`
2. **gateway/config.py**: Added `_apply_config_home_channels()` to load home channels from config.yaml's top-level keys on startup
3. **gateway/config.py**: Added support for legacy `gateway.home_channel` as fallback
4. **gateway/run.py**: Updated `/sethome` command handler to update in-memory config immediately (no restart required)

## Testing
- Home channel is now properly recognized from config.yaml without requiring a restart
- `/sethome` changes take effect immediately

Fixes the issue where users saw repeated 'home not set' notifications after using /sethome