### PR TITLE
fix(dashboard): remove duplicate skill count in Skills page badge

### DIFF
--- a/web/src/pages/SkillsPage.tsx
+++ b/web/src/pages/SkillsPage.tsx
@@ -378,7 +378,6 @@ export default function SkillsPage() {
                       : t.skills.all}
                   </CardTitle>
                   <Badge variant="secondary" className="text-[10px]">
-                    {activeSkills.length}{" "}
                     {t.skills.skillCount
                       .replace("{count}", String(activeSkills.length))
                       .replace("{s}", activeSkills.length !== 1 ? "s" : "")}


### PR DESCRIPTION
Fixes #12372

The Skills page badge rendered the count twice: once as a literal `{activeSkills.length}` prefix and once via the i18n string which already included the count. Removed the redundant literal prefix.

**Before:** `42 42 skills`
**After:** `42 skills`