### PR TITLE
fix: qqbot infinite retry - permanent error classification + circuit breaker (#12395)

### DIFF
--- a/gateway/platforms/qqbot.py
+++ b/gateway/platforms/qqbot.py
@@ -189,6 +189,10 @@ class QQAdapter(BasePlatformAdapter):
         # Upload cache: content_hash -> {file_info, file_uuid, expires_at}
         self._upload_cache: Dict[str, Dict[str, Any]] = {}
 
+        # Circuit breaker: per-chat consecutive failure tracking
+        self._chat_failures: Dict[str, int] = {}
+        self._circuit_breaker_threshold = 3
+
     # ------------------------------------------------------------------
     # Properties
     # ------------------------------------------------------------------
@@ -1560,37 +1564,68 @@ class QQAdapter(BasePlatformAdapter):
     async def _send_chunk(
         self, chat_id: str, content: str, reply_to: Optional[str] = None,
     ) -> SendResult:
-        """Send a single chunk with retry + exponential backoff."""
+        """Send a single chunk with retry + exponential backoff.
+
+        Uses 2 internal retries (outer _send_with_retry adds more).
+        QQ-specific permanent errors (sandbox, offline, permission, rate_limit,
+        system_error, 429, 403) are never retried.
+        A per-chat circuit breaker skips retries after 3 consecutive failures.
+        """
+        # Circuit breaker check
+        failures = self._chat_failures.get(chat_id, 0)
+        if failures >= self._circuit_breaker_threshold:
+            logger.warning("[%s] Circuit breaker open for %s (%d consecutive failures), skipping retry",
+                           self.name, chat_id, failures)
+            return SendResult(
+                success=False,
+                error=f"Circuit breaker open: {failures} consecutive failures for {chat_id}",
+                retryable=False,
+            )
+
         last_exc: Optional[Exception] = None
         chat_type = self._guess_chat_type(chat_id)
 
-        for attempt in range(3):
+        for attempt in range(2):
             try:
                 if chat_type == "c2c":
-                    return await self._send_c2c_text(chat_id, content, reply_to)
+                    result = await self._send_c2c_text(chat_id, content, reply_to)
                 elif chat_type == "group":
-                    return await self._send_group_text(chat_id, content, reply_to)
+                    result = await self._send_group_text(chat_id, content, reply_to)
                 elif chat_type == "guild":
-                    return await self._send_guild_text(chat_id, content, reply_to)
+                    result = await self._send_guild_text(chat_id, content, reply_to)
                 else:
                     return SendResult(success=False, error=f"Unknown chat type for {chat_id}")
+                # Success — reset failure counter
+                self._chat_failures.pop(chat_id, None)
+                return result
             except Exception as exc:
                 last_exc = exc
                 err = str(exc).lower()
-                # Permanent errors — don't retry
-                if any(k in err for k in ("invalid", "forbidden", "not found", "bad request")):
+                # QQ-specific permanent errors — don't retry
+                if any(k in err for k in (
+                    "invalid", "forbidden", "not found", "bad request",
+                    "sandbox", "offline", "permission", "rate_limit",
+                    "system_error", "429", "403",
+                )):
                     break
                 # Transient — back off and retry
-                if attempt < 2:
+                if attempt < 1:
                     delay = 1.0 * (2 ** attempt)
-                    logger.warning("[%s] send retry %d/3 after %.1fs: %s",
+                    logger.warning("[%s] send retry %d/2 after %.1fs: %s",
                                    self.name, attempt + 1, delay, exc)
                     await asyncio.sleep(delay)
 
         error_msg = str(last_exc) if last_exc else "Unknown error"
         logger.error("[%s] Send failed: %s", self.name, error_msg)
-        retryable = not any(k in error_msg.lower()
-                            for k in ("invalid", "forbidden", "not found"))
+        # Increment failure counter for circuit breaker
+        self._chat_failures[chat_id] = self._chat_failures.get(chat_id, 0) + 1
+        is_permanent = any(k in error_msg.lower()
+                           for k in (
+                               "invalid", "forbidden", "not found",
+                               "sandbox", "offline", "permission",
+                               "rate_limit", "system_error", "429", "403",
+                           ))
+        retryable = not is_permanent
         return SendResult(success=False, error=error_msg, retryable=retryable)
 
     async def _send_c2c_text(


### PR DESCRIPTION
Fixes #12395

## Problem
Two layers of retry compounded into an infinite retry loop:
1. `qqbot._send_chunk`: 3 attempts with backoff, returns `retryable=True` for transient errors
2. `base._send_with_retry`: 2 MORE retries when `retryable=True`
3. If all fail, tries to send failure notice → re-enters retry loop

## Fix (3 changes in `qqbot.py _send_chunk`)

### 1. Permanent error classification
Added QQ-specific errors to the non-retryable list: `sandbox`, `offline`, `permission`, `rate_limit`, `system_error`, `429`, `403`. These now break immediately and return `retryable=False`.

### 2. Reduced internal retries
Changed from 3 to 2 attempts (since `_send_with_retry` adds 2 more), cutting total attempts from 6 to 4.

### 3. Circuit breaker
Added per-chat consecutive failure tracking (`_chat_failures` dict). After 3 consecutive failures for a `chat_id`, `_send_chunk` returns immediately with `retryable=False` and no retries. Counter resets on any successful send to that chat.

This prevents both the infinite retry loop and hammering a permanently-broken chat.