### PR TITLE
fix(model_switch): enumerate dict-format models in /model picker + section-3 refinements

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1039,9 +1039,23 @@ def list_authenticated_providers(
         for ep_name, ep_cfg in user_providers.items():
             if not isinstance(ep_cfg, dict):
                 continue
+            # Skip if this slug was already emitted (e.g. canonical provider
+            # with the same name) or will be picked up by section 4.
+            if ep_name.lower() in seen_slugs:
+                continue
             display_name = ep_cfg.get("name", "") or ep_name
-            api_url = ep_cfg.get("api", "") or ep_cfg.get("url", "") or ""
-            default_model = ep_cfg.get("default_model", "")
+            # ``base_url`` is Hermes's canonical write key (matches
+            # custom_providers and _save_custom_provider); ``api`` / ``url``
+            # remain as fallbacks for hand-edited / legacy configs.
+            api_url = (
+                ep_cfg.get("base_url", "")
+                or ep_cfg.get("api", "")
+                or ep_cfg.get("url", "")
+                or ""
+            )
+            # ``default_model`` is the legacy key; ``model`` matches what
+            # custom_providers entries use, so accept either.
+            default_model = ep_cfg.get("default_model", "") or ep_cfg.get("model", "")
 
             # Build models list from both default_model and full models array
             models_list = []
@@ -1073,6 +1087,7 @@ def list_authenticated_providers(
                 "source": "user-config",
                 "api_url": api_url,
             })
+            seen_slugs.add(ep_name.lower())
 
     # --- 4. Saved custom providers from config ---
     # Each ``custom_providers`` entry represents one model under a named

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1047,9 +1047,16 @@ def list_authenticated_providers(
             models_list = []
             if default_model:
                 models_list.append(default_model)
-            # Also include the full models list from config
+            # Also include the full models list from config.
+            # Hermes writes ``models:`` as a dict keyed by model id
+            # (see hermes_cli/main.py::_save_custom_provider); older
+            # configs or hand-edited files may still use a list.
             cfg_models = ep_cfg.get("models", [])
-            if isinstance(cfg_models, list):
+            if isinstance(cfg_models, dict):
+                for m in cfg_models:
+                    if m and m not in models_list:
+                        models_list.append(m)
+            elif isinstance(cfg_models, list):
                 for m in cfg_models:
                     if m and m not in models_list:
                         models_list.append(m)
@@ -1100,9 +1107,26 @@ def list_authenticated_providers(
                     "api_url": api_url,
                     "models": [],
                 }
+            # The singular ``model:`` field only holds the currently
+            # active model. Hermes's own writer (main.py::_save_custom_provider)
+            # stores every configured model as a dict under ``models:``;
+            # downstream readers (agent/models_dev.py, gateway/run.py,
+            # run_agent.py, hermes_cli/config.py) already consume that dict.
+            # The /model picker previously ignored it, so multi-model
+            # custom providers appeared to have only the active model.
             default_model = (entry.get("model") or "").strip()
             if default_model and default_model not in groups[slug]["models"]:
                 groups[slug]["models"].append(default_model)
+
+            cfg_models = entry.get("models", {})
+            if isinstance(cfg_models, dict):
+                for m in cfg_models:
+                    if m and m not in groups[slug]["models"]:
+                        groups[slug]["models"].append(m)
+            elif isinstance(cfg_models, list):
+                for m in cfg_models:
+                    if m and m not in groups[slug]["models"]:
+                        groups[slug]["models"].append(m)
 
         for slug, grp in groups.items():
             if slug.lower() in seen_slugs:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -177,6 +177,7 @@ AUTHOR_MAP = {
     "duerzy@gmail.com": "duerzy",
     "emozilla@nousresearch.com": "emozilla",
     "fancydirty@gmail.com": "fancydirty",
+    "farion1231@gmail.com": "farion1231",
     "floptopbot33@gmail.com": "flobo3",
     "fontana.pedro93@gmail.com": "pefontana",
     "francis.x.fitzpatrick@gmail.com": "fxfitz",

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -156,3 +156,100 @@ def test_list_deduplicates_same_model_in_group(monkeypatch):
     assert len(my_rows) == 1
     assert my_rows[0]["models"] == ["llama3", "mistral"]
     assert my_rows[0]["total_models"] == 2
+
+
+def test_list_enumerates_dict_format_models_alongside_default(monkeypatch):
+    """custom_providers entry with dict-format ``models:`` plus singular
+    ``model:`` should surface the default and every dict key.
+
+    Regression: Hermes's own writer stores configured models as a dict
+    keyed by model id, but the /model picker previously only honored the
+    singular ``model:`` field, so multi-model custom providers appeared
+    to have only the active model.
+    """
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    providers = list_authenticated_providers(
+        current_provider="openai-codex",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "DeepSeek",
+                "base_url": "https://api.deepseek.com",
+                "api_mode": "chat_completions",
+                "model": "deepseek-chat",
+                "models": {
+                    "deepseek-chat": {"context_length": 128000},
+                    "deepseek-reasoner": {"context_length": 128000},
+                },
+            }
+        ],
+        max_models=50,
+    )
+
+    ds_rows = [p for p in providers if p["name"] == "DeepSeek"]
+    assert len(ds_rows) == 1
+    assert ds_rows[0]["models"] == ["deepseek-chat", "deepseek-reasoner"]
+    assert ds_rows[0]["total_models"] == 2
+
+
+def test_list_enumerates_dict_format_models_without_singular_model(monkeypatch):
+    """Dict-format ``models:`` with no singular ``model:`` should still
+    enumerate every dict key (previously the picker reported 0 models)."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    providers = list_authenticated_providers(
+        current_provider="openai-codex",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "Thor",
+                "base_url": "http://thor.lab:8337/v1",
+                "models": {
+                    "gemma-4-26B-A4B-it-MXFP4_MOE": {"context_length": 262144},
+                    "Qwen3.5-35B-A3B-MXFP4_MOE": {"context_length": 262144},
+                    "gemma-4-31B-it-Q4_K_M": {"context_length": 262144},
+                },
+            }
+        ],
+        max_models=50,
+    )
+
+    thor_rows = [p for p in providers if p["name"] == "Thor"]
+    assert len(thor_rows) == 1
+    assert set(thor_rows[0]["models"]) == {
+        "gemma-4-26B-A4B-it-MXFP4_MOE",
+        "Qwen3.5-35B-A3B-MXFP4_MOE",
+        "gemma-4-31B-it-Q4_K_M",
+    }
+    assert thor_rows[0]["total_models"] == 3
+
+
+def test_list_dedupes_dict_model_matching_singular_default(monkeypatch):
+    """When the singular ``model:`` is also a key in the ``models:`` dict,
+    it must appear exactly once in the picker."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+    providers = list_authenticated_providers(
+        current_provider="openai-codex",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "DeepSeek",
+                "base_url": "https://api.deepseek.com",
+                "model": "deepseek-chat",
+                "models": {
+                    "deepseek-chat": {"context_length": 128000},
+                    "deepseek-reasoner": {"context_length": 128000},
+                },
+            }
+        ],
+        max_models=50,
+    )
+
+    ds_rows = [p for p in providers if p["name"] == "DeepSeek"]
+    assert ds_rows[0]["models"].count("deepseek-chat") == 1
+    assert ds_rows[0]["models"] == ["deepseek-chat", "deepseek-reasoner"]

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -227,6 +227,83 @@ def test_list_authenticated_providers_fallback_to_default_only(monkeypatch):
     assert user_prov["models"] == ["single-model"]
 
 
+def test_list_authenticated_providers_accepts_base_url_and_singular_model(monkeypatch):
+    """providers: dict entries written in canonical Hermes shape
+    (``base_url`` + singular ``model``) should resolve the same as the
+    legacy ``api`` + ``default_model`` shape.
+
+    Regression: section 3 previously only read ``api``/``url`` and
+    ``default_model``, so new-shape entries written by Hermes's own writer
+    surfaced with empty ``api_url`` and no default.
+    """
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    user_providers = {
+        "custom": {
+            "base_url": "http://example.com/v1",
+            "model": "gpt-5.4",
+            "models": {
+                "gpt-5.4": {},
+                "grok-4.20-beta": {},
+                "minimax-m2.7": {},
+            },
+        }
+    }
+
+    providers = list_authenticated_providers(
+        current_provider="custom",
+        user_providers=user_providers,
+        custom_providers=[],
+        max_models=50,
+    )
+
+    custom = next((p for p in providers if p["slug"] == "custom"), None)
+    assert custom is not None
+    assert custom["api_url"] == "http://example.com/v1"
+    assert custom["models"] == ["gpt-5.4", "grok-4.20-beta", "minimax-m2.7"]
+    assert custom["total_models"] == 3
+
+
+def test_list_authenticated_providers_dedupes_when_user_and_custom_overlap(monkeypatch):
+    """When the same slug appears in both ``providers:`` dict and
+    ``custom_providers:`` list, emit exactly one row (providers: dict wins
+    since it is processed first).
+
+    Regression: section 3 previously had no ``seen_slugs`` check, so
+    overlapping entries produced two picker rows for the same provider.
+    """
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    providers = list_authenticated_providers(
+        current_provider="custom",
+        user_providers={
+            "custom": {
+                "base_url": "http://example.com/v1",
+                "model": "gpt-5.4",
+                "models": {
+                    "gpt-5.4": {},
+                    "grok-4.20-beta": {},
+                },
+            }
+        },
+        custom_providers=[
+            {
+                "name": "custom",
+                "base_url": "http://example.com/v1",
+                "model": "legacy-only-model",
+            }
+        ],
+        max_models=50,
+    )
+
+    matches = [p for p in providers if p["slug"] == "custom"]
+    assert len(matches) == 1
+    # providers: dict wins — legacy-only-model is suppressed.
+    assert matches[0]["models"] == ["gpt-5.4", "grok-4.20-beta"]
+
+
 # =============================================================================
 # Tests for _get_named_custom_provider with providers: dict
 # =============================================================================

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -86,6 +86,117 @@ def test_list_authenticated_providers_dedupes_models_when_default_in_list(monkey
     assert user_prov["models"].count("model-a") == 1, "model-a should not be duplicated"
 
 
+def test_list_authenticated_providers_enumerates_dict_format_models(monkeypatch):
+    """providers: dict entries with ``models:`` as a dict keyed by model id
+    (canonical Hermes write format) should surface every key in the picker.
+
+    Regression: the ``providers:`` dict path previously only accepted
+    list-format ``models:`` and silently dropped dict-format entries,
+    even though Hermes's own writer and downstream readers use dict format.
+    """
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    user_providers = {
+        "local-ollama": {
+            "name": "Local Ollama",
+            "api": "http://localhost:11434/v1",
+            "default_model": "minimax-m2.7:cloud",
+            "models": {
+                "minimax-m2.7:cloud": {"context_length": 196608},
+                "kimi-k2.5:cloud": {"context_length": 200000},
+                "glm-5.1:cloud": {"context_length": 202752},
+            },
+        }
+    }
+
+    providers = list_authenticated_providers(
+        current_provider="local-ollama",
+        user_providers=user_providers,
+        custom_providers=[],
+        max_models=50,
+    )
+
+    user_prov = next(
+        (p for p in providers if p.get("is_user_defined") and p["slug"] == "local-ollama"),
+        None,
+    )
+
+    assert user_prov is not None
+    assert user_prov["total_models"] == 3
+    assert user_prov["models"] == [
+        "minimax-m2.7:cloud",
+        "kimi-k2.5:cloud",
+        "glm-5.1:cloud",
+    ]
+
+
+def test_list_authenticated_providers_dict_models_without_default_model(monkeypatch):
+    """Dict-format ``models:`` without a ``default_model`` must still expose
+    every dict key, not collapse to an empty list."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    user_providers = {
+        "multimodel": {
+            "api": "http://example.com/v1",
+            "models": {
+                "alpha": {"context_length": 8192},
+                "beta": {"context_length": 16384},
+            },
+        }
+    }
+
+    providers = list_authenticated_providers(
+        current_provider="",
+        user_providers=user_providers,
+        custom_providers=[],
+    )
+
+    user_prov = next(
+        (p for p in providers if p.get("is_user_defined") and p["slug"] == "multimodel"),
+        None,
+    )
+
+    assert user_prov is not None
+    assert user_prov["total_models"] == 2
+    assert set(user_prov["models"]) == {"alpha", "beta"}
+
+
+def test_list_authenticated_providers_dict_models_dedupe_with_default(monkeypatch):
+    """When ``default_model`` is also a key in the ``models:`` dict, it must
+    appear exactly once (list already had this for list-format models)."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    user_providers = {
+        "my-provider": {
+            "api": "http://example.com/v1",
+            "default_model": "model-a",
+            "models": {
+                "model-a": {"context_length": 8192},
+                "model-b": {"context_length": 16384},
+                "model-c": {"context_length": 32768},
+            },
+        }
+    }
+
+    providers = list_authenticated_providers(
+        current_provider="my-provider",
+        user_providers=user_providers,
+        custom_providers=[],
+    )
+
+    user_prov = next(
+        (p for p in providers if p.get("is_user_defined")),
+        None,
+    )
+
+    assert user_prov is not None
+    assert user_prov["total_models"] == 3
+    assert user_prov["models"].count("model-a") == 1
+
+
 def test_list_authenticated_providers_fallback_to_default_only(monkeypatch):
     """When no models array is provided, should fall back to default_model."""
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})


### PR DESCRIPTION
Multi-model custom providers now show all their models in the `/model` picker instead of just the default. Salvage of @farion1231's #12505 with section-3 refinements drawn from @YangManBOBO's #11534.

## Changes
- `hermes_cli/model_switch.py` (sections 3 + 4 of `list_authenticated_providers()`):
  - Enumerate dict-format `models:` in both the `providers:` dict path and the `custom_providers:` list path (fixes #11677 and #9148)
  - Section 3: accept canonical `base_url` (matches Hermes's writer), keep `api`/`url` as fallbacks
  - Section 3: accept singular `model` as a `default_model` synonym
  - Section 3: `seen_slugs` dedup guard so a slug appearing in both `providers:` and `custom_providers:` emits one row
- 8 regression tests (6 from #12505 + 2 on top for the new section-3 behavior)
- `scripts/release.py`: AUTHOR_MAP entry for farion1231@gmail.com

## Validation
| | Before | After |
|---|---|---|
| `providers:` dict entry w/ dict-format `models:` | `(0 models)` | enumerates every key |
| `custom_providers:` entry w/ dict-format `models:` | only singular `model:` | enumerates every key, dedupes singular |
| `providers:` entry w/ canonical `base_url`/`model` | empty `api_url`, no default | resolves the same as legacy shape |
| Same slug in both `providers:` and `custom_providers:` | 2 picker rows | 1 row (providers: wins) |

Targeted test run:

```
tests/hermes_cli/test_model_switch_custom_providers.py ....... (9)
tests/hermes_cli/test_user_providers_model_switch.py   ............. (13)
22 passed in 0.78s
```

E2E verified against a real `config.yaml` containing all four shapes (new-style providers dict with dict models, legacy providers dict with list models, custom_providers with dict models + singular default, custom_providers with dict models only). All four rows surface with correct model counts, no duplicate slugs.

## Credit
- @farion1231 (PR #12505) — baseline implementation + tests for sections 3 and 4
- @YangManBOBO (PR #11534) — section-3 base_url/model fallbacks and dedup guard

Supersedes: #12505, #11534, #11546, #11968, #11403, #9864, #10326, #11130 — all solve subsets of the same bug.

Closes #11677
Closes #9148