### PR TITLE
Fix Windows gateway recovery and startup workflows

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -29,6 +29,39 @@ _IS_WINDOWS = sys.platform == "win32"
 _UNSET = object()
 
 
+def _process_exists(pid: int) -> bool:
+    """Return True when a PID exists without relying on POSIX-only semantics."""
+    if pid <= 0:
+        return False
+
+    if _IS_WINDOWS:
+        try:
+            import ctypes
+
+            PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+            handle = ctypes.windll.kernel32.OpenProcess(
+                PROCESS_QUERY_LIMITED_INFORMATION,
+                False,
+                pid,
+            )
+            if handle:
+                ctypes.windll.kernel32.CloseHandle(handle)
+                return True
+
+            # Protected system processes can deny access while still existing.
+            return ctypes.GetLastError() == 5
+        except Exception:
+            return False
+
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
 def _get_pid_path() -> Path:
     """Return the path to the gateway PID file, respecting HERMES_HOME."""
     home = get_hermes_home()
@@ -338,34 +371,31 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
             return True, existing
 
         stale = existing_pid is None
-        if not stale:
-            try:
-                os.kill(existing_pid, 0)
-            except (ProcessLookupError, PermissionError):
+        if not stale and not _process_exists(existing_pid):
+            stale = True
+        elif not stale:
+            current_start = _get_process_start_time(existing_pid)
+            if (
+                existing.get("start_time") is not None
+                and current_start is not None
+                and current_start != existing.get("start_time")
+            ):
                 stale = True
-            else:
-                current_start = _get_process_start_time(existing_pid)
-                if (
-                    existing.get("start_time") is not None
-                    and current_start is not None
-                    and current_start != existing.get("start_time")
-                ):
-                    stale = True
-                # Check if process is stopped (Ctrl+Z / SIGTSTP) — stopped
-                # processes still respond to os.kill(pid, 0) but are not
-                # actually running. Treat them as stale so --replace works.
-                if not stale:
-                    try:
-                        _proc_status = Path(f"/proc/{existing_pid}/status")
-                        if _proc_status.exists():
-                            for _line in _proc_status.read_text().splitlines():
-                                if _line.startswith("State:"):
-                                    _state = _line.split()[1]
-                                    if _state in ("T", "t"):  # stopped or tracing stop
-                                        stale = True
-                                    break
-                    except (OSError, PermissionError):
-                        pass
+            # Check if process is stopped (Ctrl+Z / SIGTSTP) — stopped
+            # processes still respond to existence checks but are not actually
+            # running. Treat them as stale so --replace works.
+            if not stale:
+                try:
+                    _proc_status = Path(f"/proc/{existing_pid}/status")
+                    if _proc_status.exists():
+                        for _line in _proc_status.read_text().splitlines():
+                            if _line.startswith("State:"):
+                                _state = _line.split()[1]
+                                if _state in ("T", "t"):  # stopped or tracing stop
+                                    stale = True
+                                break
+                except (OSError, PermissionError):
+                    pass
         if stale:
             try:
                 lock_path.unlink(missing_ok=True)
@@ -574,9 +604,7 @@ def get_running_pid(
         _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale)
         return None
 
-    try:
-        os.kill(pid, 0)  # signal 0 = existence check, no actual signal sent
-    except (ProcessLookupError, PermissionError):
+    if not _process_exists(pid):
         _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale)
         return None
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -59,6 +59,27 @@ class GatewayRuntimeSnapshot:
     def has_process_service_mismatch(self) -> bool:
         return self.service_installed and self.running and not self.service_running
 
+
+def _getuid() -> int | None:
+    getter = getattr(os, "getuid", None)
+    if getter is None:
+        return None
+    try:
+        return int(getter())
+    except (OSError, TypeError, ValueError):
+        return None
+
+
+def _geteuid() -> int | None:
+    getter = getattr(os, "geteuid", None)
+    if getter is None:
+        return _getuid()
+    try:
+        return int(getter())
+    except (OSError, TypeError, ValueError):
+        return _getuid()
+
+
 def _get_service_pids() -> set:
     """Return PIDs currently managed by systemd or launchd gateway services.
 
@@ -628,7 +649,9 @@ def _ensure_user_systemd_env() -> None:
     We detect the standard socket path and set the vars so all subsequent
     subprocess calls inherit them.
     """
-    uid = os.getuid()
+    uid = _getuid()
+    if uid is None:
+        return
     if "XDG_RUNTIME_DIR" not in os.environ:
         runtime_dir = f"/run/user/{uid}"
         if Path(runtime_dir).exists():
@@ -844,7 +867,7 @@ def remove_legacy_hermes_units(
 
     # System-scope removal (needs root)
     if system_units:
-        if os.geteuid() != 0:
+        if _geteuid() != 0:
             print()
             print_warning("System-scope legacy units require root to remove.")
             print_info("  Re-run with: sudo hermes gateway migrate-legacy")
@@ -891,7 +914,7 @@ def print_systemd_scope_conflict_warning() -> None:
 
 
 def _require_root_for_system_service(action: str) -> None:
-    if os.geteuid() != 0:
+    if _geteuid() != 0:
         print(f"System gateway {action} requires root. Re-run with sudo.")
         sys.exit(1)
 
@@ -957,7 +980,7 @@ def install_linux_gateway_from_setup(force: bool = False) -> tuple[str | None, b
 
     if scope == "system":
         run_as_user = _default_system_service_user()
-        if os.geteuid() != 0:
+        if _geteuid() != 0:
             print_warning("  System service install requires sudo, so Hermes can't create it from this user session.")
             if run_as_user:
                 print_info(f"  After setup, run: sudo hermes gateway install --system --run-as-user {run_as_user}")
@@ -1003,7 +1026,10 @@ def get_systemd_linger_status() -> tuple[bool | None, str]:
     if not username:
         try:
             import pwd
-            username = pwd.getpwuid(os.getuid()).pw_name
+            uid = _getuid()
+            if uid is None:
+                return None, "could not determine current user"
+            username = pwd.getpwuid(uid).pw_name
         except Exception:
             return None, "could not determine current user"
 
@@ -1053,7 +1079,10 @@ def _launchd_user_home() -> Path:
     """
     import pwd
 
-    return Path(pwd.getpwuid(os.getuid()).pw_dir)
+    uid = _getuid()
+    if uid is None:
+        return Path.home()
+    return Path(pwd.getpwuid(uid).pw_dir)
 
 
 def get_launchd_plist_path() -> Path:
@@ -1657,7 +1686,8 @@ def get_launchd_label() -> str:
 
 def _launchd_domain() -> str:
     import os
-    return f"gui/{os.getuid()}"
+    uid = _getuid()
+    return f"gui/{uid if uid is not None else 0}"
 
 
 def generate_launchd_plist() -> str:

--- a/install-hermes-web-ui-task.ps1
+++ b/install-hermes-web-ui-task.ps1
@@ -1,0 +1,39 @@
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$daemonScript = Join-Path $repoRoot "run-hermes-web-ui-daemon.ps1"
+$taskName = "Hermes Web UI"
+$currentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+
+$action = New-ScheduledTaskAction `
+  -Execute "powershell.exe" `
+  -Argument "-NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -File `"$daemonScript`""
+
+$triggers = @(
+  (New-ScheduledTaskTrigger -AtLogOn -User $currentUser),
+  (New-ScheduledTaskTrigger -AtStartup)
+)
+
+$settings = New-ScheduledTaskSettingsSet `
+  -AllowStartIfOnBatteries `
+  -DontStopIfGoingOnBatteries `
+  -MultipleInstances IgnoreNew `
+  -RestartCount 999 `
+  -RestartInterval (New-TimeSpan -Minutes 1) `
+  -StartWhenAvailable
+
+$principal = New-ScheduledTaskPrincipal `
+  -UserId $currentUser `
+  -LogonType Interactive `
+  -RunLevel Highest
+
+$task = New-ScheduledTask -Action $action -Trigger $triggers -Settings $settings -Principal $principal
+Register-ScheduledTask -TaskName $taskName -InputObject $task -Force | Out-Null
+
+$webUiListening = Get-NetTCPConnection -LocalPort 8648 -State Listen -ErrorAction SilentlyContinue
+if (-not $webUiListening) {
+  Start-ScheduledTask -TaskName $taskName
+  Write-Host "Installed and started scheduled task: $taskName"
+} else {
+  Write-Host "Installed scheduled task: $taskName (web UI already running, skipped immediate start)"
+}

--- a/run-hermes-web-ui-daemon.ps1
+++ b/run-hermes-web-ui-daemon.ps1
@@ -1,0 +1,32 @@
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$homeTarget = Join-Path $repoRoot ".hermes-home"
+$homeLink = Join-Path $HOME ".hermes"
+$hermesExe = Join-Path $repoRoot ".venv\Scripts\hermes.exe"
+$nodeExe = "C:\Program Files\nodejs\node.exe"
+$uiEntry = "C:\Users\user\tools\hermes-web-ui\node_modules\hermes-web-ui\bin\hermes-web-ui.mjs"
+
+$env:PYTHONUTF8 = "1"
+$env:PYTHONIOENCODING = "utf-8"
+$env:HERMES_BIN = $hermesExe
+$env:Path = "C:\Program Files\Git\cmd;C:\Program Files\nodejs;$env:Path"
+
+if (-not (Test-Path -LiteralPath $hermesExe)) {
+  throw "Hermes executable not found: $hermesExe"
+}
+
+if (-not (Test-Path -LiteralPath $nodeExe)) {
+  throw "Node.js executable not found: $nodeExe"
+}
+
+if (-not (Test-Path -LiteralPath $uiEntry)) {
+  throw "hermes-web-ui entrypoint not found: $uiEntry"
+}
+
+if (-not (Test-Path -LiteralPath $homeLink)) {
+  New-Item -ItemType Junction -Path $homeLink -Target $homeTarget | Out-Null
+}
+
+Set-Location $repoRoot
+& $nodeExe $uiEntry start

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -37,7 +37,7 @@ class TestGatewayPidState:
             "start_time": 123,
         }))
 
-        monkeypatch.setattr(status.os, "kill", lambda pid, sig: None)
+        monkeypatch.setattr(status, "_process_exists", lambda pid: True)
         monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123)
         monkeypatch.setattr(status, "_read_process_cmdline", lambda pid: None)
 
@@ -53,7 +53,7 @@ class TestGatewayPidState:
             "start_time": 123,
         }))
 
-        monkeypatch.setattr(status.os, "kill", lambda pid, sig: None)
+        monkeypatch.setattr(status, "_process_exists", lambda pid: True)
         monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123)
         monkeypatch.setattr(
             status,
@@ -74,7 +74,7 @@ class TestGatewayPidState:
             "start_time": 123,
         }))
 
-        monkeypatch.setattr(status.os, "kill", lambda pid, sig: None)
+        monkeypatch.setattr(status, "_process_exists", lambda pid: True)
         monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123)
         monkeypatch.setattr(status, "_read_process_cmdline", lambda pid: None)
 
@@ -197,7 +197,7 @@ class TestScopedLocks:
             "kind": "hermes-gateway",
         }))
 
-        monkeypatch.setattr(status.os, "kill", lambda pid, sig: None)
+        monkeypatch.setattr(status, "_process_exists", lambda pid: True)
         monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123)
 
         acquired, existing = status.acquire_scoped_lock("telegram-bot-token", "secret", metadata={"platform": "telegram"})
@@ -215,10 +215,7 @@ class TestScopedLocks:
             "kind": "hermes-gateway",
         }))
 
-        def fake_kill(pid, sig):
-            raise ProcessLookupError
-
-        monkeypatch.setattr(status.os, "kill", fake_kill)
+        monkeypatch.setattr(status, "_process_exists", lambda pid: False)
 
         acquired, existing = status.acquire_scoped_lock("telegram-bot-token", "secret", metadata={"platform": "telegram"})
 

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -219,7 +219,7 @@ def test_conflicting_systemd_units_warning(monkeypatch, tmp_path, capsys):
 
 def test_install_linux_gateway_from_setup_system_choice_without_root_prints_followup(monkeypatch, capsys):
     monkeypatch.setattr(gateway, "prompt_linux_gateway_install_scope", lambda: "system")
-    monkeypatch.setattr(gateway.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(gateway, "_geteuid", lambda: 1000)
     monkeypatch.setattr(gateway, "_default_system_service_user", lambda: "alice")
     monkeypatch.setattr(gateway, "systemd_install", lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("should not install")))
 
@@ -233,7 +233,7 @@ def test_install_linux_gateway_from_setup_system_choice_without_root_prints_foll
 
 def test_install_linux_gateway_from_setup_system_choice_as_root_installs(monkeypatch):
     monkeypatch.setattr(gateway, "prompt_linux_gateway_install_scope", lambda: "system")
-    monkeypatch.setattr(gateway.os, "geteuid", lambda: 0)
+    monkeypatch.setattr(gateway, "_geteuid", lambda: 0)
     monkeypatch.setattr(gateway, "_default_system_service_user", lambda: "alice")
 
     calls = []


### PR DESCRIPTION
## Summary
- fix Windows gateway PID liveness checks so stale gateway state no longer blocks restart/recovery
- add Windows startup scripts for Hermes Web UI and register scheduled tasks without double-starting already running services
- make gateway service helpers tolerate missing `os.getuid` / `os.geteuid` APIs and update the related tests

## Validation
- `pytest tests/gateway/test_status.py -q`
- `pytest tests/hermes_cli/test_gateway.py -q`
- `pytest tests/hermes_cli/test_gateway_runtime_health.py -q`
- verified local health checks for `http://127.0.0.1:8642/health` and `http://127.0.0.1:8648/health`