### PR TITLE
fix(agent): use correct HOME for ~ expansion in skill config resolution

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -12,7 +12,7 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
-from hermes_constants import get_config_path, get_skills_dir, is_termux
+from hermes_constants import expand_hermes_path, get_config_path, get_skills_dir, is_termux
 
 logger = logging.getLogger(__name__)
 
@@ -302,7 +302,7 @@ def get_external_skills_dirs() -> List[Path]:
         if not entry:
             continue
         # Expand ~ and environment variables
-        expanded = os.path.expanduser(os.path.expandvars(entry))
+        expanded = expand_hermes_path(entry)
         p = Path(expanded)
         # Resolve relative paths against HERMES_HOME, not cwd
         if not p.is_absolute():
@@ -505,7 +505,7 @@ def resolve_skill_config_values(
 
         # Expand ~ in path-like values
         if isinstance(value, str) and ("~" in value or "${" in value):
-            value = os.path.expanduser(os.path.expandvars(value))
+            value = expand_hermes_path(value)
 
         resolved[logical_key] = value
 

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -12,7 +12,7 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
-from hermes_constants import get_config_path, get_skills_dir
+from hermes_constants import expand_hermes_path, get_config_path, get_skills_dir
 
 logger = logging.getLogger(__name__)
 
@@ -209,7 +209,7 @@ def get_external_skills_dirs() -> List[Path]:
         if not entry:
             continue
         # Expand ~ and environment variables
-        expanded = os.path.expanduser(os.path.expandvars(entry))
+        expanded = expand_hermes_path(entry)
         p = Path(expanded).resolve()
         if p == local_skills:
             continue
@@ -405,7 +405,7 @@ def resolve_skill_config_values(
 
         # Expand ~ in path-like values
         if isinstance(value, str) and ("~" in value or "${" in value):
-            value = os.path.expanduser(os.path.expandvars(value))
+            value = expand_hermes_path(value)
 
         resolved[logical_key] = value
 

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -281,6 +281,25 @@ def get_subprocess_home() -> str | None:
     return None
 
 
+def expand_hermes_path(value: str) -> str:
+    """Expand ``~`` and ``$HOME`` using the subprocess HOME when active.
+
+    When profile isolation is enabled (``HERMES_HOME/home/`` exists),
+    subprocesses use that directory as HOME so tool configs (git, ssh,
+    npm …) land inside the Hermes data directory.  ``os.path.expanduser``
+    only knows about the Python process's HOME, so this helper replaces
+    ``~`` with the profile home first, then falls through to the standard
+    expansion for any remaining patterns.
+    """
+    profile_home = get_subprocess_home()
+    if profile_home:
+        if value.startswith("~/"):
+            value = profile_home + value[1:]
+        elif value == "~":
+            value = profile_home
+    return os.path.expanduser(os.path.expandvars(value))
+
+
 VALID_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh")
 
 

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -138,6 +138,25 @@ def get_subprocess_home() -> str | None:
     return None
 
 
+def expand_hermes_path(value: str) -> str:
+    """Expand ``~`` and ``$HOME`` using the subprocess HOME when active.
+
+    When profile isolation is enabled (``HERMES_HOME/home/`` exists),
+    subprocesses use that directory as HOME so tool configs (git, ssh,
+    npm …) land inside the Hermes data directory.  ``os.path.expanduser``
+    only knows about the Python process's HOME, so this helper replaces
+    ``~`` with the profile home first, then falls through to the standard
+    expansion for any remaining patterns.
+    """
+    profile_home = get_subprocess_home()
+    if profile_home:
+        if value.startswith("~/"):
+            value = profile_home + value[1:]
+        elif value == "~":
+            value = profile_home
+    return os.path.expanduser(os.path.expandvars(value))
+
+
 VALID_REASONING_EFFORTS = ("minimal", "low", "medium", "high", "xhigh")
 
 

--- a/tests/agent/test_expand_hermes_path.py
+++ b/tests/agent/test_expand_hermes_path.py
@@ -1,0 +1,55 @@
+"""Regression tests for expand_hermes_path subprocess home resolution.
+
+See fix #12260 — skill config paths like ~/my-data were resolving to
+/root/my-data instead of ${HERMES_HOME}/home/my-data when profile
+isolation is active.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from hermes_constants import expand_hermes_path
+
+
+class TestExpandHermesPath:
+    """Tests for expand_hermes_path using subprocess home resolution."""
+
+    def test_uses_subprocess_home(self):
+        """When get_subprocess_home() returns a profile dir, ~/foo resolves there."""
+        with patch("hermes_constants.get_subprocess_home", return_value="/data/hermes/home"):
+            result = expand_hermes_path("~/foo")
+            assert result == "/data/hermes/home/foo"
+
+    def test_uses_subprocess_home_bare_tilde(self):
+        """When get_subprocess_home() returns a profile dir, ~ alone resolves there."""
+        with patch("hermes_constants.get_subprocess_home", return_value="/data/hermes/home"):
+            result = expand_hermes_path("~")
+            assert result == "/data/hermes/home"
+
+    def test_falls_through_without_profile(self):
+        """When get_subprocess_home() returns None, ~/foo behaves like os.path.expanduser."""
+        with patch("hermes_constants.get_subprocess_home", return_value=None):
+            result = expand_hermes_path("~/foo")
+            expected = os.path.expanduser("~/foo")
+            assert result == expected
+
+    def test_handles_env_vars(self):
+        """Environment variables are expanded in the path."""
+        env_vars = {"MY_DIR": "/custom/path"}
+        with patch.dict(os.environ, env_vars, clear=False):
+            with patch("hermes_constants.get_subprocess_home", return_value=None):
+                result = expand_hermes_path("$MY_DIR/file")
+                assert result == "/custom/path/file"
+
+    def test_ignores_named_user_tilde(self):
+        """~otheruser/ does NOT use the profile home — it falls through to expanduser."""
+        with patch("hermes_constants.get_subprocess_home", return_value="/data/hermes/home"):
+            result = expand_hermes_path("~otheruser/foo")
+            # Should NOT be /data/hermes/home/otheruser/foo
+            # Should behave like normal expanduser for named users
+            expected = os.path.expanduser("~otheruser/foo")
+            assert result == expected
+            # Explicitly assert it's NOT the profile home prefix
+            assert not result.startswith("/data/hermes/home/otheruser")


### PR DESCRIPTION
## What does this PR do?

Skill config path resolution could expand `~` against the wrong HOME in profile/container contexts. This PR routes skill config path expansion through the Hermes path helper so tilde expansion follows the intended Hermes environment.

## Related Issue

Related to skill config path expansion under overridden Hermes homes.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Use the shared Hermes path expansion helper in `agent/skill_utils.py`.
- Adjust `hermes_constants.py` path expansion support.
- Add regression tests for HOME-sensitive skill config expansion.

## How to Test

1. Check out this PR branch.
2. Run: `.venv/bin/python -m pytest -o 'addopts=' tests/agent/test_expand_hermes_path.py -q`
3. Expected result: 5 passed

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — focused pytest passed; full suite was not run in this salvage pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux container / Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused verification:

```text
`.venv/bin/python -m pytest -o 'addopts=' tests/agent/test_expand_hermes_path.py -q` — 5 passed
```
