### PR TITLE
fix(agent): invalidate skills prompt cache when disabled skills change

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -613,20 +613,20 @@ def build_skills_system_prompt(
         or get_session_env("HERMES_SESSION_PLATFORM")
         or ""
     )
+    disabled = get_disabled_skill_names()
     cache_key = (
         str(skills_dir.resolve()),
         tuple(str(d) for d in external_dirs),
         tuple(sorted(str(t) for t in (available_tools or set()))),
         tuple(sorted(str(ts) for ts in (available_toolsets or set()))),
         _platform_hint,
+        tuple(sorted(disabled)),
     )
     with _SKILLS_PROMPT_CACHE_LOCK:
         cached = _SKILLS_PROMPT_CACHE.get(cache_key)
         if cached is not None:
             _SKILLS_PROMPT_CACHE.move_to_end(cache_key)
             return cached
-
-    disabled = get_disabled_skill_names()
 
     # ── Layer 2: disk snapshot ────────────────────────────────────────
     snapshot = _load_skills_snapshot(skills_dir)

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -354,6 +354,24 @@ class TestBuildSkillsSystemPrompt:
         assert "web-search" in result
         assert "old-tool" not in result
 
+    def test_rebuilds_prompt_when_disabled_skills_change(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skill_dir = tmp_path / "skills" / "tools" / "cached-skill"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: cached-skill\ndescription: Cached skill\n---\n"
+        )
+
+        first = build_skills_system_prompt()
+        assert "cached-skill" in first
+
+        (tmp_path / "config.yaml").write_text(
+            "skills:\n  disabled: [cached-skill]\n"
+        )
+
+        second = build_skills_system_prompt()
+        assert "cached-skill" not in second
+
     def test_includes_setup_needed_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         monkeypatch.delenv("MISSING_API_KEY_XYZ", raising=False)


### PR DESCRIPTION
Toggling `skills.disabled` in config.yaml now takes effect immediately without a gateway restart.

Root cause: `build_skills_system_prompt()` loaded the disabled set *after* the LRU cache lookup, so once the prompt was cached the disabled list was never re-consulted. Users paid for dead tokens (~1.7k/turn on a 92-skill, 17-disabled setup) until the process was restarted.

Salvages #7473 by @Dusk1e onto current main with authorship preserved.

## Changes
- `agent/prompt_builder.py`: resolve disabled set before cache key; include `tuple(sorted(disabled))` in cache_key.
- `tests/agent/test_prompt_builder.py`: regression test `test_rebuilds_prompt_when_disabled_skills_change`.

## Validation
| | Before | After |
|---|---|---|
| Targeted tests | 111 pass | 112 pass (new regression test) |
| E2E: toggle disabled mid-process | stale prompt returned | new prompt rebuilt, same-config still cache-hits |

Closes #12294. Credit also to @jjjojoj (#12367) for independently identifying the same root cause.