### PR TITLE
ci: bump test-job timeout from 10m to 20m

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4


### PR DESCRIPTION
## Summary
Restores green CI signal on main by giving the full test suite enough time to finish.

## Changes
- `.github/workflows/tests.yml`: `test` job `timeout-minutes: 10` → `20`

## Validation
| | Before | After |
|---|---|---|
| Recent main runs | cancelled at 10m cap | finish within window |
| e2e job | 10m cap (unchanged, runs in ~25s) | 10m cap |

Root cause: the non-integration test suite has grown past what ubuntu-latest can run in 10 minutes, so every push to main hits the cap and leaves main without a green signal.