### PR TITLE
fix(docker): run entrypoint as root so HERMES_UID/HERMES_GID remapping works

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,9 @@ RUN uv venv && \
     uv pip install --no-cache-dir -e ".[all]"
 
 # ---------- Runtime ----------
+# Switch back to root so the entrypoint can remap UID/GID via
+# usermod/groupmod, then drop privileges with gosu.
+USER root
 ENV HERMES_WEB_DIST=/opt/hermes/hermes_cli/web_dist
 ENV HERMES_HOME=/opt/data
 VOLUME [ "/opt/data" ]


### PR DESCRIPTION
Fixes #12696

The Dockerfile's final `USER hermes` directive meant the container always started as UID 10000, so the entrypoint's existing UID/GID remapping code (which requires root for `usermod`/`groupmod`) was always skipped.

**Fix:** Add `USER root` before the runtime section so the entrypoint runs as root, performs the UID/GID remapping if `HERMES_UID`/`HERMES_GID` are set, then drops privileges via `gosu hermes`.