### PR TITLE
fix: add circuit breaker for consecutive identical failing tool calls

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -8768,6 +8768,11 @@ class AIAgent:
         self._mute_post_response = False
         self._unicode_sanitization_passes = 0
 
+        # Circuit breaker for consecutive identical failing tool calls (#12395)
+        self._consecutive_tool_fail_count = 0
+        self._last_failed_tool_sig = None
+        self._tool_retry_limit = int(os.environ.get('HERMES_TOOL_RETRY_LIMIT', '3'))
+
         # Pre-turn connection health check: detect and clean up dead TCP
         # connections left over from provider outages or dropped streams.
         # This prevents the next API call from hanging on a zombie socket.
@@ -11322,7 +11327,73 @@ class AIAgent:
                     # Save session log incrementally (so progress is visible even if interrupted)
                     self._session_messages = messages
                     self._save_session_log(messages)
-                    
+
+                    # Circuit breaker: detect consecutive identical failing tool calls (#12395)
+                    # Build signature from current tool calls
+                    current_tool_sig = tuple(
+                        (tc.function.name, tc.function.arguments)
+                        for tc in assistant_message.tool_calls
+                    )
+
+                    # Find the tool results that were just added (last N messages)
+                    num_tool_calls = len(assistant_message.tool_calls)
+                    tool_result_msgs = []
+                    for msg in reversed(messages):
+                        if msg.get("role") == "tool":
+                            tool_result_msgs.append(msg)
+                            if len(tool_result_msgs) >= num_tool_calls:
+                                break
+                    tool_result_msgs.reverse()
+
+                    # Check if all tools failed
+                    all_failed = True
+                    for i, tc in enumerate(assistant_message.tool_calls):
+                        if i < len(tool_result_msgs):
+                            result_content = tool_result_msgs[i].get("content", "")
+                            is_failure, _ = _detect_tool_failure(tc.function.name, result_content)
+                            if not is_failure:
+                                all_failed = False
+                                break
+
+                    # Update circuit breaker state
+                    if all_failed and current_tool_sig == self._last_failed_tool_sig:
+                        # Same failing tools - increment counter
+                        self._consecutive_tool_fail_count += 1
+
+                        if self._consecutive_tool_fail_count >= self._tool_retry_limit:
+                            # Circuit breaker triggered
+                            _turn_exit_reason = "circuit_breaker_triggered"
+                            logger.warning(
+                                "Circuit breaker triggered after %d consecutive identical failing tool calls",
+                                self._consecutive_tool_fail_count
+                            )
+
+                            # Append warning to the last tool result
+                            if tool_result_msgs:
+                                last_tool_result = tool_result_msgs[-1]
+                                warning = (
+                                    "\n\n[CIRCUIT BREAKER] This operation has failed "
+                                    f"{self._consecutive_tool_fail_count} consecutive times with "
+                                    "the same arguments. Do not retry — inform the user about "
+                                    "the failure and move on."
+                                )
+                                last_tool_result["content"] = last_tool_result.get("content", "") + warning
+
+                            # Exit the loop
+                            final_response = (
+                                "The operation failed repeatedly. I've stopped retrying "
+                                "to avoid wasting tokens."
+                            )
+                            break
+                    elif all_failed:
+                        # Different failing tools - update signature and reset/start counter
+                        self._last_failed_tool_sig = current_tool_sig
+                        self._consecutive_tool_fail_count = 1
+                    else:
+                        # At least one tool succeeded - reset circuit breaker
+                        self._consecutive_tool_fail_count = 0
+                        self._last_failed_tool_sig = None
+
                     # Continue loop for next response
                     continue
                 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4309,3 +4309,167 @@ class TestMemoryProviderTurnStart:
         import inspect
         src = inspect.getsource(AIAgent.run_conversation)
         assert "on_turn_start(self._user_turn_count" in src
+
+
+# ---------------------------------------------------------------------------
+# Circuit breaker for consecutive identical tool failures (issue #12395)
+# ---------------------------------------------------------------------------
+
+
+class TestToolRetryCircuitBreaker:
+    """Circuit breaker should stop agent after N consecutive identical tool failures."""
+
+    def test_circuit_breaker_fires_after_three_identical_failures(self, monkeypatch):
+        """When the same tool call fails 3 times in a row with identical args, circuit breaker stops the loop."""
+        monkeypatch.setenv("HERMES_TOOL_RETRY_LIMIT", "3")
+
+        # Create agent with send_message tool defined
+        with (
+            patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("send_message")),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            agent.client = MagicMock()
+
+        # Mock tool that always fails
+        def failing_tool(name, args, task_id, **kwargs):
+            return '{"error": "Connection refused"}'
+
+        # Track how many times the LLM was called
+        llm_call_count = [0]
+
+        # Mock LLM that always calls the same failing tool with same arguments
+        def mock_llm_call(*args, **kwargs):
+            llm_call_count[0] += 1
+            tool_call = _mock_tool_call(
+                name="send_message",
+                arguments='{"message": "hello"}',
+                call_id=f"call_{llm_call_count[0]}"
+            )
+            return _mock_response(
+                content="",
+                tool_calls=[tool_call],
+                finish_reason="tool_calls"
+            )
+
+        agent.client.chat.completions.create = mock_llm_call
+
+        with (
+            patch("run_agent.handle_function_call", side_effect=failing_tool),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("Send a message")
+
+        # Should stop after 3 identical failures (circuit breaker fires)
+        # Not after max_iterations (which would be much higher)
+        assert llm_call_count[0] <= 4, (
+            f"Expected circuit breaker to stop after ~3 LLM calls, but got {llm_call_count[0]}"
+        )
+
+        # Result should be completed (circuit breaker triggered)
+        assert result["completed"] is True
+
+    def test_circuit_breaker_resets_on_different_tool_calls(self, monkeypatch):
+        """Circuit breaker should reset if tool calls change."""
+        monkeypatch.setenv("HERMES_TOOL_RETRY_LIMIT", "3")
+
+        # Create agent with multiple tools
+        with (
+            patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("send_message", "different_tool")),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            agent.client = MagicMock()
+
+        def varying_tool_handler(name, args, task_id, **kwargs):
+            return '{"error": "fail"}'
+
+        llm_calls = [0]
+
+        def mock_llm_varying(*args, **kwargs):
+            llm_calls[0] += 1
+            # First 2 calls: send_message
+            # Next 2 calls: different_tool (should reset counter)
+            # Next 3 calls: send_message again (should trigger circuit breaker)
+            if llm_calls[0] <= 2:
+                tool_name = "send_message"
+                args = '{"msg": "hello"}'
+            elif llm_calls[0] <= 4:
+                tool_name = "different_tool"
+                args = '{"data": "test"}'
+            else:
+                tool_name = "send_message"
+                args = '{"msg": "hello"}'
+
+            tc = _mock_tool_call(name=tool_name, arguments=args, call_id=f"call_{llm_calls[0]}")
+            return _mock_response(content="", tool_calls=[tc], finish_reason="tool_calls")
+
+        agent.client.chat.completions.create = mock_llm_varying
+
+        with (
+            patch("run_agent.handle_function_call", side_effect=varying_tool_handler),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("Test varying tools")
+
+        # Should make more than 3 calls because counter resets when tools change
+        # But should eventually stop when send_message fails 3 times consecutively
+        assert llm_calls[0] >= 5, "Should allow retries when tool calls differ"
+        assert llm_calls[0] <= 8, "Should eventually stop after consecutive failures"
+
+    def test_circuit_breaker_respects_env_var(self, monkeypatch):
+        """HERMES_TOOL_RETRY_LIMIT environment variable should control the limit."""
+        monkeypatch.setenv("HERMES_TOOL_RETRY_LIMIT", "2")
+
+        # Create agent with failing_tool defined
+        with (
+            patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("failing_tool")),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            agent.client = MagicMock()
+
+        llm_calls = [0]
+
+        def failing_tool(name, args, task_id, **kwargs):
+            return '{"error": "always fails"}'
+
+        def mock_llm(*args, **kwargs):
+            llm_calls[0] += 1
+            tc = _mock_tool_call(name="failing_tool", arguments='{"x": 1}', call_id=f"call_{llm_calls[0]}")
+            return _mock_response(content="", tool_calls=[tc], finish_reason="tool_calls")
+
+        agent.client.chat.completions.create = mock_llm
+
+        with (
+            patch("run_agent.handle_function_call", side_effect=failing_tool),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("Test env var limit")
+
+        # Should stop after 2 failures when HERMES_TOOL_RETRY_LIMIT=2
+        assert llm_calls[0] <= 3, f"Expected ~2 LLM calls with limit=2, got {llm_calls[0]}"


### PR DESCRIPTION
## Problem

Closes #12395

When a tool call (e.g. `send_message` for qqbot proactive push) fails and returns an error, the LLM sees the error and retries the same call with identical arguments. There is no cross-turn detection of repeated identical failing tool calls, so the agent loops until `max_iterations` (default 90), wasting significant tokens.

## Solution

Add a circuit breaker in the main agent loop (`run_conversation`) that:

1. Tracks the signature (tool name + arguments) of failing tool calls across iterations
2. When the **same** tool call fails **3 consecutive times** (configurable via `HERMES_TOOL_RETRY_LIMIT` env var), stops the loop early with a clear message
3. Resets the counter when tool calls differ or any tool succeeds

This prevents runaway token consumption when external services are down or misconfigured.

## Changes

- `run_agent.py`: Added circuit breaker state variables and detection logic after tool execution in the main conversation loop
- `tests/run_agent/test_run_agent.py`: Added `TestToolRetryCircuitBreaker` with 3 tests:
  - Circuit breaker fires after 3 identical failures
  - Counter resets when tool calls differ
  - `HERMES_TOOL_RETRY_LIMIT` env var is respected

## Testing

- All 3 new tests pass
- Full test suite: 272 passed, 1 pre-existing failure (unrelated `TestStreamingApiCall::test_tool_call_accumulation`)