### PR TITLE
fix(streaming): retry on ReadError/WriteError transport drops

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6027,7 +6027,14 @@ class AIAgent:
                             e, (_httpx.ReadTimeout, _httpx.ConnectTimeout, _httpx.PoolTimeout)
                         )
                         _is_conn_err = isinstance(
-                            e, (_httpx.ConnectError, _httpx.RemoteProtocolError, ConnectionError)
+                            e,
+                            (
+                                _httpx.ReadError,
+                                _httpx.WriteError,
+                                _httpx.ConnectError,
+                                _httpx.RemoteProtocolError,
+                                ConnectionError,
+                            ),
                         )
 
                         # SSE error events from proxies (e.g. OpenRouter sends
@@ -6527,7 +6534,7 @@ class AIAgent:
     # one more attempt with a rebuilt client / connection pool.
     _TRANSIENT_TRANSPORT_ERRORS = frozenset({
         "ReadTimeout", "ConnectTimeout", "PoolTimeout",
-        "ConnectError", "RemoteProtocolError",
+        "ReadError", "WriteError", "ConnectError", "RemoteProtocolError",
         "APIConnectionError", "APITimeoutError",
     })
 

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -262,6 +262,18 @@ class TestTryRecoverPrimaryTransport:
 
         assert result is True
 
+    def test_recovers_on_read_error(self):
+        agent = _make_agent(provider="custom")
+        error = _make_transport_error("ReadError")
+
+        with patch("run_agent.OpenAI", return_value=MagicMock()), \
+             patch("time.sleep"):
+            result = agent._try_recover_primary_transport(
+                error, retry_count=3, max_retries=3,
+            )
+
+        assert result is True
+
     def test_recovers_on_openai_api_connection_error(self):
         agent = _make_agent(provider="custom")
         error = _make_transport_error("APIConnectionError")

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -587,6 +587,38 @@ class TestStreamingFallback:
 
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_read_error_retried_as_transient(self, mock_close, mock_create):
+        """httpx.ReadError (connection reset by peer) should be retried."""
+        from run_agent import AIAgent
+        import httpx
+
+        read_error = httpx.ReadError(
+            "connection reset by peer",
+            request=httpx.Request("POST", "http://localhost:11434/v1/chat/completions"),
+        )
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = read_error
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="http://localhost:11434/v1",
+            model="gemma4:latest",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        with pytest.raises(httpx.ReadError, match="connection reset by peer"):
+            agent._interruptible_streaming_api_call({})
+
+        assert mock_client.chat.completions.create.call_count == 3
+        assert mock_close.call_count >= 2
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
     def test_sse_connection_lost_retried_as_transient(self, mock_close, mock_create):
         """SSE 'Network connection lost' (APIError w/ no status_code) retries like httpx errors.
 
@@ -1130,4 +1162,3 @@ class TestPartialToolCallWarning:
         assert "Stream stalled" not in content, (
             f"Unexpected warning on text-only partial stream: {content!r}"
         )
-


### PR DESCRIPTION
## Summary
Treat `httpx.ReadError` / `httpx.WriteError` as transient transport failures in streaming runtime recovery.

This improves resilience for local/custom providers where dropped sockets often surface as `ReadError: [Errno 54] Connection reset by peer`.

## Root Cause
The streaming retry classifier handled `ConnectError` / `RemoteProtocolError` and timeout classes, but did not include `ReadError` / `WriteError`.

As a result, connection resets were treated as non-transient in some paths and skipped recovery logic.

## Changes
- In `run_agent.py` streaming retry classification:
  - Added `_httpx.ReadError` and `_httpx.WriteError` to `_is_conn_err` detection.
- In primary transport recovery allowlist (`_TRANSIENT_TRANSPORT_ERRORS`):
  - Added `ReadError` and `WriteError`.

## Why this is safe
- Only broadens transient-network classification to two canonical httpx transport error types.
- Existing retry limits and fallback guards remain unchanged.

## Tests
Added tests:
- `tests/run_agent/test_streaming.py::TestStreamingFallback::test_read_error_retried_as_transient`
- `tests/run_agent/test_primary_runtime_restore.py::TestTryRecoverPrimaryTransport::test_recovers_on_read_error`

Local run:
```bash
./venv/bin/python -m pytest -q -o addopts='' \
  tests/run_agent/test_streaming.py::TestStreamingFallback::test_read_error_retried_as_transient \
  tests/run_agent/test_primary_runtime_restore.py::TestTryRecoverPrimaryTransport::test_recovers_on_read_error
```

Result: `2 passed`

## User-visible impact
For intermittent transport drops (especially local endpoints), Hermes is more likely to retry/recover automatically instead of failing fast after a single reset event.
