### PR TITLE
fix(skill): use profile-isolated path for plan storage

### DIFF
--- a/skills/software-development/plan/SKILL.md
+++ b/skills/software-development/plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plan
-description: Plan mode for Hermes — inspect context, write a markdown plan into the active workspace's `.hermes/plans/` directory, and do not execute the work.
+description: Plan mode for Hermes — inspect context, write a markdown plan into the profile's plans directory, and do not execute the work.
 version: 1.0.0
 author: Hermes Agent
 license: MIT
@@ -22,7 +22,7 @@ For this turn, you are planning only.
 - Do not edit project files except the plan markdown file.
 - Do not run mutating terminal commands, commit, push, or perform external actions.
 - You may inspect the repo or other context with read-only commands/tools when needed.
-- Your deliverable is a markdown plan saved inside the active workspace under `.hermes/plans/`.
+- Your deliverable is a markdown plan saved under the profile's `~/.hermes/plans/` directory.
 
 ## Output requirements
 
@@ -42,12 +42,12 @@ If the task is code-related, include exact file paths, likely test targets, and 
 ## Save location
 
 Save the plan with `write_file` under:
-- `.hermes/plans/YYYY-MM-DD_HHMMSS-<slug>.md`
+- `~/.hermes/plans/YYYY-MM-DD_HHMMSS-<slug>.md`
 
-Treat that as relative to the active working directory / backend workspace. Hermes file tools are backend-aware, so using this relative path keeps the plan with the workspace on local, docker, ssh, modal, and daytona backends.
+This path is expanded against the subprocess HOME (`{HERMES_HOME}/home/`), ensuring each profile has its own isolated plans directory. Falls back to `os.path.expanduser()` when the subprocess home directory does not exist.
 
 If the runtime provides a specific target path, use that exact path.
-If not, create a sensible timestamped filename yourself under `.hermes/plans/`.
+If not, create a sensible timestamped filename yourself under `~/.hermes/plans/`.
 
 ## Interaction style
 


### PR DESCRIPTION
Plan skill was writing to .hermes/plans/ relative to the backend workspace, causing all profiles to share the same plans directory.

Now writes to ~/.hermes/plans/ which is expanded against the subprocess HOME ({HERMES_HOME}/home/), ensuring each profile has its own isolated plans directory.

Fixes #12533.

## What does this PR do?

Fixes the plan skill to write plans to `~/.hermes/plans/` instead of `.hermes/plans/` (relative to backend workspace). The new path is expanded against the subprocess HOME (`{HERMES_HOME}/home/`), ensuring each profile has its own isolated plans directory.

## Related Issue

Fixes #12533

**Note:** This PR depends on #12260 being merged first, as the path expansion relies on `resolve_skill_config_values()` being updated to use subprocess HOME.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `skills/software-development/plan/SKILL.md`: Changed plan save path from `.hermes/plans/` to `~/.hermes/plans/`

## How to Test

1. Set up two Hermes profiles with different HERMES_HOME values
2. Run `/plan` command in profile1 — plan should be written to `{HERMES_HOME}/home/.hermes/plans/`
3. Run `/plan` command in profile2 — plan should be written to a different directory
4. Verify plans are isolated per profile

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings)
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [ ] I've updated tool descriptions/schemas if I changed tool behavior

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->
