### PR TITLE
docs(cli): document `hermes webhook subscribe --deliver-only` flag

### DIFF
--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -291,6 +291,7 @@ hermes webhook subscribe <name> [options]
 | `--deliver` | Delivery target: `log` (default), `telegram`, `discord`, `slack`, `github_comment`. |
 | `--deliver-chat-id` | Target chat/channel ID for cross-platform delivery. |
 | `--secret` | Custom HMAC secret. Auto-generated if omitted. |
+| `--deliver-only` | Skip the agent — deliver the rendered `--prompt` as the literal message. Zero LLM cost, sub-second delivery. Requires `--deliver` to be a real target (not `log`). |
 
 Subscriptions persist to `~/.hermes/webhook_subscriptions.json` and are hot-reloaded by the webhook adapter without a gateway restart.
 


### PR DESCRIPTION
## Summary

PR #12473 (merged 2026-04-19) added a new `--deliver-only` flag to `hermes webhook subscribe` for zero-LLM direct delivery, but `website/docs/reference/cli-commands.md` options table for the subcommand was not updated.

The user guide [`messaging/webhooks.md`](../user-guide/messaging/webhooks.md) already covers the declarative route field `deliver_only: true`; this PR adds the matching CLI flag row so users who reach the reference page (or search for `--deliver-only`) find it documented.

## Change

One row added to the `hermes webhook subscribe` Options table, wording mirrors the argparse `help=` text in `hermes_cli/main.py` and the `deliver_only` field description in `user-guide/messaging/webhooks.md` for consistency.

```diff
 | `--secret` | Custom HMAC secret. Auto-generated if omitted. |
+| `--deliver-only` | Skip the agent — deliver the rendered `--prompt` as the literal message. Zero LLM cost, sub-second delivery. Requires `--deliver` to be a real target (not `log`). |
```

## Scope

Docs-only, +1 line. No code change, no behavioral change.