### PR TITLE
feat(gateway): accept .epub in the document allowlist

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -592,6 +592,7 @@ SUPPORTED_DOCUMENT_TYPES = {
     ".txt": "text/plain",
     ".log": "text/plain",
     ".zip": "application/zip",
+    ".epub": "application/epub+zip",
     ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",

--- a/tests/gateway/test_document_cache.py
+++ b/tests/gateway/test_document_cache.py
@@ -151,7 +151,7 @@ class TestSupportedDocumentTypes:
 
     @pytest.mark.parametrize(
         "ext",
-        [".pdf", ".md", ".txt", ".zip", ".docx", ".xlsx", ".pptx"],
+        [".pdf", ".md", ".txt", ".zip", ".epub", ".docx", ".xlsx", ".pptx"],
     )
     def test_expected_extensions_present(self, ext):
         assert ext in SUPPORTED_DOCUMENT_TYPES


### PR DESCRIPTION
## Summary

- Adds `.epub → application/epub+zip` to `SUPPORTED_DOCUMENT_TYPES` in `gateway/platforms/base.py`.
- That single allowlist is consumed by every platform handler that caches uploaded documents (telegram, slack, discord, feishu, whatsapp), so this one-line addition lets users send `.epub` attachments on any of them.
- Without it, the handlers reject epub uploads at the gateway — e.g. telegram replies with `Unsupported document type '.epub'` — even though the `ocr-and-documents` skill's marker extractor already lists EPUB as a first-class input alongside PDF/DOCX/PPTX/XLSX/HTML.
- Updates `tests/gateway/test_document_cache.py::test_expected_extensions_present` parametrize list accordingly.

## Test plan

- [x] `pytest tests/gateway/test_document_cache.py` (23 pass)
- [x] `pytest tests/gateway/test_telegram_documents.py` (34 pass)
- [ ] Send a small .epub via Telegram to a running agent and confirm it's cached + readable by the ocr-and-documents skill