### PR TITLE
fix: support real Feishu outbound mentions

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -447,6 +447,46 @@ def _build_markdown_post_payload(content: str) -> str:
     )
 
 
+_MENTION_MARKUP_RE = re.compile(
+    r"@\[(?P<name>[^\]\n]+)\]\((?P<id>[^)\s]+)\)|<at\s+user_id=\"(?P<xml_id>[^\"]+)\">(?P<xml_name>.*?)</at>",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _build_rich_post_payload(content: str) -> str:
+    rows: List[List[Dict[str, Any]]] = []
+
+    for raw_line in content.splitlines() or [content]:
+        line = raw_line.rstrip("\r")
+        row: List[Dict[str, Any]] = []
+        cursor = 0
+        for match in _MENTION_MARKUP_RE.finditer(line):
+            start, end = match.span()
+            if start > cursor:
+                text = line[cursor:start]
+                if text:
+                    row.append({"tag": "text", "text": text})
+
+            mention_id = (match.group("id") or match.group("xml_id") or "").strip()
+            mention_name = (match.group("name") or match.group("xml_name") or mention_id).strip()
+            if mention_id:
+                row.append({"tag": "at", "user_id": mention_id, "user_name": mention_name})
+            elif match.group(0):
+                row.append({"tag": "text", "text": match.group(0)})
+            cursor = end
+
+        if cursor < len(line):
+            tail = line[cursor:]
+            if tail:
+                row.append({"tag": "text", "text": tail})
+
+        if not row:
+            row = [{"tag": "text", "text": ""}]
+        rows.append(row)
+
+    return json.dumps({"zh_cn": {"content": rows}}, ensure_ascii=False)
+
+
 def parse_feishu_post_payload(payload: Any) -> FeishuPostParseResult:
     resolved = _resolve_post_payload(payload)
     if not resolved:
@@ -3364,6 +3404,8 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
+        if _MENTION_MARKUP_RE.search(content):
+            return "post", _build_rich_post_payload(content)
         if _MARKDOWN_HINT_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}

--- a/tests/gateway/test_feishu_mentions_outbound.py
+++ b/tests/gateway/test_feishu_mentions_outbound.py
@@ -1,0 +1,29 @@
+import json
+
+from gateway.platforms.feishu import FeishuAdapter, _build_rich_post_payload
+
+
+def test_build_rich_post_payload_serializes_structured_mentions() -> None:
+    payload = json.loads(_build_rich_post_payload("你好 @[龙虾](ou_test)"))
+    row = payload["zh_cn"]["content"][0]
+    assert row == [
+        {"tag": "text", "text": "你好 "},
+        {"tag": "at", "user_id": "ou_test", "user_name": "龙虾"},
+    ]
+
+
+def test_build_outbound_payload_prefers_post_when_mentions_present() -> None:
+    adapter = object.__new__(FeishuAdapter)
+    msg_type, payload = FeishuAdapter._build_outbound_payload(adapter, "@ [broken]\n@[龙虾](ou_test)")
+    assert msg_type == "post"
+    parsed = json.loads(payload)
+    assert parsed["zh_cn"]["content"][1] == [{"tag": "at", "user_id": "ou_test", "user_name": "龙虾"}]
+
+
+def test_build_rich_post_payload_accepts_feishu_at_tag_markup() -> None:
+    payload = json.loads(_build_rich_post_payload('hello <at user_id="ou_real">龙虾</at>'))
+    row = payload["zh_cn"]["content"][0]
+    assert row == [
+        {"tag": "text", "text": "hello "},
+        {"tag": "at", "user_id": "ou_real", "user_name": "龙虾"},
+    ]


### PR DESCRIPTION
## Summary
- add outbound Feishu mention serialization for structured @mentions
- convert @[name](id) and <at user_id="id">name</at> markup into Feishu post payload at-tags
- add regression tests for outbound mention payload construction

## Validation
- source venv/bin/activate && pytest -q tests/gateway/test_feishu_mentions_outbound.py
- source venv/bin/activate && pytest -q tests/gateway/test_feishu.py -k mention

## Context
OpenClaw's Feishu integration preserves structured mention identities and emits real Feishu mentions on send. Hermes already parsed inbound mentions for gating, but outbound messages only emitted plain text/markdown, so @name did not become a real Feishu mention. This change adds the missing outbound serialization path.