### PR TITLE
fix: WhatsApp JID resolution and home channel in send_message tool

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -885,6 +885,16 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         if Platform.WHATSAPP not in config.platforms:
             config.platforms[Platform.WHATSAPP] = PlatformConfig()
         config.platforms[Platform.WHATSAPP].enabled = True
+    whatsapp_home = os.getenv("WHATSAPP_HOME_CHANNEL")
+    if whatsapp_home:
+        if Platform.WHATSAPP not in config.platforms:
+            config.platforms[Platform.WHATSAPP] = PlatformConfig()
+        config.platforms[Platform.WHATSAPP].enabled = True
+        config.platforms[Platform.WHATSAPP].home_channel = HomeChannel(
+            platform=Platform.WHATSAPP,
+            chat_id=whatsapp_home,
+            name=os.getenv("WHATSAPP_HOME_CHANNEL_NAME", ""),
+        )
     
     # Slack
     slack_token = os.getenv("SLACK_BOT_TOKEN")

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -21,6 +21,8 @@ logger = logging.getLogger(__name__)
 _TELEGRAM_TOPIC_TARGET_RE = re.compile(r"^\s*(-?\d+)(?::(\d+))?\s*$")
 _FEISHU_TARGET_RE = re.compile(r"^\s*((?:oc|ou|on|chat|open)_[-A-Za-z0-9]+)(?::([-A-Za-z0-9_]+))?\s*$")
 _WEIXIN_TARGET_RE = re.compile(r"^\s*((?:wxid|gh|v\d+|wm|wb)_[A-Za-z0-9_-]+|[A-Za-z0-9._-]+@chatroom|filehelper)\s*$")
+# WhatsApp JIDs: phone@s.whatsapp.net, number@lid, group@g.us
+_WHATSAPP_JID_RE = re.compile(r"^\s*(\d+@(?:s\.whatsapp\.net|lid|g\.us))\s*$")
 # Discord snowflake IDs are numeric, same regex pattern as Telegram topic targets.
 _NUMERIC_TOPIC_RE = _TELEGRAM_TOPIC_TARGET_RE
 _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".gif"}
@@ -315,6 +317,10 @@ def _parse_target_ref(platform_name: str, target_ref: str):
             return match.group(1), match.group(2), True
     if platform_name == "weixin":
         match = _WEIXIN_TARGET_RE.fullmatch(target_ref)
+        if match:
+            return match.group(1), None, True
+    if platform_name == "whatsapp":
+        match = _WHATSAPP_JID_RE.fullmatch(target_ref)
         if match:
             return match.group(1), None, True
     if target_ref.lstrip("-").isdigit():


### PR DESCRIPTION
## Problem

`send_message` from CLI cannot deliver to WhatsApp targets. Two issues:

### 1. WhatsApp JIDs not recognized as explicit targets

`send_message_tool.py` has explicit regex patterns for Telegram, Discord, Feishu, Weixin, and Matrix targets — but nothing for WhatsApp JIDs like `65XXXXXXXX@s.whatsapp.net`, `1916930139XXXXX@lid`, or group JIDs (`@g.us`). These fall through to friendly-name resolution (`resolve_channel_name`) which only matches display names from the channel directory, not raw JIDs.

### 2. WhatsApp home channel not loaded from env vars

`_apply_env_overrides()` in `gateway/config.py` loads home channels from environment variables for Telegram, Discord, Slack, and Signal — but has no handling for `WHATSAPP_HOME_CHANNEL`. The gateway `run.py` promotes config.yaml top-level keys to env vars at startup (so cron delivery works), but the CLI code path does not, resulting in `"No home channel set for whatsapp"` errors.

### Why cron works

The scheduler's `_resolve_single_delivery_target()` has a fallback — when it cannot resolve a JID, it passes the raw string through as `chat_id` directly instead of erroring out. This masks both bugs for scheduled delivery.

## Fix

- Added `_WHATSAPP_JID_RE` regex matching `number@s.whatsapp.net`, `number@lid`, and `number@g.us`
- Added `whatsapp` branch in `_parse_target_ref()` to recognize these as explicit targets
- Added WhatsApp home channel loading in `_apply_env_overrides()`, matching the pattern used by all other platforms

## Testing

- Verified regex matches valid JIDs.
- Verified non-matches are rejected: plain numbers, email addresses, invalid domains