### PR TITLE
feat: add self-evolution sessiondb bridge

### DIFF
--- a/SELF_EVOLUTION.md
+++ b/SELF_EVOLUTION.md
@@ -1,0 +1,75 @@
+# Hermes Self-Evolution Companion Workflow
+
+This checkout now includes a thin bridge for using the companion repo:
+
+- upstream optimizer: `https://github.com/NousResearch/hermes-agent-self-evolution`
+- local bridge: `agent/self_evolution_bridge.py`
+- local runner: `scripts/run-self-evolution.sh`
+
+## Why a bridge exists
+
+`hermes-agent-self-evolution` currently expects Hermes history in the legacy
+`~/.hermes/sessions/*.json` format.
+
+Current Hermes stores live session history in `state.db`.
+
+The bridge exports selected sessions from `state.db` into the legacy JSON shape
+on demand, inside a temporary HOME, so the optimizer can mine real Hermes
+history without changing Hermes runtime storage.
+
+## Typical usage
+
+Synthetic dataset:
+
+```bash
+scripts/run-self-evolution.sh \
+  --skill github-code-review \
+  --iterations 3 \
+  --eval-source synthetic
+```
+
+Mine real Hermes session history first:
+
+```bash
+scripts/run-self-evolution.sh \
+  --skill github-code-review \
+  --iterations 3 \
+  --eval-source sessiondb
+```
+
+## Behavior
+
+The runner will:
+
+1. Clone `NousResearch/hermes-agent-self-evolution` into
+   `${HERMES_SELF_EVOLUTION_REPO:-$HERMES_HOME/hermes-agent-self-evolution}` if missing.
+2. Create a dedicated `.venv` for the companion repo via `uv`.
+3. Install the companion repo with its `dev` dependencies.
+4. For `--eval-source sessiondb`, export recent sessions from `state.db` into a
+   temporary `~/.hermes/sessions/` tree.
+5. Run `python -m evolution.skills.evolve_skill` against this checkout via
+   `HERMES_AGENT_REPO=<this repo>`.
+
+## Useful overrides
+
+- `HERMES_SELF_EVOLUTION_REPO` — custom companion repo path
+- `SELF_EVO_SESSION_LIMIT` — cap how many sessions are exported for sessiondb runs
+
+## Model defaults
+
+Upstream defaults target OpenAI models. The local runner keeps those defaults if
+`OPENAI_API_KEY` is present.
+
+If `OPENAI_API_KEY` is missing but `ANTHROPIC_API_KEY` is available, the runner
+automatically adds:
+
+- `--optimizer-model anthropic/claude-sonnet-4.6`
+- `--eval-model anthropic/claude-sonnet-4.6`
+
+You can always override both explicitly on the command line.
+
+## Notes
+
+- This is an offline maintenance workflow, not a runtime dependency.
+- It is intentionally scoped to skill evolution first.
+- Guardrails and PR review remain in the companion repo's flow.

--- a/agent/self_evolution_bridge.py
+++ b/agent/self_evolution_bridge.py
@@ -1,0 +1,209 @@
+"""Bridge Hermes state.db sessions into the legacy JSON format expected by
+hermes-agent-self-evolution's HermesSessionImporter.
+
+The companion repo currently reads ``~/.hermes/sessions/*.json`` while Hermes
+Agent stores live conversations in ``state.db``. This module exports selected
+sessions from SQLite into one-file-per-session JSON payloads so the external
+optimizer can mine real Hermes history without changing the runtime storage
+format.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sqlite3
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Sequence
+
+from hermes_constants import get_hermes_home
+
+VALID_EXPORT_ROLES = {"system", "user", "assistant", "tool"}
+_DEFAULT_DB_PATH = get_hermes_home() / "state.db"
+_FILENAME_SAFE_RE = re.compile(r"[^A-Za-z0-9._-]+")
+_WRAPPED_SYSTEM_USER_PATTERNS = (
+    "[SYSTEM:",
+    "[The user sent an image",
+    "[The user sent a voice",
+    "[The user sent a video",
+    "[The user sent a file",
+)
+
+
+@dataclass
+class ExportSummary:
+    db_path: str
+    output_dir: str
+    sessions_exported: int
+    messages_exported: int
+    sessions_scanned: int
+    sessions_skipped: int
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), ensure_ascii=False, indent=2)
+
+
+def _safe_session_filename(session_id: str) -> str:
+    safe = _FILENAME_SAFE_RE.sub("-", session_id).strip("-.")
+    return safe or "session"
+
+
+def _should_skip_user_message(content: str) -> bool:
+    text = (content or "").strip()
+    if not text:
+        return True
+    return any(text.startswith(prefix) for prefix in _WRAPPED_SYSTEM_USER_PATTERNS)
+
+
+def _build_sessions_query(sources: Sequence[str] | None, limit_sessions: int | None) -> tuple[str, list[object]]:
+    query = ["SELECT id, source FROM sessions"]
+    params: list[object] = []
+    if sources:
+        placeholders = ", ".join("?" for _ in sources)
+        query.append(f"WHERE source IN ({placeholders})")
+        params.extend(sources)
+    query.append("ORDER BY started_at DESC")
+    if limit_sessions is not None:
+        query.append("LIMIT ?")
+        params.append(limit_sessions)
+    return " ".join(query), params
+
+
+def export_state_db_sessions(
+    output_dir: Path,
+    db_path: Path = _DEFAULT_DB_PATH,
+    *,
+    sources: Sequence[str] | None = None,
+    limit_sessions: int | None = None,
+) -> ExportSummary:
+    """Export Hermes sessions into legacy JSON files.
+
+    Args:
+        output_dir: Destination directory for ``*.json`` session files.
+        db_path: Path to Hermes ``state.db``.
+        sources: Optional source filter (e.g. ``["cli", "discord"]``).
+        limit_sessions: Optional max number of sessions to export, newest first.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    if not db_path.exists():
+        raise FileNotFoundError(f"state.db not found: {db_path}")
+
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    try:
+        query, params = _build_sessions_query(sources, limit_sessions)
+        session_rows = conn.execute(query, params).fetchall()
+
+        sessions_exported = 0
+        sessions_skipped = 0
+        messages_exported = 0
+
+        for session_row in session_rows:
+            message_rows = conn.execute(
+                """
+                SELECT role, content
+                FROM messages
+                WHERE session_id = ?
+                ORDER BY timestamp ASC, id ASC
+                """,
+                (session_row["id"],),
+            ).fetchall()
+
+            messages = []
+            for row in message_rows:
+                role = row["role"]
+                if role not in VALID_EXPORT_ROLES:
+                    continue
+                content = row["content"] or ""
+                if role == "user" and _should_skip_user_message(content):
+                    continue
+                messages.append({"role": role, "content": content})
+
+            has_dialogue = any(
+                msg["role"] in {"user", "assistant"} and msg["content"].strip()
+                for msg in messages
+            )
+            if not has_dialogue:
+                sessions_skipped += 1
+                continue
+
+            session_id = session_row["id"]
+            payload = {
+                "session_id": session_id,
+                "source": session_row["source"],
+                "messages": messages,
+            }
+            filename = f"{_safe_session_filename(session_id)}.json"
+            (output_dir / filename).write_text(
+                json.dumps(payload, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+            sessions_exported += 1
+            messages_exported += len(messages)
+
+        return ExportSummary(
+            db_path=str(db_path),
+            output_dir=str(output_dir),
+            sessions_exported=sessions_exported,
+            messages_exported=messages_exported,
+            sessions_scanned=len(session_rows),
+            sessions_skipped=sessions_skipped,
+        )
+    finally:
+        conn.close()
+
+
+def _parse_sources(raw_sources: str | None) -> list[str] | None:
+    if not raw_sources:
+        return None
+    sources = [item.strip() for item in raw_sources.split(",") if item.strip()]
+    return sources or None
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Export Hermes state.db sessions to legacy JSON files for hermes-agent-self-evolution.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        type=Path,
+        help="Directory that will receive one JSON file per exported session.",
+    )
+    parser.add_argument(
+        "--db-path",
+        default=_DEFAULT_DB_PATH,
+        type=Path,
+        help=f"Path to Hermes state.db (default: {_DEFAULT_DB_PATH}).",
+    )
+    parser.add_argument(
+        "--sources",
+        default=None,
+        help="Optional comma-separated source filter, e.g. cli,discord,telegram.",
+    )
+    parser.add_argument(
+        "--limit-sessions",
+        default=None,
+        type=int,
+        help="Optional max number of sessions to export, newest first.",
+    )
+    return parser
+
+
+def main() -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args()
+    summary = export_state_db_sessions(
+        output_dir=args.output_dir,
+        db_path=args.db_path,
+        sources=_parse_sources(args.sources),
+        limit_sessions=args.limit_sessions,
+    )
+    print(summary.to_json())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run-self-evolution.sh
+++ b/scripts/run-self-evolution.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROFILE_HOME="${HERMES_HOME:-$HOME/.hermes}"
+SELF_EVO_REPO="${HERMES_SELF_EVOLUTION_REPO:-$PROFILE_HOME/hermes-agent-self-evolution}"
+SELF_EVO_PYTHON="$SELF_EVO_REPO/.venv/bin/python"
+EVAL_SOURCE="synthetic"
+EXPORT_LIMIT="${SELF_EVO_SESSION_LIMIT:-250}"
+HAS_OPTIMIZER_MODEL_ARG=0
+HAS_EVAL_MODEL_ARG=0
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/run-self-evolution.sh --skill <name> [--iterations N] [--eval-source synthetic|sessiondb|golden] [...]
+
+What it does:
+  - ensures the companion repo NousResearch/hermes-agent-self-evolution exists locally
+  - installs its dependencies into a dedicated .venv via uv
+  - when --eval-source sessiondb is used, exports Hermes state.db sessions into the
+    legacy ~/.hermes/sessions/*.json shape expected by the companion repo
+  - runs python -m evolution.skills.evolve_skill against THIS hermes-agent checkout
+
+Environment overrides:
+  HERMES_SELF_EVOLUTION_REPO   Override clone/install path for the companion repo
+  SELF_EVO_SESSION_LIMIT       Max sessions exported for --eval-source sessiondb (default: 250)
+
+Model selection:
+  - upstream defaults stay in place when OPENAI_API_KEY is available
+  - if OPENAI_API_KEY is missing but ANTHROPIC_API_KEY exists, the runner
+    auto-adds --optimizer-model anthropic/claude-sonnet-4.6 and
+    --eval-model anthropic/claude-sonnet-4.6
+EOF
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --eval-source=sessiondb)
+      EVAL_SOURCE="sessiondb"
+      ;;
+    --eval-source=synthetic)
+      EVAL_SOURCE="synthetic"
+      ;;
+    --eval-source=golden)
+      EVAL_SOURCE="golden"
+      ;;
+    --optimizer-model=*)
+      HAS_OPTIMIZER_MODEL_ARG=1
+      ;;
+    --eval-model=*)
+      HAS_EVAL_MODEL_ARG=1
+      ;;
+  esac
+done
+
+args=("$@")
+for ((i = 0; i < ${#args[@]}; i++)); do
+  if [[ "${args[i]}" == "--eval-source" && $((i + 1)) -lt ${#args[@]} ]]; then
+    EVAL_SOURCE="${args[i + 1]}"
+  fi
+  if [[ "${args[i]}" == "--optimizer-model" && $((i + 1)) -lt ${#args[@]} ]]; then
+    HAS_OPTIMIZER_MODEL_ARG=1
+  fi
+  if [[ "${args[i]}" == "--eval-model" && $((i + 1)) -lt ${#args[@]} ]]; then
+    HAS_EVAL_MODEL_ARG=1
+  fi
+done
+
+mkdir -p "$PROFILE_HOME"
+if [[ -f "$PROFILE_HOME/.env" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  . "$PROFILE_HOME/.env"
+  set +a
+fi
+
+if [[ ! -d "$SELF_EVO_REPO/.git" ]]; then
+  echo "[self-evo] cloning companion repo to $SELF_EVO_REPO"
+  git clone --depth 1 https://github.com/NousResearch/hermes-agent-self-evolution "$SELF_EVO_REPO"
+fi
+
+if [[ ! -x "$SELF_EVO_PYTHON" ]]; then
+  echo "[self-evo] creating venv"
+  uv venv "$SELF_EVO_REPO/.venv"
+fi
+
+if ! "$SELF_EVO_PYTHON" -c 'import click, dspy, rich' >/dev/null 2>&1; then
+  echo "[self-evo] installing companion repo dependencies"
+  (
+    cd "$SELF_EVO_REPO"
+    uv pip install --python .venv/bin/python -e '.[dev]'
+  )
+fi
+
+TEMP_HOME="$(mktemp -d)"
+cleanup() {
+  rm -rf "$TEMP_HOME"
+}
+trap cleanup EXIT
+
+if [[ "$EVAL_SOURCE" == "sessiondb" ]]; then
+  mkdir -p "$TEMP_HOME/.hermes/sessions"
+  BRIDGE_PYTHON="${BRIDGE_PYTHON:-}"
+  if [[ -z "$BRIDGE_PYTHON" && -x "$ROOT_DIR/venv/bin/python" ]]; then
+    BRIDGE_PYTHON="$ROOT_DIR/venv/bin/python"
+  fi
+  if [[ -z "$BRIDGE_PYTHON" && -x "/usr/bin/python3" ]]; then
+    BRIDGE_PYTHON="/usr/bin/python3"
+  fi
+  if [[ -z "$BRIDGE_PYTHON" && -x "/usr/local/bin/python3" ]]; then
+    BRIDGE_PYTHON="/usr/local/bin/python3"
+  fi
+  if [[ -z "$BRIDGE_PYTHON" ]]; then
+    BRIDGE_PYTHON="$(command -v python3 2>/dev/null || true)"
+  fi
+  if [[ -z "$BRIDGE_PYTHON" ]]; then
+    BRIDGE_PYTHON="$(command -v python 2>/dev/null || true)"
+  fi
+  if [[ -z "$BRIDGE_PYTHON" ]]; then
+    echo "[self-evo] unable to find python interpreter for state.db export" >&2
+    exit 127
+  fi
+  echo "[self-evo] exporting state.db sessions -> $TEMP_HOME/.hermes/sessions"
+  "$BRIDGE_PYTHON" -m agent.self_evolution_bridge \
+    --output-dir "$TEMP_HOME/.hermes/sessions" \
+    --limit-sessions "$EXPORT_LIMIT"
+fi
+
+export HERMES_AGENT_REPO="${HERMES_AGENT_REPO:-$ROOT_DIR}"
+if [[ "$EVAL_SOURCE" == "sessiondb" ]]; then
+  export HOME="$TEMP_HOME"
+fi
+
+final_args=("$@")
+if [[ $HAS_OPTIMIZER_MODEL_ARG -eq 0 && -z "${OPENAI_API_KEY:-}" && -n "${ANTHROPIC_API_KEY:-}" ]]; then
+  final_args+=(--optimizer-model "anthropic/claude-sonnet-4.6")
+fi
+if [[ $HAS_EVAL_MODEL_ARG -eq 0 && -z "${OPENAI_API_KEY:-}" && -n "${ANTHROPIC_API_KEY:-}" ]]; then
+  final_args+=(--eval-model "anthropic/claude-sonnet-4.6")
+fi
+
+exec "$SELF_EVO_PYTHON" -m evolution.skills.evolve_skill "${final_args[@]}"

--- a/tests/agent/test_self_evolution_bridge.py
+++ b/tests/agent/test_self_evolution_bridge.py
@@ -1,0 +1,96 @@
+import json
+import sqlite3
+from pathlib import Path
+
+from agent.self_evolution_bridge import export_state_db_sessions
+
+
+def _create_test_db(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                source TEXT NOT NULL,
+                started_at REAL NOT NULL
+            );
+
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                role TEXT NOT NULL,
+                content TEXT,
+                timestamp REAL NOT NULL
+            );
+            """
+        )
+        conn.executemany(
+            "INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)",
+            [
+                ("discord-session", "discord", 20.0),
+                ("cli-session", "cli", 10.0),
+                ("tool-only", "cli", 5.0),
+            ],
+        )
+        conn.executemany(
+            "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+            [
+                ("cli-session", "user", "first task", 1.0),
+                ("cli-session", "assistant", "first answer", 2.0),
+                ("discord-session", "system", "sys", 1.0),
+                ("discord-session", "user", "[SYSTEM: skipped wrapper]", 1.5),
+                ("discord-session", "user", "second task", 2.0),
+                ("discord-session", "assistant", "second answer", 3.0),
+                ("tool-only", "tool", "{}", 1.0),
+            ],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_export_state_db_sessions_writes_legacy_json(tmp_path):
+    db_path = tmp_path / "state.db"
+    output_dir = tmp_path / "exported"
+    _create_test_db(db_path)
+
+    summary = export_state_db_sessions(output_dir=output_dir, db_path=db_path)
+
+    assert summary.sessions_scanned == 3
+    assert summary.sessions_exported == 2
+    assert summary.sessions_skipped == 1
+    assert summary.messages_exported == 5
+
+    exported_files = sorted(path.name for path in output_dir.glob("*.json"))
+    assert exported_files == ["cli-session.json", "discord-session.json"]
+
+    discord_payload = json.loads((output_dir / "discord-session.json").read_text())
+    assert discord_payload["session_id"] == "discord-session"
+    assert discord_payload["source"] == "discord"
+    assert [message["role"] for message in discord_payload["messages"]] == [
+        "system",
+        "user",
+        "assistant",
+    ]
+    assert all("[SYSTEM:" not in message["content"] for message in discord_payload["messages"])
+
+
+def test_export_state_db_sessions_respects_source_filter_and_limit(tmp_path):
+    db_path = tmp_path / "state.db"
+    output_dir = tmp_path / "filtered"
+    _create_test_db(db_path)
+
+    summary = export_state_db_sessions(
+        output_dir=output_dir,
+        db_path=db_path,
+        sources=["discord"],
+        limit_sessions=1,
+    )
+
+    assert summary.sessions_scanned == 1
+    assert summary.sessions_exported == 1
+    exported_files = list(output_dir.glob("*.json"))
+    assert len(exported_files) == 1
+    payload = json.loads(exported_files[0].read_text())
+    assert payload["session_id"] == "discord-session"


### PR DESCRIPTION
## Summary
- add a bridge that exports Hermes `state.db` sessions into the legacy JSON format expected by `hermes-agent-self-evolution`
- add a local runner and docs for offline self-evolution runs against the current checkout
- include regression tests for source filtering, skip rules, and session export behavior

## Validation
- `/root/.hermes/hermes-agent/venv/bin/python -m pytest tests/agent/test_self_evolution_bridge.py -q`
- `./scripts/run-self-evolution.sh --skill github-code-review --iterations 1 --eval-source sessiondb --dry-run`