### PR TITLE
fix: persist opencode-go env-seeded credentials

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1341,17 +1341,25 @@ def _seed_from_env(provider: str, entries: List[PooledCredential]) -> Tuple[bool
     return changed, active_sources
 
 
-def _prune_stale_seeded_entries(entries: List[PooledCredential], active_sources: Set[str]) -> bool:
-    retained = [
-        entry
-        for entry in entries
-        if _is_manual_source(entry.source)
-        or entry.source in active_sources
-        or not (
-            entry.source.startswith("env:")
-            or entry.source in {"claude_code", "hermes_pkce"}
-        )
-    ]
+def _prune_stale_seeded_entries(provider: str, entries: List[PooledCredential], active_sources: Set[str]) -> bool:
+    retained = []
+    for entry in entries:
+        if _is_manual_source(entry.source) or entry.source in active_sources:
+            retained.append(entry)
+            continue
+
+        if entry.source.startswith("env:"):
+            # Env-seeded API keys are treated as persisted credentials once they
+            # have been written to auth.json, so they survive process restarts.
+            # OAuth-style env seeds are different: if the env var disappears,
+            # we do not have a refresh-token-backed fallback and should prune
+            # them so the pool does not keep selecting a stale token.
+            if entry.auth_type == AUTH_TYPE_API_KEY and provider == "opencode-go":
+                retained.append(entry)
+            continue
+
+        if entry.source not in {"claude_code", "hermes_pkce"}:
+            retained.append(entry)
     if len(retained) == len(entries):
         return False
     entries[:] = retained
@@ -1440,12 +1448,12 @@ def load_pool(provider: str) -> CredentialPool:
         # Custom endpoint pool — seed from custom_providers config and model config
         custom_changed, custom_sources = _seed_custom_pool(provider, entries)
         changed = custom_changed
-        changed |= _prune_stale_seeded_entries(entries, custom_sources)
+        changed |= _prune_stale_seeded_entries(provider, entries, custom_sources)
     else:
         singleton_changed, singleton_sources = _seed_from_singletons(provider, entries)
         env_changed, env_sources = _seed_from_env(provider, entries)
         changed = singleton_changed or env_changed
-        changed |= _prune_stale_seeded_entries(entries, singleton_sources | env_sources)
+        changed |= _prune_stale_seeded_entries(provider, entries, singleton_sources | env_sources)
         changed |= _normalize_pool_priorities(provider, entries)
 
     if changed:

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -1370,3 +1370,76 @@ def test_nous_exhausted_entry_recovers_via_auth_store_sync(tmp_path, monkeypatch
     assert len(available) == 1
     assert available[0].refresh_token == "refresh-FRESH"
     assert available[0].last_status is None
+
+
+def test_opencode_go_env_seed_survives_missing_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.delenv("OPENCODE_GO_API_KEY", raising=False)
+
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "opencode-go": [
+                    {
+                        "id": "cred-opencode",
+                        "label": "OPENCODE_GO_API_KEY",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "env:OPENCODE_GO_API_KEY",
+                        "access_token": "***",
+                        "base_url": "https://opencode.ai/zen/go/v1",
+                        "request_count": 0,
+                    }
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("opencode-go")
+    entry = pool.select()
+
+    assert entry is not None
+    assert entry.source == "env:OPENCODE_GO_API_KEY"
+    assert entry.label == "OPENCODE_GO_API_KEY"
+
+    persisted = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    assert persisted["credential_pool"]["opencode-go"]
+
+
+def test_env_oauth_seed_is_pruned_when_env_missing(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "anthropic": [
+                    {
+                        "id": "cred-anthropic",
+                        "label": "CLAUDE_CODE_OAUTH_TOKEN",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "env:CLAUDE_CODE_OAUTH_TOKEN",
+                        "access_token": "***",
+                        "base_url": "https://api.anthropic.com",
+                    }
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("anthropic")
+    assert pool.select() is None
+
+    persisted = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    assert persisted["credential_pool"]["anthropic"] == []


### PR DESCRIPTION
## Summary\n- Preserve opencode-go credentials that were seeded from env so they don't disappear when the env var is absent later.\n- Prevent credential_pool from pruning already-persisted opencode-go entries during load.\n\n## Verification\n- pytest -q tests/agent/test_credential_pool.py tests/hermes_cli/test_model_normalize.py tests/hermes_cli/test_model_validation.py tests/hermes_cli/test_model_switch_opencode_anthropic.py -q\n\n## Notes\nThis fixes the runtime path where opencode-go resolved with an empty api_key because the stored credential entry had been dropped prematurely.