### PR TITLE
fix: preserve None content in assistant messages (#11906)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7267,8 +7267,11 @@ class AIAgent:
 
         # Sanitize surrogates from API response — some models (e.g. Kimi/GLM via Ollama)
         # can return invalid surrogate code points that crash json.dumps() on persist.
-        _raw_content = assistant_message.content or ""
-        _san_content = _sanitize_surrogates(_raw_content)
+        # Keep None as None — normalizing to "" causes Anthropic-compatible
+        # proxies to emit empty text blocks which triggers HTTP 400:
+        # "messages: text content blocks must be non-empty" (#11906)
+        _raw_content = assistant_message.content
+        _san_content = _sanitize_surrogates(_raw_content) if _raw_content else _raw_content
         if reasoning_text:
             reasoning_text = _sanitize_surrogates(reasoning_text)
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1117,10 +1117,20 @@ class TestBuildAssistantMessage:
         assert "reasoning_details" in result
         assert result["reasoning_details"][0]["text"] == "step1"
 
-    def test_empty_content(self, agent):
+    def test_none_content_preserved(self, agent):
+        """None content must stay None — not normalized to "" — so
+        Anthropic-compatible proxies don't emit empty text blocks (#11906)."""
         msg = _mock_assistant_msg(content=None)
         result = agent._build_assistant_message(msg, "stop")
-        assert result["content"] == ""
+        assert result["content"] is None
+
+    def test_none_content_with_tool_calls(self, agent):
+        """Tool-call-only responses have content=None; must not become ""."""
+        tc = _mock_tool_call(name="web_search", arguments='{"q":"test"}', call_id="c1")
+        msg = _mock_assistant_msg(content=None, tool_calls=[tc])
+        result = agent._build_assistant_message(msg, "tool_calls")
+        assert result["content"] is None
+        assert len(result["tool_calls"]) == 1
 
     def test_tool_call_extra_content_preserved(self, agent):
         """Gemini thinking models attach extra_content with thought_signature


### PR DESCRIPTION
## What does this PR do?

`_build_assistant_message()` normalized `None` content to `""` via `or ""`. This caused Anthropic-compatible proxies to reject responses containing empty text blocks — the proxy sees `{"type": "text", "text": ""}` and returns HTTP 400.

Fix: keep `None` as `None` instead of coercing to empty string. Only apply surrogate sanitization when content is truthy.

**Before:** `_raw_content = assistant_message.content or ""`
**After:** `_raw_content = assistant_message.content` + conditional sanitization

## Related Issue

Fixes #11906

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `_build_assistant_message()`: stop coercing `None` content to `""`; sanitize surrogates only when content is truthy.
- Updated `test_empty_content` → `test_none_content_preserved` (asserts `None` not `""`).
- Added `test_none_content_with_tool_calls` for tool-call-only responses.

## How to Test

1. Run Hermes against an Anthropic-compatible proxy that rejects empty text blocks.
2. Produce a tool-call-only assistant response (no text content).
3. Before: HTTP 400 from the proxy. After: request succeeds; assistant message carries `content=None` and tool calls only.
4. Run unit tests:

   ```
   pytest -q -k "none_content"
   ```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix:`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.5 (arm64)

### Documentation & Housekeeping

- [x] Documentation updates — N/A
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — pure Python
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

N/A — internal message normalization; covered by new unit tests.
