### PR TITLE
fix(skills): follow symlinks when discovering SKILL.md

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -217,6 +217,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     try:
         from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform, _get_disabled_skill_names
         from agent.skill_utils import get_external_skills_dirs
+        from hermes_constants import rglob_follow
         disabled = _get_disabled_skill_names()
         seen_names: set = set()
 
@@ -227,7 +228,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
         dirs_to_scan.extend(get_external_skills_dirs())
 
         for scan_dir in dirs_to_scan:
-            for skill_md in scan_dir.rglob("SKILL.md"):
+            for skill_md in rglob_follow(scan_dir, "SKILL.md"):
                 if any(part in ('.git', '.github', '.hub') for part in skill_md.parts):
                     continue
                 try:

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -435,7 +435,7 @@ def iter_skill_index_files(skills_dir: Path, filename: str):
     Excludes ``.git``, ``.github``, ``.hub`` directories.
     """
     matches = []
-    for root, dirs, files in os.walk(skills_dir):
+    for root, dirs, files in os.walk(skills_dir, followlinks=True):
         dirs[:] = [d for d in dirs if d not in EXCLUDED_SKILL_DIRS]
         if filename in files:
             matches.append(Path(root) / filename)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -443,10 +443,11 @@ def _check_unavailable_skill(command_name: str) -> str | None:
         disabled = _get_disabled_skill_names()
 
         # Check disabled skills across all dirs (local + external)
+        from hermes_constants import rglob_follow
         for skills_dir in get_all_skills_dirs():
             if not skills_dir.exists():
                 continue
-            for skill_md in skills_dir.rglob("SKILL.md"):
+            for skill_md in rglob_follow(skills_dir, "SKILL.md"):
                 if any(part in ('.git', '.github', '.hub') for part in skill_md.parts):
                     continue
                 name = skill_md.parent.name.lower().replace("_", "-")
@@ -461,7 +462,7 @@ def _check_unavailable_skill(command_name: str) -> str | None:
         repo_root = Path(__file__).resolve().parent.parent
         optional_dir = get_optional_skills_dir(repo_root / "optional-skills")
         if optional_dir.exists():
-            for skill_md in optional_dir.rglob("SKILL.md"):
+            for skill_md in rglob_follow(optional_dir, "SKILL.md"):
                 name = skill_md.parent.name.lower().replace("_", "-")
                 if name == normalized:
                     # Build install path: official/<category>/<name>

--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -61,11 +61,12 @@ def _gateway_status() -> str:
 
 def _count_skills(hermes_home: Path) -> int:
     """Count installed skills."""
+    from hermes_constants import rglob_follow
     skills_dir = hermes_home / "skills"
     if not skills_dir.is_dir():
         return 0
     count = 0
-    for item in skills_dir.rglob("SKILL.md"):
+    for item in rglob_follow(skills_dir, "SKILL.md"):
         count += 1
     return count
 

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -309,11 +309,12 @@ def _check_gateway_running(profile_dir: Path) -> bool:
 
 def _count_skills(profile_dir: Path) -> int:
     """Count installed skills in a profile."""
+    from hermes_constants import rglob_follow
     skills_dir = profile_dir / "skills"
     if not skills_dir.is_dir():
         return 0
     count = 0
-    for md in skills_dir.rglob("SKILL.md"):
+    for md in rglob_follow(skills_dir, "SKILL.md"):
         if "/.hub/" not in str(md) and "/.git/" not in str(md):
             count += 1
     return count

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -238,6 +238,21 @@ def get_skills_dir() -> Path:
     return get_hermes_home() / "skills"
 
 
+def rglob_follow(directory: Path, pattern: str):
+    """Like Path.rglob() but follows symlinks.
+
+    Python 3.12's Path.rglob() does NOT follow symlinks, so symlinked
+    skill directories (e.g. ~/.hermes/skills/claude-imported/spark-pmc-expert
+    -> ~/.claude/skills/spark-pmc-expert/) are invisible. This uses
+    os.walk(followlinks=True) to traverse symlinked directories.
+    """
+    import fnmatch
+    for dirpath, _dirnames, filenames in os.walk(directory, followlinks=True):
+        for filename in filenames:
+            if fnmatch.fnmatch(filename, pattern):
+                yield Path(dirpath) / filename
+
+
 
 def get_env_path() -> Path:
     """Return the path to the ``.env`` file under HERMES_HOME."""

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import pytest
 
 import hermes_constants
-from hermes_constants import get_default_hermes_root, is_container
+from hermes_constants import get_default_hermes_root, is_container, rglob_follow
 
 
 class TestGetDefaultHermesRoot:
@@ -111,3 +111,52 @@ class TestIsContainer:
         # Even if we make os.path.exists return False, cached value wins
         monkeypatch.setattr(os.path, "exists", lambda p: False)
         assert is_container() is True
+
+
+class TestRglobFollow:
+    """Tests for rglob_follow() — skill discovery must traverse symlinked directories."""
+
+    def test_finds_file_in_regular_subdir(self, tmp_path):
+        """Baseline: rglob_follow finds files in plain subdirectories."""
+        sub = tmp_path / "cat"
+        sub.mkdir()
+        (sub / "SKILL.md").write_text("x")
+        found = list(rglob_follow(tmp_path, "SKILL.md"))
+        assert len(found) == 1
+        assert found[0].parent.name == "cat"
+
+    def test_follows_symlinked_directory(self, tmp_path):
+        """The bug this patch fixes: Path.rglob() skips symlinked dirs, rglob_follow must not."""
+        real = tmp_path / "real"
+        real.mkdir()
+        (real / "SKILL.md").write_text("real skill")
+
+        skills_root = tmp_path / "skills"
+        skills_root.mkdir()
+        # Symlink a skill directory into the scan root (mirrors ~/.hermes/skills/claude-imported/*)
+        try:
+            (skills_root / "linked").symlink_to(real, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks not supported on this platform/account")
+
+        # Sanity check: stock Path.rglob DOES NOT find the file through the symlink
+        # on Python 3.12 — this is exactly the bug.
+        plain = list(skills_root.rglob("SKILL.md"))
+        follow = list(rglob_follow(skills_root, "SKILL.md"))
+
+        assert len(follow) == 1, f"rglob_follow should traverse symlink; got {follow}"
+        # Don't assert on `plain` — behavior has varied across Python versions,
+        # but rglob_follow must reliably find it regardless.
+        assert follow[0].parent.name == "linked"
+
+    def test_glob_pattern_matches(self, tmp_path):
+        """Pattern argument acts as a fnmatch filter on filenames."""
+        (tmp_path / "a.md").write_text("")
+        (tmp_path / "b.txt").write_text("")
+        mds = list(rglob_follow(tmp_path, "*.md"))
+        assert len(mds) == 1
+        assert mds[0].name == "a.md"
+
+    def test_empty_when_no_match(self, tmp_path):
+        """Returns nothing when no files match."""
+        assert list(rglob_follow(tmp_path, "SKILL.md")) == []

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -217,10 +217,11 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     {"path": Path} or None.
     """
     from agent.skill_utils import get_all_skills_dirs
+    from hermes_constants import rglob_follow
     for skills_dir in get_all_skills_dirs():
         if not skills_dir.exists():
             continue
-        for skill_md in skills_dir.rglob("SKILL.md"):
+        for skill_md in rglob_follow(skills_dir, "SKILL.md"):
             if skill_md.parent.name == name:
                 return {"path": skill_md.parent}
     return None

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -2255,20 +2255,22 @@ class OptionalSkillSource(SkillSource):
 
     def _find_skill_dir(self, name: str) -> Optional[Path]:
         """Find a skill directory by name anywhere in optional-skills/."""
+        from hermes_constants import rglob_follow
         if not self._optional_dir.is_dir():
             return None
-        for skill_md in self._optional_dir.rglob("SKILL.md"):
+        for skill_md in rglob_follow(self._optional_dir, "SKILL.md"):
             if skill_md.parent.name == name:
                 return skill_md.parent
         return None
 
     def _scan_all(self) -> List[SkillMeta]:
         """Enumerate all optional skills with metadata."""
+        from hermes_constants import rglob_follow
         if not self._optional_dir.is_dir():
             return []
 
         results: List[SkillMeta] = []
-        for skill_md in sorted(self._optional_dir.rglob("SKILL.md")):
+        for skill_md in sorted(rglob_follow(self._optional_dir, "SKILL.md")):
             parent = skill_md.parent
             rel_parts = parent.relative_to(self._optional_dir).parts
             if any(part.startswith(".") for part in rel_parts):

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -135,11 +135,12 @@ def _discover_bundled_skills(bundled_dir: Path) -> List[Tuple[str, Path]]:
     Find all SKILL.md files in the bundled directory.
     Returns list of (skill_name, skill_directory_path) tuples.
     """
+    from hermes_constants import rglob_follow
     skills = []
     if not bundled_dir.exists():
         return skills
 
-    for skill_md in bundled_dir.rglob("SKILL.md"):
+    for skill_md in rglob_follow(bundled_dir, "SKILL.md"):
         path_str = str(skill_md)
         if "/.git/" in path_str or "/.github/" in path_str or "/.hub/" in path_str:
             continue

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -549,8 +549,9 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
         dirs_to_scan.append(SKILLS_DIR)
     dirs_to_scan.extend(get_external_skills_dirs())
 
+    from hermes_constants import rglob_follow
     for scan_dir in dirs_to_scan:
-        for skill_md in scan_dir.rglob("SKILL.md"):
+        for skill_md in rglob_follow(scan_dir, "SKILL.md"):
             if any(part in _EXCLUDED_SKILL_DIRS for part in skill_md.parts):
                 continue
 
@@ -906,8 +907,9 @@ def skill_view(name: str, file_path: str = None, task_id: str = None) -> str:
 
         # Search by directory name across all dirs
         if not skill_md:
+            from hermes_constants import rglob_follow
             for search_dir in all_dirs:
-                for found_skill_md in search_dir.rglob("SKILL.md"):
+                for found_skill_md in rglob_follow(search_dir, "SKILL.md"):
                     if found_skill_md.parent.name == name:
                         skill_dir = found_skill_md.parent
                         skill_md = found_skill_md


### PR DESCRIPTION
## Summary

`Path.rglob()` does **not** follow directory symlinks (confirmed on Python 3.11 and 3.12; 3.13 adds an opt-in `recurse_symlinks=True` parameter but the default is still false). Every skill-discovery code path in hermes-agent uses `.rglob("SKILL.md")`, so any skill whose directory is a symlink — at any depth, including directly under the scan root — is silently invisible to:

- `/<skill>` slash command registration (`agent/skill_commands.py`)
- `skill_view`, `skill_manage`, `skills_list` tools (`tools/skills_tool.py`, `tools/skill_manager_tool.py`)
- Gateway unavailable-skill resolver (`gateway/run.py`)
- Optional skills hub (`tools/skills_hub.py`)
- Bundled-skills sync (`tools/skills_sync.py`)
- CLI `/dump` and `hermes profiles` skill counts (`hermes_cli/dump.py`, `hermes_cli/profiles.py`)

This affects any setup that symlinks skill directories into a scan root — e.g. sharing a single on-disk skill across multiple agent frameworks, or organising skills via symlinked category folders.

## Fix

- Add `hermes_constants.rglob_follow(directory, pattern)` — a thin wrapper around `os.walk(followlinks=True)` + `fnmatch` that behaves like `Path.rglob` but traverses symlinked directories.
- Replace the 8 `.rglob("SKILL.md")` call sites in skill-discovery paths with `rglob_follow(...)`.
- Switch the `os.walk(...)` in `agent/skill_utils.iter_skill_index_files` to `followlinks=True` for the same reason.

The helper is narrowly scoped and only used where skill discovery needs to cross symlink boundaries — non-skill code paths that use `rglob` are untouched.

## Test Plan

- [x] New `TestRglobFollow` class in `tests/test_hermes_constants.py` covers:
  - Regular subdirectory traversal (baseline)
  - Symlinked directory traversal (the bug) — the key assertion
  - Glob pattern matching (`*.md`)
  - Empty-result behaviour
  - Gracefully `pytest.skip`s on platforms where the test cannot create symlinks (Windows without dev mode)
- [x] `pytest tests/test_hermes_constants.py -v` passes all cases (new + existing).

## Notes

- No behaviour change for users without symlinked skills — `os.walk(followlinks=True)` produces the same file list as `Path.rglob` for trees with no symlinks.
- `EXCLUDED_SKILL_DIRS` / `.git` / `.github` / `.hub` filtering is preserved at every call site, same as before.
- Symlink cycles are not explicitly guarded against — `os.walk` itself does not detect them, but in practice skill directories don't form cycles and existing `EXCLUDED_SKILL_DIRS` filtering avoids the common cases.
