### PR TITLE
fix(vision): only inject Nous tags when call provider is actually Nous

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2377,7 +2377,7 @@ def _build_call_kwargs(
 
     # Provider-specific extra_body
     merged_extra = dict(extra_body or {})
-    if provider == "nous" or auxiliary_is_nous:
+    if provider == "nous":
         merged_extra.setdefault("tags", []).extend(["product=hermes-agent"])
     if merged_extra:
         kwargs["extra_body"] = merged_extra


### PR DESCRIPTION
## Summary

Fixes #12408

The global `auxiliary_is_nous` flag caused the Nous-specific `"tags": ["product=hermes-agent"]` extra_body to be injected into **all** auxiliary API calls — including vision calls routed to Gemini or other non-Nous providers, resulting in `400` errors:

```
Invalid JSON payload received. Unknown name "tags": Cannot find field.
```

## Change

In `_build_call_kwargs()`, removed the `or auxiliary_is_nous` condition so tags are only injected when the **current call's provider** is `"nous"`:

```python
# Before
if provider == "nous" or auxiliary_is_nous:

# After
if provider == "nous":
```

`provider` is already a parameter of `_build_call_kwargs()`, so this correctly scopes the tags to Nous-routed calls only.