### PR TITLE
fix(gateway/dingtalk): process standalone file/audio/video messages

### DIFF
--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -678,6 +678,31 @@ class DingTalkAdapter(BasePlatformAdapter):
                             parts.append(item.text)
                     content = " ".join(parts).strip()
 
+        # Standalone file/audio/video messages carry no text. The SDK
+        # (dingtalk-stream <= 0.24) only maps TextContent/ImageContent/
+        # RichTextContent inside ``from_dict``; any other msgtype leaves
+        # ``content`` in ``message.extensions['content']``. Surface a short
+        # placeholder so the agent knows *something* was sent — the
+        # downloadable URL is still attached via ``_extract_media``.
+        if not content:
+            msg_type_str = getattr(message, "message_type", "") or ""
+            if msg_type_str in ("file", "audio", "voice", "video"):
+                ext_content = (
+                    getattr(message, "extensions", None) or {}
+                ).get("content")
+                if isinstance(ext_content, dict):
+                    fname = (
+                        ext_content.get("fileName")
+                        or ext_content.get("file_name")
+                        or ""
+                    ).strip()
+                    if msg_type_str == "file":
+                        content = f"[文件] {fname}" if fname else "[文件]"
+                    elif msg_type_str in ("audio", "voice"):
+                        content = f"[语音] {fname}" if fname else "[语音]"
+                    elif msg_type_str == "video":
+                        content = f"[视频] {fname}" if fname else "[视频]"
+
         # Do NOT strip "@bot" from the text.  The mention is a routing
         # signal (delivered structurally via callback `isInAtList`), and
         # regex-stripping @handles would collateral-damage e-mails
@@ -743,6 +768,47 @@ class DingTalkAdapter(BasePlatformAdapter):
                 if any("image" in t for t in media_types)
                 else MessageType.TEXT
             )
+
+        # Standalone file/audio/video messages: SDK leaves content in
+        # ``message.extensions['content']`` because ChatbotMessage.from_dict
+        # only knows how to parse text/picture/richText. Pull the download
+        # code (already resolved to a URL by ``_resolve_media_codes``) out
+        # so the agent can actually see the attachment.
+        if msg_type_str in ("file", "audio", "voice", "video") and not media_urls:
+            ext_content = (getattr(message, "extensions", None) or {}).get("content")
+            if isinstance(ext_content, dict):
+                url = (
+                    ext_content.get("downloadCode")
+                    or ext_content.get("download_code")
+                    or ""
+                )
+                if url:
+                    media_urls.append(url)
+                    if msg_type_str == "file":
+                        # Best-effort MIME hint based on fileType / fileName
+                        ftype = (ext_content.get("fileType") or "").lower()
+                        fname = (ext_content.get("fileName") or "").lower()
+                        if ftype in {"mp3", "wav", "m4a", "aac", "ogg"} or any(
+                            fname.endswith("." + ext)
+                            for ext in ("mp3", "wav", "m4a", "aac", "ogg")
+                        ):
+                            media_types.append("audio")
+                            msg_type = MessageType.AUDIO
+                        elif ftype in {"mp4", "mov", "avi", "mkv", "webm"} or any(
+                            fname.endswith("." + ext)
+                            for ext in ("mp4", "mov", "avi", "mkv", "webm")
+                        ):
+                            media_types.append("video")
+                            msg_type = MessageType.VIDEO
+                        else:
+                            media_types.append("application/octet-stream")
+                            msg_type = MessageType.DOCUMENT
+                    elif msg_type_str in ("audio", "voice"):
+                        media_types.append("audio")
+                        msg_type = MessageType.AUDIO
+                    elif msg_type_str == "video":
+                        media_types.append("video")
+                        msg_type = MessageType.VIDEO
 
         return msg_type, media_urls, media_types
 
@@ -1184,6 +1250,19 @@ class DingTalkAdapter(BasePlatformAdapter):
                     for key in ("downloadCode", "pictureDownloadCode", "download_code"):
                         if item.get(key):
                             codes_to_resolve.append((item, key))
+
+        # 3. Standalone file/audio/video messages — SDK parks the content
+        # dict in ``message.extensions['content']`` because its from_dict
+        # only maps text/picture/richText.
+        msg_type_str = getattr(message, "message_type", "") or ""
+        if msg_type_str in ("file", "audio", "voice", "video"):
+            ext_content = (
+                getattr(message, "extensions", None) or {}
+            ).get("content")
+            if isinstance(ext_content, dict):
+                for key in ("downloadCode", "download_code"):
+                    if ext_content.get(key):
+                        codes_to_resolve.append((ext_content, key))
 
         if not codes_to_resolve:
             return

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -421,6 +421,172 @@ class TestExtractText:
         msg.rich_text = None
         assert DingTalkAdapter._extract_text(msg) == ""
 
+    def test_file_message_returns_filename_placeholder(self):
+        """msgtype=file parks content in message.extensions per SDK design.
+
+        ``ChatbotMessage.from_dict`` in dingtalk-stream <= 0.24 only maps
+        TextContent / ImageContent / RichTextContent; any other msgtype's
+        ``content`` dict falls through to ``message.extensions['content']``.
+        We must surface the filename so downstream ``_on_message`` does not
+        discard the event as "empty".
+        """
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        msg = MagicMock()
+        msg.text = None
+        msg.rich_text_content = None
+        msg.rich_text = None
+        msg.message_type = "file"
+        msg.extensions = {
+            "content": {
+                "downloadCode": "dl-code-abc",
+                "fileName": "report.pdf",
+                "fileType": "pdf",
+            }
+        }
+        assert DingTalkAdapter._extract_text(msg) == "[文件] report.pdf"
+
+    def test_audio_message_returns_placeholder(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        msg = MagicMock()
+        msg.text = None
+        msg.rich_text_content = None
+        msg.rich_text = None
+        msg.message_type = "audio"
+        msg.extensions = {"content": {"downloadCode": "dl-code", "fileName": "voice.mp3"}}
+        assert DingTalkAdapter._extract_text(msg) == "[语音] voice.mp3"
+
+    def test_file_message_without_filename(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        msg = MagicMock()
+        msg.text = None
+        msg.rich_text_content = None
+        msg.rich_text = None
+        msg.message_type = "file"
+        msg.extensions = {"content": {"downloadCode": "dl"}}
+        assert DingTalkAdapter._extract_text(msg) == "[文件]"
+
+
+class TestExtractMedia:
+    """_extract_media must recognise standalone file/audio/video msgtypes.
+
+    DingTalk Stream Mode pushes ``msgtype=file`` / ``audio`` / ``video``
+    events for single-attachment messages. The SDK does not wrap these in
+    a dedicated Content dataclass — the payload lands in
+    ``message.extensions['content']``. Before the fix the adapter's
+    ``_extract_media`` returned ``(TEXT, [], [])`` for every such event,
+    so ``_on_message`` skipped it as "empty".
+    """
+
+    def _adapter(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        return DingTalkAdapter(PlatformConfig(enabled=True))
+
+    def test_standalone_file_msgtype_extracts_download_code(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        from gateway.platforms.base import MessageType
+
+        msg = MagicMock()
+        msg.image_content = None
+        msg.rich_text_content = None
+        msg.rich_text = None
+        msg.message_type = "file"
+        msg.extensions = {
+            "content": {
+                "downloadCode": "dl-code-abc",
+                "fileName": "report.pdf",
+                "fileType": "pdf",
+            }
+        }
+        adapter = self._adapter()
+        msg_type, urls, mimes = adapter._extract_media(msg)
+        assert msg_type == MessageType.DOCUMENT
+        assert urls == ["dl-code-abc"]
+        assert mimes == ["application/octet-stream"]
+
+    def test_standalone_file_msgtype_audio_extension_maps_to_audio(self):
+        """fileType=mp3 should classify as audio, not generic document."""
+        from gateway.platforms.base import MessageType
+
+        msg = MagicMock()
+        msg.image_content = None
+        msg.rich_text_content = None
+        msg.rich_text = None
+        msg.message_type = "file"
+        msg.extensions = {
+            "content": {
+                "downloadCode": "dl-code",
+                "fileName": "voice.mp3",
+                "fileType": "mp3",
+            }
+        }
+        adapter = self._adapter()
+        msg_type, urls, mimes = adapter._extract_media(msg)
+        assert msg_type == MessageType.AUDIO
+        assert urls == ["dl-code"]
+        assert mimes == ["audio"]
+
+    def test_standalone_audio_msgtype_extracts_url(self):
+        from gateway.platforms.base import MessageType
+
+        msg = MagicMock()
+        msg.image_content = None
+        msg.rich_text_content = None
+        msg.rich_text = None
+        msg.message_type = "audio"
+        msg.extensions = {"content": {"downloadCode": "audio-dl"}}
+        adapter = self._adapter()
+        msg_type, urls, mimes = adapter._extract_media(msg)
+        assert msg_type == MessageType.AUDIO
+        assert urls == ["audio-dl"]
+        assert mimes == ["audio"]
+
+    def test_standalone_video_msgtype_extracts_url(self):
+        from gateway.platforms.base import MessageType
+
+        msg = MagicMock()
+        msg.image_content = None
+        msg.rich_text_content = None
+        msg.rich_text = None
+        msg.message_type = "video"
+        msg.extensions = {"content": {"downloadCode": "video-dl"}}
+        adapter = self._adapter()
+        msg_type, urls, mimes = adapter._extract_media(msg)
+        assert msg_type == MessageType.VIDEO
+        assert urls == ["video-dl"]
+        assert mimes == ["video"]
+
+    def test_file_msgtype_with_empty_extensions_yields_nothing(self):
+        """Must not crash and must not fabricate media when payload is degenerate."""
+        from gateway.platforms.base import MessageType
+
+        msg = MagicMock()
+        msg.image_content = None
+        msg.rich_text_content = None
+        msg.rich_text = None
+        msg.message_type = "file"
+        msg.extensions = {}
+        adapter = self._adapter()
+        msg_type, urls, mimes = adapter._extract_media(msg)
+        assert msg_type == MessageType.TEXT
+        assert urls == []
+        assert mimes == []
+
+    def test_text_msgtype_untouched_by_file_branch(self):
+        """Pre-existing text/picture/richText behaviour must be preserved."""
+        from gateway.platforms.base import MessageType
+
+        msg = MagicMock()
+        msg.image_content = None
+        msg.rich_text_content = None
+        msg.rich_text = None
+        msg.message_type = "text"
+        msg.extensions = {}
+        adapter = self._adapter()
+        msg_type, urls, mimes = adapter._extract_media(msg)
+        assert msg_type == MessageType.TEXT
+        assert urls == []
+        assert mimes == []
+
 
 # ---------------------------------------------------------------------------
 # Group gating — require_mention + allowed_users (parity with other platforms)


### PR DESCRIPTION
## Summary

DingTalk Stream Mode pushes `msgtype=file` / `audio` / `video` callback events for single-attachment messages, but `dingtalk-stream` (through at least 0.24) only maps `text` / `picture` / `richText` inside `ChatbotMessage.from_dict` — any other msgtype's `content` dict falls through to `message.extensions['content']`. The DingTalk adapter was oblivious to that fallthrough, so **a bare file/audio/video upload from a real user was silently dropped** by the "empty message" skip inside `_on_message`, and the drop is logged at `DEBUG` (below the default INFO gateway log level) — the bug is effectively invisible from the outside.

## The fix

Three tightly-scoped touch-ups in `gateway/platforms/dingtalk.py`, all piggy-backing on the existing robot SDK download path (`RobotMessageFileDownloadRequest`). No new network calls, no SDK upgrade, no change to the adapter's public contract:

- **`_extract_text`** — fall back to `extensions['content'].fileName` when `message_type in {file, audio, voice, video}`, emitting a short `[文件] foo.pdf` / `[语音] …` / `[视频] …` placeholder. Gives the agent a non-empty prompt so `_on_message` doesn't short-circuit at its `if not text and not media_urls` gate.
- **`_extract_media`** — recognise the same four msgtypes, pull the `downloadCode` out of `extensions['content']`, map into the correct `MessageType` (`DOCUMENT` / `AUDIO` / `VIDEO`). For bare `msgtype=file`, inspect `fileType` and common filename extensions so audio/video payloads uploaded via the file attachment UI get promoted to their richer `MessageType` instead of landing as opaque blobs.
- **`_resolve_media_codes`** — feed the same `extensions['content']` downloadCode through the existing `_fetch_download_url` pipeline so URLs are resolved uniformly with image / richText media.

Pre-existing behaviour for `text` / `picture` / `richText` is untouched.

## Test plan

- [x] `python -m pytest tests/gateway/test_dingtalk.py -q` → **52 passed, 19 skipped** (9 new cases added, 0 regressions):
  - `TestExtractText::test_file_message_returns_filename_placeholder`
  - `TestExtractText::test_audio_message_returns_placeholder`
  - `TestExtractText::test_file_message_without_filename`
  - `TestExtractMedia::test_standalone_file_msgtype_extracts_download_code`
  - `TestExtractMedia::test_standalone_file_msgtype_audio_extension_maps_to_audio`
  - `TestExtractMedia::test_standalone_audio_msgtype_extracts_url`
  - `TestExtractMedia::test_standalone_video_msgtype_extracts_url`
  - `TestExtractMedia::test_file_msgtype_with_empty_extensions_yields_nothing` (degenerate payload safety)
  - `TestExtractMedia::test_text_msgtype_untouched_by_file_branch` (regression guard)
- [x] **End-to-end verified** against a production DingTalk single-chat bot. Dragging a PDF into the conversation now produces a full Thinking → AI Card stream → Done cycle:
  ```
  12:21:34  inbound  msg='[文件] 270-002(3).pdf'
  12:21:35  🤔Thinking reaction
  12:21:37  AI Card created (streaming): hermes_0ce3eac75d71
  12:21:39  response ready (5.4s, 164 chars)
  12:21:40  🥳Done reaction
  ```
  Before the fix the same payload never reached `_on_message` past the empty-text/empty-media gate, so only the Thinking reaction fired and the cycle never completed.

## Notes for reviewers

- The placeholder strings are Chinese (`[文件]` / `[语音]` / `[视频]`) because that matches DingTalk's native in-chat presentation and keeps parity with what a human would type in the same slot. Happy to switch to `[file] / [audio] / [video]` or gate on locale if the project prefers English surface strings.
- `fileType` detection for audio/video promotion is intentionally conservative (small hard-coded extension set). If `MessageType.DOCUMENT` is the more desired default regardless of extension, the promotion can be removed — the `downloadCode` still flows through either way.
- No `gateway/base.py` or cross-platform contract changes; the adapter is the only surface touched.

Made with [Cursor](https://cursor.com)