### PR TITLE
fix(tests): unstick CI — sweep stale tests from recent merges

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -234,6 +234,7 @@ _CATEGORY_MERGE: Dict[str, str] = {
     "human_delay": "display",
     "smart_model_routing": "agent",
     "dashboard": "display",
+    "code_execution": "agent",
 }
 
 # Display order for tabs — unlisted categories sort alphabetically after these.

--- a/tests/hermes_cli/test_codex_cli_model_picker.py
+++ b/tests/hermes_cli/test_codex_cli_model_picker.py
@@ -1,14 +1,14 @@
-"""Regression test: openai-codex must appear in /model picker when
-credentials are only in the Codex CLI shared file (~/.codex/auth.json)
-and haven't been migrated to the Hermes auth store yet.
+"""Regression tests for the /model picker's credential-discovery paths.
 
-Root cause: list_authenticated_providers() checked the raw Hermes auth
-store but didn't know about the Codex CLI fallback import path.
+Covers:
+ - Normal path (tokens already in Hermes auth store)
+ - Claude Code fallback (tokens only in ~/.claude/.credentials.json)
+ - Negative case (no credentials anywhere)
 
-Fix: _seed_from_singletons() now imports from the Codex CLI when the
-Hermes auth store has no openai-codex tokens, and
-list_authenticated_providers() falls back to load_pool() for OAuth
-providers.
+Note: auto-import from ~/.codex/auth.json was removed in #12360 — Hermes
+now owns its own openai-codex auth state, and users explicitly adopt
+existing Codex CLI tokens via `hermes auth openai-codex`. The old
+"Codex CLI shared file" discovery tests were removed with that change.
 """
 
 import base64
@@ -29,83 +29,6 @@ def _make_fake_jwt(expiry_offset: int = 3600) -> str:
     payload_bytes = json.dumps({"exp": exp, "sub": "test"}).encode()
     payload = base64.urlsafe_b64encode(payload_bytes).rstrip(b"=").decode()
     return f"{header}.{payload}.fakesig"
-
-
-@pytest.fixture()
-def codex_cli_only_env(tmp_path, monkeypatch):
-    """Set up an environment where Codex tokens exist only in ~/.codex/auth.json,
-    NOT in the Hermes auth store."""
-    hermes_home = tmp_path / ".hermes"
-    hermes_home.mkdir()
-    codex_home = tmp_path / ".codex"
-    codex_home.mkdir()
-
-    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-    monkeypatch.setenv("CODEX_HOME", str(codex_home))
-
-    # Empty Hermes auth store
-    (hermes_home / "auth.json").write_text(
-        json.dumps({"version": 2, "providers": {}})
-    )
-
-    # Valid Codex CLI tokens
-    fake_jwt = _make_fake_jwt()
-    (codex_home / "auth.json").write_text(
-        json.dumps({
-            "tokens": {
-                "access_token": fake_jwt,
-                "refresh_token": "fake-refresh-token",
-            }
-        })
-    )
-
-    # Clear provider env vars so only OAuth is a detection path
-    for var in [
-        "OPENROUTER_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY",
-        "NOUS_API_KEY", "DEEPSEEK_API_KEY", "COPILOT_GITHUB_TOKEN",
-        "GH_TOKEN", "GEMINI_API_KEY",
-    ]:
-        monkeypatch.delenv(var, raising=False)
-
-    return hermes_home
-
-
-def test_codex_cli_tokens_detected_by_model_picker(codex_cli_only_env):
-    """openai-codex should appear when tokens only exist in ~/.codex/auth.json."""
-    from hermes_cli.model_switch import list_authenticated_providers
-
-    providers = list_authenticated_providers(
-        current_provider="openai-codex",
-        max_models=10,
-    )
-    slugs = [p["slug"] for p in providers]
-    assert "openai-codex" in slugs, (
-        f"openai-codex not found in /model picker providers: {slugs}"
-    )
-
-    codex = next(p for p in providers if p["slug"] == "openai-codex")
-    assert codex["is_current"] is True
-    assert codex["total_models"] > 0
-
-
-def test_codex_cli_tokens_migrated_after_detection(codex_cli_only_env):
-    """After the /model picker detects Codex CLI tokens, they should be
-    migrated into the Hermes auth store for subsequent fast lookups."""
-    from hermes_cli.model_switch import list_authenticated_providers
-
-    # First call triggers migration
-    list_authenticated_providers(current_provider="openai-codex")
-
-    # Verify tokens are now in Hermes auth store
-    auth_path = codex_cli_only_env / "auth.json"
-    store = json.loads(auth_path.read_text())
-    providers = store.get("providers", {})
-    assert "openai-codex" in providers, (
-        f"openai-codex not migrated to Hermes auth store: {list(providers.keys())}"
-    )
-    tokens = providers["openai-codex"].get("tokens", {})
-    assert tokens.get("access_token"), "access_token missing after migration"
-    assert tokens.get("refresh_token"), "refresh_token missing after migration"
 
 
 @pytest.fixture()

--- a/tests/run_agent/test_concurrent_interrupt.py
+++ b/tests/run_agent/test_concurrent_interrupt.py
@@ -77,6 +77,10 @@ def _make_agent(monkeypatch):
     stub._execute_tool_calls_concurrent = _ra.AIAgent._execute_tool_calls_concurrent.__get__(stub)
     stub.interrupt = _ra.AIAgent.interrupt.__get__(stub)
     stub.clear_interrupt = _ra.AIAgent.clear_interrupt.__get__(stub)
+    # /steer injection (added in PR #12116) fires after every concurrent
+    # tool batch. Stub it as a no-op — this test exercises interrupt
+    # fanout, not steer injection.
+    stub._apply_pending_steer_to_tool_results = lambda *a, **kw: None
     stub._invoke_tool = MagicMock(side_effect=lambda *a, **kw: '{"ok": true}')
     return stub
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3717,9 +3717,13 @@ class TestStreamingApiCall:
         callback.assert_any_call("World")
 
     def test_tool_call_accumulation(self, agent):
+        # Per OpenAI streaming spec, function names are delivered atomically
+        # in the first chunk; only `arguments` is fragmented across chunks.
+        # The accumulator uses assignment for names (immune to MiniMax/NIM
+        # resends of the full name) and `+=` for arguments.
         chunks = [
-            _make_chunk(tool_calls=[_make_tc_delta(0, "call_1", "web_", '{"q":')]),
-            _make_chunk(tool_calls=[_make_tc_delta(0, None, "search", '"test"}')]),
+            _make_chunk(tool_calls=[_make_tc_delta(0, "call_1", "web_search", '{"q":')]),
+            _make_chunk(tool_calls=[_make_tc_delta(0, None, None, '"test"}')]),
             _make_chunk(finish_reason="tool_calls"),
         ]
         agent.client.chat.completions.create.return_value = iter(chunks)

--- a/tests/tools/test_browser_camofox_state.py
+++ b/tests/tools/test_browser_camofox_state.py
@@ -64,4 +64,4 @@ class TestCamofoxConfigDefaults:
 
         # The current schema version is tracked globally; unrelated default
         # options may bump it after browser defaults are added.
-        assert DEFAULT_CONFIG["_config_version"] == 18
+        assert DEFAULT_CONFIG["_config_version"] == 19

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -291,11 +291,13 @@ class TestCheckFnExceptionHandling:
 class TestBuiltinDiscovery:
     def test_matches_previous_manual_builtin_tool_set(self):
         expected = {
+            "tools.browser_cdp_tool",
             "tools.browser_tool",
             "tools.clarify_tool",
             "tools.code_execution_tool",
             "tools.cronjob_tools",
             "tools.delegate_tool",
+            "tools.discord_tool",
             "tools.feishu_doc_tool",
             "tools.feishu_drive_tool",
             "tools.file_tools",


### PR DESCRIPTION
Unsticks CI — all 13 failures from the 04-19 08:16 UTC main run on `main` are now accounted for (5 already self-healed on main since then; the remaining 8 are fixed here).

## What was broken

Six files' worth of stale-test fallout from recent feature/fix merges. All source behavior is correct — the tests just didn't travel with the changes that made them stale. One exception: `hermes_cli/web_server.py` needed a small source fix (honoring its own "no single-field categories" design).

| # | Test / file | Blame commit | Cause |
|---|---|---|---|
| 1 | `test_no_single_field_categories` | #11971 (`feat(execute_code): project/strict modes`) | New `code_execution` config section has 1 field; `_CATEGORY_MERGE` map not updated. |
| 2 | `test_config_version_matches_current_schema` | #11971 | `_config_version` bumped 18→19, test hardcoded 18. |
| 3 | `test_matches_previous_manual_builtin_tool_set` | #12369 (browser_cdp), #4753 (discord_tool) | Two new tool modules; expected-set fixture never updated. |
| 4 | `test_tool_call_accumulation` | 0f778f77 (fix: prevent tool name duplication) | Streaming accumulator switched fn-name combining from `+=` to `=` (OpenAI spec / MiniMax duplication fix). Test still encoded the old "web_" + "search" fragment premise. |
| 5, 6 | `test_concurrent_interrupt_*` (×2) | #12116 (`feat(steer)`) | `_execute_tool_calls_concurrent` now calls `self._apply_pending_steer_to_tool_results()`; hand-rolled `_Stub` was missing it. |
| 7, 8 | `test_codex_cli_tokens_detected_by_model_picker`, `test_codex_cli_tokens_migrated_after_detection` | #12360 (`fix(codex): Hermes owns its own Codex auth`) | These two tests asserted auto-import from `~/.codex/auth.json` into the Hermes auth store. #12360 explicitly **removed** that behavior (refresh-token reuse races with Codex CLI / VS Code). Adoption is now explicit via `hermes auth openai-codex`. Remaining 3 tests in the file (normal path, Claude Code fallback, negative case) still cover the picker. |

## Changes

- `hermes_cli/web_server.py`: add `code_execution → agent` to `_CATEGORY_MERGE`.
- `tests/tools/test_browser_camofox_state.py`: bump 18 → 19.
- `tests/tools/test_registry.py`: add `tools.browser_cdp_tool`, `tools.discord_tool` to expected set.
- `tests/run_agent/test_run_agent.py`: rewrite `test_tool_call_accumulation` chunks so name arrives atomically in the first chunk (matching current accumulator semantics); assertion on arguments accumulation preserved.
- `tests/run_agent/test_concurrent_interrupt.py`: add no-op `_apply_pending_steer_to_tool_results` to `_Stub`.
- `tests/hermes_cli/test_codex_cli_model_picker.py`: delete the two obsolete `codex_cli_only_env`-backed tests + the fixture. Rewrite module docstring to reflect current coverage and note #12360.

## Validation

scripts/run_tests.sh across all 6 affected files + their siblings — 54 tests, all green locally in 3.4s.

```
54 passed, 4 warnings in 3.40s
```

## Also noted (no action)

The 5 failures from the 04-19 main CI run that already self-healed on current main (fixes landed between 08:16 UTC and now): `test_concurrent_inserts_settle_at_cap`, `test_tool_name_not_duplicated_when_resent_per_chunk`, `test_combined_cli_session_approves_both`, `test_warn_session_approved`, `test_telegram_produces_ogg_and_voice_compatible`.