### PR TITLE
feat(skills): add tally-forms skill for Tally.so API

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -85,6 +85,7 @@ AUTHOR_MAP = {
     "dmayhem93@gmail.com": "dmahan93",
     "samherring99@gmail.com": "samherring99",
     "desaiaum08@gmail.com": "Aum08Desai",
+    "devagarwal076@gmail.com": "DevAgarwal2",
     "shannon.sands.1979@gmail.com": "shannonsands",
     "shannon@nousresearch.com": "shannonsands",
     "eri@plasticlabs.ai": "Erosika",

--- a/skills/productivity/tally-forms/LICENSE
+++ b/skills/productivity/tally-forms/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Hermes Agent Community
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/skills/productivity/tally-forms/SKILL.md
+++ b/skills/productivity/tally-forms/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: tally-forms
+description: Tally.so API for creating and managing forms, submissions, workspaces, webhooks, and organizations via curl or Python. Build surveys, contact forms, and registration flows programmatically.
+version: 1.0.0
+author: community
+license: MIT
+metadata:
+  hermes:
+    tags: [Tally, Forms, Surveys, Productivity, API]
+    homepage: https://developers.tally.so/api-reference/introduction
+prerequisites:
+  env_vars: [TALLY_API_KEY]
+---
+
+# Tally Forms API
+
+Create and manage Tally.so forms, submissions, workspaces, webhooks, and organizations via their REST API. No OAuth required — just an API key.
+
+## Prerequisites
+
+1. Sign up at [tally.so](https://tally.so)
+2. Get your API key at [tally.so/settings/api-keys](https://tally.so/settings/api-keys) (starts with `tly-`)
+3. Store it in `~/.hermes/.env`:
+   ```
+   TALLY_API_KEY=tly-your-key-here
+   ```
+
+## API Basics
+
+- **Base URL:** `https://api.tally.so`
+- **Auth:** `Authorization: Bearer $TALLY_API_KEY`
+- **Rate limit:** 100 requests/minute
+- **Content-Type:** `application/json`
+
+## How to Use This Skill
+
+### Creating or modifying a form:
+
+1. Read `reference/blocks.md` — understand the 44+ block types and the 3-block question pattern (QUESTION + TITLE + input block sharing a `groupUuid`)
+2. Read `reference/forms.md` — POST to create, PATCH to update
+3. Read `docs/guides.md` — worked examples for contact forms, dropdowns, mentions, settings, styling
+4. **Key rule:** PATCH `/forms/:id` replaces the entire blocks array. Always GET the form first, append new blocks, then PATCH.
+
+### Fetching or managing submissions:
+
+1. Read `reference/submissions.md` — LIST with filters (date range, field values, cursor pagination), GET, DELETE
+2. See `docs/guides.md` > "Fetching Form Submissions" for the response structure with `questions` and `submissions` arrays
+
+### Setting up webhooks:
+
+1. Read `reference/webhooks.md` — CRUD + event listing and retry
+2. Event type: `FORM_RESPONSE` (fires on each new submission)
+3. Endpoints must be HTTPS and respond 2xx within 30 seconds
+
+### Managing workspaces or organizations:
+
+1. Read `reference/workspaces.md` — workspace CRUD
+2. Read `reference/organizations.md` — list/remove users, list/create/cancel invites
+3. Use `GET /users/me` (`reference/users.md`) to get the current user's organization ID
+
+## Quick Examples
+
+### Create a form (curl):
+
+```bash
+curl -X POST 'https://api.tally.so/forms' \
+  -H "Authorization: Bearer $TALLY_API_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "status": "PUBLISHED",
+    "blocks": [
+      {
+        "uuid": "550e8400-e29b-41d4-a716-446655440000",
+        "type": "FORM_TITLE",
+        "groupUuid": "660e8400-e29b-41d4-a716-446655440000",
+        "groupType": "TEXT",
+        "payload": { "html": "My Form" }
+      }
+    ]
+  }'
+```
+
+### List submissions (curl):
+
+```bash
+curl 'https://api.tally.so/forms/{formId}/submissions?limit=10' \
+  -H "Authorization: Bearer $TALLY_API_KEY"
+```
+
+### Verify API key:
+
+```bash
+curl 'https://api.tally.so/users/me' \
+  -H "Authorization: Bearer $TALLY_API_KEY"
+```
+
+## Key Concepts
+
+- **Blocks** — building units of forms. Every form is an ordered array of blocks.
+- **Question pattern** — 3 blocks with shared `groupUuid`: QUESTION (container with `isRequired`), TITLE (label HTML), input block (INPUT_TEXT, DROPDOWN, RATING, etc.)
+- **Choice nesting** — DROPDOWN_OPTION, MULTIPLE_CHOICE_OPTION, CHECKBOX use the container's `uuid` as their `groupUuid`
+- **Mentions** — dynamic field refs in HTML: `<span class="mention" data-uuid="...">@field</span>` with a `mentions` array
+- **Form statuses** — BLANK, DRAFT, PUBLISHED, DELETED
+- **Hidden fields** — populated via URL query params (`?name=John`)
+
+## Scripts
+
+Standalone Python scripts in `scripts/` (requires `pip install requests`):
+
+```bash
+python scripts/users.py                    # Verify API key
+python scripts/forms.py                    # List, create, update, delete forms
+python scripts/submissions.py <form_id>    # List submissions
+python scripts/workspaces.py               # List workspaces
+python scripts/webhooks.py <form_id>       # Manage webhooks
+python scripts/organizations.py <org_id>   # Org users and invites
+```
+
+## File Reference
+
+| Path | Contents |
+|------|----------|
+| `reference/forms.md` | Forms LIST, GET, POST, PATCH, DELETE + settings |
+| `reference/submissions.md` | Submissions LIST (filters, pagination), GET, DELETE + field value types |
+| `reference/workspaces.md` | Workspaces CRUD |
+| `reference/organizations.md` | Org users (list, remove) and invites (list, create, cancel) |
+| `reference/webhooks.md` | Webhooks CRUD + event listing, retry, payload format |
+| `reference/users.md` | GET /users/me |
+| `reference/blocks.md` | All 44+ block types, payload fields, nesting rules |
+| `scripts/*.py` | Standalone runnable scripts per endpoint group |
+| `docs/guides.md` | How-to guides from official Tally docs |
+
+## Links
+
+- [Tally API Docs](https://developers.tally.so/api-reference/introduction)
+- [Tally Dashboard](https://tally.so/dashboard)
+- [API Keys](https://tally.so/settings/api-keys)

--- a/skills/productivity/tally-forms/docs/guides.md
+++ b/skills/productivity/tally-forms/docs/guides.md
@@ -1,0 +1,311 @@
+# Tally API Documentation Guides
+
+Practical how-to guides from the official Tally documentation. Each section shows the exact API calls needed for common tasks.
+
+---
+
+## Creating a Form
+
+Create an empty form with just a title:
+
+```bash
+curl -X POST 'https://api.tally.so/forms' \
+-H 'Authorization: Bearer <token>' \
+-H 'Content-Type: application/json' \
+-d '{
+  "status": "PUBLISHED",
+  "blocks": [
+    {
+      "uuid": "6ef8675d-33cb-419b-a81e-93982e726f2e",
+      "type": "FORM_TITLE",
+      "groupUuid": "073c835f-7ad4-459c-866d-4108b6b7e2e1",
+      "groupType": "TEXT",
+      "payload": {
+        "title": "Test",
+        "html": "Test"
+      }
+    }
+  ]
+}'
+```
+
+Each block requires a unique UUID. Response returns `201` with form metadata including the `id`.
+
+---
+
+## Creating a Contact Form
+
+A form with name (INPUT_TEXT), email (INPUT_EMAIL), and message (TEXTAREA) fields:
+
+```bash
+curl -X POST 'https://api.tally.so/forms' \
+-H 'Authorization: Bearer <token>' \
+-H 'Content-Type: application/json' \
+-d '{
+  "status": "PUBLISHED",
+  "blocks": [
+    {
+      "uuid": "6ef8675d-33cb-419b-a81e-93982e726f2e",
+      "type": "FORM_TITLE",
+      "groupUuid": "073c835f-7ad4-459c-866d-4108b6b7e2e1",
+      "groupType": "TEXT",
+      "payload": { "html": "Contact form" }
+    },
+    {
+      "uuid": "48b4cdf3-2c9d-47d3-b8fb-b0ccabc5cd84",
+      "type": "TITLE",
+      "groupUuid": "93034250-5f05-4710-b8e0-5c9145c5b9ea",
+      "groupType": "QUESTION",
+      "payload": { "html": "Name" }
+    },
+    {
+      "uuid": "884ff838-97f9-4ac9-8db1-31aa052df988",
+      "type": "INPUT_TEXT",
+      "groupUuid": "93034250-5f05-4710-b8e0-5c9145c5b9ea",
+      "groupType": "QUESTION",
+      "payload": { "isRequired": true, "placeholder": "Enter your name" }
+    },
+    {
+      "uuid": "7d9c2e31-b5aa-4c8b-9c2d-123456789abc",
+      "type": "TITLE",
+      "groupUuid": "3287d15c-c2b2-4f84-a915-bc57380a4b51",
+      "groupType": "QUESTION",
+      "payload": { "html": "Email" }
+    },
+    {
+      "uuid": "9b3f5d2a-1c8e-4f7d-b6a9-def012345678",
+      "type": "INPUT_EMAIL",
+      "groupUuid": "3287d15c-c2b2-4f84-a915-bc57380a4b51",
+      "groupType": "QUESTION",
+      "payload": { "isRequired": true, "placeholder": "Enter your email" }
+    },
+    {
+      "uuid": "abc12345-6789-def0-1234-56789abcdef0",
+      "type": "TITLE",
+      "groupUuid": "456789ab-cdef-4321-b8e0-987654321def",
+      "groupType": "QUESTION",
+      "payload": { "html": "Message" }
+    },
+    {
+      "uuid": "456789ab-cdef-0123-4567-89abcdef0123",
+      "type": "TEXTAREA",
+      "groupUuid": "456789ab-cdef-4321-b8e0-987654321def",
+      "groupType": "QUESTION",
+      "payload": { "isRequired": true, "placeholder": "Enter your message" }
+    }
+  ]
+}'
+```
+
+Pattern: each question uses a shared `groupUuid` for its TITLE + input block pair.
+
+---
+
+## Creating a Dropdown
+
+Dropdown options are `DROPDOWN_OPTION` blocks sharing the same `groupUuid`. Use `index` for ordering and `text` for the label.
+
+```bash
+curl -X POST 'https://api.tally.so/forms' \
+-H 'Authorization: Bearer <token>' \
+-H 'Content-Type: application/json' \
+-d '{
+  "status": "PUBLISHED",
+  "blocks": [
+    {
+      "uuid": "6ef8675d-33cb-419b-a81e-93982e726f2e",
+      "type": "FORM_TITLE",
+      "groupUuid": "073c835f-7ad4-459c-866d-4108b6b7e2e1",
+      "groupType": "TEXT",
+      "payload": { "title": "Dropdown example", "html": "Dropdown example" }
+    },
+    {
+      "uuid": "2515b4dd-54e3-4502-afe6-074ad5019b44",
+      "type": "TITLE",
+      "groupUuid": "22a0af81-0117-4931-806f-2b83e374275b",
+      "groupType": "QUESTION",
+      "payload": { "html": "What'\''s your favorite color?" }
+    },
+    {
+      "uuid": "338631d5-64b0-4a55-8219-17658e66196b",
+      "type": "DROPDOWN_OPTION",
+      "groupUuid": "aa64831b-8695-4887-afba-31c07034cd77",
+      "groupType": "DROPDOWN",
+      "payload": { "index": 0, "text": "Red" }
+    },
+    {
+      "uuid": "4c8fe10a-b07e-407e-9347-f64d73a9ba9a",
+      "type": "DROPDOWN_OPTION",
+      "groupUuid": "aa64831b-8695-4887-afba-31c07034cd77",
+      "groupType": "DROPDOWN",
+      "payload": { "index": 1, "text": "Green" }
+    },
+    {
+      "uuid": "3bddc101-571b-4f00-aa7a-30ee629441bc",
+      "type": "DROPDOWN_OPTION",
+      "groupUuid": "aa64831b-8695-4887-afba-31c07034cd77",
+      "groupType": "DROPDOWN",
+      "payload": { "index": 2, "text": "Blue" }
+    }
+  ]
+}'
+```
+
+All dropdown options must share the same `groupUuid`.
+
+---
+
+## Creating a Form with Settings
+
+Settings cover language, closing rules, submission limits, email notifications, redirects, mentions in settings, and custom themes.
+
+Key settings fields:
+- `language` — form language code (e.g. `"fr"`)
+- `closeDate`, `closeTime`, `closeTimezone` — auto-close schedule
+- `submissionsLimit` — max submissions allowed
+- `uniqueSubmissionKey` — enforce one submission per unique field value (uses mentions)
+- `redirectOnCompletion` — URL redirect after submit (can use mentions for dynamic URLs)
+- `hasSelfEmailNotifications`, `selfEmailTo`, `selfEmailReplyTo`, `selfEmailBody` — email notifications with mention support
+- `styles` — custom theme with `theme: "CUSTOM"`, `color` object, and `css` for custom CSS
+
+Example settings object:
+```json
+{
+  "language": "fr",
+  "closeDate": "2026-01-09",
+  "closeTime": "09:41",
+  "closeTimezone": "Europe/Paris",
+  "submissionsLimit": 42,
+  "styles": {
+    "theme": "CUSTOM",
+    "color": {
+      "background": "#ffffff",
+      "text": "#37352f",
+      "accent": "#007aff",
+      "buttonBackground": "#007aff",
+      "buttonText": "#ffffff"
+    },
+    "css": ".tally-submit-button svg { display: none; }",
+    "direction": "ltr"
+  }
+}
+```
+
+---
+
+## Creating a Mention
+
+Mentions let you reference field values dynamically in titles, descriptions, and settings. They use a `<span class="mention" data-uuid="...">@fieldName</span>` HTML pattern paired with a `mentions` array.
+
+```json
+{
+  "html": "Hello <span class=\"mention\" data-uuid=\"0f7b3637-61b6-4faa-a93a-a6a31ff5ac63\">@name</span>",
+  "mentions": [
+    {
+      "uuid": "0f7b3637-61b6-4faa-a93a-a6a31ff5ac63",
+      "field": {
+        "uuid": "16826368-6cce-4066-b1da-be466f851c2d",
+        "type": "HIDDEN_FIELD",
+        "questionType": "HIDDEN_FIELDS",
+        "blockGroupUuid": "203e6532-22a0-4421-b720-5d88d603e618",
+        "title": "name"
+      },
+      "defaultValue": "there"
+    }
+  ]
+}
+```
+
+Hidden fields are populated via query parameters: `https://tally.so/r/{formId}?name=John`
+
+---
+
+## Fetching Form Submissions
+
+```bash
+curl -X GET 'https://api.tally.so/forms/:id/submissions' \
+-H 'Authorization: Bearer <token>'
+```
+
+Response structure:
+```json
+{
+  "page": 1,
+  "limit": 50,
+  "hasMore": false,
+  "totalNumberOfSubmissionsPerFilter": {
+    "all": 4,
+    "completed": 4,
+    "partial": 0
+  },
+  "questions": [
+    {
+      "id": "EKOE2N",
+      "type": "INPUT_TEXT",
+      "title": "First name",
+      "fields": [
+        {
+          "uuid": "21dd98ef-4c54-4e77-bcc6-7ec79409b3ea",
+          "type": "INPUT_FIELD",
+          "questionType": "INPUT_TEXT",
+          "title": "First name"
+        }
+      ]
+    }
+  ],
+  "submissions": [
+    {
+      "id": "GG6z5L",
+      "formId": "mexJoq",
+      "respondentId": "jzQdR9",
+      "isCompleted": true,
+      "submittedAt": "2024-12-30T09:02:01.000Z",
+      "responses": [
+        {
+          "id": "4r5rAWb",
+          "questionId": "EKOE2N",
+          "answer": "Filip"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Note: The response includes a `questions` array mapping question IDs to field metadata, and a `submissions` array with `responses` keyed by `questionId`.
+
+---
+
+## Styling Title Blocks
+
+Use HTML markup in the `html` payload field to style text:
+
+```json
+{
+  "html": "What's your <span style=\"color: #eb4d4b\"><i><b>name</b></i></span>?"
+}
+```
+
+Supported HTML tags: `<b>`, `<i>`, `<u>`, `<span style="color: ...">`, `<a href="...">`.
+
+---
+
+## Adding Blocks to a Form
+
+Use `PATCH /forms/:id` with the **complete** blocks array. You must include all existing blocks plus your new ones — the API replaces the entire blocks array.
+
+```bash
+curl -X PATCH 'https://api.tally.so/forms/:id' \
+-H 'Authorization: Bearer <token>' \
+-H 'Content-Type: application/json' \
+-d '{
+  "name": "Test",
+  "status": "PUBLISHED",
+  "blocks": [
+    ... all existing blocks ...,
+    ... new blocks ...
+  ]
+}'
+```
+
+**Important:** Always GET the form first to retrieve current blocks, then append your new blocks to that array before PATCHing.

--- a/skills/productivity/tally-forms/reference/blocks.md
+++ b/skills/productivity/tally-forms/reference/blocks.md
@@ -1,0 +1,199 @@
+# Block Types Reference
+
+Blocks are the building units of Tally forms. Every form is an ordered array of blocks. Each block has a `type`, a `uuid`, a `groupUuid` (linking it to a parent group), a `groupType`, and a `payload` with type-specific data.
+
+## Block Structure
+
+```json
+{
+  "uuid": "550e8400-e29b-41d4-a716-446655440000",
+  "type": "INPUT_TEXT",
+  "groupUuid": "660e8400-e29b-41d4-a716-446655440000",
+  "groupType": "QUESTION",
+  "payload": {
+    "isRequired": false,
+    "isHidden": false,
+    "placeholder": "",
+    "name": "question_abc12345"
+  }
+}
+```
+
+## Question Pattern
+
+Most input blocks follow the same 3-block pattern within a shared `groupUuid`:
+
+1. **QUESTION** block — container with `isRequired` and `isHidden`
+2. **TITLE** block — the question label (HTML in `payload.html`)
+3. **Input block** — the actual field (INPUT_TEXT, INPUT_EMAIL, DROPDOWN, etc.)
+
+```json
+[
+  { "type": "QUESTION",   "groupUuid": "G1", "groupType": "QUESTION", "payload": { "isRequired": true } },
+  { "type": "TITLE",      "groupUuid": "G1", "groupType": "QUESTION", "payload": { "html": "<p>Your name?</p>" } },
+  { "type": "INPUT_TEXT",  "groupUuid": "G1", "groupType": "QUESTION", "payload": { "placeholder": "Jane Doe" } }
+]
+```
+
+---
+
+## All Block Types
+
+### Form Structure
+
+| Type | Description | Key Payload Fields |
+|------|-------------|-------------------|
+| FORM_TITLE | Form title/header block | `html`, `logo`, `cover` |
+| TITLE | Question label / title text | `html` |
+| QUESTION | Question container (groups an input + title) | `isRequired`, `isHidden` |
+| TEXT | Free text / description paragraph | `html` |
+| LABEL | Static label text | `html` |
+| PAGE_BREAK | Page separator for multi-page forms | `name` |
+| DIVIDER | Visual horizontal rule | `isHidden` |
+
+### Headings
+
+| Type | Description | Key Payload Fields |
+|------|-------------|-------------------|
+| HEADING_1 | Large heading | `html` |
+| HEADING_2 | Medium heading | `html` |
+| HEADING_3 | Small heading | `html` |
+
+### Text Inputs
+
+| Type | Description | Key Payload Fields |
+|------|-------------|-------------------|
+| INPUT_TEXT | Single-line text | `isRequired`, `placeholder`, `name` |
+| TEXTAREA | Multi-line text | `isRequired`, `placeholder`, `name` |
+
+### Specialized Inputs
+
+| Type | Description | Key Payload Fields |
+|------|-------------|-------------------|
+| INPUT_EMAIL | Email with validation | `isRequired`, `placeholder`, `name` |
+| INPUT_NUMBER | Numeric input | `isRequired`, `name`, `hasMinNumber`, `minNumber`, `hasMaxNumber`, `maxNumber` |
+| INPUT_LINK | URL input | `isRequired`, `placeholder`, `name` |
+| INPUT_PHONE_NUMBER | Phone number | `isRequired`, `placeholder`, `name` |
+| INPUT_DATE | Date picker | `isRequired`, `name` |
+| INPUT_TIME | Time picker | `isRequired`, `name` |
+
+### Choice Inputs
+
+| Type | Description | Key Payload Fields |
+|------|-------------|-------------------|
+| MULTIPLE_CHOICE | Radio button group (container) | — |
+| MULTIPLE_CHOICE_OPTION | Single radio option | `label` |
+| CHECKBOXES | Checkbox group (container) | — |
+| CHECKBOX | Single checkbox option | `label` |
+| DROPDOWN | Dropdown select (container) | — |
+| DROPDOWN_OPTION | Single dropdown option | `label` |
+| MULTI_SELECT | Multi-select tags (container) | — |
+| MULTI_SELECT_OPTION | Single multi-select option | `label` |
+| RANKING | Ranking container | — |
+| RANKING_OPTION | Single ranking option | `label` |
+
+### Scale & Rating
+
+| Type | Description | Key Payload Fields |
+|------|-------------|-------------------|
+| RATING | Star rating | `isRequired`, `maxRating` |
+| LINEAR_SCALE | Numeric scale | `isRequired`, `min`, `max`, `minLabel`, `maxLabel` |
+
+### Matrix
+
+| Type | Description | Key Payload Fields |
+|------|-------------|-------------------|
+| MATRIX | Matrix/grid container | — |
+| MATRIX_ROW | Matrix row label | `label` |
+| MATRIX_COLUMN | Matrix column label | `label` |
+
+### Media
+
+| Type | Description | Key Payload Fields |
+|------|-------------|-------------------|
+| IMAGE | Embedded image | `url`, `alt` |
+| EMBED | Generic embed (iframe) | `url` |
+| EMBED_VIDEO | Video embed | `url` |
+| EMBED_AUDIO | Audio embed | `url` |
+
+### File & Signature
+
+| Type | Description | Key Payload Fields |
+|------|-------------|-------------------|
+| FILE_UPLOAD | File upload field | `isRequired`, `allowedFileTypes`, `maxFileSize` |
+| SIGNATURE | Signature pad | `isRequired` |
+
+### Payment
+
+| Type | Description | Key Payload Fields |
+|------|-------------|-------------------|
+| PAYMENT | Payment collection (Stripe) | `amount`, `currency`, `description` |
+| WALLET_CONNECT | Crypto wallet connect | — |
+
+### Advanced / Logic
+
+| Type | Description | Key Payload Fields |
+|------|-------------|-------------------|
+| HIDDEN_FIELDS | Pre-filled hidden fields | `fields` (array of key-value) |
+| CONDITIONAL_LOGIC | Show/hide blocks based on answers | `conditions`, `action` |
+| CALCULATED_FIELDS | Computed values from other fields | `formula` |
+| CAPTCHA | Bot protection | — |
+| RESPONDENT_COUNTRY | Auto-detected country | — |
+
+---
+
+## Nesting Rules
+
+- **QUESTION** groups: `groupType` = `"QUESTION"`, children share the same `groupUuid`
+- **Choice containers** (MULTIPLE_CHOICE, CHECKBOXES, DROPDOWN, MULTI_SELECT, RANKING): options use the container's `uuid` as their `groupUuid` and the container type as `groupType`
+- **MATRIX**: rows and columns use the matrix block's `uuid` as `groupUuid`
+- **Standalone blocks** (DIVIDER, PAGE_BREAK, HEADING_*, IMAGE, etc.): `groupUuid` = own `uuid`, `groupType` = own `type`
+
+## Example: Complete Dropdown Question
+
+```json
+[
+  {
+    "uuid": "q1",
+    "type": "QUESTION",
+    "groupUuid": "g1",
+    "groupType": "QUESTION",
+    "payload": { "isRequired": true, "isHidden": false }
+  },
+  {
+    "uuid": "t1",
+    "type": "TITLE",
+    "groupUuid": "g1",
+    "groupType": "QUESTION",
+    "payload": { "html": "<p>Select your country</p>" }
+  },
+  {
+    "uuid": "d1",
+    "type": "DROPDOWN",
+    "groupUuid": "g1",
+    "groupType": "QUESTION",
+    "payload": {}
+  },
+  {
+    "uuid": "o1",
+    "type": "DROPDOWN_OPTION",
+    "groupUuid": "d1",
+    "groupType": "DROPDOWN",
+    "payload": { "label": "United States" }
+  },
+  {
+    "uuid": "o2",
+    "type": "DROPDOWN_OPTION",
+    "groupUuid": "d1",
+    "groupType": "DROPDOWN",
+    "payload": { "label": "United Kingdom" }
+  },
+  {
+    "uuid": "o3",
+    "type": "DROPDOWN_OPTION",
+    "groupUuid": "d1",
+    "groupType": "DROPDOWN",
+    "payload": { "label": "Canada" }
+  }
+]
+```

--- a/skills/productivity/tally-forms/reference/forms.md
+++ b/skills/productivity/tally-forms/reference/forms.md
@@ -1,0 +1,239 @@
+# Forms API Reference
+
+Base URL: `https://api.tally.so`
+
+## Endpoints
+
+### List Forms
+```
+GET /forms
+```
+
+Returns a paginated array of form objects.
+
+**Query Parameters:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| page | number | No | Page number (default: 1) |
+| limit | number | No | Items per page (default: 50, max: 500) |
+| workspaceIds | array | No | Filter by workspace IDs |
+
+**Response (200):**
+```json
+{
+  "items": [
+    {
+      "id": "form-id",
+      "name": "Form Name",
+      "workspaceId": "workspace-id",
+      "status": "PUBLISHED",
+      "numberOfSubmissions": 42,
+      "isClosed": false,
+      "createdAt": "2024-01-01T00:00:00Z",
+      "updatedAt": "2024-01-02T00:00:00Z"
+    }
+  ],
+  "page": 1,
+  "limit": 50,
+  "total": 100,
+  "hasMore": true
+}
+```
+
+---
+
+### Get Form
+```
+GET /forms/{formId}
+```
+
+Returns a single form by its ID with all its blocks and settings.
+
+**Path Parameters:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| formId | string | Yes | The ID of the form |
+
+**Response (200):**
+```json
+{
+  "id": "form-id",
+  "name": "Form Name",
+  "workspaceId": "workspace-id",
+  "status": "PUBLISHED",
+  "numberOfSubmissions": 42,
+  "isClosed": false,
+  "settings": {
+    "language": "en",
+    "isClosed": false,
+    "hasProgressBar": false,
+    "hasPartialSubmissions": false
+  },
+  "blocks": [
+    {
+      "uuid": "block-uuid",
+      "type": "FORM_TITLE",
+      "groupUuid": "group-uuid",
+      "groupType": "FORM_TITLE",
+      "payload": {
+        "html": "<h1>Form Title</h1>"
+      }
+    }
+  ],
+  "createdAt": "2024-01-01T00:00:00Z",
+  "updatedAt": "2024-01-02T00:00:00Z"
+}
+```
+
+---
+
+### Create Form
+```
+POST /forms
+```
+
+Creates a new form, optionally based on a template or within a specific workspace.
+
+**Request Body:**
+```json
+{
+  "workspaceId": "workspace-id",
+  "templateId": "template-id",
+  "status": "DRAFT",
+  "blocks": [
+    {
+      "uuid": "uuid-v4",
+      "type": "FORM_TITLE",
+      "groupUuid": "uuid-v4",
+      "groupType": "FORM_TITLE",
+      "payload": {
+        "html": "<h1>Form Title</h1>"
+      }
+    }
+  ],
+  "settings": {
+    "language": "en",
+    "isClosed": false
+  }
+}
+```
+
+**Fields:**
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| status | string | Yes | BLANK, DRAFT, or PUBLISHED |
+| blocks | array | Yes | Array of block objects |
+| workspaceId | string | No | Target workspace ID |
+| templateId | string | No | Template to base form on |
+| settings | object | No | Form settings object |
+
+**Response (201):**
+Returns the created form object.
+
+---
+
+### Update Form
+```
+PATCH /forms/{formId}
+```
+
+Updates a form's settings, blocks, or status.
+
+**Path Parameters:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| formId | string | Yes | The ID of the form |
+
+**Request Body:**
+```json
+{
+  "name": "New Form Name",
+  "status": "PUBLISHED",
+  "blocks": [...],
+  "settings": {...}
+}
+```
+
+**Response (200):**
+Returns the updated form object.
+
+---
+
+### Delete Form
+```
+DELETE /forms/{formId}
+```
+
+Deletes a form by its ID and moves it to the trash.
+
+**Path Parameters:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| formId | string | Yes | The ID of the form |
+
+**Response (204):**
+No content on success.
+
+---
+
+## Form Status Values
+
+| Status | Description |
+|--------|-------------|
+| BLANK | Empty form, just created |
+| DRAFT | Has content but not published |
+| PUBLISHED | Live and accepting responses |
+| DELETED | Moved to trash |
+
+## Form Settings Object
+
+| Field | Type | Description |
+|-------|------|-------------|
+| language | string | Form language (e.g., "en") |
+| isClosed | boolean | Whether form is closed |
+| closeMessageTitle | string | Message when form is closed |
+| closeMessageDescription | string | Description when closed |
+| submissionsLimit | integer | Max number of submissions |
+| redirectOnCompletion | string | URL to redirect after submit |
+| hasProgressBar | boolean | Show progress bar |
+| hasPartialSubmissions | boolean | Allow partial submissions |
+| saveForLater | boolean | Enable save for later |
+
+## Example: Complete Form Object
+
+```json
+{
+  "id": "mKz8pQ",
+  "name": "Contact Us",
+  "workspaceId": "wAb3xY",
+  "status": "PUBLISHED",
+  "numberOfSubmissions": 156,
+  "isClosed": false,
+  "settings": {
+    "language": "en",
+    "isClosed": false,
+    "closeMessageTitle": "Form Closed",
+    "closeMessageDescription": "Thank you for your interest!",
+    "submissionsLimit": null,
+    "redirectOnCompletion": null,
+    "hasProgressBar": true,
+    "hasPartialSubmissions": false,
+    "saveForLater": true
+  },
+  "blocks": [
+    {
+      "uuid": "550e8400-e29b-41d4-a716-446655440000",
+      "type": "FORM_TITLE",
+      "groupUuid": "550e8400-e29b-41d4-a716-446655440000",
+      "groupType": "FORM_TITLE",
+      "payload": {
+        "html": "<h1>Contact Us</h1>",
+        "logo": null,
+        "cover": null
+      }
+    }
+  ],
+  "createdAt": "2024-01-01T00:00:00.000Z",
+  "updatedAt": "2024-01-15T12:30:00.000Z"
+}
+```

--- a/skills/productivity/tally-forms/reference/organizations.md
+++ b/skills/productivity/tally-forms/reference/organizations.md
@@ -1,0 +1,148 @@
+# Organizations API Reference
+
+Base URL: `https://api.tally.so`
+
+## Users
+
+### List Organization Users
+```
+GET /organizations/{organizationId}/users
+```
+
+Returns all users in an organization.
+
+**Path Parameters:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| organizationId | string | Yes | The organization ID |
+
+**Response (200):**
+```json
+{
+  "items": [
+    {
+      "id": "user-id",
+      "email": "user@example.com",
+      "name": "Jane Doe",
+      "role": "ADMIN",
+      "joinedAt": "2024-01-01T00:00:00Z"
+    }
+  ]
+}
+```
+
+---
+
+### Remove Organization User
+```
+DELETE /organizations/{organizationId}/users/{userId}
+```
+
+Removes a user from the organization.
+
+**Path Parameters:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| organizationId | string | Yes | The organization ID |
+| userId | string | Yes | The user ID to remove |
+
+**Response (204):**
+No content on success.
+
+---
+
+## Invites
+
+### List Organization Invites
+```
+GET /organizations/{organizationId}/invites
+```
+
+Returns all pending invites for an organization.
+
+**Path Parameters:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| organizationId | string | Yes | The organization ID |
+
+**Response (200):**
+```json
+{
+  "items": [
+    {
+      "id": "invite-id",
+      "email": "invitee@example.com",
+      "role": "MEMBER",
+      "status": "PENDING",
+      "createdAt": "2024-01-10T00:00:00Z",
+      "expiresAt": "2024-01-17T00:00:00Z"
+    }
+  ]
+}
+```
+
+---
+
+### Create Invite
+```
+POST /organizations/{organizationId}/invites
+```
+
+Sends an invitation to join the organization.
+
+**Path Parameters:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| organizationId | string | Yes | The organization ID |
+
+**Request Body:**
+```json
+{
+  "email": "newuser@example.com",
+  "role": "MEMBER"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| email | string | Yes | Email address to invite |
+| role | string | No | Role to assign (ADMIN or MEMBER, default: MEMBER) |
+
+**Response (201):**
+Returns the created invite object.
+
+---
+
+### Cancel Invite
+```
+DELETE /organizations/{organizationId}/invites/{inviteId}
+```
+
+Cancels a pending invitation.
+
+**Path Parameters:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| organizationId | string | Yes | The organization ID |
+| inviteId | string | Yes | The invite ID to cancel |
+
+**Response (204):**
+No content on success.
+
+---
+
+## Role Values
+
+| Role | Description |
+|------|-------------|
+| ADMIN | Full access, can manage users and billing |
+| MEMBER | Can create and manage forms within assigned workspaces |
+
+## Invite Status Values
+
+| Status | Description |
+|--------|-------------|
+| PENDING | Invite sent, awaiting acceptance |
+| ACCEPTED | User accepted the invite |
+| EXPIRED | Invite expired (7 days) |
+| CANCELLED | Invite was cancelled |

--- a/skills/productivity/tally-forms/reference/submissions.md
+++ b/skills/productivity/tally-forms/reference/submissions.md
@@ -1,0 +1,184 @@
+# Submissions API Reference
+
+Base URL: `https://api.tally.so`
+
+## Endpoints
+
+### List Submissions
+```
+GET /forms/{formId}/submissions
+```
+
+Returns a paginated list of submissions for a form.
+
+**Path Parameters:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| formId | string | Yes | The ID of the form |
+
+**Query Parameters:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| page | number | No | Page number (default: 1) |
+| limit | number | No | Items per page (default: 50, max: 500) |
+| filter | string | No | Filter expression for field values |
+| startDate | string | No | ISO 8601 date — only submissions after this date |
+| endDate | string | No | ISO 8601 date — only submissions before this date |
+| afterId | string | No | Return submissions after this submission ID (cursor pagination) |
+
+**Response (200):**
+```json
+{
+  "items": [
+    {
+      "id": "submission-id",
+      "formId": "form-id",
+      "respondentId": "respondent-id",
+      "createdAt": "2024-01-15T10:30:00Z",
+      "updatedAt": "2024-01-15T10:30:00Z",
+      "isCompleted": true,
+      "fields": [
+        {
+          "key": "question_abc12345",
+          "label": "Your Name",
+          "type": "INPUT_TEXT",
+          "value": "Jane Doe"
+        },
+        {
+          "key": "email_def67890",
+          "label": "Email",
+          "type": "INPUT_EMAIL",
+          "value": "jane@example.com"
+        }
+      ]
+    }
+  ],
+  "page": 1,
+  "limit": 50,
+  "total": 156,
+  "hasMore": true
+}
+```
+
+**Filter Examples:**
+
+Filter submissions where a field equals a value:
+```
+GET /forms/{formId}/submissions?filter=question_abc12345:eq:Jane
+```
+
+---
+
+### Get Submission
+```
+GET /forms/{formId}/submissions/{submissionId}
+```
+
+Returns a single submission by ID.
+
+**Path Parameters:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| formId | string | Yes | The ID of the form |
+| submissionId | string | Yes | The ID of the submission |
+
+**Response (200):**
+```json
+{
+  "id": "submission-id",
+  "formId": "form-id",
+  "respondentId": "respondent-id",
+  "createdAt": "2024-01-15T10:30:00Z",
+  "updatedAt": "2024-01-15T10:30:00Z",
+  "isCompleted": true,
+  "fields": [
+    {
+      "key": "question_abc12345",
+      "label": "Your Name",
+      "type": "INPUT_TEXT",
+      "value": "Jane Doe"
+    }
+  ]
+}
+```
+
+---
+
+### Delete Submission
+```
+DELETE /forms/{formId}/submissions/{submissionId}
+```
+
+Permanently deletes a submission.
+
+**Path Parameters:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| formId | string | Yes | The ID of the form |
+| submissionId | string | Yes | The ID of the submission |
+
+**Response (204):**
+No content on success.
+
+---
+
+## Submission Fields Object
+
+Each field in the `fields` array contains:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| key | string | The unique field identifier (matches block name) |
+| label | string | Human-readable field label |
+| type | string | Block type (INPUT_TEXT, INPUT_EMAIL, MULTIPLE_CHOICE, etc.) |
+| value | any | The submitted value — string, number, array, or object |
+
+### Value Types by Field
+
+| Block Type | Value Type | Example |
+|------------|-----------|---------|
+| INPUT_TEXT / TEXTAREA | string | `"Hello world"` |
+| INPUT_EMAIL | string | `"user@example.com"` |
+| INPUT_NUMBER | number | `42` |
+| INPUT_DATE | string | `"2024-01-15"` |
+| INPUT_TIME | string | `"14:30"` |
+| INPUT_PHONE_NUMBER | string | `"+1234567890"` |
+| INPUT_LINK | string | `"https://example.com"` |
+| MULTIPLE_CHOICE | string | `"Option A"` |
+| CHECKBOXES | array | `["Option A", "Option B"]` |
+| DROPDOWN | string | `"Option A"` |
+| MULTI_SELECT | array | `["Tag1", "Tag2"]` |
+| RATING | number | `4` |
+| LINEAR_SCALE | number | `7` |
+| FILE_UPLOAD | array | `[{"name": "file.pdf", "url": "https://..."}]` |
+| SIGNATURE | string | Base64 encoded image data |
+| MATRIX | object | `{"Row 1": "Column A", "Row 2": "Column B"}` |
+| RANKING | array | `["First", "Second", "Third"]` |
+| PAYMENT | object | `{"amount": 1000, "currency": "USD", "status": "paid"}` |
+
+## Example: Pagination with Cursor
+
+```python
+submissions = []
+after_id = None
+
+while True:
+    params = {"limit": 100}
+    if after_id:
+        params["afterId"] = after_id
+    
+    response = GET /forms/{formId}/submissions?{params}
+    
+    submissions.extend(response["items"])
+    
+    if not response["hasMore"]:
+        break
+    
+    after_id = response["items"][-1]["id"]
+```
+
+## Example: Date Filtering
+
+```
+GET /forms/{formId}/submissions?startDate=2024-01-01T00:00:00Z&endDate=2024-01-31T23:59:59Z
+```

--- a/skills/productivity/tally-forms/reference/users.md
+++ b/skills/productivity/tally-forms/reference/users.md
@@ -1,0 +1,44 @@
+# Users API Reference
+
+Base URL: `https://api.tally.so`
+
+## Endpoints
+
+### Get Current User
+```
+GET /users/me
+```
+
+Returns the authenticated user's profile information.
+
+**Response (200):**
+```json
+{
+  "id": "user-id",
+  "email": "user@example.com",
+  "name": "Jane Doe",
+  "organizationId": "org-id",
+  "createdAt": "2024-01-01T00:00:00Z",
+  "updatedAt": "2024-01-02T00:00:00Z"
+}
+```
+
+---
+
+## User Object
+
+| Field | Type | Description |
+|-------|------|-------------|
+| id | string | Unique user identifier |
+| email | string | User's email address |
+| name | string | User's display name |
+| organizationId | string | User's organization ID |
+| createdAt | string | ISO 8601 creation timestamp |
+| updatedAt | string | ISO 8601 last update timestamp |
+
+## Usage
+
+This endpoint is useful for:
+- Verifying API key validity
+- Getting the user's organization ID (needed for organization endpoints)
+- Displaying the authenticated user's info

--- a/skills/productivity/tally-forms/reference/webhooks.md
+++ b/skills/productivity/tally-forms/reference/webhooks.md
@@ -1,0 +1,204 @@
+# Webhooks API Reference
+
+Base URL: `https://api.tally.so`
+
+## Endpoints
+
+### List Webhooks
+```
+GET /webhooks
+```
+
+Returns all webhooks for the authenticated user.
+
+**Query Parameters:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| formId | string | No | Filter webhooks by form ID |
+
+**Response (200):**
+```json
+{
+  "items": [
+    {
+      "id": "webhook-id",
+      "formId": "form-id",
+      "url": "https://example.com/webhook",
+      "isActive": true,
+      "eventTypes": ["FORM_RESPONSE"],
+      "createdAt": "2024-01-01T00:00:00Z",
+      "updatedAt": "2024-01-02T00:00:00Z"
+    }
+  ]
+}
+```
+
+---
+
+### Create Webhook
+```
+POST /webhooks
+```
+
+Creates a new webhook subscription.
+
+**Request Body:**
+```json
+{
+  "formId": "form-id",
+  "url": "https://example.com/webhook",
+  "eventTypes": ["FORM_RESPONSE"]
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| formId | string | Yes | Form ID to subscribe to |
+| url | string | Yes | HTTPS URL to receive webhook events |
+| eventTypes | array | Yes | Event types to subscribe to |
+
+**Response (201):**
+Returns the created webhook object.
+
+---
+
+### Update Webhook
+```
+PATCH /webhooks/{webhookId}
+```
+
+Updates a webhook's URL, status, or event types.
+
+**Path Parameters:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| webhookId | string | Yes | The webhook ID |
+
+**Request Body:**
+```json
+{
+  "url": "https://example.com/new-webhook",
+  "isActive": true,
+  "eventTypes": ["FORM_RESPONSE"]
+}
+```
+
+**Response (200):**
+Returns the updated webhook object.
+
+---
+
+### Delete Webhook
+```
+DELETE /webhooks/{webhookId}
+```
+
+Deletes a webhook subscription.
+
+**Path Parameters:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| webhookId | string | Yes | The webhook ID |
+
+**Response (204):**
+No content on success.
+
+---
+
+### List Webhook Events
+```
+GET /webhooks/{webhookId}/events
+```
+
+Returns delivery history for a webhook.
+
+**Path Parameters:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| webhookId | string | Yes | The webhook ID |
+
+**Response (200):**
+```json
+{
+  "items": [
+    {
+      "id": "event-id",
+      "webhookId": "webhook-id",
+      "eventType": "FORM_RESPONSE",
+      "status": "DELIVERED",
+      "statusCode": 200,
+      "payload": { ... },
+      "createdAt": "2024-01-15T10:30:00Z",
+      "deliveredAt": "2024-01-15T10:30:01Z"
+    }
+  ]
+}
+```
+
+---
+
+### Retry Webhook Event
+```
+POST /webhooks/{webhookId}/events/{eventId}/retry
+```
+
+Retries delivery of a failed webhook event.
+
+**Path Parameters:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| webhookId | string | Yes | The webhook ID |
+| eventId | string | Yes | The event ID to retry |
+
+**Response (200):**
+Returns the retried event object.
+
+---
+
+## Event Types
+
+| Event Type | Description |
+|------------|-------------|
+| FORM_RESPONSE | Triggered when a form receives a new submission |
+
+## Webhook Payload (FORM_RESPONSE)
+
+When a submission is received, the webhook sends a POST request with:
+
+```json
+{
+  "eventId": "event-id",
+  "eventType": "FORM_RESPONSE",
+  "createdAt": "2024-01-15T10:30:00Z",
+  "data": {
+    "formId": "form-id",
+    "formName": "Contact Us",
+    "submissionId": "submission-id",
+    "respondentId": "respondent-id",
+    "createdAt": "2024-01-15T10:30:00Z",
+    "fields": [
+      {
+        "key": "question_abc12345",
+        "label": "Your Name",
+        "type": "INPUT_TEXT",
+        "value": "Jane Doe"
+      }
+    ]
+  }
+}
+```
+
+## Event Delivery Status
+
+| Status | Description |
+|--------|-------------|
+| DELIVERED | Successfully delivered (2xx response) |
+| FAILED | Delivery failed (non-2xx or timeout) |
+| PENDING | Queued for delivery |
+
+## Best Practices
+
+- Use HTTPS URLs only for webhook endpoints
+- Respond with a 2xx status code within 30 seconds
+- Implement idempotency — events may be delivered more than once
+- Use webhook events instead of polling submissions for real-time updates

--- a/skills/productivity/tally-forms/reference/workspaces.md
+++ b/skills/productivity/tally-forms/reference/workspaces.md
@@ -1,0 +1,128 @@
+# Workspaces API Reference
+
+Base URL: `https://api.tally.so`
+
+## Endpoints
+
+### List Workspaces
+```
+GET /workspaces
+```
+
+Returns all workspaces accessible to the authenticated user.
+
+**Response (200):**
+```json
+{
+  "items": [
+    {
+      "id": "workspace-id",
+      "name": "My Workspace",
+      "organizationId": "org-id",
+      "createdAt": "2024-01-01T00:00:00Z",
+      "updatedAt": "2024-01-02T00:00:00Z"
+    }
+  ]
+}
+```
+
+---
+
+### Get Workspace
+```
+GET /workspaces/{workspaceId}
+```
+
+Returns a single workspace by ID.
+
+**Path Parameters:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| workspaceId | string | Yes | The ID of the workspace |
+
+**Response (200):**
+```json
+{
+  "id": "workspace-id",
+  "name": "My Workspace",
+  "organizationId": "org-id",
+  "createdAt": "2024-01-01T00:00:00Z",
+  "updatedAt": "2024-01-02T00:00:00Z"
+}
+```
+
+---
+
+### Create Workspace
+```
+POST /workspaces
+```
+
+Creates a new workspace.
+
+**Request Body:**
+```json
+{
+  "name": "New Workspace"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| name | string | Yes | Workspace name |
+
+**Response (201):**
+Returns the created workspace object.
+
+---
+
+### Update Workspace
+```
+PATCH /workspaces/{workspaceId}
+```
+
+Updates a workspace's name.
+
+**Path Parameters:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| workspaceId | string | Yes | The ID of the workspace |
+
+**Request Body:**
+```json
+{
+  "name": "Renamed Workspace"
+}
+```
+
+**Response (200):**
+Returns the updated workspace object.
+
+---
+
+### Delete Workspace
+```
+DELETE /workspaces/{workspaceId}
+```
+
+Deletes a workspace. All forms within the workspace will be moved to the default workspace.
+
+**Path Parameters:**
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| workspaceId | string | Yes | The ID of the workspace |
+
+**Response (204):**
+No content on success.
+
+---
+
+## Workspace Object
+
+| Field | Type | Description |
+|-------|------|-------------|
+| id | string | Unique workspace identifier |
+| name | string | Workspace name |
+| organizationId | string | Parent organization ID |
+| createdAt | string | ISO 8601 creation timestamp |
+| updatedAt | string | ISO 8601 last update timestamp |

--- a/skills/productivity/tally-forms/scripts/forms.py
+++ b/skills/productivity/tally-forms/scripts/forms.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Tally API — Forms endpoints.
+
+Standalone script demonstrating all forms operations.
+Set TALLY_API_KEY environment variable before running.
+"""
+
+import os, requests, uuid, json
+
+BASE = "https://api.tally.so"
+HEADERS = {
+    "Authorization": f"Bearer {os.environ['TALLY_API_KEY']}",
+    "Content-Type": "application/json",
+}
+
+def _uuid():
+    return str(uuid.uuid4())
+
+# ── List forms ──────────────────────────────────────────────
+def list_forms(page=1, limit=50, workspace_ids=None):
+    params = {"page": page, "limit": limit}
+    if workspace_ids:
+        params["workspaceIds"] = workspace_ids
+    r = requests.get(f"{BASE}/forms", headers=HEADERS, params=params)
+    r.raise_for_status()
+    return r.json()
+
+# ── Get form ────────────────────────────────────────────────
+def get_form(form_id):
+    r = requests.get(f"{BASE}/forms/{form_id}", headers=HEADERS)
+    r.raise_for_status()
+    return r.json()
+
+# ── Create form ─────────────────────────────────────────────
+def create_form(title, status="PUBLISHED", description=""):
+    blocks = [
+        {
+            "uuid": _uuid(),
+            "type": "FORM_TITLE",
+            "groupUuid": _uuid(),
+            "groupType": "FORM_TITLE",
+            "payload": {"html": f"<h1>{title}</h1>"},
+        }
+    ]
+    if description:
+        blocks.append({
+            "uuid": _uuid(),
+            "type": "TEXT",
+            "groupUuid": _uuid(),
+            "groupType": "TEXT",
+            "payload": {"html": f"<p>{description}</p>"},
+        })
+    r = requests.post(f"{BASE}/forms", headers=HEADERS, json={"status": status, "blocks": blocks})
+    r.raise_for_status()
+    return r.json()
+
+# ── Update form ─────────────────────────────────────────────
+def update_form(form_id, **kwargs):
+    """Pass any combination of: name, status, blocks, settings."""
+    r = requests.patch(f"{BASE}/forms/{form_id}", headers=HEADERS, json=kwargs)
+    r.raise_for_status()
+    return r.json()
+
+# ── Delete form ─────────────────────────────────────────────
+def delete_form(form_id):
+    r = requests.delete(f"{BASE}/forms/{form_id}", headers=HEADERS)
+    r.raise_for_status()
+
+# ── Demo ────────────────────────────────────────────────────
+if __name__ == "__main__":
+    # List
+    data = list_forms(limit=5)
+    print(f"Found {data.get('total', len(data.get('items', [])))} forms")
+    for f in data.get("items", []):
+        print(f"  {f['id']}  {f['name']}  ({f['status']})")
+
+    # Create
+    form = create_form("API Test Form", description="Created via script")
+    print(f"\nCreated: https://tally.so/r/{form['id']}")
+
+    # Get
+    detail = get_form(form["id"])
+    print(f"Blocks: {len(detail.get('blocks', []))}")
+
+    # Update
+    updated = update_form(form["id"], name="Renamed Form")
+    print(f"Renamed to: {updated['name']}")
+
+    # Delete
+    delete_form(form["id"])
+    print("Deleted.")

--- a/skills/productivity/tally-forms/scripts/organizations.py
+++ b/skills/productivity/tally-forms/scripts/organizations.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Tally API — Organizations endpoints.
+
+Standalone script demonstrating organization user and invite operations.
+Set TALLY_API_KEY environment variable before running.
+"""
+
+import os, requests, json
+
+BASE = "https://api.tally.so"
+HEADERS = {
+    "Authorization": f"Bearer {os.environ['TALLY_API_KEY']}",
+    "Content-Type": "application/json",
+}
+
+# ── List organization users ─────────────────────────────────
+def list_users(org_id):
+    r = requests.get(f"{BASE}/organizations/{org_id}/users", headers=HEADERS)
+    r.raise_for_status()
+    return r.json()
+
+# ── Remove organization user ────────────────────────────────
+def remove_user(org_id, user_id):
+    r = requests.delete(f"{BASE}/organizations/{org_id}/users/{user_id}", headers=HEADERS)
+    r.raise_for_status()
+
+# ── List invites ────────────────────────────────────────────
+def list_invites(org_id):
+    r = requests.get(f"{BASE}/organizations/{org_id}/invites", headers=HEADERS)
+    r.raise_for_status()
+    return r.json()
+
+# ── Create invite ───────────────────────────────────────────
+def create_invite(org_id, email, role="MEMBER"):
+    r = requests.post(
+        f"{BASE}/organizations/{org_id}/invites",
+        headers=HEADERS,
+        json={"email": email, "role": role},
+    )
+    r.raise_for_status()
+    return r.json()
+
+# ── Cancel invite ───────────────────────────────────────────
+def cancel_invite(org_id, invite_id):
+    r = requests.delete(f"{BASE}/organizations/{org_id}/invites/{invite_id}", headers=HEADERS)
+    r.raise_for_status()
+
+# ── Demo ────────────────────────────────────────────────────
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) < 2:
+        print("Usage: python organizations.py <organization_id>")
+        sys.exit(1)
+
+    org_id = sys.argv[1]
+
+    users = list_users(org_id)
+    print(f"Users: {len(users.get('items', []))}")
+    for u in users.get("items", []):
+        print(f"  {u['email']}  role={u['role']}")
+
+    invites = list_invites(org_id)
+    print(f"Pending invites: {len(invites.get('items', []))}")

--- a/skills/productivity/tally-forms/scripts/submissions.py
+++ b/skills/productivity/tally-forms/scripts/submissions.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Tally API — Submissions endpoints.
+
+Standalone script demonstrating all submissions operations.
+Set TALLY_API_KEY environment variable before running.
+"""
+
+import os, requests, json
+
+BASE = "https://api.tally.so"
+HEADERS = {
+    "Authorization": f"Bearer {os.environ['TALLY_API_KEY']}",
+    "Content-Type": "application/json",
+}
+
+# ── List submissions ────────────────────────────────────────
+def list_submissions(form_id, page=1, limit=50, start_date=None, end_date=None, after_id=None, filter_expr=None):
+    params = {"page": page, "limit": limit}
+    if start_date:
+        params["startDate"] = start_date
+    if end_date:
+        params["endDate"] = end_date
+    if after_id:
+        params["afterId"] = after_id
+    if filter_expr:
+        params["filter"] = filter_expr
+    r = requests.get(f"{BASE}/forms/{form_id}/submissions", headers=HEADERS, params=params)
+    r.raise_for_status()
+    return r.json()
+
+# ── Get single submission ───────────────────────────────────
+def get_submission(form_id, submission_id):
+    r = requests.get(f"{BASE}/forms/{form_id}/submissions/{submission_id}", headers=HEADERS)
+    r.raise_for_status()
+    return r.json()
+
+# ── Delete submission ───────────────────────────────────────
+def delete_submission(form_id, submission_id):
+    r = requests.delete(f"{BASE}/forms/{form_id}/submissions/{submission_id}", headers=HEADERS)
+    r.raise_for_status()
+
+# ── Fetch all (cursor pagination) ──────────────────────────
+def fetch_all_submissions(form_id):
+    all_items = []
+    after_id = None
+    while True:
+        data = list_submissions(form_id, limit=100, after_id=after_id)
+        items = data.get("items", [])
+        all_items.extend(items)
+        if not data.get("hasMore"):
+            break
+        after_id = items[-1]["id"]
+    return all_items
+
+# ── Demo ────────────────────────────────────────────────────
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) < 2:
+        print("Usage: python submissions.py <form_id>")
+        sys.exit(1)
+
+    form_id = sys.argv[1]
+
+    data = list_submissions(form_id, limit=5)
+    print(f"Total submissions: {data.get('total', '?')}")
+    for s in data.get("items", []):
+        print(f"  {s['id']}  completed={s.get('isCompleted')}  {s.get('createdAt', '')[:10]}")
+        for field in s.get("fields", []):
+            print(f"    {field['label']}: {field['value']}")

--- a/skills/productivity/tally-forms/scripts/users.py
+++ b/skills/productivity/tally-forms/scripts/users.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""Tally API — Users endpoint.
+
+Standalone script to fetch the authenticated user's profile.
+Set TALLY_API_KEY environment variable before running.
+"""
+
+import os, requests, json
+
+BASE = "https://api.tally.so"
+HEADERS = {
+    "Authorization": f"Bearer {os.environ['TALLY_API_KEY']}",
+    "Content-Type": "application/json",
+}
+
+def get_me():
+    r = requests.get(f"{BASE}/users/me", headers=HEADERS)
+    r.raise_for_status()
+    return r.json()
+
+if __name__ == "__main__":
+    me = get_me()
+    print(json.dumps(me, indent=2))

--- a/skills/productivity/tally-forms/scripts/webhooks.py
+++ b/skills/productivity/tally-forms/scripts/webhooks.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Tally API — Webhooks endpoints.
+
+Standalone script demonstrating all webhook operations.
+Set TALLY_API_KEY environment variable before running.
+"""
+
+import os, requests, json
+
+BASE = "https://api.tally.so"
+HEADERS = {
+    "Authorization": f"Bearer {os.environ['TALLY_API_KEY']}",
+    "Content-Type": "application/json",
+}
+
+# ── List webhooks ───────────────────────────────────────────
+def list_webhooks(form_id=None):
+    params = {}
+    if form_id:
+        params["formId"] = form_id
+    r = requests.get(f"{BASE}/webhooks", headers=HEADERS, params=params)
+    r.raise_for_status()
+    return r.json()
+
+# ── Create webhook ──────────────────────────────────────────
+def create_webhook(form_id, url, event_types=None):
+    payload = {
+        "formId": form_id,
+        "url": url,
+        "eventTypes": event_types or ["FORM_RESPONSE"],
+    }
+    r = requests.post(f"{BASE}/webhooks", headers=HEADERS, json=payload)
+    r.raise_for_status()
+    return r.json()
+
+# ── Update webhook ──────────────────────────────────────────
+def update_webhook(webhook_id, **kwargs):
+    """Pass any of: url, isActive, eventTypes."""
+    r = requests.patch(f"{BASE}/webhooks/{webhook_id}", headers=HEADERS, json=kwargs)
+    r.raise_for_status()
+    return r.json()
+
+# ── Delete webhook ──────────────────────────────────────────
+def delete_webhook(webhook_id):
+    r = requests.delete(f"{BASE}/webhooks/{webhook_id}", headers=HEADERS)
+    r.raise_for_status()
+
+# ── List webhook events ─────────────────────────────────────
+def list_events(webhook_id):
+    r = requests.get(f"{BASE}/webhooks/{webhook_id}/events", headers=HEADERS)
+    r.raise_for_status()
+    return r.json()
+
+# ── Retry webhook event ─────────────────────────────────────
+def retry_event(webhook_id, event_id):
+    r = requests.post(f"{BASE}/webhooks/{webhook_id}/events/{event_id}/retry", headers=HEADERS)
+    r.raise_for_status()
+    return r.json()
+
+# ── Demo ────────────────────────────────────────────────────
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) < 2:
+        print("Usage: python webhooks.py <form_id> [webhook_url]")
+        sys.exit(1)
+
+    form_id = sys.argv[1]
+    url = sys.argv[2] if len(sys.argv) > 2 else "https://example.com/webhook"
+
+    # List existing
+    data = list_webhooks(form_id)
+    print(f"Existing webhooks: {len(data.get('items', []))}")
+
+    # Create
+    wh = create_webhook(form_id, url)
+    print(f"Created webhook {wh['id']} -> {wh['url']}")
+
+    # List events
+    events = list_events(wh["id"])
+    print(f"Events: {len(events.get('items', []))}")
+
+    # Cleanup
+    delete_webhook(wh["id"])
+    print("Deleted.")

--- a/skills/productivity/tally-forms/scripts/workspaces.py
+++ b/skills/productivity/tally-forms/scripts/workspaces.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Tally API — Workspaces endpoints.
+
+Standalone script demonstrating all workspace operations.
+Set TALLY_API_KEY environment variable before running.
+"""
+
+import os, requests, json
+
+BASE = "https://api.tally.so"
+HEADERS = {
+    "Authorization": f"Bearer {os.environ['TALLY_API_KEY']}",
+    "Content-Type": "application/json",
+}
+
+# ── List workspaces ─────────────────────────────────────────
+def list_workspaces():
+    r = requests.get(f"{BASE}/workspaces", headers=HEADERS)
+    r.raise_for_status()
+    return r.json()
+
+# ── Get workspace ───────────────────────────────────────────
+def get_workspace(workspace_id):
+    r = requests.get(f"{BASE}/workspaces/{workspace_id}", headers=HEADERS)
+    r.raise_for_status()
+    return r.json()
+
+# ── Create workspace ────────────────────────────────────────
+def create_workspace(name):
+    r = requests.post(f"{BASE}/workspaces", headers=HEADERS, json={"name": name})
+    r.raise_for_status()
+    return r.json()
+
+# ── Update workspace ────────────────────────────────────────
+def update_workspace(workspace_id, name):
+    r = requests.patch(f"{BASE}/workspaces/{workspace_id}", headers=HEADERS, json={"name": name})
+    r.raise_for_status()
+    return r.json()
+
+# ── Delete workspace ────────────────────────────────────────
+def delete_workspace(workspace_id):
+    r = requests.delete(f"{BASE}/workspaces/{workspace_id}", headers=HEADERS)
+    r.raise_for_status()
+
+# ── Demo ────────────────────────────────────────────────────
+if __name__ == "__main__":
+    data = list_workspaces()
+    for w in data.get("items", []):
+        print(f"  {w['id']}  {w['name']}")


### PR DESCRIPTION
## Summary

- Adds a new **tally-forms** skill under `skills/productivity/` for the [Tally.so](https://tally.so) forms API
- Full coverage of all 6 API endpoint groups: Forms, Submissions, Workspaces, Organizations, Webhooks, Users
- Includes API reference docs (`reference/*.md`), standalone Python scripts (`scripts/*.py`), and how-to guides (`docs/guides.md`) sourced from official Tally documentation

## What's included

| Directory | Contents |
|-----------|----------|
| `reference/` | 7 markdown files covering every endpoint, all 44+ block types, nesting rules |
| `scripts/` | 6 standalone Python scripts (one per endpoint group) with runnable demos |
| `docs/` | Guides for creating forms, contact forms, dropdowns, mentions, settings, styling, adding blocks, fetching submissions |
| `SKILL.md` | Full skill definition with hermes frontmatter metadata |

## Prerequisites

- Tally API key from https://tally.so/settings/api-keys
- `TALLY_API_KEY` env var set

## Links

- [Tally API Docs](https://developers.tally.so/api-reference/introduction)