### PR TITLE
fix(tools): toolset availability should pass if ANY tool passes its check

### DIFF
--- a/tools/registry.py
+++ b/tools/registry.py
@@ -19,6 +19,7 @@ import importlib
 import json
 import logging
 import threading
+from collections import defaultdict
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Set
 
@@ -417,18 +418,43 @@ class ToolRegistry:
         unavailable = []
         seen = set()
         entries, toolset_checks = self._snapshot_state()
+        # Group entries by toolset for per-tool check evaluation
+        ts_entries = defaultdict(list)
         for entry in entries:
-            ts = entry.toolset
+            ts_entries[entry.toolset].append(entry)
+        for ts in sorted(ts_entries):
             if ts in seen:
                 continue
             seen.add(ts)
-            if self._evaluate_toolset_check(ts, toolset_checks.get(ts)):
+            # A toolset is available if ANY of its tools passes its check_fn.
+            # This handles cases like browser_cdp having a stricter check than
+            # other browser tools — the toolset should still be available when
+            # the core tools (navigate, click, etc.) work.
+            any_available = False
+            for entry in ts_entries[ts]:
+                if entry.check_fn:
+                    try:
+                        if bool(entry.check_fn()):
+                            any_available = True
+                            break
+                    except Exception:
+                        continue
+                else:
+                    any_available = True
+                    break
+            # Fall back to toolset-level check if no per-tool check passed
+            if not any_available:
+                any_available = self._evaluate_toolset_check(
+                    ts, toolset_checks.get(ts)
+                )
+            if any_available:
                 available.append(ts)
             else:
+                first = ts_entries[ts][0]
                 unavailable.append({
                     "name": ts,
-                    "env_vars": entry.requires_env,
-                    "tools": [e.name for e in entries if e.toolset == ts],
+                    "env_vars": first.requires_env,
+                    "tools": [e.name for e in ts_entries[ts]],
                 })
         return available, unavailable
 


### PR DESCRIPTION
## Bug

`hermes doctor` reports the `browser` toolset as **"system dependency not met"** even when Camofox is properly configured (`CAMOFOX_URL` is set, `check_browser_requirements()` returns `True`).

## Root Cause

`check_tool_availability()` uses the **first-registered** `check_fn` for the entire toolset. Since `browser_cdp_tool.py` is alphabetically before `browser_tool.py`, its `_browser_cdp_check` becomes the toolset-level check for `browser`.

`_browser_cdp_check` requires **both** `check_browser_requirements()` **and** `_get_cdp_override()` -- but Camofox does not expose CDP, so `_get_cdp_override()` returns `None`, causing the entire browser toolset to be marked unavailable.

The irony: `check_browser_requirements()` correctly short-circuits to `True` when `_is_camofox_mode()` is `True`. The doctor never reaches that check because the stricter CDP check gatekeeps the whole toolset first.

## Fix

A toolset is now considered available if **any** of its tools passes its individual `check_fn`. Falls back to the toolset-level check only if no per-tool check passes.

This correctly handles:
- **Camofox mode**: `browser_navigate` etc. pass `check_browser_requirements()` so toolset is available
- **browser_cdp**: still individually gated by its own stricter check, won't appear in tool definitions unless CDP is configured
- **No behavior change** for toolsets where all tools share the same check_fn

## Reproduction

1. Set `CAMOFOX_URL=http://localhost:9377` in `~/.hermes/.env`
2. Run `hermes doctor`
3. Observe: ⚠ browser (system dependency not met)

After fix: ✓ browser

## Testing

- Verified locally that `check_tool_availability()` now returns `browser` in the available list when Camofox is configured
- All 31 registry tests pass (`pytest tests/tools/test_registry.py -v`)
- Platform tested: Linux (WSL2)
