### PR TITLE
fix(email): guard IMAP FETCH response against non-bytes payloads

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -361,7 +361,30 @@ class EmailAdapter(BasePlatformAdapter):
                     if status != "OK":
                         continue
 
-                    raw_email = msg_data[0][1]
+                    # Guard against malformed IMAP FETCH responses.
+                    # Some IMAP servers return [b')'] or [None] or nested
+                    # ints in place of the (header, body) tuple, which would
+                    # surface as cryptic errors such as
+                    # "'int' object has no attribute 'decode'" once the
+                    # value hits email_lib.message_from_bytes. Skip the
+                    # offending message instead of killing the poll loop.
+                    try:
+                        raw_email = msg_data[0][1]
+                    except (IndexError, TypeError):
+                        logger.warning(
+                            "[Email] Skipping UID %s: unexpected IMAP response structure (%r)",
+                            uid,
+                            msg_data,
+                        )
+                        continue
+                    if not isinstance(raw_email, (bytes, bytearray)):
+                        logger.warning(
+                            "[Email] Skipping UID %s: IMAP payload not bytes (got %s)",
+                            uid,
+                            type(raw_email).__name__,
+                        )
+                        continue
+
                     msg = email_lib.message_from_bytes(raw_email)
 
                     sender_raw = msg.get("From", "")


### PR DESCRIPTION
## What changed and why

Some IMAP servers return malformed `FETCH` responses where the body slot is an `int`, plain `bytes`, or `None` instead of the expected `(header, body)` tuple. Accessing `msg_data[0][1]` then either raises `IndexError`/`TypeError`, or returns an int (indexing `bytes` yields an int in Python 3), which only surfaces later as the opaque error:

```
ERROR gateway.platforms.email: [Email] IMAP fetch error: 'int' object has no attribute 'decode'
```

The exception kills the inner loop iteration and is caught by the outer `try/except` at the bottom of `_fetch_new_messages`, so the *entire* polling pass returns empty — no messages are dispatched for that tick.

Observed in production on a Raspberry Pi 4 / Debian bookworm talking to an OVH IMAP server. The same UID was retried every poll and flooded the error log.

### Related

Complements [#2794](https://github.com/NousResearch/hermes-agent/pull/2794) (which adds a general `try/except` around IMAP response parsing) by specifically handling the *non-bytes payload* case that the bare exception catch would still mask behind a cryptic error message.

## The fix

Two-stage guard around the fetch response, inside the per-UID loop in `_fetch_new_messages`:

1. `try/except (IndexError, TypeError)` around `msg_data[0][1]` access.
2. `isinstance(raw_email, (bytes, bytearray))` check before handing off to `email_lib.message_from_bytes`.

In both branches we log a `warning` with the offending UID (and the raw response, or the observed payload type) and `continue`, so the poll loop keeps processing the rest of the inbox rather than bailing on a single malformed message.

## How I tested

Unit-tested the guard logic against 6 shapes observed in the wild:

| Input                       | Behavior               |
| --------------------------- | ---------------------- |
| `[(b'flags', b'body')]`     | parses OK              |
| `[b')']`                    | skipped (IndexError)   |
| `[None]`                    | skipped (TypeError)    |
| `[]`                        | skipped (IndexError)   |
| `[(b'flags', b'body'), b')']` | parses OK            |
| `[(1, 2)]` — **our case**   | skipped (not bytes)    |

Deployed on the affected Raspberry Pi — previously the error fired every ~10 min; since the patch the log is clean and legitimate mail is still processed.

## Platforms tested

- Raspberry Pi 4, Debian bookworm, Python 3.11
- IMAP server: OVH (ssl0.ovh.net)