### PR TITLE
fix(agent): normalize empty assistant content to None for Anthropic compatibility

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -646,7 +646,10 @@ def build_assistant_message(agent, assistant_message, finish_reason: str) -> dic
 
     msg = {
         "role": "assistant",
-        "content": _san_content,
+        # Anthropic proxies reject empty-string content with HTTP 400, so
+        # normalize to None when content is absent to maintain compatibility
+        # (#11906).
+        "content": _san_content if _san_content else None,
         "reasoning": reasoning_text,
         "finish_reason": finish_reason,
     }

--- a/run_agent.py
+++ b/run_agent.py
@@ -7288,7 +7288,9 @@ class AIAgent:
 
         msg = {
             "role": "assistant",
-            "content": _san_content,
+            # Anthropic proxies reject empty-string content with HTTP 400, so
+            # normalize to None when content is absent to maintain compatibility.
+            "content": _san_content if _san_content else None,
             "reasoning": reasoning_text,
             "finish_reason": finish_reason,
         }

--- a/tests/run_agent/test_anthropic_empty_content.py
+++ b/tests/run_agent/test_anthropic_empty_content.py
@@ -1,0 +1,79 @@
+"""Regression tests for empty content normalization to None (issue #11906).
+
+Anthropic proxies reject empty-string content with HTTP 400.  The fix
+normalizes falsy assistant content to None in _build_assistant_message().
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from run_agent import AIAgent
+
+
+def _make_tool_defs(*names):
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": n,
+                "description": f"{n} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for n in names
+    ]
+
+
+def _mock_msg(content="Hello", tool_calls=None):
+    return SimpleNamespace(content=content, tool_calls=tool_calls)
+
+
+@pytest.fixture()
+def agent():
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        a = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    return a
+
+
+class TestEmptyContentNormalization:
+    """Test that _build_assistant_message normalizes empty content to None."""
+
+    def test_normalizes_empty_string_to_none(self, agent):
+        """Empty string content must become None to avoid Anthropic HTTP 400."""
+        msg = _mock_msg(content="")
+        result = agent._build_assistant_message(msg, "stop")
+        assert result["content"] is None
+
+    def test_preserves_nonempty_content(self, agent):
+        """Non-empty content passes through unchanged."""
+        msg = _mock_msg(content="hello")
+        result = agent._build_assistant_message(msg, "stop")
+        assert result["content"] == "hello"
+
+    def test_preserves_none_content(self, agent):
+        """None content stays None."""
+        msg = _mock_msg(content=None)
+        result = agent._build_assistant_message(msg, "stop")
+        assert result["content"] is None
+
+    def test_whitespace_only_content_becomes_none(self, agent):
+        """Whitespace-only content is stripped first, then normalized to None.
+
+        The real code path strips think blocks + whitespace before checking
+        for empty content, so '   ' → '' → None.
+        """
+        msg = _mock_msg(content="   ")
+        result = agent._build_assistant_message(msg, "stop")
+        assert result["content"] is None


### PR DESCRIPTION
## What does this PR do?

Anthropic proxies reject empty-string content with HTTP 400. This PR normalizes falsy assistant content to `None` in `_build_assistant_message()` before storing to transcript. Whitespace-only content is also normalized after the existing `strip()` pass.

## Related Issue

Fixes #11906

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `_build_assistant_message()`: normalize falsy assistant content (empty string, whitespace-only after strip) to `None` before storing to transcript

## How to Test

Tests use the real `AIAgent` fixture and `_build_assistant_message()` call path:

1. `test_normalizes_empty_string_to_none` — `""` → `None`
2. `test_preserves_nonempty_content` — `"hello"` passes through unchanged
3. `test_preserves_none_content` — `None` stays `None`
4. `test_whitespace_only_content_becomes_none` — `"   "` → stripped → `""` → `None`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin 24.6.0, Python 3.14)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — see commit description and PR diff.
