### PR TITLE
fix(tui-gateway): dispatch slow RPC handlers on a thread pool (#12546)

### DIFF
--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -4,6 +4,7 @@ import io
 import json
 import sys
 import threading
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -432,3 +433,81 @@ def test_command_dispatch_returns_skill_payload(server):
     assert result["type"] == "skill"
     assert result["message"] == fake_msg
     assert result["name"] == "hermes-agent-dev"
+
+
+# ── dispatch(): pool routing for long handlers (#12546) ──────────────
+
+
+def test_dispatch_runs_short_handlers_inline(server):
+    """Non-long handlers return their response synchronously from dispatch()."""
+    server._methods["fast.ping"] = lambda rid, params: server._ok(rid, {"pong": True})
+
+    resp = server.dispatch({"id": "r1", "method": "fast.ping", "params": {}})
+
+    assert resp == {"jsonrpc": "2.0", "id": "r1", "result": {"pong": True}}
+
+
+def test_dispatch_offloads_long_handlers_and_emits_via_stdout(capture):
+    """Long handlers run on the pool and write their response via write_json."""
+    server, buf = capture
+    server._methods["slash.exec"] = lambda rid, params: server._ok(rid, {"output": "hi"})
+
+    resp = server.dispatch({"id": "r2", "method": "slash.exec", "params": {}})
+    assert resp is None
+
+    for _ in range(50):
+        if buf.getvalue():
+            break
+        time.sleep(0.01)
+
+    written = json.loads(buf.getvalue())
+    assert written == {"jsonrpc": "2.0", "id": "r2", "result": {"output": "hi"}}
+
+
+def test_dispatch_long_handler_does_not_block_fast_handler(server):
+    """A slow long handler must not prevent a concurrent fast handler from completing."""
+    released = threading.Event()
+    server._methods["slash.exec"] = lambda rid, params: (released.wait(timeout=5), server._ok(rid, {"done": True}))[1]
+    server._methods["fast.ping"] = lambda rid, params: server._ok(rid, {"pong": True})
+
+    t0 = time.monotonic()
+    assert server.dispatch({"id": "slow", "method": "slash.exec", "params": {}}) is None
+
+    fast_resp = server.dispatch({"id": "fast", "method": "fast.ping", "params": {}})
+    fast_elapsed = time.monotonic() - t0
+
+    assert fast_resp["result"] == {"pong": True}
+    assert fast_elapsed < 0.5, f"fast handler blocked for {fast_elapsed:.2f}s behind slow handler"
+
+    released.set()
+
+
+def test_dispatch_long_handler_exception_produces_error_response(capture):
+    """An exception inside a pool-dispatched handler still yields a JSON-RPC error."""
+    server, buf = capture
+
+    def boom(rid, params):
+        raise RuntimeError("kaboom")
+
+    server._methods["slash.exec"] = boom
+
+    server.dispatch({"id": "r3", "method": "slash.exec", "params": {}})
+
+    for _ in range(50):
+        if buf.getvalue():
+            break
+        time.sleep(0.01)
+
+    written = json.loads(buf.getvalue())
+    assert written["id"] == "r3"
+    assert written["error"]["code"] == -32000
+    assert "kaboom" in written["error"]["message"]
+
+
+def test_dispatch_unknown_long_method_still_goes_inline(server):
+    """Method name not in _LONG_HANDLERS takes the sync path even if handler is slow."""
+    server._methods["some.method"] = lambda rid, params: server._ok(rid, {"ok": True})
+
+    resp = server.dispatch({"id": "r4", "method": "some.method", "params": {}})
+
+    assert resp["result"] == {"ok": True}

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -2,7 +2,7 @@ import json
 import signal
 import sys
 
-from tui_gateway.server import handle_request, resolve_skin, write_json
+from tui_gateway.server import dispatch, resolve_skin, write_json
 
 signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 signal.signal(signal.SIGINT, signal.SIG_IGN)
@@ -28,7 +28,7 @@ def main():
                 sys.exit(0)
             continue
 
-        resp = handle_request(req)
+        resp = dispatch(req)
         if resp is not None:
             if not write_json(resp):
                 sys.exit(0)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -218,31 +218,27 @@ def handle_request(req: dict) -> dict | None:
     return fn(req.get("id"), req.get("params", {}))
 
 
-def _run_and_emit(req: dict) -> None:
-    """Run a handler on the RPC pool and write its response directly.
-
-    Catches any unexpected exception so a misbehaving handler can't kill
-    the worker thread silently — the caller still sees a JSON-RPC error.
-    """
-    try:
-        resp = handle_request(req)
-    except Exception as exc:
-        resp = _err(req.get("id"), -32000, f"handler error: {exc}")
-    if resp is not None:
-        write_json(resp)
-
-
 def dispatch(req: dict) -> dict | None:
-    """Route an inbound RPC — long handlers to the pool, everything else inline.
+    """Route inbound RPCs — long handlers to the pool, everything else inline.
 
-    Returns the response for sync-dispatched requests so the caller
-    (entry.py) can write it. Returns None when the request has been
-    scheduled on the pool; the worker writes the response itself.
+    Returns a response dict when handled inline. Returns None when the
+    handler was scheduled on the pool; the worker writes its own
+    response via write_json when done.
     """
-    if req.get("method", "") in _LONG_HANDLERS:
-        _pool.submit(_run_and_emit, req)
-        return None
-    return handle_request(req)
+    if req.get("method") not in _LONG_HANDLERS:
+        return handle_request(req)
+
+    def run():
+        try:
+            resp = handle_request(req)
+        except Exception as exc:
+            resp = _err(req.get("id"), -32000, f"handler error: {exc}")
+        if resp is not None:
+            write_json(resp)
+
+    _pool.submit(run)
+
+    return None
 
 
 def _wait_agent(session: dict, rid: str, timeout: float = 30.0) -> dict | None:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1,4 +1,5 @@
 import atexit
+import concurrent.futures
 import copy
 import json
 import os
@@ -35,6 +36,29 @@ _cfg_lock = threading.Lock()
 _cfg_cache: dict | None = None
 _cfg_mtime: float | None = None
 _SLASH_WORKER_TIMEOUT_S = max(5.0, float(os.environ.get("HERMES_TUI_SLASH_TIMEOUT_S", "45") or 45))
+
+# ── Async RPC dispatch (#12546) ──────────────────────────────────────
+# A handful of handlers block the dispatcher loop in entry.py for seconds
+# to minutes (slash.exec, cli.exec, shell.exec, session.resume,
+# session.branch). While they're running, inbound RPCs — notably
+# approval.respond and session.interrupt — sit unread in the stdin pipe.
+# We route only those slow handlers onto a small thread pool; everything
+# else stays on the main thread so ordering stays sane for the fast path.
+# write_json is already _stdout_lock-guarded, so concurrent response
+# writes are safe.
+_LONG_HANDLERS = frozenset({
+    "cli.exec",
+    "session.branch",
+    "session.resume",
+    "shell.exec",
+    "slash.exec",
+})
+_RPC_POOL_WORKERS = max(2, int(os.environ.get("HERMES_TUI_RPC_POOL_WORKERS", "4") or 4))
+_pool = concurrent.futures.ThreadPoolExecutor(
+    max_workers=_RPC_POOL_WORKERS,
+    thread_name_prefix="tui-rpc",
+)
+atexit.register(lambda: _pool.shutdown(wait=False, cancel_futures=True))
 
 # Reserve real stdout for JSON-RPC only; redirect Python's stdout to stderr
 # so stray print() from libraries/tools becomes harmless gateway.stderr instead
@@ -198,6 +222,33 @@ def handle_request(req: dict) -> dict | None:
     if not fn:
         return _err(req.get("id"), -32601, f"unknown method: {req.get('method')}")
     return fn(req.get("id"), req.get("params", {}))
+
+
+def _run_and_emit(req: dict) -> None:
+    """Run a handler on the RPC pool and write its response directly.
+
+    Catches any unexpected exception so a misbehaving handler can't kill
+    the worker thread silently — the caller still sees a JSON-RPC error.
+    """
+    try:
+        resp = handle_request(req)
+    except Exception as exc:
+        resp = _err(req.get("id"), -32000, f"handler error: {exc}")
+    if resp is not None:
+        write_json(resp)
+
+
+def dispatch(req: dict) -> dict | None:
+    """Route an inbound RPC — long handlers to the pool, everything else inline.
+
+    Returns the response for sync-dispatched requests so the caller
+    (entry.py) can write it. Returns None when the request has been
+    scheduled on the pool; the worker writes the response itself.
+    """
+    if req.get("method", "") in _LONG_HANDLERS:
+        _pool.submit(_run_and_emit, req)
+        return None
+    return handle_request(req)
 
 
 def _wait_agent(session: dict, rid: str, timeout: float = 30.0) -> dict | None:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -46,16 +46,10 @@ _SLASH_WORKER_TIMEOUT_S = max(5.0, float(os.environ.get("HERMES_TUI_SLASH_TIMEOU
 # else stays on the main thread so ordering stays sane for the fast path.
 # write_json is already _stdout_lock-guarded, so concurrent response
 # writes are safe.
-_LONG_HANDLERS = frozenset({
-    "cli.exec",
-    "session.branch",
-    "session.resume",
-    "shell.exec",
-    "slash.exec",
-})
-_RPC_POOL_WORKERS = max(2, int(os.environ.get("HERMES_TUI_RPC_POOL_WORKERS", "4") or 4))
+_LONG_HANDLERS = frozenset({"cli.exec", "session.branch", "session.resume", "shell.exec", "slash.exec"})
+
 _pool = concurrent.futures.ThreadPoolExecutor(
-    max_workers=_RPC_POOL_WORKERS,
+    max_workers=max(2, int(os.environ.get("HERMES_TUI_RPC_POOL_WORKERS", "4") or 4)),
     thread_name_prefix="tui-rpc",
 )
 atexit.register(lambda: _pool.shutdown(wait=False, cancel_futures=True))

--- a/ui-tui/src/__tests__/providers.test.ts
+++ b/ui-tui/src/__tests__/providers.test.ts
@@ -4,9 +4,12 @@ import { providerDisplayNames } from '../domain/providers.js'
 
 describe('providerDisplayNames', () => {
   it('returns bare names when all are unique', () => {
-    expect(providerDisplayNames([{ name: 'Anthropic', slug: 'anthropic' }, { name: 'OpenAI', slug: 'openai' }])).toEqual(
-      ['Anthropic', 'OpenAI']
-    )
+    expect(
+      providerDisplayNames([
+        { name: 'Anthropic', slug: 'anthropic' },
+        { name: 'OpenAI', slug: 'openai' }
+      ])
+    ).toEqual(['Anthropic', 'OpenAI'])
   })
 
   it('appends slug to every collision so the disambiguation is symmetric', () => {

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -46,7 +46,6 @@ const pushNote = pushUnique(6)
 const pushTool = pushUnique(8)
 
 export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev: GatewayEvent) => void {
-  const { dequeue, queueEditRef, sendQueued } = ctx.composer
   const { rpc } = ctx.gateway
   const { STARTUP_RESUME_ID, newSession, resumeById, setCatalog } = ctx.session
   const { bellOnComplete, stdout, sys } = ctx.system
@@ -392,16 +391,6 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
         if (ev.payload?.usage) {
           patchUiState(state => ({ ...state, usage: { ...state.usage, ...ev.payload!.usage } }))
-        }
-
-        if (queueEditRef.current !== null) {
-          return
-        }
-
-        const next = dequeue()
-
-        if (next) {
-          sendQueued(next)
         }
 
         return

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -193,11 +193,6 @@ export interface InputHandlerResult {
 }
 
 export interface GatewayEventHandlerContext {
-  composer: {
-    dequeue: () => string | undefined
-    queueEditRef: MutableRefObject<null | number>
-    sendQueued: (text: string) => void
-  }
   gateway: GatewayServices
   session: {
     STARTUP_RESUME_ID: string

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -7,7 +7,6 @@ import type {
   SudoRespondResponse,
   VoiceRecordResponse
 } from '../gatewayTypes.js'
-
 import { writeOsc52Clipboard } from '../lib/osc52.js'
 
 import { getInputSelection } from './inputSelectionStore.js'

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -380,12 +380,13 @@ export function useMainApp(gw: GatewayClient) {
     sys
   })
 
-  const prevSidRef = useRef<null | string>(null)
+  // Drain one queued message whenever the session settles (busy → false):
+  // agent turn ends, interrupt, shell.exec finishes, error recovered, or the
+  // session first comes up with pre-queued messages. Without this, shell.exec
+  // and error paths never emit message.complete, so anything enqueued while
+  // `!sleep` / a failed turn was running would stay stuck forever.
   useEffect(() => {
-    const prev = prevSidRef.current
-    prevSidRef.current = ui.sid
-
-    if (prev !== null || !ui.sid || ui.busy || composerRefs.queueEditRef.current !== null) {
+    if (!ui.sid || ui.busy || composerRefs.queueEditRef.current !== null) {
       return
     }
 
@@ -416,7 +417,6 @@ export function useMainApp(gw: GatewayClient) {
   const onEvent = useMemo(
     () =>
       createGatewayEventHandler({
-        composer: { dequeue: composerActions.dequeue, queueEditRef: composerRefs.queueEditRef, sendQueued },
         gateway,
         session: {
           STARTUP_RESUME_ID,
@@ -432,11 +432,8 @@ export function useMainApp(gw: GatewayClient) {
     [
       appendMessage,
       bellOnComplete,
-      composerActions,
-      composerRefs,
       gateway,
       panel,
-      sendQueued,
       session.newSession,
       session.resetSession,
       session.resumeById,

--- a/ui-tui/src/components/modelPicker.tsx
+++ b/ui-tui/src/components/modelPicker.tsx
@@ -181,7 +181,10 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
           const idx = off + i
 
           return (
-            <Text color={providerIdx === idx ? t.color.cornsilk : t.color.dim} key={providers[idx]?.slug ?? `row-${idx}`}>
+            <Text
+              color={providerIdx === idx ? t.color.cornsilk : t.color.dim}
+              key={providers[idx]?.slug ?? `row-${idx}`}
+            >
               {providerIdx === idx ? '▸ ' : '  '}
               {i + 1}. {row}
             </Text>
@@ -212,7 +215,10 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
         const idx = off + i
 
         return (
-          <Text color={modelIdx === idx ? t.color.cornsilk : t.color.dim} key={`${provider?.slug ?? 'prov'}:${idx}:${row}`}>
+          <Text
+            color={modelIdx === idx ? t.color.cornsilk : t.color.dim}
+            key={`${provider?.slug ?? 'prov'}:${idx}:${row}`}
+          >
             {modelIdx === idx ? '▸ ' : '  '}
             {i + 1}. {row}
           </Text>

--- a/ui-tui/src/components/prompts.tsx
+++ b/ui-tui/src/components/prompts.tsx
@@ -155,31 +155,21 @@ export function ConfirmPrompt({ onCancel, onConfirm, req, t }: ConfirmPromptProp
   const [sel, setSel] = useState(0)
 
   useInput((ch, key) => {
-    if (key.escape || (key.ctrl && ch.toLowerCase() === 'c')) {
-      onCancel()
-
-      return
-    }
-
     const lower = ch.toLowerCase()
 
+    if (key.escape || (key.ctrl && lower === 'c') || lower === 'n') {
+      return onCancel()
+    }
+
     if (lower === 'y') {
-      onConfirm()
-
-      return
+      return onConfirm()
     }
 
-    if (lower === 'n') {
-      onCancel()
-
-      return
-    }
-
-    if (key.upArrow && sel > 0) {
+    if (key.upArrow) {
       setSel(0)
     }
 
-    if (key.downArrow && sel < 1) {
+    if (key.downArrow) {
       setSel(1)
     }
 
@@ -189,12 +179,10 @@ export function ConfirmPrompt({ onCancel, onConfirm, req, t }: ConfirmPromptProp
   })
 
   const accent = req.danger ? t.color.error : t.color.warn
-  const confirmLabel = req.confirmLabel ?? 'Yes'
-  const cancelLabel = req.cancelLabel ?? 'No'
 
   const rows = [
-    { color: t.color.cornsilk, label: cancelLabel },
-    { color: req.danger ? t.color.error : t.color.cornsilk, label: confirmLabel }
+    { color: t.color.cornsilk, label: req.cancelLabel ?? 'No' },
+    { color: req.danger ? t.color.error : t.color.cornsilk, label: req.confirmLabel ?? 'Yes' }
   ]
 
   return (

--- a/ui-tui/src/config/env.ts
+++ b/ui-tui/src/config/env.ts
@@ -1,5 +1,3 @@
 export const STARTUP_RESUME_ID = (process.env.HERMES_TUI_RESUME ?? '').trim()
 export const MOUSE_TRACKING = !/^(?:1|true|yes|on)$/i.test((process.env.HERMES_TUI_DISABLE_MOUSE ?? '').trim())
-export const NO_CONFIRM_DESTRUCTIVE = /^(?:1|true|yes|on)$/i.test(
-  (process.env.HERMES_TUI_NO_CONFIRM ?? '').trim()
-)
+export const NO_CONFIRM_DESTRUCTIVE = /^(?:1|true|yes|on)$/i.test((process.env.HERMES_TUI_NO_CONFIRM ?? '').trim())

--- a/ui-tui/src/domain/paths.ts
+++ b/ui-tui/src/domain/paths.ts
@@ -10,8 +10,7 @@ export const fmtCwdBranch = (cwd: string, branch: null | string, max = 40) => {
     return shortCwd(cwd, max)
   }
 
-  const b = branch.length > 16 ? `…${branch.slice(-15)}` : branch
-  const tag = ` (${b})`
+  const tag = ` (${branch.length > 16 ? `…${branch.slice(-15)}` : branch})`
 
   return `${shortCwd(cwd, Math.max(8, max - tag.length))}${tag}`
 }

--- a/ui-tui/src/domain/providers.ts
+++ b/ui-tui/src/domain/providers.ts
@@ -5,13 +5,7 @@ export const providerDisplayNames = (providers: readonly { name: string; slug: s
     counts.set(p.name, (counts.get(p.name) ?? 0) + 1)
   }
 
-  return providers.map(p => {
-    const dup = (counts.get(p.name) ?? 0) > 1
-
-    if (!dup || !p.slug || p.slug === p.name) {
-      return p.name
-    }
-
-    return `${p.name} (${p.slug})`
-  })
+  return providers.map(p =>
+    (counts.get(p.name) ?? 0) > 1 && p.slug && p.slug !== p.name ? `${p.name} (${p.slug})` : p.name
+  )
 }


### PR DESCRIPTION
## What does this PR do?

Fixes the single-threaded dispatcher freeze described in #12546. The `for raw in sys.stdin` loop in `tui_gateway/entry.py` calls `handle_request()` inline, so any handler that blocks for seconds to minutes — `slash.exec` (45s), `cli.exec` (up to 600s), `shell.exec` (30s), `session.resume` / `session.branch` (synchronous `_make_agent()`) — freezes the dispatcher. While one is running, inbound RPCs including `approval.respond` and `session.interrupt` sit unread in the stdin pipe buffer and only land after the slow handler returns.

This PR routes only those five handlers onto a small `ThreadPoolExecutor`; every other handler stays on the main thread. That's Option 2 from the issue — it gives us the user-visible responsiveness win without opening up the ordering / session-state race concerns that a full pool-everything refactor would.

## Related Issue

Fixes #12546

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/server.py`
  - Add `_LONG_HANDLERS = frozenset({"cli.exec", "session.branch", "session.resume", "shell.exec", "slash.exec"})`.
  - Add `ThreadPoolExecutor(max_workers=4, thread_name_prefix="tui-rpc")` with `atexit`-registered shutdown. Worker count is overridable via `HERMES_TUI_RPC_POOL_WORKERS` (min 2).
  - New `dispatch(req)` function: routes long methods to the pool and returns `None`; everything else goes through `handle_request()` inline and returns the response.
  - New `_run_and_emit(req)` helper: runs the handler on a pool worker, catches any unexpected exception so a bug in a handler still surfaces as a JSON-RPC `-32000` error instead of dying silently, and writes the response via the already-thread-safe `write_json()`.
- `tui_gateway/entry.py`
  - Swap `handle_request` → `dispatch`. When `dispatch` returns `None` the pool worker has taken responsibility for writing the response.
- `tests/tui_gateway/test_protocol.py` — 5 new tests
  - Non-long handlers still return synchronously from `dispatch()`.
  - Long handlers return `None` from `dispatch()` and emit their response via `write_json()`.
  - A blocked long handler does not delay a concurrent fast handler (key regression guard).
  - A handler that raises still produces a structured error response on stdout.
  - Methods not in `_LONG_HANDLERS` always take the sync path.

## Why this scope is safe

- `write_json` is already `_stdout_lock`-guarded (`server.py:33, 133`), so concurrent response writes from pool workers are already safe.
- The five pool-routed handlers all return a rendered payload and don't mutate session state that fast handlers depend on — they only touch `session["slash_worker"]` (in `slash.exec`) and create new `_sessions[sid]` entries (in `session.resume` / `session.branch`, where `sid` is a fresh `uuid.uuid4().hex[:8]`).
- The ordering hazard the issue raises around `session.close` → anything is a non-issue here because `session.close` stays on the main thread; a concurrent pool-dispatched call on the closing session would just see `_sess_nowait` return `_err(rid, 4001, "session not found")`, which is already the expected error response for a race like that.
- `session.create` is already async via its own `agent_ready: threading.Event` (`server.py:1060, 1118`), and `prompt.submit` already spawns its own worker thread (`server.py:1480`). Neither changes.

## How to Test

```bash
cd hermes-agent
uv run --python 3.12 --with pytest --with pytest-xdist pytest tests/tui_gateway/ -q
# 46 passed
```

Manual repro (same script from the issue comment), before and after:

```bash
python - <<'PY'
import subprocess, sys, json, time
p = subprocess.Popen([sys.executable, '-m', 'tui_gateway.entry'],
                     stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                     text=True, bufsize=1)
def send(m): p.stdin.write(json.dumps(m) + '\n'); p.stdin.flush()
def recv(): return json.loads(p.stdout.readline())

recv()  # gateway.ready
send({'jsonrpc':'2.0','id':1,'method':'session.create','params':{'cols':80}})
sid = recv()['result']['session_id']

t0 = time.time()
send({'jsonrpc':'2.0','id':2,'method':'shell.exec','params':{'command':'sleep 3'}})
send({'jsonrpc':'2.0','id':3,'method':'terminal.resize',
      'params':{'session_id':sid,'cols':120}})

seen = set()
while seen < {2, 3}:
    r = recv()
    if (rid := r.get('id')) in {2, 3}:
        print(f'[{time.time()-t0:5.2f}s] response id={rid}')
        seen.add(rid)
p.terminate()
PY
```

Before this PR:
```
[ 3.0xs] response id=2
[ 3.0xs] response id=3   ← terminal.resize was queued behind shell.exec
```

After this PR:
```
[ 0.00s] response id=3   ← fast handler returns immediately
[ 3.01s] response id=2   ← shell.exec continues on the pool
```

Inside `hermes chat`, the equivalent UX win: `!sleep 10` no longer freezes Ctrl+C / approval prompts.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs — none covering this
- [x] PR contains only this one logical change
- [x] `pytest tests/tui_gateway/ -q` passes (46/46)
- [x] I've added tests for my changes
- [x] Tested on Ubuntu 24.04 (WSL2), Python 3.12

### Documentation & Housekeeping

- [x] Docs — N/A (one new env var, `HERMES_TUI_RPC_POOL_WORKERS`, documented in the code comment alongside `_RPC_POOL_WORKERS`)
- [x] `cli-config.yaml.example` — N/A (env var, not config key)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform — `concurrent.futures.ThreadPoolExecutor` is stdlib, works on Windows/macOS/Linux
- [x] Tool descriptions/schemas — N/A