### PR TITLE
fix: deduplicate custom providers in /model picker (#12293)

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1087,7 +1087,10 @@ def list_authenticated_providers(
                 "source": "user-config",
                 "api_url": api_url,
             })
+            # Track both the plain slug and the custom:-prefixed slug so
+            # Section 4 (custom_providers list) can detect duplicates (#12293).
             seen_slugs.add(ep_name.lower())
+            seen_slugs.add(custom_provider_slug(display_name).lower())
 
     # --- 4. Saved custom providers from config ---
     # Each ``custom_providers`` entry represents one model under a named

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -194,6 +194,43 @@ def test_list_enumerates_dict_format_models_alongside_default(monkeypatch):
     assert ds_rows[0]["total_models"] == 2
 
 
+def test_no_duplicate_when_user_provider_and_custom_provider_overlap(monkeypatch):
+    """Provider in user_providers must suppress duplicate from custom_providers (#12293).
+
+    Section 3 (user_providers) adds the plain slug. Section 4
+    (custom_providers) generates a ``custom:``-prefixed slug. Without the
+    fix, Section 4 doesn't find the plain slug in seen_slugs and emits a
+    duplicate row.
+    """
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    providers = list_authenticated_providers(
+        current_provider="openrouter",
+        user_providers={
+            "my-modal": {
+                "name": "My Modal",
+                "api": "https://api.us-west-2.modal.direct/v1",
+                "default_model": "llama3",
+            },
+        },
+        custom_providers=[
+            {
+                "name": "My Modal",
+                "base_url": "https://api.us-west-2.modal.direct/v1",
+                "model": "llama3",
+            },
+        ],
+        max_models=50,
+    )
+
+    modal_rows = [p for p in providers if "modal" in p["name"].lower()]
+    assert len(modal_rows) == 1, (
+        f"Expected 1 provider row for 'My Modal', got {len(modal_rows)}: "
+        f"{[r['slug'] for r in modal_rows]}"
+    )
+
+
 def test_list_enumerates_dict_format_models_without_singular_model(monkeypatch):
     """Dict-format ``models:`` with no singular ``model:`` should still
     enumerate every dict key (previously the picker reported 0 models)."""


### PR DESCRIPTION
## Problem

When a provider exists in both `user_providers` (Section 3) and `custom_providers` (Section 4), the same provider appears twice in `/model`.

**Root cause:** Section 3 wasn't adding *any* slug to `seen_slugs`. Section 4 generates a `custom:`-prefixed slug via `custom_provider_slug()`, can't find it in `seen_slugs`, and emits a duplicate.

## Fix

After Section 3 appends a user-defined provider, add both the plain slug and the `custom:`-prefixed slug to `seen_slugs`:

```python
seen_slugs.add(ep_name.lower())
seen_slugs.add(custom_provider_slug(display_name).lower())
```

## Test

Added `test_no_duplicate_when_user_provider_and_custom_provider_overlap` — configures the same provider in both `user_providers` and `custom_providers`, asserts only one row appears.

All 6 tests in `test_model_switch_custom_providers.py` pass.

Closes #12293