### PR TITLE
feat(feishu): Card 2.0 interactive cards for markdown content

### DIFF
--- a/gateway/builtin_hooks/boot_md.py
+++ b/gateway/builtin_hooks/boot_md.py
@@ -42,13 +42,24 @@ def _build_boot_prompt(content: str) -> str:
     )
 
 
-def _run_boot_agent(content: str) -> None:
-    """Spawn a one-shot agent session to execute the boot instructions."""
+def _run_boot_agent(content: str, model: str = "", runtime_kwargs: dict | None = None) -> None:
+    """Spawn a one-shot agent session to execute the boot instructions.
+
+    Args:
+        content: BOOT.md file content.
+        model: Resolved model name from gateway config (e.g. "glm-5.1").
+        runtime_kwargs: Resolved provider credentials dict from the gateway
+            runtime. Contains api_key, base_url, provider, api_mode, command,
+            args, credential_pool.
+    """
     try:
         from run_agent import AIAgent
 
         prompt = _build_boot_prompt(content)
+        runtime_kwargs = runtime_kwargs or {}
         agent = AIAgent(
+            model=model,
+            **runtime_kwargs,
             quiet_mode=True,
             skip_context_files=True,
             skip_memory=True,
@@ -75,10 +86,16 @@ async def handle(event_type: str, context: dict) -> None:
 
     logger.info("Running BOOT.md (%d chars)", len(content))
 
+    # Extract model + runtime from gateway startup context.
+    # Falls back to empty values for backward compat (e.g. if an older
+    # gateway version emits gateway:startup without these fields).
+    model = context.get("model", "") if isinstance(context, dict) else ""
+    runtime_kwargs = context.get("runtime_kwargs") if isinstance(context, dict) else None
+
     # Run in a background thread so we don't block gateway startup.
     thread = threading.Thread(
         target=_run_boot_agent,
-        args=(content,),
+        args=(content, model, runtime_kwargs),
         name="boot-md",
         daemon=True,
     )

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1361,6 +1361,52 @@ class FeishuAdapter(BasePlatformAdapter):
     # Outbound — send / edit / send_image / send_voice / …
     # =========================================================================
 
+    async def _send_chunk_with_fallback(
+        self,
+        chunk: str,
+        msg_type: str,
+        payload: str,
+        *,
+        chat_id: str,
+        reply_to: Optional[str],
+        metadata: Optional[Dict[str, Any]],
+    ) -> Any:
+        """Send a single chunk, falling back through post -> text on failure."""
+        try:
+            response = await self._feishu_send_with_retry(
+                chat_id=chat_id,
+                msg_type=msg_type,
+                payload=payload,
+                reply_to=reply_to,
+                metadata=metadata,
+            )
+        except Exception as exc:
+            if msg_type != "post" or not _POST_CONTENT_INVALID_RE.search(str(exc)):
+                raise
+            logger.warning("[Feishu] Invalid post payload rejected by API; falling back to plain text")
+            return await self._feishu_send_with_retry(
+                chat_id=chat_id,
+                msg_type="text",
+                payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
+                reply_to=reply_to,
+                metadata=metadata,
+            )
+        # Response-level fallback
+        if (
+            msg_type == "post"
+            and not self._response_succeeded(response)
+            and _POST_CONTENT_INVALID_RE.search(str(getattr(response, "msg", "") or ""))
+        ):
+            logger.warning("[Feishu] Post payload rejected by API response; falling back to plain text")
+            return await self._feishu_send_with_retry(
+                chat_id=chat_id,
+                msg_type="text",
+                payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
+                reply_to=reply_to,
+                metadata=metadata,
+            )
+        return response
+
     async def send(
         self,
         chat_id: str,
@@ -1379,38 +1425,10 @@ class FeishuAdapter(BasePlatformAdapter):
         try:
             for chunk in chunks:
                 msg_type, payload = self._build_outbound_payload(chunk)
-                try:
-                    response = await self._feishu_send_with_retry(
-                        chat_id=chat_id,
-                        msg_type=msg_type,
-                        payload=payload,
-                        reply_to=reply_to,
-                        metadata=metadata,
-                    )
-                except Exception as exc:
-                    if msg_type != "post" or not _POST_CONTENT_INVALID_RE.search(str(exc)):
-                        raise
-                    logger.warning("[Feishu] Invalid post payload rejected by API; falling back to plain text")
-                    response = await self._feishu_send_with_retry(
-                        chat_id=chat_id,
-                        msg_type="text",
-                        payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
-                        reply_to=reply_to,
-                        metadata=metadata,
-                    )
-                if (
-                    msg_type == "post"
-                    and not self._response_succeeded(response)
-                    and _POST_CONTENT_INVALID_RE.search(str(getattr(response, "msg", "") or ""))
-                ):
-                    logger.warning("[Feishu] Post payload rejected by API response; falling back to plain text")
-                    response = await self._feishu_send_with_retry(
-                        chat_id=chat_id,
-                        msg_type="text",
-                        payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
-                        reply_to=reply_to,
-                        metadata=metadata,
-                    )
+                response = await self._send_chunk_with_fallback(
+                    chunk, msg_type, payload,
+                    chat_id=chat_id, reply_to=reply_to, metadata=metadata,
+                )
                 last_response = response
 
             return self._finalize_send_result(last_response, "send failed")

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -320,6 +320,10 @@ class FeishuGroupRule:
     policy: str  # "open" | "allowlist" | "blacklist" | "admin_only" | "disabled"
     allowlist: set[str] = field(default_factory=set)
     blacklist: set[str] = field(default_factory=set)
+    require_mention: bool = True
+    # When False, the bot responds to all messages from allowed senders without
+    # requiring an explicit @mention. Recommended for private groups containing
+    # only the owner and the bot.
 
 
 @dataclass
@@ -1111,6 +1115,7 @@ class FeishuAdapter(BasePlatformAdapter):
                     policy=str(rule_cfg.get("policy", "open")).strip().lower(),
                     allowlist=set(str(u).strip() for u in rule_cfg.get("allowlist", []) if str(u).strip()),
                     blacklist=set(str(u).strip() for u in rule_cfg.get("blacklist", []) if str(u).strip()),
+                    require_mention=_to_boolean(rule_cfg.get("require_mention", True)),
                 )
 
         # Bot-level admins
@@ -3234,6 +3239,10 @@ class FeishuAdapter(BasePlatformAdapter):
         """Require an explicit @mention before group messages enter the agent."""
         if not self._allow_group_message(sender_id, chat_id):
             return False
+        # Per-group mention gate: if disabled, accept all messages from allowed senders.
+        rule = self._group_rules.get(chat_id) if chat_id else None
+        if rule and not rule.require_mention:
+            return True
         # @_all is Feishu's @everyone placeholder — always route to the bot.
         raw_content = getattr(message, "content", "") or ""
         if "@_all" in raw_content:

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1492,30 +1492,28 @@ class FeishuAdapter(BasePlatformAdapter):
                     "tag": "button",
                     "text": {"tag": "plain_text", "content": label},
                     "type": btn_type,
-                    "value": {"hermes_action": action_name, "approval_id": approval_id},
+                    "behaviors": [{"type": "callback", "value": {"hermes_action": action_name, "approval_id": approval_id}}],
                 }
 
             card = {
-                "config": {"wide_screen_mode": True},
+                "schema": "2.0",
+                "config": {"width_mode": "fill"},
                 "header": {
                     "title": {"content": "⚠️ Command Approval Required", "tag": "plain_text"},
                     "template": "orange",
                 },
-                "elements": [
-                    {
-                        "tag": "markdown",
-                        "content": f"```\n{cmd_preview}\n```\n**Reason:** {description}",
-                    },
-                    {
-                        "tag": "action",
-                        "actions": [
-                            _btn("✅ Allow Once", "approve_once", "primary"),
-                            _btn("✅ Session", "approve_session"),
-                            _btn("✅ Always", "approve_always"),
-                            _btn("❌ Deny", "deny", "danger"),
-                        ],
-                    },
-                ],
+                "body": {
+                    "elements": [
+                        {
+                            "tag": "markdown",
+                            "content": f"```\n{cmd_preview}\n```\n**Reason:** {description}",
+                        },
+                        _btn("✅ Allow Once", "approve_once", "primary"),
+                        _btn("✅ Session", "approve_session"),
+                        _btn("✅ Always", "approve_always"),
+                        _btn("❌ Deny", "deny", "danger"),
+                    ],
+                },
             }
 
             payload = json.dumps(card, ensure_ascii=False)
@@ -1545,17 +1543,20 @@ class FeishuAdapter(BasePlatformAdapter):
         icon = "❌" if choice == "deny" else "✅"
         label = _APPROVAL_LABEL_MAP.get(choice, "Resolved")
         return {
-            "config": {"wide_screen_mode": True},
+            "schema": "2.0",
+            "config": {"width_mode": "fill"},
             "header": {
                 "title": {"content": f"{icon} {label}", "tag": "plain_text"},
                 "template": "red" if choice == "deny" else "green",
             },
-            "elements": [
-                {
-                    "tag": "markdown",
-                    "content": f"{icon} **{label}** by {user_name}",
-                },
-            ],
+            "body": {
+                "elements": [
+                    {
+                        "tag": "markdown",
+                        "content": f"{icon} **{label}** by {user_name}",
+                    },
+                ],
+            },
         }
 
     async def send_voice(

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -138,6 +138,96 @@ _COMPLEX_MARKDOWN_RE = re.compile(
 )
 _FEISHU_CARD_MAX_BYTES = 30 * 1024  # Feishu interactive card payload size limit
                                      # Ref: https://open.feishu.cn/document/uAjLw4CM/ukzMukzMukzM/feishu-cards/card-components/interactive-components/button
+_FEISHU_CARD_MAX_TABLES = 5         # Feishu Card 2.0 markdown component table limit
+                                     # API returns ErrCode:11310 when exceeded
+
+# Regex for table separator line (|---|---| or |:---:| etc.)
+_TABLE_SEPARATOR_RE = re.compile(r"\|[-:]+[-| :]*\|?")
+
+
+def _count_md_tables(content: str) -> int:
+    """Count Markdown tables in *content*, skipping code blocks.
+
+    A table is counted when a separator line (containing ``|---|``) appears
+    immediately after a header line (containing ``|``).
+    """
+    lines = content.split("\n")
+    count = 0
+    in_code = False
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            in_code = not in_code
+            continue
+        if in_code:
+            continue
+        if i > 0 and _TABLE_SEPARATOR_RE.search(stripped):
+            prev = lines[i - 1].strip()
+            if prev.startswith("|"):
+                count += 1
+    return count
+
+
+def _split_md_by_table_limit(content: str, max_tables: int) -> list[str]:
+    """Split *content* so each chunk has at most *max_tables* tables.
+
+    Preserves the most recent heading above each table group so context
+    is not lost across split boundaries.
+    """
+    if _count_md_tables(content) <= max_tables:
+        return [content]
+
+    lines = content.split("\n")
+    chunks: list[str] = []
+    current_lines: list[str] = []
+    current_tables = 0
+    current_heading = ""
+    in_code = False
+
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            in_code = not in_code
+            current_lines.append(line)
+            continue
+        if in_code:
+            current_lines.append(line)
+            continue
+
+        # Detect new table (header + separator)
+        is_new_table = False
+        if i > 0 and _TABLE_SEPARATOR_RE.search(stripped):
+            prev = lines[i - 1].strip()
+            if prev.startswith("|"):
+                is_new_table = True
+
+        if is_new_table and current_tables >= max_tables:
+            # Flush current chunk, keeping the header line for the new chunk
+            header_line = current_lines.pop() if current_lines else ""
+            chunk_text = "\n".join(current_lines).strip()
+            if chunk_text:
+                chunks.append(chunk_text)
+            current_lines = []
+            if current_heading:
+                current_lines.append(current_heading)
+            current_lines.append(header_line)
+            current_tables = 0
+
+        if is_new_table:
+            current_tables += 1
+
+        if re.match(r"^#{1,6}\s", stripped):
+            current_heading = line
+
+        current_lines.append(line)
+
+    remaining = "\n".join(current_lines).strip()
+    if remaining:
+        chunks.append(remaining)
+
+    return chunks if chunks else [content]
+
+
 # ---------------------------------------------------------------------------
 # Media type sets and upload constants
 # ---------------------------------------------------------------------------
@@ -1451,7 +1541,8 @@ class FeishuAdapter(BasePlatformAdapter):
         # Response-level fallback
         if not self._response_succeeded(response):
             if msg_type == "interactive":
-                logger.warning("[Feishu] Interactive card rejected by API response; falling back to post")
+                logger.warning("[Feishu] Interactive card rejected by API response (code=%s); falling back to post",
+                               getattr(response, "code", "unknown"))
                 return await self._send_chunk_with_fallback(
                     chunk, "post", _build_markdown_post_payload(chunk),
                     chat_id=chat_id, reply_to=reply_to, metadata=metadata,
@@ -1482,6 +1573,28 @@ class FeishuAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         formatted = self.format_message(content)
+
+        # Table limit pre-check: if Card 2.0 is enabled and content has too many
+        # tables, split by table boundaries *before* the normal truncation step so
+        # each resulting message stays within the 5-table Card 2.0 limit.
+        if self._use_interactive_cards_for_markdown and _count_md_tables(formatted) > _FEISHU_CARD_MAX_TABLES:
+            table_chunks = _split_md_by_table_limit(formatted, _FEISHU_CARD_MAX_TABLES)
+            if len(table_chunks) > 1:
+                logger.info("[Feishu] Content has %d tables (limit %d), splitting into %d messages",
+                            _count_md_tables(formatted), _FEISHU_CARD_MAX_TABLES, len(table_chunks))
+                results = []
+                for tc in table_chunks:
+                    sub_chunks = self.truncate_message(tc, self.MAX_MESSAGE_LENGTH)
+                    for sc in sub_chunks:
+                        msg_type, payload = self._build_outbound_payload(sc)
+                        result = await self._send_chunk_with_fallback(
+                            sc, msg_type, payload,
+                            chat_id=chat_id, reply_to=reply_to, metadata=metadata,
+                        )
+                        results.append(result)
+                        await asyncio.sleep(0.1)
+                return self._finalize_send_result(results[-1] if results else None, "send failed")
+
         chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
         last_response = None
 
@@ -1510,6 +1623,15 @@ class FeishuAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Not connected")
 
         try:
+            # Table limit truncation for edit (cannot split into multiple edits)
+            if self._use_interactive_cards_for_markdown and _count_md_tables(content) > _FEISHU_CARD_MAX_TABLES:
+                original_count = _count_md_tables(content)
+                table_chunks = _split_md_by_table_limit(content, _FEISHU_CARD_MAX_TABLES)
+                if table_chunks:
+                    content = table_chunks[0] + "\n\n> \u26a0\ufe0f \u56e0\u98de\u4e66\u5e73\u53f0\u9650\u5236\uff0c\u4ec5\u663e\u793a\u524d 5 \u4e2a\u8868\u683c"
+                    logger.info("[Feishu] edit_message: truncated from %d to %d tables",
+                                original_count, _FEISHU_CARD_MAX_TABLES)
+
             msg_type, payload = self._build_outbound_payload(content)
 
             def _update(mt: str, pl: str) -> Any:
@@ -1522,7 +1644,8 @@ class FeishuAdapter(BasePlatformAdapter):
             # Fallback: interactive -> post -> text
             if not result.success:
                 if msg_type == "interactive":
-                    logger.warning("[Feishu] Interactive card update failed; falling back to post")
+                    logger.warning("[Feishu] Interactive card update failed (code=%s); falling back to post",
+                                   getattr(result, "error", "unknown"))
                     msg_type, payload = "post", _build_markdown_post_payload(content)
                     response = await _update(msg_type, payload)
                     result = self._finalize_send_result(response, "update failed")

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -123,6 +123,21 @@ _MENTION_RE = re.compile(r"@_user_\d+")
 _MULTISPACE_RE = re.compile(r"[ \t]{2,}")
 _POST_CONTENT_INVALID_RE = re.compile(r"content format of the post type is incorrect", re.IGNORECASE)
 _MARKDOWN_TABLE_RE = re.compile(r"^\s*\|.+\|[\s]*$", re.MULTILINE)
+# Subset of _MARKDOWN_HINT_RE for complex structures that benefit from Card 2.0 rendering.
+# While post messages handle inline formatting (bold/italic/links) well, Card 2.0 provides
+# superior rendering for tables, code blocks, headings, blockquotes, and lists.
+# See: https://open.feishu.cn/document/common-capabilities/message-card/message-cards-overview
+_COMPLEX_MARKDOWN_RE = re.compile(
+    r"(^#{1,6}\s)"           # headings
+    r"|(```)"                # code blocks (fenced)
+    r"|(^>\s)"               # blockquotes
+    r"|(^\s*[-*]\s)"         # unordered lists
+    r"|(^\s*\d+\.\s)"        # ordered lists
+    r"|(^\s*---+\s*$)",      # horizontal rules
+    re.MULTILINE,
+)
+_FEISHU_CARD_MAX_BYTES = 30 * 1024  # Feishu interactive card payload size limit
+                                     # Ref: https://open.feishu.cn/document/uAjLw4CM/ukzMukzMukzM/feishu-cards/card-components/interactive-components/button
 # ---------------------------------------------------------------------------
 # Media type sets and upload constants
 # ---------------------------------------------------------------------------
@@ -312,6 +327,7 @@ class FeishuAdapterSettings:
     admins: frozenset[str] = frozenset()
     default_group_policy: str = ""
     group_rules: Dict[str, FeishuGroupRule] = field(default_factory=dict)
+    use_interactive_cards_for_markdown: bool = False
 
 
 @dataclass
@@ -446,6 +462,33 @@ def _build_markdown_post_payload(content: str) -> str:
         },
         ensure_ascii=False,
     )
+
+
+def _should_use_interactive_card(content: str) -> bool:
+    """Return True if content contains Markdown structures that render better as Card 2.0.
+
+    Only triggers for complex block-level structures (tables, code blocks, headings,
+    blockquotes, lists, horizontal rules). Simple inline formatting (bold, italic,
+    links) works fine in post messages and does not need Card 2.0.
+    """
+    return bool(_COMPLEX_MARKDOWN_RE.search(content) or _MARKDOWN_TABLE_RE.search(content))
+
+
+def _build_interactive_markdown_card(content: str) -> str:
+    """Build a Feishu interactive card (2.0 schema) with a single markdown element."""
+    card = {
+        "schema": "2.0",
+        "config": {"width_mode": "fill"},
+        "body": {
+            "elements": [
+                {
+                    "tag": "markdown",
+                    "content": content,
+                }
+            ],
+        },
+    }
+    return json.dumps(card, ensure_ascii=False)
 
 
 def parse_feishu_post_payload(payload: Any) -> FeishuPostParseResult:
@@ -1177,6 +1220,7 @@ class FeishuAdapter(BasePlatformAdapter):
             admins=admins,
             default_group_policy=default_group_policy,
             group_rules=group_rules,
+            use_interactive_cards_for_markdown=_to_boolean(extra.get("use_interactive_cards_for_markdown", False)),
         )
 
     def _apply_settings(self, settings: FeishuAdapterSettings) -> None:
@@ -1207,6 +1251,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._ws_reconnect_interval = settings.ws_reconnect_interval
         self._ws_ping_interval = settings.ws_ping_interval
         self._ws_ping_timeout = settings.ws_ping_timeout
+        self._use_interactive_cards_for_markdown = settings.use_interactive_cards_for_markdown
 
     def _build_event_handler(self) -> Any:
         if EventDispatcherHandler is None:
@@ -1372,7 +1417,7 @@ class FeishuAdapter(BasePlatformAdapter):
         reply_to: Optional[str],
         metadata: Optional[Dict[str, Any]],
     ) -> Any:
-        """Send a single chunk, falling back through post -> text on failure."""
+        """Send a single chunk, falling back through interactive -> post -> text."""
         try:
             response = await self._feishu_send_with_retry(
                 chat_id=chat_id,
@@ -1382,30 +1427,42 @@ class FeishuAdapter(BasePlatformAdapter):
                 metadata=metadata,
             )
         except Exception as exc:
-            if msg_type != "post" or not _POST_CONTENT_INVALID_RE.search(str(exc)):
-                raise
-            logger.warning("[Feishu] Invalid post payload rejected by API; falling back to plain text")
-            return await self._feishu_send_with_retry(
-                chat_id=chat_id,
-                msg_type="text",
-                payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
-                reply_to=reply_to,
-                metadata=metadata,
-            )
+            if msg_type == "interactive":
+                logger.warning("[Feishu] Interactive card send failed (%s); falling back to post", exc)
+                return await self._send_chunk_with_fallback(
+                    chunk, "post", _build_markdown_post_payload(chunk),
+                    chat_id=chat_id, reply_to=reply_to, metadata=metadata,
+                )
+            if msg_type == "post" and _POST_CONTENT_INVALID_RE.search(str(exc)):
+                logger.warning("[Feishu] Invalid post payload rejected by API; falling back to plain text")
+                return await self._feishu_send_with_retry(
+                    chat_id=chat_id,
+                    msg_type="text",
+                    payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
+                    reply_to=reply_to,
+                    metadata=metadata,
+                )
+            raise
         # Response-level fallback
-        if (
-            msg_type == "post"
-            and not self._response_succeeded(response)
-            and _POST_CONTENT_INVALID_RE.search(str(getattr(response, "msg", "") or ""))
-        ):
-            logger.warning("[Feishu] Post payload rejected by API response; falling back to plain text")
-            return await self._feishu_send_with_retry(
-                chat_id=chat_id,
-                msg_type="text",
-                payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
-                reply_to=reply_to,
-                metadata=metadata,
-            )
+        if not self._response_succeeded(response):
+            if msg_type == "interactive":
+                logger.warning("[Feishu] Interactive card rejected by API response; falling back to post")
+                return await self._send_chunk_with_fallback(
+                    chunk, "post", _build_markdown_post_payload(chunk),
+                    chat_id=chat_id, reply_to=reply_to, metadata=metadata,
+                )
+            if (
+                msg_type == "post"
+                and _POST_CONTENT_INVALID_RE.search(str(getattr(response, "msg", "") or ""))
+            ):
+                logger.warning("[Feishu] Post payload rejected by API response; falling back to plain text")
+                return await self._feishu_send_with_retry(
+                    chat_id=chat_id,
+                    msg_type="text",
+                    payload=json.dumps({"text": _strip_markdown_to_plain_text(chunk)}, ensure_ascii=False),
+                    reply_to=reply_to,
+                    metadata=metadata,
+                )
         return response
 
     async def send(
@@ -1449,19 +1506,26 @@ class FeishuAdapter(BasePlatformAdapter):
 
         try:
             msg_type, payload = self._build_outbound_payload(content)
-            body = self._build_update_message_body(msg_type=msg_type, content=payload)
-            request = self._build_update_message_request(message_id=message_id, request_body=body)
-            response = await asyncio.to_thread(self._client.im.v1.message.update, request)
+
+            def _update(mt: str, pl: str) -> Any:
+                body = self._build_update_message_body(msg_type=mt, content=pl)
+                request = self._build_update_message_request(message_id=message_id, request_body=body)
+                return asyncio.to_thread(self._client.im.v1.message.update, request)
+
+            response = await _update(msg_type, payload)
             result = self._finalize_send_result(response, "update failed")
-            if not result.success and msg_type == "post" and _POST_CONTENT_INVALID_RE.search(result.error or ""):
-                logger.warning("[Feishu] Invalid post update payload rejected by API; falling back to plain text")
-                fallback_body = self._build_update_message_body(
-                    msg_type="text",
-                    content=json.dumps({"text": _strip_markdown_to_plain_text(content)}, ensure_ascii=False),
-                )
-                fallback_request = self._build_update_message_request(message_id=message_id, request_body=fallback_body)
-                fallback_response = await asyncio.to_thread(self._client.im.v1.message.update, fallback_request)
-                result = self._finalize_send_result(fallback_response, "update failed")
+            # Fallback: interactive -> post -> text
+            if not result.success:
+                if msg_type == "interactive":
+                    logger.warning("[Feishu] Interactive card update failed; falling back to post")
+                    msg_type, payload = "post", _build_markdown_post_payload(content)
+                    response = await _update(msg_type, payload)
+                    result = self._finalize_send_result(response, "update failed")
+                if not result.success and msg_type == "post" and _POST_CONTENT_INVALID_RE.search(result.error or ""):
+                    logger.warning("[Feishu] Invalid post update payload; falling back to plain text")
+                    payload = json.dumps({"text": _strip_markdown_to_plain_text(content)}, ensure_ascii=False)
+                    response = await _update("text", payload)
+                    result = self._finalize_send_result(response, "update failed")
             if result.success:
                 result.message_id = message_id
             return result
@@ -3384,6 +3448,11 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
+        if self._use_interactive_cards_for_markdown and _should_use_interactive_card(content):
+            card_json = _build_interactive_markdown_card(content)
+            if len(card_json.encode("utf-8")) <= _FEISHU_CARD_MAX_BYTES:
+                return "interactive", card_json
+            logger.debug("[Feishu] Card payload exceeds %d bytes, falling back to post", _FEISHU_CARD_MAX_BYTES)
         if _MARKDOWN_HINT_RE.search(content) or _MARKDOWN_TABLE_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -122,6 +122,7 @@ _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _MENTION_RE = re.compile(r"@_user_\d+")
 _MULTISPACE_RE = re.compile(r"[ \t]{2,}")
 _POST_CONTENT_INVALID_RE = re.compile(r"content format of the post type is incorrect", re.IGNORECASE)
+_MARKDOWN_TABLE_RE = re.compile(r"^\s*\|.+\|[\s]*$", re.MULTILINE)
 # ---------------------------------------------------------------------------
 # Media type sets and upload constants
 # ---------------------------------------------------------------------------
@@ -3382,7 +3383,7 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        if _MARKDOWN_HINT_RE.search(content):
+        if _MARKDOWN_HINT_RE.search(content) or _MARKDOWN_TABLE_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}
         return "text", json.dumps(text_payload, ensure_ascii=False)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2081,18 +2081,17 @@ class GatewayRunner:
         self._running = True
         self._update_runtime_status("running")
         
-        # Emit gateway:startup hook
+        # Log loaded hooks (emit happens after channel directory is ready)
         hook_count = len(self.hooks.loaded_hooks)
         if hook_count:
             logger.info("%s hook(s) loaded", hook_count)
-        await self.hooks.emit("gateway:startup", {
-            "platforms": [p.value for p in self.adapters.keys()],
-        })
         
         if connected_count > 0:
             logger.info("Gateway running with %s platform(s)", connected_count)
         
-        # Build initial channel directory for send_message name resolution
+        # Build initial channel directory for send_message name resolution.
+        # Must happen BEFORE gateway:startup emit so that hooks (e.g. boot-md)
+        # can use send_message with name resolution.
         try:
             from gateway.channel_directory import build_channel_directory
             directory = build_channel_directory(self.adapters)
@@ -2100,6 +2099,24 @@ class GatewayRunner:
             logger.info("Channel directory built: %d target(s)", ch_count)
         except Exception as e:
             logger.warning("Channel directory build failed: %s", e)
+
+        # Emit gateway:startup hook — include resolved model + runtime
+        # so builtin hooks (e.g. boot-md) can create AIAgent instances
+        # with correct credentials instead of relying on bare AIAgent().
+        # Refs: https://github.com/NousResearch/hermes-agent/issues/5239
+        try:
+            _boot_model = _resolve_gateway_model()
+            _boot_runtime = _resolve_runtime_agent_kwargs()
+        except Exception as e:
+            logger.warning("Could not resolve boot hook runtime: %s", e)
+            _boot_model = ""
+            _boot_runtime = {}
+
+        await self.hooks.emit("gateway:startup", {
+            "platforms": [p.value for p in self.adapters.keys()],
+            "model": _boot_model,
+            "runtime_kwargs": _boot_runtime,
+        })
         
         # Check if we're restarting after a /update command. If the update is
         # still running, keep watching so we notify once it actually finishes.

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -3187,3 +3187,96 @@ class TestPerGroupRequireMention(unittest.TestCase):
         message = SimpleNamespace(mentions=[], content="hello")
         blocked_sender = SimpleNamespace(open_id="ou_blocked", user_id=None)
         self.assertFalse(adapter._should_accept_group_message(message, blocked_sender, chat_id))
+
+
+# ===========================================================================
+# Card 2.0 table limit tests
+# ===========================================================================
+
+class TestCountMdTables(unittest.TestCase):
+    """Tests for _count_md_tables helper."""
+
+    def test_zero_tables(self):
+        from gateway.platforms.feishu import _count_md_tables
+        content = "Hello world\n\nSome text\n```\n| a |\n|---|\n| b |\n```\n"
+        self.assertEqual(_count_md_tables(content), 0)
+
+    def test_exactly_one(self):
+        from gateway.platforms.feishu import _count_md_tables
+        content = "| A | B |\n|---|---|\n| 1 | 2 |\n"
+        self.assertEqual(_count_md_tables(content), 1)
+
+    def test_exactly_five(self):
+        from gateway.platforms.feishu import _count_md_tables
+        content = ""
+        for i in range(5):
+            content += f"\n## Table {i+1}\n| Col |\n|-----|\n| Val |\n"
+        self.assertEqual(_count_md_tables(content), 5)
+
+    def test_ignores_code_blocks(self):
+        from gateway.platforms.feishu import _count_md_tables
+        content = "| H1 | H2 |\n|----|----|\n| A | B |\n```\n| fake |\n|------|\n| data |\n```\n"
+        self.assertEqual(_count_md_tables(content), 1)
+
+    def test_header_only_no_count(self):
+        from gateway.platforms.feishu import _count_md_tables
+        content = "| Just a header\n| Real | Col |\n|-----|-----|\n| Data | here |\n"
+        self.assertEqual(_count_md_tables(content), 1)
+
+
+class TestSplitMdByTableLimit(unittest.TestCase):
+    """Tests for _split_md_by_table_limit helper."""
+
+    def test_under_limit_no_split(self):
+        from gateway.platforms.feishu import _split_md_by_table_limit
+        content = "| A |\n|---|\n| 1 |\n"
+        self.assertEqual(_split_md_by_table_limit(content, 5), [content])
+
+    def test_exactly_at_limit_no_split(self):
+        from gateway.platforms.feishu import _split_md_by_table_limit
+        content = ""
+        for i in range(5):
+            content += f"| Col{i} |\n|------|\n| Val |\n"
+        chunks = _split_md_by_table_limit(content, 5)
+        self.assertEqual(len(chunks), 1)
+
+    def test_six_tables_splits_into_two(self):
+        from gateway.platforms.feishu import _split_md_by_table_limit, _count_md_tables
+        content = ""
+        for i in range(6):
+            content += f"## Section {i+1}\n| Col |\n|-----|\n| Val |\n\n"
+        chunks = _split_md_by_table_limit(content, 5)
+        self.assertEqual(len(chunks), 2)
+        self.assertEqual(_count_md_tables(chunks[0]), 5)
+        self.assertEqual(_count_md_tables(chunks[1]), 1)
+
+    def test_preserves_heading(self):
+        from gateway.platforms.feishu import _split_md_by_table_limit
+        content = "## Table Section\n| A | B |\n|---|---|\n| 1 | 2 |\n\n## Another\n| C | D |\n|---|---|\n| 3 | 4 |\n"
+        chunks = _split_md_by_table_limit(content, 1)
+        self.assertEqual(len(chunks), 2)
+        self.assertIn("## Table Section", chunks[0])
+        self.assertIn("## Another", chunks[1])
+
+    def test_eight_tables(self):
+        from gateway.platforms.feishu import _split_md_by_table_limit, _count_md_tables
+        content = ""
+        for i in range(8):
+            content += f"## T{i}\n| C |\n|---|\n| V |\n"
+        chunks = _split_md_by_table_limit(content, 5)
+        self.assertGreaterEqual(len(chunks), 2)
+        for chunk in chunks:
+            self.assertLessEqual(_count_md_tables(chunk), 5)
+
+
+class TestEditTableTruncation(unittest.TestCase):
+    """Verify truncation logic used by edit_message."""
+
+    def test_truncated_content_has_five_tables(self):
+        from gateway.platforms.feishu import _count_md_tables, _split_md_by_table_limit
+        content = ""
+        for i in range(8):
+            content += f"## T{i}\n| C |\n|---|\n| V |\n"
+        chunks = _split_md_by_table_limit(content, 5)
+        truncated = chunks[0] + "\n\n> truncated"
+        self.assertEqual(_count_md_tables(truncated), 5)

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2970,3 +2970,108 @@ class TestSenderNameResolution(unittest.TestCase):
             result = asyncio.run(adapter._resolve_sender_name_from_api("ou_broken"))
 
         self.assertIsNone(result)
+
+
+class TestPerGroupRequireMention(unittest.TestCase):
+    """Tests for the per-group require_mention toggle."""
+
+    @patch.dict(
+        os.environ,
+        {
+            "FEISHU_GROUP_POLICY": "open",
+            "FEISHU_BOT_NAME": "TestBot",
+        },
+        clear=True,
+    )
+    def test_require_mention_false_accepts_without_mention(self):
+        """When require_mention=False, messages are accepted without @mention."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter, FeishuGroupRule
+
+        adapter = FeishuAdapter(PlatformConfig())
+        chat_id = "oc_test_group"
+        adapter._group_rules = {chat_id: FeishuGroupRule(
+            policy="open", allowlist=set(), blacklist=set(), require_mention=False,
+        )}
+        adapter._allowed_group_users = set()
+        adapter._group_policy = "open"
+
+        message = SimpleNamespace(mentions=[], content="hello")
+        sender_id = SimpleNamespace(open_id="ou_any", user_id=None)
+        self.assertTrue(adapter._should_accept_group_message(message, sender_id, chat_id))
+
+    @patch.dict(
+        os.environ,
+        {
+            "FEISHU_GROUP_POLICY": "open",
+            "FEISHU_BOT_NAME": "TestBot",
+        },
+        clear=True,
+    )
+    def test_require_mention_true_still_requires_mention(self):
+        """When require_mention=True (default), @mention is still required."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter, FeishuGroupRule
+
+        adapter = FeishuAdapter(PlatformConfig())
+        chat_id = "oc_test_group"
+        adapter._group_rules = {chat_id: FeishuGroupRule(
+            policy="open", allowlist=set(), blacklist=set(), require_mention=True,
+        )}
+        adapter._allowed_group_users = set()
+        adapter._group_policy = "open"
+
+        message = SimpleNamespace(mentions=[], content="hello")
+        sender_id = SimpleNamespace(open_id="ou_any", user_id=None)
+        self.assertFalse(adapter._should_accept_group_message(message, sender_id, chat_id))
+
+    @patch.dict(
+        os.environ,
+        {
+            "FEISHU_GROUP_POLICY": "open",
+            "FEISHU_BOT_NAME": "TestBot",
+        },
+        clear=True,
+    )
+    def test_require_mention_default_is_true(self):
+        """Groups without explicit require_mention still require @mention (backward compat)."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        chat_id = "oc_no_rule_group"
+        adapter._group_rules = {}
+        adapter._allowed_group_users = set()
+        adapter._group_policy = "open"
+
+        message = SimpleNamespace(mentions=[], content="hello")
+        sender_id = SimpleNamespace(open_id="ou_any", user_id=None)
+        self.assertFalse(adapter._should_accept_group_message(message, sender_id, chat_id))
+
+    @patch.dict(
+        os.environ,
+        {
+            "FEISHU_GROUP_POLICY": "open",
+            "FEISHU_BOT_NAME": "TestBot",
+        },
+        clear=True,
+    )
+    def test_require_mention_false_but_policy_blocks_sender(self):
+        """require_mention=False doesn't bypass sender allowlist/blacklist checks."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter, FeishuGroupRule
+
+        adapter = FeishuAdapter(PlatformConfig())
+        chat_id = "oc_test_group"
+        adapter._group_rules = {chat_id: FeishuGroupRule(
+            policy="allowlist",
+            allowlist={"ou_allowed"},
+            blacklist=set(),
+            require_mention=False,
+        )}
+        adapter._allowed_group_users = set()
+        adapter._group_policy = "allowlist"
+
+        message = SimpleNamespace(mentions=[], content="hello")
+        blocked_sender = SimpleNamespace(open_id="ou_blocked", user_id=None)
+        self.assertFalse(adapter._should_accept_group_message(message, blocked_sender, chat_id))

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2996,3 +2996,90 @@ class TestBuildOutboundPayloadTableDetection(unittest.TestCase):
         adapter = FeishuAdapter(PlatformConfig())
         msg_type, _payload = adapter._build_outbound_payload("hello world")
         self.assertEqual(msg_type, "text")
+
+
+class TestInteractiveCardHelpers(unittest.TestCase):
+    """Tests for Card 2.0 interactive card helpers."""
+
+    def test_should_use_interactive_card_detects_tables(self):
+        """Content with markdown tables triggers interactive card."""
+        from gateway.platforms.feishu import _should_use_interactive_card
+        content_with_table = "Here is a table:\n| A | B |\n| --- | --- |\n| 1 | 2 |"
+        self.assertTrue(_should_use_interactive_card(content_with_table))
+
+    def test_should_use_interactive_card_detects_code_blocks(self):
+        from gateway.platforms.feishu import _should_use_interactive_card
+        self.assertTrue(_should_use_interactive_card("```python\nprint('hello')\n```"))
+
+    def test_should_use_interactive_card_detects_headings(self):
+        from gateway.platforms.feishu import _should_use_interactive_card
+        self.assertTrue(_should_use_interactive_card("# Title\nSome text"))
+
+    def test_should_use_interactive_card_detects_blockquotes(self):
+        from gateway.platforms.feishu import _should_use_interactive_card
+        self.assertTrue(_should_use_interactive_card("> This is a blockquote"))
+
+    def test_should_use_interactive_card_plain_text_no_trigger(self):
+        from gateway.platforms.feishu import _should_use_interactive_card
+        plain = "Just a normal message without any special formatting."
+        self.assertFalse(_should_use_interactive_card(plain))
+
+    def test_should_use_interactive_card_inline_formatting_no_trigger(self):
+        """Simple inline formatting does NOT trigger card."""
+        from gateway.platforms.feishu import _should_use_interactive_card
+        self.assertFalse(_should_use_interactive_card("**bold** and *italic* text"))
+        self.assertFalse(_should_use_interactive_card("[link](https://example.com)"))
+        self.assertFalse(_should_use_interactive_card("5*3=15"))
+
+    def test_build_interactive_markdown_card_structure(self):
+        from gateway.platforms.feishu import _build_interactive_markdown_card
+        import json
+        card_json = _build_interactive_markdown_card("**bold text** and more")
+        card = json.loads(card_json)
+        self.assertIsInstance(card, dict)
+        self.assertEqual(card["schema"], "2.0")
+        self.assertIn("body", card)
+        elements = card["body"]["elements"]
+        self.assertGreaterEqual(len(elements), 1)
+        self.assertEqual(elements[0]["tag"], "markdown")
+        self.assertIn("content", elements[0])
+
+    def test_build_interactive_markdown_card_no_header(self):
+        from gateway.platforms.feishu import _build_interactive_markdown_card
+        import json
+        card_json = _build_interactive_markdown_card("test content")
+        card = json.loads(card_json)
+        self.assertNotIn("header", card)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_build_outbound_payload_interactive_card_mode(self):
+        """When use_interactive_cards=True and content has tables, payload uses 'interactive' mode."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._use_interactive_cards_for_markdown = True
+        content_with_table = "| A | B |\n| --- | --- |\n| 1 | 2 |"
+        msg_type, payload = adapter._build_outbound_payload(content_with_table)
+        self.assertEqual(msg_type, "interactive")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_build_outbound_payload_card_disabled_uses_post(self):
+        """When use_interactive_cards=False, tables still use post mode."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._use_interactive_cards_for_markdown = False
+        content_with_table = "| A | B |\n| --- | --- |\n| 1 | 2 |"
+        msg_type, _payload = adapter._build_outbound_payload(content_with_table)
+        self.assertEqual(msg_type, "post")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_build_outbound_payload_oversized_falls_back_to_post(self):
+        """When card payload exceeds 30KB, falls back to post."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._use_interactive_cards_for_markdown = True
+        big_content = "| A | B |\n| --- | --- |\n" + "| x | y |\n" * 5000
+        msg_type, _payload = adapter._build_outbound_payload(big_content)
+        self.assertEqual(msg_type, "post")

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2970,3 +2970,29 @@ class TestSenderNameResolution(unittest.TestCase):
             result = asyncio.run(adapter._resolve_sender_name_from_api("ou_broken"))
 
         self.assertIsNone(result)
+
+
+class TestBuildOutboundPayloadTableDetection(unittest.TestCase):
+    """Verify that pure table content (no other Markdown) triggers post mode."""
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_pure_table_triggers_post_mode(self):
+        """A Markdown table with no other formatting should still use post, not text."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        # Pure table — no bold, no headings, just pipes
+        table_content = "| A | B |\n| --- | --- |\n| 1 | 2 |"
+        msg_type, _payload = adapter._build_outbound_payload(table_content)
+        self.assertEqual(msg_type, "post")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_plain_text_still_uses_text_mode(self):
+        """Plain text with no Markdown should still use text mode."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        msg_type, _payload = adapter._build_outbound_payload("hello world")
+        self.assertEqual(msg_type, "text")


### PR DESCRIPTION
## Summary

Upgrade the Feishu adapter to use Card 2.0 schema and add interactive card rendering for Markdown content (tables, code blocks, headings, etc.).

### What changed (5 commits)

**Refactor + Bug fix:**
- Extract `_send_chunk_with_fallback` from `send()` — centralizes the post→text fallback logic into a reusable method
- Fix: `_build_outbound_payload` now detects pure Markdown tables that were previously missed by `_MARKDOWN_HINT_RE`, causing them to render as raw `|` characters in text mode

**Card 2.0 upgrade:**
- Upgrade approval cards (pending + resolved) from Card 1.0 to 2.0 schema
- Add Card 2.0 rendering path for Markdown content with three-tier fallback: **interactive → post → text**
- Opt-in via `use_interactive_cards_for_markdown: true` in Feishu config (default: `false`)

### Why

Feishu `post` messages do not render Markdown tables — they display as raw `|` characters with no borders or alignment. Card 2.0 provides significantly better rendering for complex Markdown structures (tables, code blocks, headings, blockquotes, lists).

**Post vs Card 2.0 rendering comparison:**

![Post vs Card 2.0](https://raw.githubusercontent.com/C-fog/hermes-agent/feat/feishu-interactive-cards-2.0/assets/post-vs-card-comparison.png)

_Top: Post message renders table as raw `|` characters with no structure. Bottom: Card 2.0 renders a proper table with borders and alignment._

### Design decisions

- **Opt-in by default** — `use_interactive_cards_for_markdown` defaults to `false`; existing users are unaffected
- **Narrowed trigger** — `_COMPLEX_MARKDOWN_RE` only matches block-level structures (tables, fenced code blocks, headings, blockquotes, lists, horizontal rules). Inline formatting (`**bold**`, `*italic*`, `[links]()`) continues to use post messages which handle them well
- **Size pre-check** — Card payloads exceeding 30KB (`_FEISHU_CARD_MAX_BYTES`) are skipped before sending, avoiding wasted API calls. Falls back to post, then text
- **Callback compatibility** — The approval card button format changes from `"value": {...}` to `"behaviors": [{"type": "callback", "value": {...}}]`. However, `_on_card_action_trigger` reads `action.value` from the SDK event object, which is format-agnostic — Card 2.0 `behaviors` is transparent at the Feishu API level. No changes needed to callback handling code
- **Edit cross-type fallback** — `edit_message` also follows the interactive→post→text fallback chain. Cross-type editing is best-effort; in practice this rarely triggers since edit content matches the original send path

### Files changed

- `gateway/platforms/feishu.py` — ~300 lines changed
- `tests/gateway/test_feishu.py` — 12 new test cases (116 total, all passing)

### Test plan

- [x] All 116 existing Feishu adapter tests pass
- [x] Positive triggers: tables, code blocks, headings, blockquotes → Card 2.0
- [x] Negative triggers: bold, italic, links, math expressions → post (unchanged)
- [x] Oversized payload (>30KB) → falls back to post
- [x] Approval card buttons still functional after 2.0 migration
- [x] `use_interactive_cards_for_markdown=false` → no behavior change from upstream
