### PR TITLE
feat(acp): bridge interim_assistant_callback for live commentary over ACP

### DIFF
--- a/acp_adapter/events.py
+++ b/acp_adapter/events.py
@@ -174,6 +174,33 @@ def make_step_cb(
     return _step
 
 
+
+
+def _merge_update_meta(update: Any, **values: Any) -> Any:
+    """Attach ACP `_meta` metadata to a generated update object.
+
+    The Python ACP SDK exposes the schema `_meta` field as `field_meta` and
+    serializes it back to `_meta`. Keeping commentary markers there avoids
+    adding non-schema top-level fields to `agent_message_chunk`.
+    """
+    existing = getattr(update, "field_meta", None)
+    metadata = dict(existing) if isinstance(existing, dict) else {}
+    metadata.update(values)
+    try:
+        update.field_meta = metadata
+        return update
+    except Exception:
+        logger.debug("Failed to attach ACP update metadata", exc_info=True)
+        try:
+            payload = update.model_dump(by_alias=True, exclude_none=True)
+        except Exception:
+            payload = {
+                "sessionUpdate": "agent_message_chunk",
+                "content": {"type": "text", "text": ""},
+            }
+        payload["_meta"] = metadata
+        return payload
+
 # ------------------------------------------------------------------
 # Agent message callback
 # ------------------------------------------------------------------
@@ -192,3 +219,42 @@ def make_message_cb(
         _send_update(conn, session_id, loop, update)
 
     return _message
+
+def make_interim_assistant_cb(
+    conn: acp.Client,
+    session_id: str,
+    loop: asyncio.AbstractEventLoop,
+) -> Callable:
+    """Create a callback for completed interim assistant commentary.
+
+    AIAgent calls this callback for real assistant-facing progress messages that
+    Hermes gateway surfaces in Telegram/Discord. Over ACP these are still
+    `agent_message_chunk` updates, but their `_meta` marks them as live-only
+    commentary so CAR can render them without treating them as final output.
+    """
+
+    def _interim_assistant(
+        text: str,
+        *,
+        already_streamed: bool = False,
+        **_: Any,
+    ) -> None:
+        if not text:
+            return
+        update = acp.update_agent_message_text(text)
+        update = _merge_update_meta(
+            update,
+            phase="commentary",
+            alreadyStreamed=bool(already_streamed),
+            car={
+                "phase": "commentary",
+                "alreadyStreamed": bool(already_streamed),
+            },
+            hermes={
+                "phase": "commentary",
+                "alreadyStreamed": bool(already_streamed),
+            },
+        )
+        _send_update(conn, session_id, loop, update)
+
+    return _interim_assistant

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -53,6 +53,7 @@ except ImportError:
 
 from acp_adapter.auth import detect_provider, has_provider
 from acp_adapter.events import (
+    make_interim_assistant_cb,
     make_message_cb,
     make_step_cb,
     make_thinking_cb,
@@ -503,12 +504,14 @@ class HermesACPAgent(acp.Agent):
             thinking_cb = make_thinking_cb(conn, session_id, loop)
             step_cb = make_step_cb(conn, session_id, loop, tool_call_ids, tool_call_meta)
             message_cb = make_message_cb(conn, session_id, loop)
+            interim_assistant_cb = make_interim_assistant_cb(conn, session_id, loop)
             approval_cb = make_approval_callback(conn.request_permission, loop, session_id)
         else:
             tool_progress_cb = None
             thinking_cb = None
             step_cb = None
             message_cb = None
+            interim_assistant_cb = None
             approval_cb = None
 
         agent = state.agent
@@ -516,6 +519,7 @@ class HermesACPAgent(acp.Agent):
         agent.thinking_callback = thinking_cb
         agent.step_callback = step_cb
         agent.message_callback = message_cb
+        agent.interim_assistant_callback = interim_assistant_cb
 
         if approval_cb:
             try:

--- a/tests/acp/test_events.py
+++ b/tests/acp/test_events.py
@@ -10,6 +10,7 @@ import acp
 from acp.schema import ToolCallStart, ToolCallProgress, AgentThoughtChunk, AgentMessageChunk
 
 from acp_adapter.events import (
+    make_interim_assistant_cb,
     make_message_cb,
     make_step_cb,
     make_thinking_cb,
@@ -325,3 +326,31 @@ class TestMessageCallback:
             cb("")
 
         mock_rcts.assert_not_called()
+
+
+
+class TestInterimAssistantCallback:
+    def test_emits_commentary_agent_message_chunk(self, mock_conn, event_loop_fixture):
+        loop = event_loop_fixture
+        cb = make_interim_assistant_cb(mock_conn, "session-1", loop)
+
+        with patch("acp_adapter.events._send_update") as mock_send:
+            cb("I’ll inspect the repo first.", already_streamed=False)
+
+        mock_send.assert_called_once()
+        update = mock_send.call_args.args[3]
+        assert update.session_update == "agent_message_chunk"
+        assert update.field_meta["phase"] == "commentary"
+        assert update.field_meta["alreadyStreamed"] is False
+        assert update.field_meta["car"]["phase"] == "commentary"
+
+    def test_marks_already_streamed_commentary(self, mock_conn, event_loop_fixture):
+        loop = event_loop_fixture
+        cb = make_interim_assistant_cb(mock_conn, "session-1", loop)
+
+        with patch("acp_adapter.events._send_update") as mock_send:
+            cb("Already visible", already_streamed=True)
+
+        update = mock_send.call_args.args[3]
+        assert update.field_meta["alreadyStreamed"] is True
+        assert update.field_meta["hermes"]["alreadyStreamed"] is True


### PR DESCRIPTION
## Summary

- Wires `AIAgent.interim_assistant_callback` in the ACP adapter, which was the only missing callback (gateway path already has it)
- Adds `_merge_update_meta()` helper to attach ACP-schema-compliant `_meta` fields to update objects
- Adds `make_interim_assistant_cb()` that emits interim commentary as `agent_message_chunk` with `_meta.phase = "commentary"`

## Problem

When Hermes runs via `hermes acp` (editor clients like CAR, VS Code, Zed), interim assistant commentary messages (e.g. "I'll inspect the repo first.") are silently dropped. The `interim_assistant_callback` exists on `AIAgent` and is wired in the gateway path, but the ACP adapter never sets it — only connecting `tool_progress`, `thinking`, `step`, `message`, and `approval`.

## Wire format

```json
{
  "sessionUpdate": "agent_message_chunk",
  "_meta": {
    "hermes": { "phase": "commentary", "alreadyStreamed": false },
    "car": { "phase": "commentary", "alreadyStreamed": false }
  },
  "content": { "type": "text", "text": "I'll inspect the repo first." }
}
```

## Test plan

- [x] `tests/acp/test_events.py::TestInterimAssistantCallback` — 2 new tests covering commentary emission and alreadyStreamed flag
- [x] All 63 existing ACP adapter tests pass
- [ ] Manual: launch `hermes acp` and verify commentary appears in editor client