### PR TITLE
fix(tools): hash SSH ControlMaster socket path to avoid macOS 104-char limit

### DIFF
--- a/tests/tools/test_ssh_environment.py
+++ b/tests/tools/test_ssh_environment.py
@@ -220,3 +220,46 @@ class TestPersistentSSH:
         assert len(lines) == 1000
         assert lines[0] == "1"
         assert lines[-1] == "1000"
+
+
+class TestSocketPathHashing:
+
+    @pytest.fixture(autouse=True)
+    def _mock_connection(self, monkeypatch):
+        monkeypatch.setattr(ssh_env.shutil, "which", lambda _name: "/usr/bin/ssh")
+        monkeypatch.setattr(ssh_env.SSHEnvironment, "_establish_connection", lambda self: None)
+        monkeypatch.setattr(ssh_env.SSHEnvironment, "_detect_remote_home", lambda self: "/home/testuser")
+        monkeypatch.setattr(ssh_env.SSHEnvironment, "_ensure_remote_dirs", lambda self: None)
+        monkeypatch.setattr(ssh_env.SSHEnvironment, "init_session", lambda self: None)
+        monkeypatch.setattr(ssh_env, "FileSyncManager", lambda **kw: type("M", (), {"sync": lambda self, **k: None})())
+
+    def test_ssh_socket_path_uses_hash(self):
+        """Socket filename is a 12-char hex string + .sock, with no @ or :."""
+        env = ssh_env.SSHEnvironment(host="example.com", user="testuser", port=22)
+        socket_name = env.control_socket.name
+        assert socket_name.endswith(".sock")
+        hex_part = socket_name[:-5]  # strip .sock
+        assert len(hex_part) == 12
+        assert all(c in "0123456789abcdef" for c in hex_part)
+        assert "@" not in socket_name
+        assert ":" not in socket_name
+
+    def test_ssh_socket_path_under_104_chars(self):
+        """Long IPv6 address still produces a socket path under 104 chars (macOS limit)."""
+        # This is a real-looking expanded IPv6 address
+        long_host = "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+        env = ssh_env.SSHEnvironment(host=long_host, user="testuser", port=22)
+        path = str(env.control_socket)
+        assert len(path) < 104, f"Socket path too long ({len(path)}): {path}"
+
+    def test_ssh_socket_path_deterministic(self):
+        """Same host/user/port always produce the same socket path."""
+        env1 = ssh_env.SSHEnvironment(host="example.com", user="testuser", port=22)
+        env2 = ssh_env.SSHEnvironment(host="example.com", user="testuser", port=22)
+        assert env1.control_socket == env2.control_socket
+
+    def test_ssh_socket_path_differs_by_port(self):
+        """Different ports produce different socket paths."""
+        env1 = ssh_env.SSHEnvironment(host="example.com", user="testuser", port=22)
+        env2 = ssh_env.SSHEnvironment(host="example.com", user="testuser", port=2222)
+        assert env1.control_socket != env2.control_socket

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -1,5 +1,6 @@
 """SSH remote execution environment with ControlMaster connection persistence."""
 
+import hashlib
 import logging
 import os
 import shlex
@@ -47,7 +48,10 @@ class SSHEnvironment(BaseEnvironment):
 
         self.control_dir = Path(tempfile.gettempdir()) / "hermes-ssh"
         self.control_dir.mkdir(parents=True, exist_ok=True)
-        self.control_socket = self.control_dir / f"{user}@{host}:{port}.sock"
+        # Use a hashed socket name to avoid exceeding macOS's 104-char socket path limit,
+        # especially with IPv6 addresses which are much longer than IPv4.
+        socket_key = hashlib.sha256(f"{user}@{host}:{port}".encode()).hexdigest()[:12]
+        self.control_socket = self.control_dir / f"{socket_key}.sock"
         _ensure_ssh_available()
         self._establish_connection()
         self._remote_home = self._detect_remote_home()


### PR DESCRIPTION
## Summary
- SSH ControlMaster socket paths like `/tmp/hermes-ssh/user@2001:0db8:85a3:0000:0000:8a2e:0370:7334:22.sock` exceed macOS's 104-character Unix socket path limit with IPv6 addresses
- Replace the literal `user@host:port.sock` filename with a 12-char SHA-256 hash, keeping paths well under the limit

## Test plan
- [x] `test_ssh_socket_path_uses_hash` — socket name is 12-char hex + `.sock`, no `@` or `:`
- [x] `test_ssh_socket_path_under_104_chars` — expanded IPv6 address stays under 104 chars
- [x] `test_ssh_socket_path_deterministic` — same host/user/port → same path
- [x] `test_ssh_socket_path_differs_by_port` — different ports → different paths

Fixes #11840

**Tested on:** macOS (Darwin 24.6.0, Python 3.14)