### PR TITLE
fix(slack): include team_id in thread-context cache key

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -1413,7 +1413,7 @@ class SlackAdapter(BasePlatformAdapter):
         Returns a formatted string with prior thread history, or empty string
         on failure or if the thread has no prior messages.
         """
-        cache_key = f"{channel_id}:{thread_ts}"
+        cache_key = f"{channel_id}:{thread_ts}:{team_id}"
         now = time.monotonic()
         cached = self._thread_context_cache.get(cache_key)
         if cached and (now - cached.fetched_at) < self._THREAD_CACHE_TTL:


### PR DESCRIPTION
## Summary

Fixes #12421

Thread context was cached under `channel_id:thread_ts`, but the rendered content depends on `team_id` for bot mention stripping and user-name resolution. In multi-workspace Slack mode, a later lookup from a different workspace could receive stale context from the first workspace.

## Change

Include `team_id` in the cache key: `f"{channel_id}:{thread_ts}:{team_id}"`

`team_id` is already a parameter of `_fetch_thread_context()` with a default of `""`, so this is backwards-compatible — single-workspace setups will use the same cache key as before.