### PR TITLE
feat(knowledge-surfaces): productize Hermes built-in repo, web, and document intelligence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -535,6 +535,10 @@ scripts/run_tests.sh                                  # full suite, CI-parity
 scripts/run_tests.sh tests/gateway/                   # one directory
 scripts/run_tests.sh tests/agent/test_foo.py::test_x  # one test
 scripts/run_tests.sh -v --tb=long                     # pass-through pytest flags
+
+# Named chunk presets for slow verification targets; still delegates to scripts/run_tests.sh.
+scripts/run_test_chunks.sh broad
+scripts/run_test_chunks.sh run-agent-file -- -q --durations=20
 ```
 
 ### Why the wrapper (and why the old "just call pytest" doesn't work)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,7 +106,7 @@ hermes chat -q "Hello"
 ### Run tests
 
 ```bash
-pytest tests/ -v
+scripts/run_tests.sh
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 uv venv venv --python 3.11
 source venv/bin/activate
 uv pip install -e ".[all,dev]"
-python -m pytest tests/ -q
+scripts/run_tests.sh
 ```
 
 > **RL Training (optional):** To work on the RL/Tinker-Atropos integration:

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -691,6 +691,81 @@ class HermesACPAgent(acp.Agent):
         logger.info("Session %s: model switched to %s", state.session_id, new_model)
         return f"Model switched to: {new_model}\nProvider: {provider_label}"
 
+    @staticmethod
+    def _truncate_tool_description(description: str, limit: int = 80) -> str:
+        rendered = str(description or "").strip()
+        if len(rendered) <= limit:
+            return rendered
+        return rendered[: limit - 3] + "..."
+
+    @classmethod
+    def _format_surface_line(cls, contract: dict[str, Any], description: str) -> str:
+        canonical_name = contract.get("canonical_name") or contract.get("name") or "?"
+        if contract.get("is_canonical_knowledge_surface"):
+            label = "built-in/canonical"
+        elif contract.get("is_additive"):
+            label = f"additive/{contract.get('source', 'registry')}"
+        else:
+            label = f"built-in/{contract.get('source', 'toolset')}"
+        tools = contract.get("tools") or []
+        suffix = f" [{label}; {len(tools)} raw tools]"
+        summary = cls._truncate_tool_description(description, limit=100)
+        return f"  {canonical_name}{suffix}: {summary}" if summary else f"  {canonical_name}{suffix}"
+
+    @classmethod
+    def _collect_visible_surface_sections(
+        cls,
+        visible_tool_names: set[str],
+        enabled_toolsets: list[str],
+    ) -> list[str]:
+        from toolsets import get_all_toolsets, get_toolset_contract
+
+        lines: list[str] = []
+        all_toolsets = get_all_toolsets()
+
+        canonical_lines: list[str] = []
+        seen_canonical: set[str] = set()
+        for toolset_name, toolset_info in all_toolsets.items():
+            contract = get_toolset_contract(toolset_name)
+            if not contract or not contract.get("is_canonical_knowledge_surface"):
+                continue
+            contract_tools = set(contract.get("tools") or [])
+            if not contract_tools or not contract_tools.issubset(visible_tool_names):
+                continue
+            canonical_name = contract.get("canonical_name") or toolset_name
+            if canonical_name in seen_canonical:
+                continue
+            seen_canonical.add(canonical_name)
+            canonical_lines.append(cls._format_surface_line(contract, toolset_info.get("description", "")))
+
+        if canonical_lines:
+            lines.append("Canonical built-in knowledge surfaces visible from current tool membership:")
+            lines.extend(canonical_lines)
+
+        additive_lines: list[str] = []
+        seen_additive: set[str] = set()
+        for toolset_name in enabled_toolsets:
+            contract = get_toolset_contract(toolset_name)
+            if not contract or not contract.get("is_additive"):
+                continue
+            contract_tools = set(contract.get("tools") or [])
+            if contract_tools and not contract_tools.issubset(visible_tool_names):
+                continue
+            canonical_name = contract.get("canonical_name") or toolset_name
+            if canonical_name in seen_additive:
+                continue
+            seen_additive.add(canonical_name)
+            toolset_info = all_toolsets.get(toolset_name) or all_toolsets.get(canonical_name) or {}
+            additive_lines.append(cls._format_surface_line(contract, toolset_info.get("description", "")))
+
+        if additive_lines:
+            if lines:
+                lines.append("")
+            lines.append("Additive tool surfaces visible from current tool membership:")
+            lines.extend(additive_lines)
+
+        return lines
+
     def _cmd_tools(self, args: str, state: SessionState) -> str:
         try:
             from model_tools import get_tool_definitions
@@ -698,13 +773,21 @@ class HermesACPAgent(acp.Agent):
             tools = get_tool_definitions(enabled_toolsets=toolsets, quiet_mode=True)
             if not tools:
                 return "No tools available."
+            visible_tool_names = {
+                t.get("function", {}).get("name", "?")
+                for t in tools
+                if t.get("function", {}).get("name")
+            }
             lines = [f"Available tools ({len(tools)}):"]
+            surface_lines = self._collect_visible_surface_sections(visible_tool_names, list(toolsets))
+            if surface_lines:
+                lines.append("")
+                lines.extend(surface_lines)
+                lines.append("")
+            lines.append(f"Raw tools ({len(tools)}):")
             for t in tools:
                 name = t.get("function", {}).get("name", "?")
-                desc = t.get("function", {}).get("description", "")
-                # Truncate long descriptions
-                if len(desc) > 80:
-                    desc = desc[:77] + "..."
+                desc = self._truncate_tool_description(t.get("function", {}).get("description", ""))
                 lines.append(f"  {name}: {desc}")
             return "\n".join(lines)
         except Exception as e:

--- a/agent/compaction_checkpoint.py
+++ b/agent/compaction_checkpoint.py
@@ -1,0 +1,219 @@
+"""Canonical compaction checkpoint artifacts for Book/JSONL memory.
+
+This module writes a structured continuation artifact every time Hermes
+compacts context. The artifact is canonical/local-first and intentionally
+separate from derived recall systems like Rasputin.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+from hermes_constants import get_hermes_home
+
+
+def write_compaction_checkpoint(
+    *,
+    session_id: str,
+    messages: List[Dict[str, Any]],
+    preservation_notes: str,
+    approx_tokens: int | None,
+    context_length: int,
+    threshold_tokens: int,
+) -> Dict[str, str]:
+    """Write canonical continuation artifacts for an imminent compaction.
+
+    Returns a dict of artifact paths for logging/testing. All writes are local,
+    profile-scoped, and safe to call repeatedly.
+    """
+    timestamp = datetime.now(timezone.utc)
+    timestamp_iso = timestamp.isoformat().replace("+00:00", "Z")
+    timestamp_slug = timestamp.strftime("%Y%m%d-%H%M%S")
+    safe_session_id = (session_id or "unknown-session").strip() or "unknown-session"
+
+    hermes_home = get_hermes_home()
+    workspace_dir = hermes_home / "workspace"
+    memory_root = _resolve_memory_root(workspace_dir)
+    handoffs_dir = memory_root / "handoffs"
+    daily_dir = memory_root / "daily"
+    events_dir = memory_root / "events"
+    checkpoints_dir = memory_root / "context-checkpoints" / "completed"
+    for directory in (handoffs_dir, daily_dir, events_dir, checkpoints_dir):
+        directory.mkdir(parents=True, exist_ok=True)
+
+    profile = _infer_profile_name(hermes_home)
+    fleet = _infer_fleet(profile)
+    context_percent = _compute_context_percent(approx_tokens, context_length)
+
+    recent_user_messages = _recent_messages(messages, roles={"user"}, limit=3)
+    recent_assistant_messages = _recent_messages(messages, roles={"assistant", "tool"}, limit=4)
+    last_user_message = recent_user_messages[-1] if recent_user_messages else ""
+
+    handoff_md = _render_handoff_markdown(
+        session_id=safe_session_id,
+        profile=profile,
+        fleet=fleet,
+        saved_at=timestamp_iso,
+        approx_tokens=approx_tokens,
+        context_length=context_length,
+        threshold_tokens=threshold_tokens,
+        context_percent=context_percent,
+        preservation_notes=preservation_notes,
+        recent_user_messages=recent_user_messages,
+        recent_assistant_messages=recent_assistant_messages,
+    )
+
+    handoff_path = handoffs_dir / f"{safe_session_id}-compaction-{timestamp_slug}.md"
+    handoff_path.write_text(handoff_md, encoding="utf-8")
+
+    latest_handoff_path = handoffs_dir / "latest.md"
+    latest_handoff_path.write_text(handoff_md, encoding="utf-8")
+
+    checkpoint_payload = {
+        "session_id": safe_session_id,
+        "saved_at": timestamp_iso,
+        "status": "pending_compaction",
+        "profile": profile,
+        "fleet": fleet,
+        "context_tokens": approx_tokens,
+        "context_length": context_length,
+        "threshold_tokens": threshold_tokens,
+        "context_percent": context_percent,
+        "last_user_message": last_user_message,
+        "recent_user_messages": recent_user_messages,
+        "recent_assistant_messages": recent_assistant_messages,
+        "preservation_notes": preservation_notes,
+        "handoff_path": str(handoff_path),
+    }
+    checkpoint_json_path = checkpoints_dir / f"{safe_session_id}-{timestamp_slug}.json"
+    checkpoint_json_path.write_text(json.dumps(checkpoint_payload, indent=2), encoding="utf-8")
+
+    event_payload = {
+        "kind": "compaction_checkpoint",
+        "session_id": safe_session_id,
+        "saved_at": timestamp_iso,
+        "profile": profile,
+        "fleet": fleet,
+        "context_tokens": approx_tokens,
+        "context_length": context_length,
+        "threshold_tokens": threshold_tokens,
+        "context_percent": context_percent,
+        "handoff_path": str(handoff_path),
+        "checkpoint_json_path": str(checkpoint_json_path),
+    }
+    event_path = events_dir / f"{timestamp.strftime('%Y-%m-%d')}.jsonl"
+    with event_path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(event_payload, ensure_ascii=False) + "\n")
+
+    daily_path = daily_dir / f"{timestamp.strftime('%Y-%m-%d')}.md"
+    with daily_path.open("a", encoding="utf-8") as f:
+        f.write(
+            "\n## Compaction Checkpoint\n"
+            f"- Timestamp: {timestamp_iso}\n"
+            f"- Session: {safe_session_id}\n"
+            f"- Profile/Fleet: {profile} / {fleet}\n"
+            f"- Context: {approx_tokens if approx_tokens is not None else 'unknown'} / {context_length}"
+            f" (threshold {threshold_tokens}, {context_percent}%)\n"
+            f"- Handoff: `{handoff_path}`\n"
+            f"- Note: {preservation_notes.strip() or 'No preservation notes.'}\n"
+        )
+
+    return {
+        "handoff_path": str(handoff_path),
+        "latest_handoff_path": str(latest_handoff_path),
+        "checkpoint_json_path": str(checkpoint_json_path),
+        "event_path": str(event_path),
+        "daily_path": str(daily_path),
+    }
+
+
+def _infer_profile_name(hermes_home: Path) -> str:
+    if hermes_home.parent.name == "profiles":
+        return hermes_home.name
+    return "default"
+
+
+def _resolve_memory_root(workspace_dir: Path) -> Path:
+    candidates = [
+        workspace_dir / "memory",
+        workspace_dir / "pantheon-migrated" / "workspace-generic" / "memory",
+        workspace_dir / "workspace-generic" / "memory",
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return candidates[0]
+
+
+def _infer_fleet(profile: str) -> str:
+    name = (profile or "").strip().lower()
+    if any(token in name for token in ("bharat", "fitlife", "bd")):
+        return "bd"
+    if any(token in name for token in ("swivo", "rani", "rs")):
+        return "rs"
+    return "generic"
+
+
+def _compute_context_percent(approx_tokens: int | None, context_length: int) -> float:
+    if not approx_tokens or context_length <= 0:
+        return 0.0
+    return round((approx_tokens / context_length) * 100, 1)
+
+
+def _recent_messages(
+    messages: Iterable[Dict[str, Any]], *, roles: set[str], limit: int
+) -> List[str]:
+    collected: List[str] = []
+    for msg in messages:
+        if msg.get("role") not in roles:
+            continue
+        content = msg.get("content", "")
+        if isinstance(content, list):
+            content = " ".join(
+                str(item.get("text", "")) if isinstance(item, dict) else str(item)
+                for item in content
+            )
+        text = " ".join(str(content).split()).strip()
+        if text:
+            collected.append(text[:600])
+    return collected[-limit:]
+
+
+def _render_handoff_markdown(
+    *,
+    session_id: str,
+    profile: str,
+    fleet: str,
+    saved_at: str,
+    approx_tokens: int | None,
+    context_length: int,
+    threshold_tokens: int,
+    context_percent: float,
+    preservation_notes: str,
+    recent_user_messages: List[str],
+    recent_assistant_messages: List[str],
+) -> str:
+    user_block = "\n".join(f"- {item}" for item in recent_user_messages) or "- None captured."
+    assistant_block = "\n".join(f"- {item}" for item in recent_assistant_messages) or "- None captured."
+    return (
+        f"# Compaction Checkpoint — {saved_at}\n\n"
+        f"- Session ID: `{session_id}`\n"
+        f"- Profile: `{profile}`\n"
+        f"- Fleet: `{fleet}`\n"
+        f"- Status: pending compaction\n"
+        f"- Context usage: `{approx_tokens if approx_tokens is not None else 'unknown'}` / `{context_length}`"
+        f" (threshold `{threshold_tokens}`, `{context_percent}%`)\n\n"
+        "## Preserve Exactly\n"
+        f"{preservation_notes.strip() or 'No explicit preservation notes.'}\n\n"
+        "## Recent User Asks\n"
+        f"{user_block}\n\n"
+        "## Recent Assistant / Tool State\n"
+        f"{assistant_block}\n\n"
+        "## Continuation Guidance\n"
+        "- Resume from the latest user ask and the recent assistant/tool state above.\n"
+        "- Treat this file as a canonical pre-compaction handoff artifact.\n"
+        "- Cross-check with the session tail and current workspace state before repeating work.\n"
+    )

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -209,6 +209,35 @@ class ContextCompressor(ContextEngine):
         self._last_compression_savings_pct = 100.0
         self._ineffective_compression_count = 0
 
+    def _resolve_threshold_tokens(self, context_length: int) -> int:
+        percentage_threshold = max(
+            int(context_length * self.threshold_percent),
+            MINIMUM_CONTEXT_LENGTH,
+        )
+        explicit = getattr(self, "explicit_threshold_tokens", None)
+        if explicit is None:
+            return percentage_threshold
+        if explicit >= context_length:
+            if not self.quiet_mode:
+                logger.warning(
+                    "Explicit compression threshold_tokens=%d is >= context_length=%d for model=%s; "
+                    "falling back to percentage threshold=%d",
+                    explicit,
+                    context_length,
+                    self.model,
+                    percentage_threshold,
+                )
+            return percentage_threshold
+        return explicit
+
+    def _refresh_token_budgets(self) -> None:
+        self.threshold_tokens = self._resolve_threshold_tokens(self.context_length)
+        target_tokens = int(self.threshold_tokens * self.summary_target_ratio)
+        self.tail_token_budget = target_tokens
+        self.max_summary_tokens = min(
+            int(self.context_length * 0.05), _SUMMARY_TOKENS_CEILING,
+        )
+
     def update_model(
         self,
         model: str,
@@ -217,6 +246,7 @@ class ContextCompressor(ContextEngine):
         api_key: str = "",
         provider: str = "",
         api_mode: str = "",
+        explicit_threshold_tokens: int | None = None,
     ) -> None:
         """Update model info after a model switch or fallback activation."""
         self.model = model
@@ -225,10 +255,9 @@ class ContextCompressor(ContextEngine):
         self.provider = provider
         self.api_mode = api_mode
         self.context_length = context_length
-        self.threshold_tokens = max(
-            int(context_length * self.threshold_percent),
-            MINIMUM_CONTEXT_LENGTH,
-        )
+        if explicit_threshold_tokens is not None:
+            self.explicit_threshold_tokens = explicit_threshold_tokens
+        self._refresh_token_budgets()
 
     def __init__(
         self,
@@ -244,6 +273,7 @@ class ContextCompressor(ContextEngine):
         config_context_length: int | None = None,
         provider: str = "",
         api_mode: str = "",
+        explicit_threshold_tokens: int | None = None,
     ):
         self.model = model
         self.base_url = base_url
@@ -255,6 +285,11 @@ class ContextCompressor(ContextEngine):
         self.protect_last_n = protect_last_n
         self.summary_target_ratio = max(0.10, min(summary_target_ratio, 0.80))
         self.quiet_mode = quiet_mode
+        self.explicit_threshold_tokens = (
+            int(explicit_threshold_tokens)
+            if explicit_threshold_tokens is not None and int(explicit_threshold_tokens) > 0
+            else None
+        )
 
         self.context_length = get_model_context_length(
             model, base_url=base_url, api_key=api_key,
@@ -262,29 +297,30 @@ class ContextCompressor(ContextEngine):
             provider=provider,
         )
         # Floor: never compress below MINIMUM_CONTEXT_LENGTH tokens even if
-        # the percentage would suggest a lower value.  This prevents premature
-        # compression on large-context models at 50% while keeping the % sane
-        # for models right at the minimum.
-        self.threshold_tokens = max(
-            int(self.context_length * threshold_percent),
-            MINIMUM_CONTEXT_LENGTH,
-        )
+        # the percentage would suggest a lower value.  When an explicit
+        # threshold_tokens override is configured, it takes precedence so long
+        # as it still fits inside the active model context window.
+        self._refresh_token_budgets()
         self.compression_count = 0
 
-        # Derive token budgets: ratio is relative to the threshold, not total context
-        target_tokens = int(self.threshold_tokens * self.summary_target_ratio)
-        self.tail_token_budget = target_tokens
-        self.max_summary_tokens = min(
-            int(self.context_length * 0.05), _SUMMARY_TOKENS_CEILING,
-        )
-
         if not quiet_mode:
+            effective_threshold_pct = (
+                (self.threshold_tokens / self.context_length) * 100
+                if self.context_length else 0
+            )
+            threshold_source = (
+                "explicit_threshold_tokens"
+                if self.explicit_threshold_tokens is not None
+                and self.threshold_tokens == self.explicit_threshold_tokens
+                else "threshold_percent"
+            )
             logger.info(
                 "Context compressor initialized: model=%s context_length=%d "
-                "threshold=%d (%.0f%%) target_ratio=%.0f%% tail_budget=%d "
+                "threshold=%d (%.0f%%, %s) target_ratio=%.0f%% tail_budget=%d "
                 "provider=%s base_url=%s",
                 model, self.context_length, self.threshold_tokens,
-                threshold_percent * 100, self.summary_target_ratio * 100,
+                effective_threshold_pct, threshold_source,
+                self.summary_target_ratio * 100,
                 self.tail_token_budget,
                 provider or "none", base_url or "none",
             )

--- a/agent/continuation_enforcer.py
+++ b/agent/continuation_enforcer.py
@@ -1,0 +1,457 @@
+"""Continuation queue + delegation loop guard for Hermes orchestration.
+
+Phase 2 builds on the lightweight orchestration state added in Phase 1.
+This module keeps a small durable queue of sessions that ended with open work,
+and exposes a simple circuit breaker for repeated delegated-child failures.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from agent.orchestration_state import get_session_state
+from hermes_constants import get_hermes_dir
+
+_QUEUE_LOCK = threading.RLock()
+_ACTIVE_TODO_STATUSES = {"pending", "in_progress"}
+_DELEGATION_FAILURE_STATUSES = {"failed", "error", "interrupted", "blocked"}
+_MAX_CONSECUTIVE_DELEGATION_FAILURES = 3
+_MAX_PREVIEW_CHARS = 500
+_DEFAULT_RETRY_LEASE_SECONDS = 300
+_DEFAULT_MAX_RETRY_AGE_SECONDS = 6 * 60 * 60
+_DEFAULT_MAX_AUTO_RESUME_ATTEMPTS = 3
+_MAX_CONTINUATION_EVENTS = 25
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _parse_iso(value: Optional[str]) -> Optional[datetime]:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00")).astimezone(timezone.utc)
+    except ValueError:
+        return None
+
+
+def _iso_from_datetime(value: datetime) -> str:
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _clear_retry_runtime_fields(item: Dict[str, Any]) -> None:
+    for key in ("leaseOwner", "leaseClaimedAt", "leaseExpiresAt"):
+        item.pop(key, None)
+
+
+def _append_event(
+    item: Dict[str, Any],
+    event_type: str,
+    message: Optional[str],
+    *,
+    timestamp: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> None:
+    events = item.get("events")
+    if not isinstance(events, list):
+        events = []
+        item["events"] = events
+    entry: Dict[str, Any] = {
+        "type": str(event_type or "event").strip() or "event",
+        "timestamp": timestamp or _now_iso(),
+        "message": _truncate_preview(message) or "Continuation updated.",
+    }
+    if metadata:
+        clean_metadata = {
+            str(key): value
+            for key, value in metadata.items()
+            if value is not None
+        }
+        if clean_metadata:
+            entry["metadata"] = clean_metadata
+    events.append(entry)
+    if len(events) > _MAX_CONTINUATION_EVENTS:
+        item["events"] = events[-_MAX_CONTINUATION_EVENTS:]
+
+
+def _truncate_preview(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    if len(text) <= _MAX_PREVIEW_CHARS:
+        return text
+    return text[:_MAX_PREVIEW_CHARS].rstrip() + "…"
+
+
+def _queue_dir() -> Path:
+    directory = get_hermes_dir("runtime/orchestration", "orchestration_state")
+    directory.mkdir(parents=True, exist_ok=True)
+    return directory
+
+
+def _queue_path() -> Path:
+    return _queue_dir() / "continuations.json"
+
+
+def _normalize_todo(item: Dict[str, Any]) -> Dict[str, str]:
+    status = str(item.get("status", "pending")).strip().lower()
+    return {
+        "id": str(item.get("id", "")).strip() or "?",
+        "content": str(item.get("content", "")).strip() or "(no description)",
+        "status": status or "pending",
+    }
+
+
+def _active_todos(todos: List[Dict[str, Any]]) -> List[Dict[str, str]]:
+    return [
+        _normalize_todo(item)
+        for item in todos or []
+        if str(item.get("status", "")).strip().lower() in _ACTIVE_TODO_STATUSES
+    ]
+
+
+def _read_queue() -> Dict[str, Any]:
+    path = _queue_path()
+    if not path.exists():
+        return {"items": []}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(payload, dict):
+            items = payload.get("items")
+            payload["items"] = items if isinstance(items, list) else []
+            return payload
+    except Exception:
+        pass
+    return {"items": []}
+
+
+def _write_queue(payload: Dict[str, Any]) -> Dict[str, Any]:
+    path = _queue_path()
+    tmp_path = path.with_suffix(".json.tmp")
+    tmp_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    tmp_path.replace(path)
+    return payload
+
+
+def get_pending_continuations() -> List[Dict[str, Any]]:
+    with _QUEUE_LOCK:
+        payload = _read_queue()
+        items = [item for item in payload.get("items", []) if isinstance(item, dict) and item.get("status") == "pending"]
+        items.sort(key=lambda item: str(item.get("updatedAt") or item.get("createdAt") or ""), reverse=True)
+        return items
+
+
+def get_continuation_record(session_id: str) -> Optional[Dict[str, Any]]:
+    normalized_session_id = str(session_id or "").strip()
+    if not normalized_session_id:
+        return None
+    with _QUEUE_LOCK:
+        payload = _read_queue()
+        for item in payload.get("items", []):
+            if isinstance(item, dict) and item.get("sessionId") == normalized_session_id:
+                return dict(item)
+    return None
+
+
+def append_continuation_event(
+    session_id: str,
+    event_type: str,
+    message: Optional[str],
+    *,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Optional[Dict[str, Any]]:
+    normalized_session_id = str(session_id or "").strip()
+    if not normalized_session_id:
+        raise ValueError("session_id is required")
+
+    now = _now_iso()
+    with _QUEUE_LOCK:
+        payload = _read_queue()
+        items = payload.setdefault("items", [])
+        existing = next((item for item in items if item.get("sessionId") == normalized_session_id), None)
+        if existing is None:
+            return None
+        _append_event(existing, event_type, message, timestamp=now, metadata=metadata)
+        existing["updatedAt"] = now
+        _write_queue(payload)
+        return dict(existing)
+
+
+def request_continuation_retry(
+    session_id: str,
+    *,
+    requested_by: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    normalized_session_id = str(session_id or "").strip()
+    if not normalized_session_id:
+        raise ValueError("session_id is required")
+
+    now = _now_iso()
+    with _QUEUE_LOCK:
+        payload = _read_queue()
+        items = payload.setdefault("items", [])
+        existing = next((item for item in items if item.get("sessionId") == normalized_session_id), None)
+        if existing is None or not (existing.get("openTodos") or []):
+            return None
+
+        existing["status"] = "retry_requested"
+        existing["retryRequestedAt"] = now
+        existing["updatedAt"] = now
+        existing["requestedBy"] = str(requested_by or "").strip() or existing.get("requestedBy")
+        existing["retryRequestCount"] = int(existing.get("retryRequestCount") or 0) + 1
+        existing.pop("resolution", None)
+        _clear_retry_runtime_fields(existing)
+        _append_event(
+            existing,
+            "retry_requested",
+            f"Retry requested by {existing.get('requestedBy') or 'operator'}.",
+            timestamp=now,
+            metadata={"requested_by": existing.get("requestedBy")},
+        )
+        _write_queue(payload)
+        return dict(existing)
+
+
+def block_continuation(
+    session_id: str,
+    *,
+    resolution: str,
+) -> Optional[Dict[str, Any]]:
+    normalized_session_id = str(session_id or "").strip()
+    if not normalized_session_id:
+        raise ValueError("session_id is required")
+
+    now = _now_iso()
+    with _QUEUE_LOCK:
+        payload = _read_queue()
+        items = payload.setdefault("items", [])
+        existing = next((item for item in items if item.get("sessionId") == normalized_session_id), None)
+        if existing is None:
+            return None
+
+        existing["status"] = "blocked"
+        existing["resolution"] = str(resolution or "blocked").strip() or "blocked"
+        existing["updatedAt"] = now
+        _clear_retry_runtime_fields(existing)
+        _append_event(existing, "blocked", str(existing.get("resolution") or "blocked"), timestamp=now)
+        _write_queue(payload)
+        return dict(existing)
+
+
+def release_continuation_claim(
+    session_id: str,
+    worker_id: str,
+    *,
+    reason: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    normalized_session_id = str(session_id or "").strip()
+    normalized_worker_id = str(worker_id or "").strip()
+    if not normalized_session_id:
+        raise ValueError("session_id is required")
+    if not normalized_worker_id:
+        raise ValueError("worker_id is required")
+
+    now = _now_iso()
+    with _QUEUE_LOCK:
+        payload = _read_queue()
+        items = payload.setdefault("items", [])
+        existing = next((item for item in items if item.get("sessionId") == normalized_session_id), None)
+        if existing is None:
+            return None
+        if str(existing.get("leaseOwner") or "").strip() not in ("", normalized_worker_id):
+            return None
+
+        existing["status"] = "retry_requested"
+        existing["updatedAt"] = now
+        if reason:
+            existing["lastReleaseReason"] = str(reason).strip()
+        _clear_retry_runtime_fields(existing)
+        _append_event(existing, "retry_released", str(reason or "released"), timestamp=now, metadata={"worker_id": normalized_worker_id})
+        _write_queue(payload)
+        return dict(existing)
+
+
+def claim_retry_requested_continuation(
+    worker_id: str,
+    *,
+    lease_seconds: int = _DEFAULT_RETRY_LEASE_SECONDS,
+    max_retry_age_seconds: int = _DEFAULT_MAX_RETRY_AGE_SECONDS,
+    max_auto_resume_attempts: int = _DEFAULT_MAX_AUTO_RESUME_ATTEMPTS,
+) -> Optional[Dict[str, Any]]:
+    normalized_worker_id = str(worker_id or "").strip()
+    if not normalized_worker_id:
+        raise ValueError("worker_id is required")
+
+    now = _now_iso()
+    now_dt = _parse_iso(now) or datetime.now(timezone.utc)
+
+    with _QUEUE_LOCK:
+        payload = _read_queue()
+        items = payload.setdefault("items", [])
+        dirty = False
+        candidates: List[Dict[str, Any]] = []
+
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+
+            status = str(item.get("status") or "").strip().lower()
+            if status == "running":
+                lease_expires_at = _parse_iso(item.get("leaseExpiresAt"))
+                if lease_expires_at and lease_expires_at > now_dt:
+                    continue
+                item["status"] = "retry_requested"
+                item["updatedAt"] = now
+                _clear_retry_runtime_fields(item)
+                dirty = True
+                status = "retry_requested"
+
+            if status != "retry_requested":
+                continue
+
+            retry_requested_at = _parse_iso(item.get("retryRequestedAt") or item.get("updatedAt") or item.get("createdAt"))
+            if (
+                max_retry_age_seconds >= 0
+                and retry_requested_at is not None
+                and (now_dt - retry_requested_at).total_seconds() > max_retry_age_seconds
+            ):
+                item["status"] = "blocked"
+                item["resolution"] = "retry_request_expired"
+                item["updatedAt"] = now
+                _clear_retry_runtime_fields(item)
+                _append_event(item, "blocked", "retry_request_expired", timestamp=now)
+                dirty = True
+                continue
+
+            if max_auto_resume_attempts >= 0 and int(item.get("resumeCount") or 0) >= max_auto_resume_attempts:
+                item["status"] = "blocked"
+                item["resolution"] = "max_auto_resume_attempts_exceeded"
+                item["updatedAt"] = now
+                _clear_retry_runtime_fields(item)
+                _append_event(item, "blocked", "max_auto_resume_attempts_exceeded", timestamp=now)
+                dirty = True
+                continue
+
+            candidates.append(item)
+
+        candidates.sort(key=lambda item: str(item.get("retryRequestedAt") or item.get("updatedAt") or item.get("createdAt") or ""))
+        if not candidates:
+            if dirty:
+                _write_queue(payload)
+            return None
+
+        claimed = candidates[0]
+        claimed["status"] = "running"
+        claimed["leaseOwner"] = normalized_worker_id
+        claimed["leaseClaimedAt"] = now
+        claimed["leaseExpiresAt"] = _iso_from_datetime(now_dt + timedelta(seconds=max(int(lease_seconds or 0), 1)))
+        claimed["resumeCount"] = int(claimed.get("resumeCount") or 0) + 1
+        claimed["lastResumedAt"] = now
+        claimed["updatedAt"] = now
+        claimed.pop("resolution", None)
+        _append_event(claimed, "auto_resume_claimed", f"Claimed by {normalized_worker_id}.", timestamp=now, metadata={"worker_id": normalized_worker_id})
+        _write_queue(payload)
+        return dict(claimed)
+
+
+def reconcile_session_continuation(
+    session_id: str,
+    *,
+    outcome_status: str,
+    todos: List[Dict[str, Any]] | None,
+    response_preview: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Create/update/remove pending continuation state for a finished session.
+
+    Returns the pending record when one exists after reconciliation, otherwise None.
+    """
+    normalized_session_id = str(session_id or "").strip()
+    if not normalized_session_id:
+        raise ValueError("session_id is required")
+
+    active_todos = _active_todos(todos or [])
+    normalized_status = str(outcome_status or "failed").strip().lower() or "failed"
+    now = _now_iso()
+
+    with _QUEUE_LOCK:
+        payload = _read_queue()
+        items = payload.setdefault("items", [])
+        existing = next((item for item in items if item.get("sessionId") == normalized_session_id), None)
+
+        if normalized_status == "completed" or not active_todos:
+            if existing is not None:
+                existing["status"] = "resolved"
+                existing["resolution"] = normalized_status if normalized_status == "completed" else "cleared"
+                existing["openTodos"] = active_todos
+                existing["responsePreview"] = _truncate_preview(response_preview)
+                existing["updatedAt"] = now
+                _clear_retry_runtime_fields(existing)
+                _append_event(existing, "resolved", str(existing.get("resolution") or "resolved"), timestamp=now)
+                _write_queue(payload)
+            return None
+
+        if existing is None:
+            existing = {
+                "sessionId": normalized_session_id,
+                "status": "pending",
+                "reason": normalized_status,
+                "responsePreview": _truncate_preview(response_preview),
+                "openTodos": active_todos,
+                "createdAt": now,
+                "updatedAt": now,
+                "attemptCount": 1,
+            }
+            _append_event(existing, "pending_created", f"Continuation created from {normalized_status} outcome.", timestamp=now)
+            items.append(existing)
+        else:
+            existing["status"] = "pending"
+            existing["reason"] = normalized_status
+            existing["responsePreview"] = _truncate_preview(response_preview)
+            existing["openTodos"] = active_todos
+            existing["updatedAt"] = now
+            existing["attemptCount"] = int(existing.get("attemptCount") or 0) + 1
+            existing.setdefault("createdAt", now)
+            existing.pop("resolution", None)
+            _clear_retry_runtime_fields(existing)
+            _append_event(existing, "pending_updated", f"Continuation updated from {normalized_status} outcome.", timestamp=now)
+
+        _write_queue(payload)
+        return dict(existing)
+
+
+def should_block_delegation(session_id: str, goal: str) -> Optional[str]:
+    normalized_session_id = str(session_id or "").strip()
+    normalized_goal = " ".join(str(goal or "").split()).strip().casefold()
+    if not normalized_session_id or not normalized_goal:
+        return None
+
+    state = get_session_state(normalized_session_id)
+    if not state:
+        return None
+
+    matching = [
+        entry
+        for entry in (state.get("delegations") or [])
+        if isinstance(entry, dict)
+        and " ".join(str(entry.get("goal") or "").split()).strip().casefold() == normalized_goal
+    ]
+    if len(matching) < _MAX_CONSECUTIVE_DELEGATION_FAILURES:
+        return None
+
+    recent = matching[-_MAX_CONSECUTIVE_DELEGATION_FAILURES:]
+    if all(str(entry.get("status") or "").strip().lower() in _DELEGATION_FAILURE_STATUSES for entry in recent):
+        display_goal = str(goal).strip()
+        return (
+            f"Blocked delegated retry loop for '{display_goal}': the last "
+            f"{_MAX_CONSECUTIVE_DELEGATION_FAILURES} attempts all ended without completion. "
+            "Surface the unfinished work through the continuation queue instead of retrying automatically."
+        )
+    return None

--- a/agent/orchestration_state.py
+++ b/agent/orchestration_state.py
@@ -1,0 +1,216 @@
+"""Durable orchestration state for active Hermes sessions.
+
+Stores small per-session JSON snapshots under HERMES_HOME so Pan and future
+continuation logic can inspect what the agent is currently doing, including
+child delegations. This is intentionally lightweight and profile-scoped.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from hermes_constants import get_hermes_dir
+
+_STATE_LOCK = threading.RLock()
+_MAX_PREVIEW_CHARS = 500
+_MAX_DELEGATIONS = 20
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _truncate_preview(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    if len(text) <= _MAX_PREVIEW_CHARS:
+        return text
+    return text[:_MAX_PREVIEW_CHARS].rstrip() + "…"
+
+
+def _state_dir() -> Path:
+    directory = get_hermes_dir("runtime/orchestration", "orchestration_state")
+    directory.mkdir(parents=True, exist_ok=True)
+    return directory
+
+
+def _state_path(session_id: str) -> Path:
+    safe_session_id = str(session_id or "").strip()
+    if not safe_session_id:
+        raise ValueError("session_id is required")
+    return _state_dir() / f"{safe_session_id}.json"
+
+
+def _read_state(session_id: str) -> Dict[str, Any]:
+    path = _state_path(session_id)
+    if not path.exists():
+        return {
+            "sessionId": session_id,
+            "status": "running",
+            "platform": None,
+            "userId": None,
+            "messagePreview": None,
+            "responsePreview": None,
+            "startedAt": None,
+            "updatedAt": None,
+            "endedAt": None,
+            "sessionLifecycle": "active",
+            "delegations": [],
+        }
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(payload, dict):
+            payload.setdefault("sessionId", session_id)
+            payload.setdefault("delegations", [])
+            payload.setdefault("sessionLifecycle", "active")
+            return payload
+    except Exception:
+        pass
+    return {
+        "sessionId": session_id,
+        "status": "running",
+        "platform": None,
+        "userId": None,
+        "messagePreview": None,
+        "responsePreview": None,
+        "startedAt": None,
+        "updatedAt": None,
+        "endedAt": None,
+        "sessionLifecycle": "active",
+        "delegations": [],
+    }
+
+
+def _write_state(session_id: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    path = _state_path(session_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(".json.tmp")
+    tmp_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    tmp_path.replace(path)
+    return payload
+
+
+def get_session_state(session_id: str) -> Optional[Dict[str, Any]]:
+    with _STATE_LOCK:
+        path = _state_path(session_id)
+        if not path.exists():
+            return None
+        return _read_state(session_id)
+
+
+def record_agent_start(
+    session_id: str,
+    *,
+    platform: Optional[str] = None,
+    user_id: Optional[str] = None,
+    message: Optional[str] = None,
+) -> Dict[str, Any]:
+    with _STATE_LOCK:
+        payload = _read_state(session_id)
+        now = _now_iso()
+        payload["status"] = "running"
+        payload["platform"] = platform or payload.get("platform")
+        payload["userId"] = user_id or payload.get("userId")
+        payload["messagePreview"] = _truncate_preview(message) or payload.get("messagePreview")
+        payload["startedAt"] = payload.get("startedAt") or now
+        payload["updatedAt"] = now
+        payload["endedAt"] = None
+        payload["sessionLifecycle"] = "active"
+        return _write_state(session_id, payload)
+
+
+def record_agent_end(
+    session_id: str,
+    *,
+    status: str = "completed",
+    response: Optional[str] = None,
+) -> Dict[str, Any]:
+    with _STATE_LOCK:
+        payload = _read_state(session_id)
+        now = _now_iso()
+        payload["status"] = status
+        payload["responsePreview"] = _truncate_preview(response) if response is not None else payload.get("responsePreview")
+        payload["updatedAt"] = now
+        if status and status != "running":
+            payload["endedAt"] = now
+        return _write_state(session_id, payload)
+
+
+def record_session_lifecycle(session_id: str, lifecycle: str) -> Dict[str, Any]:
+    with _STATE_LOCK:
+        payload = _read_state(session_id)
+        now = _now_iso()
+        payload["sessionLifecycle"] = lifecycle
+        payload["updatedAt"] = now
+        if lifecycle in {"ended", "reset"}:
+            payload["endedAt"] = now
+        return _write_state(session_id, payload)
+
+
+def record_delegation_start(
+    session_id: str,
+    *,
+    goal: str,
+    task_index: Optional[int] = None,
+    toolsets: Optional[list[str]] = None,
+) -> str:
+    with _STATE_LOCK:
+        payload = _read_state(session_id)
+        now = _now_iso()
+        delegations = payload.setdefault("delegations", [])
+        delegation_id = f"dlg_{len(delegations) + 1}_{int(datetime.now(timezone.utc).timestamp() * 1000)}"
+        delegations.append(
+            {
+                "id": delegation_id,
+                "taskIndex": task_index,
+                "goal": _truncate_preview(goal),
+                "status": "running",
+                "summary": None,
+                "apiCalls": None,
+                "durationSeconds": None,
+                "model": None,
+                "toolsets": toolsets or [],
+                "startedAt": now,
+                "updatedAt": now,
+            }
+        )
+        if len(delegations) > _MAX_DELEGATIONS:
+            payload["delegations"] = delegations[-_MAX_DELEGATIONS:]
+        payload["updatedAt"] = now
+        _write_state(session_id, payload)
+        return delegation_id
+
+
+def record_delegation_end(
+    session_id: str,
+    delegation_id: str,
+    *,
+    status: str,
+    summary: Optional[str] = None,
+    api_calls: Optional[int] = None,
+    duration_seconds: Optional[float] = None,
+    model: Optional[str] = None,
+) -> Dict[str, Any]:
+    with _STATE_LOCK:
+        payload = _read_state(session_id)
+        now = _now_iso()
+        delegations = payload.setdefault("delegations", [])
+        for entry in delegations:
+            if entry.get("id") != delegation_id:
+                continue
+            entry["status"] = status
+            entry["summary"] = _truncate_preview(summary) if summary is not None else entry.get("summary")
+            entry["apiCalls"] = api_calls if api_calls is not None else entry.get("apiCalls")
+            entry["durationSeconds"] = duration_seconds if duration_seconds is not None else entry.get("durationSeconds")
+            entry["model"] = model if model is not None else entry.get("model")
+            entry["updatedAt"] = now
+            break
+        payload["updatedAt"] = now
+        return _write_state(session_id, payload)

--- a/agent/smart_model_routing.py
+++ b/agent/smart_model_routing.py
@@ -59,6 +59,101 @@ def _coerce_int(value: Any, default: int) -> int:
         return default
 
 
+def _build_result(model: Any, runtime: Dict[str, Any], label: Optional[str]) -> Dict[str, Any]:
+    return {
+        "model": model,
+        "runtime": {
+            "api_key": runtime.get("api_key"),
+            "base_url": runtime.get("base_url"),
+            "provider": runtime.get("provider"),
+            "api_mode": runtime.get("api_mode"),
+            "command": runtime.get("command"),
+            "args": list(runtime.get("args") or []),
+            "credential_pool": runtime.get("credential_pool"),
+        },
+        "label": label,
+        "signature": (
+            model,
+            runtime.get("provider"),
+            runtime.get("base_url"),
+            runtime.get("api_mode"),
+            runtime.get("command"),
+            tuple(runtime.get("args") or ()),
+        ),
+    }
+
+
+def _build_primary_result(primary: Dict[str, Any]) -> Dict[str, Any]:
+    return _build_result(
+        primary.get("model"),
+        {
+            "api_key": primary.get("api_key"),
+            "base_url": primary.get("base_url"),
+            "provider": primary.get("provider"),
+            "api_mode": primary.get("api_mode"),
+            "command": primary.get("command"),
+            "args": list(primary.get("args") or []),
+            "credential_pool": primary.get("credential_pool"),
+        },
+        None,
+    )
+
+
+def _normalize_route_entry(route: Any, *, reason: str) -> Optional[Dict[str, Any]]:
+    if not isinstance(route, dict):
+        return None
+
+    provider = str(route.get("provider") or "").strip().lower()
+    model = str(route.get("model") or "").strip()
+    if not provider or not model:
+        return None
+
+    normalized = dict(route)
+    normalized["provider"] = provider
+    normalized["model"] = model
+    normalized["routing_reason"] = reason
+    return normalized
+
+
+def _resolve_configured_route(route: Optional[Dict[str, Any]], *, label_prefix: str) -> Optional[Dict[str, Any]]:
+    if not route:
+        return None
+
+    from hermes_cli.runtime_provider import resolve_runtime_provider
+
+    explicit_api_key = None
+    api_key_env = str(route.get("api_key_env") or "").strip()
+    if api_key_env:
+        explicit_api_key = os.getenv(api_key_env) or None
+
+    try:
+        runtime = resolve_runtime_provider(
+            requested=route.get("provider"),
+            explicit_api_key=explicit_api_key,
+            explicit_base_url=route.get("base_url"),
+        )
+    except Exception:
+        return None
+
+    return _build_result(
+        route.get("model"),
+        runtime,
+        f"{label_prefix} {route.get('model')} ({runtime.get('provider')})",
+    )
+
+
+def choose_primary_agent_route(routing_config: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """Return the configured strong/primary route when smart routing is enabled."""
+    cfg = routing_config or {}
+    if not _coerce_bool(cfg.get("enabled"), False):
+        return None
+
+    return _normalize_route_entry(
+        cfg.get("primary_agent"),
+        reason="primary_agent",
+    )
+
+
 def choose_cheap_model_route(user_message: str, routing_config: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
     """Return the configured cheap-model route when a message looks simple.
 
@@ -69,12 +164,11 @@ def choose_cheap_model_route(user_message: str, routing_config: Optional[Dict[st
     if not _coerce_bool(cfg.get("enabled"), False):
         return None
 
-    cheap_model = cfg.get("cheap_model") or {}
-    if not isinstance(cheap_model, dict):
-        return None
-    provider = str(cheap_model.get("provider") or "").strip().lower()
-    model = str(cheap_model.get("model") or "").strip()
-    if not provider or not model:
+    cheap_model = _normalize_route_entry(
+        cfg.get("cheap_model") or {},
+        reason="simple_turn",
+    )
+    if not cheap_model:
         return None
 
     text = (user_message or "").strip()
@@ -100,11 +194,7 @@ def choose_cheap_model_route(user_message: str, routing_config: Optional[Dict[st
     if words & _COMPLEX_KEYWORDS:
         return None
 
-    route = dict(cheap_model)
-    route["provider"] = provider
-    route["model"] = model
-    route["routing_reason"] = "simple_turn"
-    return route
+    return cheap_model
 
 
 def resolve_turn_route(user_message: str, routing_config: Optional[Dict[str, Any]], primary: Dict[str, Any]) -> Dict[str, Any]:
@@ -112,84 +202,19 @@ def resolve_turn_route(user_message: str, routing_config: Optional[Dict[str, Any
 
     Returns a dict with model/runtime/signature/label fields.
     """
+    default_primary = _build_primary_result(primary)
+    primary_route = choose_primary_agent_route(routing_config)
+
+    def _resolve_effective_primary() -> Dict[str, Any]:
+        configured_primary = _resolve_configured_route(
+            primary_route,
+            label_prefix="smart route → primary",
+        )
+        return configured_primary or default_primary
+
     route = choose_cheap_model_route(user_message, routing_config)
     if not route:
-        return {
-            "model": primary.get("model"),
-            "runtime": {
-                "api_key": primary.get("api_key"),
-                "base_url": primary.get("base_url"),
-                "provider": primary.get("provider"),
-                "api_mode": primary.get("api_mode"),
-                "command": primary.get("command"),
-                "args": list(primary.get("args") or []),
-                "credential_pool": primary.get("credential_pool"),
-            },
-            "label": None,
-            "signature": (
-                primary.get("model"),
-                primary.get("provider"),
-                primary.get("base_url"),
-                primary.get("api_mode"),
-                primary.get("command"),
-                tuple(primary.get("args") or ()),
-            ),
-        }
+        return _resolve_effective_primary()
 
-    from hermes_cli.runtime_provider import resolve_runtime_provider
-
-    explicit_api_key = None
-    api_key_env = str(route.get("api_key_env") or "").strip()
-    if api_key_env:
-        explicit_api_key = os.getenv(api_key_env) or None
-
-    try:
-        runtime = resolve_runtime_provider(
-            requested=route.get("provider"),
-            explicit_api_key=explicit_api_key,
-            explicit_base_url=route.get("base_url"),
-        )
-    except Exception:
-        return {
-            "model": primary.get("model"),
-            "runtime": {
-                "api_key": primary.get("api_key"),
-                "base_url": primary.get("base_url"),
-                "provider": primary.get("provider"),
-                "api_mode": primary.get("api_mode"),
-                "command": primary.get("command"),
-                "args": list(primary.get("args") or []),
-                "credential_pool": primary.get("credential_pool"),
-            },
-            "label": None,
-            "signature": (
-                primary.get("model"),
-                primary.get("provider"),
-                primary.get("base_url"),
-                primary.get("api_mode"),
-                primary.get("command"),
-                tuple(primary.get("args") or ()),
-            ),
-        }
-
-    return {
-        "model": route.get("model"),
-        "runtime": {
-            "api_key": runtime.get("api_key"),
-            "base_url": runtime.get("base_url"),
-            "provider": runtime.get("provider"),
-            "api_mode": runtime.get("api_mode"),
-            "command": runtime.get("command"),
-            "args": list(runtime.get("args") or []),
-            "credential_pool": runtime.get("credential_pool"),
-        },
-        "label": f"smart route → {route.get('model')} ({runtime.get('provider')})",
-        "signature": (
-            route.get("model"),
-            runtime.get("provider"),
-            runtime.get("base_url"),
-            runtime.get("api_mode"),
-            runtime.get("command"),
-            tuple(runtime.get("args") or ()),
-        ),
-    }
+    cheap_result = _resolve_configured_route(route, label_prefix="smart route →")
+    return cheap_result or _resolve_effective_primary()

--- a/cli.py
+++ b/cli.py
@@ -4598,9 +4598,28 @@ class HermesCLI:
             _ask()
         return result[0]
 
-    def _open_model_picker(self, providers: list, current_model: str, current_provider: str, user_provs=None, custom_provs=None) -> None:
+    def _open_model_picker(
+        self,
+        providers: list,
+        current_model: str,
+        current_provider: str,
+        user_provs=None,
+        custom_provs=None,
+        trigger_command: str | None = None,
+    ) -> None:
         """Open prompt_toolkit-native /model picker modal."""
-        self._capture_modal_input_snapshot()
+        consumed_trigger = False
+        if trigger_command and getattr(self, "_app", None):
+            try:
+                buf = self._app.current_buffer
+                if (buf.text or "").strip() == trigger_command.strip():
+                    buf.reset()
+                    self._modal_input_snapshot = None
+                    consumed_trigger = True
+            except Exception:
+                consumed_trigger = False
+        if not consumed_trigger:
+            self._capture_modal_input_snapshot()
         default_idx = next((i for i, p in enumerate(providers) if p.get("is_current")), 0)
         self._model_picker_state = {
             "stage": "provider",
@@ -4848,6 +4867,7 @@ class HermesCLI:
                 provider_display,
                 user_provs=user_provs,
                 custom_provs=custom_provs,
+                trigger_command=cmd_original,
             )
             return
 

--- a/gateway/authority_snapshot.py
+++ b/gateway/authority_snapshot.py
@@ -1,0 +1,356 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import yaml
+
+from hermes_state import SessionDB
+from hermes_cli.profiles import get_active_profile_name, get_profile_dir, list_profiles
+
+
+_ACTIONABLE_CONTINUATION_STATUSES = {"pending", "retry_requested", "running"}
+
+
+def _to_iso(value: Any) -> Optional[str]:
+    if value in (None, ""):
+        return None
+    try:
+        return datetime.fromtimestamp(float(value)).isoformat()
+    except Exception:
+        return None
+
+
+def _profile_root(profile_id: Optional[str]) -> Path:
+    normalized = str(profile_id or "").strip() or get_active_profile_name()
+    return get_profile_dir(normalized)
+
+
+def _load_yaml(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            payload = yaml.safe_load(handle) or {}
+            return payload if isinstance(payload, dict) else {}
+    except Exception:
+        return {}
+
+
+def _load_soul(profile_root: Path) -> Optional[str]:
+    soul_path = profile_root / "SOUL.md"
+    if not soul_path.exists():
+        return None
+    try:
+        return soul_path.read_text(encoding="utf-8")
+    except Exception:
+        return None
+
+
+def _count_sessions(profile_root: Path) -> int:
+    db_path = profile_root / "state.db"
+    if not db_path.exists():
+        return 0
+    try:
+        conn = sqlite3.connect(str(db_path))
+        try:
+            cursor = conn.execute("SELECT COUNT(*) FROM sessions")
+            row = cursor.fetchone()
+            return int(row[0]) if row else 0
+        finally:
+            conn.close()
+    except Exception:
+        return 0
+
+
+def _count_skills(profile_root: Path) -> int:
+    skills_dir = profile_root / "skills"
+    if not skills_dir.is_dir():
+        return 0
+    count = 0
+    for skill_md in skills_dir.rglob("SKILL.md"):
+        skill_path = str(skill_md)
+        if "/.hub/" in skill_path or "/.git/" in skill_path:
+            continue
+        count += 1
+    return count
+
+
+def _read_profile_config_subset(profile_id: str) -> Optional[Dict[str, Any]]:
+    profile_root = _profile_root(profile_id)
+    if not profile_root.exists():
+        return None
+
+    raw = _load_yaml(profile_root / "config.yaml")
+    model_cfg = raw.get("model") if isinstance(raw.get("model"), dict) else {}
+    agent_cfg = raw.get("agent") if isinstance(raw.get("agent"), dict) else {}
+    terminal_cfg = raw.get("terminal") if isinstance(raw.get("terminal"), dict) else {}
+    display_cfg = raw.get("display") if isinstance(raw.get("display"), dict) else {}
+    memory_cfg = raw.get("memory") if isinstance(raw.get("memory"), dict) else {}
+    approvals_cfg = raw.get("approvals") if isinstance(raw.get("approvals"), dict) else {}
+    compression_cfg = raw.get("compression") if isinstance(raw.get("compression"), dict) else {}
+
+    return {
+        "modelDefault": model_cfg.get("default"),
+        "modelProvider": model_cfg.get("provider"),
+        "modelBaseUrl": model_cfg.get("base_url"),
+        "maxTurns": agent_cfg.get("max_turns"),
+        "reasoningEffort": agent_cfg.get("reasoning_effort"),
+        "toolUseEnforcement": agent_cfg.get("tool_use_enforcement"),
+        "policyPreset": raw.get("ui_policy_preset"),
+        "toolsets": raw.get("toolsets"),
+        "terminalBackend": terminal_cfg.get("backend"),
+        "terminalTimeout": terminal_cfg.get("timeout"),
+        "displayCompact": display_cfg.get("compact"),
+        "displayStreaming": display_cfg.get("streaming"),
+        "displayShowCost": display_cfg.get("show_cost"),
+        "displayPersonality": display_cfg.get("personality"),
+        "memoryEnabled": memory_cfg.get("memory_enabled"),
+        "userProfileEnabled": memory_cfg.get("user_profile_enabled"),
+        "approvalsMode": approvals_cfg.get("mode"),
+        "compressionEnabled": compression_cfg.get("enabled"),
+        "compressionThreshold": compression_cfg.get("threshold"),
+        "soul": _load_soul(profile_root),
+    }
+
+
+def _list_authority_profiles(active_profile: str) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    for profile in list_profiles():
+        config = _load_yaml(profile.path / "config.yaml")
+        model_cfg = config.get("model") if isinstance(config.get("model"), dict) else {}
+        model_default = model_cfg.get("default")
+        policy_preset = config.get("ui_policy_preset") or "safe-chat"
+        session_count = _count_sessions(profile.path)
+        skill_count = _count_skills(profile.path)
+        rows.append(
+            {
+                "id": profile.name,
+                "name": profile.name,
+                "modelDefault": model_default,
+                "policyPreset": policy_preset,
+                "sessionCount": session_count,
+                "skillCount": skill_count,
+                "extensionCount": 0,
+                "integrationsCount": 0,
+                "runtimeProvider": "real-hermes" if model_default else "unconfigured",
+                "runtimeSummary": f"{model_default or 'No default model'} · {session_count} sessions · {skill_count} skills",
+                "trustMode": policy_preset,
+                "runtimeHealth": "healthy" if model_default else "degraded",
+                "profileContextLabel": (
+                    f"{profile.name} · active runtime profile"
+                    if profile.name == active_profile
+                    else f"{profile.name} · authority api profile"
+                ),
+                "workspacePath": ((config.get("terminal") or {}).get("cwd") if isinstance(config.get("terminal"), dict) else None),
+                "active": profile.name == active_profile,
+            }
+        )
+    return rows
+
+
+def _open_session_db(profile_id: str) -> Optional[SessionDB]:
+    profile_root = _profile_root(profile_id)
+    db_path = profile_root / "state.db"
+    if not db_path.exists():
+        return None
+    try:
+        return SessionDB(db_path)
+    except Exception:
+        return None
+
+
+def _list_sessions(profile_id: str, search: Optional[str] = None) -> List[Dict[str, Any]]:
+    db = _open_session_db(profile_id)
+    if db is None:
+        return []
+    try:
+        rows = db.list_sessions_rich(limit=100, include_children=True)
+    finally:
+        db.close()
+
+    query = str(search or "").strip().lower()
+    sessions: List[Dict[str, Any]] = []
+    for row in rows:
+        preview = str(row.get("preview") or "") or None
+        title = str(row.get("title") or "").strip() or ((preview or "")[:40] if preview else "Untitled session")
+        hay = f"{title} {preview or ''}".lower()
+        if query and query not in hay:
+            continue
+        archived = bool(row.get("ended_at"))
+        model_config: Dict[str, Any] = {}
+        raw_model_config = row.get("model_config")
+        if raw_model_config:
+            try:
+                model_config = json.loads(raw_model_config) or {}
+            except Exception:
+                model_config = {}
+        sessions.append(
+            {
+                "id": row.get("id"),
+                "title": title,
+                "updatedAt": _to_iso(row.get("last_active") or row.get("started_at")),
+                "preview": preview,
+                "workspaceLabel": "Archived" if archived else ("Forks" if row.get("parent_session_id") else "Active workspace"),
+                "pinned": bool(model_config.get("pinned", False)),
+                "archived": archived,
+                "parentSessionId": row.get("parent_session_id"),
+                "source": str(row.get("source") or "unknown").lower(),
+                "profileId": profile_id,
+                "model": row.get("model") or "unknown",
+                "provider": model_config.get("provider", "real-hermes"),
+            }
+        )
+    return sessions
+
+
+def _get_session(profile_id: str, session_id: str) -> Optional[Dict[str, Any]]:
+    db = _open_session_db(profile_id)
+    if db is None:
+        return None
+    try:
+        row = db.get_session(session_id)
+        if not row:
+            return None
+        messages = db.get_messages(session_id)
+    finally:
+        db.close()
+
+    model_config: Dict[str, Any] = {}
+    raw_model_config = row.get("model_config")
+    if raw_model_config:
+        try:
+            model_config = json.loads(raw_model_config) or {}
+        except Exception:
+            model_config = {}
+
+    normalized_messages = []
+    preview = None
+    for index, message in enumerate(messages, start=1):
+        content = message.get("content") or ""
+        if preview is None and message.get("role") == "user" and content:
+            preview = str(content)[:160]
+        normalized_messages.append(
+            {
+                "id": f"{session_id}-{index}",
+                "role": message.get("role"),
+                "content": content,
+                "createdAt": _to_iso(message.get("timestamp")),
+            }
+        )
+
+    title = str(row.get("title") or "").strip() or ((preview or "")[:40] if preview else "Untitled session")
+    archived = bool(row.get("ended_at"))
+    return {
+        "id": row.get("id"),
+        "title": title,
+        "updatedAt": _to_iso(row.get("started_at")),
+        "preview": preview,
+        "messages": normalized_messages,
+        "parentSessionId": row.get("parent_session_id"),
+        "loadedSkillIds": model_config.get("loadedSkillIds", []),
+        "archived": archived,
+        "pinned": bool(model_config.get("pinned", False)),
+        "source": str(row.get("source") or "unknown").lower(),
+        "profileId": profile_id,
+        "settings": {
+            "model": row.get("model") or "unknown",
+            "provider": model_config.get("provider", "real-hermes"),
+            "policyPreset": model_config.get("policyPreset", "safe-chat"),
+            "memoryMode": model_config.get("memoryMode", "standard"),
+        },
+    }
+
+
+def _read_runs(profile_id: str) -> List[Dict[str, Any]]:
+    runs_path = _profile_root(profile_id) / "runtime" / "runs" / "index.json"
+    if not runs_path.exists():
+        return []
+    try:
+        payload = json.loads(runs_path.read_text(encoding="utf-8")) or {}
+        runs = payload.get("runs") if isinstance(payload, dict) else []
+        return runs if isinstance(runs, list) else []
+    except Exception:
+        return []
+
+
+def _read_continuations(profile_id: str) -> Dict[str, List[Dict[str, Any]]]:
+    queue_path = _profile_root(profile_id) / "runtime" / "orchestration" / "continuations.json"
+    if not queue_path.exists():
+        return {"continuations": [], "history": []}
+    try:
+        payload = json.loads(queue_path.read_text(encoding="utf-8")) or {}
+        items = payload.get("items") if isinstance(payload, dict) else []
+        if not isinstance(items, list):
+            items = []
+    except Exception:
+        items = []
+
+    actionable: List[Dict[str, Any]] = []
+    history: List[Dict[str, Any]] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        status = str(item.get("status") or "unknown").strip().lower()
+        if status in _ACTIONABLE_CONTINUATION_STATUSES:
+            actionable.append(item)
+        else:
+            history.append(item)
+
+    actionable.sort(key=lambda item: str(item.get("updatedAt") or item.get("createdAt") or ""), reverse=True)
+    history.sort(key=lambda item: str(item.get("updatedAt") or item.get("createdAt") or ""), reverse=True)
+    return {"continuations": actionable, "history": history}
+
+
+def _get_workspaces(profile_id: str) -> Dict[str, Any]:
+    profile_root = _profile_root(profile_id)
+    config = _load_yaml(profile_root / "config.yaml")
+    terminal_cfg = config.get("terminal") if isinstance(config.get("terminal"), dict) else {}
+    known: List[Dict[str, Any]] = []
+    configured_cwd = str(terminal_cfg.get("cwd") or "").strip() or None
+    if configured_cwd:
+        known.append(
+            {
+                "id": "terminal-cwd",
+                "label": "Configured workspace",
+                "path": configured_cwd,
+                "source": "terminal.cwd",
+            }
+        )
+    workspace_root = profile_root / "workspace"
+    if workspace_root.exists():
+        known.append(
+            {
+                "id": "profile-workspace",
+                "label": "Profile workspace",
+                "path": str(workspace_root),
+                "source": "profile-workspace",
+            }
+        )
+    current = known[0] if known else None
+    return {"current": current, "known": known}
+
+
+def get_authority_snapshot(
+    *,
+    profile_id: Optional[str] = None,
+    search: Optional[str] = None,
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    selected_profile = str(profile_id or "").strip() or get_active_profile_name()
+    active_profile = get_active_profile_name()
+    continuations = _read_continuations(selected_profile)
+    return {
+        "profileId": selected_profile,
+        "profiles": _list_authority_profiles(active_profile),
+        "config": _read_profile_config_subset(selected_profile),
+        "sessions": _list_sessions(selected_profile, search),
+        "session": _get_session(selected_profile, str(session_id or "").strip()) if session_id else None,
+        "runs": _read_runs(selected_profile),
+        "continuations": continuations["continuations"],
+        "history": continuations["history"],
+        "workspaces": _get_workspaces(selected_profile),
+    }

--- a/gateway/builtin_hooks/orchestration_state.py
+++ b/gateway/builtin_hooks/orchestration_state.py
@@ -1,0 +1,44 @@
+"""Built-in orchestration-state hook.
+
+Persists lightweight lifecycle state for gateway sessions so Pan can show the
+current session status and delegated-child progress without parsing transcripts.
+"""
+
+from __future__ import annotations
+
+from agent.orchestration_state import record_agent_end, record_agent_start, record_session_lifecycle
+
+
+async def handle(event_type: str, context: dict) -> None:
+    session_id = str((context or {}).get("session_id") or "").strip()
+    if not session_id:
+        return
+
+    if event_type == "agent:start":
+        record_agent_start(
+            session_id,
+            platform=(context or {}).get("platform"),
+            user_id=(context or {}).get("user_id"),
+            message=(context or {}).get("message"),
+        )
+        return
+
+    if event_type == "agent:end":
+        status = str((context or {}).get("status") or "").strip() or ""
+        if not status:
+            orchestration = (context or {}).get("orchestration") or {}
+            if isinstance(orchestration, dict):
+                status = str(orchestration.get("outcomeStatus") or "").strip()
+        record_agent_end(
+            session_id,
+            status=status or "completed",
+            response=(context or {}).get("response"),
+        )
+        return
+
+    if event_type == "session:end":
+        record_session_lifecycle(session_id, "ended")
+        return
+
+    if event_type == "session:reset":
+        record_session_lifecycle(session_id, "reset")

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -40,6 +40,7 @@ except ImportError:
     AIOHTTP_AVAILABLE = False
     web = None  # type: ignore[assignment]
 
+from gateway.authority_snapshot import get_authority_snapshot
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -486,6 +487,23 @@ class APIServerAdapter(BasePlatformAdapter):
             {"error": {"message": "Invalid API key", "type": "invalid_request_error", "code": "invalid_api_key"}},
             status=401,
         )
+
+    async def _handle_authority_snapshot(self, request: "web.Request") -> "web.Response":
+        """GET /api/authority/snapshot — return a profile-scoped authority snapshot."""
+        auth_err = self._check_auth(request)
+        if auth_err is not None:
+            return auth_err
+
+        try:
+            snapshot = get_authority_snapshot(
+                profile_id=request.query.get("profile_id"),
+                search=request.query.get("search"),
+                session_id=request.query.get("session_id"),
+            )
+            return web.json_response(snapshot)
+        except Exception as e:
+            logger.exception("Authority snapshot request failed")
+            return web.json_response({"error": str(e)}, status=500)
 
     # ------------------------------------------------------------------
     # Session DB helper
@@ -2315,6 +2333,7 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app["api_server_adapter"] = self
             self._app.router.add_get("/health", self._handle_health)
             self._app.router.add_get("/health/detailed", self._handle_health_detailed)
+            self._app.router.add_get("/api/authority/snapshot", self._handle_authority_snapshot)
             self._app.router.add_get("/v1/health", self._handle_health)
             self._app.router.add_get("/v1/models", self._handle_models)
             self._app.router.add_post("/v1/chat/completions", self._handle_chat_completions)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -104,9 +104,11 @@ if _config_path.exists():
         import yaml as _yaml
         with open(_config_path, encoding="utf-8") as _f:
             _cfg = _yaml.safe_load(_f) or {}
-        # Expand ${ENV_VAR} references before bridging to env vars.
-        from hermes_cli.config import _expand_env_vars
-        _cfg = _expand_env_vars(_cfg)
+        # Expand ${ENV_VAR} references and normalize known profile-local paths
+        # before bridging values into env vars. This repairs legacy in-container
+        # paths like /root/.hermes/profiles/<name>/workspace on host installs.
+        from hermes_cli.config import _expand_env_vars, _normalize_profile_path_settings
+        _cfg = _normalize_profile_path_settings(_expand_env_vars(_cfg))
         # Top-level simple values (fallback only — don't override .env)
         for _key, _val in _cfg.items():
             if isinstance(_val, (str, int, float, bool)) and _key not in os.environ:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4127,6 +4127,51 @@ class GatewayRunner:
             if agent_result.get("session_id") and agent_result["session_id"] != session_entry.session_id:
                 session_entry.session_id = agent_result["session_id"]
 
+            orchestration = agent_result.get("orchestration")
+            if not isinstance(orchestration, dict):
+                orchestration = {}
+            active_todos = orchestration.get("activeTodos") or orchestration.get("todoItems") or []
+            if not isinstance(active_todos, list):
+                active_todos = []
+            status = str(orchestration.get("outcomeStatus") or "").strip().lower()
+            if not status:
+                if agent_result.get("interrupted"):
+                    status = "interrupted"
+                elif agent_result.get("failed"):
+                    status = "failed"
+                elif agent_result.get("completed", True):
+                    status = "completed"
+                else:
+                    status = "interrupted" if active_todos else "completed"
+            response_preview = (
+                orchestration.get("responsePreview")
+                or response
+                or agent_result.get("final_response")
+                or agent_result.get("error")
+                or ""
+            )
+            if not orchestration:
+                orchestration = {
+                    "sessionId": session_entry.session_id,
+                    "outcomeStatus": status,
+                    "activeTodos": active_todos,
+                    "responsePreview": str(response_preview or "").strip(),
+                }
+                agent_result["orchestration"] = orchestration
+            try:
+                from agent.continuation_enforcer import reconcile_session_continuation
+
+                continuation = reconcile_session_continuation(
+                    str(session_entry.session_id or orchestration.get("sessionId") or "").strip(),
+                    outcome_status=status,
+                    todos=active_todos,
+                    response_preview=str(response_preview or "").strip(),
+                )
+                if continuation is not None:
+                    agent_result["continuation"] = continuation
+            except Exception as exc:
+                logger.debug("Failed to reconcile continuation state: %s", exc)
+
             # Prepend reasoning/thinking if display is enabled (per-platform)
             try:
                 from gateway.display_config import resolve_display_setting as _rds
@@ -4154,6 +4199,8 @@ class GatewayRunner:
             await self.hooks.emit("agent:end", {
                 **hook_ctx,
                 "response": (response or "")[:500],
+                "status": status,
+                "orchestration": orchestration,
             })
             
             # Check for pending process watchers (check_interval on background processes)
@@ -4382,6 +4429,104 @@ class GatewayRunner:
             # Restore session context variables to their pre-handler state
             self._clear_session_env(_session_env_tokens)
     
+    def _build_auto_resume_message(self, continuation: Dict[str, Any]) -> str:
+        reason = str(continuation.get("reason") or "interrupted").strip() or "interrupted"
+        todos = continuation.get("openTodos") or continuation.get("activeTodos") or []
+        todo_lines = []
+        for item in todos:
+            if isinstance(item, dict):
+                content = str(item.get("content") or item.get("id") or "pending work").strip()
+                status = str(item.get("status") or "pending").strip()
+                todo_lines.append(f"- [{status}] {content}")
+        todo_block = "\n".join(todo_lines) if todo_lines else "- Continue the interrupted task"
+        return (
+            "[System note: Auto-resume the previously interrupted task. "
+            f"Previous outcome: {reason}. Finish the remaining work before anything else.]\n\n"
+            "Open work:\n"
+            f"{todo_block}"
+        )
+
+    async def _process_retry_requested_continuations_once(self) -> int:
+        from agent.continuation_enforcer import (
+            append_continuation_event,
+            claim_retry_requested_continuation,
+            reconcile_session_continuation,
+            release_continuation_claim,
+        )
+
+        worker_id = getattr(self, "_auto_resume_worker_id", None) or f"gateway-auto-resume:{os.getpid()}"
+        self._auto_resume_worker_id = worker_id
+        continuation = claim_retry_requested_continuation(worker_id)
+        if not continuation:
+            return 0
+
+        session_id = str(continuation.get("sessionId") or "").strip()
+        session_entry = next(
+            (
+                entry
+                for entry in self.session_store.list_sessions()
+                if getattr(entry, "session_id", None) == session_id
+            ),
+            None,
+        )
+        if session_entry is None or session_entry.origin is None:
+            release_continuation_claim(session_id, worker_id, reason="session_missing")
+            return 0
+
+        if self._running_agents.get(session_entry.session_key):
+            release_continuation_claim(session_id, worker_id, reason="session_busy")
+            return 0
+
+        result = await self._run_agent(
+            message=self._build_auto_resume_message(continuation),
+            context_prompt="",
+            history=self.session_store.load_transcript(session_entry.session_id),
+            source=session_entry.origin,
+            session_id=session_entry.session_id,
+            session_key=session_entry.session_key,
+        )
+
+        orchestration = result.get("orchestration") if isinstance(result, dict) else {}
+        if not isinstance(orchestration, dict):
+            orchestration = {}
+        status = str(orchestration.get("outcomeStatus") or "").strip().lower()
+        if not status:
+            if result.get("interrupted"):
+                status = "interrupted"
+            elif result.get("failed"):
+                status = "failed"
+            elif result.get("completed", True):
+                status = "completed"
+            else:
+                status = "interrupted"
+        active_todos = orchestration.get("activeTodos") or orchestration.get("todoItems") or []
+        if not isinstance(active_todos, list):
+            active_todos = []
+        response_preview = (
+            orchestration.get("responsePreview")
+            or result.get("final_response")
+            or result.get("error")
+            or ""
+        )
+        reconcile_session_continuation(
+            session_entry.session_id,
+            outcome_status=status,
+            todos=active_todos,
+            response_preview=str(response_preview or "").strip(),
+        )
+
+        adapter = self.adapters.get(session_entry.origin.platform)
+        if adapter is not None and result.get("final_response"):
+            metadata = {"thread_id": session_entry.origin.thread_id} if session_entry.origin.thread_id else None
+            await adapter.send(session_entry.origin.chat_id, result.get("final_response"), metadata=metadata)
+            append_continuation_event(
+                session_entry.session_id,
+                "auto_resume_delivered",
+                result.get("final_response"),
+                metadata={"worker_id": worker_id},
+            )
+        return 1
+
     def _format_session_info(self) -> str:
         """Resolve current model config and return a formatted info block.
 
@@ -9294,6 +9439,12 @@ class GatewayRunner:
                 unregister_gateway_notify(_approval_session_key)
                 reset_current_session_key(_approval_session_token)
             result_holder[0] = result
+            _orchestration = result.get("orchestration") if isinstance(result, dict) else None
+            if not isinstance(_orchestration, dict) and agent is not None and hasattr(agent, "get_orchestration_continuation_snapshot"):
+                try:
+                    _orchestration = agent.get_orchestration_continuation_snapshot(result)
+                except Exception:
+                    _orchestration = None
 
             # Signal the stream consumer that the agent is done
             if _stream_consumer is not None:
@@ -9319,6 +9470,8 @@ class GatewayRunner:
                     "final_response": error_msg,
                     "messages": result.get("messages", []),
                     "api_calls": result.get("api_calls", 0),
+                    "completed": result.get("completed", False),
+                    "interrupted": result.get("interrupted", False),
                     "failed": result.get("failed", False),
                     "compression_exhausted": result.get("compression_exhausted", False),
                     "tools": tools_holder[0] or [],
@@ -9327,6 +9480,8 @@ class GatewayRunner:
                     "input_tokens": _input_toks,
                     "output_tokens": _output_toks,
                     "model": _resolved_model,
+                    "session_id": getattr(_agent, "session_id", session_id) if _agent else session_id,
+                    "orchestration": _orchestration,
                 }
             
             # Scan tool results for MEDIA:<path> tags that need to be delivered
@@ -9410,6 +9565,9 @@ class GatewayRunner:
                 "last_reasoning": result.get("last_reasoning"),
                 "messages": result_holder[0].get("messages", []) if result_holder[0] else [],
                 "api_calls": result_holder[0].get("api_calls", 0) if result_holder[0] else 0,
+                "completed": result.get("completed", False),
+                "interrupted": result.get("interrupted", False),
+                "failed": result.get("failed", False),
                 "tools": tools_holder[0] or [],
                 "history_offset": _effective_history_offset,
                 "last_prompt_tokens": _last_prompt_toks,
@@ -9418,6 +9576,7 @@ class GatewayRunner:
                 "model": _resolved_model,
                 "session_id": effective_session_id,
                 "response_previewed": result.get("response_previewed", False),
+                "orchestration": _orchestration,
             }
         
         # Start progress message sender if enabled
@@ -9805,7 +9964,24 @@ class GatewayRunner:
                         merge_pending_message_event(adapter._pending_messages, session_key, pending_event)
                     elif adapter and hasattr(adapter, 'queue_message'):
                         adapter.queue_message(session_key, pending)
-                    return result_holder[0] or {"final_response": response, "messages": history}
+                    payload = result_holder[0] or {"final_response": response, "messages": history}
+                    if not isinstance(payload, dict):
+                        payload = {"final_response": response, "messages": history}
+                    orchestration = payload.get("orchestration")
+                    _agent_for_orchestration = agent_holder[0]
+                    if not isinstance(orchestration, dict) and _agent_for_orchestration is not None and hasattr(_agent_for_orchestration, "get_orchestration_continuation_snapshot"):
+                        try:
+                            orchestration = _agent_for_orchestration.get_orchestration_continuation_snapshot(payload)
+                        except Exception:
+                            orchestration = None
+                    if not isinstance(orchestration, dict):
+                        orchestration = {}
+                    if not orchestration.get("outcomeStatus"):
+                        orchestration["outcomeStatus"] = "interrupted"
+                    payload["interrupted"] = True
+                    payload["completed"] = False
+                    payload["orchestration"] = orchestration
+                    return payload
 
                 was_interrupted = result.get("interrupted")
                 if not was_interrupted:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -203,7 +203,7 @@ def get_container_exec_info() -> Optional[dict]:
 # =============================================================================
 
 # Re-export from hermes_constants — canonical definition lives there.
-from hermes_constants import get_hermes_home  # noqa: F811,E402
+from hermes_constants import get_default_hermes_root, get_hermes_home  # noqa: F811,E402
 
 def get_config_path() -> Path:
     """Get the main config file path."""
@@ -216,6 +216,57 @@ def get_env_path() -> Path:
 def get_project_root() -> Path:
     """Get the project installation directory."""
     return Path(__file__).parent.parent.resolve()
+
+
+def _normalize_profile_local_path(value: Any) -> Any:
+    """Map legacy in-container profile paths onto the local Hermes root when safe.
+
+    Older profile files sometimes persisted paths like
+    ``/root/.hermes/profiles/<name>/workspace``. On a host install, the same
+    profile lives under the local Hermes root (for example
+    ``/Users/alice/.hermes/profiles/<name>/workspace``). Only rewrite when the
+    equivalent local target already exists, so we don't silently point users at
+    a guessed path.
+    """
+    if not isinstance(value, str):
+        return value
+
+    raw = value.strip()
+    if not raw.startswith("/root/.hermes/"):
+        return raw
+
+    try:
+        relative = Path(raw).relative_to(Path("/root/.hermes"))
+    except ValueError:
+        return raw
+
+    candidate = get_default_hermes_root() / relative
+    if candidate.exists() or candidate.parent.exists():
+        return str(candidate)
+    return raw
+
+
+def _normalize_profile_path_settings(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize known profile-local path settings without touching unrelated keys."""
+    normalized = dict(config)
+
+    terminal_cfg = normalized.get("terminal")
+    if isinstance(terminal_cfg, dict) and "cwd" in terminal_cfg:
+        updated_terminal = dict(terminal_cfg)
+        updated_terminal["cwd"] = _normalize_profile_local_path(updated_terminal.get("cwd"))
+        normalized["terminal"] = updated_terminal
+
+    skills_cfg = normalized.get("skills")
+    if isinstance(skills_cfg, dict):
+        external_dirs = skills_cfg.get("external_dirs")
+        if isinstance(external_dirs, list):
+            updated_skills = dict(skills_cfg)
+            updated_skills["external_dirs"] = [
+                _normalize_profile_local_path(item) for item in external_dirs
+            ]
+            normalized["skills"] = updated_skills
+
+    return normalized
 
 def _secure_dir(path):
     """Set directory to owner-only access (0700 by default). No-op on Windows.
@@ -346,6 +397,10 @@ DEFAULT_CONFIG = {
     "providers": {},
     "fallback_providers": [],
     "credential_pool_strategies": {},
+    "agents": {},
+    "categories": {},
+    "runtime_fallback": {"enabled": False},
+    "model_capabilities": {},
     "toolsets": ["hermes-cli"],
     "agent": {
         "max_turns": 90,
@@ -668,6 +723,10 @@ DEFAULT_CONFIG = {
     # so child agents can run on a different (cheaper/faster) provider and model.
     # Uses the same runtime provider resolution as CLI/gateway startup, so all
     # configured providers (OpenRouter, Nous, Z.ai, Kimi, etc.) are supported.
+    # Category profiles also serve as Hermes-native routing hints for the
+    # primary agent: the delegate_task schema and orchestration notes surface
+    # their names and routing_description values so the parent can choose the
+    # right category before spawning subagents.
     "delegation": {
         "model": "",       # e.g. "google/gemini-3-flash-preview" (empty = inherit parent model)
         "provider": "",    # e.g. "openrouter" (empty = inherit parent provider + credentials)
@@ -675,8 +734,52 @@ DEFAULT_CONFIG = {
         "api_key": "",     # API key for delegation.base_url (falls back to OPENAI_API_KEY)
         "max_iterations": 50,  # per-subagent iteration cap (each subagent gets its own budget,
                                # independent of the parent's max_iterations)
+        "max_concurrent_children": 3,
         "reasoning_effort": "",  # reasoning effort for subagents: "xhigh", "high", "medium",
                                  # "low", "minimal", "none" (empty = inherit parent's level)
+        "auto_decompose_large_tasks": True,  # prompt the primary agent to make a todo list on large requests
+        "auto_fanout_batch_mode": True,      # prefer one batched delegate_task call over many single-task calls
+        "auto_fanout_max_tasks": 3,          # soft cap for one delegated batch after routing/truncation logic
+        "default_category": "general",     # fallback routing label when the primary agent omits category
+        "categories": {
+            "general": {
+                "routing_description": "Default fallback for uncategorized delegated work.",
+                "max_concurrent_children": 3,
+            },
+            "research": {
+                "routing_description": "Audits, comparisons, investigation, and read-heavy research.",
+                "max_concurrent_children": 3,
+                "max_iterations": 25,
+                "enabled_tools": [
+                    "read_file",
+                    "search_files",
+                    "session_search",
+                    "skills_list",
+                    "skill_view",
+                    "web_search",
+                    "web_extract",
+                    "browser_navigate",
+                    "browser_snapshot",
+                    "browser_console",
+                    "browser_scroll",
+                    "browser_get_images",
+                    "vision_analyze",
+                    "browser_vision",
+                ],
+            },
+            "implementation": {
+                "routing_description": "Code changes, patches, refactors, and other write-heavy implementation work.",
+                "max_concurrent_children": 2,
+                "max_iterations": 35,
+                "toolsets": ["terminal", "file"],
+            },
+            "verification": {
+                "routing_description": "Tests, validation, regression checks, and review passes.",
+                "max_concurrent_children": 3,
+                "max_iterations": 20,
+                "toolsets": ["terminal", "file", "web"],
+            },
+        },
     },
 
     # Ephemeral prefill messages file — JSON list of {role, content} dicts
@@ -788,7 +891,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 18,
+    "_config_version": 19,
 }
 
 # =============================================================================
@@ -1952,7 +2055,8 @@ def check_config_version() -> Tuple[int, int]:
 # Fields that are valid at root level of config.yaml
 _KNOWN_ROOT_KEYS = {
     "_config_version", "model", "providers", "fallback_model",
-    "fallback_providers", "credential_pool_strategies", "toolsets",
+    "fallback_providers", "credential_pool_strategies", "agents",
+    "categories", "runtime_fallback", "model_capabilities", "toolsets",
     "agent", "terminal", "display", "compression", "delegation",
     "auxiliary", "custom_providers", "context", "memory", "gateway",
 }
@@ -1991,6 +2095,38 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
             return [ConfigIssue("error", "Could not load config.yaml", "Run 'hermes setup' to create a valid config")]
 
     issues: List[ConfigIssue] = []
+
+    agents_cfg = config.get("agents")
+    if agents_cfg is not None and not isinstance(agents_cfg, dict):
+        issues.append(ConfigIssue(
+            "warning",
+            f"agents should be a mapping of named agent configs, got {type(agents_cfg).__name__}",
+            "Change to:\n  agents:\n    oracle:\n      model: openai/gpt-5.4",
+        ))
+
+    categories_cfg = config.get("categories")
+    if categories_cfg is not None and not isinstance(categories_cfg, dict):
+        issues.append(ConfigIssue(
+            "warning",
+            f"categories should be a mapping of named category configs, got {type(categories_cfg).__name__}",
+            "Change to:\n  categories:\n    research:\n      model: anthropic/claude-haiku-4-5",
+        ))
+
+    runtime_fallback_cfg = config.get("runtime_fallback")
+    if runtime_fallback_cfg is not None and not isinstance(runtime_fallback_cfg, (bool, dict)):
+        issues.append(ConfigIssue(
+            "warning",
+            f"runtime_fallback should be either a boolean or a config dict, got {type(runtime_fallback_cfg).__name__}",
+            "Use either 'runtime_fallback: true' or a mapping like runtime_fallback:\n  enabled: true",
+        ))
+
+    model_capabilities_cfg = config.get("model_capabilities")
+    if model_capabilities_cfg is not None and not isinstance(model_capabilities_cfg, dict):
+        issues.append(ConfigIssue(
+            "warning",
+            f"model_capabilities should be a config dict, got {type(model_capabilities_cfg).__name__}",
+            "Change to:\n  model_capabilities:\n    enabled: true",
+        ))
 
     # ── custom_providers must be a list, not a dict ──────────────────────
     cp = config.get("custom_providers")
@@ -2083,6 +2219,40 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
             "    default: your-model-name\n"
             "    base_url: https://...",
         ))
+
+    delegation_cfg = config.get("delegation")
+    if delegation_cfg is not None:
+        if not isinstance(delegation_cfg, dict):
+            issues.append(ConfigIssue(
+                "error",
+                f"delegation should be a dict, got {type(delegation_cfg).__name__}",
+                "Change to:\n  delegation:\n    max_iterations: 50\n    max_concurrent_children: 3",
+            ))
+        else:
+            categories = delegation_cfg.get("categories")
+            if categories is not None and not isinstance(categories, dict):
+                issues.append(ConfigIssue(
+                    "error",
+                    f"delegation.categories should be a dict of category profiles, got {type(categories).__name__}",
+                    "Change to:\n  delegation:\n    categories:\n      research:\n        enabled_tools:\n          - read_file",
+                ))
+            elif isinstance(categories, dict):
+                for name, entry in categories.items():
+                    if not isinstance(entry, dict):
+                        issues.append(ConfigIssue(
+                            "warning",
+                            f"delegation.categories.{name} should be a dict, got {type(entry).__name__}",
+                            "Each category should define keys like toolsets, enabled_tools, max_iterations, or max_concurrent_children",
+                        ))
+                        continue
+
+                    routing_description = entry.get("routing_description")
+                    if routing_description is not None and not isinstance(routing_description, str):
+                        issues.append(ConfigIssue(
+                            "warning",
+                            f"delegation.categories.{name}.routing_description should be a string, got {type(routing_description).__name__}",
+                            "Use a short sentence describing when the primary agent should route work into this category.",
+                        ))
 
     # ── Root-level keys that look misplaced ──────────────────────────────
     for key in config:
@@ -2762,6 +2932,56 @@ def _normalize_max_turns_config(config: Dict[str, Any]) -> Dict[str, Any]:
     return config
 
 
+def _normalize_openagent_named_bucket(bucket: Any) -> Dict[str, Dict[str, Any]]:
+    """Normalize OpenAgent-style named agent/category mappings."""
+    if not isinstance(bucket, dict):
+        return {}
+
+    normalized: Dict[str, Dict[str, Any]] = {}
+    for raw_name, entry in bucket.items():
+        name = str(raw_name or "").strip()
+        if not name:
+            continue
+        if isinstance(entry, str):
+            model = entry.strip()
+            if model:
+                normalized[name] = {"model": model}
+        elif isinstance(entry, dict):
+            normalized[name] = dict(entry)
+    return normalized
+
+
+def _normalize_runtime_fallback_config(config: Any) -> Dict[str, Any]:
+    """Normalize runtime_fallback from bool-or-dict into dict form."""
+    if isinstance(config, bool):
+        return {"enabled": config}
+    if isinstance(config, dict):
+        return dict(config)
+    return {"enabled": False}
+
+
+def _normalize_model_capabilities_config(config: Any) -> Dict[str, Any]:
+    """Normalize model_capabilities to a mapping or empty dict."""
+    return dict(config) if isinstance(config, dict) else {}
+
+
+def _normalize_openagent_config_buckets(
+    config: Dict[str, Any], *, include_defaults: bool = True,
+) -> Dict[str, Any]:
+    """Normalize OpenAgent-style config buckets while preserving shorthand."""
+    config = dict(config)
+
+    if include_defaults or "agents" in config:
+        config["agents"] = _normalize_openagent_named_bucket(config.get("agents"))
+    if include_defaults or "categories" in config:
+        config["categories"] = _normalize_openagent_named_bucket(config.get("categories"))
+    if include_defaults or "runtime_fallback" in config:
+        config["runtime_fallback"] = _normalize_runtime_fallback_config(config.get("runtime_fallback"))
+    if include_defaults or "model_capabilities" in config:
+        config["model_capabilities"] = _normalize_model_capabilities_config(config.get("model_capabilities"))
+
+    return config
+
 
 def read_raw_config() -> Dict[str, Any]:
     """Read ~/.hermes/config.yaml as-is, without merging defaults or migrating.
@@ -2804,10 +3024,15 @@ def load_config() -> Dict[str, Any]:
         except Exception as e:
             print(f"Warning: Failed to load config: {e}")
 
-    normalized = _normalize_root_model_keys(_normalize_max_turns_config(config))
-    expanded = _expand_env_vars(normalized)
-    _LAST_EXPANDED_CONFIG_BY_PATH[str(config_path)] = copy.deepcopy(expanded)
-    return expanded
+    normalized = _normalize_profile_path_settings(
+        _expand_env_vars(
+            _normalize_openagent_config_buckets(
+                _normalize_root_model_keys(_normalize_max_turns_config(config))
+            )
+        )
+    )
+    _LAST_EXPANDED_CONFIG_BY_PATH[str(config_path)] = copy.deepcopy(normalized)
+    return normalized
 
 
 _SECURITY_COMMENT = """
@@ -2916,9 +3141,19 @@ def save_config(config: Dict[str, Any]):
 
     ensure_hermes_home()
     config_path = get_config_path()
-    current_normalized = _normalize_root_model_keys(_normalize_max_turns_config(config))
+    current_normalized = _normalize_profile_path_settings(
+        _normalize_openagent_config_buckets(
+            _normalize_root_model_keys(_normalize_max_turns_config(config)),
+            include_defaults=False,
+        )
+    )
     normalized = current_normalized
-    raw_existing = _normalize_root_model_keys(_normalize_max_turns_config(read_raw_config()))
+    raw_existing = _normalize_profile_path_settings(
+        _normalize_openagent_config_buckets(
+            _normalize_root_model_keys(_normalize_max_turns_config(read_raw_config())),
+            include_defaults=False,
+        )
+    )
     if raw_existing:
         normalized = _preserve_env_ref_templates(
             normalized,
@@ -2969,7 +3204,11 @@ def load_env() -> Dict[str, str]:
             line = line.strip()
             if line and not line.startswith('#') and '=' in line:
                 key, _, value = line.partition('=')
-                env_vars[key.strip()] = value.strip().strip('"\'')
+                parsed_key = key.strip()
+                parsed_value = value.strip().strip('"\'')
+                if parsed_key in {"MESSAGING_CWD", "TERMINAL_CWD"}:
+                    parsed_value = _normalize_profile_local_path(parsed_value)
+                env_vars[parsed_key] = parsed_value
     
     return env_vars
 
@@ -3119,6 +3358,8 @@ def save_env_value(key: str, value: str):
     if not _ENV_VAR_NAME_RE.match(key):
         raise ValueError(f"Invalid environment variable name: {key!r}")
     value = value.replace("\n", "").replace("\r", "")
+    if key in {"MESSAGING_CWD", "TERMINAL_CWD"}:
+        value = _normalize_profile_local_path(value)
     # API keys / tokens must be ASCII — strip non-ASCII with a warning.
     value = _check_non_ascii_credential(key, value)
     ensure_hermes_home()

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7540,6 +7540,16 @@ Examples:
         help="Environment variables for stdio servers (KEY=VALUE)",
     )
 
+    mcp_sub.add_parser("catalog", help="Browse built-in MCP presets and bundles")
+
+    mcp_install_p = mcp_sub.add_parser(
+        "install",
+        help="Install a built-in MCP preset or bundle into config.yaml",
+    )
+    mcp_install_p.add_argument("catalog_name", help="Built-in MCP preset or bundle name")
+    mcp_install_p.add_argument("--as", dest="as_name", help="Custom server name when installing a single preset")
+    mcp_install_p.add_argument("--yes", "-y", action="store_true", help="Skip overwrite confirmation")
+
     mcp_rm_p = mcp_sub.add_parser("remove", aliases=["rm"], help="Remove an MCP server")
     mcp_rm_p.add_argument("name", help="Server name to remove")
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4042,6 +4042,12 @@ def cmd_auth(args):
     auth_command(args)
 
 
+def cmd_project(args):
+    """Project OS management."""
+    from hermes_cli.projects import project_command
+    project_command(args)
+
+
 def cmd_status(args):
     """Show status of all components."""
     from hermes_cli.status import show_status
@@ -6648,6 +6654,35 @@ For more help on a command:
     )
     auth_reset.add_argument("provider", help="Provider id")
     auth_parser.set_defaults(func=cmd_auth)
+
+    # =========================================================================
+    # project command
+    # =========================================================================
+    project_parser = subparsers.add_parser(
+        "project",
+        help="Manage local project cells",
+        description="List, initialize, inspect, and refresh Hermes Project OS cells",
+    )
+    project_subparsers = project_parser.add_subparsers(dest="project_action")
+
+    project_subparsers.add_parser("list", help="List known projects")
+
+    project_init = project_subparsers.add_parser("init", help="Initialize a new project cell")
+    project_init.add_argument("project_id", help="Project id (lowercase, alphanumeric, '_' and '-')")
+    project_init.add_argument("name", help="Human-readable project name")
+    project_init.add_argument("summary", help="Short project summary")
+    project_init.add_argument("--repo-path", default=None, help="Optional git repository path to associate")
+
+    project_show = project_subparsers.add_parser("show", help="Show project metadata")
+    project_show.add_argument("project_id", help="Project id")
+
+    project_digest = project_subparsers.add_parser("digest", help="Generate a status digest report")
+    project_digest.add_argument("project_id", help="Project id")
+
+    project_status = project_subparsers.add_parser("status", help="Alias for generating a status digest")
+    project_status.add_argument("project_id", help="Project id")
+
+    project_parser.set_defaults(func=cmd_project, project_action="list")
 
     # =========================================================================
     # status command

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -13,6 +13,7 @@ import logging
 import os
 import re
 import time
+from copy import deepcopy
 from typing import Any, Dict, List, Optional, Tuple
 
 from hermes_cli.config import (
@@ -30,7 +31,167 @@ logger = logging.getLogger(__name__)
 _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
-_MCP_PRESETS: Dict[str, Dict[str, Any]] = {}
+_MCP_PRESET_CONFIG_KEYS = frozenset({
+    "url",
+    "command",
+    "args",
+    "env",
+    "headers",
+    "auth",
+    "timeout",
+    "connect_timeout",
+    "sampling",
+    "tools",
+})
+
+_MCP_PRESETS: Dict[str, Dict[str, Any]] = {
+    "fetch": {
+        "display_name": "Fetch",
+        "description": "Fetch and convert remote web content to agent-friendly text.",
+        "command": "npx",
+        "args": ["-y", "@modelcontextprotocol/server-fetch"],
+    },
+    "github": {
+        "display_name": "GitHub",
+        "description": "Read and mutate GitHub issues, PRs, repos, and code search.",
+        "command": "npx",
+        "args": ["-y", "@modelcontextprotocol/server-github"],
+        "env": {
+            "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}",
+        },
+    },
+    "ink": {
+        "display_name": "Ink",
+        "description": "Hosted remote MCP endpoint for Ink deployment workflows.",
+        "url": "https://mcp.ml.ink/mcp",
+    },
+    "memory": {
+        "display_name": "Memory",
+        "description": "Lightweight knowledge graph + memory primitives.",
+        "command": "npx",
+        "args": ["-y", "@modelcontextprotocol/server-memory"],
+    },
+    "sequential-thinking": {
+        "display_name": "Sequential Thinking",
+        "description": "Stepwise planning and reasoning helper tools.",
+        "command": "npx",
+        "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"],
+    },
+    "time": {
+        "display_name": "Time",
+        "description": "Time and timezone helper tools.",
+        "command": "npx",
+        "args": ["-y", "@modelcontextprotocol/server-time"],
+    },
+}
+
+_MCP_BUNDLES: Dict[str, Dict[str, Any]] = {
+    "developer": {
+        "display_name": "Developer Essentials",
+        "description": "Common coding and repo helpers for day-to-day development work.",
+        "servers": [
+            {"name": "github", "preset": "github"},
+            {"name": "fetch", "preset": "fetch"},
+            {"name": "sequential-thinking", "preset": "sequential-thinking"},
+        ],
+    },
+    "research": {
+        "display_name": "Research Starter",
+        "description": "Web retrieval plus structured reasoning helpers.",
+        "servers": [
+            {"name": "fetch", "preset": "fetch"},
+            {"name": "sequential-thinking", "preset": "sequential-thinking"},
+            {"name": "time", "preset": "time"},
+        ],
+    },
+}
+
+_ENV_VAR_INTERPOLATION_RE = re.compile(r"\$\{([^}]+)\}")
+
+
+def _canonical_catalog_name(name: Optional[str]) -> str:
+    return str(name or "").strip().lower().replace("_", "-")
+
+
+def _resolve_mcp_preset(preset_name: str) -> Dict[str, Any]:
+    preset = _MCP_PRESETS.get(_canonical_catalog_name(preset_name))
+    if not preset:
+        raise ValueError(f"Unknown MCP preset: {preset_name}")
+    return preset
+
+
+def _resolve_mcp_bundle(bundle_name: str) -> Dict[str, Any]:
+    bundle = _MCP_BUNDLES.get(_canonical_catalog_name(bundle_name))
+    if not bundle:
+        raise ValueError(f"Unknown MCP bundle: {bundle_name}")
+    return bundle
+
+
+def _iter_required_env_vars(value: Any) -> set[str]:
+    found: set[str] = set()
+    if isinstance(value, str):
+        found.update(_ENV_VAR_INTERPOLATION_RE.findall(value))
+    elif isinstance(value, dict):
+        for item in value.values():
+            found.update(_iter_required_env_vars(item))
+    elif isinstance(value, list):
+        for item in value:
+            found.update(_iter_required_env_vars(item))
+    return found
+
+
+def _materialize_mcp_preset(
+    preset_name: str,
+    *,
+    overrides: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    preset = _resolve_mcp_preset(preset_name)
+    config: Dict[str, Any] = {}
+    for key in _MCP_PRESET_CONFIG_KEYS:
+        if key in preset:
+            config[key] = deepcopy(preset[key])
+
+    for key, value in (overrides or {}).items():
+        if key not in _MCP_PRESET_CONFIG_KEYS:
+            continue
+        if key in {"env", "headers"} and isinstance(value, dict):
+            merged = dict(config.get(key) or {})
+            merged.update(deepcopy(value))
+            if merged:
+                config[key] = merged
+        else:
+            config[key] = deepcopy(value)
+    return config
+
+
+def _expand_mcp_bundle(bundle_name: str) -> Dict[str, Dict[str, Any]]:
+    bundle = _resolve_mcp_bundle(bundle_name)
+    entries: Dict[str, Dict[str, Any]] = {}
+    for entry in bundle.get("servers") or []:
+        if not isinstance(entry, dict):
+            raise ValueError(f"Invalid MCP bundle entry in '{bundle_name}'")
+        server_name = str(entry.get("name") or "").strip()
+        preset_name = str(entry.get("preset") or "").strip()
+        if not server_name or not preset_name:
+            raise ValueError(f"Invalid MCP bundle entry in '{bundle_name}'")
+        overrides = {
+            key: entry[key]
+            for key in _MCP_PRESET_CONFIG_KEYS
+            if key in entry
+        }
+        entries[server_name] = _materialize_mcp_preset(preset_name, overrides=overrides)
+        entries[server_name].setdefault("enabled", True)
+    return entries
+
+
+def _preset_transport_summary(config: Dict[str, Any]) -> str:
+    if config.get("url"):
+        return f"http {config['url']}"
+    if config.get("command"):
+        args = config.get("args") or []
+        preview = " ".join(str(arg) for arg in args[:2])
+        return f"stdio {config['command']} {preview}".strip()
+    return "custom"
 
 
 # ─── UI Helpers ───────────────────────────────────────────────────────────────
@@ -134,25 +295,111 @@ def _apply_mcp_preset(
     if not preset_name:
         return url, command, cmd_args, False
 
-    preset = _MCP_PRESETS.get(preset_name)
-    if not preset:
-        raise ValueError(f"Unknown MCP preset: {preset_name}")
-
     if url or command:
         return url, command, cmd_args, False
 
-    url = preset.get("url")
-    command = preset.get("command")
-    cmd_args = list(preset.get("args") or [])
+    preset_config = _materialize_mcp_preset(preset_name)
+    url = preset_config.get("url")
+    command = preset_config.get("command")
+    cmd_args = list(preset_config.get("args") or [])
 
-    if url:
-        server_config["url"] = url
-    if command:
-        server_config["command"] = command
-    if cmd_args:
-        server_config["args"] = cmd_args
+    for key, value in preset_config.items():
+        if key == "args":
+            if cmd_args:
+                server_config["args"] = cmd_args
+            continue
+        server_config[key] = value
 
     return url, command, cmd_args, True
+
+
+def cmd_mcp_catalog(args=None):
+    """List the built-in MCP preset and bundle catalog."""
+    print()
+    print(color("  Built-in MCP Presets:", Colors.CYAN + Colors.BOLD))
+    print()
+    for preset_name in sorted(_MCP_PRESETS):
+        preset = _MCP_PRESETS[preset_name]
+        display_name = preset.get("display_name") or preset_name
+        transport = _preset_transport_summary(preset)
+        required_env = sorted(_iter_required_env_vars(_materialize_mcp_preset(preset_name)))
+        env_suffix = f" [env: {', '.join(required_env)}]" if required_env else ""
+        print(f"  {preset_name:<22} {display_name}")
+        print(f"    {preset.get('description', '').strip()}")
+        print(f"    {transport}{env_suffix}")
+    if _MCP_BUNDLES:
+        print()
+        print(color("  Built-in MCP Bundles:", Colors.CYAN + Colors.BOLD))
+        print()
+        for bundle_name in sorted(_MCP_BUNDLES):
+            bundle = _MCP_BUNDLES[bundle_name]
+            display_name = bundle.get("display_name") or bundle_name
+            members = ", ".join(entry.get("name", "?") for entry in (bundle.get("servers") or []))
+            print(f"  {bundle_name:<22} {display_name}")
+            print(f"    {bundle.get('description', '').strip()}")
+            print(f"    installs: {members}")
+    print()
+    _info("Install one with: hermes mcp install <preset-or-bundle>")
+    _info("Or discovery-install a single server with: hermes mcp add <name> --preset <preset>")
+
+
+def cmd_mcp_install(args):
+    """Install a built-in MCP preset or bundle into plain mcp_servers config."""
+    catalog_name = getattr(args, "catalog_name", None) or getattr(args, "name", None)
+    alias = str(getattr(args, "as_name", None) or "").strip() or None
+    yes = bool(getattr(args, "yes", False))
+
+    if not catalog_name:
+        _error("Missing MCP preset or bundle name")
+        return
+
+    catalog_key = _canonical_catalog_name(catalog_name)
+
+    try:
+        if catalog_key in _MCP_PRESETS:
+            server_name = alias or catalog_key
+            installs = {
+                server_name: _materialize_mcp_preset(catalog_key)
+            }
+            installs[server_name].setdefault("enabled", True)
+            installed_kind = "preset"
+        elif catalog_key in _MCP_BUNDLES:
+            if alias:
+                _error("--as is only supported when installing a single MCP preset")
+                return
+            installs = _expand_mcp_bundle(catalog_key)
+            installed_kind = "bundle"
+        else:
+            _error(f"Unknown MCP preset or bundle: {catalog_name}")
+            return
+    except ValueError as exc:
+        _error(str(exc))
+        return
+
+    existing = _get_mcp_servers()
+    conflicts = sorted(name for name in installs if name in existing)
+    if conflicts and not yes:
+        if not _confirm(
+            f"Overwrite existing MCP server(s): {', '.join(conflicts)}?",
+            default=False,
+        ):
+            _info("Cancelled.")
+            return
+
+    config = load_config()
+    config.setdefault("mcp_servers", {}).update(installs)
+    save_config(config)
+
+    print()
+    _success(
+        f"Installed MCP {installed_kind} '{catalog_key}' to {display_hermes_home()}/config.yaml"
+    )
+    for server_name, server_config in installs.items():
+        required_env = sorted(_iter_required_env_vars(server_config))
+        env_suffix = f" [env: {', '.join(required_env)}]" if required_env else ""
+        _info(f"{server_name}: {_preset_transport_summary(server_config)}{env_suffix}")
+    _info("These entries were expanded into normal mcp_servers config entries.")
+    _info("Run `hermes mcp test <name>` to verify each server, or `hermes mcp list` to review them.")
 
 
 # ─── Discovery (temporary connect) ───────────────────────────────────────────
@@ -237,6 +484,7 @@ def cmd_mcp_add(args):
             cmd_args=list(cmd_args),
             server_config=server_config,
         )
+        auth_type = auth_type or server_config.get("auth")
     except ValueError as exc:
         _error(str(exc))
         return
@@ -269,7 +517,13 @@ def cmd_mcp_add(args):
         if cmd_args:
             server_config["args"] = cmd_args
         if explicit_env:
-            server_config["env"] = explicit_env
+            merged_env = dict(server_config.get("env") or {})
+            merged_env.update(explicit_env)
+            server_config["env"] = merged_env
+
+    required_env = sorted(_iter_required_env_vars(server_config))
+    if required_env:
+        _info(f"Required environment variables: {', '.join(required_env)}")
 
 
     # ── Authentication ────────────────────────────────────────────────
@@ -748,6 +1002,8 @@ def mcp_command(args):
 
     handlers = {
         "add": cmd_mcp_add,
+        "catalog": cmd_mcp_catalog,
+        "install": cmd_mcp_install,
         "remove": cmd_mcp_remove,
         "rm": cmd_mcp_remove,
         "list": cmd_mcp_list,
@@ -766,6 +1022,8 @@ def mcp_command(args):
         cmd_mcp_list()
         print(color("  Commands:", Colors.CYAN))
         _info("hermes mcp serve                              Run as MCP server")
+        _info("hermes mcp catalog                            Browse built-in presets and bundles")
+        _info("hermes mcp install <preset-or-bundle>         Install built-in catalog entries")
         _info("hermes mcp add <name> --url <endpoint>        Add an MCP server")
         _info("hermes mcp add <name> --command <cmd>         Add a stdio server")
         _info("hermes mcp add <name> --preset <preset>       Add from a known preset")

--- a/hermes_cli/projects.py
+++ b/hermes_cli/projects.py
@@ -1,0 +1,524 @@
+"""Project OS CLI helpers for Hermes.
+
+Implements a small local-first project operating system on top of the current
+profile-scoped HERMES_HOME. Projects live under:
+
+    <HERMES_HOME>/project-os-v1/projects/<project_id>/
+
+The registry lives at:
+
+    <HERMES_HOME>/project-os-v1/projects/registry.json
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from hermes_cli.colors import Colors, color
+from hermes_constants import get_hermes_home
+
+_PROJECT_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{1,63}$")
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _project_os_root() -> Path:
+    return get_hermes_home() / "project-os-v1"
+
+
+def _projects_root() -> Path:
+    return _project_os_root() / "projects"
+
+
+def _registry_path() -> Path:
+    return _projects_root() / "registry.json"
+
+
+def _detect_owner_profile() -> str:
+    home = get_hermes_home().resolve()
+    if home.parent.name == "profiles":
+        return home.name
+    return "default"
+
+
+def _validate_project_id(project_id: str) -> None:
+    if not _PROJECT_ID_RE.match(project_id):
+        raise ValueError(
+            f"Invalid project id {project_id!r}. Must match [a-z0-9][a-z0-9_-]{{1,63}}"
+        )
+
+
+def _read_registry() -> Dict[str, Any]:
+    path = _registry_path()
+    if not path.exists():
+        return {
+            "schema_version": "1",
+            "generated_at": _iso_now(),
+            "projects": [],
+        }
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_registry(payload: Dict[str, Any]) -> None:
+    path = _registry_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload["generated_at"] = _iso_now()
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _default_pairing_status(now: str) -> Dict[str, Any]:
+    return {
+        "state": "unpaired",
+        "issued_at": None,
+        "approved_at": None,
+        "revoked_at": None,
+        "expires_at": None,
+        "device_label": None,
+        "code_hint": None,
+        "updated_at": now,
+    }
+
+
+def _git_metadata(repo_path: Optional[str]) -> Optional[Dict[str, Any]]:
+    if not repo_path:
+        return None
+    repo = Path(repo_path)
+    if not repo.exists():
+        raise FileNotFoundError(f"Repo path does not exist: {repo_path}")
+
+    def _run(*args: str) -> str:
+        return subprocess.run(args, cwd=repo, capture_output=True, text=True, check=True).stdout.strip()
+
+    commit = _run("/usr/bin/git", "rev-parse", "HEAD")
+    short_commit = _run("/usr/bin/git", "rev-parse", "--short", "HEAD")
+    branch = _run("/usr/bin/git", "rev-parse", "--abbrev-ref", "HEAD")
+    if branch == "HEAD":
+        branch = "detached-head"
+    dirty = bool(_run("/usr/bin/git", "status", "--short"))
+
+    return {
+        "path": str(repo),
+        "url": None,
+        "branch": branch,
+        "commit": commit,
+        "short_commit": short_commit,
+        "dirty": dirty,
+    }
+
+
+def _project_dir(project_id: str) -> Path:
+    return _projects_root() / project_id
+
+
+def _manifest_path(project_id: str) -> Path:
+    return _project_dir(project_id) / "reports" / "manifest.json"
+
+
+def _status_digest_path(project_id: str) -> Path:
+    return _project_dir(project_id) / "reports" / "01-status-digest.md"
+
+
+def _load_project_from_registry(project_id: str) -> Optional[Dict[str, Any]]:
+    payload = _read_registry()
+    for project in payload.get("projects", []):
+        if project.get("id") == project_id:
+            return project
+    return None
+
+
+def _load_manifest(project_id: str) -> Dict[str, Any]:
+    path = _manifest_path(project_id)
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _load_project_yaml(project_id: str) -> Dict[str, Any]:
+    path = _project_dir(project_id) / "project.yaml"
+    if not path.exists():
+        return {}
+    try:
+        import yaml
+
+        payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _display_value(value: Any, default: str = "n/a") -> str:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return str(value).lower()
+    text = str(value).strip()
+    return text or default
+
+
+def get_project_details(project_id: str) -> Dict[str, Any]:
+    project = _load_project_from_registry(project_id)
+    if not project:
+        raise FileNotFoundError(f"Project '{project_id}' not found")
+
+    project_dir = _project_dir(project_id)
+    project_yaml = _load_project_yaml(project_id)
+    manifest = _load_manifest(project_id)
+    digest_path = _status_digest_path(project_id)
+
+    pairing_state = "unknown"
+    pairing_path = project_dir / "pairing" / "status.json"
+    if pairing_path.exists():
+        try:
+            pairing_payload = json.loads(pairing_path.read_text(encoding="utf-8"))
+            pairing_state = pairing_payload.get("state") or "unknown"
+        except json.JSONDecodeError:
+            pairing_state = "invalid"
+
+    repo_cfg = project_yaml.get("repo") if isinstance(project_yaml.get("repo"), dict) else {}
+    repo_path = project.get("repo_path") or repo_cfg.get("path")
+    repo_state: Dict[str, Any] = {
+        "path": repo_path,
+        "branch": repo_cfg.get("branch") if repo_path else None,
+        "commit": repo_cfg.get("commit") if repo_path else None,
+        "short_commit": None,
+        "dirty": repo_cfg.get("dirty") if repo_path else None,
+    }
+    if repo_state.get("commit"):
+        repo_state["short_commit"] = str(repo_state["commit"])[:7]
+
+    repo_error = None
+    if repo_path:
+        try:
+            repo_state = _git_metadata(repo_path)
+        except (FileNotFoundError, subprocess.CalledProcessError) as exc:
+            repo_error = str(exc)
+
+    return {
+        "project": project,
+        "project_dir": project_dir,
+        "project_yaml": project_yaml,
+        "manifest": manifest,
+        "digest_path": digest_path,
+        "pairing_state": pairing_state,
+        "repo": repo_state,
+        "repo_error": repo_error,
+    }
+
+
+def print_project_details(project_id: str) -> None:
+    details = get_project_details(project_id)
+    project = details["project"]
+    project_dir = details["project_dir"]
+    manifest = details["manifest"]
+    repo = details["repo"]
+    digest_path = details["digest_path"]
+
+    print()
+    print(color(f"Project: {project['id']}", Colors.BOLD, Colors.CYAN))
+    print(f"Name:          {project['name']}")
+    print(f"Summary:       {project['summary']}")
+    print(f"Status:        {project['status']}")
+    print(f"Owner profile: {project['owner_profile']}")
+    print(f"Cell path:     {project_dir}")
+    print(f"Created:       {_display_value(details['project_yaml'].get('created_at'))}")
+    print(f"Updated:       {_display_value(details['project_yaml'].get('updated_at'))}")
+
+    print()
+    print(color("Artifacts", Colors.BOLD))
+    print(f"Project config:     {project_dir / 'project.yaml'}")
+    print(f"Brief:              {project_dir / 'brief.md'}")
+    print(f"Executive summary:  {project_dir / 'reports' / '00-executive-summary.md'}")
+    if digest_path.exists():
+        digest_label = str(digest_path)
+    else:
+        digest_label = f"{digest_path} (not generated yet)"
+    print(f"Status digest:      {digest_label}")
+    print(f"Manifest:           {_manifest_path(project['id'])}")
+    print(f"Manifest artifacts: {len(manifest.get('artifacts', []))}")
+    print(f"Latest workflow:    {_display_value(manifest.get('workflow'))}")
+    print(f"Pairing state:      {_display_value(details['pairing_state'], default='unknown')}")
+
+    print()
+    print(color("Repository", Colors.BOLD))
+    print(f"Path:   {_display_value(repo.get('path'))}")
+    print(f"Branch: {_display_value(repo.get('branch'))}")
+    print(f"Commit: {_display_value(repo.get('short_commit') or repo.get('commit'))}")
+    print(f"Dirty:  {_display_value(repo.get('dirty'))}")
+    if details["repo_error"]:
+        print(f"Repo check: {details['repo_error']}")
+    print()
+
+
+def init_project(project_id: str, name: str, summary: str, repo_path: Optional[str] = None) -> Path:
+    _validate_project_id(project_id)
+    if not name.strip():
+        raise ValueError("Project name is required")
+    if not summary.strip():
+        raise ValueError("Project summary is required")
+
+    project_dir = _project_dir(project_id)
+    if project_dir.exists():
+        raise FileExistsError(f"Project '{project_id}' already exists at {project_dir}")
+
+    repo = _git_metadata(repo_path)
+    now = _iso_now()
+    owner_profile = _detect_owner_profile()
+    config_dir = _project_os_root() / "config"
+
+    project_yaml_lines = [
+        'schema_version: "1"',
+        f'id: {project_id}',
+        f'name: {name}',
+        f'summary: {summary}',
+        'status: active',
+        'priority: medium',
+        f'owner_profile: {owner_profile}',
+        f'project_root: {project_dir}',
+        'workspace_contracts:',
+        f'  path_policies: {config_dir / "path-policies.yaml"}',
+        f'  modules: {config_dir / "modules.yaml"}',
+        f'  modules_lock: {config_dir / "modules.lock.yaml"}',
+        'repo:',
+    ]
+    if repo:
+        project_yaml_lines.extend([
+            f"  path: {repo['path']}",
+            '  url: null',
+            f"  branch: {repo['branch']}",
+            f"  commit: {repo['commit']}",
+            f"  dirty: {'true' if repo['dirty'] else 'false'}",
+        ])
+    else:
+        project_yaml_lines.extend([
+            '  path: null',
+            '  url: null',
+            '  branch: null',
+            '  commit: null',
+            '  dirty: false',
+        ])
+    project_yaml_lines.extend([
+        'artifacts:',
+        '  reports_dir: reports',
+        '  tasks_dir: tasks',
+        '  checkpoints_dir: checkpoints',
+        '  logs_dir: logs',
+        '  assets_dir: assets',
+        '  approvals_file: approvals.jsonl',
+        '  sync_dir: sync',
+        '  pairing_dir: pairing',
+        'sync:',
+        '  mode: local-only',
+        '  path_policies:',
+        '    - path: repo',
+        '      policy: git-owned',
+        '    - path: reports',
+        '      policy: mirror',
+        '    - path: checkpoints',
+        '      policy: mirror',
+        '    - path: project.yaml',
+        '      policy: merge',
+        '    - path: memories.jsonl',
+        '      policy: append-only',
+        'cloudflare:',
+        '  enabled: false',
+        '  workspace_id: null',
+        '  remote_mode: null',
+        f'created_at: {now}',
+        f'updated_at: {now}',
+    ])
+    _write(project_dir / "project.yaml", "\n".join(project_yaml_lines) + "\n")
+    _write(project_dir / "brief.md", f"# {name}\n\n{summary}\n")
+    _write(project_dir / "tasks" / "README.md", "# Tasks\n\nTrack next actions and operator-owned work here.\n")
+    _write(project_dir / "tasks" / "next-actions.md", "# Next Actions\n\n- Review latest project digest\n- Decide whether any lightweight report artifacts should be approved\n- Refresh sync projection before mobile/operator review\n")
+    _write(project_dir / "checkpoints" / "README.md", "# Checkpoints\n\nStore resumable state snapshots here.\n")
+    _write(project_dir / "logs" / "README.md", "# Logs\n\nStore operator logs, run notes, and workflow outputs here.\n")
+    _write(project_dir / "assets" / "README.md", "# Assets\n\nStore diagrams, screenshots, and auxiliary artifacts here.\n")
+    _write(project_dir / "sync" / "README.md", "# Sync\n\nGenerated project-aware sync manifests live here.\n")
+    _write(project_dir / "approvals.jsonl", "")
+    _write(project_dir / "pairing" / "status.json", json.dumps(_default_pairing_status(now), indent=2) + "\n")
+
+    short_commit = repo.get("short_commit") if repo else None
+    summary_body = (
+        f"# Executive Summary\n\n"
+        f"Project: {name}\n"
+        f"Status: active\n"
+        f"Updated: {now}\n\n"
+        f"## What this project is\n{summary}\n\n"
+        f"## Current state\n"
+        f"- Phase: kickoff\n"
+        f"- Primary objective: establish a canonical Hermes Project OS cell\n"
+        f"- Biggest risk: artifact drift before UI integration exists\n"
+        f"- Next operator action: connect this project to Pan project views\n\n"
+        f"## Evidence\n"
+        f"- Repo path: {repo['path'] if repo else 'n/a'}\n"
+        f"- Commit: {short_commit or 'n/a'}\n"
+        f"- Generated from: hermes project init\n"
+    )
+    _write(project_dir / "reports" / "00-executive-summary.md", summary_body)
+
+    manifest = {
+        "project_id": project_id,
+        "generated_at": now,
+        "workflow": "project-kickoff",
+        "artifacts": [
+            "project.yaml",
+            "brief.md",
+            "tasks/README.md",
+            "tasks/next-actions.md",
+            "reports/00-executive-summary.md",
+            "reports/manifest.json",
+            "checkpoints/README.md",
+            "logs/README.md",
+            "assets/README.md",
+            "approvals.jsonl",
+            "pairing/status.json",
+        ],
+    }
+    _write(_manifest_path(project_id), json.dumps(manifest, indent=2) + "\n")
+
+    payload = _read_registry()
+    payload.setdefault("projects", []).append({
+        "id": project_id,
+        "name": name,
+        "status": "active",
+        "owner_profile": owner_profile,
+        "path": str(project_dir),
+        "repo_path": repo.get("path") if repo else None,
+        "summary": summary,
+    })
+    _write_registry(payload)
+    return project_dir
+
+
+def list_projects() -> List[Dict[str, Any]]:
+    return list(_read_registry().get("projects", []))
+
+
+def generate_status_digest(project_id: str) -> Path:
+    project = _load_project_from_registry(project_id)
+    if not project:
+        raise FileNotFoundError(f"Project '{project_id}' not found")
+
+    project_yaml_path = _project_dir(project_id) / "project.yaml"
+    if not project_yaml_path.exists():
+        raise FileNotFoundError(f"Missing project.yaml for '{project_id}'")
+    project_yaml = project_yaml_path.read_text(encoding="utf-8")
+
+    repo_path = project.get("repo_path")
+    repo_state = {"path": repo_path or "n/a", "branch": "n/a", "commit": "n/a", "dirty": "n/a"}
+    if repo_path:
+        repo = _git_metadata(repo_path)
+        if repo:
+            repo_state = {
+                "path": repo["path"],
+                "branch": repo["branch"],
+                "commit": repo["commit"],
+                "dirty": str(repo["dirty"]).lower(),
+            }
+
+    now = _iso_now()
+    body = (
+        f"# Status Digest\n\n"
+        f"Updated: {now}\n\n"
+        f"## Current status\n"
+        f"- Project: {project['name']}\n"
+        f"- Status: {project['status']}\n"
+        f"- Owner profile: {project['owner_profile']}\n\n"
+        f"## Repo state\n"
+        f"- Path: {repo_state['path']}\n"
+        f"- Branch: {repo_state['branch']}\n"
+        f"- Commit: {repo_state['commit']}\n"
+        f"- Dirty: {repo_state['dirty']}\n\n"
+        f"## Open work\n"
+        f"- Connect project cell to Pan UI project routes\n"
+        f"- Promote owner workflows into installed skills after prototype review\n\n"
+        f"## Risks / blockers\n"
+        f"- UI integration may still be incomplete for this profile\n"
+        f"- Cloud sync intentionally not enabled\n\n"
+        f"## Recommended next actions\n"
+        f"1. Build or verify Pan project routes\n"
+        f"2. Review project.yaml for completeness\n"
+        f"3. Generate richer project docs if the repo is ready\n"
+    )
+    digest_path = _status_digest_path(project_id)
+    _write(digest_path, body)
+
+    manifest_path = _manifest_path(project_id)
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if "reports/01-status-digest.md" not in manifest.get("artifacts", []):
+        manifest["artifacts"].append("reports/01-status-digest.md")
+    manifest["generated_at"] = now
+    _write(manifest_path, json.dumps(manifest, indent=2) + "\n")
+    return digest_path
+
+
+def project_command(args) -> int:
+    action = getattr(args, "project_action", None)
+
+    if action is None or action == "list":
+        projects = list_projects()
+        if not projects:
+            print(color("No projects found. Create one with 'hermes project init ...'", Colors.DIM))
+            return 0
+
+        print()
+        print(f" {'Project':<18} {'Status':<10} {'Profile':<16} Summary")
+        print(f" {'─'*17}  {'─'*9}  {'─'*15}  {'─'*40}")
+        for project in projects:
+            print(
+                f" {project['id']:<18} {project['status']:<10} {project['owner_profile']:<16} "
+                f"{project['summary'][:80]}"
+            )
+        print()
+        return 0
+
+    if action == "init":
+        try:
+            project_dir = init_project(
+                project_id=args.project_id,
+                name=args.name,
+                summary=args.summary,
+                repo_path=getattr(args, "repo_path", None),
+            )
+        except (ValueError, FileExistsError, FileNotFoundError, subprocess.CalledProcessError) as exc:
+            print(color(f"Error: {exc}", Colors.RED))
+            return 1
+        print(color(f"Created project cell: {project_dir}", Colors.GREEN))
+        return 0
+
+    if action == "show":
+        try:
+            print_project_details(args.project_id)
+        except FileNotFoundError as exc:
+            print(color(f"Error: {exc}", Colors.RED))
+            return 1
+        return 0
+
+    if action in {"digest", "status"}:
+        try:
+            digest_path = generate_status_digest(args.project_id)
+            project = _load_project_from_registry(args.project_id)
+        except (FileNotFoundError, subprocess.CalledProcessError) as exc:
+            print(color(f"Error: {exc}", Colors.RED))
+            return 1
+        print(color(f"Updated status digest: {digest_path}", Colors.GREEN))
+        if project:
+            print(f"Project: {project['name']}")
+            print(f"Profile: {project['owner_profile']}")
+            print(f"Path:    {project['path']}")
+        return 0
+
+    print(color(f"Unknown project action: {action}", Colors.RED))
+    return 1

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -51,6 +51,7 @@ CONFIGURABLE_TOOLSETS = [
     ("browser",         "🌐 Browser Automation",       "navigate, click, type, scroll"),
     ("terminal",        "💻 Terminal & Processes",      "terminal, process"),
     ("file",            "📁 File Operations",           "read, write, patch, search"),
+    ("code_intel",      "🧩 Code Intelligence",         "AST structure, definitions, diagnostics"),
     ("code_execution",  "⚡ Code Execution",            "execute_code"),
     ("vision",          "👁️  Vision / Image Analysis",  "vision_analyze"),
     ("image_gen",       "🎨 Image Generation",          "image_generate"),

--- a/model_tools.py
+++ b/model_tools.py
@@ -209,6 +209,7 @@ def _append_description_suffix(description: str, suffix: str) -> str:
 
 def get_tool_definitions(
     enabled_toolsets: List[str] = None,
+    enabled_tools: List[str] = None,
     disabled_toolsets: List[str] = None,
     quiet_mode: bool = False,
 ) -> List[Dict[str, Any]]:
@@ -219,6 +220,7 @@ def get_tool_definitions(
 
     Args:
         enabled_toolsets: Only include tools from these toolsets.
+        enabled_tools: Only include these exact tool names (intersected after toolset filtering).
         disabled_toolsets: Exclude tools from these toolsets (if enabled_toolsets is None).
         quiet_mode: Suppress status prints.
 
@@ -267,6 +269,19 @@ def get_tool_definitions(
         from toolsets import get_all_toolsets
         for ts_name in get_all_toolsets():
             tools_to_include.update(resolve_toolset(ts_name))
+
+    if enabled_tools is not None:
+        explicit_tools = {
+            str(name).strip()
+            for name in enabled_tools
+            if isinstance(name, str) and str(name).strip()
+        }
+        tools_to_include &= explicit_tools
+        if not quiet_mode:
+            if explicit_tools:
+                print(f"🎯 Explicit tool filter: {', '.join(sorted(explicit_tools))}")
+            else:
+                print("🎯 Explicit tool filter provided, but it resolved to no valid tool names")
 
     # Plugin-registered tools are now resolved through the normal toolset
     # path — validate_toolset() / resolve_toolset() / get_all_toolsets()

--- a/model_tools.py
+++ b/model_tools.py
@@ -188,6 +188,20 @@ _LEGACY_TOOLSET_MAP = {
     "tts_tools": ["text_to_speech"],
 }
 
+_LSP_TOOL_NAMES = {"lsp_document_symbols", "lsp_definition", "lsp_diagnostics"}
+
+
+def _append_description_suffix(description: str, suffix: str) -> str:
+    description = (description or "").rstrip()
+    suffix = (suffix or "").strip()
+    if not suffix or suffix in description:
+        return description
+    if not description:
+        return suffix
+    if description.endswith("."):
+        return f"{description} {suffix}"
+    return f"{description}. {suffix}"
+
 
 # =============================================================================
 # get_tool_definitions  (the main schema provider)
@@ -301,6 +315,22 @@ def get_tool_definitions(
                         "function": {**td["function"], "description": desc},
                     }
                     break
+
+    if _LSP_TOOL_NAMES & available_tool_names:
+        from tools.lsp_tools import get_lsp_host_capability_description
+
+        capability_suffix = get_lsp_host_capability_description()
+        for i, td in enumerate(filtered_tools):
+            if td.get("function", {}).get("name") not in _LSP_TOOL_NAMES:
+                continue
+            desc = td["function"].get("description", "")
+            filtered_tools[i] = {
+                "type": "function",
+                "function": {
+                    **td["function"],
+                    "description": _append_description_suffix(desc, capability_suffix),
+                },
+            }
 
     if not quiet_mode:
         if filtered_tools:

--- a/plugins/memory/rasputin/README.md
+++ b/plugins/memory/rasputin/README.md
@@ -1,0 +1,23 @@
+# Rasputin memory provider
+
+Rasputin is a bundled Hermes memory provider that treats Rasputin as a derived retrieval sidecar rather than the canonical memory store.
+
+Behavior in this V1 implementation:
+- best-effort `/health` check during initialize
+- best-effort `/search` recall for prompt injection
+- best-effort background `/commit` mirroring for completed turns
+- mirrored commits for built-in memory writes
+- pre-compaction checkpoint commits before old turns are summarized away
+- fail-open behavior throughout so Hermes continues normally when Rasputin is unavailable
+
+Canonical memory remains Hermes built-ins plus Ryan Book/JSONL. No model-facing Rasputin tools are exposed in V1.
+
+Environment variables:
+- `RASPUTIN_ENABLED` (default: `true`)
+- `RASPUTIN_BASE_URL` (default: `http://127.0.0.1:7777`)
+- `RASPUTIN_TIMEOUT_SECONDS` (default: `8.0`)
+- `RASPUTIN_COMMIT_TIMEOUT_SECONDS` (default: `20.0`)
+- `RASPUTIN_SOURCE_NAMESPACE` (default: `hermes`)
+- `RASPUTIN_PREFETCH_LIMIT` (default: `8`)
+- `RASPUTIN_COMMIT_IMPORTANCE_DEFAULT` (default: `60`)
+- `RASPUTIN_FAIL_OPEN` (default: `true`)

--- a/plugins/memory/rasputin/__init__.py
+++ b/plugins/memory/rasputin/__init__.py
@@ -1,0 +1,310 @@
+"""Rasputin memory provider for Hermes.
+
+V1 scope from the planning docs:
+- Rasputin is a derived retrieval and enrichment sidecar
+- built-in Hermes memory plus Ryan Book/JSONL remain canonical
+- no model-facing Rasputin tools in v1
+- all failures must fail open so turns continue normally
+
+The provider implements Hermes' memory lifecycle with best-effort recall,
+mirrored writes, and pre-compaction checkpoint syncing while keeping the
+canonical memory path authoritative.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from agent.memory_provider import MemoryProvider
+
+from .client import RasputinClient, RasputinClientConfig
+from .formatter import format_recall_block
+from .mappers import (
+    build_compaction_checkpoint_commit,
+    build_memory_write_commit,
+    build_turn_commit,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() not in {"0", "false", "no", "off", ""}
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except ValueError:
+        return default
+
+
+@dataclass(frozen=True)
+class RasputinProviderConfig:
+    """Environment-backed provider config for the Rasputin integration."""
+
+    enabled: bool = True
+    base_url: str = "http://127.0.0.1:7777"
+    timeout_seconds: float = 8.0
+    commit_timeout_seconds: float = 20.0
+    source_namespace: str = "hermes"
+    prefetch_limit: int = 8
+    commit_importance_default: int = 60
+    fail_open: bool = True
+
+    @classmethod
+    def from_env(cls) -> "RasputinProviderConfig":
+        return cls(
+            enabled=_env_bool("RASPUTIN_ENABLED", True),
+            base_url=os.getenv("RASPUTIN_BASE_URL", cls.base_url).strip() or cls.base_url,
+            timeout_seconds=_env_float("RASPUTIN_TIMEOUT_SECONDS", cls.timeout_seconds),
+            commit_timeout_seconds=_env_float(
+                "RASPUTIN_COMMIT_TIMEOUT_SECONDS",
+                cls.commit_timeout_seconds,
+            ),
+            source_namespace=os.getenv("RASPUTIN_SOURCE_NAMESPACE", cls.source_namespace).strip() or cls.source_namespace,
+            prefetch_limit=max(1, _env_int("RASPUTIN_PREFETCH_LIMIT", cls.prefetch_limit)),
+            commit_importance_default=max(
+                1,
+                min(100, _env_int("RASPUTIN_COMMIT_IMPORTANCE_DEFAULT", cls.commit_importance_default)),
+            ),
+            fail_open=_env_bool("RASPUTIN_FAIL_OPEN", True),
+        )
+
+
+class RasputinMemoryProvider(MemoryProvider):
+    """Derived-memory Rasputin provider.
+
+    The implementation stays intentionally conservative: it wires up Hermes'
+    provider lifecycle, performs best-effort search and commit calls, and keeps
+    every path safe when Rasputin is unavailable.
+    """
+
+    def __init__(self) -> None:
+        self._config = RasputinProviderConfig.from_env()
+        self._client: Optional[RasputinClient] = None
+        self._session_id = ""
+        self._platform = "cli"
+        self._agent_context = "primary"
+        self._user_id = ""
+        self._healthy = False
+        self._prefetch_cache: Dict[str, List[Dict[str, Any]]] = {}
+        self._prefetch_lock = threading.Lock()
+
+    @property
+    def name(self) -> str:
+        return "rasputin"
+
+    def is_available(self) -> bool:
+        """Return True when the provider is enabled by config.
+
+        Per the MemoryProvider contract, this does not make network calls.
+        Actual server reachability is checked in initialize().
+        """
+        self._config = RasputinProviderConfig.from_env()
+        return self._config.enabled and bool(self._config.base_url)
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        """Initialize the provider for a session and run a best-effort health check."""
+        self._config = RasputinProviderConfig.from_env()
+        self._session_id = session_id
+        self._platform = str(kwargs.get("platform") or "cli")
+        self._agent_context = str(kwargs.get("agent_context") or "primary")
+        self._user_id = str(kwargs.get("user_id") or "")
+        self._client = RasputinClient(
+            RasputinClientConfig(
+                base_url=self._config.base_url,
+                timeout_seconds=self._config.timeout_seconds,
+                commit_timeout_seconds=self._config.commit_timeout_seconds,
+                fail_open=self._config.fail_open,
+            )
+        )
+
+        # Fail-open by design: provider readiness should never break canonical memory.
+        self._healthy = self._client.healthcheck()
+        if self._healthy:
+            logger.info("Rasputin provider initialized against %s", self._config.base_url)
+        else:
+            logger.warning(
+                "Rasputin health check failed for %s; continuing in fail-open mode",
+                self._config.base_url,
+            )
+
+    def system_prompt_block(self) -> str:
+        if not self._config.enabled:
+            return ""
+        return (
+            "# Rasputin Memory\n"
+            "Derived retrieval sidecar only. Canonical memory remains Hermes built-ins "
+            "plus Ryan Book/JSONL.\n"
+            "V1 exposes no Rasputin tools to the model; recall and mirrored writes are "
+            "best-effort and may be absent when Rasputin is unavailable."
+        )
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        """Return formatted recall, using cached results when available."""
+        query = (query or "").strip()
+        if not query or not self._client:
+            return ""
+
+        cache_key = session_id or self._session_id
+        with self._prefetch_lock:
+            cached = self._prefetch_cache.pop(cache_key, None)
+        if cached is not None:
+            return format_recall_block(cached, limit=self._config.prefetch_limit)
+
+        results = self._client.search(query, limit=self._config.prefetch_limit)
+        return format_recall_block(results, limit=self._config.prefetch_limit)
+
+    def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
+        """Start a best-effort background search for the next turn."""
+        query = (query or "").strip()
+        if not query or not self._client:
+            return
+
+        cache_key = session_id or self._session_id
+
+        def _run() -> None:
+            try:
+                results = self._client.search(query, limit=self._config.prefetch_limit)
+                with self._prefetch_lock:
+                    self._prefetch_cache[cache_key] = results
+            except Exception:
+                logger.debug("Rasputin queue_prefetch failed", exc_info=True)
+
+        threading.Thread(target=_run, daemon=True, name="rasputin-prefetch").start()
+
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+        """Mirror a completed turn into Rasputin without blocking the response path."""
+        if not self._client or self._agent_context != "primary":
+            return
+        if not (user_content or "").strip() and not (assistant_content or "").strip():
+            return
+
+        payload = build_turn_commit(
+            user_content,
+            assistant_content,
+            session_id=session_id or self._session_id,
+            platform=self._platform,
+            agent_context=self._agent_context,
+            user_id=self._user_id,
+            namespace=self._config.source_namespace,
+        )
+        self._commit_best_effort(payload, label="turn")
+
+    def on_memory_write(self, action: str, target: str, content: str) -> None:
+        """Mirror built-in memory writes while preserving canonical ownership."""
+        if not self._client:
+            return
+        if action not in {"add", "replace"}:
+            return
+        if not (content or "").strip():
+            return
+
+        payload = build_memory_write_commit(
+            action,
+            target,
+            content,
+            namespace=self._config.source_namespace,
+            session_id=self._session_id,
+        )
+        self._commit_best_effort(payload, label="memory-write")
+
+    def on_pre_compress(self, messages: List[Dict[str, Any]]) -> str:
+        """Mirror a structured checkpoint before compaction discards turns."""
+        if not self._client or self._agent_context != "primary" or not messages:
+            return ""
+
+        excerpt_lines: List[str] = []
+        for msg in messages[-8:]:
+            role = str(msg.get("role") or "").strip().lower()
+            if role not in {"user", "assistant", "tool"}:
+                continue
+            content = msg.get("content", "")
+            if isinstance(content, list):
+                content = " ".join(
+                    str(item.get("text", "")) if isinstance(item, dict) else str(item)
+                    for item in content
+                )
+            text = " ".join(str(content).split()).strip()
+            if not text:
+                continue
+            excerpt_lines.append(f"{role.upper()}: {text[:500]}")
+
+        if not excerpt_lines:
+            return ""
+
+        excerpt = "\n".join(excerpt_lines)
+        notes = (
+            "Preserve the latest unresolved user asks, exact errors, ports, IDs, file paths, and active decisions from this pre-compaction checkpoint.\n"
+            f"Recent excerpt:\n{excerpt}"
+        )
+        payload = build_compaction_checkpoint_commit(
+            notes,
+            session_id=self._session_id,
+            platform=self._platform,
+            agent_context=self._agent_context,
+            user_id=self._user_id,
+            namespace=self._config.source_namespace,
+        )
+        self._commit_best_effort(payload, label="compaction-checkpoint")
+        return notes
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        """V1 is context-only; no model-facing Rasputin tools are exposed."""
+        return []
+
+    def _commit_best_effort(self, payload: Dict[str, Any], *, label: str) -> None:
+        """Fire a background commit and swallow failures.
+
+        TODO:
+        - add a bounded queue and flush on shutdown if reliability needs increase
+        - consider retries once real traffic patterns are known
+        """
+        if not self._client:
+            return
+
+        def _run() -> None:
+            try:
+                ok = self._client.commit(payload)
+                if not ok:
+                    logger.debug("Rasputin %s commit skipped/failed (fail-open)", label)
+            except Exception:
+                logger.debug("Rasputin %s commit failed", label, exc_info=True)
+
+        threading.Thread(target=_run, daemon=True, name=f"rasputin-{label}").start()
+
+
+def register(ctx) -> None:
+    """Register Rasputin as a Hermes memory provider plugin."""
+    ctx.register_memory_provider(RasputinMemoryProvider())
+
+
+__all__ = [
+    "RasputinClient",
+    "RasputinClientConfig",
+    "RasputinMemoryProvider",
+    "RasputinProviderConfig",
+    "format_recall_block",
+    "register",
+]

--- a/plugins/memory/rasputin/client.py
+++ b/plugins/memory/rasputin/client.py
@@ -1,0 +1,106 @@
+"""HTTP client for the bundled Rasputin memory provider."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, List, Mapping
+from urllib import request
+
+logger = logging.getLogger(__name__)
+
+_MAX_COMMIT_TEXT_CHARS = 12_000
+
+
+@dataclass(frozen=True)
+class RasputinClientConfig:
+    base_url: str
+    timeout_seconds: float = 8.0
+    commit_timeout_seconds: float = 20.0
+    fail_open: bool = True
+
+
+class RasputinClient:
+    def __init__(self, config: RasputinClientConfig):
+        self.config = config
+        self.base_url = (config.base_url or "").rstrip("/")
+
+    def _url(self, path: str) -> str:
+        return f"{self.base_url}{path}"
+
+    def _post_json(self, path: str, payload: Mapping[str, Any], *, timeout: float) -> Dict[str, Any] | None:
+        body = json.dumps(dict(payload)).encode("utf-8")
+        req = request.Request(
+            self._url(path),
+            data=body,
+            headers={"Content-Type": "application/json"},
+        )
+        try:
+            with request.urlopen(req, timeout=timeout) as response:
+                raw = response.read().decode("utf-8", errors="replace")
+        except Exception:
+            if self.config.fail_open:
+                logger.debug("Rasputin POST %s failed", path, exc_info=True)
+                return None
+            raise
+
+        if not raw.strip():
+            return {}
+        try:
+            data = json.loads(raw)
+            return data if isinstance(data, dict) else {"results": data}
+        except Exception:
+            if self.config.fail_open:
+                logger.debug("Rasputin POST %s returned non-JSON payload", path, exc_info=True)
+                return None
+            raise
+
+    def healthcheck(self) -> bool:
+        req = request.Request(self._url("/health"))
+        try:
+            with request.urlopen(req, timeout=self.config.timeout_seconds) as response:
+                response.read()
+            return True
+        except Exception:
+            if self.config.fail_open:
+                logger.debug("Rasputin healthcheck failed", exc_info=True)
+                return False
+            raise
+
+    def search(self, query: str, *, limit: int = 8) -> List[Dict[str, Any]]:
+        clean_query = (query or "").strip()
+        if not clean_query:
+            return []
+        payload = {
+            "query": clean_query,
+            "limit": max(int(limit or 1), 1),
+        }
+        data = self._post_json("/search", payload, timeout=self.config.timeout_seconds)
+        if not isinstance(data, Mapping):
+            return []
+        results = data.get("results") or data.get("matches") or data.get("items") or []
+        return [dict(item) for item in results if isinstance(item, Mapping)]
+
+    @staticmethod
+    def _prepare_commit_payload(payload: Mapping[str, Any]) -> Dict[str, Any]:
+        prepared = dict(payload)
+        metadata = prepared.get("metadata")
+        prepared["metadata"] = dict(metadata) if isinstance(metadata, Mapping) else {}
+
+        text = str(prepared.get("text") or "")
+        if len(text) > _MAX_COMMIT_TEXT_CHARS:
+            prepared["text"] = text[:_MAX_COMMIT_TEXT_CHARS]
+            prepared["metadata"]["rasputin_truncated"] = True
+            prepared["metadata"]["rasputin_original_text_length"] = len(text)
+        else:
+            prepared["text"] = text
+        return prepared
+
+    def commit(self, payload: Mapping[str, Any]) -> bool:
+        prepared = self._prepare_commit_payload(payload)
+        data = self._post_json("/commit", prepared, timeout=self.config.commit_timeout_seconds)
+        if data is None:
+            return False
+        ok = data.get("ok")
+        return True if ok is None else bool(ok)

--- a/plugins/memory/rasputin/formatter.py
+++ b/plugins/memory/rasputin/formatter.py
@@ -1,0 +1,151 @@
+"""Formatting helpers for Rasputin recall blocks.
+
+The provider is context-only in V1, so the formatter's job is simply to turn
+raw search hits into a compact injected block with provenance. Canonical memory
+stays in Hermes built-ins and JSONL; Rasputin output is advisory context.
+
+TODO:
+- tighten formatting against the final Rasputin hit schema
+- add richer grouping for daily-log windows if they become noisy
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Mapping
+import textwrap
+
+
+def format_recall_block(results: Iterable[Mapping[str, Any]], *, limit: int = 8) -> str:
+    """Render a compact recall block for prompt injection."""
+    hits = [dict(hit) for hit in list(results or [])[: max(int(limit or 1), 1)]]
+    if not hits:
+        return ""
+
+    facts: List[Dict[str, Any]] = []
+    windows: List[Dict[str, Any]] = []
+    other: List[Dict[str, Any]] = []
+
+    for hit in hits:
+        bucket = _bucket_for_hit(hit)
+        if bucket == "facts":
+            facts.append(hit)
+        elif bucket == "windows":
+            windows.append(hit)
+        else:
+            other.append(hit)
+
+    lines = ["# Rasputin Recall"]
+    mixed = sum(bool(group) for group in (facts, windows, other)) > 1
+
+    if facts:
+        if mixed:
+            lines.append("## Facts")
+        lines.extend(_format_group(facts))
+    if windows:
+        if mixed:
+            lines.append("## Windows")
+        lines.extend(_format_group(windows))
+    if other:
+        if mixed:
+            lines.append("## Other")
+        lines.extend(_format_group(other))
+
+    return "\n".join(lines)
+
+
+def _format_group(hits: Iterable[Mapping[str, Any]]) -> List[str]:
+    lines: List[str] = []
+    for hit in hits:
+        metadata = _metadata(hit)
+        identifier = (
+            str(metadata.get("canonical_id") or "").strip()
+            or str(hit.get("id") or "").strip()
+            or str(hit.get("source") or "").strip()
+            or "rasputin-hit"
+        )
+        score = _score_text(hit)
+        provenance = _provenance_text(hit, metadata)
+        text = _truncate(_extract_text(hit), width=220)
+
+        lines.append(f"- [score {score}] {identifier}")
+        if provenance:
+            lines.append(f"  {provenance}")
+        if text:
+            lines.append(f"  text: {text}")
+        lines.append("")
+    if lines:
+        lines.pop()
+    return lines
+
+
+def _bucket_for_hit(hit: Mapping[str, Any]) -> str:
+    metadata = _metadata(hit)
+    kind = str(metadata.get("kind") or "").lower()
+    source = str(hit.get("source") or metadata.get("source") or "").lower()
+    if kind in {"typed_memory", "memory_write"}:
+        return "facts"
+    if kind in {"conversation_window", "session_window", "daily_log_window"}:
+        return "windows"
+    if "window" in kind or "window" in source:
+        return "windows"
+    if metadata.get("canonical_id") or metadata.get("memory_type"):
+        return "facts"
+    return "other"
+
+
+def _metadata(hit: Mapping[str, Any]) -> Dict[str, Any]:
+    metadata = hit.get("metadata")
+    return dict(metadata) if isinstance(metadata, Mapping) else {}
+
+
+def _score_text(hit: Mapping[str, Any]) -> str:
+    value = hit.get("score")
+    if value is None:
+        value = hit.get("similarity")
+    if value is None:
+        return "n/a"
+    try:
+        return f"{float(value):.2f}"
+    except (TypeError, ValueError):
+        return "n/a"
+
+
+def _provenance_text(hit: Mapping[str, Any], metadata: Mapping[str, Any]) -> str:
+    parts: List[str] = []
+
+    source = str(hit.get("source") or metadata.get("source") or "").strip()
+    if source:
+        parts.append(f"source: {source}")
+
+    fleet = str(metadata.get("fleet") or "").strip()
+    if fleet:
+        parts.append(f"fleet: {fleet}")
+
+    memory_type = str(metadata.get("memory_type") or metadata.get("type") or "").strip()
+    if memory_type:
+        parts.append(f"type: {memory_type}")
+
+    session_id = str(metadata.get("session_id") or "").strip()
+    if session_id:
+        parts.append(f"session: {session_id}")
+
+    kind = str(metadata.get("kind") or "").strip()
+    if kind and kind not in {"typed_memory", "conversation_window", "session_window", "daily_log_window", "memory_write"}:
+        parts.append(f"kind: {kind}")
+
+    return " | ".join(parts)
+
+
+def _extract_text(hit: Mapping[str, Any]) -> str:
+    for key in ("text", "content", "snippet", "summary"):
+        value = hit.get(key)
+        if isinstance(value, str) and value.strip():
+            return " ".join(value.split())
+    return ""
+
+
+def _truncate(text: str, *, width: int) -> str:
+    text = " ".join((text or "").split())
+    if not text:
+        return ""
+    return textwrap.shorten(text, width=width, placeholder=" …")

--- a/plugins/memory/rasputin/mappers.py
+++ b/plugins/memory/rasputin/mappers.py
@@ -1,0 +1,198 @@
+"""Payload mappers for Rasputin commit bodies.
+
+These helpers preserve the architectural rule from the planning docs:
+Rasputin is a derived retrieval plane, not the canonical memory store.
+Mappings therefore keep provenance metadata so Rasputin commits remain
+rebuildable from Hermes-native sources.
+
+TODO:
+- wire build_jsonl_fact_commit() into the separate backfill/import scripts
+- refine text rendering once real canonical JSONL samples are exercised
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping
+
+
+_TYPE_IMPORTANCE = {
+    "fact": 80,
+    "decision": 90,
+    "pattern": 70,
+    "gotcha": 85,
+    "incident": 90,
+    "preference": 85,
+}
+
+
+def build_turn_commit(
+    user_content: str,
+    assistant_content: str,
+    *,
+    session_id: str = "",
+    platform: str = "cli",
+    agent_context: str = "primary",
+    user_id: str = "",
+    namespace: str = "hermes",
+) -> Dict[str, Any]:
+    """Map one completed Hermes turn into a Rasputin window commit."""
+    return {
+        "text": _strip_join(
+            f"USER: {(user_content or '').strip()}",
+            f"ASSISTANT: {(assistant_content or '').strip()}",
+        ),
+        "source": "hermes-turn",
+        "importance": 55,
+        "metadata": {
+            "namespace": namespace,
+            "kind": "conversation_window",
+            "session_id": session_id,
+            "platform": platform,
+            "agent_context": agent_context,
+            "user_id": user_id or None,
+        },
+    }
+
+
+def build_memory_write_commit(
+    action: str,
+    target: str,
+    content: str,
+    *,
+    namespace: str = "hermes",
+    session_id: str = "",
+) -> Dict[str, Any]:
+    """Map a built-in Hermes memory write into a Rasputin mirror commit."""
+    clean_action = (action or "").strip() or "add"
+    clean_target = (target or "").strip() or "memory"
+    clean_content = (content or "").strip()
+    return {
+        "text": f"MEMORY WRITE [target={clean_target} action={clean_action}]: {clean_content}",
+        "source": "hermes-memory-write",
+        "importance": 75,
+        "metadata": {
+            "namespace": namespace,
+            "kind": "memory_write",
+            "session_id": session_id or None,
+            "target": clean_target,
+            "action": clean_action,
+        },
+    }
+
+
+def build_compaction_checkpoint_commit(
+    checkpoint_text: str,
+    *,
+    session_id: str = "",
+    platform: str = "cli",
+    agent_context: str = "primary",
+    user_id: str = "",
+    namespace: str = "hermes",
+) -> Dict[str, Any]:
+    """Map a pre-compaction checkpoint into a Rasputin mirror commit."""
+    clean_text = (checkpoint_text or "").strip()
+    return {
+        "text": f"COMPACTION CHECKPOINT:\n{clean_text}",
+        "source": "hermes-compaction-checkpoint",
+        "importance": 82,
+        "metadata": {
+            "namespace": namespace,
+            "kind": "compaction_checkpoint",
+            "session_id": session_id or None,
+            "platform": platform,
+            "agent_context": agent_context,
+            "user_id": user_id or None,
+        },
+    }
+
+
+def build_jsonl_fact_commit(
+    record: Mapping[str, Any],
+    *,
+    namespace: str = "ryan-book",
+    source_path: str = "",
+) -> Dict[str, Any]:
+    """Scaffold mapper for canonical JSONL typed memory backfill.
+
+    This is intentionally not wired into the live provider yet. It exists so the
+    backfill/import phase can reuse a single mapping definition later.
+    """
+    memory_type = str(record.get("type") or "fact").strip() or "fact"
+    pinned = bool(record.get("pinned"))
+    trust = _coerce_float(record.get("trust"))
+    importance = _importance_for_record(memory_type, pinned=pinned, trust=trust)
+    metadata = {
+        "namespace": namespace,
+        "kind": "typed_memory",
+        "canonical_id": record.get("id"),
+        "memory_type": memory_type,
+        "fleet": record.get("fleet"),
+        "tags": list(record.get("tags") or []),
+        "trust": trust,
+        "pinned": pinned,
+        "source_path": source_path or None,
+        "source_created_at": record.get("created_at"),
+    }
+    return {
+        "text": _render_typed_memory_text(record, memory_type),
+        "source": f"jsonl-{memory_type}",
+        "importance": importance,
+        "metadata": metadata,
+    }
+
+
+def _render_typed_memory_text(record: Mapping[str, Any], memory_type: str) -> str:
+    content = record.get("content")
+    pieces = [f"[{memory_type}]"]
+    if isinstance(content, Mapping):
+        for key, value in content.items():
+            rendered = _render_value(value)
+            if rendered:
+                pieces.append(f"{key}: {rendered}")
+    else:
+        rendered = _render_value(content)
+        if rendered:
+            pieces.append(rendered)
+    return "\n".join(pieces)
+
+
+def _importance_for_record(memory_type: str, *, pinned: bool, trust: float | None) -> int:
+    importance = _TYPE_IMPORTANCE.get(memory_type, 80)
+    if pinned:
+        importance = min(100, importance + 5)
+    if trust is not None and trust < 0.6:
+        importance = max(40, importance - 10)
+    return importance
+
+
+def _render_value(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, (int, float, bool)):
+        return str(value)
+    if isinstance(value, list):
+        parts = [part for part in (_render_value(item) for item in value) if part]
+        return ", ".join(parts)
+    if isinstance(value, Mapping):
+        parts = []
+        for key, item in value.items():
+            rendered = _render_value(item)
+            if rendered:
+                parts.append(f"{key}={rendered}")
+        return ", ".join(parts)
+    return str(value).strip()
+
+
+def _strip_join(*parts: str) -> str:
+    return "\n".join(part for part in parts if part and part.strip())
+
+
+def _coerce_float(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None

--- a/plugins/memory/rasputin/plugin.yaml
+++ b/plugins/memory/rasputin/plugin.yaml
@@ -1,0 +1,6 @@
+name: rasputin
+version: 0.1.0
+description: "Rasputin derived-memory sidecar — best-effort recall, mirrored writes, and pre-compaction checkpoint syncing with fail-open behavior."
+hooks:
+  - on_pre_compress
+  - on_memory_write

--- a/run_agent.py
+++ b/run_agent.py
@@ -1035,46 +1035,51 @@ class AIAgent:
                 elif "portal.qwen.ai" in effective_base.lower():
                     client_kwargs["default_headers"] = _qwen_portal_headers()
             else:
-                # No explicit creds — use the centralized provider router
-                from agent.auxiliary_client import resolve_provider_client
-                _routed_client, _ = resolve_provider_client(
-                    self.provider or "auto", model=self.model, raw_codex=True)
-                if _routed_client is not None:
-                    client_kwargs = {
-                        "api_key": _routed_client.api_key,
-                        "base_url": str(_routed_client.base_url),
-                    }
-                    # Preserve any default_headers the router set
-                    if hasattr(_routed_client, '_default_headers') and _routed_client._default_headers:
-                        client_kwargs["default_headers"] = dict(_routed_client._default_headers)
+                if api_key:
+                    client_kwargs = {"api_key": api_key}
+                    if base_url:
+                        client_kwargs["base_url"] = base_url
                 else:
-                    # When the user explicitly chose a non-OpenRouter provider
-                    # but no credentials were found, fail fast with a clear
-                    # message instead of silently routing through OpenRouter.
-                    _explicit = (self.provider or "").strip().lower()
-                    if _explicit and _explicit not in ("auto", "openrouter", "custom"):
-                        # Look up the actual env var name from the provider
-                        # config — some providers use non-standard names
-                        # (e.g. alibaba → DASHSCOPE_API_KEY, not ALIBABA_API_KEY).
-                        _env_hint = f"{_explicit.upper()}_API_KEY"
-                        try:
-                            from hermes_cli.auth import PROVIDER_REGISTRY
-                            _pcfg = PROVIDER_REGISTRY.get(_explicit)
-                            if _pcfg and _pcfg.api_key_env_vars:
-                                _env_hint = _pcfg.api_key_env_vars[0]
-                        except Exception:
-                            pass
+                    # No explicit creds — use the centralized provider router
+                    from agent.auxiliary_client import resolve_provider_client
+                    _routed_client, _ = resolve_provider_client(
+                        self.provider or "auto", model=self.model, raw_codex=True)
+                    if _routed_client is not None:
+                        client_kwargs = {
+                            "api_key": _routed_client.api_key,
+                            "base_url": str(_routed_client.base_url),
+                        }
+                        # Preserve any default_headers the router set
+                        if hasattr(_routed_client, '_default_headers') and _routed_client._default_headers:
+                            client_kwargs["default_headers"] = dict(_routed_client._default_headers)
+                    else:
+                        # When the user explicitly chose a non-OpenRouter provider
+                        # but no credentials were found, fail fast with a clear
+                        # message instead of silently routing through OpenRouter.
+                        _explicit = (self.provider or "").strip().lower()
+                        if _explicit and _explicit not in ("auto", "openrouter", "custom"):
+                            # Look up the actual env var name from the provider
+                            # config — some providers use non-standard names
+                            # (e.g. alibaba → DASHSCOPE_API_KEY, not ALIBABA_API_KEY).
+                            _env_hint = f"{_explicit.upper()}_API_KEY"
+                            try:
+                                from hermes_cli.auth import PROVIDER_REGISTRY
+                                _pcfg = PROVIDER_REGISTRY.get(_explicit)
+                                if _pcfg and _pcfg.api_key_env_vars:
+                                    _env_hint = _pcfg.api_key_env_vars[0]
+                            except Exception:
+                                pass
+                            raise RuntimeError(
+                                f"Provider '{_explicit}' is set in config.yaml but no API key "
+                                f"was found. Set the {_env_hint} environment "
+                                f"variable, or switch to a different provider with `hermes model`."
+                            )
+                        # No provider configured — reject with a clear message.
                         raise RuntimeError(
-                            f"Provider '{_explicit}' is set in config.yaml but no API key "
-                            f"was found. Set the {_env_hint} environment "
-                            f"variable, or switch to a different provider with `hermes model`."
+                            "No LLM provider configured. Run `hermes model` to "
+                            "select a provider, or run `hermes setup` for first-time "
+                            "configuration."
                         )
-                    # No provider configured — reject with a clear message.
-                    raise RuntimeError(
-                        "No LLM provider configured. Run `hermes model` to "
-                        "select a provider, or run `hermes setup` for first-time "
-                        "configuration."
-                    )
             
             self._client_kwargs = client_kwargs  # stored for rebuilding after interrupt
 
@@ -1141,6 +1146,7 @@ class AIAgent:
         # Get available tools with filtering
         self.tools = get_tool_definitions(
             enabled_toolsets=enabled_toolsets,
+            enabled_tools=self.enabled_tools,
             disabled_toolsets=disabled_toolsets,
             quiet_mode=self.quiet_mode,
         )
@@ -1156,6 +1162,8 @@ class AIAgent:
                 # Show filtering info if applied
                 if enabled_toolsets:
                     print(f"   ✅ Enabled toolsets: {', '.join(enabled_toolsets)}")
+                if self.enabled_tools:
+                    print(f"   🎯 Enabled tools: {', '.join(self.enabled_tools)}")
                 if disabled_toolsets:
                     print(f"   ❌ Disabled toolsets: {', '.join(disabled_toolsets)}")
         elif not self.quiet_mode:
@@ -1251,6 +1259,7 @@ class AIAgent:
             _agent_cfg = _load_agent_config()
         except Exception:
             _agent_cfg = {}
+        self._delegation_cfg = _agent_cfg.get("delegation", {}) if isinstance(_agent_cfg.get("delegation", {}), dict) else {}
 
         # Persistent memory (MEMORY.md + USER.md) -- loaded from disk
         self._memory_store = None

--- a/run_agent.py
+++ b/run_agent.py
@@ -1414,6 +1414,19 @@ class AIAgent:
         compression_enabled = str(_compression_cfg.get("enabled", True)).lower() in ("true", "1", "yes")
         compression_target_ratio = float(_compression_cfg.get("target_ratio", 0.20))
         compression_protect_last = int(_compression_cfg.get("protect_last_n", 20))
+        compression_threshold_tokens = _compression_cfg.get("threshold_tokens")
+        if compression_threshold_tokens is not None:
+            try:
+                compression_threshold_tokens = int(compression_threshold_tokens)
+                if compression_threshold_tokens <= 0:
+                    raise ValueError("threshold_tokens must be positive")
+            except (TypeError, ValueError):
+                logger.warning(
+                    "Invalid compression.threshold_tokens in config.yaml: %r — must be a positive integer. "
+                    "Falling back to percentage threshold.",
+                    compression_threshold_tokens,
+                )
+                compression_threshold_tokens = None
 
         # Read explicit context_length override from model config
         _model_cfg = _agent_cfg.get("model", {})
@@ -1554,6 +1567,7 @@ class AIAgent:
                 config_context_length=_config_context_length,
                 provider=self.provider,
                 api_mode=self.api_mode,
+                explicit_threshold_tokens=compression_threshold_tokens,
             )
         self.compression_enabled = compression_enabled
 
@@ -1642,7 +1656,20 @@ class AIAgent:
 
         if not self.quiet_mode:
             if compression_enabled:
-                print(f"📊 Context limit: {self.context_compressor.context_length:,} tokens (compress at {int(compression_threshold*100)}% = {self.context_compressor.threshold_tokens:,})")
+                _threshold_pct = int(
+                    (self.context_compressor.threshold_tokens / max(self.context_compressor.context_length, 1)) * 100
+                )
+                _explicit_threshold = getattr(self.context_compressor, "explicit_threshold_tokens", None)
+                if _explicit_threshold is not None and self.context_compressor.threshold_tokens == _explicit_threshold:
+                    print(
+                        f"📊 Context limit: {self.context_compressor.context_length:,} tokens "
+                        f"(compress at explicit threshold_tokens = {self.context_compressor.threshold_tokens:,} ≈ {_threshold_pct}%)"
+                    )
+                else:
+                    print(
+                        f"📊 Context limit: {self.context_compressor.context_length:,} tokens "
+                        f"(compress at {_threshold_pct}% = {self.context_compressor.threshold_tokens:,})"
+                    )
             else:
                 print(f"📊 Context limit: {self.context_compressor.context_length:,} tokens (auto-compression disabled)")
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -616,6 +616,7 @@ class AIAgent:
         max_iterations: int = 90,  # Default tool-calling iterations (shared with subagents)
         tool_delay: float = 1.0,
         enabled_toolsets: List[str] = None,
+        enabled_tools: List[str] = None,
         disabled_toolsets: List[str] = None,
         save_trajectories: bool = False,
         verbose_logging: bool = False,
@@ -847,6 +848,7 @@ class AIAgent:
 
         # Store toolset filtering options
         self.enabled_toolsets = enabled_toolsets
+        self.enabled_tools = list(enabled_tools) if enabled_tools is not None else None
         self.disabled_toolsets = disabled_toolsets
         
         # Model response configuration
@@ -3292,6 +3294,42 @@ class AIAgent:
             "budget_max": self.iteration_budget.max_total,
         }
 
+    def get_orchestration_continuation_snapshot(self, result: Optional[dict]) -> dict:
+        """Summarize resumable work for gateway continuation handling."""
+        payload = result if isinstance(result, dict) else {}
+        todo_items = []
+        try:
+            if getattr(self, "_todo_store", None) is not None:
+                raw_items = self._todo_store.read() or []
+                if isinstance(raw_items, list):
+                    todo_items = [dict(item) for item in raw_items if isinstance(item, dict)]
+        except Exception:
+            todo_items = []
+
+        active_todos = [
+            dict(item)
+            for item in todo_items
+            if str(item.get("status") or "").strip().lower() in {"pending", "in_progress"}
+        ]
+
+        if payload.get("interrupted"):
+            outcome_status = "interrupted"
+        elif payload.get("failed"):
+            outcome_status = "failed"
+        elif payload.get("completed") or not active_todos:
+            outcome_status = "completed"
+        else:
+            outcome_status = "incomplete"
+
+        response_preview = str(payload.get("final_response") or payload.get("error") or "").strip()
+        return {
+            "sessionId": str(getattr(self, "session_id", "") or ""),
+            "outcomeStatus": outcome_status,
+            "todoItems": todo_items,
+            "activeTodos": active_todos,
+            "responsePreview": response_preview,
+        }
+
     def shutdown_memory_provider(self, messages: list = None) -> None:
         """Shut down the memory provider and context engine — call at actual session boundaries.
 
@@ -3732,6 +3770,73 @@ class AIAgent:
             )
         return messages
 
+    def _todo_has_active_items(self) -> bool:
+        try:
+            items = self._todo_store.read()
+        except Exception:
+            return False
+        return any(item.get("status") in ("pending", "in_progress") for item in items)
+
+    def _should_inject_orchestration_note(self, user_message: str, api_call_count: int) -> bool:
+        cfg = self._delegation_cfg if isinstance(self._delegation_cfg, dict) else {}
+        if getattr(self, "_delegate_depth", 0) != 0:
+            return False
+        if api_call_count != 1:
+            return False
+        if not cfg.get("auto_decompose_large_tasks", True):
+            return False
+        if not isinstance(user_message, str) or not user_message.strip():
+            return False
+        if "todo" not in self.valid_tool_names:
+            return False
+        if self._todo_has_active_items():
+            return False
+        text = user_message.lower()
+        score = 0
+        if len(user_message) >= 220:
+            score += 2
+        if len(re.findall(r"\b(and|also|then|after|before|while)\b", text)) >= 2:
+            score += 2
+        if any(token in text for token in ("across the board", "all profiles", "across all profiles", "end-to-end", "hardening pass", "make sure", "implement", "verify", "fix regressions", "audit")):
+            score += 2
+        if len(re.findall(r"\b(test|verify|implement|update|check|ensure|review|compare|patch|refactor)\b", text)) >= 3:
+            score += 2
+        if text.count("\n-") >= 2 or text.count("\n1.") >= 1 or text.count("; ") >= 2:
+            score += 2
+        return score >= 4
+
+    def _build_orchestration_user_note(self) -> str:
+        cfg = self._delegation_cfg if isinstance(self._delegation_cfg, dict) else {}
+        max_children = cfg.get("max_concurrent_children", 3)
+        try:
+            max_children = max(1, int(max_children))
+        except (TypeError, ValueError):
+            max_children = 3
+        auto_fanout_max = self._resolve_auto_fanout_max_tasks(cfg, max_children)
+        lines = [
+            "<runtime-orchestration-policy>",
+            "This request appears large or multi-step.",
+            "Before substantive execution, create a concise todo list with 2-7 items and mark exactly one item in_progress.",
+            "After planning, continue execution immediately instead of stopping after the plan.",
+        ]
+        if cfg.get("auto_fanout_batch_mode", True) and "delegate_task" in self.valid_tool_names:
+            lines.append(
+                f"When independent subtasks exist, prefer ONE delegate_task batch call with tasks=[...] (up to {auto_fanout_max} tasks) instead of many separate delegate_task calls."
+            )
+            lines.append(
+                "Use delegation categories when they fit: research for audits/comparison, implementation for code changes, verification for tests/review."
+            )
+        lines.append("</runtime-orchestration-policy>")
+        return "\n".join(lines)
+
+    @staticmethod
+    def _resolve_auto_fanout_max_tasks(cfg: dict, max_children: int) -> int:
+        auto_fanout_max = cfg.get("auto_fanout_max_tasks", max_children)
+        try:
+            return max(1, min(max_children, int(auto_fanout_max)))
+        except (TypeError, ValueError):
+            return min(max_children, 3)
+
     @staticmethod
     def _cap_delegate_task_calls(tool_calls: list) -> list:
         """Truncate excess delegate_task calls to max_concurrent_children.
@@ -3762,6 +3867,106 @@ class AIAgent:
             delegate_count - max_children, max_children,
         )
         return truncated
+
+    @staticmethod
+    def _coalesce_delegate_task_calls(tool_calls: list) -> list:
+        if not tool_calls:
+            return tool_calls
+        try:
+            from tools.delegate_tool import _load_config, _resolve_batch_concurrency_limit
+            cfg = _load_config()
+        except Exception:
+            cfg = {}
+            from tools.delegate_tool import _resolve_batch_concurrency_limit
+        if not cfg.get("auto_fanout_batch_mode", True):
+            return tool_calls
+
+        merged_tasks = []
+        first_delegate = None
+        max_iterations = None
+        delegate_count = 0
+
+        for tc in tool_calls:
+            if tc.function.name != "delegate_task":
+                continue
+            delegate_count += 1
+            first_delegate = first_delegate or tc
+            try:
+                args = json.loads(tc.function.arguments or "{}")
+            except Exception:
+                return tool_calls
+            if not isinstance(args, dict):
+                return tool_calls
+            current_max_iterations = args.get("max_iterations")
+            if current_max_iterations is not None:
+                try:
+                    max_iterations = max(int(current_max_iterations), max_iterations or 0)
+                except (TypeError, ValueError):
+                    return tool_calls
+            top_level_defaults = {
+                key: args.get(key)
+                for key in ("category", "acp_command", "acp_args")
+                if args.get(key) is not None
+            }
+            if isinstance(args.get("tasks"), list):
+                for task in args["tasks"]:
+                    if not isinstance(task, dict) or not str(task.get("goal", "")).strip():
+                        return tool_calls
+                    normalized = dict(task)
+                    for key, value in top_level_defaults.items():
+                        normalized.setdefault(key, value)
+                    merged_tasks.append(normalized)
+            else:
+                goal = str(args.get("goal") or "").strip()
+                if not goal:
+                    return tool_calls
+                task = {"goal": goal}
+                for key in ("context", "toolsets", "category", "acp_command", "acp_args"):
+                    if args.get(key) is not None:
+                        task[key] = args.get(key)
+                merged_tasks.append(task)
+
+        if delegate_count == 0:
+            return tool_calls
+
+        batch_limit, _limit_category = _resolve_batch_concurrency_limit(merged_tasks, None, cfg)
+        auto_fanout_max = AIAgent._resolve_auto_fanout_max_tasks(cfg, batch_limit)
+        needs_rewrite = delegate_count > 1
+
+        if len(merged_tasks) > auto_fanout_max:
+            merged_tasks = merged_tasks[:auto_fanout_max]
+            needs_rewrite = True
+            logger.warning(
+                "Coalesced delegate_task fanout exceeded auto_fanout_max_tasks=%d; truncating merged batch",
+                auto_fanout_max,
+            )
+
+        if not needs_rewrite:
+            return tool_calls
+
+        merged_args = {"tasks": merged_tasks}
+        if max_iterations is not None:
+            merged_args["max_iterations"] = max_iterations
+        merged_call = SimpleNamespace(
+            id=getattr(first_delegate, "id", None),
+            type=getattr(first_delegate, "type", "function"),
+            function=SimpleNamespace(
+                name="delegate_task",
+                arguments=json.dumps(merged_args, ensure_ascii=False, separators=(",", ":"), sort_keys=True),
+            ),
+        )
+
+        output = []
+        inserted = False
+        for tc in tool_calls:
+            if tc.function.name == "delegate_task":
+                if not inserted:
+                    output.append(merged_call)
+                    inserted = True
+                continue
+            output.append(tc)
+        logger.info("Coalesced %d delegate_task calls into one batch with %d task(s)", delegate_count, len(merged_tasks))
+        return output
 
     @staticmethod
     def _deduplicate_tool_calls(tool_calls: list) -> list:
@@ -7551,7 +7756,10 @@ class AIAgent:
                 context=function_args.get("context"),
                 toolsets=function_args.get("toolsets"),
                 tasks=function_args.get("tasks"),
+                category=function_args.get("category"),
                 max_iterations=function_args.get("max_iterations"),
+                acp_command=function_args.get("acp_command"),
+                acp_args=function_args.get("acp_args"),
                 parent_agent=self,
             )
         else:
@@ -8839,6 +9047,8 @@ class AIAgent:
                 # never mutated, so nothing leaks into session persistence.
                 if idx == current_turn_user_idx and msg.get("role") == "user":
                     _injections = []
+                    if self._should_inject_orchestration_note(original_user_message, api_call_count):
+                        _injections.append(self._build_orchestration_user_note())
                     if _ext_prefetch_cache:
                         _fenced = build_memory_context_block(_ext_prefetch_cache)
                         if _fenced:
@@ -10885,6 +11095,9 @@ class AIAgent:
                     self._invalid_json_retries = 0
 
                     # ── Post-call guardrails ──────────────────────────
+                    assistant_message.tool_calls = self._coalesce_delegate_task_calls(
+                        assistant_message.tool_calls
+                    )
                     assistant_message.tool_calls = self._cap_delegate_task_calls(
                         assistant_message.tool_calls
                     )

--- a/scripts/run_test_chunks.sh
+++ b/scripts/run_test_chunks.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+# Named chunk runner for hermes-agent verification suites.
+# Delegates every chunk to scripts/run_tests.sh so CI-parity policy stays in one place.
+#
+# Usage:
+#   scripts/run_test_chunks.sh list
+#   scripts/run_test_chunks.sh list broad
+#   scripts/run_test_chunks.sh broad
+#   scripts/run_test_chunks.sh broad run-agent-a run-agent-b
+#   scripts/run_test_chunks.sh run-agent-file -- -q --durations=20
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUN_TESTS="$SCRIPT_DIR/run_tests.sh"
+
+if [ ! -x "$RUN_TESTS" ]; then
+  echo "error: expected executable runner at $RUN_TESTS" >&2
+  exit 1
+fi
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/run_test_chunks.sh list [suite]
+  scripts/run_test_chunks.sh <suite> [chunk ...] [-- <extra pytest args>]
+
+Suites:
+  broad              Broad verification suite for current orchestration hardening targets.
+  native-orchestration-broad
+  run-agent-file     Chunked runner for tests/run_agent/test_run_agent.py.
+
+Examples:
+  scripts/run_test_chunks.sh broad
+  scripts/run_test_chunks.sh broad run-agent-a run-agent-b
+  scripts/run_test_chunks.sh run-agent-file -- -q --durations=20
+EOF
+}
+
+suite_alias() {
+  case "$1" in
+    broad) echo "native-orchestration-broad" ;;
+    run-agent) echo "run-agent-file" ;;
+    *) echo "$1" ;;
+  esac
+}
+
+suite_chunks() {
+  case "$1" in
+    native-orchestration-broad)
+      printf '%s\n' \
+        config-validation \
+        delegate \
+        delegate-toolset-scope \
+        run-agent-a \
+        run-agent-b \
+        run-agent-c \
+        run-agent-d \
+        run-agent-e \
+        run-agent-f
+      ;;
+    run-agent-file)
+      printf '%s\n' \
+        run-agent-a \
+        run-agent-b \
+        run-agent-c \
+        run-agent-d \
+        run-agent-e \
+        run-agent-f
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+chunk_nodes() {
+  case "$1" in
+    config-validation)
+      printf '%s\n' tests/hermes_cli/test_config_validation.py
+      ;;
+    delegate)
+      printf '%s\n' tests/tools/test_delegate.py
+      ;;
+    delegate-toolset-scope)
+      printf '%s\n' tests/tools/test_delegate_toolset_scope.py
+      ;;
+    run-agent-a)
+      printf '%s\n' \
+        tests/run_agent/test_run_agent.py::test_aiagent_reuses_existing_errors_log_handler \
+        tests/run_agent/test_run_agent.py::TestProviderModelNormalization \
+        tests/run_agent/test_run_agent.py::TestHasContentAfterThinkBlock \
+        tests/run_agent/test_run_agent.py::TestStripThinkBlocks \
+        tests/run_agent/test_run_agent.py::TestExtractReasoning \
+        tests/run_agent/test_run_agent.py::TestCleanSessionContent \
+        tests/run_agent/test_run_agent.py::TestGetMessagesUpToLastAssistant \
+        tests/run_agent/test_run_agent.py::TestMaskApiKey \
+        tests/run_agent/test_run_agent.py::TestInit \
+        tests/run_agent/test_run_agent.py::TestInterrupt \
+        tests/run_agent/test_run_agent.py::TestHydrateTodoStore \
+        tests/run_agent/test_run_agent.py::TestBuildSystemPrompt \
+        tests/run_agent/test_run_agent.py::TestToolUseEnforcementConfig \
+        tests/run_agent/test_run_agent.py::TestInvalidateSystemPrompt \
+        tests/run_agent/test_run_agent.py::TestBuildApiKwargs \
+        tests/run_agent/test_run_agent.py::TestBuildAssistantMessage
+      ;;
+    run-agent-b)
+      printf '%s\n' \
+        tests/run_agent/test_run_agent.py::TestFormatToolsForSystemMessage \
+        tests/run_agent/test_run_agent.py::TestExecuteToolCalls \
+        tests/run_agent/test_run_agent.py::TestConcurrentToolExecution \
+        tests/run_agent/test_run_agent.py::TestPathsOverlap \
+        tests/run_agent/test_run_agent.py::TestParallelScopePathNormalization \
+        tests/run_agent/test_run_agent.py::TestHandleMaxIterations \
+        tests/run_agent/test_run_agent.py::TestRunConversation
+      ;;
+    run-agent-c)
+      printf '%s\n' \
+        tests/run_agent/test_run_agent.py::TestRetryExhaustion \
+        tests/run_agent/test_run_agent.py::TestFlushSentinelNotLeaked \
+        tests/run_agent/test_run_agent.py::TestConversationHistoryNotMutated \
+        tests/run_agent/test_run_agent.py::TestNousCredentialRefresh \
+        tests/run_agent/test_run_agent.py::TestCredentialPoolRecovery \
+        tests/run_agent/test_run_agent.py::TestMaxTokensParam \
+        tests/run_agent/test_run_agent.py::TestSystemPromptStability \
+        tests/run_agent/test_run_agent.py::TestBudgetPressure \
+        tests/run_agent/test_run_agent.py::TestSafeWriter \
+        tests/run_agent/test_run_agent.py::TestSaveSessionLogAtomicWrite
+      ;;
+    run-agent-d)
+      printf '%s\n' \
+        tests/run_agent/test_run_agent.py::TestBuildApiKwargsAnthropicMaxTokens \
+        tests/run_agent/test_run_agent.py::TestAnthropicImageFallback \
+        tests/run_agent/test_run_agent.py::TestFallbackAnthropicProvider \
+        tests/run_agent/test_run_agent.py::test_aiagent_uses_copilot_acp_client \
+        tests/run_agent/test_run_agent.py::test_quiet_spinner_allowed_with_explicit_print_fn \
+        tests/run_agent/test_run_agent.py::test_quiet_spinner_allowed_on_real_tty \
+        tests/run_agent/test_run_agent.py::test_quiet_spinner_suppressed_on_non_tty_without_print_fn \
+        tests/run_agent/test_run_agent.py::test_is_openai_client_closed_honors_custom_client_flag \
+        tests/run_agent/test_run_agent.py::test_is_openai_client_closed_handles_method_form \
+        tests/run_agent/test_run_agent.py::test_is_openai_client_closed_falls_back_to_http_client \
+        tests/run_agent/test_run_agent.py::TestAnthropicBaseUrlPassthrough \
+        tests/run_agent/test_run_agent.py::TestAnthropicCredentialRefresh
+      ;;
+    run-agent-e)
+      printf '%s\n' tests/run_agent/test_run_agent.py::TestStreamingApiCall
+      ;;
+    run-agent-f)
+      printf '%s\n' \
+        tests/run_agent/test_run_agent.py::TestInterruptVprintForceTrue \
+        tests/run_agent/test_run_agent.py::TestAnthropicInterruptHandler \
+        tests/run_agent/test_run_agent.py::TestStreamCallbackNonStreamingProvider \
+        tests/run_agent/test_run_agent.py::TestPersistUserMessageOverride \
+        tests/run_agent/test_run_agent.py::TestVprintForceOnErrors \
+        tests/run_agent/test_run_agent.py::TestNormalizeCodexDictArguments \
+        tests/run_agent/test_run_agent.py::TestOAuthFlagAfterCredentialRefresh \
+        tests/run_agent/test_run_agent.py::TestFallbackSetsOAuthFlag \
+        tests/run_agent/test_run_agent.py::TestMemoryNudgeCounterPersistence \
+        tests/run_agent/test_run_agent.py::TestDeadRetryCode \
+        tests/run_agent/test_run_agent.py::TestMemoryContextSanitization \
+        tests/run_agent/test_run_agent.py::TestMemoryProviderTurnStart \
+        tests/run_agent/test_run_agent.py::TestNativeOrchestrationHardening
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+if [ "$#" -eq 0 ]; then
+  usage
+  exit 1
+fi
+
+if [ "$1" = "list" ]; then
+  if [ "$#" -eq 1 ]; then
+    echo "native-orchestration-broad"
+    echo "run-agent-file"
+    exit 0
+  fi
+  SUITE="$(suite_alias "$2")"
+  suite_chunks "$SUITE"
+  exit 0
+fi
+
+SUITE="$(suite_alias "$1")"
+shift
+
+DEFAULT_CHUNKS=()
+while IFS= read -r chunk_name; do
+  DEFAULT_CHUNKS+=("$chunk_name")
+done < <(suite_chunks "$SUITE")
+if [ "${#DEFAULT_CHUNKS[@]}" -eq 0 ]; then
+  usage
+  exit 1
+fi
+
+SELECTED_CHUNKS=()
+PASSTHROUGH_ARGS=()
+PARSING_CHUNKS=1
+for arg in "$@"; do
+  if [ "$arg" = "--" ]; then
+    PARSING_CHUNKS=0
+    continue
+  fi
+  if [ "$PARSING_CHUNKS" -eq 1 ]; then
+    SELECTED_CHUNKS+=("$arg")
+  else
+    PASSTHROUGH_ARGS+=("$arg")
+  fi
+done
+
+if [ "${#SELECTED_CHUNKS[@]}" -eq 0 ]; then
+  SELECTED_CHUNKS=("${DEFAULT_CHUNKS[@]}")
+fi
+
+for chunk in "${SELECTED_CHUNKS[@]}"; do
+  if ! chunk_nodes "$chunk" >/dev/null; then
+    echo "error: unknown chunk '$chunk' for suite '$SUITE'" >&2
+    echo "available chunks:" >&2
+    suite_chunks "$SUITE" >&2
+    exit 1
+  fi
+done
+
+echo "▶ suite: $SUITE"
+echo "▶ chunks: ${SELECTED_CHUNKS[*]}"
+if [ "${#PASSTHROUGH_ARGS[@]}" -gt 0 ]; then
+  echo "▶ pass-through pytest args: ${PASSTHROUGH_ARGS[*]}"
+fi
+
+for chunk in "${SELECTED_CHUNKS[@]}"; do
+  nodes=()
+  while IFS= read -r node; do
+    nodes+=("$node")
+  done < <(chunk_nodes "$chunk")
+  echo
+  echo "== chunk: $chunk =="
+  if [ "${#PASSTHROUGH_ARGS[@]}" -gt 0 ]; then
+    "$RUN_TESTS" "${PASSTHROUGH_ARGS[@]}" "${nodes[@]}"
+  else
+    "$RUN_TESTS" "${nodes[@]}"
+  fi
+done

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -24,19 +24,34 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # ── Activate venv ───────────────────────────────────────────────────────────
-# Prefer a .venv in the current tree, fall back to the main checkout's venv
-# (useful for worktrees where we don't always duplicate the venv).
+# Prefer the first working env in the current tree, then fall back to the main
+# checkout's venv (useful for worktrees where we don't always duplicate the
+# virtualenv). A stale `.venv` without pytest should not block a healthy `venv`.
 VENV=""
-for candidate in "$REPO_ROOT/.venv" "$REPO_ROOT/venv" "$HOME/.hermes/hermes-agent/venv"; do
-  if [ -f "$candidate/bin/activate" ]; then
+CANDIDATES=("$REPO_ROOT/.venv" "$REPO_ROOT/venv" "$HOME/.hermes/hermes-agent/venv")
+SKIPPED_VENVS=()
+for candidate in "${CANDIDATES[@]}"; do
+  PYTHON_CANDIDATE="$candidate/bin/python"
+  if [ ! -x "$PYTHON_CANDIDATE" ]; then
+    continue
+  fi
+  if "$PYTHON_CANDIDATE" -c "import pytest" >/dev/null 2>&1; then
     VENV="$candidate"
     break
   fi
+  SKIPPED_VENVS+=("$candidate")
 done
 
 if [ -z "$VENV" ]; then
-  echo "error: no virtualenv found in $REPO_ROOT/.venv or $REPO_ROOT/venv" >&2
+  if [ "${#SKIPPED_VENVS[@]}" -gt 0 ]; then
+    echo "warning: skipped unusable virtualenv(s) without pytest: ${SKIPPED_VENVS[*]}" >&2
+  fi
+  echo "error: no working virtualenv found in $REPO_ROOT/.venv or $REPO_ROOT/venv" >&2
   exit 1
+fi
+
+if [ "${#SKIPPED_VENVS[@]}" -gt 0 ]; then
+  echo "warning: skipped unusable virtualenv(s) without pytest: ${SKIPPED_VENVS[*]}" >&2
 fi
 
 PYTHON="$VENV/bin/python"

--- a/tests/agent/test_compaction_checkpoint.py
+++ b/tests/agent/test_compaction_checkpoint.py
@@ -1,0 +1,113 @@
+import json
+from pathlib import Path
+
+from agent.compaction_checkpoint import write_compaction_checkpoint
+
+
+def _sample_messages():
+    return [
+        {"role": "user", "content": "Build the Thindi SEO architecture plan."},
+        {"role": "assistant", "content": "I gathered the current constraints and architecture options."},
+        {"role": "tool", "content": "{\"status\": \"success\", \"output\": \"Council review loaded\"}"},
+        {"role": "user", "content": "Continue from the council review and produce final blind spots."},
+        {"role": "assistant", "content": "Working through the final synthesis now."},
+    ]
+
+
+def test_write_compaction_checkpoint_creates_canonical_artifacts(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes" / "profiles" / "thindi"
+    workspace = hermes_home / "workspace"
+    workspace.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    result = write_compaction_checkpoint(
+        session_id="session-123",
+        messages=_sample_messages(),
+        preservation_notes="Preserve exact port 8642 and the unresolved backlink strategy gap.",
+        approx_tokens=185000,
+        context_length=200000,
+        threshold_tokens=185000,
+    )
+
+    handoff_path = Path(result["handoff_path"])
+    checkpoint_json_path = Path(result["checkpoint_json_path"])
+    event_path = Path(result["event_path"])
+    daily_path = Path(result["daily_path"])
+    latest_path = Path(result["latest_handoff_path"])
+
+    assert handoff_path.exists()
+    assert checkpoint_json_path.exists()
+    assert event_path.exists()
+    assert daily_path.exists()
+    assert latest_path.exists()
+
+    checkpoint_payload = json.loads(checkpoint_json_path.read_text())
+    assert checkpoint_payload["session_id"] == "session-123"
+    assert checkpoint_payload["profile"] == "thindi"
+    assert checkpoint_payload["fleet"] == "generic"
+    assert checkpoint_payload["context_length"] == 200000
+    assert checkpoint_payload["threshold_tokens"] == 185000
+    assert checkpoint_payload["context_percent"] == 92.5
+    assert "8642" in checkpoint_payload["preservation_notes"]
+
+    event_lines = [line for line in event_path.read_text().splitlines() if line.strip()]
+    assert len(event_lines) == 1
+    event_payload = json.loads(event_lines[0])
+    assert event_payload["kind"] == "compaction_checkpoint"
+    assert event_payload["session_id"] == "session-123"
+    assert event_payload["profile"] == "thindi"
+
+    daily_text = daily_path.read_text()
+    assert "Compaction Checkpoint" in daily_text
+    assert "session-123" in daily_text
+    assert "185000" in daily_text
+
+    latest_text = latest_path.read_text()
+    assert "session-123" in latest_text
+
+
+def test_write_compaction_checkpoint_appends_event_jsonl(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    workspace = hermes_home / "workspace"
+    workspace.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    write_compaction_checkpoint(
+        session_id="session-a",
+        messages=_sample_messages(),
+        preservation_notes="first",
+        approx_tokens=90000,
+        context_length=100000,
+        threshold_tokens=85000,
+    )
+    second = write_compaction_checkpoint(
+        session_id="session-b",
+        messages=_sample_messages(),
+        preservation_notes="second",
+        approx_tokens=91000,
+        context_length=100000,
+        threshold_tokens=85000,
+    )
+
+    event_path = Path(second["event_path"])
+    lines = [json.loads(line) for line in event_path.read_text().splitlines() if line.strip()]
+    assert [line["session_id"] for line in lines] == ["session-a", "session-b"]
+
+
+def test_write_compaction_checkpoint_prefers_existing_legacy_book_memory_root(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes" / "profiles" / "generic-core"
+    legacy_memory_root = hermes_home / "workspace" / "pantheon-migrated" / "workspace-generic" / "memory"
+    legacy_memory_root.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    result = write_compaction_checkpoint(
+        session_id="legacy-session",
+        messages=_sample_messages(),
+        preservation_notes="legacy",
+        approx_tokens=120000,
+        context_length=200000,
+        threshold_tokens=185000,
+    )
+
+    assert str(legacy_memory_root) in result["handoff_path"]
+    assert str(legacy_memory_root) in result["event_path"]

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -621,6 +621,19 @@ class TestSummaryTargetRatio:
         # 50% of 200K = 100K, which is above the 64K floor
         assert c.threshold_tokens == 100_000
 
+    def test_explicit_threshold_tokens_override_percentage(self):
+        """An explicit token threshold should take precedence over threshold_percent."""
+        with patch("agent.context_compressor.get_model_context_length", return_value=200_000):
+            c = ContextCompressor(
+                model="test",
+                quiet_mode=True,
+                threshold_percent=0.50,
+                explicit_threshold_tokens=185_000,
+            )
+        assert c.threshold_percent == 0.50
+        assert c.threshold_tokens == 185_000
+        assert c.tail_token_budget == 37_000
+
     def test_default_protect_last_n_is_20(self):
         """Default protect_last_n should be 20."""
         with patch("agent.context_compressor.get_model_context_length", return_value=100_000):

--- a/tests/agent/test_continuation_enforcer.py
+++ b/tests/agent/test_continuation_enforcer.py
@@ -1,0 +1,137 @@
+import agent.continuation_enforcer as continuation_enforcer
+from agent.continuation_enforcer import (
+    claim_retry_requested_continuation,
+    get_continuation_record,
+    get_pending_continuations,
+    reconcile_session_continuation,
+    request_continuation_retry,
+    should_block_delegation,
+)
+from agent.orchestration_state import (
+    record_agent_start,
+    record_delegation_end,
+    record_delegation_start,
+)
+
+
+class TestContinuationEnforcer:
+    def test_reconcile_creates_pending_continuation_for_open_todos(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        record = reconcile_session_continuation(
+            "session-1",
+            outcome_status="interrupted",
+            todos=[
+                {"id": "t1", "content": "Inspect failing logs", "status": "in_progress"},
+                {"id": "t2", "content": "Write final summary", "status": "completed"},
+            ],
+            response_preview="Interrupted while collecting the remaining evidence.",
+        )
+
+        assert record is not None
+        assert record["sessionId"] == "session-1"
+        assert record["status"] == "pending"
+        assert record["reason"] == "interrupted"
+        assert [item["id"] for item in record["openTodos"]] == ["t1"]
+        assert record["attemptCount"] == 1
+
+        queue = get_pending_continuations()
+        assert len(queue) == 1
+        assert queue[0]["sessionId"] == "session-1"
+
+    def test_reconcile_resolves_existing_continuation_after_completion(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        reconcile_session_continuation(
+            "session-2",
+            outcome_status="failed",
+            todos=[{"id": "t1", "content": "Recover partial output", "status": "pending"}],
+            response_preview="Provider call failed before the wrap-up.",
+        )
+
+        resolved = reconcile_session_continuation(
+            "session-2",
+            outcome_status="completed",
+            todos=[{"id": "t1", "content": "Recover partial output", "status": "completed"}],
+            response_preview="Recovered and completed successfully.",
+        )
+
+        assert resolved is None
+        assert get_pending_continuations() == []
+
+    def test_retry_requested_claim_sets_running_lease_and_blocks_second_claim(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        reconcile_session_continuation(
+            "session-retry",
+            outcome_status="interrupted",
+            todos=[{"id": "t1", "content": "Inspect failing logs", "status": "pending"}],
+            response_preview="Need another pass.",
+        )
+
+        requested = request_continuation_retry("session-retry", requested_by="pan")
+        assert requested is not None
+        assert requested["status"] == "retry_requested"
+        assert requested["requestedBy"] == "pan"
+
+        claimed = claim_retry_requested_continuation("gateway-worker-1", lease_seconds=90)
+        assert claimed is not None
+        assert claimed["sessionId"] == "session-retry"
+        assert claimed["status"] == "running"
+        assert claimed["leaseOwner"] == "gateway-worker-1"
+        assert claimed["resumeCount"] == 1
+
+        assert claim_retry_requested_continuation("gateway-worker-2", lease_seconds=90) is None
+
+        persisted = get_continuation_record("session-retry")
+        assert persisted is not None
+        assert persisted["status"] == "running"
+        assert persisted["leaseOwner"] == "gateway-worker-1"
+        assert [event["type"] for event in persisted["events"]][-2:] == ["retry_requested", "auto_resume_claimed"]
+
+    def test_retry_requested_claim_blocks_stale_request(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(continuation_enforcer, "_now_iso", lambda: "2026-04-16T20:00:00Z")
+
+        reconcile_session_continuation(
+            "session-stale",
+            outcome_status="failed",
+            todos=[{"id": "t1", "content": "Recover partial output", "status": "pending"}],
+            response_preview="Worker crashed mid-flight.",
+        )
+        request_continuation_retry("session-stale", requested_by="pan")
+
+        monkeypatch.setattr(continuation_enforcer, "_now_iso", lambda: "2026-04-16T20:05:00Z")
+
+        claimed = claim_retry_requested_continuation(
+            "gateway-worker-1",
+            max_retry_age_seconds=60,
+        )
+
+        assert claimed is None
+        blocked = get_continuation_record("session-stale")
+        assert blocked is not None
+        assert blocked["status"] == "blocked"
+        assert blocked["resolution"] == "retry_request_expired"
+
+    def test_delegation_guard_blocks_after_three_recent_failures_for_same_goal(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        record_agent_start("session-guard", message="Parent task")
+
+        for status in ("failed", "error", "interrupted"):
+            delegation_id = record_delegation_start("session-guard", goal="Inspect auth middleware", task_index=0)
+            record_delegation_end(
+                "session-guard",
+                delegation_id,
+                status=status,
+                summary=f"Attempt ended with {status}.",
+                api_calls=2,
+                duration_seconds=1.5,
+                model="gpt-5.4",
+            )
+
+        guard_reason = should_block_delegation("session-guard", "Inspect auth middleware")
+        assert guard_reason is not None
+        assert "Inspect auth middleware" in guard_reason
+
+        assert should_block_delegation("session-guard", "Different task") is None

--- a/tests/agent/test_orchestration_state.py
+++ b/tests/agent/test_orchestration_state.py
@@ -1,0 +1,76 @@
+from agent.orchestration_state import (
+    get_session_state,
+    record_agent_end,
+    record_agent_start,
+    record_delegation_end,
+    record_delegation_start,
+    record_session_lifecycle,
+)
+
+
+class TestOrchestrationState:
+    def test_agent_start_creates_running_state(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        state = record_agent_start(
+            "session-1",
+            platform="telegram",
+            user_id="user-123",
+            message="Investigate why the task stalled and summarize the fix.",
+        )
+
+        assert state["sessionId"] == "session-1"
+        assert state["status"] == "running"
+        assert state["platform"] == "telegram"
+        assert state["userId"] == "user-123"
+        assert state["messagePreview"].startswith("Investigate why the task stalled")
+        assert state["startedAt"] is not None
+        assert state["updatedAt"] is not None
+
+    def test_delegation_start_and_end_update_same_session_file(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        record_agent_start("session-2", message="Parent task")
+
+        delegation_id = record_delegation_start(
+            "session-2",
+            goal="Search the repo for all auth middleware implementations.",
+            task_index=1,
+            toolsets=["terminal", "file"],
+        )
+        state = get_session_state("session-2")
+        assert state is not None
+        assert len(state["delegations"]) == 1
+        assert state["delegations"][0]["id"] == delegation_id
+        assert state["delegations"][0]["status"] == "running"
+        assert state["delegations"][0]["taskIndex"] == 1
+        assert state["delegations"][0]["toolsets"] == ["terminal", "file"]
+
+        record_delegation_end(
+            "session-2",
+            delegation_id,
+            status="completed",
+            summary="Found three auth middleware entrypoints and one shared helper.",
+            api_calls=4,
+            duration_seconds=12.5,
+            model="gpt-5.4",
+        )
+        updated = get_session_state("session-2")
+        assert updated is not None
+        assert updated["delegations"][0]["status"] == "completed"
+        assert updated["delegations"][0]["summary"].startswith("Found three auth middleware")
+        assert updated["delegations"][0]["apiCalls"] == 4
+        assert updated["delegations"][0]["durationSeconds"] == 12.5
+        assert updated["delegations"][0]["model"] == "gpt-5.4"
+
+    def test_agent_end_and_session_lifecycle_mark_completion(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        record_agent_start("session-3", message="Parent task")
+        record_agent_end("session-3", status="completed", response="Implemented the requested fix and verified it.")
+        record_session_lifecycle("session-3", "ended")
+
+        state = get_session_state("session-3")
+        assert state is not None
+        assert state["status"] == "completed"
+        assert state["responsePreview"] == "Implemented the requested fix and verified it."
+        assert state["sessionLifecycle"] == "ended"
+        assert state["endedAt"] is not None

--- a/tests/agent/test_smart_model_routing.py
+++ b/tests/agent/test_smart_model_routing.py
@@ -1,4 +1,7 @@
-from agent.smart_model_routing import choose_cheap_model_route
+from agent.smart_model_routing import (
+    choose_cheap_model_route,
+    choose_primary_agent_route,
+)
 
 
 _BASE_CONFIG = {
@@ -7,6 +10,14 @@ _BASE_CONFIG = {
         "provider": "openrouter",
         "model": "google/gemini-2.5-flash",
     },
+}
+
+_PRIMARY = {
+    "model": "anthropic/claude-sonnet-4",
+    "provider": "openrouter",
+    "base_url": "https://openrouter.ai/api/v1",
+    "api_mode": "chat_completions",
+    "api_key": "***",
 }
 
 
@@ -38,6 +49,89 @@ def test_skips_tool_heavy_prompt_keywords():
     assert choose_cheap_model_route(prompt, _BASE_CONFIG) is None
 
 
+def test_primary_agent_route_requires_enabled_flag():
+    cfg = {
+        "enabled": False,
+        "primary_agent": {"provider": "anthropic", "model": "claude-sonnet-4.6"},
+    }
+    assert choose_primary_agent_route(cfg) is None
+
+
+def test_resolve_turn_route_uses_configured_primary_agent_when_prompt_is_complex(monkeypatch):
+    from agent.smart_model_routing import resolve_turn_route
+
+    calls = []
+
+    def _runtime_resolve(**kwargs):
+        calls.append(kwargs)
+        assert kwargs["requested"] == "anthropic"
+        return {
+            "provider": "anthropic",
+            "api_mode": "anthropic_messages",
+            "base_url": "https://api.anthropic.com",
+            "api_key": "strong-key",
+            "source": "env/config",
+        }
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve)
+
+    result = resolve_turn_route(
+        "implement a patch for this docker error",
+        {
+            **_BASE_CONFIG,
+            "primary_agent": {
+                "provider": "anthropic",
+                "model": "claude-sonnet-4.6",
+            },
+        },
+        _PRIMARY,
+    )
+
+    assert len(calls) == 1
+    assert result["model"] == "claude-sonnet-4.6"
+    assert result["runtime"]["provider"] == "anthropic"
+    assert result["runtime"]["api_key"] == "strong-key"
+    assert result["label"] == "smart route → primary claude-sonnet-4.6 (anthropic)"
+
+
+def test_resolve_turn_route_falls_back_to_configured_primary_agent_when_cheap_runtime_cannot_be_resolved(monkeypatch):
+    from agent.smart_model_routing import resolve_turn_route
+
+    calls = []
+
+    def _runtime_resolve(**kwargs):
+        calls.append(kwargs["requested"])
+        if kwargs["requested"] == "openrouter":
+            raise RuntimeError("cheap route unavailable")
+        assert kwargs["requested"] == "anthropic"
+        return {
+            "provider": "anthropic",
+            "api_mode": "anthropic_messages",
+            "base_url": "https://api.anthropic.com",
+            "api_key": "strong-key",
+            "source": "env/config",
+        }
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve)
+
+    result = resolve_turn_route(
+        "what time is it in tokyo?",
+        {
+            **_BASE_CONFIG,
+            "primary_agent": {
+                "provider": "anthropic",
+                "model": "claude-sonnet-4.6",
+            },
+        },
+        _PRIMARY,
+    )
+
+    assert calls == ["openrouter", "anthropic"]
+    assert result["model"] == "claude-sonnet-4.6"
+    assert result["runtime"]["provider"] == "anthropic"
+    assert result["label"] == "smart route → primary claude-sonnet-4.6 (anthropic)"
+
+
 def test_resolve_turn_route_falls_back_to_primary_when_route_runtime_cannot_be_resolved(monkeypatch):
     from agent.smart_model_routing import resolve_turn_route
 
@@ -48,13 +142,7 @@ def test_resolve_turn_route_falls_back_to_primary_when_route_runtime_cannot_be_r
     result = resolve_turn_route(
         "what time is it in tokyo?",
         _BASE_CONFIG,
-        {
-            "model": "anthropic/claude-sonnet-4",
-            "provider": "openrouter",
-            "base_url": "https://openrouter.ai/api/v1",
-            "api_mode": "chat_completions",
-            "api_key": "sk-primary",
-        },
+        _PRIMARY,
     )
     assert result["model"] == "anthropic/claude-sonnet-4"
     assert result["runtime"]["provider"] == "openrouter"

--- a/tests/cli/test_cli_model_picker.py
+++ b/tests/cli/test_cli_model_picker.py
@@ -1,0 +1,70 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from cli import HermesCLI
+
+
+class _FakeBuffer:
+    def __init__(self, text="", cursor_position=None):
+        self.text = text
+        self.cursor_position = len(text) if cursor_position is None else cursor_position
+
+    def reset(self, append_to_history=False):
+        self.text = ""
+        self.cursor_position = 0
+
+
+def _make_cli_stub(initial_text="/model"):
+    cli = HermesCLI.__new__(HermesCLI)
+    cli._app = SimpleNamespace(invalidate=MagicMock(), current_buffer=_FakeBuffer(initial_text))
+    cli._invalidate = MagicMock()
+    cli._model_picker_state = None
+    cli._modal_input_snapshot = None
+    cli.model = "glm-5.1"
+    cli.provider = "zai"
+    cli.requested_provider = "zai"
+    cli.api_key = ""
+    cli.base_url = "https://api.z.ai/api/coding/paas/v4"
+    cli.api_mode = "chat_completions"
+    cli.agent = None
+    return cli
+
+
+def test_model_picker_does_not_restore_triggering_slash_command_after_selection():
+    cli = _make_cli_stub("/model")
+    providers = [{
+        "slug": "zai",
+        "name": "Z.AI",
+        "models": ["glm-5.1"],
+        "total_models": 1,
+        "is_current": True,
+    }]
+    switch_result = SimpleNamespace(
+        success=True,
+        new_model="glm-5.1",
+        target_provider="zai",
+        provider_changed=False,
+        api_key="",
+        base_url="https://api.z.ai/api/coding/paas/v4",
+        api_mode="chat_completions",
+        error_message="",
+        warning_message="",
+        provider_label="Z.AI",
+        model_info=None,
+    )
+
+    with patch("cli._cprint"), \
+         patch("hermes_cli.model_switch.list_authenticated_providers", return_value=providers), \
+         patch("hermes_cli.models.provider_model_ids", return_value=[]), \
+         patch("hermes_cli.model_switch.switch_model", return_value=switch_result):
+        cli._handle_model_switch("/model")
+        assert cli._model_picker_state is not None
+        assert cli._modal_input_snapshot is None
+        assert cli._app.current_buffer.text == ""
+
+        cli._handle_model_picker_selection()
+        assert cli._model_picker_state["stage"] == "model"
+
+        cli._handle_model_picker_selection()
+        assert cli._model_picker_state is None
+        assert cli._app.current_buffer.text == ""

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -251,6 +251,41 @@ def test_cli_turn_routing_uses_cheap_model_when_simple(monkeypatch):
     assert result["label"] is not None
 
 
+def test_cli_turn_routing_uses_configured_primary_agent_when_prompt_is_complex(monkeypatch):
+    cli = _import_cli()
+
+    def _runtime_resolve(**kwargs):
+        assert kwargs["requested"] == "anthropic"
+        return {
+            "provider": "anthropic",
+            "api_mode": "anthropic_messages",
+            "base_url": "https://api.anthropic.com",
+            "api_key": "***",
+            "source": "env/config",
+        }
+
+    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", _runtime_resolve)
+
+    shell = cli.HermesCLI(model="gpt-5", compact=True, max_turns=1)
+    shell.provider = "openrouter"
+    shell.api_mode = "chat_completions"
+    shell.base_url = "https://openrouter.ai/api/v1"
+    shell.api_key = "primary-key"
+    shell._smart_model_routing = {
+        "enabled": True,
+        "cheap_model": {"provider": "zai", "model": "glm-5-air"},
+        "primary_agent": {"provider": "anthropic", "model": "claude-sonnet-4.6"},
+        "max_simple_chars": 160,
+        "max_simple_words": 28,
+    }
+
+    result = shell._resolve_turn_agent_config("implement a patch for this docker error")
+
+    assert result["model"] == "claude-sonnet-4.6"
+    assert result["runtime"]["provider"] == "anthropic"
+    assert result["label"] == "smart route → primary claude-sonnet-4.6 (anthropic)"
+
+
 def test_cli_prefers_config_provider_over_stale_env_override(monkeypatch):
     cli = _import_cli()
 

--- a/tests/gateway/test_api_server_authority.py
+++ b/tests/gateway/test_api_server_authority.py
@@ -1,0 +1,184 @@
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.platforms.api_server import APIServerAdapter, cors_middleware, security_headers_middleware
+from gateway.config import PlatformConfig
+from hermes_state import SessionDB
+
+
+def _make_adapter(api_key: str = "") -> APIServerAdapter:
+    extra = {}
+    if api_key:
+        extra["key"] = api_key
+    return APIServerAdapter(PlatformConfig(enabled=True, extra=extra))
+
+
+def _create_app(adapter: APIServerAdapter) -> web.Application:
+    mws = [mw for mw in (cors_middleware, security_headers_middleware) if mw is not None]
+    app = web.Application(middlewares=mws)
+    app["api_server_adapter"] = adapter
+    app.router.add_get("/api/authority/snapshot", adapter._handle_authority_snapshot)
+    return app
+
+
+def _seed_profile(profile_root: Path, *, session_id: str = "session-123") -> None:
+    profile_root.mkdir(parents=True, exist_ok=True)
+    (profile_root / "workspace").mkdir(parents=True, exist_ok=True)
+    (profile_root / "runtime" / "orchestration").mkdir(parents=True, exist_ok=True)
+    (profile_root / "runtime" / "runs").mkdir(parents=True, exist_ok=True)
+
+    config = {
+        "model": {
+            "default": "glm-5.1",
+            "provider": "zai",
+            "base_url": "https://api.z.ai/api/coding/paas/v4",
+        },
+        "agent": {
+            "max_turns": 42,
+            "reasoning_effort": "high",
+            "tool_use_enforcement": "required",
+        },
+        "ui_policy_preset": "full-power",
+        "toolsets": ["terminal", "file"],
+        "terminal": {
+            "backend": "local",
+            "timeout": 180,
+            "cwd": str(profile_root / "workspace"),
+        },
+        "memory": {
+            "memory_enabled": True,
+            "user_profile_enabled": True,
+        },
+        "compression": {
+            "enabled": True,
+            "threshold": 0.5,
+        },
+    }
+    (profile_root / "config.yaml").write_text(yaml.safe_dump(config), encoding="utf-8")
+    (profile_root / "SOUL.md").write_text("You are Hermes.\n", encoding="utf-8")
+
+    db = SessionDB(profile_root / "state.db")
+    db.create_session(
+        session_id,
+        source="webui",
+        model="glm-5.1",
+        model_config={
+            "provider": "zai",
+            "policyPreset": "full-power",
+            "memoryMode": "standard",
+            "loadedSkillIds": ["skill-authoring"],
+            "pinned": True,
+        },
+    )
+    db.append_message(session_id, "user", "Hello gateway authority")
+    db.append_message(session_id, "assistant", "Hi from Hermes authority")
+    db.close()
+
+    runs_payload = {
+        "runs": [
+            {
+                "id": "run-123",
+                "session_id": session_id,
+                "status": "completed",
+                "source": "webui-stream",
+                "started_at": "2026-04-17T00:00:00Z",
+                "updated_at": "2026-04-17T00:00:05Z",
+                "finished_at": "2026-04-17T00:00:05Z",
+                "last_error": None,
+            }
+        ]
+    }
+    (profile_root / "runtime" / "runs" / "index.json").write_text(json.dumps(runs_payload), encoding="utf-8")
+
+    continuations_payload = {
+        "items": [
+            {
+                "sessionId": session_id,
+                "status": "pending",
+                "reason": "needs follow-up",
+                "responsePreview": "Hi from Hermes authority",
+                "openTodos": [{"id": "todo-1", "content": "Finish review", "status": "pending"}],
+                "createdAt": "2026-04-17T00:00:00Z",
+                "updatedAt": "2026-04-17T00:00:05Z",
+                "attemptCount": 1,
+                "events": [{"type": "pending_created", "timestamp": "2026-04-17T00:00:00Z", "message": "Created"}],
+            },
+            {
+                "sessionId": "session-history",
+                "status": "resolved",
+                "reason": "done",
+                "responsePreview": "Completed",
+                "openTodos": [],
+                "createdAt": "2026-04-16T00:00:00Z",
+                "updatedAt": "2026-04-16T00:00:05Z",
+                "attemptCount": 0,
+                "events": [{"type": "resolved", "timestamp": "2026-04-16T00:00:05Z", "message": "Resolved"}],
+            },
+        ]
+    }
+    (profile_root / "runtime" / "orchestration" / "continuations.json").write_text(
+        json.dumps(continuations_payload),
+        encoding="utf-8",
+    )
+
+
+class TestAuthoritySnapshotEndpoint:
+    def test_returns_profile_scoped_authority_snapshot(self, tmp_path, monkeypatch):
+        async def _scenario():
+            monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+            profile_root = tmp_path / "profiles" / "generic-core"
+            _seed_profile(profile_root)
+
+            adapter = _make_adapter()
+            app = _create_app(adapter)
+
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.get("/api/authority/snapshot?profile_id=generic-core&search=gateway&session_id=session-123")
+                assert resp.status == 200
+                payload = await resp.json()
+
+            assert payload["profileId"] == "generic-core"
+            assert payload["config"]["modelDefault"] == "glm-5.1"
+            assert payload["config"]["policyPreset"] == "full-power"
+            assert len(payload["profiles"]) >= 1
+            assert any(profile["id"] == "generic-core" for profile in payload["profiles"])
+            assert len(payload["sessions"]) == 1
+            assert payload["sessions"][0]["id"] == "session-123"
+            assert payload["sessions"][0]["pinned"] is True
+            assert payload["session"]["id"] == "session-123"
+            assert payload["session"]["pinned"] is True
+            assert payload["session"]["messages"][0]["content"] == "Hello gateway authority"
+            assert payload["runs"][0]["id"] == "run-123"
+            assert len(payload["continuations"]) == 1
+            assert len(payload["history"]) == 1
+            assert payload["workspaces"]["current"]["path"] == str(profile_root / "workspace")
+
+        asyncio.run(_scenario())
+
+    def test_requires_auth_when_api_key_is_configured(self, tmp_path, monkeypatch):
+        async def _scenario():
+            monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+            _seed_profile(tmp_path / "profiles" / "generic-core")
+
+            adapter = _make_adapter(api_key="sk-secret")
+            app = _create_app(adapter)
+
+            async with TestClient(TestServer(app)) as cli:
+                denied = await cli.get("/api/authority/snapshot?profile_id=generic-core")
+                assert denied.status == 401
+
+                allowed = await cli.get(
+                    "/api/authority/snapshot?profile_id=generic-core",
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                assert allowed.status == 200
+                payload = await allowed.json()
+                assert payload["profileId"] == "generic-core"
+
+        asyncio.run(_scenario())

--- a/tests/gateway/test_api_server_toolset.py
+++ b/tests/gateway/test_api_server_toolset.py
@@ -35,6 +35,15 @@ class TestHermesApiServerToolset:
         for tool in expected:
             assert tool in tools, f"Missing expected tool: {tool}"
 
+    def test_toolset_includes_code_intel_tools(self):
+        tools = resolve_toolset("hermes-api-server")
+        expected = [
+            "ast_list_defs", "ast_find_nodes",
+            "lsp_document_symbols", "lsp_definition", "lsp_diagnostics",
+        ]
+        for tool in expected:
+            assert tool in tools, f"Missing code_intel tool: {tool}"
+
     def test_toolset_includes_browser_tools(self):
         tools = resolve_toolset("hermes-api-server")
         for tool in ["browser_navigate", "browser_snapshot", "browser_click",

--- a/tests/gateway/test_api_server_toolset.py
+++ b/tests/gateway/test_api_server_toolset.py
@@ -5,7 +5,7 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
-from toolsets import resolve_toolset, get_toolset, validate_toolset
+from toolsets import resolve_toolset, get_toolset, get_toolset_contract, validate_toolset
 
 
 class TestHermesApiServerToolset:
@@ -22,6 +22,7 @@ class TestHermesApiServerToolset:
         tools = resolve_toolset("hermes-api-server")
         assert "web_search" in tools
         assert "web_extract" in tools
+        assert "web_crawl" not in tools
 
     def test_toolset_includes_core_tools(self):
         tools = resolve_toolset("hermes-api-server")
@@ -34,6 +35,39 @@ class TestHermesApiServerToolset:
         ]
         for tool in expected:
             assert tool in tools, f"Missing expected tool: {tool}"
+
+    def test_toolset_includes_repo_code_knowledge_primitives(self):
+        tools = resolve_toolset("hermes-api-server")
+        expected = [
+            "read_file", "search_files",
+            "ast_list_defs", "ast_find_nodes",
+            "lsp_document_symbols", "lsp_definition", "lsp_diagnostics",
+        ]
+        for tool in expected:
+            assert tool in tools, f"Missing repo-code knowledge primitive: {tool}"
+
+    def test_api_server_default_covers_each_canonical_knowledge_surface_as_overlay(self):
+        api_tools = set(resolve_toolset("hermes-api-server"))
+        canonical_names = [
+            "repo-code-knowledge",
+            "web-research-knowledge",
+            "document-pdf-diagram-intelligence",
+        ]
+
+        for name in canonical_names:
+            contract = get_toolset_contract(name)
+            assert contract is not None
+            assert contract["canonical_name"] == name
+            assert contract["is_builtin"] is True
+            assert contract["is_additive"] is False
+            assert contract["is_canonical_knowledge_surface"] is True
+            assert set(contract["tools"]) <= api_tools
+
+    def test_api_server_default_is_not_replaced_by_canonical_surface_names(self):
+        contract = get_toolset_contract("hermes-api-server")
+        assert contract is not None
+        assert contract["canonical_name"] == "hermes-api-server"
+        assert contract["is_canonical_knowledge_surface"] is False
 
     def test_toolset_includes_code_intel_tools(self):
         tools = resolve_toolset("hermes-api-server")

--- a/tests/gateway/test_config_cwd_bridge.py
+++ b/tests/gateway/test_config_cwd_bridge.py
@@ -19,7 +19,10 @@ def _simulate_config_bridge(cfg: dict, initial_env: dict | None = None):
 
     Returns the resulting env dict (only TERMINAL_* and MESSAGING_CWD keys).
     """
+    from hermes_cli.config import _normalize_profile_path_settings
+
     env = dict(initial_env or {})
+    cfg = _normalize_profile_path_settings(cfg)
 
     # --- Replicate lines 54-56: generic top-level bridge (for context) ---
     for key, val in cfg.items():
@@ -182,6 +185,17 @@ class TestNestedTerminalCwdPlaceholderSkip:
         cfg = {"terminal": {"cwd": "/explicit/path"}}
         result = _simulate_config_bridge(cfg, {"TERMINAL_CWD": "/old/value"})
         assert result["TERMINAL_CWD"] == "/explicit/path"
+
+    def test_legacy_in_container_profile_cwd_is_normalized(self, tmp_path, monkeypatch):
+        profile_home = tmp_path / "profiles" / "thindi"
+        workspace = profile_home / "workspace"
+        workspace.mkdir(parents=True)
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+        cfg = {"terminal": {"cwd": "/root/.hermes/profiles/thindi/workspace"}}
+        result = _simulate_config_bridge(cfg)
+
+        assert result["TERMINAL_CWD"] == str(workspace)
 
     def test_terminal_dot_cwd_falls_back_to_messaging_cwd(self):
         """terminal.cwd: '.' with no TERMINAL_CWD should fall to MESSAGING_CWD."""

--- a/tests/gateway/test_orchestration_continuation_gateway.py
+++ b/tests/gateway/test_orchestration_continuation_gateway.py
@@ -1,0 +1,471 @@
+import asyncio
+import importlib
+import sys
+import types
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import agent.continuation_enforcer as continuation_enforcer
+from agent.continuation_enforcer import get_continuation_record, reconcile_session_continuation, request_continuation_retry
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from agent.orchestration_state import get_session_state
+from gateway.session import SessionEntry, SessionSource, build_session_key
+
+
+class _ContinuationAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="***"), Platform.TELEGRAM)
+        self.sent = []
+
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.sent.append(
+            {
+                "chat_id": chat_id,
+                "content": content,
+                "reply_to": reply_to,
+                "metadata": metadata,
+            }
+        )
+        return SendResult(success=True, message_id=f"sent-{len(self.sent)}")
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id, "type": "dm"}
+
+
+class _BaseTodoAgent:
+    outcome_status = "completed"
+    run_result = {"final_response": "done", "messages": [], "api_calls": 1, "completed": True}
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.session_id = kwargs.get("session_id") or "sess-1"
+        self.tools = []
+        self.model = "openai/test-model"
+        self.context_compressor = SimpleNamespace(last_prompt_tokens=0)
+        self.session_prompt_tokens = 0
+        self.session_completion_tokens = 0
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        return dict(self.run_result)
+
+    def get_orchestration_continuation_snapshot(self, result):
+        return {
+            "sessionId": self.session_id,
+            "outcomeStatus": self.outcome_status,
+            "todoItems": [
+                {"id": "plan", "content": "Inspect the failing step", "status": "in_progress"},
+            ],
+            "activeTodos": [
+                {"id": "plan", "content": "Inspect the failing step", "status": "in_progress"},
+            ],
+            "responsePreview": result.get("final_response") or result.get("error"),
+        }
+
+
+class _FailedTodoAgent(_BaseTodoAgent):
+    outcome_status = "failed"
+    run_result = {
+        "final_response": None,
+        "messages": [],
+        "api_calls": 1,
+        "completed": False,
+        "failed": True,
+        "error": "model backend crashed",
+    }
+
+
+class _InterruptedTodoAgent(_BaseTodoAgent):
+    outcome_status = "interrupted"
+    run_result = {
+        "final_response": "Operation interrupted while work remained pending.",
+        "messages": [],
+        "api_calls": 1,
+        "completed": False,
+        "interrupted": True,
+        "interrupt_message": "follow up",
+    }
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text: str = "hello") -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        source=_make_source(),
+        message_id="m1",
+        message_type=MessageType.TEXT,
+    )
+
+
+def _install_fake_agent(monkeypatch, agent_cls):
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = agent_cls
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+
+def _make_run_agent_runner(adapter):
+    gateway_run = importlib.import_module("gateway.run")
+    GatewayRunner = gateway_run.GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {adapter.platform: adapter}
+    runner.delivery_router = SimpleNamespace(adapters=runner.adapters)
+    runner._voice_mode = {}
+    runner._prefill_messages = []
+    runner._ephemeral_system_prompt = ""
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._session_db = None
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_model_overrides = {}
+    runner._draining = False
+    runner._restart_requested = False
+    runner._show_reasoning = False
+    runner._agent_cache = {}
+    runner._agent_cache_lock = None
+    runner._busy_input_mode = "interrupt"
+    runner._background_tasks = set()
+    runner._update_runtime_status = lambda *args, **kwargs: None
+    runner._evict_cached_agent = lambda *args, **kwargs: None
+    runner._is_intentional_model_switch = lambda *args, **kwargs: False
+    runner._capture_gateway_honcho_if_configured = lambda *args, **kwargs: None
+    runner.hooks = SimpleNamespace(loaded_hooks=False)
+    runner.config = SimpleNamespace(
+        thread_sessions_per_user=False,
+        group_sessions_per_user=False,
+        stt_enabled=False,
+    )
+    return runner
+
+
+def _make_handle_message_runner(session_entry: SessionEntry):
+    gateway_run = importlib.import_module("gateway.run")
+    GatewayRunner = gateway_run.GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+    )
+    adapter = _ContinuationAdapter()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner.delivery_router = SimpleNamespace(adapters=runner.adapters)
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = MagicMock()
+    runner._session_db.get_session_title.return_value = None
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._show_reasoning = False
+    runner._draining = False
+    runner._restart_requested = False
+    runner._background_tasks = set()
+    runner._agent_cache = {}
+    runner._agent_cache_lock = None
+    runner._session_model_overrides = {}
+    runner._update_prompt_pending = {}
+    runner._failed_platforms = {}
+    runner._busy_input_mode = "interrupt"
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: []
+    runner._clear_session_env = lambda _tokens: None
+    runner._should_send_voice_reply = lambda *_args, **_kwargs: False
+    runner._send_voice_reply = AsyncMock()
+    runner._capture_gateway_honcho_if_configured = lambda *args, **kwargs: None
+    runner._emit_gateway_run_progress = AsyncMock()
+    runner._prepare_inbound_message_text = AsyncMock(return_value="hello")
+    return runner
+
+
+def _make_auto_resume_runner(session_entry: SessionEntry):
+    runner = _make_handle_message_runner(session_entry)
+    runner.session_store.list_sessions.return_value = [session_entry]
+    runner.session_store.load_transcript.return_value = [
+        {"role": "user", "content": "Please investigate the failing step."},
+        {"role": "assistant", "content": "I was interrupted before finishing."},
+    ]
+    runner._run_agent = AsyncMock()
+    runner._build_auto_resume_message = lambda item: f"Resume work on: {item['openTodos'][0]['content']}"
+    runner._prepare_inbound_message_text = AsyncMock(
+        side_effect=lambda *args, **kwargs: (kwargs.get("event") or args[0]).text
+    )
+    return runner
+
+
+async def _run_real_gateway_agent(monkeypatch, tmp_path, agent_cls, *, pending_event=None, interrupt_depth=0):
+    _install_fake_agent(monkeypatch, agent_cls)
+
+    adapter = _ContinuationAdapter()
+    runner = _make_run_agent_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    source = _make_source()
+    session_key = build_session_key(source)
+    if pending_event is not None:
+        adapter._pending_messages[session_key] = pending_event
+
+    return await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-1",
+        session_key=session_key,
+        _interrupt_depth=interrupt_depth,
+    )
+
+
+def test_run_agent_failed_result_keeps_orchestration_snapshot(monkeypatch, tmp_path):
+    result = asyncio.run(_run_real_gateway_agent(monkeypatch, tmp_path, _FailedTodoAgent))
+
+    assert result["orchestration"]["outcomeStatus"] == "failed"
+    assert result["orchestration"]["activeTodos"] == [
+        {"id": "plan", "content": "Inspect the failing step", "status": "in_progress"},
+    ]
+    assert result["orchestration"]["responsePreview"] == "model backend crashed"
+
+
+def test_run_agent_depth_capped_interrupt_still_returns_orchestration_snapshot(monkeypatch, tmp_path):
+    pending_event = MessageEvent(
+        text="follow up",
+        source=_make_source(),
+        message_id="q1",
+        message_type=MessageType.TEXT,
+    )
+
+    result = asyncio.run(
+        _run_real_gateway_agent(
+            monkeypatch,
+            tmp_path,
+            _InterruptedTodoAgent,
+            pending_event=pending_event,
+            interrupt_depth=importlib.import_module("gateway.run").GatewayRunner._MAX_INTERRUPT_DEPTH,
+        )
+    )
+
+    assert result["orchestration"]["outcomeStatus"] == "interrupted"
+    assert result["orchestration"]["activeTodos"] == [
+        {"id": "plan", "content": "Inspect the failing step", "status": "in_progress"},
+    ]
+
+
+def test_handle_message_reconciles_failed_status_and_agent_end_hook(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    result = asyncio.run(_run_real_gateway_agent(monkeypatch, tmp_path, _FailedTodoAgent))
+
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_handle_message_runner(session_entry)
+    runner._run_agent = AsyncMock(return_value=result)
+
+    response = asyncio.run(runner._handle_message(_make_event()))
+
+    assert response == "⚠️ model backend crashed"
+    end_call = runner.hooks.emit.await_args_list[-1]
+    assert end_call.args[0] == "agent:end"
+    assert end_call.args[1]["status"] == "failed"
+
+    from agent.continuation_enforcer import get_pending_continuations
+
+    queue = get_pending_continuations()
+    assert len(queue) == 1
+    assert queue[0]["sessionId"] == "sess-1"
+    assert queue[0]["reason"] == "failed"
+
+
+def test_handle_message_reconciles_interrupted_status_and_agent_end_hook(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    pending_event = MessageEvent(
+        text="follow up",
+        source=_make_source(),
+        message_id="q1",
+        message_type=MessageType.TEXT,
+    )
+    result = asyncio.run(
+        _run_real_gateway_agent(
+            monkeypatch,
+            tmp_path,
+            _InterruptedTodoAgent,
+            pending_event=pending_event,
+            interrupt_depth=importlib.import_module("gateway.run").GatewayRunner._MAX_INTERRUPT_DEPTH,
+        )
+    )
+
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_handle_message_runner(session_entry)
+    runner._run_agent = AsyncMock(return_value=result)
+
+    response = asyncio.run(runner._handle_message(_make_event()))
+
+    assert response == "Operation interrupted while work remained pending."
+    end_call = runner.hooks.emit.await_args_list[-1]
+    assert end_call.args[0] == "agent:end"
+    assert end_call.args[1]["status"] == "interrupted"
+
+    from agent.continuation_enforcer import get_pending_continuations
+
+    queue = get_pending_continuations()
+    assert len(queue) == 1
+    assert queue[0]["sessionId"] == "sess-1"
+    assert queue[0]["reason"] == "interrupted"
+
+
+def test_retry_requested_auto_resume_runs_agent_and_resolves_queue(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    source = _make_source()
+    session_entry = SessionEntry(
+        session_key=build_session_key(source),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_auto_resume_runner(session_entry)
+    runner._run_agent.return_value = {
+        "final_response": "Auto-resume complete",
+        "messages": [],
+        "api_calls": 1,
+        "orchestration": {
+            "sessionId": "sess-1",
+            "outcomeStatus": "completed",
+            "activeTodos": [],
+            "responsePreview": "Auto-resume complete",
+        },
+    }
+
+    reconcile_session_continuation(
+        "sess-1",
+        outcome_status="interrupted",
+        todos=[{"id": "plan", "content": "Inspect the failing step", "status": "in_progress"}],
+        response_preview="Need another pass.",
+    )
+    request_continuation_retry("sess-1", requested_by="pan")
+
+    processed = asyncio.run(runner._process_retry_requested_continuations_once())
+
+    assert processed == 1
+    runner._run_agent.assert_awaited_once()
+    run_call = runner._run_agent.await_args
+    assert run_call.kwargs["message"] == "Resume work on: Inspect the failing step"
+    assert run_call.kwargs["session_id"] == "sess-1"
+    assert run_call.kwargs["session_key"] == session_entry.session_key
+    assert runner.adapters[Platform.TELEGRAM].sent[-1]["content"] == "Auto-resume complete"
+
+    record = get_continuation_record("sess-1")
+    assert record is not None
+    assert record["status"] == "resolved"
+    assert record["resolution"] == "completed"
+    assert record["events"][-1]["type"] == "auto_resume_delivered"
+    assert 'Auto-resume complete' in record["events"][-1]["message"]
+
+
+def test_retry_requested_auto_resume_skips_busy_session_without_double_execution(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    source = _make_source()
+    session_entry = SessionEntry(
+        session_key=build_session_key(source),
+        session_id="sess-busy",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=source,
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_auto_resume_runner(session_entry)
+    runner._running_agents[session_entry.session_key] = object()
+
+    reconcile_session_continuation(
+        "sess-busy",
+        outcome_status="failed",
+        todos=[{"id": "plan", "content": "Retry the failed step", "status": "pending"}],
+        response_preview="Need another pass.",
+    )
+    request_continuation_retry("sess-busy", requested_by="pan")
+
+    processed = asyncio.run(runner._process_retry_requested_continuations_once())
+
+    assert processed == 0
+    runner._run_agent.assert_not_awaited()
+    record = get_continuation_record("sess-busy")
+    assert record is not None
+    assert record["status"] == "retry_requested"
+    assert record["events"][-1]["type"] == 'retry_released'
+    assert record["events"][-1]["message"] == 'session_busy'
+
+
+def test_builtin_agent_end_hook_records_interrupted_status(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from gateway.builtin_hooks.orchestration_state import handle
+
+    asyncio.run(
+        handle(
+            "agent:end",
+            {
+                "session_id": "sess-1",
+                "status": "interrupted",
+                "response": "Paused with work still pending.",
+            },
+        )
+    )
+
+    state = get_session_state("sess-1")
+    assert state is not None
+    assert state["status"] == "interrupted"
+    assert state["responsePreview"] == "Paused with work still pending."

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -172,3 +172,17 @@ class TestConfigIssueDataclass:
         a = ConfigIssue("error", "msg", "hint")
         b = ConfigIssue("error", "msg", "hint")
         assert a == b
+
+
+class TestDelegationCategoryValidation:
+    def test_delegation_categories_must_be_dict(self):
+        issues = validate_config_structure({
+            "delegation": {"categories": ["research"]},
+        })
+        assert any("delegation.categories should be a dict" in i.message for i in issues)
+
+    def test_delegation_category_entries_warn_when_not_dict(self):
+        issues = validate_config_structure({
+            "delegation": {"categories": {"research": "read-only"}},
+        })
+        assert any("delegation.categories.research should be a dict" in i.message for i in issues)

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -48,6 +48,9 @@ def _make_args(**kwargs):
         "auth": None,
         "preset": None,
         "env": None,
+        "catalog_name": None,
+        "as_name": None,
+        "yes": False,
         "mcp_action": None,
     }
     defaults.update(kwargs)
@@ -409,6 +412,139 @@ class TestMcpAdd:
         cmd_mcp_add(_make_args(name="foo", preset="nonexistent"))
         out = capsys.readouterr().out
         assert "Unknown MCP preset" in out
+
+    def test_add_preset_merges_preset_env_with_cli_env(self, tmp_path, capsys, monkeypatch):
+        """Preset-provided env placeholders are preserved and merged with --env."""
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._MCP_PRESETS",
+            {
+                "github": {
+                    "command": "npx",
+                    "args": ["-y", "test-mcp-server"],
+                    "env": {"TOKEN": "${TOKEN}"},
+                    "display_name": "GitHub",
+                }
+            },
+        )
+        fake_tools = [FakeTool("search", "Search repos")]
+
+        def mock_probe(name, config, **kw):
+            assert config["command"] == "npx"
+            assert config["args"] == ["-y", "test-mcp-server"]
+            assert config["env"] == {"TOKEN": "${TOKEN}", "DEBUG": "true"}
+            return [(t.name, t.description) for t in fake_tools]
+
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._probe_single_server", mock_probe
+        )
+        monkeypatch.setattr("builtins.input", lambda _: "")
+
+        from hermes_cli.mcp_config import cmd_mcp_add
+        from hermes_cli.config import read_raw_config
+
+        cmd_mcp_add(_make_args(
+            name="github-local",
+            preset="github",
+            env=["DEBUG=true"],
+        ))
+        out = capsys.readouterr().out
+        assert "Required environment variables: TOKEN" in out
+
+        config = read_raw_config()
+        srv = config["mcp_servers"]["github-local"]
+        assert srv["env"] == {"TOKEN": "${TOKEN}", "DEBUG": "true"}
+
+
+class TestMcpCatalogInstall:
+    def test_catalog_lists_builtin_presets_and_bundles(self, capsys):
+        from hermes_cli.mcp_config import cmd_mcp_catalog
+
+        cmd_mcp_catalog()
+        out = capsys.readouterr().out
+        assert "Built-in MCP Presets" in out
+        assert "github" in out
+        assert "developer" in out
+        assert "Install one with: hermes mcp install" in out
+
+    def test_install_single_preset_with_alias(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._MCP_PRESETS",
+            {
+                "fetch": {
+                    "command": "npx",
+                    "args": ["-y", "test-fetch"],
+                    "display_name": "Fetch",
+                }
+            },
+        )
+
+        from hermes_cli.mcp_config import cmd_mcp_install
+        from hermes_cli.config import read_raw_config
+
+        cmd_mcp_install(_make_args(catalog_name="fetch", as_name="web", yes=True))
+        out = capsys.readouterr().out
+        assert "Installed MCP preset 'fetch'" in out
+
+        config = read_raw_config()
+        assert config["mcp_servers"]["web"] == {
+            "command": "npx",
+            "args": ["-y", "test-fetch"],
+            "enabled": True,
+        }
+
+    def test_install_bundle_expands_to_plain_mcp_servers(self, tmp_path, capsys, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._MCP_PRESETS",
+            {
+                "github": {
+                    "command": "npx",
+                    "args": ["-y", "test-github"],
+                    "env": {"TOKEN": "${TOKEN}"},
+                    "display_name": "GitHub",
+                },
+                "fetch": {
+                    "command": "npx",
+                    "args": ["-y", "test-fetch"],
+                    "display_name": "Fetch",
+                },
+            },
+        )
+        monkeypatch.setattr(
+            "hermes_cli.mcp_config._MCP_BUNDLES",
+            {
+                "starter": {
+                    "display_name": "Starter",
+                    "description": "Starter bundle",
+                    "servers": [
+                        {"name": "github", "preset": "github"},
+                        {"name": "fetch", "preset": "fetch"},
+                    ],
+                }
+            },
+        )
+
+        from hermes_cli.mcp_config import cmd_mcp_install
+        from hermes_cli.config import read_raw_config
+
+        cmd_mcp_install(_make_args(catalog_name="starter", yes=True))
+        out = capsys.readouterr().out
+        assert "Installed MCP bundle 'starter'" in out
+        assert "expanded into normal mcp_servers config entries" in out
+
+        config = read_raw_config()
+        assert config["mcp_servers"] == {
+            "github": {
+                "command": "npx",
+                "args": ["-y", "test-github"],
+                "env": {"TOKEN": "${TOKEN}"},
+                "enabled": True,
+            },
+            "fetch": {
+                "command": "npx",
+                "args": ["-y", "test-fetch"],
+                "enabled": True,
+            },
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_openagent_config_scaffolding.py
+++ b/tests/hermes_cli/test_openagent_config_scaffolding.py
@@ -1,0 +1,161 @@
+"""Focused tests for OpenAgent-style config bucket scaffolding."""
+
+import os
+from unittest.mock import patch
+
+import yaml
+
+from hermes_cli.config import (
+    _normalize_model_capabilities_config,
+    _normalize_openagent_config_buckets,
+    _normalize_openagent_named_bucket,
+    _normalize_runtime_fallback_config,
+    load_config,
+    save_config,
+    validate_config_structure,
+)
+
+
+class TestOpenAgentBucketHelpers:
+    def test_named_bucket_normalizes_string_shorthand(self):
+        normalized = _normalize_openagent_named_bucket({
+            "oracle": "openai/gpt-5.4",
+            "explore": {"model": "anthropic/claude-sonnet-4", "temperature": 0.2},
+            "ignored": 7,
+            "": {"model": "should-not-survive"},
+        })
+
+        assert normalized == {
+            "oracle": {"model": "openai/gpt-5.4"},
+            "explore": {"model": "anthropic/claude-sonnet-4", "temperature": 0.2},
+        }
+
+    def test_runtime_fallback_boolean_normalizes_to_enabled_dict(self):
+        assert _normalize_runtime_fallback_config(True) == {"enabled": True}
+        assert _normalize_runtime_fallback_config(False) == {"enabled": False}
+
+    def test_model_capabilities_invalid_shape_resets_to_empty_mapping(self):
+        assert _normalize_model_capabilities_config(["not", "a", "dict"]) == {}
+
+    def test_openagent_bucket_normalizer_adds_default_scaffolds(self):
+        normalized = _normalize_openagent_config_buckets({})
+
+        assert normalized["agents"] == {}
+        assert normalized["categories"] == {}
+        assert normalized["runtime_fallback"] == {"enabled": False}
+        assert normalized["model_capabilities"] == {}
+
+
+class TestLoadConfigOpenAgentBuckets:
+    def test_defaults_include_openagent_scaffolding(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config = load_config()
+
+        assert config["agents"] == {}
+        assert config["categories"] == {}
+        assert config["runtime_fallback"] == {"enabled": False}
+        assert config["model_capabilities"] == {}
+
+    def test_load_config_normalizes_openagent_bucket_shapes(self, tmp_path):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            "\n".join([
+                "agents:",
+                "  oracle: openai/gpt-5.4",
+                "  explore:",
+                "    model: anthropic/claude-sonnet-4",
+                "    temperature: 0.2",
+                "categories:",
+                "  research: anthropic/claude-haiku-4-5",
+                "runtime_fallback: true",
+                "model_capabilities:",
+                "  enabled: true",
+                "  source_url: https://example.invalid/models.json",
+                "",
+            ]),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config = load_config()
+
+        assert config["agents"]["oracle"] == {"model": "openai/gpt-5.4"}
+        assert config["agents"]["explore"] == {
+            "model": "anthropic/claude-sonnet-4",
+            "temperature": 0.2,
+        }
+        assert config["categories"]["research"] == {"model": "anthropic/claude-haiku-4-5"}
+        assert config["runtime_fallback"] == {"enabled": True}
+        assert config["model_capabilities"] == {
+            "enabled": True,
+            "source_url": "https://example.invalid/models.json",
+        }
+
+    def test_invalid_openagent_bucket_types_fall_back_without_breaking_existing_config(self, tmp_path):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            "\n".join([
+                "model: openai/gpt-5.4",
+                "max_turns: 42",
+                "agents:",
+                "  - oracle",
+                "categories: true",
+                "runtime_fallback:",
+                "  - 429",
+                "model_capabilities: disabled",
+                "",
+            ]),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config = load_config()
+
+        assert config["model"] == "openai/gpt-5.4"
+        assert config["agent"]["max_turns"] == 42
+        assert config["agents"] == {}
+        assert config["categories"] == {}
+        assert config["runtime_fallback"] == {"enabled": False}
+        assert config["model_capabilities"] == {}
+
+
+class TestSaveConfigOpenAgentBuckets:
+    def test_save_config_persists_normalized_openagent_buckets(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            save_config({
+                "agents": {"oracle": "openai/gpt-5.4"},
+                "runtime_fallback": True,
+                "model_capabilities": {"enabled": True},
+            })
+
+        saved = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
+        assert saved["agents"] == {"oracle": {"model": "openai/gpt-5.4"}}
+        assert saved["runtime_fallback"] == {"enabled": True}
+        assert saved["model_capabilities"] == {"enabled": True}
+        assert "categories" not in saved
+
+
+class TestValidateConfigStructureOpenAgentBuckets:
+    def test_warns_for_invalid_openagent_bucket_shapes(self):
+        issues = validate_config_structure({
+            "agents": ["oracle"],
+            "categories": True,
+            "runtime_fallback": [429],
+            "model_capabilities": "enabled",
+        })
+        messages = [issue.message for issue in issues]
+
+        assert any("agents should be a mapping" in message for message in messages)
+        assert any("categories should be a mapping" in message for message in messages)
+        assert any("runtime_fallback should be either a boolean or a config dict" in message for message in messages)
+        assert any("model_capabilities should be a config dict" in message for message in messages)
+
+    def test_accepts_runtime_fallback_boolean_without_warnings(self):
+        issues = validate_config_structure({
+            "agents": {"oracle": {"model": "openai/gpt-5.4"}},
+            "categories": {"reasoning": {"model": "anthropic/claude-sonnet-4"}},
+            "runtime_fallback": True,
+            "model_capabilities": {"enabled": True},
+        })
+
+        assert not any("runtime_fallback" in issue.message for issue in issues)

--- a/tests/hermes_cli/test_projects.py
+++ b/tests/hermes_cli/test_projects.py
@@ -1,0 +1,190 @@
+import sys
+from argparse import Namespace
+
+import pytest
+
+
+@pytest.fixture()
+def project_env(tmp_path, monkeypatch):
+    hermes_home = tmp_path / '.hermes'
+    hermes_home.mkdir()
+    monkeypatch.setenv('HERMES_HOME', str(hermes_home))
+    return hermes_home
+
+
+def test_project_list_empty(project_env, capsys):
+    from hermes_cli.projects import project_command
+
+    rc = project_command(Namespace(project_action='list', project_id=None, name=None, summary=None, repo_path=None))
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert 'No projects found' in out
+
+
+def test_project_init_creates_project_cell(project_env):
+    from hermes_cli.projects import project_command
+
+    rc = project_command(
+        Namespace(
+            project_action='init',
+            project_id='alpha',
+            name='Alpha',
+            summary='Alpha project summary',
+            repo_path=None,
+        )
+    )
+
+    assert rc == 0
+    project_dir = project_env / 'project-os-v1' / 'projects' / 'alpha'
+    assert (project_dir / 'project.yaml').exists()
+    assert (project_dir / 'brief.md').exists()
+    assert (project_dir / 'reports' / '00-executive-summary.md').exists()
+    assert (project_dir / 'tasks' / 'next-actions.md').exists()
+    assert (project_dir / 'approvals.jsonl').exists()
+    assert (project_dir / 'pairing' / 'status.json').exists()
+    assert (project_env / 'project-os-v1' / 'projects' / 'registry.json').exists()
+    project_yaml = (project_dir / 'project.yaml').read_text()
+    assert 'workspace_contracts:' in project_yaml
+    assert 'approvals_file: approvals.jsonl' in project_yaml
+    assert 'sync_dir: sync' in project_yaml
+    assert 'pairing_dir: pairing' in project_yaml
+    assert str(project_env / 'project-os-v1' / 'config' / 'path-policies.yaml') in project_yaml
+    assert str(project_env / 'project-os-v1' / 'config' / 'modules.yaml') in project_yaml
+    assert str(project_env / 'project-os-v1' / 'config' / 'modules.lock.yaml') in project_yaml
+
+
+def test_project_show_displays_metadata(project_env, capsys):
+    from hermes_cli.projects import project_command
+
+    project_command(
+        Namespace(
+            project_action='init',
+            project_id='alpha',
+            name='Alpha',
+            summary='Alpha project summary',
+            repo_path=None,
+        )
+    )
+    capsys.readouterr()
+
+    rc = project_command(
+        Namespace(
+            project_action='show',
+            project_id='alpha',
+            name=None,
+            summary=None,
+            repo_path=None,
+        )
+    )
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert 'Project: alpha' in out
+    assert 'Name:          Alpha' in out
+    assert 'Summary:       Alpha project summary' in out
+    assert 'Status digest:' in out
+    assert 'not generated yet' in out
+    assert str(project_env / 'project-os-v1' / 'projects' / 'alpha') in out
+
+
+def test_project_digest_generates_digest(project_env, capsys):
+    from hermes_cli.projects import project_command
+
+    project_command(
+        Namespace(
+            project_action='init',
+            project_id='alpha',
+            name='Alpha',
+            summary='Alpha project summary',
+            repo_path=None,
+        )
+    )
+    capsys.readouterr()
+
+    rc = project_command(
+        Namespace(
+            project_action='digest',
+            project_id='alpha',
+            name=None,
+            summary=None,
+            repo_path=None,
+        )
+    )
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    digest_path = project_env / 'project-os-v1' / 'projects' / 'alpha' / 'reports' / '01-status-digest.md'
+    assert digest_path.exists()
+    assert 'Recommended next actions' in digest_path.read_text()
+    assert f'Updated status digest: {digest_path}' in out
+
+
+def test_project_status_alias_generates_digest(project_env, capsys):
+    from hermes_cli.projects import project_command
+
+    project_command(
+        Namespace(
+            project_action='init',
+            project_id='alpha',
+            name='Alpha',
+            summary='Alpha project summary',
+            repo_path=None,
+        )
+    )
+    capsys.readouterr()
+
+    rc = project_command(
+        Namespace(
+            project_action='status',
+            project_id='alpha',
+            name=None,
+            summary=None,
+            repo_path=None,
+        )
+    )
+
+    assert rc == 0
+
+
+def test_project_main_parser_dispatches_list(monkeypatch):
+    import hermes_cli.main as main_mod
+
+    captured = {}
+
+    def fake_cmd_project(args):
+        captured['action'] = args.project_action
+        captured['command'] = args.command
+
+    monkeypatch.setattr(main_mod, 'cmd_project', fake_cmd_project, raising=False)
+    monkeypatch.setattr(sys, 'argv', ['hermes', 'project', 'list'])
+
+    main_mod.main()
+
+    assert captured == {'action': 'list', 'command': 'project'}
+
+
+@pytest.mark.parametrize(
+    ('argv', 'expected'),
+    [
+        (['hermes', 'project', 'show', 'alpha'], {'action': 'show', 'command': 'project', 'project_id': 'alpha'}),
+        (['hermes', 'project', 'digest', 'alpha'], {'action': 'digest', 'command': 'project', 'project_id': 'alpha'}),
+        (['hermes', 'project', 'status', 'alpha'], {'action': 'status', 'command': 'project', 'project_id': 'alpha'}),
+    ],
+)
+def test_project_main_parser_dispatches_project_actions(monkeypatch, argv, expected):
+    import hermes_cli.main as main_mod
+
+    captured = {}
+
+    def fake_cmd_project(args):
+        captured['action'] = args.project_action
+        captured['command'] = args.command
+        captured['project_id'] = getattr(args, 'project_id', None)
+
+    monkeypatch.setattr(main_mod, 'cmd_project', fake_cmd_project, raising=False)
+    monkeypatch.setattr(sys, 'argv', argv)
+
+    main_mod.main()
+
+    assert captured == expected

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -26,10 +26,33 @@ def test_get_platform_tools_uses_default_when_platform_not_configured():
 def test_configurable_toolsets_include_messaging():
     assert any(ts_key == "messaging" for ts_key, _, _ in CONFIGURABLE_TOOLSETS)
 
+
+def test_configurable_toolsets_include_code_intel():
+    assert any(ts_key == "code_intel" for ts_key, _, _ in CONFIGURABLE_TOOLSETS)
+
+
 def test_get_platform_tools_default_telegram_includes_messaging():
     enabled = _get_platform_tools({}, "telegram")
 
     assert "messaging" in enabled
+
+
+def test_get_platform_tools_default_cli_includes_code_intel():
+    enabled = _get_platform_tools({}, "cli")
+
+    assert "code_intel" in enabled
+
+
+def test_get_platform_tools_default_telegram_excludes_code_intel():
+    enabled = _get_platform_tools({}, "telegram")
+
+    assert "code_intel" not in enabled
+
+
+def test_get_platform_tools_default_api_server_includes_code_intel():
+    enabled = _get_platform_tools({}, "api_server")
+
+    assert "code_intel" in enabled
 
 
 def test_get_platform_tools_preserves_explicit_empty_selection():

--- a/tests/hermes_cli/test_tools_disable_enable.py
+++ b/tests/hermes_cli/test_tools_disable_enable.py
@@ -51,6 +51,14 @@ class TestToolsEnableBuiltin:
         saved = mock_save.call_args[0][0]
         assert "web" in saved["platform_toolsets"]["cli"]
 
+    def test_enable_adds_code_intel_to_platform(self):
+        config = {"platform_toolsets": {"cli": ["memory"]}}
+        with patch("hermes_cli.tools_config.load_config", return_value=config), \
+             patch("hermes_cli.tools_config.save_config") as mock_save:
+            tools_disable_enable_command(Namespace(tools_action="enable", names=["code_intel"], platform="cli"))
+        saved = mock_save.call_args[0][0]
+        assert "code_intel" in saved["platform_toolsets"]["cli"]
+
     def test_enable_already_present_is_idempotent(self):
         config = {"platform_toolsets": {"cli": ["web"]}}
         with patch("hermes_cli.tools_config.load_config", return_value=config), \

--- a/tests/plugins/memory/test_rasputin_provider.py
+++ b/tests/plugins/memory/test_rasputin_provider.py
@@ -1,0 +1,131 @@
+import json
+
+from plugins.memory import discover_memory_providers, load_memory_provider
+from plugins.memory.rasputin import RasputinMemoryProvider
+from plugins.memory.rasputin.client import (
+    RasputinClient,
+    RasputinClientConfig,
+    _MAX_COMMIT_TEXT_CHARS,
+)
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def read(self):
+        return json.dumps(self._payload).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_provider_loading_and_discovery_manifest():
+    provider = load_memory_provider("rasputin")
+
+    assert provider is not None
+    assert provider.name == "rasputin"
+    assert provider.is_available() is True
+
+    providers = {name: (description, available) for name, description, available in discover_memory_providers()}
+    assert "rasputin" in providers
+    description, available = providers["rasputin"]
+    assert "derived-memory sidecar" in description
+    assert available is True
+
+
+def test_search_uses_post_body(monkeypatch):
+    captured = {}
+
+    def fake_urlopen(req, timeout=0):
+        captured["url"] = req.full_url
+        captured["method"] = req.get_method()
+        captured["headers"] = dict(req.header_items())
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+        captured["timeout"] = timeout
+        return _FakeResponse({"results": [{"id": "r1", "text": "match"}]})
+
+    monkeypatch.setattr("plugins.memory.rasputin.client.request.urlopen", fake_urlopen)
+
+    client = RasputinClient(RasputinClientConfig(base_url="http://127.0.0.1:7777"))
+    results = client.search("x" * 12000, limit=3)
+
+    assert results == [{"id": "r1", "text": "match"}]
+    assert captured["url"] == "http://127.0.0.1:7777/search"
+    assert captured["method"] == "POST"
+    assert captured["body"] == {"query": "x" * 12000, "limit": 3}
+    assert captured["headers"]["Content-type"] == "application/json"
+
+
+def test_prepare_commit_payload_truncates_oversized_text():
+    original = "x" * (_MAX_COMMIT_TEXT_CHARS + 250)
+
+    prepared = RasputinClient._prepare_commit_payload(
+        {
+            "text": original,
+            "source": "hermes-turn",
+            "metadata": {"kind": "conversation_window"},
+        }
+    )
+
+    assert len(prepared["text"]) == _MAX_COMMIT_TEXT_CHARS
+    assert prepared["text"] == original[:_MAX_COMMIT_TEXT_CHARS]
+    assert prepared["metadata"]["kind"] == "conversation_window"
+    assert prepared["metadata"]["rasputin_truncated"] is True
+    assert prepared["metadata"]["rasputin_original_text_length"] == len(original)
+
+
+def test_commit_sends_truncated_payload(monkeypatch):
+    captured = {}
+
+    def fake_urlopen(req, timeout=0):
+        captured["url"] = req.full_url
+        captured["method"] = req.get_method()
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+        captured["timeout"] = timeout
+        return _FakeResponse({"ok": True})
+
+    monkeypatch.setattr("plugins.memory.rasputin.client.request.urlopen", fake_urlopen)
+
+    client = RasputinClient(RasputinClientConfig(base_url="http://127.0.0.1:7777"))
+    ok = client.commit({"text": "y" * (_MAX_COMMIT_TEXT_CHARS + 10), "source": "hermes-turn"})
+
+    assert ok is True
+    assert captured["url"] == "http://127.0.0.1:7777/commit"
+    assert captured["method"] == "POST"
+    assert len(captured["body"]["text"]) == _MAX_COMMIT_TEXT_CHARS
+    assert captured["body"]["metadata"]["rasputin_truncated"] is True
+
+
+def test_provider_on_pre_compress_returns_notes_and_mirrors_checkpoint():
+    provider = RasputinMemoryProvider()
+    provider._client = object()
+    provider._session_id = "session-abc"
+    provider._platform = "cli"
+    provider._agent_context = "primary"
+    provider._user_id = "user-1"
+
+    captured = {}
+
+    def _capture(payload, *, label):
+        captured["payload"] = payload
+        captured["label"] = label
+
+    provider._commit_best_effort = _capture
+
+    notes = provider.on_pre_compress(
+        [
+            {"role": "user", "content": "Please preserve the exact backlink gap and port 8642 issue."},
+            {"role": "assistant", "content": "I am preparing the final architecture recommendation now."},
+        ]
+    )
+
+    assert "backlink gap" in notes
+    assert "8642" in notes
+    assert captured["label"] == "compaction-checkpoint"
+    assert captured["payload"]["source"] == "hermes-compaction-checkpoint"
+    assert captured["payload"]["metadata"]["kind"] == "compaction_checkpoint"
+    assert captured["payload"]["metadata"]["session_id"] == "session-abc"

--- a/tests/run_agent/test_compression_threshold_override.py
+++ b/tests/run_agent/test_compression_threshold_override.py
@@ -1,0 +1,41 @@
+from unittest.mock import patch
+
+
+def test_aiagent_uses_explicit_compression_threshold_tokens_from_config():
+    cfg = {
+        "model": {
+            "default": "gpt5.4",
+            "provider": "custom",
+            "base_url": "http://localhost:4000/v1",
+            "context_length": 200000,
+        },
+        "compression": {
+            "enabled": True,
+            "threshold": 0.50,
+            "threshold_tokens": 185000,
+            "target_ratio": 0.20,
+            "protect_last_n": 20,
+        },
+        "agent": {},
+    }
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("agent.context_compressor.get_model_context_length", return_value=200_000),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            model="gpt5.4",
+            api_key="test-key-1234567890",
+            base_url="http://localhost:4000/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent.context_compressor.threshold_tokens == 185_000
+    assert agent.context_compressor.tail_token_budget == 37_000

--- a/tests/run_agent/test_orchestration_continuation.py
+++ b/tests/run_agent/test_orchestration_continuation.py
@@ -1,0 +1,79 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+
+
+def _make_tool_defs(*names: str) -> list:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+@pytest.fixture()
+def agent():
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("todo", "web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        instance = AIAgent(
+            api_key="test-key-1234567890",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        instance.client = MagicMock()
+        return instance
+
+
+class TestOrchestrationContinuationSnapshot:
+    def test_snapshot_reports_active_todos_for_incomplete_run(self, agent):
+        agent._todo_store.write(
+            [
+                {"id": "plan", "content": "Inspect runtime logs", "status": "in_progress"},
+                {"id": "done", "content": "Document old issue", "status": "completed"},
+            ]
+        )
+
+        snapshot = agent.get_orchestration_continuation_snapshot(
+            {
+                "completed": False,
+                "interrupted": True,
+                "failed": False,
+                "final_response": "Interrupted during the final tool call.",
+            }
+        )
+
+        assert snapshot["outcomeStatus"] == "interrupted"
+        assert [item["id"] for item in snapshot["activeTodos"]] == ["plan"]
+        assert snapshot["responsePreview"] == "Interrupted during the final tool call."
+
+    def test_snapshot_marks_completed_when_no_open_todos_remain(self, agent):
+        agent._todo_store.write(
+            [
+                {"id": "plan", "content": "Inspect runtime logs", "status": "completed"},
+            ]
+        )
+
+        snapshot = agent.get_orchestration_continuation_snapshot(
+            {
+                "completed": True,
+                "interrupted": False,
+                "failed": False,
+                "final_response": "All requested work is complete.",
+            }
+        )
+
+        assert snapshot["outcomeStatus"] == "completed"
+        assert snapshot["activeTodos"] == []
+        assert snapshot["responsePreview"] == "All requested work is complete."

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4220,3 +4220,143 @@ class TestMemoryProviderTurnStart:
         import inspect
         src = inspect.getsource(AIAgent.run_conversation)
         assert "on_turn_start(self._user_turn_count" in src
+
+
+class TestNativeOrchestrationHardening:
+    def test_enabled_tools_forwarded_to_tool_loader(self):
+        with (
+            patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("read_file")) as mock_get_tools,
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            AIAgent(
+                api_key="test-key-1234567890",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                enabled_tools=["read_file", "search_files"],
+            )
+
+        assert mock_get_tools.call_args.kwargs["enabled_tools"] == ["read_file", "search_files"]
+
+    def test_coalesce_delegate_task_calls_merges_into_batch(self):
+        call_a = _mock_tool_call(
+            name="delegate_task",
+            arguments=json.dumps({"goal": "Research profile configs", "category": "research"}),
+            call_id="call_a",
+        )
+        call_b = _mock_tool_call(
+            name="delegate_task",
+            arguments=json.dumps({"goal": "Verify runtime hooks", "category": "verification"}),
+            call_id="call_b",
+        )
+
+        with (
+            patch("tools.delegate_tool._load_config", return_value={"auto_fanout_batch_mode": True}),
+            patch("tools.delegate_tool._get_max_concurrent_children", return_value=5),
+        ):
+            merged = AIAgent._coalesce_delegate_task_calls([call_a, call_b])
+
+        assert len(merged) == 1
+        assert merged[0].function.name == "delegate_task"
+        args = json.loads(merged[0].function.arguments)
+        assert [task["goal"] for task in args["tasks"]] == [
+            "Research profile configs",
+            "Verify runtime hooks",
+        ]
+        assert [task["category"] for task in args["tasks"]] == ["research", "verification"]
+
+    def test_coalesce_delegate_task_calls_respects_auto_fanout_max_tasks(self):
+        call_a = _mock_tool_call(
+            name="delegate_task",
+            arguments=json.dumps(
+                {
+                    "tasks": [
+                        {"goal": "Task A"},
+                        {"goal": "Task B"},
+                        {"goal": "Task C"},
+                    ]
+                }
+            ),
+            call_id="call_a",
+        )
+
+        with (
+            patch(
+                "tools.delegate_tool._load_config",
+                return_value={
+                    "auto_fanout_batch_mode": True,
+                    "auto_fanout_max_tasks": 2,
+                    "max_concurrent_children": 5,
+                },
+            ),
+            patch("tools.delegate_tool._get_max_concurrent_children", return_value=5),
+        ):
+            merged = AIAgent._coalesce_delegate_task_calls([call_a])
+
+        assert len(merged) == 1
+        args = json.loads(merged[0].function.arguments)
+        assert [task["goal"] for task in args["tasks"]] == ["Task A", "Task B"]
+
+    def test_coalesce_delegate_task_calls_allows_explicit_category_batch_above_root_default(self):
+        calls = [
+            _mock_tool_call(
+                name="delegate_task",
+                arguments=json.dumps({"goal": f"Research {idx}", "category": "research"}),
+                call_id=f"call_{idx}",
+            )
+            for idx in range(4)
+        ]
+
+        with (
+            patch(
+                "tools.delegate_tool._load_config",
+                return_value={
+                    "auto_fanout_batch_mode": True,
+                    "auto_fanout_max_tasks": 5,
+                    "max_concurrent_children": 3,
+                    "categories": {"research": {"max_concurrent_children": 5}},
+                },
+            ),
+            patch("tools.delegate_tool._get_max_concurrent_children", return_value=3),
+        ):
+            merged = AIAgent._coalesce_delegate_task_calls(calls)
+
+        assert len(merged) == 1
+        args = json.loads(merged[0].function.arguments)
+        assert [task["goal"] for task in args["tasks"]] == [
+            "Research 0",
+            "Research 1",
+            "Research 2",
+            "Research 3",
+        ]
+
+    def test_large_task_note_detection_prefers_todo_and_batch_delegation(self):
+        with (
+            patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("todo", "delegate_task")),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        agent._delegation_cfg = {
+            "auto_decompose_large_tasks": True,
+            "auto_fanout_batch_mode": True,
+            "auto_fanout_max_tasks": 4,
+            "max_concurrent_children": 5,
+        }
+        message = (
+            "Please audit all profiles, compare the runtime behavior across the board, "
+            "implement any missing orchestration hooks, run tests, verify the CLI behavior, "
+            "and fix regressions before you finish."
+        )
+
+        assert agent._should_inject_orchestration_note(message, api_call_count=1) is True
+        note = agent._build_orchestration_user_note()
+        assert "create a concise todo list" in note
+        assert "delegate_task batch call" in note

--- a/tests/test_acp_tools_output.py
+++ b/tests/test_acp_tools_output.py
@@ -1,0 +1,268 @@
+from collections import OrderedDict
+from types import ModuleType, SimpleNamespace
+import sys
+
+import model_tools
+import toolsets
+
+
+if "acp" not in sys.modules:
+    fake_acp = ModuleType("acp")
+    fake_acp.Agent = type("Agent", (), {})
+    fake_acp.Client = type("Client", (), {})
+    sys.modules["acp"] = fake_acp
+
+if "acp.schema" not in sys.modules:
+    fake_schema = ModuleType("acp.schema")
+
+    def _schema_getattr(name: str):
+        value = type(name, (), {})
+        setattr(fake_schema, name, value)
+        return value
+
+    fake_schema.__getattr__ = _schema_getattr
+    for name in [
+        "AgentCapabilities",
+        "AuthenticateResponse",
+        "AvailableCommand",
+        "AvailableCommandsUpdate",
+        "ClientCapabilities",
+        "EmbeddedResourceContentBlock",
+        "ForkSessionResponse",
+        "ImageContentBlock",
+        "AudioContentBlock",
+        "Implementation",
+        "InitializeResponse",
+        "ListSessionsResponse",
+        "LoadSessionResponse",
+        "McpServerHttp",
+        "McpServerSse",
+        "McpServerStdio",
+        "ModelInfo",
+        "NewSessionResponse",
+        "PromptResponse",
+        "ResumeSessionResponse",
+        "SetSessionConfigOptionResponse",
+        "SetSessionModelResponse",
+        "SetSessionModeResponse",
+        "ResourceContentBlock",
+        "SessionCapabilities",
+        "SessionForkCapabilities",
+        "SessionListCapabilities",
+        "SessionModelState",
+        "SessionResumeCapabilities",
+        "SessionInfo",
+        "TextContentBlock",
+        "UnstructuredCommandInput",
+        "Usage",
+        "AuthMethodAgent",
+        "AuthMethod",
+    ]:
+        setattr(fake_schema, name, type(name, (), {}))
+    sys.modules["acp.schema"] = fake_schema
+
+from acp_adapter.server import HermesACPAgent
+from acp_adapter.session import SessionState
+
+
+def _tool_def(name: str, description: str = "") -> dict:
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": description or f"Description for {name}",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+
+
+def _make_state(enabled_toolsets: list[str]) -> SessionState:
+    return SessionState(
+        session_id="test-session",
+        agent=SimpleNamespace(enabled_toolsets=enabled_toolsets),
+    )
+
+
+def _install_toolset_metadata(monkeypatch, all_toolsets: OrderedDict, contracts: dict[str, dict]) -> None:
+    monkeypatch.setattr(toolsets, "get_all_toolsets", lambda: all_toolsets)
+    monkeypatch.setattr(toolsets, "get_toolset_contract", lambda name: contracts.get(name))
+
+
+def test_cmd_tools_surfaces_canonical_knowledge_first_when_visible(monkeypatch):
+    visible_tools = [
+        _tool_def("read_file"),
+        _tool_def("search_files"),
+        _tool_def("ast_list_defs"),
+        _tool_def("ast_find_nodes"),
+        _tool_def("lsp_document_symbols"),
+        _tool_def("lsp_definition"),
+        _tool_def("lsp_diagnostics"),
+        _tool_def("web_search"),
+        _tool_def("web_extract"),
+        _tool_def("browser_navigate"),
+        _tool_def("browser_snapshot"),
+        _tool_def("browser_click"),
+        _tool_def("browser_scroll"),
+        _tool_def("browser_back"),
+        _tool_def("browser_press"),
+        _tool_def("browser_get_images"),
+        _tool_def("browser_vision"),
+        _tool_def("browser_console"),
+        _tool_def("vision_analyze"),
+    ]
+    monkeypatch.setattr(model_tools, "get_tool_definitions", lambda **kwargs: visible_tools)
+
+    all_toolsets = OrderedDict(
+        [
+            (
+                "repo-code-knowledge",
+                {"description": "Canonical repo/code surface"},
+            ),
+            (
+                "web-research-knowledge",
+                {"description": "Canonical web/research surface"},
+            ),
+            (
+                "document-pdf-diagram-intelligence",
+                {"description": "Canonical document surface"},
+            ),
+        ]
+    )
+    contracts = {
+        "repo-code-knowledge": {
+            "name": "repo-code-knowledge",
+            "canonical_name": "repo-code-knowledge",
+            "source": "builtin",
+            "is_builtin": True,
+            "is_additive": False,
+            "is_alias": False,
+            "is_canonical_knowledge_surface": True,
+            "tools": [
+                "ast_find_nodes",
+                "ast_list_defs",
+                "lsp_definition",
+                "lsp_diagnostics",
+                "lsp_document_symbols",
+                "read_file",
+                "search_files",
+            ],
+        },
+        "web-research-knowledge": {
+            "name": "web-research-knowledge",
+            "canonical_name": "web-research-knowledge",
+            "source": "builtin",
+            "is_builtin": True,
+            "is_additive": False,
+            "is_alias": False,
+            "is_canonical_knowledge_surface": True,
+            "tools": ["web_extract", "web_search"],
+        },
+        "document-pdf-diagram-intelligence": {
+            "name": "document-pdf-diagram-intelligence",
+            "canonical_name": "document-pdf-diagram-intelligence",
+            "source": "builtin",
+            "is_builtin": True,
+            "is_additive": False,
+            "is_alias": False,
+            "is_canonical_knowledge_surface": True,
+            "tools": [
+                "browser_back",
+                "browser_click",
+                "browser_console",
+                "browser_get_images",
+                "browser_navigate",
+                "browser_press",
+                "browser_scroll",
+                "browser_snapshot",
+                "browser_vision",
+                "vision_analyze",
+            ],
+        },
+    }
+    _install_toolset_metadata(monkeypatch, all_toolsets, contracts)
+
+    output = HermesACPAgent(session_manager=SimpleNamespace())._cmd_tools(
+        "",
+        _make_state(["hermes-acp"]),
+    )
+
+    assert "Canonical built-in knowledge surfaces visible from current tool membership:" in output
+    assert "repo-code-knowledge [built-in/canonical; 7 raw tools]" in output
+    assert "web-research-knowledge [built-in/canonical; 2 raw tools]" in output
+    assert "document-pdf-diagram-intelligence [built-in/canonical; 10 raw tools]" in output
+    assert output.index("Canonical built-in knowledge surfaces visible from current tool membership:") < output.index("Raw tools (19):")
+
+
+def test_cmd_tools_keeps_raw_tool_names_visible(monkeypatch):
+    visible_tools = [
+        _tool_def("read_file", "Read files from disk"),
+        _tool_def("search_files", "Search across the repo"),
+    ]
+    monkeypatch.setattr(model_tools, "get_tool_definitions", lambda **kwargs: visible_tools)
+    _install_toolset_metadata(monkeypatch, OrderedDict(), {})
+
+    output = HermesACPAgent(session_manager=SimpleNamespace())._cmd_tools(
+        "",
+        _make_state(["hermes-acp"]),
+    )
+
+    assert "Raw tools (2):" in output
+    assert "  read_file: Read files from disk" in output
+    assert "  search_files: Search across the repo" in output
+
+
+def test_cmd_tools_labels_additive_surfaces_without_calling_them_builtin(monkeypatch):
+    visible_tools = [
+        _tool_def("read_file"),
+        _tool_def("search_files"),
+        _tool_def("mcp_surface_lookup"),
+    ]
+    monkeypatch.setattr(model_tools, "get_tool_definitions", lambda **kwargs: visible_tools)
+
+    all_toolsets = OrderedDict(
+        [
+            (
+                "repo-code-knowledge",
+                {"description": "Canonical repo/code surface"},
+            ),
+            (
+                "test-surface",
+                {"description": "Additive lookup surface"},
+            ),
+        ]
+    )
+    contracts = {
+        "repo-code-knowledge": {
+            "name": "repo-code-knowledge",
+            "canonical_name": "repo-code-knowledge",
+            "source": "builtin",
+            "is_builtin": True,
+            "is_additive": False,
+            "is_alias": False,
+            "is_canonical_knowledge_surface": True,
+            "tools": ["read_file", "search_files"],
+        },
+        "test-surface": {
+            "name": "test-surface",
+            "canonical_name": "mcp-test-surface",
+            "source": "mcp",
+            "is_builtin": False,
+            "is_additive": True,
+            "is_alias": True,
+            "tools": ["mcp_surface_lookup"],
+        },
+    }
+    _install_toolset_metadata(monkeypatch, all_toolsets, contracts)
+
+    output = HermesACPAgent(session_manager=SimpleNamespace())._cmd_tools(
+        "",
+        _make_state(["hermes-acp", "test-surface"]),
+    )
+
+    additive_line = next(
+        line for line in output.splitlines() if "mcp-test-surface" in line
+    )
+    assert "Additive tool surfaces visible from current tool membership:" in output
+    assert "additive/mcp" in additive_line
+    assert "built-in" not in additive_line
+    assert "canonical" not in additive_line

--- a/tests/test_knowledge_surface_toolsets.py
+++ b/tests/test_knowledge_surface_toolsets.py
@@ -1,0 +1,175 @@
+from toolsets import (
+    get_toolset,
+    get_toolset_contract,
+    get_toolset_info,
+    get_toolset_names,
+    resolve_toolset,
+    validate_toolset,
+)
+
+
+class TestKnowledgeSurfaceToolsets:
+    def test_canonical_knowledge_surface_toolsets_exist(self):
+        canonical_names = {
+            "repo-code-knowledge",
+            "web-research-knowledge",
+            "document-pdf-diagram-intelligence",
+        }
+
+        for name in canonical_names:
+            toolset = get_toolset(name)
+            assert toolset is not None
+            assert validate_toolset(name)
+            assert name in get_toolset_names()
+
+    def test_static_aliases_validate_and_resolve_to_canonical_toolsets(self):
+        alias_to_canonical = {
+            "repo_code_knowledge": "repo-code-knowledge",
+            "repo-knowledge": "repo-code-knowledge",
+            "web_research_knowledge": "web-research-knowledge",
+            "research-knowledge": "web-research-knowledge",
+            "document_intelligence": "document-pdf-diagram-intelligence",
+            "document-intelligence": "document-pdf-diagram-intelligence",
+        }
+
+        for alias, canonical in alias_to_canonical.items():
+            assert validate_toolset(alias)
+            alias_toolset = get_toolset(alias)
+            canonical_toolset = get_toolset(canonical)
+            assert alias_toolset is not None
+            assert canonical_toolset is not None
+            assert alias_toolset["canonical_name"] == canonical
+            assert resolve_toolset(alias) == resolve_toolset(canonical)
+
+    def test_aliases_are_not_reported_as_canonical_toolset_names(self):
+        toolset_names = set(get_toolset_names())
+
+        assert "repo-code-knowledge" in toolset_names
+        assert "web-research-knowledge" in toolset_names
+        assert "document-pdf-diagram-intelligence" in toolset_names
+
+        assert "repo_code_knowledge" not in toolset_names
+        assert "web_research_knowledge" not in toolset_names
+        assert "document_intelligence" not in toolset_names
+
+    def test_repo_code_knowledge_surface_uses_builtin_file_ast_and_lsp_primitives(self):
+        tools = set(resolve_toolset("repo-code-knowledge"))
+
+        assert tools == {
+            "read_file",
+            "search_files",
+            "ast_list_defs",
+            "ast_find_nodes",
+            "lsp_document_symbols",
+            "lsp_definition",
+            "lsp_diagnostics",
+        }
+
+    def test_web_research_knowledge_surface_uses_current_builtin_web_primitives(self):
+        tools = set(resolve_toolset("web-research-knowledge"))
+
+        assert tools == {"web_search", "web_extract"}
+        assert "web_crawl" not in tools
+
+    def test_document_intelligence_surface_uses_builtin_browser_and_vision_primitives(self):
+        tools = set(resolve_toolset("document-pdf-diagram-intelligence"))
+
+        assert tools == {
+            "browser_navigate",
+            "browser_snapshot",
+            "browser_click",
+            "browser_scroll",
+            "browser_back",
+            "browser_press",
+            "browser_get_images",
+            "browser_vision",
+            "browser_console",
+            "vision_analyze",
+        }
+
+    def test_canonical_descriptions_use_honest_builtin_wording(self):
+        repo_desc = get_toolset("repo-code-knowledge")["description"]
+        web_desc = get_toolset("web-research-knowledge")["description"]
+        doc_desc = get_toolset("document-pdf-diagram-intelligence")["description"]
+        alias_desc = get_toolset("document_intelligence")["description"]
+
+        assert "Canonical built-in repo/code knowledge surface" in repo_desc
+        assert "AST structure lookup" in repo_desc
+
+        assert "Canonical built-in web/research knowledge surface" in web_desc
+        assert "not an additive MCP crawl stack" in web_desc
+
+        assert "Canonical built-in document/PDF/diagram intelligence surface" in doc_desc
+        assert "not a standalone PDF parser or diagram editor" in doc_desc
+        assert "Alias for canonical toolset 'document-pdf-diagram-intelligence'." in alias_desc
+
+    def test_builtin_knowledge_surface_contract_marks_builtin_not_additive(self):
+        contract = get_toolset_contract("repo_code_knowledge")
+        info = get_toolset_info("repo_code_knowledge")
+
+        assert contract == {
+            "name": "repo_code_knowledge",
+            "canonical_name": "repo-code-knowledge",
+            "source": "builtin",
+            "is_builtin": True,
+            "is_additive": False,
+            "is_alias": True,
+            "aliases": ["repo_code_knowledge", "repo-knowledge"],
+            "is_canonical_knowledge_surface": True,
+            "boundary_note": (
+                "Canonical built-in control-plane surface; downstream wrappers, propagation, "
+                "and additive MCP/plugin productization stay separate."
+            ),
+            "tools": [
+                "ast_find_nodes",
+                "ast_list_defs",
+                "lsp_definition",
+                "lsp_diagnostics",
+                "lsp_document_symbols",
+                "read_file",
+                "search_files",
+            ],
+        }
+        assert info["canonical_name"] == "repo-code-knowledge"
+        assert info["source"] == "builtin"
+        assert info["is_builtin"] is True
+        assert info["is_additive"] is False
+        assert info["is_alias"] is True
+        assert info["is_canonical_knowledge_surface"] is True
+        assert info["boundary_note"] == (
+            "Canonical built-in control-plane surface; downstream wrappers, propagation, "
+            "and additive MCP/plugin productization stay separate."
+        )
+
+    def test_registry_managed_toolsets_are_classified_as_additive(self):
+        from tools.registry import registry
+
+        schema = {
+            "name": "mcp_test_surface_lookup",
+            "description": "Lookup test surface",
+            "parameters": {"type": "object", "properties": {}},
+        }
+
+        registry.register(
+            name="mcp_test_surface_lookup",
+            toolset="mcp-test-surface",
+            schema=schema,
+            handler=lambda args: "{}",
+            description="Lookup test surface",
+        )
+        registry.register_toolset_alias("test-surface", "mcp-test-surface")
+        try:
+            contract = get_toolset_contract("test-surface")
+            assert contract == {
+                "name": "test-surface",
+                "canonical_name": "mcp-test-surface",
+                "source": "mcp",
+                "is_builtin": False,
+                "is_additive": True,
+                "is_alias": True,
+                "aliases": ["test-surface"],
+                "boundary_note": "Additive registry surface; not a canonical built-in knowledge surface.",
+                "tools": ["mcp_test_surface_lookup"],
+            }
+        finally:
+            registry.deregister("mcp_test_surface_lookup")

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -197,13 +197,18 @@ class TestToolsetConsistency:
             for inc in ts["includes"]:
                 assert inc in TOOLSETS, f"{name} includes unknown toolset '{inc}'"
 
-    def test_hermes_platforms_share_core_tools(self):
-        """All hermes-* platform toolsets should have the same tools."""
-        platforms = ["hermes-cli", "hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-homeassistant"]
+    def test_hermes_messaging_platforms_share_core_tools(self):
+        """Messaging-oriented hermes-* platform toolsets should share the same tools."""
+        platforms = ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-homeassistant"]
         tool_sets = [set(TOOLSETS[p]["tools"]) for p in platforms]
-        # All platform toolsets should be identical
         for ts in tool_sets[1:]:
             assert ts == tool_sets[0]
+
+    def test_local_coding_toolsets_include_code_intel(self):
+        code_intel_tools = set(resolve_toolset("code_intel"))
+
+        for toolset_name in ["hermes-cli", "hermes-acp", "hermes-api-server"]:
+            assert code_intel_tools <= set(resolve_toolset(toolset_name))
 
 
 class TestPluginToolsets:

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1,3 +1,4 @@
+import importlib
 import json
 import sys
 import threading
@@ -5,6 +6,8 @@ import time
 import types
 from pathlib import Path
 from unittest.mock import patch
+
+import pytest
 
 from tui_gateway import server
 
@@ -131,10 +134,160 @@ def test_enable_gateway_prompts_sets_gateway_env(monkeypatch):
 
 def test_setup_status_reports_provider_config(monkeypatch):
     monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda: False)
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"model": {"default": "claude", "provider": "anthropic"}})
 
     resp = server.handle_request({"id": "1", "method": "setup.status", "params": {}})
 
-    assert resp["result"]["provider_configured"] is False
+    assert resp["result"] == {
+        "provider": "anthropic",
+        "model": "claude",
+        "provider_configured": False,
+    }
+
+
+def test_setup_status_delegates_to_setup_bridge(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(
+        server,
+        "_build_setup_status_payload_impl",
+        lambda **kwargs: seen.update(kwargs) or {"provider": "anthropic", "model": "claude", "provider_configured": True},
+    )
+
+    resp = server.handle_request({"id": "1", "method": "setup.status", "params": {}})
+
+    assert resp["result"] == {"provider": "anthropic", "model": "claude", "provider_configured": True}
+    assert seen["load_cfg"] is server._load_cfg
+    assert seen["resolve_model"] is server._resolve_model
+
+
+def test_setup_catalog_lists_native_bootstrap_providers(monkeypatch):
+    monkeypatch.setattr("hermes_cli.main._has_any_provider_configured", lambda: False)
+    monkeypatch.setattr(server, "_load_cfg", lambda: {"model": {"default": "claude", "provider": "anthropic"}})
+    monkeypatch.setattr(
+        server,
+        "_native_setup_catalog",
+        lambda: [
+            {
+                "slug": "anthropic",
+                "name": "Anthropic",
+                "description": "Anthropic desc",
+                "auth_type": "api_key",
+                "configured": False,
+                "key_env_var": "ANTHROPIC_API_KEY",
+                "supports_native": True,
+                "models": ["claude-sonnet-4-5"],
+                "total_models": 1,
+            }
+        ],
+    )
+
+    resp = server.handle_request({"id": "1", "method": "setup.catalog", "params": {}})
+
+    assert resp["result"] == {
+        "provider_configured": False,
+        "provider": "anthropic",
+        "model": "claude",
+        "providers": [
+            {
+                "slug": "anthropic",
+                "name": "Anthropic",
+                "description": "Anthropic desc",
+                "auth_type": "api_key",
+                "configured": False,
+                "key_env_var": "ANTHROPIC_API_KEY",
+                "supports_native": True,
+                "models": ["claude-sonnet-4-5"],
+                "total_models": 1,
+            }
+        ],
+    }
+
+
+def test_setup_catalog_delegates_to_setup_bridge(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(
+        server,
+        "_build_setup_catalog_payload_impl",
+        lambda **kwargs: seen.update(kwargs) or {"provider_configured": False, "provider": "", "model": "m", "providers": []},
+    )
+
+    resp = server.handle_request({"id": "1", "method": "setup.catalog", "params": {}})
+
+    assert resp["result"] == {"provider_configured": False, "provider": "", "model": "m", "providers": []}
+    assert seen["catalog_builder"] is server._native_setup_catalog
+
+
+def test_setup_bootstrap_persists_provider_and_model(monkeypatch):
+    captured = {}
+
+    monkeypatch.setattr(
+        server,
+        "_bootstrap_provider_config",
+        lambda provider, *, api_key="", model="", base_url="": captured.update(
+            {"provider": provider, "api_key": api_key, "model": model, "base_url": base_url}
+        )
+        or {"provider": provider, "model": model},
+    )
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "setup.bootstrap",
+            "params": {"provider": "anthropic", "api_key": "***", "model": "claude-sonnet-4-5"},
+        }
+    )
+
+    assert resp["result"] == {
+        "provider": "anthropic",
+        "model": "claude-sonnet-4-5",
+        "provider_configured": True,
+    }
+    assert captured == {"provider": "anthropic", "api_key": "***", "model": "claude-sonnet-4-5", "base_url": ""}
+
+
+def test_setup_bootstrap_delegates_to_setup_bridge(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(
+        server,
+        "_run_setup_bootstrap_impl",
+        lambda **kwargs: seen.update(kwargs) or {"provider": "anthropic", "model": "claude", "provider_configured": True},
+    )
+
+    params = {"provider": "anthropic", "api_key": "sekret", "model": "claude"}
+    resp = server.handle_request({"id": "1", "method": "setup.bootstrap", "params": params})
+
+    assert resp["result"] == {"provider": "anthropic", "model": "claude", "provider_configured": True}
+    assert seen["provider"] == "anthropic"
+    assert seen["bootstrapper"] is server._bootstrap_provider_config
+
+
+def test_native_setup_catalog_keeps_external_process_explicit_and_excludes_oauth_device_code(monkeypatch):
+    fake_models = types.SimpleNamespace(
+        CANONICAL_PROVIDERS=[
+            types.SimpleNamespace(slug="anthropic", tui_desc="Anthropic desc", label="Anthropic"),
+            types.SimpleNamespace(slug="copilot-acp", tui_desc="Copilot desc", label="Copilot ACP"),
+            types.SimpleNamespace(slug="nous", tui_desc="Nous desc", label="Nous")
+        ]
+    )
+
+    monkeypatch.setitem(sys.modules, "hermes_cli.models", fake_models)
+    monkeypatch.setattr(
+        server,
+        "_setup_provider_status",
+        lambda provider: {
+            "anthropic": {"auth_type": "api_key", "configured": False, "key_env_var": "ANTHROPIC_API_KEY", "name": "Anthropic"},
+            "copilot-acp": {"auth_type": "external_process", "configured": False, "key_env_var": "", "name": "Copilot ACP"},
+            "nous": {"auth_type": "oauth_device_code", "configured": False, "key_env_var": "", "name": "Nous"},
+        }[provider],
+    )
+    monkeypatch.setattr(server, "_setup_provider_models", lambda provider: ([f"{provider}/model"], ""))
+
+    providers = server._native_setup_catalog()
+
+    assert [p["slug"] for p in providers] == ["anthropic", "copilot-acp"]
+    assert providers[0]["supports_native"] is True
+    assert providers[1]["supports_native"] is False
+    assert providers[1]["auth_type"] == "external_process"
 
 
 def test_config_set_reasoning_updates_live_session_and_agent(tmp_path, monkeypatch):
@@ -228,6 +381,464 @@ def test_config_set_model_global_persists(monkeypatch):
     assert saved["model"]["default"] == "anthropic/claude-sonnet-4.6"
     assert saved["model"]["provider"] == "anthropic"
     assert saved["model"]["base_url"] == "https://api.anthropic.com"
+
+
+def test_tools_catalog_reports_provider_and_mcp_state(monkeypatch):
+    import hermes_cli.config as config_mod
+    import hermes_cli.tools_config as tools_config_mod
+
+    monkeypatch.setattr(tools_config_mod, "CONFIGURABLE_TOOLSETS", [("web", "Web", "search"), ("plugin_x", "Plugin", "plugin")])
+    monkeypatch.setattr(
+        tools_config_mod,
+        "TOOL_CATEGORIES",
+        {"web": {"providers": [{"name": "Firecrawl", "web_backend": "firecrawl", "env_vars": [{"key": "FIRECRAWL_API_KEY"}]}]}},
+    )
+    monkeypatch.setattr(tools_config_mod, "_get_effective_configurable_toolsets", lambda: [("web", "Web", "search"), ("plugin_x", "Plugin", "plugin")])
+    monkeypatch.setattr(tools_config_mod, "_get_platform_tools", lambda cfg, platform, include_default_mcp_servers=False: {"web", "plugin_x"})
+    monkeypatch.setattr(config_mod, "load_config", lambda: {"web": {"backend": "firecrawl"}, "mcp_servers": {"github": {"enabled": True, "tools": {"exclude": ["create_issue"]}}}})
+    monkeypatch.setattr(config_mod, "get_env_value", lambda key: "sekret" if key == "FIRECRAWL_API_KEY" else "")
+
+    resp = server.handle_request({"id": "1", "method": "tools.catalog", "params": {}})
+
+    assert resp["result"] == {
+        "toolsets": [
+            {
+                "active_provider": "",
+                "configurable": False,
+                "description": "plugin",
+                "enabled": True,
+                "kind": "builtin",
+                "name": "plugin_x",
+                "providers": [],
+                "title": "Plugin",
+            },
+            {
+                "active_provider": "firecrawl",
+                "configurable": True,
+                "description": "search",
+                "enabled": True,
+                "kind": "builtin",
+                "name": "web",
+                "providers": [
+                    {
+                        "active": True,
+                        "badge": "",
+                        "env_vars": [
+                            {"configured": True, "key": "FIRECRAWL_API_KEY", "prompt": "FIRECRAWL_API_KEY", "url": ""}
+                        ],
+                        "name": "Firecrawl",
+                        "slug": "firecrawl",
+                        "tag": "",
+                    }
+                ],
+                "title": "Web",
+            },
+        ],
+        "mcp_servers": [{"enabled": True, "exclude": ["create_issue"], "include": [], "name": "github"}],
+    }
+
+
+def test_tools_catalog_delegates_to_tools_bridge(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(
+        server,
+        "_build_tools_catalog_payload_impl",
+        lambda **kwargs: seen.update(kwargs) or {"toolsets": [], "mcp_servers": []},
+    )
+
+    resp = server.handle_request({"id": "1", "method": "tools.catalog", "params": {}})
+
+    assert resp["result"] == {"toolsets": [], "mcp_servers": []}
+    assert seen["load_config"]
+    assert seen["effective_toolsets"]
+
+
+def test_toolsets_list_derives_canonical_repo_surface_enabled_from_visible_members(monkeypatch):
+    import model_tools
+    import toolsets
+
+    visible_defs = [
+        {"function": {"name": "read_file", "description": "Read file contents."}},
+        {"function": {"name": "search_files", "description": "Search files."}},
+        {"function": {"name": "ast_list_defs", "description": "List AST defs."}},
+        {"function": {"name": "ast_find_nodes", "description": "Find AST nodes."}},
+        {"function": {"name": "lsp_document_symbols", "description": "List document symbols."}},
+        {"function": {"name": "lsp_definition", "description": "Find definitions."}},
+        {"function": {"name": "lsp_diagnostics", "description": "Show diagnostics."}},
+    ]
+    info_map = {
+        "file": {
+            "description": "File tools",
+            "resolved_tools": ["read_file", "write_file", "patch", "search_files"],
+        },
+        "code_intel": {
+            "description": "Code intel",
+            "resolved_tools": [
+                "ast_list_defs",
+                "ast_find_nodes",
+                "lsp_document_symbols",
+                "lsp_definition",
+                "lsp_diagnostics",
+            ],
+        },
+        "repo-code-knowledge": {
+            "description": "Canonical repo knowledge",
+            "resolved_tools": [
+                "read_file",
+                "search_files",
+                "ast_list_defs",
+                "ast_find_nodes",
+                "lsp_document_symbols",
+                "lsp_definition",
+                "lsp_diagnostics",
+            ],
+        },
+    }
+    contract_map = {
+        "file": {
+            "canonical_name": "file",
+            "source": "builtin",
+            "is_builtin": True,
+            "is_additive": False,
+            "is_alias": False,
+            "is_canonical_knowledge_surface": False,
+            "boundary_note": "Built-in toolset",
+        },
+        "code_intel": {
+            "canonical_name": "code_intel",
+            "source": "builtin",
+            "is_builtin": True,
+            "is_additive": False,
+            "is_alias": False,
+            "is_canonical_knowledge_surface": False,
+            "boundary_note": "Built-in toolset",
+        },
+        "repo-code-knowledge": {
+            "canonical_name": "repo-code-knowledge",
+            "source": "builtin",
+            "is_builtin": True,
+            "is_additive": False,
+            "is_alias": False,
+            "is_canonical_knowledge_surface": True,
+            "boundary_note": "Canonical built-in control-plane surface",
+        },
+    }
+
+    monkeypatch.setattr(
+        model_tools,
+        "get_available_toolsets",
+        lambda: {
+            name: {
+                "description": info_map[name]["description"],
+                "tools": list(info_map[name]["resolved_tools"]),
+                **contract_map[name],
+            }
+            for name in ("file", "code_intel", "repo-code-knowledge")
+        },
+    )
+    monkeypatch.setattr(model_tools, "get_tool_definitions", lambda **kwargs: visible_defs)
+    monkeypatch.setattr(toolsets, "get_toolset_info", lambda name: {**info_map[name], "tool_count": len(info_map[name]["resolved_tools"])})
+    monkeypatch.setattr(toolsets, "get_toolset_contract", lambda name: contract_map[name])
+
+    server._sessions["sid"] = _session(agent=types.SimpleNamespace(enabled_toolsets=["file", "code_intel"]))
+    try:
+        resp = server.handle_request({"id": "1", "method": "toolsets.list", "params": {"session_id": "sid"}})
+    finally:
+        server._sessions.clear()
+
+    rows = {row["name"]: row for row in resp["result"]["toolsets"]}
+    assert rows["repo-code-knowledge"]["enabled"] is True
+    assert rows["repo-code-knowledge"]["canonical_name"] == "repo-code-knowledge"
+    assert rows["repo-code-knowledge"]["is_canonical_knowledge_surface"] is True
+    assert rows["file"]["enabled"] is True
+    assert rows["code_intel"]["enabled"] is True
+
+
+def test_tools_show_exposes_canonical_knowledge_surfaces_as_first_class_sections(monkeypatch):
+    import model_tools
+    import toolsets
+
+    visible_defs = [
+        {"function": {"name": "read_file", "description": "Read file contents. Extra detail."}},
+        {"function": {"name": "search_files", "description": "Search files. Extra detail."}},
+        {"function": {"name": "web_search", "description": "Search the web. Extra detail."}},
+        {"function": {"name": "web_extract", "description": "Extract web pages. Extra detail."}},
+        {"function": {"name": "browser_navigate", "description": "Navigate browser. Extra detail."}},
+        {"function": {"name": "browser_snapshot", "description": "Snapshot browser. Extra detail."}},
+        {"function": {"name": "vision_analyze", "description": "Analyze images. Extra detail."}},
+    ]
+    info_map = {
+        "repo-code-knowledge": {
+            "description": "Canonical repo knowledge",
+            "resolved_tools": ["read_file", "search_files"],
+        },
+        "web-research-knowledge": {
+            "description": "Canonical web knowledge",
+            "resolved_tools": ["web_search", "web_extract"],
+        },
+        "document-pdf-diagram-intelligence": {
+            "description": "Canonical document intelligence",
+            "resolved_tools": ["browser_navigate", "browser_snapshot", "vision_analyze"],
+        },
+    }
+    contract_map = {
+        name: {
+            "canonical_name": name,
+            "source": "builtin",
+            "is_builtin": True,
+            "is_additive": False,
+            "is_alias": False,
+            "is_canonical_knowledge_surface": True,
+            "boundary_note": "Canonical built-in control-plane surface",
+        }
+        for name in info_map
+    }
+    owner_map = {
+        "read_file": "file",
+        "search_files": "file",
+        "web_search": "web",
+        "web_extract": "web",
+        "browser_navigate": "browser",
+        "browser_snapshot": "browser",
+        "vision_analyze": "vision",
+    }
+
+    monkeypatch.setattr(
+        model_tools,
+        "get_available_toolsets",
+        lambda: {
+            name: {
+                "description": info_map[name]["description"],
+                "tools": list(info_map[name]["resolved_tools"]),
+                **contract_map[name],
+            }
+            for name in info_map
+        },
+    )
+    monkeypatch.setattr(model_tools, "get_tool_definitions", lambda **kwargs: visible_defs)
+    monkeypatch.setattr(model_tools, "get_toolset_for_tool", lambda name: owner_map[name])
+    monkeypatch.setattr(toolsets, "get_toolset_info", lambda name: {**info_map[name], "tool_count": len(info_map[name]["resolved_tools"])})
+    monkeypatch.setattr(toolsets, "get_toolset_contract", lambda name: contract_map[name])
+
+    resp = server.handle_request({"id": "1", "method": "tools.show", "params": {}})
+
+    section_names = [section["name"] for section in resp["result"]["sections"]]
+    assert section_names == [
+        "document-pdf-diagram-intelligence",
+        "repo-code-knowledge",
+        "web-research-knowledge",
+    ]
+    sections = {section["name"]: section for section in resp["result"]["sections"]}
+    assert [tool["name"] for tool in sections["repo-code-knowledge"]["tools"]] == ["read_file", "search_files"]
+    assert [tool["name"] for tool in sections["web-research-knowledge"]["tools"]] == ["web_search", "web_extract"]
+    assert [tool["name"] for tool in sections["document-pdf-diagram-intelligence"]["tools"]] == [
+        "browser_navigate",
+        "browser_snapshot",
+        "vision_analyze",
+    ]
+    legacy_names = [section["name"] for section in resp["result"]["legacy_sections"]]
+    assert legacy_names == ["browser", "file", "vision", "web"]
+    assert resp["result"]["tools"][0]["owner_toolset"] in {"file", "web", "browser", "vision"}
+
+
+def test_tools_catalog_remains_provider_config_oriented_and_skips_visibility_derivation(monkeypatch):
+    monkeypatch.setattr(server, "_derive_visible_toolsets", lambda enabled_toolsets: (_ for _ in ()).throw(AssertionError("should not run")))
+    monkeypatch.setattr(server, "_tools_catalog_payload", lambda: {"toolsets": [{"name": "web", "enabled": True}], "mcp_servers": []})
+
+    resp = server.handle_request({"id": "1", "method": "tools.catalog", "params": {}})
+
+    assert resp["result"] == {"toolsets": [{"name": "web", "enabled": True}], "mcp_servers": []}
+
+
+def test_tools_provider_configure_updates_config_and_resets_session(monkeypatch):
+    server._sessions["sid"] = _session()
+    saved_env = {}
+    saved_cfg = {}
+    reset_calls = []
+    fake_tools = types.SimpleNamespace(
+        TOOL_CATEGORIES={"web": {"providers": [{"name": "Firecrawl", "web_backend": "firecrawl", "env_vars": [{"key": "FIRECRAWL_API_KEY"}]}]}},
+        _visible_providers=lambda cat, cfg: cat["providers"],
+    )
+    fake_config = types.SimpleNamespace(
+        load_config=lambda: {"web": {}, "mcp_servers": {}},
+        save_config=lambda cfg: saved_cfg.update(cfg),
+        save_env_value=lambda key, value: saved_env.update({key: value}),
+        get_env_value=lambda key: saved_env.get(key, ""),
+    )
+    monkeypatch.setitem(sys.modules, "hermes_cli.tools_config", fake_tools)
+    monkeypatch.setitem(sys.modules, "hermes_cli.config", fake_config)
+    monkeypatch.setitem(sys.modules, "hermes_cli.nous_subscription", types.SimpleNamespace(get_nous_subscription_features=lambda cfg: {}))
+    monkeypatch.setitem(sys.modules, "tools.tool_backend_helpers", types.SimpleNamespace(managed_nous_tools_enabled=lambda: False))
+    monkeypatch.setattr(server, "_tools_catalog_payload", lambda: {"mcp_servers": [], "toolsets": [{"name": "web"}]})
+    monkeypatch.setattr(server, "_reset_session_agent", lambda sid, session: reset_calls.append((sid, session["session_key"])) or {"model": "claude", "skills": {}, "tools": {}})
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "tools.provider.configure",
+            "params": {
+                "env": {"FIRECRAWL_API_KEY": "sekret"},
+                "provider": "firecrawl",
+                "session_id": "sid",
+                "toolset": "web",
+            },
+        }
+    )
+
+    assert saved_env == {"FIRECRAWL_API_KEY": "sekret"}
+    assert saved_cfg["web"]["backend"] == "firecrawl"
+    assert saved_cfg["web"]["use_gateway"] is False
+    assert reset_calls == [("sid", "session-key")]
+    assert resp["result"] == {
+        "mcp_servers": [],
+        "toolsets": [{"name": "web"}],
+        "info": {"model": "claude", "skills": {}, "tools": {}},
+        "provider": "firecrawl",
+        "reset": True,
+        "toolset": "web",
+    }
+
+
+def test_tools_provider_configure_delegates_to_tools_bridge(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(
+        server,
+        "_configure_tool_provider_impl",
+        lambda **kwargs: seen.update(kwargs) or {"missing_env": ["FIRECRAWL_API_KEY"], "provider": "firecrawl", "toolset": "web"},
+    )
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "tools.provider.configure",
+            "params": {"toolset": "web", "provider": "firecrawl", "env": {"FIRECRAWL_API_KEY": "sekret"}},
+        }
+    )
+
+    assert resp["result"] == {"missing_env": ["FIRECRAWL_API_KEY"], "provider": "firecrawl", "toolset": "web"}
+    assert seen["catalog_payload_builder"] is server._tools_catalog_payload
+
+
+def test_tools_mcp_configure_delegates_to_tools_bridge(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(
+        server,
+        "_configure_mcp_servers_impl",
+        lambda **kwargs: seen.update(kwargs) or {"changed": ["github"], "info": None, "reset": False, "unknown": [], "mcp_servers": [], "toolsets": []},
+    )
+
+    resp = server.handle_request(
+        {"id": "1", "method": "tools.mcp.configure", "params": {"action": "disable", "names": ["github"]}}
+    )
+
+    assert resp["result"] == {
+        "changed": ["github"],
+        "info": None,
+        "reset": False,
+        "unknown": [],
+        "mcp_servers": [],
+        "toolsets": [],
+    }
+    assert seen["catalog_payload_builder"] is server._tools_catalog_payload
+
+
+def test_tools_mcp_probe_delegates_to_tools_bridge(monkeypatch):
+    monkeypatch.setattr(server, "_probe_mcp_servers_impl", lambda **kwargs: {"servers": [{"name": "github", "reachable": True, "tools": []}]})
+
+    resp = server.handle_request({"id": "1", "method": "tools.mcp.probe", "params": {}})
+
+    assert resp["result"] == {"servers": [{"name": "github", "reachable": True, "tools": []}]}
+
+
+def test_tools_configure_delegates_to_tools_bridge(monkeypatch):
+    seen = {}
+    monkeypatch.setattr(
+        server,
+        "_configure_tools_impl",
+        lambda **kwargs: seen.update(kwargs) or {
+            "changed": ["web"],
+            "enabled_toolsets": ["terminal"],
+            "info": None,
+            "missing_servers": [],
+            "reset": False,
+            "unknown": [],
+        },
+    )
+
+    resp = server.handle_request(
+        {"id": "1", "method": "tools.configure", "params": {"action": "disable", "names": ["web"]}}
+    )
+
+    assert resp["result"] == {
+        "changed": ["web"],
+        "enabled_toolsets": ["terminal"],
+        "info": None,
+        "missing_servers": [],
+        "reset": False,
+        "unknown": [],
+    }
+    assert seen["session_lookup"]("missing") is None
+
+
+def test_skills_manage_delegates_to_bridge(monkeypatch):
+    seen = {}
+    fake_banner = types.SimpleNamespace(get_available_skills=lambda: ["alpha", "beta"])
+    fake_source_hub = types.SimpleNamespace(
+        GitHubAuth=lambda: "auth",
+        create_source_router=lambda auth: {"auth": auth},
+        unified_search=lambda *args, **kwargs: [],
+    )
+    fake_skills = types.SimpleNamespace(
+        browse_skills=lambda **kwargs: {"items": []},
+        do_audit=lambda *args, **kwargs: None,
+        do_check=lambda *args, **kwargs: None,
+        do_install=lambda *args, **kwargs: None,
+        do_uninstall=lambda *args, **kwargs: None,
+        do_update=lambda *args, **kwargs: None,
+        inspect_skill=lambda query: {"identifier": query},
+    )
+
+    monkeypatch.setitem(sys.modules, "hermes_cli.banner", fake_banner)
+    monkeypatch.setitem(sys.modules, "hermes_cli.skills_hub", fake_skills)
+    monkeypatch.setitem(sys.modules, "tools.skills_hub", fake_source_hub)
+    monkeypatch.setattr(
+        server,
+        "_dispatch_skills_manage_impl",
+        lambda params, **kwargs: seen.update({"params": params, **kwargs}) or {"skills": ["alpha", "beta"]},
+    )
+
+    resp = server.handle_request({"id": "1", "method": "skills.manage", "params": {"action": "LIST"}})
+
+    assert resp["result"] == {"skills": ["alpha", "beta"]}
+    assert seen["params"] == {"action": "list", "query": ""}
+    assert seen["get_available_skills"] is fake_banner.get_available_skills
+    assert seen["capture_console_output"] is server._capture_console_output
+    assert seen["browse_skills"] is fake_skills.browse_skills
+    assert seen["inspect_skill"] is fake_skills.inspect_skill
+    assert seen["do_install"] is fake_skills.do_install
+    assert seen["do_update"] is fake_skills.do_update
+    assert seen["do_audit"] is fake_skills.do_audit
+    assert seen["do_uninstall"] is fake_skills.do_uninstall
+    assert seen["source_router_factory"]("auth") == {"auth": "auth"}
+    assert seen["auth_factory"]() == "auth"
+
+
+@pytest.mark.parametrize(
+    ("params", "message"),
+    [
+        ({"action": "search"}, "skills.search requires query"),
+        ({"action": "install", "query": ""}, "skills.install requires query"),
+        ({"action": "list", "query": "alpha"}, "unexpected skills params for list: query"),
+        ({"action": "browse", "page": 0}, "skills.browse requires positive page"),
+        ({"action": "audit", "query": "all", "source": "github"}, "unexpected skills params for audit: source"),
+        ({"action": "wat"}, "unknown skills action: wat"),
+    ],
+)
+def test_skills_manage_contract_rejects_invalid_action_shapes(params, message):
+    resp = server.handle_request({"id": "1", "method": "skills.manage", "params": params})
+
+    assert resp["error"]["code"] == 4017
+    assert resp["error"]["message"] == message
 
 
 def test_config_set_personality_rejects_unknown_name(monkeypatch):
@@ -375,6 +986,203 @@ def test_command_dispatch_exec_nonzero_surfaces_error(monkeypatch):
 
     assert "error" in resp
     assert "failed" in resp["error"]["message"]
+
+
+def test_routing_owner_lane_locks_authoritative_route_sets():
+    assert server._NATIVE_PRODUCT_COMMANDS == frozenset({"setup", "skills", "tools"})
+    assert server._LIVE_SLASH_COMMANDS == frozenset({"handoff", "init-deep", "model", "provider", "ralph-loop", "start-work", "ulw-loop"})
+    assert server._LEGACY_SLASH_WORKER_COMMANDS == frozenset({
+        "agents",
+        "browser",
+        "config",
+        "cron",
+        "debug",
+        "fast",
+        "gquota",
+        "history",
+        "insights",
+        "platforms",
+        "plugins",
+        "profile",
+        "reload",
+        "reload-mcp",
+        "rollback",
+        "save",
+        "snapshot",
+        "status",
+        "stop",
+        "title",
+        "toolsets",
+    })
+    assert server._SLASH_EXEC_COMMANDS == server._LIVE_SLASH_COMMANDS | server._LEGACY_SLASH_WORKER_COMMANDS
+
+
+def test_command_dispatch_rejects_route_owned_commands():
+    native = server.handle_request({"id": "1", "method": "command.dispatch", "params": {"name": "tools"}})
+    live = server.handle_request({"id": "2", "method": "command.dispatch", "params": {"name": "start-work"}})
+    legacy = server.handle_request({"id": "3", "method": "command.dispatch", "params": {"name": "config"}})
+
+    assert native["error"]["message"] == "/tools is handled by native product routing; command.dispatch is fallback-only"
+    assert live["error"]["message"] == "/start-work is handled by slash.exec; command.dispatch is fallback-only"
+    assert legacy["error"]["message"] == "/config is handled by slash.exec; command.dispatch is fallback-only"
+
+
+def test_slash_worker_locks_legacy_only_execution(monkeypatch):
+    fake_cli = types.ModuleType("cli")
+
+    class FakeHermesCLI:
+        def process_command(self, command):
+            print(f"ran:{command}")
+
+    fake_cli.HermesCLI = FakeHermesCLI
+    fake_cli._cprint = lambda text: None
+    monkeypatch.setitem(sys.modules, "cli", fake_cli)
+
+    import tui_gateway.slash_worker as slash_worker
+
+    slash_worker = importlib.reload(slash_worker)
+
+    assert slash_worker._NATIVE_PRODUCT_COMMANDS == frozenset({"setup", "skills", "tools"})
+    assert slash_worker._LIVE_SLASH_COMMANDS == frozenset({"handoff", "init-deep", "model", "provider", "ralph-loop", "start-work", "ulw-loop"})
+    assert slash_worker._LEGACY_SLASH_WORKER_COMMANDS == server._LEGACY_SLASH_WORKER_COMMANDS
+
+    cli = FakeHermesCLI()
+    with patch.object(slash_worker.cli_mod, "_cprint", lambda text: None):
+        assert slash_worker._run(cli, "/config") == "ran:/config"
+
+    with patch.object(slash_worker.cli_mod, "_cprint", lambda text: None):
+        try:
+            slash_worker._run(cli, "/tools")
+        except RuntimeError as exc:
+            assert str(exc) == "/tools is handled by native product routing; slash worker is legacy-only"
+        else:
+            raise AssertionError("expected native route rejection")
+
+    with patch.object(slash_worker.cli_mod, "_cprint", lambda text: None):
+        try:
+            slash_worker._run(cli, "/provider claude")
+        except RuntimeError as exc:
+            assert str(exc) == "/provider is handled by slash.exec live routing; slash worker is legacy-only"
+        else:
+            raise AssertionError("expected live route rejection")
+
+    with patch.object(slash_worker.cli_mod, "_cprint", lambda text: None):
+        try:
+            slash_worker._run(cli, "/resume")
+        except RuntimeError as exc:
+            assert str(exc) == "/resume is not eligible for slash worker execution"
+        else:
+            raise AssertionError("expected non-legacy rejection")
+
+
+def test_slash_exec_work_command_submits_live_prompt(monkeypatch):
+    captured = {}
+    session = _session()
+    server._sessions["sid"] = session
+
+    monkeypatch.setattr(
+        server,
+        "_start_prompt_submit",
+        lambda rid, sid, session, text: captured.update({"args": (rid, sid, session["session_key"], text)}) or {"result": {"status": "streaming"}},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.work_command_adapter.prepare_work_command",
+        lambda canonical, raw_args, session_id, cwd: f"prepared::{canonical}::{raw_args}::{session_id}",
+    )
+
+    resp = server.handle_request({"id": "1", "method": "slash.exec", "params": {"session_id": "sid", "command": "handoff request"}})
+
+    assert resp["result"]["output"] == "/handoff started"
+    assert captured["args"] == ("1", "sid", "session-key", "prepared::handoff::request::session-key")
+
+
+
+def test_slash_exec_work_command_busy_is_deterministic(monkeypatch):
+    server._sessions["sid"] = _session(running=True)
+    monkeypatch.setattr(
+        "hermes_cli.work_command_adapter.prepare_work_command",
+        lambda canonical, raw_args, session_id, cwd: "prepared prompt",
+    )
+
+    resp = server.handle_request({"id": "1", "method": "slash.exec", "params": {"session_id": "sid", "command": "start-work ship it"}})
+
+    assert "error" in resp
+    assert resp["error"]["code"] == 4009
+    assert resp["error"]["message"] == "session busy"
+
+
+
+def test_slash_exec_model_uses_live_switch_path(monkeypatch):
+    server._sessions["sid"] = _session()
+    seen = {}
+
+    def _fake_apply(sid, session, raw):
+        seen["args"] = (sid, session["session_key"], raw)
+        return {"value": "new/model", "warning": "catalog unreachable"}
+
+    monkeypatch.setattr(server, "_apply_model_switch", _fake_apply)
+    resp = server.handle_request(
+        {"id": "1", "method": "slash.exec", "params": {"session_id": "sid", "command": "model new/model"}}
+    )
+
+    assert resp["result"]["output"] == "model → new/model"
+    assert resp["result"]["warning"] == "catalog unreachable"
+    assert seen["args"] == ("sid", "session-key", "new/model")
+
+
+
+def test_slash_exec_provider_alias_uses_live_model_path(monkeypatch):
+    server._sessions["sid"] = _session()
+    seen = {}
+
+    def _fake_apply(sid, session, raw):
+        seen["args"] = (sid, session["session_key"], raw)
+        return {"value": "provider/model", "warning": ""}
+
+    monkeypatch.setattr(server, "_apply_model_switch", _fake_apply)
+    resp = server.handle_request(
+        {"id": "1", "method": "slash.exec", "params": {"session_id": "sid", "command": "provider provider/model"}}
+    )
+
+    assert resp["result"]["output"] == "model → provider/model"
+    assert seen["args"] == ("sid", "session-key", "provider/model")
+
+
+
+def test_slash_exec_native_product_command_rejects_worker(monkeypatch):
+    session = _session()
+    server._sessions["sid"] = session
+    worker_ctor = []
+
+    monkeypatch.setattr(server, "_SlashWorker", lambda *args, **kwargs: worker_ctor.append((args, kwargs)))
+    resp = server.handle_request({"id": "1", "method": "slash.exec", "params": {"session_id": "sid", "command": "tools"}})
+
+    assert "error" in resp
+    assert resp["error"]["message"] == "/tools is handled by native product routing; slash.exec is legacy-only"
+    assert worker_ctor == []
+    assert session["slash_worker"] is None
+
+
+
+def test_slash_exec_legacy_command_still_uses_worker(monkeypatch):
+    session = _session()
+    server._sessions["sid"] = session
+    seen = {}
+
+    class _Worker:
+        def run(self, command):
+            seen["command"] = command
+            return "legacy output"
+
+        def close(self):
+            seen["closed"] = True
+
+    monkeypatch.setattr(server, "_SlashWorker", lambda session_key, model: _Worker())
+    resp = server.handle_request({"id": "1", "method": "slash.exec", "params": {"session_id": "sid", "command": "config"}})
+
+    assert resp["result"]["output"] == "legacy output"
+    assert seen["command"] == "config"
+
 
 
 def test_plugins_list_surfaces_loader_error(monkeypatch):

--- a/tests/tools/test_ast_tools.py
+++ b/tests/tools/test_ast_tools.py
@@ -1,0 +1,191 @@
+import json
+
+from model_tools import get_tool_definitions
+from toolsets import resolve_toolset
+from tools.ast_tools import (
+    AST_TOOLS,
+    AST_FIND_NODES_SCHEMA,
+    AST_LIST_DEFS_SCHEMA,
+    ast_find_nodes_tool,
+    ast_list_defs_tool,
+)
+
+
+class TestAstToolRegistration:
+    def test_exports_expected_tools_and_schemas(self):
+        names = {tool["name"] for tool in AST_TOOLS}
+        assert names == {"ast_list_defs", "ast_find_nodes"}
+
+        for schema in [AST_LIST_DEFS_SCHEMA, AST_FIND_NODES_SCHEMA]:
+            assert "name" in schema
+            assert "description" in schema
+            assert "properties" in schema["parameters"]
+
+        assert "language" in AST_LIST_DEFS_SCHEMA["parameters"]["properties"]
+        assert "language" in AST_FIND_NODES_SCHEMA["parameters"]["properties"]
+
+    def test_code_intel_toolset_exposes_ast_tools(self):
+        code_intel_tools = set(resolve_toolset("code_intel"))
+        assert {"ast_list_defs", "ast_find_nodes"} <= code_intel_tools
+
+        model_tool_names = {
+            tool["function"]["name"]
+            for tool in get_tool_definitions(enabled_toolsets=["code_intel"], quiet_mode=True)
+        }
+        assert {"ast_list_defs", "ast_find_nodes"} <= model_tool_names
+
+
+class TestAstHandlers:
+    def test_list_defs_reports_top_level_items_and_optional_nested_items(self, tmp_path):
+        source_path = tmp_path / "sample.py"
+        source_path.write_text(
+            "import os\n\n"
+            "class Example:\n"
+            "    def method(self):\n"
+            "        return 1\n\n"
+            "async def run():\n"
+            "    return 2\n\n"
+            "def outer():\n"
+            "    def inner():\n"
+            "        return 3\n"
+            "    return inner()\n",
+            encoding="utf-8",
+        )
+
+        top_level = json.loads(ast_list_defs_tool(path=str(source_path)))
+        nested = json.loads(ast_list_defs_tool(path=str(source_path), include_nested=True))
+
+        assert [item["name"] for item in top_level["definitions"]] == ["Example", "run", "outer"]
+        assert "inner" not in [item["name"] for item in top_level["definitions"]]
+        nested_names = [item["name"] for item in nested["definitions"]]
+        assert "inner" in nested_names
+        assert nested["definitions"][-1]["parent"] == "outer"
+
+    def test_find_nodes_filters_by_type_and_name(self, tmp_path):
+        source_path = tmp_path / "sample.py"
+        source_path.write_text(
+            "def helper():\n"
+            "    return 1\n\n"
+            "def build():\n"
+            "    value = helper()\n"
+            "    return helper()\n",
+            encoding="utf-8",
+        )
+
+        calls = json.loads(ast_find_nodes_tool(path=str(source_path), node_type="Call", name="helper"))
+        defs = json.loads(ast_find_nodes_tool(path=str(source_path), node_type="FunctionDef", name="build"))
+
+        assert calls["count"] == 2
+        assert all(match["display_name"] == "helper" for match in calls["matches"])
+        assert defs["count"] == 1
+        assert defs["matches"][0]["name"] == "build"
+        assert defs["matches"][0]["parent"] is None
+
+    def test_syntax_error_returns_structured_error(self, tmp_path):
+        source_path = tmp_path / "broken.py"
+        source_path.write_text("def broken(:\n    pass\n", encoding="utf-8")
+
+        result = json.loads(ast_list_defs_tool(path=str(source_path)))
+
+        assert "error" in result
+        assert result["error_type"] == "SyntaxError"
+        assert result["path"] == str(source_path)
+        assert result["lineno"] == 1
+
+    def test_list_defs_supports_json_structural_traversal(self, tmp_path):
+        source_path = tmp_path / "config.json"
+        source_path.write_text(
+            '{\n'
+            '  "name": "demo",\n'
+            '  "build": {\n'
+            '    "entry": "src/index.js",\n'
+            '    "flags": {"watch": true}\n'
+            '  },\n'
+            '  "metadata": {"owner": "hermes"}\n'
+            '}\n',
+            encoding="utf-8",
+        )
+
+        top_level = json.loads(ast_list_defs_tool(path=str(source_path)))
+        nested = json.loads(ast_list_defs_tool(path=str(source_path), include_nested=True))
+        watch_matches = json.loads(
+            ast_find_nodes_tool(path=str(source_path), node_type="ObjectProperty", name="watch")
+        )
+
+        assert top_level["language"] == "json"
+        assert top_level["parser"] == "json_structure_v1"
+        assert top_level["confidence"] == "high"
+        assert [item["name"] for item in top_level["definitions"]] == ["name", "build", "metadata"]
+        assert "flags" in [item["name"] for item in nested["definitions"]]
+        assert watch_matches["count"] == 1
+        assert watch_matches["matches"][0]["parent"] == "flags"
+        assert watch_matches["matches"][0]["node_type"] == "ObjectProperty"
+
+    def test_javascript_heuristics_list_defs_and_find_nodes(self, tmp_path):
+        source_path = tmp_path / "sample.js"
+        source_path.write_text(
+            'export class Example {\n'
+            '  async method() {\n'
+            '    function innerHelper() {\n'
+            '      return 1;\n'
+            '    }\n'
+            '    return innerHelper();\n'
+            '  }\n'
+            '}\n\n'
+            'export async function runTask() {\n'
+            '  return 2;\n'
+            '}\n\n'
+            'const helper = () => 3;\n',
+            encoding="utf-8",
+        )
+
+        top_level = json.loads(ast_list_defs_tool(path=str(source_path)))
+        nested = json.loads(ast_list_defs_tool(path=str(source_path), include_nested=True))
+        method_matches = json.loads(
+            ast_find_nodes_tool(path=str(source_path), node_type="MethodDefinition", name="method")
+        )
+
+        assert top_level["language"] == "javascript"
+        assert top_level["parser"] == "hermes_js_structure_v1"
+        assert top_level["confidence"] == "medium"
+        assert [item["name"] for item in top_level["definitions"]] == ["Example", "runTask", "helper"]
+        nested_items = {item["name"]: item for item in nested["definitions"]}
+        assert nested_items["method"]["parent"] == "Example"
+        assert nested_items["innerHelper"]["parent"] == "method"
+        assert method_matches["count"] == 1
+        assert method_matches["matches"][0]["parent"] == "Example"
+
+    def test_typescript_heuristics_support_interfaces_and_type_aliases(self, tmp_path):
+        source_path = tmp_path / "sample.ts"
+        source_path.write_text(
+            'export interface User {\n'
+            '  name: string;\n'
+            '}\n\n'
+            'export type UserId = string;\n\n'
+            'export const loadUser = async (): Promise<User> => ({ name: "demo" });\n',
+            encoding="utf-8",
+        )
+
+        result = json.loads(ast_list_defs_tool(path=str(source_path)))
+        interface_matches = json.loads(
+            ast_find_nodes_tool(path=str(source_path), node_type="InterfaceDeclaration", name="User")
+        )
+
+        assert result["language"] == "typescript"
+        assert result["parser"] == "hermes_js_structure_v1"
+        assert [item["name"] for item in result["definitions"]] == ["User", "UserId", "loadUser"]
+        assert result["definitions"][0]["node_type"] == "InterfaceDeclaration"
+        assert interface_matches["count"] == 1
+        assert interface_matches["matches"][0]["name"] == "User"
+
+    def test_unsupported_language_returns_structured_error(self, tmp_path):
+        source_path = tmp_path / "notes.md"
+        source_path.write_text("# hello\n", encoding="utf-8")
+
+        result = json.loads(ast_list_defs_tool(path=str(source_path)))
+
+        assert "error" in result
+        assert result["error_type"] == "UnsupportedLanguage"
+        assert result["path"] == str(source_path)
+        assert result["detected_language"] == "unknown"
+        assert set(result["supported_languages"]) == {"python", "javascript", "typescript", "json"}

--- a/tests/tools/test_ast_tools.py
+++ b/tests/tools/test_ast_tools.py
@@ -11,6 +11,18 @@ from tools.ast_tools import (
 )
 
 
+class TestAstRepoCodeKnowledgeFraming:
+    def test_repo_code_knowledge_toolset_treats_ast_primitives_as_canonical(self):
+        repo_code_tools = set(resolve_toolset("repo-code-knowledge"))
+        assert {"ast_list_defs", "ast_find_nodes"} <= repo_code_tools
+
+    def test_ast_schemas_mention_repo_code_knowledge_grounding(self):
+        assert "repo/code knowledge primitive" in AST_LIST_DEFS_SCHEMA["description"]
+        assert "local source grounding" in AST_LIST_DEFS_SCHEMA["description"]
+        assert "repo/code knowledge primitive" in AST_FIND_NODES_SCHEMA["description"]
+        assert "targeted structural lookup" in AST_FIND_NODES_SCHEMA["description"]
+
+
 class TestAstToolRegistration:
     def test_exports_expected_tools_and_schemas(self):
         names = {tool["name"] for tool in AST_TOOLS}

--- a/tests/tools/test_browser_console.py
+++ b/tests/tools/test_browser_console.py
@@ -16,6 +16,19 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 class TestBrowserConsole:
     """browser_console() returns console messages + JS errors in one call."""
 
+    def test_expression_mode_delegates_to_browser_eval(self):
+        from tools.browser_tool import browser_console
+
+        with (
+            patch("tools.browser_tool._browser_eval", return_value='{"success": true, "result": "Doc title"}') as mock_eval,
+            patch("tools.browser_tool._run_browser_command") as mock_cmd,
+        ):
+            result = browser_console(expression="document.title", task_id="test")
+
+        assert json.loads(result)["result"] == "Doc title"
+        mock_eval.assert_called_once_with("document.title", "test")
+        mock_cmd.assert_not_called()
+
     def test_returns_console_messages_and_errors(self):
         from tools.browser_tool import browser_console
 
@@ -116,6 +129,18 @@ class TestBrowserConsoleSchema:
         assert "clear" in props
         assert props["clear"]["type"] == "boolean"
 
+    def test_schema_describes_rendered_page_state_inspection(self):
+        from tools.browser_tool import BROWSER_TOOL_SCHEMAS
+
+        console_schema = next(s for s in BROWSER_TOOL_SCHEMAS if s["name"] == "browser_console")
+        get_images_schema = next(s for s in BROWSER_TOOL_SCHEMAS if s["name"] == "browser_get_images")
+        vision_schema = next(s for s in BROWSER_TOOL_SCHEMAS if s["name"] == "browser_vision")
+
+        assert "browser-rendered document viewers" in console_schema["description"]
+        assert "live page context" in console_schema["description"]
+        assert "rendered documents, slide decks, diagrams" in get_images_schema["description"]
+        assert "rendered PDF pages, slide decks, diagrams, charts" in vision_schema["description"]
+
 
 class TestBrowserConsoleToolsetWiring:
     """browser_console must be reachable via toolset resolution."""
@@ -192,6 +217,38 @@ class TestBrowserVisionAnnotate:
                 args = mock_cmd.call_args[0]
                 cmd_args = args[2] if len(args) > 2 else []
                 assert "--annotate" in cmd_args
+
+    def test_success_returns_screenshot_path_and_annotations(self, tmp_path):
+        from tools.browser_tool import browser_vision
+
+        screenshot = tmp_path / "page.png"
+        screenshot.write_bytes(b"fake-image-bytes")
+
+        mock_response = MagicMock()
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Rendered PDF page with a chart"
+        mock_response.choices = [mock_choice]
+
+        with (
+            patch("tools.browser_tool._run_browser_command") as mock_cmd,
+            patch("tools.browser_tool.call_llm", return_value=mock_response),
+            patch("tools.browser_tool._get_vision_model", return_value="test-model"),
+            patch("agent.redact.redact_sensitive_text", side_effect=lambda text: text),
+        ):
+            mock_cmd.return_value = {
+                "success": True,
+                "data": {
+                    "path": str(screenshot),
+                    "annotations": [{"label": 1, "ref": "@e1"}],
+                },
+            }
+
+            result = json.loads(browser_vision("Inspect this document page", annotate=True, task_id="test"))
+
+        assert result["success"] is True
+        assert result["analysis"] == "Rendered PDF page with a chart"
+        assert result["screenshot_path"] == str(screenshot)
+        assert result["annotations"] == [{"label": 1, "ref": "@e1"}]
 
 
 # ── auto-recording config ────────────────────────────────────────────

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -15,6 +15,8 @@ import sys
 import threading
 import time
 import unittest
+from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor as RealThreadPoolExecutor
 from unittest.mock import MagicMock, patch
 
 from tools.delegate_tool import (
@@ -569,6 +571,39 @@ class TestBlockedTools(unittest.TestCase):
         self.assertEqual(MAX_DEPTH, 2)
 
 
+class TestDelegationConfigIsolation(unittest.TestCase):
+    def test_stale_cli_config_from_other_hermes_home_is_ignored(self):
+        import cli
+
+        parent = _make_mock_parent()
+        stale_cfg = {
+            "delegation": {
+                "provider": "openai-codex",
+                "model": "gpt-5.4",
+                "max_concurrent_children": 12,
+            }
+        }
+
+        with (
+            patch.object(cli, "CLI_CONFIG", stale_cfg),
+            patch.object(cli, "_hermes_home", Path("/tmp/stale-hermes-home")),
+            patch("hermes_cli.config.load_config", return_value={}),
+            patch("tools.delegate_tool._run_single_child") as mock_run,
+        ):
+            mock_run.return_value = {
+                "task_index": 0,
+                "status": "completed",
+                "summary": "Done!",
+                "api_calls": 1,
+                "duration_seconds": 1.0,
+            }
+            self.assertEqual(_get_max_concurrent_children(), 3)
+            result = json.loads(delegate_task(goal="Ignore stale CLI config", parent_agent=parent))
+
+        self.assertIn("results", result)
+        mock_run.assert_called_once()
+
+
 class TestDelegationCredentialResolution(unittest.TestCase):
     """Tests for provider:model credential resolution in delegation config."""
 
@@ -592,6 +627,27 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertIsNone(creds["provider"])
         self.assertIsNone(creds["base_url"])
         self.assertIsNone(creds["api_key"])
+
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_matching_provider_reuses_parent_runtime_credentials(self, mock_resolve):
+        parent = _make_mock_parent(depth=0)
+        parent.model = "gpt-5.4"
+        parent.provider = "openai-codex"
+        parent.base_url = "https://chatgpt.com/backend-api/codex"
+        parent.api_key = "runtime-codex-key"
+        parent.api_mode = "codex_responses"
+
+        creds = _resolve_delegation_credentials(
+            {"model": "gpt-5.4", "provider": "openai-codex"},
+            parent,
+        )
+
+        self.assertEqual(creds["model"], "gpt-5.4")
+        self.assertEqual(creds["provider"], "openai-codex")
+        self.assertEqual(creds["base_url"], parent.base_url)
+        self.assertEqual(creds["api_key"], parent.api_key)
+        self.assertEqual(creds["api_mode"], parent.api_mode)
+        mock_resolve.assert_not_called()
 
     @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
     def test_provider_resolves_full_credentials(self, mock_resolve):
@@ -1276,6 +1332,103 @@ class TestDelegationReasoningEffort(unittest.TestCase):
         )
         call_kwargs = MockAgent.call_args[1]
         self.assertEqual(call_kwargs["reasoning_config"], {"enabled": True, "effort": "medium"})
+
+
+class TestDelegationCategoryPolicy(unittest.TestCase):
+    @patch("tools.delegate_tool._run_single_child")
+    @patch("tools.delegate_tool._build_child_agent")
+    @patch("tools.delegate_tool._load_config")
+    def test_category_profile_applies_tool_policy(self, mock_load_config, mock_build_child, mock_run_child):
+        mock_load_config.return_value = {
+            "max_concurrent_children": 5,
+            "categories": {
+                "research": {
+                    "enabled_tools": ["read_file", "search_files"],
+                    "toolsets": ["file"],
+                    "max_iterations": 7,
+                }
+            },
+        }
+        mock_build_child.return_value = MagicMock()
+        mock_run_child.return_value = {
+            "task_index": 0,
+            "status": "completed",
+            "summary": "Done!",
+            "api_calls": 1,
+            "duration_seconds": 0.1,
+        }
+        parent = _make_mock_parent()
+
+        result = json.loads(delegate_task(goal="Audit the repo", category="research", parent_agent=parent))
+
+        self.assertIn("results", result)
+        kwargs = mock_build_child.call_args.kwargs
+        self.assertEqual(kwargs["toolsets"], ["file"])
+        self.assertEqual(kwargs["enabled_tools"], ["read_file", "search_files"])
+        self.assertEqual(kwargs["max_iterations"], 7)
+
+    @patch("tools.delegate_tool._load_config")
+    def test_category_concurrency_cap_rejected(self, mock_load_config):
+        mock_load_config.return_value = {
+            "max_concurrent_children": 5,
+            "categories": {
+                "implementation": {"max_concurrent_children": 1},
+            },
+        }
+        parent = _make_mock_parent()
+
+        result = json.loads(delegate_task(
+            tasks=[
+                {"goal": "Patch module A", "category": "implementation"},
+                {"goal": "Patch module B", "category": "implementation"},
+            ],
+            parent_agent=parent,
+        ))
+
+        self.assertIn("error", result)
+        self.assertIn("category at 1", result["error"])
+
+    @patch("tools.delegate_tool._run_single_child")
+    @patch("tools.delegate_tool._build_child_agent")
+    @patch("tools.delegate_tool._load_config")
+    def test_category_only_batch_can_exceed_root_default(self, mock_load_config, mock_build_child, mock_run_child):
+        mock_load_config.return_value = {
+            "max_concurrent_children": 3,
+            "categories": {
+                "research": {"max_concurrent_children": 5},
+            },
+        }
+        mock_build_child.side_effect = [MagicMock() for _ in range(4)]
+        mock_run_child.side_effect = lambda *, task_index, goal, child, parent_agent: {
+            "task_index": task_index,
+            "status": "completed",
+            "summary": f"Done {goal}",
+            "api_calls": 1,
+            "duration_seconds": 0.1,
+        }
+        parent = _make_mock_parent()
+        captured = {}
+
+        def _recording_executor(*args, **kwargs):
+            captured["max_workers"] = kwargs.get("max_workers")
+            return RealThreadPoolExecutor(*args, **kwargs)
+
+        with patch("tools.delegate_tool.ThreadPoolExecutor", side_effect=_recording_executor):
+            result = json.loads(delegate_task(
+                tasks=[
+                    {"goal": "Research A"},
+                    {"goal": "Research B"},
+                    {"goal": "Research C"},
+                    {"goal": "Research D"},
+                ],
+                category="research",
+                parent_agent=parent,
+            ))
+
+        self.assertIn("results", result)
+        self.assertEqual(len(result["results"]), 4)
+        self.assertEqual(mock_build_child.call_count, 4)
+        self.assertEqual(captured["max_workers"], 4)
 
 
 if __name__ == "__main__":

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -8,12 +8,27 @@ import json
 import logging
 from unittest.mock import MagicMock, patch
 
+from toolsets import resolve_toolset
 from tools.file_tools import (
     READ_FILE_SCHEMA,
     WRITE_FILE_SCHEMA,
     PATCH_SCHEMA,
     SEARCH_FILES_SCHEMA,
 )
+
+
+class TestRepoCodeKnowledgeFraming:
+    def test_repo_code_knowledge_toolset_treats_file_primitives_as_canonical(self):
+        repo_code_tools = set(resolve_toolset("repo-code-knowledge"))
+        assert {"read_file", "search_files"} <= repo_code_tools
+
+    def test_read_file_schema_mentions_repo_code_knowledge_grounding(self):
+        assert "repo/code knowledge primitive" in READ_FILE_SCHEMA["description"]
+        assert "local source grounding" in READ_FILE_SCHEMA["description"]
+
+    def test_search_files_schema_mentions_repo_code_knowledge_grounding(self):
+        assert "repo/code knowledge primitive" in SEARCH_FILES_SCHEMA["description"]
+        assert "codebase grounding" in SEARCH_FILES_SCHEMA["description"]
 
 
 class TestReadFileHandler:
@@ -30,6 +45,12 @@ class TestReadFileHandler:
         result = json.loads(read_file_tool("/tmp/test.txt"))
         assert result["content"] == "line1\nline2"
         assert result["total_lines"] == 2
+        assert result["knowledge_surface"] == {
+            "surface": "repo-code-knowledge",
+            "surface_role": "local-file-grounding",
+            "operation": "read_file",
+            "source": "builtin",
+        }
         mock_ops.read_file.assert_called_once_with("/tmp/test.txt", 1, 500)
 
     @patch("tools.file_tools._get_file_ops")
@@ -173,6 +194,12 @@ class TestSearchHandler:
         from tools.file_tools import search_tool
         result = json.loads(search_tool(pattern="TODO", target="content", path="."))
         assert "matches" in result
+        assert result["knowledge_surface"] == {
+            "surface": "repo-code-knowledge",
+            "surface_role": "local-file-grounding",
+            "operation": "search_files",
+            "source": "builtin",
+        }
         mock_ops.search.assert_called_once()
 
     @patch("tools.file_tools._get_file_ops")

--- a/tests/tools/test_lsp_tools.py
+++ b/tests/tools/test_lsp_tools.py
@@ -15,6 +15,18 @@ from tools.lsp_tools import (
 )
 
 
+class TestLspRepoCodeKnowledgeFraming:
+    def test_repo_code_knowledge_toolset_treats_lsp_primitives_as_canonical(self):
+        repo_code_tools = set(resolve_toolset("repo-code-knowledge"))
+        assert {"lsp_document_symbols", "lsp_definition", "lsp_diagnostics"} <= repo_code_tools
+
+    def test_lsp_schemas_mention_repo_code_knowledge_grounding(self):
+        assert "repo/code knowledge primitive" in LSP_DOCUMENT_SYMBOLS_SCHEMA["description"]
+        assert "semantic local source grounding" in LSP_DOCUMENT_SYMBOLS_SCHEMA["description"]
+        assert "repo/code knowledge primitive" in LSP_DEFINITION_SCHEMA["description"]
+        assert "repo/code knowledge primitive" in LSP_DIAGNOSTICS_SCHEMA["description"]
+
+
 def _frame(payload):
     body = json.dumps(payload).encode("utf-8")
     return f"Content-Length: {len(body)}\r\n\r\n".encode("ascii") + body

--- a/tests/tools/test_lsp_tools.py
+++ b/tests/tools/test_lsp_tools.py
@@ -1,0 +1,262 @@
+import io
+import json
+
+from model_tools import get_tool_definitions
+from toolsets import resolve_toolset
+from tools.lsp_tools import (
+    LSP_TOOLS,
+    LSP_DIAGNOSTICS_SCHEMA,
+    LSP_DOCUMENT_SYMBOLS_SCHEMA,
+    LSP_DEFINITION_SCHEMA,
+    get_host_lsp_capabilities,
+    lsp_definition_tool,
+    lsp_diagnostics_tool,
+    lsp_document_symbols_tool,
+)
+
+
+def _frame(payload):
+    body = json.dumps(payload).encode("utf-8")
+    return f"Content-Length: {len(body)}\r\n\r\n".encode("ascii") + body
+
+
+class _FakeProcess:
+    def __init__(self, frames):
+        self.stdin = io.BytesIO()
+        self.stdout = io.BytesIO(b"".join(frames))
+        self.stderr = io.BytesIO()
+        self.returncode = None
+        self.command = None
+
+    def poll(self):
+        return self.returncode
+
+    def wait(self, timeout=None):
+        self.returncode = 0
+        return 0
+
+    def terminate(self):
+        self.returncode = 0
+
+    def kill(self):
+        self.returncode = -9
+
+
+class TestLspToolRegistration:
+    def test_exports_expected_tools_and_schemas(self):
+        names = {tool["name"] for tool in LSP_TOOLS}
+        assert names == {"lsp_document_symbols", "lsp_definition", "lsp_diagnostics"}
+
+        for schema in [
+            LSP_DOCUMENT_SYMBOLS_SCHEMA,
+            LSP_DEFINITION_SCHEMA,
+            LSP_DIAGNOSTICS_SCHEMA,
+        ]:
+            assert "name" in schema
+            assert "description" in schema
+            assert "properties" in schema["parameters"]
+
+    def test_code_intel_toolset_lists_lsp_tools(self):
+        code_intel_tools = set(resolve_toolset("code_intel"))
+        assert {"lsp_document_symbols", "lsp_definition", "lsp_diagnostics"} <= code_intel_tools
+
+    def test_model_tool_definitions_expose_lsp_tools_when_server_exists(self, monkeypatch):
+        monkeypatch.setattr("tools.lsp_tools.shutil.which", lambda name: "/usr/bin/fake-lsp")
+        model_tool_names = {
+            tool["function"]["name"]
+            for tool in get_tool_definitions(enabled_toolsets=["code_intel"], quiet_mode=True)
+        }
+        assert {"lsp_document_symbols", "lsp_definition", "lsp_diagnostics"} <= model_tool_names
+
+    def test_model_tool_definitions_hide_lsp_tools_when_no_server_exists(self, monkeypatch):
+        monkeypatch.setattr("tools.lsp_tools.shutil.which", lambda name: None)
+        model_tool_names = {
+            tool["function"]["name"]
+            for tool in get_tool_definitions(enabled_toolsets=["code_intel"], quiet_mode=True)
+        }
+        assert {"lsp_document_symbols", "lsp_definition", "lsp_diagnostics"}.isdisjoint(model_tool_names)
+
+    def test_host_capability_helper_reports_language_specific_auto_detection(self, monkeypatch):
+        available_binaries = {
+            "pylsp": "/usr/bin/pylsp",
+            "typescript-language-server": "/usr/bin/typescript-language-server",
+        }
+        monkeypatch.setattr("tools.lsp_tools.shutil.which", lambda name: available_binaries.get(name))
+
+        capabilities = get_host_lsp_capabilities()
+
+        assert capabilities["available"] is True
+        assert capabilities["auto_detect_languages"] == [
+            "javascript",
+            "javascriptreact",
+            "python",
+            "typescript",
+            "typescriptreact",
+        ]
+        assert capabilities["auto_detect_commands"]["python"] == ["pylsp"]
+        assert capabilities["auto_detect_commands"]["typescript"] == ["typescript-language-server --stdio"]
+
+    def test_model_tool_definitions_enrich_lsp_descriptions_with_host_languages(self, monkeypatch):
+        available_binaries = {
+            "pylsp": "/usr/bin/pylsp",
+            "rust-analyzer": "/usr/bin/rust-analyzer",
+        }
+        monkeypatch.setattr("tools.lsp_tools.shutil.which", lambda name: available_binaries.get(name))
+
+        tool_definitions = get_tool_definitions(enabled_toolsets=["code_intel"], quiet_mode=True)
+        descriptions = {
+            tool["function"]["name"]: tool["function"]["description"]
+            for tool in tool_definitions
+            if tool["function"]["name"] in {"lsp_document_symbols", "lsp_definition", "lsp_diagnostics"}
+        }
+
+        assert descriptions
+        for description in descriptions.values():
+            assert "Auto-detect currently supports: python, rust." in description
+            assert "server_command" in description
+
+
+class TestLspHandlers:
+    def test_document_symbols_returns_structured_error_when_no_server_is_available(self, monkeypatch, tmp_path):
+        source_path = tmp_path / "sample.py"
+        source_path.write_text("def demo():\n    return 1\n", encoding="utf-8")
+        monkeypatch.setattr("tools.lsp_tools.shutil.which", lambda name: None)
+
+        result = json.loads(lsp_document_symbols_tool(path=str(source_path)))
+
+        assert "error" in result
+        assert "No LSP server found" in result["error"]
+        assert result["language"] == "python"
+        assert result["requested_method"] == "textDocument/documentSymbol"
+
+    def test_document_symbols_round_trip_uses_explicit_server_command(self, monkeypatch, tmp_path):
+        source_path = tmp_path / "sample.py"
+        source_path.write_text("class Example:\n    pass\n", encoding="utf-8")
+
+        fake_process = _FakeProcess(
+            [
+                _frame({"jsonrpc": "2.0", "id": 1, "result": {"capabilities": {}}}),
+                _frame(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 2,
+                        "result": [
+                            {
+                                "name": "Example",
+                                "kind": 5,
+                                "range": {
+                                    "start": {"line": 0, "character": 0},
+                                    "end": {"line": 1, "character": 8},
+                                },
+                                "selectionRange": {
+                                    "start": {"line": 0, "character": 6},
+                                    "end": {"line": 0, "character": 13},
+                                },
+                                "children": [],
+                            }
+                        ],
+                    }
+                ),
+                _frame({"jsonrpc": "2.0", "id": 3, "result": None}),
+            ]
+        )
+
+        def _fake_popen(command, **kwargs):
+            fake_process.command = command
+            return fake_process
+
+        monkeypatch.setattr("tools.lsp_tools.subprocess.Popen", _fake_popen)
+
+        result = json.loads(
+            lsp_document_symbols_tool(
+                path=str(source_path),
+                server_command="fake-lsp --stdio",
+            )
+        )
+
+        assert result["ok"] is True
+        assert result["server_command"] == ["fake-lsp", "--stdio"]
+        assert fake_process.command == ["fake-lsp", "--stdio"]
+        assert result["symbols"][0]["name"] == "Example"
+        sent_payload = fake_process.stdin.getvalue().decode("utf-8")
+        assert "textDocument/documentSymbol" in sent_payload
+        assert "textDocument/didOpen" in sent_payload
+
+    def test_definition_and_diagnostics_round_trip(self, monkeypatch, tmp_path):
+        source_path = tmp_path / "sample.py"
+        source_path.write_text("value = helper()\n", encoding="utf-8")
+
+        definition_process = _FakeProcess(
+            [
+                _frame({"jsonrpc": "2.0", "id": 1, "result": {"capabilities": {}}}),
+                _frame(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 2,
+                        "result": [
+                            {
+                                "uri": source_path.resolve().as_uri(),
+                                "range": {
+                                    "start": {"line": 0, "character": 0},
+                                    "end": {"line": 0, "character": 5},
+                                },
+                            }
+                        ],
+                    }
+                ),
+                _frame({"jsonrpc": "2.0", "id": 3, "result": None}),
+            ]
+        )
+        diagnostics_process = _FakeProcess(
+            [
+                _frame({"jsonrpc": "2.0", "id": 1, "result": {"capabilities": {}}}),
+                _frame(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 2,
+                        "result": {
+                            "kind": "full",
+                            "items": [
+                                {
+                                    "message": "Undefined name 'helper'",
+                                    "severity": 1,
+                                    "source": "fake-lsp",
+                                    "range": {
+                                        "start": {"line": 0, "character": 8},
+                                        "end": {"line": 0, "character": 14},
+                                    },
+                                }
+                            ],
+                        },
+                    }
+                ),
+                _frame({"jsonrpc": "2.0", "id": 3, "result": None}),
+            ]
+        )
+        processes = [definition_process, diagnostics_process]
+
+        def _fake_popen(command, **kwargs):
+            return processes.pop(0)
+
+        monkeypatch.setattr("tools.lsp_tools.subprocess.Popen", _fake_popen)
+
+        definition_result = json.loads(
+            lsp_definition_tool(
+                path=str(source_path),
+                line=0,
+                character=8,
+                server_command="fake-lsp --stdio",
+            )
+        )
+        diagnostics_result = json.loads(
+            lsp_diagnostics_tool(
+                path=str(source_path),
+                server_command="fake-lsp --stdio",
+            )
+        )
+
+        assert definition_result["ok"] is True
+        assert definition_result["definitions"][0]["path"] == str(source_path.resolve())
+        assert diagnostics_result["ok"] is True
+        assert diagnostics_result["diagnostics"][0]["message"] == "Undefined name 'helper'"
+        assert diagnostics_result["diagnostics"][0]["severity"] == 1

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -676,6 +676,19 @@ class TestVisionRegistration:
         assert "image_url" in props
         assert "question" in props
 
+    def test_schema_describes_local_and_rendered_image_support(self):
+        from tools.registry import registry
+
+        entry = registry._tools.get("vision_analyze")
+        schema = entry.schema
+        props = schema["parameters"]["properties"]
+
+        assert "HTTP/HTTPS URL or local image file path" in schema["description"]
+        assert "screenshots, diagrams, charts, photos, and page captures" in schema["description"]
+        assert "Not for raw PDF parsing" in schema["description"]
+        assert "file:// image URI" in props["image_url"]["description"]
+        assert "first understand the image itself" in props["question"]["description"]
+
     def test_handler_is_callable(self):
         from tools.registry import registry
 

--- a/tests/tools/test_web_tools.py
+++ b/tests/tools/test_web_tools.py
@@ -1,0 +1,98 @@
+import inspect
+import importlib
+
+import pytest
+
+from tools.registry import registry
+
+web_tools = importlib.import_module("tools.web_tools")
+
+
+class TestWebToolSchemas:
+    def test_web_search_schema_frames_builtin_grounding_primitive(self):
+        description = web_tools.WEB_SEARCH_SCHEMA["description"]
+
+        assert "Hermes built-in web/research grounding primitive" in description
+        assert "live web search" in description
+        assert "current external information" in description
+
+    def test_web_extract_schema_frames_text_first_boundary_and_browser_fallback(self):
+        description = web_tools.WEB_EXTRACT_SCHEMA["description"]
+
+        assert "Hermes built-in web/research grounding primitive" in description
+        assert "text-first extraction" in description
+        assert "browser-driven navigation and document/PDF intelligence are outside this tool's scope" in description
+        assert "fall back to Hermes browser/document tools" in description
+
+
+class TestWebToolRegistry:
+    def test_registry_exposes_only_public_web_search_and_extract_entries(self):
+        search_entry = registry.get_entry("web_search")
+        extract_entry = registry.get_entry("web_extract")
+        crawl_entry = registry.get_entry("web_crawl")
+
+        assert search_entry is not None
+        assert search_entry.toolset == "web"
+        assert search_entry.schema["name"] == "web_search"
+
+        assert extract_entry is not None
+        assert extract_entry.toolset == "web"
+        assert extract_entry.schema["name"] == "web_extract"
+        assert extract_entry.is_async is True
+
+        assert crawl_entry is None
+
+    def test_web_crawl_docstring_keeps_canonical_defer_truth_explicit(self):
+        doc = inspect.getdoc(web_tools.web_crawl_tool)
+
+        assert doc is not None
+        assert "lives in ``tools/web_tools.py``" in doc
+        assert "not" in doc and "canonical built-in web/research surface today" in doc
+        assert "``web_search``" in doc
+        assert "``web_extract``" in doc
+
+
+class TestWebToolAvailabilityChecks:
+    @pytest.mark.parametrize("tool_name", ["web_search", "web_extract"])
+    def test_registry_check_fn_uses_configured_backend_readiness(self, monkeypatch, tool_name):
+        entry = registry.get_entry(tool_name)
+        seen = []
+
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "parallel"})
+
+        def fake_is_backend_available(backend):
+            seen.append(backend)
+            return backend == "parallel"
+
+        monkeypatch.setattr(web_tools, "_is_backend_available", fake_is_backend_available)
+
+        assert entry is not None
+        assert entry.check_fn() is True
+        assert seen == ["parallel"]
+
+    @pytest.mark.parametrize("tool_name", ["web_search", "web_extract"])
+    def test_registry_check_fn_falls_back_to_any_available_backend(self, monkeypatch, tool_name):
+        entry = registry.get_entry(tool_name)
+        seen = []
+
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {})
+
+        def fake_is_backend_available(backend):
+            seen.append(backend)
+            return backend == "tavily"
+
+        monkeypatch.setattr(web_tools, "_is_backend_available", fake_is_backend_available)
+
+        assert entry is not None
+        assert entry.check_fn() is True
+        assert seen == ["exa", "parallel", "firecrawl", "tavily"]
+
+    @pytest.mark.parametrize("tool_name", ["web_search", "web_extract"])
+    def test_registry_check_fn_reports_unavailable_when_no_backend_is_ready(self, monkeypatch, tool_name):
+        entry = registry.get_entry(tool_name)
+
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "firecrawl"})
+        monkeypatch.setattr(web_tools, "_is_backend_available", lambda backend: False)
+
+        assert entry is not None
+        assert entry.check_fn() is False

--- a/tools/ast_tools.py
+++ b/tools/ast_tools.py
@@ -1,5 +1,11 @@
 #!/usr/bin/env python3
-"""Hermes-native structural code inspection for Python, JSON, JavaScript, and TypeScript."""
+"""Hermes-native structural code inspection for local repo/code grounding.
+
+These AST tools remain lightweight built-in structure inspectors, but their primary
+product framing is the canonical `repo-code-knowledge` surface: helping the model
+inspect local source definitions and structural nodes without reaching for external
+indexers or networked code search.
+"""
 
 from __future__ import annotations
 
@@ -42,7 +48,7 @@ LANGUAGE_BY_SUFFIX = {
 
 AST_LIST_DEFS_SCHEMA = {
     "name": "ast_list_defs",
-    "description": "List structural definitions from local Python, JSON, JavaScript, or TypeScript files using Hermes-native parsers.",
+    "description": "List structural definitions from local Python, JSON, JavaScript, or TypeScript files using Hermes-native parsers. This is a built-in repo/code knowledge primitive for local source grounding and structural inventory.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -59,7 +65,7 @@ AST_LIST_DEFS_SCHEMA = {
 
 AST_FIND_NODES_SCHEMA = {
     "name": "ast_find_nodes",
-    "description": "Find structural nodes from local Python, JSON, JavaScript, or TypeScript files by node type and/or display name.",
+    "description": "Find structural nodes from local Python, JSON, JavaScript, or TypeScript files by node type and/or display name. This is a built-in repo/code knowledge primitive for local source grounding and targeted structural lookup.",
     "parameters": {
         "type": "object",
         "properties": {

--- a/tools/ast_tools.py
+++ b/tools/ast_tools.py
@@ -1,0 +1,693 @@
+#!/usr/bin/env python3
+"""Hermes-native structural code inspection for Python, JSON, JavaScript, and TypeScript."""
+
+from __future__ import annotations
+
+import ast
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any
+
+from tools.registry import registry, tool_error, tool_result
+
+logger = logging.getLogger(__name__)
+
+SUPPORTED_LANGUAGES = ("python", "javascript", "typescript", "json")
+LANGUAGE_ALIASES = {
+    "py": "python",
+    "python": "python",
+    "js": "javascript",
+    "jsx": "javascript",
+    "mjs": "javascript",
+    "cjs": "javascript",
+    "javascript": "javascript",
+    "ts": "typescript",
+    "tsx": "typescript",
+    "typescript": "typescript",
+    "json": "json",
+}
+LANGUAGE_BY_SUFFIX = {
+    ".py": "python",
+    ".pyi": "python",
+    ".js": "javascript",
+    ".jsx": "javascript",
+    ".mjs": "javascript",
+    ".cjs": "javascript",
+    ".ts": "typescript",
+    ".tsx": "typescript",
+    ".json": "json",
+}
+
+AST_LIST_DEFS_SCHEMA = {
+    "name": "ast_list_defs",
+    "description": "List structural definitions from local Python, JSON, JavaScript, or TypeScript files using Hermes-native parsers.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "path": {"type": "string", "description": "Path to a Python, JSON, JavaScript, or TypeScript source file"},
+            "language": {
+                "type": "string",
+                "description": "Optional language override. Supported: python, javascript, typescript, json",
+            },
+            "include_nested": {"type": "boolean", "description": "Include nested class/function/method or nested structural definitions", "default": False},
+        },
+        "required": ["path"],
+    },
+}
+
+AST_FIND_NODES_SCHEMA = {
+    "name": "ast_find_nodes",
+    "description": "Find structural nodes from local Python, JSON, JavaScript, or TypeScript files by node type and/or display name.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "path": {"type": "string", "description": "Path to a Python, JSON, JavaScript, or TypeScript source file"},
+            "language": {
+                "type": "string",
+                "description": "Optional language override. Supported: python, javascript, typescript, json",
+            },
+            "node_type": {"type": "string", "description": "Optional structural node type, for example FunctionDef, ClassDeclaration, MethodDefinition, ObjectProperty"},
+            "name": {"type": "string", "description": "Optional display-name filter (case-insensitive substring match)"},
+            "include_source": {"type": "boolean", "description": "Include a source snippet or structural value preview for each match", "default": False},
+            "max_results": {"type": "integer", "description": "Maximum number of matches to return", "default": 100},
+        },
+        "required": ["path"],
+    },
+}
+
+
+_CLASS_RE = re.compile(r"^\s*(?:export\s+)?(?:default\s+)?class\s+([A-Za-z_$][\w$]*)\b")
+_FUNCTION_RE = re.compile(r"^\s*(?:export\s+)?(?:default\s+)?(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\s*\(")
+_VARIABLE_RE = re.compile(
+    r"^\s*(?:export\s+)?(?:default\s+)?(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s*)?(?:function\b|\([^)]*\)\s*(?::[^=]+)?=>|[A-Za-z_$][\w$]*\s*=>)"
+)
+_INTERFACE_RE = re.compile(r"^\s*(?:export\s+)?interface\s+([A-Za-z_$][\w$]*)\b")
+_TYPE_ALIAS_RE = re.compile(r"^\s*(?:export\s+)?type\s+([A-Za-z_$][\w$]*)\b")
+_METHOD_RE = re.compile(
+    r"^\s*(?:(?:public|private|protected|static|readonly|abstract|override)\s+)*(?:async\s+)?([A-Za-z_$][\w$]*)\s*\("
+)
+_METHOD_EXCLUDED = {"if", "for", "while", "switch", "catch", "function", "class", "return"}
+
+
+PYTHON_LIMITATIONS = []
+JSON_LIMITATIONS = [
+    "JSON support is structural and does not provide exact source spans.",
+    "JSON nodes are limited to object properties and array items rather than executable AST constructs.",
+]
+JS_TS_LIMITATIONS = [
+    "JavaScript/TypeScript support is heuristic and focuses on declarations, methods, and assignment-based function definitions.",
+    "Heuristic parsing does not attempt full ECMAScript syntax coverage or call-expression traversal.",
+]
+
+
+def _check_ast_requirements() -> bool:
+    return True
+
+
+def _supported_languages() -> list[str]:
+    return list(SUPPORTED_LANGUAGES)
+
+
+def _normalize_language(language: str | None) -> str | None:
+    if not language:
+        return None
+    return LANGUAGE_ALIASES.get(language.strip().lower())
+
+
+def _detect_language(source_path: Path, language: str | None) -> str | None:
+    normalized = _normalize_language(language)
+    if language and not normalized:
+        return None
+    if normalized:
+        return normalized
+    return LANGUAGE_BY_SUFFIX.get(source_path.suffix.lower())
+
+
+def _resolve_source_path(path: str) -> Path | None:
+    source_path = Path(path).expanduser()
+    if not source_path.exists():
+        return None
+    return source_path.resolve()
+
+
+def _unsupported_language_error(path: Path, language: str | None = None) -> str:
+    return tool_error(
+        "Unsupported language for Hermes AST tooling v1",
+        error_type="UnsupportedLanguage",
+        path=str(path),
+        detected_language=language or "unknown",
+        supported_languages=_supported_languages(),
+    )
+
+
+def _read_source(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _attach_parents(node: ast.AST) -> None:
+    for parent in ast.walk(node):
+        for child in ast.iter_child_nodes(parent):
+            setattr(child, "_hermes_parent", parent)
+
+
+def _find_parent_name(node: ast.AST) -> str | None:
+    current = getattr(node, "_hermes_parent", None)
+    while current is not None:
+        name = getattr(current, "name", None)
+        if name:
+            return name
+        current = getattr(current, "_hermes_parent", None)
+    return None
+
+
+def _node_range(node: ast.AST) -> dict[str, Any]:
+    return {
+        "lineno": getattr(node, "lineno", None),
+        "end_lineno": getattr(node, "end_lineno", None),
+        "col_offset": getattr(node, "col_offset", None),
+        "end_col_offset": getattr(node, "end_col_offset", None),
+    }
+
+
+def _expr_name(node: ast.AST | None) -> str | None:
+    if node is None:
+        return None
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        base = _expr_name(node.value)
+        return f"{base}.{node.attr}" if base else node.attr
+    if isinstance(node, ast.Call):
+        return _expr_name(node.func)
+    if isinstance(node, ast.alias):
+        return node.asname or node.name
+    if isinstance(node, ast.Constant):
+        return repr(node.value)
+    return None
+
+
+def _decorators(node: ast.AST) -> list[str]:
+    values = []
+    for decorator in getattr(node, "decorator_list", []):
+        values.append(_expr_name(decorator) or ast.dump(decorator, include_attributes=False))
+    return values
+
+
+def _serialize_named_node(node: ast.AST, parent: str | None) -> dict[str, Any]:
+    payload = {
+        "name": getattr(node, "name", None),
+        "display_name": getattr(node, "name", None),
+        "node_type": type(node).__name__,
+        "parent": parent,
+        "docstring": ast.get_docstring(node, clean=False) if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)) else None,
+        "decorators": _decorators(node),
+        "is_async": isinstance(node, ast.AsyncFunctionDef),
+    }
+    payload.update(_node_range(node))
+    return payload
+
+
+def _is_named_definition(node: ast.AST) -> bool:
+    return isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef))
+
+
+def _list_nested_defs(node: ast.AST, items: list[dict[str, Any]]) -> None:
+    parent_name = getattr(node, "name", None)
+    body = getattr(node, "body", [])
+    for child in body:
+        if _is_named_definition(child):
+            items.append(_serialize_named_node(child, parent_name))
+            _list_nested_defs(child, items)
+
+
+def _display_name(node: ast.AST) -> str | None:
+    name = getattr(node, "name", None)
+    if isinstance(name, str):
+        return name
+    return _expr_name(node)
+
+
+def _serialize_match(node: ast.AST, source: str, include_source: bool) -> dict[str, Any]:
+    payload = {
+        "node_type": type(node).__name__,
+        "name": getattr(node, "name", None),
+        "display_name": _display_name(node),
+        "parent": _find_parent_name(node),
+    }
+    payload.update(_node_range(node))
+    if include_source:
+        payload["source"] = ast.get_source_segment(source, node)
+    return payload
+
+
+def _parse_python_module(path: Path) -> dict[str, Any] | str:
+    try:
+        source = _read_source(path)
+        module = ast.parse(source, filename=str(path), type_comments=True)
+        _attach_parents(module)
+        return {
+            "path": path,
+            "source": source,
+            "module": module,
+            "language": "python",
+            "parser": "python_ast",
+            "confidence": "high",
+            "limitations": list(PYTHON_LIMITATIONS),
+        }
+    except SyntaxError as exc:
+        return tool_error(
+            f"SyntaxError: {exc.msg}",
+            error_type="SyntaxError",
+            path=str(path),
+            lineno=exc.lineno,
+            offset=exc.offset,
+            text=exc.text,
+        )
+    except Exception as exc:
+        logger.debug("AST parse failed", exc_info=True)
+        return tool_error(str(exc), error_type=type(exc).__name__, path=str(path))
+
+
+def _json_value_type(value: Any) -> str:
+    if isinstance(value, dict):
+        return "object"
+    if isinstance(value, list):
+        return "array"
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, (int, float)):
+        return "number"
+    return "string"
+
+
+def _json_preview(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True)
+
+
+def _json_node(
+    *,
+    name: str,
+    node_type: str,
+    parent: str | None,
+    json_path: str,
+    value: Any,
+) -> dict[str, Any]:
+    return {
+        "name": name,
+        "display_name": name,
+        "node_type": node_type,
+        "parent": parent,
+        "json_path": json_path,
+        "value_type": _json_value_type(value),
+        "source": _json_preview(value),
+        "lineno": None,
+        "end_lineno": None,
+        "col_offset": None,
+        "end_col_offset": None,
+    }
+
+
+def _json_child_path(base_path: str, child: str) -> str:
+    if base_path == "$":
+        return f"$.{child}"
+    return f"{base_path}.{child}"
+
+
+def _collect_json_nodes(value: Any, *, parent: str | None, json_path: str, items: list[dict[str, Any]]) -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            child_path = _json_child_path(json_path, key)
+            items.append(
+                _json_node(
+                    name=key,
+                    node_type="ObjectProperty",
+                    parent=parent,
+                    json_path=child_path,
+                    value=child,
+                )
+            )
+            if isinstance(child, (dict, list)):
+                _collect_json_nodes(child, parent=key, json_path=child_path, items=items)
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            item_name = f"[{index}]"
+            child_path = f"{json_path}{item_name}"
+            items.append(
+                _json_node(
+                    name=item_name,
+                    node_type="ArrayItem",
+                    parent=parent,
+                    json_path=child_path,
+                    value=child,
+                )
+            )
+            if isinstance(child, (dict, list)):
+                _collect_json_nodes(child, parent=item_name, json_path=child_path, items=items)
+
+
+def _parse_json_document(path: Path) -> dict[str, Any] | str:
+    try:
+        source = _read_source(path)
+        document = json.loads(source)
+    except json.JSONDecodeError as exc:
+        return tool_error(
+            f"JSONDecodeError: {exc.msg}",
+            error_type="JSONDecodeError",
+            path=str(path),
+            lineno=exc.lineno,
+            colno=exc.colno,
+            pos=exc.pos,
+        )
+    except Exception as exc:
+        logger.debug("JSON parse failed", exc_info=True)
+        return tool_error(str(exc), error_type=type(exc).__name__, path=str(path))
+
+    definitions: list[dict[str, Any]] = []
+    _collect_json_nodes(document, parent=None, json_path="$", items=definitions)
+    return {
+        "path": path,
+        "source": source,
+        "document": document,
+        "definitions": definitions,
+        "language": "json",
+        "parser": "json_structure_v1",
+        "confidence": "high",
+        "limitations": list(JSON_LIMITATIONS),
+    }
+
+
+def _strip_js_comments(source: str) -> list[str]:
+    cleaned_lines = []
+    in_block_comment = False
+    for raw_line in source.splitlines():
+        line = raw_line
+        if in_block_comment:
+            if "*/" in line:
+                line = line.split("*/", 1)[1]
+                in_block_comment = False
+            else:
+                cleaned_lines.append("")
+                continue
+        while "/*" in line:
+            before, after = line.split("/*", 1)
+            if "*/" in after:
+                after = after.split("*/", 1)[1]
+                line = before + " " + after
+            else:
+                line = before
+                in_block_comment = True
+                break
+        if "//" in line:
+            line = line.split("//", 1)[0]
+        cleaned_lines.append(line)
+    return cleaned_lines
+
+
+def _count_braces(line: str) -> tuple[int, int]:
+    return line.count("{"), line.count("}")
+
+
+def _line_has_block_start(line: str) -> bool:
+    return bool(re.search(r"\{\s*$", line))
+
+
+def _heuristic_node(
+    *,
+    name: str,
+    node_type: str,
+    parent: str | None,
+    line_number: int,
+    raw_line: str,
+    is_async: bool = False,
+) -> dict[str, Any]:
+    col_offset = raw_line.find(name)
+    return {
+        "name": name,
+        "display_name": name,
+        "node_type": node_type,
+        "parent": parent,
+        "docstring": None,
+        "decorators": [],
+        "is_async": is_async,
+        "lineno": line_number,
+        "end_lineno": line_number,
+        "col_offset": col_offset if col_offset >= 0 else None,
+        "end_col_offset": (col_offset + len(name)) if col_offset >= 0 else None,
+        "source": raw_line.strip() or None,
+    }
+
+
+def _match_js_ts_declaration(line: str, *, inside_class: bool) -> tuple[str, str, bool, bool] | None:
+    match = _CLASS_RE.match(line)
+    if match:
+        return match.group(1), "ClassDeclaration", _line_has_block_start(line), False
+
+    match = _FUNCTION_RE.match(line)
+    if match:
+        return match.group(1), "FunctionDeclaration", _line_has_block_start(line), "async function" in line
+
+    match = _VARIABLE_RE.match(line)
+    if match:
+        return match.group(1), "VariableDeclarator", _line_has_block_start(line), bool(re.search(r"=\s*async\b", line))
+
+    match = _INTERFACE_RE.match(line)
+    if match:
+        return match.group(1), "InterfaceDeclaration", _line_has_block_start(line), False
+
+    match = _TYPE_ALIAS_RE.match(line)
+    if match:
+        return match.group(1), "TypeAliasDeclaration", False, False
+
+    if inside_class:
+        match = _METHOD_RE.match(line)
+        if match and match.group(1) not in _METHOD_EXCLUDED:
+            return match.group(1), "MethodDefinition", _line_has_block_start(line), line.lstrip().startswith("async ") or " async " in line
+
+    return None
+
+
+def _parse_js_ts_structure(path: Path, language: str) -> dict[str, Any] | str:
+    try:
+        source = _read_source(path)
+    except Exception as exc:
+        logger.debug("JS/TS read failed", exc_info=True)
+        return tool_error(str(exc), error_type=type(exc).__name__, path=str(path))
+
+    cleaned_lines = _strip_js_comments(source)
+    raw_lines = source.splitlines()
+    definitions: list[dict[str, Any]] = []
+    stack: list[dict[str, Any]] = []
+    depth = 0
+
+    for line_number, (raw_line, line) in enumerate(zip(raw_lines, cleaned_lines), start=1):
+        while stack and depth <= stack[-1]["depth"]:
+            stack.pop()
+
+        parent = stack[-1]["name"] if stack else None
+        inside_class = bool(stack) and stack[-1]["node_type"] == "ClassDeclaration"
+        matched = _match_js_ts_declaration(line, inside_class=inside_class)
+        if matched:
+            name, node_type, opens_block, is_async = matched
+            item = _heuristic_node(
+                name=name,
+                node_type=node_type,
+                parent=parent,
+                line_number=line_number,
+                raw_line=raw_line,
+                is_async=is_async,
+            )
+            definitions.append(item)
+            if opens_block:
+                stack.append({"name": name, "node_type": node_type, "depth": depth})
+
+        open_braces, close_braces = _count_braces(line)
+        depth += open_braces - close_braces
+        if depth < 0:
+            depth = 0
+
+    return {
+        "path": path,
+        "source": source,
+        "definitions": definitions,
+        "language": language,
+        "parser": "hermes_js_structure_v1",
+        "confidence": "medium",
+        "limitations": list(JS_TS_LIMITATIONS),
+    }
+
+
+def _parse_source(path: str, language: str | None) -> dict[str, Any] | str:
+    source_path = _resolve_source_path(path)
+    if source_path is None:
+        return tool_error(f"File not found: {path}", path=str(Path(path).expanduser()))
+
+    detected_language = _detect_language(source_path, language)
+    if detected_language == "python":
+        return _parse_python_module(source_path)
+    if detected_language == "json":
+        return _parse_json_document(source_path)
+    if detected_language in {"javascript", "typescript"}:
+        return _parse_js_ts_structure(source_path, detected_language)
+    return _unsupported_language_error(source_path, language=detected_language)
+
+
+def _result_metadata(parsed: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "path": str(parsed["path"]),
+        "language": parsed["language"],
+        "parser": parsed["parser"],
+        "confidence": parsed["confidence"],
+        "limitations": parsed["limitations"],
+    }
+
+
+def _structural_matches(
+    definitions: list[dict[str, Any]],
+    *,
+    node_type: str | None,
+    name: str | None,
+    include_source: bool,
+    max_results: int,
+) -> list[dict[str, Any]]:
+    target_name = name.lower() if name else None
+    matches: list[dict[str, Any]] = []
+    for item in definitions:
+        if node_type and item.get("node_type") != node_type:
+            continue
+        display_name = item.get("display_name") or item.get("name")
+        if target_name and not display_name:
+            continue
+        if target_name and target_name not in display_name.lower():
+            continue
+        match = {
+            key: value
+            for key, value in item.items()
+            if include_source or key != "source"
+        }
+        matches.append(match)
+        if len(matches) >= max_results:
+            break
+    return matches
+
+
+def ast_list_defs_tool(*, path: str, include_nested: bool = False, language: str | None = None) -> str:
+    parsed = _parse_source(path, language)
+    if isinstance(parsed, str):
+        return parsed
+
+    if parsed["language"] == "python":
+        module = parsed["module"]
+        definitions = []
+        for node in module.body:
+            if _is_named_definition(node):
+                definitions.append(_serialize_named_node(node, None))
+                if include_nested:
+                    _list_nested_defs(node, definitions)
+    else:
+        definitions = parsed["definitions"] if include_nested else [
+            item for item in parsed["definitions"] if item.get("parent") is None
+        ]
+
+    payload = {
+        "ok": True,
+        **_result_metadata(parsed),
+        "definitions": definitions,
+    }
+    return tool_result(payload)
+
+
+def ast_find_nodes_tool(
+    *,
+    path: str,
+    node_type: str | None = None,
+    name: str | None = None,
+    include_source: bool = False,
+    max_results: int = 100,
+    language: str | None = None,
+) -> str:
+    parsed = _parse_source(path, language)
+    if isinstance(parsed, str):
+        return parsed
+
+    if not node_type and not name:
+        return tool_error("Provide at least one filter: node_type or name", path=str(parsed["path"]))
+
+    if parsed["language"] == "python":
+        source = parsed["source"]
+        module = parsed["module"]
+        target_name = name.lower() if name else None
+        matches = []
+        for node in ast.walk(module):
+            if node_type and type(node).__name__ != node_type:
+                continue
+            display_name = _display_name(node)
+            if target_name and not display_name:
+                continue
+            if target_name and target_name not in display_name.lower():
+                continue
+            matches.append(_serialize_match(node, source, include_source))
+            if len(matches) >= max_results:
+                break
+    else:
+        matches = _structural_matches(
+            parsed["definitions"],
+            node_type=node_type,
+            name=name,
+            include_source=include_source,
+            max_results=max_results,
+        )
+
+    payload = {
+        "ok": True,
+        **_result_metadata(parsed),
+        "count": len(matches),
+        "matches": matches,
+    }
+    return tool_result(payload)
+
+
+AST_TOOLS = [
+    {"name": "ast_list_defs", "function": ast_list_defs_tool},
+    {"name": "ast_find_nodes", "function": ast_find_nodes_tool},
+]
+
+
+def _handle_ast_list_defs(args, **_kwargs):
+    return ast_list_defs_tool(
+        path=args.get("path", ""),
+        include_nested=args.get("include_nested", False),
+        language=args.get("language"),
+    )
+
+
+def _handle_ast_find_nodes(args, **_kwargs):
+    return ast_find_nodes_tool(
+        path=args.get("path", ""),
+        language=args.get("language"),
+        node_type=args.get("node_type"),
+        name=args.get("name"),
+        include_source=args.get("include_source", False),
+        max_results=args.get("max_results", 100),
+    )
+
+
+registry.register(
+    name="ast_list_defs",
+    toolset="code_intel",
+    schema=AST_LIST_DEFS_SCHEMA,
+    handler=_handle_ast_list_defs,
+    check_fn=_check_ast_requirements,
+    emoji="🌳",
+)
+registry.register(
+    name="ast_find_nodes",
+    toolset="code_intel",
+    schema=AST_FIND_NODES_SCHEMA,
+    handler=_handle_ast_find_nodes,
+    check_fn=_check_ast_requirements,
+    emoji="🔍",
+)

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -837,7 +837,7 @@ BROWSER_TOOL_SCHEMAS = [
     },
     {
         "name": "browser_get_images",
-        "description": "Get a list of all images on the current page with their URLs and alt text. Useful for finding images to analyze with the vision tool. Requires browser_navigate to be called first.",
+        "description": "Get a list of images visible from the current browser page with their URLs and alt text. Useful when inspecting rendered documents, slide decks, diagrams, or complex pages before handing specific images to the vision tools. Requires browser_navigate to be called first.",
         "parameters": {
             "type": "object",
             "properties": {},
@@ -846,7 +846,7 @@ BROWSER_TOOL_SCHEMAS = [
     },
     {
         "name": "browser_vision",
-        "description": "Take a screenshot of the current page and analyze it with vision AI. Use this when you need to visually understand what's on the page - especially useful for CAPTCHAs, visual verification challenges, complex layouts, or when the text snapshot doesn't capture important visual information. Returns both the AI analysis and a screenshot_path that you can share with the user by including MEDIA:<screenshot_path> in your response. Requires browser_navigate to be called first.",
+        "description": "Take a screenshot of the current browser page and analyze the rendered view with vision AI. Use this for rendered PDF pages, slide decks, diagrams, charts, visual verification challenges, or any layout where browser_snapshot misses important visual information. Returns both the AI analysis and a screenshot_path that you can share with the user by including MEDIA:<screenshot_path> in your response. Requires browser_navigate to be called first.",
         "parameters": {
             "type": "object",
             "properties": {
@@ -865,7 +865,7 @@ BROWSER_TOOL_SCHEMAS = [
     },
     {
         "name": "browser_console",
-        "description": "Get browser console output and JavaScript errors from the current page. Returns console.log/warn/error/info messages and uncaught JS exceptions. Use this to detect silent JavaScript errors, failed API calls, and application warnings. Requires browser_navigate to be called first. When 'expression' is provided, evaluates JavaScript in the page context and returns the result — use this for DOM inspection, reading page state, or extracting data programmatically.",
+        "description": "Get browser console output and JavaScript errors from the current page. Returns console.log/warn/error/info messages and uncaught JS exceptions. Use this to detect silent JavaScript errors, failed API calls, and application warnings in web apps or browser-rendered document viewers. Requires browser_navigate to be called first. When 'expression' is provided, evaluates JavaScript in the live page context and returns the result — use this for DOM inspection, browser page-state checks, or extracting structured data from rendered pages.",
         "parameters": {
             "type": "object",
             "properties": {
@@ -1761,10 +1761,14 @@ def browser_press(key: str, task_id: Optional[str] = None) -> str:
 
 def browser_console(clear: bool = False, expression: Optional[str] = None, task_id: Optional[str] = None) -> str:
     """Get browser console messages and JavaScript errors, or evaluate JS in the page.
-    
-    When ``expression`` is provided, evaluates JavaScript in the page context
-    (like the DevTools console) and returns the result.  Otherwise returns
-    console output (log/warn/error/info) and uncaught exceptions.
+
+    When ``expression`` is provided, evaluates JavaScript in the live page
+    context (like the DevTools console) and returns the result. Otherwise it
+    returns console output (log/warn/error/info) and uncaught exceptions.
+
+    Use this for browser page-state inspection, DOM checks, and structured
+    extraction from rendered pages or browser-based document viewers. It
+    inspects the live page state; it is not a raw document parser.
     
     Args:
         clear: If True, clear the message/error buffers after reading
@@ -1943,7 +1947,11 @@ def _maybe_stop_recording(task_id: str):
 
 def browser_get_images(task_id: Optional[str] = None) -> str:
     """
-    Get all images on the current page.
+    Get images exposed by the current browser page.
+
+    Useful for inspecting rendered documents, slide decks, diagrams, and
+    complex pages before handing a specific image to ``vision_analyze`` or
+    using ``browser_vision`` on the full rendered page.
     
     Args:
         task_id: Task identifier for session isolation
@@ -2002,11 +2010,11 @@ def browser_get_images(task_id: Optional[str] = None) -> str:
 def browser_vision(question: str, annotate: bool = False, task_id: Optional[str] = None) -> str:
     """
     Take a screenshot of the current page and analyze it with vision AI.
-    
-    This tool captures what's visually displayed in the browser and sends it
-    to Gemini for analysis. Useful for understanding visual content that the
-    text-based snapshot may not capture (CAPTCHAs, verification challenges,
-    images, complex layouts, etc.).
+
+    This tool captures the rendered browser view and analyzes it with the
+    configured vision model. It is especially useful for rendered PDF pages,
+    slide decks, diagrams, charts, verification challenges, or any page where
+    the accessibility-tree snapshot misses important visual structure.
     
     The screenshot is saved persistently and its file path is returned alongside
     the analysis, so it can be shared with users via MEDIA:<path> in the response.

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -22,7 +22,9 @@ logger = logging.getLogger(__name__)
 import os
 import threading
 import time
+from collections import Counter
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from toolsets import TOOLSETS
@@ -80,6 +82,30 @@ def _get_max_concurrent_children() -> int:
 DEFAULT_MAX_ITERATIONS = 50
 _HEARTBEAT_INTERVAL = 30  # seconds between parent activity heartbeats during delegation
 DEFAULT_TOOLSETS = ["terminal", "file", "web"]
+DEFAULT_DELEGATION_CATEGORY = "general"
+DEFAULT_CATEGORY_PROFILES = {
+    "general": {"max_concurrent_children": _DEFAULT_MAX_CONCURRENT_CHILDREN},
+    "research": {
+        "max_concurrent_children": 3,
+        "max_iterations": 25,
+        "enabled_tools": [
+            "read_file", "search_files", "session_search", "skills_list", "skill_view",
+            "web_search", "web_extract", "browser_navigate", "browser_snapshot",
+            "browser_console", "browser_scroll", "browser_get_images", "vision_analyze",
+            "browser_vision",
+        ],
+    },
+    "implementation": {
+        "max_concurrent_children": 2,
+        "max_iterations": 35,
+        "toolsets": ["terminal", "file"],
+    },
+    "verification": {
+        "max_concurrent_children": 3,
+        "max_iterations": 20,
+        "toolsets": ["terminal", "file", "web"],
+    },
+}
 
 
 def check_delegate_requirements() -> bool:
@@ -153,6 +179,143 @@ def _strip_blocked_tools(toolsets: List[str]) -> List[str]:
         "delegation", "clarify", "memory", "code_execution",
     }
     return [t for t in toolsets if t not in blocked_toolset_names]
+
+
+def _normalize_category_name(value: Optional[str]) -> str:
+    if not value or not isinstance(value, str):
+        return ""
+    return value.strip().lower().replace(" ", "_").replace("-", "_")
+
+
+def _normalize_category_profile(raw: Any) -> Dict[str, Any]:
+    if not isinstance(raw, dict):
+        return {}
+    profile: Dict[str, Any] = {}
+    if isinstance(raw.get("toolsets"), list):
+        profile["toolsets"] = [str(t).strip() for t in raw["toolsets"] if str(t).strip()]
+    if isinstance(raw.get("enabled_tools"), list):
+        profile["enabled_tools"] = [str(t).strip() for t in raw["enabled_tools"] if str(t).strip()]
+    for key in ("model", "provider", "base_url", "api_key", "reasoning_effort", "acp_command"):
+        if isinstance(raw.get(key), str) and raw.get(key).strip():
+            profile[key] = raw.get(key).strip()
+    if isinstance(raw.get("acp_args"), list):
+        profile["acp_args"] = [str(v) for v in raw["acp_args"]]
+    for key in ("max_iterations", "max_concurrent_children"):
+        if raw.get(key) is not None:
+            try:
+                profile[key] = max(1, int(raw.get(key)))
+            except (TypeError, ValueError):
+                logger.warning("Ignoring invalid delegation category %s=%r", key, raw.get(key))
+    return profile
+
+
+def _merge_category_profile(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+    merged = dict(base or {})
+    for key, value in (override or {}).items():
+        if value in (None, "", [], {}):
+            continue
+        merged[key] = list(value) if isinstance(value, list) else value
+    return merged
+
+
+def _normalize_delegation_config(cfg: Any) -> Dict[str, Any]:
+    if not isinstance(cfg, dict):
+        cfg = {}
+    normalized = dict(cfg)
+    categories = {name: dict(profile) for name, profile in DEFAULT_CATEGORY_PROFILES.items()}
+    raw_categories = cfg.get("categories") if isinstance(cfg, dict) else None
+    if isinstance(raw_categories, dict):
+        for name, raw_profile in raw_categories.items():
+            normalized_name = _normalize_category_name(name)
+            if not normalized_name:
+                continue
+            categories[normalized_name] = _merge_category_profile(
+                categories.get(normalized_name, {}),
+                _normalize_category_profile(raw_profile),
+            )
+    normalized["categories"] = categories
+    default_category = _normalize_category_name(cfg.get("default_category")) if isinstance(cfg, dict) else ""
+    normalized["default_category"] = default_category or DEFAULT_DELEGATION_CATEGORY
+    return normalized
+
+
+def _resolve_task_category(task: Dict[str, Any], top_level_category: Optional[str], cfg: Dict[str, Any]) -> str:
+    explicit = _normalize_category_name(task.get("category"))
+    if explicit:
+        return explicit
+    inherited = _normalize_category_name(top_level_category)
+    if inherited:
+        return inherited
+    return _normalize_category_name(cfg.get("default_category")) or DEFAULT_DELEGATION_CATEGORY
+
+
+def _resolve_category_profile(cfg: Dict[str, Any], category: str) -> Dict[str, Any]:
+    categories = cfg.get("categories") if isinstance(cfg, dict) else {}
+    profile = categories.get(category) if isinstance(categories, dict) else None
+    if profile:
+        return _merge_category_profile({}, profile)
+    return _merge_category_profile({}, categories.get(DEFAULT_DELEGATION_CATEGORY, {})) if isinstance(categories, dict) else {}
+
+
+def _enforce_category_concurrency(
+    task_list: List[Dict[str, Any]],
+    cfg: Dict[str, Any],
+    top_level_category: Optional[str] = None,
+) -> Optional[str]:
+    categories = [_resolve_task_category(task, top_level_category, cfg) for task in task_list]
+    counts = Counter(categories)
+    for category, count in counts.items():
+        profile = _resolve_category_profile(cfg, category)
+        cap = profile.get("max_concurrent_children")
+        if cap is None:
+            continue
+        try:
+            cap_int = max(1, int(cap))
+        except (TypeError, ValueError):
+            continue
+        if count > cap_int:
+            return (
+                f"Too many '{category}' delegation tasks: {count} provided, but "
+                f"category policy caps this category at {cap_int}."
+            )
+    return None
+
+
+def _resolve_batch_concurrency_limit(
+    task_list: List[Dict[str, Any]],
+    top_level_category: Optional[str],
+    cfg: Dict[str, Any],
+) -> tuple[int, Optional[str]]:
+    """Return the effective concurrency limit for one delegation batch.
+
+    The root ``max_concurrent_children`` remains the default/global guardrail.
+    When every task is explicitly assigned to the same category, that category's
+    higher concurrency cap may override the root default for that batch.
+    """
+    base_limit = _get_max_concurrent_children()
+    if not task_list:
+        return base_limit, None
+
+    resolved_categories = [_resolve_task_category(task, top_level_category, cfg) for task in task_list]
+    if len(set(resolved_categories)) != 1:
+        return base_limit, None
+
+    category_name = resolved_categories[0]
+    explicit_top_level = _normalize_category_name(top_level_category)
+    explicit_per_task = all(_normalize_category_name(task.get("category")) == category_name for task in task_list)
+    if explicit_top_level != category_name and not explicit_per_task:
+        return base_limit, None
+
+    profile = _resolve_category_profile(cfg, category_name)
+    category_limit = profile.get("max_concurrent_children")
+    try:
+        category_limit = max(1, int(category_limit))
+    except (TypeError, ValueError):
+        return base_limit, None
+
+    if category_limit > base_limit:
+        return category_limit, category_name
+    return base_limit, None
 
 
 def _build_child_progress_callback(task_index: int, goal: str, parent_agent, task_count: int = 1) -> Optional[callable]:
@@ -267,10 +430,11 @@ def _build_child_agent(
     goal: str,
     context: Optional[str],
     toolsets: Optional[List[str]],
-    model: Optional[str],
-    max_iterations: int,
-    task_count: int,
-    parent_agent,
+    enabled_tools: Optional[List[str]] = None,
+    model: Optional[str] = None,
+    max_iterations: int = DEFAULT_MAX_ITERATIONS,
+    task_count: int = 1,
+    parent_agent=None,
     # Credential overrides from delegation config (provider:model resolution)
     override_provider: Optional[str] = None,
     override_base_url: Optional[str] = None,
@@ -317,6 +481,18 @@ def _build_child_agent(
         child_toolsets = _strip_blocked_tools(sorted(parent_toolsets))
     else:
         child_toolsets = _strip_blocked_tools(DEFAULT_TOOLSETS)
+
+    child_enabled_tools = None
+    if enabled_tools is not None:
+        parent_tool_names = set(getattr(parent_agent, "valid_tool_names", set()) or [])
+        child_enabled_tools = sorted({
+            str(name).strip()
+            for name in enabled_tools
+            if isinstance(name, str)
+            and str(name).strip()
+            and str(name).strip() in parent_tool_names
+            and str(name).strip() not in DELEGATE_BLOCKED_TOOLS
+        })
 
     workspace_hint = _resolve_workspace_hint(parent_agent)
     child_prompt = _build_child_system_prompt(goal, context, workspace_path=workspace_hint)
@@ -386,6 +562,7 @@ def _build_child_agent(
         reasoning_config=child_reasoning,
         prefill_messages=getattr(parent_agent, "prefill_messages", None),
         enabled_toolsets=child_toolsets,
+        enabled_tools=child_enabled_tools,
         quiet_mode=True,
         ephemeral_system_prompt=child_prompt,
         log_prefix=f"[subagent-{task_index}]",
@@ -682,6 +859,7 @@ def delegate_task(
     context: Optional[str] = None,
     toolsets: Optional[List[str]] = None,
     tasks: Optional[List[Dict[str, Any]]] = None,
+    category: Optional[str] = None,
     max_iterations: Optional[int] = None,
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
@@ -710,7 +888,7 @@ def delegate_task(
         })
 
     # Load config
-    cfg = _load_config()
+    cfg = _normalize_delegation_config(_load_config())
     default_max_iter = cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS)
     effective_max_iter = max_iterations or default_max_iter
 
@@ -725,9 +903,19 @@ def delegate_task(
         return tool_error(str(exc))
 
     # Normalize to task list
-    max_children = _get_max_concurrent_children()
+    max_children, limit_category = _resolve_batch_concurrency_limit(
+        task_list=tasks or [],
+        top_level_category=category,
+        cfg=cfg,
+    )
     if tasks and isinstance(tasks, list):
         if len(tasks) > max_children:
+            if limit_category:
+                return tool_error(
+                    f"Too many tasks: {len(tasks)} provided, but category '{limit_category}' allows at most "
+                    f"{max_children} concurrent tasks in a single batch. Either reduce the task count or increase "
+                    f"delegation.categories.{limit_category}.max_concurrent_children in config.yaml."
+                )
             return tool_error(
                 f"Too many tasks: {len(tasks)} provided, but "
                 f"max_concurrent_children is {max_children}. "
@@ -737,7 +925,7 @@ def delegate_task(
             )
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
-        task_list = [{"goal": goal, "context": context, "toolsets": toolsets}]
+        task_list = [{"goal": goal, "context": context, "toolsets": toolsets, "category": category}]
     else:
         return tool_error("Provide either 'goal' (single task) or 'tasks' (batch).")
 
@@ -748,6 +936,10 @@ def delegate_task(
     for i, task in enumerate(task_list):
         if not task.get("goal", "").strip():
             return tool_error(f"Task {i} is missing a 'goal'.")
+
+    category_error = _enforce_category_concurrency(task_list, cfg, top_level_category=category)
+    if category_error:
+        return tool_error(category_error)
 
     overall_start = time.monotonic()
     results = []
@@ -768,15 +960,22 @@ def delegate_task(
     children = []
     try:
         for i, t in enumerate(task_list):
+            task_category = _resolve_task_category(t, category, cfg)
+            category_profile = _resolve_category_profile(cfg, task_category)
+            merged_cfg = _merge_category_profile(cfg, category_profile)
+            category_creds = _resolve_delegation_credentials(merged_cfg, parent_agent)
+            task_toolsets = t.get("toolsets") or category_profile.get("toolsets") or toolsets
+            task_enabled_tools = category_profile.get("enabled_tools")
+            task_max_iter = int(category_profile.get("max_iterations") or effective_max_iter)
             child = _build_child_agent(
                 task_index=i, goal=t["goal"], context=t.get("context"),
-                toolsets=t.get("toolsets") or toolsets, model=creds["model"],
-                max_iterations=effective_max_iter, task_count=n_tasks, parent_agent=parent_agent,
-                override_provider=creds["provider"], override_base_url=creds["base_url"],
-                override_api_key=creds["api_key"],
-                override_api_mode=creds["api_mode"],
-                override_acp_command=t.get("acp_command") or acp_command,
-                override_acp_args=t.get("acp_args") or acp_args,
+                toolsets=task_toolsets, enabled_tools=task_enabled_tools, model=category_creds["model"] or creds["model"],
+                max_iterations=task_max_iter, task_count=n_tasks, parent_agent=parent_agent,
+                override_provider=category_creds["provider"] or creds["provider"], override_base_url=category_creds["base_url"] or creds["base_url"],
+                override_api_key=category_creds["api_key"] or creds["api_key"],
+                override_api_mode=category_creds["api_mode"] or creds["api_mode"],
+                override_acp_command=t.get("acp_command") or category_profile.get("acp_command") or acp_command,
+                override_acp_args=t.get("acp_args") or category_profile.get("acp_args") or acp_args,
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names
@@ -795,7 +994,7 @@ def delegate_task(
         completed_count = 0
         spinner_ref = getattr(parent_agent, '_delegate_spinner', None)
 
-        with ThreadPoolExecutor(max_workers=max_children) as executor:
+        with ThreadPoolExecutor(max_workers=min(max_children, n_tasks)) as executor:
             futures = {}
             for i, t, child in children:
                 future = executor.submit(
@@ -1001,6 +1200,33 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
             "api_mode": None,
         }
 
+    parent_provider = str(getattr(parent_agent, "provider", "") or "").strip()
+    parent_base_url = str(getattr(parent_agent, "base_url", "") or "").strip()
+    parent_api_key = str(getattr(parent_agent, "api_key", "") or "").strip()
+    parent_api_mode = str(getattr(parent_agent, "api_mode", "") or "").strip()
+    runtime_parent_providers = {
+        "openai-codex",
+        "nous",
+        "qwen-oauth",
+        "google-gemini-cli",
+        "copilot-acp",
+    }
+    if (
+        configured_provider == parent_provider
+        and configured_provider in runtime_parent_providers
+        and parent_base_url
+        and parent_api_key
+    ):
+        return {
+            "model": configured_model,
+            "provider": parent_provider,
+            "base_url": parent_base_url,
+            "api_key": parent_api_key,
+            "api_mode": parent_api_mode or None,
+            "command": getattr(parent_agent, "acp_command", None),
+            "args": list(getattr(parent_agent, "acp_args", []) or []),
+        }
+
     # Provider is configured — resolve full credentials
     try:
         from hermes_cli.runtime_provider import resolve_runtime_provider
@@ -1034,24 +1260,30 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
 def _load_config() -> dict:
     """Load delegation config from CLI_CONFIG or persistent config.
 
-    Checks the runtime config (cli.py CLI_CONFIG) first, then falls back
-    to the persistent config (hermes_cli/config.py load_config()) so that
-    ``delegation.model`` / ``delegation.provider`` are picked up regardless
-    of the entry point (CLI, gateway, cron).
+    Prefer the live CLI runtime config when it was loaded for the current
+    HERMES_HOME. If ``cli`` was imported earlier under a different home/profile
+    (common in tests that isolate HERMES_HOME after collection), its module-level
+    ``CLI_CONFIG`` is stale and must not leak into delegation.
     """
     try:
-        from cli import CLI_CONFIG
-        cfg = CLI_CONFIG.get("delegation", {})
-        if cfg:
-            return cfg
+        import cli as cli_mod
+        from hermes_constants import get_hermes_home
+
+        current_home = Path(get_hermes_home()).resolve()
+        cli_home = getattr(cli_mod, "_hermes_home", None)
+        cli_home_resolved = Path(cli_home).resolve() if cli_home is not None else None
+        if cli_home_resolved == current_home:
+            cfg = getattr(cli_mod, "CLI_CONFIG", {}).get("delegation", {})
+            if cfg:
+                return _normalize_delegation_config(cfg)
     except Exception:
         pass
     try:
         from hermes_cli.config import load_config
         full = load_config()
-        return full.get("delegation", {})
+        return _normalize_delegation_config(full.get("delegation", {}))
     except Exception:
-        return {}
+        return _normalize_delegation_config({})
 
 
 # ---------------------------------------------------------------------------
@@ -1128,6 +1360,10 @@ DELEGATE_TASK_SCHEMA = {
                             "items": {"type": "string"},
                             "description": f"Toolsets for this specific task. Available: {_TOOLSET_LIST_STR}. Use 'web' for network access, 'terminal' for shell, 'browser' for web interaction.",
                         },
+                        "category": {
+                            "type": "string",
+                            "description": "Optional delegation policy category (e.g. research, implementation, verification). Category profiles can constrain concurrency, tool access, and model/runtime defaults.",
+                        },
                         "acp_command": {
                             "type": "string",
                             "description": "Per-task ACP command override (e.g. 'claude'). Overrides the top-level acp_command for this task only.",
@@ -1148,6 +1384,10 @@ DELEGATE_TASK_SCHEMA = {
                     "its own subagent with isolated context and terminal session. "
                     "When provided, top-level goal/context/toolsets are ignored."
                 ),
+            },
+            "category": {
+                "type": "string",
+                "description": "Optional delegation policy category (e.g. research, implementation, verification). Applies to all tasks unless a task overrides it.",
             },
             "max_iterations": {
                 "type": "integer",
@@ -1191,6 +1431,7 @@ registry.register(
         context=args.get("context"),
         toolsets=args.get("toolsets"),
         tasks=args.get("tasks"),
+        category=args.get("category"),
         max_iterations=args.get("max_iterations"),
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1,10 +1,18 @@
 #!/usr/bin/env python3
-"""File Tools Module - LLM agent file manipulation tools."""
+"""File tools for local file retrieval, search, and editing.
+
+These tools remain general-purpose filesystem primitives, but they are also
+part of Hermes's built-in ``repo-code-knowledge`` surface. Their wording and
+result metadata should therefore make local repo/code grounding obvious without
+breaking existing file-tool callers.
+"""
 
 import errno
+import hashlib
 import json
 import logging
 import os
+import re
 import threading
 from pathlib import Path
 from tools.binary_extensions import has_binary_extension
@@ -13,6 +21,8 @@ from agent.redact import redact_sensitive_text
 
 logger = logging.getLogger(__name__)
 
+_REPLACE_HASHLINE_RE = re.compile(r"^\s*#\s*HASHLINE\s+sha256:([0-9a-fA-F]{64})\s*$")
+_PATCH_HASHLINE_RE = re.compile(r"^\*\*\*\s+Hashline:\s+(.+?)\s+sha256:([0-9a-fA-F]{64})\s*$")
 
 _EXPECTED_WRITE_ERRNOS = {errno.EACCES, errno.EPERM, errno.EROFS}
 
@@ -115,6 +125,60 @@ def _check_sensitive_path(filepath: str) -> str | None:
             return _err
     if resolved in _SENSITIVE_EXACT_PATHS or normalized in _SENSITIVE_EXACT_PATHS:
         return _err
+    return None
+
+
+def _compute_file_sha256(path: str) -> str:
+    digest = hashlib.sha256()
+    with open(os.path.expanduser(path), "rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _extract_replace_hashline(payload: str) -> tuple[str | None, str]:
+    if not isinstance(payload, str):
+        return None, payload
+    if "\n" in payload:
+        first_line, remainder = payload.split("\n", 1)
+    else:
+        first_line, remainder = payload, ""
+    match = _REPLACE_HASHLINE_RE.match(first_line)
+    if not match:
+        return None, payload
+    return match.group(1).lower(), remainder
+
+
+def _extract_patch_hashlines(payload: str) -> tuple[dict[str, str], str]:
+    if not isinstance(payload, str):
+        return {}, payload
+    expected_hashes: dict[str, str] = {}
+    kept_lines: list[str] = []
+    for line in payload.splitlines():
+        match = _PATCH_HASHLINE_RE.match(line)
+        if match:
+            expected_hashes[match.group(1).strip()] = match.group(2).lower()
+            continue
+        kept_lines.append(line)
+    rebuilt = "\n".join(kept_lines)
+    if payload.endswith("\n"):
+        rebuilt += "\n"
+    return expected_hashes, rebuilt
+
+
+def _validate_hashline_expectation(path: str, expected_sha256: str) -> str | None:
+    expanded = os.path.expanduser(path)
+    if not os.path.exists(expanded):
+        return f"HASHLINE validation failed: file not found: {path}"
+    try:
+        current_hash = _compute_file_sha256(expanded)
+    except Exception as exc:
+        return f"HASHLINE validation failed for {path}: {exc}"
+    if current_hash.lower() != str(expected_sha256 or "").lower():
+        return (
+            f"HASHLINE validation failed for {path}: expected sha256:{expected_sha256}, "
+            f"got sha256:{current_hash}. Re-read the file before editing."
+        )
     return None
 
 
@@ -500,6 +564,10 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                 "If you are stuck in a loop, stop reading and proceed with writing or responding."
             )
 
+        result_dict = _annotate_repo_code_knowledge_result(
+            result_dict,
+            operation="read_file",
+        )
         return json.dumps(result_dict, ensure_ascii=False)
     except Exception as e:
         return tool_error(str(e))
@@ -595,6 +663,20 @@ def _check_file_staleness(filepath: str, task_id: str) -> str | None:
     return None
 
 
+def _annotate_repo_code_knowledge_result(result_dict: dict, *, operation: str) -> dict:
+    """Add additive repo/code knowledge metadata to file-tool results."""
+    result_dict.setdefault(
+        "knowledge_surface",
+        {
+            "surface": "repo-code-knowledge",
+            "surface_role": "local-file-grounding",
+            "operation": operation,
+            "source": "builtin",
+        },
+    )
+    return result_dict
+
+
 def write_file_tool(path: str, content: str, task_id: str = "default") -> str:
     """Write content to a file."""
     sensitive_err = _check_sensitive_path(path)
@@ -623,6 +705,12 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                new_string: str = None, replace_all: bool = False, patch: str = None,
                task_id: str = "default") -> str:
     """Patch a file using replace mode or V4A patch format."""
+    old_string_hash = None
+    patch_hashes: dict[str, str] = {}
+    if mode == "replace" and isinstance(old_string, str):
+        old_string_hash, old_string = _extract_replace_hashline(old_string)
+    elif mode == "patch" and isinstance(patch, str):
+        patch_hashes, patch = _extract_patch_hashlines(patch)
     # Check sensitive paths for both replace (explicit path) and V4A patch (extract paths)
     _paths_to_check = []
     if path:
@@ -635,6 +723,19 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
         sensitive_err = _check_sensitive_path(_p)
         if sensitive_err:
             return tool_error(sensitive_err)
+    if mode == "replace" and old_string_hash:
+        hashline_err = _validate_hashline_expectation(path or "", old_string_hash)
+        if hashline_err:
+            return tool_error(hashline_err)
+    if mode == "patch" and patch_hashes:
+        for _p in _paths_to_check:
+            if _p not in patch_hashes:
+                return tool_error(
+                    f"HASHLINE validation failed: missing '*** Hashline: {_p} sha256:...' for patched file {_p}"
+                )
+            hashline_err = _validate_hashline_expectation(_p, patch_hashes[_p])
+            if hashline_err:
+                return tool_error(hashline_err)
     try:
         # Check staleness for all files this patch will touch.
         stale_warnings = []
@@ -725,7 +826,10 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
             for m in result.matches:
                 if hasattr(m, 'content') and m.content:
                     m.content = redact_sensitive_text(m.content)
-        result_dict = result.to_dict()
+        result_dict = _annotate_repo_code_knowledge_result(
+            result.to_dict(),
+            operation="search_files",
+        )
 
         if count >= 3:
             result_dict["_warning"] = (
@@ -759,7 +863,7 @@ def _check_file_reqs():
 
 READ_FILE_SCHEMA = {
     "name": "read_file",
-    "description": "Read a text file with line numbers and pagination. Use this instead of cat/head/tail in terminal. Output format: 'LINE_NUM|CONTENT'. Suggests similar filenames if not found. Use offset and limit for large files. Reads exceeding ~100K characters are rejected; use offset and limit to read specific sections of large files. NOTE: Cannot read images or binary files — use vision_analyze for images.",
+    "description": "Read a text file with line numbers and pagination. Use this instead of cat/head/tail in terminal. This is also a built-in repo/code knowledge primitive for local source grounding. Output format: 'LINE_NUM|CONTENT'. Suggests similar filenames if not found. Use offset and limit for large files. Reads exceeding ~100K characters are rejected; use offset and limit to read specific sections of large files. NOTE: Cannot read images or binary files — use vision_analyze for images.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -803,7 +907,7 @@ PATCH_SCHEMA = {
 
 SEARCH_FILES_SCHEMA = {
     "name": "search_files",
-    "description": "Search file contents or find files by name. Use this instead of grep/rg/find/ls in terminal. Ripgrep-backed, faster than shell equivalents.\n\nContent search (target='content'): Regex search inside files. Output modes: full matches with line numbers, file paths only, or match counts.\n\nFile search (target='files'): Find files by glob pattern (e.g., '*.py', '*config*'). Also use this instead of ls — results sorted by modification time.",
+    "description": "Search file contents or find files by name. Use this instead of grep/rg/find/ls in terminal. This is also a built-in repo/code knowledge primitive for local source retrieval and codebase grounding. Ripgrep-backed, faster than shell equivalents.\n\nContent search (target='content'): Regex search inside files. Output modes: full matches with line numbers, file paths only, or match counts.\n\nFile search (target='files'): Find files by glob pattern (e.g., '*.py', '*config*'). Also use this instead of ls — results sorted by modification time.",
     "parameters": {
         "type": "object",
         "properties": {

--- a/tools/lsp_tools.py
+++ b/tools/lsp_tools.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
-"""Local-first LSP tools for document symbols, definitions, and diagnostics."""
+"""Local-first LSP tools for repo/code grounding via document symbols, definitions, and diagnostics.
+
+These LSP helpers stay local-first and host-dependent, but their primary product
+framing is the canonical `repo-code-knowledge` surface: deeper semantic grounding
+inside a local codebase when AST-only structure is not enough.
+"""
 
 from __future__ import annotations
 
@@ -180,7 +185,7 @@ class _LspSession:
 
 LSP_DOCUMENT_SYMBOLS_SCHEMA = {
     "name": "lsp_document_symbols",
-    "description": "Get document symbols for a source file using a local Language Server Protocol server. Supports explicit server_command or local auto-detection by language.",
+    "description": "Get document symbols for a source file using a local Language Server Protocol server. Supports explicit server_command or local auto-detection by language. This is a built-in repo/code knowledge primitive for semantic local source grounding.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -195,7 +200,7 @@ LSP_DOCUMENT_SYMBOLS_SCHEMA = {
 
 LSP_DEFINITION_SCHEMA = {
     "name": "lsp_definition",
-    "description": "Resolve definitions at a zero-based line/character position using a local LSP server.",
+    "description": "Resolve definitions at a zero-based line/character position using a local LSP server. This is a built-in repo/code knowledge primitive for semantic local source grounding.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -212,7 +217,7 @@ LSP_DEFINITION_SCHEMA = {
 
 LSP_DIAGNOSTICS_SCHEMA = {
     "name": "lsp_diagnostics",
-    "description": "Request file diagnostics from a local LSP server using textDocument/diagnostic.",
+    "description": "Request file diagnostics from a local LSP server using textDocument/diagnostic. This is a built-in repo/code knowledge primitive for semantic local source grounding.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -250,7 +255,7 @@ def get_lsp_host_capability_description() -> str:
     if languages:
         return (
             f"Auto-detect currently supports: {', '.join(languages)}. "
-            "Use server_command to target any other installed local LSP server."
+            "Use server_command to target any other installed local LSP server for repo/code grounding."
         )
     return "Auto-detect is unavailable on this host. Use server_command to target an installed local LSP server."
 

--- a/tools/lsp_tools.py
+++ b/tools/lsp_tools.py
@@ -1,0 +1,595 @@
+#!/usr/bin/env python3
+"""Local-first LSP tools for document symbols, definitions, and diagnostics."""
+
+from __future__ import annotations
+
+import json
+import logging
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+from urllib.parse import unquote, urlparse
+
+from tools.registry import registry, tool_error, tool_result
+
+logger = logging.getLogger(__name__)
+
+
+_LANGUAGE_IDS = {
+    ".py": "python",
+    ".pyi": "python",
+    ".js": "javascript",
+    ".jsx": "javascriptreact",
+    ".mjs": "javascript",
+    ".cjs": "javascript",
+    ".ts": "typescript",
+    ".tsx": "typescriptreact",
+    ".go": "go",
+    ".rs": "rust",
+    ".json": "json",
+    ".yaml": "yaml",
+    ".yml": "yaml",
+    ".sh": "shellscript",
+    ".bash": "shellscript",
+}
+
+_AUTO_DETECT_COMMANDS = {
+    "python": [["pylsp"], ["pyright-langserver", "--stdio"], ["jedi-language-server"]],
+    "javascript": [["typescript-language-server", "--stdio"], ["vtsls", "--stdio"]],
+    "javascriptreact": [["typescript-language-server", "--stdio"], ["vtsls", "--stdio"]],
+    "typescript": [["typescript-language-server", "--stdio"], ["vtsls", "--stdio"]],
+    "typescriptreact": [["typescript-language-server", "--stdio"], ["vtsls", "--stdio"]],
+    "go": [["gopls"]],
+    "rust": [["rust-analyzer"]],
+    "json": [["vscode-json-language-server", "--stdio"]],
+    "yaml": [["yaml-language-server", "--stdio"]],
+    "shellscript": [["bash-language-server", "start"]],
+}
+
+_SYMBOL_KINDS = {
+    1: "File",
+    2: "Module",
+    3: "Namespace",
+    4: "Package",
+    5: "Class",
+    6: "Method",
+    7: "Property",
+    8: "Field",
+    9: "Constructor",
+    10: "Enum",
+    11: "Interface",
+    12: "Function",
+    13: "Variable",
+    14: "Constant",
+    15: "String",
+    16: "Number",
+    17: "Boolean",
+    18: "Array",
+    19: "Object",
+    20: "Key",
+    21: "Null",
+    22: "EnumMember",
+    23: "Struct",
+    24: "Event",
+    25: "Operator",
+    26: "TypeParameter",
+}
+
+_DIAGNOSTIC_SEVERITIES = {
+    1: "Error",
+    2: "Warning",
+    3: "Information",
+    4: "Hint",
+}
+
+
+class LspProtocolError(RuntimeError):
+    """Raised when an LSP server returns malformed or error responses."""
+
+
+class _LspSession:
+    def __init__(self, command: list[str], cwd: str):
+        self.command = command
+        self.process = subprocess.Popen(
+            command,
+            cwd=cwd,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        self._next_id = 1
+
+    def _send(self, payload: dict[str, Any]) -> None:
+        if not self.process.stdin:
+            raise LspProtocolError("LSP server stdin is unavailable")
+        body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        header = f"Content-Length: {len(body)}\r\n\r\n".encode("ascii")
+        self.process.stdin.write(header + body)
+        self.process.stdin.flush()
+
+    def _read_message(self) -> dict[str, Any]:
+        if not self.process.stdout:
+            raise LspProtocolError("LSP server stdout is unavailable")
+
+        content_length = None
+        while True:
+            line = self.process.stdout.readline()
+            if not line:
+                raise LspProtocolError("LSP server closed stdout before a response was received")
+            if line in (b"\r\n", b"\n"):
+                break
+            key, _, value = line.decode("utf-8", errors="replace").partition(":")
+            if key.lower() == "content-length":
+                try:
+                    content_length = int(value.strip())
+                except ValueError as exc:
+                    raise LspProtocolError("LSP response had an invalid Content-Length header") from exc
+
+        if content_length is None:
+            raise LspProtocolError("LSP response missing Content-Length header")
+
+        body = self.process.stdout.read(content_length)
+        if len(body) != content_length:
+            raise LspProtocolError("LSP response body was truncated")
+
+        try:
+            return json.loads(body.decode("utf-8"))
+        except json.JSONDecodeError as exc:
+            raise LspProtocolError("LSP response body was not valid JSON") from exc
+
+    def notify(self, method: str, params: dict[str, Any]) -> None:
+        self._send({"jsonrpc": "2.0", "method": method, "params": params})
+
+    def request(self, method: str, params: dict[str, Any]) -> Any:
+        request_id = self._next_id
+        self._next_id += 1
+        self._send({"jsonrpc": "2.0", "id": request_id, "method": method, "params": params})
+
+        while True:
+            message = self._read_message()
+            if message.get("id") != request_id:
+                continue
+            if "error" in message:
+                error = message["error"] or {}
+                code = error.get("code", "unknown")
+                detail = error.get("message", "Unknown LSP error")
+                raise LspProtocolError(f"LSP request failed ({method}, code={code}): {detail}")
+            return message.get("result")
+
+    def shutdown(self) -> None:
+        try:
+            self.request("shutdown", {})
+        except Exception:
+            logger.debug("Best-effort LSP shutdown failed", exc_info=True)
+        try:
+            self.notify("exit", {})
+        except Exception:
+            logger.debug("Best-effort LSP exit failed", exc_info=True)
+        try:
+            if self.process.poll() is None:
+                self.process.terminate()
+                self.process.wait(timeout=1)
+        except Exception:
+            try:
+                self.process.kill()
+            except Exception:
+                logger.debug("Best-effort LSP kill failed", exc_info=True)
+
+
+LSP_DOCUMENT_SYMBOLS_SCHEMA = {
+    "name": "lsp_document_symbols",
+    "description": "Get document symbols for a source file using a local Language Server Protocol server. Supports explicit server_command or local auto-detection by language.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "path": {"type": "string", "description": "Path to the source file"},
+            "language": {"type": "string", "description": "Optional LSP language id override (for example: python, typescript, rust)"},
+            "workspace_root": {"type": "string", "description": "Optional workspace root directory passed to the language server"},
+            "server_command": {"type": "string", "description": "Optional explicit server command, for example 'pylsp' or 'typescript-language-server --stdio'"},
+        },
+        "required": ["path"],
+    },
+}
+
+LSP_DEFINITION_SCHEMA = {
+    "name": "lsp_definition",
+    "description": "Resolve definitions at a zero-based line/character position using a local LSP server.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "path": {"type": "string", "description": "Path to the source file"},
+            "line": {"type": "integer", "description": "Zero-based line number"},
+            "character": {"type": "integer", "description": "Zero-based character offset on the line"},
+            "language": {"type": "string", "description": "Optional LSP language id override"},
+            "workspace_root": {"type": "string", "description": "Optional workspace root directory"},
+            "server_command": {"type": "string", "description": "Optional explicit server command"},
+        },
+        "required": ["path", "line", "character"],
+    },
+}
+
+LSP_DIAGNOSTICS_SCHEMA = {
+    "name": "lsp_diagnostics",
+    "description": "Request file diagnostics from a local LSP server using textDocument/diagnostic.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "path": {"type": "string", "description": "Path to the source file"},
+            "language": {"type": "string", "description": "Optional LSP language id override"},
+            "workspace_root": {"type": "string", "description": "Optional workspace root directory"},
+            "server_command": {"type": "string", "description": "Optional explicit server command"},
+        },
+        "required": ["path"],
+    },
+}
+
+
+def get_host_lsp_capabilities() -> dict[str, Any]:
+    auto_detect_commands: dict[str, list[str]] = {}
+    for language, candidates in sorted(_AUTO_DETECT_COMMANDS.items()):
+        available_commands = []
+        for candidate in candidates:
+            binary = candidate[0] if candidate else None
+            if binary and shutil.which(binary):
+                available_commands.append(" ".join(candidate))
+        if available_commands:
+            auto_detect_commands[language] = available_commands
+
+    return {
+        "available": bool(auto_detect_commands),
+        "auto_detect_languages": list(auto_detect_commands.keys()),
+        "auto_detect_commands": auto_detect_commands,
+    }
+
+
+def get_lsp_host_capability_description() -> str:
+    capabilities = get_host_lsp_capabilities()
+    languages = capabilities["auto_detect_languages"]
+    if languages:
+        return (
+            f"Auto-detect currently supports: {', '.join(languages)}. "
+            "Use server_command to target any other installed local LSP server."
+        )
+    return "Auto-detect is unavailable on this host. Use server_command to target an installed local LSP server."
+
+
+def _check_lsp_requirements() -> bool:
+    return get_host_lsp_capabilities()["available"]
+
+
+def _detect_language(path: Path, language: str | None) -> str:
+    if language:
+        return language
+    return _LANGUAGE_IDS.get(path.suffix.lower(), "plaintext")
+
+
+def _normalize_command(server_command: str | list[str] | None, language: str) -> tuple[list[str] | None, list[str]]:
+    if server_command:
+        if isinstance(server_command, str):
+            command = shlex.split(server_command)
+        else:
+            command = list(server_command)
+        if not command:
+            raise ValueError("server_command must not be empty")
+        return command, []
+
+    candidates = _AUTO_DETECT_COMMANDS.get(language, [])
+    for candidate in candidates:
+        if shutil.which(candidate[0]):
+            return candidate, [" ".join(entry) for entry in candidates]
+    return None, [" ".join(entry) for entry in candidates]
+
+
+def _path_to_uri(path: Path) -> str:
+    return path.resolve().as_uri()
+
+
+def _uri_to_path(uri: str | None) -> str | None:
+    if not uri:
+        return None
+    parsed = urlparse(uri)
+    if parsed.scheme != "file":
+        return uri
+    return unquote(parsed.path)
+
+
+def _normalize_range(value: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not value:
+        return None
+    return {
+        "start": value.get("start"),
+        "end": value.get("end"),
+    }
+
+
+def _normalize_symbol(item: dict[str, Any]) -> dict[str, Any]:
+    if "location" in item:
+        location = item.get("location") or {}
+        return {
+            "name": item.get("name"),
+            "detail": item.get("detail"),
+            "kind": item.get("kind"),
+            "kind_name": _SYMBOL_KINDS.get(item.get("kind"), "Unknown"),
+            "container_name": item.get("containerName"),
+            "uri": location.get("uri"),
+            "path": _uri_to_path(location.get("uri")),
+            "range": _normalize_range(location.get("range")),
+        }
+
+    return {
+        "name": item.get("name"),
+        "detail": item.get("detail"),
+        "kind": item.get("kind"),
+        "kind_name": _SYMBOL_KINDS.get(item.get("kind"), "Unknown"),
+        "range": _normalize_range(item.get("range")),
+        "selection_range": _normalize_range(item.get("selectionRange")),
+        "children": [_normalize_symbol(child) for child in item.get("children", [])],
+    }
+
+
+def _normalize_locations(result: Any) -> list[dict[str, Any]]:
+    if result is None:
+        return []
+    if isinstance(result, dict):
+        items = [result]
+    else:
+        items = list(result)
+
+    normalized = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        if "targetUri" in item:
+            uri = item.get("targetUri")
+            normalized.append(
+                {
+                    "uri": uri,
+                    "path": _uri_to_path(uri),
+                    "target_range": _normalize_range(item.get("targetRange")),
+                    "target_selection_range": _normalize_range(item.get("targetSelectionRange")),
+                    "origin_selection_range": _normalize_range(item.get("originSelectionRange")),
+                }
+            )
+            continue
+
+        uri = item.get("uri")
+        normalized.append(
+            {
+                "uri": uri,
+                "path": _uri_to_path(uri),
+                "range": _normalize_range(item.get("range")),
+            }
+        )
+    return normalized
+
+
+def _normalize_diagnostics(result: Any) -> list[dict[str, Any]]:
+    if result is None:
+        return []
+    items = result.get("items", []) if isinstance(result, dict) else result
+    normalized = []
+    for item in items or []:
+        if not isinstance(item, dict):
+            continue
+        severity = item.get("severity")
+        normalized.append(
+            {
+                "message": item.get("message"),
+                "severity": severity,
+                "severity_name": _DIAGNOSTIC_SEVERITIES.get(severity, "Unknown"),
+                "code": item.get("code"),
+                "source": item.get("source"),
+                "range": _normalize_range(item.get("range")),
+                "tags": item.get("tags", []),
+            }
+        )
+    return normalized
+
+
+def _read_source(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _build_initialize_params(workspace_root: Path) -> dict[str, Any]:
+    root_uri = _path_to_uri(workspace_root)
+    return {
+        "processId": None,
+        "clientInfo": {"name": "hermes-agent", "version": "phase-3"},
+        "rootUri": root_uri,
+        "workspaceFolders": [{"uri": root_uri, "name": workspace_root.name or str(workspace_root)}],
+        "capabilities": {
+            "textDocument": {
+                "definition": {"dynamicRegistration": False},
+                "documentSymbol": {"hierarchicalDocumentSymbolSupport": True},
+                "diagnostic": {"dynamicRegistration": False},
+            }
+        },
+    }
+
+
+def _run_lsp_request(
+    *,
+    path: str,
+    requested_method: str,
+    request_params: dict[str, Any],
+    language: str | None = None,
+    workspace_root: str | None = None,
+    server_command: str | list[str] | None = None,
+) -> str:
+    try:
+        source_path = Path(path).expanduser()
+        if not source_path.exists():
+            return tool_error(f"File not found: {path}", path=str(source_path), requested_method=requested_method)
+        source_path = source_path.resolve()
+        language_id = _detect_language(source_path, language)
+        command, candidates = _normalize_command(server_command, language_id)
+        if not command:
+            return tool_error(
+                f"No LSP server found for language '{language_id}'",
+                path=str(source_path),
+                language=language_id,
+                requested_method=requested_method,
+                candidate_commands=candidates,
+            )
+
+        workspace_path = Path(workspace_root).expanduser().resolve() if workspace_root else source_path.parent
+        uri = _path_to_uri(source_path)
+        session = _LspSession(command, cwd=str(workspace_path))
+        try:
+            session.request("initialize", _build_initialize_params(workspace_path))
+            session.notify("initialized", {})
+            session.notify(
+                "textDocument/didOpen",
+                {
+                    "textDocument": {
+                        "uri": uri,
+                        "languageId": language_id,
+                        "version": 1,
+                        "text": _read_source(source_path),
+                    }
+                },
+            )
+            raw_result = session.request(requested_method, request_params)
+        finally:
+            session.shutdown()
+
+        payload = {
+            "ok": True,
+            "path": str(source_path),
+            "language": language_id,
+            "requested_method": requested_method,
+            "server_command": command,
+            "workspace_root": str(workspace_path),
+        }
+        if requested_method == "textDocument/documentSymbol":
+            payload["symbols"] = [_normalize_symbol(item) for item in raw_result or []]
+        elif requested_method == "textDocument/definition":
+            payload["definitions"] = _normalize_locations(raw_result)
+        elif requested_method == "textDocument/diagnostic":
+            payload["diagnostics"] = _normalize_diagnostics(raw_result)
+        else:
+            payload["result"] = raw_result
+        return tool_result(payload)
+    except Exception as exc:
+        logger.debug("LSP request failed", exc_info=True)
+        return tool_error(str(exc), path=path, requested_method=requested_method)
+
+
+def lsp_document_symbols_tool(
+    *,
+    path: str,
+    language: str | None = None,
+    workspace_root: str | None = None,
+    server_command: str | None = None,
+) -> str:
+    return _run_lsp_request(
+        path=path,
+        language=language,
+        workspace_root=workspace_root,
+        server_command=server_command,
+        requested_method="textDocument/documentSymbol",
+        request_params={"textDocument": {"uri": _path_to_uri(Path(path).expanduser().resolve())}},
+    )
+
+
+def lsp_definition_tool(
+    *,
+    path: str,
+    line: int,
+    character: int,
+    language: str | None = None,
+    workspace_root: str | None = None,
+    server_command: str | None = None,
+) -> str:
+    return _run_lsp_request(
+        path=path,
+        language=language,
+        workspace_root=workspace_root,
+        server_command=server_command,
+        requested_method="textDocument/definition",
+        request_params={
+            "textDocument": {"uri": _path_to_uri(Path(path).expanduser().resolve())},
+            "position": {"line": line, "character": character},
+        },
+    )
+
+
+def lsp_diagnostics_tool(
+    *,
+    path: str,
+    language: str | None = None,
+    workspace_root: str | None = None,
+    server_command: str | None = None,
+) -> str:
+    return _run_lsp_request(
+        path=path,
+        language=language,
+        workspace_root=workspace_root,
+        server_command=server_command,
+        requested_method="textDocument/diagnostic",
+        request_params={"textDocument": {"uri": _path_to_uri(Path(path).expanduser().resolve())}},
+    )
+
+
+LSP_TOOLS = [
+    {"name": "lsp_document_symbols", "function": lsp_document_symbols_tool},
+    {"name": "lsp_definition", "function": lsp_definition_tool},
+    {"name": "lsp_diagnostics", "function": lsp_diagnostics_tool},
+]
+
+
+def _handle_lsp_document_symbols(args, **_kwargs):
+    return lsp_document_symbols_tool(
+        path=args.get("path", ""),
+        language=args.get("language"),
+        workspace_root=args.get("workspace_root"),
+        server_command=args.get("server_command"),
+    )
+
+
+def _handle_lsp_definition(args, **_kwargs):
+    return lsp_definition_tool(
+        path=args.get("path", ""),
+        line=args.get("line", 0),
+        character=args.get("character", 0),
+        language=args.get("language"),
+        workspace_root=args.get("workspace_root"),
+        server_command=args.get("server_command"),
+    )
+
+
+def _handle_lsp_diagnostics(args, **_kwargs):
+    return lsp_diagnostics_tool(
+        path=args.get("path", ""),
+        language=args.get("language"),
+        workspace_root=args.get("workspace_root"),
+        server_command=args.get("server_command"),
+    )
+
+
+registry.register(
+    name="lsp_document_symbols",
+    toolset="code_intel",
+    schema=LSP_DOCUMENT_SYMBOLS_SCHEMA,
+    handler=_handle_lsp_document_symbols,
+    check_fn=_check_lsp_requirements,
+    emoji="🛰️",
+)
+registry.register(
+    name="lsp_definition",
+    toolset="code_intel",
+    schema=LSP_DEFINITION_SCHEMA,
+    handler=_handle_lsp_definition,
+    check_fn=_check_lsp_requirements,
+    emoji="📍",
+)
+registry.register(
+    name="lsp_diagnostics",
+    toolset="code_intel",
+    schema=LSP_DIAGNOSTICS_SCHEMA,
+    handler=_handle_lsp_diagnostics,
+    check_fn=_check_lsp_requirements,
+    emoji="🚨",
+)

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -2,17 +2,19 @@
 """
 Vision Tools Module
 
-This module provides vision analysis tools that work with image URLs.
-Uses the centralized auxiliary vision router, which can select OpenRouter,
-Nous, Codex, native Anthropic, or a custom OpenAI-compatible endpoint.
+This module provides vision analysis tools for screenshots, diagrams, charts,
+photos, and other image inputs. It uses the centralized auxiliary vision
+router, which can select OpenRouter, Nous, Codex, native Anthropic, or a
+custom OpenAI-compatible endpoint.
 
 Available tools:
-- vision_analyze_tool: Analyze images from URLs with custom prompts
+- vision_analyze_tool: Analyze remote or local image inputs with custom prompts
 
 Features:
-- Downloads images from URLs and converts to base64 for API compatibility
-- Comprehensive image description
-- Context-aware analysis based on user queries
+- Downloads remote images and converts them to base64 for API compatibility
+- Supports local image files and file:// image URIs
+- Comprehensive visual description plus question answering
+- Helpful for screenshots, rendered document captures, diagrams, and charts
 - Automatic temporary file cleanup
 - Proper error handling and validation
 - Debug logging support
@@ -21,7 +23,7 @@ Usage:
     from vision_tools import vision_analyze_tool
     import asyncio
     
-    # Analyze an image
+    # Analyze an image or screenshot
     result = await vision_analyze_tool(
         image_url="https://example.com/image.jpg",
         user_prompt="What architectural style is this building?"
@@ -749,17 +751,17 @@ from tools.registry import registry, tool_error
 
 VISION_ANALYZE_SCHEMA = {
     "name": "vision_analyze",
-    "description": "Analyze images using AI vision. Provides a comprehensive description and answers a specific question about the image content.",
+    "description": "Analyze an image with AI vision from an HTTP/HTTPS URL or local image file path. Best for screenshots, diagrams, charts, photos, and page captures. Not for raw PDF parsing.",
     "parameters": {
         "type": "object",
         "properties": {
             "image_url": {
                 "type": "string",
-                "description": "Image URL (http/https) or local file path to analyze."
+                "description": "HTTP/HTTPS image URL, file:// image URI, or local image file path to analyze."
             },
             "question": {
                 "type": "string",
-                "description": "Your specific question or request about the image to resolve. The AI will automatically provide a complete image description AND answer your specific question."
+                "description": "Your specific question or request about the image. The model will first understand the image itself, then answer this request."
             }
         },
         "required": ["image_url", "question"]

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -1,16 +1,32 @@
 #!/usr/bin/env python3
 """
-Standalone Web Tools Module
+Standalone Web and Research Knowledge Tools
 
-This module provides generic web tools that work with multiple backend providers.
-Backend is selected during ``hermes tools`` setup (web.backend in config.yaml).
-When available, Hermes can route Firecrawl calls through a Nous-hosted tool-gateway
-for Nous Subscribers only.
+This module defines Hermes-native built-in web/research grounding primitives.
+The canonical built-in surface currently exposed from this file is:
+- web_search_tool: live web search for current external information
+- web_extract_tool: text-first extraction from specific public URLs
 
-Available tools:
-- web_search_tool: Search the web for information
-- web_extract_tool: Extract content from specific web pages
-- web_crawl_tool: Crawl websites with specific instructions
+A crawl implementation also exists in this module, but it is not currently part of
+Hermes's canonical built-in web/research surface unless another layer explicitly
+registers or exposes it.
+
+Backend behavior:
+- Hermes presents a stable built-in interface while routing to the configured backend
+  selected during ``hermes tools`` setup (web.backend in config.yaml).
+- Result shape and retrieval behavior can vary somewhat by backend/provider.
+- When available, Hermes can route Firecrawl calls through a Nous-hosted tool gateway
+  for Nous Subscribers only.
+
+Text-first boundary:
+- These tools are for live web/research grounding and page text retrieval.
+- ``web_extract`` is text-first: it returns markdown/plain extracted content when a
+  backend can fetch the URL directly, and it may summarize long pages with an
+  auxiliary text model.
+- If direct retrieval fails, times out, or the task requires interactive navigation,
+  login handling, or visual inspection, use Hermes browser/document surfaces instead.
+- URL-accessed PDFs may still be converted into text when the backend supports it,
+  but document/PDF intelligence remains outside this module's product boundary.
 
 Backend compatibility:
 - Exa: https://exa.ai (search, extract)
@@ -28,15 +44,17 @@ Debug Mode:
 - Captures all tool calls, results, and compression metrics
 
 Usage:
-    from web_tools import web_search_tool, web_extract_tool, web_crawl_tool
-    
+    from web_tools import web_search_tool, web_extract_tool
+
     # Search the web
     results = web_search_tool("Python machine learning libraries", limit=3)
-    
-    # Extract content from URLs  
+
+    # Extract text-first content from URLs
     content = web_extract_tool(["https://example.com"], format="markdown")
-    
-    # Crawl a website
+
+    # Crawl is implemented here for internal/explicit use only; it is not part of
+    # Hermes's canonical built-in web/research surface unless a later layer
+    # explicitly registers or exposes it.
     crawl_data = web_crawl_tool("example.com", "Find contact information")
 """
 
@@ -570,7 +588,7 @@ async def process_content_with_llm(
                 f"\n\n[Content truncated — showing first {MAX_OUTPUT_SIZE:,} of "
                 f"{len(content):,} chars. LLM summarization timed out. "
                 f"To fix: increase auxiliary.web_extract.timeout in config.yaml, "
-                f"or use a faster auxiliary model. Use browser_navigate for the full page.]"
+                f"or use a faster auxiliary model. If you need the full page or interactive access, use the browser/document surfaces.]"
             )
         return truncated
 
@@ -1034,13 +1052,12 @@ async def _parallel_extract(urls: List[str]) -> List[Dict[str, Any]]:
 
 def web_search_tool(query: str, limit: int = 5) -> str:
     """
-    Search the web for information using available search API backend.
+    Search the live web using Hermes's built-in web/research grounding surface.
 
-    This function provides a generic interface for web search that can work
-    with multiple backends (Parallel or Firecrawl).
-
-    Note: This function returns search result metadata only (URLs, titles, descriptions).
-    Use web_extract_tool to get full content from specific URLs.
+    Hermes keeps the interface stable while routing to the configured backend.
+    This tool returns search-result metadata only (titles, URLs, descriptions)
+    so the model can identify promising external sources before deeper retrieval
+    with ``web_extract_tool``.
     
     Args:
         query (str): The search query to look up
@@ -1170,10 +1187,12 @@ async def web_extract_tool(
     min_length: int = DEFAULT_MIN_LENGTH_FOR_SUMMARIZATION
 ) -> str:
     """
-    Extract content from specific web pages using available extraction API backend.
+    Extract text-first content from specific public URLs using Hermes's built-in
+    web/research grounding surface.
 
-    This function provides a generic interface for web content extraction that
-    can work with multiple backends. Currently uses Firecrawl.
+    Hermes keeps the interface stable while routing to the configured backend.
+    This tool is for direct URL retrieval and optional auxiliary summarization,
+    not browser-driven interaction or document/PDF intelligence workflows.
 
     Args:
         urls (List[str]): List of URLs to extract content from
@@ -1302,7 +1321,7 @@ async def web_extract_tool(
                             logger.warning("Firecrawl scrape timed out for %s", url)
                             results.append({
                                 "url": url, "title": "", "content": "",
-                                "error": "Scrape timed out after 60s — page may be too large or unresponsive. Try browser_navigate instead.",
+                                "error": "Scrape timed out after 60s — page may be too large or unresponsive. If direct extraction is not enough, fall back to the browser/document surfaces.",
                             })
                             continue
 
@@ -1499,11 +1518,18 @@ async def web_crawl_tool(
     min_length: int = DEFAULT_MIN_LENGTH_FOR_SUMMARIZATION
 ) -> str:
     """
-    Crawl a website with specific instructions using available crawling API backend.
-    
-    This function provides a generic interface for web crawling that can work
-    with multiple backends. Currently uses Firecrawl.
-    
+    Crawl a website with specific instructions using an available crawling backend.
+
+    This implementation lives in ``tools/web_tools.py`` but is intentionally not
+    part of Hermes's canonical built-in web/research surface today. The current
+    built-in surface exposed via registry/toolsets remains ``web_search`` and
+    ``web_extract`` only unless some other layer explicitly registers or exposes
+    crawl later.
+
+    The function provides a generic interface for crawling across supported
+    backends. Today that means Tavily crawl support and Firecrawl/direct-gateway
+    crawl support when configured.
+
     Args:
         url (str): The base URL to crawl (can include or exclude https://)
         instructions (str): Instructions for what to crawl/extract using LLM intelligence (optional)
@@ -1627,7 +1653,9 @@ async def web_crawl_tool(
             _debug.save()
             return cleaned_result
 
-        # web_crawl requires Firecrawl or the Firecrawl tool-gateway — Parallel has no crawl API
+        # web_crawl is implemented here for explicit/internal use only and
+        # requires Firecrawl or the Firecrawl tool-gateway on this path.
+        # Parallel has no crawl API.
         if not check_firecrawl_api_key():
             return json.dumps({
                 "error": "web_crawl requires Firecrawl. Set FIRECRAWL_API_KEY, FIRECRAWL_API_URL"
@@ -1986,6 +2014,8 @@ if __name__ == "__main__":
         exit(1)
 
     print("🛠️  Web tools ready for use!")
+    print("   Canonical built-in Hermes surface from this module: web_search + web_extract")
+    print("   web_crawl is implemented here but not registered as a built-in public tool")
     
     if nous_available:
         print(f"🧠 LLM content processing available with {default_summarizer_model}")
@@ -1999,24 +2029,27 @@ if __name__ == "__main__":
         print("🐛 Debug mode disabled (set WEB_TOOLS_DEBUG=true to enable)")
     
     print("\nBasic usage:")
-    print("  from web_tools import web_search_tool, web_extract_tool, web_crawl_tool")
+    print("  from web_tools import web_search_tool, web_extract_tool")
     print("  import asyncio")
     print("")
     print("  # Search (synchronous)")
     print("  results = web_search_tool('Python tutorials')")
     print("")
-    print("  # Extract and crawl (asynchronous)")
+    print("  # Extract from the canonical built-in surface (asynchronous)")
     print("  async def main():")
     print("      content = await web_extract_tool(['https://example.com'])")
-    print("      crawl_data = await web_crawl_tool('example.com', 'Find docs')")
     print("  asyncio.run(main())")
+    print("")
+    print("  # Optional/internal crawl implementation in this module (not registry-exposed)")
+    print("  # from web_tools import web_crawl_tool")
+    print("  # crawl_data = await web_crawl_tool('example.com', 'Find docs')")
     
     if nous_available:
         print("\nLLM-enhanced usage:")
         print("  # Content automatically processed for pages >5000 chars (default)")
         print("  content = await web_extract_tool(['https://python.org/about/'])")
         print("")
-        print("  # Customize processing parameters")
+        print("  # Optional/internal crawl implementation (still not part of the built-in surface)")
         print("  crawl_data = await web_crawl_tool(")
         print("      'docs.python.org',")
         print("      'Find key concepts',")
@@ -2047,13 +2080,13 @@ from tools.registry import registry, tool_error
 
 WEB_SEARCH_SCHEMA = {
     "name": "web_search",
-    "description": "Search the web for information on any topic. Returns up to 5 relevant results with titles, URLs, and descriptions.",
+    "description": "Hermes built-in web/research grounding primitive for live web search. Use it to gather current external information and candidate sources before deeper retrieval. Hermes keeps the interface stable, but exact ranking and result details can vary by configured backend. Returns up to 5 results with titles, URLs, and descriptions.",
     "parameters": {
         "type": "object",
         "properties": {
             "query": {
                 "type": "string",
-                "description": "The search query to look up on the web"
+                "description": "Search query for live web/research grounding"
             }
         },
         "required": ["query"]
@@ -2062,14 +2095,14 @@ WEB_SEARCH_SCHEMA = {
 
 WEB_EXTRACT_SCHEMA = {
     "name": "web_extract",
-    "description": "Extract content from web page URLs. Returns page content in markdown format. Also works with PDF URLs (arxiv papers, documents, etc.) — pass the PDF link directly and it converts to markdown text. Pages under 5000 chars return full markdown; larger pages are LLM-summarized and capped at ~5000 chars per page. Pages over 2M chars are refused. If a URL fails or times out, use the browser tool to access it instead.",
+    "description": "Hermes built-in web/research grounding primitive for text-first extraction from public URLs. Returns extracted page text in markdown form when the configured backend can fetch the URL directly, and may summarize long pages with an auxiliary text model. URL-accessed PDFs may still be converted to text, but browser-driven navigation and document/PDF intelligence are outside this tool's scope. Pages under 5000 chars return full markdown; larger pages are LLM-summarized and capped at ~5000 chars per page. Pages over 2M chars are refused. If direct extraction fails, times out, or the task needs interactive/visual access, fall back to Hermes browser/document tools.",
     "parameters": {
         "type": "object",
         "properties": {
             "urls": {
                 "type": "array",
                 "items": {"type": "string"},
-                "description": "List of URLs to extract content from (max 5 URLs per call)",
+                "description": "List of public URLs to extract text content from directly (max 5 URLs per call)",
                 "maxItems": 5
             }
         },

--- a/toolsets.py
+++ b/toolsets.py
@@ -71,6 +71,42 @@ _CODE_INTEL_TOOLS = [
 ]
 
 
+# Canonical built-in knowledge-surface names for the Priority 1 control-plane
+# freeze. These intentionally distinguish the product-facing knowledge
+# families from older low-level family buckets like `web`, `browser`, `vision`,
+# and `code_intel` without changing behavior yet.
+_KNOWLEDGE_SURFACE_ALIASES = {
+    "repo_code_knowledge": "repo-code-knowledge",
+    "repo-knowledge": "repo-code-knowledge",
+    "web_research_knowledge": "web-research-knowledge",
+    "research-knowledge": "web-research-knowledge",
+    "document_intelligence": "document-pdf-diagram-intelligence",
+    "document-intelligence": "document-pdf-diagram-intelligence",
+}
+
+_CANONICAL_KNOWLEDGE_SURFACES = {
+    "repo-code-knowledge",
+    "web-research-knowledge",
+    "document-pdf-diagram-intelligence",
+}
+
+_REPO_CODE_KNOWLEDGE_TOOLS = [
+    "read_file", "search_files",
+    *_CODE_INTEL_TOOLS,
+]
+
+_WEB_RESEARCH_KNOWLEDGE_TOOLS = [
+    "web_search", "web_extract",
+]
+
+_DOCUMENT_INTELLIGENCE_TOOLS = [
+    "browser_navigate", "browser_snapshot", "browser_click",
+    "browser_scroll", "browser_back", "browser_press",
+    "browser_get_images", "browser_vision", "browser_console",
+    "vision_analyze",
+]
+
+
 # Core toolset definitions
 # These can include individual tools or reference other toolsets
 TOOLSETS = {
@@ -192,6 +228,27 @@ TOOLSETS = {
         "description": "Code intelligence tools for AST structure, symbol lookup, definitions, and diagnostics",
         "tools": _CODE_INTEL_TOOLS,
         "includes": []
+    },
+
+    "repo-code-knowledge": {
+        "description": "Canonical built-in repo/code knowledge surface for local file reading, file search, AST structure lookup, and LSP symbol/definition/diagnostic inspection.",
+        "tools": _REPO_CODE_KNOWLEDGE_TOOLS,
+        "includes": [],
+        "aliases": ["repo_code_knowledge", "repo-knowledge"],
+    },
+
+    "web-research-knowledge": {
+        "description": "Canonical built-in web/research knowledge surface for live web search and page extraction. This is a built-in web intelligence surface, not an additive MCP crawl stack.",
+        "tools": _WEB_RESEARCH_KNOWLEDGE_TOOLS,
+        "includes": [],
+        "aliases": ["web_research_knowledge", "research-knowledge"],
+    },
+
+    "document-pdf-diagram-intelligence": {
+        "description": "Canonical built-in document/PDF/diagram intelligence surface for browser navigation, page inspection, image collection, and vision analysis. This is built-in document intelligence, not a standalone PDF parser or diagram editor.",
+        "tools": _DOCUMENT_INTELLIGENCE_TOOLS,
+        "includes": [],
+        "aliases": ["document_intelligence", "document-intelligence"],
     },
     
     "code_execution": {
@@ -441,9 +498,17 @@ def get_toolset(name: str) -> Optional[Dict[str, Any]]:
         Dict: Toolset definition with description, tools, and includes
         None: If toolset not found
     """
-    toolset = TOOLSETS.get(name)
+    canonical_name = _KNOWLEDGE_SURFACE_ALIASES.get(name, name)
+    toolset = TOOLSETS.get(canonical_name)
     if toolset:
-        return toolset
+        if canonical_name == name:
+            return toolset
+        aliased_toolset = dict(toolset)
+        aliased_toolset["description"] = (
+            f"{toolset['description']} Alias for canonical toolset '{canonical_name}'."
+        )
+        aliased_toolset["canonical_name"] = canonical_name
+        return aliased_toolset
 
     try:
         from tools.registry import registry
@@ -492,6 +557,8 @@ def resolve_toolset(name: str, visited: Set[str] = None) -> List[str]:
     """
     if visited is None:
         visited = set()
+
+    name = _KNOWLEDGE_SURFACE_ALIASES.get(name, name)
     
     # Special aliases that represent all tools across every toolset
     # This ensures future toolsets are automatically included without changes.
@@ -574,6 +641,36 @@ def _get_registry_toolset_aliases() -> Dict[str, str]:
         return {}
 
 
+def get_toolset_contract(name: str) -> Optional[Dict[str, Any]]:
+    """Return control-plane classification metadata for a toolset or alias."""
+    canonical_name = _KNOWLEDGE_SURFACE_ALIASES.get(name, name)
+    toolset = TOOLSETS.get(canonical_name)
+    if toolset:
+        return {
+            "name": name,
+            "canonical_name": canonical_name,
+            "source": "builtin",
+            "is_builtin": True,
+            "is_additive": False,
+            "is_alias": name != canonical_name,
+            "aliases": list(toolset.get("aliases", [])),
+            "is_canonical_knowledge_surface": canonical_name in _CANONICAL_KNOWLEDGE_SURFACES,
+            "boundary_note": (
+                "Canonical built-in control-plane surface; downstream wrappers, propagation, "
+                "and additive MCP/plugin productization stay separate."
+                if canonical_name in _CANONICAL_KNOWLEDGE_SURFACES
+                else "Built-in toolset; not an additive registry surface."
+            ),
+            "tools": resolve_toolset(canonical_name),
+        }
+
+    try:
+        from tools.registry import registry
+        return registry.get_registered_toolset_contract(name)
+    except Exception:
+        return None
+
+
 def get_all_toolsets() -> Dict[str, Dict[str, Any]]:
     """
     Get all available toolsets with their definitions.
@@ -583,7 +680,10 @@ def get_all_toolsets() -> Dict[str, Dict[str, Any]]:
     Returns:
         Dict: All toolset definitions
     """
-    result = dict(TOOLSETS)
+    result = {}
+    for name, toolset in TOOLSETS.items():
+        contract = get_toolset_contract(name) or {}
+        result[name] = {**toolset, **contract}
     aliases = _get_registry_toolset_aliases()
     for ts_name in _get_plugin_toolset_names():
         display_name = ts_name
@@ -595,7 +695,8 @@ def get_all_toolsets() -> Dict[str, Dict[str, Any]]:
             continue
         toolset = get_toolset(display_name)
         if toolset:
-            result[display_name] = toolset
+            contract = get_toolset_contract(display_name) or {}
+            result[display_name] = {**toolset, **contract}
     return result
 
 
@@ -634,6 +735,8 @@ def validate_toolset(name: str) -> bool:
     """
     # Accept special alias names for convenience
     if name in {"all", "*"}:
+        return True
+    if name in _KNOWLEDGE_SURFACE_ALIASES:
         return True
     if name in TOOLSETS:
         return True
@@ -681,6 +784,7 @@ def get_toolset_info(name: str) -> Dict[str, Any]:
         return None
     
     resolved_tools = resolve_toolset(name)
+    contract = get_toolset_contract(name) or {}
     
     return {
         "name": name,
@@ -689,7 +793,16 @@ def get_toolset_info(name: str) -> Dict[str, Any]:
         "includes": toolset["includes"],
         "resolved_tools": resolved_tools,
         "tool_count": len(resolved_tools),
-        "is_composite": bool(toolset["includes"])
+        "is_composite": bool(toolset["includes"]),
+        "canonical_name": contract.get("canonical_name", name),
+        "source": contract.get("source"),
+        "is_builtin": contract.get("is_builtin", False),
+        "is_additive": contract.get("is_additive", False),
+        "is_alias": contract.get("is_alias", False),
+        "is_canonical_knowledge_surface": contract.get(
+            "is_canonical_knowledge_surface", False
+        ),
+        "boundary_note": contract.get("boundary_note"),
     }
 
 

--- a/toolsets.py
+++ b/toolsets.py
@@ -26,8 +26,8 @@ Usage:
 from typing import List, Dict, Any, Set, Optional
 
 
-# Shared tool list for CLI and all messaging platform toolsets.
-# Edit this once to update all platforms simultaneously.
+# Shared tool list for messaging-style Hermes platform toolsets.
+# CLI/editor/API defaults can layer additional development-oriented tools on top.
 _HERMES_CORE_TOOLS = [
     # Web
     "web_search", "web_extract",
@@ -60,6 +60,14 @@ _HERMES_CORE_TOOLS = [
     "send_message",
     # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)
     "ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service",
+]
+
+
+_CODE_INTEL_TOOLS = [
+    # AST structure and lightweight local source analysis
+    "ast_list_defs", "ast_find_nodes",
+    # LSP-backed symbol lookup, definitions, and diagnostics
+    "lsp_document_symbols", "lsp_definition", "lsp_diagnostics",
 ]
 
 
@@ -179,6 +187,12 @@ TOOLSETS = {
         "tools": ["clarify"],
         "includes": []
     },
+
+    "code_intel": {
+        "description": "Code intelligence tools for AST structure, symbol lookup, definitions, and diagnostics",
+        "tools": _CODE_INTEL_TOOLS,
+        "includes": []
+    },
     
     "code_execution": {
         "description": "Run Python scripts that call tools programmatically (reduces LLM round trips)",
@@ -244,6 +258,7 @@ TOOLSETS = {
             "web_search", "web_extract",
             "terminal", "process",
             "read_file", "write_file", "patch", "search_files",
+            *_CODE_INTEL_TOOLS,
             "vision_analyze",
             "skills_list", "skill_view", "skill_manage",
             "browser_navigate", "browser_snapshot", "browser_click",
@@ -266,6 +281,8 @@ TOOLSETS = {
             "terminal", "process",
             # File manipulation
             "read_file", "write_file", "patch", "search_files",
+            # Code intelligence
+            *_CODE_INTEL_TOOLS,
             # Vision + image generation
             "vision_analyze", "image_generate",
             # Skills
@@ -292,7 +309,7 @@ TOOLSETS = {
     
     "hermes-cli": {
         "description": "Full interactive CLI toolset - all default tools plus cronjob management",
-        "tools": _HERMES_CORE_TOOLS,
+        "tools": [*_HERMES_CORE_TOOLS, *_CODE_INTEL_TOOLS],
         "includes": []
     },
     

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -24,6 +24,38 @@ except Exception:
     pass
 
 from tui_gateway.render import make_stream_renderer, render_diff, render_message
+from tui_gateway.setup_services import (
+    bootstrap_provider_config as _bootstrap_provider_config_impl,
+    build_setup_catalog_payload as _build_setup_catalog_payload_impl,
+    build_setup_status_payload as _build_setup_status_payload_impl,
+    native_setup_catalog as _native_setup_catalog_impl,
+    persist_bootstrap_model as _persist_bootstrap_model_impl,
+    run_setup_bootstrap as _run_setup_bootstrap_impl,
+    setup_provider_models as _setup_provider_models_impl,
+    setup_provider_status as _setup_provider_status_impl,
+)
+from tui_gateway.skills_services import (
+    SKILLS_AUDIT_ACTION as _SKILLS_AUDIT_ACTION,
+    SKILLS_BROWSE_ACTION as _SKILLS_BROWSE_ACTION,
+    SKILLS_CHECK_ACTION as _SKILLS_CHECK_ACTION,
+    SKILLS_INSPECT_ACTION as _SKILLS_INSPECT_ACTION,
+    SKILLS_INSTALL_ACTION as _SKILLS_INSTALL_ACTION,
+    SKILLS_LIST_ACTION as _SKILLS_LIST_ACTION,
+    SKILLS_MANAGE_ACTIONS as _SKILLS_MANAGE_ACTIONS,
+    SKILLS_SEARCH_ACTION as _SKILLS_SEARCH_ACTION,
+    SKILLS_UNINSTALL_ACTION as _SKILLS_UNINSTALL_ACTION,
+    SKILLS_UPDATE_ACTION as _SKILLS_UPDATE_ACTION,
+    dispatch_skills_manage as _dispatch_skills_manage_impl,
+    normalize_skills_action as _normalize_skills_action_impl,
+)
+from tui_gateway.tools_services import (
+    build_tools_catalog_payload as _build_tools_catalog_payload_impl,
+    configure_mcp_servers as _configure_mcp_servers_impl,
+    configure_tool_provider as _configure_tool_provider_impl,
+    configure_tools as _configure_tools_impl,
+    probe_mcp_servers as _probe_mcp_servers_impl,
+    slugify_name as _slugify_name_impl,
+)
 
 _sessions: dict[str, dict] = {}
 _methods: dict[str, callable] = {}
@@ -35,6 +67,44 @@ _cfg_lock = threading.Lock()
 _cfg_cache: dict | None = None
 _cfg_mtime: float | None = None
 _SLASH_WORKER_TIMEOUT_S = max(5.0, float(os.environ.get("HERMES_TUI_SLASH_TIMEOUT_S", "45") or 45))
+_LIVE_WORK_COMMANDS = frozenset({"handoff", "init-deep", "start-work", "ralph-loop", "ulw-loop"})
+_NATIVE_PRODUCT_COMMANDS = frozenset({"setup", "skills", "tools"})
+_LIVE_SLASH_COMMANDS = frozenset({"model", "provider"}) | _LIVE_WORK_COMMANDS
+_LEGACY_SLASH_WORKER_COMMANDS = frozenset({
+    "agents",
+    "browser",
+    "config",
+    "cron",
+    "debug",
+    "fast",
+    "gquota",
+    "history",
+    "insights",
+    "platforms",
+    "plugins",
+    "profile",
+    "reload",
+    "reload-mcp",
+    "rollback",
+    "save",
+    "snapshot",
+    "status",
+    "stop",
+    "title",
+    "toolsets",
+})
+_SLASH_EXEC_COMMANDS = _LIVE_SLASH_COMMANDS | _LEGACY_SLASH_WORKER_COMMANDS
+
+
+def _routing_owner(name: str) -> str:
+    canonical = _resolve_slash_command_name(name)
+    if canonical in _NATIVE_PRODUCT_COMMANDS:
+        return "native"
+    if canonical in _LIVE_SLASH_COMMANDS:
+        return "slash-live"
+    if canonical in _LEGACY_SLASH_WORKER_COMMANDS:
+        return "slash-legacy"
+    return "dispatch"
 
 # Reserve real stdout for JSON-RPC only; redirect Python's stdout to stderr
 # so stray print() from libraries/tools becomes harmless gateway.stderr instead
@@ -218,6 +288,25 @@ def _sess(params, rid):
     return (None, err) if err else (s, _wait_agent(s, rid))
 
 
+def _parse_slash_command(command: str) -> tuple[str, str]:
+    parts = command.strip().lstrip("/").split(None, 1)
+    if not parts:
+        return "", ""
+    return parts[0].lower(), (parts[1].strip() if len(parts) > 1 else "")
+
+
+def _resolve_slash_command_name(name: str) -> str:
+    if not name:
+        return ""
+    try:
+        from hermes_cli.commands import resolve_command
+
+        resolved = resolve_command(name)
+        return resolved.name if resolved else name
+    except Exception:
+        return name
+
+
 def _normalize_completion_path(path_part: str) -> str:
     expanded = os.path.expanduser(path_part)
     if os.name != "nt":
@@ -264,6 +353,19 @@ def _save_cfg(cfg: dict):
             _cfg_mtime = path.stat().st_mtime
         except Exception:
             _cfg_mtime = None
+
+
+def _slugify_name(value: str) -> str:
+    return _slugify_name_impl(value)
+
+
+def _capture_console_output(fn, *args, **kwargs) -> str:
+    from rich.console import Console
+
+    console = Console(record=True, width=100, force_terminal=False, color_system=None)
+    kwargs.setdefault("console", console)
+    fn(*args, **kwargs)
+    return console.export_text(clear=False).strip()
 
 
 def _set_session_context(session_key: str) -> list:
@@ -395,6 +497,69 @@ def _load_enabled_toolsets() -> list[str] | None:
         return None
 
 
+def _visible_tool_payload(enabled_toolsets: list[str] | None) -> tuple[list[dict], set[str]]:
+    from model_tools import get_tool_definitions
+
+    tools = get_tool_definitions(enabled_toolsets=enabled_toolsets, quiet_mode=True)
+    visible_names = {
+        str(tool.get("function", {}).get("name", "") or "")
+        for tool in tools
+        if str(tool.get("function", {}).get("name", "") or "")
+    }
+    return tools, visible_names
+
+
+def _tool_summary_row(tool: dict) -> dict:
+    fn = tool.get("function", {}) or {}
+    name = str(fn.get("name", "") or "")
+    desc = str(fn.get("description", "") or "").split("\n")[0]
+    if ". " in desc:
+        desc = desc[:desc.index(". ") + 1]
+    return {"name": name, "description": desc}
+
+
+def _derive_visible_toolsets(enabled_toolsets: list[str] | None) -> tuple[list[dict], list[dict], set[str]]:
+    from model_tools import get_available_toolsets
+    from toolsets import get_toolset_contract, get_toolset_info
+
+    visible_tools, visible_names = _visible_tool_payload(enabled_toolsets)
+    visible_rows_by_name = {
+        row["name"]: row
+        for row in (_tool_summary_row(tool) for tool in visible_tools)
+        if row["name"]
+    }
+
+    items = []
+    for name, metadata in sorted(get_available_toolsets().items()):
+        info = get_toolset_info(name) or {}
+        contract = get_toolset_contract(name) or {}
+        resolved_tools = list(info.get("resolved_tools") or metadata.get("tools") or contract.get("tools") or [])
+        visible_members = [tool_name for tool_name in resolved_tools if tool_name in visible_names]
+        items.append({
+            "name": name,
+            "description": info.get("description") or metadata.get("description", ""),
+            "tool_count": len(resolved_tools),
+            "enabled": bool(visible_members),
+            "tools": resolved_tools,
+            "resolved_tools": resolved_tools,
+            "visible_tools": [visible_rows_by_name[tool_name] for tool_name in visible_members if tool_name in visible_rows_by_name],
+            "visible_tool_names": visible_members,
+            "available": metadata.get("available", True),
+            "requirements": list(metadata.get("requirements") or []),
+            "canonical_name": contract.get("canonical_name", metadata.get("canonical_name", name)),
+            "source": contract.get("source", metadata.get("source")),
+            "is_builtin": contract.get("is_builtin", metadata.get("is_builtin", False)),
+            "is_additive": contract.get("is_additive", metadata.get("is_additive", False)),
+            "is_alias": contract.get("is_alias", metadata.get("is_alias", False)),
+            "is_canonical_knowledge_surface": contract.get(
+                "is_canonical_knowledge_surface",
+                metadata.get("is_canonical_knowledge_surface", False),
+            ),
+            "boundary_note": contract.get("boundary_note", metadata.get("boundary_note")),
+        })
+    return items, visible_tools, visible_names
+
+
 def _session_tool_progress_mode(sid: str) -> str:
     return str(_sessions.get(sid, {}).get("tool_progress_mode", "all") or "all")
 
@@ -432,6 +597,33 @@ def _persist_model_switch(result) -> None:
     else:
         model_cfg.pop("base_url", None)
     save_config(cfg)
+
+
+def _setup_provider_models(provider: str, max_models: int = 24) -> tuple[list[str], str]:
+    return _setup_provider_models_impl(provider, max_models=max_models)
+
+
+def _setup_provider_status(provider: str) -> dict:
+    return _setup_provider_status_impl(provider)
+
+
+def _native_setup_catalog() -> list[dict]:
+    return _native_setup_catalog_impl(provider_status=_setup_provider_status, provider_models=_setup_provider_models)
+
+
+def _persist_bootstrap_model(provider: str, model: str, *, base_url: str = "", api_mode: str | None = None) -> None:
+    _persist_bootstrap_model_impl(provider, model, base_url=base_url, api_mode=api_mode)
+
+
+def _bootstrap_provider_config(provider: str, *, api_key: str = "", model: str = "", base_url: str = "") -> dict:
+    return _bootstrap_provider_config_impl(
+        provider,
+        api_key=api_key,
+        model=model,
+        base_url=base_url,
+        provider_models=_setup_provider_models,
+        persist_model=_persist_bootstrap_model,
+    )
 
 
 def _apply_model_switch(sid: str, session: dict, raw_input: str) -> dict:
@@ -1357,6 +1549,10 @@ def _(rid, params: dict) -> dict:
     session, err = _sess(params, rid)
     if err:
         return err
+    return _start_prompt_submit(rid, sid, session, text)
+
+
+def _start_prompt_submit(rid, sid: str, session: dict, text: str) -> dict:
     with session["history_lock"]:
         if session.get("running"):
             return _err(rid, 4009, "session busy")
@@ -1878,13 +2074,59 @@ def _(rid, params: dict) -> dict:
     return _err(rid, 4002, f"unknown config key: {key}")
 
 
+def _setup_status_payload() -> dict:
+    from hermes_cli.main import _has_any_provider_configured
+
+    return _build_setup_status_payload_impl(
+        load_cfg=_load_cfg,
+        resolve_model=_resolve_model,
+        provider_configured=_has_any_provider_configured,
+    )
+
+
+def _setup_catalog_payload() -> dict:
+    from hermes_cli.main import _has_any_provider_configured
+
+    return _build_setup_catalog_payload_impl(
+        load_cfg=_load_cfg,
+        resolve_model=_resolve_model,
+        provider_configured=_has_any_provider_configured,
+        catalog_builder=_native_setup_catalog,
+    )
+
+
+def _setup_bootstrap_payload(params: dict) -> dict:
+    return _run_setup_bootstrap_impl(
+        provider=str(params.get("provider", "") or ""),
+        api_key=str(params.get("api_key", "") or ""),
+        model=str(params.get("model", "") or ""),
+        base_url=str(params.get("base_url", "") or ""),
+        bootstrapper=_bootstrap_provider_config,
+    )
+
+
 @method("setup.status")
 def _(rid, params: dict) -> dict:
     try:
-        from hermes_cli.main import _has_any_provider_configured
-        return _ok(rid, {"provider_configured": bool(_has_any_provider_configured())})
+        return _ok(rid, _setup_status_payload())
     except Exception as e:
         return _err(rid, 5016, str(e))
+
+
+@method("setup.catalog")
+def _(rid, params: dict) -> dict:
+    try:
+        return _ok(rid, _setup_catalog_payload())
+    except Exception as e:
+        return _err(rid, 5034, str(e))
+
+
+@method("setup.bootstrap")
+def _(rid, params: dict) -> dict:
+    try:
+        return _ok(rid, _setup_bootstrap_payload(params))
+    except Exception as e:
+        return _err(rid, 5035, str(e))
 
 
 # ── Methods: tools & system ──────────────────────────────────────────
@@ -2059,6 +2301,13 @@ def _(rid, params: dict) -> dict:
     resolved = _resolve_name(name)
     if resolved != name:
         name = resolved
+
+    owner = _routing_owner(name)
+    if owner == "native":
+        return _err(rid, 4002, f"/{name} is handled by native product routing; command.dispatch is fallback-only")
+    if owner.startswith("slash"):
+        return _err(rid, 4002, f"/{name} is handled by slash.exec; command.dispatch is fallback-only")
+
     session = _sessions.get(params.get("session_id", ""))
 
     qcmds = _load_cfg().get("quick_commands", {})
@@ -2260,10 +2509,10 @@ def _(rid, params: dict) -> dict:
 
 def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
     """Apply side effects that must also hit the gateway's live agent."""
-    parts = command.lstrip("/").split(None, 1)
-    if not parts:
+    name, arg = _parse_slash_command(command)
+    if not name:
         return ""
-    name, arg, agent = parts[0], (parts[1].strip() if len(parts) > 1 else ""), session.get("agent")
+    agent = session.get("agent")
 
     try:
         if name == "model" and arg and agent:
@@ -2298,6 +2547,42 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
     return ""
 
 
+def _run_live_work_slash(rid, sid: str, session: dict, command: str) -> dict:
+    from hermes_cli.work_command_adapter import WorkCommandContractError, prepare_work_command
+
+    name, arg = _parse_slash_command(command)
+    try:
+        prepared = prepare_work_command(
+            name,
+            raw_args=arg,
+            session_id=session["session_key"],
+            cwd=os.environ.get("TERMINAL_CWD") or os.getcwd(),
+        )
+    except WorkCommandContractError as exc:
+        return _err(rid, 4002, str(exc))
+    except Exception as exc:
+        return _err(rid, 5030, str(exc))
+
+    started = _start_prompt_submit(rid, sid, session, prepared)
+    if started.get("error"):
+        return started
+    return _ok(rid, {"output": f"/{name} started"})
+
+
+def _run_live_model_slash(rid, sid: str, session: dict, arg: str) -> dict:
+    if not arg:
+        return _err(rid, 4002, "model value required")
+    try:
+        result = _apply_model_switch(sid, session, arg)
+    except Exception as exc:
+        return _err(rid, 5001, str(exc))
+
+    payload = {"output": f"model → {result['value']}"}
+    if result.get("warning"):
+        payload["warning"] = result["warning"]
+    return _ok(rid, payload)
+
+
 @method("slash.exec")
 def _(rid, params: dict) -> dict:
     session, err = _sess(params, rid)
@@ -2308,6 +2593,23 @@ def _(rid, params: dict) -> dict:
     if not cmd:
         return _err(rid, 4004, "empty command")
 
+    sid = params.get("session_id", "")
+    name, arg = _parse_slash_command(cmd)
+    name = _resolve_slash_command_name(name)
+    normalized_cmd = f"{name}{(' ' + arg) if arg else ''}"
+    owner = _routing_owner(name)
+
+    if owner == "slash-live":
+        if name in _LIVE_WORK_COMMANDS:
+            return _run_live_work_slash(rid, sid, session, normalized_cmd)
+        return _run_live_model_slash(rid, sid, session, arg)
+
+    if owner == "native":
+        return _err(rid, 4002, f"/{name} is handled by native product routing; slash.exec is legacy-only")
+
+    if owner != "slash-legacy":
+        return _err(rid, 4002, f"/{name} is not eligible for slash.exec; use native routing or command.dispatch")
+
     worker = session.get("slash_worker")
     if not worker:
         try:
@@ -2317,8 +2619,8 @@ def _(rid, params: dict) -> dict:
             return _err(rid, 5030, f"slash worker start failed: {e}")
 
     try:
-        output = worker.run(cmd)
-        warning = _mirror_slash_side_effects(params.get("session_id", ""), session, cmd)
+        output = worker.run(normalized_cmd)
+        warning = _mirror_slash_side_effects(params.get("session_id", ""), session, normalized_cmd)
         payload = {"output": output or "(no output)"}
         if warning:
             payload["warning"] = warning
@@ -2565,53 +2867,289 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 5030, str(e))
 
 
+def _tools_catalog_payload() -> dict:
+    from hermes_cli.config import get_env_value, load_config
+    from hermes_cli.nous_subscription import get_nous_subscription_features
+    from hermes_cli.tools_config import (
+        CONFIGURABLE_TOOLSETS,
+        TOOL_CATEGORIES,
+        _get_effective_configurable_toolsets,
+        _get_platform_tools,
+    )
+    from tools.tool_backend_helpers import managed_nous_tools_enabled
+
+    return _build_tools_catalog_payload_impl(
+        load_config=load_config,
+        get_env_value=get_env_value,
+        configurable_toolsets=CONFIGURABLE_TOOLSETS,
+        tool_categories=TOOL_CATEGORIES,
+        effective_toolsets=_get_effective_configurable_toolsets,
+        get_platform_tools=_get_platform_tools,
+        get_subscription_features=get_nous_subscription_features,
+        managed_nous_tools_enabled=managed_nous_tools_enabled,
+    )
+
+
+def _tools_provider_configure_payload(params: dict) -> dict:
+    from hermes_cli.config import get_env_value, load_config, save_config, save_env_value
+    from hermes_cli.nous_subscription import get_nous_subscription_features
+    from hermes_cli.tools_config import TOOL_CATEGORIES
+    from tools.tool_backend_helpers import managed_nous_tools_enabled
+
+    return _configure_tool_provider_impl(
+        toolset=str(params.get("toolset", "") or ""),
+        provider_name=str(params.get("provider", "") or ""),
+        model=str(params.get("model", "") or ""),
+        env_values=params.get("env") or {},
+        session_id=str(params.get("session_id", "") or ""),
+        session_lookup=_sessions.get,
+        reset_session_agent=_reset_session_agent,
+        catalog_payload_builder=_tools_catalog_payload,
+        load_config=load_config,
+        save_config=save_config,
+        save_env_value=save_env_value,
+        get_env_value=get_env_value,
+        tool_categories=TOOL_CATEGORIES,
+        get_subscription_features=get_nous_subscription_features,
+        managed_nous_tools_enabled=managed_nous_tools_enabled,
+    )
+
+
+def _tools_mcp_configure_payload(params: dict) -> dict:
+    from hermes_cli.config import load_config, save_config
+
+    return _configure_mcp_servers_impl(
+        action=str(params.get("action", "") or ""),
+        names=params.get("names", []) or [],
+        session_id=str(params.get("session_id", "") or ""),
+        session_lookup=_sessions.get,
+        reset_session_agent=_reset_session_agent,
+        catalog_payload_builder=_tools_catalog_payload,
+        load_config=load_config,
+        save_config=save_config,
+    )
+
+
+def _tools_mcp_probe_payload() -> dict:
+    from hermes_cli.config import load_config
+    from tools.mcp_tool import probe_mcp_server_tools
+
+    return _probe_mcp_servers_impl(
+        load_config=load_config,
+        probe_mcp_server_tools=probe_mcp_server_tools,
+    )
+
+
+def _validate_skills_manage_params(params: dict) -> dict:
+    action = _normalize_skills_action_impl(params.get("action"))
+    if action not in _SKILLS_MANAGE_ACTIONS:
+        raise ValueError(f"unknown skills action: {action}")
+
+    allowed_keys_by_action = {
+        _SKILLS_LIST_ACTION: frozenset({"action"}),
+        _SKILLS_SEARCH_ACTION: frozenset({"action", "query"}),
+        _SKILLS_BROWSE_ACTION: frozenset({"action", "page", "page_size", "query", "source"}),
+        _SKILLS_INSPECT_ACTION: frozenset({"action", "query"}),
+        _SKILLS_INSTALL_ACTION: frozenset({"action", "query"}),
+        _SKILLS_CHECK_ACTION: frozenset({"action", "query"}),
+        _SKILLS_UPDATE_ACTION: frozenset({"action", "query"}),
+        _SKILLS_AUDIT_ACTION: frozenset({"action", "query"}),
+        _SKILLS_UNINSTALL_ACTION: frozenset({"action", "query"}),
+    }
+    unexpected_keys = sorted(str(key) for key in params.keys() if key not in allowed_keys_by_action[action])
+    if unexpected_keys:
+        raise ValueError(f"unexpected skills params for {action}: {', '.join(unexpected_keys)}")
+
+    query = str(params.get("query", "") or "")
+    if action in {_SKILLS_SEARCH_ACTION, _SKILLS_INSPECT_ACTION, _SKILLS_INSTALL_ACTION, _SKILLS_UNINSTALL_ACTION} and not query.strip():
+        raise ValueError(f"skills.{action} requires query")
+
+    if action == _SKILLS_BROWSE_ACTION:
+        for key in ("page", "page_size"):
+            raw = params.get(key)
+            if raw is None or str(raw).strip() == "":
+                continue
+            value = int(raw)
+            if value <= 0:
+                raise ValueError(f"skills.browse requires positive {key}")
+
+    return dict(params, action=action, query=query)
+
+
+def _skills_manage_payload(params: dict) -> dict:
+    validated = _validate_skills_manage_params(params)
+
+    from hermes_cli.banner import get_available_skills
+    from hermes_cli.skills_hub import browse_skills, do_audit, do_check, do_install, do_uninstall, do_update, inspect_skill
+    from tools.skills_hub import GitHubAuth, create_source_router, unified_search
+
+    return _dispatch_skills_manage_impl(
+        validated,
+        get_available_skills=get_available_skills,
+        capture_console_output=_capture_console_output,
+        auth_factory=GitHubAuth,
+        source_router_factory=create_source_router,
+        unified_search=unified_search,
+        browse_skills=browse_skills,
+        inspect_skill=inspect_skill,
+        do_install=do_install,
+        do_check=do_check,
+        do_update=do_update,
+        do_audit=do_audit,
+        do_uninstall=do_uninstall,
+    )
+
+
+def _tools_configure_payload(params: dict) -> dict:
+    from hermes_cli.config import load_config, save_config
+    from hermes_cli.tools_config import (
+        CONFIGURABLE_TOOLSETS,
+        _get_platform_tools,
+        _get_plugin_toolset_keys,
+        _save_platform_tools,
+    )
+
+    return _configure_tools_impl(
+        action=str(params.get("action", "") or ""),
+        targets=params.get("names", []) or [],
+        session_id=str(params.get("session_id", "") or ""),
+        session_lookup=_sessions.get,
+        reset_session_agent=_reset_session_agent,
+        load_config=load_config,
+        save_config=save_config,
+        configurable_toolsets=CONFIGURABLE_TOOLSETS,
+        plugin_toolset_keys=_get_plugin_toolset_keys,
+        get_platform_tools=_get_platform_tools,
+        save_platform_tools=_save_platform_tools,
+    )
+
+
 @method("tools.list")
 def _(rid, params: dict) -> dict:
     try:
-        from toolsets import get_all_toolsets, get_toolset_info
         session = _sessions.get(params.get("session_id", ""))
-        enabled = set(getattr(session["agent"], "enabled_toolsets", []) or []) if session else set(_load_enabled_toolsets() or [])
-
-        items = []
-        for name in sorted(get_all_toolsets().keys()):
-            info = get_toolset_info(name)
-            if not info:
-                continue
-            items.append({
-                "name": name,
-                "description": info["description"],
-                "tool_count": info["tool_count"],
-                "enabled": name in enabled if enabled else True,
-                "tools": info["resolved_tools"],
-            })
+        enabled = getattr(session["agent"], "enabled_toolsets", None) if session else _load_enabled_toolsets()
+        toolsets, _, _ = _derive_visible_toolsets(enabled)
+        items = [{
+            "name": item["name"],
+            "description": item["description"],
+            "tool_count": item["tool_count"],
+            "enabled": item["enabled"],
+            "tools": item["resolved_tools"],
+            "canonical_name": item["canonical_name"],
+            "source": item["source"],
+            "is_builtin": item["is_builtin"],
+            "is_additive": item["is_additive"],
+            "is_alias": item["is_alias"],
+            "is_canonical_knowledge_surface": item["is_canonical_knowledge_surface"],
+            "boundary_note": item["boundary_note"],
+            "visible_tools": item["visible_tools"],
+        } for item in toolsets]
         return _ok(rid, {"toolsets": items})
     except Exception as e:
         return _err(rid, 5031, str(e))
 
 
+@method("tools.catalog")
+def _(rid, params: dict) -> dict:
+    try:
+        return _ok(rid, _tools_catalog_payload())
+    except Exception as e:
+        return _err(rid, 5036, str(e))
+
+
+@method("tools.provider.configure")
+def _(rid, params: dict) -> dict:
+    try:
+        return _ok(rid, _tools_provider_configure_payload(params))
+    except ValueError as e:
+        message = str(e)
+        if message == "toolset required":
+            return _err(rid, 4019, message)
+        if message == "provider required":
+            return _err(rid, 4020, message)
+        return _err(rid, 5037, message)
+    except TypeError as e:
+        return _err(rid, 4021, str(e))
+    except LookupError as e:
+        message = str(e)
+        if message.startswith("toolset has no native provider flow"):
+            return _err(rid, 4022, message)
+        if message.startswith("unknown provider for "):
+            return _err(rid, 4023, message)
+        return _err(rid, 5037, message)
+    except Exception as e:
+        return _err(rid, 5037, str(e))
+
+
+@method("tools.mcp.configure")
+def _(rid, params: dict) -> dict:
+    try:
+        return _ok(rid, _tools_mcp_configure_payload(params))
+    except ValueError as e:
+        message = str(e)
+        if message.startswith("unknown mcp action: "):
+            return _err(rid, 4024, message)
+        if message == "server names required":
+            return _err(rid, 4025, message)
+        return _err(rid, 5038, message)
+    except Exception as e:
+        return _err(rid, 5038, str(e))
+
+
+@method("tools.mcp.probe")
+def _(rid, params: dict) -> dict:
+    try:
+        return _ok(rid, _tools_mcp_probe_payload())
+    except Exception as e:
+        return _err(rid, 5039, str(e))
+
+
 @method("tools.show")
 def _(rid, params: dict) -> dict:
     try:
-        from model_tools import get_toolset_for_tool, get_tool_definitions
+        from model_tools import get_toolset_for_tool
 
         session = _sessions.get(params.get("session_id", ""))
         enabled = getattr(session["agent"], "enabled_toolsets", None) if session else _load_enabled_toolsets()
-        tools = get_tool_definitions(enabled_toolsets=enabled, quiet_mode=True)
-        sections = {}
+        toolsets, tools, _ = _derive_visible_toolsets(enabled)
+        visible_rows = []
+        for tool in sorted(tools, key=lambda t: t.get("function", {}).get("name", "")):
+            row = _tool_summary_row(tool)
+            if not row["name"]:
+                continue
+            row["owner_toolset"] = get_toolset_for_tool(row["name"]) or "unknown"
+            visible_rows.append(row)
 
-        for tool in sorted(tools, key=lambda t: t["function"]["name"]):
-            name = tool["function"]["name"]
-            desc = str(tool["function"].get("description", "") or "").split("\n")[0]
-            if ". " in desc:
-                desc = desc[:desc.index(". ") + 1]
-            sections.setdefault(get_toolset_for_tool(name) or "unknown", []).append({
-                "name": name,
-                "description": desc,
+        sections = [
+            {
+                "name": item["name"],
+                "canonical_name": item["canonical_name"],
+                "description": item["description"],
+                "source": item["source"],
+                "is_builtin": item["is_builtin"],
+                "is_additive": item["is_additive"],
+                "is_alias": item["is_alias"],
+                "is_canonical_knowledge_surface": item["is_canonical_knowledge_surface"],
+                "boundary_note": item["boundary_note"],
+                "tools": item["visible_tools"],
+            }
+            for item in toolsets
+            if item["enabled"] and item["is_canonical_knowledge_surface"]
+        ]
+
+        legacy_sections = {}
+        for row in visible_rows:
+            legacy_sections.setdefault(row["owner_toolset"], []).append({
+                "name": row["name"],
+                "description": row["description"],
             })
 
         return _ok(rid, {
-            "sections": [{"name": name, "tools": rows} for name, rows in sorted(sections.items())],
-            "total": len(tools),
+            "sections": sections,
+            "legacy_sections": [{"name": name, "tools": rows} for name, rows in sorted(legacy_sections.items())],
+            "tools": visible_rows,
+            "total": len(visible_rows),
         })
     except Exception as e:
         return _err(rid, 5034, str(e))
@@ -2619,52 +3157,15 @@ def _(rid, params: dict) -> dict:
 
 @method("tools.configure")
 def _(rid, params: dict) -> dict:
-    action = str(params.get("action", "") or "").strip().lower()
-    targets = [str(name).strip() for name in params.get("names", []) or [] if str(name).strip()]
-    if action not in {"disable", "enable"}:
-        return _err(rid, 4017, f"unknown tools action: {action}")
-    if not targets:
-        return _err(rid, 4018, "names required")
-
     try:
-        from hermes_cli.config import load_config, save_config
-        from hermes_cli.tools_config import (
-            CONFIGURABLE_TOOLSETS,
-            _apply_mcp_change,
-            _apply_toolset_change,
-            _get_platform_tools,
-            _get_plugin_toolset_keys,
-        )
-
-        cfg = load_config()
-        valid_toolsets = {ts_key for ts_key, _, _ in CONFIGURABLE_TOOLSETS} | _get_plugin_toolset_keys()
-        toolset_targets = [name for name in targets if ":" not in name]
-        mcp_targets = [name for name in targets if ":" in name]
-        unknown = [name for name in toolset_targets if name not in valid_toolsets]
-        toolset_targets = [name for name in toolset_targets if name in valid_toolsets]
-
-        if toolset_targets:
-            _apply_toolset_change(cfg, "cli", toolset_targets, action)
-
-        missing_servers = _apply_mcp_change(cfg, mcp_targets, action) if mcp_targets else set()
-        save_config(cfg)
-
-        session = _sessions.get(params.get("session_id", ""))
-        info = _reset_session_agent(params.get("session_id", ""), session) if session else None
-        enabled = sorted(_get_platform_tools(load_config(), "cli", include_default_mcp_servers=False))
-        changed = [
-            name for name in targets
-            if name not in unknown and (":" not in name or name.split(":", 1)[0] not in missing_servers)
-        ]
-
-        return _ok(rid, {
-            "changed": changed,
-            "enabled_toolsets": enabled,
-            "info": info,
-            "missing_servers": sorted(missing_servers),
-            "reset": bool(session),
-            "unknown": unknown,
-        })
+        return _ok(rid, _tools_configure_payload(params))
+    except ValueError as e:
+        message = str(e)
+        if message.startswith("unknown tools action: "):
+            return _err(rid, 4017, message)
+        if message == "names required":
+            return _err(rid, 4018, message)
+        return _err(rid, 5035, message)
     except Exception as e:
         return _err(rid, 5035, str(e))
 
@@ -2672,21 +3173,23 @@ def _(rid, params: dict) -> dict:
 @method("toolsets.list")
 def _(rid, params: dict) -> dict:
     try:
-        from toolsets import get_all_toolsets, get_toolset_info
         session = _sessions.get(params.get("session_id", ""))
-        enabled = set(getattr(session["agent"], "enabled_toolsets", []) or []) if session else set(_load_enabled_toolsets() or [])
-
-        items = []
-        for name in sorted(get_all_toolsets().keys()):
-            info = get_toolset_info(name)
-            if not info:
-                continue
-            items.append({
-                "name": name,
-                "description": info["description"],
-                "tool_count": info["tool_count"],
-                "enabled": name in enabled if enabled else True,
-            })
+        enabled = getattr(session["agent"], "enabled_toolsets", None) if session else _load_enabled_toolsets()
+        toolsets, _, _ = _derive_visible_toolsets(enabled)
+        items = [{
+            "name": item["name"],
+            "description": item["description"],
+            "tool_count": item["tool_count"],
+            "enabled": item["enabled"],
+            "canonical_name": item["canonical_name"],
+            "source": item["source"],
+            "is_builtin": item["is_builtin"],
+            "is_additive": item["is_additive"],
+            "is_alias": item["is_alias"],
+            "is_canonical_knowledge_surface": item["is_canonical_knowledge_surface"],
+            "boundary_note": item["boundary_note"],
+            "tools": item["resolved_tools"],
+        } for item in toolsets]
         return _ok(rid, {"toolsets": items})
     except Exception as e:
         return _err(rid, 5032, str(e))
@@ -2728,29 +3231,10 @@ def _(rid, params: dict) -> dict:
 
 @method("skills.manage")
 def _(rid, params: dict) -> dict:
-    action, query = params.get("action", "list"), params.get("query", "")
     try:
-        if action == "list":
-            from hermes_cli.banner import get_available_skills
-            return _ok(rid, {"skills": get_available_skills()})
-        if action == "search":
-            from hermes_cli.skills_hub import unified_search, GitHubAuth, create_source_router
-            raw = unified_search(query, create_source_router(GitHubAuth()), source_filter="all", limit=20) or []
-            return _ok(rid, {"results": [{"name": r.name, "description": r.description} for r in raw]})
-        if action == "install":
-            from hermes_cli.skills_hub import do_install
-            class _Q:
-                def print(self, *a, **k): pass
-            do_install(query, skip_confirm=True, console=_Q())
-            return _ok(rid, {"installed": True, "name": query})
-        if action == "browse":
-            from hermes_cli.skills_hub import browse_skills
-            pg = int(params.get("page", 0) or 0) or (int(query) if query.isdigit() else 1)
-            return _ok(rid, browse_skills(page=pg, page_size=int(params.get("page_size", 20))))
-        if action == "inspect":
-            from hermes_cli.skills_hub import inspect_skill
-            return _ok(rid, {"info": inspect_skill(query) or {}})
-        return _err(rid, 4017, f"unknown skills action: {action}")
+        return _ok(rid, _skills_manage_payload(params))
+    except ValueError as e:
+        return _err(rid, 4017, str(e))
     except Exception as e:
         return _err(rid, 5024, str(e))
 


### PR DESCRIPTION
Summary
This PR completes the post-Wave-8 Built-in Knowledge Surfaces Program across four lanes:
repo/code knowledge
web/research knowledge
document/PDF/diagram intelligence
ACP/TUI/API propagation
It turns Hermes-native built-in primitives into three explicit canonical knowledge surfaces:
repo-code-knowledge
web-research-knowledge
document-pdf-diagram-intelligence
It keeps the implementation honest:
repo/code remains grounded in file + AST + LSP primitives
web/research remains grounded in web_search + web_extract
web_crawl remains deferred rather than being overclaimed as canonically exposed
document/PDF/diagram intelligence is browser-rendered and image/screenshot-aware, not a raw PDF parser or OCR pipeline
downstream propagation teaches canonical surfaces first while preserving compatibility with raw tools and legacy sections
What changed
Lane 1 — Repo/code knowledge
aligned read_file, search_files, AST, and LSP wording around canonical repo-code-knowledge
added additive knowledge_surface metadata to file-tool results
added optional HASHLINE SHA-256 validation in patch_tool()
locked repo/code canonical coverage with tool and API tests
Lane 2 — Web/research knowledge
reframed web_search and web_extract as the built-in web-research-knowledge surface
made the text-first boundary explicit relative to browser/document flows
kept web_crawl truth honest and explicitly deferred from canonical exposure
added direct web-tools regression coverage
Lane 3 — Document/PDF/diagram intelligence
reframed browser-side descriptions toward rendered document, slide, chart, and diagram inspection
reframed vision_analyze toward remote + local image/screenshot inputs with explicit non-PDF-parser limits
added direct acceptance tests for browser page-state inspection, rendered screenshot analysis, and local image support
Lane 4 — Propagation
surfaced canonical knowledge-surface metadata in TUI introspection
surfaced canonical knowledge families first in ACP /tools
preserved raw tools and legacy sections for compatibility
added API-server guards so canonical surfaces are treated as overlays rather than replacements for hermes-api-server
Why
Hermes already had strong native primitives for code grounding, web retrieval, browser inspection, and vision analysis. This PR productizes them into coherent built-in knowledge surfaces with honest boundaries and downstream exposure coherence.
This is a Hermes-native productization pass, not a literal OMO clone and not a claim of full OMO parity.

Behavior and compatibility notes
repo-code-knowledge, web-research-knowledge, and document-pdf-diagram-intelligence remain canonical built-in overlays
compatibility aliases remain secondary and supported
web_crawl exists in code but is still not canonically exposed in the built-in web/research surface
document intelligence is browser-rendered and image/screenshot-aware; it does not claim raw PDF parsing, OCR-first ingestion, or diagram editing
TUI and ACP now teach canonical surfaces first, but still preserve raw-tool compatibility views
API-server defaults still use hermes-api-server; canonical surfaces are covered as overlays, not as replacements
Testing
Fresh lane-scoped verification run:
python3 -m pytest tests/tools/test_file_tools.py tests/tools/test_ast_tools.py tests/tools/test_lsp_tools.py tests/tools/test_web_tools.py tests/tools/test_browser_console.py tests/tools/test_vision_tools.py tests/test_knowledge_surface_toolsets.py tests/test_tui_gateway_server.py tests/test_acp_tools_output.py tests/gateway/test_api_server_toolset.py tests/gateway/test_discord_document_handling.py -q
Result: 240 passed, 6 skipped in 11.98s
Reviewer notes
Please focus on:
whether the canonical surface boundaries are honest and stable
whether web_crawl should remain deferred from canonical exposure in this PR
whether the document-intelligence wording is appropriately browser-rendered/image-first and not overclaimed
whether the propagation changes in TUI/ACP preserve compatibility while still teaching the canonical product story
whether toolsets.py and the shared contract tests are appropriately central for the combined lane stack
🤖 This PR was created by an AI coding agent 🤖 This was written by an AI coding agent