### PR TITLE
fix(discord): shield text-batch flush from follow-up cancel

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3265,7 +3265,20 @@ class DiscordAdapter(BasePlatformAdapter):
                 "[Discord] Flushing text batch %s (%d chars)",
                 key, len(event.text or ""),
             )
-            await self.handle_message(event)
+            # Shield the downstream dispatch so that a subsequent chunk
+            # arriving while handle_message is mid-flight cannot cancel
+            # the running agent turn.  _enqueue_text_event always cancels
+            # the prior flush task when a new chunk lands; without this
+            # shield, CancelledError would propagate from our task down
+            # into handle_message → the agent's streaming request,
+            # aborting the response the user was waiting on.  The new
+            # chunk is handled by the fresh flush task regardless.
+            await asyncio.shield(self.handle_message(event))
+        except asyncio.CancelledError:
+            # Only reached if cancel landed before the pop — the shielded
+            # handle_message is unaffected either way.  Let the task exit
+            # cleanly so the finally block cleans up.
+            pass
         finally:
             if self._pending_text_batch_tasks.get(key) is current_task:
                 self._pending_text_batch_tasks.pop(key, None)

--- a/tests/gateway/test_text_batching.py
+++ b/tests/gateway/test_text_batching.py
@@ -148,6 +148,70 @@ class TestDiscordTextBatching:
         await asyncio.sleep(0.25)
         adapter.handle_message.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_shield_protects_handle_message_from_cancel(self):
+        """Regression guard: a follow-up chunk arriving while
+        handle_message is mid-flight must NOT cancel the running
+        dispatch.  _enqueue_text_event fires prior_task.cancel() on
+        every new chunk; without asyncio.shield around handle_message
+        the cancel propagates into the agent's streaming request and
+        aborts the response.
+        """
+        adapter = _make_discord_adapter()
+
+        handle_started = asyncio.Event()
+        release_handle = asyncio.Event()
+        first_handle_cancelled = asyncio.Event()
+        first_handle_completed = asyncio.Event()
+        call_count = [0]
+
+        async def slow_handle(event):
+            call_count[0] += 1
+            # Only the first call (batch 1) is the one we're protecting.
+            if call_count[0] == 1:
+                handle_started.set()
+                try:
+                    await release_handle.wait()
+                    first_handle_completed.set()
+                except asyncio.CancelledError:
+                    first_handle_cancelled.set()
+                    raise
+            # Second call (batch 2) returns immediately — not the subject
+            # of this test.
+
+        adapter.handle_message = slow_handle
+
+        # Prime batch 1 and wait for it to land inside handle_message.
+        adapter._enqueue_text_event(_make_event("batch 1", Platform.DISCORD))
+        await asyncio.wait_for(handle_started.wait(), timeout=1.0)
+
+        # A new chunk arrives — _enqueue_text_event fires
+        # prior_task.cancel() on batch 1's flush task, which is
+        # currently awaiting inside handle_message.
+        adapter._enqueue_text_event(_make_event("batch 2 follow-up", Platform.DISCORD))
+
+        # Let the cancel propagate.
+        await asyncio.sleep(0.05)
+
+        # CRITICAL ASSERTION: batch 1's handle_message must NOT have
+        # been cancelled.  Without asyncio.shield this assertion fails
+        # because CancelledError propagates from the flush task's
+        # `await self.handle_message(event)` into slow_handle.
+        assert not first_handle_cancelled.is_set(), (
+            "handle_message for batch 1 was cancelled by a follow-up "
+            "chunk — asyncio.shield is missing or broken"
+        )
+
+        # Release batch 1's handle_message and let it complete.
+        release_handle.set()
+        await asyncio.wait_for(first_handle_completed.wait(), timeout=1.0)
+        assert first_handle_completed.is_set()
+
+        # Cleanup
+        for task in list(adapter._pending_text_batch_tasks.values()):
+            task.cancel()
+        await asyncio.sleep(0.01)
+
 
 # =====================================================================
 # Matrix text batching


### PR DESCRIPTION
## Summary
A follow-up chunk of a split Discord message can no longer cancel the in-flight dispatch of the previous chunk. Previously the chain `_enqueue_text_event → prior_task.cancel() → CancelledError into await handle_message` aborted the agent's streaming request, leaving the user with a truncated or missing reply.

## Scenario
User sends a 3000-char prompt. Discord splits it at 2000 chars into two messages. Chunk 1 lands → flush task scheduled. Chunk 1's flush delay expires → pops chunk 1, enters `await self.handle_message(chunk_1)`. Chunk 2 lands during that in-flight dispatch → `_enqueue_text_event` calls `prior_task.cancel()` → CancelledError propagates from the flush task down into `handle_message` → base adapter session processing → agent's `run_conversation` → the streaming HTTP request. Response aborts.

## Fix
- `gateway/platforms/discord.py`: wrap the inner call in `asyncio.shield(self.handle_message(event))` so the cancel of the outer flush task doesn't reach the inner dispatch. Add an `except asyncio.CancelledError` clause so the outer task still exits cleanly when cancel arrives during the sleep window (before `pop`) — that semantic is unchanged.
- Follow-up chunks still get their own flush task and are dispatched via the normal pending-message / active-session machinery in `base.py`. Nothing is lost.

## Validation
| | Before | After |
|---|---|---|
| Follow-up chunk during in-flight handle_message | chunk 1's handle_message receives CancelledError | chunk 1's handle_message runs to completion |
| Cancel during the sleep window (before pop) | flush task exits, new task takes the aggregated batch | same |
| Normal single-chunk flush | works | works |
| Adaptive split-delay for near-2000-char chunks | works | works |

Regression-guard: `test_shield_protects_handle_message_from_cancel` uses a distinct `first_handle_cancelled` event so the assertion fails cleanly when the shield is missing. Verified — stashing the fix makes the test FAIL with the exact message we want; re-applying makes it pass.

Targeted: `test_text_batching.py` 16/16, `test_discord_send.py` 17/17, `test_discord_reactions.py` 14/14, `test_discord_reply_mode.py` 26/26 — 73 total.

Live E2E against the live-loaded `DiscordAdapter`:
```
=== _flush_text_batch in live-loaded DiscordAdapter ===
asyncio.shield wrapping handle_message: OK
CancelledError clause for early-cancel path: OK

=== End-to-end cancel test ===
  first_handle_cancelled: False  (expected: False)
  first_handle_completed: True   (expected: True)
```