### PR TITLE
fix(context_compressor): harden tool-call previews in summaries

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -936,6 +936,91 @@ def resolve_model_threshold(
         return float(model_thresholds[best_key])
     return default
 
+def _preview_tool_args_for_summary(
+    tool_name: str,
+    raw_args: Any,
+    *,
+    max_string_chars: int = 160,
+    max_items: int = 8,
+    max_depth: int = 4,
+    max_preview_chars: int = 2_000,
+) -> str:
+    """Return a compact, JSON-safe tool-argument preview for compaction.
+
+    Weak local tool-calling models can get confused when the compaction summary
+    contains raw function-call-shaped snippets with truncated JSON strings such
+    as ``execute_code({"code":"import ...``. Summaries are reference text, not
+    executable examples, so we convert arguments into a descriptive JSON preview
+    that preserves salient details while replacing huge multiline payloads with
+    a bounded summary string.
+    """
+
+    def _shorten_string(value: str) -> str:
+        normalized = value.replace("\r\n", "\n")
+        line_count = normalized.count("\n") + 1 if normalized else 0
+        single_line = re.sub(r"\s+", " ", normalized).strip()
+        if len(single_line) <= max_string_chars and line_count <= 2:
+            return value
+        preview = single_line[:max_string_chars]
+        if len(single_line) > max_string_chars:
+            preview += "..."
+        return f"<{len(value)} chars, {line_count} lines: {preview}>"
+
+    def _simplify(value: Any, depth: int = 0) -> Any:
+        if depth >= max_depth:
+            return f"<{type(value).__name__}>"
+        if isinstance(value, str):
+            return _shorten_string(value)
+        if isinstance(value, list):
+            items = [_simplify(item, depth + 1) for item in value[:max_items]]
+            if len(value) > max_items:
+                items.append(f"<+{len(value) - max_items} more items>")
+            return items
+        if isinstance(value, dict):
+            result = {}
+            items = list(value.items())
+            for key, item in items[:max_items]:
+                preview_key = _shorten_string(str(key))
+                if preview_key in result:
+                    suffix = 2
+                    while f"{preview_key} #{suffix}" in result:
+                        suffix += 1
+                    preview_key = f"{preview_key} #{suffix}"
+                result[preview_key] = _simplify(item, depth + 1)
+            if len(items) > max_items:
+                result["__truncated_keys__"] = len(items) - max_items
+            return result
+        return value
+
+    parsed: Any = raw_args
+    if isinstance(raw_args, str):
+        try:
+            parsed = json.loads(raw_args)
+        except (json.JSONDecodeError, TypeError):
+            parsed = {
+                "raw_args": _shorten_string(raw_args),
+                "tool": tool_name,
+            }
+
+    simplified = _simplify(parsed)
+    try:
+        serialized = json.dumps(simplified, ensure_ascii=False, sort_keys=True)
+    except TypeError:
+        fallback = {
+            "tool": _shorten_string(str(tool_name)),
+            "raw_args": _shorten_string(str(raw_args)),
+        }
+        serialized = json.dumps(fallback, ensure_ascii=False, sort_keys=True)
+
+    if len(serialized) <= max_preview_chars:
+        return serialized
+
+    bounded = {
+        "__preview_chars__": len(serialized),
+        "__truncated_preview__": _shorten_string(serialized),
+    }
+    return json.dumps(bounded, ensure_ascii=False, sort_keys=True)
+
 
 class ContextCompressor(ContextEngine):
     """Default context engine — compresses conversation context via lossy summarization.
@@ -2154,14 +2239,12 @@ class ContextCompressor(ContextEngine):
                             fn = tc.get("function", {})
                             name = fn.get("name", "?")
                             args = _redact_compaction_text(fn.get("arguments", ""))
-                            # Truncate long arguments but keep enough for context
-                            if len(args) > self._TOOL_ARGS_MAX:
-                                args = args[:self._TOOL_ARGS_HEAD] + "..."
-                            tc_parts.append(f"  {name}({args})")
                         else:
                             fn = getattr(tc, "function", None)
                             name = getattr(fn, "name", "?") if fn else "?"
-                            tc_parts.append(f"  {name}(...)")
+                            args = redact_sensitive_text(getattr(fn, "arguments", "") if fn else "")
+                        args_preview = _preview_tool_args_for_summary(name, args)
+                        tc_parts.append(f"  {name} args={args_preview}")
                     content += "\n[Tool calls:\n" + "\n".join(tc_parts) + "\n]"
                 parts.append(f"[ASSISTANT]: {content}")
                 continue

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -231,6 +231,76 @@ def _summarize_tool_result(tool_name: str, tool_args: str, tool_content: str) ->
     return f"[{tool_name}]{first_arg} ({content_len:,} chars result)"
 
 
+def _preview_tool_args_for_summary(
+    tool_name: str,
+    raw_args: Any,
+    *,
+    max_string_chars: int = 160,
+    max_items: int = 8,
+    max_depth: int = 4,
+) -> str:
+    """Return a compact, JSON-safe tool-argument preview for compaction.
+
+    Weak local tool-calling models can get confused when the compaction summary
+    contains raw function-call-shaped snippets with truncated JSON strings such
+    as ``execute_code({"code":"import ...``. Summaries are reference text, not
+    executable examples, so we convert arguments into a descriptive JSON preview
+    that preserves salient details while replacing huge multiline payloads with
+    a bounded summary string.
+    """
+
+    def _shorten_string(value: str) -> str:
+        normalized = value.replace("\r\n", "\n")
+        line_count = normalized.count("\n") + 1 if normalized else 0
+        single_line = re.sub(r"\s+", " ", normalized).strip()
+        if len(single_line) <= max_string_chars and line_count <= 2:
+            return value
+        preview = single_line[:max_string_chars]
+        if len(single_line) > max_string_chars:
+            preview += "..."
+        return f"<{len(value)} chars, {line_count} lines: {preview}>"
+
+    def _simplify(value: Any, depth: int = 0) -> Any:
+        if depth >= max_depth:
+            return f"<{type(value).__name__}>"
+        if isinstance(value, str):
+            return _shorten_string(value)
+        if isinstance(value, list):
+            items = [_simplify(item, depth + 1) for item in value[:max_items]]
+            if len(value) > max_items:
+                items.append(f"<+{len(value) - max_items} more items>")
+            return items
+        if isinstance(value, dict):
+            result = {}
+            items = list(value.items())
+            for key, item in items[:max_items]:
+                result[str(key)] = _simplify(item, depth + 1)
+            if len(items) > max_items:
+                result["__truncated_keys__"] = len(items) - max_items
+            return result
+        return value
+
+    parsed: Any = raw_args
+    if isinstance(raw_args, str):
+        try:
+            parsed = json.loads(raw_args)
+        except (json.JSONDecodeError, TypeError):
+            parsed = {
+                "raw_args": _shorten_string(raw_args),
+                "tool": tool_name,
+            }
+
+    simplified = _simplify(parsed)
+    try:
+        return json.dumps(simplified, ensure_ascii=False, sort_keys=True)
+    except TypeError:
+        fallback = {
+            "tool": tool_name,
+            "raw_args": _shorten_string(str(raw_args)),
+        }
+        return json.dumps(fallback, ensure_ascii=False, sort_keys=True)
+
+
 class ContextCompressor(ContextEngine):
     """Default context engine — compresses conversation context via lossy summarization.
 
@@ -576,14 +646,12 @@ class ContextCompressor(ContextEngine):
                             fn = tc.get("function", {})
                             name = fn.get("name", "?")
                             args = fn.get("arguments", "")
-                            # Truncate long arguments but keep enough for context
-                            if len(args) > self._TOOL_ARGS_MAX:
-                                args = args[:self._TOOL_ARGS_HEAD] + "..."
-                            tc_parts.append(f"  {name}({args})")
                         else:
                             fn = getattr(tc, "function", None)
                             name = getattr(fn, "name", "?") if fn else "?"
-                            tc_parts.append(f"  {name}(...)")
+                            args = getattr(fn, "arguments", "") if fn else ""
+                        args_preview = _preview_tool_args_for_summary(name, args)
+                        tc_parts.append(f"  {name} args={args_preview}")
                     content += "\n[Tool calls:\n" + "\n".join(tc_parts) + "\n]"
                 parts.append(f"[ASSISTANT]: {content}")
                 continue

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -1,6 +1,7 @@
 """Tests for agent/context_compressor.py — compression logic, thresholds, truncation fallback."""
 
 import json
+
 import pytest
 import time
 from unittest.mock import patch, MagicMock
@@ -12,6 +13,7 @@ from agent.context_compressor import (
     COMPRESSED_SUMMARY_METADATA_KEY,
     _summarize_tool_result,
     _is_summary_access_or_quota_error,
+    _preview_tool_args_for_summary,
 )
 from hermes_state import SessionDB
 
@@ -897,6 +899,84 @@ None.
             "api_key": "codex-token",
             "api_mode": "codex_responses",
         }
+
+
+class TestToolArgsPreview:
+    def test_preview_preserves_short_json_args(self):
+        preview = _preview_tool_args_for_summary(
+            "read_file", '{"path":"x.py","offset":1}'
+        )
+        assert preview == '{"offset": 1, "path": "x.py"}'
+
+    def test_preview_summarizes_long_multiline_string_values(self):
+        long_code = (
+            "import os\nimport re\n\n"
+            "target_dir = os.path.expanduser(\'~/workspace/reports\')\n"
+            "print(target_dir)\n"
+        ) * 30
+        raw_args = json.dumps({"code": long_code})
+        preview = _preview_tool_args_for_summary("execute_code", raw_args)
+        parsed = json.loads(preview)
+        assert parsed["code"].startswith("<")
+        assert "chars" in parsed["code"]
+        assert "lines" in parsed["code"]
+        assert "execute_code({" not in preview
+
+    def test_preview_bounds_long_object_keys_without_dropping_values(self):
+        shared_prefix = "x" * 500
+        raw_args = json.dumps({
+            f"{shared_prefix}a": "first",
+            f"{shared_prefix}b": "second",
+        })
+
+        preview = _preview_tool_args_for_summary("execute_code", raw_args)
+        parsed = json.loads(preview)
+
+        assert len(parsed) == 2
+        assert set(parsed.values()) == {"first", "second"}
+        assert max(len(key) for key in parsed) < 200
+        assert shared_prefix not in preview
+
+    def test_preview_bounds_total_serialized_size(self):
+        raw_args = json.dumps({
+            f"section_{index}": ["x" * 150 for _ in range(8)]
+            for index in range(8)
+        })
+
+        preview = _preview_tool_args_for_summary(
+            "execute_code",
+            raw_args,
+            max_preview_chars=400,
+        )
+        parsed = json.loads(preview)
+
+        assert len(preview) <= 400
+        assert parsed["__preview_chars__"] > 400
+        assert parsed["__truncated_preview__"].startswith("<")
+
+    def test_serialize_for_summary_avoids_function_call_shaped_tool_examples(self):
+        long_code = (
+            "import os\nimport re\n\n"
+            "target_dir = os.path.expanduser(\'~/workspace/reports\')\n"
+            "print(target_dir)\n"
+        ) * 30
+        raw_args = json.dumps({"code": long_code})
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+        serialized = c._serialize_for_summary([
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{
+                    "id": "call1",
+                    "type": "function",
+                    "function": {"name": "execute_code", "arguments": raw_args},
+                }],
+            }
+        ])
+        assert "execute_code args=" in serialized
+        assert "execute_code({" not in serialized
+        assert "<" in serialized and "lines:" in serialized
 
 
 class TestSummaryFailureCooldown:

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -1,9 +1,15 @@
 """Tests for agent/context_compressor.py — compression logic, thresholds, truncation fallback."""
 
+import json
+
 import pytest
 from unittest.mock import patch, MagicMock
 
-from agent.context_compressor import ContextCompressor, SUMMARY_PREFIX
+from agent.context_compressor import (
+    ContextCompressor,
+    SUMMARY_PREFIX,
+    _preview_tool_args_for_summary,
+)
 
 
 @pytest.fixture()
@@ -221,6 +227,52 @@ class TestNonStringContent:
             "api_key": "codex-token",
             "api_mode": "codex_responses",
         }
+
+
+class TestToolArgsPreview:
+    def test_preview_preserves_short_json_args(self):
+        preview = _preview_tool_args_for_summary(
+            "read_file", '{"path":"x.py","offset":1}'
+        )
+        assert preview == '{"offset": 1, "path": "x.py"}'
+
+    def test_preview_summarizes_long_multiline_string_values(self):
+        long_code = (
+            "import os\nimport re\n\n"
+            "target_dir = os.path.expanduser(\'~/workspace/reports\')\n"
+            "print(target_dir)\n"
+        ) * 30
+        raw_args = json.dumps({"code": long_code})
+        preview = _preview_tool_args_for_summary("execute_code", raw_args)
+        parsed = json.loads(preview)
+        assert parsed["code"].startswith("<")
+        assert "chars" in parsed["code"]
+        assert "lines" in parsed["code"]
+        assert "execute_code({" not in preview
+
+    def test_serialize_for_summary_avoids_function_call_shaped_tool_examples(self):
+        long_code = (
+            "import os\nimport re\n\n"
+            "target_dir = os.path.expanduser(\'~/workspace/reports\')\n"
+            "print(target_dir)\n"
+        ) * 30
+        raw_args = json.dumps({"code": long_code})
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="test", quiet_mode=True)
+        serialized = c._serialize_for_summary([
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{
+                    "id": "call1",
+                    "type": "function",
+                    "function": {"name": "execute_code", "arguments": raw_args},
+                }],
+            }
+        ])
+        assert "execute_code args=" in serialized
+        assert "execute_code({" not in serialized
+        assert "<" in serialized and "lines:" in serialized
 
 
 class TestSummaryFailureCooldown:


### PR DESCRIPTION
## What does this PR do?

Hardens context-compaction summary rendering for assistant tool calls.

Compaction summaries currently render tool arguments as truncated function-call-shaped pseudo examples such as `execute_code({ ... })`. Those summaries are injected into later model context. This change renders bounded, JSON-safe descriptive previews as `name args={preview}`, reducing ambiguity while preserving useful argument context.

## Related Issue

Fixes #12586

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/context_compressor.py`
  - Add `_preview_tool_args_for_summary()` for bounded, JSON-safe argument previews.
  - Bound string values, collection sizes, nesting depth, dictionary-key lengths, and total serialized size.
  - Preserve distinct values when shortening dictionary keys would otherwise collide.
  - Fall back to a compact valid-JSON envelope when a branching object exceeds the total preview budget.
  - Change summary serialization from `name(args)` pseudo calls to `name args={preview}`.
  - Preserve current sensitive-text redaction before preview construction.
- `tests/agent/test_context_compressor.py`
  - Cover short JSON, long/multiline values, long and colliding keys, total-size bounds, and non-call-shaped serializer output.

## How to Test

1. Run `scripts/run_tests.sh tests/agent/test_context_compressor.py -q`.
2. Confirm long-key previews retain both values while bounding key length.
3. Confirm deeply branching arguments produce valid JSON within the configured budget.
4. Confirm summaries contain `execute_code args=` and not `execute_code({`.

Final focused verification after resolving the current-`main` redaction-helper rebase:

```text
200 passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the focused context-compressor suite on the final rebased head: 200 passed
- [x] I've added tests for my changes
- [x] I've tested on my platform: Fedora Linux x86_64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — behavior is documented in helper docstrings and tests
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure serializer logic; no platform API
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
/tmp/hermes-pr-venv/bin/python -m pytest tests/agent/test_context_compressor.py -q
200 passed in 8.39s
```
