### PR TITLE
docs(site): stop appending ?_highlight= to search result URLs

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -37,7 +37,9 @@ const config: Config = {
         language: ['en'],
         indexBlog: false,
         docsRouteBasePath: '/',
-        highlightSearchTermsOnTargetPage: true,
+        // Disabled: appends ?_highlight=... to URLs (before the #anchor),
+        // which makes copy/pasted doc links ugly. Ctrl+F on the page is fine.
+        highlightSearchTermsOnTargetPage: false,
       }),
     ],
   ],


### PR DESCRIPTION
## Summary
Clicking a search-bar result produced URLs like `/docs/foo?_highlight=bar#section`, which look broken when copy-pasted. Turning off `highlightSearchTermsOnTargetPage` keeps URLs clean; browser Ctrl+F covers the highlight use case.

## Changes
- `website/docusaurus.config.ts`: set `highlightSearchTermsOnTargetPage: false` on the `@easyops-cn/docusaurus-search-local` theme, with a comment explaining why.

## Validation
| | Before | After |
|---|---|---|
| Search result URL | `/docs/user-guide/configuration?_highlight=foo#section` | `/docs/user-guide/configuration#section` |
| On-page highlight | Yes (unreliable across navigation) | No (use Ctrl+F) |