### PR TITLE
feat: configurable prompt_caching.cache_ttl for Anthropic TTL tier

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -333,6 +333,16 @@ compression:
   # auxiliary section below (auxiliary.compression.provider / model).
 
 # =============================================================================
+# Anthropic prompt caching TTL
+# =============================================================================
+# When prompt caching is active (Claude via OpenRouter or native Anthropic),
+# Anthropic supports two TTL tiers for cached prefixes: "5m" (default) and
+# "1h". Other values are ignored and "5m" is used.
+#
+prompt_caching:
+  cache_ttl: "5m" # use "1h" for long sessions with pauses between turns
+
+# =============================================================================
 # Auxiliary Models (Advanced — Experimental)
 # =============================================================================
 # Hermes uses lightweight "auxiliary" models for side tasks: image analysis,

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -454,6 +454,12 @@ DEFAULT_CONFIG = {
 
     },
 
+    # Anthropic prompt caching (Claude via OpenRouter or native Anthropic API).
+    # cache_ttl must be "5m" or "1h" (Anthropic-supported tiers); other values are ignored.
+    "prompt_caching": {
+        "cache_ttl": "5m",
+    },
+
     # AWS Bedrock provider configuration.
     # Only used when model.provider is "bedrock".
     "bedrock": {

--- a/run_agent.py
+++ b/run_agent.py
@@ -899,8 +899,19 @@ class AIAgent:
         is_claude = "claude" in self.model.lower()
         is_native_anthropic = self.api_mode == "anthropic_messages" and self.provider == "anthropic"
         self._use_prompt_caching = (is_openrouter and is_claude) or is_native_anthropic
-        self._cache_ttl = "5m"  # Default 5-minute TTL (1.25x write cost)
-        
+        # Anthropic supports "5m" (default) and "1h" cache TTL tiers. Read from
+        # config.yaml under prompt_caching.cache_ttl; unknown values keep "5m".
+        self._cache_ttl = "5m"
+        try:
+            from hermes_cli.config import load_config as _load_pc_cfg
+
+            _pc_cfg = _load_pc_cfg().get("prompt_caching", {}) or {}
+            _ttl = _pc_cfg.get("cache_ttl", "5m")
+            if _ttl in ("5m", "1h"):
+                self._cache_ttl = _ttl
+        except Exception:
+            pass
+
         # Iteration budget: the LLM is only notified when it actually exhausts
         # the iteration budget (api_call_count >= max_iterations).  At that
         # point we inject ONE message, allow one final API call, and if the

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -591,6 +591,66 @@ class TestInit:
             assert a.api_mode == "anthropic_messages"
             assert a._use_prompt_caching is True
 
+    def test_prompt_caching_cache_ttl_defaults_without_config(self):
+        """cache_ttl stays 5m when prompt_caching is absent from config."""
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch("hermes_cli.config.load_config", return_value={}),
+        ):
+            a = AIAgent(
+                api_key="test-k...7890",
+                model="anthropic/claude-sonnet-4-20250514",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            assert a._cache_ttl == "5m"
+
+    def test_prompt_caching_cache_ttl_custom_1h(self):
+        """prompt_caching.cache_ttl 1h is applied when present in config."""
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={"prompt_caching": {"cache_ttl": "1h"}},
+            ),
+        ):
+            a = AIAgent(
+                api_key="test-k...7890",
+                model="anthropic/claude-sonnet-4-20250514",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            assert a._cache_ttl == "1h"
+
+    def test_prompt_caching_cache_ttl_invalid_falls_back(self):
+        """Non-Anthropic TTL values keep default 5m without raising."""
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch(
+                "hermes_cli.config.load_config",
+                return_value={"prompt_caching": {"cache_ttl": "30m"}},
+            ),
+        ):
+            a = AIAgent(
+                api_key="test-k...7890",
+                model="anthropic/claude-sonnet-4-20250514",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            assert a._cache_ttl == "5m"
+
     def test_valid_tool_names_populated(self):
         """valid_tool_names should contain names from loaded tools."""
         tools = _make_tool_defs("web_search", "terminal")

--- a/website/docs/developer-guide/context-compression-and-caching.md
+++ b/website/docs/developer-guide/context-compression-and-caching.md
@@ -332,9 +332,9 @@ Prompt caching is automatically enabled when:
 - The provider supports `cache_control` (native Anthropic API or OpenRouter)
 
 ```yaml
-# config.yaml — TTL is configurable
-model:
-  cache_ttl: "5m"   # "5m" or "1h"
+# config.yaml — TTL is configurable (must be "5m" or "1h")
+prompt_caching:
+  cache_ttl: "5m"
 ```
 
 The CLI shows caching status at startup:


### PR DESCRIPTION
## What does this PR do?

Adds a **`prompt_caching.cache_ttl`** config knob so operators can opt into Anthropic's **`1h`** prompt-cache TTL tier instead of the default **`5m`**. The default remains **`5m`**.

**Motivation:** With **`5m`**, long interactive sessions that pause (reading tool output, context switching) often cross the TTL boundary and pay full write pricing again on the next turn. Anthropic documents a **`1h`** tier for the same cache-control flow; exposing it via config makes longer sessions cheaper without changing caching strategy (still `system_and_3` / `apply_anthropic_cache_control`).

**Approach:** `AIAgent.__init__` reads `load_config().get("prompt_caching", {}).get("cache_ttl", "5m")`, accepts only **`5m`** and **`1h`**, and ignores anything else (stays **`5m`**, no exception). `DEFAULT_CONFIG` and `cli-config.yaml.example` document the key; developer guide YAML is corrected (it previously showed `model.cache_ttl`, which is not wired).

## Related Issue

<!-- Nous upstream — no repo issue ID -->

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `run_agent.py` — load `prompt_caching.cache_ttl` into `self._cache_ttl` (same call site as existing `apply_anthropic_cache_control(..., cache_ttl=self._cache_ttl)`).
- `hermes_cli/config.py` — `DEFAULT_CONFIG["prompt_caching"]["cache_ttl"]`.
- `cli-config.yaml.example` — commented example block.
- `website/docs/developer-guide/context-compression-and-caching.md` — fix YAML to `prompt_caching.cache_ttl`.
- `tests/run_agent/test_run_agent.py` — three `TestInit` tests (default, `1h`, invalid fallback).

## How to Test

```bash
cd hermes-agent
uv run --with pytest --with pytest-asyncio --with pytest-xdist python -m pytest \
  tests/run_agent/test_run_agent.py::TestInit::test_prompt_caching_cache_ttl_defaults_without_config \
  tests/run_agent/test_run_agent.py::TestInit::test_prompt_caching_cache_ttl_custom_1h \
  tests/run_agent/test_run_agent.py::TestInit::test_prompt_caching_cache_ttl_invalid_falls_back \
  -q
```

## Verification

- Targeted pytest (commands above): **3 passed, 0 failed** (Linux agent host, `uv` resolves deps per `pyproject.toml`).

## Risks

- **Unsupported / non-Anthropic providers:** unchanged — prompt caching remains gated by existing `_use_prompt_caching` logic; this only changes the TTL string passed when caching is already on.
- **Invalid config values** (e.g. typos, `"30m"`, wrong types): **silently keep `5m`** — same broad `try`/`except` pattern as other optional config reads in `AIAgent.__init__`; no crash.
- **Very long TTL (`1h`):** higher cache-write cost if the conversation prefix churns every turn; users opt in explicitly. Maliciously huge strings are not accepted (not in `("5m", "1h")`).

## Model used

Contribution prepared in a **Wildcat Paperclip** agent heartbeat using the **Cursor** harness. The exact LLM id/version is determined by the operator's Cursor product settings (not pinned in-repo).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass *(targeted tests above; full suite not run in this environment)*
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (Debian-based agent runner)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
