### PR TITLE
fix(mcp): reap stdio subprocesses in _run_stdio finally block

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -962,25 +962,33 @@ class MCPServerTask:
 
         # Snapshot child PIDs before spawning so we can track the new one.
         pids_before = _snapshot_child_pids()
-        async with stdio_client(server_params) as (read_stream, write_stream):
-            # Capture the newly spawned subprocess PID for force-kill cleanup.
-            new_pids = _snapshot_child_pids() - pids_before
+        new_pids: set = set()
+        try:
+            async with stdio_client(server_params) as (read_stream, write_stream):
+                # Capture the newly spawned subprocess PID for force-kill cleanup.
+                new_pids = _snapshot_child_pids() - pids_before
+                if new_pids:
+                    with _lock:
+                        _stdio_pids.update(new_pids)
+                async with ClientSession(read_stream, write_stream, **sampling_kwargs) as session:
+                    await session.initialize()
+                    self.session = session
+                    await self._discover_tools()
+                    self._ready.set()
+                    # stdio transport does not use OAuth, but we still honor
+                    # _reconnect_event (e.g. future manual /mcp refresh) for
+                    # consistency with _run_http.
+                    await self._wait_for_lifecycle_event()
+        finally:
+            # Defense: stdio_client's anyio cleanup does not always reap the
+            # subprocess on exception paths (stdin pipe stays open → child
+            # blocks on read). Over long uptimes with transient MCP errors,
+            # each reconnect in run()'s outer loop would otherwise leak one
+            # subprocess. Explicitly reap tracked PIDs here.
             if new_pids:
+                await _reap_pids(new_pids, grace=1.5)
                 with _lock:
-                    _stdio_pids.update(new_pids)
-            async with ClientSession(read_stream, write_stream, **sampling_kwargs) as session:
-                await session.initialize()
-                self.session = session
-                await self._discover_tools()
-                self._ready.set()
-                # stdio transport does not use OAuth, but we still honor
-                # _reconnect_event (e.g. future manual /mcp refresh) for
-                # consistency with _run_http.
-                await self._wait_for_lifecycle_event()
-        # Context exited cleanly — subprocess was terminated by the SDK.
-        if new_pids:
-            with _lock:
-                _stdio_pids.difference_update(new_pids)
+                    _stdio_pids.difference_update(new_pids)
 
     async def _run_http(self, config: dict):
         """Run the server using HTTP/StreamableHTTP transport."""
@@ -2552,6 +2560,47 @@ def shutdown_mcp_servers():
             logger.debug("Error during MCP shutdown: %s", exc)
 
     _stop_mcp_loop()
+
+
+def _pid_alive(pid: int) -> bool:
+    """Return True if the process is still running (signal 0 probe)."""
+    try:
+        os.kill(pid, 0)
+        return True
+    except (ProcessLookupError, PermissionError):
+        return False
+    except OSError:
+        return False
+
+
+async def _reap_pids(pids: set, grace: float = 1.5) -> None:
+    """SIGTERM tracked PIDs, wait up to ``grace`` seconds, then SIGKILL stragglers.
+
+    Called from ``_run_stdio``'s finally block so stdio-MCP subprocesses that
+    the SDK failed to reap (e.g. on anyio cancel-scope error paths) do not
+    accumulate across reconnects.
+    """
+    import signal as _signal
+
+    for pid in pids:
+        try:
+            os.kill(pid, _signal.SIGTERM)
+        except (ProcessLookupError, PermissionError, OSError):
+            pass
+
+    deadline = time.monotonic() + grace
+    while time.monotonic() < deadline:
+        if not any(_pid_alive(p) for p in pids):
+            return
+        await asyncio.sleep(0.1)
+
+    for pid in pids:
+        if _pid_alive(pid):
+            try:
+                os.kill(pid, getattr(_signal, "SIGKILL", _signal.SIGTERM))
+                logger.debug("Force-killed leaked MCP stdio process %d", pid)
+            except (ProcessLookupError, PermissionError, OSError):
+                pass
 
 
 def _kill_orphaned_mcp_children() -> None:


### PR DESCRIPTION
Closes #11202.

## Summary

`_run_stdio` in `tools/mcp_tool.py` relies on `stdio_client(...)`'s `__aexit__` (anyio-backed) to reap the MCP subprocess. On exception paths (transient read/decode error, timeout, etc.) anyio's cancel-scope cleanup does not always close the subprocess's stdin pipe, leaving the child blocked on `read` indefinitely.

`MCPServerTask.run()`'s outer reconnect loop (mcp_tool.py:1113–1200) then catches the exception, sleeps, and re-enters `_run_stdio` — spawning a fresh subprocess. The previously tracked PID stays in `_stdio_pids` but nothing reaps it until full gateway shutdown. `_kill_orphaned_mcp_children()` only fires from `_stop_mcp_loop()`, not on per-server reconnect.

Net effect: on a stable gateway PID (no `--replace`, no reload), subprocess count grows roughly linearly with uptime × transient-error rate. Field report in #11202 shows 28 orphans in ~1 day, all blocked on `read` of stdin, one reaching 300 MiB RSS.

## Change

- Wrap the `async with stdio_client(...)` block in `_run_stdio` with `try/finally`.
- In the finally, explicitly reap the tracked PID set: `SIGTERM` → up to 1.5 s grace → `SIGKILL` stragglers.
- Add two small helpers alongside `_kill_orphaned_mcp_children`:
  - `_pid_alive(pid)` — `kill(pid, 0)` probe
  - `_reap_pids(pids, grace)` — async SIGTERM/grace/SIGKILL

HTTP transport is untouched. `_kill_orphaned_mcp_children` still handles the full-gateway-shutdown path.

## Why in-tool instead of upstream SDK

Fixing `stdio_client`'s anyio cleanup belongs in the MCP Python SDK, but:

1. Hermes already tracks PIDs for force-kill (`_stdio_pids`), so the information needed to reap is already on hand.
2. This pattern gives Hermes a floor of correctness that doesn't depend on SDK version pinning.
3. Even after an SDK fix ships, this stays useful as defense-in-depth.

## Test plan

- [ ] `python -m pytest tests/tools/test_mcp_tool.py -x`
- [ ] Manual: induce a reconnect storm with a stdio MCP server that rejects the second `initialize` call, confirm child count stays flat via `ps --ppid $GATEWAY_PID | grep stdio-mcp | wc -l`.
- [ ] Sanity: clean shutdown via `SIGTERM` to gateway still reaps children (should, since `__aexit__` path now has belt-and-suspenders).
