### PR TITLE
feat(orchestration): DAG TaskGraph + delegate bridge + A2A bus + reflex hints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,7 +137,8 @@ py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajector
 hermes_cli = ["web_dist/**/*"]
 
 [tool.setuptools.packages.find]
-include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "acp_adapter", "plugins", "plugins.*"]
+where = [".", "src"]
+include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "acp_adapter", "plugins", "plugins.*", "orchestration"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -316,7 +316,8 @@ hermes-acp = "acp_adapter.entry:main"
 py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_bootstrap", "hermes_constants", "hermes_state", "hermes_time", "hermes_logging", "utils", "mcp_serve"]
 
 [tool.setuptools.packages.find]
-include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "hermes_cli.*", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "cron.*", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*"]
+where = [".", "src"]
+include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "hermes_cli.*", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "cron.*", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*", "orchestration"]
 
 [tool.setuptools.package-data]
 # gateway/assets/ ships status_phrases.yaml and the Telegram BotFather
@@ -328,6 +329,7 @@ gateway = ["assets/**/*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["src"]
 markers = [
     "integration: marks tests requiring external services (API keys, Modal, etc.)",
     "real_concurrent_gate: opt out of the autouse stub that disables _detect_concurrent_hermes_instances",

--- a/src/orchestration/__init__.py
+++ b/src/orchestration/__init__.py
@@ -1,0 +1,22 @@
+"""Hermes native multi-agent orchestration (DAG + delegation + A2A bus)."""
+
+from orchestration.agent_bus import AgentCommunicationBus, AgentMessage
+from orchestration.learning import load_recent_hints, record_failure
+from orchestration.multi_agent_orchestrator import MultiAgentOrchestrator
+from orchestration.registry import OrchestratorRegistry
+from orchestration.task_graph import TaskGraph, topo_sort
+from orchestration.types import GraphTaskRun, GraphTaskSpec, TaskStatus
+
+__all__ = [
+    "AgentCommunicationBus",
+    "AgentMessage",
+    "GraphTaskRun",
+    "GraphTaskSpec",
+    "MultiAgentOrchestrator",
+    "OrchestratorRegistry",
+    "TaskGraph",
+    "TaskStatus",
+    "load_recent_hints",
+    "record_failure",
+    "topo_sort",
+]

--- a/src/orchestration/agent_bus.py
+++ b/src/orchestration/agent_bus.py
@@ -1,0 +1,65 @@
+"""In-process Agent-to-Agent message bus (async queue)."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+
+
+@dataclass(frozen=True)
+class AgentMessage:
+    """Single A2A envelope (tool-call shaped payloads allowed)."""
+
+    kind: str
+    from_agent: str
+    to_agent: str
+    payload: Dict[str, Any] = field(default_factory=dict)
+    correlation_id: Optional[str] = None
+
+
+class AgentCommunicationBus:
+    """Lightweight pub/sub bus for sandboxed subagents in one process."""
+
+    def __init__(self) -> None:
+        self._queues: Dict[str, asyncio.Queue[AgentMessage]] = {}
+        self._lock = asyncio.Lock()
+
+    async def ensure_peer(self, agent_id: str) -> None:
+        async with self._lock:
+            if agent_id not in self._queues:
+                self._queues[agent_id] = asyncio.Queue()
+
+    async def publish(self, msg: AgentMessage) -> None:
+        await self.ensure_peer(msg.to_agent)
+        await self._queues[msg.to_agent].put(msg)
+
+    async def drain_for(
+        self,
+        agent_id: str,
+        *,
+        max_messages: int = 32,
+    ) -> list[AgentMessage]:
+        await self.ensure_peer(agent_id)
+        q = self._queues[agent_id]
+        out: list[AgentMessage] = []
+        for _ in range(max_messages):
+            try:
+                out.append(q.get_nowait())
+            except asyncio.QueueEmpty:
+                break
+        return out
+
+    def broadcast_tool_hint(
+        self,
+        *,
+        from_agent: str,
+        tool_name: str,
+        args_preview: str,
+    ) -> AgentMessage:
+        return AgentMessage(
+            kind="tool.hint",
+            from_agent=from_agent,
+            to_agent="*",
+            payload={"tool": tool_name, "preview": args_preview},
+        )

--- a/src/orchestration/delegate_runner.py
+++ b/src/orchestration/delegate_runner.py
@@ -1,0 +1,81 @@
+"""Bridge DAG nodes to Hermes delegate_task (thread offload)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from contextlib import contextmanager
+from typing import Any, Iterator, Mapping, Optional
+
+from orchestration.honcho_context import honcho_memory_preamble, optional_honcho_env_patch
+from orchestration.types import GraphTaskSpec
+
+
+@contextmanager
+def _temporary_environ(updates: Mapping[str, str]) -> Iterator[None]:
+    previous: dict[str, Optional[str]] = {}
+    try:
+        for key, val in updates.items():
+            previous[key] = os.environ.get(key)
+            os.environ[key] = val
+        yield
+    finally:
+        for key, old in previous.items():
+            if old is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = old
+
+
+def _sync_delegate(
+    parent_agent: Any,
+    spec: GraphTaskSpec,
+    *,
+    orch_id: str,
+) -> dict[str, Any]:
+    from tools.delegate_tool import delegate_task
+
+    honcho_block = honcho_memory_preamble(orch_id=orch_id, role=f"worker-{spec.task_id}")
+    merged_ctx = "\n\n".join(
+        x for x in (spec.context, honcho_block) if x and str(x).strip()
+    )
+
+    env_updates = dict(spec.profile_env or {})
+    env_updates.update(optional_honcho_env_patch())
+
+    with _temporary_environ(env_updates):
+        raw = delegate_task(
+            goal=spec.goal,
+            context=merged_ctx or None,
+            toolsets=list(spec.toolsets) if spec.toolsets else None,
+            parent_agent=parent_agent,
+        )
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return {"ok": False, "raw": raw}
+    results = payload.get("results") if isinstance(payload, dict) else None
+    if not results:
+        return {"ok": False, "payload": payload}
+    first = results[0]
+    status = first.get("status")
+    ok = status == "completed"
+    return {
+        "ok": ok,
+        "status": status,
+        "summary": first.get("summary"),
+        "error": first.get("error"),
+        "payload": payload,
+    }
+
+
+async def run_delegate_node(
+    parent_agent: Any,
+    spec: GraphTaskSpec,
+    *,
+    orch_id: str,
+) -> dict[str, Any]:
+    """Execute a single DAG node via delegate_task in a worker thread."""
+
+    return await asyncio.to_thread(_sync_delegate, parent_agent, spec, orch_id=orch_id)

--- a/src/orchestration/honcho_context.py
+++ b/src/orchestration/honcho_context.py
@@ -1,0 +1,43 @@
+"""Optional Honcho / group-model hints (profile-safe, no hard Honcho import)."""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from hermes_constants import display_hermes_home, get_hermes_home
+
+
+def group_session_label(orchestration_id: str, extra: Optional[str] = None) -> str:
+    """Stable label for correlating swarm turns with long-term user memory."""
+
+    base = orchestration_id.strip() or "orch"
+    if extra and extra.strip():
+        return f"{base}:{extra.strip()}"
+    return base
+
+
+def honcho_memory_preamble(*, orch_id: str, role: str = "coordinator") -> str:
+    """Short prose block suitable for appending to delegate context."""
+
+    home = display_hermes_home()
+    return (
+        f"[multi-agent orchestration] id={orch_id} role={role} "
+        f"hermes_home={home} "
+        "Use Honcho tools only when enabled; respect profile isolation."
+    )
+
+
+def peer_namespace_hint() -> str:
+    """Echo active profile path for Honcho peer resolution."""
+
+    return f"HONCHO_NAMESPACE_HINT={get_hermes_home()}"
+
+
+def optional_honcho_env_patch() -> dict[str, str]:
+    """Extra env keys downstream plugins may read (best-effort)."""
+
+    patch = {"HERMES_ORCH_MARK": "1"}
+    if os.getenv("HONCHO_APP_ID"):
+        patch["HERMES_ORCH_HONCHO"] = "1"
+    return patch

--- a/src/orchestration/learning.py
+++ b/src/orchestration/learning.py
@@ -1,0 +1,62 @@
+"""Persist lightweight reflex hints from failure trajectories."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from hermes_constants import get_hermes_home
+
+
+def _reflex_path() -> Path:
+    root = get_hermes_home() / "orchestration"
+    root.mkdir(parents=True, exist_ok=True)
+    return root / "reflex_hints.jsonl"
+
+
+def record_failure(
+    *,
+    orchestration_id: str,
+    task_id: str,
+    error: str,
+    trajectory_snippet: Optional[str] = None,
+    metadata: Optional[Mapping[str, Any]] = None,
+) -> str:
+    """Append a reflex record; returns suggested prompt refinement text."""
+
+    line = {
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "orchestration_id": orchestration_id,
+        "task_id": task_id,
+        "error": error[:4000],
+        "trajectory_snippet": (trajectory_snippet or "")[:4000],
+        "meta": dict(metadata or {}),
+    }
+    path = _reflex_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(line, ensure_ascii=False) + "\n")
+
+    refine = (
+        f"When coordinating `{task_id}`, avoid repeating: {error[:280]}. "
+        "Add explicit checkpoints and narrower tool scopes."
+    )
+    return refine
+
+
+def load_recent_hints(limit: int = 10) -> list[dict[str, Any]]:
+    """Best-effort tail read for prompt stitching."""
+
+    path = _reflex_path()
+    if not path.exists():
+        return []
+    lines = path.read_text(encoding="utf-8").splitlines()
+    out: list[dict[str, Any]] = []
+    for raw in lines[-limit:]:
+        try:
+            out.append(json.loads(raw))
+        except json.JSONDecodeError:
+            continue
+    return out

--- a/src/orchestration/multi_agent_orchestrator.py
+++ b/src/orchestration/multi_agent_orchestrator.py
@@ -1,0 +1,56 @@
+"""Multi-agent orchestration façade (DAG + delegate_task + reflex hooks)."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, Dict, Mapping, Sequence
+
+from orchestration.agent_bus import AgentCommunicationBus
+from orchestration.delegate_runner import run_delegate_node
+from orchestration.learning import record_failure
+from orchestration.registry import OrchestratorRegistry
+from orchestration.task_graph import TaskGraph
+from orchestration.types import GraphTaskRun, GraphTaskSpec, TaskStatus
+
+
+class MultiAgentOrchestrator:
+    """Coordinates profile-scoped Hermes workers on a dependency graph."""
+
+    def __init__(self, orchestration_id: str | None = None) -> None:
+        self.orchestration_id = orchestration_id or uuid.uuid4().hex[:12]
+        self.bus = AgentCommunicationBus()
+        self.registry = OrchestratorRegistry()
+
+    async def run(
+        self,
+        parent_agent: Any,
+        specs: Sequence[GraphTaskSpec],
+    ) -> Mapping[str, GraphTaskRun]:
+        graph = TaskGraph(specs)
+        runs: Dict[str, GraphTaskRun] = graph.runs()
+
+        async def execute(run: GraphTaskRun) -> None:
+            run.status = TaskStatus.RUNNING
+            try:
+                payload = await run_delegate_node(
+                    parent_agent,
+                    run.spec,
+                    orch_id=self.orchestration_id,
+                )
+                run.extra["delegate"] = payload
+                if not payload.get("ok"):
+                    msg = payload.get("error") or payload.get("status") or "delegate failed"
+                    raise RuntimeError(str(msg))
+                run.summary = str(payload.get("summary") or "")
+                run.status = TaskStatus.DONE
+            except Exception as exc:
+                run.status = TaskStatus.FAILED
+                run.error = str(exc)
+                record_failure(
+                    orchestration_id=self.orchestration_id,
+                    task_id=run.spec.task_id,
+                    error=str(exc),
+                    trajectory_snippet=run.summary,
+                )
+
+        return await graph.run(execute, runs=runs)

--- a/src/orchestration/registry.py
+++ b/src/orchestration/registry.py
@@ -1,0 +1,33 @@
+"""Register pluggable coordinator implementations."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Optional, Protocol, TypeVar
+
+T_co = TypeVar("T_co", covariant=True)
+
+
+class CoordinatorFactory(Protocol[T_co]):
+    def __call__(self, **kwargs: Any) -> T_co: ...
+
+
+class OrchestratorRegistry:
+    """Maps coordinator names to factories (dependency injection hook)."""
+
+    def __init__(self) -> None:
+        self._factories: Dict[str, Callable[..., Any]] = {}
+
+    def register(self, name: str, factory: Callable[..., Any]) -> None:
+        key = name.strip().lower()
+        if not key:
+            raise ValueError("coordinator name must be non-empty")
+        self._factories[key] = factory
+
+    def unregister(self, name: str) -> None:
+        self._factories.pop(name.strip().lower(), None)
+
+    def get(self, name: str) -> Optional[Callable[..., Any]]:
+        return self._factories.get(name.strip().lower())
+
+    def names(self) -> tuple[str, ...]:
+        return tuple(sorted(self._factories.keys()))

--- a/src/orchestration/task_graph.py
+++ b/src/orchestration/task_graph.py
@@ -1,0 +1,114 @@
+"""DAG task graph with async parallel execution."""
+
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict, deque
+from typing import Awaitable, Callable, Dict, Iterable, List, Mapping, Sequence, Tuple
+
+from orchestration.types import GraphTaskRun, GraphTaskSpec, TaskStatus
+
+
+def _validate_specs(specs: Sequence[GraphTaskSpec]) -> Dict[str, GraphTaskSpec]:
+    by_id: Dict[str, GraphTaskSpec] = {}
+    for spec in specs:
+        if spec.task_id in by_id:
+            raise ValueError(f"duplicate task_id {spec.task_id!r}")
+        by_id[spec.task_id] = spec
+    for spec in specs:
+        for dep in spec.depends_on:
+            if dep not in by_id:
+                raise ValueError(f"unknown dependency {dep!r} for task {spec.task_id!r}")
+        if spec.task_id in spec.depends_on:
+            raise ValueError(f"self-cycle on task {spec.task_id!r}")
+    # Cycle detection (DFS)
+    WHITE, GREY, BLACK = 0, 1, 2
+    color: Dict[str, int] = {k: WHITE for k in by_id}
+
+    def visit(node: str) -> None:
+        color[node] = GREY
+        for dep in by_id[node].depends_on:
+            if color[dep] == GREY:
+                raise ValueError(f"cycle detected involving {node!r} -> {dep!r}")
+            if color[dep] == WHITE:
+                visit(dep)
+        color[node] = BLACK
+
+    for tid in by_id:
+        if color[tid] == WHITE:
+            visit(tid)
+    return by_id
+
+
+class TaskGraph:
+    """Directed acyclic batch executor."""
+
+    def __init__(self, specs: Sequence[GraphTaskSpec]) -> None:
+        self._spec_by_id = _validate_specs(tuple(specs))
+        self._dependents: Dict[str, List[str]] = defaultdict(list)
+        self._pending_deps: Dict[str, int] = {}
+        for tid, spec in self._spec_by_id.items():
+            self._pending_deps[tid] = len(spec.depends_on)
+            for dep in spec.depends_on:
+                self._dependents[dep].append(tid)
+
+    @property
+    def task_ids(self) -> Tuple[str, ...]:
+        return tuple(self._spec_by_id.keys())
+
+    def runs(self) -> Dict[str, GraphTaskRun]:
+        return {tid: GraphTaskRun(spec=self._spec_by_id[tid]) for tid in self._spec_by_id}
+
+    async def run(
+        self,
+        execute: Callable[[GraphTaskRun], Awaitable[None]],
+        *,
+        runs: Mapping[str, GraphTaskRun] | None = None,
+    ) -> Dict[str, GraphTaskRun]:
+        """Execute nodes in parallel waves respecting dependencies."""
+
+        local: Dict[str, GraphTaskRun] = dict(runs) if runs else self.runs()
+        pending = dict(self._pending_deps)
+        queue: deque[str] = deque(tid for tid, c in pending.items() if c == 0)
+
+        while queue:
+            wave = list(queue)
+            queue.clear()
+            await asyncio.gather(*(execute(local[w]) for w in wave))
+            for tid in wave:
+                if local[tid].status == TaskStatus.FAILED:
+                    continue
+                for dst in self._dependents[tid]:
+                    pending[dst] -= 1
+                    if pending[dst] == 0:
+                        queue.append(dst)
+
+        unfinished = [tid for tid, r in local.items() if r.status == TaskStatus.PENDING]
+        if unfinished:
+            for tid in unfinished:
+                local[tid].status = TaskStatus.SKIPPED
+                local[tid].error = "skipped due to upstream failure or deadlock"
+        return local
+
+
+def topo_sort(specs: Iterable[GraphTaskSpec]) -> List[str]:
+    """Return topological order (stable tie-break by task_id)."""
+
+    specs_t = tuple(specs)
+    _validate_specs(specs_t)
+    by_id = {s.task_id: s for s in specs_t}
+    indegree: Dict[str, int] = {t: len(by_id[t].depends_on) for t in by_id}
+    ready = sorted(t for t, d in indegree.items() if d == 0)
+    order: List[str] = []
+    while ready:
+        tid = ready.pop(0)
+        order.append(tid)
+        for oid, spec in sorted(by_id.items()):
+            if tid in spec.depends_on:
+                indegree[oid] -= 1
+                if indegree[oid] == 0:
+                    ready.append(oid)
+                    ready.sort()
+    if len(order) != len(by_id):
+        raise ValueError("task graph has a cycle or missing nodes")
+    return order

--- a/src/orchestration/types.py
+++ b/src/orchestration/types.py
@@ -1,0 +1,41 @@
+"""Typed structures for DAG orchestration (stdlib only)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Mapping, MutableMapping, Sequence
+
+
+class TaskStatus(str, Enum):
+    """Lifecycle state for a graph node."""
+
+    PENDING = "pending"
+    RUNNING = "running"
+    DONE = "done"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+
+
+@dataclass(frozen=True)
+class GraphTaskSpec:
+    """DAG node definition supplied by callers."""
+
+    task_id: str
+    goal: str
+    depends_on: tuple[str, ...] = ()
+    context: str | None = None
+    toolsets: Sequence[str] | None = None
+    profile_env: Mapping[str, str] | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class GraphTaskRun:
+    """Mutable runtime record while executing a node."""
+
+    spec: GraphTaskSpec
+    status: TaskStatus = TaskStatus.PENDING
+    summary: str | None = None
+    error: str | None = None
+    extra: MutableMapping[str, Any] = field(default_factory=dict)

--- a/tests/orchestration/test_task_graph.py
+++ b/tests/orchestration/test_task_graph.py
@@ -1,0 +1,63 @@
+"""Unit tests for DAG orchestration primitives."""
+
+from __future__ import annotations
+
+import pytest
+
+from orchestration.task_graph import TaskGraph, topo_sort
+from orchestration.types import GraphTaskRun, GraphTaskSpec, TaskStatus
+
+
+def test_topo_sort_chain() -> None:
+    specs = (
+        GraphTaskSpec("root", "do root"),
+        GraphTaskSpec("leaf", "do leaf", depends_on=("root",)),
+    )
+    assert topo_sort(specs) == ["root", "leaf"]
+
+
+def test_cycle_rejected() -> None:
+    specs = (
+        GraphTaskSpec("a", "ga", depends_on=("b",)),
+        GraphTaskSpec("b", "gb", depends_on=("a",)),
+    )
+    with pytest.raises(ValueError, match="cycle detected"):
+        TaskGraph(specs)
+
+
+@pytest.mark.asyncio
+async def test_fail_fast_blocks_dependents() -> None:
+    specs = (
+        GraphTaskSpec("first", "g1"),
+        GraphTaskSpec("second", "g2", depends_on=("first",)),
+    )
+    graph = TaskGraph(specs)
+    runs = graph.runs()
+
+    async def execute(run: GraphTaskRun) -> None:
+        if run.spec.task_id == "first":
+            run.status = TaskStatus.FAILED
+            run.error = "boom"
+        else:
+            run.status = TaskStatus.DONE
+
+    out = await graph.run(execute, runs=runs)
+    assert out["first"].status == TaskStatus.FAILED
+    assert out["second"].status == TaskStatus.SKIPPED
+
+
+@pytest.mark.asyncio
+async def test_parallel_wave_executes_all_roots() -> None:
+    specs = (
+        GraphTaskSpec("x", "gx"),
+        GraphTaskSpec("y", "gy"),
+    )
+    graph = TaskGraph(specs)
+    reached: list[str] = []
+
+    async def execute(run: GraphTaskRun) -> None:
+        reached.append(run.spec.task_id)
+        run.status = TaskStatus.DONE
+
+    await graph.run(execute)
+    assert set(reached) == {"x", "y"}


### PR DESCRIPTION
## Summary

Adds a new **`orchestration`** package under **`src/orchestration/`**:

- **`TaskGraph`**: DAG validation (cycle detection), parallel **wave** execution with `asyncio`, fail-fast propagation (dependents → `SKIPPED`).
- **`MultiAgentOrchestrator`**: orchestrates nodes via existing **`delegate_task`** (thread offload with `asyncio.to_thread`), no edits to **`delegate_tool.py`**.
- **`AgentCommunicationBus`**: in-process async queue for Agent-to-Agent style messaging (wire to MCP transport can be layered on later).
- **`OrchestratorRegistry`**: hooks for custom coordinator factories.
- **Honcho/profile hints**: optional context strings + env markers (`hermes_constants`); state under **`$HERMES_HOME/orchestration/reflex_hints.jsonl`** via **`record_failure`** / **`load_recent_hints`**.

## Packaging

- **`pyproject.toml`**: `[tool.setuptools.packages.find]` adds **`where = [".", "src"]`** and **`orchestration`** to **`include`** (resolved against **`origin/main`** during cherry-pick).

## Tests

```bash
pytest tests/orchestration/test_task_graph.py -q -o addopts=