### PR TITLE
fix(bedrock): preserve dots in model names for Bedrock inference profiles

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6760,8 +6760,9 @@ class AIAgent:
         Alibaba/DashScope keeps dots (e.g. qwen3.5-plus).
         MiniMax keeps dots (e.g. MiniMax-M2.7).
         OpenCode Go/Zen keeps dots for non-Claude models (e.g. minimax-m2.5-free).
-        ZAI/Zhipu keeps dots (e.g. glm-4.7, glm-5.1)."""
-        if (getattr(self, "provider", "") or "").lower() in {"alibaba", "minimax", "minimax-cn", "opencode-go", "opencode-zen", "zai"}:
+        ZAI/Zhipu keeps dots (e.g. glm-4.7, glm-5.1).
+        Bedrock keeps dots (e.g. global.anthropic.claude-opus-4-7, us.anthropic.claude-sonnet-4-6)."""
+        if (getattr(self, "provider", "") or "").lower() in {"alibaba", "minimax", "minimax-cn", "opencode-go", "opencode-zen", "zai", "bedrock"}:
             return True
         base = (getattr(self, "base_url", "") or "").lower()
         return "dashscope" in base or "aliyuncs" in base or "minimax" in base or "opencode.ai/zen/" in base or "bigmodel.cn" in base


### PR DESCRIPTION
## Summary

Bedrock cross-region inference profiles use dots in model IDs (e.g. `global.anthropic.claude-opus-4-7`, `us.anthropic.claude-sonnet-4-6`).

`normalize_model_name()` converts dots to hyphens by default, which breaks Bedrock API calls with:

```
HTTP 400: The provided model identifier is invalid.
```

This fix adds `"bedrock"` to the `_anthropic_preserve_dots()` provider set so that dots are preserved when using the Bedrock provider.

## Reproduce

1. Set provider to `bedrock` with model `global.anthropic.claude-opus-4-7`
2. Run `hermes` and send any message
3. Get 400 error: "The provided model identifier is invalid"

## Root Cause

`_anthropic_preserve_dots()` returns `False` for the `bedrock` provider, causing `normalize_model_name()` to transform:
- `global.anthropic.claude-opus-4-7` → `global-anthropic-claude-opus-4-7`

The Bedrock API rejects the hyphenated form.

## Test plan

- [x] Verified `aws bedrock-runtime converse` works with `global.anthropic.claude-opus-4-7`
- [x] Verified `AnthropicBedrock` SDK works with the same model ID
- [x] Confirmed `hermes` conversation works after applying this patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)