### PR TITLE
fix(bedrock): preserve dots in Bedrock inference profile model IDs

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6760,11 +6760,12 @@ class AIAgent:
         Alibaba/DashScope keeps dots (e.g. qwen3.5-plus).
         MiniMax keeps dots (e.g. MiniMax-M2.7).
         OpenCode Go/Zen keeps dots for non-Claude models (e.g. minimax-m2.5-free).
-        ZAI/Zhipu keeps dots (e.g. glm-4.7, glm-5.1)."""
-        if (getattr(self, "provider", "") or "").lower() in {"alibaba", "minimax", "minimax-cn", "opencode-go", "opencode-zen", "zai"}:
+        ZAI/Zhipu keeps dots (e.g. glm-4.7, glm-5.1).
+        Bedrock inference profile IDs keep dots (e.g. us.anthropic.claude-sonnet-4-6)."""
+        if (getattr(self, "provider", "") or "").lower() in {"alibaba", "minimax", "minimax-cn", "opencode-go", "opencode-zen", "zai", "bedrock"}:
             return True
         base = (getattr(self, "base_url", "") or "").lower()
-        return "dashscope" in base or "aliyuncs" in base or "minimax" in base or "opencode.ai/zen/" in base or "bigmodel.cn" in base
+        return "dashscope" in base or "aliyuncs" in base or "minimax" in base or "opencode.ai/zen/" in base or "bigmodel.cn" in base or "bedrock-runtime" in base
 
     def _is_qwen_portal(self) -> bool:
         """Return True when the base URL targets Qwen Portal."""


### PR DESCRIPTION
## Summary

Bedrock Claude calls fail with `HTTP 400: The provided model identifier is invalid` when using cross-region inference profile IDs such as `us.anthropic.claude-sonnet-4-6`.

**Root cause:** `AIAgent._anthropic_preserve_dots()` is missing `bedrock` from its whitelist. The default `normalize_model_name()` converts dots → hyphens to normalize OpenRouter-style IDs (e.g. `anthropic/claude-opus-4.6` → `claude-opus-4-6`), which mangles Bedrock's inference profile IDs:

```
us.anthropic.claude-sonnet-4-6  →  us-anthropic-claude-sonnet-4-6  ❌
```

Bedrock then rejects the mangled ID. This is a follow-up to #10549 (native AWS Bedrock provider) — the Bedrock path is wired up in `runtime_provider.py` / `bedrock_adapter.py`, but this whitelist missed it, so Claude-on-Bedrock breaks end-to-end as soon as an inference-profile ID is needed.

## Reproduction

Configure Bedrock + any Claude model that requires a cross-region inference profile (Claude 4.6 / 4.7 family on-demand). Send any message → `HTTP 400: The provided model identifier is invalid`.

Confirmed the raw SDK call with the dotted ID works fine:

```python
from anthropic import AnthropicBedrock
AnthropicBedrock(aws_region="...").messages.create(
    model="us.anthropic.claude-sonnet-4-6",
    max_tokens=64,
    messages=[{"role": "user", "content": "ping"}],
)
```

So it's purely a model-name normalization bug, not a credential / region / profile access issue.

## Fix

`run_agent.py::AIAgent._anthropic_preserve_dots()` — add `bedrock` to the provider whitelist and `bedrock-runtime` to the base_url match.

## Verification

Round-trip `AIAgent(...).chat(...)` against Bedrock returns a proper response after the fix; before the fix it aborts on `HTTP 400`. Gateway end-to-end also works after restart.

Verified with the following Bedrock inference profile IDs:

- `us.anthropic.claude-sonnet-4-6`
- `us.anthropic.claude-opus-4-7`
- `us.anthropic.claude-opus-4-6-v1`

All previously failed with the 400; all work after the fix.

## Scope / side effects

- Only affects Bedrock paths (gated by `provider == "bedrock"` and `bedrock-runtime` in `base_url`).
- No behavior change for OpenRouter / native Anthropic / Nous / any other provider.
- `AnthropicBedrock` SDK accepts dotted inference profile IDs natively — no further conversion needed downstream.
