### PR TITLE
fix(skills): allow non-ASCII characters in skill command names (#12351)

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 _skill_commands: Dict[str, Dict[str, Any]] = {}
 _PLAN_SLUG_RE = re.compile(r"[^a-z0-9]+")
 # Patterns for sanitizing skill names into clean hyphen-separated slugs.
-_SKILL_INVALID_CHARS = re.compile(r"[^a-z0-9-]")
+_SKILL_INVALID_CHARS = re.compile(r"[^\w-]")
 _SKILL_MULTI_HYPHEN = re.compile(r"-{2,}")
 
 
@@ -251,8 +251,8 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                                 break
                     seen_names.add(name)
                     # Normalize to hyphen-separated slug, stripping
-                    # non-alnum chars (e.g. +, /) to avoid invalid
-                    # Telegram command names downstream.
+                    # non-word chars (e.g. +, /) while preserving
+                    # Unicode letters (CJK, Cyrillic, etc.).
                     cmd_name = name.lower().replace(' ', '-').replace('_', '-')
                     cmd_name = _SKILL_INVALID_CHARS.sub('', cmd_name)
                     cmd_name = _SKILL_MULTI_HYPHEN.sub('-', cmd_name).strip('-')

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -144,6 +144,63 @@ class TestScanSkillCommands:
         assert "/sonarr-v3v4-api" in result
         assert any("/" in k[1:] for k in result) is False  # no unescaped /
 
+    def test_chinese_name_registers_command(self, tmp_path):
+        """Skill with a pure Chinese name should register a slash command."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_dir = tmp_path / "novel-clipper"
+            skill_dir.mkdir()
+            (skill_dir / "SKILL.md").write_text(
+                "---\nname: 小说拆条\ndescription: Split novels into clips.\n---\n\nBody.\n"
+            )
+            result = scan_skill_commands()
+        assert "/小说拆条" in result
+        assert result["/小说拆条"]["name"] == "小说拆条"
+
+    def test_mixed_ascii_and_cjk_name_registers_command(self, tmp_path):
+        """Skill with mixed ASCII and CJK characters keeps both."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_dir = tmp_path / "daily-news"
+            skill_dir.mkdir()
+            (skill_dir / "SKILL.md").write_text(
+                "---\nname: daily-新闻摘要\ndescription: Daily news summary.\n---\n\nBody.\n"
+            )
+            result = scan_skill_commands()
+        assert "/daily-新闻摘要" in result
+
+    def test_japanese_name_registers_command(self, tmp_path):
+        """Skill with Japanese name should register correctly."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_dir = tmp_path / "recipe"
+            skill_dir.mkdir()
+            (skill_dir / "SKILL.md").write_text(
+                "---\nname: レシピ検索\ndescription: Search recipes.\n---\n\nBody.\n"
+            )
+            result = scan_skill_commands()
+        assert "/レシピ検索" in result
+
+    def test_unicode_name_special_chars_still_stripped(self, tmp_path):
+        """Special characters are still stripped from Unicode skill names."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_dir = tmp_path / "emoji-skill"
+            skill_dir.mkdir()
+            (skill_dir / "SKILL.md").write_text(
+                "---\nname: 小说+拆条\ndescription: Plus stripped.\n---\n\nBody.\n"
+            )
+            result = scan_skill_commands()
+        # The + should be stripped, CJK chars preserved
+        assert "/小说拆条" in result
+
+    def test_resolve_unicode_skill_command(self, tmp_path):
+        """resolve_skill_command_key works for Unicode command names."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            skill_dir = tmp_path / "novel-clipper"
+            skill_dir.mkdir()
+            (skill_dir / "SKILL.md").write_text(
+                "---\nname: 小说拆条\ndescription: Split novels.\n---\n\nBody.\n"
+            )
+            scan_skill_commands()
+            assert resolve_skill_command_key("小说拆条") == "/小说拆条"
+
 
 class TestResolveSkillCommandKey:
     """Telegram bot-command names disallow hyphens, so the menu registers


### PR DESCRIPTION
## Summary

- Fix `_SKILL_INVALID_CHARS` regex in `scan_skill_commands()` to preserve Unicode word characters (CJK, Cyrillic, Japanese, etc.) instead of stripping them
- Skills with non-ASCII names (e.g. `小说拆条`) were silently skipped because the regex `[^a-z0-9-]` stripped all Unicode characters, producing an empty slug
- Changed regex from `[^a-z0-9-]` to `[^\w-]` — special chars like `+`, `/` are still stripped, but Unicode letters/digits are preserved
- Platform-specific sanitizers (Telegram's `_sanitize_telegram_name`, Discord) already handle their own character restrictions downstream, so this change is safe

## Test plan

- [x] Added 5 new test cases covering:
  - Pure Chinese name (`小说拆条`) registers as `/小说拆条`
  - Mixed ASCII + CJK name (`daily-新闻摘要`) preserves both scripts
  - Japanese name (`レシピ検索`) registers correctly
  - Special chars still stripped from Unicode names (`小说+拆条` → `/小说拆条`)
  - `resolve_skill_command_key` works for Unicode command names
- [x] All 31 tests in `test_skill_commands.py` pass (26 existing + 5 new)
- [x] All 30 Telegram menu command tests still pass (platform sanitizer is independent)

Fixes #12351