### PR TITLE
fix(agent): fall back on rate limit when pool has no rotation room

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -572,6 +572,31 @@ def _sanitize_structure_non_ascii(payload: Any) -> bool:
 _QWEN_CODE_VERSION = "0.14.1"
 
 
+def _pool_may_recover_from_rate_limit(pool) -> bool:
+    """Decide whether to wait for credential-pool rotation instead of falling back.
+
+    The existing pool-rotation path requires the pool to (1) exist and (2) have
+    at least one entry not currently in exhaustion cooldown.  But rotation is
+    only meaningful when the pool has more than one entry.
+
+    With a single-credential pool (common for Gemini OAuth, Vertex service
+    accounts, and any "one personal key" configuration), the primary entry
+    just 429'd and there is nothing to rotate to.  Waiting for the pool
+    cooldown to expire means retrying against the same exhausted quota — the
+    daily-quota 429 will recur immediately, and the retry budget is burned.
+
+    In that case we must fall back to the configured ``fallback_model``
+    instead.  Returns True only when rotation has somewhere to go.
+
+    See issue #11314.
+    """
+    if pool is None:
+        return False
+    if not pool.has_available():
+        return False
+    return len(pool.entries()) > 1
+
+
 def _qwen_portal_headers() -> dict:
     """Return default HTTP headers required by Qwen Portal API."""
     import platform as _plat
@@ -10352,11 +10377,11 @@ class AIAgent:
                     )
                     if is_rate_limited and self._fallback_index < len(self._fallback_chain):
                         # Don't eagerly fallback if credential pool rotation may
-                        # still recover.  The pool's retry-then-rotate cycle needs
-                        # at least one more attempt to fire — jumping to a fallback
-                        # provider here short-circuits it.
-                        pool = self._credential_pool
-                        pool_may_recover = pool is not None and pool.has_available()
+                        # still recover.  See _pool_may_recover_from_rate_limit
+                        # for the single-credential-pool exception.  Fixes #11314.
+                        pool_may_recover = _pool_may_recover_from_rate_limit(
+                            self._credential_pool
+                        )
                         if not pool_may_recover:
                             self._emit_status("⚠️ Rate limited — switching to fallback provider...")
                             if self._try_activate_fallback():

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -7,7 +7,7 @@ advancement through multiple providers.
 
 from unittest.mock import MagicMock, patch
 
-from run_agent import AIAgent
+from run_agent import AIAgent, _pool_may_recover_from_rate_limit
 
 
 def _make_agent(fallback_model=None):
@@ -155,3 +155,42 @@ class TestFallbackChainAdvancement:
             ]
             assert agent._try_activate_fallback() is True
             assert agent.model == "gpt-4o"
+
+
+# ── Pool-rotation vs fallback gating (#11314) ────────────────────────────
+
+
+def _pool(n_entries: int, has_available: bool = True):
+    """Make a minimal credential-pool stand-in for rotation-room checks."""
+    pool = MagicMock()
+    pool.entries.return_value = [MagicMock() for _ in range(n_entries)]
+    pool.has_available.return_value = has_available
+    return pool
+
+
+class TestPoolRotationRoom:
+    def test_none_pool_returns_false(self):
+        assert _pool_may_recover_from_rate_limit(None) is False
+
+    def test_single_credential_returns_false(self):
+        """With one credential that just 429'd, rotation has nowhere to go.
+
+        The pool may still report has_available() True once cooldown expires,
+        but retrying against the same entry will hit the same daily-quota
+        429 and burn the retry budget.  Must fall back.
+        """
+        assert _pool_may_recover_from_rate_limit(_pool(1)) is False
+
+    def test_single_credential_in_cooldown_returns_false(self):
+        assert _pool_may_recover_from_rate_limit(_pool(1, has_available=False)) is False
+
+    def test_two_credentials_available_returns_true(self):
+        """With >1 credentials and at least one available, rotate instead of fallback."""
+        assert _pool_may_recover_from_rate_limit(_pool(2)) is True
+
+    def test_multiple_credentials_all_in_cooldown_returns_false(self):
+        """All credentials cooling down — fall back rather than wait."""
+        assert _pool_may_recover_from_rate_limit(_pool(3, has_available=False)) is False
+
+    def test_many_credentials_available_returns_true(self):
+        assert _pool_may_recover_from_rate_limit(_pool(10)) is True


### PR DESCRIPTION
## Summary

The existing eager-fallback path for rate-limit errors gates on `pool is not None and pool.has_available()`. With a **single-credential pool** (the common Gemini OAuth, Vertex service-account, or personal-key setup), `has_available()` returns True as soon as the per-entry cooldown expires — Hermes retries against the same entry, hits the same daily-quota 429, and burns the retry budget in a tight loop before the configured `fallback_model` ever activates.

Rotation only helps when there is somewhere to rotate **to**. This PR adds `len(pool.entries()) > 1` to the gate via a small module-level helper `_pool_may_recover_from_rate_limit`, so single-credential pools fall through to the fallback provider immediately.

Fixes #11314. Related to #8947, #10210, #7230.

## The loop this prevents

Before the fix, with a single Gemini key configured as primary and Vertex as `fallback_model`:

```
HTTP 429 (RESOURCE_EXHAUSTED, 1M tokens/day limit hit)
  → pool.has_available() = True (cooldown ~60s, not daily-quota aware)
  → pool_may_recover = True
  → retry against same key
  → HTTP 429 again
  → ... repeat for hours ...
```

After the fix:

```
HTTP 429
  → pool has 1 entry → pool_may_recover = False
  → ⚠️ Rate limited — switching to fallback provider...
  → Vertex takes over
```

## Scope

Narrower than the adjacent open PRs:

- **#8023** changes classification semantics for `RateLimitError`.
- **#11492** bypasses credential-pool for 503/529 overloaded errors.

This PR doesn't change either surface. It only refines the existing `pool_may_recover` gate in `run_agent.py` for the 429 case. Should land cleanly alongside or before either of them.

## Test plan

- [x] New unit tests in `tests/run_agent/test_provider_fallback.py::TestPoolRotationRoom` cover:
  - None pool
  - single-credential available (the specific regression)
  - single-credential in cooldown
  - 2-credential available (rotation still preferred)
  - multi-credential all in cooldown (fall back)
  - many-credential available (rotation still preferred)
- [x] All 18 tests in the file pass locally.
- [x] Helper is pure, no side effects; existing retry-loop semantics for multi-credential pools unchanged.