### PR TITLE
fix(auxiliary): retry on temperature deprecation + memoize rejecting models

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -99,6 +99,28 @@ _FIXED_TEMPERATURE_MODELS: Dict[str, float] = {
     "kimi-for-coding": 0.6,
 }
 
+# Runtime-learned set of model IDs that 400 with "`temperature` is deprecated
+# for this model."  The static `_forbids_sampling_params` list in
+# `anthropic_adapter` is the fast path, but it lags whenever Anthropic adds
+# another restricted family (Haiku 4.5, Opus 4.6, …).  On a rejection we retry
+# once without the param and record the model here so future calls skip it
+# pre-emptively — one 30ms retry per (model, process) pair and no maintenance
+# burden as new models ship.
+_TEMP_UNSUPPORTED_MODELS: set = set()
+
+
+def _is_temperature_deprecated_error(exc: BaseException) -> bool:
+    """Return True if `exc` is the Anthropic 400 signalling that the model
+    no longer accepts a `temperature` value."""
+    try:
+        import anthropic
+    except ImportError:
+        return False
+    if not isinstance(exc, anthropic.BadRequestError):
+        return False
+    msg = str(exc).lower()
+    return "temperature" in msg and "deprecated" in msg
+
 # Moonshot's kimi-for-coding endpoint (api.kimi.com/coding) documents:
 # "k2.5 model will use a fixed value 1.0, non-thinking mode will use a fixed
 # value 0.6.  Any other value will result in an error."  The same lock applies
@@ -569,12 +591,26 @@ class _AnthropicCompletionsAdapter:
         # Opus 4.7+ rejects any non-default temperature/top_p/top_k; only set
         # temperature for models that still accept it. build_anthropic_kwargs
         # additionally strips these keys as a safety net — keep both layers.
+        # A third layer below (retry + memoize) catches restricted models that
+        # aren't yet in the static substring list (e.g. Haiku 4.5, Opus 4.6).
         if temperature is not None:
             from agent.anthropic_adapter import _forbids_sampling_params
-            if not _forbids_sampling_params(model):
+            if not _forbids_sampling_params(model) and model not in _TEMP_UNSUPPORTED_MODELS:
                 anthropic_kwargs["temperature"] = temperature
 
-        response = self._client.messages.create(**anthropic_kwargs)
+        try:
+            response = self._client.messages.create(**anthropic_kwargs)
+        except Exception as e:
+            if _is_temperature_deprecated_error(e) and "temperature" in anthropic_kwargs:
+                _TEMP_UNSUPPORTED_MODELS.add(model)
+                logger.info(
+                    "Model %s rejects `temperature`; retrying without it and "
+                    "memoizing for the life of this process.", model,
+                )
+                anthropic_kwargs.pop("temperature", None)
+                response = self._client.messages.create(**anthropic_kwargs)
+            else:
+                raise
         assistant_message, finish_reason = normalize_anthropic_response(response)
 
         usage = None

--- a/tests/agent/test_auxiliary_temperature_retry.py
+++ b/tests/agent/test_auxiliary_temperature_retry.py
@@ -1,0 +1,151 @@
+"""Regression tests for temperature retry + memoization in the Anthropic aux client.
+
+The static `_forbids_sampling_params` list in `agent/anthropic_adapter.py` only
+covers model families known to reject sampling params at the time of writing
+(Opus 4.7+). Newer restricted families — Haiku 4.5, Opus 4.6 — 400 with
+"`temperature` is deprecated for this model." when the param is forwarded.
+
+These tests exercise the runtime defense: catch that specific 400, retry once
+without `temperature`, and memoize the model so subsequent calls skip the
+param pre-emptively.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+import anthropic
+
+from agent.auxiliary_client import _AnthropicCompletionsAdapter
+import agent.auxiliary_client as aux_mod
+
+
+def _temperature_deprecated_error() -> anthropic.BadRequestError:
+    resp = httpx.Response(400, request=httpx.Request("POST", "http://x"))
+    body = {"error": {"type": "invalid_request_error",
+                      "message": "`temperature` is deprecated for this model."}}
+    return anthropic.BadRequestError(
+        message="Error code: 400 - {'error': {'message': "
+                "'`temperature` is deprecated for this model.'}}",
+        response=resp,
+        body=body,
+    )
+
+
+def _unrelated_bad_request() -> anthropic.BadRequestError:
+    resp = httpx.Response(400, request=httpx.Request("POST", "http://x"))
+    body = {"error": {"type": "invalid_request_error",
+                      "message": "messages: roles must alternate"}}
+    return anthropic.BadRequestError(
+        message="Error code: 400 - messages: roles must alternate",
+        response=resp,
+        body=body,
+    )
+
+
+def _ok_response() -> SimpleNamespace:
+    """Minimal shape normalize_anthropic_response can consume."""
+    return SimpleNamespace(
+        content=[SimpleNamespace(type="text", text="ok")],
+        stop_reason="end_turn",
+        usage=SimpleNamespace(input_tokens=1, output_tokens=1, total_tokens=2),
+    )
+
+
+@pytest.fixture
+def patched_adapter():
+    """Wire up an adapter with build_anthropic_kwargs passing temperature
+    straight through, and normalize_anthropic_response returning a minimal
+    assistant message. Focuses the tests on retry behaviour, not the adapter's
+    argument plumbing or response parsing (covered elsewhere).
+    """
+    def fake_build(**kwargs):
+        out = {"model": kwargs["model"],
+               "messages": kwargs["messages"],
+               "max_tokens": kwargs.get("max_tokens", 2000)}
+        return out
+
+    def fake_normalize(response):
+        return SimpleNamespace(role="assistant", content="ok", tool_calls=None), "stop"
+
+    with patch("agent.anthropic_adapter.build_anthropic_kwargs", fake_build), \
+         patch("agent.anthropic_adapter.normalize_anthropic_response", fake_normalize), \
+         patch("agent.anthropic_adapter._forbids_sampling_params", return_value=False):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _reset_temp_cache():
+    """Clear the module-level memoization before/after each test."""
+    aux_mod._TEMP_UNSUPPORTED_MODELS.clear()
+    yield
+    aux_mod._TEMP_UNSUPPORTED_MODELS.clear()
+
+
+def test_temperature_rejection_retried_without_param(patched_adapter):
+    """First call raises the deprecated-temperature 400; retry without
+    temperature succeeds and returns a normalized response."""
+    client = MagicMock()
+    client.messages.create.side_effect = [_temperature_deprecated_error(), _ok_response()]
+
+    adapter = _AnthropicCompletionsAdapter(client, model="haiku-4-5")
+    result = adapter.create(messages=[{"role": "user", "content": "hi"}], temperature=0.1)
+
+    assert client.messages.create.call_count == 2
+    first_call = client.messages.create.call_args_list[0].kwargs
+    retry_call = client.messages.create.call_args_list[1].kwargs
+    assert first_call.get("temperature") == 0.1
+    assert "temperature" not in retry_call
+    assert result.choices[0].message.content == "ok"
+
+
+def test_rejecting_model_is_memoized(patched_adapter):
+    """After a rejection, the same model's next call strips temperature
+    before hitting the API — no second retry needed."""
+    client = MagicMock()
+    client.messages.create.side_effect = [
+        _temperature_deprecated_error(),
+        _ok_response(),   # retry of first call
+        _ok_response(),   # second invocation, first attempt
+    ]
+
+    adapter = _AnthropicCompletionsAdapter(client, model="haiku-4-5")
+    adapter.create(messages=[{"role": "user", "content": "a"}], temperature=0.1)
+    adapter.create(messages=[{"role": "user", "content": "b"}], temperature=0.1)
+
+    # Three total: rejection + retry + second call's single attempt
+    assert client.messages.create.call_count == 3
+    third_call = client.messages.create.call_args_list[2].kwargs
+    assert "temperature" not in third_call
+    assert "haiku-4-5" in aux_mod._TEMP_UNSUPPORTED_MODELS
+
+
+def test_unrelated_bad_request_is_not_retried(patched_adapter):
+    """A 400 that isn't about temperature must propagate unchanged and must
+    not add the model to the unsupported set."""
+    client = MagicMock()
+    client.messages.create.side_effect = _unrelated_bad_request()
+
+    adapter = _AnthropicCompletionsAdapter(client, model="haiku-4-5")
+
+    with pytest.raises(anthropic.BadRequestError):
+        adapter.create(messages=[{"role": "user", "content": "hi"}], temperature=0.1)
+
+    assert client.messages.create.call_count == 1
+    assert "haiku-4-5" not in aux_mod._TEMP_UNSUPPORTED_MODELS
+
+
+def test_call_without_temperature_is_not_retried(patched_adapter):
+    """If temperature wasn't sent in the first place, the deprecated-temperature
+    error (if it somehow still fires) should propagate rather than infinite-loop."""
+    client = MagicMock()
+    client.messages.create.side_effect = _temperature_deprecated_error()
+
+    adapter = _AnthropicCompletionsAdapter(client, model="haiku-4-5")
+
+    with pytest.raises(anthropic.BadRequestError):
+        adapter.create(messages=[{"role": "user", "content": "hi"}])  # no temperature
+
+    assert client.messages.create.call_count == 1


### PR DESCRIPTION
## Summary

The `_forbids_sampling_params` check in `agent/anthropic_adapter.py` statically matches the substrings `4-7`/`4.7`, so other restricted families still forward `temperature` and 400 with ``` `temperature` is deprecated for this model. ``` Confirmed for `claude-haiku-4-5-20251001` (observed in production logs); per internal comments, `claude-opus-4-6` also rejects it.

Adds a runtime layer of defence in `_AnthropicCompletionsAdapter.create()` that complements the two existing static strips:

1. `_forbids_sampling_params(model)` guard at the call site (unchanged).
2. Safety-net strip inside `build_anthropic_kwargs` (unchanged).
3. **New:** catch the specific 400, drop `temperature`, retry once, and memoize the model name in a module-level `_TEMP_UNSUPPORTED_MODELS` set so subsequent calls skip the param pre-emptively.

One-time ~30ms retry per (model, process) pair; zero overhead on subsequent calls. No regression on older models that still accept `temperature` (they keep their configured values — avoids quality loss on OCR / vision defaults that rely on `temperature=0.1`). Self-healing against future restricted families with no code change needed.

## Why not just expand the static substring list

Tempting, but `4-5` matches `claude-sonnet-4-5` (accepts temperature) as well as `claude-haiku-4-5-20251001` (rejects it), so substrings alone can't disambiguate. A runtime-learned set avoids that brittleness and stays correct when Anthropic ships a new restricted family tomorrow.

## Test plan

- [x] `tests/agent/test_auxiliary_temperature_retry.py` — 4 new tests:
  - deprecated-temperature 400 is retried without the param, response normalized
  - model added to `_TEMP_UNSUPPORTED_MODELS` and skipped on the next call
  - unrelated `BadRequestError` propagates unchanged; model not cached
  - deprecated-temperature 400 without `temperature` in kwargs does not infinite-loop
- [x] Full `tests/agent/` suite (1,402 tests) — all pass
- [x] Full aux-client-specific suites — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)