### PR TITLE
fix(skills): warn when skill names normalize to empty slugs

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -373,6 +373,13 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     cmd_name = _SKILL_INVALID_CHARS.sub('', cmd_name)
                     cmd_name = _SKILL_MULTI_HYPHEN.sub('-', cmd_name).strip('-')
                     if not cmd_name:
+                        logger.warning(
+                            "Skipping skill %r: normalized slug is empty after "
+                            "removing invalid characters. Skill names must "
+                            "contain at least one ASCII alphanumeric character "
+                            "(a-z, 0-9).",
+                            name,
+                        )
                         continue
                     _skill_commands[f"/{cmd_name}"] = {
                         "name": name,

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -257,6 +257,13 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     cmd_name = _SKILL_INVALID_CHARS.sub('', cmd_name)
                     cmd_name = _SKILL_MULTI_HYPHEN.sub('-', cmd_name).strip('-')
                     if not cmd_name:
+                        logger.warning(
+                            "Skipping skill %r: normalized slug is empty after "
+                            "removing invalid characters. Skill names must "
+                            "contain at least one ASCII alphanumeric character "
+                            "(a-z, 0-9).",
+                            name,
+                        )
                         continue
                     _skill_commands[f"/{cmd_name}"] = {
                         "name": name,

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -351,8 +351,9 @@ class TestScanSkillCommands:
         # The old buggy key should NOT exist
         assert "/jellyfin-+-jellystat-24h-summary" not in result
 
-    def test_allspecial_name_skipped(self, tmp_path):
-        """Skill with name consisting only of special chars is silently skipped."""
+    def test_allspecial_name_emits_warning(self, tmp_path, caplog):
+        """Skill with name consisting only of special chars is skipped with a warning."""
+        caplog.set_level('WARNING')
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             skill_dir = tmp_path / "bad-name"
             skill_dir.mkdir()
@@ -363,6 +364,35 @@ class TestScanSkillCommands:
         # Should not create a "/" key or any entry
         assert "/" not in result
         assert result == {}
+        # A warning should have been logged about the empty normalized slug
+        assert any(
+            "normalized slug is empty" in record.message or "at least one ASCII alphanumeric" in record.message
+            for record in caplog.records
+        )
+
+    def test_non_ascii_skill_name_not_registered_and_logs_warning(self, tmp_path, caplog):
+        """Skill with name containing only non-ASCII chars produces empty slug and logs warning."""
+        caplog.set_level('WARNING')
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "文档搜索")
+            result = scan_skill_commands()
+        # Non-ASCII chars are stripped, leaving empty slug → skill not registered
+        assert "/" not in result
+        assert result == {}
+        # A warning should have been logged about the empty normalized slug
+        assert any(
+            "normalized slug is empty" in record.message or "at least one ASCII alphanumeric" in record.message
+            for record in caplog.records
+        )
+
+    def test_mixed_ascii_nonascii_skill_name_strips_nonascii(self, tmp_path):
+        """Skill with mixed ASCII and non-ASCII chars registers with ASCII chars only."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "my-文档-tool")
+            result = scan_skill_commands()
+        # Non-ASCII chars stripped, multi-hyphen collapsed → /my-tool
+        assert "/my-tool" in result
+        assert result["/my-tool"]["name"] == "my-文档-tool"
 
     def test_slash_in_name_stripped_from_cmd_key(self, tmp_path):
         """Skill names with / chars produce clean cmd keys."""

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -118,7 +118,7 @@ class TestScanSkillCommands:
         # The old buggy key should NOT exist
         assert "/jellyfin-+-jellystat-24h-summary" not in result
 
-    def test_allspecial_name_skipped(self, tmp_path):
+    def test_allspecial_name_skipped(self, tmp_path, caplog):
         """Skill with name consisting only of special chars is silently skipped."""
         with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
             skill_dir = tmp_path / "bad-name"
@@ -130,6 +130,30 @@ class TestScanSkillCommands:
         # Should not create a "/" key or any entry
         assert "/" not in result
         assert result == {}
+
+    def test_non_ascii_skill_name_not_registered_and_logs_warning(self, tmp_path, caplog):
+        """Skill with name containing only non-ASCII chars produces empty slug and logs warning."""
+        caplog.set_level('WARNING')
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "文档搜索")
+            result = scan_skill_commands()
+        # Non-ASCII chars are stripped, leaving empty slug → skill not registered
+        assert "/" not in result
+        assert result == {}
+        # A warning should have been logged about the empty normalized slug
+        assert any(
+            "normalized slug is empty" in record.message or "at least one ASCII alphanumeric" in record.message
+            for record in caplog.records
+        )
+
+    def test_mixed_ascii_nonascii_skill_name_strips_nonascii(self, tmp_path):
+        """Skill with mixed ASCII and non-ASCII chars registers with ASCII chars only."""
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "my-文档-tool")
+            result = scan_skill_commands()
+        # Non-ASCII chars stripped, multi-hyphen collapsed → /my-tool
+        assert "/my-tool" in result
+        assert result["/my-tool"]["name"] == "my-文档-tool"
 
     def test_slash_in_name_stripped_from_cmd_key(self, tmp_path):
         """Skill names with / chars produce clean cmd keys."""


### PR DESCRIPTION
## What does this PR do?

Skills with names consisting entirely of non-ASCII characters (e.g. `文档搜索`) are silently dropped during slug normalization — the regex strips all non-ASCII chars, leaving an empty slug.

This PR adds a `logger.warning()` with a clear message explaining that skill names must contain at least one ASCII alphanumeric character. Mixed names like `my-文档-tool` correctly normalize to `/my-tool` and register successfully.

## Related Issue

Fixes #12351

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Skill name normalization now emits a `logger.warning()` when the result is an empty slug, instead of silently dropping the skill.
- Mixed-script names continue to register on their ASCII subset.

## How to Test

1. `pytest` the three covering tests:
   - `test_non_ascii_skill_name_not_registered_and_logs_warning` — pure non-ASCII name logs warning.
   - `test_mixed_ascii_nonascii_skill_name_strips_nonascii` — mixed name registers with ASCII part.
   - `test_allspecial_name_skipped` — existing test for special-char-only names (updated with caplog).

Tested on: macOS (Darwin 24.6.0, Python 3.14).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — see commit description and PR diff.
