### PR TITLE
feat(skills): add social-post optional skill for multi-platform publishing

### DIFF
--- a/optional-skills/social-media/DESCRIPTION.md
+++ b/optional-skills/social-media/DESCRIPTION.md
@@ -1,0 +1,3 @@
+---
+description: Skills for interacting with social platforms and social-media workflows — posting, reading, monitoring, and account operations.
+---

--- a/optional-skills/social-media/social-post/SKILL.md
+++ b/optional-skills/social-media/social-post/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: social-post
+description: >
+  Post messages to a social media matrix — X (Twitter), LinkedIn, Facebook Page,
+  Reddit, and Buffer — simultaneously or selectively from a single command.
+  Use when the user wants to publish content to one or more social platforms at once,
+  cross-post announcements, or automate social media publishing workflows.
+version: 1.0.0
+author: Zijian Guo
+license: MIT
+platforms: [linux, macos]
+required_environment_variables:
+  - name: BUFFER_ACCESS_TOKEN
+    prompt: Buffer API key
+    help: Generate at https://publish.buffer.com/settings/api
+    required_for: Buffer posting
+  - name: X_API_KEY
+    prompt: X (Twitter) API key
+    help: Create an app at https://developer.twitter.com/en/portal/dashboard
+    required_for: X posting
+  - name: X_API_SECRET
+    prompt: X (Twitter) API secret
+    help: From the same app at https://developer.twitter.com/en/portal/dashboard
+    required_for: X posting
+  - name: X_ACCESS_TOKEN
+    prompt: X (Twitter) access token
+    help: Generate under your app's Keys and Tokens tab (requires Read and Write permissions)
+    required_for: X posting
+  - name: X_ACCESS_TOKEN_SECRET
+    prompt: X (Twitter) access token secret
+    help: Generated alongside X_ACCESS_TOKEN
+    required_for: X posting
+  - name: LINKEDIN_ACCESS_TOKEN
+    prompt: LinkedIn OAuth2 access token
+    help: Create an app at https://www.linkedin.com/developers/apps with w_member_social scope
+    required_for: LinkedIn posting
+  - name: FACEBOOK_PAGE_ID
+    prompt: Facebook Page ID
+    help: Found in your Page settings or via the Graph API Explorer
+    required_for: Facebook posting
+  - name: FACEBOOK_PAGE_ACCESS_TOKEN
+    prompt: Facebook Page access token
+    help: Generate at https://developers.facebook.com/apps with pages_manage_posts permission
+    required_for: Facebook posting
+  - name: REDDIT_CLIENT_ID
+    prompt: Reddit app client ID
+    help: Create a script-type app at https://www.reddit.com/prefs/apps
+    required_for: Reddit posting
+  - name: REDDIT_CLIENT_SECRET
+    prompt: Reddit app client secret
+    help: From the same app at https://www.reddit.com/prefs/apps
+    required_for: Reddit posting
+  - name: REDDIT_USERNAME
+    prompt: Reddit account username
+    required_for: Reddit posting
+  - name: REDDIT_PASSWORD
+    prompt: Reddit account password
+    required_for: Reddit posting
+prerequisites:
+  commands: [python3, uv]
+metadata:
+  hermes:
+    tags: [social-media, twitter, x, linkedin, facebook, reddit, buffer, publishing, cross-posting]
+    related_skills: [xitter]
+---
+
+# social-post — Multi-platform social media publishing
+
+Publish a message to X (Twitter), LinkedIn, Facebook Page, Reddit, and Buffer
+simultaneously or selectively using a single Python script.
+
+## When to Use
+
+- User wants to cross-post an announcement, blog post, or update to multiple platforms at once.
+- User wants to publish to a specific subset of platforms.
+- User wants to post with an attached image.
+- User wants to push content through Buffer to all connected accounts.
+
+Do NOT use this skill for reading timelines, searching posts, or interacting with
+existing content — use the `xitter` skill for X-specific read operations.
+
+## Setup
+
+### Install dependencies
+
+```bash
+uv pip install --python ~/.hermes/hermes-agent/venv/bin/python tweepy praw
+```
+
+`requests` and `python-dotenv` are already present in the Hermes venv.
+
+### Script location
+
+After installing this skill, the helper script is at:
+
+```
+~/.hermes/skills/social-media/social-post/scripts/social_post.py
+```
+
+Set a short alias for convenience in this session:
+
+```bash
+SOCIAL="$(python3 -c "import os; print(os.path.expanduser('~/.hermes/skills/social-media/social-post/scripts/social_post.py'))")"
+PYTHON="$(python3 -c "import os; print(os.path.expanduser('~/.hermes/hermes-agent/venv/bin/python'))")" 2>/dev/null || PYTHON=python3
+```
+
+### Credentials
+
+Each platform only needs its own credentials. Unset platforms are simply skipped.
+
+| Platform | Required env vars |
+|---|---|
+| X (Twitter) | `X_API_KEY`, `X_API_SECRET`, `X_ACCESS_TOKEN`, `X_ACCESS_TOKEN_SECRET` |
+| LinkedIn | `LINKEDIN_ACCESS_TOKEN` |
+| Facebook Page | `FACEBOOK_PAGE_ID`, `FACEBOOK_PAGE_ACCESS_TOKEN` |
+| Reddit | `REDDIT_CLIENT_ID`, `REDDIT_CLIENT_SECRET`, `REDDIT_USERNAME`, `REDDIT_PASSWORD` |
+| Buffer | `BUFFER_ACCESS_TOKEN` (optional: `BUFFER_CHANNEL_IDS`) |
+
+Store credentials in `~/.hermes/.env` — they are loaded automatically.
+
+## Quick Reference
+
+| Action | Command |
+|---|---|
+| Post to all platforms | `$PYTHON $SOCIAL "text" --platforms all --reddit-subreddit NAME --reddit-title "Title"` |
+| Post to specific platforms | `$PYTHON $SOCIAL "text" --platforms x linkedin` |
+| Post via Buffer only | `$PYTHON $SOCIAL "text" --platforms buffer` |
+| Post with image | `$PYTHON $SOCIAL "text" --platforms all --image /path/to/photo.jpg ...` |
+| Dry run preview | `$PYTHON $SOCIAL "text" --platforms all --dry-run ...` |
+| JSON output | `$PYTHON $SOCIAL "text" --platforms x --output json` |
+
+## Procedure
+
+1. Confirm which platforms the user wants to post to.
+2. Verify that credentials for those platforms are present in `~/.hermes/.env`.
+3. For Reddit, confirm the subreddit name and post title.
+4. Run with `--dry-run` first to preview what will be sent.
+5. Run without `--dry-run` to publish.
+6. Report back post IDs and URLs from the output.
+
+## Platform Notes
+
+### X (Twitter)
+
+Requires a developer app with **Read and Write** permissions. Regenerate the access
+token and secret after enabling write permissions or posts will fail with a 403.
+X API free tier has strict rate limits — avoid posting identical content twice in
+quick succession.
+
+### LinkedIn
+
+Requires an OAuth2 access token with `w_member_social` scope. Access tokens expire;
+if posting fails with a 401, a new token must be generated via the OAuth2 flow.
+
+### Facebook Page
+
+Requires a Page Access Token (not a User token) with `pages_manage_posts` permission.
+Text-only short posts render with large font on Facebook — this is Facebook's design,
+not a bug. Attach an image or write longer text to get normal font rendering.
+
+### Reddit
+
+Uses username + password authentication (script-type app). Reddit blocks posting
+identical content twice in a short window — vary the text if reposting.
+
+### Buffer
+
+Uses the Buffer GraphQL API (`https://api.buffer.com`) with a personal API key.
+Get the key at https://publish.buffer.com/settings/api.
+
+By default the script posts to **all channels** connected to the Buffer account.
+To restrict to specific channels, set `BUFFER_CHANNEL_IDS` as a comma-separated
+list of channel IDs, or pass `--buffer-channel-ids ID1 ID2`.
+
+Facebook channels connected via Buffer require a post type. The default is `post`.
+Override with `--buffer-facebook-post-type story` or `--buffer-facebook-post-type reel`.
+
+## Options Reference
+
+| Option | Default | Description |
+|---|---|---|
+| `--platforms` | `all` | Space-separated: `x`, `linkedin`, `facebook`, `reddit`, `buffer`, `all` |
+| `--image` | — | Path to image file to attach |
+| `--reddit-subreddit` | — | Subreddit name (required when Reddit is targeted) |
+| `--reddit-title` | — | Post title for Reddit (required when Reddit is targeted) |
+| `--buffer-channel-ids` | — | Buffer channel IDs (overrides `BUFFER_CHANNEL_IDS` env var) |
+| `--buffer-facebook-post-type` | `post` | Facebook post type via Buffer: `post`, `story`, `reel` |
+| `--dry-run` | — | Preview without sending |
+| `--output` | `text` | Output format: `text` or `json` |
+
+## Verification
+
+- `[OK]` lines appear for each platform targeted.
+- For JSON output, check `"success": true` per platform entry.
+- Each successful post includes an `id` or `url` field that can be used to verify the post exists.
+- If a platform returns `[FAIL]`, check the error message — most failures are credential
+  or rate-limit issues, not script bugs.
+
+## Pitfalls
+
+- **X 403 oauth1-permissions**: Regenerate the access token after enabling Read and Write permissions.
+- **LinkedIn 401**: Access token has expired — generate a new one via OAuth2.
+- **Reddit duplicate**: Reddit rejects identical posts posted close together — vary the text.
+- **Buffer Facebook missing type**: Always passes `metadata.facebook.type` — defaults to `post`. If the channel requires a different type, use `--buffer-facebook-post-type`.
+- **Buffer OIDC token rejected**: The token must be the API key from https://publish.buffer.com/settings/api, not an OAuth login token.

--- a/optional-skills/social-media/social-post/scripts/social_post.py
+++ b/optional-skills/social-media/social-post/scripts/social_post.py
@@ -1,0 +1,523 @@
+#!/usr/bin/env python3
+"""
+social_post.py - Social media matrix posting tool.
+
+Supports posting to X (Twitter), LinkedIn, Facebook Page, Reddit, and Buffer
+simultaneously or selectively via a single command.
+
+Usage:
+    python social_post.py "Your message here" [options]
+
+Setup:
+    Copy .env.example to .env and fill in your API credentials.
+"""
+
+import argparse
+import os
+import sys
+import json
+from pathlib import Path
+
+try:
+    from dotenv import load_dotenv
+except ImportError:
+    print("Missing dependency: pip install python-dotenv", file=sys.stderr)
+    sys.exit(1)
+
+load_dotenv()
+
+
+# ---------------------------------------------------------------------------
+# Platform clients
+# ---------------------------------------------------------------------------
+
+
+def post_to_x(text: str, image_path: str | None = None) -> dict:
+    """Post to X (Twitter) using the v2 API via tweepy."""
+    try:
+        import tweepy
+    except ImportError:
+        return {"platform": "X", "success": False, "error": "tweepy not installed: pip install tweepy"}
+
+    api_key = os.getenv("X_API_KEY")
+    api_secret = os.getenv("X_API_SECRET")
+    access_token = os.getenv("X_ACCESS_TOKEN")
+    access_token_secret = os.getenv("X_ACCESS_TOKEN_SECRET")
+
+    missing = [k for k, v in {
+        "X_API_KEY": api_key,
+        "X_API_SECRET": api_secret,
+        "X_ACCESS_TOKEN": access_token,
+        "X_ACCESS_TOKEN_SECRET": access_token_secret,
+    }.items() if not v]
+    if missing:
+        return {"platform": "X", "success": False, "error": f"Missing env vars: {', '.join(missing)}"}
+
+    client = tweepy.Client(
+        consumer_key=api_key,
+        consumer_secret=api_secret,
+        access_token=access_token,
+        access_token_secret=access_token_secret,
+    )
+
+    media_ids = None
+    if image_path:
+        auth = tweepy.OAuth1UserHandler(api_key, api_secret, access_token, access_token_secret)
+        api_v1 = tweepy.API(auth)
+        media = api_v1.media_upload(image_path)
+        media_ids = [media.media_id]
+
+    kwargs = {"text": text}
+    if media_ids:
+        kwargs["media_ids"] = media_ids
+
+    response = client.create_tweet(**kwargs)
+    tweet_id = response.data["id"]
+    return {
+        "platform": "X",
+        "success": True,
+        "id": tweet_id,
+        "url": f"https://x.com/i/web/status/{tweet_id}",
+    }
+
+
+def post_to_linkedin(text: str, image_path: str | None = None) -> dict:
+    """Post to LinkedIn as a personal share using the v2 API."""
+    try:
+        import requests
+    except ImportError:
+        return {"platform": "LinkedIn", "success": False, "error": "requests not installed: pip install requests"}
+
+    access_token = os.getenv("LINKEDIN_ACCESS_TOKEN")
+    if not access_token:
+        return {"platform": "LinkedIn", "success": False, "error": "Missing env var: LINKEDIN_ACCESS_TOKEN"}
+
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "Content-Type": "application/json",
+        "X-Restli-Protocol-Version": "2.0.0",
+    }
+
+    # Resolve the authenticated member's URN
+    me_resp = requests.get("https://api.linkedin.com/v2/userinfo", headers=headers)
+    if not me_resp.ok:
+        return {"platform": "LinkedIn", "success": False, "error": f"Failed to fetch profile: {me_resp.text}"}
+    profile = me_resp.json()
+    person_urn = f"urn:li:person:{profile['sub']}"
+
+    media_asset = None
+    if image_path:
+        # Step 1: register upload
+        register_body = {
+            "registerUploadRequest": {
+                "recipes": ["urn:li:digitalmediaRecipe:feedshare-image"],
+                "owner": person_urn,
+                "serviceRelationships": [
+                    {"relationshipType": "OWNER", "identifier": "urn:li:userGeneratedContent"}
+                ],
+            }
+        }
+        reg_resp = requests.post(
+            "https://api.linkedin.com/v2/assets?action=registerUpload",
+            headers=headers,
+            json=register_body,
+        )
+        if not reg_resp.ok:
+            return {"platform": "LinkedIn", "success": False, "error": f"Image register failed: {reg_resp.text}"}
+        reg_data = reg_resp.json()
+        upload_url = reg_data["value"]["uploadMechanism"][
+            "com.linkedin.digitalmedia.uploading.MediaUploadHttpRequest"
+        ]["uploadUrl"]
+        media_asset = reg_data["value"]["asset"]
+
+        # Step 2: upload binary
+        with open(image_path, "rb") as fh:
+            upload_resp = requests.put(upload_url, data=fh, headers={"Authorization": f"Bearer {access_token}"})
+        if not upload_resp.ok:
+            return {"platform": "LinkedIn", "success": False, "error": f"Image upload failed: {upload_resp.text}"}
+
+    post_body: dict = {
+        "author": person_urn,
+        "lifecycleState": "PUBLISHED",
+        "specificContent": {
+            "com.linkedin.ugc.ShareContent": {
+                "shareCommentary": {"text": text},
+                "shareMediaCategory": "IMAGE" if media_asset else "NONE",
+            }
+        },
+        "visibility": {"com.linkedin.ugc.MemberNetworkVisibility": "PUBLIC"},
+    }
+
+    if media_asset:
+        post_body["specificContent"]["com.linkedin.ugc.ShareContent"]["media"] = [
+            {"status": "READY", "media": media_asset}
+        ]
+
+    post_resp = requests.post("https://api.linkedin.com/v2/ugcPosts", headers=headers, json=post_body)
+    if not post_resp.ok:
+        return {"platform": "LinkedIn", "success": False, "error": f"Post failed: {post_resp.text}"}
+
+    post_id = post_resp.headers.get("x-restli-id", "")
+    return {"platform": "LinkedIn", "success": True, "id": post_id}
+
+
+def post_to_facebook(text: str, image_path: str | None = None) -> dict:
+    """Post to a Facebook Page using the Graph API."""
+    try:
+        import requests
+    except ImportError:
+        return {"platform": "Facebook", "success": False, "error": "requests not installed: pip install requests"}
+
+    page_id = os.getenv("FACEBOOK_PAGE_ID")
+    page_access_token = os.getenv("FACEBOOK_PAGE_ACCESS_TOKEN")
+
+    missing = [k for k, v in {
+        "FACEBOOK_PAGE_ID": page_id,
+        "FACEBOOK_PAGE_ACCESS_TOKEN": page_access_token,
+    }.items() if not v]
+    if missing:
+        return {"platform": "Facebook", "success": False, "error": f"Missing env vars: {', '.join(missing)}"}
+
+    base_url = f"https://graph.facebook.com/v19.0/{page_id}"
+
+    if image_path:
+        with open(image_path, "rb") as fh:
+            resp = requests.post(
+                f"{base_url}/photos",
+                data={"message": text, "access_token": page_access_token},
+                files={"source": fh},
+            )
+    else:
+        resp = requests.post(
+            f"{base_url}/feed",
+            data={"message": text, "access_token": page_access_token},
+        )
+
+    if not resp.ok:
+        return {"platform": "Facebook", "success": False, "error": f"Post failed: {resp.text}"}
+
+    data = resp.json()
+    post_id = data.get("post_id") or data.get("id", "")
+    return {"platform": "Facebook", "success": True, "id": post_id}
+
+
+def post_to_buffer(
+    text: str,
+    image_path: str | None = None,
+    channel_ids: list[str] | None = None,
+    facebook_post_type: str = "post",
+) -> dict:
+    """Post to one or more connected channels via the Buffer GraphQL API."""
+    try:
+        import requests
+    except ImportError:
+        return {"platform": "Buffer", "success": False, "error": "requests not installed: pip install requests"}
+
+    access_token = os.getenv("BUFFER_ACCESS_TOKEN")
+    if not access_token:
+        return {"platform": "Buffer", "success": False, "error": "Missing env var: BUFFER_ACCESS_TOKEN"}
+
+    endpoint = "https://api.buffer.com"
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "Content-Type": "application/json",
+    }
+
+    def gql(query: str, variables: dict | None = None) -> dict:
+        payload: dict = {"query": query}
+        if variables:
+            payload["variables"] = variables
+        resp = requests.post(endpoint, headers=headers, json=payload)
+        resp.raise_for_status()
+        return resp.json()
+
+    # Always fetch all channels to get service info for metadata decisions
+    account_data = gql("{ account { organizations { id } } }")
+    errors = account_data.get("errors")
+    if errors:
+        return {"platform": "Buffer", "success": False, "error": f"Failed to fetch account: {errors}"}
+    orgs = account_data["data"]["account"]["organizations"]
+    if not orgs:
+        return {"platform": "Buffer", "success": False, "error": "No organizations found in Buffer account"}
+    org_id = orgs[0]["id"]
+
+    channels_data = gql(
+        "query GetChannels($input: ChannelsInput!) { channels(input: $input) { id name service } }",
+        {"input": {"organizationId": org_id}},
+    )
+    errors = channels_data.get("errors")
+    if errors:
+        return {"platform": "Buffer", "success": False, "error": f"Failed to fetch channels: {errors}"}
+    all_channels = channels_data["data"]["channels"]
+    if not all_channels:
+        return {"platform": "Buffer", "success": False, "error": "No connected channels found in Buffer account"}
+
+    # Resolve which channels to post to: CLI arg > env var > all
+    if not channel_ids:
+        env_ids = os.getenv("BUFFER_CHANNEL_IDS", "")
+        channel_ids = [c.strip() for c in env_ids.split(",") if c.strip()]
+
+    channel_map = {c["id"]: c["service"] for c in all_channels}
+
+    if channel_ids:
+        # Filter to only known channels; warn about unknown IDs
+        unknown = [cid for cid in channel_ids if cid not in channel_map]
+        if unknown:
+            return {"platform": "Buffer", "success": False, "error": f"Unknown channel IDs: {', '.join(unknown)}"}
+        target_channels = [(cid, channel_map[cid]) for cid in channel_ids]
+    else:
+        target_channels = [(c["id"], c["service"]) for c in all_channels]
+
+    # Create a post for each channel
+    create_mutation = """
+    mutation CreatePost($input: CreatePostInput!) {
+      createPost(input: $input) {
+        ... on PostActionSuccess {
+          post { id text dueAt }
+        }
+        ... on MutationError {
+          message
+        }
+      }
+    }
+    """
+
+    results_per_channel = []
+    errors_per_channel = []
+
+    for cid, service in target_channels:
+        post_input: dict = {
+            "channelId": cid,
+            "text": text,
+            "schedulingType": "automatic",
+            "mode": "shareNow",
+        }
+        if service == "facebook":
+            post_input["metadata"] = {"facebook": {"type": facebook_post_type}}
+
+        variables: dict = {"input": post_input}
+        data = gql(create_mutation, variables)
+        gql_errors = data.get("errors")
+        if gql_errors:
+            errors_per_channel.append(f"{cid}({service}): {gql_errors}")
+            continue
+        result = data["data"]["createPost"]
+        if "message" in result:
+            errors_per_channel.append(f"{cid}({service}): {result['message']}")
+        else:
+            post = result.get("post", {})
+            results_per_channel.append({
+                "channel_id": cid,
+                "service": service,
+                "post_id": post.get("id", ""),
+                "due_at": post.get("dueAt", ""),
+            })
+
+    if errors_per_channel and not results_per_channel:
+        return {"platform": "Buffer", "success": False, "error": "; ".join(errors_per_channel)}
+
+    return {
+        "platform": "Buffer",
+        "success": True,
+        "posts": results_per_channel,
+        "channel_count": len(results_per_channel),
+        **({"partial_errors": errors_per_channel} if errors_per_channel else {}),
+    }
+
+
+def post_to_reddit(text: str, subreddit_name: str, title: str, image_path: str | None = None) -> dict:
+    """Post to a Reddit subreddit (text or image post)."""
+    try:
+        import praw
+    except ImportError:
+        return {"platform": "Reddit", "success": False, "error": "praw not installed: pip install praw"}
+
+    client_id = os.getenv("REDDIT_CLIENT_ID")
+    client_secret = os.getenv("REDDIT_CLIENT_SECRET")
+    username = os.getenv("REDDIT_USERNAME")
+    password = os.getenv("REDDIT_PASSWORD")
+    user_agent = os.getenv("REDDIT_USER_AGENT", "social_post/1.0")
+
+    missing = [k for k, v in {
+        "REDDIT_CLIENT_ID": client_id,
+        "REDDIT_CLIENT_SECRET": client_secret,
+        "REDDIT_USERNAME": username,
+        "REDDIT_PASSWORD": password,
+    }.items() if not v]
+    if missing:
+        return {"platform": "Reddit", "success": False, "error": f"Missing env vars: {', '.join(missing)}"}
+
+    reddit = praw.Reddit(
+        client_id=client_id,
+        client_secret=client_secret,
+        username=username,
+        password=password,
+        user_agent=user_agent,
+    )
+
+    subreddit = reddit.subreddit(subreddit_name)
+
+    if image_path:
+        submission = subreddit.submit_image(title=title, image_path=image_path)
+    else:
+        submission = subreddit.submit(title=title, selftext=text)
+
+    return {
+        "platform": "Reddit",
+        "success": True,
+        "id": submission.id,
+        "url": submission.url,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+PLATFORM_CHOICES = ["x", "linkedin", "facebook", "reddit", "buffer", "all"]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Post a message to one or more social media platforms.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Post to all platforms
+  python social_post.py "Hello world!" --platforms all --reddit-subreddit python --reddit-title "Hello"
+
+  # Post only to X and LinkedIn
+  python social_post.py "New blog post" --platforms x linkedin
+
+  # Post with an image
+  python social_post.py "Check this out" --platforms all --image ./photo.jpg \\
+      --reddit-subreddit python --reddit-title "Check this out"
+
+  # Post via Buffer to specific profiles
+  python social_post.py "New post" --platforms buffer --buffer-profile-ids abc123 def456
+
+  # Dry run (preview without posting)
+  python social_post.py "Test message" --platforms all --dry-run \\
+      --reddit-subreddit test --reddit-title "Test"
+""",
+    )
+
+    parser.add_argument("message", help="The text content to post")
+    parser.add_argument(
+        "--platforms",
+        nargs="+",
+        choices=PLATFORM_CHOICES,
+        default=["all"],
+        metavar="PLATFORM",
+        help=f"Platforms to post to. Choices: {', '.join(PLATFORM_CHOICES)} (default: all)",
+    )
+    parser.add_argument("--image", metavar="PATH", help="Optional image file to attach to the post")
+    parser.add_argument("--reddit-subreddit", metavar="NAME", help="Subreddit name (required when posting to Reddit)")
+    parser.add_argument("--reddit-title", metavar="TITLE", help="Post title for Reddit (required when posting to Reddit)")
+    parser.add_argument(
+        "--buffer-channel-ids",
+        nargs="+",
+        metavar="ID",
+        help="Buffer channel IDs to post to (overrides BUFFER_CHANNEL_IDS env var; defaults to all connected channels)",
+    )
+    parser.add_argument(
+        "--buffer-facebook-post-type",
+        choices=["post", "story", "reel"],
+        default="post",
+        help="Post type for Facebook channels connected via Buffer (default: post)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview what would be posted without actually sending anything",
+    )
+    parser.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    return parser
+
+
+def resolve_platforms(platforms: list[str]) -> list[str]:
+    if "all" in platforms:
+        return ["x", "linkedin", "facebook", "reddit", "buffer"]
+    return list(dict.fromkeys(platforms))  # deduplicate while preserving order
+
+
+def print_result(result: dict, fmt: str) -> None:
+    if fmt == "json":
+        print(json.dumps(result))
+        return
+    platform = result["platform"]
+    if result["success"]:
+        url = result.get("url", "")
+        post_id = result.get("id", "")
+        detail = url or (f"id={post_id}" if post_id else "")
+        print(f"[OK]    {platform}" + (f" — {detail}" if detail else ""))
+    else:
+        print(f"[FAIL]  {platform} — {result['error']}")
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    platforms = resolve_platforms(args.platforms)
+    message: str = args.message
+    image: str | None = args.image
+
+    if image and not Path(image).is_file():
+        print(f"Error: image file not found: {image}", file=sys.stderr)
+        return 1
+
+    needs_reddit = "reddit" in platforms
+    if needs_reddit and (not args.reddit_subreddit or not args.reddit_title):
+        print("Error: --reddit-subreddit and --reddit-title are required when posting to Reddit.", file=sys.stderr)
+        return 1
+
+    if args.dry_run:
+        print("Dry run — no posts will be sent.\n")
+        print(f"Message : {message}")
+        print(f"Image   : {image or '(none)'}")
+        print(f"Platforms: {', '.join(platforms)}")
+        if needs_reddit:
+            print(f"Reddit  : r/{args.reddit_subreddit} — \"{args.reddit_title}\"")
+        if "buffer" in platforms:
+            buf_ids = args.buffer_channel_ids or os.getenv("BUFFER_CHANNEL_IDS") or "(all connected channels)"
+            print(f"Buffer  : channels={buf_ids}")
+        return 0
+
+    results: list[dict] = []
+
+    for platform in platforms:
+        if platform == "x":
+            results.append(post_to_x(message, image))
+        elif platform == "linkedin":
+            results.append(post_to_linkedin(message, image))
+        elif platform == "facebook":
+            results.append(post_to_facebook(message, image))
+        elif platform == "reddit":
+            results.append(
+                post_to_reddit(message, args.reddit_subreddit, args.reddit_title, image)
+            )
+        elif platform == "buffer":
+            results.append(post_to_buffer(message, image, args.buffer_channel_ids, args.buffer_facebook_post_type))
+
+    exit_code = 0
+    if args.output == "json":
+        print(json.dumps(results, indent=2))
+    else:
+        for result in results:
+            print_result(result, "text")
+        failures = [r for r in results if not r["success"]]
+        if failures:
+            exit_code = 1
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Adds `optional-skills/social-media/social-post/` — a new optional skill for publishing content to X (Twitter), LinkedIn, Facebook Page, Reddit, and Buffer from a single command
- Includes a bundled Python helper script (`scripts/social_post.py`) that handles auth and API calls for each platform
- Uses the Buffer GraphQL API (`api.buffer.com`) — not the deprecated REST v1 API

## Platforms supported

| Platform | API | Auth |
|---|---|---|
| X (Twitter) | v2 via tweepy | OAuth1 (4 keys) |
| LinkedIn | UGC Posts v2 | OAuth2 Bearer token |
| Facebook Page | Graph API v19 | Page Access Token |
| Reddit | via praw | Username + password (script app) |
| Buffer | GraphQL (`api.buffer.com`) | Personal API key |

## Why optional-skills

The skill requires third-party API credentials for paid/gated services (X developer access, LinkedIn app approval, Facebook app review) and Python dependencies (`tweepy`, `praw`) that are not universally needed. It fits the optional-skills model well.

## Test plan

- [ ] `hermes skills install social-post` installs the skill
- [ ] `--dry-run` previews without posting
- [ ] Each platform posts successfully when credentials are present
- [ ] Missing credentials produce a clear error per platform, not a crash
- [ ] `--output json` returns machine-readable results

🤖 Generated with [Claude Code](https://claude.com/claude-code)