### PR TITLE
feat(web_tools): add Brave Search as a search backend

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -236,6 +236,15 @@ TOOL_CATEGORIES = {
                 ],
             },
             {
+                "name": "Brave Search",
+                "badge": "free tier",
+                "tag": "Independent index, privacy-focused — 2000 free queries/mo; search only (extract/crawl need Firecrawl)",
+                "web_backend": "brave",
+                "env_vars": [
+                    {"key": "BRAVE_API_KEY", "prompt": "Brave Search API key", "url": "https://api-dashboard.search.brave.com/"},
+                ],
+            },
+            {
                 "name": "Firecrawl Self-Hosted",
                 "badge": "free · self-hosted",
                 "tag": "Run your own Firecrawl instance (Docker)",

--- a/tests/tools/test_web_tools_brave.py
+++ b/tests/tools/test_web_tools_brave.py
@@ -87,6 +87,36 @@ class TestBraveSearchRequest:
                 with pytest.raises(_httpx.HTTPStatusError):
                     _brave_search("q")
 
+    def test_does_not_set_search_lang(self):
+        """Hermes must NOT pin ``search_lang`` — Brave's auto-detection gives
+        better results for non-English queries. Regression guard for a bug
+        where an earlier approach hardcoded ``search_lang: \"en\"``."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"web": {"results": []}}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.dict(os.environ, {"BRAVE_API_KEY": "k"}):
+            with patch("tools.web_tools.httpx.get", return_value=mock_response) as mock_get:
+                from tools.web_tools import _brave_search
+                _brave_search("recette de pain au miel", limit=3)
+                params = mock_get.call_args.kwargs.get("params") or {}
+                assert "search_lang" not in params
+
+    def test_brave_api_url_override(self):
+        """``BRAVE_API_URL`` env var redirects the request to a custom host
+        (useful for proxies / self-hosted gateways). Trailing slashes are
+        stripped so both ``https://proxy/`` and ``https://proxy`` work."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"web": {"results": []}}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.dict(os.environ, {"BRAVE_API_KEY": "k", "BRAVE_API_URL": "https://brave.proxy.internal/v1/"}):
+            with patch("tools.web_tools.httpx.get", return_value=mock_response) as mock_get:
+                from tools.web_tools import _brave_search
+                _brave_search("q")
+                called_url = mock_get.call_args.args[0]
+                assert called_url == "https://brave.proxy.internal/v1/web/search"
+
 
 # ─── _normalize_brave_search_results ─────────────────────────────────────────
 
@@ -141,6 +171,43 @@ class TestNormalizeBraveSearchResults:
         assert web[0]["url"] == ""
         assert web[0]["description"] == ""
         assert web[0]["position"] == 1
+
+    def test_extra_snippets_merged_into_description(self):
+        """Brave's ``extra_snippets`` hold additional context from the page.
+        We merge the first two into the description so the caller sees
+        richer information without having to know about the Brave-specific
+        field."""
+        from tools.web_tools import _normalize_brave_search_results
+        raw = {"web": {"results": [{
+            "title": "T", "url": "https://x", "description": "Main description.",
+            "extra_snippets": ["First extra.", "Second extra.", "Third dropped."],
+        }]}}
+        result = _normalize_brave_search_results(raw)
+        desc = result["data"]["web"][0]["description"]
+        assert "Main description." in desc
+        assert "First extra." in desc
+        assert "Second extra." in desc
+        # Only first two are merged
+        assert "Third dropped." not in desc
+
+    def test_extra_snippets_used_when_description_empty(self):
+        """When Brave returns no main description, fall back to snippets only."""
+        from tools.web_tools import _normalize_brave_search_results
+        raw = {"web": {"results": [{
+            "title": "T", "url": "https://x", "description": "",
+            "extra_snippets": ["Only snippet."],
+        }]}}
+        result = _normalize_brave_search_results(raw)
+        assert result["data"]["web"][0]["description"] == "Only snippet."
+
+    def test_no_extra_snippets(self):
+        """Absent ``extra_snippets`` → description unchanged (no trailing space)."""
+        from tools.web_tools import _normalize_brave_search_results
+        raw = {"web": {"results": [{
+            "title": "T", "url": "https://x", "description": "Just main.",
+        }]}}
+        result = _normalize_brave_search_results(raw)
+        assert result["data"]["web"][0]["description"] == "Just main."
 
 
 # ─── Backend detection ───────────────────────────────────────────────────────

--- a/tests/tools/test_web_tools_brave.py
+++ b/tests/tools/test_web_tools_brave.py
@@ -1,0 +1,231 @@
+"""Tests for Brave Search web backend integration.
+
+Coverage:
+  _brave_search() — API key handling, header auth, query params, error propagation.
+  _normalize_brave_search_results() — Brave → standard search response mapping.
+  _is_backend_available() / check_web_api_key() — backend detection.
+  web_search_tool — Brave dispatch.
+  web_extract_tool — Firecrawl fallback when backend=brave, clear error otherwise.
+"""
+
+import json
+import os
+import asyncio
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+# ─── _brave_search ───────────────────────────────────────────────────────────
+
+class TestBraveSearchRequest:
+    """Test suite for the _brave_search helper."""
+
+    def test_raises_without_api_key(self):
+        """No BRAVE_API_KEY → ValueError with guidance."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("BRAVE_API_KEY", None)
+            from tools.web_tools import _brave_search
+            with pytest.raises(ValueError, match="BRAVE_API_KEY"):
+                _brave_search("test")
+
+    def test_sends_subscription_token_header(self):
+        """API key is sent via X-Subscription-Token header (not JSON body)."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"web": {"results": []}}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.dict(os.environ, {"BRAVE_API_KEY": "brave-test-key"}):
+            with patch("tools.web_tools.httpx.get", return_value=mock_response) as mock_get:
+                from tools.web_tools import _brave_search
+                _brave_search("hello world", limit=3)
+
+                mock_get.assert_called_once()
+                call = mock_get.call_args
+                headers = call.kwargs.get("headers") or {}
+                params = call.kwargs.get("params") or {}
+                assert headers.get("X-Subscription-Token") == "brave-test-key"
+                assert headers.get("Accept") == "application/json"
+                assert params["q"] == "hello world"
+                assert params["count"] == 3
+                assert "api.search.brave.com/res/v1/web/search" in call.args[0]
+
+    def test_clamps_limit_to_brave_max(self):
+        """Brave caps count at 20 — our code must clamp before sending."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"web": {"results": []}}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.dict(os.environ, {"BRAVE_API_KEY": "k"}):
+            with patch("tools.web_tools.httpx.get", return_value=mock_response) as mock_get:
+                from tools.web_tools import _brave_search
+                _brave_search("q", limit=999)
+                assert mock_get.call_args.kwargs["params"]["count"] == 20
+
+    def test_clamps_limit_to_at_least_one(self):
+        """Zero/negative limit should clamp to 1 (Brave rejects count=0)."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"web": {"results": []}}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.dict(os.environ, {"BRAVE_API_KEY": "k"}):
+            with patch("tools.web_tools.httpx.get", return_value=mock_response) as mock_get:
+                from tools.web_tools import _brave_search
+                _brave_search("q", limit=0)
+                assert mock_get.call_args.kwargs["params"]["count"] == 1
+
+    def test_raises_on_http_error(self):
+        """Non-2xx responses propagate as httpx.HTTPStatusError."""
+        import httpx as _httpx
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = _httpx.HTTPStatusError(
+            "429 Too Many Requests", request=MagicMock(), response=mock_response
+        )
+
+        with patch.dict(os.environ, {"BRAVE_API_KEY": "k"}):
+            with patch("tools.web_tools.httpx.get", return_value=mock_response):
+                from tools.web_tools import _brave_search
+                with pytest.raises(_httpx.HTTPStatusError):
+                    _brave_search("q")
+
+
+# ─── _normalize_brave_search_results ─────────────────────────────────────────
+
+class TestNormalizeBraveSearchResults:
+    """Test Brave response → standard web search format."""
+
+    def test_basic_normalization(self):
+        from tools.web_tools import _normalize_brave_search_results
+        raw = {
+            "web": {
+                "results": [
+                    {"title": "Python Docs", "url": "https://docs.python.org", "description": "Official docs"},
+                    {"title": "Tutorial", "url": "https://example.com", "description": "A tutorial"},
+                ]
+            }
+        }
+        result = _normalize_brave_search_results(raw)
+        assert result["success"] is True
+        web = result["data"]["web"]
+        assert len(web) == 2
+        assert web[0]["title"] == "Python Docs"
+        assert web[0]["url"] == "https://docs.python.org"
+        assert web[0]["description"] == "Official docs"
+        assert web[0]["position"] == 1
+        assert web[1]["position"] == 2
+
+    def test_empty_results(self):
+        from tools.web_tools import _normalize_brave_search_results
+        result = _normalize_brave_search_results({"web": {"results": []}})
+        assert result["success"] is True
+        assert result["data"]["web"] == []
+
+    def test_missing_web_key(self):
+        """Brave may omit the ``web`` key when no web results are returned."""
+        from tools.web_tools import _normalize_brave_search_results
+        result = _normalize_brave_search_results({})
+        assert result["success"] is True
+        assert result["data"]["web"] == []
+
+    def test_web_is_null(self):
+        """Defensive: Brave returns ``web: null`` in some edge cases."""
+        from tools.web_tools import _normalize_brave_search_results
+        result = _normalize_brave_search_results({"web": None})
+        assert result["success"] is True
+        assert result["data"]["web"] == []
+
+    def test_missing_fields(self):
+        from tools.web_tools import _normalize_brave_search_results
+        result = _normalize_brave_search_results({"web": {"results": [{}]}})
+        web = result["data"]["web"]
+        assert web[0]["title"] == ""
+        assert web[0]["url"] == ""
+        assert web[0]["description"] == ""
+        assert web[0]["position"] == 1
+
+
+# ─── Backend detection ───────────────────────────────────────────────────────
+
+class TestBraveBackendDetection:
+    """Brave recognised by _is_backend_available / _get_backend / check_web_api_key."""
+
+    def test_is_backend_available_brave(self):
+        from tools.web_tools import _is_backend_available
+        with patch.dict(os.environ, {"BRAVE_API_KEY": "k"}):
+            assert _is_backend_available("brave") is True
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("BRAVE_API_KEY", None)
+            assert _is_backend_available("brave") is False
+
+    def test_get_backend_honours_configured_brave(self):
+        from tools.web_tools import _get_backend
+        with patch("tools.web_tools._load_web_config", return_value={"backend": "brave"}):
+            assert _get_backend() == "brave"
+
+
+# ─── web_search_tool (Brave dispatch) ────────────────────────────────────────
+
+class TestWebSearchBrave:
+    """Test web_search_tool dispatch to Brave."""
+
+    def test_search_dispatches_to_brave(self):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "web": {"results": [{"title": "Result", "url": "https://r.com", "description": "desc"}]}
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("tools.web_tools._get_backend", return_value="brave"), \
+             patch.dict(os.environ, {"BRAVE_API_KEY": "k"}), \
+             patch("tools.web_tools.httpx.get", return_value=mock_response), \
+             patch("tools.interrupt.is_interrupted", return_value=False):
+            from tools.web_tools import web_search_tool
+            result = json.loads(web_search_tool("test query", limit=3))
+            assert result["success"] is True
+            assert len(result["data"]["web"]) == 1
+            assert result["data"]["web"][0]["title"] == "Result"
+            assert result["data"]["web"][0]["position"] == 1
+
+
+# ─── web_extract_tool (Brave fallback behaviour) ─────────────────────────────
+
+class TestWebExtractBraveFallback:
+    """When backend is Brave, extract must fall back to Firecrawl or error."""
+
+    def test_extract_errors_when_brave_and_no_firecrawl(self):
+        """No Firecrawl key → clear tool_error, not a cryptic crash."""
+        with patch("tools.web_tools._get_backend", return_value="brave"), \
+             patch("tools.web_tools.check_firecrawl_api_key", return_value=False), \
+             patch("tools.web_tools.is_safe_url", return_value=True), \
+             patch("tools.web_tools.check_website_access", return_value=None):
+            from tools.web_tools import web_extract_tool
+            result = json.loads(asyncio.get_event_loop().run_until_complete(
+                web_extract_tool(["https://example.com"], use_llm_processing=False)
+            ))
+            assert result.get("success") is False
+            assert "Brave backend supports web_search only" in result.get("error", "")
+            assert "FIRECRAWL_API_KEY" in result.get("error", "")
+
+    def test_extract_falls_back_to_firecrawl_when_available(self):
+        """Brave + Firecrawl → extract routes through Firecrawl seamlessly."""
+        fake_firecrawl_client = MagicMock()
+        fake_scrape_result = MagicMock()
+        fake_scrape_result.markdown = "Extracted markdown"
+        fake_scrape_result.html = "<p>Extracted</p>"
+        fake_scrape_result.metadata = {"title": "Example", "sourceURL": "https://example.com"}
+        fake_firecrawl_client.scrape.return_value = fake_scrape_result
+
+        with patch("tools.web_tools._get_backend", return_value="brave"), \
+             patch("tools.web_tools.check_firecrawl_api_key", return_value=True), \
+             patch("tools.web_tools._get_firecrawl_client", return_value=fake_firecrawl_client), \
+             patch("tools.web_tools.is_safe_url", return_value=True), \
+             patch("tools.web_tools.check_website_access", return_value=None), \
+             patch("tools.web_tools.process_content_with_llm", return_value=None):
+            from tools.web_tools import web_extract_tool
+            raw = asyncio.get_event_loop().run_until_complete(
+                web_extract_tool(["https://example.com"], use_llm_processing=False)
+            )
+            # Firecrawl path returns the Firecrawl-shape envelope; just
+            # assert it didn't short-circuit to the Brave error and that
+            # Firecrawl's scrape was actually invoked.
+            assert "Brave backend supports web_search only" not in raw
+            fake_firecrawl_client.scrape.assert_called()

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -13,6 +13,7 @@ Available tools:
 - web_crawl_tool: Crawl websites with specific instructions
 
 Backend compatibility:
+- Brave: https://api.search.brave.com (search only; extract/crawl fall back to Firecrawl)
 - Exa: https://exa.ai (search, extract)
 - Firecrawl: https://docs.firecrawl.dev/introduction (search, extract, crawl; direct or derived firecrawl-gateway.<domain> for Nous Subscribers)
 - Parallel: https://docs.parallel.ai (search, extract)
@@ -88,7 +89,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in ("parallel", "firecrawl", "tavily", "exa"):
+    if configured in ("parallel", "firecrawl", "tavily", "exa", "brave"):
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -99,6 +100,7 @@ def _get_backend() -> str:
         ("parallel", _has_env("PARALLEL_API_KEY")),
         ("tavily", _has_env("TAVILY_API_KEY")),
         ("exa", _has_env("EXA_API_KEY")),
+        ("brave", _has_env("BRAVE_API_KEY")),
     )
     for backend, available in backend_candidates:
         if available:
@@ -117,6 +119,8 @@ def _is_backend_available(backend: str) -> bool:
         return check_firecrawl_api_key()
     if backend == "tavily":
         return _has_env("TAVILY_API_KEY")
+    if backend == "brave":
+        return _has_env("BRAVE_API_KEY")
     return False
 
 # ─── Firecrawl Client ────────────────────────────────────────────────────────
@@ -360,6 +364,57 @@ def _normalize_tavily_documents(response: dict, fallback_url: str = "") -> List[
             "metadata": {"sourceURL": url_str},
         })
     return documents
+
+
+# ─── Brave Search Client ─────────────────────────────────────────────────────
+
+_BRAVE_BASE_URL = "https://api.search.brave.com/res/v1"
+
+
+def _brave_search(query: str, limit: int = 5) -> dict:
+    """Call the Brave Search API and return results in the standard format.
+
+    Brave exposes search only (no extract/crawl), so ``web_extract_tool`` and
+    ``web_crawl_tool`` fall back to Firecrawl for Brave users.
+    Auth is via the ``X-Subscription-Token`` header.
+    """
+    api_key = os.getenv("BRAVE_API_KEY")
+    if not api_key:
+        raise ValueError(
+            "BRAVE_API_KEY environment variable not set. "
+            "Get your API key at https://api-dashboard.search.brave.com/"
+        )
+    url = f"{_BRAVE_BASE_URL}/web/search"
+    headers = {
+        "X-Subscription-Token": api_key,
+        "Accept": "application/json",
+    }
+    params = {
+        "q": query,
+        "count": max(1, min(limit, 20)),
+    }
+    logger.info("Brave search: '%s' (limit: %d)", query, params["count"])
+    response = httpx.get(url, headers=headers, params=params, timeout=60)
+    response.raise_for_status()
+    return _normalize_brave_search_results(response.json())
+
+
+def _normalize_brave_search_results(response: dict) -> dict:
+    """Normalize Brave /web/search response to the standard web search format.
+
+    Brave returns ``{web: {results: [{title, url, description, ...}]}}``.
+    We map to ``{success, data: {web: [{title, url, description, position}]}}``.
+    """
+    raw_results = (response.get("web") or {}).get("results") or []
+    web_results = []
+    for i, result in enumerate(raw_results):
+        web_results.append({
+            "title": result.get("title", ""),
+            "url": result.get("url", ""),
+            "description": result.get("description", ""),
+            "position": i + 1,
+        })
+    return {"success": True, "data": {"web": web_results}}
 
 
 def _to_plain_object(value: Any) -> Any:
@@ -1102,6 +1157,15 @@ def web_search_tool(query: str, limit: int = 5) -> str:
             _debug.save()
             return result_json
 
+        if backend == "brave":
+            response_data = _brave_search(query, limit)
+            debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
+            result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
+            debug_call_data["final_response_size"] = len(result_json)
+            _debug.log_call("web_search_tool", debug_call_data)
+            _debug.save()
+            return result_json
+
         if backend == "tavily":
             logger.info("Tavily search: '%s' (limit: %d)", query, limit)
             raw = _tavily_request("search", {
@@ -1252,6 +1316,14 @@ async def web_extract_tool(
                     "include_images": False,
                 })
                 results = _normalize_tavily_documents(raw, fallback_url=safe_urls[0] if safe_urls else "")
+            elif backend == "brave":
+                # Brave has no extract API — tell the caller to switch
+                # backends or configure Firecrawl for extraction.
+                return tool_error(
+                    "Brave backend supports web_search only. Configure FIRECRAWL_API_KEY "
+                    "or set web.backend to firecrawl/tavily/exa/parallel for extract.",
+                    success=False,
+                )
             else:
                 # ── Firecrawl extraction ──
                 # Determine requested formats for Firecrawl v2
@@ -1922,9 +1994,9 @@ def check_firecrawl_api_key() -> bool:
 def check_web_api_key() -> bool:
     """Check whether the configured web backend is available."""
     configured = _load_web_config().get("backend", "").lower().strip()
-    if configured in ("exa", "parallel", "firecrawl", "tavily"):
+    if configured in ("exa", "parallel", "firecrawl", "tavily", "brave"):
         return _is_backend_available(configured)
-    return any(_is_backend_available(backend) for backend in ("exa", "parallel", "firecrawl", "tavily"))
+    return any(_is_backend_available(backend) for backend in ("exa", "parallel", "firecrawl", "tavily", "brave"))
 
 
 def check_auxiliary_model() -> bool:
@@ -1959,6 +2031,8 @@ if __name__ == "__main__":
             print("   Using Parallel API (https://parallel.ai)")
         elif backend == "tavily":
             print("   Using Tavily API (https://tavily.com)")
+        elif backend == "brave":
+            print("   Using Brave Search API (https://api.search.brave.com)")
         else:
             if firecrawl_url_available:
                 print(f"   Using self-hosted Firecrawl: {os.getenv('FIRECRAWL_API_URL').strip().rstrip('/')}")
@@ -1971,7 +2045,7 @@ if __name__ == "__main__":
     else:
         print("❌ No web search backend configured")
         print(
-            "Set EXA_API_KEY, PARALLEL_API_KEY, TAVILY_API_KEY, FIRECRAWL_API_KEY, FIRECRAWL_API_URL"
+            "Set EXA_API_KEY, PARALLEL_API_KEY, TAVILY_API_KEY, BRAVE_API_KEY, FIRECRAWL_API_KEY, FIRECRAWL_API_URL"
             f"{_firecrawl_backend_help_suffix()}"
         )
 

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -13,7 +13,7 @@ Available tools:
 - web_crawl_tool: Crawl websites with specific instructions
 
 Backend compatibility:
-- Brave: https://api.search.brave.com (search only; extract/crawl fall back to Firecrawl)
+- Brave: https://api.search.brave.com (search only; extract/crawl require Firecrawl as fallback)
 - Exa: https://exa.ai (search, extract)
 - Firecrawl: https://docs.firecrawl.dev/introduction (search, extract, crawl; direct or derived firecrawl-gateway.<domain> for Nous Subscribers)
 - Parallel: https://docs.parallel.ai (search, extract)
@@ -374,8 +374,10 @@ _BRAVE_BASE_URL = "https://api.search.brave.com/res/v1"
 def _brave_search(query: str, limit: int = 5) -> dict:
     """Call the Brave Search API and return results in the standard format.
 
-    Brave exposes search only (no extract/crawl), so ``web_extract_tool`` and
-    ``web_crawl_tool`` fall back to Firecrawl for Brave users.
+    Brave exposes search only. ``web_extract_tool`` falls back to Firecrawl
+    automatically when ``FIRECRAWL_API_KEY`` is configured, and returns a
+    clear ``tool_error`` otherwise. ``web_crawl_tool`` is gated by the
+    existing ``check_firecrawl_api_key()`` guard in that function.
     Auth is via the ``X-Subscription-Token`` header.
     """
     api_key = os.getenv("BRAVE_API_KEY")
@@ -1305,6 +1307,20 @@ async def web_extract_tool(
         else:
             backend = _get_backend()
 
+            # Brave has no extract API. Fall back to Firecrawl when it is
+            # configured; otherwise emit a clear error with remediation
+            # steps rather than a cryptic failure.
+            if backend == "brave":
+                if check_firecrawl_api_key():
+                    logger.info("Brave backend has no extract — routing extract to Firecrawl")
+                    backend = "firecrawl"
+                else:
+                    return tool_error(
+                        "Brave backend supports web_search only. Configure FIRECRAWL_API_KEY "
+                        "for extract, or set web.backend to firecrawl/tavily/exa/parallel.",
+                        success=False,
+                    )
+
             if backend == "parallel":
                 results = await _parallel_extract(safe_urls)
             elif backend == "exa":
@@ -1316,14 +1332,6 @@ async def web_extract_tool(
                     "include_images": False,
                 })
                 results = _normalize_tavily_documents(raw, fallback_url=safe_urls[0] if safe_urls else "")
-            elif backend == "brave":
-                # Brave has no extract API — tell the caller to switch
-                # backends or configure Firecrawl for extraction.
-                return tool_error(
-                    "Brave backend supports web_search only. Configure FIRECRAWL_API_KEY "
-                    "or set web.backend to firecrawl/tavily/exa/parallel for extract.",
-                    success=False,
-                )
             else:
                 # ── Firecrawl extraction ──
                 # Determine requested formats for Firecrawl v2

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -368,7 +368,16 @@ def _normalize_tavily_documents(response: dict, fallback_url: str = "") -> List[
 
 # ─── Brave Search Client ─────────────────────────────────────────────────────
 
-_BRAVE_BASE_URL = "https://api.search.brave.com/res/v1"
+_BRAVE_DEFAULT_BASE_URL = "https://api.search.brave.com/res/v1"
+
+
+def _get_brave_base_url() -> str:
+    """Return the Brave API base URL, honouring the ``BRAVE_API_URL`` override.
+
+    The override is read at call time (not at import time) so tests and
+    runtime config changes take effect without reloading the module.
+    """
+    return (os.getenv("BRAVE_API_URL") or _BRAVE_DEFAULT_BASE_URL).rstrip("/")
 
 
 def _brave_search(query: str, limit: int = 5) -> dict:
@@ -378,7 +387,12 @@ def _brave_search(query: str, limit: int = 5) -> dict:
     automatically when ``FIRECRAWL_API_KEY`` is configured, and returns a
     clear ``tool_error`` otherwise. ``web_crawl_tool`` is gated by the
     existing ``check_firecrawl_api_key()`` guard in that function.
-    Auth is via the ``X-Subscription-Token`` header.
+
+    Auth is via the ``X-Subscription-Token`` header. ``search_lang`` is
+    intentionally *not* set — Brave auto-detects the query language, which
+    gives better results for non-English users than pinning to a single
+    locale. Callers that need a specific locale can send ``BRAVE_API_URL``
+    to a proxy that injects the parameter.
     """
     api_key = os.getenv("BRAVE_API_KEY")
     if not api_key:
@@ -386,10 +400,11 @@ def _brave_search(query: str, limit: int = 5) -> dict:
             "BRAVE_API_KEY environment variable not set. "
             "Get your API key at https://api-dashboard.search.brave.com/"
         )
-    url = f"{_BRAVE_BASE_URL}/web/search"
+    url = f"{_get_brave_base_url()}/web/search"
     headers = {
         "X-Subscription-Token": api_key,
         "Accept": "application/json",
+        "Accept-Encoding": "gzip",
     }
     params = {
         "q": query,
@@ -404,16 +419,23 @@ def _brave_search(query: str, limit: int = 5) -> dict:
 def _normalize_brave_search_results(response: dict) -> dict:
     """Normalize Brave /web/search response to the standard web search format.
 
-    Brave returns ``{web: {results: [{title, url, description, ...}]}}``.
-    We map to ``{success, data: {web: [{title, url, description, position}]}}``.
+    Brave returns ``{web: {results: [{title, url, description, extra_snippets, ...}]}}``.
+    We map to ``{success, data: {web: [{title, url, description, position}]}}``
+    and merge up to two ``extra_snippets`` into the description so the caller
+    gets the richer context Brave provides without changing the output shape.
     """
     raw_results = (response.get("web") or {}).get("results") or []
     web_results = []
     for i, result in enumerate(raw_results):
+        description = result.get("description", "") or ""
+        extra = result.get("extra_snippets") or []
+        if extra:
+            joined_extra = " ".join(s for s in extra[:2] if s)
+            description = f"{description} {joined_extra}".strip() if description else joined_extra
         web_results.append({
             "title": result.get("title", ""),
             "url": result.get("url", ""),
-            "description": result.get("description", ""),
+            "description": description,
             "position": i + 1,
         })
     return {"success": True, "data": {"web": web_results}}


### PR DESCRIPTION
Closes #10644.

## Summary

Adds Brave Search (https://api.search.brave.com) as an additional web search backend alongside Exa, Firecrawl, Parallel, and Tavily.

## Acknowledgement & relationship to #4372

I opened this after missing @vitobotta's parallel PR [#4372](https://github.com/NousResearch/hermes-agent/pull/4372) (my apologies for the noise — I've also commented over there). Since both PRs aim at the same feature, I've consolidated the useful surface area from #4372 into this PR and differentiated on two points:

- **`search_lang` default**: #4372 hardcodes `search_lang: "en"`, which pins Brave's index to English and degrades results for non-English queries (I run this in French; this is not hypothetical). This PR omits `search_lang` and lets Brave auto-detect from the query text. A regression test guards against re-adding the hardcoded locale.
- **Test coverage**: 20 unit tests, vs none in #4372.

The `hermes_cli/tools_config.py` wiring, the `extra_snippets` merge, and the `BRAVE_API_URL` override are adapted from @vitobotta's approach — credited in the commit message.

I'm happy to close this in favour of #4372 if the maintainers prefer; just let me know.

## Changes

- **`tools/web_tools.py`**
  - `_brave_search()` using `X-Subscription-Token` header auth against `/res/v1/web/search`.
  - `_get_brave_base_url()` honours `BRAVE_API_URL` env override at call time (proxies / self-hosted gateways).
  - `_normalize_brave_search_results()` maps Brave's `web.results[]` to the standard `{success, data: {web: [{title, url, description, position}]}}` shape and merges up to two `extra_snippets` into the description so callers get Brave's richer context without shape changes.
  - `_get_backend()` and `_is_backend_available()` recognise `brave`; fallback `backend_candidates` includes it.
  - `web_search_tool()` dispatches to `_brave_search` when backend is `brave`.
  - `web_extract_tool` auto-falls-back to Firecrawl when backend is `brave` and `FIRECRAWL_API_KEY` is configured; returns a clear `tool_error` with remediation steps otherwise.
  - `web_crawl_tool` hits the existing `check_firecrawl_api_key()` guard.
  - `check_web_api_key()` and the CLI status banner include Brave.

- **`hermes_cli/tools_config.py`**: Brave entry in the `hermes tools` setup wizard, labelled with the 2000-query free tier and the search-only limitation.

## Design notes

- **No `search_lang`**: Brave auto-detects from the query. Locale-specific deployments can point `BRAVE_API_URL` at a proxy that injects parameters if strict control is needed.
- **BRAVE_API_URL read at call time**: tests and runtime config changes take effect without reloading the module.
- **Extract fallback**: `web_extract_tool` rewrites `backend = "firecrawl"` when Brave + Firecrawl are both configured, re-entering the normal Firecrawl path. When neither is set, returns a `tool_error` naming the missing env var rather than letting the Firecrawl client fail cryptically.

## Tests

New file `tests/tools/test_web_tools_brave.py` — **20 tests**:

- `_brave_search` (7): missing API key raises with guidance, header-based auth, `count` clamping to `[1, 20]`, HTTP error propagation, **no `search_lang` regression guard**, `BRAVE_API_URL` override with trailing-slash normalisation.
- `_normalize_brave_search_results` (7): basic mapping, empty results, missing `web` key, `web: null`, missing fields, **extra_snippets merged into description (with cap of 2)**, **extra_snippets used when description is empty**, absent extra_snippets leaves description unchanged.
- Backend detection (2): `_is_backend_available("brave")`, configured-backend honouring.
- `web_search_tool` Brave dispatch (1).
- `web_extract_tool` fallback (2): clean error with no Firecrawl; routes to Firecrawl when available.

## How to test locally

```bash
# From this branch:
pytest tests/tools/test_web_tools_brave.py -v                                          # 20 tests
pytest tests/tools/test_web_tools_tavily.py tests/tools/test_web_tools_config.py -q    # no regressions

# Live end-to-end (needs a real key):
export BRAVE_API_KEY=<free-tier-key-from-api-dashboard.search.brave.com>
python -c "from tools.web_tools import _brave_search; print(_brave_search('recette de pain au miel', limit=3))"   # auto-detects French

# Wizard integration:
hermes tools   # "Brave Search" now appears in the web-search backend list
```

## Test checklist

- [x] Python syntax check
- [x] 20 new unit tests in `tests/tools/test_web_tools_brave.py` all pass
- [x] 60 existing `test_web_tools_tavily.py` + `test_web_tools_config.py` tests still pass (no regressions)
- [x] Live call against `api.search.brave.com` — returns normalized French + English results
- [x] `web_search_tool()` dispatch returns JSON with `success: true` and expected hits
- [x] `web_extract_tool` auto-fallback to Firecrawl verified (test + live)
- [x] `hermes tools` wizard shows Brave Search entry
- [ ] Upstream CI

## Env

Set `BRAVE_API_KEY` from https://api-dashboard.search.brave.com/ and select Brave when running `hermes tools` (or set `web.backend: brave` directly in `~/.hermes/config.yaml`). Optional: `BRAVE_API_URL` for self-hosted proxies.