### PR TITLE
fix(model_metadata): divide llama.cpp n_ctx by total_slots (#6797)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -552,10 +552,25 @@ def fetch_endpoint_model_metadata(
                         gen_settings = props.get("default_generation_settings", {})
                         n_ctx = gen_settings.get("n_ctx")
                         model_alias = props.get("model_alias", "")
+                        # llama.cpp divides its KV cache across parallel slots, so a
+                        # single request can only use n_ctx / total_slots tokens before
+                        # the server silently truncates the prompt. Report the per-slot
+                        # capacity so the compressor fires against the real limit
+                        # (issue #6797).
+                        total_slots = props.get("total_slots")
+                        if not isinstance(total_slots, int) or total_slots < 1:
+                            total_slots = 1
                         if n_ctx and model_alias and model_alias in cache:
-                            cache[model_alias]["context_length"] = n_ctx
-                except Exception:
-                    pass
+                            per_slot_ctx = n_ctx // total_slots
+                            cache[model_alias]["context_length"] = per_slot_ctx
+                            if total_slots > 1:
+                                logger.info(
+                                    "llama.cpp: n_ctx=%s across %s slots -> using %s tokens per request "
+                                    "(run the server with --parallel 1 to use the full context)",
+                                    n_ctx, total_slots, per_slot_ctx,
+                                )
+                except Exception as exc:
+                    logger.debug("Failed to fetch llama.cpp /props metadata: %s", exc)
 
             _endpoint_model_metadata_cache[normalized] = cache
             _endpoint_model_metadata_cache_time[normalized] = time.time()

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -25,6 +25,7 @@ from agent.model_metadata import (
     _strip_provider_prefix,
     estimate_tokens_rough,
     estimate_messages_tokens_rough,
+    fetch_endpoint_model_metadata,
     get_model_context_length,
     get_next_probe_tier,
     get_cached_context_length,
@@ -711,3 +712,128 @@ class TestContextLengthCache:
         with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
             save_context_length(model, url, 200000)
             assert get_cached_context_length(model, url) == 200000
+
+
+# =========================================================================
+# fetch_endpoint_model_metadata — llama.cpp /props slot-aware context
+# =========================================================================
+
+class TestFetchEndpointLlamaCppSlotAwareContext:
+    """Regression tests for issue #6797.
+
+    llama.cpp divides its KV cache across parallel slots, so a single request
+    can only use ``n_ctx / total_slots`` tokens. Hermes must report the per-slot
+    capacity so the compressor fires before the server silently truncates the
+    prompt (which strips tool definitions and produces hallucinated tool calls).
+    """
+
+    def _reset_cache(self):
+        import agent.model_metadata as mm
+        mm._endpoint_model_metadata_cache = {}
+        mm._endpoint_model_metadata_cache_time = {}
+
+    def _mock_responses(self, models_payload, props_payload, props_ok=True):
+        """Build a side_effect sequence: /models, then /v1/props."""
+        models_resp = MagicMock()
+        models_resp.json.return_value = models_payload
+        models_resp.raise_for_status = MagicMock()
+        models_resp.ok = True
+
+        props_resp = MagicMock()
+        props_resp.json.return_value = props_payload
+        props_resp.ok = props_ok
+        return [models_resp, props_resp]
+
+    @patch("agent.model_metadata.requests.get")
+    def test_divides_n_ctx_by_total_slots(self, mock_get):
+        """n_ctx=65536 across 4 slots → 16384 per-request context."""
+        self._reset_cache()
+        mock_get.side_effect = self._mock_responses(
+            {"data": [{"id": "my-model.gguf", "owned_by": "llamacpp"}]},
+            {
+                "default_generation_settings": {"n_ctx": 65536},
+                "total_slots": 4,
+                "model_alias": "my-model.gguf",
+            },
+        )
+
+        result = fetch_endpoint_model_metadata("http://localhost:8080/v1", force_refresh=True)
+
+        assert result["my-model.gguf"]["context_length"] == 16384
+
+    @patch("agent.model_metadata.requests.get")
+    def test_single_slot_uses_full_n_ctx(self, mock_get):
+        """--parallel 1 means the full n_ctx is available per request."""
+        self._reset_cache()
+        mock_get.side_effect = self._mock_responses(
+            {"data": [{"id": "my-model.gguf", "owned_by": "llamacpp"}]},
+            {
+                "default_generation_settings": {"n_ctx": 32768},
+                "total_slots": 1,
+                "model_alias": "my-model.gguf",
+            },
+        )
+
+        result = fetch_endpoint_model_metadata("http://localhost:8080/v1", force_refresh=True)
+
+        assert result["my-model.gguf"]["context_length"] == 32768
+
+    @patch("agent.model_metadata.requests.get")
+    def test_missing_total_slots_defaults_to_one(self, mock_get):
+        """Older llama.cpp builds may omit total_slots — don't over-divide."""
+        self._reset_cache()
+        mock_get.side_effect = self._mock_responses(
+            {"data": [{"id": "my-model.gguf", "owned_by": "llamacpp"}]},
+            {
+                "default_generation_settings": {"n_ctx": 16384},
+                "model_alias": "my-model.gguf",
+            },
+        )
+
+        result = fetch_endpoint_model_metadata("http://localhost:8080/v1", force_refresh=True)
+
+        assert result["my-model.gguf"]["context_length"] == 16384
+
+    @patch("agent.model_metadata.requests.get")
+    def test_invalid_total_slots_falls_back_to_one(self, mock_get):
+        """Non-integer or zero total_slots must not crash or produce 0 ctx."""
+        self._reset_cache()
+        mock_get.side_effect = self._mock_responses(
+            {"data": [{"id": "my-model.gguf", "owned_by": "llamacpp"}]},
+            {
+                "default_generation_settings": {"n_ctx": 8192},
+                "total_slots": "oops",
+                "model_alias": "my-model.gguf",
+            },
+        )
+
+        result = fetch_endpoint_model_metadata("http://localhost:8080/v1", force_refresh=True)
+
+        assert result["my-model.gguf"]["context_length"] == 8192
+
+    @patch("agent.model_metadata.requests.get")
+    def test_props_failure_leaves_models_endpoint_value(self, mock_get):
+        """If /props fails, the /models endpoint value (if any) is preserved."""
+        self._reset_cache()
+        models_resp = MagicMock()
+        models_resp.json.return_value = {
+            "data": [{
+                "id": "my-model.gguf",
+                "owned_by": "llamacpp",
+                "context_length": 4096,
+            }]
+        }
+        models_resp.raise_for_status = MagicMock()
+        models_resp.ok = True
+
+        v1_props_resp = MagicMock()
+        v1_props_resp.ok = False
+        legacy_props_resp = MagicMock()
+        legacy_props_resp.ok = False
+
+        mock_get.side_effect = [models_resp, v1_props_resp, legacy_props_resp]
+
+        result = fetch_endpoint_model_metadata("http://localhost:8080/v1", force_refresh=True)
+
+        # /models reported 4096; /props failed so we don't override it.
+        assert result["my-model.gguf"]["context_length"] == 4096


### PR DESCRIPTION
## Summary

Fixes #6797.

When Hermes connects to a llama.cpp server, `fetch_endpoint_model_metadata` reads `default_generation_settings.n_ctx` from `/props` but ignores the sibling `total_slots` field. llama.cpp divides its KV cache evenly across parallel slots, so the effective per-request context is `n_ctx / total_slots` — each slot's KV is carved from the single `--ctx-size` allocation.

Hermes' compressor therefore sizes its threshold against a number the server will never honor. Past the per-slot limit, the server silently truncates the beginning of the prompt — tool definitions go first — and the model starts emitting hallucinated tool calls. The `⏰` indicators still fire, the tool handler returns `{"success": true}`, but the underlying state is never touched. Cron jobs, memory edits, etc. appear to work and actually don't.

The original reporter confirmed the mechanism empirically in #6797: running llama.cpp with `--parallel 1` restored correct behavior on a session that had been stuck for hours.

## Root cause

`agent/model_metadata.py`, llama.cpp branch of `fetch_endpoint_model_metadata`:

```python
n_ctx = gen_settings.get("n_ctx")
...
if n_ctx and model_alias and model_alias in cache:
    cache[model_alias]["context_length"] = n_ctx   # full n_ctx, not per-slot
```

## Fix

Read `total_slots` from the same `/props` response (llama.cpp returns it at the top level) and store `n_ctx // total_slots`. When `total_slots > 1`, emit an info log so users see what Hermes is using and learn how to reclaim the full context (`--parallel 1`).

| case | before | after |
|---|---|---|
| `--ctx-size 65536 --parallel 4` | `context_length=65536` (compressor too loose; silent truncation at ~16K) | `context_length=16384` (compressor fires correctly) |
| `--ctx-size 32768 --parallel 1` | `context_length=32768` | `context_length=32768` (unchanged) |
| older llama.cpp (no `total_slots` field) | `context_length=n_ctx` | `context_length=n_ctx` (defaults to slots=1) |
| non-integer `total_slots` in payload | unchanged | defaults to slots=1 (no crash, no div-by-zero) |
| `/props` fetch fails | `except: pass` (invisible) | `logger.debug(...)` (diagnostics) |

## Scope

Only the llama.cpp path in `fetch_endpoint_model_metadata`. The Ollama path is untouched: Ollama internally passes `num_ctx * num_parallel` as the underlying llama.cpp `--ctx-size`, so `/api/show` already returns the per-slot number at the API surface. If follow-up investigation shows otherwise for some Ollama configuration, that's a separate fix.

## Changes

- `agent/model_metadata.py`: read `total_slots` from `/props`, divide `n_ctx` accordingly, info-log when slots > 1. Replace the bare `except: pass` on the `/props` fetch with `logger.debug(...)`.
- `tests/agent/test_model_metadata.py`: new `TestFetchEndpointLlamaCppSlotAwareContext` class — 5 regression cases covering the slot division, single-slot pass-through, missing `total_slots`, invalid `total_slots`, and `/props` failure preserving the `/models` endpoint value.

## Validation

- New tests: 5/5 pass.
- Full `tests/agent/test_model_metadata.py` + `tests/agent/test_model_metadata_local_ctx.py`: 105/105 pass.
- Regression guard: against unpatched code, `test_divides_n_ctx_by_total_slots` fails as expected.

## Severity

Medium — the failure mode is silent data-integrity corruption (tools report success while mutating nothing), affecting any local-LLM user running llama.cpp/Ollama with parallel slots, which is the default on recent builds (`--parallel auto`, `OLLAMA_NUM_PARALLEL=4`).