### PR TITLE
fix(web): remove duplicate skill count in dashboard Skills badge (#12372)

### DIFF
--- a/web/src/pages/SkillsPage.tsx
+++ b/web/src/pages/SkillsPage.tsx
@@ -328,7 +328,7 @@ export default function SkillsPage() {
                       : t.skills.all}
                   </CardTitle>
                   <Badge variant="secondary" className="text-[10px]">
-                    {activeSkills.length} {t.skills.skillCount.replace("{count}", String(activeSkills.length)).replace("{s}", activeSkills.length !== 1 ? "s" : "")}
+                    {t.skills.skillCount.replace("{count}", String(activeSkills.length)).replace("{s}", activeSkills.length !== 1 ? "s" : "")}
                   </Badge>
                 </div>
               </CardHeader>


### PR DESCRIPTION
## Summary

Fixes duplicate numeric display in the Dashboard **Skills** view header badge: the UI rendered both `activeSkills.length` and the localized `skillCount` string (which already substitutes `{count}`), producing strings like `12 12 skills`.

## Changes

- `web/src/pages/SkillsPage.tsx`: drop the redundant numeric prefix in the badge; rely solely on `t.skills.skillCount` after `{count}` / `{s}` substitution.

## Verification

- `npm ci` (under `web/`), then `npx tsc -b` and `npx vite build` succeed locally.

Closes #12372