### PR TITLE
fix(vision): resolve Nous vision model correctly in auto-detect path

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -165,6 +165,7 @@ _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = {
 _PROVIDER_VISION_MODELS: Dict[str, str] = {
     "xiaomi": "mimo-v2-omni",
     "zai": "glm-5v-turbo",
+    "nous": "xiaomi/mimo-v2-omni",
 }
 
 # OpenRouter app attribution headers
@@ -908,14 +909,23 @@ def _try_nous(vision: bool = False) -> Tuple[Optional[OpenAI], Optional[str]]:
         model = _NOUS_MODEL
     # Free-tier users can't use paid auxiliary models — use the free
     # models instead: mimo-v2-omni for vision, mimo-v2-pro for text tasks.
+    # For vision tasks, always use mimo-v2-omni regardless of tier —
+    # Nous inference API does not support image inputs for gemini models.
     try:
         from hermes_cli.models import check_nous_free_tier
         if check_nous_free_tier():
             model = _NOUS_FREE_TIER_VISION_MODEL if vision else _NOUS_FREE_TIER_AUX_MODEL
             logger.debug("Free-tier Nous account — using %s for auxiliary/%s",
                          model, "vision" if vision else "text")
+        elif vision:
+            model = _NOUS_FREE_TIER_VISION_MODEL
+            logger.debug("Nous vision task — using %s (gemini models lack "
+                         "image support on Nous inference API)", model)
     except Exception:
-        pass
+        if vision:
+            model = _NOUS_FREE_TIER_VISION_MODEL
+    if vision:
+        logger.debug("Nous vision: final model = %s", model)
     return (
         OpenAI(
             api_key=_nous_api_key(nous),
@@ -1552,7 +1562,13 @@ def resolve_provider_client(
 
     # ── Nous Portal (OAuth) ──────────────────────────────────────────
     if provider == "nous":
-        client, default = _try_nous()
+        # Detect vision tasks: either explicit model override from
+        # _PROVIDER_VISION_MODELS, or caller passed a known vision model.
+        _is_vision = (
+            model in _PROVIDER_VISION_MODELS.values()
+            or (model or "").strip().lower() == "mimo-v2-omni"
+        )
+        client, default = _try_nous(vision=_is_vision)
         if client is None:
             logger.warning("resolve_provider_client: nous requested "
                            "but Nous Portal not configured (run: hermes auth)")


### PR DESCRIPTION
## Problem

The vision auto-detect chain calls `resolve_provider_client()` with the vision model from `_PROVIDER_VISION_MODELS`, but `resolve_provider_client()` always called `_try_nous()` **without** `vision=True`. This caused it to return the default text model instead of the vision-capable `xiaomi/mimo-v2-omni`, resulting in 404 errors from the Nous inference API when sending images.

Additionally, `_PROVIDER_VISION_MODELS` was missing an entry for the `nous` provider.

## Root Cause

The auto-detect path in `resolve_vision_provider_client()`:
1. Looks up `_PROVIDER_VISION_MODELS.get("nous")` → returns `xiaomi/mimo-v2-omni`
2. Calls `resolve_provider_client("nous", model="xiaomi/mimo-v2-omni")`
3. `resolve_provider_client` calls `_try_nous()` **without** `vision=True`
4. `_try_nous()` ignores the passed model, returns the default text model

The fallback path (`_resolve_strict_vision_backend`) worked correctly because it called `_try_nous(vision=True)` directly.

## Fix

1. **`_PROVIDER_VISION_MODELS`**: Added `"nous": "xiaomi/mimo-v2-omni"` entry so the vision auto-detect chain picks the correct multimodal model.

2. **`resolve_provider_client`**: Auto-detects vision tasks by checking if the requested model matches a value in `_PROVIDER_VISION_MODELS` or is a known vision model name, then passes `vision=True` to `_try_nous()`.

## Verification

- `xiaomi/mimo-v2-omni` returns HTTP 200 with image inputs on Nous inference API
- `google/gemini-3-flash-preview` returns 404 with image inputs on Nous inference API
- Free tier Nous accounts: only Xiaomi models are available, making this fix essential

## Impact

Fixes `browser_vision` and `vision_analyze` tools for all Hermes users on Nous (both free and paid tiers).