### PR TITLE
wip: preserve local provider and gateway tweaks

### DIFF
--- a/gateway/platforms/telegram_network.py
+++ b/gateway/platforms/telegram_network.py
@@ -67,8 +67,20 @@ class TelegramFallbackTransport(httpx.AsyncBaseTransport):
         if proxy_url and "proxy" not in transport_kwargs:
             transport_kwargs["proxy"] = proxy_url
         self._primary = httpx.AsyncHTTPTransport(**transport_kwargs)
+
+        # Fallback transports connect to raw IPs, so SSL verification must
+        # target the original hostname (set via ``sni_hostname`` in
+        # ``_rewrite_request_for_ip``) rather than the IP embedded in the URL.
+        # httpx validates the certificate against the URL host, which fails
+        # with CERTIFICATE_VERIFY_FAILED for raw IPs.  Disable verification
+        # for fallback IPs — the IPs are known Telegram Bot API endpoints
+        # (discovered via DNS-over-HTTPS or shipped seed list), SNI still
+        # sends the correct hostname, and the alternative is a total
+        # connectivity loss when the primary path is blocked.
+        fallback_kwargs = dict(transport_kwargs)
+        fallback_kwargs["verify"] = False
         self._fallbacks = {
-            ip: httpx.AsyncHTTPTransport(**transport_kwargs) for ip in self._fallback_ips
+            ip: httpx.AsyncHTTPTransport(**fallback_kwargs) for ip in self._fallback_ips
         }
         self._sticky_ip: Optional[str] = None
         self._sticky_lock = asyncio.Lock()

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -71,20 +71,20 @@ def _get_service_pids() -> set:
         try:
             label = get_launchd_label()
             result = subprocess.run(
-                ["launchctl", "list", label],
+                ["launchctl", "print", f"{_launchd_domain()}/{label}"],
                 capture_output=True, text=True, timeout=5,
             )
             if result.returncode == 0:
-                # Output: "PID\tStatus\tLabel" header, then one data line
                 for line in result.stdout.strip().splitlines():
-                    parts = line.split()
-                    if len(parts) >= 3 and parts[2] == label:
-                        try:
-                            pid = int(parts[0])
-                            if pid > 0:
-                                pids.add(pid)
-                        except ValueError:
-                            pass
+                    line = line.strip()
+                    if not line.startswith("pid = "):
+                        continue
+                    try:
+                        pid = int(line.split("=", 1)[1].strip())
+                        if pid > 0:
+                            pids.add(pid)
+                    except ValueError:
+                        pass
         except (FileNotFoundError, subprocess.TimeoutExpired):
             pass
 
@@ -988,6 +988,20 @@ def _launchd_domain() -> str:
     return f"gui/{os.getuid()}"
 
 
+def _launchd_target(label: str | None = None) -> str:
+    return f"{_launchd_domain()}/{label or get_launchd_label()}"
+
+
+def _launchd_print_status(label: str | None = None, timeout: int = 10) -> tuple[bool, str]:
+    result = subprocess.run(
+        ["launchctl", "print", _launchd_target(label)],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    return result.returncode == 0, result.stdout
+
+
 def generate_launchd_plist() -> str:
     python_path = get_python_path()
     working_dir = str(PROJECT_ROOT)
@@ -1238,14 +1252,7 @@ def launchd_status(deep: bool = False):
     plist_path = get_launchd_plist_path()
     label = get_launchd_label()
     try:
-        result = subprocess.run(
-            ["launchctl", "list", label],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        loaded = result.returncode == 0
-        loaded_output = result.stdout
+        loaded, loaded_output = _launchd_print_status(label, timeout=10)
     except subprocess.TimeoutExpired:
         loaded = False
         loaded_output = ""
@@ -1811,11 +1818,8 @@ def _is_service_running() -> bool:
         return False
     elif is_macos() and get_launchd_plist_path().exists():
         try:
-            result = subprocess.run(
-                ["launchctl", "list", get_launchd_label()],
-                capture_output=True, text=True, timeout=10,
-            )
-            return result.returncode == 0
+            loaded, _ = _launchd_print_status(timeout=10)
+            return loaded
         except subprocess.TimeoutExpired:
             return False
     # Check for manual processes

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import List, NamedTuple, Optional
+from typing import Any, List, NamedTuple, Optional
 
 from hermes_cli.providers import (
     determine_api_mode,
@@ -351,6 +351,86 @@ def get_authenticated_provider_slugs(
         return [p["slug"] for p in providers]
     except Exception:
         return []
+
+
+def _normalize_user_provider_slug(value: str) -> str:
+    """Normalize user-configured provider names for menu/display matching."""
+    return (value or "").strip().lower().replace(" ", "-")
+
+
+def _extract_configured_model_ids(entry: dict[str, Any]) -> list[str]:
+    """Extract model IDs from a user-configured provider entry."""
+    model_ids: list[str] = []
+    configured = entry.get("models")
+    if isinstance(configured, list):
+        for item in configured:
+            if isinstance(item, str):
+                model_id = item.strip()
+            elif isinstance(item, dict):
+                model_id = str(item.get("id") or item.get("model") or item.get("name") or "").strip()
+            else:
+                model_id = ""
+            if model_id and model_id not in model_ids:
+                model_ids.append(model_id)
+
+    for key in ("default_model", "model"):
+        model_id = str(entry.get(key) or "").strip()
+        if model_id and model_id not in model_ids:
+            model_ids.append(model_id)
+    return model_ids
+
+
+def _collect_user_defined_providers(user_providers: Any) -> list[dict[str, Any]]:
+    """Return normalized user-configured provider entries from config sources."""
+    collected: list[dict[str, Any]] = []
+    seen_slugs: set[str] = set()
+
+    def _add_provider(slug: str, name: str, entry: dict[str, Any]) -> None:
+        normalized_slug = _normalize_user_provider_slug(slug)
+        if not normalized_slug or normalized_slug in seen_slugs:
+            return
+        collected.append({
+            "slug": normalized_slug,
+            "name": (name or slug or normalized_slug).strip(),
+            "api_url": str(
+                entry.get("api")
+                or entry.get("url")
+                or entry.get("base_url")
+                or ""
+            ).strip(),
+            "models": _extract_configured_model_ids(entry),
+        })
+        seen_slugs.add(normalized_slug)
+
+    def _consume(source: Any) -> None:
+        if isinstance(source, dict):
+            for ep_name, ep_cfg in source.items():
+                if isinstance(ep_cfg, dict):
+                    display_name = str(ep_cfg.get("name", "") or ep_name).strip()
+                    _add_provider(ep_name, display_name, ep_cfg)
+        elif isinstance(source, list):
+            for entry in source:
+                if not isinstance(entry, dict):
+                    continue
+                name = str(entry.get("name") or "").strip()
+                if not name:
+                    continue
+                _add_provider(name, name, entry)
+
+    _consume(user_providers)
+
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+    except Exception:
+        cfg = {}
+
+    if isinstance(cfg, dict):
+        _consume(cfg.get("providers"))
+        _consume(cfg.get("custom_providers"))
+
+    return collected
 
 
 def _resolve_alias_fallback(
@@ -819,31 +899,24 @@ def list_authenticated_providers(
         })
         seen_slugs.add(pid)
 
-    # --- 3. User-defined endpoints from config ---
-    if user_providers and isinstance(user_providers, dict):
-        for ep_name, ep_cfg in user_providers.items():
-            if not isinstance(ep_cfg, dict):
-                continue
-            display_name = ep_cfg.get("name", "") or ep_name
-            api_url = ep_cfg.get("api", "") or ep_cfg.get("url", "") or ""
-            default_model = ep_cfg.get("default_model", "")
-
-            models_list = []
-            if default_model:
-                models_list.append(default_model)
-
-            # Try to probe /v1/models if URL is set (but don't block on it)
-            # For now just show what we know from config
-            results.append({
-                "slug": ep_name,
-                "name": display_name,
-                "is_current": ep_name == current_provider,
-                "is_user_defined": True,
-                "models": models_list,
-                "total_models": len(models_list) if models_list else 0,
-                "source": "user-config",
-                "api_url": api_url,
-            })
+    # --- 3. User-defined endpoints from config (providers + custom_providers) ---
+    current_provider_norm = _normalize_user_provider_slug(current_provider)
+    for provider_entry in _collect_user_defined_providers(user_providers):
+        slug = provider_entry["slug"]
+        if slug in seen_slugs:
+            continue
+        models_list = provider_entry["models"]
+        results.append({
+            "slug": slug,
+            "name": provider_entry["name"],
+            "is_current": slug == current_provider_norm,
+            "is_user_defined": True,
+            "models": models_list[:max_models] if max_models else [],
+            "total_models": len(models_list),
+            "source": "user-config",
+            "api_url": provider_entry["api_url"],
+        })
+        seen_slugs.add(slug)
 
     # Sort: current provider first, then by model count descending
     results.sort(key=lambda r: (not r["is_current"], -r["total_models"]))

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -247,6 +247,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     # to https://dashscope-intl.aliyuncs.com/compatible-mode/v1 (OpenAI-compat)
     # or https://dashscope-intl.aliyuncs.com/apps/anthropic (Anthropic-compat).
     "alibaba": [
+        "qwen3.6-plus",
         "qwen3.5-plus",
         "qwen3-coder-plus",
         "qwen3-coder-next",

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -344,15 +344,9 @@ def show_status(args):
         print("  Manager:      systemd (user)")
         
     elif sys.platform == 'darwin':
-        from hermes_cli.gateway import get_launchd_label
+        from hermes_cli.gateway import _launchd_print_status
         try:
-            result = subprocess.run(
-                ["launchctl", "list", get_launchd_label()],
-                capture_output=True,
-                text=True,
-                timeout=5
-            )
-            is_loaded = result.returncode == 0
+            is_loaded, _ = _launchd_print_status(timeout=5)
         except subprocess.TimeoutExpired:
             is_loaded = False
         print(f"  Status:       {check_mark(is_loaded)} {'loaded' if is_loaded else 'not loaded'}")

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -250,6 +250,28 @@ class TestLaunchdServiceRecovery:
         assert "stale" in output.lower()
         assert "not loaded" in output.lower()
 
+    def test_launchd_status_uses_launchctl_print_target_on_macos(self, tmp_path, monkeypatch, capsys):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
+        monkeypatch.setattr(gateway_cli.os, "getuid", lambda: 501)
+
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="service running", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_status()
+
+        output = capsys.readouterr().out
+        assert ["launchctl", "print", "gui/501/ai.hermes.gateway"] in calls
+        assert "loaded" in output.lower()
+
 
 class TestGatewayServiceDetection:
     def test_is_service_running_checks_system_scope_when_user_scope_is_inactive(self, monkeypatch):

--- a/tests/hermes_cli/test_model_switch_custom_provider_menu.py
+++ b/tests/hermes_cli/test_model_switch_custom_provider_menu.py
@@ -1,0 +1,31 @@
+from unittest.mock import patch
+
+from hermes_cli.model_switch import list_authenticated_providers
+
+
+def test_list_authenticated_providers_includes_custom_providers_from_config():
+    config = {
+        "custom_providers": [
+            {
+                "name": "miaomiaocode",
+                "base_url": "https://codex.miaomiaocode.com/v1",
+                "api_key": "test-key",
+                "models": [
+                    {"id": "gpt-5-codex-mini", "name": "GPT-5 Codex Mini"},
+                    {"id": "gpt-5.4", "name": "GPT 5.4"},
+                ],
+            }
+        ]
+    }
+
+    with patch("agent.models_dev.fetch_models_dev", return_value={}), patch(
+        "hermes_cli.config.load_config", return_value=config
+    ):
+        providers = list_authenticated_providers(current_provider="miaomiaocode")
+
+    miaomiao = next((p for p in providers if p["slug"] == "miaomiaocode"), None)
+    assert miaomiao is not None
+    assert miaomiao["is_current"] is True
+    assert miaomiao["models"] == ["gpt-5-codex-mini", "gpt-5.4"]
+    assert miaomiao["total_models"] == 2
+    assert miaomiao["source"] == "user-config"

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 
+import hermes_cli.status as status_mod
 from hermes_cli.status import show_status
 
 
@@ -12,3 +13,26 @@ def test_show_status_includes_tavily_key(monkeypatch, capsys, tmp_path):
     output = capsys.readouterr().out
     assert "Tavily" in output
     assert "tvly...cdef" in output
+
+
+def test_show_status_uses_launchctl_print_target_on_macos(monkeypatch, capsys, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(status_mod.sys, "platform", "darwin")
+    monkeypatch.setattr(status_mod.os, "getuid", lambda: 501)
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return SimpleNamespace(returncode=0, stdout="service running", stderr="")
+
+    monkeypatch.setattr(status_mod.subprocess, "run", fake_run)
+
+    show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert any(
+        cmd[:2] == ["launchctl", "print"] and cmd[2].startswith("gui/501/ai.hermes.gateway")
+        for cmd in calls
+    )
+    assert "loaded" in output.lower()


### PR DESCRIPTION
## Summary
- preserve local gateway/provider tweaks from the current workstation branch state
- keep the model-switch custom-provider menu test with the related gateway/status coverage updates
- intentionally exclude the large `package-lock.json` churn and local Chinese note files from this preservation branch

## Verification
- `/Users/wangbin/.hermes/hermes-agent/venv/bin/pytest -o addopts='' tests/hermes_cli/test_gateway_service.py tests/hermes_cli/test_status.py tests/hermes_cli/test_model_switch_custom_provider_menu.py`
- result: 52 passed

## Caveat
- this branch is based on the workstation's current `main` HEAD, not the latest `origin/main`
- it is a preservation/review branch and will likely need rebase or selective cherry-picking before merge upstream
