### PR TITLE
fix(cli): guard _signal_handler against reentrant SIGINT during shutdown

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10158,7 +10158,19 @@ class HermesCLI:
             call _kill_process (SIGTERM + 1 s wait + SIGKILL if needed) →
             return from _wait_for_process.  ``time.sleep`` releases the
             GIL so the daemon actually runs during the window.
+
+            Reentrancy guard: once shutdown is in flight we must NOT
+            raise KeyboardInterrupt again.  A second SIGINT/SIGTERM
+            arriving while prompt_toolkit is inside its final
+            ``_redraw(render_as_done=True)`` lands in the middle of
+            ``_get_tui_prompt_symbols`` (``stripped.split()``) and
+            then cascades into ``renderer.reset()`` → stdout.flush(),
+            which fails with ``OSError: [Errno 5] Input/output error``
+            because the terminal is already being torn down.
             """
+            if getattr(self, "_shutdown_signal_received", False):
+                return  # already shutting down — swallow reentrant signal
+            self._shutdown_signal_received = True
             logger.debug("Received signal %s, triggering graceful shutdown", signum)
             try:
                 if getattr(self, "agent", None) and getattr(self, "_agent_running", False):


### PR DESCRIPTION
# PR: fix(cli): guard `_signal_handler` against reentrant SIGINT during shutdown
Branch: `fix/sigint-reentrancy-guard` (on fork `ivanmorey80-debug/hermes-agent`)
Target: `NousResearch/hermes-agent:main`
## Summary
A second `SIGINT` (or `SIGTERM`) arriving while `prompt_toolkit` is inside its
final `_redraw(render_as_done=True)` lands in the middle of
`HermesCLI._get_tui_prompt_symbols` (specifically `stripped.split()`) and then
cascades through `renderer.reset()` → `stdout.flush()`, failing with
`OSError: [Errno 5] Input/output error` because the terminal is already being
torn down.
This PR adds a reentrancy guard to `_signal_handler` so only the first signal
raises `KeyboardInterrupt`; subsequent signals are swallowed.
## Observed repro (from `~/.hermes/logs/errors.log`)
```
2026-04-19 13:50:36,842 ERROR asyncio: unhandled exception during asyncio.run() shutdown
Traceback (most recent call last):
  File ".../prompt_toolkit/application/application.py", line 751, in _run_async
    self._redraw(render_as_done=True)
  ...
  File "cli.py", line 9251, in _input_height
    prompt_width = max(2, get_cwidth(self._get_tui_prompt_text()))
  File "cli.py", line 8483, in _get_tui_prompt_text
  File "cli.py", line 8445, in _get_tui_prompt_fragments
  File "cli.py", line 8422, in _get_tui_prompt_symbols
    parts = stripped.split()
  File "cli.py", line 10168, in _signal_handler
    raise KeyboardInterrupt()
KeyboardInterrupt
During handling of the above exception, another exception occurred:
  File ".../prompt_toolkit/output/flush_stdout.py", line 37, in flush_stdout
    stdout.flush()
OSError: [Errno 5] Input/output error
```
## Change
`cli.py` — in `HermesCLI.run()`'s nested `_signal_handler`, add a
`_shutdown_signal_received` flag on the CLI instance and early-return when a
second signal arrives. The existing graceful-shutdown behavior (agent
`interrupt()` + `HERMES_SIGTERM_GRACE` window) is preserved for the first
signal.
## Test notes
Reproduced on macOS (Sequoia 15.75), Hermes v0.10.0 @ upstream `7e3b3565`,
Python 3.11.15, prompt_toolkit installed via `venv/`.
After the patch, Ctrl-C during an active TUI session exits cleanly with no
`OSError [Errno 5]` in `errors.log`. An end-to-end multi-tool test
(6 tool calls, 9 messages) also completed without growing `errors.log`.
## Risk
Low. The guard only affects the *second* signal within one lifetime of the
CLI instance; on the first signal, behavior is byte-identical to before.
## Provenance
Diagnosed and patched during an investigative session using Warp.
Conversation: https://app.warp.dev/conversation/3838b263-2b63-43a4-bd1b-92c89c2629d8
Co-Authored-By: Oz <oz-agent@warp.dev>
