### PR TITLE
fix(web): handle binary data in session messages to prevent 500 errors

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -10,6 +10,7 @@ Usage:
 """
 
 import asyncio
+import base64
 import hmac
 import importlib.util
 import json
@@ -27,6 +28,23 @@ from typing import Any, Dict, List, Optional
 import yaml
 
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
+
+
+def _sanitize_for_json(obj: Any) -> Any:
+    """Recursively sanitize data structures for JSON serialization.
+
+    Handles bytes objects that may contain non-UTF-8 data in the database.
+    """
+    if isinstance(obj, bytes):
+        try:
+            return obj.decode("utf-8")
+        except (UnicodeDecodeError, ValueError):
+            return base64.b64encode(obj).decode("ascii")
+    if isinstance(obj, dict):
+        return {k: _sanitize_for_json(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_sanitize_for_json(item) for item in obj]
+    return obj
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
@@ -490,7 +508,12 @@ async def get_sessions(limit: int = 20, offset: int = 0):
                     s.get("ended_at") is None
                     and (now - s.get("last_active", s.get("started_at", 0))) < 300
                 )
-            return {"sessions": sessions, "total": total, "limit": limit, "offset": offset}
+            return {
+                "sessions": _sanitize_for_json(sessions),
+                "total": total,
+                "limit": limit,
+                "offset": offset,
+            }
         finally:
             db.close()
     except Exception as e:
@@ -1678,7 +1701,7 @@ async def get_session_detail(session_id: str):
         session = db.get_session(sid) if sid else None
         if not session:
             raise HTTPException(status_code=404, detail="Session not found")
-        return session
+        return _sanitize_for_json(session)
     finally:
         db.close()
 
@@ -1692,7 +1715,7 @@ async def get_session_messages(session_id: str):
         if not sid:
             raise HTTPException(status_code=404, detail="Session not found")
         messages = db.get_messages(sid)
-        return {"session_id": sid, "messages": messages}
+        return {"session_id": sid, "messages": _sanitize_for_json(messages)}
     finally:
         db.close()
 


### PR DESCRIPTION
## Problem

When the database contains non-UTF-8 binary data (e.g. from image attachments or binary tool outputs), FastAPI's `jsonable_encoder` fails with `UnicodeDecodeError` when serializing session data for the web UI, causing all session-related API endpoints to return 500 errors.

## Fix

Added a `_sanitize_for_json()` helper that recursively converts `bytes` objects to UTF-8 strings (or base64 as fallback) before JSON serialization. Applied to all session-related API endpoints:

- `GET /api/sessions`
- `GET /api/sessions/{session_id}`
- `GET /api/sessions/{session_id}/messages`
