### PR TITLE
fix(discord): strip MIME parameters before document type lookup (#12511)

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3109,8 +3109,10 @@ class DiscordAdapter(BasePlatformAdapter):
                     _, ext = os.path.splitext(att.filename)
                     ext = ext.lower()
                 if not ext and content_type:
+                    # Strip MIME parameters (e.g. "text/plain; charset=utf-8" → "text/plain")
+                    bare_mime = content_type.split(";")[0].strip()
                     mime_to_ext = {v: k for k, v in SUPPORTED_DOCUMENT_TYPES.items()}
-                    ext = mime_to_ext.get(content_type, "")
+                    ext = mime_to_ext.get(bare_mime, "")
                 if ext not in SUPPORTED_DOCUMENT_TYPES:
                     logger.warning(
                         "[Discord] Unsupported document type '%s' (%s), skipping",

--- a/tests/gateway/test_discord_document_handling.py
+++ b/tests/gateway/test_discord_document_handling.py
@@ -194,6 +194,33 @@ class TestIncomingDocumentHandling:
         assert event.text.index("[Content of") < event.text.index("summarize this")
 
     @pytest.mark.asyncio
+    async def test_discord_auto_message_txt(self, adapter):
+        """Discord auto-generates message.txt when users paste long text (#12511).
+
+        The attachment should be downloaded, its content injected into event.text,
+        and message.content (usually empty) should not cause issues.
+        """
+        pasted_code = b"def hello():\n    print('world')\n" * 50
+
+        with _mock_aiohttp_download(pasted_code):
+            msg = make_message(
+                attachments=[make_attachment(
+                    filename="message.txt",
+                    content_type="text/plain; charset=utf-8",
+                )],
+                content="",  # Discord leaves content empty
+            )
+            await adapter._handle_message(msg)
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.DOCUMENT
+        assert len(event.media_urls) == 1
+        assert event.media_types == ["text/plain"]
+        # Text content should be injected
+        assert "[Content of message.txt]:" in event.text
+        assert "def hello():" in event.text
+
+    @pytest.mark.asyncio
     async def test_md_content_injected(self, adapter):
         """.md file under 100KB should have its content injected."""
         file_content = b"# Title\nSome markdown content"


### PR DESCRIPTION
## Problem
Discord auto-converts pasted large text/code blocks into `message.txt` attachments with content_type `text/plain; charset=utf-8`. The MIME-to-extension fallback lookup used the full content_type string (including `; charset=utf-8`), which never matched the bare MIME types in `SUPPORTED_DOCUMENT_TYPES`.

Note: For the common case where Discord provides `filename='message.txt'`, the extension is extracted from the filename directly and the MIME lookup is not needed. This fix addresses the fallback path when filename-based extension detection is unavailable.

## Fix
Strip MIME parameters (`content_type.split(';')[0].strip()`) before the reverse MIME-to-extension lookup.

## Tests
Added test for Discord's auto-generated `message.txt` attachment verifying the attachment is downloaded, cached, and its content injected into `event.text`.

Fixes #12511