### PR TITLE
fix(cli): allow named custom providers in chat --provider

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6410,30 +6410,11 @@ For more help on a command:
     )
     chat_parser.add_argument(
         "--provider",
-        choices=[
-            "auto",
-            "openrouter",
-            "nous",
-            "openai-codex",
-            "copilot-acp",
-            "copilot",
-            "anthropic",
-            "gemini",
-            "xai",
-            "ollama-cloud",
-            "huggingface",
-            "zai",
-            "kimi-coding",
-            "kimi-coding-cn",
-            "minimax",
-            "minimax-cn",
-            "kilocode",
-            "xiaomi",
-            "arcee",
-            "nvidia",
-        ],
         default=None,
-        help="Inference provider (default: auto)",
+        help=(
+            "Inference provider (default: auto). Accepts built-ins like openrouter/anthropic "
+            "and named custom providers from config.yaml (for example claude-max-proxy)."
+        ),
     )
     chat_parser.add_argument(
         "-v", "--verbose", action="store_true", help="Verbose output"

--- a/tests/hermes_cli/test_chat_provider_custom_provider.py
+++ b/tests/hermes_cli/test_chat_provider_custom_provider.py
@@ -1,0 +1,31 @@
+"""Regression test for chat --provider accepting named custom providers.
+
+The CLI should not reject config-defined custom provider names at argparse
+parse-time. This test intentionally exercises the real CLI entrypoint via a
+subprocess because the previous failure happened before runtime provider
+resolution, inside argument parsing.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_chat_help_accepts_named_custom_provider() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "hermes_cli.main",
+            "chat",
+            "--provider",
+            "claude-max-proxy",
+            "--help",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Inference provider" in result.stdout


### PR DESCRIPTION
## Summary
- remove argparse `choices=[...]` validation from `hermes chat --provider`
- allow named custom providers defined in `config.yaml` to pass parse-time validation
- clarify `--provider` help text with built-in and custom-provider examples

## Why
Today `hermes chat --provider <name>` rejects valid config-defined custom providers too early at argparse parse-time.

That makes CLI behavior inconsistent with Hermes' existing configuration-driven provider resolution, which already supports named custom providers.

Provider validation should happen at runtime resolution, not in the parser.

## Test Plan
- [x] `python -m hermes_cli.main chat --provider claude-max-proxy --help`
- [x] command exits successfully (`0`)

## Notes
- This PR intentionally does **not** include local AI-router workflow enforcement.
- This PR intentionally does **not** include unrelated WhatsApp lockfile changes.
- Scope is limited to parser acceptance and help text for `chat --provider`.
