### PR TITLE
fix(cli): prevent config migration from writing expanded secrets to disk

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3574,6 +3574,13 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
     """
     results = {"env_added": [], "config_added": [], "warnings": []}
 
+    # ── Pre-populate the expanded-config cache so that save_config()
+    # can restore ${VAR} templates even when migration steps use
+    # read_raw_config() instead of load_config().  Without this, the
+    # first migration save may write expanded secrets to disk.
+    # ──
+    load_config()
+
     # ── Always: sanitize .env (split concatenated keys) ──
     try:
         fixes = sanitize_env_file()
@@ -4524,7 +4531,7 @@ _FALLBACK_COMMENT = """
 #   minimax-cn   (MINIMAX_CN_API_KEY)  — MiniMax (China)
 #   bedrock      (AWS IAM / boto3)     — AWS Bedrock (Converse API)
 #
-# For custom OpenAI-compatible endpoints, add base_url and key_env.
+# For custom OpenAI-compatible endpoints, add base_url and api_key_env.
 #
 # fallback_model:
 #   provider: openrouter
@@ -4556,7 +4563,7 @@ _COMMENTED_SECTIONS = """
 #   minimax-cn   (MINIMAX_CN_API_KEY)  — MiniMax (China)
 #   bedrock      (AWS IAM / boto3)     — AWS Bedrock (Converse API)
 #
-# For custom OpenAI-compatible endpoints, add base_url and key_env.
+# For custom OpenAI-compatible endpoints, add base_url and api_key_env.
 #
 # fallback_model:
 #   provider: openrouter
@@ -4605,7 +4612,14 @@ def save_config(config: Dict[str, Any]):
             extra_content="".join(parts) if parts else None,
         )
         _secure_file(config_path)
-        _LAST_EXPANDED_CONFIG_BY_PATH[str(config_path)] = copy.deepcopy(current_normalized)
+        # Cache the expanded form so subsequent save_config() calls can
+        # restore ${VAR} templates even when the caller passes raw config
+        # (e.g. during migration).  Without this, the cache would contain
+        # raw templates and _preserve_env_ref_templates() would be unable
+        # to match expanded values back to their original templates. (#11864)
+        _LAST_EXPANDED_CONFIG_BY_PATH[str(config_path)] = copy.deepcopy(
+            _expand_env_vars(current_normalized)
+        )
 
 
 def load_env() -> Dict[str, str]:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2199,6 +2199,13 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
     """
     results = {"env_added": [], "config_added": [], "warnings": []}
 
+    # ── Pre-populate the expanded-config cache so that save_config()
+    # can restore ${VAR} templates even when migration steps use
+    # read_raw_config() instead of load_config().  Without this, the
+    # first migration save may write expanded secrets to disk.
+    # ──
+    load_config()
+
     # ── Always: sanitize .env (split concatenated keys) ──
     try:
         fixes = sanitize_env_file()
@@ -2861,7 +2868,7 @@ _FALLBACK_COMMENT = """
 #   minimax      (MINIMAX_API_KEY)     — MiniMax
 #   minimax-cn   (MINIMAX_CN_API_KEY)  — MiniMax (China)
 #
-# For custom OpenAI-compatible endpoints, add base_url and key_env.
+# For custom OpenAI-compatible endpoints, add base_url and api_key_env.
 #
 # fallback_model:
 #   provider: openrouter
@@ -2905,7 +2912,7 @@ _COMMENTED_SECTIONS = """
 #   minimax      (MINIMAX_API_KEY)     — MiniMax
 #   minimax-cn   (MINIMAX_CN_API_KEY)  — MiniMax (China)
 #
-# For custom OpenAI-compatible endpoints, add base_url and key_env.
+# For custom OpenAI-compatible endpoints, add base_url and api_key_env.
 #
 # fallback_model:
 #   provider: openrouter
@@ -2961,7 +2968,14 @@ def save_config(config: Dict[str, Any]):
         extra_content="".join(parts) if parts else None,
     )
     _secure_file(config_path)
-    _LAST_EXPANDED_CONFIG_BY_PATH[str(config_path)] = copy.deepcopy(current_normalized)
+    # Cache the expanded form so subsequent save_config() calls can
+    # restore ${VAR} templates even when the caller passes raw config
+    # (e.g. during migration).  Without this, the cache would contain
+    # raw templates and _preserve_env_ref_templates() would be unable
+    # to match expanded values back to their original templates.
+    _LAST_EXPANDED_CONFIG_BY_PATH[str(config_path)] = copy.deepcopy(
+        _expand_env_vars(normalized)
+    )
 
 
 def load_env() -> Dict[str, str]:

--- a/tests/hermes_cli/test_config_env_refs.py
+++ b/tests/hermes_cli/test_config_env_refs.py
@@ -167,3 +167,73 @@ def test_save_config_falls_back_to_positional_matching_for_duplicate_names(monke
     assert "api_key: ${SECOND_SECRET}" in saved
     assert "first-secret" not in saved
     assert "second-secret" not in saved
+
+
+def test_save_config_caches_expanded_form_not_raw_templates(monkeypatch, tmp_path):
+    """save_config() must cache the expanded form so subsequent saves still
+    restore ${VAR} templates, even when the first save got raw templates."""
+    from hermes_cli.config import load_config, save_config
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("SECRET_KEY", "super-secret-value")
+    _write_config(
+        tmp_path,
+        """\
+        _config_version: 19
+        model:
+          default: claude-opus-4-6
+        custom_providers:
+          - name: example
+            api_key: ${SECRET_KEY}
+        """,
+    )
+
+    # First load + save: populate cache with expanded value, restore template
+    config = load_config()
+    assert config["custom_providers"][0]["api_key"] == "super-secret-value"
+    save_config(config)
+    assert "api_key: ${SECRET_KEY}" in _read_config(tmp_path)
+
+    # Second save (no prior load): cache must hold expanded form so template
+    # is still recognised and restored, not replaced with plaintext
+    config2 = load_config()
+    config2["model"]["default"] = "gpt-4o"
+    save_config(config2)
+    saved = _read_config(tmp_path)
+    assert "api_key: ${SECRET_KEY}" in saved
+    assert "super-secret-value" not in saved
+
+
+def test_migrate_config_preserves_env_refs(monkeypatch, tmp_path):
+    """migrate_config() must call load_config() first so the expanded-form
+    cache is populated before any migration step calls save_config().
+    Without that, save_config() would cache raw templates and write
+    expanded plaintext secrets to disk on the first migration save."""
+    from hermes_cli.config import migrate_config
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("MIGRATION_SECRET", "migration-secret-value")
+    # Write a config at version 13 (below the latest 19) so migration runs.
+    # Version 13→14 migration adds a `toolsets` field; subsequent migrations
+    # up to 19 touch other fields but all call save_config() internally.
+    _write_config(
+        tmp_path,
+        """\
+        _config_version: 13
+        model:
+          default: claude-opus-4-6
+        custom_providers:
+          - name: old-provider
+            base_url: https://api.example.com
+            api_key: ${MIGRATION_SECRET}
+        """,
+    )
+
+    results = migrate_config(interactive=False, quiet=True)
+
+    saved = _read_config(tmp_path)
+    # Env var template must be preserved — no plaintext leak
+    assert "api_key: ${MIGRATION_SECRET}" in saved
+    assert "migration-secret-value" not in saved
+    # Migration should have updated the version
+    assert "_config_version: 19" in saved or "_config_version: 1" not in saved


### PR DESCRIPTION
## What does this PR do?

Config migration calls `save_config()` before the expanded-config cache is populated, causing `${ENV_VAR}` templates to be written as plaintext secrets to disk. This PR:

- Adds a `load_config()` call at the start of `migrate_config()` to pre-populate the cache
- Fixes `save_config()` to cache the expanded form (not raw templates) so subsequent saves can match expanded values back to their original templates

## Related Issue

Fixes #11864

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `migrate_config()` — `load_config()` call added at the start to pre-populate the expanded-config cache before the first save
- `save_config()` — caches the expanded form rather than the raw templates, so subsequent saves can match expanded values back to their original `${ENV_VAR}` templates
- Tests: `test_save_config_caches_expanded_form_not_raw_templates`, `test_migrate_config_preserves_env_refs`

## How to Test

1. `pytest -k test_save_config_caches_expanded_form_not_raw_templates` — verifies cache holds expanded form after save
2. `pytest -k test_migrate_config_preserves_env_refs` — end-to-end migration from v13→v19 preserves `${MIGRATION_SECRET}` template

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin 24.6.0, Python 3.14)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — see commit description and PR diff.
