### PR TITLE
feat: allow delegate_task model overrides

### DIFF
--- a/docs/superpowers/plans/2026-04-19-stitch-gemini-subagent.md
+++ b/docs/superpowers/plans/2026-04-19-stitch-gemini-subagent.md
@@ -1,0 +1,50 @@
+# Stitch Gemini Subagent Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow `delegate_task` callers and skills such as `google-stitch` to route specific subagents to a different provider/model than the global `delegation` default.
+
+**Architecture:** Extend the delegation schema and runtime so top-level and per-task overrides can specify `provider` and `model`, with provider resolution reusing the existing runtime-provider path. Then document the new routing pattern in the `google-stitch` skill so prototyping subagents can target Gemini 3+ while coding subagents continue using Codex.
+
+**Tech Stack:** Python, pytest, Hermes skills markdown
+
+---
+
+### Task 1: Add Failing Tests For Per-Task Delegation Overrides
+
+**Files:**
+- Modify: `tests/tools/test_delegate.py`
+
+- [ ] Add tests that prove `delegate_task(tasks=[...])` can pass distinct `provider` and `model` overrides per task.
+- [ ] Add tests that prove top-level `provider` / `model` overrides work without changing `config.yaml`.
+- [ ] Run targeted delegate tests and verify the new assertions fail before implementation.
+
+### Task 2: Implement Provider/Model Overrides In Delegate Tool
+
+**Files:**
+- Modify: `tools/delegate_tool.py`
+- Test: `tests/tools/test_delegate.py`
+
+- [ ] Extend the tool schema to accept top-level and per-task `provider` / `model`.
+- [ ] Resolve effective child credentials with priority `task override > top-level override > delegation config > parent inherit`.
+- [ ] Keep existing behavior unchanged when no override is supplied.
+- [ ] Re-run targeted delegate tests until they pass.
+
+### Task 3: Document Google Stitch Routing
+
+**Files:**
+- Modify: `skills/software-development/google-stitch/SKILL.md`
+
+- [ ] Update the skill to instruct Hermes to dispatch prototyping/frontend subagents with Gemini 3+ overrides.
+- [ ] Preserve current Stitch CLI usage and timeout guidance.
+- [ ] Re-read the skill for consistency with the new `delegate_task` arguments.
+
+### Task 4: Verify, Commit, And Prepare PR
+
+**Files:**
+- Modify: any touched files above
+
+- [ ] Run focused verification commands for delegation tests.
+- [ ] Review `git diff` for only intended changes.
+- [ ] Commit on the feature branch with a focused message.
+- [ ] Push the branch to `fork` and open a PR against the fork-ready upstream flow.

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -66,7 +66,12 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertIn("tasks", props)
         self.assertIn("context", props)
         self.assertIn("toolsets", props)
+        self.assertIn("model", props)
+        self.assertIn("provider", props)
         self.assertIn("max_iterations", props)
+        task_props = props["tasks"]["items"]["properties"]
+        self.assertIn("model", task_props)
+        self.assertIn("provider", task_props)
         self.assertNotIn("maxItems", props["tasks"])  # removed — limit is now runtime-configurable
 
 
@@ -160,6 +165,100 @@ class TestDelegateTask(unittest.TestCase):
         self.assertEqual(result["results"][0]["summary"], "Result A")
         self.assertEqual(result["results"][1]["summary"], "Result B")
         self.assertIn("total_duration_seconds", result)
+
+    @patch("tools.delegate_tool._build_child_agent")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._load_config")
+    def test_top_level_model_provider_override_beats_config(self, mock_cfg, mock_creds, mock_build):
+        mock_cfg.return_value = {
+            "max_iterations": 45,
+            "model": "cx/gpt-5.3-codex",
+            "provider": "omnirouter",
+        }
+        mock_creds.side_effect = [
+            {
+                "model": "antigravity/gemini-3.1-pro-low",
+                "provider": "omnirouter",
+                "base_url": "http://localhost:20128/v1",
+                "api_key": "gemini-key",
+                "api_mode": "chat_completions",
+                "command": None,
+                "args": [],
+            }
+        ]
+        mock_child = MagicMock()
+        mock_build.return_value = mock_child
+        parent = _make_mock_parent()
+
+        with patch("tools.delegate_tool._run_single_child", return_value={
+            "task_index": 0, "status": "completed", "summary": "ok", "api_calls": 1, "duration_seconds": 1.0
+        }):
+            delegate_task(
+                goal="Prototype with Stitch",
+                model="antigravity/gemini-3.1-pro-low",
+                provider="omnirouter",
+                parent_agent=parent,
+            )
+
+        mock_creds.assert_called_once()
+        override_cfg = mock_creds.call_args.args[0]
+        self.assertEqual(override_cfg["model"], "antigravity/gemini-3.1-pro-low")
+        self.assertEqual(override_cfg["provider"], "omnirouter")
+
+    @patch("tools.delegate_tool._build_child_agent")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._load_config")
+    def test_per_task_model_provider_override_beats_top_level_and_config(self, mock_cfg, mock_creds, mock_build):
+        mock_cfg.return_value = {
+            "max_iterations": 45,
+            "model": "cx/gpt-5.3-codex",
+            "provider": "omnirouter",
+        }
+        mock_creds.side_effect = [
+            {
+                "model": "antigravity/gemini-3.1-pro-low",
+                "provider": "omnirouter",
+                "base_url": "http://localhost:20128/v1",
+                "api_key": "gemini-key",
+                "api_mode": "chat_completions",
+                "command": None,
+                "args": [],
+            },
+            {
+                "model": "cx/gpt-5.3-codex",
+                "provider": "omnirouter",
+                "base_url": "http://localhost:20128/v1",
+                "api_key": "codex-key",
+                "api_mode": "chat_completions",
+                "command": None,
+                "args": [],
+            },
+        ]
+        mock_build.side_effect = [MagicMock(), MagicMock()]
+        parent = _make_mock_parent()
+
+        with patch("tools.delegate_tool._run_single_child", return_value={
+            "task_index": 0, "status": "completed", "summary": "ok", "api_calls": 1, "duration_seconds": 1.0
+        }):
+            delegate_task(
+                tasks=[
+                    {"goal": "Prototype", "model": "antigravity/gemini-3.1-pro-low", "provider": "omnirouter"},
+                    {"goal": "Implement", "model": "cx/gpt-5.3-codex", "provider": "omnirouter"},
+                ],
+                model="antigravity/gemini-3-flash",
+                provider="omnirouter",
+                parent_agent=parent,
+            )
+
+        self.assertEqual(mock_creds.call_count, 2)
+        first_cfg = mock_creds.call_args_list[0].args[0]
+        second_cfg = mock_creds.call_args_list[1].args[0]
+        self.assertEqual(first_cfg["model"], "antigravity/gemini-3.1-pro-low")
+        self.assertEqual(second_cfg["model"], "cx/gpt-5.3-codex")
+        first_build = mock_build.call_args_list[0].kwargs
+        second_build = mock_build.call_args_list[1].kwargs
+        self.assertEqual(first_build["model"], "antigravity/gemini-3.1-pro-low")
+        self.assertEqual(second_build["model"], "cx/gpt-5.3-codex")
 
     @patch("tools.delegate_tool._run_single_child")
     def test_batch_capped_at_3(self, mock_run):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -681,6 +681,8 @@ def delegate_task(
     goal: Optional[str] = None,
     context: Optional[str] = None,
     toolsets: Optional[List[str]] = None,
+    model: Optional[str] = None,
+    provider: Optional[str] = None,
     tasks: Optional[List[Dict[str, Any]]] = None,
     max_iterations: Optional[int] = None,
     acp_command: Optional[str] = None,
@@ -714,16 +716,6 @@ def delegate_task(
     default_max_iter = cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS)
     effective_max_iter = max_iterations or default_max_iter
 
-    # Resolve delegation credentials (provider:model pair).
-    # When delegation.provider is configured, this resolves the full credential
-    # bundle (base_url, api_key, api_mode) via the same runtime provider system
-    # used by CLI/gateway startup.  When unconfigured, returns None values so
-    # children inherit from the parent.
-    try:
-        creds = _resolve_delegation_credentials(cfg, parent_agent)
-    except ValueError as exc:
-        return tool_error(str(exc))
-
     # Normalize to task list
     max_children = _get_max_concurrent_children()
     if tasks and isinstance(tasks, list):
@@ -737,7 +729,13 @@ def delegate_task(
             )
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
-        task_list = [{"goal": goal, "context": context, "toolsets": toolsets}]
+        task_list = [{
+            "goal": goal,
+            "context": context,
+            "toolsets": toolsets,
+            "model": model,
+            "provider": provider,
+        }]
     else:
         return tool_error("Provide either 'goal' (single task) or 'tasks' (batch).")
 
@@ -768,6 +766,19 @@ def delegate_task(
     children = []
     try:
         for i, t in enumerate(task_list):
+            task_cfg = dict(cfg)
+            if provider is not None:
+                task_cfg["provider"] = provider
+            if model is not None:
+                task_cfg["model"] = model
+            if t.get("provider") is not None:
+                task_cfg["provider"] = t.get("provider")
+            if t.get("model") is not None:
+                task_cfg["model"] = t.get("model")
+            try:
+                creds = _resolve_delegation_credentials(task_cfg, parent_agent)
+            except ValueError as exc:
+                return tool_error(str(exc))
             child = _build_child_agent(
                 task_index=i, goal=t["goal"], context=t.get("context"),
                 toolsets=t.get("toolsets") or toolsets, model=creds["model"],
@@ -1116,6 +1127,20 @@ DELEGATE_TASK_SCHEMA = {
                     "['terminal', 'file', 'web'] for full-stack tasks."
                 ),
             },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Optional subagent model override. When set together with provider, "
+                    "this task can route to a different model than delegation.model."
+                ),
+            },
+            "provider": {
+                "type": "string",
+                "description": (
+                    "Optional subagent provider override. Uses the same provider names as "
+                    "runtime provider resolution and overrides delegation.provider."
+                ),
+            },
             "tasks": {
                 "type": "array",
                 "items": {
@@ -1127,6 +1152,14 @@ DELEGATE_TASK_SCHEMA = {
                             "type": "array",
                             "items": {"type": "string"},
                             "description": f"Toolsets for this specific task. Available: {_TOOLSET_LIST_STR}. Use 'web' for network access, 'terminal' for shell, 'browser' for web interaction.",
+                        },
+                        "model": {
+                            "type": "string",
+                            "description": "Per-task subagent model override. Takes precedence over the top-level model and delegation.model.",
+                        },
+                        "provider": {
+                            "type": "string",
+                            "description": "Per-task subagent provider override. Takes precedence over the top-level provider and delegation.provider.",
                         },
                         "acp_command": {
                             "type": "string",
@@ -1190,6 +1223,8 @@ registry.register(
         goal=args.get("goal"),
         context=args.get("context"),
         toolsets=args.get("toolsets"),
+        model=args.get("model"),
+        provider=args.get("provider"),
         tasks=args.get("tasks"),
         max_iterations=args.get("max_iterations"),
         acp_command=args.get("acp_command"),


### PR DESCRIPTION
## Summary
- add top-level and per-task provider/model overrides to delegate_task
- keep existing delegation behavior unchanged when no override is provided
- add focused delegate tool tests covering override precedence and schema exposure

## Testing
- pytest tests/tools/test_delegate.py -q