### PR TITLE
feat(mattermost): native slash commands + ./ command fallback

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -705,16 +705,22 @@ class MessageEvent:
     timestamp: datetime = field(default_factory=datetime.now)
     
     def is_command(self) -> bool:
-        """Check if this is a command message (e.g., /new, /reset)."""
-        return self.text.startswith("/")
-    
+        """Check if this is a command message (e.g., /new, ./reset)."""
+        return self.text.startswith("/") or self.text.startswith("./")
+
     def get_command(self) -> Optional[str]:
         """Extract command name if this is a command message."""
         if not self.is_command():
             return None
-        # Split on space and get first word, strip the /
+        # Split on space and get first word, strip the / or ./
         parts = self.text.split(maxsplit=1)
-        raw = parts[0][1:].lower() if parts else None
+        first = parts[0] if parts else ""
+        if first.startswith("./"):
+            raw = first[2:].lower()
+        elif first.startswith("/"):
+            raw = first[1:].lower()
+        else:
+            return None
         if raw and "@" in raw:
             raw = raw.split("@", 1)[0]
         # Reject file paths: valid command names never contain /

--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -9,6 +9,7 @@ Environment variables:
     MATTERMOST_TOKEN            Bot token or personal-access token
     MATTERMOST_ALLOWED_USERS    Comma-separated user IDs
     MATTERMOST_HOME_CHANNEL     Channel ID for cron/notification delivery
+    MATTERMOST_COMMAND_PORT     Local HTTP port for slash command callbacks (default: 8477)
 """
 
 from __future__ import annotations
@@ -48,6 +49,9 @@ _CHANNEL_TYPE_MAP = {
 _RECONNECT_BASE_DELAY = 2.0
 _RECONNECT_MAX_DELAY = 60.0
 _RECONNECT_JITTER = 0.2
+
+# Default local port for Mattermost slash command HTTP callbacks.
+_DEFAULT_COMMAND_PORT = 8477
 
 
 def check_mattermost_requirements() -> bool:
@@ -98,6 +102,38 @@ class MattermostAdapter(BasePlatformAdapter):
 
         # Dedup cache (prevent reprocessing)
         self._dedup = MessageDeduplicator()
+
+        # Slash command registration: enabled by default. Set
+        # MATTERMOST_SLASH_COMMANDS=false to disable (e.g. on profiles
+        # that share the same bot token as the main profile — only one
+        # gateway should register commands to avoid port conflicts).
+        self._slash_commands_enabled = os.getenv(
+            "MATTERMOST_SLASH_COMMANDS", "true"
+        ).lower() in ("true", "1", "yes")
+
+        # Local HTTP server for slash command callbacks.
+        self._command_port: int = int(
+            config.extra.get("command_port", "")
+            or os.getenv("MATTERMOST_COMMAND_PORT", _DEFAULT_COMMAND_PORT)
+        )
+        self._http_runner: Any = None  # aiohttp.web.AppRunner
+        self._http_site: Any = None
+
+        # Registered Mattermost command IDs (for cleanup on disconnect).
+        self._registered_command_ids: List[str] = []
+
+        # Per-command verification tokens issued by Mattermost at registration
+        # time; used to authenticate incoming slash command callbacks.
+        self._command_tokens: set = set()
+
+        # Team id the bot registers slash commands under (resolved in connect()).
+        self._team_id: str = ""
+
+        # Callback URL base — inferred from config or defaulted to localhost.
+        self._callback_url: str = (
+            config.extra.get("command_callback_url", "")
+            or os.getenv("MATTERMOST_COMMAND_CALLBACK_URL", "")
+        )
 
     # ------------------------------------------------------------------
     # HTTP helpers
@@ -221,14 +257,43 @@ class MattermostAdapter(BasePlatformAdapter):
             self._base_url,
         )
 
+        # Resolve the bot's team for slash command registration.
+        teams = await self._api_get("users/me/teams")
+        if isinstance(teams, list) and teams:
+            self._team_id = teams[0]["id"]
+            logger.info(
+                "Mattermost: slash commands will register under team %s (%s)",
+                teams[0].get("name", "?"),
+                self._team_id,
+            )
+        else:
+            logger.warning(
+                "Mattermost: bot belongs to no team — slash command registration will be skipped"
+            )
+
         # Start WebSocket in background.
         self._ws_task = asyncio.create_task(self._ws_loop())
         self._mark_connected()
+
+        # Post-connect initialization: start HTTP server and register slash commands.
+        asyncio.create_task(self._run_post_connect_initialization())
+
         return True
 
     async def disconnect(self) -> None:
         """Disconnect from Mattermost."""
         self._closing = True
+
+        # Clean up registered slash commands.
+        await self._unregister_commands()
+
+        # Stop the HTTP server.
+        if self._http_site:
+            await self._http_site.stop()
+        if self._http_runner:
+            await self._http_runner.cleanup()
+        self._http_runner = None
+        self._http_site = None
 
         if self._ws_task and not self._ws_task.done():
             self._ws_task.cancel()
@@ -391,6 +456,243 @@ class MattermostAdapter(BasePlatformAdapter):
         # image URLs as inline previews automatically.
         content = re.sub(r"!\[([^\]]*)\]\(([^)]+)\)", r"\2", content)
         return content
+
+    # ------------------------------------------------------------------
+    # Slash command HTTP server
+    # ------------------------------------------------------------------
+
+    async def _run_post_connect_initialization(self) -> None:
+        """Called after WebSocket connect — starts HTTP server and registers slash commands."""
+        if not self._slash_commands_enabled:
+            return
+
+        # Start the local HTTP server for slash command callbacks.
+        await self._start_command_server()
+
+        # Register Mattermost slash commands for each gateway-available command.
+        await self._register_commands()
+
+    async def _start_command_server(self) -> None:
+        """Start the aiohttp HTTP server that receives Mattermost slash command callbacks."""
+        from aiohttp import web
+
+        app = web.Application()
+        app.router.add_post("/mattermost-command", self._handle_mattermost_command)
+        app.router.add_get("/health", self._handle_health)
+
+        self._http_runner = web.AppRunner(app)
+        await self._http_runner.setup()
+        self._http_site = web.TCPSite(self._http_runner, "0.0.0.0", self._command_port)
+        await self._http_site.start()
+        logger.info(
+            "Mattermost: slash command HTTP server listening on 0.0.0.0:%d",
+            self._command_port,
+        )
+
+    async def _handle_mattermost_command(self, request: Any) -> Any:
+        """Receive and validate a Mattermost slash command callback.
+
+        Mattermost sends ``application/x-www-form-urlencoded`` with:
+          command, text, user_name, channel_id, team_id, token, ...
+        """
+        from aiohttp import web
+
+        # Token validation.
+        try:
+            data = await request.post()
+        except Exception:
+            return web.Response(status=400, text="Invalid request body")
+
+        token = data.get("token", "")
+        if token not in self._command_tokens:
+            logger.warning("Mattermost: rejected slash command with invalid token")
+            return web.Response(status=403, text="Forbidden")
+
+        command: str = data.get("command", "").lstrip("/")
+        text: str = data.get("text", "")
+        user_id: str = data.get("user_id", "")
+        user_name: str = data.get("user_name", "")
+        channel_id: str = data.get("channel_id", "")
+        team_id: str = data.get("team_id", "")
+
+        # Build the full command string the gateway expects.
+        full_text = f"/{command} {text}".strip() if text else f"/{command}"
+
+        # Determine whether the invoking channel is a DM, private group, or open channel.
+        chat_type = "channel"
+        if channel_id:
+            ch = await self._api_get(f"channels/{channel_id}")
+            ch_type = (ch or {}).get("type")
+            if ch_type == "D":
+                chat_type = "dm"
+            elif ch_type == "G":
+                chat_type = "group"
+
+        source = self.build_source(
+            chat_id=channel_id,
+            chat_type=chat_type,
+            user_id=user_id or user_name,
+            user_name=user_name,
+        )
+
+        event = MessageEvent(
+            text=full_text,
+            message_type=MessageType.COMMAND,
+            source=source,
+            raw_message=dict(data),
+        )
+
+        # Respond to Mattermost immediately — process asynchronously.
+        asyncio.create_task(self.handle_message(event))
+
+        return web.Response(status=200, text="")
+
+    async def _handle_health(self, request: Any) -> Any:
+        from aiohttp import web
+        return web.Response(status=200, text="ok")
+
+    # ------------------------------------------------------------------
+    # Slash command registration
+    # ------------------------------------------------------------------
+
+    async def _register_commands(self) -> None:
+        """Register each gateway-available command as a native Mattermost slash command.
+
+        Idempotent: checks for existing commands before creating, and handles
+        409 Conflict gracefully.
+        """
+        if not self._team_id:
+            logger.warning(
+                "Mattermost: no team_id resolved, skipping slash command registration"
+            )
+            return
+
+        # Build the callback URL.  Use the explicitly configured URL, otherwise
+        # default to localhost on the configured command port.
+        if self._callback_url:
+            callback_url = f"{self._callback_url.rstrip('/')}/mattermost-command"
+        else:
+            callback_url = f"http://localhost:{self._command_port}/mattermost-command"
+
+        # Get the list of commands already registered by this bot.
+        existing_commands = await self._list_registered_commands()
+        existing_triggers = {cmd.get("trigger") for cmd in existing_commands if cmd.get("trigger")}
+
+        # Seed the per-command token set so callbacks for already-registered
+        # commands authenticate on gateway restart.
+        for cmd in existing_commands:
+            tok = cmd.get("token")
+            if tok:
+                self._command_tokens.add(tok)
+
+        # Filter COMMAND_REGISTRY to gateway-available commands.
+        from hermes_cli.commands import COMMAND_REGISTRY
+
+        for cmd in COMMAND_REGISTRY:
+            # Include if: not cli_only, OR has gateway_config_gate.
+            if cmd.cli_only and not cmd.gateway_config_gate:
+                continue
+
+            trigger = cmd.name
+
+            # Skip if already registered.
+            if trigger in existing_triggers:
+                logger.debug(
+                    "Mattermost: command '/%s' already registered, skipping",
+                    trigger,
+                )
+                continue
+
+            hint = cmd.args_hint or ""
+            description = cmd.description
+
+            payload: Dict[str, Any] = {
+                "team_id": self._team_id,
+                "trigger": trigger,
+                "url": callback_url,
+                "method": "P",
+                "title": f"/{trigger}",
+                "description": description,
+                "auto_complete": True,
+                "auto_complete_hint": hint,
+                "auto_complete_desc": description,
+            }
+
+            result = await self._api_post("commands", payload)
+            if result and result.get("id"):
+                self._registered_command_ids.append(result["id"])
+                tok = result.get("token")
+                if tok:
+                    self._command_tokens.add(tok)
+                logger.info(
+                    "Mattermost: registered slash command '/%s' (ID: %s)",
+                    trigger,
+                    result["id"],
+                )
+            elif result and result.get("status_code") == 409:
+                logger.debug(
+                    "Mattermost: command '/%s' already exists (409), skipping",
+                    trigger,
+                )
+            else:
+                logger.warning(
+                    "Mattermost: failed to register command '/%s': %s",
+                    trigger,
+                    result,
+                )
+
+    async def _list_registered_commands(self) -> List[Dict[str, Any]]:
+        """List custom commands already registered for this team."""
+        if not self._team_id:
+            return []
+        result = await self._api_get(
+            f"commands?team_id={self._team_id}&custom_only=true"
+        )
+        if isinstance(result, dict):
+            # Some Mattermost versions return {"items": [...]}
+            return result.get("items", [])
+        if isinstance(result, list):
+            return result
+        return []
+
+    async def _unregister_commands(self) -> None:
+        """Delete previously registered Mattermost slash commands (cleanup)."""
+        for cmd_id in self._registered_command_ids:
+            result = await self._api_delete(f"commands/{cmd_id}")
+            if result and result.get("id"):
+                logger.info(
+                    "Mattermost: deleted slash command ID %s",
+                    cmd_id,
+                )
+            else:
+                logger.warning(
+                    "Mattermost: failed to delete slash command ID %s: %s",
+                    cmd_id,
+                    result,
+                )
+
+    async def _api_delete(self, path: str) -> Dict[str, Any]:
+        """DELETE /api/v4/{path}."""
+        import aiohttp
+        url = f"{self._base_url}/api/v4/{path.lstrip('/')}"
+        try:
+            async with self._session.delete(
+                url, headers=self._headers(), timeout=aiohttp.ClientTimeout(total=30)
+            ) as resp:
+                if resp.status >= 400:
+                    body = await resp.text()
+                    logger.error("MM API DELETE %s → %s: %s", path, resp.status, body[:200])
+                    return {}
+                text = await resp.text()
+                if text:
+                    try:
+                        return json.loads(text)
+                    except json.JSONDecodeError:
+                        return {"status": resp.status}
+                return {"status": resp.status}
+        except aiohttp.ClientError as exc:
+            logger.error("MM API DELETE %s network error: %s", path, exc)
+            return {}
 
     # ------------------------------------------------------------------
     # File helpers
@@ -659,7 +961,7 @@ class MattermostAdapter(BasePlatformAdapter):
         # Determine message type.
         file_ids = post.get("file_ids") or []
         msg_type = MessageType.TEXT
-        if message_text.startswith("/"):
+        if message_text.startswith("/") or message_text.startswith("./"):
             msg_type = MessageType.COMMAND
 
         # Download file attachments immediately (URLs require auth headers
@@ -736,5 +1038,3 @@ class MattermostAdapter(BasePlatformAdapter):
         )
 
         await self.handle_message(msg_event)
-
-

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10300,13 +10300,15 @@ class GatewayRunner:
                     logger.debug("Processing queued message after agent completion: '%s...'", pending[:40])
 
             # Safety net: if the pending text is a slash command (e.g. "/stop",
-            # "/new"), discard it — commands should never be passed to the agent
+            # "./stop", "/new"), discard it — commands should never be passed to the agent
             # as user input.  The primary fix is in base.py (commands bypass the
             # active-session guard), but this catches edge cases where command
             # text leaks through the interrupt_message fallback.
-            if pending and pending.strip().startswith("/"):
-                _pending_parts = pending.strip().split(None, 1)
-                _pending_cmd_word = _pending_parts[0][1:].lower() if _pending_parts else ""
+            _pending_stripped = pending.strip() if pending else ""
+            if _pending_stripped.startswith("/") or _pending_stripped.startswith("./"):
+                _pending_parts = _pending_stripped.split(None, 1)
+                _first = _pending_parts[0]
+                _pending_cmd_word = _first[2:].lower() if _first.startswith("./") else _first[1:].lower() if _first.startswith("/") else ""
                 if _pending_cmd_word:
                     try:
                         from hermes_cli.commands import resolve_command as _rc_pending


### PR DESCRIPTION
## Summary

- Adds Mattermost native slash commands: the gateway registers every `COMMAND_REGISTRY` entry via `POST /api/v4/commands`, spins up an HTTP server to receive the callbacks, and authenticates them against the per-command `token` MM issues at registration time.
- Adds a cross-platform `./command` fallback to `MessageEvent.is_command()` / `get_command()` and the `_run_agent` safety net, so users can invoke commands on any platform even without native slash-command registration.
- Guards `_run_agent`'s pending-queue inspection against a `None` pending value (`AttributeError: 'NoneType' object has no attribute 'strip'`).

## Why

Native MM slash commands never worked end-to-end in the existing code. Every registration call returned `403 api.context.permissions.app_error` because the payload was missing `team_id` and used `callback_url` instead of the API's `url` field. Even once I fixed that, the callback handler compared the incoming per-command `token` against the bot's bearer token (`self._token`) — they're different values, so every callback was rejected with 403. The other fixes (correct `chat_type` via channel lookup, real `user_id` from the form, SSRF docs) came out of getting a real Hermit DM round-trip to succeed.

## Key fixes in `gateway/platforms/mattermost.py`

| Bug | Before | After |
|---|---|---|
| Registration payload | `callback_url`, no `team_id` | `url`, `team_id`, `auto_complete_desc` |
| Callback auth | compares MM's per-command token to bot bearer token | compares against the set of per-command tokens seeded from the listing + appended at registration |
| `chat_type` | hardcoded `"dm"` | `GET /api/v4/channels/{id}` → `D`/`G`/other |
| Session identity | passes `user_name` as `user_id` | passes form's actual `user_id`, falls back to `user_name` |
| Listing for idempotency | `GET /api/v4/commands` (no scope) | `?team_id=...&custom_only=true` |

## New env vars

- `MATTERMOST_COMMAND_PORT` — local HTTP port (default `8477`).
- `MATTERMOST_COMMAND_CALLBACK_URL` — base URL only, e.g. `http://<your-server>:<port>`. The `/mattermost-command` path is appended.
- `MATTERMOST_SLASH_COMMANDS` — `true` / `false`. Disable on secondary profiles that share a bot token (only one gateway can bind the callback port).

## Operator note

Mattermost's `ServiceSettings.AllowedUntrustedInternalConnections` must include the callback host if it's an RFC-1918 address; otherwise the SSRF guard silently drops outbound callbacks and the user sees *Command with a trigger of '…' failed*.

## Test plan

- [x] Restart `hermes-gateway-main.service` — log shows `registered slash command '/...' (ID: ...)` for all `COMMAND_REGISTRY` entries except MM built-in collisions (`/help`, `/status`).
- [x] `GET /api/v4/commands?team_id=...&custom_only=true` returns the registered set with correct `url` values.
- [x] Typing `/` in a Hermit DM surfaces the autocomplete.
- [x] `/new` in a DM starts a fresh session and the agent replies — no pairing prompt, no AttributeError.
- [x] Restart the gateway again: the listing-based idempotency seeds `_command_tokens` from existing entries, new registrations are skipped, callbacks still authenticate.
- [x] `./command` works on platforms without native registration (Matrix, Telegram, Slack).