### PR TITLE
fix: add token estimation fallback when streaming usage is missing (#12023)

### DIFF
--- a/tests/tools/test_ssh_socket_path.py
+++ b/tests/tools/test_ssh_socket_path.py
@@ -1,0 +1,32 @@
+"""Test that SSH ControlMaster socket paths stay under macOS 104-char limit."""
+
+import hashlib
+import tempfile
+from pathlib import Path
+
+
+MACOS_UNIX_SOCKET_LIMIT = 104
+
+
+def _build_control_socket(user: str, host: str, port: int) -> Path:
+    """Reproduce the socket path logic from SSHEnvironment.__init__."""
+    control_dir = Path(tempfile.gettempdir()) / "hermes-ssh"
+    socket_id = hashlib.sha256(f"{user}@{host}:{port}".encode()).hexdigest()[:12]
+    return control_dir / f"{socket_id}.sock"
+
+
+def test_socket_path_short_for_ipv6():
+    long_ipv6 = "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+    sock = _build_control_socket("deployuser", long_ipv6, 22)
+    assert len(str(sock)) < MACOS_UNIX_SOCKET_LIMIT, f"path too long: {sock}"
+
+
+def test_socket_path_short_for_long_username():
+    sock = _build_control_socket("a" * 64, "example.com", 22)
+    assert len(str(sock)) < MACOS_UNIX_SOCKET_LIMIT, f"path too long: {sock}"
+
+
+def test_different_hosts_get_different_sockets():
+    s1 = _build_control_socket("user", "host1", 22)
+    s2 = _build_control_socket("user", "host2", 22)
+    assert s1 != s2

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -1,5 +1,6 @@
 """SSH remote execution environment with ControlMaster connection persistence."""
 
+import hashlib
 import logging
 import os
 import shlex
@@ -47,7 +48,8 @@ class SSHEnvironment(BaseEnvironment):
 
         self.control_dir = Path(tempfile.gettempdir()) / "hermes-ssh"
         self.control_dir.mkdir(parents=True, exist_ok=True)
-        self.control_socket = self.control_dir / f"{user}@{host}:{port}.sock"
+        socket_id = hashlib.sha256(f"{user}@{host}:{port}".encode()).hexdigest()[:12]
+        self.control_socket = self.control_dir / f"{socket_id}.sock"
         _ensure_ssh_available()
         self._establish_connection()
         self._remote_home = self._detect_remote_home()


### PR DESCRIPTION
Fixes #12023

When a streaming provider returns no usage data, the token accounting block was skipped entirely, silently recording 0/0 tokens.

This adds an else branch that:
- Estimates input tokens via `estimate_messages_tokens_rough(messages)`
- Estimates output tokens via `estimate_tokens_rough()` on the streamed text
- Logs a warning about using estimates
- Updates session counters and persists to the session DB

Also adds tests for the estimation fallback logic.