### PR TITLE
feat(gateway): accept .html / .htm in the document allowlist

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -592,6 +592,8 @@ SUPPORTED_DOCUMENT_TYPES = {
     ".txt": "text/plain",
     ".log": "text/plain",
     ".zip": "application/zip",
+    ".html": "text/html",
+    ".htm": "text/html",
     ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",

--- a/tests/gateway/test_document_cache.py
+++ b/tests/gateway/test_document_cache.py
@@ -151,7 +151,7 @@ class TestSupportedDocumentTypes:
 
     @pytest.mark.parametrize(
         "ext",
-        [".pdf", ".md", ".txt", ".zip", ".docx", ".xlsx", ".pptx"],
+        [".pdf", ".md", ".txt", ".zip", ".html", ".htm", ".docx", ".xlsx", ".pptx"],
     )
     def test_expected_extensions_present(self, ext):
         assert ext in SUPPORTED_DOCUMENT_TYPES


### PR DESCRIPTION
## Summary

Same pattern as #12590 (epub). ``SUPPORTED_DOCUMENT_TYPES`` in ``gateway/platforms/base.py`` is the single allowlist used by every platform handler (telegram, slack, discord, feishu, whatsapp) to decide whether to cache an uploaded document. It currently rejects ``.html`` uploads at the gateway — users trying to share saved web pages get ``Unsupported document type '.html'`` — even though the ``ocr-and-documents`` skill's ``marker`` extractor already handles HTML alongside PDF/DOCX/PPTX/XLSX/EPUB.

Add ``.html`` / ``.htm`` → ``text/html``.

## Test plan

- [x] `pytest tests/gateway/test_document_cache.py tests/gateway/test_telegram_documents.py` — 58 pass
- [ ] Send an .html file via Telegram and confirm the agent can read it via the ocr-and-documents skill