### PR TITLE
fix: TUI displays terminal.backend from config instead of defaulting to docker (#12485)

### DIFF
--- a/tests/tui_gateway/test_terminal_backend.py
+++ b/tests/tui_gateway/test_terminal_backend.py
@@ -1,0 +1,93 @@
+"""Tests for terminal.backend display in TUI session info and config.show."""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_original_stdout = sys.stdout
+
+
+@pytest.fixture(autouse=True)
+def _restore_stdout():
+    yield
+    sys.stdout = _original_stdout
+
+
+@pytest.fixture()
+def server():
+    with patch.dict("sys.modules", {
+        "hermes_constants": MagicMock(get_hermes_home=MagicMock(return_value="/tmp/hermes_test")),
+        "hermes_cli.env_loader": MagicMock(),
+        "hermes_cli.banner": MagicMock(),
+        "hermes_state": MagicMock(),
+    }):
+        import importlib
+        mod = importlib.import_module("tui_gateway.server")
+        yield mod
+        mod._sessions.clear()
+        mod._pending.clear()
+        mod._answers.clear()
+        mod._methods.clear()
+        importlib.reload(mod)
+
+
+def _make_agent():
+    agent = MagicMock()
+    agent.model = "test-model"
+    agent.tools = []
+    agent.context_compressor = None
+    return agent
+
+
+# ── _session_info includes terminal_backend ─────────────────────────
+
+
+def test_session_info_reads_terminal_backend_from_config(server):
+    agent = _make_agent()
+    with patch.object(server, "_load_cfg", return_value={"terminal": {"backend": "local"}}):
+        info = server._session_info(agent)
+    assert info["terminal_backend"] == "local"
+
+
+def test_session_info_terminal_backend_defaults_to_local(server):
+    agent = _make_agent()
+    with patch.object(server, "_load_cfg", return_value={}):
+        info = server._session_info(agent)
+    assert info["terminal_backend"] == "local"
+
+
+def test_session_info_terminal_backend_docker(server):
+    agent = _make_agent()
+    with patch.object(server, "_load_cfg", return_value={"terminal": {"backend": "docker"}}):
+        info = server._session_info(agent)
+    assert info["terminal_backend"] == "docker"
+
+
+# ── config.show includes Terminal section ────────────────────────────
+
+
+def test_config_show_includes_terminal_section(server):
+    from pathlib import Path
+    with patch.object(server, "_load_cfg", return_value={"terminal": {"backend": "local"}}), \
+         patch.object(server, "_resolve_model", return_value="test-model"), \
+         patch.object(server, "_hermes_home", Path("/tmp/hermes_test")):
+        resp = server.handle_request({"id": "r1", "method": "config.show", "params": {}})
+
+    sections = resp["result"]["sections"]
+    terminal_sections = [s for s in sections if s["title"] == "Terminal"]
+    assert len(terminal_sections) == 1
+    assert ["Backend", "local"] in terminal_sections[0]["rows"]
+
+
+def test_config_show_terminal_backend_defaults_to_local(server):
+    from pathlib import Path
+    with patch.object(server, "_load_cfg", return_value={}), \
+         patch.object(server, "_resolve_model", return_value="test-model"), \
+         patch.object(server, "_hermes_home", Path("/tmp/hermes_test")):
+        resp = server.handle_request({"id": "r1", "method": "config.show", "params": {}})
+
+    sections = resp["result"]["sections"]
+    terminal_sections = [s for s in sections if s["title"] == "Terminal"]
+    assert len(terminal_sections) == 1
+    assert ["Backend", "local"] in terminal_sections[0]["rows"]

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -578,6 +578,7 @@ def _session_info(agent) -> dict:
         "update_behind": None,
         "update_command": "",
         "usage": _get_usage(agent),
+        "terminal_backend": _load_cfg().get("terminal", {}).get("backend", "local"),
     }
     try:
         from hermes_cli import __version__, __release_date__
@@ -2760,6 +2761,11 @@ def _(rid, params: dict) -> dict:
                 ["Max Turns", str(cfg.get("max_turns", 25))],
                 ["Toolsets", ", ".join(cfg.get("enabled_toolsets", [])) or "all"],
                 ["Verbose", str(cfg.get("verbose", False))],
+            ]
+        }, {
+            "title": "Terminal",
+            "rows": [
+                ["Backend", cfg.get("terminal", {}).get("backend", "local")],
             ]
         }, {
             "title": "Environment",

--- a/ui-tui/src/__tests__/terminal_backend.test.ts
+++ b/ui-tui/src/__tests__/terminal_backend.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import type { SessionInfo } from '../types.js'
+
+describe('SessionInfo terminal_backend', () => {
+  it('accepts terminal_backend field', () => {
+    const info: SessionInfo = {
+      model: 'test',
+      skills: {},
+      tools: {},
+      terminal_backend: 'local',
+    }
+    expect(info.terminal_backend).toBe('local')
+  })
+
+  it('terminal_backend is optional', () => {
+    const info: SessionInfo = {
+      model: 'test',
+      skills: {},
+      tools: {},
+    }
+    expect(info.terminal_backend).toBeUndefined()
+  })
+})

--- a/ui-tui/src/components/branding.tsx
+++ b/ui-tui/src/components/branding.tsx
@@ -106,6 +106,13 @@ export function SessionPanel({ info, sid, t }: SessionPanelProps) {
             {info.cwd || process.cwd()}
           </Text>
 
+          {info.terminal_backend && (
+            <Text>
+              <Text color={t.color.sessionLabel}>Terminal: </Text>
+              <Text color={t.color.cornsilk}>{info.terminal_backend}</Text>
+            </Text>
+          )}
+
           {sid && (
             <Text>
               <Text color={t.color.sessionLabel}>Session: </Text>

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -73,6 +73,7 @@ export interface SessionInfo {
   model: string
   release_date?: string
   skills: Record<string, string[]>
+  terminal_backend?: string
   tools: Record<string, string[]>
   update_behind?: number | null
   update_command?: string


### PR DESCRIPTION
## Problem
TUI shows terminal.backend as 'docker' even when config.yaml has `terminal.backend: local`. The TUI was reading from `TERMINAL_ENV` env var which could be stale or defaulted.

## Fix
Read terminal.backend from the actual config instead of env var default.

Fixes #12485