### PR TITLE
fix(model_metadata): add Ollama-format gemma4 entries to DEFAULT_CONTEXT_LENGTHS

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -123,8 +123,12 @@ DEFAULT_CONTEXT_LENGTHS = {
     "gpt-4": 128000,
     # Google
     "gemini": 1048576,
-    # Gemma (open models served via AI Studio)
+    # Gemma (open models served via AI Studio / Ollama)
+    # Ollama uses "gemma4" (no dash); Google/AI Studio use "gemma-4"
     "gemma-4-31b": 256000,
+    "gemma4:31b": 256000,     # Ollama tag format
+    "gemma4:26b": 256000,     # Ollama tag format (MoE, 256K context)
+    "gemma4": 131072,          # Gemma 4 catch-all (e2b/e4b = 128K)
     "gemma-3": 131072,
     "gemma": 8192,  # fallback for older gemma models
     # DeepSeek

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -158,6 +158,29 @@ class TestDefaultContextLengths:
                 f"{key} should be {value}, got {DEFAULT_CONTEXT_LENGTHS[key]}"
             )
 
+    def test_gemma4_ollama_naming(self):
+        # Ollama uses "gemma4:31b" (no dash, tag format) while Google/AI Studio
+        # use "gemma-4-31b-it" (dashed). Both must resolve to 256K context.
+        # The "gemma4" catch-all (128K) covers e2b/e4b edge models.
+        from agent.model_metadata import get_model_context_length
+        from unittest.mock import patch as mock_patch
+
+        with mock_patch("agent.model_metadata.fetch_model_metadata", return_value={}),             mock_patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}),             mock_patch("agent.model_metadata.get_cached_context_length", return_value=None):
+            cases = [
+                ("gemma4:31b", 256000),
+                ("gemma4:31b-cloud", 256000),   # Ollama Cloud variant
+                ("gemma4:26b", 256000),           # MoE variant
+                ("gemma4:e4b", 131072),           # Edge model → catch-all 128K
+                ("gemma4:e2b", 131072),           # Edge model → catch-all 128K
+                ("gemma-4-31b", 256000),          # Dashed Google naming
+                ("gemma-4-31b-it", 256000),       # Instruction-tuned variant
+            ]
+            for model_id, expected_ctx in cases:
+                actual = get_model_context_length(model_id)
+                assert actual == expected_ctx, (
+                    f"{model_id}: expected {expected_ctx}, got {actual}"
+                )
+
     def test_grok_substring_matching(self):
         # Longest-first substring matching must resolve the real xAI model
         # IDs to the correct fallback entries without 128k probe-down.


### PR DESCRIPTION
## Bug

Ollama's Gemma 4 models use `gemma4:31b` naming (no dash, colon-tag format), but `DEFAULT_CONTEXT_LENGTHS` only had the dashed Google/AI Studio form (`gemma-4-31b`). This caused Ollama models like `gemma4:31b-cloud` to fall through the fuzzy substring matching to the `"gemma": 8192` catch-all instead of resolving to 256K.

## Impact

When `gemma4:31b-cloud` is used as an auxiliary/compression model, the context compressor sees only 8K context and refuses to summarise conversations that exceed 8K tokens — even though the model actually supports 256K. This breaks context compression entirely for users with Ollama Cloud Gemma 4 models.

The error manifests as:
```
Compression model (gemma4:31b-cloud) context is 8,192 tokens, but the main model's compression threshold is 101,376 tokens. Context compression will not be possible — the content to summarise will exceed the auxiliary model's context window.
```

## Fix

Added Ollama-format entries to `DEFAULT_CONTEXT_LENGTHS`:
- `"gemma4:31b": 256000` — dense 31B model
- `"gemma4:26b": 256000` — MoE 26B model  
- `"gemma4": 131072` — catch-all for Gemma 4 edge models (e2b/e4b = 128K)

The longest-first substring matching ensures `gemma4:31b-cloud` matches `"gemma4:31b"` (256K) before the shorter `"gemma4"` (128K) or `"gemma"` (8K) entries.

## Testing

Added `test_gemma4_ollama_naming` covering:
- `gemma4:31b` → 256K
- `gemma4:31b-cloud` → 256K (Ollama Cloud variant)
- `gemma4:26b` → 256K (MoE)
- `gemma4:e4b` → 128K (edge model)
- `gemma4:e2b` → 128K (edge model)
- `gemma-4-31b` → 256K (Google dashed naming — unchanged)
- `gemma-4-31b-it` → 256K (instruction-tuned variant)

All `TestDefaultContextLengths` tests pass (9/9).