### PR TITLE
fix(models): use local catalog for MiniMax validation instead of /v1/models (fixes false negative)

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2108,6 +2108,49 @@ def validate_requested_model(
     # api_models is None — couldn't reach API.  Accept and persist,
     # but warn so typos don't silently break things.
 
+    # MiniMax (global + CN): /v1/models returns 404 — use our local catalog
+    # instead of failing with a misleading "could not reach API" message.
+    if normalized in ("minimax", "minimax-cn"):
+        known = provider_model_ids(normalized)
+        if known:
+            if requested_for_lookup in set(known):
+                return {
+                    "accepted": True,
+                    "persist": True,
+                    "recognized": True,
+                    "message": None,
+                }
+            auto = get_close_matches(requested_for_lookup, known, n=1, cutoff=0.9)
+            if auto:
+                return {
+                    "accepted": True,
+                    "persist": True,
+                    "recognized": True,
+                    "corrected_model": auto[0],
+                    "message": f"Auto-corrected `{requested}` -> `{auto[0]}`",
+                }
+            suggestions = get_close_matches(requested, known, n=3, cutoff=0.5)
+            suggestion_text = ""
+            if suggestions:
+                suggestion_text = "\n  Similar models: " + ", ".join(f"`{s}`" for s in suggestions)
+            return {
+                "accepted": True,
+                "persist": True,
+                "recognized": False,
+                "message": (
+                    f"Note: `{requested}` was not found in the MiniMax model catalog. "
+                    f"It may still work if your account has access to it."
+                    f"{suggestion_text}"
+                ),
+            }
+        # catalog empty — fall through to generic accept
+        return {
+            "accepted": True,
+            "persist": True,
+            "recognized": False,
+            "message": None,
+        }
+
     # Bedrock: use our own discovery instead of HTTP /models endpoint.
     # Bedrock's bedrock-runtime URL doesn't support /models — it uses the
     # AWS SDK control plane (ListFoundationModels + ListInferenceProfiles).


### PR DESCRIPTION
## Problem

MiniMax (both global and CN endpoints) does not implement `/v1/models` — it returns 404. When a user runs `hermes model MiniMax-M2.7`, `validate_requested_model()` calls `fetch_api_models()` which probes `/v1/models`, gets 404, returns `None`, and falls through to the generic error:

```
Could not reach the MiniMax API to validate 'MiniMax-M2.7'.
If the service isn't down, this model may not be valid.
```

The chat endpoint works fine — only the models listing endpoint is missing.

## Fix

Add a `minimax` / `minimax-cn` branch in `validate_requested_model()` that uses `provider_model_ids()` (local catalog) instead of probing `/v1/models`. Same pattern already used for Bedrock.

- Valid model names → `accepted=True, recognized=True`
- Close matches → auto-correct
- Unknown names → `accepted=True` with a warning (user may have plan-specific access)

## Result

`hermes model MiniMax-M2.7` succeeds when `MiniMax-M2.7` is in the local catalog. No network call needed for validation.

Fixes #12547