### PR TITLE
feat(compression): summaries respect the conversation's language

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -633,7 +633,9 @@ class ContextCompressor(ContextEngine):
             "assistant that continues the conversation. "
             "Do NOT respond to any questions or requests in the conversation — "
             "only output the structured summary. "
-            "Do NOT include any preamble, greeting, or prefix."
+            "Do NOT include any preamble, greeting, or prefix. "
+            "Write the summary in the same language the user was using in the "
+            "conversation — do not translate or switch to English."
         )
 
         # Shared structured template (used by both paths).


### PR DESCRIPTION
## Summary

Context compaction summaries now get produced in the conversation's language instead of always coming back in English.

## Why this matters

When a user converses in Spanish, Mandarin, Japanese, Arabic, Portuguese — and their session eventually hits the compaction threshold — the continuation assistant sees an English-language summary of their own conversation injected into context. That feels wrong and it materially hurts continuation quality: the assistant that picks up after compaction has to mentally translate back, which sometimes drops nuance and sometimes triggers the wrong persona. This is especially rough for Chinese/Japanese users on long coding sessions.

After this change: the compaction summary comes back in whatever language the user was speaking. The continuation assistant sees their own language. Nothing else changes — structure, token budget, focus-topic behavior all the same.

## Scope

One sentence added to the shared `_summarizer_preamble` in `agent/context_compressor.py`:

```
Write the summary in the same language the user was using in the conversation — do not translate or switch to English.
```

The preamble is used by both prompt paths (initial compaction and iterative update), so one edit covers both. Four lines of diff, one file.

## Why the shape changed from PR #4670

#4670 opened against pre-refactor prompts where the two paths had duplicate inline sections. Main has since factored them into a shared `_summarizer_preamble` + `_template_sections`. The cherry-pick hit conflicts on the now-obsolete inline sections; re-applied the essential one-line instruction on top of the current structure instead. Same value, cleaner landing.

Credit to anomalyco/opencode#20581 for the original idea.

## Validation

- 48/48 existing tests in `tests/agent/test_context_compressor.py` pass
- Syntax check clean
- No behavioral change for English conversations (the instruction is a no-op when the user was already speaking English)

Closes #4670.