### PR TITLE
feat: add voicebox STT and TTS provider support

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -154,12 +154,12 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
     "tts.provider": {
         "type": "select",
         "description": "Text-to-speech provider",
-        "options": ["edge", "elevenlabs", "openai", "neutts"],
+        "options": ["edge", "elevenlabs", "openai", "mistral", "neutts", "voicebox"],
     },
     "stt.provider": {
         "type": "select",
         "description": "Speech-to-text provider",
-        "options": ["local", "openai", "mistral"],
+        "options": ["local", "openai", "mistral", "voicebox"],
     },
     "display.skin": {
         "type": "select",

--- a/tests/tools/test_tts_voicebox.py
+++ b/tests/tools/test_tts_voicebox.py
@@ -1,0 +1,78 @@
+import json
+from unittest.mock import patch
+
+import pytest
+
+
+class TestGenerateVoiceboxTts:
+    def test_missing_profile_id_raises(self, tmp_path):
+        from tools.tts_tool import _generate_voicebox_tts
+
+        with pytest.raises(ValueError, match="profile_id"):
+            _generate_voicebox_tts("hello", str(tmp_path / "out.wav"), {"voicebox": {"base_url": "http://localhost:17493"}})
+
+    def test_successful_generation_downloads_audio(self, tmp_path):
+        from tools.tts_tool import _generate_voicebox_tts
+
+        responses = [
+            {"id": "gen-123"},
+            {"id": "gen-123", "status": "completed", "audio_path": "/tmp/fake.wav", "error": None},
+            b"FAKEAUDIO",
+        ]
+
+        class FakeResponse:
+            def __init__(self, payload):
+                self.payload = payload
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                if isinstance(self.payload, bytes):
+                    return self.payload
+                return json.dumps(self.payload).encode("utf-8")
+
+        def fake_urlopen(request, timeout=0):
+            return FakeResponse(responses.pop(0))
+
+        output_path = str(tmp_path / "out.wav")
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen), \
+             patch("tools.tts_tool.time.sleep", return_value=None):
+            result = _generate_voicebox_tts(
+                "hello world",
+                output_path,
+                {"voicebox": {"base_url": "http://localhost:17493", "profile_id": "profile-1", "language": "ko"}},
+            )
+
+        assert result == output_path
+        assert (tmp_path / "out.wav").read_bytes() == b"FAKEAUDIO"
+
+
+class TestVoiceboxTtsDispatcher:
+    def test_dispatcher_routes_to_voicebox(self, tmp_path):
+        from tools.tts_tool import text_to_speech_tool
+
+        output_path = str(tmp_path / "out.wav")
+        with patch("tools.tts_tool._load_tts_config", return_value={"provider": "voicebox", "voicebox": {"base_url": "http://localhost:17493", "profile_id": "profile-1"}}), \
+             patch("tools.tts_tool._generate_voicebox_tts", side_effect=lambda text, path, cfg: open(path, "wb").write(b"VOICEBOX") or path):
+            result = json.loads(text_to_speech_tool("hello", output_path=output_path))
+
+        assert result["success"] is True
+        assert result["provider"] == "voicebox"
+        assert result["file_path"] == output_path
+
+
+class TestVoiceboxTtsRequirements:
+    def test_voicebox_configured_returns_true(self):
+        from tools.tts_tool import check_tts_requirements
+
+        with patch("tools.tts_tool._import_edge_tts", side_effect=ImportError), \
+             patch("tools.tts_tool._import_elevenlabs", side_effect=ImportError), \
+             patch("tools.tts_tool._import_openai_client", side_effect=ImportError), \
+             patch("tools.tts_tool._import_mistral_client", side_effect=ImportError), \
+             patch("tools.tts_tool._check_neutts_available", return_value=False), \
+             patch("tools.tts_tool._load_tts_config", return_value={"provider": "voicebox", "voicebox": {"base_url": "http://localhost:17493", "profile_id": "profile-1"}}):
+            assert check_tts_requirements() is True

--- a/tests/tools/test_voicebox_stt.py
+++ b/tests/tools/test_voicebox_stt.py
@@ -1,0 +1,63 @@
+import json
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def sample_wav(tmp_path):
+    path = tmp_path / "sample.wav"
+    path.write_bytes(b"RIFF0000WAVEfmt ")
+    return str(path)
+
+
+class TestVoiceboxProviderSelection:
+    def test_explicit_voicebox_provider_selected(self):
+        from tools.transcription_tools import _get_provider
+
+        assert _get_provider({"provider": "voicebox", "voicebox": {"base_url": "http://localhost:17493"}}) == "voicebox"
+
+
+class TestTranscribeVoicebox:
+    def test_missing_base_url_raises(self, sample_wav):
+        from tools.transcription_tools import _transcribe_voicebox
+
+        with pytest.raises(ValueError, match="base_url"):
+            _transcribe_voicebox(sample_wav, "base", {"voicebox": {"base_url": ""}})
+
+    def test_successful_transcription(self, sample_wav):
+        from tools.transcription_tools import _transcribe_voicebox
+
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def read(self):
+                return json.dumps({"text": "hello voicebox", "duration": 1.2}).encode("utf-8")
+
+        with patch("urllib.request.urlopen", return_value=FakeResponse()):
+            result = _transcribe_voicebox(
+                sample_wav,
+                "turbo",
+                {"voicebox": {"base_url": "http://localhost:17493", "language": "ko"}},
+            )
+
+        assert result["success"] is True
+        assert result["transcript"] == "hello voicebox"
+        assert result["provider"] == "voicebox"
+
+
+class TestTranscribeAudioDispatchVoicebox:
+    def test_transcribe_audio_dispatches_to_voicebox(self, sample_wav):
+        from tools.transcription_tools import transcribe_audio
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={"provider": "voicebox", "voicebox": {"base_url": "http://localhost:17493", "model": "turbo"}}), \
+             patch("tools.transcription_tools._transcribe_voicebox", return_value={"success": True, "transcript": "from dispatch", "provider": "voicebox"}):
+            result = transcribe_audio(sample_wav)
+
+        assert result["success"] is True
+        assert result["transcript"] == "from dispatch"
+        assert result["provider"] == "voicebox"

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -23,12 +23,17 @@ Usage::
         print(result["transcript"])
 """
 
+import json
 import logging
+import mimetypes
 import os
 import shlex
 import shutil
 import subprocess
 import tempfile
+import urllib.error
+import urllib.request
+import uuid
 from pathlib import Path
 from typing import Optional, Dict, Any
 from urllib.parse import urljoin
@@ -64,6 +69,7 @@ _HAS_MISTRAL = _safe_find_spec("mistralai")
 DEFAULT_PROVIDER = "local"
 DEFAULT_LOCAL_MODEL = "base"
 DEFAULT_LOCAL_STT_LANGUAGE = "en"
+DEFAULT_VOICEBOX_STT_BASE_URL = "http://localhost:17493"
 DEFAULT_STT_MODEL = os.getenv("STT_OPENAI_MODEL", "whisper-1")
 DEFAULT_GROQ_STT_MODEL = os.getenv("STT_GROQ_MODEL", "whisper-large-v3-turbo")
 DEFAULT_MISTRAL_STT_MODEL = os.getenv("STT_MISTRAL_MODEL", "voxtral-mini-latest")
@@ -223,6 +229,13 @@ def _get_provider(stt_config: dict) -> str:
             )
             return "none"
 
+        if provider == "voicebox":
+            voicebox_cfg = stt_config.get("voicebox", {})
+            if (voicebox_cfg.get("base_url") or DEFAULT_VOICEBOX_STT_BASE_URL).strip():
+                return "voicebox"
+            logger.warning("STT provider 'voicebox' configured but no base_url set")
+            return "none"
+
         return provider  # Unknown — let it fail downstream
 
     # --- Auto-detect (no explicit provider): local > groq > openai > mistral -
@@ -273,6 +286,41 @@ def _validate_audio_file(file_path: str) -> Optional[Dict[str, Any]]:
         return {"success": False, "transcript": "", "error": f"Failed to access file: {e}"}
 
     return None
+
+
+def _build_multipart_form_data(
+    file_path: str,
+    *,
+    file_field_name: str = "file",
+    fields: Optional[Dict[str, Any]] = None,
+) -> tuple[bytes, str]:
+    """Build a multipart/form-data payload for simple file uploads."""
+    boundary = f"----HermesBoundary{uuid.uuid4().hex}"
+    body = bytearray()
+
+    for key, value in (fields or {}).items():
+        if value is None or value == "":
+            continue
+        body.extend(f"--{boundary}\r\n".encode("utf-8"))
+        body.extend(
+            f'Content-Disposition: form-data; name="{key}"\r\n\r\n{value}\r\n'.encode("utf-8")
+        )
+
+    mime_type = mimetypes.guess_type(file_path)[0] or "application/octet-stream"
+    filename = Path(file_path).name
+    file_bytes = Path(file_path).read_bytes()
+    body.extend(f"--{boundary}\r\n".encode("utf-8"))
+    body.extend(
+        (
+            f'Content-Disposition: form-data; name="{file_field_name}"; '
+            f'filename="{filename}"\r\n'
+            f"Content-Type: {mime_type}\r\n\r\n"
+        ).encode("utf-8")
+    )
+    body.extend(file_bytes)
+    body.extend(b"\r\n")
+    body.extend(f"--{boundary}--\r\n".encode("utf-8"))
+    return bytes(body), f"multipart/form-data; boundary={boundary}"
 
 # ---------------------------------------------------------------------------
 # Provider: local (faster-whisper)
@@ -405,6 +453,62 @@ def _transcribe_local_command(file_path: str, model_name: str) -> Dict[str, Any]
     except Exception as e:
         logger.error("Unexpected error during local command transcription: %s", e, exc_info=True)
         return {"success": False, "transcript": "", "error": f"Local transcription failed: {e}"}
+
+
+def _transcribe_voicebox(file_path: str, model_name: str, stt_config: Dict[str, Any]) -> Dict[str, Any]:
+    """Transcribe via a local Voicebox server."""
+    voicebox_cfg = stt_config.get("voicebox", {}) if isinstance(stt_config, dict) else {}
+    base_url = (voicebox_cfg.get("base_url") or "").strip()
+    if not base_url:
+        raise ValueError("voicebox.base_url is required")
+
+    language = (
+        voicebox_cfg.get("language")
+        or stt_config.get("local", {}).get("language")
+        or os.getenv(LOCAL_STT_LANGUAGE_ENV)
+        or ""
+    )
+
+    body, content_type = _build_multipart_form_data(
+        file_path,
+        fields={"model": model_name, "language": language},
+    )
+    request = urllib.request.Request(
+        urljoin(f"{base_url.rstrip('/')}/", "transcribe"),
+        data=body,
+        headers={"Content-Type": content_type, "Accept": "application/json"},
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(request, timeout=300) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+        transcript = str(payload.get("text") or "").strip()
+        if not transcript:
+            return {"success": False, "transcript": "", "error": "Voicebox returned empty transcript"}
+        return {"success": True, "transcript": transcript, "provider": "voicebox"}
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode("utf-8", errors="replace")
+        detail = raw
+        try:
+            parsed = json.loads(raw)
+            detail = parsed.get("detail", parsed)
+        except Exception:
+            pass
+        if exc.code == 202:
+            return {
+                "success": False,
+                "transcript": "",
+                "error": f"Voicebox model download in progress: {detail}",
+            }
+        return {
+            "success": False,
+            "transcript": "",
+            "error": f"Voicebox transcription failed: HTTP {exc.code}: {detail}",
+        }
+    except Exception as e:
+        logger.error("Voicebox transcription failed: %s", e, exc_info=True)
+        return {"success": False, "transcript": "", "error": f"Voicebox transcription failed: {e}"}
 
 # ---------------------------------------------------------------------------
 # Provider: groq (Whisper API — free tier)
@@ -614,6 +718,11 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         openai_cfg = stt_config.get("openai", {})
         model_name = model or openai_cfg.get("model", DEFAULT_STT_MODEL)
         return _transcribe_openai(file_path, model_name)
+
+    if provider == "voicebox":
+        voicebox_cfg = stt_config.get("voicebox", {})
+        model_name = model or voicebox_cfg.get("model", "turbo")
+        return _transcribe_voicebox(file_path, model_name, stt_config)
 
     if provider == "mistral":
         mistral_cfg = stt_config.get("mistral", {})

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -35,6 +35,9 @@ import shutil
 import subprocess
 import tempfile
 import threading
+import time
+import urllib.error
+import urllib.request
 import uuid
 from pathlib import Path
 from typing import Callable, Dict, Any, Optional
@@ -88,6 +91,7 @@ DEFAULT_ELEVENLABS_STREAMING_MODEL_ID = "eleven_flash_v2_5"
 DEFAULT_OPENAI_MODEL = "gpt-4o-mini-tts"
 DEFAULT_OPENAI_VOICE = "alloy"
 DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1"
+DEFAULT_VOICEBOX_TTS_BASE_URL = "http://localhost:17493"
 DEFAULT_MINIMAX_MODEL = "speech-2.8-hd"
 DEFAULT_MINIMAX_VOICE_ID = "English_Graceful_Lady"
 DEFAULT_MINIMAX_BASE_URL = "https://api.minimax.io/v1/t2a_v2"
@@ -127,6 +131,13 @@ def _load_tts_config() -> Dict[str, Any]:
 def _get_provider(tts_config: Dict[str, Any]) -> str:
     """Get the configured TTS provider name."""
     return (tts_config.get("provider") or DEFAULT_PROVIDER).lower().strip()
+
+
+def _voicebox_tts_configured(tts_config: Optional[Dict[str, Any]] = None) -> bool:
+    if tts_config is None:
+        tts_config = _load_tts_config()
+    voicebox_cfg = tts_config.get("voicebox", {}) if isinstance(tts_config, dict) else {}
+    return bool((voicebox_cfg.get("base_url") or "").strip() and (voicebox_cfg.get("profile_id") or "").strip())
 
 
 # ===========================================================================
@@ -435,6 +446,65 @@ def _generate_mistral_tts(text: str, output_path: str, tts_config: Dict[str, Any
     return output_path
 
 
+def _generate_voicebox_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate audio using a local Voicebox server."""
+    voicebox_cfg = tts_config.get("voicebox", {})
+    base_url = (voicebox_cfg.get("base_url") or "").strip()
+    if not base_url:
+        raise ValueError("voicebox.base_url is required")
+
+    profile_id = (voicebox_cfg.get("profile_id") or "").strip()
+    if not profile_id:
+        raise ValueError("voicebox.profile_id is required")
+
+    payload = {
+        "profile_id": profile_id,
+        "text": text,
+        "language": voicebox_cfg.get("language", "en"),
+    }
+    for key in ("engine", "seed", "model_size", "instruct"):
+        value = voicebox_cfg.get(key)
+        if value not in (None, ""):
+            payload[key] = value
+
+    create_request = urllib.request.Request(
+        urljoin(f"{base_url.rstrip('/')}/", "generate"),
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(create_request, timeout=120) as response:
+        created = json.loads(response.read().decode("utf-8"))
+
+    generation_id = created.get("id")
+    if not generation_id:
+        raise RuntimeError("Voicebox generate response missing generation id")
+
+    timeout_seconds = int(voicebox_cfg.get("timeout_seconds", 180) or 180)
+    poll_interval = float(voicebox_cfg.get("poll_interval_seconds", 1.0) or 1.0)
+    history_url = urljoin(f"{base_url.rstrip('/')}/", f"history/{generation_id}")
+    export_url = urljoin(f"{base_url.rstrip('/')}/", f"history/{generation_id}/export-audio")
+
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        history_request = urllib.request.Request(history_url, headers={"Accept": "application/json"})
+        with urllib.request.urlopen(history_request, timeout=60) as response:
+            history = json.loads(response.read().decode("utf-8"))
+        status = str(history.get("status") or "").lower()
+        if status == "completed":
+            audio_request = urllib.request.Request(export_url)
+            with urllib.request.urlopen(audio_request, timeout=120) as response:
+                audio_bytes = response.read()
+            with open(output_path, "wb") as f:
+                f.write(audio_bytes)
+            return output_path
+        if status == "failed":
+            raise RuntimeError(f"Voicebox generation failed: {history.get('error') or 'unknown error'}")
+        time.sleep(poll_interval)
+
+    raise RuntimeError("Voicebox generation timed out")
+
+
 # ===========================================================================
 # NeuTTS (local, on-device TTS via neutts_cli)
 # ===========================================================================
@@ -612,6 +682,10 @@ def text_to_speech_tool(
             logger.info("Generating speech with Mistral Voxtral TTS...")
             _generate_mistral_tts(text, file_str, tts_config)
 
+        elif provider == "voicebox":
+            logger.info("Generating speech with Voicebox...")
+            _generate_voicebox_tts(text, file_str, tts_config)
+
         elif provider == "neutts":
             if not _check_neutts_available():
                 return json.dumps({
@@ -661,7 +735,7 @@ def text_to_speech_tool(
         # Try Opus conversion for Telegram compatibility
         # Edge TTS outputs MP3, NeuTTS outputs WAV — both need ffmpeg conversion
         voice_compatible = False
-        if provider in ("edge", "neutts", "minimax") and not file_str.endswith(".ogg"):
+        if provider in ("edge", "neutts", "minimax", "voicebox") and not file_str.endswith(".ogg"):
             opus_path = _convert_to_opus(file_str)
             if opus_path:
                 file_str = opus_path
@@ -740,6 +814,8 @@ def check_tts_requirements() -> bool:
             return True
     except ImportError:
         pass
+    if _voicebox_tts_configured():
+        return True
     if _check_neutts_available():
         return True
     return False

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -963,6 +963,8 @@ def check_voice_requirements() -> Dict[str, Any]:
         details_parts.append("STT provider: OK (Groq)")
     elif stt_provider == "openai":
         details_parts.append("STT provider: OK (OpenAI)")
+    elif stt_provider == "voicebox":
+        details_parts.append("STT provider: OK (Voicebox)")
     else:
         details_parts.append(
             "STT provider: MISSING (pip install faster-whisper, "


### PR DESCRIPTION
## Summary
- add Voicebox as a native STT provider in transcription_tools
- add Voicebox as a native TTS provider in tts_tool and config UI
- add targeted tests for Voicebox STT/TTS plus status wiring

## Test Plan
- source venv/bin/activate && python -m pytest tests/tools/test_voicebox_stt.py tests/tools/test_tts_voicebox.py -q
- source venv/bin/activate && python -m pytest tests/tools/test_transcription_tools.py tests/tools/test_tts_mistral.py tests/tools/test_voice_mode.py -q