### PR TITLE
fix: Windows compatibility for process lock check

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -341,7 +341,8 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
         if not stale:
             try:
                 os.kill(existing_pid, 0)
-            except (ProcessLookupError, PermissionError):
+            except (ProcessLookupError, PermissionError, OSError):
+                # Windows raises OSError with WinError 87 for invalid pid check
                 stale = True
             else:
                 current_start = _get_process_start_time(existing_pid)
@@ -576,7 +577,8 @@ def get_running_pid(
 
     try:
         os.kill(pid, 0)  # signal 0 = existence check, no actual signal sent
-    except (ProcessLookupError, PermissionError):
+    except (ProcessLookupError, PermissionError, OSError):
+        # Windows raises OSError with WinError 87 instead of ProcessLookupError
         _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale)
         return None
 


### PR DESCRIPTION
## Problem

On Windows, `os.kill(pid, 0)` raises `OSError: [WinError 87]` (invalid parameter) instead of `ProcessLookupError`. This causes the gateway to fail on startup when checking for existing process locks.

## Solution

Simply add `OSError` to the exception list. This is a minimal fix that requires no additional dependencies.

## Testing

Tested on Windows 10/11 with Git Bash (MINGW64). Gateway now starts successfully.

## Error Before Fix

```
ERROR gateway.platforms.telegram: [Telegram] Failed to connect to Telegram: [WinError 87] 参数错误。
OSError: [WinError 87] 参数错误。
```

## After Fix

Gateway starts normally and connects to Telegram successfully.