### PR TITLE
fix(feishu): allow bot-originated mentions from other bots

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1925,8 +1925,8 @@ class FeishuAdapter(BasePlatformAdapter):
         if not message_id or self._is_duplicate(message_id):
             logger.debug("[Feishu] Dropping duplicate/missing message_id: %s", message_id)
             return
-        if getattr(sender, "sender_type", "") == "bot":
-            logger.debug("[Feishu] Dropping bot-originated event: %s", message_id)
+        if self._is_self_sent_bot_message(event):
+            logger.debug("[Feishu] Dropping self-sent bot event: %s", message_id)
             return
 
         chat_type = getattr(message, "chat_type", "p2p")
@@ -3247,6 +3247,23 @@ class FeishuAdapter(BasePlatformAdapter):
         )
         if normalized.mentioned_ids:
             return self._post_mentions_bot(normalized.mentioned_ids)
+        return False
+
+    def _is_self_sent_bot_message(self, event: Any) -> bool:
+        """Return True only for Feishu events emitted by this Hermes bot."""
+        sender = getattr(event, "sender", None)
+        sender_type = str(getattr(sender, "sender_type", "") or "").strip().lower()
+        if sender_type not in {"bot", "app"}:
+            return False
+
+        sender_id = getattr(sender, "sender_id", None)
+        sender_open_id = str(getattr(sender_id, "open_id", "") or "").strip()
+        sender_user_id = str(getattr(sender_id, "user_id", "") or "").strip()
+
+        if self._bot_open_id and sender_open_id == self._bot_open_id:
+            return True
+        if self._bot_user_id and sender_user_id == self._bot_user_id:
+            return True
         return False
 
     def _message_mentions_bot(self, mentions: List[Any]) -> bool:

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -746,6 +746,57 @@ class TestAdapterBehavior(unittest.TestCase):
     @patch.dict(
         os.environ,
         {
+            "FEISHU_BOT_OPEN_ID": "ou_hermes",
+            "FEISHU_BOT_USER_ID": "u_hermes",
+        },
+        clear=True,
+    )
+    def test_other_bot_sender_is_not_treated_as_self_sent_message(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        event = SimpleNamespace(
+            sender=SimpleNamespace(
+                sender_type="bot",
+                sender_id=SimpleNamespace(open_id="ou_other_bot", user_id="u_other_bot"),
+            )
+        )
+
+        self.assertFalse(adapter._is_self_sent_bot_message(event))
+
+    @patch.dict(
+        os.environ,
+        {
+            "FEISHU_BOT_OPEN_ID": "ou_hermes",
+            "FEISHU_BOT_USER_ID": "u_hermes",
+        },
+        clear=True,
+    )
+    def test_self_bot_sender_is_treated_as_self_sent_message(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        by_open_id = SimpleNamespace(
+            sender=SimpleNamespace(
+                sender_type="bot",
+                sender_id=SimpleNamespace(open_id="ou_hermes", user_id="u_other"),
+            )
+        )
+        by_user_id = SimpleNamespace(
+            sender=SimpleNamespace(
+                sender_type="app",
+                sender_id=SimpleNamespace(open_id="ou_other", user_id="u_hermes"),
+            )
+        )
+
+        self.assertTrue(adapter._is_self_sent_bot_message(by_open_id))
+        self.assertTrue(adapter._is_self_sent_bot_message(by_user_id))
+
+    @patch.dict(
+        os.environ,
+        {
             "FEISHU_GROUP_POLICY": "allowlist",
             "FEISHU_ALLOWED_USERS": "ou_allowed",
             "FEISHU_BOT_NAME": "Hermes Bot",


### PR DESCRIPTION
## Summary

Fix Feishu group message handling so Hermes no longer drops every bot-originated `im.message.receive_v1` event at the adapter entrypoint.

Before this change, any message with `sender_type=bot` was rejected immediately. As a result, group messages sent by other bots could never reach Hermes, even when they explicitly @mentioned Hermes.

After this change, Hermes only drops self-sent bot/app loopback events. Bot-originated messages from other senders continue through the normal mention parsing and group policy gates.

## Why this is needed

Feishu's latest `Message received v2.0` event subscription for `im.message.receive_v1` now supports receiving mentions from both users and other bots (`Receive other bots' and users' mentions`).

Hermes already subscribes to `im.message.receive_v1`, but the current adapter behavior still drops all bot-originated messages before mention routing runs. This prevents Hermes from using the newer Feishu capability.

This change updates Hermes' Feishu behavior to match the current platform capability: messages from other bots are allowed to pass through the existing mention and group policy gates, while Hermes' own self-sent bot/app loopback events are still filtered to avoid feedback loops.

It also enables a useful multi-agent collaboration pattern in Feishu groups: bots can @mention each other to trigger automated workflows without requiring a human to manually relay messages between agents.

## Root cause

The Feishu adapter already subscribes to `im.message.receive_v1`, so this was not an event subscription issue.

The real problem was this early return in the inbound message path:
```python
if getattr(sender, "sender_type", "") == "bot":
    logger.debug("[Feishu] Dropping bot-originated event: %s", message_id)
    return
```

## Validation

Validated in two ways:

- Ran focused local tests covering the new self-sent bot detection behavior:
  - `test_other_bot_sender_is_not_treated_as_self_sent_message`
  - `test_self_bot_sender_is_treated_as_self_sent_message`

- Manually restarted Hermes and verified the behavior in a Feishu group chat scenario where another bot @mentions Hermes.

Verified behavior:

- Messages from other bots that @mention Hermes are no longer dropped at event ingress.
- Hermes continues to evaluate mention and group policy gates normally.
- Hermes' own self-sent bot/app loopback messages are still filtered.
