### PR TITLE
fix(tools/memory): require old_text param for replace/remove actions

### DIFF
--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -478,6 +478,10 @@ def memory_tool(
     if target not in ("memory", "user"):
         return tool_error(f"Invalid target '{target}'. Use 'memory' or 'user'.", success=False)
 
+    # Normalize: for 'add' action, old_text is not meaningful — treat empty/absent as None
+    if action == "add":
+        old_text = None
+
     if action == "add":
         if not content:
             return tool_error("Content is required for 'add' action.", success=False)
@@ -554,10 +558,10 @@ MEMORY_SCHEMA = {
             },
             "old_text": {
                 "type": "string",
-                "description": "Short unique substring identifying the entry to replace or remove."
+                "description": "Required for 'replace' and 'remove'. Short unique substring identifying the entry to replace or remove."
             },
         },
-        "required": ["action", "target"],
+        "required": ["action", "target", "old_text"],
     },
 }
 


### PR DESCRIPTION
## Problem

The `old_text` parameter was optional in the memory tool JSON schema (not in the `required` list). Thinking models like `glm-5.1:cloud` skip non-required params when calling tools, so `replace` and `remove` actions would fail with `"old_text is required"` at runtime because the handler always expects it.

## Changes

1. **Add `old_text` to schema `required` list** — ensures all models include it in tool calls for replace/remove
2. **Update `old_text` description** — clarify "Required for replace and remove"
3. **Add normalization for `add` action** — treat empty/absent `old_text` as `None` when action is `add`, avoiding false validation errors

## Testing

Tested locally with `glm-5.1:cloud` (the model that exposed the bug). After patching:
- `replace` and `remove` actions now receive `old_text` reliably
- `add` actions no longer error when `old_text` is absent
- No regressions in other memory operations