### PR TITLE
fix(models): accept model switch when /models probe fails (warn-and-accept)

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2190,11 +2190,11 @@ def validate_requested_model(
 
     provider_label = _PROVIDER_LABELS.get(normalized, normalized)
     return {
-        "accepted": False,
-        "persist": False,
+        "accepted": True,
+        "persist": True,
         "recognized": False,
         "message": (
-            f"Could not reach the {provider_label} API to validate `{requested}`. "
-            f"If the service isn't down, this model may not be valid."
+            f"Warning: could not reach the {provider_label} API to validate `{requested}`. "
+            f"If the service isn't down, this model may not be valid. Switching anyway."
         ),
     }


### PR DESCRIPTION
## Summary

When the live `/models` probe returns `None` (endpoint unreachable or 404), accept and persist the model switch instead of hard-rejecting it. This restores warn-and-accept behavior for providers with non-standard `/ai/models` endpoints (e.g. MiniMax at `api.minimax.io/anthropic` returns 404 despite having a functional chat API).

## Changes

**File:** `hermes_cli/models.py`

Changed the fallback return at the end of `validate_requested_model()` from:
- `accepted: False, persist: False` → `accepted: True, persist: True`
- Message updated to say "Warning: ... Switching anyway" instead of hard-rejecting

This mirrors how Bedrock is already handled in the same function — when AWS SDK discovery fails, it falls back to warn-and-accept.

## Why this is safe

- The model switch is validated by actual inference, not just the `/models` probe
- Many providers have working chat APIs but non-standard or missing `/models` endpoints (see #12460)
- The warning message is still shown to the user so they know validation couldn't be performed
- Prevents blocking legitimate model switches that would work fine in actual use

## Fixes

Fixes: #12460