### PR TITLE
fix(tui): replace unreadable yellow colors with dark goldenrod (#11300)

### DIFF
--- a/ui-tui/src/components/branding.tsx
+++ b/ui-tui/src/components/branding.tsx
@@ -161,16 +161,16 @@ export function SessionPanel({ info, sid, t }: SessionPanelProps) {
         </Text>
 
         {typeof info.update_behind === 'number' && info.update_behind > 0 && (
-          <Text bold color="yellow">
+          <Text bold color="#b8860b">
             ! {info.update_behind} {info.update_behind === 1 ? 'commit' : 'commits'} behind
-            <Text bold={false} color="yellow" dimColor>
+            <Text bold={false} color="#b8860b" dimColor>
               {' '}
               - run{' '}
             </Text>
-            <Text bold color="yellow">
+            <Text bold color="#b8860b">
               {info.update_command || 'hermes update'}
             </Text>
-            <Text bold={false} color="yellow" dimColor>
+            <Text bold={false} color="#b8860b" dimColor>
               {' '}
               to update
             </Text>


### PR DESCRIPTION
Fixes #11300

Bright yellow text in the TUI branding component was unreadable on white/light terminal backgrounds. Replaced all four instances of hardcoded `color="yellow"` in `ui-tui/src/components/branding.tsx` with `color="#b8860b"` (dark goldenrod), which provides good contrast on both light and dark backgrounds.