### PR TITLE
docs(memory): steer agents to save declarative facts, not instructions

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -152,7 +152,13 @@ MEMORY_GUIDANCE = (
     "Do NOT save task progress, session outcomes, completed-work logs, or temporary TODO "
     "state to memory; use session_search to recall those from past transcripts. "
     "If you've discovered a new way to do something, solved a problem that could be "
-    "necessary later, save it as a skill with the skill tool."
+    "necessary later, save it as a skill with the skill tool.\n"
+    "Write memories as declarative facts, not instructions to yourself. "
+    "'User prefers concise responses' ✓ — 'Always respond concisely' ✗. "
+    "'Project uses pytest with xdist' ✓ — 'Run tests with pytest -n 4' ✗. "
+    "Imperative phrasing gets re-read as a directive in later sessions and can "
+    "cause repeated work or override the user's current request. Procedures and "
+    "workflows belong in skills, not memory."
 )
 
 SESSION_SEARCH_GUIDANCE = (


### PR DESCRIPTION
## Summary
Memory entries phrased as instructions ('Always respond concisely', 'Run tests with pytest -n 4') get re-read as directives in future sessions, causing repeated work or overriding the user's current request. This extends `MEMORY_GUIDANCE` with a short phrasing rule so the model writes declarative facts instead.

## Changes
- `agent/prompt_builder.py`: append a phrasing guideline to `MEMORY_GUIDANCE` with ✓/✗ examples.

## Validation
- `scripts/run_tests.sh tests/agent/test_prompt_builder.py` → 112/112 pass
- Existing invariants preserved (`durable facts`, `Do NOT save task progress`, `session_search` still present)

## Note
One-time prompt-cache invalidation on users' next session after they pull (new guidance text = new cache key). No ongoing impact.

## Credit
Observation from @Mariandipietra on X.