### PR TITLE
fix(trajectory): add file locking to prevent JSONL corruption under concurrent writes

### DIFF
--- a/agent/trajectory.py
+++ b/agent/trajectory.py
@@ -7,6 +7,8 @@ the file-write logic live here.
 
 import json
 import logging
+import os
+import sys
 from datetime import datetime
 from typing import Any, Dict, List
 
@@ -49,8 +51,24 @@ def save_trajectory(trajectory: List[Dict[str, Any]], model: str,
     }
 
     try:
+        line = json.dumps(entry, ensure_ascii=False) + "\n"
         with open(filename, "a", encoding="utf-8") as f:
-            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+            if sys.platform == "win32":
+                import msvcrt
+                msvcrt.locking(f.fileno(), msvcrt.LK_LOCK, 1)
+                try:
+                    f.write(line)
+                    f.flush()
+                finally:
+                    msvcrt.locking(f.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+                try:
+                    fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+                    f.write(line)
+                    f.flush()
+                finally:
+                    fcntl.flock(f.fileno(), fcntl.LOCK_UN)
         logger.info("Trajectory saved to %s", filename)
     except Exception as e:
         logger.warning("Failed to save trajectory: %s", e)

--- a/tests/test_trajectory_locking.py
+++ b/tests/test_trajectory_locking.py
@@ -1,0 +1,51 @@
+"""Tests that concurrent save_trajectory() calls produce valid JSONL."""
+
+import json
+import os
+import tempfile
+from concurrent.futures import ThreadPoolExecutor
+
+from agent.trajectory import save_trajectory
+
+
+def test_concurrent_writes_produce_valid_jsonl():
+    """Multiple threads writing simultaneously must not corrupt the file."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "test.jsonl")
+        n_writers = 20
+
+        def _write(i):
+            save_trajectory(
+                trajectory=[{"from": "human", "value": f"msg-{i}"}],
+                model="test-model",
+                completed=True,
+                filename=path,
+            )
+
+        with ThreadPoolExecutor(max_workers=n_writers) as pool:
+            list(pool.map(_write, range(n_writers)))
+
+        with open(path, encoding="utf-8") as f:
+            lines = f.readlines()
+
+        assert len(lines) == n_writers
+        for line in lines:
+            entry = json.loads(line)  # must not raise
+            assert "conversations" in entry
+            assert entry["completed"] is True
+
+
+def test_single_write_produces_valid_jsonl():
+    """Sanity check: a single write is valid JSONL."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "test.jsonl")
+        save_trajectory(
+            trajectory=[{"from": "human", "value": "hello"}],
+            model="m",
+            completed=False,
+            filename=path,
+        )
+        with open(path, encoding="utf-8") as f:
+            entry = json.loads(f.readline())
+        assert entry["model"] == "m"
+        assert entry["completed"] is False


### PR DESCRIPTION
Fixes #12684

## Problem
`save_trajectory()` uses plain `open('a') + write()` with no file locking, causing JSONL corruption under concurrent writes.

## Solution
- Added `fcntl.flock(LOCK_EX)` around the write operation to serialize concurrent appends
- `try/finally` ensures the lock is always released
- `msvcrt.locking` fallback for Windows
- Full JSON line including newline written and flushed atomically within the lock

## Tests
- Added `tests/test_trajectory_locking.py` — 20 concurrent threads verify all lines are valid JSONL (2 tests passing)