### PR TITLE
chore: add sgaofen to AUTHOR_MAP

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -77,6 +77,7 @@ AUTHOR_MAP = {
     "Asunfly@users.noreply.github.com": "Asunfly",
     "2500400+honghua@users.noreply.github.com": "honghua",
     "nish3451@users.noreply.github.com": "nish3451",
+    "135070653+sgaofen@users.noreply.github.com": "sgaofen",
     # contributors (manual mapping from git names)
     "ahmedsherif95@gmail.com": "asheriif",
     "liujinkun@bytedance.com": "liujinkun2025",


### PR DESCRIPTION
## Summary
- add `135070653+sgaofen@users.noreply.github.com` to `AUTHOR_MAP`
- unblock contributor attribution for the Feishu salvage of #8638

## Why
The salvaged PR for #8638 will preserve the original contributor commit authored by @sgaofen. `scripts/contributor_audit.py` requires the commit email to be present in `AUTHOR_MAP` before that salvage PR can merge cleanly.

## Test plan
- grep `scripts/release.py` for `135070653+sgaofen@users.noreply.github.com`

Refs #8638
