### PR TITLE
fix(docker): HERMES_UID and HERMES_GID usage in container + feature(docker): add new SYNC_CODE_DIR environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/opt/hermes/.playwright
 # Install system dependencies in one layer, clear APT cache
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        build-essential nodejs npm python3 ripgrep ffmpeg gcc python3-dev libffi-dev procps git && \
+        build-essential nodejs npm python3 ripgrep ffmpeg gcc python3-dev libffi-dev procps git rsync && \
     rm -rf /var/lib/apt/lists/*
 
 # Non-root user for runtime; UID can be overridden via HERMES_UID at runtime
@@ -48,6 +48,9 @@ RUN chown hermes:hermes /opt/hermes
 USER hermes
 RUN uv venv && \
     uv pip install --no-cache-dir -e ".[all]"
+
+# Swtich back to root to force HERMES_UID and HERMES_GID logic in entrypoint.sh to work correctly (i.e. if we created the hermes user with a different UID/GID, we want to be able to chown files to that UID/GID at runtime).
+USER root
 
 # ---------- Runtime ----------
 ENV HERMES_WEB_DIST=/opt/hermes/hermes_cli/web_dist

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -37,6 +37,27 @@ if [ "$(id -u)" = "0" ]; then
 fi
 
 # --- Running as hermes from here ---
+echo "Running as $(id -u):$(id -g) ($(id -un):$(id -gn))"
+# if SYNC_CODE_DIR is set to an existing target path that we can write to, copy the code in /opt/hermes as set in INSTALL_DIR (only the code) so that external tools can use hermes-agent and install it in their own venv.  
+# This is useful for development with bind mounts, but also for production if someone wants to use the image as a base for their own image and install hermes-agent into their own venv instead of using the bundled one.
+# check SYNC_CODE_DIR exist
+if [ ! -z "${SYNC_CODE_DIR+x}" ]; then
+    if [ -d "$SYNC_CODE_DIR" ] && [ -w "$SYNC_CODE_DIR" ]; then
+        it="${SYNC_CODE_DIR}/.testfile"; rm -f "$it"; touch "$it" 
+        if [ -f $it ]; then
+            rm -f "$it" || echo "Test file created successfully in SYNC_CODE_DIR directory, but deletion failed, it is likely not fully writable by the hermes user. We will attempt the code copy anyway."
+            echo "SYNC_CODE_DIR is set to $SYNC_CODE_DIR, copying code there"
+            rsync -a --exclude='.venv' --exclude='__pycache__' --exclude='*.pyc' --exclude='*.pyo' --exclude='.git' --exclude ".playwright" ${INSTALL_DIR}/ "$SYNC_CODE_DIR"/ --delete || echo "Failed to copy all files from ${INSTALL_DIR} to ${SYNC_CODE_DIR} directory, will continue anyway."
+            # The delete option ensures that if files are removed from the source (INSTALL_DIR), they are also removed from the target (SYNC_CODE_DIR) on subsequent runs, keeping them in sync.
+            echo "Code copied to SYNC_CODE_DIR successfully (this oes not invalidted any previous message, but the attempt was made), you can use the SYNC_CODE_DIR directory to access the code and install hermes-agent in your own venv if needed."
+        else
+            echo "Failed to write a test file to SYNC_CODE_DIR directory as the hermes user, we will skip code copy to avoid potential issues with file permissions. Please ensure that the SYNC_CODE_DIR directory is writable by the hermes user."
+        fi
+    else
+        echo "SYNC_CODE_DIR is not set to a writable directory, skipping code copy"
+    fi
+fi
+
 source "${INSTALL_DIR}/.venv/bin/activate"
 
 # Create essential directory structure.  Cache and platform directories


### PR DESCRIPTION
## What does this PR do?

The entrypoint contains runtime ownership/remap logic that only works correctly when the container starts as `root`. After the image build switched to running as `hermes`, that logic no longer had the privileges needed to honor `HERMES_UID` / `HERMES_GID`.

Separately, some downstream/containerized workflows need access to the exact Hermes source code shipped in the image so they can install it into their own virtualenv or consume files like requirements.txt from a mounted path.

This PR makes two Docker-focused changes:

1. Restores the intended `HERMES_UID` / `HERMES_GID` behavior by switching the image back to `root` before the runtime entrypoint executes.
2. Adds an optional `SYNC_CODE_DIR` environment variable that `rsync`s the installed Hermes source tree to a writable external directory at container startup (to allow third party solutions to add hermes agent to their venv; example: Hermes WebUI)

## Related Issue

I did not see an existing issue, and created one https://github.com/NousResearch/hermes-agent/issues/12696

I discovered the issue while trying to use `HERMES_UID` and `HERMES_GID` and found that they were not being respected (the intent was to provide an Unraid template for Hermes Agent, and the Hermes WebUI project; the second one would need the new feature to function)

The root cause is the `USER hermes` usage in the `Dockerfile` while the `entrypoint.sh` checks against `id = 0` (ie the `root` user)

## Type of Change


- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [X] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- Dockerfile:
  - Installs rsync
  - Switches back to `USER root` after dependency installation so the `entrypoint.sh` can perform UID/GID and ownership setup correctly at runtime

- `docker/entrypoint.sh`
  - Adds optional `SYNC_CODE_DIR` support. If `SYNC_CODE_DIR` points to an existing writable directory, the entrypoint copies `/opt/hermes` into it with `rsync` (excludes runtime/build noise such as `.venv`, `.git`, `__pycache__`, `*.pyc`, `*.pyo`, and `.playwright` + uses `--delete` so the synced directory stays aligned with the source tree across restarts). Fails open: if the sync target is missing or not writable, container startup continues normally

Behavior: Default behavior is unchanged when `SYNC_CODE_DIR` is unset. The sync is best-effort and does not block container startup. This is mainly useful for bind-mounted development workflows and derived images that want to install Hermes into a separate venv.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. `docker build -f Dockerfile --tag ha:test .`
2. `mkdir -p ../test/{data,src}`
3. `docker run --rm -it -e HERMES_UID=$(id -u) -e HERMES_GID=$(id -g)   -v $(pwd)/../test/data:/test/data   -e HERMES_HOME=/test/data   -v $(pwd)/../test/src:/test/src   -e SYNC_CODE_DIR=/test/src  ha:test`

Result:
```text
Changing hermes UID to 1000
Changing hermes GID to 1000
Dropping root privileges
Running as 1000:1000 (hermes:hermes)
SYNC_CODE_DIR is set to /test/src, copying code there
Code copied to SYNC_CODE_DIR successfully (...
Syncing bundled skills into ~/.hermes/skills/ ...
  + dogfood
[...]
Done: 77 new, 0 updated, 0 unchanged. 77 total bundled.
[... followed by Hermes TUI access]
```

Local folders:
- `../test/data` contains the hermes runtime (including `config.yaml`, ...) owned by user matching `HERMES_UID` and `HERMES_GID`
- `../test/src` contains the content of `/opt/hermes` (without the `.venv` and other dropped files/folders) to support usage with 3rd party extensions more easily

## Checklist

### Code

- [X] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [X] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [X] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [X] I've run `pytest tests/ -q` and all tests pass 
  - only fix container build and usage, no hermes behavior
- [X] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
  - described in how to test, this is not a recursion issue, same comment as above re no change to hermes behavior
- [X] I've tested on my platform: Ubuntu 24.04 w/ Docker

### Documentation & Housekeeping


- [N/A] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [N/A] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [N/A] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [N/A] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [N/A] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

