### PR TITLE
fix(status): treat empty sudo env as enabled

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -295,7 +295,9 @@ def show_status(args):
         print(f"  Daytona Image: {daytona_image}")
     
     sudo_password = os.getenv("SUDO_PASSWORD", "")
-    print(f"  Sudo:         {check_mark(bool(sudo_password))} {'enabled' if sudo_password else 'disabled'}")
+    sudo_configured = "SUDO_PASSWORD" in os.environ
+    sudo_enabled = bool(sudo_password) or sudo_configured
+    print(f"  Sudo:         {check_mark(sudo_enabled)} {'enabled' if sudo_enabled else 'disabled'}")
     
     # =========================================================================
     # Messaging Platforms

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -42,3 +42,14 @@ def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys,
     assert "Manager:      Termux / manual process" in output
     assert "Start with:   hermes gateway" in output
     assert "systemd (user)" not in output
+
+
+def test_show_status_treats_empty_sudo_password_env_as_configured(monkeypatch, capsys, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("SUDO_PASSWORD", "")
+
+    show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert "Sudo:         " in output
+    assert "enabled" in output


### PR DESCRIPTION
## Summary
- treat the presence of `SUDO_PASSWORD` as a configured sudo path in `hermes status`
- keep empty-string `SUDO_PASSWORD=` deployments from being shown as disabled
- add a regression test for the empty-string environment case

## Why
Some deployments intentionally set `SUDO_PASSWORD=` while relying on passwordless sudo and `sudo -n`. In that configuration, terminal execution works, but `hermes status` currently reports `Sudo: disabled` because it only checks whether the value is non-empty.

## Testing
- `python3 -m pytest -o addopts= tests/hermes_cli/test_status.py -q`