### PR TITLE
fix(plugins): await coroutines returned by async plugin callbacks

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5844,11 +5844,15 @@ class HermesCLI:
             # Check for plugin-registered slash commands
             elif base_cmd.lstrip("/") in _get_plugin_cmd_handler_names():
                 from hermes_cli.plugins import get_plugin_command_handler
+                import asyncio
+                import inspect as _inspect
                 plugin_handler = get_plugin_command_handler(base_cmd.lstrip("/"))
                 if plugin_handler:
                     user_args = cmd_original[len(base_cmd):].strip()
                     try:
                         result = plugin_handler(user_args)
+                        if _inspect.iscoroutine(result):
+                            result = asyncio.run(result)
                         if result:
                             _cprint(str(result))
                     except Exception as e:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import importlib
 import importlib.metadata
 import importlib.util
+import inspect
 import logging
 import sys
 import types
@@ -654,6 +655,13 @@ class PluginManager:
         for cb in callbacks:
             try:
                 ret = cb(**kwargs)
+                if inspect.iscoroutine(ret):
+                    import asyncio
+                    logger.debug(
+                        "Hook '%s' callback %s returned a coroutine — awaiting",
+                        hook_name, getattr(cb, "__name__", repr(cb)),
+                    )
+                    ret = asyncio.run(ret)
                 if ret is not None:
                     results.append(ret)
             except Exception as exc:


### PR DESCRIPTION
## Summary

Fixes #12449

Plugin hook dispatch (`PluginManager.invoke_hook`) and slash command handler (`process_command`) called callbacks synchronously, ignoring returned coroutines. This caused `RuntimeWarning: coroutine was never awaited` and `<coroutine object>` printed to the terminal.

## Changes

**`hermes_cli/plugins.py`** — `PluginManager.invoke_hook`:
- Added `inspect.iscoroutine()` check on callback return value
- Await coroutines via `asyncio.run()` before appending to results

**`cli.py`** — `process_command` plugin handler:
- Same pattern: detect coroutine returns and await via `asyncio.run()`

Both call sites are synchronous (CLI interactive mode / prompt_toolkit), so `asyncio.run()` is safe — no running event loop to conflict with.