### PR TITLE
fix(file-tools): resolve relative paths against TERMINAL_CWD

### DIFF
--- a/tests/tools/test_file_tools_terminal_cwd.py
+++ b/tests/tools/test_file_tools_terminal_cwd.py
@@ -1,0 +1,63 @@
+"""Tests for TERMINAL_CWD-aware path resolution in file_tools and file_operations."""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from tools.file_tools import _resolve_path
+
+
+class TestResolvePath:
+    """Unit tests for _resolve_path helper."""
+
+    def test_absolute_path_ignores_terminal_cwd(self, tmp_path):
+        with mock.patch.dict(os.environ, {"TERMINAL_CWD": str(tmp_path)}):
+            result = _resolve_path("/usr/bin/python")
+            assert result == Path("/usr/bin/python").resolve()
+
+    def test_relative_path_uses_terminal_cwd(self, tmp_path):
+        target = tmp_path / "hello.txt"
+        target.touch()
+        with mock.patch.dict(os.environ, {"TERMINAL_CWD": str(tmp_path)}):
+            result = _resolve_path("hello.txt")
+            assert result == target.resolve()
+
+    def test_relative_path_falls_back_to_cwd_without_terminal_cwd(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("TERMINAL_CWD", None)
+            result = _resolve_path("somefile.txt")
+            assert result == (Path.cwd() / "somefile.txt").resolve()
+
+    def test_tilde_expansion(self, tmp_path):
+        with mock.patch.dict(os.environ, {"TERMINAL_CWD": str(tmp_path)}):
+            result = _resolve_path("~/test.txt")
+            assert str(result).startswith(str(Path.home()))
+
+    def test_empty_terminal_cwd_ignored(self):
+        with mock.patch.dict(os.environ, {"TERMINAL_CWD": "  "}):
+            result = _resolve_path("file.txt")
+            assert result == (Path.cwd() / "file.txt").resolve()
+
+
+class TestFileOperationsExpandPath:
+    """Test that ShellFileOperations._expand_path honours TERMINAL_CWD."""
+
+    def test_relative_path_resolved_via_terminal_cwd(self, tmp_path):
+        from tools.file_operations import ShellFileOperations
+
+        ops = ShellFileOperations.__new__(ShellFileOperations)
+        # Minimal stub so _expand_path works without a real terminal
+        with mock.patch.dict(os.environ, {"TERMINAL_CWD": str(tmp_path)}):
+            result = ops._expand_path("subdir/file.py")
+            assert result == os.path.join(str(tmp_path), "subdir/file.py")
+
+    def test_absolute_path_unchanged(self, tmp_path):
+        from tools.file_operations import ShellFileOperations
+
+        ops = ShellFileOperations.__new__(ShellFileOperations)
+        with mock.patch.dict(os.environ, {"TERMINAL_CWD": str(tmp_path)}):
+            result = ops._expand_path("/absolute/path.py")
+            assert result == "/absolute/path.py"

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -470,6 +470,14 @@ class ShellFileOperations(FileOperations):
                         suffix = path[1 + len(username):]  # e.g. "/rest/of/path"
                         return user_home + suffix
         
+        # Resolve relative paths against TERMINAL_CWD when set.
+        # In worktree (-w) mode, TERMINAL_CWD points to the worktree
+        # while the process cwd is the main repository.
+        if not os.path.isabs(path):
+            terminal_cwd = os.environ.get("TERMINAL_CWD", "").strip()
+            if terminal_cwd:
+                return os.path.join(terminal_cwd, path)
+
         return path
     
     def _escape_shell_arg(self, arg: str) -> str:

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -14,6 +14,26 @@ from agent.redact import redact_sensitive_text
 logger = logging.getLogger(__name__)
 
 
+def _resolve_path(path: str) -> Path:
+    """Resolve *path* relative to ``TERMINAL_CWD`` when set.
+
+    In worktree (``-w``) mode the ``TERMINAL_CWD`` environment variable
+    points to the worktree directory while ``os.getcwd()`` still refers
+    to the main repository.  File tools must honour ``TERMINAL_CWD`` so
+    that relative paths are resolved against the correct root.
+
+    Falls back to the normal ``Path.resolve()`` behaviour (i.e. relative
+    to ``os.getcwd()``) when the variable is unset or empty.
+    """
+    p = Path(path).expanduser()
+    if p.is_absolute():
+        return p.resolve()
+    terminal_cwd = os.environ.get("TERMINAL_CWD", "").strip()
+    if terminal_cwd:
+        return (Path(terminal_cwd) / p).resolve()
+    return p.resolve()
+
+
 _EXPECTED_WRITE_ERRNOS = {errno.EACCES, errno.EPERM, errno.EROFS}
 
 # ---------------------------------------------------------------------------
@@ -345,7 +365,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                 ),
             })
 
-        _resolved = Path(path).expanduser().resolve()
+        _resolved = _resolve_path(path)
 
         # ── Binary file guard ─────────────────────────────────────────
         # Block binary files by extension (no I/O).
@@ -553,7 +573,7 @@ def _update_read_timestamp(filepath: str, task_id: str) -> None:
     refreshes the stored timestamp to match the file's new state.
     """
     try:
-        resolved = str(Path(filepath).expanduser().resolve())
+        resolved = str(_resolve_path(filepath))
         current_mtime = os.path.getmtime(resolved)
     except (OSError, ValueError):
         return
@@ -572,7 +592,7 @@ def _check_file_staleness(filepath: str, task_id: str) -> str | None:
     or was never read.  Does not block — the write still proceeds.
     """
     try:
-        resolved = str(Path(filepath).expanduser().resolve())
+        resolved = str(_resolve_path(filepath))
     except (OSError, ValueError):
         return None
     with _read_tracker_lock:


### PR DESCRIPTION
## Summary

Fixes #12689 — file tools (, , ) resolve relative paths using `os.getcwd()` / `Path.resolve()`, which in worktree (`-w`) mode points to the main repository instead of the worktree directory set by `TERMINAL_CWD`.

## Changes

- **`tools/file_tools.py`**: Add `_resolve_path(path)` helper that resolves relative paths against `TERMINAL_CWD` when set, falling back to `os.getcwd()`. Replace all `Path(path).expanduser().resolve()` calls with it.
- **`tools/file_operations.py`**: Update `ShellFileOperations._expand_path()` to join relative paths with `TERMINAL_CWD` before returning.
- **`tests/tools/test_file_tools_terminal_cwd.py`**: 7 unit tests covering both layers (absolute paths, relative paths with/without `TERMINAL_CWD`, tilde expansion, empty/whitespace env var).

## Behavior

| Scenario | Before | After |
|---|---|---|
| Relative path, `TERMINAL_CWD` set | Resolves against main repo cwd | Resolves against `TERMINAL_CWD` |
| Relative path, `TERMINAL_CWD` unset | Resolves against cwd | Resolves against cwd (unchanged) |
| Absolute path | No change | No change |

All 7 new tests pass. Existing test suite unaffected.