### PR TITLE
fix(mcp): coerce stringified arrays/objects in tool call arguments

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -387,6 +387,31 @@ def _coerce_value(value: str, expected_type):
         return _coerce_number(value, integer_only=(expected_type == "integer"))
     if expected_type == "boolean":
         return _coerce_boolean(value)
+    if expected_type == "array":
+        return _coerce_json(value, list)
+    if expected_type == "object":
+        return _coerce_json(value, dict)
+    return value
+
+
+def _coerce_json(value: str, expected_python_type: type):
+    """Parse *value* as JSON when the schema expects an array or object.
+
+    Handles model output drift where a complex oneOf/discriminated-union schema
+    causes the LLM to emit the array/object as a JSON string instead of a native
+    structure.  Returns the original string if parsing fails or yields the wrong
+    Python type.
+    """
+    try:
+        parsed = json.loads(value)
+    except (ValueError, TypeError):
+        return value
+    if isinstance(parsed, expected_python_type):
+        logger.debug(
+            "coerce_tool_args: coerced string to %s via json.loads",
+            expected_python_type.__name__,
+        )
+        return parsed
     return value
 
 


### PR DESCRIPTION
## Summary

- `_coerce_value` in `model_tools.py` now handles `type: array` and `type: object`: when the model emits a JSON string where the schema expects an array or object, the value is parsed with `json.loads` before dispatch to the MCP transport
- New `_coerce_json` helper carries the logic with a debug log so occurrences can be audited

## Root cause

Tools whose array parameters use a `oneOf` discriminated union schema (e.g. `add-reminders`, which has relative/absolute/location variants) trigger model output drift — the LLM serializes the array as a JSON string instead of emitting a native structure. The MCP server then rejects the call with `-32602 "expected array, received string"`.

Confirmed via live testing against `ai.todoist.net/mcp`:
- Sending a real array → passes schema validation ✓
- Sending a stringified array → exact reproduction of the error ✗

Simpler array schemas (e.g. `add-tasks`, whose items are a plain `type: object`) don't trigger the drift. The `oneOf` union is the differentiating factor.

## Test plan

- [x] Unit: `_coerce_value("[{...}]", "array")` returns a `list`
- [x] Unit: `_coerce_value` with a real list passes through unchanged (`result is value`)
- [x] Integration: `coerce_tool_args("mcp_todoist_add_reminders", {"reminders": "[...]"})` returns `reminders` as a list when schema is registered
- [x] Live: `add-reminders` call succeeds end-to-end (previously 100% failure rate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)