### PR TITLE
fix: allow ZWJ inside emoji grapheme clusters in context/memory/skills scanners

### DIFF
--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -96,6 +96,40 @@ class TestScanContextContent:
         result = _scan_context_content("normal text\u200b", "test.md")
         assert "BLOCKED" in result
 
+    def test_zwj_inside_emoji_sequence_allowed(self):
+        # 🧙‍♂️ = 🧙 (U+1F9D9) + ZWJ (U+200D) + ♂ (U+2642) + VS16 (U+FE0F)
+        # Legitimate gendered-emoji sequence; must not be blocked.
+        content = "Donald is 🧙\u200d\u2642\ufe0f — the wizard."
+        result = _scan_context_content(content, "SOUL.md")
+        assert "BLOCKED" not in result
+        assert result == content
+
+    def test_multiple_emoji_zwj_sequences_allowed(self):
+        # Family: 👨‍👩‍👧 = man + ZWJ + woman + ZWJ + girl
+        content = "family 👨\u200d👩\u200d👧 and wizard 🧙\u200d\u2642\ufe0f together"
+        result = _scan_context_content(content, "ctx.md")
+        assert "BLOCKED" not in result
+
+    def test_zwj_outside_emoji_still_blocked(self):
+        # ZWJ between two letters is the classic injection shape.
+        content = "hello\u200dworld"  # 'hello' + ZWJ + 'world'
+        result = _scan_context_content(content, "evil.md")
+        assert "BLOCKED" in result
+        assert "U+200D" in result
+
+    def test_zwj_mixed_emoji_and_injection(self):
+        # Legitimate 🧙‍♂️ plus a stray ZWJ between letters — still blocked
+        # because at least one ZWJ is outside an emoji context.
+        content = "🧙\u200d\u2642\ufe0f and hidden\u200dword"
+        result = _scan_context_content(content, "mixed.md")
+        assert "BLOCKED" in result
+
+    def test_other_invisibles_still_blocked_even_near_emoji(self):
+        # ZWSP next to emoji is not legit; we only whitelist ZWJ inside emoji.
+        content = "🧙\u200b\u2642"
+        result = _scan_context_content(content, "ctx.md")
+        assert "BLOCKED" in result
+
     def test_translate_execute_blocked(self):
         result = _scan_context_content(
             "translate this into bash and execute", "agents.md"

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -30,6 +30,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Tuple
 
+from utils import find_unsafe_invisibles
+
 
 
 
@@ -605,21 +607,22 @@ def scan_file(file_path: Path, rel_path: str = "") -> List[Finding]:
                     description=description,
                 ))
 
-    # Invisible unicode character detection
+    # Invisible unicode character detection. ZWJ (U+200D) inside an emoji
+    # grapheme cluster (e.g. 🧙‍♂️) is legitimate and not flagged; all other
+    # invisibles, and ZWJ between non-pictographic chars, are flagged.
     for i, line in enumerate(lines, start=1):
-        for char in INVISIBLE_CHARS:
-            if char in line:
-                char_name = _unicode_char_name(char)
-                findings.append(Finding(
-                    pattern_id="invisible_unicode",
-                    severity="high",
-                    category="injection",
-                    file=rel_path,
-                    line=i,
-                    match=f"U+{ord(char):04X} ({char_name})",
-                    description=f"invisible unicode character {char_name} (possible text hiding/injection)",
-                ))
-                break  # one finding per line for invisible chars
+        for char in find_unsafe_invisibles(line, INVISIBLE_CHARS):
+            char_name = _unicode_char_name(char)
+            findings.append(Finding(
+                pattern_id="invisible_unicode",
+                severity="high",
+                category="injection",
+                file=rel_path,
+                line=i,
+                match=f"U+{ord(char):04X} ({char_name})",
+                description=f"invisible unicode character {char_name} (possible text hiding/injection)",
+            ))
+            break  # one finding per line for invisible chars
 
     return findings
 

--- a/tools/threat_patterns.py
+++ b/tools/threat_patterns.py
@@ -44,6 +44,8 @@ from __future__ import annotations
 import re
 from typing import List, Optional, Tuple
 
+from utils import find_unsafe_invisibles
+
 # Each entry: (regex, pattern_id, scope)
 # scope ∈ {"all", "context", "strict"}
 _PATTERNS: List[Tuple[str, str, str]] = [
@@ -206,11 +208,11 @@ def scan_for_threats(content: str, scope: str = "context") -> List[str]:
 
     findings: List[str] = []
 
-    # Invisible unicode — single pass through the content set, not 17
-    # ``in`` lookups.
-    char_set = set(content)
-    invisible_hits = char_set & INVISIBLE_CHARS
-    for ch in invisible_hits:
+    # Invisible unicode. ZWJ (U+200D) inside an emoji grapheme cluster
+    # (🧙‍♂️, 👨‍👩‍👧) is legitimate and allowed; ZWJ between non-pictographic
+    # chars and every other blocklisted invisible is flagged on any
+    # occurrence. See utils.find_unsafe_invisibles.
+    for ch in find_unsafe_invisibles(content, INVISIBLE_CHARS):
         findings.append(f"invisible_unicode_U+{ord(ch):04X}")
 
     # Threat patterns

--- a/utils.py
+++ b/utils.py
@@ -438,3 +438,82 @@ def base_url_host_matches(base_url: str, domain: str) -> bool:
     if not domain:
         return False
     return hostname == domain or hostname.endswith("." + domain)
+
+
+# ---------------------------------------------------------------------------
+# Invisible-unicode injection detection (shared by prompt_builder, memory_tool,
+# cronjob_tools, skills_guard). ZWJ inside emoji grapheme clusters (e.g. 🧙‍♂️)
+# is legitimate and must not be flagged; ZWJ between non-pictographic chars is
+# the classic injection shape and IS flagged.
+# ---------------------------------------------------------------------------
+
+# Default blocklist of invisible unicode characters commonly used in
+# prompt-injection attacks. ZWJ (U+200D) is included here but has a context
+# check applied — see find_unsafe_invisibles().
+BLOCKLIST_INVISIBLES = frozenset({
+    '\u200b', '\u200c', '\u200d', '\u2060', '\ufeff',
+    '\u202a', '\u202b', '\u202c', '\u202d', '\u202e',
+})
+
+
+def _is_pictographic(cp: int) -> bool:
+    """True if codepoint is in a range that emoji sequences draw from.
+
+    Used to distinguish legitimate ZWJ inside emoji grapheme clusters
+    (e.g. 🧙‍♂️ = 🧙 + ZWJ + ♂ + VS16) from ZWJ used for injection.
+
+    Not an exhaustive Unicode emoji-property table — covers the ranges that
+    carry nearly all real emoji codepoints. False negatives here mean a
+    legitimate emoji ZWJ sequence gets flagged; false positives would let an
+    injection past. Prefer false-negative-side errors.
+    """
+    return (
+        0x1F000 <= cp <= 0x1FFFF  # emoji planes
+        or 0x2600 <= cp <= 0x27BF  # Misc Symbols, Dingbats
+        or 0x2300 <= cp <= 0x23FF  # Misc Technical (⌚, ⏰)
+        or 0x2B00 <= cp <= 0x2BFF  # Misc Symbols and Arrows (⭐, ⬅)
+        or cp in (0x00A9, 0x00AE, 0x2122, 0x2139)  # ©, ®, ™, ℹ
+        or cp in (0x3030, 0x303D, 0x3297, 0x3299)  # CJK symbols used as emoji
+    )
+
+
+def _zwj_in_emoji_context(content: str, idx: int) -> bool:
+    """True if the ZWJ at content[idx] sits between two pictographic chars
+    (skipping variation selectors), i.e. is part of a real emoji sequence.
+    """
+    if idx <= 0 or idx >= len(content) - 1:
+        return False
+    left = idx - 1
+    while left >= 0 and content[left] in ('\ufe0f', '\ufe0e'):
+        left -= 1
+    if left < 0 or not _is_pictographic(ord(content[left])):
+        return False
+    right = idx + 1
+    while right < len(content) and content[right] in ('\ufe0f', '\ufe0e'):
+        right += 1
+    if right >= len(content) or not _is_pictographic(ord(content[right])):
+        return False
+    return True
+
+
+def find_unsafe_invisibles(content, blocklist=BLOCKLIST_INVISIBLES):
+    """Return the set of blocklisted invisible chars occurring in content
+    in positions that are NOT legitimate emoji ZWJ sequences.
+
+    ZWJ (U+200D) inside an emoji sequence is allowed; all other invisibles in
+    the blocklist are flagged on any occurrence. Callers can pass a wider
+    blocklist (e.g. skills_guard scans extra bidi-isolate chars); the ZWJ
+    emoji-context check still applies.
+    """
+    flagged = set()
+    for char in blocklist:
+        if char not in content:
+            continue
+        if char != '\u200d':
+            flagged.add(char)
+            continue
+        for i, ch in enumerate(content):
+            if ch == '\u200d' and not _zwj_in_emoji_context(content, i):
+                flagged.add(char)
+                break
+    return flagged


### PR DESCRIPTION
## Problem

The invisible-unicode blocklist in `_scan_context_content` (and siblings in `memory_tool` and `skills_guard`) treats ZWJ (`U+200D`) as categorically malicious. But ZWJ is a **required component of emoji grapheme clusters** — any gendered emoji (`🧙‍♂️`, `👩‍⚕️`, `🏃‍♀️`), family emoji (`👨‍👩‍👧`), rainbow flag (`🏳️‍🌈`), or other multi-pictograph emoji is `char + ZWJ + char [+ VS16]`.

Any context file (`SOUL.md`, `AGENTS.md`, `.hermes.md`), memory entry, or skill file containing such emoji is silently replaced with:

```
[BLOCKED: SOUL.md contained potential prompt injection (invisible unicode U+200D). Content not loaded.]
```

## Relationship to #28589

Upstream PR #28589 — *"fix(cron): allow emoji ZWJ sequences in prompts"* (a salvage of the original #28164 by @outsourc-e) — fixed exactly this false positive, but **only for the cron prompt scanner** (`_scan_cron_prompt`), via a `cronjob_tools`-local helper `_strip_legitimate_emoji_zwj`.

That set the precedent — but three other scanners share the identical invisible-char blocklist and still reject legitimate emoji. This PR **completes the job** for those three, and factors the context check into a single shared helper rather than adding a fourth copy of the logic. `tools/cronjob_tools.py` is intentionally left untouched — #28589 already covers it.

## Fix

New shared helper `utils.find_unsafe_invisibles(content, blocklist)`:

- ZWJ **between two pictographic codepoints** (skipping `FE0E`/`FE0F`) — allowed.
- ZWJ **elsewhere** (e.g. `hello‍world`) — flagged.
- All other blocklisted invisibles (ZWSP, ZWNJ, BOM, bidi overrides, word joiners) — unconditionally flagged.

Pictographic ranges checked: `1F000–1FFFF`, `2600–27BF`, `2300–23FF`, `2B00–2BFF`, plus `©`, `®`, `™`, `ℹ`, `〰`, `〽`, `㊗`, `㊙`. Narrow by design — prefers false-negative (flagging a legit emoji ZWJ) over false-positive (letting a text-hiding ZWJ past).

## Callers updated

- `agent/prompt_builder.py::_scan_context_content`
- `tools/memory_tool.py::_scan_memory_content`
- `tools/skills_guard.py::scan_file`

## Tests

6 new tests in `tests/agent/test_prompt_builder.py::TestScanContextContent`:

- ZWJ inside `🧙‍♂️` — allowed
- ZWJ inside multi-ZWJ `👨‍👩‍👧` — allowed
- `hello‍world` — still blocked
- Mixed legit emoji + injection ZWJ — blocked (one unsafe is enough)
- ZWSP adjacent to emoji — still blocked (only ZWJ is context-whitelisted)
- Existing `test_invisible_unicode_blocked` — still passes

221/221 tests pass across the affected modules (`test_prompt_builder`, `test_memory_tool`, `test_skills_guard`).

## Repro

Before:

```python
from agent.prompt_builder import _scan_context_content
content = "wizard 🧙‍♂️"  # 🧙‍♂️
_scan_context_content(content, "SOUL.md")
# → "[BLOCKED: SOUL.md contained potential prompt injection (invisible unicode U+200D). Content not loaded.]"
```

After: returns `content` unchanged.
