### PR TITLE
fix(gateway): honor MATRIX_HOME_ROOM in onboarding

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -79,6 +79,16 @@ def _ensure_ssl_certs() -> None:
             os.environ["SSL_CERT_FILE"] = candidate
             return
 
+def _home_target_env_var(platform_name: str) -> str:
+    """Return the configured home-target env var for a platform."""
+    from cron.scheduler import _HOME_TARGET_ENV_VARS
+
+    return _HOME_TARGET_ENV_VARS.get(
+        platform_name.lower(),
+        f"{platform_name.upper()}_HOME_CHANNEL",
+    )
+
+
 _ensure_ssl_certs()
 
 # Add parent directory to path
@@ -4210,7 +4220,7 @@ class GatewayRunner:
         # Skip for webhooks - they deliver directly to configured targets (github_comment, etc.)
         if not history and source.platform and source.platform != Platform.LOCAL and source.platform != Platform.WEBHOOK:
             platform_name = source.platform.value
-            env_key = f"{platform_name.upper()}_HOME_CHANNEL"
+            env_key = _home_target_env_var(platform_name)
             if not os.getenv(env_key):
                 adapter = self.adapters.get(source.platform)
                 if adapter:
@@ -5739,9 +5749,9 @@ class GatewayRunner:
         platform_name = source.platform.value if source.platform else "unknown"
         chat_id = source.chat_id
         chat_name = source.chat_name or chat_id
-        
-        env_key = f"{platform_name.upper()}_HOME_CHANNEL"
-        
+
+        env_key = _home_target_env_var(platform_name)
+
         # Save to config.yaml
         try:
             import yaml
@@ -5756,7 +5766,7 @@ class GatewayRunner:
             os.environ[env_key] = str(chat_id)
         except Exception as e:
             return f"Failed to save home channel: {e}"
-        
+
         return (
             f"✅ Home channel set to **{chat_name}** (ID: {chat_id}).\n"
             f"Cron jobs and cross-platform messages will be delivered here."

--- a/tests/gateway/test_home_target_env_var.py
+++ b/tests/gateway/test_home_target_env_var.py
@@ -1,0 +1,9 @@
+from gateway.run import _home_target_env_var
+
+
+def test_matrix_home_target_env_var_uses_home_room():
+    assert _home_target_env_var("matrix") == "MATRIX_HOME_ROOM"
+
+
+def test_unknown_platform_home_target_env_var_falls_back_to_home_channel():
+    assert _home_target_env_var("custom") == "CUSTOM_HOME_CHANNEL"


### PR DESCRIPTION
## Bug Description

Matrix home delivery is configured with `MATRIX_HOME_ROOM`, but Hermes could still warn that no Matrix home target was set. The warning path and `/sethome` were not using the same home-target env-var mapping, so Matrix looked misconfigured even when it was correct.

Fixes N/A

## Root Cause

`gateway/run.py` still had logic that assumed `MATRIX_HOME_CHANNEL` in the onboarding warning path, while Matrix actually uses `MATRIX_HOME_ROOM`. `/sethome` and onboarding were not grounded on the same shared mapping.

## Fix

- use the shared home-target env-var mapping in gateway onboarding warnings
- make `/sethome` use the same mapping instead of assuming `*_HOME_CHANNEL`
- add regression coverage for Matrix and fallback behavior

## How to Verify

1. Configure Matrix home delivery with `MATRIX_HOME_ROOM`.
2. Start the gateway and confirm Hermes does not emit the false "No home channel is set for Matrix" warning.
3. Run `/sethome` for Matrix and confirm the command resolves the same env-var mapping as onboarding.
4. Run the regression tests below.

## Test Plan

- [x] Added regression test for this bug
- [x] Existing tests still pass
- [x] Manual verification of the fix

Commands run:
- `PYTEST_ADDOPTS= pytest -q tests/gateway/test_home_target_env_var.py tests/gateway/test_steer_command.py tests/gateway/test_unauthorized_dm_behavior.py`
- `PYTEST_ADDOPTS= pytest -q tests/gateway/test_home_target_env_var.py tests/gateway/test_matrix.py tests/cron/test_scheduler.py`

## Risk Assessment

Low — the change narrows behavior onto the existing shared home-target mapping and adds regression coverage around Matrix and fallback resolution.
