### PR TITLE
fix(cron): show delivery failure inline with last-run status

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5339,7 +5339,12 @@ class HermesCLI:
                     print(f"  Skills: {', '.join(job['skills'])}")
                 print(f"  Prompt: {job.get('prompt_preview', '')}")
                 if job.get("last_run_at"):
-                    print(f"  Last run: {job['last_run_at']} ({job.get('last_status', '?')})")
+                    delivery_err = job.get("last_delivery_error")
+                    last_status = job.get("last_status", "?")
+                    status_str = f"{last_status} ⚠ delivery failed" if (last_status == "ok" and delivery_err) else last_status
+                    print(f"  Last run: {job['last_run_at']} ({status_str})")
+                    if delivery_err:
+                        print(f"  Delivery error: {delivery_err}")
                 print()
             return
 

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -96,15 +96,17 @@ def cron_list(show_all: bool = False):
 
         # Execution history
         last_status = job.get("last_status")
+        delivery_err = job.get("last_delivery_error")
         if last_status:
             last_run = job.get("last_run_at", "?")
             if last_status == "ok":
-                status_display = color("ok", Colors.GREEN)
+                if delivery_err:
+                    status_display = color("ok", Colors.GREEN) + "  " + color("⚠ delivery failed", Colors.YELLOW)
+                else:
+                    status_display = color("ok", Colors.GREEN)
             else:
                 status_display = color(f"{last_status}: {job.get('last_error', '?')}", Colors.RED)
             print(f"    Last run:  {last_run}  {status_display}")
-
-        delivery_err = job.get("last_delivery_error")
         if delivery_err:
             print(f"    {color('⚠ Delivery failed:', Colors.YELLOW)} {delivery_err}")
 


### PR DESCRIPTION
## Problem

When a cron job succeeds at running the agent but fails to deliver the output (Discord, Telegram, etc.), `last_status` is `"ok"` while the failure sits silently in `last_delivery_error`. The previous display printed a yellow warning on a separate line — easy to miss, and the status cell still showed a plain green **ok**, making the job look healthy at a glance.

## Fix

**`hermes_cli/cron.py`** (`hermes cron list` terminal command):  
When `last_delivery_error` is set and status is `"ok"`, the status cell now renders as `ok  ⚠ delivery failed` (green + yellow) instead of just `ok`. The detail line below it is kept.

**`cli.py`** (in-chat `/cron list`):  
Status string becomes `ok ⚠ delivery failed` and a
`Delivery error: …` line is printed below.

No changes to `cron/jobs.py` or the data model — `last_status`
continues to reflect agent execution only, consistent with the
maintainer design in commit `c5ab760`.

## Testing

```python
# hermes cron list — job with delivery error now shows:
#   Last run:  2026-04-18T10:00Z  ok  ⚠ delivery failed
#   ⚠ Delivery failed: discord: 403 Forbidden

# /cron list (in-chat) — same job now shows:
#   Last run: 2026-04-18T10:00Z (ok ⚠ delivery failed)
#   Delivery error: discord: 403 Forbidden
```
Fixes #5861