### PR TITLE
fix(custom): avoid env-key fallback for loopback custom endpoints

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import logging
 import os
 import re
+import ipaddress
 from typing import Any, Dict, Optional
+from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
@@ -47,6 +49,26 @@ def _detect_api_mode_for_url(base_url: str) -> Optional[str]:
     if "api.openai.com" in normalized and "openrouter" not in normalized:
         return "codex_responses"
     return None
+
+
+def _is_loopback_base_url(base_url: str) -> bool:
+    """Return True when ``base_url`` targets localhost / loopback IPs."""
+    candidate = str(base_url or "").strip()
+    if not candidate:
+        return False
+    try:
+        parsed = urlparse(candidate)
+    except Exception:
+        return False
+    host = (parsed.hostname or "").strip().lower()
+    if not host:
+        return False
+    if host == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
 
 
 def _auto_detect_local_model(base_url: str) -> str:
@@ -401,13 +423,19 @@ def _resolve_named_custom_runtime(
             pool_result["model"] = model_name
         return pool_result
 
+    is_loopback = _is_loopback_base_url(base_url)
+    is_ollama_cloud = "ollama.com" in base_url.lower()
     api_key_candidates = [
         (explicit_api_key or "").strip(),
         str(custom_provider.get("api_key", "") or "").strip(),
         os.getenv(str(custom_provider.get("key_env", "") or "").strip(), "").strip(),
-        os.getenv("OPENAI_API_KEY", "").strip(),
-        os.getenv("OPENROUTER_API_KEY", "").strip(),
+        (os.getenv("OLLAMA_API_KEY", "").strip() if is_ollama_cloud else ""),
     ]
+    if not is_loopback:
+        api_key_candidates.extend([
+            os.getenv("OPENAI_API_KEY", "").strip(),
+            os.getenv("OPENROUTER_API_KEY", "").strip(),
+        ])
     api_key = next((candidate for candidate in api_key_candidates if has_usable_secret(candidate)), "")
 
     result = {
@@ -480,14 +508,18 @@ def _resolve_openrouter_runtime(
         # Custom endpoint: use api_key from config when using config base_url (#1760).
         # When the endpoint is Ollama Cloud, check OLLAMA_API_KEY — it's
         # the canonical env var for ollama.com authentication.
+        _is_loopback_url = _is_loopback_base_url(base_url)
         _is_ollama_url = "ollama.com" in base_url.lower()
         api_key_candidates = [
             explicit_api_key,
             (cfg_api_key if use_config_base_url else ""),
             (os.getenv("OLLAMA_API_KEY") if _is_ollama_url else ""),
-            os.getenv("OPENAI_API_KEY"),
-            os.getenv("OPENROUTER_API_KEY"),
         ]
+        if not _is_loopback_url:
+            api_key_candidates.extend([
+                os.getenv("OPENAI_API_KEY"),
+                os.getenv("OPENROUTER_API_KEY"),
+            ])
     api_key = next(
         (str(candidate or "").strip() for candidate in api_key_candidates if has_usable_secret(candidate)),
         "",

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -457,7 +457,7 @@ def test_custom_endpoint_uses_saved_config_base_url_when_env_missing(monkeypatch
         "_get_model_config",
         lambda: {
             "provider": "custom",
-            "base_url": "http://127.0.0.1:1234/v1",
+            "base_url": "https://custom.example.com/v1",
         },
     )
     monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
@@ -467,7 +467,7 @@ def test_custom_endpoint_uses_saved_config_base_url_when_env_missing(monkeypatch
 
     resolved = rp.resolve_runtime_provider(requested="custom")
 
-    assert resolved["base_url"] == "http://127.0.0.1:1234/v1"
+    assert resolved["base_url"] == "https://custom.example.com/v1"
     assert resolved["api_key"] == "local-key"
 
 
@@ -662,6 +662,38 @@ def test_named_custom_provider_falls_back_to_openai_api_key(monkeypatch):
         lambda: {
             "custom_providers": [
                 {
+                    "name": "Corp Proxy",
+                    "base_url": "https://proxy.example.com/v1",
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_provider",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError(
+                "resolve_provider should not be called for named custom providers"
+            )
+        ),
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="custom:corp-proxy")
+
+    assert resolved["base_url"] == "https://proxy.example.com/v1"
+    assert resolved["api_key"] == "env-openai-key"
+    assert resolved["requested_provider"] == "custom:corp-proxy"
+
+
+def test_named_custom_provider_local_ignores_openai_api_key(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "env-openai-key")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "env-openrouter-key")
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "custom_providers": [
+                {
                     "name": "Local LLM",
                     "base_url": "http://localhost:1234/v1",
                 }
@@ -681,7 +713,7 @@ def test_named_custom_provider_falls_back_to_openai_api_key(monkeypatch):
     resolved = rp.resolve_runtime_provider(requested="custom:local-llm")
 
     assert resolved["base_url"] == "http://localhost:1234/v1"
-    assert resolved["api_key"] == "env-openai-key"
+    assert resolved["api_key"] == "no-key-required"
     assert resolved["requested_provider"] == "custom:local-llm"
 
 
@@ -1205,6 +1237,29 @@ def test_custom_provider_no_key_gets_placeholder(monkeypatch):
     assert resolved["provider"] == "custom"
     assert resolved["api_key"] == "no-key-required"
     assert resolved["base_url"] == "http://localhost:8080/v1"
+
+
+def test_custom_provider_local_ignores_env_keys(monkeypatch):
+    """Local custom endpoints should not inherit OpenAI/OpenRouter API keys."""
+    monkeypatch.setenv("OPENAI_API_KEY", "env-openai-key")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "env-openrouter-key")
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "model": {
+                "provider": "custom",
+                "base_url": "http://127.0.0.1:11434/v1",
+            }
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="custom")
+    assert resolved["provider"] == "custom"
+    assert resolved["api_key"] == "no-key-required"
+    assert resolved["base_url"] == "http://127.0.0.1:11434/v1"
 
 
 def test_auto_detected_nous_auth_failure_falls_through_to_openrouter(monkeypatch):


### PR DESCRIPTION
## Summary
Fix custom runtime credential resolution for local loopback endpoints (`localhost` / `127.0.0.1` / loopback IPs).

When users configure a local OpenAI-compatible endpoint (for example Ollama) and also have `OPENAI_API_KEY` / `OPENROUTER_API_KEY` in their shell, Hermes currently falls back to those env keys for `provider=custom`. This can leak unrelated cloud keys into local endpoints and cause hard-to-debug behavior.

This PR prevents env-key fallback for loopback custom endpoints and keeps the existing `no-key-required` placeholder behavior.

## Root Cause
`hermes_cli/runtime_provider.py` included `OPENAI_API_KEY` / `OPENROUTER_API_KEY` in fallback candidates for custom endpoints, including `http://localhost/...`.

## Changes
- Added `_is_loopback_base_url(base_url)` helper.
- In `_resolve_named_custom_runtime(...)`:
  - Skip `OPENAI_API_KEY` / `OPENROUTER_API_KEY` fallback when base URL is loopback.
  - Keep explicit `api_key`, `key_env`, and `OLLAMA_API_KEY` (for ollama.com cloud endpoints) behavior.
- In `_resolve_openrouter_runtime(...)` custom path:
  - Apply the same loopback guard for env fallback.

## Why this is safe
- Affects only custom endpoints that resolve to loopback hosts.
- Non-loopback custom endpoints keep existing behavior.
- OpenRouter resolution logic is unchanged for actual OpenRouter URLs.

## Tests
Updated and added targeted tests in `tests/hermes_cli/test_runtime_provider_resolution.py`:
- `test_custom_endpoint_uses_saved_config_base_url_when_env_missing`
- `test_named_custom_provider_falls_back_to_openai_api_key` (non-loopback case)
- `test_named_custom_provider_local_ignores_openai_api_key` (new)
- `test_custom_provider_local_ignores_env_keys` (new)

Local run:
```bash
./venv/bin/python -m pytest -q -o addopts='' \
  tests/hermes_cli/test_runtime_provider_resolution.py::test_custom_endpoint_uses_saved_config_base_url_when_env_missing \
  tests/hermes_cli/test_runtime_provider_resolution.py::test_named_custom_provider_falls_back_to_openai_api_key \
  tests/hermes_cli/test_runtime_provider_resolution.py::test_named_custom_provider_local_ignores_openai_api_key \
  tests/hermes_cli/test_runtime_provider_resolution.py::test_custom_provider_local_ignores_env_keys
```

Result: `4 passed`

## User-visible impact
For local custom providers (e.g. Ollama on localhost), Hermes now consistently uses:
- configured key / key_env when present, otherwise
- `no-key-required`

instead of accidentally inheriting unrelated cloud API keys from environment variables.
