### PR TITLE
feat(telegram): download inbound video messages to agent cache

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -569,6 +569,12 @@ SUPPORTED_DOCUMENT_TYPES = {
     ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    ".mp4": "video/mp4",
+    ".mov": "video/quicktime",
+    ".avi": "video/x-msvideo",
+    ".mkv": "video/x-matroska",
+    ".webm": "video/webm",
+    ".3gp": "video/3gpp",
 }
 
 

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2429,6 +2429,48 @@ class TelegramAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.warning("[Telegram] Failed to cache audio: %s", e, exc_info=True)
 
+        # Download video files to cache so the agent can process and forward them.
+        # Telegram compresses videos to ≤20 MB (Bot API download limit); larger
+        # clips must be shared via URL or sent with "Send as File" in Telegram.
+        elif msg.video:
+            video = msg.video
+            MAX_VIDEO_BYTES = 20 * 1024 * 1024
+            if video.file_size and video.file_size > MAX_VIDEO_BYTES:
+                event.text = (
+                    f"The video is too large to download "
+                    f"({video.file_size // (1024 * 1024)} MB). "
+                    "Maximum is 20 MB (Telegram Bot API limit). "
+                    "Use 'Send as File' for smaller clips, or share a URL instead."
+                )
+                logger.info("[Telegram] Video too large: %s bytes", video.file_size)
+                await self.handle_message(event)
+                return
+            try:
+                _VIDEO_MIME_TO_EXT = {
+                    "video/mp4": ".mp4",
+                    "video/quicktime": ".mov",
+                    "video/x-msvideo": ".avi",
+                    "video/x-matroska": ".mkv",
+                    "video/webm": ".webm",
+                    "video/3gpp": ".3gp",
+                }
+                ext = ".mp4"
+                if video.file_name:
+                    _, file_ext = os.path.splitext(video.file_name)
+                    if file_ext.lower() in _VIDEO_MIME_TO_EXT.values():
+                        ext = file_ext.lower()
+                elif video.mime_type:
+                    ext = _VIDEO_MIME_TO_EXT.get(video.mime_type, ".mp4")
+                file_obj = await video.get_file()
+                video_bytes = await file_obj.download_as_bytearray()
+                filename = video.file_name or f"video{ext}"
+                cached_path = cache_document_from_bytes(bytes(video_bytes), filename)
+                event.media_urls = [cached_path]
+                event.media_types = [video.mime_type or f"video/{ext.lstrip('.')}"]
+                logger.info("[Telegram] Cached user video at %s", cached_path)
+            except Exception as e:
+                logger.warning("[Telegram] Failed to cache video: %s", e, exc_info=True)
+
         # Download document files to cache for agent processing
         elif msg.document:
             doc = msg.document


### PR DESCRIPTION
## What does this PR do?

Videos sent by users via Telegram were silently dropped. The gateway registered `filters.VIDEO` in the update handler but `_handle_media_message` had no download block for `msg.video` — the agent received a blank `MessageEvent` with empty `media_urls` and (when no caption was set) empty text. The user's video was lost with no error or acknowledgement.

This PR adds inbound video handling that mirrors the existing document handler: download the file, cache it locally, and populate `event.media_urls` so the agent sees the file path and can process or re-send it.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/telegram.py`: adds `elif msg.video:` block in `_handle_media_message`, following the same pattern as the document handler — `get_file()` → `download_as_bytearray()` → `cache_document_from_bytes()` → `event.media_urls`. Sends a clear error message when the file exceeds the 20 MB Bot API download limit.
- `gateway/platforms/base.py`: adds video MIME types (`.mp4`, `.mov`, `.avi`, `.mkv`, `.webm`, `.3gp`) to `SUPPORTED_DOCUMENT_TYPES` so videos sent via Telegram's **Send as File** option are also accepted by the document handler instead of being rejected as unsupported.

## How to Test

1. Send a short video (< 20 MB) via Telegram — the agent should receive the cached file path in `event.media_urls` and acknowledge the video in its response
2. Send a video > 20 MB — the agent should reply with a clear size-limit error message
3. Send a video using Telegram's **Send as File** option (`.mp4`) — should be accepted and cached via the document handler
4. Verify existing photo, voice, audio, and document handling is unaffected

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A (path handling uses existing `cache_document_from_bytes` which is already cross-platform)

## Screenshots / Logs

**Before:** user sends a video, agent log shows `inbound message: ... msg=''` with no file path.

**After:** agent log shows `[Telegram] Cached user video at /path/to/cache/documents/doc_<uuid>_video.mp4` and the agent receives the path in context.