### PR TITLE
fix(gateway): pass model + runtime to BOOT.md startup hook

### DIFF
--- a/gateway/builtin_hooks/boot_md.py
+++ b/gateway/builtin_hooks/boot_md.py
@@ -42,13 +42,24 @@ def _build_boot_prompt(content: str) -> str:
     )
 
 
-def _run_boot_agent(content: str) -> None:
-    """Spawn a one-shot agent session to execute the boot instructions."""
+def _run_boot_agent(content: str, model: str = "", runtime_kwargs: dict | None = None) -> None:
+    """Spawn a one-shot agent session to execute the boot instructions.
+
+    Args:
+        content: BOOT.md file content.
+        model: Resolved model name from gateway config (e.g. "glm-5.1").
+        runtime_kwargs: Resolved provider credentials dict from the gateway
+            runtime. Contains api_key, base_url, provider, api_mode, command,
+            args, credential_pool.
+    """
     try:
         from run_agent import AIAgent
 
         prompt = _build_boot_prompt(content)
+        runtime_kwargs = runtime_kwargs or {}
         agent = AIAgent(
+            model=model,
+            **runtime_kwargs,
             quiet_mode=True,
             skip_context_files=True,
             skip_memory=True,
@@ -75,10 +86,16 @@ async def handle(event_type: str, context: dict) -> None:
 
     logger.info("Running BOOT.md (%d chars)", len(content))
 
+    # Extract model + runtime from gateway startup context.
+    # Falls back to empty values for backward compat (e.g. if an older
+    # gateway version emits gateway:startup without these fields).
+    model = context.get("model", "") if isinstance(context, dict) else ""
+    runtime_kwargs = context.get("runtime_kwargs") if isinstance(context, dict) else None
+
     # Run in a background thread so we don't block gateway startup.
     thread = threading.Thread(
         target=_run_boot_agent,
-        args=(content,),
+        args=(content, model, runtime_kwargs),
         name="boot-md",
         daemon=True,
     )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2081,18 +2081,17 @@ class GatewayRunner:
         self._running = True
         self._update_runtime_status("running")
         
-        # Emit gateway:startup hook
+        # Log loaded hooks (emit happens after channel directory is ready)
         hook_count = len(self.hooks.loaded_hooks)
         if hook_count:
             logger.info("%s hook(s) loaded", hook_count)
-        await self.hooks.emit("gateway:startup", {
-            "platforms": [p.value for p in self.adapters.keys()],
-        })
         
         if connected_count > 0:
             logger.info("Gateway running with %s platform(s)", connected_count)
         
-        # Build initial channel directory for send_message name resolution
+        # Build initial channel directory for send_message name resolution.
+        # Must happen BEFORE gateway:startup emit so that hooks (e.g. boot-md)
+        # can use send_message with name resolution.
         try:
             from gateway.channel_directory import build_channel_directory
             directory = build_channel_directory(self.adapters)
@@ -2100,6 +2099,24 @@ class GatewayRunner:
             logger.info("Channel directory built: %d target(s)", ch_count)
         except Exception as e:
             logger.warning("Channel directory build failed: %s", e)
+
+        # Emit gateway:startup hook — include resolved model + runtime
+        # so builtin hooks (e.g. boot-md) can create AIAgent instances
+        # with correct credentials instead of relying on bare AIAgent().
+        # Refs: https://github.com/NousResearch/hermes-agent/issues/5239
+        try:
+            _boot_model = _resolve_gateway_model()
+            _boot_runtime = _resolve_runtime_agent_kwargs()
+        except Exception as e:
+            logger.warning("Could not resolve boot hook runtime: %s", e)
+            _boot_model = ""
+            _boot_runtime = {}
+
+        await self.hooks.emit("gateway:startup", {
+            "platforms": [p.value for p in self.adapters.keys()],
+            "model": _boot_model,
+            "runtime_kwargs": _boot_runtime,
+        })
         
         # Check if we're restarting after a /update command. If the update is
         # still running, keep watching so we notify once it actually finishes.


### PR DESCRIPTION
## Problem

The `gateway:startup` hook (`boot_md.py`) creates a bare `AIAgent()` without passing `model` or provider runtime kwargs. When using providers that require a model parameter (e.g. zai/GLM), this causes a `400 model: The model code cannot be empty` error. Every boot-md execution silently logs "nothing to report."

Refs #5239

## Root Cause

`boot_md.py::_run_boot_agent()` instantiated `AIAgent()` with no `model` argument, defaulting to `anthropic/claude-opus-4.6`. For non-Anthropic providers, this either fails or uses the wrong model.

## Fix

Enrich the `gateway:startup` hook context with the resolved `model` name and `runtime_kwargs`, then extract and pass them to `AIAgent()` in `boot_md.py`.

### Changes

**`gateway/run.py`** (+27/-5):
- Emit `gateway:startup` after channel directory is built (so hooks can use `send_message` with name resolution)
- Resolve model via `_resolve_gateway_model()` and runtime kwargs via `_resolve_runtime_agent_kwargs()`
- Pass both in the hook context dict with try/except fallback for robustness

**`gateway/builtin_hooks/boot_md.py`** (+23/-3):
- Extract `model` and `runtime_kwargs` from hook context
- Forward to `_run_boot_agent()` → `AIAgent(model=model, **runtime_kwargs, ...)`
- Graceful fallback: if context is missing keys, behavior is unchanged from before

### Verification

Tested with zai/GLM provider — BOOT.md now successfully reads instructions, calls the LLM, and delivers the startup notification to Feishu:

```
2026-04-19 17:52:03 boot-md completed: Message sent successfully to Feishu chat oc_e7e081af...
✅ Boot checklist complete — gateway startup test message delivered.
```

## Notes

- No unit tests added for `boot_md` (pre-existing code also lacked tests — difficult to unit-test due to AIAgent + gateway runtime dependency)
- `runtime_kwargs` may contain `api_key` but this is safe within the gateway process (same as all other AIAgent call sites)
- Implementation is consistent with how other gateway components pass model/runtime to AIAgent