### PR TITLE
fix: prevent custom provider model from overriding /model switch

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1773,6 +1773,7 @@ class HermesCLI:
             or "auto"
         )
         self._provider_source: Optional[str] = None
+        self._model_explicitly_set: bool = False
         self.provider = self.requested_provider
         self.api_mode = "chat_completions"
         self.acp_command: Optional[str] = None
@@ -2851,7 +2852,7 @@ class HermesCLI:
         # (e.g. "my-provider") as the model string to the API instead of
         # the configured model (e.g. "qwen3.6-plus"), causing 400 errors.
         runtime_model = runtime.get("model")
-        if runtime_model and isinstance(runtime_model, str):
+        if runtime_model and isinstance(runtime_model, str) and not self._model_explicitly_set:
             self.model = runtime_model
 
         # If model is still empty (e.g. user ran `hermes auth add openai-codex`
@@ -4704,6 +4705,7 @@ class HermesCLI:
         self.model = result.new_model
         self.provider = result.target_provider
         self.requested_provider = result.target_provider
+        self._model_explicitly_set = True
         if result.api_key:
             self.api_key = result.api_key
             self._explicit_api_key = result.api_key
@@ -4924,6 +4926,7 @@ class HermesCLI:
         self.model = result.new_model
         self.provider = result.target_provider
         self.requested_provider = result.target_provider
+        self._model_explicitly_set = True
         if result.api_key:
             self.api_key = result.api_key
             self._explicit_api_key = result.api_key


### PR DESCRIPTION
## Summary

Fixes #12467

`custom_providers[].model` was unconditionally overwriting `self.model` in `_ensure_runtime_credentials()` on every turn, causing `/model` switches to revert after a single message.

## Changes

- Added `_model_explicitly_set` flag to `HermesCLI.__init__` (mirrors the existing `requested_provider` guard pattern)
- Set flag to `True` in both model switch paths (`_apply_model_switch_result` and `_handle_model_switch`)
- Skip `custom_providers[].model` override when flag is set

## Testing

- Verified the diff targets exactly the lines identified in the issue (cli.py:2853-2855)
- The fix follows the same pattern already used for `requested_provider` (comment at cli.py:4921-4922 confirms this was the intended design)