### PR TITLE
fix(tools): keep default-off toolsets disabled

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -546,6 +546,10 @@ def _get_platform_tools(
             ts_tools = set(resolve_toolset(ts_key))
             if ts_tools and ts_tools.issubset(all_tool_names):
                 enabled_toolsets.add(ts_key)
+        default_off = set(_DEFAULT_OFF_TOOLSETS)
+        if platform in default_off:
+            default_off.remove(platform)
+        enabled_toolsets -= default_off
 
     # Plugin toolsets: enabled by default unless explicitly disabled.
     # A plugin toolset is "known" for a platform once `hermes tools`

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -3,6 +3,8 @@
 from unittest.mock import patch
 
 from hermes_cli.tools_config import (
+    _DEFAULT_OFF_TOOLSETS,
+    _apply_toolset_change,
     _configure_provider,
     _get_platform_tools,
     _platform_toolset_summary,
@@ -21,6 +23,7 @@ def test_get_platform_tools_uses_default_when_platform_not_configured():
     enabled = _get_platform_tools(config, "cli")
 
     assert enabled
+    assert enabled.isdisjoint(_DEFAULT_OFF_TOOLSETS)
 
 
 def test_configurable_toolsets_include_messaging():
@@ -32,12 +35,44 @@ def test_get_platform_tools_default_telegram_includes_messaging():
     assert "messaging" in enabled
 
 
+def test_get_platform_tools_homeassistant_platform_keeps_homeassistant_toolset():
+    enabled = _get_platform_tools({}, "homeassistant")
+
+    assert "homeassistant" in enabled
+
+
 def test_get_platform_tools_preserves_explicit_empty_selection():
     config = {"platform_toolsets": {"cli": []}}
 
     enabled = _get_platform_tools(config, "cli")
 
     assert enabled == set()
+
+
+def test_apply_toolset_change_from_default_does_not_enable_default_off_toolsets():
+    """Disabling one default toolset on a fresh config must not persist
+    default-off toolsets as explicitly enabled.
+    """
+    config = {}
+
+    with patch("hermes_cli.tools_config.save_config"):
+        _apply_toolset_change(config, "cli", ["memory"], "disable")
+
+    saved = set(config["platform_toolsets"]["cli"])
+    assert "memory" not in saved
+    assert "terminal" in saved
+    assert saved.isdisjoint(_DEFAULT_OFF_TOOLSETS)
+
+
+def test_apply_toolset_change_can_enable_default_off_toolset_from_default():
+    config = {}
+
+    with patch("hermes_cli.tools_config.save_config"):
+        _apply_toolset_change(config, "cli", ["homeassistant"], "enable")
+
+    saved = set(config["platform_toolsets"]["cli"])
+    assert "homeassistant" in saved
+    assert "terminal" in saved
 
 
 def test_get_platform_tools_handles_null_platform_toolsets():


### PR DESCRIPTION
## What does this PR do?

Keeps default-off toolsets out of a fresh CLI platform config when a user disables an unrelated default toolset.

This fixes a fresh-config edge case in `hermes tools disable memory --platform cli`: Hermes starts from the composite `hermes-cli` default, reverse-maps it to configurable toolsets, and could persist default-off integrations such as `homeassistant` as explicitly enabled even though the user only disabled `memory`.

The fix keeps default-off toolsets out of inferred defaults while preserving platform-owned defaults, so the `homeassistant` platform still receives the `homeassistant` toolset by default.

## Related Issue

Fixes #2761.

This targets the remaining fresh-config default-off toolset edge case called out in the issue comments. The original core `memory` deselection behavior was already fixed upstream, but the issue remains open and the documented edge case still allowed `hermes tools disable memory --platform cli` to persist default-off toolsets such as `homeassistant`, `moa`, and `rl` on a clean config.

## Duplicate Check

I searched existing upstream PRs for the exact code path and issue terms before opening this:

- `DEFAULT_OFF_TOOLSETS`
- `default-off toolsets`
- `disable memory`
- `homeassistant` + `platform_toolsets`

I did not find an open PR that fixes this specific fresh-config default-off resolver behavior. The closest related PRs are about different surfaces, such as memory runtime gating, doctor/tool availability reporting, plugin toolsets, MCP toolset resolution, or Home Assistant gateway/tool behavior.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Updated `hermes_cli/tools_config.py` so inferred default toolsets exclude `_DEFAULT_OFF_TOOLSETS` when resolving a platform with no explicit `platform_toolsets` entry yet.
- Preserved the current platform's own default-off toolset when the platform name itself is default-off, so `homeassistant` still gets the `homeassistant` toolset by default.
- Added regression coverage in `tests/hermes_cli/test_tools_config.py` for:
  - CLI defaults not including default-off toolsets
  - Home Assistant platform defaults still including `homeassistant`
  - `hermes tools disable memory --platform cli` not persisting default-off toolsets on a fresh config
  - explicit `hermes tools enable homeassistant --platform cli` still working from a fresh config

## How to Test

1. Run the focused regression set:

   ```bash
   scripts/run_tests.sh tests/hermes_cli/test_tools_config.py \
     tests/gateway/test_reasoning_command.py::TestReasoningCommand::test_run_agent_homeassistant_uses_default_platform_toolset \
     -q
   ```

2. Confirm the targeted suite passes.

3. From a fresh `HERMES_HOME`, run:

   ```bash
   hermes tools disable memory --platform cli
   hermes tools list --platform cli
   ```

4. Confirm `memory` is disabled and default-off toolsets such as `homeassistant`, `moa`, and `rl` remain disabled instead of being saved as explicit CLI toolsets.

5. From another fresh `HERMES_HOME`, run:

   ```bash
   hermes tools enable homeassistant --platform cli
   hermes tools list --platform cli
   ```

6. Confirm explicit Home Assistant opt-in still enables and persists `homeassistant`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 22.04.4 LTS under WSL2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

Targeted test run through the documented wrapper:

```text
36 passed in 6.11s
```

Additional focused run:

```bash
.venv/bin/python -m pytest tests/hermes_cli/test_tools_config.py tests/gateway/test_reasoning_command.py -q -n 0
```

```text
42 passed in 16.41s
```

Manual runtime checks:

- `hermes tools disable memory --platform cli` on a fresh config kept `homeassistant`, `moa`, and `rl` disabled and did not save them under `platform_toolsets.cli`.
- `hermes tools enable homeassistant --platform cli` on a fresh config still explicitly enabled and saved `homeassistant`.

Full suite with the documented wrapper:

```bash
scripts/run_tests.sh -q
```

```text
17 failed, 13314 passed, 36 skipped, 177 warnings in 3239.63s (0:53:59)
```

The full-suite failures are outside this patch's touched files and do not reproduce in the focused tool configuration tests. They include existing unrelated failures around Discord voice test setup, cron runtime provider configuration, Qwen OAuth provider resolution, update-check timing, gateway agent cache timeout, toolset consistency drift, streaming/provider setup, Discord tool allowlist behavior, and interrupt cleanup.
