### PR TITLE
feat(memory): add vector_hybrid provider (Qdrant/Pinecone + keyword cache + optional Honcho bridge)

### DIFF
--- a/agent/vector_hybrid/__init__.py
+++ b/agent/vector_hybrid/__init__.py
@@ -1,0 +1,15 @@
+"""Vector hybrid memory core: backends, embedding, fusion, eviction."""
+
+from agent.vector_hybrid.backend import MemoryBackend, build_memory_backend
+from agent.vector_hybrid.embedder import EmbeddingService
+from agent.vector_hybrid.eviction import evict_by_policy
+from agent.vector_hybrid.hybrid_retrieval import fuse_hybrid, keyword_score
+
+__all__ = [
+    "MemoryBackend",
+    "build_memory_backend",
+    "EmbeddingService",
+    "evict_by_policy",
+    "fuse_hybrid",
+    "keyword_score",
+]

--- a/agent/vector_hybrid/backend.py
+++ b/agent/vector_hybrid/backend.py
@@ -1,0 +1,72 @@
+"""Factory for optional vector backends."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, Protocol, runtime_checkable
+
+from agent.vector_hybrid.backends.noop import NoOpMemoryBackend
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class MemoryBackend(Protocol):
+    async def upsert(
+        self,
+        ids: list[str],
+        vectors: list[list[float]],
+        payloads: list[dict[str, Any]],
+    ) -> None: ...
+
+    async def query_vector(
+        self, vector: list[float], top_k: int
+    ) -> list[tuple[str, float, dict[str, Any]]]: ...
+
+    async def delete(self, ids: list[str]) -> None: ...
+
+
+def build_memory_backend(cfg: Dict[str, Any]) -> MemoryBackend:
+    """Return a backend from merged vector_hybrid config (no network)."""
+    raw = (cfg.get("backend") or "").strip().lower()
+    if raw in ("", "none"):
+        return NoOpMemoryBackend()  # type: ignore[return-value]
+
+    if raw == "qdrant":
+        url_env = cfg.get("qdrant_url_env") or "QDRANT_URL"
+        key_env = cfg.get("qdrant_api_key_env") or "QDRANT_API_KEY"
+        url = os.environ.get(url_env, "").strip()
+        if not url:
+            logger.warning("Qdrant selected but %s unset — using noop backend", url_env)
+            return NoOpMemoryBackend()  # type: ignore[return-value]
+        api_key = os.environ.get(key_env, "").strip() or None
+        coll = cfg.get("collection") or "hermes_memory"
+        dim = int(cfg.get("embedding_dimensions") or 1536)
+        try:
+            from agent.vector_hybrid.backends.qdrant import QdrantMemoryBackend
+
+            return QdrantMemoryBackend(url, api_key, coll, vector_size=dim)  # type: ignore[return-value]
+        except Exception as e:
+            logger.warning("Qdrant backend unavailable: %s", e)
+            return NoOpMemoryBackend()  # type: ignore[return-value]
+
+    if raw == "pinecone":
+        key_env = cfg.get("pinecone_api_key_env") or "PINECONE_API_KEY"
+        idx_env = cfg.get("pinecone_index_env") or "PINECONE_INDEX"
+        key = os.environ.get(key_env, "").strip()
+        idx = os.environ.get(idx_env, "").strip()
+        if not key or not idx:
+            logger.warning("Pinecone selected but env incomplete — noop backend")
+            return NoOpMemoryBackend()  # type: ignore[return-value]
+        ns = (cfg.get("pinecone_namespace") or "").strip()
+        try:
+            from agent.vector_hybrid.backends.pinecone import PineconeMemoryBackend
+
+            return PineconeMemoryBackend(key, idx, namespace=ns)  # type: ignore[return-value]
+        except Exception as e:
+            logger.warning("Pinecone backend unavailable: %s", e)
+            return NoOpMemoryBackend()  # type: ignore[return-value]
+
+    logger.warning("Unknown vector_hybrid.backend %r — noop", raw)
+    return NoOpMemoryBackend()  # type: ignore[return-value]

--- a/agent/vector_hybrid/backends/noop.py
+++ b/agent/vector_hybrid/backends/noop.py
@@ -1,0 +1,25 @@
+"""No-op vector backend — queries return empty (keyword path still works)."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Sequence
+
+from agent.vector_hybrid.types import VectorHit
+
+
+class NoOpMemoryBackend:
+    async def upsert(
+        self,
+        ids: Sequence[str],
+        vectors: Sequence[Sequence[float]],
+        payloads: Sequence[Dict[str, Any]],
+    ) -> None:
+        return
+
+    async def query_vector(
+        self, vector: Sequence[float], top_k: int
+    ) -> List[VectorHit]:
+        return []
+
+    async def delete(self, ids: Sequence[str]) -> None:
+        return

--- a/agent/vector_hybrid/backends/pinecone.py
+++ b/agent/vector_hybrid/backends/pinecone.py
@@ -1,0 +1,74 @@
+"""Thin Pinecone adapter (optional dependency)."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Dict, List, Sequence
+
+from agent.vector_hybrid.types import VectorHit
+
+logger = logging.getLogger(__name__)
+
+
+class PineconeMemoryBackend:
+    def __init__(
+        self,
+        api_key: str,
+        index_name: str,
+        *,
+        namespace: str = "",
+    ) -> None:
+        from pinecone import Pinecone  # type: ignore[import-untyped]
+
+        self._ns = namespace or ""
+        pc = Pinecone(api_key=api_key)
+        self._index = pc.Index(index_name)
+
+    async def upsert(
+        self,
+        ids: Sequence[str],
+        vectors: Sequence[Sequence[float]],
+        payloads: Sequence[Dict[str, Any]],
+    ) -> None:
+        rows = [
+            {"id": i, "values": list(v), "metadata": {k: str(val) for k, val in p.items()}}
+            for i, v, p in zip(ids, vectors, payloads)
+        ]
+
+        def _sync():
+            self._index.upsert(vectors=rows, namespace=self._ns)
+
+        await asyncio.to_thread(_sync)
+
+    async def query_vector(
+        self, vector: Sequence[float], top_k: int
+    ) -> List[VectorHit]:
+        def _sync():
+            return self._index.query(
+                vector=list(vector),
+                top_k=top_k,
+                namespace=self._ns,
+                include_metadata=True,
+            )
+
+        res = await asyncio.to_thread(_sync)
+        out: List[VectorHit] = []
+        raw = getattr(res, "matches", None) or (res.get("matches") if isinstance(res, dict) else None) or []
+        for m in raw:
+            if isinstance(m, dict):
+                rid = str(m.get("id", ""))
+                sc = float(m.get("score", 0.0))
+                meta = dict(m.get("metadata") or {})
+            else:
+                rid = str(getattr(m, "id", ""))
+                sc = float(getattr(m, "score", 0.0) or 0.0)
+                meta = dict(getattr(m, "metadata", None) or {})
+            out.append((rid, sc, meta))
+        return out
+
+    async def delete(self, ids: Sequence[str]) -> None:
+        def _sync():
+            self._index.delete(ids=list(ids), namespace=self._ns)
+
+        await asyncio.to_thread(_sync)

--- a/agent/vector_hybrid/backends/qdrant.py
+++ b/agent/vector_hybrid/backends/qdrant.py
@@ -1,0 +1,98 @@
+"""Thin Qdrant adapter (optional dependency)."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+from typing import Any, Dict, List, Sequence
+
+from agent.vector_hybrid.types import VectorHit
+
+logger = logging.getLogger(__name__)
+
+
+def _stable_point_id(hermes_id: str) -> int:
+    h = hashlib.sha256(hermes_id.encode()).digest()[:8]
+    return int.from_bytes(h, "big", signed=False) % (2**63 - 1)
+
+
+class QdrantMemoryBackend:
+    def __init__(
+        self,
+        url: str,
+        api_key: str | None,
+        collection: str,
+        *,
+        vector_size: int,
+    ) -> None:
+        from qdrant_client import QdrantClient  # type: ignore[import-untyped]
+        from qdrant_client.models import (  # type: ignore[import-untyped]
+            Distance,
+            PointStruct,
+            VectorParams,
+        )
+
+        self._collection = collection
+        self._client = QdrantClient(url=url, api_key=api_key or None)
+        self._PointStruct = PointStruct
+
+        try:
+            self._client.get_collection(collection_name=collection)
+        except Exception:
+            self._client.recreate_collection(
+                collection_name=collection,
+                vectors_config=VectorParams(size=vector_size, distance=Distance.COSINE),
+            )
+
+    async def upsert(
+        self,
+        ids: Sequence[str],
+        vectors: Sequence[Sequence[float]],
+        payloads: Sequence[Dict[str, Any]],
+    ) -> None:
+        pts = []
+        for hid, vec, pay in zip(ids, vectors, payloads):
+            p = dict(pay)
+            p["hermes_id"] = hid
+            pts.append(
+                self._PointStruct(id=_stable_point_id(hid), vector=list(vec), payload=p)
+            )
+
+        def _sync() -> None:
+            self._client.upsert(collection_name=self._collection, points=pts)
+
+        await asyncio.to_thread(_sync)
+
+    async def query_vector(
+        self, vector: Sequence[float], top_k: int
+    ) -> List[VectorHit]:
+        def _sync():
+            return self._client.search(
+                collection_name=self._collection,
+                query_vector=list(vector),
+                limit=top_k,
+                with_payload=True,
+            )
+
+        hits = await asyncio.to_thread(_sync)
+        out: List[VectorHit] = []
+        for h in hits:
+            payload = dict(h.payload or {})
+            rid = str(payload.get("hermes_id") or h.id)
+            sc = float(h.score or 0.0)
+            out.append((rid, sc, payload))
+        return out
+
+    async def delete(self, ids: Sequence[str]) -> None:
+        from qdrant_client.models import PointIdsList  # type: ignore[import-untyped]
+
+        int_ids = [_stable_point_id(i) for i in ids]
+
+        def _sync():
+            self._client.delete(
+                collection_name=self._collection,
+                points_selector=PointIdsList(points=int_ids),
+            )
+
+        await asyncio.to_thread(_sync)

--- a/agent/vector_hybrid/embedder.py
+++ b/agent/vector_hybrid/embedder.py
@@ -1,0 +1,88 @@
+"""OpenAI-compatible embedding HTTP client with RPS guard and FTS fallback flag."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+import urllib.error
+import urllib.request
+from typing import Any, Dict, List
+
+logger = logging.getLogger(__name__)
+
+
+class EmbeddingService:
+    """Sync embeddings; safe for MemoryProvider.prefetch (no asyncio required)."""
+
+    def __init__(self, cfg: Dict[str, Any]) -> None:
+        self._model = (cfg.get("embedding_model") or "text-embedding-3-small").strip()
+        base_env = cfg.get("embedding_api_base_env") or "OPENAI_API_BASE"
+        key_env = cfg.get("embedding_api_key_env") or "OPENAI_API_KEY"
+        self._base = os.environ.get(base_env, "").strip() or "https://api.openai.com/v1"
+        self._key = os.environ.get(key_env, "").strip()
+        self._rps = max(0.25, float(cfg.get("rate_limit_rps") or 4.0))
+        self._fallback_seconds = float(cfg.get("fallback_fts_seconds") or 90.0)
+        self._lock = threading.Lock()
+        self._next_slot = 0.0
+        self._fallback_until = 0.0
+
+    def fts_fallback_active(self) -> bool:
+        return time.monotonic() < self._fallback_until
+
+    def embed_texts(self, texts: List[str]) -> List[List[float]]:
+        """Return empty list on failure (caller uses keyword / FTS-only path)."""
+        if not texts:
+            return []
+        if not self._key:
+            self._trigger_fallback("missing embedding API key")
+            return []
+        self._throttle()
+        url = self._base.rstrip("/") + "/embeddings"
+        body = json.dumps({"model": self._model, "input": texts}).encode()
+        req = urllib.request.Request(
+            url,
+            data=body,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {self._key}",
+            },
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                payload = json.loads(resp.read().decode())
+        except urllib.error.HTTPError as e:
+            if e.code in (429, 503):
+                self._trigger_fallback(f"embedding HTTP {e.code}")
+            logger.warning("Embedding HTTP error: %s", e)
+            return []
+        except Exception as e:
+            self._trigger_fallback(str(e))
+            logger.warning("Embedding failed: %s", e)
+            return []
+
+        data = payload.get("data") or []
+        out: List[List[float]] = []
+        for item in sorted(data, key=lambda x: x.get("index", 0)):
+            vec = item.get("embedding")
+            if isinstance(vec, list):
+                out.append([float(v) for v in vec])
+        if len(out) != len(texts):
+            logger.warning("Embedding payload length mismatch")
+            return []
+        return out
+
+    def _throttle(self) -> None:
+        gap = 1.0 / self._rps
+        with self._lock:
+            now = time.monotonic()
+            if now < self._next_slot:
+                time.sleep(self._next_slot - now)
+            self._next_slot = max(self._next_slot, now) + gap
+
+    def _trigger_fallback(self, reason: str) -> None:
+        logger.info("Embedding FTS fallback: %s", reason)
+        self._fallback_until = time.monotonic() + self._fallback_seconds

--- a/agent/vector_hybrid/eviction.py
+++ b/agent/vector_hybrid/eviction.py
@@ -1,0 +1,65 @@
+"""Byte-budget eviction for hybrid memory metadata records."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, List
+
+
+def estimate_record_bytes(payload: dict[str, Any], text: str = "") -> int:
+    """Rough payload size for eviction budgeting."""
+    n = len(text.encode("utf-8"))
+    pri = payload.get("priority")
+    if pri is not None:
+        n += 8
+    la = payload.get("last_access_ts")
+    if la is not None:
+        n += 8
+    return n + 64
+
+
+def evict_by_policy(
+    records: List[tuple[str, dict[str, Any], str]],
+    *,
+    policy: str,
+    budget_bytes: int,
+    now_ts: float | None = None,
+) -> List[str]:
+    """Return IDs to delete to stay within budget_bytes (lowest priority first).
+
+    records: list of (id, payload, text_snippet)
+    policy: fifo | ttl | honcho_priority
+    """
+    if budget_bytes <= 0 or not records:
+        return []
+    now = now_ts if now_ts is not None else datetime.now(timezone.utc).timestamp()
+    sizes = [(rid, estimate_record_bytes(meta, txt), rid, meta) for rid, meta, txt in records]
+    total = sum(s[1] for s in sizes)
+    if total <= budget_bytes:
+        return []
+
+    to_remove: List[str] = []
+    # Sort order: lower priority evicted first
+    keyed: List[tuple[float, float, str]] = []
+    for rid, sz, _, meta in sizes:
+        pri = float(meta.get("priority", 0.5))
+        if policy == "honcho_priority":
+            sort_pri = pri  # higher priority keeps — evict low pri first
+            keyed.append((sort_pri, -sz, rid))
+        elif policy == "ttl":
+            age = now - float(meta.get("created_ts", now))
+            keyed.append((age, -sz, rid))  # oldest first
+        else:  # fifo
+            created = float(meta.get("created_ts", now))
+            keyed.append((created, -sz, rid))  # smallest ts evicted first
+
+    keyed.sort()
+    over = total - budget_bytes
+    acc = 0
+    for _, _, rid in keyed:
+        if acc >= over:
+            break
+        sz = next(s for s in sizes if s[2] == rid)[1]
+        to_remove.append(rid)
+        acc += sz
+    return to_remove

--- a/agent/vector_hybrid/hybrid_retrieval.py
+++ b/agent/vector_hybrid/hybrid_retrieval.py
@@ -1,0 +1,69 @@
+"""Fuse dense vector hits with keyword-cache (pseudo-FTS) scores."""
+
+from __future__ import annotations
+
+import re
+from typing import Dict, List, Sequence
+
+from agent.vector_hybrid.types import KeywordHit, VectorHit
+
+
+def _norm_scores(raw: Sequence[float]) -> List[float]:
+    if not raw:
+        return []
+    lo, hi = min(raw), max(raw)
+    if hi <= lo:
+        return [1.0 for _ in raw]
+    return [(x - lo) / (hi - lo) for x in raw]
+
+
+def _tokenize(q: str) -> set[str]:
+    return {t for t in re.split(r"\W+", q.lower()) if len(t) > 1}
+
+
+def keyword_score(query: str, text: str) -> float:
+    """Cheap overlap score in [0, 1]."""
+    qtok = _tokenize(query)
+    if not qtok:
+        return 0.0
+    ttok = _tokenize(text)
+    if not ttok:
+        return 0.0
+    inter = len(qtok & ttok)
+    return inter / max(len(qtok), 1)
+
+
+def fuse_hybrid(
+    query: str,
+    vec_hits: List[VectorHit],
+    kw_hits: List[KeywordHit],
+    *,
+    alpha: float,
+    max_chunks: int,
+) -> List[tuple[str, float, str]]:
+    """Blend vector and keyword lists; return (id, fused_score, text).
+
+    alpha weights dense similarity vs keyword score after normalization.
+    """
+    scores: Dict[str, tuple[float, str]] = {}
+    vec_ids = [h[0] for h in vec_hits]
+    vec_vals = [h[1] for h in vec_hits]
+    vec_norm = _norm_scores(vec_vals)
+    for i, hid in enumerate(vec_ids):
+        payload = vec_hits[i][2]
+        text = str(payload.get("text", ""))
+        scores[hid] = (alpha * vec_norm[i], text)
+
+    kw_vals = [h[2] for h in kw_hits]
+    kw_norm = _norm_scores(kw_vals)
+    for i, kh in enumerate(kw_hits):
+        hid, txt, _ = kh
+        dense = scores.get(hid, (0.0, txt))[0]
+        merged = dense + (1.0 - alpha) * kw_norm[i]
+        scores[hid] = (merged, txt or scores.get(hid, ("", txt))[1])
+
+    ranked = sorted(scores.items(), key=lambda x: -x[1][0])
+    out: List[tuple[str, float, str]] = []
+    for hid, (sc, txt) in ranked[:max_chunks]:
+        out.append((hid, sc, txt))
+    return out

--- a/agent/vector_hybrid/types.py
+++ b/agent/vector_hybrid/types.py
@@ -1,0 +1,10 @@
+"""Shared types for vector hybrid memory (dimension-agnostic vectors)."""
+
+from __future__ import annotations
+
+from typing import Any, List, Tuple
+
+# (id, score, payload dict)
+VectorHit = Tuple[str, float, dict[str, Any]]
+# (id, text, keyword_score)
+KeywordHit = Tuple[str, str, float]

--- a/plugins/memory/vector_hybrid/README.md
+++ b/plugins/memory/vector_hybrid/README.md
@@ -1,0 +1,8 @@
+# vector_hybrid memory provider
+
+Select with `memory.provider: vector_hybrid` in `config.yaml`.
+
+Configure backends and embeddings under `memory.vector_hybrid` (see defaults in `hermes_cli/config.py`).
+
+- Only one external memory provider may be active; use this provider alone, or enable `honcho_bridge` for optional dialectic snippets (requires Honcho credentials).
+- Optional extras: `hermes-agent[vector-qdrant]`, `hermes-agent[vector-pinecone]`.

--- a/plugins/memory/vector_hybrid/__init__.py
+++ b/plugins/memory/vector_hybrid/__init__.py
@@ -1,0 +1,9 @@
+"""Vector hybrid memory plugin registration."""
+
+from __future__ import annotations
+
+from plugins.memory.vector_hybrid.provider import VectorHybridMemoryProvider
+
+
+def register(ctx: object) -> None:
+    ctx.register_memory_provider(VectorHybridMemoryProvider())

--- a/plugins/memory/vector_hybrid/async_util.py
+++ b/plugins/memory/vector_hybrid/async_util.py
@@ -1,0 +1,37 @@
+"""Dedicated asyncio loop for optional async vector backends."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Any, Coroutine, TypeVar
+
+_T = TypeVar("_T")
+
+_loop: asyncio.AbstractEventLoop | None = None
+_loop_thread: threading.Thread | None = None
+_loop_lock = threading.Lock()
+
+
+def _ensure_loop() -> asyncio.AbstractEventLoop:
+    global _loop, _loop_thread
+    with _loop_lock:
+        if _loop is not None and _loop.is_running():
+            return _loop
+        _loop = asyncio.new_event_loop()
+
+        def _run() -> None:
+            asyncio.set_event_loop(_loop)
+            assert _loop is not None
+            _loop.run_forever()
+
+        _loop_thread = threading.Thread(target=_run, daemon=True, name="vector-hybrid-loop")
+        _loop_thread.start()
+        return _loop
+
+
+def run_async(coro: Coroutine[Any, Any, _T], *, timeout: float = 120.0) -> _T:
+    """Run *coro* on the shared loop from a sync caller."""
+    loop = _ensure_loop()
+    fut = asyncio.run_coroutine_threadsafe(coro, loop)
+    return fut.result(timeout=timeout)

--- a/plugins/memory/vector_hybrid/honcho_bridge.py
+++ b/plugins/memory/vector_hybrid/honcho_bridge.py
@@ -1,0 +1,69 @@
+"""Optional Honcho dialectic snippet for VectorHybrid prefetch (composition)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class HonchoDialecticBridge:
+    """Best-effort dialectic line via HonchoSessionManager (same SDK as honcho plugin)."""
+
+    def __init__(self, enabled: bool) -> None:
+        self._enabled = enabled
+        self._manager = None
+        self._session_key = ""
+        self._logged_skip = False
+
+    def setup(self, session_id: str, **kwargs: Any) -> None:
+        if not self._enabled:
+            return
+        try:
+            from plugins.memory.honcho.client import HonchoClientConfig, get_honcho_client
+            from plugins.memory.honcho.session import HonchoSessionManager
+
+            cfg = HonchoClientConfig.from_global_config()
+            if not cfg.enabled or not (cfg.api_key or cfg.base_url):
+                return
+            client = get_honcho_client(cfg)
+            self._manager = HonchoSessionManager(
+                honcho=client,
+                config=cfg,
+                context_tokens=cfg.context_tokens,
+            )
+            title = kwargs.get("session_title")
+            gsk = kwargs.get("gateway_session_key")
+            self._session_key = (
+                cfg.resolve_session_name(
+                    session_title=title,
+                    session_id=session_id,
+                    gateway_session_key=gsk,
+                )
+                or session_id
+                or "hermes-default"
+            )
+            self._manager.get_or_create(self._session_key)
+        except Exception as e:
+            if not self._logged_skip:
+                logger.debug("Honcho dialectic bridge unavailable: %s", e)
+                self._logged_skip = True
+
+    def dialectic_nudge(self, query: str, *, max_chars: int = 600) -> str:
+        if not self._enabled or not self._manager or not self._session_key:
+            return ""
+        q = (query or "").strip()
+        if not q:
+            return ""
+        try:
+            out = self._manager.dialectic_query(self._session_key, q[:2000])
+            if not out:
+                return ""
+            out = out.strip()
+            if len(out) > max_chars:
+                out = out[:max_chars].rsplit(" ", 1)[0] + " …"
+            return out
+        except Exception as e:
+            logger.debug("Dialectic nudge failed (non-fatal): %s", e)
+            return ""

--- a/plugins/memory/vector_hybrid/plugin.yaml
+++ b/plugins/memory/vector_hybrid/plugin.yaml
@@ -1,0 +1,6 @@
+name: vector_hybrid
+description: >-
+  Hybrid vector (Qdrant/Pinecone) + keyword-cache recall with optional Honcho dialectic bridge.
+version: "1.0.0"
+author: Hermes Agent contributors
+license: Apache-2.0

--- a/plugins/memory/vector_hybrid/prefetch_fmt.py
+++ b/plugins/memory/vector_hybrid/prefetch_fmt.py
@@ -1,0 +1,42 @@
+"""Format hybrid recall block for system prompt injection."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from agent.vector_hybrid import fuse_hybrid, keyword_score
+
+from plugins.memory.vector_hybrid.honcho_bridge import HonchoDialecticBridge
+
+
+def format_hybrid_prefetch(
+    *,
+    query: str,
+    cfg: Dict[str, Any],
+    vec_hits: List[tuple[str, float, dict[str, Any]]],
+    kw_map: Dict[str, tuple[str, dict[str, Any]]],
+    bridge: Optional[HonchoDialecticBridge],
+) -> str:
+    cap = int(cfg.get("prefetch_char_cap") or 3500)
+    alpha = float(cfg.get("hybrid_alpha") or 0.65)
+    fts_scope = (cfg.get("fts_scope") or "keyword_cache").strip()
+    kw_hits: List[tuple[str, str, float]] = []
+    if fts_scope != "none":
+        for cid, (txt, _) in kw_map.items():
+            sc = keyword_score(query, txt)
+            if sc > 0.02:
+                kw_hits.append((cid, txt, sc))
+    fused = fuse_hybrid(query, vec_hits, kw_hits, alpha=alpha, max_chunks=12)
+    lines = []
+    for hid, _sc, txt in fused[:8]:
+        snippet = (txt or "").strip().replace("\n", " ")
+        if snippet:
+            lines.append(f"- ({hid[:8]}…) {snippet[:320]}")
+    block = "[vector_hybrid recall]\n" + "\n".join(lines) if lines else ""
+    if bridge:
+        nudge = bridge.dialectic_nudge(query)
+        if nudge:
+            block += ("\n\n[dialectic nudge]\n" + nudge)[: max(1, cap // 4)]
+    if len(block) > cap:
+        block = block[:cap].rsplit("\n", 1)[0] + "\n…"
+    return block

--- a/plugins/memory/vector_hybrid/provider.py
+++ b/plugins/memory/vector_hybrid/provider.py
@@ -1,0 +1,173 @@
+"""VectorHybrid MemoryProvider — dense index + keyword cache + optional Honcho nudge."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import time
+from typing import Any, Dict, List
+
+from agent.memory_provider import MemoryProvider
+from agent.vector_hybrid import EmbeddingService, build_memory_backend
+from plugins.memory.vector_hybrid.async_util import run_async
+from plugins.memory.vector_hybrid.honcho_bridge import HonchoDialecticBridge
+from plugins.memory.vector_hybrid.prefetch_fmt import format_hybrid_prefetch
+from tools.registry import tool_error
+
+logger = logging.getLogger(__name__)
+
+SEARCH_SCHEMA = {
+    "name": "vector_hybrid_search",
+    "description": (
+        "Search hybrid vector + keyword memory indexed for this Hermes session."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Natural language query."},
+        },
+        "required": ["query"],
+    },
+}
+
+
+class VectorHybridMemoryProvider(MemoryProvider):
+    def __init__(self) -> None:
+        self._cfg: Dict[str, Any] = {}
+        self._backend = None
+        self._embedder: EmbeddingService | None = None
+        self._bridge: HonchoDialecticBridge | None = None
+        self._cron_skip = False
+        self._kw: Dict[str, tuple[str, dict[str, Any]]] = {}
+        self._session_id = ""
+
+    @property
+    def name(self) -> str:
+        return "vector_hybrid"
+
+    def is_available(self) -> bool:
+        """True when noop / keyword path is usable or backend env vars are set."""
+        try:
+            import os
+
+            from hermes_cli.config import load_config
+
+            vh = (load_config().get("memory") or {}).get("vector_hybrid") or {}
+            b = (vh.get("backend") or "").strip().lower()
+            if b in ("", "none"):
+                return True
+            if b == "qdrant":
+                envk = vh.get("qdrant_url_env") or "QDRANT_URL"
+                return bool(os.environ.get(envk, "").strip())
+            if b == "pinecone":
+                pk = vh.get("pinecone_api_key_env") or "PINECONE_API_KEY"
+                pi = vh.get("pinecone_index_env") or "PINECONE_INDEX"
+                return bool(os.environ.get(pk, "").strip() and os.environ.get(pi, "").strip())
+            return False
+        except Exception:
+            return False
+
+    def initialize(self, session_id: str, **kwargs: Any) -> None:
+        self._session_id = session_id
+        ctx = kwargs.get("agent_context", "")
+        plat = kwargs.get("platform", "")
+        if ctx in ("cron", "flush") or plat == "cron":
+            self._cron_skip = True
+            logger.debug("vector_hybrid skipped (cron/flush)")
+            return
+
+        from hermes_cli.config import load_config
+
+        merged = load_config().get("memory") or {}
+        self._cfg = dict(merged.get("vector_hybrid") or {})
+
+        self._backend = build_memory_backend(self._cfg)
+        self._embedder = EmbeddingService(self._cfg)
+        self._bridge = HonchoDialecticBridge(bool(self._cfg.get("honcho_bridge")))
+        if self._bridge:
+            self._bridge.setup(session_id, **kwargs)
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        if self._cron_skip or not query.strip():
+            return ""
+        vec_hits: List[tuple[str, float, dict[str, Any]]] = []
+        emb: List[List[float]] = []
+        if self._embedder and not self._embedder.fts_fallback_active():
+            emb = self._embedder.embed_texts([query.strip()])
+        if emb and self._backend:
+            try:
+                vec_hits = run_async(
+                    self._backend.query_vector(emb[0], top_k=10),
+                    timeout=60,
+                )
+            except Exception as e:
+                logger.debug("Vector query failed (fallback to keywords): %s", e)
+
+        return format_hybrid_prefetch(
+            query=query,
+            cfg=self._cfg,
+            vec_hits=vec_hits,
+            kw_map=self._kw,
+            bridge=self._bridge,
+        )
+
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+        if self._cron_skip or not self._backend or not self._embedder:
+            return
+        blob = (user_content + "\n---\n" + assistant_content).strip()
+        if not blob:
+            return
+        tid = hashlib.sha256(blob.encode()).hexdigest()[:20]
+        now = time.time()
+        meta = {"created_ts": now, "priority": 0.35, "text": blob[:1200]}
+        self._kw[tid] = (blob[:8000], meta)
+
+        vecs = self._embedder.embed_texts([blob[:4000]])
+        if not vecs:
+            return
+        try:
+            run_async(
+                self._backend.upsert([tid], vecs, [meta]),
+                timeout=120,
+            )
+        except Exception as e:
+            logger.debug("vector_hybrid upsert skipped: %s", e)
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return [SEARCH_SCHEMA]
+
+    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs: Any) -> str:
+        if tool_name != "vector_hybrid_search":
+            raise NotImplementedError(tool_name)
+        q = (args.get("query") or "").strip()
+        if not q:
+            return tool_error("query required")
+        body = self.prefetch(q, session_id=str(kwargs.get("session_id", "")))
+        return json.dumps({"ok": True, "context": body})
+
+    def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
+        if self._cron_skip or not self._backend or not self._embedder:
+            return
+        parts: List[str] = []
+        for m in messages[-40:]:
+            role = m.get("role", "")
+            content = str(m.get("content", ""))[:4000]
+            if content.strip():
+                parts.append(f"{role}: {content}")
+        blob = "\n".join(parts)[:16000]
+        if len(blob) < 40:
+            return
+        sid = hashlib.sha256(blob.encode()).hexdigest()[:24]
+        now = time.time()
+        meta = {"created_ts": now, "priority": 0.9, "text": blob[:2000], "kind": "session_summary"}
+        vecs = self._embedder.embed_texts([blob[:6000]])
+        if not vecs:
+            return
+        try:
+            run_async(self._backend.upsert([sid], vecs, [meta]), timeout=180)
+        except Exception as e:
+            logger.debug("session summary upsert skipped: %s", e)
+
+    def shutdown(self) -> None:
+        self._kw.clear()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,8 @@ pty = [
   "pywinpty>=2.0.0,<3; sys_platform == 'win32'",
 ]
 honcho = ["honcho-ai>=2.0.1,<3"]
+vector-qdrant = ["qdrant-client>=1.12.0,<2"]
+vector-pinecone = ["pinecone-client>=5.0.0,<8"]
 mcp = ["mcp>=1.2.0,<2"]
 homeassistant = ["aiohttp>=3.9.0,<4"]
 sms = ["aiohttp>=3.9.0,<4"]

--- a/tests/plugins/memory/test_vector_hybrid_provider.py
+++ b/tests/plugins/memory/test_vector_hybrid_provider.py
@@ -1,0 +1,81 @@
+"""Tests for vector_hybrid memory provider and hybrid retrieval helpers."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.vector_hybrid.eviction import estimate_record_bytes, evict_by_policy
+from agent.vector_hybrid.hybrid_retrieval import fuse_hybrid, keyword_score
+from plugins.memory.vector_hybrid.provider import VectorHybridMemoryProvider
+
+
+def test_keyword_score_basic():
+    assert keyword_score("hello world", "hello there world") > 0.2
+
+
+def test_fuse_hybrid_vec_and_kw():
+    vec = [("a", 0.9, {"text": "alpha"}), ("b", 0.5, {"text": "beta"})]
+    kw = [("a", "alpha soup", 0.4)]
+    out = fuse_hybrid("alpha", vec, kw, alpha=0.6, max_chunks=5)
+    assert len(out) >= 1
+    assert out[0][0] == "a"
+
+
+def test_evict_fifo_orders_oldest():
+    now = 1_700_000_000.0
+    recs = [
+        ("x", {"created_ts": now - 100, "priority": 0.5}, "a"),
+        ("y", {"created_ts": now - 10, "priority": 0.5}, "b"),
+    ]
+    total = sum(estimate_record_bytes(m, t) for _, m, t in recs)
+    victim = evict_by_policy(
+        [(rid, m, t) for rid, m, t in recs],
+        policy="fifo",
+        budget_bytes=total // 2,
+        now_ts=now,
+    )
+    assert "x" in victim
+
+
+def test_provider_available_noop_backend(monkeypatch):
+    monkeypatch.setenv("QDRANT_URL", "")
+    monkeypatch.setenv("PINECONE_API_KEY", "")
+    with patch("hermes_cli.config.load_config") as lc:
+        lc.return_value = {
+            "memory": {
+                "vector_hybrid": {"backend": ""},
+            }
+        }
+        p = VectorHybridMemoryProvider()
+        assert p.is_available() is True
+
+
+def test_prefetch_keyword_fallback(monkeypatch):
+    p = VectorHybridMemoryProvider()
+    p._cron_skip = False
+    p._cfg = {"prefetch_char_cap": 2000, "hybrid_alpha": 0.5, "fts_scope": "keyword_cache"}
+    p._backend = MagicMock()
+    p._embedder = MagicMock()
+    p._embedder.fts_fallback_active.return_value = True
+    p._embedder.embed_texts.return_value = []
+    p._bridge = None
+    p._kw = {"id1": ("python asyncio testing", {"created_ts": 1.0})}
+    out = p.prefetch("async python")
+    assert "vector_hybrid recall" in out or "async" in out.lower()
+
+
+def test_tool_search_json():
+    p = VectorHybridMemoryProvider()
+    p._cron_skip = False
+    p._cfg = {"prefetch_char_cap": 500, "hybrid_alpha": 0.5, "fts_scope": "keyword_cache"}
+    p._backend = None
+    p._embedder = MagicMock()
+    p._embedder.fts_fallback_active.return_value = True
+    p._embedder.embed_texts.return_value = []
+    p._kw = {}
+    raw = p.handle_tool_call("vector_hybrid_search", {"query": "hi"}, session_id="s")
+    data = json.loads(raw)
+    assert data.get("ok") is True


### PR DESCRIPTION
## Summary

Adds a new bundled memory provider `vector_hybrid` that combines optional **Qdrant** or **Pinecone** vector search with an in-process **keyword cache** (pseudo-FTS), **OpenAI-compatible** `/embeddings` with RPS throttling, and automatic **keyword-only fallback** when embedding calls fail or rate limits apply. Optional **Honcho dialectic** snippets can be enabled via `memory.vector_hybrid.honcho_bridge` (composition inside this provider, not a second external memory slot).

## Why

- Pluggable vector backends behind a small `MemoryBackend` abstraction (`agent/vector_hybrid/`).
- Hybrid recall merges dense hits with keyword overlap scoring for better robustness when embeddings are unavailable.
- Keeps alignment with existing `MemoryProvider` lifecycle (`prefetch`, `sync_turn`, `on_session_end`) and gateway resilience (Honcho failures are non-fatal).

## Configuration

- Set `memory.provider: vector_hybrid`.
- Tune under `memory.vector_hybrid` (defaults in `hermes_cli/config.py`): `backend`, `collection`, env-backed URL/key keys, `embedding_*`, `hybrid_alpha`, `fts_scope`, `honcho_bridge`, etc.

Optional installs:

- `pip install hermes-agent[vector-qdrant]`
- `pip install hermes-agent[vector-pinecone]`

## Limitations / notes

- Only **one** external memory provider may be active at a time (`MemoryManager`). Users choose either standalone Honcho **or** `vector_hybrid` (with optional internal Honcho bridge).

## Testing

- `pytest tests/plugins/memory/test_vector_hybrid_provider.py -q -o addopts=`
- `pytest tests/agent/test_memory_provider.py -q -o addopts=`

## Docs

- Developer guide + user-facing memory providers updated for `vector_hybrid`.