### PR TITLE
fix(gateway): leave pending in adapter queue when run generation is stale

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10284,20 +10284,37 @@ class GatewayRunner:
             pending_event = None
             pending = None
             if result and adapter and session_key:
-                pending_event = _dequeue_pending_event(adapter, session_key)
-                if result.get("interrupted") and not pending_event and result.get("interrupt_message"):
-                    interrupt_message = result.get("interrupt_message")
-                    if _is_control_interrupt_message(interrupt_message):
-                        logger.info(
-                            "Ignoring control interrupt message for session %s: %s",
-                            session_key[:20] if session_key else "?",
-                            interrupt_message,
-                        )
-                    else:
-                        pending = interrupt_message
-                elif pending_event:
-                    pending = pending_event.text or _build_media_placeholder(pending_event)
-                    logger.debug("Processing queued message after agent completion: '%s...'", pending[:40])
+                # Stale-generation guard: if /new (or similar) bumped the
+                # session's run generation while we were unwinding, DO NOT
+                # consume from the adapter's pending queue.  Leaving those
+                # messages in place lets base.py's post-run drain re-enter
+                # via _process_message_background → handle_message, which
+                # claims a fresh run generation.  Consuming them here would
+                # recurse with this stale generation; the recursive result
+                # would then be discarded at _handle_message_with_agent's
+                # stale check, silently swallowing the user's follow-up.
+                if not self._is_session_run_current(session_key, run_generation):
+                    logger.info(
+                        "Leaving pending messages in adapter queue for %s — "
+                        "run generation %d is stale; late-arrival drain will reprocess",
+                        session_key[:20] if session_key else "?",
+                        run_generation,
+                    )
+                else:
+                    pending_event = _dequeue_pending_event(adapter, session_key)
+                    if result.get("interrupted") and not pending_event and result.get("interrupt_message"):
+                        interrupt_message = result.get("interrupt_message")
+                        if _is_control_interrupt_message(interrupt_message):
+                            logger.info(
+                                "Ignoring control interrupt message for session %s: %s",
+                                session_key[:20] if session_key else "?",
+                                interrupt_message,
+                            )
+                        else:
+                            pending = interrupt_message
+                    elif pending_event:
+                        pending = pending_event.text or _build_media_placeholder(pending_event)
+                        logger.debug("Processing queued message after agent completion: '%s...'", pending[:40])
 
             # Safety net: if the pending text is a slash command (e.g. "/stop",
             # "/new"), discard it — commands should never be passed to the agent

--- a/tests/gateway/test_run_agent_stale_dequeue.py
+++ b/tests/gateway/test_run_agent_stale_dequeue.py
@@ -1,0 +1,133 @@
+"""Regression tests for the stale-generation dequeue guard in _run_agent.
+
+When /new (or any other command that invalidates the session run generation)
+fires while an old _run_agent is still unwinding, the old run used to
+dequeue pending messages from ``adapter._pending_messages`` and recurse
+with its already-stale ``run_generation``.  The recursive result was
+then discarded at ``_handle_message_with_agent``'s stale check, so the
+user's follow-up messages were silently swallowed — busy-ack fired but
+no reply was ever produced.
+
+The fix at ``gateway/run.py`` post-run dequeue guards the pop with
+``_is_session_run_current``: on stale, leave the queue intact so
+``base.py``'s late-arrival drain re-enters via
+``_process_message_background`` → ``_message_handler`` → ``handle_message``
+→ ``_begin_session_run_generation`` — i.e. with a fresh generation.
+
+This test follows the pattern in ``test_pending_event_none.py``:
+re-derive the fixed check-and-branch logic in a small helper and
+exercise both paths (stale + current) without having to drive the
+full _run_agent body.
+"""
+
+from types import SimpleNamespace
+
+
+def _consume_pending_if_current(runner, adapter, session_key, run_generation):
+    """Mirror the post-run dequeue guard at ``gateway/run.py``.
+
+    Returns the popped event only when ``run_generation`` is still
+    current for ``session_key``; when stale, leaves
+    ``adapter._pending_messages[session_key]`` intact so the drain
+    at ``gateway/platforms/base.py`` can re-process the message with
+    a fresh generation.
+    """
+    if not runner._is_session_run_current(session_key, run_generation):
+        return None
+    return adapter._pending_messages.pop(session_key, None)
+
+
+class _Runner:
+    """Minimal runner exposing ``_is_session_run_current``.
+
+    Mirrors the method on ``GatewayRunner`` so tests don't need to
+    instantiate the full runner (which pulls in every platform adapter).
+    """
+
+    def __init__(self, generations):
+        self._session_run_generation = dict(generations)
+
+    def _is_session_run_current(self, session_key, generation):
+        if not session_key:
+            return True
+        current = int(self._session_run_generation.get(session_key, 0))
+        return current == int(generation)
+
+
+class _Adapter:
+    def __init__(self):
+        self._pending_messages = {}
+
+
+class TestStaleDequeueGuard:
+    def test_stale_generation_leaves_pending_in_adapter(self):
+        """/new bumped current gen=4; old run at stale gen=2 must NOT pop."""
+        session_key = "telegram:user:1"
+        runner = _Runner({session_key: 4})
+        adapter = _Adapter()
+        event = SimpleNamespace(text="你认识我吗")
+        adapter._pending_messages[session_key] = event
+
+        result = _consume_pending_if_current(runner, adapter, session_key, 2)
+
+        assert result is None, "stale run must not dequeue"
+        assert session_key in adapter._pending_messages, (
+            "pending must remain for base.py late-arrival drain to reprocess"
+        )
+        assert adapter._pending_messages[session_key] is event
+
+    def test_current_generation_still_consumes_pending(self):
+        """Non-stale runs must still pop normally."""
+        session_key = "telegram:user:2"
+        runner = _Runner({session_key: 3})
+        adapter = _Adapter()
+        event = SimpleNamespace(text="hello")
+        adapter._pending_messages[session_key] = event
+
+        result = _consume_pending_if_current(runner, adapter, session_key, 3)
+
+        assert result is event
+        assert session_key not in adapter._pending_messages
+
+    def test_stale_with_empty_queue_still_returns_none(self):
+        """Stale generation with no pending must not blow up."""
+        session_key = "telegram:user:3"
+        runner = _Runner({session_key: 10})
+        adapter = _Adapter()
+
+        result = _consume_pending_if_current(runner, adapter, session_key, 1)
+
+        assert result is None
+        assert session_key not in adapter._pending_messages
+
+    def test_current_with_empty_queue_returns_none(self):
+        """Current generation with no pending returns None harmlessly."""
+        session_key = "telegram:user:4"
+        runner = _Runner({session_key: 2})
+        adapter = _Adapter()
+
+        result = _consume_pending_if_current(runner, adapter, session_key, 2)
+
+        assert result is None
+
+    def test_empty_session_key_treated_as_current(self):
+        """Empty session_key short-circuits to current (matches runner behavior)."""
+        runner = _Runner({})
+        adapter = _Adapter()
+
+        result = _consume_pending_if_current(runner, adapter, "", 5)
+
+        assert result is None
+
+    def test_no_prior_generation_treats_gen_zero_as_current(self):
+        """A session that never had a generation defaults to 0; gen=0 is current."""
+        session_key = "fresh:user:99"
+        runner = _Runner({})
+        adapter = _Adapter()
+        event = SimpleNamespace(text="new chat")
+        adapter._pending_messages[session_key] = event
+
+        result = _consume_pending_if_current(runner, adapter, session_key, 0)
+
+        assert result is event
+        assert session_key not in adapter._pending_messages


### PR DESCRIPTION
## What

When `/new` (or another command that invalidates the session run generation) fires while the old `_run_agent` is still unwinding, the old run consumes pending follow-up messages from `adapter._pending_messages` and recurses with its already-stale `run_generation`. The recursive result is then discarded at `_handle_message_with_agent`'s stale check (`gateway/run.py` line ~4299), so the user's follow-up messages are silently swallowed — busy-ack fires twice but no reply is ever produced.

The bug is at the post-run dequeue site in `_run_agent` (`gateway/run.py` line ~10287), which was consuming from the adapter queue without checking whether our generation was still current.

## Why

The late-arrival drain at `gateway/platforms/base.py` (checked at `_process_message_background`'s try-block end and in the finally's cleanup path) is designed exactly for this case: it re-enters `_process_message_background` → `handle_message`, which claims a fresh generation via `_begin_session_run_generation`. But it can only fire if pending messages are still in the queue — the old stale run was consuming them first, leaving the drain with nothing to pick up.

Reproduction: in any gateway session, send a long-running request (e.g., a tool-heavy agent turn), then quickly send `/new` followed by one or two follow-up messages. Before this fix, the follow-ups are lost and the user just sees two `⚡ Interrupting` acks with no response. Logs during the incident contain `"Discarding stale agent result"` with the stale generation number.

## Fix

Guard the post-run dequeue with `_is_session_run_current(session_key, run_generation)`. On stale, log and leave pending messages in the adapter queue so the late-arrival drain re-enters with a fresh generation. When current, behavior is unchanged.

Minimal surface: one added branch around the existing dequeue site. No new helpers, no signature changes.

## How to test

```
pytest tests/gateway/test_run_agent_stale_dequeue.py -v
```

The test file follows the idiom used in `tests/gateway/test_pending_event_none.py`: re-derive the fixed check-and-branch logic in a small helper, then exercise both paths (stale + current) and edge cases (empty queue, empty session_key, no prior generation recorded). Six tests total.

## Platforms tested

Windows 10 (native) — where the bug was originally observed. The fix is platform-neutral Python (pure generation-counter check); no OS-specific calls involved, so it should apply identically on Linux/macOS.

## Related

Related in spirit to `tests/gateway/test_pending_event_none.py` (which guarded against a different failure in the same post-run block) and to the session-race-guard work — this is the third variant of "old unwind path consumes state that belongs to a newer generation".