### PR TITLE
fix(gateway): recover systemd restart when gateway is unresponsive

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1527,7 +1527,28 @@ def systemd_restart(system: bool = False):
             except (ProcessLookupError, PermissionError):
                 break  # old process is gone
         else:
-            print(f"⚠ Old process (PID {pid}) still alive after 90s")
+            # The gateway didn't respond to SIGUSR1 within the drain window.
+            # This happens when the asyncio loop is dead/frozen (crash-loop,
+            # wedged event loop, etc.) and the restart signal handler can't
+            # execute — leaving us with a hung process that systemd cannot
+            # recover on its own (#12438). Force-kill and ask systemd to
+            # restart explicitly so `hermes gateway restart` still works in
+            # crashed/unresponsive states.
+            print(f"⚠ Old process (PID {pid}) still alive after 90s — forcing termination")
+            try:
+                terminate_pid(pid, force=True)
+            except (ProcessLookupError, PermissionError, OSError):
+                pass
+            try:
+                _run_systemctl(
+                    ["restart", svc],
+                    system=system,
+                    check=True,
+                    timeout=90,
+                )
+            except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+                # Phase 2 will surface the final state below if this also fails.
+                pass
 
         # Phase 2: wait for systemd to start the new process
         print(f"⏳ Waiting for {svc} to restart...")

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -497,6 +497,71 @@ class TestGatewaySystemServiceRouting:
         out = capsys.readouterr().out.lower()
         assert "restarted" in out
 
+    def test_systemd_restart_force_kills_unresponsive_gateway_and_triggers_restart(self, monkeypatch, capsys):
+        """#12438: when SIGUSR1 is sent but the gateway is crashed/unresponsive,
+        the drain wait times out at 90s and we must force-kill the process and
+        explicitly ask systemd to restart the service, rather than silently
+        falling into is-active polling against a dead asyncio loop."""
+        import time as time_mod
+
+        calls = []
+
+        monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
+        monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: None)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda: 4242)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_request_gateway_self_restart",
+            lambda pid: True,
+        )
+
+        # Fake time so the 90s drain deadline hits on the second tick, rather
+        # than actually sleeping for 90s in CI.
+        t = {"now": 1000.0}
+        monkeypatch.setattr(time_mod, "time", lambda: t["now"])
+        monkeypatch.setattr(time_mod, "sleep", lambda s: t.update(now=t["now"] + 100))
+
+        # os.kill(pid, 0) always succeeds — simulates a stuck process that
+        # never processes SIGUSR1.
+        monkeypatch.setattr(os, "kill", lambda pid, sig: None)
+
+        # Record force-termination.
+        def fake_terminate(pid, *, force=False):
+            calls.append(("terminate", pid, force))
+        monkeypatch.setattr(gateway_cli, "terminate_pid", fake_terminate)
+
+        # Record the explicit systemctl restart call, and treat it as success.
+        def fake_run_systemctl(cmd, system=False, check=False, **kwargs):
+            calls.append(("systemctl", tuple(cmd)))
+            return SimpleNamespace(returncode=0, stdout="active\n", stderr="")
+        monkeypatch.setattr(gateway_cli, "_run_systemctl", fake_run_systemctl)
+
+        # Phase 2 is-active polling goes through subprocess.run directly.
+        def fake_subprocess_run(cmd, **kwargs):
+            return SimpleNamespace(stdout="active\n", returncode=0)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_subprocess_run)
+
+        # Phase 2's get_running_pid must return a new PID so the "it restarted"
+        # branch fires.
+        pid_calls = {"n": 0}
+        def fake_get_pid():
+            pid_calls["n"] += 1
+            return 9999 if pid_calls["n"] > 1 else 4242
+        monkeypatch.setattr("gateway.status.get_running_pid", fake_get_pid)
+
+        gateway_cli.systemd_restart()
+
+        assert ("terminate", 4242, True) in calls, (
+            "unresponsive gateway must be force-killed after drain timeout"
+        )
+        assert any(
+            kind == "systemctl" and cmd[0] == "restart"
+            for kind, cmd in (c for c in calls if c[0] == "systemctl")
+        ), "unresponsive gateway must trigger an explicit systemctl restart"
+
+        out = capsys.readouterr().out
+        assert "forcing termination" in out
+
     def test_gateway_install_passes_system_flags(self, monkeypatch):
         monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: True)
         monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)


### PR DESCRIPTION
## Problem

\`hermes gateway restart\` sends \`SIGUSR1\` to trigger a graceful drain, then polls systemd for up to 60s waiting for \`is-active\` to report the new PID. When the gateway is in a crashed / unresponsive state (wedged event loop, crash-loop, etc.):

1. The signal handler never runs — \`asyncio.get_running_loop()\` can't schedule tasks in a dead loop.
2. The 90s phase-1 drain times out and prints \`⚠ Old process still alive after 90s\`.
3. Phase 2 begins polling \`systemctl is-active\` — but systemd sees the old process as still present, so no restart happens.
4. The user ends up with a stuck gateway and no CLI recovery path.

Reported by @shengbai4-hub in #12438. The \`launchd_restart\` path already has the right shape (\`terminate_pid\` + \`launchctl kickstart -k\` after drain timeout); only the systemd path was missing that escape hatch.

## Fix

In \`systemd_restart\`, when the 90s drain-wait exits without the process dying, force-kill via \`terminate_pid(pid, force=True)\` and then explicitly call \`systemctl restart <unit>\` so systemd replaces the process. Phase 2's \`is-active\` polling then correctly confirms the fresh PID.

No change to the common path (SIGUSR1 processed, process exits, systemd auto-restarts — still works as before).

## Testing

- \`tests/hermes_cli/test_gateway_service.py::TestGatewaySystemServiceRouting::test_systemd_restart_force_kills_unresponsive_gateway_and_triggers_restart\` — new regression test that simulates a stuck process (os.kill always succeeds, drain clock advances past 90s) and asserts \`terminate_pid(pid, force=True)\` + \`systemctl restart\` are both invoked.
- Full \`test_gateway_service.py\` suite passes (97/97).

Fixes #12438