### PR TITLE
feat: harden quiet CLI output for automation

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10300,6 +10300,8 @@ def main(
     query: str = None,
     q: str = None,
     image: str = None,
+    output_format: str = "text",
+    include_metadata: bool = False,
     toolsets: str = None,
     skills: str | list[str] | tuple[str, ...] = None,
     model: str = None,
@@ -10326,6 +10328,8 @@ def main(
         query: Single query to execute (then exit). Alias: -q
         q: Shorthand for --query
         image: Optional local image path to attach to a single query
+        output_format: Output format for quiet single-query mode (text or json)
+        include_metadata: Include extra metadata in quiet JSON output
         toolsets: Comma-separated list of toolsets to enable (e.g., "web,terminal")
         skills: Comma-separated or repeated list of skills to preload for the session
         model: Model to use (default: anthropic/claude-opus-4-20250514)
@@ -10507,6 +10511,18 @@ def main(
     except Exception:
         pass  # signal handler may fail in restricted environments
     
+    if output_format not in ("text", "json"):
+        raise ValueError(f"Unsupported output format: {output_format}")
+
+    if output_format == "json" and not (query or image):
+        raise ValueError("--format json is only supported for single-query mode")
+
+    if output_format == "json" and not quiet:
+        raise ValueError("--format json requires --quiet")
+
+    if include_metadata and output_format != "json":
+        raise ValueError("--include-metadata requires --format json")
+
     # Handle single query mode
     if query or image:
         query, single_query_images = _collect_query_images(query, image)
@@ -10533,23 +10549,50 @@ def main(
                 ):
                     cli.agent.quiet_mode = True
                     cli.agent.suppress_status_output = True
-                    # Suppress streaming display callbacks so stdout stays
-                    # machine-readable (no styled "Hermes" box, no tool-gen
-                    # status lines).  The response is printed once below.
-                    cli.agent.stream_delta_callback = None
-                    cli.agent.tool_gen_callback = None
+                    # Single-query quiet mode has no prompt_toolkit TUI app.
+                    # If streaming callbacks remain attached here, streamed deltas
+                    # can render the full answer once and the explicit final print
+                    # below renders it again, causing duplicate output.
+                    if getattr(cli, "_app", None) is None:
+                        cli.agent.stream_delta_callback = None
+                        cli.agent.tool_gen_callback = None
                     result = cli.agent.run_conversation(
                         user_message=effective_query,
                         conversation_history=cli.conversation_history,
                     )
                     response = result.get("final_response", "") if isinstance(result, dict) else str(result)
-                    if response:
-                        print(response)
-                    # Session ID goes to stderr so piped stdout is clean.
-                    print(f"\nsession_id: {cli.session_id}", file=sys.stderr)
-                    
+                    error_detail = None
+                    if isinstance(result, dict) and result.get("failed") and not response:
+                        error_detail = result.get("error", "Unknown error")
+                        response = f"Error: {error_detail}"
+                    elif isinstance(result, dict) and result.get("failed"):
+                        error_detail = result.get("error")
+
+                    failed = bool(isinstance(result, dict) and result.get("failed"))
+                    if output_format == "json":
+                        payload = {
+                            "ok": not failed,
+                            "response": response,
+                            "session_id": cli.session_id,
+                        }
+                        if error_detail:
+                            payload["error"] = error_detail
+                        if include_metadata:
+                            payload["metadata"] = {
+                                "format": output_format,
+                                "failed": failed,
+                                "model": turn_route.get("model"),
+                                "provider": turn_route.get("runtime", {}).get("provider") or getattr(cli, "provider", None),
+                            }
+                        sys.stdout.write(json.dumps(payload, ensure_ascii=False) + "\n")
+                    else:
+                        if response:
+                            sys.stdout.write(response.rstrip("\n") + "\n")
+                        sys.stdout.write(f"session_id: {cli.session_id}\n")
+                    sys.stdout.flush()
+
                     # Ensure proper exit code for automation wrappers
-                    sys.exit(1 if isinstance(result, dict) and result.get("failed") else 0)
+                    sys.exit(1 if failed else 0)
             
             # Exit with error code if credentials or agent init fails
             sys.exit(1)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1116,6 +1116,8 @@ def cmd_chat(args):
         "skills": getattr(args, "skills", None),
         "verbose": args.verbose,
         "quiet": getattr(args, "quiet", False),
+        "output_format": getattr(args, "format", None),
+        "include_metadata": getattr(args, "include_metadata", False),
         "query": args.query,
         "image": getattr(args, "image", None),
         "resume": getattr(args, "resume", None),
@@ -6439,14 +6441,24 @@ For more help on a command:
         "-v", "--verbose", action="store_true", help="Verbose output"
     )
     chat_parser.add_argument(
-        "-Q",
-        "--quiet",
+        "-Q", "--quiet",
         action="store_true",
-        help="Quiet mode for programmatic use: suppress banner, spinner, and tool previews. Only output the final response and session info.",
+        help="Quiet mode for programmatic use: suppress banner, spinner, and tool previews. Only output the final response and session info."
     )
     chat_parser.add_argument(
-        "--resume",
-        "-r",
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format for single-query quiet mode (default: text)"
+    )
+    chat_parser.add_argument(
+        "--include-metadata",
+        action="store_true",
+        default=False,
+        help="Include extra metadata fields in --format json output"
+    )
+    chat_parser.add_argument(
+        "--resume", "-r",
         metavar="SESSION_ID",
         default=argparse.SUPPRESS,
         help="Resume a previous session by ID (shown on exit)",

--- a/tests/cli/test_cli_single_query_quiet.py
+++ b/tests/cli/test_cli_single_query_quiet.py
@@ -1,0 +1,197 @@
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+class _FakeAgent:
+    def __init__(self, result=None):
+        self.quiet_mode = False
+        self.suppress_status_output = False
+        self.stream_delta_callback = object()
+        self.tool_gen_callback = object()
+        self.calls = []
+        self.result = result or {"final_response": "hello once", "failed": False}
+
+    def run_conversation(self, user_message, conversation_history):
+        self.calls.append(
+            {
+                "user_message": user_message,
+                "conversation_history": conversation_history,
+            }
+        )
+        return self.result
+
+
+class _FakeCLI:
+    def __init__(self, result=None):
+        self._app = None
+        self._result = result
+        self.agent = _FakeAgent(result=result)
+        self.session_id = "sess_test"
+        self.conversation_history = []
+        self.tool_progress_mode = "all"
+        self._active_agent_route_signature = None
+        self.provider = "openai-codex"
+
+    def _ensure_runtime_credentials(self):
+        return True
+
+    def _preprocess_images_with_vision(self, query, images, announce=False):
+        return query
+
+    def _resolve_turn_agent_config(self, effective_query):
+        return {
+            "signature": ("sig",),
+            "model": "gpt-5.4",
+            "runtime": {"provider": "openai-codex"},
+            "label": "default",
+            "request_overrides": None,
+        }
+
+    def _init_agent(self, **kwargs):
+        if self.agent is None:
+            self.agent = _FakeAgent(result=self._result)
+        return True
+
+
+def test_quiet_single_query_disables_stream_callbacks_and_prints_once(monkeypatch, capsys):
+    import cli as cli_module
+
+    fake_cli = _FakeCLI()
+    monkeypatch.setattr(cli_module, "HermesCLI", lambda *args, **kwargs: fake_cli)
+    monkeypatch.setattr(cli_module, "_collect_query_images", lambda query, image: (query, []))
+
+    with pytest.raises(SystemExit) as exc:
+        cli_module.main(query="test", quiet=True)
+
+    assert exc.value.code == 0
+    assert fake_cli.agent.stream_delta_callback is None
+    assert fake_cli.agent.tool_gen_callback is None
+    assert fake_cli.agent.calls == [
+        {
+            "user_message": "test",
+            "conversation_history": [],
+        }
+    ]
+
+    out = capsys.readouterr().out
+    assert out == "hello once\nsession_id: sess_test\n"
+
+
+def test_quiet_single_query_failed_result_is_single_block_and_exit_1(monkeypatch, capsys):
+    import cli as cli_module
+
+    fake_cli = _FakeCLI(result={"final_response": "Error: boom", "failed": True})
+    monkeypatch.setattr(cli_module, "HermesCLI", lambda *args, **kwargs: fake_cli)
+    monkeypatch.setattr(cli_module, "_collect_query_images", lambda query, image: (query, []))
+
+    with pytest.raises(SystemExit) as exc:
+        cli_module.main(query="test", quiet=True)
+
+    assert exc.value.code == 1
+    out = capsys.readouterr().out
+    assert out == "Error: boom\nsession_id: sess_test\n"
+
+
+def test_quiet_single_query_failed_result_without_final_response_uses_error_field(monkeypatch, capsys):
+    import cli as cli_module
+
+    fake_cli = _FakeCLI(result={"failed": True, "error": "rate limited"})
+    monkeypatch.setattr(cli_module, "HermesCLI", lambda *args, **kwargs: fake_cli)
+    monkeypatch.setattr(cli_module, "_collect_query_images", lambda query, image: (query, []))
+
+    with pytest.raises(SystemExit) as exc:
+        cli_module.main(query="test", quiet=True)
+
+    assert exc.value.code == 1
+    out = capsys.readouterr().out
+    assert out == "Error: rate limited\nsession_id: sess_test\n"
+
+
+def test_quiet_single_query_json_success(monkeypatch, capsys):
+    import cli as cli_module
+
+    fake_cli = _FakeCLI()
+    monkeypatch.setattr(cli_module, "HermesCLI", lambda *args, **kwargs: fake_cli)
+    monkeypatch.setattr(cli_module, "_collect_query_images", lambda query, image: (query, []))
+
+    with pytest.raises(SystemExit) as exc:
+        cli_module.main(query="test", quiet=True, output_format="json")
+
+    assert exc.value.code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {
+        "ok": True,
+        "response": "hello once",
+        "session_id": "sess_test",
+    }
+
+
+def test_quiet_single_query_json_failure(monkeypatch, capsys):
+    import cli as cli_module
+
+    fake_cli = _FakeCLI(result={"failed": True, "error": "rate limited"})
+    monkeypatch.setattr(cli_module, "HermesCLI", lambda *args, **kwargs: fake_cli)
+    monkeypatch.setattr(cli_module, "_collect_query_images", lambda query, image: (query, []))
+
+    with pytest.raises(SystemExit) as exc:
+        cli_module.main(query="test", quiet=True, output_format="json")
+
+    assert exc.value.code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {
+        "ok": False,
+        "response": "Error: rate limited",
+        "session_id": "sess_test",
+        "error": "rate limited",
+    }
+
+
+def test_quiet_single_query_json_with_metadata(monkeypatch, capsys):
+    import cli as cli_module
+
+    fake_cli = _FakeCLI()
+    monkeypatch.setattr(cli_module, "HermesCLI", lambda *args, **kwargs: fake_cli)
+    monkeypatch.setattr(cli_module, "_collect_query_images", lambda query, image: (query, []))
+
+    with pytest.raises(SystemExit) as exc:
+        cli_module.main(query="test", quiet=True, output_format="json", include_metadata=True)
+
+    assert exc.value.code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {
+        "ok": True,
+        "response": "hello once",
+        "session_id": "sess_test",
+        "metadata": {
+            "format": "json",
+            "failed": False,
+            "model": "gpt-5.4",
+            "provider": "openai-codex",
+        },
+    }
+
+
+def test_json_format_requires_quiet(monkeypatch):
+    import cli as cli_module
+
+    fake_cli = _FakeCLI()
+    monkeypatch.setattr(cli_module, "HermesCLI", lambda *args, **kwargs: fake_cli)
+
+    with pytest.raises(ValueError, match="requires --quiet"):
+        cli_module.main(query="test", quiet=False, output_format="json")
+
+
+def test_include_metadata_requires_json(monkeypatch):
+    import cli as cli_module
+
+    fake_cli = _FakeCLI()
+    monkeypatch.setattr(cli_module, "HermesCLI", lambda *args, **kwargs: fake_cli)
+
+    with pytest.raises(ValueError, match="requires --format json"):
+        cli_module.main(query="test", quiet=True, output_format="text", include_metadata=True)
+
+
+import pytest

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -86,6 +86,8 @@ Common options:
 | `-s`, `--skills <name>` | Preload one or more skills for the session (can be repeated or comma-separated). |
 | `-v`, `--verbose` | Verbose output. |
 | `-Q`, `--quiet` | Programmatic mode: suppress banner/spinner/tool previews. |
+| `--format <text\|json>` | Output format for quiet single-query mode. `json` requires `--quiet` and `-q/--query`. |
+| `--include-metadata` | Include extra metadata in `--format json` output. |
 | `--image <path>` | Attach a local image to a single query. |
 | `--resume <session>` / `--continue [name]` | Resume a session directly from `chat`. |
 | `--worktree` | Create an isolated git worktree for this run. |
@@ -102,9 +104,18 @@ hermes
 hermes chat -q "Summarize the latest PRs"
 hermes chat --provider openrouter --model anthropic/claude-sonnet-4.6
 hermes chat --toolsets web,terminal,skills
-hermes chat --quiet -q "Return only JSON"
+hermes chat --quiet -q "Return only the answer text"
+hermes chat --quiet --format json -q "Return the answer as structured output"
+hermes chat --quiet --format json --include-metadata -q "Return JSON plus metadata"
 hermes chat --worktree -q "Review this repo and open a PR"
 ```
+
+Quiet single-query output contracts:
+
+- `--quiet` text mode prints the final response followed by `session_id: <id>` on the next line, with no blank spacer line.
+- `--quiet --format json` prints exactly one JSON object with at least `ok`, `response`, and `session_id`.
+- `--include-metadata` adds a `metadata` object to quiet JSON output.
+- When the run fails and no final response exists, Hermes synthesizes `Error: ...` from the internal error and exits non-zero.
 
 ## `hermes model`
 

--- a/website/docs/reference/release-notes.md
+++ b/website/docs/reference/release-notes.md
@@ -1,0 +1,63 @@
+---
+title: Release Notes
+---
+
+# Release Notes
+
+## 2026-04-19 — Quiet single-query output hardening
+
+Hermes CLI single-query mode (`hermes chat -q ...`) got a programmatic output cleanup focused on automation wrappers and shell integrations.
+
+What changed:
+
+- Fixed duplicate final answers in `--quiet` mode when non-interactive streaming callbacks were still attached.
+- Tightened quiet text output so it prints:
+  1. the final response
+  2. `session_id: <id>` on the next line
+  3. no blank spacer line between them
+- Added `--format json` for quiet single-query mode.
+- Added `--include-metadata` for quiet JSON output when wrappers want a small structured metadata block.
+- Standardized failure output so Hermes emits `Error: ...` even when the underlying run failed without a populated `final_response`.
+
+Examples:
+
+```bash
+# Stable text output
+hermes chat -q "2+2は？" --quiet
+
+# Stable JSON output
+hermes chat -q "2+2は？" --quiet --format json
+
+# Stable JSON output with metadata
+hermes chat -q "2+2は？" --quiet --format json --include-metadata
+```
+
+JSON contract:
+
+```json
+{"ok": true, "response": "4", "session_id": "20260419_135733_e10f98"}
+```
+
+JSON + metadata contract:
+
+```json
+{"ok": true, "response": "4", "session_id": "20260419_135733_e10f98", "metadata": {"format": "json", "failed": false, "model": "gpt-5.4", "provider": "openai-codex"}}
+```
+
+Failure contract:
+
+```json
+{"ok": false, "response": "Error: rate limited", "session_id": "...", "error": "rate limited"}
+```
+
+Constraints:
+
+- `--format json` is supported only for quiet single-query mode.
+- `--include-metadata` requires `--format json`.
+- Using `--format json` without `--quiet` returns a CLI error instead of mixing human and machine-oriented output.
+
+Verification:
+
+- CLI help updated to show `--format {text,json}` and `--include-metadata`
+- Quiet text/json tests added and passing
+- Real command smoke tests run for both text and JSON output

--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -386,12 +386,24 @@ Background sessions do not appear in your main conversation history. They are st
 
 ## Quiet Mode
 
-By default, the CLI runs in quiet mode which:
-- Suppresses verbose logging from tools
-- Enables kawaii-style animated feedback
-- Keeps output clean and user-friendly
+Interactive Hermes is not "quiet" by default. `--quiet` is a programmatic single-query mode for scripts, wrappers, and other tools that need stable stdout.
 
-For debug output:
+Use it like this:
+
+```bash
+hermes chat -q "2+2は？" --quiet
+hermes chat -q "Summarize this as JSON" --quiet --format json
+hermes chat -q "Summarize this as JSON with metadata" --quiet --format json --include-metadata
+```
+
+Output contracts:
+
+- text mode (`--quiet`) prints the final response, then `session_id: <id>` on the next line
+- json mode (`--quiet --format json`) prints exactly one JSON object
+- `--include-metadata` adds a `metadata` object to JSON output
+- `--format json` requires both `--quiet` and single-query mode (`-q/--query`)
+
+For debug output in normal interactive use:
 ```bash
 hermes chat --verbose
 ```


### PR DESCRIPTION
## Summary
- fix duplicate final output in quiet single-query mode
- add `--format json` and `--include-metadata` for machine-readable CLI output
- standardize quiet text/error/session_id contracts and document them
- add regression tests plus a release-notes entry

## Test Plan
- [x] ~/.hermes/hermes-agent/venv/bin/python -m pytest tests/cli/test_cli_single_query_quiet.py tests/cli/test_cli_init.py -q
- [x] hermes chat -q "2+2は？" --quiet
- [x] hermes chat -q "2+2は？" --quiet --format json
- [x] hermes chat -q "2+2は？" --quiet --format json --include-metadata

## Notes
- `--format json` is intentionally limited to quiet single-query mode.
- `--include-metadata` is intentionally limited to JSON output to keep text-mode automation simple.