### PR TITLE
fix(gateway): sanitize cached document filenames for Windows safe paths

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -233,7 +233,7 @@ def proxy_kwargs_for_aiohttp(proxy_url: str | None) -> tuple[dict, dict]:
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Dict, List, Optional, Any, Callable, Awaitable, Tuple
 from enum import Enum
 
@@ -597,9 +597,13 @@ def cache_document_from_bytes(data: bytes, filename: str) -> str:
         ValueError: If the sanitized path escapes the cache directory.
     """
     cache_dir = get_document_cache_dir()
-    # Sanitize: strip directory components, null bytes, and control characters
-    safe_name = Path(filename).name if filename else "document"
-    safe_name = safe_name.replace("\x00", "").strip()
+    # Strip both POSIX and Windows path components before filename sanitization.
+    raw_name = str(filename) if filename else "document"
+    safe_name = PureWindowsPath(PurePosixPath(raw_name).name).name
+    # Remove control chars and Windows-reserved filename characters. This keeps
+    # returned cache paths stable across platforms and avoids NTFS ADS/truncation.
+    safe_name = "".join(ch for ch in safe_name if ch >= " " and ch != "\x7f")
+    safe_name = re.sub(r'[<>:"/\\|?*]', "_", safe_name).strip().rstrip(" .")
     if not safe_name or safe_name in (".", ".."):
         safe_name = "document"
     cached_name = f"doc_{uuid.uuid4().hex[:12]}_{safe_name}"

--- a/tests/gateway/test_document_cache.py
+++ b/tests/gateway/test_document_cache.py
@@ -98,6 +98,20 @@ class TestCacheDocumentFromBytes:
         path = cache_document_from_bytes(b"data", None)
         assert "document" in os.path.basename(path)
 
+    def test_windows_reserved_filename_chars_are_sanitized(self):
+        path = cache_document_from_bytes(b"data", 'report:final*?.pdf')
+        basename = os.path.basename(path)
+        assert "report_final__.pdf" in basename
+        for ch in ':*?"<>|':
+            assert ch not in basename
+
+    def test_windows_path_components_are_stripped_cross_platform(self):
+        path = cache_document_from_bytes(b"data", r"..\..\secret\report.pdf")
+        basename = os.path.basename(path)
+        assert "report.pdf" in basename
+        assert "\\" not in basename
+        assert ".." not in basename
+
 
 # ---------------------------------------------------------------------------
 # TestCleanupDocumentCache


### PR DESCRIPTION
## Summary

Fix document cache filename sanitization so gateway adapters do not emit Windows-unsafe cache paths.

`cache_document_from_bytes()` previously stripped only path components and null bytes. On Windows, filenames containing reserved characters like `:` or `?` could produce truncated/ADS-like paths instead of a normal cached file, which breaks downstream document handling.

## What changed

- Strip both POSIX and Windows path components before caching document filenames
- Sanitize Windows-reserved filename characters (`<>:"/\|?*`)
- Trim trailing spaces/dots that are invalid on Windows
- Add regression tests for:
  - Windows-reserved characters in filenames
  - Windows-style backslash path components on non-Windows hosts

## Why this is a bug

Messaging platforms can send human-authored filenames verbatim. A filename like `report:final?.pdf` should cache as a normal local file, but on Windows it could resolve to an NTFS-unsafe path and diverge from the real filesystem entry.

## Testing

- `py -3 -m pytest tests/gateway/test_document_cache.py -q`
- `py -3 -m pytest tests/gateway/test_telegram_documents.py -k "document_cached" -q`
- `py -3 -m pytest tests/gateway/test_discord_document_handling.py -k "document_cached" -q`
- `py -3 -m pytest tests/gateway/test_slack.py -k "document_cached" -q`
