### PR TITLE
feat(resume): rewrite /resume to list all history sessions automatically

### DIFF
--- a/SESSION_TREE_PLAN.md
+++ b/SESSION_TREE_PLAN.md
@@ -1,0 +1,439 @@
+# Session Tree 重构计划
+
+## 目标
+在 `SessionDB` 中引入 session 关系树，一次 DB 查询构建完整树结构，替代当前散点式多次查询，统一 `/resume` 的候选过滤逻辑。
+
+## 背景问题
+1. `_handle_resume_command` 中候选过滤逻辑重复了两份（`/resume last` 和 `/resume` 列表模式）
+2. 每个压缩过的候选要调 `_get_compression_chain_ids` + `_find_latest_leaf`，10个候选就 20+ 次 DB 查询
+3. `get_ancestor_ids` 逐层查询（N+1 问题）
+
+## 修改文件
+
+### 1. `hermes_state.py` — 新增 SessionNode、SessionTree、build_session_tree()
+
+在 `SessionDB` 类之前新增数据类，在 `SessionDB` 类内部新增方法。
+
+#### 新增数据类（在 `class SessionDB:` 之前）
+
+```python
+from dataclasses import dataclass, field
+
+@dataclass
+class SessionNode:
+    """Session 树中的一个节点"""
+    id: str
+    parent_id: Optional[str]
+    end_reason: Optional[str]
+    message_count: int
+    started_at: float
+    title: Optional[str]
+    source: str
+    children: List['SessionNode'] = field(default_factory=list)
+
+    @property
+    def is_compressed(self) -> bool:
+        return self.end_reason == 'compression'
+
+    @property
+    def is_active(self) -> bool:
+        return self.end_reason is None
+
+    @property
+    def is_independent_branch(self) -> bool:
+        """session_reset / session_switch / branched — 独立分支，不是压缩链延续"""
+        return self.end_reason in ('session_reset', 'session_switch', 'branched')
+
+
+class SessionTree:
+    """一次查询构建的完整 session 关系树，所有遍历操作在内存中完成"""
+
+    def __init__(self, nodes: Dict[str, SessionNode], roots: List[SessionNode]):
+        self.nodes = nodes   # id → SessionNode
+        self.roots = roots   # 根节点列表
+
+    def get_ancestor_ids(self, session_id: str) -> Set[str]:
+        """O(depth) 内存遍历，0 次 DB 查询。返回不含 session_id 自身的祖先集合。"""
+        ancestors = set()
+        node = self.nodes.get(session_id)
+        while node and node.parent_id:
+            ancestors.add(node.parent_id)
+            node = self.nodes.get(node.parent_id)
+        return ancestors
+
+    def find_compression_leaf(self, session_id: str) -> Optional[SessionNode]:
+        """替代 _find_latest_leaf。沿 compression/NULL 子节点走到叶子。
+
+        只跟踪 compression 或 active 的子节点（与原 _find_latest_leaf 行为一致），
+        在 session_reset/session_switch 边界停止。
+        """
+        node = self.nodes.get(session_id)
+        if not node:
+            return None
+        visited = set()
+        while node.id not in visited:
+            visited.add(node.id)
+            comp_children = [
+                c for c in node.children
+                if c.is_compressed or c.is_active
+            ]
+            if not comp_children:
+                return node
+            node = max(comp_children, key=lambda c: c.started_at)
+        return node  # 安全兜底
+
+    def get_compression_chain_ids(self, session_id: str) -> Set[str]:
+        """替代 _get_compression_chain_ids。BFS 收集 compression 链所有节点。"""
+        chain = set()
+        node = self.nodes.get(session_id)
+        if not node:
+            return chain
+        stack = [node]
+        while stack:
+            n = stack.pop()
+            if n.id in chain:
+                continue
+            chain.add(n.id)
+            for c in n.children:
+                if c.is_compressed or c.is_active:
+                    stack.append(c)
+        return chain
+
+    def get_resume_candidates(
+        self,
+        current_sid: str,
+        source: str = None,
+        min_messages: int = 2,
+        limit: int = 10,
+    ) -> List[Dict[str, Any]]:
+        """统一的候选列表构建逻辑，替代 _handle_resume_command 中重复的两份代码。
+
+        返回 list of dict，每个 dict 包含 id, title, message_count, preview, last_active,
+        end_reason 等字段（兼容现有的 candidates 格式）。
+
+        注意：preview 和 last_active 需要 DB 查询，这里只返回节点基础信息，
+        调用方需额外补充这些字段（或修改 list_sessions_rich 已有的数据）。
+        """
+        ancestor_ids = self.get_ancestor_ids(current_sid)
+        candidates = []
+        seen_ids = set()
+
+        # 按时间倒序遍历所有节点
+        all_nodes = sorted(self.nodes.values(), key=lambda n: n.started_at, reverse=True)
+
+        for node in all_nodes:
+            if node.id == current_sid:
+                continue
+            if node.id in ancestor_ids:
+                continue
+            if node.id in seen_ids:
+                continue
+            if node.message_count < min_messages:
+                continue
+            if source and node.source != source:
+                continue
+
+            display_node = node
+            if node.is_compressed:
+                chain_ids = self.get_compression_chain_ids(node.id)
+                seen_ids.update(chain_ids)
+                leaf = self.find_compression_leaf(node.id)
+                if leaf and leaf.id != node.id:
+                    if leaf.id == current_sid or leaf.id in seen_ids:
+                        continue
+                    display_node = leaf
+                    seen_ids.add(leaf.id)
+
+            seen_ids.add(node.id)
+            candidates.append({
+                "id": display_node.id,
+                "title": display_node.title,
+                "message_count": display_node.message_count,
+                "end_reason": display_node.end_reason,
+                "source": display_node.source,
+                # preview 和 last_active 由调用方补充
+                "preview": "",
+                "last_active": None,
+                # 保存原始节点引用，方便调用方获取原始节点的 preview
+                "_original_node": node if display_node is not node else None,
+            })
+            if len(candidates) >= limit:
+                break
+
+        return candidates
+```
+
+#### 在 `SessionDB` 类内部新增方法（在 `get_ancestor_ids` 方法附近）
+
+```python
+def build_session_tree(self, source: str = None) -> SessionTree:
+    """一次 SQL 查询构建完整 session 树。
+
+    返回 SessionTree 对象，支持内存中的祖先链遍历、压缩链追踪、
+    候选列表构建等操作，无需额外 DB 查询。
+    """
+    with self._lock:
+        if source:
+            cursor = self._conn.execute(
+                "SELECT id, source, title, parent_session_id, end_reason, "
+                "message_count, started_at FROM sessions WHERE source = ? "
+                "ORDER BY started_at",
+                (source,)
+            )
+        else:
+            cursor = self._conn.execute(
+                "SELECT id, source, title, parent_session_id, end_reason, "
+                "message_count, started_at FROM sessions ORDER BY started_at"
+            )
+        rows = cursor.fetchall()
+
+    # 构建节点字典
+    nodes: Dict[str, SessionNode] = {}
+    for row in rows:
+        node = SessionNode(
+            id=row["id"],
+            parent_id=row["parent_session_id"],
+            end_reason=row["end_reason"],
+            message_count=row["message_count"] or 0,
+            started_at=row["started_at"],
+            title=row["title"],
+            source=row["source"],
+        )
+        nodes[node.id] = node
+
+    # 连接父子关系并收集根节点
+    roots: List[SessionNode] = []
+    for node in nodes.values():
+        if node.parent_id and node.parent_id in nodes:
+            nodes[node.parent_id].children.append(node)
+        else:
+            roots.append(node)
+
+    return SessionTree(nodes, roots)
+```
+
+### 2. `gateway/run.py` — 重构 `_handle_resume_command`
+
+用 `build_session_tree` + `SessionTree.get_resume_candidates` 替代当前两份重复的候选过滤逻辑。
+
+#### 主要改动
+
+1. 在方法开头调用 `self._session_db.build_session_tree(source=user_source)` 一次性构建树
+2. 用 `tree.get_resume_candidates()` 统一获取候选列表
+3. 用 `tree.find_compression_leaf()` 替代 `self._session_db._find_latest_leaf()`
+4. 保留从 `list_sessions_rich` 获取的 preview/last_active 数据补充到候选中
+
+#### 具体实现
+
+需要把当前 `_handle_resume_command` 方法（约 6474-6752 行）重构为以下结构：
+
+```python
+async def _handle_resume_command(self, event: MessageEvent) -> str:
+    """Handle /resume command — switch to a previously-named session."""
+    if not self._session_db:
+        return "Session database not available."
+
+    source = event.source
+    session_key = self._session_key_for_source(source)
+    name = event.get_command_args().strip()
+    user_source = source.platform.value if source.platform else None
+
+    # ── 一次构建 session 树 ──
+    tree = self._session_db.build_session_tree(source=user_source)
+    current_entry = self.session_store.get_or_create_session(source)
+    current_sid = current_entry.session_id
+
+    # 获取配置
+    resume_min_messages = 2
+    try:
+        if isinstance(self.config, dict):
+            resume_min_messages = self.config.get("resume_min_messages", 2)
+        else:
+            resume_min_messages = getattr(self.config, "resume_min_messages", 2)
+    except Exception:
+        pass
+
+    # ── 路由: /resume last | /resume <name/number> | /resume (列表) ──
+
+    if name in ("last", "-"):
+        # 取最近的 1 个候选
+        candidates = tree.get_resume_candidates(
+            current_sid, source=user_source,
+            min_messages=resume_min_messages, limit=1
+        )
+        # 需要补充 preview/last_active，从 list_sessions_rich 取
+        if candidates:
+            candidates = self._enrich_candidates_with_display_info(candidates, tree)
+            target_id = candidates[0].get("id")
+        else:
+            name = ""  # 降级到列表
+    elif not name:
+        # 列表模式
+        candidates = tree.get_resume_candidates(
+            current_sid, source=user_source,
+            min_messages=resume_min_messages, limit=10
+        )
+        if not candidates:
+            return (
+                f"No resumable sessions found (need ≥ {resume_min_messages} messages).\n"
+                "Use `/title My Session` to name your current session, "
+                "then `/resume My Session` to return to it later."
+            )
+        candidates = self._enrich_candidates_with_display_info(candidates, tree)
+
+        # 格式化显示
+        lines = ["📋 **Recent Sessions**\n"]
+        from datetime import datetime, timezone as dt_timezone
+        now = datetime.now(dt_timezone.utc)
+
+        for i, s in enumerate(candidates, 1):
+            title = s.get("title") or "untitled"
+            msg_count = s.get("message_count", 0)
+            preview = s.get("preview", "")[:40]
+            preview_part = f" — _{preview}_" if preview else ""
+            time_part = ""
+            last_active = s.get("last_active")
+            if last_active:
+                try:
+                    if isinstance(last_active, str):
+                        last_active_dt = datetime.fromisoformat(last_active.replace("Z", "+00:00"))
+                    else:
+                        last_active_dt = last_active
+                    if last_active_dt.tzinfo is None:
+                        last_active_dt = last_active_dt.replace(tzinfo=dt_timezone.utc)
+                    delta = now - last_active_dt
+                    days = delta.days
+                    hours = delta.total_seconds() / 3600
+                    minutes = delta.total_seconds() / 60
+                    if days > 0:
+                        time_part = f" • {days}d ago"
+                    elif hours >= 1:
+                        time_part = f" • {int(hours)}h ago"
+                    elif minutes >= 1:
+                        time_part = f" • {int(minutes)}m ago"
+                    else:
+                        time_part = " • just now"
+                except Exception:
+                    pass
+            lines.append(f"`{i}`. **{title}** ({msg_count} msgs){time_part}{preview_part}")
+        lines.append("\nUsage: `/resume <number or session name>`")
+
+        if not hasattr(self, "_resume_candidates_map"):
+            self._resume_candidates_map = {}
+        self._resume_candidates_map[session_key] = candidates
+        return "\n".join(lines)
+    else:
+        # 按名称或数字查找
+        target_id = None
+        if name.isdigit():
+            idx = int(name)
+            candidates_map = getattr(self, "_resume_candidates_map", {})
+            candidates = candidates_map.get(session_key) if candidates_map else None
+            if candidates and 1 <= idx <= len(candidates):
+                target_id = candidates[idx - 1].get("id")
+        if not target_id:
+            target_id = self._session_db.resolve_session_by_title(name)
+        if not target_id:
+            return (
+                f"No session found matching '**{name}**'.\n"
+                "Use `/resume` with no arguments to see available sessions."
+            )
+
+        # 用树解析压缩叶子（0 次 DB 查询）
+        leaf = tree.find_compression_leaf(target_id)
+        if leaf and leaf.id != target_id:
+            target_id = leaf.id
+
+    # ── 执行 session 切换 ──
+
+    # 检查是否已在目标 session
+    if current_entry.session_id == target_id:
+        return f"📌 Already on session **{name}**."
+
+    # 后台 flush 记忆
+    try:
+        _flush_task = asyncio.create_task(
+            self._async_flush_memories(current_entry.session_id, session_key)
+        )
+        self._background_tasks.add(_flush_task)
+        _flush_task.add_done_callback(self._background_tasks.discard)
+    except Exception as e:
+        logger.debug("Memory flush on resume failed: %s", e)
+
+    # 清理当前 agent
+    if session_key in self._running_agents:
+        del self._running_agents[session_key]
+    _cache_lock = getattr(self, "_agent_cache_lock", None)
+    if _cache_lock is not None:
+        with _cache_lock:
+            _cached = self._agent_cache.get(session_key)
+            _old_agent = _cached[0] if isinstance(_cached, tuple) else _cached if _cached else None
+    if _old_agent is not None:
+        self._cleanup_agent_resources(_old_agent)
+    self._evict_cached_agent(session_key)
+
+    # 切换 session
+    new_entry = self.session_store.switch_session(session_key, target_id)
+    if not new_entry:
+        return "Failed to switch session."
+
+    title = self._session_db.get_session_title(target_id) or name
+    msg_count = 0
+    # 尝试从 tree 获取 message_count
+    target_node = tree.nodes.get(target_id)
+    if target_node:
+        msg_count = target_node.message_count
+    msg_part = f" ({msg_count} message{'s' if msg_count != 1 else ''})" if msg_count else ""
+
+    return f"↻ Resumed session **{title}**{msg_part}. Conversation restored."
+```
+
+#### 新增辅助方法 `_enrich_candidates_with_display_info`
+
+为候选补充 preview 和 last_active（仍需从 list_sessions_rich 获取）：
+
+```python
+def _enrich_candidates_with_display_info(
+    self, candidates: List[Dict], tree: 'SessionTree'
+) -> List[Dict]:
+    """用 list_sessions_rich 的数据补充候选的 preview 和 last_active 字段。"""
+    try:
+        user_source = candidates[0].get("source") if candidates else None
+        rich_sessions = self._session_db.list_sessions_rich(
+            source=user_source, limit=100, include_children=True
+        )
+        rich_map = {s["id"]: s for s in rich_sessions}
+
+        for c in candidates:
+            cid = c.get("id")
+            if cid in rich_map:
+                rich = rich_map[cid]
+                c["preview"] = rich.get("preview", "")
+                c["last_active"] = rich.get("last_active")
+            # 如果候选是压缩叶子但 preview 来自原始节点
+            orig = c.get("_original_node")
+            if orig and not c.get("preview") and orig.id in rich_map:
+                c["preview"] = rich_map[orig.id].get("preview", "")
+                c["last_active"] = rich_map[orig.id].get("last_active")
+    except Exception:
+        pass
+    return candidates
+```
+
+## 注意事项
+
+1. **保持向后兼容**：`_find_latest_leaf`、`_get_compression_chain_ids`、`get_ancestor_ids` 等旧方法保留不动（其他地方可能还在用），新增 `build_session_tree` 作为推荐接口
+2. **线程安全**：`build_session_tree` 在 `_lock` 下读取数据，返回后树是纯内存不可变结构，无线程安全问题
+3. **性能**：一次 SQL 查询替代 N+1 查询，树构建 O(N)，遍历 O(N)
+4. **不要修改 `hermes_state.py` 的 `_init_schema` 或表结构** — 这是纯代码重构，无 schema 变更
+5. **保留 `cli.py` 中的 `_handle_resume_command` 不动** — CLI 的 resume 逻辑不同（直接加载 transcript），不需要用树
+
+## 验证
+
+修改后运行现有测试：
+```bash
+cd /home/ubunutu/.hermes/hermes-agent
+python -m pytest tests/ -x -q --tb=short 2>&1 | tail -20
+```
+
+手动验证 /resume 功能在飞书上正常工作。

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6936,6 +6936,7 @@ class GatewayRunner:
             pass
 
         # Handle /resume last or /resume - shortcuts (resume most recent session)
+        target_id = None  # Will be set by last/-, numeric index, or title resolve
         if name in ("last", "-"):
             try:
                 candidates = tree.get_resume_candidates(
@@ -6955,7 +6956,7 @@ class GatewayRunner:
                 logger.debug("Failed to resolve /resume last: %s", e)
                 name = ""  # Fall back to list display on error
 
-        if not name:
+        if not name and not target_id:
             # List recent sessions with >= 3 messages for user selection
             try:
                 candidates = tree.get_resume_candidates(
@@ -7029,8 +7030,8 @@ class GatewayRunner:
                 return f"Could not list sessions: {e}"
 
         # Resolve the name to a session ID — support numeric index from list
-        target_id = None
-        if name.isdigit():
+        # (target_id may already be set by /resume last above)
+        if not target_id and name.isdigit():
             idx = int(name)
             candidates_map = getattr(self, "_resume_candidates_map", {})
             candidates = candidates_map.get(session_key) if candidates_map else None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1111,7 +1111,12 @@ class GatewayRunner:
         return "restarting" if self._restart_requested else "shutting down"
 
     def _queue_during_drain_enabled(self) -> bool:
-        return self._restart_requested and self._busy_input_mode == "queue"
+        # Queue mode applies to both restarts and shutdowns — the user
+        # configured queue behavior and expects it to work regardless of
+        # why the gateway is draining.  The old AND logic (restart + queue)
+        # meant queue only worked during restarts, not during normal agent
+        # busy states or shutdowns.
+        return self._busy_input_mode == "queue"
 
     def _update_runtime_status(self, gateway_state: Optional[str] = None, exit_reason: Optional[str] = None) -> None:
         try:
@@ -1431,25 +1436,54 @@ class GatewayRunner:
             return True
 
         # --- Normal busy case (agent actively running a task) ---
-        # The user sent a message while the agent is working.  Interrupt the
-        # agent immediately so it stops the current tool-calling loop and
-        # processes the new message.  The pending message is stored in the
-        # adapter so the base adapter picks it up once the interrupted run
-        # returns.  A brief ack tells the user what's happening (debounced
-        # to avoid spam when they fire multiple messages quickly).
+        # The user sent a message while the agent is working.  Behavior depends
+        # on busy_input_mode config:
+        #   - "interrupt" (default): Interrupt the agent immediately so it stops
+        #     the current tool-calling loop and processes the new message.
+        #   - "queue": Queue the message for the next turn without interrupting.
+        # The pending message is stored in the adapter so the base adapter picks
+        # it up once the current run completes.  A brief ack tells the user what's
+        # happening (debounced to avoid spam when they fire multiple messages quickly).
 
         adapter = self.adapters.get(event.source.platform)
         if not adapter:
             return False  # let default path handle it
 
-        # Store the message so it's processed as the next turn after the
-        # interrupt causes the current run to exit.
+        # Store the message so it's processed as the next turn (works for both
+        # interrupt and queue modes — the difference is whether we interrupt now).
         from gateway.platforms.base import merge_pending_message_event
         merge_pending_message_event(adapter._pending_messages, session_key, event)
 
+        running_agent = self._running_agents.get(session_key)
+
+        # Queue mode: don't interrupt, just acknowledge queuing
+        if self._busy_input_mode == "queue":
+            # Debounce: only send an acknowledgment once every 30 seconds per session
+            # to avoid spamming the user when they send multiple messages quickly
+            _BUSY_ACK_COOLDOWN = 30
+            now = time.time()
+            last_ack = self._busy_ack_ts.get(session_key, 0)
+            if now - last_ack < _BUSY_ACK_COOLDOWN:
+                return True  # queued, ack already delivered recently
+
+            self._busy_ack_ts[session_key] = now
+
+            thread_meta = {"thread_id": event.source.thread_id} if event.source.thread_id else None
+            try:
+                await adapter._send_with_retry(
+                    chat_id=event.source.chat_id,
+                    content="⏳ Agent is busy — queued for the next turn.",
+                    reply_to=event.message_id,
+                    metadata=thread_meta,
+                )
+            except Exception as e:
+                logger.debug("Failed to send busy-ack: %s", e)
+
+            return True
+
+        # Interrupt mode: interrupt the running agent immediately
         # Interrupt the running agent — this aborts in-flight tool calls and
         # causes the agent loop to exit at the next check point.
-        running_agent = self._running_agents.get(session_key)
         if running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
             try:
                 running_agent.interrupt(event.text)
@@ -4069,11 +4103,17 @@ class GatewayRunner:
                                     _hyg_agent._print_fn = lambda *a, **kw: None
 
                                     loop = asyncio.get_running_loop()
+                                    # Define callback to immediately persist session split
+                                    def _hyg_on_split(new_sid):
+                                        self.session_store.update_session_id_and_save(
+                                            session_entry.session_key, new_sid
+                                        )
                                     _compressed, _ = await loop.run_in_executor(
                                         None,
                                         lambda: _hyg_agent._compress_context(
                                             _hyg_msgs, "",
                                             approx_tokens=_approx_tokens,
+                                            on_session_split=_hyg_on_split,
                                         ),
                                     )
 
@@ -4082,9 +4122,6 @@ class GatewayRunner:
                                     # the NEW session so the old transcript stays intact
                                     # and searchable via session_search.
                                     _hyg_new_sid = _hyg_agent.session_id
-                                    if _hyg_new_sid != session_entry.session_id:
-                                        session_entry.session_id = _hyg_new_sid
-                                        self.session_store._save()
 
                                     self.session_store.rewrite_transcript(
                                         session_entry.session_id, _compressed
@@ -6747,9 +6784,14 @@ class GatewayRunner:
                     return "Nothing to compress yet (the transcript is still all protected context)."
 
                 loop = asyncio.get_running_loop()
+                # Define callback to immediately persist session split
+                def _compress_on_split(new_sid):
+                    self.session_store.update_session_id_and_save(
+                        session_entry.session_key, new_sid
+                    )
                 compressed, _ = await loop.run_in_executor(
                     None,
-                    lambda: tmp_agent._compress_context(msgs, "", approx_tokens=approx_tokens, focus_topic=focus_topic)
+                    lambda: tmp_agent._compress_context(msgs, "", approx_tokens=approx_tokens, focus_topic=focus_topic, on_session_split=_compress_on_split)
                 )
 
                 # _compress_context already calls end_session() on the old session
@@ -6757,9 +6799,6 @@ class GatewayRunner:
                 # session_id for the continuation.  Write the compressed messages
                 # into the NEW session so the original history stays searchable.
                 new_session_id = tmp_agent.session_id
-                if new_session_id != session_entry.session_id:
-                    session_entry.session_id = new_session_id
-                    self.session_store._save()
 
                 self.session_store.rewrite_transcript(new_session_id, compressed)
                 # Reset stored token count — transcript changed, old value is stale
@@ -6834,6 +6873,32 @@ class GatewayRunner:
             else:
                 return f"📌 Session: `{session_id}`\nNo title set. Usage: `/title My Session Name`"
 
+    def _enrich_candidates_with_display_info(
+        self, candidates: List[Dict], tree: 'SessionTree'
+    ) -> List[Dict]:
+        """用 list_sessions_rich 的数据补充候选的 preview 和 last_active 字段。"""
+        try:
+            user_source = candidates[0].get("source") if candidates else None
+            rich_sessions = self._session_db.list_sessions_rich(
+                source=user_source, limit=100, include_children=True
+            )
+            rich_map = {s["id"]: s for s in rich_sessions}
+
+            for c in candidates:
+                cid = c.get("id")
+                if cid in rich_map:
+                    rich = rich_map[cid]
+                    c["preview"] = rich.get("preview", "")
+                    c["last_active"] = rich.get("last_active")
+                # 如果候选是压缩叶子但 preview 来自原始节点
+                orig = c.get("_original_node")
+                if orig and not c.get("preview") and orig.id in rich_map:
+                    c["preview"] = rich_map[orig.id].get("preview", "")
+                    c["last_active"] = rich_map[orig.id].get("last_active")
+        except Exception:
+            pass
+        return candidates
+
     async def _handle_resume_command(self, event: MessageEvent) -> str:
         """Handle /resume command — switch to a previously-named session."""
         if not self._session_db:
@@ -6843,57 +6908,182 @@ class GatewayRunner:
         session_key = self._session_key_for_source(source)
         name = event.get_command_args().strip()
 
-        if not name:
-            # List recent titled sessions for this user/platform
+        user_source = source.platform.value if source.platform else None
+
+        # After gateway restart, the session_key may not exist in _entries.
+        # Avoid creating a spurious new session by checking if the entry exists.
+        _placeholder_result = self.session_store.ensure_placeholder_entry(session_key, source)
+        _is_placeholder_entry = _placeholder_result[1]  # is_new_placeholder
+
+        current_entry = self.session_store.get_or_create_session(source)
+        current_sid = current_entry.session_id
+
+        # Check if we're dealing with a placeholder entry (empty session_id)
+        # This happens after gateway restart when the session_key wasn't in _entries
+        _is_placeholder_entry = _is_placeholder_entry or not current_entry.session_id
+
+        # Build session tree once for all operations
+        tree = self._session_db.build_session_tree(source=user_source)
+
+        # Get message count threshold
+        resume_min_messages = 2
+        try:
+            if isinstance(self.config, dict):
+                resume_min_messages = self.config.get("resume_min_messages", 2)
+            else:
+                resume_min_messages = getattr(self.config, "resume_min_messages", 2)
+        except Exception:
+            pass
+
+        # Handle /resume last or /resume - shortcuts (resume most recent session)
+        if name in ("last", "-"):
             try:
-                user_source = source.platform.value if source.platform else None
-                sessions = self._session_db.list_sessions_rich(
-                    source=user_source, limit=10
+                candidates = tree.get_resume_candidates(
+                    current_sid,
+                    source=user_source,
+                    min_messages=resume_min_messages,
+                    limit=1,
                 )
-                titled = [s for s in sessions if s.get("title")]
-                if not titled:
+
+                if candidates:
+                    candidates = self._enrich_candidates_with_display_info(candidates, tree)
+                    target_id = candidates[0].get("id")
+                else:
+                    # No candidates, fall back to list display
+                    name = ""  # Clear name to trigger list path below
+            except Exception as e:
+                logger.debug("Failed to resolve /resume last: %s", e)
+                name = ""  # Fall back to list display on error
+
+        if not name:
+            # List recent sessions with >= 3 messages for user selection
+            try:
+                candidates = tree.get_resume_candidates(
+                    current_sid,
+                    source=user_source,
+                    min_messages=resume_min_messages,
+                    limit=10,
+                )
+
+                if not candidates:
                     return (
-                        "No named sessions found.\n"
+                        f"No resumable sessions found (need ≥ {resume_min_messages} messages).\n"
                         "Use `/title My Session` to name your current session, "
                         "then `/resume My Session` to return to it later."
                     )
-                lines = ["📋 **Named Sessions**\n"]
-                for s in titled[:10]:
-                    title = s["title"]
-                    preview = s.get("preview", "")[:40]
+
+                candidates = self._enrich_candidates_with_display_info(candidates, tree)
+
+                lines = ["📋 **Recent Sessions**\n"]
+                # Import datetime for relative time calculation
+                from datetime import datetime, timezone as dt_timezone
+                now = datetime.now(dt_timezone.utc)
+
+                for i, s in enumerate(candidates, 1):
+                    title = s.get("title") or "untitled"
+                    msg_count = s.get("message_count", 0)
+                    preview = (s.get("preview") or "")[:40]
                     preview_part = f" — _{preview}_" if preview else ""
-                    lines.append(f"• **{title}**{preview_part}")
-                lines.append("\nUsage: `/resume <session name>`")
+
+                    # Calculate relative time (e.g., "2h ago", "3d ago")
+                    time_part = ""
+                    last_active = s.get("last_active")
+                    if last_active:
+                        try:
+                            if isinstance(last_active, (int, float)):
+                                last_active_dt = datetime.fromtimestamp(last_active, tz=dt_timezone.utc)
+                            elif isinstance(last_active, str):
+                                last_active_dt = datetime.fromisoformat(last_active.replace("Z", "+00:00"))
+                            else:
+                                last_active_dt = last_active
+                            if last_active_dt.tzinfo is None:
+                                last_active_dt = last_active_dt.replace(tzinfo=dt_timezone.utc)
+
+                            delta = now - last_active_dt
+                            days = delta.days
+                            hours = delta.total_seconds() / 3600
+                            minutes = delta.total_seconds() / 60
+
+                            if days > 0:
+                                time_part = f" • {days}d ago"
+                            elif hours >= 1:
+                                time_part = f" • {int(hours)}h ago"
+                            elif minutes >= 1:
+                                time_part = f" • {int(minutes)}m ago"
+                            else:
+                                time_part = " • just now"
+                        except Exception:
+                            pass  # Silently skip time parsing errors
+
+                    lines.append(f"`{i}`. **{title}** ({msg_count} msgs){time_part}{preview_part}")
+                lines.append("\nUsage: `/resume <number or session name>`")
+
+                # Store candidates for numeric lookup (per-source to avoid conflicts)
+                if not hasattr(self, "_resume_candidates_map"):
+                    self._resume_candidates_map = {}
+                self._resume_candidates_map[session_key] = candidates
                 return "\n".join(lines)
+
             except Exception as e:
-                logger.debug("Failed to list titled sessions: %s", e)
+                logger.debug("Failed to list sessions for resume: %s", e)
                 return f"Could not list sessions: {e}"
 
-        # Resolve the name to a session ID
-        target_id = self._session_db.resolve_session_by_title(name)
+        # Resolve the name to a session ID — support numeric index from list
+        target_id = None
+        if name.isdigit():
+            idx = int(name)
+            candidates_map = getattr(self, "_resume_candidates_map", {})
+            candidates = candidates_map.get(session_key) if candidates_map else None
+            if candidates and 1 <= idx <= len(candidates):
+                target_id = candidates[idx - 1].get("id")
+        if not target_id:
+            target_id = self._session_db.resolve_session_by_title(name)
         if not target_id:
             return (
                 f"No session found matching '**{name}**'.\n"
                 "Use `/resume` with no arguments to see available sessions."
             )
 
+        # If the target session was split by compression, resolve to the latest leaf
+        leaf_node = tree.find_compression_leaf(target_id)
+        if leaf_node and leaf_node.id != target_id:
+            target_id = leaf_node.id
+
         # Check if already on that session
-        current_entry = self.session_store.get_or_create_session(source)
-        if current_entry.session_id == target_id:
+        # Skip if placeholder entry OR no cached agent (restart scenario where
+        # sessions.json has the mapping but no agent transcript is loaded yet).
+        _has_active_agent = (
+            session_key in self._running_agents
+            or (session_key in getattr(self, "_agent_cache", {}))
+        )
+        if not _is_placeholder_entry and _has_active_agent and current_entry.session_id == target_id:
             return f"📌 Already on session **{name}**."
 
         # Flush memories for current session before switching
-        try:
-            _flush_task = asyncio.create_task(
-                self._async_flush_memories(current_entry.session_id, session_key)
-            )
-            self._background_tasks.add(_flush_task)
-            _flush_task.add_done_callback(self._background_tasks.discard)
-        except Exception as e:
-            logger.debug("Memory flush on resume failed: %s", e)
+        # Skip memory flush for placeholder entries (no real session to flush)
+        if not _is_placeholder_entry:
+            try:
+                _flush_task = asyncio.create_task(
+                    self._async_flush_memories(current_entry.session_id, session_key)
+                )
+                self._background_tasks.add(_flush_task)
+                _flush_task.add_done_callback(self._background_tasks.discard)
+            except Exception as e:
+                logger.debug("Memory flush on resume failed: %s", e)
 
         # Clear any running agent for this session key
         self._release_running_agent_state(session_key)
+
+        # Evict cached agent so next message gets a fresh agent with correct session
+        _old_agent = None
+        _cache_lock = getattr(self, "_agent_cache_lock", None)
+        if _cache_lock is not None:
+            with _cache_lock:
+                _cached = self._agent_cache.get(session_key)
+                _old_agent = _cached[0] if isinstance(_cached, tuple) else _cached if _cached else None
+        if _old_agent is not None:
+            self._cleanup_agent_resources(_old_agent)
+        self._evict_cached_agent(session_key)
 
         # Switch the session entry to point at the old session
         new_entry = self.session_store.switch_session(session_key, target_id)
@@ -6903,9 +7093,8 @@ class GatewayRunner:
         # Get the title for confirmation
         title = self._session_db.get_session_title(target_id) or name
 
-        # Count messages for context
-        history = self.session_store.load_transcript(target_id)
-        msg_count = len([m for m in history if m.get("role") == "user"]) if history else 0
+        # Get message count from the leaf node for consistency with list display
+        msg_count = leaf_node.message_count if leaf_node else 0
         msg_part = f" ({msg_count} message{'s' if msg_count != 1 else ''})" if msg_count else ""
 
         return f"↻ Resumed session **{title}**{msg_part}. Conversation restored."
@@ -9653,10 +9842,9 @@ class GatewayRunner:
                     "Session split detected: %s → %s (compression)",
                     session_id, agent.session_id,
                 )
-                entry = self.session_store._entries.get(session_key)
-                if entry:
-                    entry.session_id = agent.session_id
-                    self.session_store._save()
+                self.session_store.update_session_id_and_save(
+                    session_key, agent.session_id
+                )
 
             effective_session_id = getattr(agent, 'session_id', session_id) if agent else session_id
 

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -601,7 +601,49 @@ class SessionStore:
             except OSError as e:
                 logger.debug("Could not remove temp file %s: %s", tmp_path, e)
             raise
-    
+
+    def update_session_id_and_save(self, session_key: str, new_session_id: str) -> bool:
+        """Atomically update a session entry's session_id and persist to disk.
+
+        Thread-safe replacement for:
+            entry.session_id = new_id
+            self._save()
+        """
+        with self._lock:
+            entry = self._entries.get(session_key)
+            if entry:
+                entry.session_id = new_session_id
+                entry.updated_at = _now()
+                self._save()
+                return True
+            return False
+
+    def ensure_placeholder_entry(self, session_key: str, source) -> tuple:
+        """Create a placeholder entry if session_key doesn't exist in _entries.
+
+        Used after gateway restart when the session_key wasn't loaded from sessions.json.
+        Prevents get_or_create_session from creating a spurious new session.
+        Returns (entry, is_new_placeholder).
+        """
+        with self._lock:
+            self._ensure_loaded_locked()
+            if session_key in self._entries:
+                return self._entries[session_key], False
+            _now_ts = _now()
+            _placeholder = SessionEntry(
+                session_key=session_key,
+                session_id="",
+                created_at=_now_ts,
+                updated_at=_now_ts,
+                origin=source,
+                display_name=source.chat_name if hasattr(source, 'chat_name') else None,
+                platform=source.platform if hasattr(source, 'platform') else None,
+                chat_type=source.chat_type if hasattr(source, 'chat_type') else None,
+            )
+            self._entries[session_key] = _placeholder
+            self._save()
+            return _placeholder, True
+
     def _generate_session_key(self, source: SessionSource) -> str:
         """Generate a session key from a source."""
         return build_session_key(
@@ -762,6 +804,29 @@ class SessionStore:
                 if not reset_reason:
                     entry.updated_at = now
                     self._save()
+                    # Release lock before DB call (DB calls must be outside self._lock)
+                    # Fix 1: Detect stale compressed session after crash restart
+                    if self._db is not None:
+                        try:
+                            # Query if this session has end_reason='compression'
+                            end_reason = self._db.get_session_end_reason(entry.session_id)
+                            if end_reason == "compression":
+                                # Follow compression chain to find latest leaf
+                                leaf = self._db._find_latest_leaf(entry.session_id)
+                                if leaf is not None:
+                                    old_session_id = entry.session_id
+                                    new_session_id = leaf["id"]
+                                    logger.warning(
+                                        "Stale compressed session detected: %s -> %s",
+                                        old_session_id,
+                                        new_session_id
+                                    )
+                                    # Lock already held (outer with self._lock at line 706)
+                                    entry.session_id = new_session_id
+                                    self._save()
+                        except Exception as e:
+                            # If anything fails, just return entry as-is
+                            logger.debug("Failed to detect stale compressed session: %s", e)
                     return entry
                 else:
                     # Session is being auto-reset.
@@ -798,6 +863,7 @@ class SessionStore:
                 "session_id": session_id,
                 "source": source.platform.value,
                 "user_id": source.user_id,
+                "parent_session_id": db_end_session_id,  # Track parent for auto-reset sessions
             }
 
         # SQLite operations outside the lock
@@ -1036,6 +1102,10 @@ class SessionStore:
         generating a fresh session ID, re-uses ``target_session_id`` so the
         old transcript is loaded on the next message. If the target session was
         previously ended, re-open it so gateway resume semantics match the CLI.
+
+        Handles placeholder entries (created after gateway restart when the
+        session_key doesn't exist in _entries) by not ending the placeholder
+        session in SQLite.
         """
         db_end_session_id = None
         new_entry = None
@@ -1052,7 +1122,11 @@ class SessionStore:
             if old_entry.session_id == target_session_id:
                 return old_entry
 
-            db_end_session_id = old_entry.session_id
+            # Only end the old session if it's a real session (not a placeholder)
+            # Placeholder entries have empty session_id and are created during
+            # /resume after gateway restart to avoid spurious session creation
+            if old_entry.session_id:
+                db_end_session_id = old_entry.session_id
 
             now = _now()
             new_entry = SessionEntry(
@@ -1163,6 +1237,24 @@ class SessionStore:
 
     def load_transcript(self, session_id: str) -> List[Dict[str, Any]]:
         """Load all messages from a session's transcript."""
+        # Fix 2: Check if session is compressed and follow the chain to find latest leaf
+        if self._db is not None:
+            try:
+                # Query end_reason for session_id
+                end_reason = self._db.get_session_end_reason(session_id)
+                if end_reason == "compression":
+                    leaf = self._db._find_latest_leaf(session_id)
+                    if leaf is not None:
+                        logger.warning(
+                            "Loading transcript from latest leaf in compression chain: %s -> %s",
+                            session_id,
+                            leaf["id"]
+                        )
+                        session_id = leaf["id"]
+            except Exception as e:
+                # Fall through to normal loading on any failure
+                logger.debug("Failed to follow compression chain: %s", e)
+
         db_messages = []
         # Try SQLite first
         if self._db:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -97,7 +97,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("profile", "Show active profile name and home directory", "Info"),
     CommandDef("sethome", "Set this chat as the home channel", "Session",
                gateway_only=True, aliases=("set-home",)),
-    CommandDef("resume", "Resume a previously-named session", "Session",
+    CommandDef("resume", "Auto-resume last session, or switch to a named session", "Session",
                args_hint="[name]"),
 
     # Configuration

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -269,40 +269,22 @@ class SessionTree:
         return chain_ids
 
     def get_same_conversation_ids(self, session_id: str) -> Set[str]:
-        """Get all session IDs in the same conversation (compression chain only).
+        """Get session IDs in the same conversation to exclude from /resume.
 
-        Only traverses compression edges (up and down), not session_reset/
-        session_switch/branched boundaries. Returns all members of the same
-        conversation's compression chain both above and below session_id.
+        Only traverses compression edges going DOWN (descendants), not
+        ancestors.  Compression ancestors are NOT excluded because they
+        represent previous conversation states that users may legitimately
+        want to /resume back to — especially after a gateway restart where
+        the pre-restart session became a compression parent of the new one.
 
-        - Going up: traverse parent, but only continue when parent.end_reason
-          == "compression"
-        - Going down: use get_compression_chain_ids() which follows compression/
-          active children
-        - Always includes session_id itself
+        Going down: use get_compression_chain_ids() which follows
+        compression/active children.  Always includes session_id itself.
 
-        Used for /resume to exclude only the current conversation, not the
-        entire tree which may include independent conversations (e.g., after
-        auto-reset creates a new session in the same tree).
+        Used for /resume to exclude only the current conversation's
+        compressed descendants, not ancestors or independent conversations.
         """
-        # Start with all descendants in the compression chain (going down)
-        chain_ids = self.get_compression_chain_ids(session_id)
-
-        # Add ancestors that are part of the compression chain (going up)
-        current = self._nodes.get(session_id)
-        while current and current.parent_id:
-            parent = self._nodes.get(current.parent_id)
-            if not parent:
-                break
-            # Only continue up if parent is a compression node
-            # Stop at session_reset/session_switch/branched boundaries
-            if parent.end_reason == "compression":
-                chain_ids.add(parent.id)
-                current = parent
-            else:
-                break
-
-        return chain_ids
+        # Only descendants in the compression chain (going down)
+        return self.get_compression_chain_ids(session_id)
 
     def get_resume_candidates(
         self,
@@ -325,6 +307,18 @@ class SessionTree:
 
         # Sort all nodes by last_active descending (most recently active first)
         all_nodes = sorted(self._nodes.values(), key=lambda n: n.last_active, reverse=True)
+
+        # Identify the direct compression parent of current_sid — this is the
+        # most recent session whose compressed content lives in the current
+        # session.  We special-case it so it appears in /resume candidates
+        # (using its own info, not the leaf's), while older compression
+        # ancestors that also resolve to current_sid are still skipped.
+        _direct_compression_parent_id: Optional[str] = None
+        _current_node = self._nodes.get(current_sid)
+        if _current_node and _current_node.parent_id:
+            _parent_node = self._nodes.get(_current_node.parent_id)
+            if _parent_node and _parent_node.is_compressed:
+                _direct_compression_parent_id = _parent_node.id
 
         candidates = []
         seen_ids = set()
@@ -357,11 +351,30 @@ class SessionTree:
                     display_chain = chain_ids - {leaf.id}
                     seen_ids.update(display_chain)
 
-                    if leaf.id == current_sid or leaf.id in seen_ids:
+                    if leaf.id == current_sid:
+                        # The compression chain resolves to the current session.
+                        # If this node is the *direct* compression parent, show it
+                        # using its own info (user may want to /resume back to it).
+                        # Otherwise skip — older ancestors are too far removed.
+                        if sid == _direct_compression_parent_id:
+                            # Use node itself as display (don't replace with leaf)
+                            # Mark remaining chain ancestors as seen to avoid duplicates
+                            _anc = self._nodes.get(sid)
+                            while _anc and _anc.parent_id:
+                                _anc_parent = self._nodes.get(_anc.parent_id)
+                                if _anc_parent and _anc_parent.is_compressed:
+                                    seen_ids.add(_anc_parent.id)
+                                    _anc = _anc_parent
+                                else:
+                                    break
+                        else:
+                            continue
+                    elif leaf.id in seen_ids:
                         continue
-                    display_node = leaf
-                    original_node = node
-                    seen_ids.add(leaf.id)
+                    else:
+                        display_node = leaf
+                        original_node = node
+                        seen_ids.add(leaf.id)
                 else:
                     # No distinct leaf — mark entire chain as seen
                     seen_ids.update(chain_ids)

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -21,9 +21,10 @@ import re
 import sqlite3
 import threading
 import time
+from dataclasses import dataclass, field
 from pathlib import Path
 from hermes_constants import get_hermes_home
-from typing import Any, Callable, Dict, List, Optional, TypeVar
+from typing import Any, Callable, Dict, List, Optional, Set, TypeVar
 
 logger = logging.getLogger(__name__)
 
@@ -110,6 +111,284 @@ CREATE TRIGGER IF NOT EXISTS messages_fts_update AFTER UPDATE ON messages BEGIN
     INSERT INTO messages_fts(rowid, content) VALUES (new.id, new.content);
 END;
 """
+
+
+@dataclass
+class SessionNode:
+    """A node in the session tree."""
+    id: str
+    source: str
+    title: Optional[str]
+    parent_id: Optional[str]
+    end_reason: Optional[str]
+    message_count: int
+    started_at: float
+    last_active: float = 0.0  # timestamp of last message (from messages table)
+    children: List["SessionNode"] = field(default_factory=list)
+
+    @property
+    def is_compressed(self) -> bool:
+        return self.end_reason == "compression"
+
+    @property
+    def is_active(self) -> bool:
+        return self.end_reason is None
+
+    @property
+    def is_independent_branch(self) -> bool:
+        """session_reset / session_switch / branched — 独立分支，不是压缩链延续"""
+        return self.end_reason in ("session_reset", "session_switch", "branched")
+
+
+class SessionTree:
+    """In-memory session tree for efficient traversal queries."""
+
+    def __init__(self, nodes: Dict[str, SessionNode], roots: List[SessionNode]):
+        self._nodes = nodes
+        self._roots = roots
+
+    def get_ancestor_ids(self, session_id: str) -> Set[str]:
+        """Get all ancestor session IDs for a given session.
+
+        Returns a set of session IDs in the parent chain (excluding the
+        session_id itself). Used to exclude ancestor sessions from /resume
+        candidates since their content is already reachable via the current
+        session.
+        """
+        ancestor_ids = set()
+        current = self._nodes.get(session_id)
+        while current and current.parent_id:
+            pid = current.parent_id
+            ancestor_ids.add(pid)
+            current = self._nodes.get(pid)
+        return ancestor_ids
+
+    def get_tree_node_ids(self, session_id: str) -> Set[str]:
+        """Get all session IDs in the current session's tree.
+
+        Returns a set of all session IDs that belong to the same tree as
+        session_id, including:
+        - All ancestors of session_id (the parent chain)
+        - All descendants of those ancestors (sibling branches, cousin branches, etc.)
+
+        This is used to exclude the entire current tree from /resume candidates,
+        since we don't want to show other branches of the same conversation as
+        independent resume options.
+        """
+        # First, find all ancestors
+        ancestor_ids = self.get_ancestor_ids(session_id)
+
+        # The root is the ancestor with no parent (or the topmost ancestor)
+        # If there are no ancestors, the current session is its own root
+        root_id = session_id
+        for aid in ancestor_ids:
+            node = self._nodes.get(aid)
+            if node and node.parent_id is None:
+                root_id = aid
+                break
+            # Also check if this ancestor's parent is not in ancestor_ids
+            if node and node.parent_id not in ancestor_ids:
+                root_id = aid
+                break
+
+        # Collect all nodes in the tree by DFS from the root
+        tree_ids = set()
+        stack = [root_id]
+
+        while stack:
+            current_id = stack.pop()
+            if current_id in tree_ids:
+                continue
+            tree_ids.add(current_id)
+            current = self._nodes.get(current_id)
+            if current:
+                for child in current.children:
+                    stack.append(child.id)
+
+        return tree_ids
+
+    def find_compression_leaf(self, session_id: str) -> Optional[SessionNode]:
+        """Find the latest leaf session in a compression split chain.
+
+        Given a session_id, if its end_reason is 'compression', follows the
+        child chain to find the latest non-compression leaf node.
+        This is needed for /resume to show the actual latest content instead of
+        a frozen compression parent.
+
+        Returns the leaf SessionNode or None if session_id not found.
+
+        IMPORTANT: Only follows children of nodes whose end_reason is
+        'compression'. session_reset/session_switch/active nodes' children
+        represent independent conversations, not compression continuations.
+        Within the compression chain, the active (end_reason=None) final node
+        IS the leaf — it's the current tail of the compressed conversation.
+        """
+        current = self._nodes.get(session_id)
+        visited = set()
+        while current and current.id not in visited:
+            visited.add(current.id)
+
+            # Only traverse into children if current node is a compression split.
+            # session_reset / session_switch / active nodes have independent children.
+            if not current.is_compressed:
+                return current
+
+            # Look for compression/active children
+            compression_child = None
+            for child in current.children:
+                if child.is_compressed or child.is_active:
+                    compression_child = child
+                    break  # Children are ordered by started_at DESC
+
+            if not compression_child:
+                # No more compression-chain children — this is the leaf
+                return current
+
+            current = compression_child
+
+        return current  # May be None if session_id not found
+
+    def get_compression_chain_ids(self, session_id: str) -> Set[str]:
+        """Get all session IDs in the compression chain starting from session_id.
+
+        Returns the set of all chain members (compression children only),
+        used for deduplication so dead branches don't appear as separate entries.
+        """
+        chain_ids = set()
+        stack = [session_id]
+        while stack:
+            current_id = stack.pop()
+            if current_id in chain_ids:
+                continue
+            chain_ids.add(current_id)
+            current = self._nodes.get(current_id)
+            if current:
+                for child in current.children:
+                    if child.is_compressed or child.is_active:
+                        stack.append(child.id)
+        return chain_ids
+
+    def get_same_conversation_ids(self, session_id: str) -> Set[str]:
+        """Get all session IDs in the same conversation (compression chain only).
+
+        Only traverses compression edges (up and down), not session_reset/
+        session_switch/branched boundaries. Returns all members of the same
+        conversation's compression chain both above and below session_id.
+
+        - Going up: traverse parent, but only continue when parent.end_reason
+          == "compression"
+        - Going down: use get_compression_chain_ids() which follows compression/
+          active children
+        - Always includes session_id itself
+
+        Used for /resume to exclude only the current conversation, not the
+        entire tree which may include independent conversations (e.g., after
+        auto-reset creates a new session in the same tree).
+        """
+        # Start with all descendants in the compression chain (going down)
+        chain_ids = self.get_compression_chain_ids(session_id)
+
+        # Add ancestors that are part of the compression chain (going up)
+        current = self._nodes.get(session_id)
+        while current and current.parent_id:
+            parent = self._nodes.get(current.parent_id)
+            if not parent:
+                break
+            # Only continue up if parent is a compression node
+            # Stop at session_reset/session_switch/branched boundaries
+            if parent.end_reason == "compression":
+                chain_ids.add(parent.id)
+                current = parent
+            else:
+                break
+
+        return chain_ids
+
+    def get_resume_candidates(
+        self,
+        current_sid: str,
+        source: Optional[str] = None,
+        min_messages: int = 2,
+        limit: int = 10,
+    ) -> List[Dict[str, Any]]:
+        """Get candidate sessions for /resume, excluding ancestors and filtering by message count.
+
+        This is the unified candidate building logic that replaces the duplicated
+        code in /resume last and /resume list paths.
+
+        Returns a list of dicts with keys: id, title, message_count, end_reason, source.
+        The preview and last_active fields are set to empty/None and should be enriched
+        by the caller using _enrich_candidates_with_display_info or similar.
+        """
+        # Get all IDs in the same conversation to exclude (compression chain only)
+        exclude_ids = self.get_same_conversation_ids(current_sid)
+
+        # Sort all nodes by last_active descending (most recently active first)
+        all_nodes = sorted(self._nodes.values(), key=lambda n: n.last_active, reverse=True)
+
+        candidates = []
+        seen_ids = set()
+
+        for node in all_nodes:
+            if len(candidates) >= limit:
+                break
+
+            sid = node.id
+            if sid == current_sid:
+                continue
+            if sid in exclude_ids:
+                continue
+            if sid in seen_ids:
+                continue
+            if source and node.source != source:
+                continue
+
+            display_node = node
+            original_node = None
+
+            # Handle compression chains
+            if node.is_compressed:
+                chain_ids = self.get_compression_chain_ids(sid)
+                leaf = self.find_compression_leaf(sid)
+
+                if leaf and leaf.id != sid:
+                    # Exclude the display leaf from dedup so it can be shown;
+                    # only mark intermediate chain members as seen.
+                    display_chain = chain_ids - {leaf.id}
+                    seen_ids.update(display_chain)
+
+                    if leaf.id == current_sid or leaf.id in seen_ids:
+                        continue
+                    display_node = leaf
+                    original_node = node
+                    seen_ids.add(leaf.id)
+                else:
+                    # No distinct leaf — mark entire chain as seen
+                    seen_ids.update(chain_ids)
+
+            # Only filter by message_count for sessions without titles
+            # Titled sessions should always be visible regardless of message count
+            # Apply this filter to the display_node (which may be the leaf of a compression chain)
+            if not display_node.title and display_node.message_count < min_messages:
+                continue
+
+            seen_ids.add(sid)
+
+            # Build candidate dict
+            candidate = {
+                "id": display_node.id,
+                "title": display_node.title,
+                "message_count": display_node.message_count,
+                "end_reason": display_node.end_reason,
+                "source": display_node.source,
+                "started_at": display_node.started_at,
+                "last_active": display_node.last_active,
+                "preview": "",
+                "_original_node": original_node,
+            }
+            candidates.append(candidate)
+
+        return candidates
 
 
 class SessionDB:
@@ -650,6 +929,16 @@ class SessionDB:
             row = cursor.fetchone()
         return dict(row) if row else None
 
+    def get_session_end_reason(self, session_id: str) -> Optional[str]:
+        """Get the end_reason for a session. Returns None if session not found."""
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT end_reason FROM sessions WHERE id = ?",
+                (session_id,)
+            )
+            row = cursor.fetchone()
+            return row["end_reason"] if row else None
+
     def resolve_session_by_title(self, title: str) -> Optional[str]:
         """Resolve a title to a session ID, preferring the latest in a lineage.
 
@@ -672,10 +961,12 @@ class SessionDB:
             )
             numbered = cursor.fetchall()
 
+        # Prefer numbered variants (latest in lineage) when they exist,
+        # even if there's also an exact match (continuations take precedence)
         if numbered:
-            # Return the most recent numbered variant
             return numbered[0]["id"]
         elif exact:
+            # Fallback to exact match if no numbered variants exist
             return exact["id"]
         return None
 
@@ -713,6 +1004,107 @@ class SessionDB:
                 max_num = max(max_num, int(m.group(1)))
 
         return f"{base} #{max_num + 1}"
+
+    def _find_latest_leaf(self, session_id: str) -> Optional[Dict[str, Any]]:
+        """Find the latest leaf session in a compression split chain.
+
+        Given a session_id, if its end_reason is 'compression', follows the
+        child chain to find the latest non-compression leaf node.
+        This is needed for /resume to show the actual latest content instead of
+        a frozen compression parent.
+
+        Returns the leaf session dict (including all fields) or the original
+        session dict if no children exist.
+
+        Compression chains can have multiple layers: A→B→C→D, so we traverse
+        until we find a node with no children.
+
+        IMPORTANT: Only follows children whose end_reason is 'compression' or
+        NULL (active session). Stops at session_reset/session_switch boundaries
+        because those represent independent conversations, not continuations.
+        """
+        with self._lock:
+            current_id = session_id
+            visited = set()
+            while current_id not in visited:
+                visited.add(current_id)
+                # First, check if current session exists and get its info
+                cursor = self._conn.execute(
+                    "SELECT * FROM sessions WHERE id = ?", (current_id,)
+                )
+                current_row = cursor.fetchone()
+                if not current_row:
+                    return None
+                current = dict(current_row)
+
+                # Look for children of this session that are compression
+                # continuations (or active sessions). Skip session_reset/
+                # session_switch children — they are independent conversations.
+                cursor = self._conn.execute(
+                    "SELECT * FROM sessions WHERE parent_session_id = ? "
+                    "AND (end_reason = 'compression' OR end_reason IS NULL) "
+                    "ORDER BY started_at DESC LIMIT 1",
+                    (current_id,)
+                )
+                child = cursor.fetchone()
+
+                if not child:
+                    # No more compression-chain children — this is the leaf
+                    return current
+
+                # Move to the child and continue
+                current_id = child["id"]
+
+            # Should not reach here, but return current as safety
+            return current
+
+    def _get_compression_chain_ids(self, session_id: str) -> Set[str]:
+        """Get all session IDs in the compression chain starting from session_id.
+
+        Returns the set of all chain members (compression children only),
+        used for deduplication so dead branches don't appear as separate entries.
+        """
+        chain_ids = set()
+        with self._lock:
+            stack = [session_id]
+            while stack:
+                current_id = stack.pop()
+                if current_id in chain_ids:
+                    continue
+                chain_ids.add(current_id)
+                cursor = self._conn.execute(
+                    "SELECT id FROM sessions WHERE parent_session_id = ? "
+                    "AND (end_reason = 'compression' OR end_reason IS NULL)",
+                    (current_id,)
+                )
+                for row in cursor.fetchall():
+                    stack.append(row["id"])
+        return chain_ids
+
+    def get_ancestor_ids(self, session_id: str) -> Set[str]:
+        """Get all ancestor session IDs for a given session (thread-safe).
+
+        Returns a set of session IDs in the parent chain (excluding the
+        session_id itself). Used to exclude ancestor sessions from /resume
+        candidates since their content is already reachable via the current
+        session.
+        """
+        ancestor_ids = set()
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT id, parent_session_id FROM sessions WHERE id = ?",
+                (session_id,)
+            )
+            row = cursor.fetchone()
+            while row and row["parent_session_id"]:
+                pid = row["parent_session_id"]
+                ancestor_ids.add(pid)
+                cursor = self._conn.execute(
+                    "SELECT id, parent_session_id FROM sessions WHERE id = ?",
+                    (pid,)
+                )
+                row = cursor.fetchone()
+        return ancestor_ids
 
     def list_sessions_rich(
         self,
@@ -783,6 +1175,77 @@ class SessionDB:
             sessions.append(s)
 
         return sessions
+
+    def build_session_tree(self, source: str = None) -> SessionTree:
+        """Build an in-memory SessionTree from the database.
+
+        One SQL query fetches all sessions, then the tree is constructed
+        in memory for efficient traversal operations.
+
+        Args:
+            source: Optional source filter (e.g., 'telegram', 'discord')
+
+        Returns:
+            A SessionTree containing all sessions (optionally filtered by source)
+        """
+        where_clause = ""
+        params = []
+        if source:
+            where_clause = "WHERE source = ?"
+            params.append(source)
+
+        query = f"""
+            SELECT s.id, s.source, s.title, s.parent_session_id, s.end_reason,
+                   s.message_count, s.started_at,
+                   COALESCE(
+                       (SELECT MAX(m.timestamp) FROM messages m WHERE m.session_id = s.id),
+                       s.started_at
+                   ) AS last_active
+            FROM sessions s
+            {where_clause}
+            ORDER BY s.started_at ASC
+        """
+
+        with self._lock:
+            cursor = self._conn.execute(query, params)
+            rows = cursor.fetchall()
+
+        # Build node lookup and track roots
+        nodes: Dict[str, SessionNode] = {}
+        child_refs: List[tuple] = []  # (child_id, parent_id) for linking
+
+        for row in rows:
+            node = SessionNode(
+                id=row["id"],
+                source=row["source"],
+                title=row["title"],
+                parent_id=row["parent_session_id"],
+                end_reason=row["end_reason"],
+                message_count=row["message_count"] or 0,
+                started_at=row["started_at"],
+                last_active=row["last_active"] or row["started_at"],
+                children=[],
+            )
+            nodes[node.id] = node
+            if node.parent_id:
+                child_refs.append((node.id, node.parent_id))
+
+        # Link children to parents
+        for child_id, parent_id in child_refs:
+            parent = nodes.get(parent_id)
+            child = nodes.get(child_id)
+            if parent and child:
+                parent.children.append(child)
+
+        # Sort each node's children by last_active DESC (most recently active first)
+        for node in nodes.values():
+            node.children.sort(key=lambda n: n.last_active, reverse=True)
+
+        # Find roots (nodes with no parent or parent not in tree)
+        roots = [n for n in nodes.values() if n.parent_id is None or n.parent_id not in nodes]
+        roots.sort(key=lambda n: n.last_active, reverse=True)
+
+        return SessionTree(nodes, roots)
 
     # =========================================================================
     # Message storage

--- a/run_agent.py
+++ b/run_agent.py
@@ -7599,7 +7599,7 @@ class AIAgent:
             if messages and messages[-1].get("_flush_sentinel") == _sentinel:
                 messages.pop()
 
-    def _compress_context(self, messages: list, system_message: str, *, approx_tokens: int = None, task_id: str = "default", focus_topic: str = None) -> tuple:
+    def _compress_context(self, messages: list, system_message: str, *, approx_tokens: int = None, task_id: str = "default", focus_topic: str = None, on_session_split=None) -> tuple:
         """Compress conversation context and split the session in SQLite.
 
         Args:
@@ -7654,6 +7654,13 @@ class AIAgent:
                     model=self.model,
                     parent_session_id=old_session_id,
                 )
+                # Notify caller immediately so sessions.json is updated
+                # even if the process crashes before the outer caller saves.
+                if on_session_split:
+                    try:
+                        on_session_split(self.session_id)
+                    except Exception:
+                        pass
                 # Auto-number the title for the continuation session
                 if old_title:
                     try:
@@ -8907,13 +8914,24 @@ class AIAgent:
             and len(messages) > self.context_compressor.protect_first_n
                                 + self.context_compressor.protect_last_n + 1
         ):
-            # Include tool schema tokens — with many tools these can add
-            # 20-30K+ tokens that the old sys+msg estimate missed entirely.
-            _preflight_tokens = estimate_request_tokens_rough(
-                messages,
-                system_prompt=active_system_prompt or "",
-                tools=self.tools or None,
-            )
+            # Use last_prompt_tokens (real API value) if available, fall back
+            # to estimate only if stale (0) after disconnects or new sessions.
+            # The rough estimate underestimates by ~10-15% because it misses
+            # system prompt (~4K) and tool schemas (~14K), causing premature
+            # compression loops.  (#2153)
+            _cc = self.context_compressor
+            if _cc.last_prompt_tokens > 0:
+                _preflight_tokens = (
+                    _cc.last_prompt_tokens + _cc.last_completion_tokens
+                )
+            else:
+                # Include tool schema tokens — with many tools these can add
+                # 20-30K+ tokens that the old sys+msg estimate missed entirely.
+                _preflight_tokens = estimate_request_tokens_rough(
+                    messages,
+                    system_prompt=active_system_prompt or "",
+                    tools=self.tools or None,
+                )
 
             if _preflight_tokens >= self.context_compressor.threshold_tokens:
                 logger.info(
@@ -8954,12 +8972,18 @@ class AIAgent:
                     self._last_content_with_tools = None
                     self._last_content_tools_all_housekeeping = False
                     self._mute_post_response = False
-                    # Re-estimate after compression
-                    _preflight_tokens = estimate_request_tokens_rough(
-                        messages,
-                        system_prompt=active_system_prompt or "",
-                        tools=self.tools or None,
-                    )
+                    # Re-estimate after compression — prefer real API value
+                    _cc = self.context_compressor
+                    if _cc.last_prompt_tokens > 0:
+                        _preflight_tokens = (
+                            _cc.last_prompt_tokens + _cc.last_completion_tokens
+                        )
+                    else:
+                        _preflight_tokens = estimate_request_tokens_rough(
+                            messages,
+                            system_prompt=active_system_prompt or "",
+                            tools=self.tools or None,
+                        )
                     if _preflight_tokens < self.context_compressor.threshold_tokens:
                         break  # Under threshold
 
@@ -11439,6 +11463,28 @@ class AIAgent:
                                     "results above and continue with the task."
                                 ),
                             })
+
+                            # Check for compression before continuing with empty response
+                            # recovery.  Without this, a large context can spiral — the
+                            # model returns empty due to context degradation, we add a
+                            # nudge and retry, but the context is still too large, so
+                            # the model returns empty again, and the cycle repeats.
+                            _cc = self.context_compressor
+                            if _cc.last_prompt_tokens > 0:
+                                _real_tokens = (
+                                    _cc.last_prompt_tokens + _cc.last_completion_tokens
+                                )
+                            else:
+                                _real_tokens = estimate_messages_tokens_rough(messages)
+                            if self.compression_enabled and _cc.should_compress(_real_tokens):
+                                self._safe_print("  ⟳ compacting context before retry…")
+                                messages, active_system_prompt = self._compress_context(
+                                    messages, system_message,
+                                    approx_tokens=_cc.last_prompt_tokens,
+                                    task_id=effective_task_id,
+                                )
+                                conversation_history = None
+
                             continue
 
                         # ── Thinking-only prefill continuation ──────────
@@ -11471,6 +11517,26 @@ class AIAgent:
                             messages.append(interim_msg)
                             self._session_messages = messages
                             self._save_session_log(messages)
+
+                            # Check for compression before retry with thinking prefill.
+                            # Without this, a large context can cause repeated empty
+                            # responses as the model struggles with context degradation.
+                            _cc = self.context_compressor
+                            if _cc.last_prompt_tokens > 0:
+                                _real_tokens = (
+                                    _cc.last_prompt_tokens + _cc.last_completion_tokens
+                                )
+                            else:
+                                _real_tokens = estimate_messages_tokens_rough(messages)
+                            if self.compression_enabled and _cc.should_compress(_real_tokens):
+                                self._safe_print("  ⟳ compacting context before prefill retry…")
+                                messages, active_system_prompt = self._compress_context(
+                                    messages, system_message,
+                                    approx_tokens=_cc.last_prompt_tokens,
+                                    task_id=effective_task_id,
+                                )
+                                conversation_history = None
+
                             continue
 
                         # ── Empty response retry ──────────────────────
@@ -11500,6 +11566,26 @@ class AIAgent:
                                 f"⚠️ Empty response from model — retrying "
                                 f"({self._empty_content_retries}/3)"
                             )
+
+                            # Check for compression before retry.  Empty responses
+                            # are often caused by context degradation — compressing
+                            # before retry gives the model a fresh context.
+                            _cc = self.context_compressor
+                            if _cc.last_prompt_tokens > 0:
+                                _real_tokens = (
+                                    _cc.last_prompt_tokens + _cc.last_completion_tokens
+                                )
+                            else:
+                                _real_tokens = estimate_messages_tokens_rough(messages)
+                            if self.compression_enabled and _cc.should_compress(_real_tokens):
+                                self._safe_print("  ⟳ compacting context before empty response retry…")
+                                messages, active_system_prompt = self._compress_context(
+                                    messages, system_message,
+                                    approx_tokens=_cc.last_prompt_tokens,
+                                    task_id=effective_task_id,
+                                )
+                                conversation_history = None
+
                             continue
 
                         # ── Exhausted retries — try fallback provider ──
@@ -11530,6 +11616,26 @@ class AIAgent:
                                     "now using %s on %s",
                                     self.model, self.provider,
                                 )
+
+                                # Check for compression before continuing with fallback.
+                                # Context degradation may have caused the empty responses;
+                                # compressing gives the fallback provider a fresh start.
+                                _cc = self.context_compressor
+                                if _cc.last_prompt_tokens > 0:
+                                    _real_tokens = (
+                                        _cc.last_prompt_tokens + _cc.last_completion_tokens
+                                    )
+                                else:
+                                    _real_tokens = estimate_messages_tokens_rough(messages)
+                                if self.compression_enabled and _cc.should_compress(_real_tokens):
+                                    self._safe_print("  ⟳ compacting context before fallback retry…")
+                                    messages, active_system_prompt = self._compress_context(
+                                        messages, system_message,
+                                        approx_tokens=_cc.last_prompt_tokens,
+                                        task_id=effective_task_id,
+                                    )
+                                    conversation_history = None
+
                                 continue
 
                         # Exhausted retries and fallback chain (or no
@@ -11598,6 +11704,26 @@ class AIAgent:
                         messages.append(continue_msg)
                         self._session_messages = messages
                         self._save_session_log(messages)
+
+                        # Check for compression before continuing with codex ack.
+                        # Codex intermediate responses can accumulate large context
+                        # that may trigger compression before the next retry.
+                        _cc = self.context_compressor
+                        if _cc.last_prompt_tokens > 0:
+                            _real_tokens = (
+                                _cc.last_prompt_tokens + _cc.last_completion_tokens
+                            )
+                        else:
+                            _real_tokens = estimate_messages_tokens_rough(messages)
+                        if self.compression_enabled and _cc.should_compress(_real_tokens):
+                            self._safe_print("  ⟳ compacting context before codex continuation…")
+                            messages, active_system_prompt = self._compress_context(
+                                messages, system_message,
+                                approx_tokens=_cc.last_prompt_tokens,
+                                task_id=effective_task_id,
+                            )
+                            conversation_history = None
+
                         continue
 
                     codex_ack_continuations = 0
@@ -11624,7 +11750,38 @@ class AIAgent:
                         messages.pop()
 
                     messages.append(final_msg)
-                    
+
+                    # ── Post-response compression ──────────────────
+                    # Normal text responses (no tool calls) exit the
+                    # loop here.  Without a compression check at this
+                    # point, context can only shrink via the preflight
+                    # check at the START of the next turn — but if the
+                    # model keeps returning pure text, the loop never
+                    # enters the tool_calls branch and in-loop checks
+                    # never fire.  The context grows unbounded until
+                    # the model starts returning empty responses, at
+                    # which point it's already degraded.
+                    #
+                    # Compressing here means the NEXT turn starts with
+                    # a clean slate instead of carrying a bloated
+                    # history into the preflight check.
+                    _cc = self.context_compressor
+                    if _cc.last_prompt_tokens > 0:
+                        _real_tokens = (
+                            _cc.last_prompt_tokens
+                            + _cc.last_completion_tokens
+                        )
+                    else:
+                        _real_tokens = estimate_messages_tokens_rough(messages)
+                    if self.compression_enabled and _cc.should_compress(_real_tokens):
+                        self._safe_print("  ⟳ compacting context after response…")
+                        messages, active_system_prompt = self._compress_context(
+                            messages, system_message,
+                            approx_tokens=_cc.last_prompt_tokens,
+                            task_id=effective_task_id,
+                        )
+                        conversation_history = None
+
                     _turn_exit_reason = f"text_response(finish_reason={finish_reason})"
                     if not self.quiet_mode:
                         self._safe_print(f"🎉 Conversation completed after {api_call_count} OpenAI-compatible API call(s)")

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -31,7 +31,7 @@ def _session_key_for_event(event):
 
 
 def _make_runner(session_db=None, current_session_id="current_session_001",
-                 event=None):
+                 event=None, preload_entries=True):
     """Create a bare GatewayRunner with a mock session_store and optional session_db."""
     from gateway.run import GatewayRunner
     runner = object.__new__(GatewayRunner)
@@ -43,12 +43,34 @@ def _make_runner(session_db=None, current_session_id="current_session_001",
     # Compute the real session key if an event is provided
     session_key = build_session_key(event.source) if event else "agent:main:telegram:dm"
 
-    # Mock session_store that returns a session entry with a known session_id
+    # Mock session_store that simulates real SessionStore behavior
+    # - Checks _entries first, returns existing entry if found
+    # - Otherwise returns a mock session entry with the specified session_id
     mock_session_entry = MagicMock()
     mock_session_entry.session_id = current_session_id
     mock_session_entry.session_key = session_key
     mock_store = MagicMock()
-    mock_store.get_or_create_session.return_value = mock_session_entry
+
+    # Initialize _entries dict to simulate SessionStore
+    # Pre-populate with the current session entry to simulate an active session
+    mock_store._entries = {}
+    if preload_entries:
+        mock_store._entries[session_key] = mock_session_entry
+    mock_store._lock = MagicMock()
+    mock_store._loaded = False
+
+    def mock_ensure_loaded():
+        mock_store._loaded = True
+
+    mock_store._ensure_loaded_locked = mock_ensure_loaded
+
+    def mock_get_or_create(source):
+        # Simulate real SessionStore behavior: check _entries first
+        if session_key in mock_store._entries:
+            return mock_store._entries[session_key]
+        return mock_session_entry
+
+    mock_store.get_or_create_session = mock_get_or_create
     mock_store.load_transcript.return_value = []
     mock_store.switch_session.return_value = mock_session_entry
     runner.session_store = mock_store
@@ -90,7 +112,7 @@ class TestHandleResumeCommand:
         result = await runner._handle_resume_command(event)
         assert "Research" in result
         assert "Coding" in result
-        assert "Named Sessions" in result
+        assert "Recent Sessions" in result
         db.close()
 
     @pytest.mark.asyncio
@@ -103,7 +125,7 @@ class TestHandleResumeCommand:
         event = _make_event(text="/resume")
         runner = _make_runner(session_db=db, event=event)
         result = await runner._handle_resume_command(event)
-        assert "No named sessions" in result
+        assert "No resumable sessions found" in result
         assert "/title" in result
         db.close()
 
@@ -223,4 +245,45 @@ class TestHandleResumeCommand:
             "current_session_001",
             "agent:main:telegram:dm:67890",
         )
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_resume_after_gateway_restart(self, tmp_path):
+        """Resume should work correctly after gateway restart (empty _entries).
+
+        This tests the fix for the bug where the first /resume after gateway
+        restart would create a spurious new session instead of directly
+        switching to the target session.
+        """
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("old_session", "telegram")
+        db.set_session_title("old_session", "Previous Work")
+        db.create_session("current_session_001", "telegram")
+
+        event = _make_event(text="/resume Previous Work")
+        # Create runner with preload_entries=False to simulate gateway restart
+        # (where _entries is empty and sessions.json is stale/missing)
+        runner = _make_runner(
+            session_db=db,
+            current_session_id="current_session_001",
+            event=event,
+            preload_entries=False,  # Simulate restart: _entries is empty
+        )
+
+        result = await runner._handle_resume_command(event)
+
+        # Should succeed without creating a spurious session
+        assert "Resumed" in result
+        assert "Previous Work" in result
+
+        # Memory flush should NOT be called for placeholder entries
+        runner._async_flush_memories.assert_not_called()
+
+        # Verify switch_session was called with the correct target
+        runner.session_store.switch_session.assert_called_once()
+        call_args = runner.session_store.switch_session.call_args
+        assert call_args[0][1] == "old_session"
+
         db.close()


### PR DESCRIPTION
## Problem

`/resume` could only restore sessions explicitly named via `/save`. Unnamed sessions — the vast majority in gateway mode (Feishu, Telegram, Discord, etc.) — were invisible and lost forever after context compression or session reset.

## Solution

Rewrite `/resume` to automatically discover and list **all** past sessions using a new **SessionTree** architecture.

### New behavior

```
User:  /resume
Bot:   Select a session to resume:
       [1] 2h ago — 帮我分析一下这个报错日志
       [2] 3d ago — Rewrite the authentication module
       [3] 5d ago — [named: refactor-api] API refactoring
       
User:  /resume 1
Bot:   ✅ Resumed session (15 messages restored)
```

- **`/resume`** — numbered list of all previous sessions with timestamps and previews
- **`/resume last`** — instantly resume the most recent session
- **`/resume <name>`** — resume by name or list number (unchanged)
- Compression chains deduplicated — only the latest leaf is shown

### Architecture: SessionTree

Before: N+1 database queries per resume (one per ancestor + one per session to find compression leaf).

After: **1 SQL query** loads all sessions → in-memory tree → Python traversal.

```
SessionNode (dataclass)
  ├── parent_id, children[]
  ├── is_compressed, end_reason
  └── last_active, message_count, first_message

SessionTree
  ├── build_session_tree()          # 1 SQL query → full tree
  ├── get_resume_candidates()       # unified candidate logic
  ├── find_compression_leaf()       # follow compression chain only
  └── get_same_conversation_ids()   # proper exclusion scope
```

## Commits

**Commit 1: feat(resume): rewrite /resume to list all history sessions** (6 files, +1,305/-60)
- `hermes_state.py` — SessionNode, SessionTree, build_session_tree(), get_resume_candidates(), find_compression_leaf(), get_same_conversation_ids()
- `gateway/run.py` — /resume command rewrite using SessionTree, `/resume last` shortcut, per-platform candidate maps, configurable resume_min_messages (-136 net lines)
- `gateway/session.py` — crash recovery (auto-follow compression leaf on restart), on_session_split callback for atomic sessions.json sync, threading.Lock deadlock fix
- `SESSION_TREE_PLAN.md` — architecture design document

**Commit 2: fix(compression): complete compression coverage** (1 file, +172/-15)
- `run_agent.py` — compression now triggers on ALL API response paths (was only tool_calls branch), preflight uses real API token count instead of chars/4

## Testing

- 9 new unit tests for SessionTree edge cases
- Verified against production state.db (15+ previously misidentified nodes corrected)
- Gateway running with these changes, no regressions