### PR TITLE
feat(skills): add locked frontmatter field to protect skills from age…

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -270,6 +270,27 @@ class TestEditSkill:
         content = (tmp_path / "my-skill" / "SKILL.md").read_text()
         assert "A test skill" in content
 
+    def test_edit_locked_skill_blocked(self, tmp_path):
+        locked_content = """\
+---
+name: test-skill
+description: A locked skill.
+locked: true
+---
+
+# Locked Skill
+
+Do not modify.
+"""
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", locked_content)
+            result = _edit_skill("my-skill", VALID_SKILL_CONTENT_2)
+        assert result["success"] is False
+        assert "locked" in result["error"]
+        # Original content must be untouched
+        content = (tmp_path / "my-skill" / "SKILL.md").read_text()
+        assert "Do not modify." in content
+
 
 class TestPatchSkill:
     def test_patch_unique_match(self, tmp_path):
@@ -332,6 +353,26 @@ word word
             result = _patch_skill("nonexistent", "old", "new")
         assert result["success"] is False
 
+    def test_patch_locked_skill_blocked(self, tmp_path):
+        locked_content = """\
+---
+name: test-skill
+description: A locked skill.
+locked: true
+---
+
+# Locked Skill
+
+Original text here.
+"""
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", locked_content)
+            result = _patch_skill("my-skill", "Original text", "Modified text")
+        assert result["success"] is False
+        assert "locked" in result["error"]
+        content = (tmp_path / "my-skill" / "SKILL.md").read_text()
+        assert "Original text here." in content
+
     def test_patch_supporting_file_symlink_escape_blocked(self, tmp_path):
         outside_file = tmp_path / "outside.txt"
         outside_file.write_text("old text here")
@@ -364,6 +405,23 @@ class TestDeleteSkill:
         with _skill_dir(tmp_path):
             result = _delete_skill("nonexistent")
         assert result["success"] is False
+
+    def test_delete_locked_skill_blocked(self, tmp_path):
+        locked_content = """\
+---
+name: test-skill
+description: A locked skill.
+locked: true
+---
+
+# Locked Skill
+"""
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", locked_content)
+            result = _delete_skill("my-skill")
+        assert result["success"] is False
+        assert "locked" in result["error"]
+        assert (tmp_path / "my-skill").exists()
 
     def test_delete_cleans_empty_category_dir(self, tmp_path):
         with _skill_dir(tmp_path):

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -94,6 +94,26 @@ def _is_local_skill(skill_path: Path) -> bool:
         return True
     except ValueError:
         return False
+
+
+def _is_locked(skill_path: Path) -> bool:
+    """Return True if the skill's SKILL.md declares locked: true in frontmatter.
+
+    Locked skills cannot be modified or deleted by the agent's self-improvement
+    loop, preserving manual edits and tuned workflows.
+    """
+    try:
+        from tools.skills_tool import _parse_frontmatter
+        skill_md = skill_path / "SKILL.md"
+        if not skill_md.exists():
+            return False
+        content = skill_md.read_text(encoding="utf-8")
+        frontmatter, _ = _parse_frontmatter(content)
+        return bool(frontmatter.get("locked", False))
+    except Exception:
+        return False
+
+
 MAX_SKILL_CONTENT_CHARS = 100_000   # ~36k tokens at 2.75 chars/token
 MAX_SKILL_FILE_BYTES = 1_048_576    # 1 MiB per supporting file
 
@@ -375,6 +395,9 @@ def _edit_skill(name: str, content: str) -> Dict[str, Any]:
     if not _is_local_skill(existing["path"]):
         return {"success": False, "error": f"Skill '{name}' is in an external directory and cannot be modified. Copy it to your local skills directory first."}
 
+    if _is_locked(existing["path"]):
+        return {"success": False, "error": f"Skill '{name}' is locked (locked: true in frontmatter). Remove the 'locked' field to allow modifications."}
+
     skill_md = existing["path"] / "SKILL.md"
     # Back up original content for rollback
     original_content = skill_md.read_text(encoding="utf-8") if skill_md.exists() else None
@@ -417,6 +440,9 @@ def _patch_skill(
 
     if not _is_local_skill(existing["path"]):
         return {"success": False, "error": f"Skill '{name}' is in an external directory and cannot be modified. Copy it to your local skills directory first."}
+
+    if _is_locked(existing["path"]):
+        return {"success": False, "error": f"Skill '{name}' is locked (locked: true in frontmatter). Remove the 'locked' field to allow modifications."}
 
     skill_dir = existing["path"]
 
@@ -493,6 +519,9 @@ def _delete_skill(name: str) -> Dict[str, Any]:
 
     if not _is_local_skill(existing["path"]):
         return {"success": False, "error": f"Skill '{name}' is in an external directory and cannot be deleted."}
+
+    if _is_locked(existing["path"]):
+        return {"success": False, "error": f"Skill '{name}' is locked (locked: true in frontmatter). Remove the 'locked' field to allow modifications."}
 
     skill_dir = existing["path"]
     shutil.rmtree(skill_dir)


### PR DESCRIPTION
Skills with `locked: true` in their `SKILL.md` frontmatter are now protected from being overwritten or deleted by the agent's self-improvement loop.

## What does this PR do?

Adds a `locked` frontmatter field to `SKILL.md` that prevents the agent from autonomously modifying or deleting a skill via `skill_manage`. Users who carefully tune skills for their workflows have no way to protect them from being silently overwritten during the self-improvement loop — this was one of the most upvoted community complaints.

## Related Issue

No existing issue — addresses the top community feedback around skill auto-overwrite.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/skill_manager_tool.py` — added `_is_locked(skill_path)` helper that reads the `locked` field from SKILL.md frontmatter; added lock guard to `_edit_skill`, `_patch_skill`, and `_delete_skill`
- `tests/tools/test_skill_manager_tool.py` — 3 new tests: `test_edit_locked_skill_blocked`, `test_patch_locked_skill_blocked`, `test_delete_locked_skill_blocked` (57 passing, was 54)

## How to Test

Add `locked: true` to any skill's frontmatter:

```yaml
---
name: my-tuned-skill
description: Carefully tuned workflow
locked: true
---
```

Then call `skill_manage(action='edit', name='my-tuned-skill', content='...')` — should return:
```json
{"success": false, "error": "Skill 'my-tuned-skill' is locked (locked: true in frontmatter). Remove the 'locked' field to allow modifications."}
```

Or run the tests directly: `pytest tests/tools/test_skill_manager_tool.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(skills):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/tools/test_skill_manager_tool.py -q` and all tests pass (57 passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (field is self-documenting via error message)
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — no OS-specific code used
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (new field is additive, no schema change needed)