### PR TITLE
fix(slack): preserve third-party bot parents in thread context

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -1466,8 +1466,10 @@ class SlackAdapter(BasePlatformAdapter):
                 # as the user message itself, so including it here would duplicate it.
                 if msg_ts == current_ts:
                     continue
-                # Exclude our own bot messages to avoid circular context.
-                if msg.get("bot_id") or msg.get("subtype") == "bot_message":
+                # Skip our own bot to avoid circular context, but keep other
+                # bots (alerts, webhooks) — often the thread parent.
+                is_bot_msg = bool(msg.get("bot_id")) or msg.get("subtype") == "bot_message"
+                if is_bot_msg and (not bot_uid or msg.get("user") == bot_uid):
                     continue
 
                 msg_text = msg.get("text", "").strip()


### PR DESCRIPTION
## Problem

When an agent is @-mentioned in a Slack thread whose parent is a **third-party bot** (Intercom escalations, GitHub/Sentry alerts, webhook posts), the parent message — often the entire reason for the ping — never reaches the model. The agent then has to ask the user for clarification or manually fetch the thread via the Slack API.

## Root cause

`_fetch_thread_context()` in `gateway/platforms/slack.py` filtered every message carrying a `bot_id` or `subtype: bot_message`:

```python
# Exclude our own bot messages to avoid circular context.
if msg.get("bot_id") or msg.get("subtype") == "bot_message":
    continue
```

The comment says "our own bot messages" but the predicate matches **all** bots.

## Fix

Match the filter against the resolved `bot_uid` (already computed a few lines above). Our own replies stay excluded (no circular context); every other bot's messages flow through as normal thread context.

If `bot_uid` is unresolved, fall back to the old behavior (drop all bot messages) so we can't accidentally feed our own output back in.

```python
is_bot_msg = bool(msg.get("bot_id")) or msg.get("subtype") == "bot_message"
if is_bot_msg and (not bot_uid or msg.get("user") == bot_uid):
    continue
```

## Testing

Locally reproduced with an Intercom-style bot-authored thread parent:
- **Before:** agent saw only the user's `[investigate]` ping, no parent.
- **After:** `[Thread context —]` block includes the bot parent verbatim.