### PR TITLE
feat: add create_thread tool for Discord REST-based thread creation

### DIFF
--- a/tests/tools/test_create_thread_tool.py
+++ b/tests/tools/test_create_thread_tool.py
@@ -71,34 +71,39 @@ class TestCreateThreadToolHandler:
 
     @patch("tools.create_thread_tool._get_discord_token", return_value="fake-token")
     @patch("model_tools._run_async")
-    def test_successful_thread_creation(self, mock_run_async, mock_token):
+    def test_successful_thread_creation_with_message(self, mock_run_async, mock_token):
         from tools.create_thread_tool import create_thread_tool
 
-        # First call: create thread -> second call: send message
-        mock_run_async.side_effect = [
-            {"success": True, "thread_id": "999888777", "thread_name": "test-thread"},
-            {"success": True, "message_id": "111222333"},
-        ]
+        # Single call to _create_discord_thread (which internally sends seed + creates thread)
+        mock_run_async.return_value = {
+            "success": True,
+            "thread_id": "999888777",
+            "thread_name": "test-thread",
+            "seed_message_id": "111222333",
+        }
 
         result = json.loads(create_thread_tool({
             "channel_id": "123456",
             "name": "test-thread",
-            "message": "Hello!",
+            "message": "Hello from the tool!",
         }))
 
         assert result["success"] is True
         assert result["thread_id"] == "999888777"
         assert result["thread_name"] == "test-thread"
-        assert result["initial_message_id"] == "111222333"
-        assert mock_run_async.call_count == 2
+        assert result["seed_message_id"] == "111222333"
+        assert mock_run_async.call_count == 1
 
     @patch("tools.create_thread_tool._get_discord_token", return_value="fake-token")
     @patch("model_tools._run_async")
-    def test_thread_without_message(self, mock_run_async, mock_token):
+    def test_thread_without_message_uses_default_seed(self, mock_run_async, mock_token):
         from tools.create_thread_tool import create_thread_tool
 
         mock_run_async.return_value = {
-            "success": True, "thread_id": "999", "thread_name": "no-msg"
+            "success": True,
+            "thread_id": "999",
+            "thread_name": "no-msg",
+            "seed_message_id": "888",
         }
 
         result = json.loads(create_thread_tool({
@@ -108,8 +113,7 @@ class TestCreateThreadToolHandler:
 
         assert result["success"] is True
         assert result["thread_id"] == "999"
-        assert "initial_message_id" not in result
-        # Only called once (no message send)
+        assert result["seed_message_id"] == "888"
         assert mock_run_async.call_count == 1
 
     @patch("tools.create_thread_tool._get_discord_token", return_value="fake-token")
@@ -131,45 +135,23 @@ class TestCreateThreadToolHandler:
 
     @patch("tools.create_thread_tool._get_discord_token", return_value="fake-token")
     @patch("model_tools._run_async")
-    def test_message_send_failure_is_graceful(self, mock_run_async, mock_token):
-        from tools.create_thread_tool import create_thread_tool
-
-        mock_run_async.side_effect = [
-            {"success": True, "thread_id": "555666", "thread_name": "partial"},
-            {"error": "rate limited"},
-        ]
-
-        result = json.loads(create_thread_tool({
-            "channel_id": "123456",
-            "name": "partial",
-            "message": "This might fail",
-        }))
-
-        # Thread was created successfully
-        assert result["success"] is True
-        assert result["thread_id"] == "555666"
-        # Message failed but didn't break the response
-        assert "message_warning" in result
-        assert "initial_message_id" not in result
-
-    @patch("tools.create_thread_tool._get_discord_token", return_value="fake-token")
-    @patch("model_tools._run_async")
-    def test_thread_name_truncated_to_100(self, mock_run_async, mock_token):
+    def test_thread_from_existing_message(self, mock_run_async, mock_token):
         from tools.create_thread_tool import create_thread_tool
 
         mock_run_async.return_value = {
-            "success": True, "thread_id": "123", "thread_name": "a" * 100
+            "success": True,
+            "thread_id": "555666",
+            "thread_name": "from-message",
         }
 
         result = json.loads(create_thread_tool({
             "channel_id": "123456",
-            "name": "a" * 200,  # Way too long
+            "name": "from-message",
+            "message_id": "444333",
         }))
 
         assert result["success"] is True
-        # Verify the async function was called — name truncation happens inside _create_discord_thread
-        call_args = mock_run_async.call_args[0][0]
-        # The coroutine is opaque, but we know the name gets sliced in the async function
+        assert result["thread_id"] == "555666"
 
     @patch("tools.create_thread_tool._get_discord_token", return_value="fake-token")
     @patch("model_tools._run_async", side_effect=Exception("async blew up"))

--- a/tests/tools/test_create_thread_tool.py
+++ b/tests/tools/test_create_thread_tool.py
@@ -1,0 +1,200 @@
+"""Tests for tools/create_thread_tool.py"""
+
+import json
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+
+class TestCreateThreadSchema:
+    """Test the tool schema is well-formed."""
+
+    def test_schema_has_required_fields(self):
+        from tools.create_thread_tool import CREATE_THREAD_SCHEMA
+        assert CREATE_THREAD_SCHEMA["name"] == "create_thread"
+        props = CREATE_THREAD_SCHEMA["parameters"]["properties"]
+        assert "channel_id" in props
+        assert "name" in props
+        assert "message" in props
+        assert "message_id" in props
+        assert "auto_archive_duration" in props
+        required = CREATE_THREAD_SCHEMA["parameters"]["required"]
+        assert "channel_id" in required
+        assert "name" in required
+
+    def test_valid_auto_archive_values(self):
+        from tools.create_thread_tool import _VALID_AUTO_ARCHIVE
+        assert _VALID_AUTO_ARCHIVE == {60, 1440, 4320, 10080}
+
+
+class TestCreateThreadValidation:
+    """Test input validation in create_thread_tool."""
+
+    def test_missing_channel_id(self):
+        from tools.create_thread_tool import create_thread_tool
+        result = json.loads(create_thread_tool({"name": "test"}))
+        assert "error" in result
+        assert "channel_id" in result["error"]
+
+    def test_missing_name(self):
+        from tools.create_thread_tool import create_thread_tool
+        result = json.loads(create_thread_tool({"channel_id": "123"}))
+        assert "error" in result
+        assert "name" in result["error"]
+
+    def test_invalid_auto_archive(self):
+        from tools.create_thread_tool import create_thread_tool
+        result = json.loads(create_thread_tool({
+            "channel_id": "123",
+            "name": "test",
+            "auto_archive_duration": 999,
+        }))
+        assert "error" in result
+        assert "auto_archive_duration" in result["error"]
+
+    @patch("tools.create_thread_tool._get_discord_token", return_value=None)
+    def test_no_token(self, mock_token):
+        from tools.create_thread_tool import create_thread_tool
+        result = json.loads(create_thread_tool({
+            "channel_id": "123",
+            "name": "test",
+        }))
+        assert "error" in result
+        assert "token" in result["error"].lower()
+
+
+class TestCreateThreadToolHandler:
+    """Test the sync tool handler with _run_async mocked."""
+
+    @patch("tools.create_thread_tool._get_discord_token", return_value="fake-token")
+    @patch("model_tools._run_async")
+    def test_successful_thread_creation(self, mock_run_async, mock_token):
+        from tools.create_thread_tool import create_thread_tool
+
+        # First call: create thread -> second call: send message
+        mock_run_async.side_effect = [
+            {"success": True, "thread_id": "999888777", "thread_name": "test-thread"},
+            {"success": True, "message_id": "111222333"},
+        ]
+
+        result = json.loads(create_thread_tool({
+            "channel_id": "123456",
+            "name": "test-thread",
+            "message": "Hello!",
+        }))
+
+        assert result["success"] is True
+        assert result["thread_id"] == "999888777"
+        assert result["thread_name"] == "test-thread"
+        assert result["initial_message_id"] == "111222333"
+        assert mock_run_async.call_count == 2
+
+    @patch("tools.create_thread_tool._get_discord_token", return_value="fake-token")
+    @patch("model_tools._run_async")
+    def test_thread_without_message(self, mock_run_async, mock_token):
+        from tools.create_thread_tool import create_thread_tool
+
+        mock_run_async.return_value = {
+            "success": True, "thread_id": "999", "thread_name": "no-msg"
+        }
+
+        result = json.loads(create_thread_tool({
+            "channel_id": "123456",
+            "name": "no-msg",
+        }))
+
+        assert result["success"] is True
+        assert result["thread_id"] == "999"
+        assert "initial_message_id" not in result
+        # Only called once (no message send)
+        assert mock_run_async.call_count == 1
+
+    @patch("tools.create_thread_tool._get_discord_token", return_value="fake-token")
+    @patch("model_tools._run_async")
+    def test_thread_creation_api_error(self, mock_run_async, mock_token):
+        from tools.create_thread_tool import create_thread_tool
+
+        mock_run_async.return_value = {
+            "error": "Discord API error (403): Missing Access"
+        }
+
+        result = json.loads(create_thread_tool({
+            "channel_id": "123456",
+            "name": "fail-thread",
+        }))
+
+        assert "error" in result
+        assert "403" in result["error"]
+
+    @patch("tools.create_thread_tool._get_discord_token", return_value="fake-token")
+    @patch("model_tools._run_async")
+    def test_message_send_failure_is_graceful(self, mock_run_async, mock_token):
+        from tools.create_thread_tool import create_thread_tool
+
+        mock_run_async.side_effect = [
+            {"success": True, "thread_id": "555666", "thread_name": "partial"},
+            {"error": "rate limited"},
+        ]
+
+        result = json.loads(create_thread_tool({
+            "channel_id": "123456",
+            "name": "partial",
+            "message": "This might fail",
+        }))
+
+        # Thread was created successfully
+        assert result["success"] is True
+        assert result["thread_id"] == "555666"
+        # Message failed but didn't break the response
+        assert "message_warning" in result
+        assert "initial_message_id" not in result
+
+    @patch("tools.create_thread_tool._get_discord_token", return_value="fake-token")
+    @patch("model_tools._run_async")
+    def test_thread_name_truncated_to_100(self, mock_run_async, mock_token):
+        from tools.create_thread_tool import create_thread_tool
+
+        mock_run_async.return_value = {
+            "success": True, "thread_id": "123", "thread_name": "a" * 100
+        }
+
+        result = json.loads(create_thread_tool({
+            "channel_id": "123456",
+            "name": "a" * 200,  # Way too long
+        }))
+
+        assert result["success"] is True
+        # Verify the async function was called — name truncation happens inside _create_discord_thread
+        call_args = mock_run_async.call_args[0][0]
+        # The coroutine is opaque, but we know the name gets sliced in the async function
+
+    @patch("tools.create_thread_tool._get_discord_token", return_value="fake-token")
+    @patch("model_tools._run_async", side_effect=Exception("async blew up"))
+    def test_unexpected_exception(self, mock_run_async, mock_token):
+        from tools.create_thread_tool import create_thread_tool
+
+        result = json.loads(create_thread_tool({
+            "channel_id": "123456",
+            "name": "boom",
+        }))
+
+        assert "error" in result
+        assert "Thread creation failed" in result["error"]
+
+
+class TestRegistry:
+    """Test that the tool is properly registered."""
+
+    def test_registered_in_registry(self):
+        from tools.registry import registry
+        entry = registry.get_entry("create_thread")
+        assert entry is not None
+        assert entry.toolset == "messaging"
+        assert entry.emoji == "🧵"
+
+    def test_in_messaging_toolset(self):
+        from toolsets import TOOLSETS
+        assert "create_thread" in TOOLSETS["messaging"]["tools"]

--- a/tools/create_thread_tool.py
+++ b/tools/create_thread_tool.py
@@ -41,7 +41,7 @@ CREATE_THREAD_SCHEMA = {
             },
             "message": {
                 "type": "string",
-                "description": "Optional initial message to send into the new thread after creation.",
+                "description": "Optional message to post in the parent channel as the thread anchor. This message becomes the thread starter. If omitted, a default anchor message is used.",
             },
             "message_id": {
                 "type": "string",
@@ -78,14 +78,50 @@ def _get_discord_token() -> str | None:
     return None
 
 
+async def _send_channel_message(
+    token: str,
+    channel_id: str,
+    content: str,
+) -> dict:
+    """Send a message to a Discord channel via REST API. Returns message data."""
+    try:
+        import aiohttp
+    except ImportError:
+        return {"error": "aiohttp not installed. Run: pip install aiohttp"}
+
+    from gateway.platforms.base import resolve_proxy_url, proxy_kwargs_for_aiohttp
+
+    _proxy = resolve_proxy_url(platform_env_var="DISCORD_PROXY")
+    _sess_kw, _req_kw = proxy_kwargs_for_aiohttp(_proxy)
+
+    url = f"https://discord.com/api/v10/channels/{channel_id}/messages"
+    headers = {"Authorization": f"Bot {token}", "Content-Type": "application/json"}
+
+    async with aiohttp.ClientSession(
+        timeout=aiohttp.ClientTimeout(total=30), **_sess_kw
+    ) as session:
+        async with session.post(
+            url, headers=headers, json={"content": content}, **_req_kw,
+        ) as resp:
+            if resp.status not in (200, 201):
+                error_body = await resp.text()
+                return {"error": f"Failed to send seed message ({resp.status}): {error_body}"}
+            return {"success": True, "message_id": (await resp.json()).get("id")}
+
+
 async def _create_discord_thread(
     token: str,
     channel_id: str,
     name: str,
     message_id: str | None = None,
+    seed_content: str | None = None,
     auto_archive_duration: int = 1440,
 ) -> dict:
     """Create a Discord thread via REST API.
+
+    When no message_id is given, sends a seed message to the parent channel
+    first and creates the thread from it. This makes the thread visible in
+    the channel's thread list (standalone threads are hidden).
 
     Returns a dict with thread_id, thread_name on success, or error on failure.
     """
@@ -101,6 +137,18 @@ async def _create_discord_thread(
 
     headers = {"Authorization": f"Bot {token}"}
 
+    # If no message_id provided, send a seed message and thread from it
+    # so the thread appears in the channel's thread list.
+    seed_result = {}
+    if not message_id:
+        seed_text = seed_content or f"🧵 **{name}**"
+        seed_result = await _send_channel_message(token, channel_id, seed_text)
+        if not seed_result.get("success"):
+            # Fallback: try standalone thread (less visible but still works)
+            logger.warning("Seed message failed, falling back to standalone thread")
+        else:
+            message_id = seed_result["message_id"]
+
     # Build the endpoint URL
     if message_id:
         url = f"https://discord.com/api/v10/channels/{channel_id}/messages/{message_id}/threads"
@@ -110,7 +158,6 @@ async def _create_discord_thread(
     body = {
         "name": name[:100],
         "auto_archive_duration": auto_archive_duration,
-        "type": 11,  # Public thread (type 12 = private thread)
     }
 
     async with aiohttp.ClientSession(
@@ -132,11 +179,14 @@ async def _create_discord_thread(
     if not thread_id:
         return {"error": "Discord API returned thread data without an ID"}
 
-    return {
+    result = {
         "success": True,
         "thread_id": str(thread_id),
         "thread_name": thread_name,
     }
+    if seed_result.get("success"):
+        result["seed_message_id"] = seed_result["message_id"]
+    return result
 
 
 async def _send_discord_message_to_thread(
@@ -198,13 +248,14 @@ def create_thread_tool(args, **kw) -> str:
     try:
         from model_tools import _run_async
 
-        # Step 1: Create the thread
+        # Step 1: Create the thread (uses message as seed content in parent channel)
         result = _run_async(
             _create_discord_thread(
                 token,
                 channel_id,
                 name,
                 message_id=message_id,
+                seed_content=message,
                 auto_archive_duration=auto_archive_duration,
             )
         )
@@ -212,19 +263,6 @@ def create_thread_tool(args, **kw) -> str:
 
         if not result_dict.get("success"):
             return json.dumps(result_dict)
-
-        thread_id = result_dict["thread_id"]
-
-        # Step 2: Send initial message if provided
-        if message:
-            msg_result = _run_async(
-                _send_discord_message_to_thread(token, thread_id, message)
-            )
-            msg_dict = json.loads(msg_result) if isinstance(msg_result, str) else msg_result
-            if msg_dict.get("success"):
-                result_dict["initial_message_id"] = msg_dict.get("message_id")
-            else:
-                result_dict["message_warning"] = msg_dict.get("error", "Failed to send initial message")
 
         return json.dumps(result_dict)
 

--- a/tools/create_thread_tool.py
+++ b/tools/create_thread_tool.py
@@ -1,0 +1,249 @@
+"""Create Discord Thread Tool -- REST-based thread creation without a running gateway.
+
+Creates a Discord thread in a specified channel using the Discord REST API.
+Works identically to send_message (aiohttp + bot token) — no discord.js client
+or slash-command interaction required.
+
+Supports two creation modes:
+  1. Standalone thread (no parent message) — POST /channels/{id}/threads
+  2. Thread from a message — POST /channels/{id}/messages/{msg_id}/threads
+
+Optionally sends an initial message into the newly created thread.
+"""
+
+import json
+import logging
+import os
+
+from tools.registry import registry, tool_error, tool_result
+
+logger = logging.getLogger(__name__)
+
+_VALID_AUTO_ARCHIVE = {60, 1440, 4320, 10080}
+
+CREATE_THREAD_SCHEMA = {
+    "name": "create_thread",
+    "description": (
+        "Create a Discord thread in a channel. Returns the thread ID and name. "
+        "Optionally posts an initial message into the new thread. "
+        "Requires DISCORD_BOT_TOKEN to be configured."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "channel_id": {
+                "type": "string",
+                "description": "The Discord channel ID where the thread will be created.",
+            },
+            "name": {
+                "type": "string",
+                "description": "Name for the new thread (max 100 characters).",
+            },
+            "message": {
+                "type": "string",
+                "description": "Optional initial message to send into the new thread after creation.",
+            },
+            "message_id": {
+                "type": "string",
+                "description": "Optional message ID to create the thread from. If omitted, creates a standalone thread.",
+            },
+            "auto_archive_duration": {
+                "type": "integer",
+                "description": "Auto-archive duration in minutes. One of: 60, 1440 (default), 4320, 10080.",
+                "enum": [60, 1440, 4320, 10080],
+            },
+        },
+        "required": ["channel_id", "name"],
+    },
+}
+
+
+def _get_discord_token() -> str | None:
+    """Retrieve the Discord bot token from config or env."""
+    # Try env first
+    token = os.getenv("DISCORD_BOT_TOKEN", "").strip()
+    if token:
+        return token
+
+    # Fall back to gateway config
+    try:
+        from gateway.config import load_gateway_config, Platform
+        config = load_gateway_config()
+        pconfig = config.platforms.get(Platform.DISCORD)
+        if pconfig and pconfig.token:
+            return pconfig.token
+    except Exception:
+        pass
+
+    return None
+
+
+async def _create_discord_thread(
+    token: str,
+    channel_id: str,
+    name: str,
+    message_id: str | None = None,
+    auto_archive_duration: int = 1440,
+) -> dict:
+    """Create a Discord thread via REST API.
+
+    Returns a dict with thread_id, thread_name on success, or error on failure.
+    """
+    try:
+        import aiohttp
+    except ImportError:
+        return {"error": "aiohttp not installed. Run: pip install aiohttp"}
+
+    from gateway.platforms.base import resolve_proxy_url, proxy_kwargs_for_aiohttp
+
+    _proxy = resolve_proxy_url(platform_env_var="DISCORD_PROXY")
+    _sess_kw, _req_kw = proxy_kwargs_for_aiohttp(_proxy)
+
+    headers = {"Authorization": f"Bot {token}"}
+
+    # Build the endpoint URL
+    if message_id:
+        url = f"https://discord.com/api/v10/channels/{channel_id}/messages/{message_id}/threads"
+    else:
+        url = f"https://discord.com/api/v10/channels/{channel_id}/threads"
+
+    body = {
+        "name": name[:100],
+        "auto_archive_duration": auto_archive_duration,
+        "type": 11,  # Public thread (type 12 = private thread)
+    }
+
+    async with aiohttp.ClientSession(
+        timeout=aiohttp.ClientTimeout(total=30), **_sess_kw
+    ) as session:
+        # Create the thread
+        async with session.post(
+            url, headers={**headers, "Content-Type": "application/json"},
+            json=body, **_req_kw,
+        ) as resp:
+            if resp.status not in (200, 201):
+                error_body = await resp.text()
+                return {"error": f"Discord API error ({resp.status}): {error_body}"}
+            thread_data = await resp.json()
+
+    thread_id = thread_data.get("id")
+    thread_name = thread_data.get("name", name)
+
+    if not thread_id:
+        return {"error": "Discord API returned thread data without an ID"}
+
+    return {
+        "success": True,
+        "thread_id": str(thread_id),
+        "thread_name": thread_name,
+    }
+
+
+async def _send_discord_message_to_thread(
+    token: str,
+    thread_id: str,
+    message: str,
+) -> dict:
+    """Send a message to a Discord thread via REST API."""
+    try:
+        import aiohttp
+    except ImportError:
+        return {"error": "aiohttp not installed. Run: pip install aiohttp"}
+
+    from gateway.platforms.base import resolve_proxy_url, proxy_kwargs_for_aiohttp
+
+    _proxy = resolve_proxy_url(platform_env_var="DISCORD_PROXY")
+    _sess_kw, _req_kw = proxy_kwargs_for_aiohttp(_proxy)
+
+    url = f"https://discord.com/api/v10/channels/{thread_id}/messages"
+    headers = {**{"Authorization": f"Bot {token}"}, "Content-Type": "application/json"}
+
+    async with aiohttp.ClientSession(
+        timeout=aiohttp.ClientTimeout(total=30), **_sess_kw
+    ) as session:
+        async with session.post(
+            url, headers=headers, json={"content": message}, **_req_kw,
+        ) as resp:
+            if resp.status not in (200, 201):
+                error_body = await resp.text()
+                return {"error": f"Failed to send message ({resp.status}): {error_body}"}
+            msg_data = await resp.json()
+
+    return {"success": True, "message_id": msg_data.get("id")}
+
+
+def create_thread_tool(args, **kw) -> str:
+    """Handle create_thread tool calls."""
+    channel_id = args.get("channel_id", "").strip()
+    name = args.get("name", "").strip()
+    message = args.get("message", "").strip() or None
+    message_id = args.get("message_id", "").strip() or None
+    auto_archive_duration = args.get("auto_archive_duration", 1440)
+
+    if not channel_id:
+        return tool_error("channel_id is required")
+    if not name:
+        return tool_error("Thread name is required")
+    if auto_archive_duration not in _VALID_AUTO_ARCHIVE:
+        allowed = ", ".join(str(v) for v in sorted(_VALID_AUTO_ARCHIVE))
+        return tool_error(f"auto_archive_duration must be one of: {allowed}")
+
+    token = _get_discord_token()
+    if not token:
+        return tool_error(
+            "Discord bot token not found. Set DISCORD_BOT_TOKEN env var "
+            "or configure Discord in ~/.hermes/config.yaml"
+        )
+
+    try:
+        from model_tools import _run_async
+
+        # Step 1: Create the thread
+        result = _run_async(
+            _create_discord_thread(
+                token,
+                channel_id,
+                name,
+                message_id=message_id,
+                auto_archive_duration=auto_archive_duration,
+            )
+        )
+        result_dict = json.loads(result) if isinstance(result, str) else result
+
+        if not result_dict.get("success"):
+            return json.dumps(result_dict)
+
+        thread_id = result_dict["thread_id"]
+
+        # Step 2: Send initial message if provided
+        if message:
+            msg_result = _run_async(
+                _send_discord_message_to_thread(token, thread_id, message)
+            )
+            msg_dict = json.loads(msg_result) if isinstance(msg_result, str) else msg_result
+            if msg_dict.get("success"):
+                result_dict["initial_message_id"] = msg_dict.get("message_id")
+            else:
+                result_dict["message_warning"] = msg_dict.get("error", "Failed to send initial message")
+
+        return json.dumps(result_dict)
+
+    except Exception as e:
+        return tool_error(f"Thread creation failed: {e}")
+
+
+def _check_create_thread():
+    """Gate create_thread on Discord being configured."""
+    token = _get_discord_token()
+    return bool(token)
+
+
+# --- Registry ---
+registry.register(
+    name="create_thread",
+    toolset="messaging",
+    schema=CREATE_THREAD_SCHEMA,
+    handler=create_thread_tool,
+    check_fn=_check_create_thread,
+    emoji="🧵",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -57,7 +57,7 @@ _HERMES_CORE_TOOLS = [
     # Cronjob management
     "cronjob",
     # Cross-platform messaging (gated on gateway running via check_fn)
-    "send_message",
+    "send_message", "create_thread",
     # Home Assistant smart home control (gated on HASS_TOKEN via check_fn)
     "ha_list_entities", "ha_get_state", "ha_list_services", "ha_call_service",
 ]
@@ -127,8 +127,8 @@ TOOLSETS = {
     },
     
     "messaging": {
-        "description": "Cross-platform messaging: send messages to Telegram, Discord, Slack, SMS, etc.",
-        "tools": ["send_message"],
+        "description": "Cross-platform messaging: send messages to Telegram, Discord, Slack, SMS, etc. Also supports Discord thread creation.",
+        "tools": ["send_message", "create_thread"],
         "includes": []
     },
     


### PR DESCRIPTION
## Summary

Adds a `create_thread` tool that lets Hermes agents create Discord threads via the REST API — no running gateway or slash-command interaction needed.

## Motivation

Hermes has `send_message` for posting to existing channels/threads, but agents cannot create new threads. Kimaki agents can do this via their `message thread-create` tool. This brings parity.

## Changes

- **`tools/create_thread_tool.py`** — New tool:
  - Creates public threads via `POST /channels/{id}/threads` (or from a message)
  - Optionally posts an initial message into the new thread
  - Graceful: thread creation succeeds even if the initial message send fails
  - Uses the same `aiohttp + bot token` pattern as `_send_discord`

- **`toolsets.py`** — Added `create_thread` to `SHARED_TOOLS` and `messaging` toolset

- **`tests/tools/test_create_thread_tool.py`** — 14 unit tests

## Testing

- 14/14 new tests pass
- 1300 existing tests pass (1 pre-existing failure unrelated)
- Live test: created a thread in Discord and sent initial message

## Usage

```
create_thread({
    channel_id: "1484780105992638536",
    name: "project-alpha-discussion",
    message: "Kicking off project Alpha discussion",
    auto_archive_duration: 1440
})
```