### PR TITLE
fix(agent): correct temperature for kimi-k2.5 to 1.0

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -107,13 +107,13 @@ _FIXED_TEMPERATURE_MODELS: Dict[str, float] = {
 # the standard chat API and third parties) are NOT clamped.
 # Source: https://platform.kimi.ai/docs/guide/kimi-k2-5-quickstart
 _KIMI_INSTANT_MODELS: frozenset = frozenset({
-    "kimi-k2.5",
     "kimi-k2-turbo-preview",
     "kimi-k2-0905-preview",
 })
 _KIMI_THINKING_MODELS: frozenset = frozenset({
     "kimi-k2-thinking",
     "kimi-k2-thinking-turbo",
+    "kimi-k2.5",
 })
 
 
@@ -121,8 +121,8 @@ def _fixed_temperature_for_model(model: Optional[str]) -> Optional[float]:
     """Return a required temperature override for models with strict contracts.
 
     Moonshot's kimi-for-coding endpoint rejects any non-approved temperature on
-    the k2.5 family.  Non-thinking variants require exactly 0.6; thinking
-    variants require 1.0.  An optional ``vendor/`` prefix (e.g.
+    the k2.5 family.  k2.5 and thinking variants require exactly 1.0; instant/
+    preview variants require 0.6.  An optional ``vendor/`` prefix (e.g.
     ``moonshotai/kimi-k2.5``) is tolerated for aggregator routings.
 
     Returns ``None`` for every other model, including ``kimi-k2-instruct*``

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -780,19 +780,19 @@ class TestKimiForCodingTemperature:
     @pytest.mark.parametrize(
         "model,expected",
         [
-            ("kimi-k2.5", 0.6),
+            ("kimi-k2.5", 1.0),
             ("kimi-k2-turbo-preview", 0.6),
             ("kimi-k2-0905-preview", 0.6),
             ("kimi-k2-thinking", 1.0),
             ("kimi-k2-thinking-turbo", 1.0),
-            ("moonshotai/kimi-k2.5", 0.6),
+            ("moonshotai/kimi-k2.5", 1.0),
             ("moonshotai/Kimi-K2-Thinking", 1.0),
         ],
     )
     def test_kimi_k2_family_temperature_override(self, model, expected):
         """Moonshot kimi-k2.* models only accept fixed temperatures.
 
-        Non-thinking models → 0.6, thinking-mode models → 1.0.
+        k2.5 and thinking models → 1.0, instant/preview models → 0.6.
         """
         from agent.auxiliary_client import _build_call_kwargs
 


### PR DESCRIPTION
The kimi-k2.5 model requires temperature=1.0, not 0.6. The API returns: "invalid temperature: only 1 is allowed for this model"

Move kimi-k2.5 from _KIMI_INSTANT_MODELS to _KIMI_THINKING_MODELS so it gets the correct fixed temperature of 1.0 instead of 0.6.

Update tests and docstring to reflect the correct behavior.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

