### PR TITLE
refactor(process): swap preexec_fn=os.setsid for start_new_session across all Popen sites

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -543,8 +543,7 @@ Hermes runs on Linux, macOS, and Windows. When writing code that touches the OS:
 3. **Process management.** `os.setsid()`, `os.killpg()`, and signal handling differ on Windows. Use platform checks:
    ```python
    import platform
-   if platform.system() != "Windows":
-       kwargs["preexec_fn"] = os.setsid
+   kwargs["start_new_session"] = platform.system() != "Windows"
    ```
 
 4. **Path separators.** Use `pathlib.Path` instead of string concatenation with `/`.

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -372,7 +372,7 @@ class WhatsAppAdapter(BasePlatformAdapter):
                 ],
                 stdout=bridge_log_fh,
                 stderr=bridge_log_fh,
-                preexec_fn=None if _IS_WINDOWS else os.setsid,
+                start_new_session=not _IS_WINDOWS,
                 env=bridge_env,
             )
             

--- a/tests/tools/test_windows_compat.py
+++ b/tests/tools/test_windows_compat.py
@@ -19,13 +19,13 @@ GUARDED_FILES = [
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
 
 
-def _get_preexec_fn_values(filepath: Path) -> list:
-    """Find all preexec_fn= keyword arguments in Popen calls."""
+def _get_kwarg_values(filepath: Path, kwarg_name: str) -> list:
+    """Find all ``kwarg_name=...`` keyword arguments in function calls."""
     source = filepath.read_text(encoding="utf-8")
     tree = ast.parse(source, filename=str(filepath))
     values = []
     for node in ast.walk(tree):
-        if isinstance(node, ast.keyword) and node.arg == "preexec_fn":
+        if isinstance(node, ast.keyword) and node.arg == kwarg_name:
             values.append(ast.dump(node.value))
     return values
 
@@ -38,11 +38,31 @@ class TestNoUnconditionalSetsid:
         filepath = PROJECT_ROOT / relpath
         if not filepath.exists():
             pytest.skip(f"{relpath} not found")
-        values = _get_preexec_fn_values(filepath)
+        values = _get_kwarg_values(filepath, "preexec_fn")
         for val in values:
             # A bare os.setsid would be: Attribute(value=Name(id='os'), attr='setsid')
             assert "attr='setsid'" not in val or "IfExp" in val or "None" in val, (
                 f"{relpath} has unconditional preexec_fn=os.setsid"
+            )
+
+    @pytest.mark.parametrize("relpath", GUARDED_FILES)
+    def test_start_new_session_is_guarded(self, relpath):
+        """start_new_session must not be an unconditional True.
+
+        The modern thread-safe replacement for ``preexec_fn=os.setsid`` is
+        ``start_new_session=<bool>``, but Windows' subprocess backend doesn't
+        support it — so it must always be gated on a platform check (typically
+        ``not _IS_WINDOWS``), never a bare ``True``.
+        """
+        filepath = PROJECT_ROOT / relpath
+        if not filepath.exists():
+            pytest.skip(f"{relpath} not found")
+        values = _get_kwarg_values(filepath, "start_new_session")
+        for val in values:
+            # A bare True literal would be: Constant(value=True)
+            assert val != "Constant(value=True)", (
+                f"{relpath} has unconditional start_new_session=True "
+                f"(must be guarded, e.g. `not _IS_WINDOWS`)"
             )
 
 

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1065,7 +1065,7 @@ def execute_code(
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             stdin=subprocess.DEVNULL,
-            preexec_fn=None if _IS_WINDOWS else os.setsid,
+            start_new_session=not _IS_WINDOWS,
         )
 
         # --- Poll loop: watch for exit, timeout, and interrupt ---

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -115,7 +115,7 @@ def _popen_bash(
     """Spawn a subprocess with standard stdout/stderr/stdin setup.
 
     If *stdin_data* is provided, writes it asynchronously via :func:`_pipe_stdin`.
-    Backends with special Popen needs (e.g. local's ``preexec_fn``) can bypass
+    Backends with special Popen needs (e.g. local's ``start_new_session``) can bypass
     this and call :func:`_pipe_stdin` directly.
     """
     proc = subprocess.Popen(

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -269,7 +269,7 @@ class LocalEnvironment(BaseEnvironment):
             stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
             start_new_session=not _IS_WINDOWS,
         )
-                      
+
         if stdin_data is not None:
             _pipe_stdin(proc, stdin_data)
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -267,9 +267,9 @@ class LocalEnvironment(BaseEnvironment):
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
-            preexec_fn=None if _IS_WINDOWS else os.setsid,
+            start_new_session=not _IS_WINDOWS,
         )
-
+                      
         if stdin_data is not None:
             _pipe_stdin(proc, stdin_data)
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -395,7 +395,7 @@ class ProcessRegistry:
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             stdin=subprocess.PIPE,
-            preexec_fn=None if _IS_WINDOWS else os.setsid,
+            start_new_session=not _IS_WINDOWS,
         )
 
         session.process = proc

--- a/website/docs/developer-guide/contributing.md
+++ b/website/docs/developer-guide/contributing.md
@@ -129,8 +129,7 @@ except UnicodeDecodeError:
 
 ```python
 import platform
-if platform.system() != "Windows":
-    kwargs["preexec_fn"] = os.setsid
+kwargs["start_new_session"] = platform.system() != "Windows"
 ```
 
 ### 4. Path separators


### PR DESCRIPTION
Salvages #8399 (@dippwho) as a consistent modernization pass across all four files guarded by `tests/tools/test_windows_compat.py`.

## Summary
Replace `preexec_fn=None if _IS_WINDOWS else os.setsid` with `start_new_session=not _IS_WINDOWS` at every `subprocess.Popen` call site that needs a new POSIX session. Both forms invoke the same `setsid()` syscall, but `start_new_session` uses CPython's `_posixsubprocess` fastpath between fork and exec instead of an arbitrary Python callback — no thread-safety caveats, cleaner idiom.

## Scope
This is **code hygiene, not a fix for #8340**. The `setsid ... & disown` hang reported there is not caused by the `preexec_fn` vs `start_new_session` choice — the two forms are behaviourally equivalent w.r.t. the syscall, confirmed by E2E repro (wrapper returns in 0.24s before and after). @kingtobi1337's comment on that issue identifies the more plausible root cause (job control in `bash -l -c`). Leaving #8340 open.

## Changes
| File | Change |
|---|---|
| `tools/environments/local.py` | swap (from @dippwho's original PR) + strip trailing-whitespace line |
| `tools/code_execution_tool.py` | swap |
| `tools/process_registry.py` | swap |
| `gateway/platforms/whatsapp.py` | swap |
| `tools/environments/base.py` | update stale `_popen_bash` docstring (`preexec_fn` → `start_new_session`) |
| `CONTRIBUTING.md` + `website/docs/developer-guide/contributing.md` | cross-platform process management snippet now recommends `start_new_session` |
| `tests/tools/test_windows_compat.py` | add `test_start_new_session_is_guarded` — rejects bare `start_new_session=True`, mirroring the existing `preexec_fn=os.setsid` guard |

## Validation
- `py_compile` on all 6 modified Python files: ok
- `scripts/run_tests.sh tests/tools/test_windows_compat.py -v`: 16/16 passed (4 old guards + 4 new `start_new_session` guards, parametrised across the four files)
- E2E repro of the #8340 scenario against the patched `LocalEnvironment._run_bash`: 0.24s return, parent command completes, detached `setsid … & disown` child survives and runs to completion — `setsid` semantics unchanged

Credit to @dippwho for the original PR #8399 and the idea; cherry-picked with original authorship preserved.

Closes #8399