### PR TITLE
fix(gateway): load WHATSAPP_HOME_CHANNEL env var into config

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -885,6 +885,13 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         if Platform.WHATSAPP not in config.platforms:
             config.platforms[Platform.WHATSAPP] = PlatformConfig()
         config.platforms[Platform.WHATSAPP].enabled = True
+    whatsapp_home = os.getenv("WHATSAPP_HOME_CHANNEL")
+    if whatsapp_home and Platform.WHATSAPP in config.platforms:
+        config.platforms[Platform.WHATSAPP].home_channel = HomeChannel(
+            platform=Platform.WHATSAPP,
+            chat_id=whatsapp_home,
+            name=os.getenv("WHATSAPP_HOME_CHANNEL_NAME", "Home"),
+        )
     
     # Slack
     slack_token = os.getenv("SLACK_BOT_TOKEN")

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -272,6 +272,7 @@ AUTHOR_MAP = {
     "junminliu@gmail.com": "JimLiu",
     "jarvischer@gmail.com": "maxchernin",
     "levantam.98.2324@gmail.com": "LVT382009",
+    "bernardo@torresautomacao.com.br": "bernardotorres",
 }
 
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -672,6 +672,7 @@ AUTHOR_MAP = {
     "web3blind@gmail.com": "web3blind",
     "ztzheng@163.com": "chengoak",  # PR #17467
     "24110240104@m.fudan.edu.cn": "YuShu",  # co-author only
+    "bernardo@torresautomacao.com.br": "bernardotorres",
 }
 
 

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -442,6 +442,12 @@ class TestHomeChannelEnvOverrides:
                 {"SMS_HOME_CHANNEL": "+15559876543", "SMS_HOME_CHANNEL_NAME": "My Phone"},
                 ("+15559876543", "My Phone"),
             ),
+            (
+                Platform.WHATSAPP,
+                PlatformConfig(enabled=True),
+                {"WHATSAPP_HOME_CHANNEL": "555555555555555@lid", "WHATSAPP_HOME_CHANNEL_NAME": "Home"},
+                ("555555555555555@lid", "Home"),
+            ),
         ]
 
         for platform, platform_config, env, expected in cases:

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -599,6 +599,12 @@ class TestHomeChannelEnvOverrides:
                 {"SMS_HOME_CHANNEL": "+15559876543", "SMS_HOME_CHANNEL_NAME": "My Phone"},
                 ("+15559876543", "My Phone"),
             ),
+            (
+                Platform.WHATSAPP,
+                PlatformConfig(enabled=True),
+                {"WHATSAPP_HOME_CHANNEL": "555555555555555@lid", "WHATSAPP_HOME_CHANNEL_NAME": "Home"},
+                ("555555555555555@lid", "Home"),
+            ),
         ]
 
         for platform, platform_config, env, expected in cases:


### PR DESCRIPTION
Other platforms (Telegram, Discord, Slack, Signal, Matrix, SMS, etc.) construct a `HomeChannel` from their respective `*_HOME_CHANNEL` env var in `gateway/config.py`, but WhatsApp is missing this block.

As a result, `/sethome` on WhatsApp silently fails: `_handle_set_home_command` writes `WHATSAPP_HOME_CHANNEL` to `config.yaml` and sets it in `os.environ`, and the top-level bridge in `gateway/run.py` re-applies it on startup, but `config.get_home_channel(Platform.WHATSAPP)` still returns `None`. That breaks cron delivery and `send_message_tool` home-channel lookups for WhatsApp, and the `/sethome` confirmation message is misleading.

This PR mirrors the Signal/Slack pattern to close the gap — 7 lines of fix, plus a test case added to the existing `TestHomeChannelEnvOverrides` parametric list (which already covered Slack/Signal/Mattermost/Matrix/Email/SMS — the absence of a WhatsApp case is how the bug shipped).

## How to test

```bash
pytest tests/gateway/test_config.py::TestHomeChannelEnvOverrides -v
```

Confirmed the new WhatsApp case fails on `main` without the `config.py` fix (`AssertionError: whatsapp: home_channel should not be None`) and passes with the fix applied.

Full `tests/gateway/` suite: 595 passed, 2 unrelated pre-existing failures (`test_dingtalk` card lifecycle and an agent-cache concurrency test).

## Platforms tested

Linux (Ubuntu 24.04) — the fix is pure config bridging, so no cross-platform risk.

---

Supersedes #12520 (re-opened from a clean branch to avoid timeline churn).