### PR TITLE
fix(gateway/bluebubbles): skip webhook server bind in standalone send path

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -153,7 +153,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     # Lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
+    async def connect(self, *, send_only: bool = False) -> bool:
         if not self.server_url or not self.password:
             logger.error(
                 "[bluebubbles] BLUEBUBBLES_SERVER_URL and BLUEBUBBLES_PASSWORD are required"
@@ -182,6 +182,13 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 await self.client.aclose()
                 self.client = None
             return False
+
+        # send_only=True skips the local webhook server — outbound-only callers
+        # (standalone cron delivery, send_message_tool) don't need to receive
+        # inbound events and must not bind a port already held by the gateway.
+        if send_only:
+            self._mark_connected()
+            return True
 
         app = web.Application()
         app.router.add_get("/health", lambda _: web.Response(text="ok"))
@@ -910,9 +917,9 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self._background_tasks.add(task)
         task.add_done_callback(self._background_tasks.discard)
 
+
         # Fire-and-forget read receipt
         if self.send_read_receipts and session_chat_id:
             asyncio.create_task(self.mark_read(session_chat_id))
 
         return web.Response(text="ok")
-

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1325,7 +1325,7 @@ async def _send_bluebubbles(extra, chat_id, message):
         from gateway.config import PlatformConfig
         pconfig = PlatformConfig(extra=extra)
         adapter = BlueBubblesAdapter(pconfig)
-        connected = await adapter.connect()
+        connected = await adapter.connect(send_only=True)
         if not connected:
             return _error("BlueBubbles: failed to connect to server")
         try:


### PR DESCRIPTION
## What broke

Standalone outbound senders — `send_message_tool` and cron delivery via CLI (`hermes cron run`) — call `BlueBubblesAdapter.connect()` before sending. `connect()` unconditionally starts an aiohttp `TCPSite` to listen for inbound webhooks. When the gateway is already running, that port is already held, and the bind raises:

```
[Errno 48] error while attempting to bind on address ('127.0.0.1', 28789): address already in use
```

The send fails even though the BlueBubbles server is reachable and the outbound REST API works fine.

## Root cause

`connect()` always executes the full lifecycle: verify server → start webhook listener → register webhook URL. The webhook listener is only needed to **receive** inbound events. Outbound-only callers have no use for it and must not bind a port that may already be held by the running gateway.

## Fix

Add a keyword-only `send_only: bool = False` flag to `connect()`. When `True`, the method returns after verifying server reachability and marking the adapter connected — skipping `TCPSite.start()` and `_register_webhook()`.

`disconnect()` and `_unregister_webhook()` already guard against `_runner=None` and no registered webhook, so no changes are needed there.

Pass `send_only=True` from `_send_bluebubbles()` in `send_message_tool.py` — the only standalone send path for BlueBubbles.

## What I tested

- 45 existing BlueBubbles unit tests pass unchanged (`tests/gateway/test_bluebubbles.py`)
- Confirmed reproduce path: cron delivery via CLI against a running gateway previously failed with the bind error above; with this fix it succeeds