### PR TITLE
feat(whatsapp): implement send_voice for native audio message delivery

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -766,6 +766,17 @@ class WhatsAppAdapter(BasePlatformAdapter):
         """Send a video natively via bridge — plays inline in WhatsApp."""
         return await self._send_media_to_bridge(chat_id, video_path, "video", caption)
 
+    async def send_voice(
+        self,
+        chat_id: str,
+        audio_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Send an audio file as a WhatsApp voice message via bridge."""
+        return await self._send_media_to_bridge(chat_id, audio_path, "audio", caption)
+
     async def send_document(
         self,
         chat_id: str,


### PR DESCRIPTION
## What does this PR do?

WhatsApp already receives incoming voice messages (audio/ogg via the bridge) but `send_voice` was not implemented. TTS and audio responses fell back to the base class `send_image` path, delivering audio as an image URL instead of a native voice message.

This PR implements `send_voice` by routing through the existing `_send_media_to_bridge` helper with `media_type='audio'`, matching the pattern used by `send_video` and `send_document`.

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- `gateway/platforms/whatsapp.py` — added `send_voice` method that calls `_send_media_to_bridge` with `media_type='audio'`

## How to Test

1. Configure Hermes with WhatsApp gateway
2. Enable TTS or send an audio file via the agent
3. Verify audio is delivered as a native WhatsApp voice message instead of falling back to image delivery

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] Tested on: Ubuntu 24.04 (WSL2)

### Documentation & Housekeeping
- [x] I've updated relevant documentation — N/A
- [x] I've updated cli-config.yaml.example — N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md — N/A
- [x] Cross-platform impact considered — N/A
- [x] Tool descriptions/schemas updated — N/A

## Screenshots / Logs

11 lines added, 1 file changed.
