### PR TITLE
fix(gateway): suppress busy-ack to unauthorized senders + EMAIL_IGNORED_SENDERS env var

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -410,6 +410,17 @@ class EmailAdapter(BasePlatformAdapter):
         if sender_addr == self._address.lower():
             return
 
+        # Drop senders explicitly blocklisted via EMAIL_IGNORED_SENDERS.
+        # Defense in depth against intra-fleet email loops where two
+        # gateways configured with each other as unauthorized senders
+        # ping-pong busy-ack notifications forever.
+        ignored_raw = os.getenv('EMAIL_IGNORED_SENDERS', '').strip()
+        if ignored_raw and sender_addr:
+            ignored_set = {a.strip().lower() for a in ignored_raw.split(',') if a.strip()}
+            if sender_addr.lower() in ignored_set:
+                logger.info('[Email] Ignoring blocklisted sender: %s', sender_addr)
+                return
+
         # Never reply to automated senders
         if _is_automated_sender(sender_addr, {}):
             logger.debug("[Email] Dropping automated sender at dispatch: %s", sender_addr)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1489,6 +1489,21 @@ class GatewayRunner:
         merge_pending_message_event(adapter._pending_messages, session_key, event)
 
     async def _handle_active_session_busy_message(self, event: MessageEvent, session_key: str) -> bool:
+        # Auth check FIRST: unauthorized senders must never trigger an
+        # outbound reply, including the busy-ack. Without this, two
+        # gateways configured with each other's address as unauthorized
+        # can ping-pong busy-acks forever (Toryx 2026-04-19 incident:
+        # 487 emails between two MD profiles in 20 min). Internal events
+        # bypass auth as elsewhere in the codebase.
+        if not getattr(event, 'internal', False) and event.source.user_id is not None:
+            if not self._is_user_authorized(event.source):
+                logger.info(
+                    'Suppressed busy-ack to unauthorized sender %s on %s',
+                    event.source.user_id,
+                    event.source.platform.value if event.source.platform else 'unknown',
+                )
+                return True  # consume event silently
+
         # --- Draining case (gateway restarting/stopping) ---
         if self._draining:
             adapter = self.adapters.get(event.source.platform)


### PR DESCRIPTION
## Summary

Two compounding bugs let two gateway instances configured with each other's address as 'unauthorized' bounce `⚡ Interrupting current task` notifications between themselves forever. Observed in production: 487 emails between two profiles in 20 minutes before manual stop.

## Root cause

- `gateway/platforms/base.py` dispatches inbound events to `_busy_session_handler` **before** routing through `_handle_message`.
- `_handle_active_session_busy_message` in `gateway/run.py` sends the busy-ack reply without consulting `_is_user_authorized`.
- `_handle_message` does have an auth check, but it only fires for the **first** message of a session — once a session is active, every subsequent inbound message takes the busy path and replies regardless of allowlist.

So an unauthorized sender that picks the same subject can keep an in-flight session "busy" indefinitely, and each busy-ack we emit lands in their inbox and triggers their own busy-ack back at us. Two gateway instances on the same SMTP domain (e.g., a fleet of agents with `<name>@company.com`) become a self-perpetuating storm.

## Fix

**1. `gateway/run.py` — auth-first ordering in the busy handler.**

Add an auth check at the very top of `_handle_active_session_busy_message`. Internal events bypass as elsewhere; user-facing events from unauthorized senders are silently consumed without any outbound message. Returns `True` so the adapter does not fall through to the interrupt path. This is the structural fix and applies to every platform.

**2. `gateway/platforms/email.py` — `EMAIL_IGNORED_SENDERS` env var.**

Comma-separated list of sender addresses to drop at `_dispatch_message`, before any reply path. Defense-in-depth for fleets running multiple gateways on the same SMTP domain (where you may want to drop intra-fleet email at the wire level even if auth would already reject).

```bash
# example: prevent agents in the same domain from accidentally talking to each other
EMAIL_IGNORED_SENDERS=alice@example.com,bob@example.com,carol@example.com
```

Both fixes are independent and additive.

## Test plan

- [x] Reproduced on a fleet of 5 gateway profiles sharing one SMTP domain.
- [x] Applied both fixes; restarted all 5 gateways; verified no further loop emails for 1+ hour and `[Email] Ignoring blocklisted sender:` log line on each test.
- [x] Verified `internal=True` events still pass busy-ack (they should — they are system-generated, not user-driven).
- [ ] Unit test for `_handle_active_session_busy_message` auth path — happy to add if reviewers want it before merge; flagging that the existing test setup for gateway runner is heavy and I'd want a steer on the right shape.

## Why I didn't just fix it in the email adapter alone

Same bug would surface on Discord/Slack/Matrix the moment two bot instances share an allowlist gap. The auth check belongs in the platform-agnostic busy handler.

## Operational notes for downstream operators hitting this today

If you need to stop an active loop **right now**, set `EMAIL_IGNORED_SENDERS` and restart the gateway — that fix is dispatcher-level and stops further reply emission immediately. The `run.py` change is the structural fix you want long-term.

cc @karan4d