### PR TITLE
fix(telegram): require entity mentions for group gating

### DIFF
--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -74,6 +74,21 @@ def test_group_messages_can_require_direct_trigger_via_config():
     assert adapter._should_process_message(_group_message("/status"), is_command=True) is True
 
 
+def test_email_like_substrings_do_not_count_as_mentions():
+    adapter = _make_adapter(require_mention=True)
+
+    assert adapter._should_process_message(_group_message("email me at foo@hermes_bot.example")) is False
+
+
+def test_longer_handles_do_not_count_as_bot_mentions():
+    adapter = _make_adapter(require_mention=True)
+    text = "ping @hermes_botx for help"
+
+    assert adapter._should_process_message(
+        _group_message(text, entities=[_mention_entity(text, "@hermes_botx")])
+    ) is False
+
+
 def test_free_response_chats_bypass_mention_requirement():
     adapter = _make_adapter(require_mention=True, free_response_chats=["-200"])
 


### PR DESCRIPTION
## Summary
Fix Telegram group mention gating so only real Telegram mention entities wake the bot.

## Root Cause
`TelegramAdapter._message_mentions_bot()` returned `True` on any raw `@<bot_username>` substring before checking Telegram entities. That let unrelated text like `foo@hermes_bot.example` and longer handles like `@hermes_botx` bypass `require_mention=true`.

## Changes
- remove the raw substring fast-path from `gateway/platforms/telegram.py`
- keep the existing entity-based `mention` and `text_mention` handling intact
- add regression tests for email-domain and longer-handle false positives in `tests/gateway/test_telegram_group_gating.py`

## Validation
- `scripts/run_tests.sh tests/gateway/test_telegram_group_gating.py -q`

Closes #12545.
