### PR TITLE
feat(compressor): rehydrate _previous_summary from transcript on agent boot

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -871,6 +871,39 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                 break
         return f"{SUMMARY_PREFIX}\n{text}" if text else SUMMARY_PREFIX
 
+    def rehydrate_previous_summary(self, messages: List[Dict[str, Any]]) -> bool:
+        """Restore ``_previous_summary`` from a compaction marker in ``messages``.
+
+        The gateway creates a fresh ``AIAgent`` (and therefore a fresh
+        ``ContextCompressor``) per turn or after a process restart, so
+        ``_previous_summary`` is otherwise ``None`` on the first compaction
+        of a reloaded session — forcing the iterative-update path to fall
+        back to summarize-from-scratch.  That re-runs the prior compaction
+        summary through the LLM as raw turn content, which is exactly how
+        fidelity degrades across the "compressed N times" warning.
+
+        This scans the transcript from newest to oldest for a message whose
+        content starts with ``SUMMARY_PREFIX`` (or the legacy prefix),
+        strips the prefix, and seeds ``_previous_summary`` with the body so
+        the next compaction uses the UPDATE prompt.
+
+        Returns ``True`` if a summary was rehydrated.
+        """
+        if self._previous_summary:
+            return False
+        for msg in reversed(messages):
+            content = msg.get("content") if isinstance(msg, dict) else None
+            if not isinstance(content, str):
+                continue
+            for prefix in (SUMMARY_PREFIX, LEGACY_SUMMARY_PREFIX):
+                if content.startswith(prefix):
+                    body = content[len(prefix):].lstrip("\n")
+                    if body:
+                        self._previous_summary = body
+                        return True
+                    return False
+        return False
+
     # ------------------------------------------------------------------
     # Tool-call / tool-result pair integrity helpers
     # ------------------------------------------------------------------

--- a/run_agent.py
+++ b/run_agent.py
@@ -8756,7 +8756,23 @@ class AIAgent:
         # recover the todo state from the most recent todo tool response in history)
         if conversation_history and not self._todo_store.has_items():
             self._hydrate_todo_store(conversation_history)
-        
+
+        # Same problem for the context compressor's iterative-update state:
+        # ``_previous_summary`` lives only on the in-memory ContextCompressor,
+        # so a fresh AIAgent starts with it set to ``None`` and the next
+        # compaction falls back to summarize-from-scratch — which re-runs
+        # the prior [CONTEXT COMPACTION] marker through the LLM as raw turn
+        # content and blurs it. Seed from the most recent marker so the
+        # UPDATE prompt path stays active across process restarts.
+        if conversation_history and getattr(self, "context_compressor", None):
+            try:
+                self.context_compressor.rehydrate_previous_summary(conversation_history)
+            except Exception as _rehydrate_err:
+                logger.debug(
+                    "context_compressor rehydrate_previous_summary failed: %s",
+                    _rehydrate_err,
+                )
+
         # Prefill messages (few-shot priming) are injected at API-call time only,
         # never stored in the messages list. This keeps them ephemeral: they won't
         # be saved to session DB, session logs, or batch trajectories, but they're

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -252,6 +252,69 @@ class TestSummaryPrefixNormalization:
         assert summary == f"{SUMMARY_PREFIX}\ndid work"
 
 
+class TestRehydratePreviousSummary:
+    def test_rehydrate_from_latest_marker(self, compressor):
+        body = "## Goal\nbuild the thing\n## Progress\ndone"
+        history = [
+            {"role": "user", "content": "first user turn"},
+            {"role": "assistant", "content": "first reply"},
+            {"role": "user", "content": f"{SUMMARY_PREFIX}\n{body}"},
+            {"role": "user", "content": "follow-up after compaction"},
+        ]
+        assert compressor._previous_summary is None
+        assert compressor.rehydrate_previous_summary(history) is True
+        assert compressor._previous_summary == body
+
+    def test_rehydrate_picks_most_recent_when_multiple(self, compressor):
+        old = "older summary body"
+        new = "newer summary body"
+        history = [
+            {"role": "user", "content": f"{SUMMARY_PREFIX}\n{old}"},
+            {"role": "assistant", "content": "work happened"},
+            {"role": "user", "content": f"{SUMMARY_PREFIX}\n{new}"},
+            {"role": "user", "content": "latest user turn"},
+        ]
+        compressor.rehydrate_previous_summary(history)
+        assert compressor._previous_summary == new
+
+    def test_rehydrate_accepts_legacy_prefix(self, compressor):
+        from agent.context_compressor import LEGACY_SUMMARY_PREFIX
+        body = "legacy summary body"
+        history = [{"role": "user", "content": f"{LEGACY_SUMMARY_PREFIX}\n{body}"}]
+        assert compressor.rehydrate_previous_summary(history) is True
+        assert compressor._previous_summary == body
+
+    def test_rehydrate_noop_when_already_set(self, compressor):
+        compressor._previous_summary = "in-memory value"
+        history = [{"role": "user", "content": f"{SUMMARY_PREFIX}\nother"}]
+        assert compressor.rehydrate_previous_summary(history) is False
+        assert compressor._previous_summary == "in-memory value"
+
+    def test_rehydrate_noop_when_no_marker(self, compressor):
+        history = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+        ]
+        assert compressor.rehydrate_previous_summary(history) is False
+        assert compressor._previous_summary is None
+
+    def test_rehydrate_ignores_non_string_content(self, compressor):
+        # Multimodal content arrives as a list of parts; must not crash
+        history = [
+            {"role": "user", "content": [{"type": "text", "text": "hi"}]},
+            {"role": "assistant", "content": None},
+        ]
+        assert compressor.rehydrate_previous_summary(history) is False
+        assert compressor._previous_summary is None
+
+    def test_rehydrate_empty_body_returns_false(self, compressor):
+        # A bare SUMMARY_PREFIX with no body is the failure-fallback marker —
+        # don't seed iterative-update state from it.
+        history = [{"role": "user", "content": SUMMARY_PREFIX}]
+        assert compressor.rehydrate_previous_summary(history) is False
+        assert compressor._previous_summary is None
+
+
 class TestCompressWithClient:
     def test_system_content_list_gets_compression_note_without_crashing(self):
         mock_response = MagicMock()


### PR DESCRIPTION
## Summary

`ContextCompressor` already has a two-prompt compaction strategy: an INITIAL prompt that summarizes from scratch, and an UPDATE prompt that merges new turns into a prior structured summary. The UPDATE path depends on `self._previous_summary` being set — and it lives only on the in-memory `ContextCompressor`.

Every fresh `AIAgent` starts with `_previous_summary = None`:
- The gateway evicts the per-session agent cache under load.
- Process restarts (deploys, OOM, `systemctl restart`) wipe the cache.
- Background/cron paths construct ephemeral agents per turn.

After any of those, the next compaction takes the INITIAL path. The transcript still contains the prior `[CONTEXT COMPACTION — REFERENCE ONLY]` marker from the earlier compaction, which then gets re-summarized *as raw turn content* — the exact recursive-blur pattern that produces the `⚠️ Session compressed N times — accuracy may degrade` warning on long-lived threads.

This change adds `ContextCompressor.rehydrate_previous_summary(messages)`, called once per turn in `run_conversation` right after `_hydrate_todo_store`. It walks the transcript newest-to-oldest, finds the most recent `SUMMARY_PREFIX` (or legacy `[CONTEXT SUMMARY]:`) message, strips the prefix, and seeds `_previous_summary` with the body. The next compaction then takes the UPDATE path and preserves the structured sections instead of re-blurring them.

Behavior guarantees:
- Never overwrites an existing in-memory `_previous_summary` (within a single agent instance, normal iterative updates still win).
- Tolerates multimodal (list-typed) `content`, `None`, and missing fields without raising.
- A bare `SUMMARY_PREFIX` with no body (the failure-fallback marker the compressor emits when the summarizer LLM is unavailable) does NOT seed state.

## Test plan

- [x] 7 new unit tests in `TestRehydratePreviousSummary` covering: newest-marker selection, multiple markers, legacy prefix, no-op when already set, no-op when no marker, non-string content, empty body.
- [x] Full `tests/agent/test_context_compressor.py` + `tests/run_agent/test_session_reset_fix.py` + `tests/agent/test_compress_focus.py` + `tests/agent/test_context_engine.py` — 82 pass.
- [ ] Smoke test on a live agent: force 2 compactions across a process restart, verify structured sections from the first summary are preserved in the second.