### PR TITLE
feat(memory): claude-mem memory provider plugin

### DIFF
--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -297,8 +297,18 @@ class _ProviderCollector:
     def register_tool(self, *args, **kwargs):
         pass
 
-    def register_hook(self, *args, **kwargs):
-        pass
+    def register_hook(self, hook_name, callback):
+        # Forward to the real PluginManager so memory-provider plugins can
+        # register lifecycle hooks (post_tool_call, on_session_finalize, etc.)
+        # via the same register(ctx) entry-point they use for the provider itself.
+        try:
+            from hermes_cli.plugins import get_plugin_manager, VALID_HOOKS
+            if hook_name not in VALID_HOOKS:
+                return
+            pm = get_plugin_manager()
+            pm._hooks.setdefault(hook_name, []).append(callback)
+        except Exception as e:
+            logger.debug("register_hook forward failed for %s: %s", hook_name, e)
 
     def register_cli_command(self, *args, **kwargs):
         pass  # CLI registration happens via discover_plugin_cli_commands()

--- a/plugins/memory/claude-mem/README.md
+++ b/plugins/memory/claude-mem/README.md
@@ -1,0 +1,79 @@
+# claude-mem — automatic hook-driven memory for Hermes
+
+Cross-session memory backed by a local worker that captures observations automatically, indexes them with SQLite FTS5, and serves semantic recall via Chroma.
+
+## What it is
+
+Claude-mem runs as a local worker on `http://127.0.0.1:37777` and captures observations automatically (via hooks) as you work. It provides keyword search over SQLite FTS5 and semantic search over Chroma embeddings. Because the same worker is shared with Claude Code sessions, memory follows you across tools — what you did in a Hermes session is recallable from Claude Code and vice versa.
+
+## Prerequisites
+
+Install the worker globally and start it:
+
+```bash
+npm install -g @thedotmack/claude-mem
+claude-mem worker start
+```
+
+Verify it's running:
+
+```bash
+curl http://127.0.0.1:37777/health
+# {"status":"ok",...}
+```
+
+## Setup
+
+```bash
+hermes memory setup    # select "claude-mem" and accept the defaults
+```
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `claude_mem_recall(query, limit?, obs_type?)` | Search past observations, decisions, and session summaries. |
+| `claude_mem_save(text, title?)` | Store a durable fact the user explicitly wants remembered. |
+| `claude_mem_timeline(anchor_id, depth_before?, depth_after?)` | Pull context around a specific observation. |
+
+Most capture is automatic via lifecycle hooks — `claude_mem_save` is for the rare case where the user asks you to remember something that tool use alone wouldn't have captured.
+
+## Lifecycle integration
+
+The provider wires into the standard `MemoryProvider` lifecycle:
+
+- `initialize` — registers the Hermes session with the worker.
+- `sync_turn` — posts each user/assistant turn as an observation.
+- `prefetch` / `queue_prefetch` — background semantic recall; results are injected into the next LLM prompt.
+- `on_pre_compress` — queues a session summary before compression.
+- `on_session_end` — marks the session complete so the worker can finalize it.
+
+All writes run on daemon threads. The main loop never blocks on the worker.
+
+## Configuration
+
+Config file: `$HERMES_HOME/claude-mem.json`
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `base_url` | `http://127.0.0.1:37777` | Worker URL. |
+| `default_project` | `""` | Project name for scoping. Auto-detected from `agent_workspace` if empty. |
+
+Environment overrides:
+
+- `CLAUDE_MEM_WORKER_URL` — overrides `base_url`.
+- `CLAUDE_MEM_DEFAULT_PROJECT` — overrides `default_project`.
+
+## Troubleshooting
+
+**Worker not running?** Check health:
+
+```bash
+curl http://127.0.0.1:37777/health
+```
+
+Should return `{"status":"ok",...}`. If it doesn't, run `claude-mem worker start`.
+
+**Port conflict on 37777?** Start the worker on a different port (`CLAUDE_MEM_WORKER_PORT=NNNN claude-mem worker start`) and point the plugin at it via `base_url` in `$HERMES_HOME/claude-mem.json` or `CLAUDE_MEM_WORKER_URL`.
+
+**Short queries return nothing from semantic recall.** The worker's `/api/context/semantic` endpoint silently returns empty for queries under 20 characters. The plugin falls back to FTS5 keyword search via `/api/search` in that case — this is expected behavior, not a bug.

--- a/plugins/memory/claude-mem/__init__.py
+++ b/plugins/memory/claude-mem/__init__.py
@@ -33,6 +33,63 @@ def _load_config() -> dict:
     return cfg
 
 
+RECALL_SCHEMA = {
+    "name": "claude_mem_recall",
+    "description": (
+        "Search claude-mem's cross-session memory for past observations, decisions, "
+        "and session summaries relevant to the query. Returns a ranked list. "
+        "Use when the user references something from a past session, or when you need "
+        "to check whether a problem has been solved before."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Natural language search query."},
+            "limit": {"type": "integer", "default": 10, "minimum": 1, "maximum": 50},
+            "obs_type": {
+                "type": "string",
+                "description": "Filter by observation type: bugfix, feature, decision, discovery, change, refactor.",
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+SAVE_SCHEMA = {
+    "name": "claude_mem_save",
+    "description": (
+        "Manually save a durable fact or decision to claude-mem. Use sparingly — "
+        "claude-mem captures observations automatically from tool use. Only call this "
+        "when the user explicitly asks you to remember something that wasn't captured."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "text": {"type": "string", "description": "The fact or decision to store."},
+            "title": {"type": "string", "description": "Short title (optional)."},
+        },
+        "required": ["text"],
+    },
+}
+
+TIMELINE_SCHEMA = {
+    "name": "claude_mem_timeline",
+    "description": (
+        "Get context around a specific observation ID. Use after claude_mem_recall "
+        "to pull surrounding work (what led up to a decision, what came after)."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "anchor_id": {"type": "integer", "description": "Observation ID to anchor on."},
+            "depth_before": {"type": "integer", "default": 3},
+            "depth_after": {"type": "integer", "default": 3},
+        },
+        "required": ["anchor_id"],
+    },
+}
+
+
 class ClaudeMemMemoryProvider(MemoryProvider):
     @property
     def name(self) -> str:
@@ -197,8 +254,71 @@ class ClaudeMemMemoryProvider(MemoryProvider):
             "claude_mem_save(text) to store a durable fact."
         )
 
-    def get_tool_schemas(self):
-        return []  # filled in Phase 4
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return [RECALL_SCHEMA, SAVE_SCHEMA, TIMELINE_SCHEMA]
+
+    def handle_tool_call(self, tool_name: str, args: dict, **kwargs) -> str:
+        from .client import ClaudeMemUnavailable
+
+        try:
+            if tool_name == "claude_mem_recall":
+                res = self._client.search(
+                    query=args["query"],
+                    project=self._project,
+                    limit=min(int(args.get("limit", 10)), 50),
+                    obs_type=args.get("obs_type"),
+                    order_by="relevance",
+                )
+                return json.dumps({"results": res.get("observations", [])})
+
+            if tool_name == "claude_mem_save":
+                res = self._client.memory_save(
+                    text=args["text"],
+                    title=args.get("title"),
+                    project=self._project,
+                )
+                return json.dumps(res)
+
+            if tool_name == "claude_mem_timeline":
+                res = self._client.timeline(
+                    anchor=int(args["anchor_id"]),
+                    depth_before=int(args.get("depth_before", 3)),
+                    depth_after=int(args.get("depth_after", 3)),
+                    project=self._project,
+                )
+                return json.dumps(res)
+
+            return json.dumps({"error": f"unknown tool: {tool_name}"})
+
+        except ClaudeMemUnavailable as e:
+            return json.dumps({"error": "claude-mem worker unavailable", "detail": str(e)})
+        except Exception as e:
+            logger.exception("claude-mem tool call failed")
+            return json.dumps({"error": str(e)})
+
+    def get_config_schema(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "key": "base_url",
+                "description": "Claude-mem worker URL",
+                "default": _DEFAULT_BASE_URL,
+                "required": False,
+            },
+            {
+                "key": "default_project",
+                "description": "Default project name for scoping (auto-detected from cwd if empty)",
+                "default": "",
+                "required": False,
+            },
+        ]
+
+    def save_config(self, values: Dict[str, Any], hermes_home: str) -> None:
+        cfg_path = Path(hermes_home) / "claude-mem.json"
+        payload = {
+            "base_url": values.get("base_url") or _DEFAULT_BASE_URL,
+            "default_project": values.get("default_project") or "",
+        }
+        cfg_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
 
 
 def register(ctx) -> None:

--- a/plugins/memory/claude-mem/__init__.py
+++ b/plugins/memory/claude-mem/__init__.py
@@ -203,6 +203,8 @@ class ClaudeMemMemoryProvider(MemoryProvider):
         self._prefetch_thread.start()
 
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
+        if not self._session_id:
+            return
         if self._agent_context != "primary":
             return
 
@@ -240,6 +242,132 @@ class ClaudeMemMemoryProvider(MemoryProvider):
 
         threading.Thread(target=_bg, daemon=True, name="claude-mem-summarize").start()
         return ""  # we don't contribute to the compression prompt directly
+
+    # --- hermes plugin hooks ------------------------------------------------
+
+    def _on_post_tool_call(self, *, tool_name=None, args=None, result=None,
+                           task_id=None, **kwargs) -> None:
+        """Record every tool call as an observation (real-time capture)."""
+        if not getattr(self, "_client", None) or not getattr(self, "_session_id", None):
+            return
+        if self._agent_context != "primary":
+            return
+        # sync_turn already captures the user/assistant conversation pair;
+        # don't double-record it under the "conversation" tool name.
+        if tool_name == "conversation":
+            return
+
+        tool_input = args or {}
+        tool_response = {"result": str(result)[:4000] if result is not None else ""}
+        sid = self._session_id
+        platform_source = f"hermes-{self._platform}"
+        cwd = os.getcwd()
+
+        def _bg():
+            try:
+                self._client.post_observation(
+                    content_session_id=sid,
+                    tool_name=tool_name,
+                    tool_input=tool_input,
+                    tool_response=tool_response,
+                    cwd=cwd,
+                    platform_source=platform_source,
+                )
+            except Exception as e:
+                logger.debug("claude-mem post_tool_call failed: %s", e)
+
+        threading.Thread(
+            target=_bg, daemon=True, name="claude-mem-post-tool"
+        ).start()
+
+    def _on_post_llm_call(self, *, session_id=None, user_message=None,
+                          assistant_response=None, conversation_history=None,
+                          model=None, platform=None, **kwargs) -> None:
+        """Always-on per-turn summarize: sends the assistant response to the worker."""
+        if not getattr(self, "_client", None) or not getattr(self, "_session_id", None):
+            return
+        if self._agent_context != "primary":
+            return
+        if not assistant_response:
+            return
+
+        summary_text = assistant_response[:4000]
+        sid = self._session_id
+        platform_source = f"hermes-{self._platform}"
+
+        def _bg():
+            try:
+                self._client.post_summarize(
+                    content_session_id=sid,
+                    last_assistant_message=summary_text,
+                    platform_source=platform_source,
+                )
+            except Exception as e:
+                logger.debug("claude-mem post_llm_call summarize failed: %s", e)
+
+        threading.Thread(
+            target=_bg, daemon=True, name="claude-mem-post-llm"
+        ).start()
+
+    def _on_session_finalize(self, *, session_id=None, platform=None, **kwargs) -> None:
+        """Idempotent session completion; clears session id so on_session_end can't double-complete."""
+        if not getattr(self, "_client", None):
+            return
+        if self._agent_context != "primary":
+            return
+        sid = getattr(self, "_session_id", None)
+        if sid is None:
+            return
+
+        # Clear immediately so a subsequent on_session_end won't re-dispatch.
+        self._session_id = None
+        platform_source = f"hermes-{self._platform}"
+
+        def _bg():
+            try:
+                self._client.complete_session(
+                    content_session_id=sid,
+                    platform_source=platform_source,
+                )
+            except Exception as e:
+                logger.debug("claude-mem session_finalize failed: %s", e)
+
+        threading.Thread(
+            target=_bg, daemon=True, name="claude-mem-finalize"
+        ).start()
+
+    def _on_session_reset(self, *, session_id=None, platform=None, **kwargs) -> None:
+        """On reset: complete the OLD session in the background and clear per-session state."""
+        if not getattr(self, "_client", None):
+            return
+        if self._agent_context != "primary":
+            return
+
+        old_sid = getattr(self, "_session_id", None)
+        platform_source = f"hermes-{self._platform}"
+
+        # Clear per-session state so the next initialize() starts fresh.
+        # Do NOT clear _client itself.
+        self._session_id = None
+        if hasattr(self, "_prefetch_result"):
+            with self._prefetch_lock:
+                self._prefetch_result = ""
+
+        if old_sid is None:
+            return
+
+        def _bg():
+            try:
+                self._client.complete_session(
+                    content_session_id=old_sid,
+                    platform_source=platform_source,
+                )
+            except Exception as e:
+                logger.debug("claude-mem session_reset complete failed: %s", e)
+
+        threading.Thread(
+            target=_bg, daemon=True, name="claude-mem-reset"
+        ).start()
 
     def system_prompt_block(self) -> str:
         return (
@@ -319,4 +447,9 @@ class ClaudeMemMemoryProvider(MemoryProvider):
 
 def register(ctx) -> None:
     """Register claude-mem as a memory provider plugin."""
-    ctx.register_memory_provider(ClaudeMemMemoryProvider())
+    provider = ClaudeMemMemoryProvider()
+    ctx.register_memory_provider(provider)
+    ctx.register_hook("post_tool_call", provider._on_post_tool_call)
+    ctx.register_hook("post_llm_call", provider._on_post_llm_call)
+    ctx.register_hook("on_session_finalize", provider._on_session_finalize)
+    ctx.register_hook("on_session_reset", provider._on_session_reset)

--- a/plugins/memory/claude-mem/__init__.py
+++ b/plugins/memory/claude-mem/__init__.py
@@ -1,11 +1,36 @@
 """claude-mem memory provider for Hermes Agent."""
 from __future__ import annotations
 
+import json
 import logging
+import os
+import threading
+from pathlib import Path
+from typing import Any, Dict, List
 
 from agent.memory_provider import MemoryProvider
 
 logger = logging.getLogger(__name__)
+
+_DEFAULT_BASE_URL = "http://127.0.0.1:37777"
+
+
+def _load_config() -> dict:
+    """Load config from $HERMES_HOME/claude-mem.json with env-var overrides."""
+    from hermes_constants import get_hermes_home
+
+    cfg: dict = {
+        "base_url": os.environ.get("CLAUDE_MEM_WORKER_URL") or _DEFAULT_BASE_URL,
+        "default_project": os.environ.get("CLAUDE_MEM_DEFAULT_PROJECT", ""),
+    }
+    try:
+        cfg_path = Path(get_hermes_home()) / "claude-mem.json"
+        if cfg_path.exists():
+            file_cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+            cfg.update({k: v for k, v in file_cfg.items() if v})
+    except Exception:
+        pass
+    return cfg
 
 
 class ClaudeMemMemoryProvider(MemoryProvider):
@@ -14,10 +39,163 @@ class ClaudeMemMemoryProvider(MemoryProvider):
         return "claude-mem"
 
     def is_available(self) -> bool:
-        return False  # filled in Phase 3
+        # Dependency presence + config presence only; no network call.
+        try:
+            import requests  # noqa: F401
+        except ImportError:
+            return False
+        _load_config()  # must not raise
+        return True
 
     def initialize(self, session_id: str, **kwargs) -> None:
-        pass  # filled in Phase 3
+        from .client import ClaudeMemClient, ClaudeMemUnavailable
+
+        self._session_id = session_id                   # IS the contentSessionId
+        self._hermes_home = kwargs.get("hermes_home", "")
+        self._platform = kwargs.get("platform", "cli")
+        self._agent_context = kwargs.get("agent_context", "primary")
+        self._project = kwargs.get("agent_workspace") or _load_config()["default_project"] or "hermes"
+
+        self._cfg = _load_config()
+        self._client = ClaudeMemClient(base_url=self._cfg["base_url"])
+        self._prefetch_lock = threading.Lock()
+        self._prefetch_result = ""
+        self._prefetch_thread: threading.Thread | None = None
+        self._sync_thread: threading.Thread | None = None
+
+        # Skip session init for non-primary contexts (subagent/cron/flush).
+        # Intent per agent/memory_provider.py:73-76.
+        if self._agent_context != "primary" or self._platform == "cron":
+            logger.debug("claude-mem skipped init: agent_context=%s platform=%s",
+                         self._agent_context, self._platform)
+            return
+
+        def _init_bg():
+            try:
+                self._client.init_session(
+                    content_session_id=session_id,
+                    project=self._project,
+                    platform_source=f"hermes-{self._platform}",
+                )
+            except ClaudeMemUnavailable as e:
+                logger.warning("claude-mem worker unreachable at startup: %s", e)
+
+        threading.Thread(target=_init_bg, daemon=True, name="claude-mem-init").start()
+
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+        if self._agent_context != "primary":
+            return
+        sid = session_id or self._session_id
+
+        def _bg():
+            try:
+                self._client.post_observation(
+                    content_session_id=sid,
+                    tool_name="conversation",
+                    tool_input={"user": user_content},
+                    tool_response={"assistant": assistant_content},
+                    cwd=os.getcwd(),
+                    platform_source=f"hermes-{self._platform}",
+                )
+            except Exception as e:
+                logger.debug("claude-mem sync_turn failed: %s", e)
+
+        if self._sync_thread and self._sync_thread.is_alive():
+            self._sync_thread.join(timeout=5.0)
+        self._sync_thread = threading.Thread(target=_bg, daemon=True, name="claude-mem-sync")
+        self._sync_thread.start()
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        if self._prefetch_thread and self._prefetch_thread.is_alive():
+            self._prefetch_thread.join(timeout=3.0)
+        with self._prefetch_lock:
+            result = self._prefetch_result
+            self._prefetch_result = ""
+        # MemoryManager wraps this in <memory-context> automatically
+        # (agent/memory_manager.py:65-80), so return raw markdown.
+        return result
+
+    def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
+        if self._agent_context != "primary":
+            return
+
+        def _bg():
+            try:
+                # Semantic endpoint requires >= 20 chars; fall back to /api/search.
+                if query and len(query) >= 20:
+                    res = self._client.context_semantic(
+                        q=query, project=self._project, limit=5,
+                    )
+                    ctx = res.get("context", "")
+                else:
+                    res = self._client.search(
+                        query=query, project=self._project,
+                        limit=5, order_by="relevance",
+                    )
+                    lines = []
+                    for obs in (res.get("observations") or [])[:5]:
+                        title = obs.get("title") or "Observation"
+                        narrative = obs.get("narrative") or ""
+                        lines.append(f"- **{title}** — {narrative}")
+                    ctx = "\n".join(lines)
+
+                if ctx:
+                    with self._prefetch_lock:
+                        self._prefetch_result = f"## Claude-Mem Recall\n{ctx}"
+            except Exception as e:
+                logger.debug("claude-mem prefetch failed: %s", e)
+
+        self._prefetch_thread = threading.Thread(
+            target=_bg, daemon=True, name="claude-mem-prefetch"
+        )
+        self._prefetch_thread.start()
+
+    def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
+        if self._agent_context != "primary":
+            return
+
+        def _bg():
+            try:
+                self._client.complete_session(
+                    content_session_id=self._session_id,
+                    platform_source=f"hermes-{self._platform}",
+                )
+            except Exception as e:
+                logger.debug("claude-mem complete_session failed: %s", e)
+
+        threading.Thread(target=_bg, daemon=True, name="claude-mem-end").start()
+
+    def on_pre_compress(self, messages: List[Dict[str, Any]]) -> str:
+        if self._agent_context != "primary":
+            return ""
+
+        # Fire-and-forget summarize request; the worker queues it.
+        last_assistant = ""
+        for m in reversed(messages):
+            if m.get("role") == "assistant" and isinstance(m.get("content"), str):
+                last_assistant = m["content"][:4000]
+                break
+
+        def _bg():
+            try:
+                self._client.post_summarize(
+                    content_session_id=self._session_id,
+                    last_assistant_message=last_assistant,
+                    platform_source=f"hermes-{self._platform}",
+                )
+            except Exception as e:
+                logger.debug("claude-mem summarize failed: %s", e)
+
+        threading.Thread(target=_bg, daemon=True, name="claude-mem-summarize").start()
+        return ""  # we don't contribute to the compression prompt directly
+
+    def system_prompt_block(self) -> str:
+        return (
+            "# Claude-Mem Memory\n"
+            "Active. Persistent cross-session memory via local worker.\n"
+            "Use claude_mem_recall(query) to search past sessions and "
+            "claude_mem_save(text) to store a durable fact."
+        )
 
     def get_tool_schemas(self):
         return []  # filled in Phase 4

--- a/plugins/memory/claude-mem/__init__.py
+++ b/plugins/memory/claude-mem/__init__.py
@@ -189,12 +189,7 @@ class ClaudeMemMemoryProvider(MemoryProvider):
                         query=query, project=self._project,
                         limit=5, order_by="relevance",
                     )
-                    lines = []
-                    for obs in (res.get("observations") or [])[:5]:
-                        title = obs.get("title") or "Observation"
-                        narrative = obs.get("narrative") or ""
-                        lines.append(f"- **{title}** — {narrative}")
-                    ctx = "\n".join(lines)
+                    ctx = res.get("text", "")
 
                 if ctx:
                     with self._prefetch_lock:
@@ -269,7 +264,8 @@ class ClaudeMemMemoryProvider(MemoryProvider):
                     obs_type=args.get("obs_type"),
                     order_by="relevance",
                 )
-                return json.dumps({"results": res.get("observations", [])})
+                text = res.get("text", "")
+                return json.dumps({"results_markdown": text}) if text else json.dumps({"results_markdown": "No matching observations."})
 
             if tool_name == "claude_mem_save":
                 res = self._client.memory_save(
@@ -286,7 +282,7 @@ class ClaudeMemMemoryProvider(MemoryProvider):
                     depth_after=int(args.get("depth_after", 3)),
                     project=self._project,
                 )
-                return json.dumps(res)
+                return json.dumps({"timeline_markdown": res.get("text", "")})
 
             return json.dumps({"error": f"unknown tool: {tool_name}"})
 

--- a/plugins/memory/claude-mem/__init__.py
+++ b/plugins/memory/claude-mem/__init__.py
@@ -1,0 +1,28 @@
+"""claude-mem memory provider for Hermes Agent."""
+from __future__ import annotations
+
+import logging
+
+from agent.memory_provider import MemoryProvider
+
+logger = logging.getLogger(__name__)
+
+
+class ClaudeMemMemoryProvider(MemoryProvider):
+    @property
+    def name(self) -> str:
+        return "claude-mem"
+
+    def is_available(self) -> bool:
+        return False  # filled in Phase 3
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        pass  # filled in Phase 3
+
+    def get_tool_schemas(self):
+        return []  # filled in Phase 4
+
+
+def register(ctx) -> None:
+    """Register claude-mem as a memory provider plugin."""
+    ctx.register_memory_provider(ClaudeMemMemoryProvider())

--- a/plugins/memory/claude-mem/client.py
+++ b/plugins/memory/claude-mem/client.py
@@ -139,6 +139,20 @@ class ClaudeMemClient:
             )
         return data
 
+    @staticmethod
+    def _extract_mcp_text(payload: dict) -> str:
+        """Pull the rendered markdown out of an MCP `{content:[{type,text}]}` envelope.
+
+        Returns "" if the envelope is missing or malformed — never raises.
+        """
+        try:
+            content = payload.get("content") or []
+            if content and isinstance(content[0], dict):
+                return content[0].get("text") or ""
+        except Exception:
+            pass
+        return ""
+
     # ------------------------------------------------------------------
     # The nine endpoints
     # ------------------------------------------------------------------
@@ -251,8 +265,11 @@ class ClaudeMemClient:
     ) -> dict:
         """GET ``/api/search``.
 
-        Returns a dict like ``{"observations": [...], "total": N, ...}``.
-        Callers should NOT assume a flat list.
+        The worker returns an MCP envelope (``{"content":[{"type","text"}]}``)
+        whose ``text`` field is a rendered markdown block. This method
+        normalizes that shape into ``{"text": <markdown>, "raw": <envelope>}``
+        so callers work with the markdown directly and can still inspect
+        the original envelope when needed.
         """
         params: dict[str, Any] = {
             "query": query,
@@ -265,7 +282,8 @@ class ClaudeMemClient:
             "offset": offset,
             "orderBy": order_by,
         }
-        return self._get("/api/search", params=params, timeout=_READ_TIMEOUT)
+        raw = self._get("/api/search", params=params, timeout=_READ_TIMEOUT)
+        return {"text": self._extract_mcp_text(raw), "raw": raw}
 
     def timeline(
         self,
@@ -276,7 +294,14 @@ class ClaudeMemClient:
         depth_after: int = 3,
         project: str | None = None,
     ) -> dict:
-        """GET ``/api/timeline`` — observations around an anchor."""
+        """GET ``/api/timeline`` — observations around an anchor.
+
+        The worker returns an MCP envelope (``{"content":[{"type","text"}]}``)
+        whose ``text`` field is a rendered markdown timeline. This method
+        normalizes that shape into ``{"text": <markdown>, "raw": <envelope>}``
+        so callers work with the markdown directly and can still inspect
+        the original envelope when needed.
+        """
         params: dict[str, Any] = {
             "anchor": anchor,
             "query": query,
@@ -284,7 +309,8 @@ class ClaudeMemClient:
             "depth_after": depth_after,
             "project": project,
         }
-        return self._get("/api/timeline", params=params, timeout=_READ_TIMEOUT)
+        raw = self._get("/api/timeline", params=params, timeout=_READ_TIMEOUT)
+        return {"text": self._extract_mcp_text(raw), "raw": raw}
 
     def context_semantic(
         self,

--- a/plugins/memory/claude-mem/client.py
+++ b/plugins/memory/claude-mem/client.py
@@ -1,0 +1,329 @@
+"""HTTP client for the claude-mem local worker.
+
+Wraps the nine endpoints exposed by the claude-mem worker on
+``localhost:37777`` (see plan §0.C). Transport only — no caching,
+retries, or backoff. Callers in ``__init__.py`` are responsible for
+threading and fallback logic (e.g. using ``/api/search`` when a
+semantic query is too short).
+
+Error model:
+    * :class:`ClaudeMemError`       — HTTP / worker-side errors.
+    * :class:`ClaudeMemUnavailable` — worker unreachable (subclass of
+      :class:`ClaudeMemError`).
+
+Every method (except ``health()``) catches ``requests.RequestException``
+and re-raises as :class:`ClaudeMemUnavailable`. ``health()`` swallows
+all exceptions and returns ``False`` so callers can use it as a cheap
+probe.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class ClaudeMemError(Exception):
+    """Raised for HTTP or worker-side errors."""
+
+
+class ClaudeMemUnavailable(ClaudeMemError):
+    """Raised when the worker is unreachable or unhealthy."""
+
+
+# ---------------------------------------------------------------------------
+# Timeouts (seconds)
+# ---------------------------------------------------------------------------
+
+_HEALTH_TIMEOUT = 2.0
+_READ_TIMEOUT = 5.0
+_WRITE_TIMEOUT = 10.0
+
+
+# ---------------------------------------------------------------------------
+# Client
+# ---------------------------------------------------------------------------
+
+
+class ClaudeMemClient:
+    """Typed, timeout-safe HTTP client for the claude-mem worker."""
+
+    def __init__(
+        self,
+        base_url: str = "http://127.0.0.1:37777",
+        timeout: float = 5.0,
+    ) -> None:
+        # Strip trailing slash so we can always concatenate with a leading-slash path.
+        self._base_url = base_url.rstrip("/")
+        self._timeout = float(timeout)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _url(self, path: str) -> str:
+        return f"{self._base_url}{path}"
+
+    def _get(self, path: str, *, params: dict[str, Any] | None = None, timeout: float | None = None) -> dict:
+        """GET a worker endpoint and return the decoded JSON body.
+
+        Filters ``None`` values out of ``params`` so optional query args
+        don't end up as the literal string "None".
+        """
+        import requests  # lazy import — is_available() must not trigger HTTP
+
+        clean_params = None
+        if params is not None:
+            clean_params = {k: v for k, v in params.items() if v is not None}
+
+        try:
+            resp = requests.get(
+                self._url(path),
+                params=clean_params,
+                timeout=timeout if timeout is not None else self._timeout,
+            )
+        except requests.RequestException as e:
+            raise ClaudeMemUnavailable(f"claude-mem worker unreachable: {e}") from e
+
+        return self._decode(resp, path)
+
+    def _post(self, path: str, *, json_body: dict[str, Any] | None = None, timeout: float | None = None) -> dict:
+        """POST a JSON body to a worker endpoint and return the decoded JSON body."""
+        import requests  # lazy import
+
+        clean_body = None
+        if json_body is not None:
+            clean_body = {k: v for k, v in json_body.items() if v is not None}
+
+        try:
+            resp = requests.post(
+                self._url(path),
+                json=clean_body,
+                timeout=timeout if timeout is not None else self._timeout,
+            )
+        except requests.RequestException as e:
+            raise ClaudeMemUnavailable(f"claude-mem worker unreachable: {e}") from e
+
+        return self._decode(resp, path)
+
+    @staticmethod
+    def _decode(resp, path: str) -> dict:
+        """Validate an HTTP response and return a decoded dict body."""
+        if resp.status_code >= 500:
+            raise ClaudeMemError(
+                f"claude-mem worker error on {path}: "
+                f"HTTP {resp.status_code} {resp.text[:200]!r}"
+            )
+        if resp.status_code >= 400:
+            raise ClaudeMemError(
+                f"claude-mem request to {path} failed: "
+                f"HTTP {resp.status_code} {resp.text[:200]!r}"
+            )
+        try:
+            data = resp.json()
+        except ValueError as e:
+            raise ClaudeMemError(
+                f"claude-mem {path} returned non-JSON body: {resp.text[:200]!r}"
+            ) from e
+
+        if not isinstance(data, dict):
+            raise ClaudeMemError(
+                f"claude-mem {path} returned non-object JSON: {type(data).__name__}"
+            )
+        return data
+
+    # ------------------------------------------------------------------
+    # The nine endpoints
+    # ------------------------------------------------------------------
+
+    def health(self) -> bool:
+        """GET ``/health``. Never raises — returns ``False`` on any error."""
+        try:
+            import requests  # lazy import
+            resp = requests.get(self._url("/health"), timeout=_HEALTH_TIMEOUT)
+            if resp.status_code != 200:
+                return False
+            try:
+                data = resp.json()
+            except ValueError:
+                return False
+            return isinstance(data, dict) and data.get("status") == "ok"
+        except Exception:
+            # Swallow everything — health() is a probe, not an assertion.
+            return False
+
+    def init_session(
+        self,
+        content_session_id: str,
+        *,
+        project: str | None = None,
+        prompt: str | None = None,
+        platform_source: str = "hermes",
+        custom_title: str | None = None,
+    ) -> dict:
+        """POST ``/api/sessions/init``.
+
+        Returns ``{sessionDbId, promptNumber, skipped, reason?, contextInjected}``.
+        """
+        body: dict[str, Any] = {
+            "contentSessionId": content_session_id,
+            "project": project,
+            "prompt": prompt,
+            "platformSource": platform_source,
+            "customTitle": custom_title,
+        }
+        return self._post("/api/sessions/init", json_body=body, timeout=_WRITE_TIMEOUT)
+
+    def post_observation(
+        self,
+        content_session_id: str,
+        *,
+        tool_name: str,
+        tool_input: dict,
+        tool_response: dict,
+        cwd: str,
+        platform_source: str = "hermes",
+    ) -> dict:
+        """POST ``/api/sessions/observations`` — queue a tool-use observation."""
+        body: dict[str, Any] = {
+            "contentSessionId": content_session_id,
+            "tool_name": tool_name,
+            "tool_input": tool_input,
+            "tool_response": tool_response,
+            "cwd": cwd,
+            "platformSource": platform_source,
+        }
+        return self._post(
+            "/api/sessions/observations", json_body=body, timeout=_WRITE_TIMEOUT
+        )
+
+    def post_summarize(
+        self,
+        content_session_id: str,
+        *,
+        last_assistant_message: str,
+        platform_source: str = "hermes",
+    ) -> dict:
+        """POST ``/api/sessions/summarize`` — queue a session summary."""
+        body: dict[str, Any] = {
+            "contentSessionId": content_session_id,
+            "last_assistant_message": last_assistant_message,
+            "platformSource": platform_source,
+        }
+        return self._post(
+            "/api/sessions/summarize", json_body=body, timeout=_WRITE_TIMEOUT
+        )
+
+    def complete_session(
+        self,
+        content_session_id: str,
+        *,
+        platform_source: str = "hermes",
+    ) -> dict:
+        """POST ``/api/sessions/complete`` — mark a session complete."""
+        body: dict[str, Any] = {
+            "contentSessionId": content_session_id,
+            "platformSource": platform_source,
+        }
+        return self._post(
+            "/api/sessions/complete", json_body=body, timeout=_WRITE_TIMEOUT
+        )
+
+    def search(
+        self,
+        query: str,
+        *,
+        project: str | None = None,
+        type: str | None = None,  # one of: observations|sessions|prompts|all  # noqa: A002
+        limit: int = 20,
+        obs_type: str | None = None,
+        date_start: str | None = None,
+        date_end: str | None = None,
+        offset: int = 0,
+        order_by: str = "date_desc",
+    ) -> dict:
+        """GET ``/api/search``.
+
+        Returns a dict like ``{"observations": [...], "total": N, ...}``.
+        Callers should NOT assume a flat list.
+        """
+        params: dict[str, Any] = {
+            "query": query,
+            "project": project,
+            "type": type,
+            "limit": limit,
+            "obs_type": obs_type,
+            "dateStart": date_start,
+            "dateEnd": date_end,
+            "offset": offset,
+            "orderBy": order_by,
+        }
+        return self._get("/api/search", params=params, timeout=_READ_TIMEOUT)
+
+    def timeline(
+        self,
+        *,
+        anchor: int | None = None,
+        query: str | None = None,
+        depth_before: int = 3,
+        depth_after: int = 3,
+        project: str | None = None,
+    ) -> dict:
+        """GET ``/api/timeline`` — observations around an anchor."""
+        params: dict[str, Any] = {
+            "anchor": anchor,
+            "query": query,
+            "depth_before": depth_before,
+            "depth_after": depth_after,
+            "project": project,
+        }
+        return self._get("/api/timeline", params=params, timeout=_READ_TIMEOUT)
+
+    def context_semantic(
+        self,
+        q: str,
+        *,
+        project: str | None = None,
+        limit: int = 5,  # server default is 5, clamped to [1, 20]
+    ) -> dict:
+        """POST ``/api/context/semantic``.
+
+        Returns ``{context: str, count: int}``.
+
+        Note: the worker silently returns an empty result for queries
+        shorter than 20 characters. This client does NOT enforce that
+        constraint — transport only. The provider layer is responsible
+        for falling back to :meth:`search` when appropriate.
+        """
+        body: dict[str, Any] = {
+            "q": q,
+            "project": project,
+            "limit": limit,
+        }
+        return self._post(
+            "/api/context/semantic", json_body=body, timeout=_WRITE_TIMEOUT
+        )
+
+    def memory_save(
+        self,
+        text: str,
+        *,
+        title: str | None = None,
+        project: str | None = None,
+    ) -> dict:
+        """POST ``/api/memory/save`` — manually save a durable fact."""
+        body: dict[str, Any] = {
+            "text": text,
+            "title": title,
+            "project": project,
+        }
+        return self._post(
+            "/api/memory/save", json_body=body, timeout=_WRITE_TIMEOUT
+        )

--- a/plugins/memory/claude-mem/plugin.yaml
+++ b/plugins/memory/claude-mem/plugin.yaml
@@ -1,0 +1,12 @@
+name: claude-mem
+version: 1.0.0
+description: "Claude-Mem — automatic hook-driven observation capture with SQLite FTS5 + Chroma semantic search, via a local worker on localhost:37777."
+pip_dependencies:
+  - requests
+external_dependencies:
+  - name: claude-mem-worker
+    install: "npm install -g @thedotmack/claude-mem && claude-mem worker start"
+    check: "curl -sf http://127.0.0.1:37777/health >/dev/null"
+hooks:
+  - on_session_end
+  - on_pre_compress

--- a/tests/plugins/memory/test_claude_mem_provider.py
+++ b/tests/plugins/memory/test_claude_mem_provider.py
@@ -288,6 +288,177 @@ def test_on_session_end_fires_complete(provider):
 
 
 # ---------------------------------------------------------------------------
+# Plugin hooks: _on_post_tool_call / _on_post_llm_call /
+# _on_session_finalize / _on_session_reset
+# ---------------------------------------------------------------------------
+
+
+def _wait_for_mock_call(mock_method, timeout: float = 1.0) -> bool:
+    """Poll until mock_method has been called, or timeout elapses.
+
+    Returns True if the mock was called within the timeout. Used instead of
+    a bare time.sleep because the hooks spawn daemon threads and we don't
+    have a handle to join.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if mock_method.called:
+            return True
+        time.sleep(0.01)
+    return mock_method.called
+
+
+def test_on_post_tool_call_records_observation(provider):
+    """post_tool_call hook fires post_observation with the expected kwargs."""
+    provider._on_post_tool_call(
+        tool_name="Read", args={"path": "/x"}, result="ok", task_id="t1"
+    )
+    assert _wait_for_mock_call(provider._client.post_observation)
+
+    call_kwargs = provider._client.post_observation.call_args.kwargs
+    assert call_kwargs["content_session_id"] == "test-content-session-abc"
+    assert call_kwargs["tool_name"] == "Read"
+    assert call_kwargs["tool_input"] == {"path": "/x"}
+    assert call_kwargs["tool_response"] == {"result": "ok"}
+    assert call_kwargs["platform_source"] == "hermes-cli"
+    assert isinstance(call_kwargs["cwd"], str)
+
+
+def test_on_post_tool_call_skips_conversation_tool(provider):
+    """tool_name=='conversation' is already captured by sync_turn — skip."""
+    provider._on_post_tool_call(
+        tool_name="conversation", args={}, result="", task_id="t1"
+    )
+    # Give any stray thread a chance to (incorrectly) fire.
+    time.sleep(0.05)
+    provider._client.post_observation.assert_not_called()
+
+
+def test_on_post_tool_call_skips_when_uninitialized(provider_cls):
+    """Without a _client or _session_id, the hook must be a no-op."""
+    # Case 1: _client is None (never initialized in primary context).
+    provider_cls._client = None
+    provider_cls._session_id = "sess-1"
+    provider_cls._platform = "cli"
+    provider_cls._agent_context = "primary"
+    # Should not raise even though _client is None.
+    provider_cls._on_post_tool_call(
+        tool_name="Read", args={}, result="ok", task_id="t1"
+    )
+
+    # Case 2: _client is a mock but _session_id is falsy.
+    mock_client = MagicMock()
+    provider_cls._client = mock_client
+    provider_cls._session_id = None
+    provider_cls._on_post_tool_call(
+        tool_name="Read", args={}, result="ok", task_id="t1"
+    )
+    time.sleep(0.05)
+    mock_client.post_observation.assert_not_called()
+
+
+def test_on_post_llm_call_sends_summarize(provider):
+    """post_llm_call hook fires post_summarize with assistant_response trimmed to 4000 chars."""
+    long_response = "A" * 5000
+    provider._on_post_llm_call(
+        session_id="s",
+        user_message="u",
+        assistant_response=long_response,
+    )
+    assert _wait_for_mock_call(provider._client.post_summarize)
+
+    call_kwargs = provider._client.post_summarize.call_args.kwargs
+    assert call_kwargs["content_session_id"] == "test-content-session-abc"
+    assert call_kwargs["platform_source"] == "hermes-cli"
+    assert len(call_kwargs["last_assistant_message"]) == 4000
+
+
+def test_on_post_llm_call_skips_when_empty_response(provider):
+    """Empty / None assistant_response must not fire post_summarize."""
+    provider._on_post_llm_call(
+        session_id="s", user_message="u", assistant_response=None
+    )
+    provider._on_post_llm_call(
+        session_id="s", user_message="u", assistant_response=""
+    )
+    time.sleep(0.05)
+    provider._client.post_summarize.assert_not_called()
+
+
+def test_on_session_finalize_completes_and_clears(provider):
+    """_on_session_finalize fires complete_session and clears _session_id synchronously."""
+    assert provider._session_id == "test-content-session-abc"
+    provider._on_session_finalize(session_id="test-content-session-abc", platform="cli")
+
+    # _session_id is cleared BEFORE the background thread is spawned, so this
+    # is observable synchronously.
+    assert provider._session_id is None
+
+    assert _wait_for_mock_call(provider._client.complete_session)
+    call_kwargs = provider._client.complete_session.call_args.kwargs
+    assert call_kwargs["content_session_id"] == "test-content-session-abc"
+    assert call_kwargs["platform_source"] == "hermes-cli"
+
+
+def test_on_session_finalize_then_on_session_end_does_not_double_complete(provider):
+    """finalize + on_session_end must result in EXACTLY ONE complete_session call."""
+    provider._on_session_finalize(session_id="test-content-session-abc", platform="cli")
+    # Now on_session_end would previously have fired again; the guard should stop it.
+    provider.on_session_end([])
+
+    # Give both hypothetical threads a chance.
+    time.sleep(0.15)
+    assert provider._client.complete_session.call_count == 1
+    call_kwargs = provider._client.complete_session.call_args.kwargs
+    assert call_kwargs["content_session_id"] == "test-content-session-abc"
+
+
+def test_on_session_reset_completes_old_and_clears_state(provider):
+    """_on_session_reset completes the OLD session and clears per-session state."""
+    provider._session_id = "old-sess"
+    with provider._prefetch_lock:
+        provider._prefetch_result = "prior context"
+
+    provider._on_session_reset(session_id="new-sess", platform="cli")
+
+    # State clears happen synchronously, before the bg thread spawns.
+    assert provider._session_id is None
+    assert provider._prefetch_result == ""
+
+    assert _wait_for_mock_call(provider._client.complete_session)
+    assert provider._client.complete_session.call_count == 1
+    call_kwargs = provider._client.complete_session.call_args.kwargs
+    assert call_kwargs["content_session_id"] == "old-sess"
+
+
+def test_on_session_reset_without_prior_session_is_noop(provider):
+    """Reset with no prior _session_id must not fire complete_session."""
+    provider._session_id = None
+    provider._on_session_reset(session_id="new-sess", platform="cli")
+    time.sleep(0.05)
+    provider._client.complete_session.assert_not_called()
+
+
+def test_hooks_skip_when_agent_context_not_primary(provider):
+    """All four new hooks must no-op when agent_context != 'primary'."""
+    provider._agent_context = "subagent"
+
+    provider._on_post_tool_call(
+        tool_name="Read", args={}, result="ok", task_id="t1"
+    )
+    provider._on_post_llm_call(
+        session_id="s", user_message="u", assistant_response="hi"
+    )
+    provider._on_session_finalize(session_id="test-content-session-abc", platform="cli")
+    provider._on_session_reset(session_id="new-sess", platform="cli")
+
+    time.sleep(0.1)
+    provider._client.post_observation.assert_not_called()
+    provider._client.post_summarize.assert_not_called()
+    provider._client.complete_session.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # JSON-string contract
 # ---------------------------------------------------------------------------
 

--- a/tests/plugins/memory/test_claude_mem_provider.py
+++ b/tests/plugins/memory/test_claude_mem_provider.py
@@ -1,0 +1,287 @@
+"""Tests for the claude-mem memory provider plugin.
+
+Covers is_available, initialize (primary/subagent/cron), prefetch (semantic
++ search fallback + worker-down path), tool dispatch (recall/save/timeline/
+unknown), non-blocking sync_turn, and on_session_end. All HTTP calls are
+mocked via ``provider._client = MagicMock()`` — no network traffic.
+"""
+import json
+import sys
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Ensure no stale claude-mem env vars leak between tests."""
+    for key in ("CLAUDE_MEM_WORKER_URL", "CLAUDE_MEM_DEFAULT_PROJECT"):
+        monkeypatch.delenv(key, raising=False)
+
+
+@pytest.fixture()
+def provider_cls(tmp_path, monkeypatch):
+    """Fresh ClaudeMemMemoryProvider instance loaded via the plugin loader."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from plugins.memory import load_memory_provider
+
+    p = load_memory_provider("claude-mem")
+    assert p is not None
+    return p
+
+
+@pytest.fixture()
+def client_module():
+    """The claude-mem client submodule (hyphenated; must be looked up via sys.modules)."""
+    # load_memory_provider triggers import of both parent and client submodule.
+    from plugins.memory import load_memory_provider
+
+    assert load_memory_provider("claude-mem") is not None
+    mod = sys.modules.get("plugins.memory.claude-mem.client")
+    assert mod is not None, "claude-mem client submodule was not registered"
+    return mod
+
+
+@pytest.fixture()
+def provider(provider_cls, tmp_path):
+    """Provider initialized in primary context with a mocked HTTP client."""
+    provider_cls.initialize(
+        session_id="test-content-session-abc",
+        hermes_home=str(tmp_path),
+        platform="cli",
+        agent_context="primary",
+        agent_workspace="test-project",
+    )
+    # Replace the real HTTP client with a mock so no network calls happen.
+    provider_cls._client = MagicMock()
+    # Drain the background init thread so subsequent assertions are stable.
+    time.sleep(0.2)
+    return provider_cls
+
+
+# ---------------------------------------------------------------------------
+# is_available
+# ---------------------------------------------------------------------------
+
+
+def test_is_available_true_when_requests_installed(provider_cls):
+    assert provider_cls.is_available() is True
+
+
+# ---------------------------------------------------------------------------
+# initialize
+# ---------------------------------------------------------------------------
+
+
+def test_initialize_primary_posts_init_async(provider_cls, client_module, tmp_path, monkeypatch):
+    """Primary context: init_session is called asynchronously via a daemon thread."""
+    fake_client = MagicMock()
+    # Patch the ClaudeMemClient constructor on the client submodule so that
+    # when initialize() does `from .client import ClaudeMemClient`, it picks
+    # up our mock factory.
+    monkeypatch.setattr(client_module, "ClaudeMemClient", lambda **kw: fake_client)
+
+    provider_cls.initialize(
+        session_id="sess-xyz",
+        hermes_home=str(tmp_path),
+        platform="cli",
+        agent_context="primary",
+        agent_workspace="my-proj",
+    )
+    # Allow the background init thread to run.
+    time.sleep(0.3)
+
+    fake_client.init_session.assert_called_once()
+    call_kwargs = fake_client.init_session.call_args.kwargs
+    assert call_kwargs["content_session_id"] == "sess-xyz"
+    assert call_kwargs["project"] == "my-proj"
+    assert call_kwargs["platform_source"] == "hermes-cli"
+
+
+def test_initialize_subagent_skips_init(provider_cls, client_module, tmp_path, monkeypatch):
+    """agent_context='subagent' must NOT fire init_session."""
+    fake_client = MagicMock()
+    monkeypatch.setattr(client_module, "ClaudeMemClient", lambda **kw: fake_client)
+
+    provider_cls.initialize(
+        session_id="sub-1",
+        hermes_home=str(tmp_path),
+        platform="cli",
+        agent_context="subagent",
+        agent_workspace="proj",
+    )
+    time.sleep(0.2)
+    fake_client.init_session.assert_not_called()
+
+
+def test_initialize_cron_skips_init(provider_cls, client_module, tmp_path, monkeypatch):
+    """platform='cron' must NOT fire init_session."""
+    fake_client = MagicMock()
+    monkeypatch.setattr(client_module, "ClaudeMemClient", lambda **kw: fake_client)
+
+    provider_cls.initialize(
+        session_id="cron-1",
+        hermes_home=str(tmp_path),
+        platform="cron",
+        agent_context="primary",
+        agent_workspace="proj",
+    )
+    time.sleep(0.2)
+    fake_client.init_session.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# prefetch / queue_prefetch
+# ---------------------------------------------------------------------------
+
+
+def test_prefetch_returns_cached_context(provider):
+    """Long (>=20 char) query routes through context_semantic; prefetch returns the cached markdown."""
+    provider._client.context_semantic.return_value = {
+        "context": "some markdown recall",
+        "count": 1,
+    }
+    provider.queue_prefetch("this is a query longer than twenty characters")
+    # prefetch() joins the background thread (up to 3s) and returns the cache.
+    result = provider.prefetch("this is a query longer than twenty characters")
+
+    provider._client.context_semantic.assert_called_once()
+    provider._client.search.assert_not_called()
+    assert "some markdown recall" in result
+
+
+def test_prefetch_short_query_uses_search_fallback(provider):
+    """Queries shorter than 20 chars should fall back to /api/search, not context_semantic."""
+    provider._client.search.return_value = {
+        "observations": [{"title": "t", "narrative": "n"}]
+    }
+    provider.queue_prefetch("short")  # 5 chars
+    # Drain the background worker.
+    if provider._prefetch_thread:
+        provider._prefetch_thread.join(timeout=3.0)
+
+    provider._client.search.assert_called_once()
+    provider._client.context_semantic.assert_not_called()
+
+
+def test_prefetch_returns_empty_on_worker_down(provider, client_module):
+    """If the worker raises ClaudeMemUnavailable, prefetch returns '' — no exception."""
+    unavailable_exc = client_module.ClaudeMemUnavailable
+    provider._client.context_semantic.side_effect = unavailable_exc("worker down")
+
+    provider.queue_prefetch("this query is definitely long enough to trigger semantic")
+    result = provider.prefetch("this query is definitely long enough to trigger semantic")
+
+    assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# handle_tool_call dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_recall_tool_routes_to_search(provider):
+    provider._client.search.return_value = {
+        "observations": [{"id": 1, "title": "x"}]
+    }
+    result_str = provider.handle_tool_call(
+        "claude_mem_recall", {"query": "test", "limit": 5}
+    )
+    assert isinstance(result_str, str)
+    result = json.loads(result_str)
+    assert result == {"results": [{"id": 1, "title": "x"}]}
+    provider._client.search.assert_called_once()
+
+
+def test_save_tool_routes_to_memory_save(provider):
+    provider._client.memory_save.return_value = {"ok": True, "id": 42}
+    result_str = provider.handle_tool_call(
+        "claude_mem_save", {"text": "remember this", "title": "note"}
+    )
+    assert isinstance(result_str, str)
+    assert json.loads(result_str) == {"ok": True, "id": 42}
+    provider._client.memory_save.assert_called_once()
+
+
+def test_timeline_tool_routes_to_timeline(provider):
+    provider._client.timeline.return_value = {"observations": [{"id": 7}]}
+    result_str = provider.handle_tool_call(
+        "claude_mem_timeline",
+        {"anchor_id": 7, "depth_before": 2, "depth_after": 2},
+    )
+    assert isinstance(result_str, str)
+    assert json.loads(result_str) == {"observations": [{"id": 7}]}
+    provider._client.timeline.assert_called_once()
+
+
+def test_unknown_tool_returns_json_error(provider):
+    result_str = provider.handle_tool_call("bogus", {})
+    assert isinstance(result_str, str)
+    assert json.loads(result_str) == {"error": "unknown tool: bogus"}
+
+
+# ---------------------------------------------------------------------------
+# sync_turn non-blocking contract
+# ---------------------------------------------------------------------------
+
+
+def test_sync_turn_is_non_blocking(provider):
+    """sync_turn must return in <100ms even if the underlying HTTP call is slow."""
+    def slow(*a, **kw):
+        time.sleep(1.0)
+
+    provider._client.post_observation.side_effect = slow
+
+    t0 = time.time()
+    provider.sync_turn("u", "a", session_id="test-content-session-abc")
+    elapsed = time.time() - t0
+    assert elapsed < 0.1, f"sync_turn must return in <100ms, took {elapsed:.3f}s"
+
+    # The background thread should eventually complete.
+    if provider._sync_thread:
+        provider._sync_thread.join(timeout=5.0)
+        assert not provider._sync_thread.is_alive()
+    provider._client.post_observation.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# on_session_end
+# ---------------------------------------------------------------------------
+
+
+def test_on_session_end_fires_complete(provider):
+    """on_session_end must fire a complete_session call exactly once."""
+    provider.on_session_end([])
+    # Background daemon thread fires-and-forgets; wait briefly.
+    time.sleep(0.2)
+    provider._client.complete_session.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# JSON-string contract
+# ---------------------------------------------------------------------------
+
+
+def test_handle_tool_call_returns_string(provider):
+    """Every tool call result must be a string (per MemoryProvider ABC)."""
+    provider._client.search.return_value = {"observations": []}
+    provider._client.memory_save.return_value = {}
+    provider._client.timeline.return_value = {}
+
+    calls = [
+        ("claude_mem_recall", {"query": "x"}),
+        ("claude_mem_save", {"text": "y"}),
+        ("claude_mem_timeline", {"anchor_id": 1}),
+        ("bogus", {}),
+    ]
+    for name, args in calls:
+        result = provider.handle_tool_call(name, args)
+        assert isinstance(result, str), f"{name} returned {type(result)}"
+        # And it must be valid JSON.
+        json.loads(result)

--- a/tests/plugins/memory/test_claude_mem_provider.py
+++ b/tests/plugins/memory/test_claude_mem_provider.py
@@ -158,8 +158,10 @@ def test_prefetch_returns_cached_context(provider):
 
 def test_prefetch_short_query_uses_search_fallback(provider):
     """Queries shorter than 20 chars should fall back to /api/search, not context_semantic."""
+    markdown = "- obs 1\n- obs 2"
     provider._client.search.return_value = {
-        "observations": [{"title": "t", "narrative": "n"}]
+        "text": markdown,
+        "raw": {"content": [{"type": "text", "text": markdown}]},
     }
     provider.queue_prefetch("short")  # 5 chars
     # Drain the background worker.
@@ -168,6 +170,10 @@ def test_prefetch_short_query_uses_search_fallback(provider):
 
     provider._client.search.assert_called_once()
     provider._client.context_semantic.assert_not_called()
+    # The prefetch worker wraps the markdown in "## Claude-Mem Recall\n...".
+    result = provider.prefetch("short")
+    assert "## Claude-Mem Recall" in result
+    assert markdown in result
 
 
 def test_prefetch_returns_empty_on_worker_down(provider, client_module):
@@ -187,16 +193,30 @@ def test_prefetch_returns_empty_on_worker_down(provider, client_module):
 
 
 def test_recall_tool_routes_to_search(provider):
+    markdown = "## Results\n- hit A\n- hit B"
     provider._client.search.return_value = {
-        "observations": [{"id": 1, "title": "x"}]
+        "text": markdown,
+        "raw": {"content": [{"type": "text", "text": markdown}]},
     }
     result_str = provider.handle_tool_call(
         "claude_mem_recall", {"query": "test", "limit": 5}
     )
     assert isinstance(result_str, str)
     result = json.loads(result_str)
-    assert result == {"results": [{"id": 1, "title": "x"}]}
+    assert result == {"results_markdown": markdown}
     provider._client.search.assert_called_once()
+
+
+def test_recall_tool_empty_text_returns_no_match_message(provider):
+    """When the worker returns no markdown, recall surfaces a human-friendly sentinel."""
+    provider._client.search.return_value = {
+        "text": "",
+        "raw": {"content": [{"type": "text", "text": ""}]},
+    }
+    result_str = provider.handle_tool_call(
+        "claude_mem_recall", {"query": "nothing matches", "limit": 5}
+    )
+    assert json.loads(result_str) == {"results_markdown": "No matching observations."}
 
 
 def test_save_tool_routes_to_memory_save(provider):
@@ -210,13 +230,17 @@ def test_save_tool_routes_to_memory_save(provider):
 
 
 def test_timeline_tool_routes_to_timeline(provider):
-    provider._client.timeline.return_value = {"observations": [{"id": 7}]}
+    markdown = "## Timeline around #7\n- #5 foo\n- #7 anchor\n- #9 bar"
+    provider._client.timeline.return_value = {
+        "text": markdown,
+        "raw": {"content": [{"type": "text", "text": markdown}]},
+    }
     result_str = provider.handle_tool_call(
         "claude_mem_timeline",
         {"anchor_id": 7, "depth_before": 2, "depth_after": 2},
     )
     assert isinstance(result_str, str)
-    assert json.loads(result_str) == {"observations": [{"id": 7}]}
+    assert json.loads(result_str) == {"timeline_markdown": markdown}
     provider._client.timeline.assert_called_once()
 
 
@@ -270,9 +294,15 @@ def test_on_session_end_fires_complete(provider):
 
 def test_handle_tool_call_returns_string(provider):
     """Every tool call result must be a string (per MemoryProvider ABC)."""
-    provider._client.search.return_value = {"observations": []}
+    provider._client.search.return_value = {
+        "text": "",
+        "raw": {"content": [{"type": "text", "text": ""}]},
+    }
     provider._client.memory_save.return_value = {}
-    provider._client.timeline.return_value = {}
+    provider._client.timeline.return_value = {
+        "text": "",
+        "raw": {"content": [{"type": "text", "text": ""}]},
+    }
 
     calls = [
         ("claude_mem_recall", {"query": "x"}),
@@ -285,3 +315,29 @@ def test_handle_tool_call_returns_string(provider):
         assert isinstance(result, str), f"{name} returned {type(result)}"
         # And it must be valid JSON.
         json.loads(result)
+
+
+# ---------------------------------------------------------------------------
+# _extract_mcp_text malformed-envelope handling
+# ---------------------------------------------------------------------------
+
+
+def test_extract_mcp_text_handles_malformed_envelopes(client_module):
+    """_extract_mcp_text must never raise on bad envelopes — it returns '' instead."""
+    ClaudeMemClient = client_module.ClaudeMemClient
+
+    # Missing content key.
+    assert ClaudeMemClient._extract_mcp_text({}) == ""
+    # Empty content list.
+    assert ClaudeMemClient._extract_mcp_text({"content": []}) == ""
+    # Non-dict element inside content.
+    assert ClaudeMemClient._extract_mcp_text({"content": ["not a dict"]}) == ""
+    # Dict element missing the text key.
+    assert ClaudeMemClient._extract_mcp_text({"content": [{"type": "text"}]}) == ""
+    # Happy path: text is extracted verbatim.
+    assert (
+        ClaudeMemClient._extract_mcp_text(
+            {"content": [{"type": "text", "text": "hi"}]}
+        )
+        == "hi"
+    )


### PR DESCRIPTION
![hermes × claude-mem handshake](https://raw.githubusercontent.com/thedotmack/hermes-agent/pr-assets/pr-12730/hermes-handshake.jpg)

## Summary

Adds claude-mem as a bundled memory provider plugin under `plugins/memory/claude-mem/`. Talks to the local claude-mem worker (default `http://127.0.0.1:37777`) for persistent cross-session memory — search, timeline, manual saves, per-turn summarize, and per-tool observations.

- HTTP client wrapping the 9 worker endpoints (`/health`, `/api/sessions/*`, `/api/search`, `/api/timeline`, `/api/context/semantic`, `/api/memory/save`) with timeouts and typed errors
- Provider implements the full `MemoryProvider` lifecycle (initialize, prefetch, sync_turn, on_session_end, on_pre_compress) plus three tools (`claude_mem_recall`, `claude_mem_save`, `claude_mem_timeline`)
- Lifecycle hooks wired through `register(ctx)`: `post_tool_call`, `post_llm_call`, `on_session_finalize`, `on_session_reset`
- `_ProviderCollector.register_hook` now forwards to the real `PluginManager` so memory-provider plugins can register lifecycle hooks from the same entry point as the provider itself
- MCP envelope (`{content:[{type,text}]}`) normalized in the client; tool handlers consume the `{text,raw}` shape

## Test plan

- [x] `tests/plugins/memory/test_claude_mem_provider.py` — 26 tests covering `is_available`, `initialize` (primary/subagent/cron), prefetch fallback, tool dispatch, non-blocking `sync_turn`, hooks, envelope extraction
- [x] `tests/hermes_cli/test_plugins.py`, `tests/cli/test_session_boundary_hooks.py`, `tests/agent/test_memory_provider.py` — 112 adjacent tests still green
- [ ] Smoke test against a running claude-mem worker (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)