### PR TITLE
fix: SSH ControlMaster socket path exceeds macOS limit with IPv6 hosts

### DIFF
--- a/tests/tools/test_ssh_environment.py
+++ b/tests/tools/test_ssh_environment.py
@@ -33,6 +33,61 @@ def _cleanup(task_id="ssh_test"):
     cleanup_vm(task_id)
 
 
+class TestSocketPathLength:
+    """Regression test for #11840: socket path must fit within macOS's 104-char limit."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_connection(self, monkeypatch):
+        monkeypatch.setattr("tools.environments.ssh.subprocess.run",
+                            lambda *a, **k: subprocess.CompletedProcess([], 0))
+        monkeypatch.setattr("tools.environments.ssh.subprocess.Popen",
+                            lambda *a, **k: MagicMock(stdout=iter([]),
+                                                      stderr=iter([]),
+                                                      stdin=MagicMock()))
+        monkeypatch.setattr("tools.environments.base.time.sleep", lambda _: None)
+
+    def test_ipv6_socket_path_under_macos_limit(self, monkeypatch):
+        """IPv6 hosts must not generate socket paths exceeding macOS's 104-char limit."""
+        # macOS temp dir can be long: /var/folders/xx/.../T/
+        long_temp = "/var/folders/2t/wbkw5yb158jc3zhswgl7tz9c0000gn/T"
+        monkeypatch.setattr("tools.environments.ssh.tempfile.gettempdir", lambda: long_temp)
+
+        # IPv6 address from the original bug report
+        ipv6_host = "9373:9b91:4480:558d:708e:e601:24e8:d8d0"
+        env = SSHEnvironment(host=ipv6_host, user="user", port=22)
+
+        socket_path = str(env.control_socket)
+        # macOS's sun_path limit is 104 chars (including null terminator)
+        assert len(socket_path) < 104, f"Socket path too long: {socket_path} ({len(socket_path)} chars)"
+
+    def test_ipv4_socket_path_under_macos_limit(self, monkeypatch):
+        """IPv4 hosts should also generate short socket paths."""
+        long_temp = "/var/folders/2t/wbkw5yb158jc3zhswgl7tz9c0000gn/T"
+        monkeypatch.setattr("tools.environments.ssh.tempfile.gettempdir", lambda: long_temp)
+
+        env = SSHEnvironment(host="192.168.1.1", user="user", port=22)
+        socket_path = str(env.control_socket)
+        assert len(socket_path) < 104, f"Socket path too long: {socket_path} ({len(socket_path)} chars)"
+
+    def test_socket_path_is_deterministic(self, monkeypatch):
+        """Same connection params should always generate the same socket path."""
+        monkeypatch.setattr("tools.environments.ssh.tempfile.gettempdir", lambda: "/tmp")
+
+        env1 = SSHEnvironment(host="example.com", user="alice", port=22)
+        env2 = SSHEnvironment(host="example.com", user="alice", port=22)
+
+        assert env1.control_socket == env2.control_socket
+
+    def test_different_hosts_have_different_sockets(self, monkeypatch):
+        """Different hosts should have different socket paths."""
+        monkeypatch.setattr("tools.environments.ssh.tempfile.gettempdir", lambda: "/tmp")
+
+        env1 = SSHEnvironment(host="host1.com", user="alice", port=22)
+        env2 = SSHEnvironment(host="host2.com", user="alice", port=22)
+
+        assert env1.control_socket != env2.control_socket
+
+
 class TestBuildSSHCommand:
 
     @pytest.fixture(autouse=True)

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -1,5 +1,6 @@
 """SSH remote execution environment with ControlMaster connection persistence."""
 
+import hashlib
 import logging
 import os
 import shlex
@@ -47,7 +48,10 @@ class SSHEnvironment(BaseEnvironment):
 
         self.control_dir = Path(tempfile.gettempdir()) / "hermes-ssh"
         self.control_dir.mkdir(parents=True, exist_ok=True)
-        self.control_socket = self.control_dir / f"{user}@{host}:{port}.sock"
+        # Use a hash-based socket name to avoid macOS's 104-char Unix socket path limit
+        # when connecting to IPv6 hosts (e.g., "user@9373:9b91:...:d8d0:22.sock" is too long)
+        socket_id = hashlib.sha256(f"{user}@{host}:{port}".encode()).hexdigest()[:12]
+        self.control_socket = self.control_dir / f"{socket_id}.sock"
         _ensure_ssh_available()
         self._establish_connection()
         self._remote_home = self._detect_remote_home()


### PR DESCRIPTION
## What broke
On macOS, Unix domain socket paths are limited to 104 characters. When connecting to an SSH host via IPv6, the ControlMaster socket path exceeded this limit, causing all terminal/file operations to fail immediately.

## Root cause
The socket path embedded the full host address literally, which exceeded macOS 104-char limit for IPv6 addresses.

## Why this fix is minimal
- Single import added (hashlib)
- Two-line change to use 12-char SHA256 hash instead of literal address
- Socket path stays under 77 chars even with longest macOS temp dir

## What I tested
- Old IPv6 path: 112 chars (exceeds limit)
- New IPv6 path: 77 chars (within limit)
- Added regression tests for socket path length and determinism

Fixes #11840