### PR TITLE
fix: await async plugin command handlers in CLI dispatcher (#12449)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5841,7 +5841,11 @@ class HermesCLI:
                 if plugin_handler:
                     user_args = cmd_original[len(base_cmd):].strip()
                     try:
+                        import inspect
                         result = plugin_handler(user_args)
+                        if inspect.isawaitable(result):
+                            import asyncio
+                            result = asyncio.run(result)
                         if result:
                             _cprint(str(result))
                     except Exception as e:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -649,11 +649,25 @@ class PluginManager:
         are reused.  All injected context is ephemeral — never
         persisted to session DB.
         """
+        import asyncio
+        import inspect
+
         callbacks = self._hooks.get(hook_name, [])
         results: List[Any] = []
         for cb in callbacks:
             try:
                 ret = cb(**kwargs)
+                if inspect.isawaitable(ret):
+                    try:
+                        loop = asyncio.get_running_loop()
+                    except RuntimeError:
+                        loop = None
+                    if loop and loop.is_running():
+                        import concurrent.futures
+                        with concurrent.futures.ThreadPoolExecutor() as pool:
+                            ret = pool.submit(asyncio.run, ret).result()
+                    else:
+                        ret = asyncio.run(ret)
                 if ret is not None:
                     results.append(ret)
             except Exception as exc:

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -896,3 +896,77 @@ class TestPluginDispatchTool:
             result = ctx.dispatch_tool("fake", {})
 
         assert '"error"' in result
+
+
+# ── Async dispatch tests ─────────────────────────────────────────────────
+
+
+class TestAsyncPluginCommandDispatch:
+    """Async plugin command handlers and hooks must be awaited."""
+
+    def test_invoke_hook_awaits_async_callback(self):
+        """invoke_hook should await an async callback and collect its result."""
+        async def async_hook(**kwargs):
+            return "async-result"
+
+        mgr = PluginManager()
+        mgr._hooks["on_session_start"] = [async_hook]
+
+        results = mgr.invoke_hook("on_session_start")
+        assert results == ["async-result"]
+
+    def test_invoke_hook_handles_mixed_sync_async(self):
+        """invoke_hook handles a mix of sync and async callbacks."""
+        def sync_hook(**kwargs):
+            return "sync"
+
+        async def async_hook(**kwargs):
+            return "async"
+
+        mgr = PluginManager()
+        mgr._hooks["on_session_start"] = [sync_hook, async_hook]
+
+        results = mgr.invoke_hook("on_session_start")
+        assert results == ["sync", "async"]
+
+    def test_invoke_hook_async_returning_none(self):
+        """Async callbacks returning None are excluded from results."""
+        async def async_hook(**kwargs):
+            return None
+
+        mgr = PluginManager()
+        mgr._hooks["on_session_start"] = [async_hook]
+
+        results = mgr.invoke_hook("on_session_start")
+        assert results == []
+
+    def test_invoke_hook_async_exception_caught(self):
+        """Async callbacks that raise are caught, not propagated."""
+        async def bad_hook(**kwargs):
+            raise ValueError("boom")
+
+        mgr = PluginManager()
+        mgr._hooks["on_session_start"] = [bad_hook]
+
+        results = mgr.invoke_hook("on_session_start")
+        assert results == []
+
+    def test_plugin_command_handler_async(self):
+        """get_plugin_command_handler returns an async handler; caller must await."""
+        async def my_handler(args):
+            return f"got: {args}"
+
+        mgr = PluginManager()
+        mgr._plugin_commands["myasync"] = {
+            "handler": my_handler,
+            "description": "test",
+            "plugin": "test",
+        }
+
+        with patch("hermes_cli.plugins._plugin_manager", mgr):
+            handler = get_plugin_command_handler("myasync")
+            assert handler is my_handler
+
+            import asyncio
+            result = asyncio.run(handler("hello"))
+            assert result == "got: hello"


### PR DESCRIPTION
## Problem
When a plugin registers an `async def` command handler, the CLI dispatcher in `process_command` (cli.py) and `invoke_hook` (plugins.py) calls the handler but doesn't await the resulting coroutine. This causes `<coroutine object ...>` to be printed instead of the actual result.

## Fix
- In `process_command` (cli.py): after calling a plugin command handler, check `inspect.isawaitable(result)` and await it via `asyncio.run()` if true.
- In `invoke_hook` (plugins.py): same pattern, with handling for already-running event loops using a thread pool executor.

## Tests
Added 5 new tests in `TestAsyncPluginCommandDispatch`:
- Async hook callback is awaited and result collected
- Mixed sync/async callbacks both work
- Async returning None is excluded from results
- Async exceptions are caught gracefully
- Async command handler round-trip

Closes #12449