### PR TITLE
fix(tui): visual-row Up/Down navigation and cross-newline Left/Right in the input area

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8866,24 +8866,16 @@ class HermesCLI:
             self._close_model_picker()
             event.app.current_buffer.reset()
             event.app.invalidate()
-
-        # --- History navigation: up/down browse history in normal input mode ---
-        # The TextArea is multiline, so by default up/down only move the cursor.
-        # Buffer.auto_up/auto_down handle both: cursor movement when multi-line,
-        # history browsing when on the first/last line (or single-line input).
+        # --- History navigation: Up/Down in normal input mode ---
+        # prompt_toolkit's auto_up/auto_down only check hard newlines (\n), so
+        # they treat a long soft-wrapped line as a single text row and immediately
+        # step to history on the first Up keypress, even when the cursor is
+        # not at the first text row of the prompt.  The render_info-aware
+        # smart Up/Down bindings are registered below, after input_area is
+        # created, so that input_area.window.render_info is accessible.
         _normal_input = Condition(
             lambda: not self._clarify_state and not self._approval_state and not self._sudo_state and not self._secret_state and not self._model_picker_state
         )
-
-        @kb.add('up', filter=_normal_input)
-        def history_up(event):
-            """Up arrow: browse history when on first line, else move cursor up."""
-            event.app.current_buffer.auto_up(count=event.arg)
-
-        @kb.add('down', filter=_normal_input)
-        def history_down(event):
-            """Down arrow: browse history when on last line, else move cursor down."""
-            event.app.current_buffer.auto_down(count=event.arg)
 
         @kb.add('c-c')
         def handle_ctrl_c(event):
@@ -9771,6 +9763,161 @@ class HermesCLI:
 
         # Allow wrapper CLIs to register extra keybindings.
         self._register_extra_tui_keybindings(kb, input_area=input_area)
+
+        # --- Smart Up/Down/Left/Right: visual-row navigation in the input area ---
+        #
+        # prompt_toolkit's auto_up/auto_down use document.cursor_position_row,
+        # which counts only hard newlines (\n). On a long soft-wrapped prompt
+        # with no hard newlines, cursor_position_row is always 0, so auto_up
+        # immediately steps to history instead of moving the cursor up one visual
+        # row. The bindings below fix this by computing cursor movement from the
+        # rendered screen layout.
+        #
+        # smart_right/smart_left replace the default bindings so that the cursor
+        # can cross hard-newline boundaries; next/previous word already did
+        # this correctly, by the way.
+        #
+        # input_area must be in scope here so that input_area.window.render_info
+        # is accessible at key-press time (render_info is None before first render).
+
+        def _get_window_width() -> tuple[int, int]:
+            """Return (window_width, prompt_width) for the input area.
+
+            window_width is the full content-area width reported by
+            prompt_toolkit (terminal columns minus any left/right margins).
+            prompt_width is the display width of the prompt prefix (e.g. "› ")
+            which BeforeInput prepends only to the first visual row of the
+            first logical line.
+
+            The first visual row therefore holds window_width - prompt_width
+            buffer characters; every other visual row holds window_width."""
+            from prompt_toolkit.utils import get_cwidth
+            info = input_area.window.render_info
+            if info is not None and info.window_width > 0:
+                win_w = info.window_width
+            else:
+                try:
+                    cols = shutil.get_terminal_size((80, 24)).columns
+                except Exception:
+                    cols = 80
+                win_w = max(1, cols)
+            try:
+                prompt_w = get_cwidth(self._get_tui_prompt_text())
+            except Exception:
+                prompt_w = 2
+            return win_w, max(0, prompt_w)
+
+        def _visual_move(buf, direction: int) -> bool:
+            """Move the cursor up (direction=-1) or down (direction=+1) by one
+            visual row within the soft-wrapped, possibly multi-line input.
+
+            Each visual row is represented as (row_start, row_end, loglineno)
+            where row_start/row_end are buffer indices (row_end exclusive of
+            the trailing newline) and loglineno is the logical line index.
+
+            History recall is triggered by loglineno:
+              UP:   return False when loglineno == 0 (on the first logical line)
+              DOWN: return False when loglineno == max_logical_lines
+
+            The prompt prefix occupies prompt_w screen columns on visual row 0
+            only, so hpos is adjusted when crossing the row-0 / row-1 boundary.
+            """
+            win_w, prompt_w = _get_window_width()
+            pos = buf.cursor_position
+            text = buf.text
+            logical_lines = text.split('\n')
+            max_logical_lines = len(logical_lines) - 1  # 0-based index of last
+
+            # Build list of visual rows: (row_start, row_end, loglineno)
+            rows = []
+            char_idx = 0
+            for loglineno, line in enumerate(logical_lines):
+                first_row_w = (win_w - prompt_w) if loglineno == 0 else win_w
+                first_row_w = max(1, first_row_w)
+                line_start = char_idx
+                line_len = len(line)
+                if line_len == 0:
+                    rows.append((line_start, line_start, loglineno))
+                else:
+                    offset = 0
+                    while offset < line_len:
+                        rw = first_row_w if offset == 0 else win_w
+                        r_start = line_start + offset
+                        r_end = min(r_start + rw, line_start + line_len)
+                        rows.append((r_start, r_end, loglineno))
+                        offset += rw
+                char_idx += line_len + 1  # +1 for the '\n'
+
+            # Find the visual row the cursor is currently on.
+            cur_row_idx = len(rows) - 1
+            for i, (r_start, r_end, _) in enumerate(rows):
+                if r_start <= pos <= r_end:
+                    cur_row_idx = i
+                    break
+
+            r_start, r_end, loglineno = rows[cur_row_idx]
+            hpos = pos - r_start  # horizontal position within current visual row
+
+            if direction == -1:  # UP
+                # History recall when on the first logical line.
+                if loglineno == 0 and cur_row_idx == 0:
+                    return False
+                if cur_row_idx == 0:
+                    # Shouldn't happen (loglineno > 0 but cur_row_idx == 0),
+                    # but guard anyway.
+                    return False
+                prev_start, prev_end, prev_loglineno = rows[cur_row_idx - 1]
+                # Crossing from visual row 1 to visual row 0: subtract prompt_w
+                # because visual row 0 has the prompt prefix.
+                target_hpos = max(0, hpos - prompt_w) if cur_row_idx == 1 else hpos
+                buf.cursor_position = prev_start + min(target_hpos, prev_end - prev_start)
+                return True
+            else:  # DOWN
+                # History recall when on the last logical line.
+                if loglineno == max_logical_lines and cur_row_idx == len(rows) - 1:
+                    return False
+                if cur_row_idx == len(rows) - 1:
+                    return False
+                next_start, next_end, next_loglineno = rows[cur_row_idx + 1]
+                # Crossing from visual row 0 to visual row 1: add prompt_w.
+                target_hpos = (hpos + prompt_w) if cur_row_idx == 0 else hpos
+                buf.cursor_position = next_start + min(target_hpos, next_end - next_start)
+                return True
+
+        @kb.add('up', filter=_normal_input, eager=True)
+        def smart_up(event):
+            """Move cursor up one visual row within the soft-wrapped input, or
+            step to the previous history entry when already on the first visual
+            row.  The unsubmitted draft is preserved in prompt_toolkit's
+            working_index and is restored when stepping back down past the most
+            recent entry."""
+            if not _visual_move(event.app.current_buffer, -1):
+                event.app.current_buffer.history_backward(count=event.arg)
+
+        @kb.add('down', filter=_normal_input, eager=True)
+        def smart_down(event):
+            """Move cursor down one visual row within the soft-wrapped input,
+            or step to the next history entry when already on the last visual
+            row.  At the most recent entry the unsubmitted draft is
+            automatically restored."""
+            buf = event.app.current_buffer
+            if not _visual_move(buf, +1):
+                buf.history_forward(count=event.arg)
+                buf.cursor_position = len(buf.text)
+
+        @kb.add('right', filter=_normal_input, eager=True)
+        def smart_right(event):
+            """Right arrow: move one character right, crossing hard newlines."""
+            buf = event.app.current_buffer
+            if buf.cursor_position < len(buf.text):
+                buf.cursor_position += 1
+
+        @kb.add('left', filter=_normal_input, eager=True)
+        def smart_left(event):
+            """Left arrow: move one character left, crossing hard newlines."""
+            buf = event.app.current_buffer
+            if buf.cursor_position > 0:
+                buf.cursor_position -= 1
 
         # Layout: interactive prompt widgets + ruled input at bottom.
         # The sudo, approval, and clarify widgets appear above the input when


### PR DESCRIPTION
## What does this PR do?

I tend to write long prompts for the LLM, and using Hermes Agent was frustrating
because I couldn't move the cursor freely within the input area. I found that the
TUI area is a multiline `TextArea` with soft-wrap enabled.

The previous `Up`/`Down` bindings called `Buffer.auto_up()` / `Buffer.auto_down()`,
which use `document.cursor_position_row` to decide whether to move the cursor or
step to history. `cursor_position_row` counts only hard newlines (`\n`), so on a
long soft-wrapped prompt with no hard newlines it is always `0`. As a result,
pressing `Up` on any row of a wrapped prompt immediately stepped to history instead
of moving the cursor up one visual row. Other AI CLIs — notably Gemini CLI —
handle this correctly.

Additionally, `Right`/`Left` arrow stopped at hard-newline boundaries because
`get_cursor_right_position` / `get_cursor_left_position` are clamped to the
current logical line.

## Related Issue

No existing issue found — this PR is the first report of this bug.

## Type of Change

- ✅ 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

Replace the four affected bindings with `smart_up`, `smart_down`, `smart_right`,
and `smart_left`. All additions are in one contiguous block in `cli.py`; nothing
else in the codebase is touched. The core logic to review is `_visual_move`
(~50 lines of code, excluding comments).

**`_visual_move`** builds a list of visual rows from the buffer text, using
`render_info.window_width` for the wrap width and `_get_tui_prompt_text()` for
the prompt prefix width (the `BeforeInput` processor shifts the first visual row
right by `prompt_w` columns, so the first row holds `window_width - prompt_w`
buffer characters while all subsequent rows hold `window_width`). It then:

1. Locates the cursor's current visual row and horizontal position (`hpos`).
2. Moves to the adjacent visual row at the same `hpos`, clamped to that row's
   length.
3. Adjusts `hpos` by `±prompt_w` when crossing the visual-row-0 / visual-row-1
   boundary to keep the screen column consistent.
4. Returns `False` (triggering history recall) only when the cursor is on the
   first visual row of the first logical line (Up) or the last visual row of the
   last logical line (Down).

**`smart_right` / `smart_left`** are one-liners that increment/decrement
`buf.cursor_position` with a bounds check, allowing the cursor to cross hard
newlines naturally.

### Smart Up/Down Arrow Navigation in the Prompt Input Area — Behavior Table

| Key | Cursor position | Action |
|-----|-----------------|--------|
| ↑ Up | NOT on the first text row<br>(or text rows are scrolled above) | Move cursor up one text row |
| ↑ Up | On the first text row,<br>nothing scrolled above | Step to previous history entry<br>(draft preserved) |
| ↓ Down | NOT on the last text row<br>(or text rows are scrolled below) | Move cursor down one text row |
| ↓ Down | On the last text row,<br>nothing scrolled below | Step to next history entry<br>(last entry: restore draft) |

*Note: When stepping to history, the user's unsubmitted draft is automatically
preserved in `prompt_toolkit`'s `working_index` and is restored when stepping
back down past the most recent entry. This matches the behavior of `fish`, `zsh`,
and Gemini CLI.*

| File | Removed | Added |
|------|---------|-------|
| `cli.py` | 15 lines | 159 lines |

## How to Test

1. Start the CLI: `python cli.py`
2. Type a long prompt that soft-wraps across at least 3 visual rows (do not press Enter).
3. Press **Up**. The cursor should move up one visual row within your draft.
4. Press **Up** until the cursor is on the first visual row.
5. Press **Up** again. The prompt should step to the previous history entry.
6. Press **Down**. Your unsubmitted draft should be restored exactly as you left it.
7. Type a prompt with a hard newline (Ctrl+J), then use **Right**/**Left** to confirm the cursor crosses the newline boundary.

## Checklist

### Code

- ✅ I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- ✅ My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- ✅ I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- ✅ My PR contains **only** changes related to this fix (no unrelated commits)
- ✅ I've run `pytest tests/ -q` and all tests pass
- ⬜ I've added tests for my changes — the fix is in interactive TUI key bindings; automated testing requires a running terminal emulator and is not covered by the existing `pytest` suite
- ✅ I've tested on my platform: macOS

### Documentation & Housekeeping

- ✅ I've updated relevant documentation — N/A (no public API or config change)
- ✅ I've updated `cli-config.yaml.example` — N/A
- ✅ I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- ✅ I've considered cross-platform impact — the fix relies purely on `prompt_toolkit`'s `WindowRenderInfo` and `buf.cursor_position`, which are platform-independent
- ✅ I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

Platform tested on: macOS (should work identically on Linux as it relies purely
on `prompt_toolkit`'s internal `WindowRenderInfo`).

<!-- Add screenshots here once captured -->
