### PR TITLE
feat(feishu): add per-group require_mention toggle

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -320,6 +320,10 @@ class FeishuGroupRule:
     policy: str  # "open" | "allowlist" | "blacklist" | "admin_only" | "disabled"
     allowlist: set[str] = field(default_factory=set)
     blacklist: set[str] = field(default_factory=set)
+    require_mention: bool = True
+    # When False, the bot responds to all messages from allowed senders without
+    # requiring an explicit @mention. Recommended for private groups containing
+    # only the owner and the bot.
 
 
 @dataclass
@@ -1111,6 +1115,7 @@ class FeishuAdapter(BasePlatformAdapter):
                     policy=str(rule_cfg.get("policy", "open")).strip().lower(),
                     allowlist=set(str(u).strip() for u in rule_cfg.get("allowlist", []) if str(u).strip()),
                     blacklist=set(str(u).strip() for u in rule_cfg.get("blacklist", []) if str(u).strip()),
+                    require_mention=_to_boolean(rule_cfg.get("require_mention", True)),
                 )
 
         # Bot-level admins
@@ -3234,6 +3239,10 @@ class FeishuAdapter(BasePlatformAdapter):
         """Require an explicit @mention before group messages enter the agent."""
         if not self._allow_group_message(sender_id, chat_id):
             return False
+        # Per-group mention gate: if disabled, accept all messages from allowed senders.
+        rule = self._group_rules.get(chat_id) if chat_id else None
+        if rule and not rule.require_mention:
+            return True
         # @_all is Feishu's @everyone placeholder — always route to the bot.
         raw_content = getattr(message, "content", "") or ""
         if "@_all" in raw_content:

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2970,3 +2970,108 @@ class TestSenderNameResolution(unittest.TestCase):
             result = asyncio.run(adapter._resolve_sender_name_from_api("ou_broken"))
 
         self.assertIsNone(result)
+
+
+class TestPerGroupRequireMention(unittest.TestCase):
+    """Tests for the per-group require_mention toggle."""
+
+    @patch.dict(
+        os.environ,
+        {
+            "FEISHU_GROUP_POLICY": "open",
+            "FEISHU_BOT_NAME": "TestBot",
+        },
+        clear=True,
+    )
+    def test_require_mention_false_accepts_without_mention(self):
+        """When require_mention=False, messages are accepted without @mention."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter, FeishuGroupRule
+
+        adapter = FeishuAdapter(PlatformConfig())
+        chat_id = "oc_test_group"
+        adapter._group_rules = {chat_id: FeishuGroupRule(
+            policy="open", allowlist=set(), blacklist=set(), require_mention=False,
+        )}
+        adapter._allowed_group_users = set()
+        adapter._group_policy = "open"
+
+        message = SimpleNamespace(mentions=[], content="hello")
+        sender_id = SimpleNamespace(open_id="ou_any", user_id=None)
+        self.assertTrue(adapter._should_accept_group_message(message, sender_id, chat_id))
+
+    @patch.dict(
+        os.environ,
+        {
+            "FEISHU_GROUP_POLICY": "open",
+            "FEISHU_BOT_NAME": "TestBot",
+        },
+        clear=True,
+    )
+    def test_require_mention_true_still_requires_mention(self):
+        """When require_mention=True (default), @mention is still required."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter, FeishuGroupRule
+
+        adapter = FeishuAdapter(PlatformConfig())
+        chat_id = "oc_test_group"
+        adapter._group_rules = {chat_id: FeishuGroupRule(
+            policy="open", allowlist=set(), blacklist=set(), require_mention=True,
+        )}
+        adapter._allowed_group_users = set()
+        adapter._group_policy = "open"
+
+        message = SimpleNamespace(mentions=[], content="hello")
+        sender_id = SimpleNamespace(open_id="ou_any", user_id=None)
+        self.assertFalse(adapter._should_accept_group_message(message, sender_id, chat_id))
+
+    @patch.dict(
+        os.environ,
+        {
+            "FEISHU_GROUP_POLICY": "open",
+            "FEISHU_BOT_NAME": "TestBot",
+        },
+        clear=True,
+    )
+    def test_require_mention_default_is_true(self):
+        """Groups without explicit require_mention still require @mention (backward compat)."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        chat_id = "oc_no_rule_group"
+        adapter._group_rules = {}
+        adapter._allowed_group_users = set()
+        adapter._group_policy = "open"
+
+        message = SimpleNamespace(mentions=[], content="hello")
+        sender_id = SimpleNamespace(open_id="ou_any", user_id=None)
+        self.assertFalse(adapter._should_accept_group_message(message, sender_id, chat_id))
+
+    @patch.dict(
+        os.environ,
+        {
+            "FEISHU_GROUP_POLICY": "open",
+            "FEISHU_BOT_NAME": "TestBot",
+        },
+        clear=True,
+    )
+    def test_require_mention_false_but_policy_blocks_sender(self):
+        """require_mention=False doesn't bypass sender allowlist/blacklist checks."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter, FeishuGroupRule
+
+        adapter = FeishuAdapter(PlatformConfig())
+        chat_id = "oc_test_group"
+        adapter._group_rules = {chat_id: FeishuGroupRule(
+            policy="allowlist",
+            allowlist={"ou_allowed"},
+            blacklist=set(),
+            require_mention=False,
+        )}
+        adapter._allowed_group_users = set()
+        adapter._group_policy = "allowlist"
+
+        message = SimpleNamespace(mentions=[], content="hello")
+        blocked_sender = SimpleNamespace(open_id="ou_blocked", user_id=None)
+        self.assertFalse(adapter._should_accept_group_message(message, blocked_sender, chat_id))


### PR DESCRIPTION
## Summary

Add an optional `require_mention` field to `FeishuGroupRule` (default `True`). When set to `False` for a specific group, the @mention requirement is skipped so the bot responds to all messages from allowed senders.

**Recommended for private groups containing only the owner and the bot.** Not recommended for large work groups where the bot should only respond when explicitly mentioned.

## Motivation

When Hermes runs as a personal assistant where group chats contain only the owner and the bot, requiring @mention on every message creates unnecessary friction. This change allows those groups to behave like parallel private sessions.

## Changes

- `FeishuGroupRule`: add `require_mention: bool = True`
- Config parsing: read `require_mention` from group rules via `_to_boolean()`
- `_should_accept_group_message()`: check per-group gate before enforcing @mention requirement

## Configuration Example

```yaml
platforms:
  feishu:
    group_rules:
      oc_my_private_group:
        policy: open
        require_mention: false   # Bot responds to all messages without @mention
```

## Backward Compatibility

Default is `True`, so existing configurations are unaffected.

## Test Coverage

- `require_mention=False` accepts messages without @mention
- `require_mention=True` still requires @mention
- Groups without explicit rule still require @mention (backward compat)
- `require_mention=False` does not bypass sender allowlist/blacklist checks