### PR TITLE
perf: optimize Anthropic prompt caching and harden webhooks

### DIFF
--- a/agent/prompt_caching.py
+++ b/agent/prompt_caching.py
@@ -8,8 +8,35 @@ the conversation prefix. Uses 4 cache_control breakpoints (Anthropic max):
 Pure functions -- no class state, no AIAgent dependency.
 """
 
-import copy
 from typing import Any, Dict, List
+
+
+def _clone_message_for_cache(msg: Dict[str, Any]) -> Dict[str, Any]:
+    """Clone message fields that later retry/sanitization paths may mutate."""
+    cloned = dict(msg)
+
+    content = msg.get("content")
+    if isinstance(content, list):
+        cloned["content"] = [
+            dict(part) if isinstance(part, dict) else part
+            for part in content
+        ]
+
+    tool_calls = msg.get("tool_calls")
+    if isinstance(tool_calls, list):
+        cloned_tool_calls = []
+        for tc in tool_calls:
+            if isinstance(tc, dict):
+                tc_clone = dict(tc)
+                fn = tc.get("function")
+                if isinstance(fn, dict):
+                    tc_clone["function"] = dict(fn)
+                cloned_tool_calls.append(tc_clone)
+            else:
+                cloned_tool_calls.append(tc)
+        cloned["tool_calls"] = cloned_tool_calls
+
+    return cloned
 
 
 def _apply_cache_marker(msg: dict, cache_marker: dict, native_anthropic: bool = False) -> None:
@@ -48,25 +75,27 @@ def apply_anthropic_cache_control(
     Places up to 4 cache_control breakpoints: system prompt + last 3 non-system messages.
 
     Returns:
-        Deep copy of messages with cache_control breakpoints injected.
+        Copy of messages with cache_control breakpoints injected.
+        Unmodified messages are structurally shared to avoid a full deep copy.
     """
-    messages = copy.deepcopy(api_messages)
-    if not messages:
-        return messages
+    if not api_messages:
+        return []
 
     marker = {"type": "ephemeral"}
     if cache_ttl == "1h":
         marker["ttl"] = "1h"
 
-    breakpoints_used = 0
+    breakpoint_indices: List[int] = []
+    if api_messages[0].get("role") == "system":
+        breakpoint_indices.append(0)
 
-    if messages[0].get("role") == "system":
-        _apply_cache_marker(messages[0], marker, native_anthropic=native_anthropic)
-        breakpoints_used += 1
+    remaining = 4 - len(breakpoint_indices)
+    non_sys = [i for i, msg in enumerate(api_messages) if msg.get("role") != "system"]
+    breakpoint_indices.extend(non_sys[-remaining:])
 
-    remaining = 4 - breakpoints_used
-    non_sys = [i for i in range(len(messages)) if messages[i].get("role") != "system"]
-    for idx in non_sys[-remaining:]:
+    messages = [_clone_message_for_cache(msg) for msg in api_messages]
+
+    for idx in breakpoint_indices:
         _apply_cache_marker(messages[idx], marker, native_anthropic=native_anthropic)
 
     return messages

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -46,6 +46,7 @@ from gateway.platforms.base import (
     MessageEvent,
     MessageType,
     SendResult,
+    is_network_accessible,
 )
 
 logger = logging.getLogger(__name__)
@@ -108,12 +109,10 @@ class WebhookAdapter(BasePlatformAdapter):
     # Lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self) -> bool:
-        # Load agent-created subscriptions before validating
-        self._reload_dynamic_routes()
-
-        # Validate routes at startup — secret is required per route
-        for name, route in self._routes.items():
+    def _validate_routes(self, routes: Dict[str, dict]) -> None:
+        """Validate webhook route auth requirements for current bind host."""
+        public_bind = is_network_accessible(self._host)
+        for name, route in routes.items():
             secret = route.get("secret", self._global_secret)
             if not secret:
                 raise ValueError(
@@ -121,6 +120,20 @@ class WebhookAdapter(BasePlatformAdapter):
                     f"Set 'secret' on the route or globally. "
                     f"For testing without auth, set secret to '{_INSECURE_NO_AUTH}'."
                 )
+            if public_bind and secret == _INSECURE_NO_AUTH:
+                raise ValueError(
+                    f"[webhook] Route '{name}' uses '{_INSECURE_NO_AUTH}' while binding to "
+                    f"network-accessible host {self._host}. Refusing to expose unauthenticated "
+                    f"webhook endpoint on a public interface. Use 127.0.0.1 for local testing "
+                    f"or configure a real secret before exposing the webhook server."
+                )
+
+    async def connect(self) -> bool:
+        # Load agent-created subscriptions before validating
+        self._reload_dynamic_routes()
+
+        # Validate routes at startup — secret is required per route
+        self._validate_routes(self._routes)
 
         app = web.Application()
         app.router.add_get("/health", self._handle_health)
@@ -261,11 +274,14 @@ class WebhookAdapter(BasePlatformAdapter):
             if not isinstance(data, dict):
                 return
             # Merge: static routes take precedence over dynamic ones
-            self._dynamic_routes = {
+            dynamic_routes = {
                 k: v for k, v in data.items()
                 if k not in self._static_routes
             }
-            self._routes = {**self._dynamic_routes, **self._static_routes}
+            merged_routes = {**dynamic_routes, **self._static_routes}
+            self._validate_routes(merged_routes)
+            self._dynamic_routes = dynamic_routes
+            self._routes = merged_routes
             self._dynamic_routes_mtime = mtime
             logger.info(
                 "[webhook] Reloaded %d dynamic route(s): %s",

--- a/run_agent.py
+++ b/run_agent.py
@@ -614,6 +614,7 @@ class AIAgent:
         checkpoint_max_snapshots: int = 50,
         pass_session_id: bool = False,
         persist_session: bool = True,
+        cache_ttl: str | None = None,
     ):
         """
         Initialize the AI Agent.
@@ -810,7 +811,17 @@ class AIAgent:
         is_claude = "claude" in self.model.lower()
         is_native_anthropic = self.api_mode == "anthropic_messages" and self.provider == "anthropic"
         self._use_prompt_caching = (is_openrouter and is_claude) or is_native_anthropic
-        self._cache_ttl = "5m"  # Default 5-minute TTL (1.25x write cost)
+        configured_cache_ttl = cache_ttl
+        if configured_cache_ttl is None:
+            try:
+                from hermes_cli.config import read_raw_config as _read_raw_config
+                _raw_cfg = _read_raw_config() or {}
+                _model_cfg = _raw_cfg.get("model")
+                if isinstance(_model_cfg, dict):
+                    configured_cache_ttl = _model_cfg.get("cache_ttl")
+            except Exception:
+                configured_cache_ttl = None
+        self._cache_ttl = "1h" if configured_cache_ttl == "1h" else "5m"
         
         # Iteration budget: the LLM is only notified when it actually exhausts
         # the iteration budget (api_call_count >= max_iterations).  At that

--- a/tests/agent/test_prompt_caching.py
+++ b/tests/agent/test_prompt_caching.py
@@ -141,3 +141,23 @@ class TestApplyAnthropicCacheControl:
             elif "cache_control" in msg:
                 count += 1
         assert count <= 4
+
+    def test_clones_messages_without_mutating_original(self):
+        msgs = [
+            {"role": "system", "content": "System"},
+            {"role": "user", "content": [{"type": "text", "text": "old"}]},
+            {"role": "assistant", "content": "recent-1"},
+            {"role": "user", "content": "recent-2"},
+            {"role": "assistant", "content": "recent-3"},
+        ]
+
+        original = copy.deepcopy(msgs)
+        result = apply_anthropic_cache_control(msgs)
+
+        # Returned structure is isolated from later in-place retry sanitization.
+        assert result[0] is not msgs[0]
+        assert result[1] is not msgs[1]
+        assert result[1]["content"] is not msgs[1]["content"]
+        assert result[1]["content"][0] is not msgs[1]["content"][0]
+        # Original input must stay unchanged.
+        assert msgs == original

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -352,7 +352,7 @@ class TestHTTPHandling:
     async def test_connect_starts_server(self):
         """connect() starts the HTTP listener and marks adapter as connected."""
         routes = {"r1": {"secret": _INSECURE_NO_AUTH, "prompt": "x"}}
-        adapter = _make_adapter(routes=routes, port=0)
+        adapter = _make_adapter(routes=routes, host="127.0.0.1", port=0)
         # Use port 0 — the OS picks a free port, but aiohttp requires a real bind.
         # We just test that the method completes and marks connected.
         # Need to mock TCPSite to avoid actual binding.
@@ -370,6 +370,14 @@ class TestHTTPHandling:
             mock_site_inst.start.assert_awaited_once()
 
         await adapter.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_connect_rejects_insecure_no_auth_on_public_interface(self):
+        routes = {"r1": {"secret": _INSECURE_NO_AUTH, "prompt": "x"}}
+        adapter = _make_adapter(routes=routes, host="0.0.0.0", port=0)
+
+        with pytest.raises(ValueError, match="INSECURE_NO_AUTH"):
+            await adapter.connect()
 
     @pytest.mark.asyncio
     async def test_disconnect_cleans_up(self):

--- a/tests/gateway/test_webhook_dynamic_routes.py
+++ b/tests/gateway/test_webhook_dynamic_routes.py
@@ -1,12 +1,14 @@
 """Tests for webhook adapter dynamic route loading."""
 
 import json
-import os
 import pytest
-from pathlib import Path
 
 from gateway.config import PlatformConfig
-from gateway.platforms.webhook import WebhookAdapter, _DYNAMIC_ROUTES_FILENAME
+from gateway.platforms.webhook import (
+    WebhookAdapter,
+    _DYNAMIC_ROUTES_FILENAME,
+    _INSECURE_NO_AUTH,
+)
 
 
 def _make_adapter(routes=None, extra=None):
@@ -81,7 +83,16 @@ class TestDynamicRouteLoading:
 
     def test_corrupted_file(self, tmp_path):
         (tmp_path / _DYNAMIC_ROUTES_FILENAME).write_text("not json")
-        adapter = _make_adapter(routes={"static": {"secret": "s"}})
+        adapter = _make_adapter(routes={"static": {"secret": "***"}})
         adapter._reload_dynamic_routes()
         assert "static" in adapter._routes
         assert len(adapter._dynamic_routes) == 0
+
+    def test_rejects_insecure_public_dynamic_route(self, tmp_path):
+        (tmp_path / _DYNAMIC_ROUTES_FILENAME).write_text(
+            json.dumps({"danger": {"secret": _INSECURE_NO_AUTH, "prompt": "x"}})
+        )
+        adapter = _make_adapter(extra={"host": "0.0.0.0"})
+        adapter._reload_dynamic_routes()
+        assert adapter._routes == {}
+        assert adapter._dynamic_routes == {}

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -84,6 +84,25 @@ def agent_with_memory_tool():
         return a
 
 
+def test_aiagent_honors_configured_prompt_cache_ttl():
+    with (
+        patch(
+            "run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("hermes_cli.config.read_raw_config", return_value={"model": {"cache_ttl": "1h"}}),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent._cache_ttl == "1h"
+
+
 def test_aiagent_reuses_existing_errors_log_handler():
     """Repeated AIAgent init should not accumulate duplicate errors.log handlers."""
     root_logger = logging.getLogger()


### PR DESCRIPTION
## Summary
- optimize Anthropic prompt caching to avoid unnecessary full message deep copies while preserving safe mutable isolation
- honor configurable `model.cache_ttl` values (`5m` or `1h`) in `AIAgent`
- refuse `INSECURE_NO_AUTH` for webhook servers bound to network-accessible hosts, including dynamic route reloads

## Tests
- `source venv/bin/activate && python -m pytest tests/agent/test_prompt_caching.py tests/run_agent/test_run_agent.py::test_aiagent_honors_configured_prompt_cache_ttl tests/gateway/test_webhook_adapter.py tests/gateway/test_webhook_dynamic_routes.py -q`

## Notes
- leaves unrelated local `scripts/whatsapp-bridge/package-lock.json` changes out of this PR
- motivated by Hermes docs review for security + performance improvements