### PR TITLE
docs(acp): update VS Code setup instructions for ACP Client integration

### DIFF
--- a/website/docs/user-guide/features/acp.md
+++ b/website/docs/user-guide/features/acp.md
@@ -67,18 +67,24 @@ Hermes logs to stderr so stdout remains reserved for ACP JSON-RPC traffic.
 
 ### VS Code
 
-Install an ACP client extension, then point it at the repo's `acp_registry/` directory.
+Install the [ACP Client](https://marketplace.visualstudio.com/items?itemName=formulahendry.acp-client) extension.
 
-Example settings snippet:
+To connect:
+
+1. Open the ACP Client panel from the Activity Bar.
+2. Select **Hermes Agent** from the built-in agent list.
+3. Connect and start chatting.
+
+If you want to define Hermes manually, add it through VS Code settings under `acp.agents`:
 
 ```json
 {
-  "acpClient.agents": [
-    {
-      "name": "hermes-agent",
-      "registryDir": "/path/to/hermes-agent/acp_registry"
+  "acp.agents": {
+    "Hermes Agent": {
+      "command": "hermes",
+      "args": ["acp"]
     }
-  ]
+  }
 }
 ```
 


### PR DESCRIPTION
## What does this PR do?

Updates the ACP documentation for VS Code to match the current ACP Client extension behavior.

The previous instructions told users to point VS Code at `acp_registry/`, which is not the right setup for the [ACP Client extension](https://marketplace.visualstudio.com/items?itemName=formulahendry.acp-client) now that Hermes Agent is available as a built-in pre-configured agent. This change updates the VS Code section to document the current connection flow and keeps a short manual `acp.agents` fallback for users who want to define Hermes explicitly.

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- Updated the VS Code setup steps in `website/docs/user-guide/features/acp.md`
- Removed the outdated instruction to configure VS Code with `acp_registry/`
- Documented the current ACP Client flow: install the extension, select **Hermes Agent**, and connect
- Added a manual VS Code settings example using `acp.agents` with `hermes acp`

## How to Test

1. Open the ACP docs page source at `website/docs/user-guide/features/acp.md`
2. Confirm the VS Code section tells users to install ACP Client, select **Hermes Agent**, and connect
3. Confirm the section no longer instructs users to point VS Code at `acp_registry/`, and that the manual fallback uses `acp.agents`