### PR TITLE
fix(routing): carry model.routes bundle through background-agent spawn

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -898,6 +898,7 @@ class GatewayRunner:
         self,
         old_session_id: str,
         session_key: Optional[str] = None,
+        source: Optional[SessionSource] = None,
     ):
         """Prompt the agent to save memories/skills before context is lost.
 
@@ -915,8 +916,24 @@ class GatewayRunner:
             if not history or len(history) < 4:
                 return
 
+            # Recover source from the session entry if the caller didn't
+            # thread it through. ``_resolve_session_agent_runtime`` needs it
+            # to fire ``model.routes`` — otherwise the flush agent inherits
+            # ``model.default`` + ``model.base_url`` (slate-1 / litellm-1)
+            # even when the owner session should route to a different
+            # endpoint, and the mismatched model/base_url pair 401s at the
+            # integration proxy.
+            if source is None and session_key:
+                try:
+                    entry = self.session_store._entries.get(session_key)
+                    if entry is not None:
+                        source = entry.origin
+                except Exception:
+                    source = None
+
             from run_agent import AIAgent
             model, runtime_kwargs = self._resolve_session_agent_runtime(
+                source=source,
                 session_key=session_key,
             )
             if not runtime_kwargs.get("api_key"):
@@ -1005,6 +1022,7 @@ class GatewayRunner:
         self,
         old_session_id: str,
         session_key: Optional[str] = None,
+        source: Optional[SessionSource] = None,
     ):
         """Run the sync memory flush in a thread pool so it won't block the event loop."""
         loop = asyncio.get_running_loop()
@@ -1013,6 +1031,7 @@ class GatewayRunner:
             self._flush_memories_for_session,
             old_session_id,
             session_key,
+            source,
         )
 
     @property
@@ -2308,7 +2327,7 @@ class GatewayRunner:
 
                 for key, entry in _expired_entries:
                     try:
-                        await self._async_flush_memories(entry.session_id, key)
+                        await self._async_flush_memories(entry.session_id, key, entry.origin)
                         # Shut down memory provider and close tool resources
                         # on the cached agent.  Idle agents live in
                         # _agent_cache (not _running_agents), so look there.
@@ -4971,7 +4990,7 @@ class GatewayRunner:
             old_entry = self.session_store._entries.get(session_key)
             if old_entry:
                 _flush_task = asyncio.create_task(
-                    self._async_flush_memories(old_entry.session_id, session_key)
+                    self._async_flush_memories(old_entry.session_id, session_key, old_entry.origin)
                 )
                 self._background_tasks.add(_flush_task)
                 _flush_task.add_done_callback(self._background_tasks.discard)
@@ -7247,7 +7266,7 @@ class GatewayRunner:
         # Flush memories for current session before switching
         try:
             _flush_task = asyncio.create_task(
-                self._async_flush_memories(current_entry.session_id, session_key)
+                self._async_flush_memories(current_entry.session_id, session_key, current_entry.origin)
             )
             self._background_tasks.add(_flush_task)
             _flush_task.add_done_callback(self._background_tasks.discard)

--- a/run_agent.py
+++ b/run_agent.py
@@ -2906,12 +2906,29 @@ class AIAgent:
                 with open(os.devnull, "w") as _devnull, \
                      contextlib.redirect_stdout(_devnull), \
                      contextlib.redirect_stderr(_devnull):
+                    # Forward the full provider bundle — not just model/provider.
+                    # ``AIAgent.__init__`` re-resolves ``base_url``/``api_key``
+                    # from ``resolve_provider_client`` when they're missing,
+                    # which reads ``model.default`` / ``model.base_url`` from
+                    # config and ignores any ``model.routes`` entry that the
+                    # parent agent's turn resolved against. If the parent is
+                    # on a routed model (e.g. owner → slate-3 at a dedicated
+                    # integration), re-resolving pairs the routed ``model``
+                    # with the config-default ``base_url`` — that's the exact
+                    # mismatch that lands ``slate-3`` requests on ``litellm-1``
+                    # and gets rejected with ``key_model_access_denied``.
                     review_agent = AIAgent(
                         model=self.model,
+                        base_url=self.base_url,
+                        api_key=getattr(self, "api_key", ""),
+                        api_mode=getattr(self, "api_mode", ""),
+                        provider=self.provider,
+                        acp_command=getattr(self, "acp_command", None),
+                        acp_args=getattr(self, "acp_args", None),
+                        credential_pool=getattr(self, "_credential_pool", None),
                         max_iterations=8,
                         quiet_mode=True,
                         platform=self.platform,
-                        provider=self.provider,
                     )
                     review_agent._memory_store = self._memory_store
                     review_agent._memory_enabled = self._memory_enabled

--- a/tests/gateway/test_flush_memory_routing.py
+++ b/tests/gateway/test_flush_memory_routing.py
@@ -1,0 +1,128 @@
+"""Regression: post-turn/background flush-agent construction must carry the
+session's ``model.routes`` bundle forward.
+
+If ``_flush_memories_for_session`` calls ``_resolve_session_agent_runtime``
+without a ``source``, ``_build_routing_context`` returns ``{}`` and
+``apply_route`` short-circuits at ``smart_model_routing.py``. The flush
+agent then inherits ``model.default`` + ``model.base_url`` from config
+instead of the owner/hub_peer route — so a routed turn whose main agent
+ran at ``(slate-3, litellm-3)`` spawns a flush agent at
+``(slate-1, litellm-1)``, and its auxiliary compression / memory calls
+can end up 401'ing against an integration key scoped to a different
+model.
+
+These tests pin the plumbing: the source is recovered from the session
+entry when the caller omits it, and forwarded through to the resolver
+so ``model.routes`` can fire.
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _mock_dotenv(monkeypatch):
+    fake = types.ModuleType("dotenv")
+    fake.load_dotenv = lambda *a, **kw: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake)
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._honcho_managers = {}
+    runner._honcho_configs = {}
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner.adapters = {}
+    runner.hooks = MagicMock()
+    runner.session_store = MagicMock()
+    return runner
+
+
+_TRANSCRIPT = [
+    {"role": "user", "content": "hi"},
+    {"role": "assistant", "content": "hello"},
+    {"role": "user", "content": "a real conversation"},
+    {"role": "assistant", "content": "acknowledged"},
+]
+
+
+class TestFlushSourceRecovery:
+    def _seed(self, monkeypatch):
+        tmp_agent = MagicMock()
+        fake_run_agent = types.ModuleType("run_agent")
+        fake_run_agent.AIAgent = MagicMock(return_value=tmp_agent)
+        monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+        runner = _make_runner()
+        runner.session_store.load_transcript.return_value = _TRANSCRIPT
+        runner._resolve_session_agent_runtime = MagicMock(
+            return_value=("slate-1", {"api_key": "k", "base_url": "u", "provider": "custom"})
+        )
+        runner._cleanup_agent_resources = MagicMock()
+        return runner, tmp_agent
+
+    def test_recovers_source_from_session_entry_when_not_passed(self, monkeypatch):
+        runner, _ = self._seed(monkeypatch)
+        entry = MagicMock()
+        entry.origin = MagicMock(name="source_from_entry")
+        runner.session_store._entries = {"agent:main:telegram:dm:123": entry}
+
+        runner._flush_memories_for_session(
+            "session_abc", session_key="agent:main:telegram:dm:123"
+        )
+
+        runner._resolve_session_agent_runtime.assert_called_once()
+        _, kwargs = runner._resolve_session_agent_runtime.call_args
+        assert kwargs.get("source") is entry.origin, (
+            "source must be recovered from session_store._entries so "
+            "apply_route can fire model.routes for the flush agent"
+        )
+        assert kwargs.get("session_key") == "agent:main:telegram:dm:123"
+
+    def test_prefers_explicit_source_over_store_lookup(self, monkeypatch):
+        runner, _ = self._seed(monkeypatch)
+        stale_entry = MagicMock()
+        stale_entry.origin = MagicMock(name="stale_source")
+        runner.session_store._entries = {"agent:main:telegram:dm:123": stale_entry}
+
+        explicit = MagicMock(name="explicit_source")
+        runner._flush_memories_for_session(
+            "session_abc",
+            session_key="agent:main:telegram:dm:123",
+            source=explicit,
+        )
+
+        _, kwargs = runner._resolve_session_agent_runtime.call_args
+        assert kwargs.get("source") is explicit
+
+    def test_missing_session_key_does_not_crash(self, monkeypatch):
+        runner, _ = self._seed(monkeypatch)
+        runner.session_store._entries = {}
+        # No session_key, no source — still resolves (source=None), doesn't raise
+        runner._flush_memories_for_session("session_abc")
+        runner._resolve_session_agent_runtime.assert_called_once()
+        _, kwargs = runner._resolve_session_agent_runtime.call_args
+        assert kwargs.get("source") is None
+
+    def test_async_wrapper_forwards_source(self, monkeypatch):
+        import asyncio
+
+        runner = _make_runner()
+        runner._flush_memories_for_session = MagicMock()
+
+        entry_source = MagicMock(name="entry_source")
+        asyncio.run(
+            runner._async_flush_memories(
+                "session_abc", "agent:main:telegram:dm:123", entry_source
+            )
+        )
+        # ``run_in_executor`` passes positional args; verify all three made it through.
+        _args, _ = runner._flush_memories_for_session.call_args
+        assert _args == ("session_abc", "agent:main:telegram:dm:123", entry_source)

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -219,8 +219,11 @@ class TestHandleResumeCommand:
 
         await runner._handle_resume_command(event)
 
-        runner._async_flush_memories.assert_called_once_with(
-            "current_session_001",
-            "agent:main:telegram:dm:67890",
-        )
+        runner._async_flush_memories.assert_called_once()
+        _args, _ = runner._async_flush_memories.call_args
+        assert _args[0] == "current_session_001"
+        assert _args[1] == "agent:main:telegram:dm:67890"
+        # Third arg is the SessionSource (``entry.origin``) so the flush
+        # agent can route via ``model.routes``.
+        assert len(_args) == 3
         db.close()

--- a/tests/run_agent/test_background_review_routing.py
+++ b/tests/run_agent/test_background_review_routing.py
@@ -1,0 +1,124 @@
+"""Regression: background review agent must inherit the parent agent's
+full provider bundle, not just ``model`` and ``provider``.
+
+Failure mode this guards against: if the parent's turn resolved via
+``model.routes`` (e.g. owner → slate-3 at a dedicated integration
+endpoint), spawning a review agent with only ``model=self.model`` and
+``provider=self.provider`` triggers ``AIAgent.__init__`` to re-resolve
+``base_url`` / ``api_key`` from ``resolve_provider_client``, which
+reads the *config-default* ``model.base_url`` / ``model.api_key``.
+That pairs the routed ``model`` with the default ``base_url`` — slate-3
+lands on litellm-1 — and the review agent 401s with
+``key_model_access_denied`` because the default integration's key is
+scoped to a different model.
+
+This test pins the construction shape so that regression stays caught.
+"""
+
+import threading
+from unittest.mock import MagicMock, patch
+
+
+def _parent_stub():
+    """Build the minimum AIAgent-like stub ``_spawn_background_review``
+    reads from ``self``. Avoids building a real AIAgent (expensive,
+    pulls in providers, skills, etc.)."""
+    from run_agent import AIAgent
+
+    parent = object.__new__(AIAgent)
+    parent.model = "slate-3"
+    parent.base_url = "https://litellm-3.int.exe.xyz/v1"
+    parent.api_key = "slate-3-key"
+    parent.api_mode = "chat_completions"
+    parent.provider = "custom"
+    parent.platform = "telegram"
+    parent.acp_command = None
+    parent.acp_args = []
+    parent._credential_pool = None
+    parent._memory_store = MagicMock()
+    parent._memory_enabled = True
+    parent._user_profile_enabled = True
+    return parent
+
+
+def test_background_review_forwards_full_runtime_bundle():
+    parent = _parent_stub()
+
+    captured = {}
+
+    def _capture(*args, **kwargs):
+        captured.update(kwargs)
+        agent = MagicMock()
+        agent._session_messages = []
+        return agent
+
+    # Replace threading.Thread so _run_review executes inline and we
+    # can assert on the construction kwargs deterministically.
+    class _InlineThread:
+        def __init__(self, *args, target=None, daemon=None, name=None, **kwargs):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    with patch("run_agent.AIAgent", side_effect=_capture), \
+         patch.object(threading, "Thread", _InlineThread):
+        parent._spawn_background_review(
+            messages_snapshot=[{"role": "user", "content": "hi"}],
+            review_memory=True,
+            review_skills=False,
+        )
+
+    # Routed fields that previously got dropped. Missing any of these
+    # triggers the ``slate-3 @ litellm-1`` mismatch.
+    assert captured.get("model") == "slate-3"
+    assert captured.get("base_url") == "https://litellm-3.int.exe.xyz/v1"
+    assert captured.get("api_key") == "slate-3-key"
+    assert captured.get("api_mode") == "chat_completions"
+    assert captured.get("provider") == "custom"
+
+
+def test_background_review_tolerates_missing_optional_attrs():
+    """A parent without ``api_key``/``api_mode`` attributes (legacy
+    construction paths, incomplete stubs) must still spawn a review
+    agent without AttributeError — ``getattr`` fallbacks cover it."""
+    from run_agent import AIAgent
+
+    parent = object.__new__(AIAgent)
+    parent.model = "slate-1"
+    parent.base_url = "https://litellm-1.int.exe.xyz/v1"
+    parent.provider = "custom"
+    parent.platform = "cli"
+    parent._memory_store = MagicMock()
+    parent._memory_enabled = True
+    parent._user_profile_enabled = True
+    # Intentionally omit: api_key, api_mode, acp_command, acp_args,
+    # _credential_pool
+
+    captured = {}
+
+    def _capture(*args, **kwargs):
+        captured.update(kwargs)
+        agent = MagicMock()
+        agent._session_messages = []
+        return agent
+
+    class _InlineThread:
+        def __init__(self, *args, target=None, daemon=None, name=None, **kwargs):
+            self._target = target
+
+        def start(self):
+            self._target()
+
+    with patch("run_agent.AIAgent", side_effect=_capture), \
+         patch.object(threading, "Thread", _InlineThread):
+        parent._spawn_background_review(
+            messages_snapshot=[{"role": "user", "content": "hi"}],
+            review_memory=True,
+            review_skills=False,
+        )
+
+    assert captured.get("model") == "slate-1"
+    assert captured.get("base_url") == "https://litellm-1.int.exe.xyz/v1"
+    assert captured.get("api_key") == ""
+    assert captured.get("api_mode") == ""


### PR DESCRIPTION
## Summary

When a routed turn (e.g. an owner DM resolved via `model.routes` to `slate-3` at a dedicated LiteLLM integration) ends, two follow-up paths spawn new `AIAgent` instances that **lose the routing bundle** and silently fall back to the config default. On deployments where each LiteLLM integration's key is scoped to one model (the common pattern for exe.dev-style zero-secret integrations), the mismatch 401s with `key_model_access_denied`.

The two paths:

1. **`gateway/run.py:_flush_memories_for_session`** called `_resolve_session_agent_runtime(session_key=...)` with **no `source`**. `_build_routing_context(None)` returns `{}`, `apply_route` short-circuits at `agent/smart_model_routing.py:328`, and the flush agent is built from `model.default` / `model.base_url` regardless of which route the originating turn fired against.

2. **`run_agent._spawn_background_review`** constructed `AIAgent(model=self.model, provider=self.provider)` with no `base_url` / `api_key` / `api_mode`. `AIAgent.__init__` then re-resolves the missing fields via `resolve_provider_client("custom", ...)` → `_try_custom_endpoint()`, which reads `model.base_url` / `model.api_key` from config. The routed `model` (e.g. `slate-3`) ends up paired with the default `base_url` (e.g. `litellm-1`) and default key → 401.

Symptom in real deployments: compression auxiliary call logs `model_metadata: slate-3 at https://litellm-1.int.exe.xyz/v1/` followed immediately by `Failed to generate context summary: Error code: 401 - key_model_access_denied`. Main turns succeed (they pass through `_resolve_session_agent_runtime(source=source, ...)` correctly); only the post-turn auxiliary path fails.

## Changes

- `_flush_memories_for_session` / `_async_flush_memories` accept an explicit `source`. When the caller omits it and `session_key` is known, recover from `session_store._entries[key].origin`. The three gateway callers (session-expiry flush, `/reset` flush, `/resume` flush) now pass `entry.origin` directly.
- `_spawn_background_review` forwards the full bundle: `base_url`, `api_key`, `api_mode`, `acp_command`, `acp_args`, `credential_pool` in addition to the existing `model` / `provider`. `getattr` fallbacks keep construction safe when the parent agent is a stub or was built via a legacy path.
- New regression tests:
  - `tests/gateway/test_flush_memory_routing.py` — 4 cases covering source recovery from entry, explicit source wins, missing session_key doesn't crash, async wrapper forwards.
  - `tests/run_agent/test_background_review_routing.py` — 2 cases covering full bundle forwarding and safe handling when optional parent attrs are missing.
- `tests/gateway/test_resume_command.test_resume_flushes_memories` loosened to accept the new third positional arg (`SessionSource`).

## Scope

A third, orthogonal defense — hardening `auxiliary_client._resolve_auto` to refuse silently mixing a caller-supplied routed `model` with config-default `base_url` — is **not** included. Once both spawn sites forward a complete bundle, `main_runtime.base_url` is never empty when the model is routed, so the silent fallback in `_resolve_auto` doesn't trigger. It's defense-in-depth, not required.

## Test plan

- [x] `pytest tests/gateway/test_flush_memory_stale_guard.py tests/gateway/test_flush_memory_routing.py tests/gateway/test_resume_command.py tests/run_agent/test_background_review_routing.py tests/test_empty_model_fallback.py` → 37 pass
- [ ] Deploy to a staging agent with a `model.routes` config where the routed integration's key is scoped to a different model than the default. Before: post-turn compressions 401. After: post-turn compressions succeed and log `model.routes matched: fields=['model', 'api_key', 'base_url']` for the flush/review paths.