### PR TITLE
feat(opencode): inject x-opencode-session header for prompt caching

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6847,7 +6847,7 @@ class AIAgent:
             ephemeral_out = getattr(self, "_ephemeral_max_output_tokens", None)
             if ephemeral_out is not None:
                 self._ephemeral_max_output_tokens = None  # consume immediately
-            return build_anthropic_kwargs(
+            kwargs = build_anthropic_kwargs(
                 model=self.model,
                 messages=anthropic_messages,
                 tools=self.tools,
@@ -6859,6 +6859,10 @@ class AIAgent:
                 base_url=getattr(self, "_anthropic_base_url", None),
                 fast_mode=(self.request_overrides or {}).get("speed") == "fast",
             )
+            # OpenCode Go/Zen prompt caching via Anthropic Messages route.
+            if "opencode.ai" in getattr(self, "_base_url_lower", "") and getattr(self, "session_id", None):
+                kwargs.setdefault("extra_headers", {})["x-opencode-session"] = self.session_id
+            return kwargs
 
         # AWS Bedrock native Converse API — bypasses the OpenAI client entirely.
         # The adapter handles message/tool conversion and boto3 calls directly.
@@ -6952,6 +6956,10 @@ class AIAgent:
 
             if is_xai_responses and getattr(self, "session_id", None):
                 kwargs["extra_headers"] = {"x-grok-conv-id": self.session_id}
+
+            # OpenCode Go/Zen prompt caching via Codex Responses route.
+            if "opencode.ai" in getattr(self, "_base_url_lower", "") and getattr(self, "session_id", None):
+                kwargs.setdefault("extra_headers", {})["x-opencode-session"] = self.session_id
 
             return kwargs
 
@@ -7159,6 +7167,12 @@ class AIAgent:
         # Applied last so overrides win over any defaults set above.
         if self.request_overrides:
             api_kwargs.update(self.request_overrides)
+
+        # OpenCode Go/Zen prompt caching: send x-opencode-session header
+        # so the proxy can cache the prompt prefix across requests in the
+        # same conversation.
+        if "opencode.ai" in getattr(self, "_base_url_lower", "") and getattr(self, "session_id", None):
+            api_kwargs.setdefault("extra_headers", {})["x-opencode-session"] = self.session_id
 
         return api_kwargs
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1089,6 +1089,125 @@ class TestBuildApiKwargs:
         assert kwargs.get("extra_body", {}).get("think") is None
 
 
+class TestOpencodeSessionHeader:
+    """x-opencode-session header for prompt caching on OpenCode Go/Zen.
+
+    All three API modes (chat_completions, anthropic_messages, codex_responses)
+    are used by opencode providers depending on the model:
+      opencode-go:  chat_completions (default), anthropic_messages (minimax-*)
+      opencode-zen: chat_completions (default), anthropic_messages (claude-*),
+                    codex_responses (gpt-*)
+    """
+
+    # -- chat_completions path --
+
+    def test_header_injected_chat_completions(self, agent):
+        agent.base_url = "https://opencode.ai/zen/go/v1"
+        agent.session_id = "test-session-123"
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs["extra_headers"]["x-opencode-session"] == "test-session-123"
+
+    def test_no_header_without_session_id(self, agent):
+        agent.base_url = "https://opencode.ai/zen/go/v1"
+        agent.session_id = None
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert "extra_headers" not in kwargs
+
+    def test_no_header_for_other_providers(self, agent):
+        agent.base_url = "https://openrouter.ai/api/v1"
+        agent.session_id = "test-session-123"
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert "extra_headers" not in kwargs
+
+    def test_header_follows_model_switch(self, agent):
+        agent.base_url = "https://openrouter.ai/api/v1"
+        agent.session_id = "test-session-123"
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert "extra_headers" not in kwargs
+
+        # Switch to opencode
+        agent.base_url = "https://opencode.ai/zen/go/v1"
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs["extra_headers"]["x-opencode-session"] == "test-session-123"
+
+    def test_header_follows_session_id_change(self, agent):
+        agent.base_url = "https://opencode.ai/zen/go/v1"
+        agent.session_id = "parent-session"
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs["extra_headers"]["x-opencode-session"] == "parent-session"
+
+        # Simulate context compression rotating session_id
+        agent.session_id = "child-session-456"
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs["extra_headers"]["x-opencode-session"] == "child-session-456"
+
+    # -- anthropic_messages path --
+
+    def test_header_injected_anthropic_messages(self, agent):
+        agent.base_url = "https://opencode.ai/zen/go/v1"
+        agent.api_mode = "anthropic_messages"
+        agent.session_id = "test-session-123"
+        agent._anthropic_client = MagicMock()
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs["extra_headers"]["x-opencode-session"] == "test-session-123"
+
+    def test_no_header_anthropic_messages_non_opencode(self, agent):
+        agent.base_url = "https://api.anthropic.com"
+        agent.api_mode = "anthropic_messages"
+        agent.session_id = "test-session-123"
+        agent._anthropic_client = MagicMock()
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert "x-opencode-session" not in kwargs.get("extra_headers", {})
+
+    # -- codex_responses path --
+
+    def test_header_injected_codex_responses(self):
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            a = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://opencode.ai/zen/v1",
+                api_mode="codex_responses",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            a.client = MagicMock()
+            a.session_id = "test-session-123"
+            a.model = "gpt-5"
+            kwargs = a._build_api_kwargs([{"role": "user", "content": "hi"}])
+            assert kwargs["extra_headers"]["x-opencode-session"] == "test-session-123"
+
+    def test_no_header_codex_responses_non_opencode(self):
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            a = AIAgent(
+                api_key="test-key-1234567890",
+                base_url="https://api.openai.com/v1",
+                api_mode="codex_responses",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            a.client = MagicMock()
+            a.session_id = "test-session-123"
+            a.model = "gpt-5"
+            kwargs = a._build_api_kwargs([{"role": "user", "content": "hi"}])
+            assert "x-opencode-session" not in kwargs.get("extra_headers", {})
+
 
 class TestBuildAssistantMessage:
     def test_basic_message(self, agent):


### PR DESCRIPTION
Send the x-opencode-session header on every API request to OpenCode Go/Zen providers so the proxy can cache the prompt prefix across requests in the same conversation.

The header is injected per-request in _build_api_kwargs() across all three API modes:
  - chat_completions (opencode-go default, opencode-zen default)
  - anthropic_messages (opencode-go minimax-\*, opencode-zen claude-\*)
  - codex_responses (opencode-zen gpt-\*)

Includes 9 tests covering all three paths, negative cases (no header leakage to other providers), and state mutation (model switch, session rotation after compression).

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

Adds a header to all opencode zen/go api calls to ensure that opencode can track sessions for context caching, otherwise each call pays for the full uncached context!

Solution orients itself after the existing x-grok-conv-id implementation. 

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Related to #5252. This is a minimal fix for OpenCode Go and Zen while the broader routing table architecture from #5252 is developed.

 This PR takes a minimal, targeted approach: direct conditionals in
    `_build_api_kwargs()` for the OpenCode provider only. When the
    data-driven routing table from #5252 lands, the OpenCode entries
    can be migrated into it.

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)


## Changes Made
    
    **`run_agent.py` -- `_build_api_kwargs()` (3 injection points)**
    
    - **`chat_completions` path** (~line 7168): Inject `x-opencode-session` header into `api_kwargs["extra_headers"]` when `"opencode.ai"` is detected in `self._base_url_lower` and `self.session_id` is set.
    
    - **`anthropic_messages` path** (~line 6860): Capture the return value of `build_anthropic_kwargs()` into a local `kwargs` variable (previously returned directly), then inject the header before returning. This route is used by `opencode-go` with `minimax-*` models and `opencode-zen` with `claude-*` models.
    
    - **`codex_responses` path** (~line 6957): Inject the header alongside the existing `x-grok-conv-id` injection for xAI. This route is used by `opencode-zen` with `gpt-*` models.
    
    The header is injected per-request, reading `self.session_id` and `self._base_url_lower` fresh on every API call. This ensures it automatically follows runtime state changes from model switches (`/model`) and context compression (which rotates `session_id`).
    
**Defensive attribute access:** Uses `getattr(self, "_base_url_lower", "")` rather than
    `self._base_url_lower` because some code paths (notably tests using `object.__new__()`
    to bypass `__init__`) reach `_build_api_kwargs` without the setter having run. Returns
    `""` which safely skips the opencode check — correct behavior for non-opencode agents.


    **`tests/run_agent/test_run_agent.py` -- `TestOpencodeSessionHeader` (9 tests)**
    
    - 3 positive tests: header present with correct value for `chat_completions`, `anthropic_messages`, and `codex_responses` API modes
    - 3 negative tests: no header when session_id is None, no header for non-OpenCode providers (OpenRouter, Anthropic, OpenAI), no header leakage across API modes
    - 2 state mutation tests: header follows `base_url` changes (model switch scenario) and `session_id` changes (context compression scenario)
    - 1 edge case: header uses child session_id after compression, not stale parent

 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1.  Used my opencode-go subscription, verified that sessions now cache properly on my dashboard  (actual entries in session columns and pricing staying low with growing context)
2.  Went through a compression and verified new session ID after compression as base for new caching 
3. Cannot test zen provider though -> only have opencode go

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (-> see #5252 )
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass ( there are pre-existing unrelated failures!)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: cachyOS

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] N/A - I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] N/A - I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] N/A - I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] N/A - I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] N/A - I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

