### PR TITLE
fix(agent): also send chat_template_kwargs.enable_thinking=false for llama.cpp/vLLM

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7134,17 +7134,22 @@ class AIAgent:
             options["num_ctx"] = self._ollama_num_ctx
             extra_body["options"] = options
 
-        # Ollama / custom provider: pass think=false when reasoning is disabled.
-        # Ollama does not recognise the OpenRouter-style `reasoning` extra_body
-        # field, so we use its native `think` parameter instead.
-        # This prevents thinking-capable models (Qwen3, etc.) from generating
-        # <think> blocks and producing empty-response errors when the user has
-        # set reasoning_effort: none.
+        # Custom provider: opt out of thinking when reasoning is disabled.
+        # Different OpenAI-compat backends use different field names and
+        # ignore unknown fields, so send all the common ones:
+        #   * Ollama:                   think: false
+        #   * llama.cpp / vLLM (Qwen):  chat_template_kwargs.enable_thinking: false
+        # Without this, thinking-capable models (Qwen3, etc.) emit <think>
+        # blocks and trigger llama.cpp's prefill-incompatibility 400 on the
+        # next turn (see llama.cpp tools/server/server-common.cpp).
         if self.provider == "custom" and self.reasoning_config and isinstance(self.reasoning_config, dict):
             _effort = (self.reasoning_config.get("effort") or "").strip().lower()
             _enabled = self.reasoning_config.get("enabled", True)
             if _effort == "none" or _enabled is False:
                 extra_body["think"] = False
+                _ctk = extra_body.setdefault("chat_template_kwargs", {})
+                if isinstance(_ctk, dict):
+                    _ctk["enable_thinking"] = False
 
         if self._is_qwen_portal():
             extra_body["vl_high_resolution_images"] = True

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1088,6 +1088,44 @@ class TestBuildApiKwargs:
         kwargs = agent._build_api_kwargs(messages)
         assert kwargs.get("extra_body", {}).get("think") is None
 
+    def test_custom_chat_template_kwargs_on_effort_none(self, agent):
+        """Custom provider with effort=none should also inject
+        chat_template_kwargs.enable_thinking=false (llama.cpp / vLLM)."""
+        agent.provider = "custom"
+        agent.base_url = "http://localhost:11434/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.reasoning_config = {"effort": "none"}
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        extra = kwargs.get("extra_body", {})
+        assert extra.get("think") is False
+        assert extra.get("chat_template_kwargs", {}).get("enable_thinking") is False
+
+    def test_custom_chat_template_kwargs_on_enabled_false(self, agent):
+        """Custom provider with enabled=false should also inject
+        chat_template_kwargs.enable_thinking=false."""
+        agent.provider = "custom"
+        agent.base_url = "http://localhost:11434/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.reasoning_config = {"enabled": False}
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        extra = kwargs.get("extra_body", {})
+        assert extra.get("think") is False
+        assert extra.get("chat_template_kwargs", {}).get("enable_thinking") is False
+
+    def test_custom_no_chat_template_kwargs_when_reasoning_enabled(self, agent):
+        """Custom provider with reasoning enabled should NOT inject
+        chat_template_kwargs.enable_thinking=false."""
+        agent.provider = "custom"
+        agent.base_url = "http://localhost:11434/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.reasoning_config = {"enabled": True, "effort": "medium"}
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        extra = kwargs.get("extra_body", {})
+        assert extra.get("chat_template_kwargs") is None
+
 
 
 class TestBuildAssistantMessage:


### PR DESCRIPTION
## What does this PR do?

The custom-provider thinking opt-out in `_build_api_kwargs` only sets `extra_body.think=false`, which is Ollama's field. `llama-server` and vLLM ignore `think` and look for `chat_template_kwargs.enable_thinking` instead.

Net effect: setting `agent.reasoning_effort: none` on a custom provider pointed at llama.cpp / vLLM has no effect. Thinking-capable models (Qwen3, etc.) still emit `<think>` blocks, and any subsequent assistant-prefill turn (including Hermes' own thinking-only continuation path in `run_agent.py`) hits llama.cpp's prefill-incompatibility 400:

```
HTTP 400: Assistant response prefill is incompatible with enable_thinking.
```

The fix sends both fields. Different OpenAI-compat backends use different keys and ignore unknown body fields by convention, so adding `chat_template_kwargs.enable_thinking` is additive for Ollama.

## Related Issue

No issue filed; this is a small, surgical fix to behaviour added in the same block.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `run_agent.py`: also set `extra_body["chat_template_kwargs"]["enable_thinking"] = False` when the existing custom-provider opt-out fires. Updated the surrounding comment.
- `tests/run_agent/test_run_agent.py`: 3 new tests next to the existing `test_ollama_think_*` cluster covering both the on-paths and the negative case.

## How to Test

Reproduction against llama.cpp `b8808-408225bb1` with Qwen3-14B (Bartowski GGUF):

```bash
# Without the fix: Hermes sends only think=false; llama.cpp ignores it,
# thinking stays on, prefill 400 fires on the next turn.
curl -s $LLAMA/v1/chat/completions -d '{
  "messages":[
    {"role":"user","content":"hi"},
    {"role":"assistant","content":"x"}
  ],
  "think": false,
  "chat_template_kwargs": {"enable_thinking": true}
}'
# → 400 "Assistant response prefill is incompatible with enable_thinking."

# With the fix: chat_template_kwargs.enable_thinking=false is also sent.
curl -s $LLAMA/v1/chat/completions -d '{
  ...,
  "chat_template_kwargs": {"enable_thinking": false}
}'
# → 200
```

Test suite:

```bash
pytest tests/run_agent/test_run_agent.py -k "ollama_think or chat_template_kwargs or non_custom_provider_unaffected" -q
# 6 passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow Conventional Commits (`fix(agent):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 22.04 (WSL2) + llama.cpp `b8808-408225bb1` (remote) + Qwen3-14B Q4_K_M

### Documentation & Housekeeping

- [x] N/A — no public-API or config-key changes; comment updated in-place
- [x] N/A — no cross-platform impact (pure body-shape change in HTTP client)

## Notes for reviewers

- Verified on llama.cpp + vLLM (both honour `chat_template_kwargs`).
- Not retested on Ollama with `chat_template_kwargs` co-present, but it's an unknown OpenAI-extension field so should be ignored. Happy to gate by base URL if you'd prefer a more conservative landing.
- This is adjacent to #11324 (assistant-prefill + enable_thinking conflict). That PR fixes the prefill code path for Ollama; this PR fixes the request-build path so the opt-out actually reaches llama.cpp / vLLM.
