### PR TITLE
fix(mcp): MCP OAuth broken - PEP 525 generator delegation bug (#12400)

### DIFF
--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -125,9 +125,35 @@ def _make_hermes_provider_class() -> Optional[type]:
                     self._hermes_server_name, exc,
                 )
 
-            # Delegate to the SDK's auth flow
-            async for item in super().async_auth_flow(request):
-                yield item
+            # Delegate to the SDK's auth flow with full bidirectional
+            # forwarding (asend/athrow/aclose).  Plain `async for ... yield`
+            # does NOT forward asend() values back to the inner generator —
+            # this is a PEP 525 limitation.  The MCP SDK's auth flow expects
+            # the caller to asend() the HTTP response back in, so without
+            # manual forwarding the flow silently receives None and OAuth
+            # token exchange / refresh breaks.
+            inner = super().async_auth_flow(request)
+            try:
+                sent = None
+                thrown = None
+                while True:
+                    try:
+                        if thrown is not None:
+                            exc, thrown = thrown, None
+                            item = await inner.athrow(exc)
+                        elif sent is None:
+                            item = await inner.__anext__()
+                        else:
+                            val, sent = sent, None
+                            item = await inner.asend(val)
+                    except StopAsyncIteration:
+                        return
+                    try:
+                        sent = yield item
+                    except BaseException as exc:
+                        thrown = exc
+            finally:
+                await inner.aclose()
 
     return HermesMCPOAuthProvider
 


### PR DESCRIPTION
## Problem

MCP OAuth is broken because `async for item in super().async_auth_flow(request): yield item` does **not** forward `asend()` values back to the inner generator.

This is a known **PEP 525 limitation** — the `async for ... in` iteration protocol does not support bidirectional communication. The MCP SDK's `OAuthClientProvider.async_auth_flow` (built on `httpx.Auth`) uses `asend()` to receive the HTTP response from the caller. Without manual forwarding, the inner generator silently receives `None`, breaking token exchange and refresh.

## Fix

Replace the `async for ... yield` delegation with explicit bidirectional forwarding that properly handles `asend()`, `athrow()`, and `aclose()`.

## Files Changed

- `tools/mcp_oauth_manager.py` — `HermesMCPOAuthProvider.async_auth_flow` method (lines 128-130 → bidirectional forwarding pattern)

Closes #12400