### PR TITLE
feat(send_message): add filePath param and feishu media attachment support

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -118,6 +118,10 @@ SEND_MESSAGE_SCHEMA = {
             "message": {
                 "type": "string",
                 "description": "The message text to send"
+            },
+            "filePath": {
+                "type": "string",
+                "description": "Absolute path to a local file to send as an attachment. Supports images, videos, audio, and documents. Currently supported platforms: telegram, discord, feishu, weixin."
             }
         },
         "required": []
@@ -148,8 +152,21 @@ def _handle_send(args):
     """Send a message to a platform target."""
     target = args.get("target", "")
     message = args.get("message", "")
-    if not target or not message:
-        return tool_error("Both 'target' and 'message' are required when action='send'")
+    file_path = args.get("filePath", "")
+
+    # Build media_files from filePath parameter
+    extra_media_files = []
+    if file_path:
+        if not os.path.isfile(file_path):
+            return json.dumps({"error": f"File not found: {file_path}"})
+        ext = os.path.splitext(file_path)[1].lower()
+        is_voice = ext in _VOICE_EXTS
+        extra_media_files = [(file_path, is_voice)]
+        if not message:
+            message = ""
+
+    if not target or (not message and not extra_media_files):
+        return tool_error("Both 'target' and 'message' are required when action='send' (or provide 'filePath' instead of 'message')")
 
     parts = target.split(":", 1)
     platform_name = parts[0].strip().lower()
@@ -241,6 +258,12 @@ def _handle_send(args):
     from gateway.platforms.base import BasePlatformAdapter
 
     media_files, cleaned_message = BasePlatformAdapter.extract_media(message)
+    # Merge in filePath-based media
+    if extra_media_files:
+        existing_paths = {mf[0] for mf in media_files}
+        for mf in extra_media_files:
+            if mf[0] not in existing_paths:
+                media_files.append(mf)
     mirror_text = cleaned_message.strip() or _describe_media_for_mirror(media_files)
 
     used_home_channel = False
@@ -500,19 +523,35 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             last_result = result
         return last_result
 
-    # --- Non-Telegram/Discord platforms ---
-    if media_files and not message.strip():
+    # --- Feishu: special handling for media attachments ---
+    if platform == Platform.FEISHU:
+        last_result = None
+        for i, chunk in enumerate(chunks):
+            is_last = (i == len(chunks) - 1)
+            result = await _send_feishu(
+                pconfig, chat_id, chunk,
+                media_files=media_files if is_last else [],
+                thread_id=thread_id,
+            )
+            if isinstance(result, dict) and result.get("error"):
+                return result
+            last_result = result
+        return last_result
+
+    # --- Non-Telegram/Discord/Media-capable platforms ---
+    _MEDIA_CAPABLE = {Platform.TELEGRAM, Platform.DISCORD, Platform.MATRIX, Platform.FEISHU, Platform.WEIXIN}
+    if media_files and not message.strip() and platform not in _MEDIA_CAPABLE:
         return {
             "error": (
-                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, and weixin; "
+                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, feishu, and weixin; "
                 f"target {platform.value} had only media attachments"
             )
         }
     warning = None
-    if media_files:
+    if media_files and platform not in _MEDIA_CAPABLE:
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
-            "native send_message media delivery is currently only supported for telegram, discord, matrix, and weixin"
+            "native send_message media delivery is currently only supported for telegram, discord, matrix, feishu, and weixin"
         )
 
     last_result = None
@@ -535,8 +574,6 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             result = await _send_homeassistant(pconfig.token, pconfig.extra, chat_id, chunk)
         elif platform == Platform.DINGTALK:
             result = await _send_dingtalk(pconfig.extra, chat_id, chunk)
-        elif platform == Platform.FEISHU:
-            result = await _send_feishu(pconfig, chat_id, chunk, thread_id=thread_id)
         elif platform == Platform.WECOM:
             result = await _send_wecom(pconfig.extra, chat_id, chunk)
         elif platform == Platform.BLUEBUBBLES:


### PR DESCRIPTION
## Summary

- Add `filePath` parameter to `send_message` tool schema for sending local files as attachments
- Enable native media delivery for Feishu (images, videos, audio, documents)
- Previously `_send_feishu` accepted `media_files` but the caller never passed them

## Changes

1. **Schema**: new `filePath` (string) parameter with platform support description
2. **_handle_send**: validates file existence, builds `media_files` list from `filePath`, merges with MEDIA:-tagged files from message
3. **_send_to_platform**: Feishu gets dedicated media-capable path (like Telegram/Discord) with proper chunking and `media_files` passthrough
4. **Validation**: allow sending file-only messages (no text required when `filePath` is provided)
5. **Guard messages**: updated to list feishu alongside telegram, discord, weixin

## Test Plan

- [x] Send text + file to feishu via `send_message(filePath=...)`
- [x] Send file-only to feishu (no message text)
- [x] Existing text-only send still works
- [ ] CI passes