### PR TITLE
fix(agent): estimate token usage for non-reporting streaming providers

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -36,7 +36,11 @@ from urllib.parse import urlparse, parse_qs, urlunparse
 from hermes_cli.timeouts import get_provider_request_timeout, get_provider_stale_timeout
 from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
 from agent.error_classifier import classify_api_error, FailoverReason
-from agent.model_metadata import is_local_endpoint
+from agent.model_metadata import (
+    estimate_messages_tokens_rough,
+    estimate_tokens_rough,
+    is_local_endpoint,
+)
 from agent.message_sanitization import (
     _sanitize_surrogates,
     _sanitize_messages_surrogates,
@@ -1805,6 +1809,19 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             message=mock_message,
             finish_reason=effective_finish_reason,
         )
+        # Fall back to rough estimation for providers that don't send usage
+        # data in stream chunks (MiniMax, Kimi, etc.).  A None usage object
+        # or one missing both token fields is treated as "no data received".
+        _raw = usage_obj
+        _prompt = getattr(_raw, "prompt_tokens", None) if _raw else None
+        _completion = getattr(_raw, "completion_tokens", None) if _raw else None
+        if _prompt is None and _completion is None:
+            _est = estimate_messages_tokens_rough(api_kwargs.get("messages") or [])
+            _comp_text = "".join(content_parts) if content_parts else ""
+            usage_obj = SimpleNamespace(
+                prompt_tokens=_est,
+                completion_tokens=estimate_tokens_rough(_comp_text),
+            )
         return SimpleNamespace(
             id="stream-" + str(uuid.uuid4()),
             model=model_name,

--- a/run_agent.py
+++ b/run_agent.py
@@ -585,6 +585,29 @@ def _qwen_portal_headers() -> dict:
     }
 
 
+def apply_streaming_token_fallback(usage_obj, api_messages, content_parts):
+    """Fall back to rough estimation for providers that don't send usage data.
+
+    Providers like MiniMax and Kimi don't include token counts in stream
+    chunks.  A None usage object or one missing both token fields is treated
+    as "no data received" and replaced with rough estimates.
+
+    Uses ``is None`` checks (not falsiness) so that valid zero values
+    (e.g. cache hits with prompt_tokens=0) are preserved.
+    """
+    _raw = usage_obj
+    _prompt = getattr(_raw, "prompt_tokens", None) if _raw else None
+    _completion = getattr(_raw, "completion_tokens", None) if _raw else None
+    if _prompt is None and _completion is None:
+        _est = estimate_messages_tokens_rough(api_messages)
+        _comp_text = "".join(content_parts) if content_parts else ""
+        usage_obj = SimpleNamespace(
+            prompt_tokens=_est,
+            completion_tokens=estimate_tokens_rough(_comp_text),
+        )
+    return usage_obj
+
+
 class AIAgent:
     """
     AI Agent with tool calling capabilities.
@@ -5936,6 +5959,9 @@ class AIAgent:
                 index=0,
                 message=mock_message,
                 finish_reason=effective_finish_reason,
+            )
+            usage_obj = apply_streaming_token_fallback(
+                usage_obj, api_messages, content_parts
             )
             return SimpleNamespace(
                 id="stream-" + str(uuid.uuid4()),

--- a/tests/run_agent/test_streaming_token_estimation.py
+++ b/tests/run_agent/test_streaming_token_estimation.py
@@ -1,0 +1,130 @@
+"""Regression tests for streaming token estimation fallback.
+
+Tests the fix for providers that don't send usage data in stream chunks
+(MiniMax, Kimi, etc.).  Verifies the `is None` check (not falsiness) is
+used so that valid zero values (e.g. cache hits with prompt_tokens=0)
+are preserved instead of being overwritten with estimated values.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from agent.model_metadata import (
+    estimate_messages_tokens_rough,
+    estimate_tokens_rough,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper: extracts and runs the token-accounting conditional block from
+# _call_chat_completions (run_agent.py ~line 5965-5974).
+# ---------------------------------------------------------------------------
+def _apply_token_fallback(usage_obj, api_messages, content_parts):
+    """Mirror the token-fallback logic from the streaming response builder."""
+    _raw = usage_obj
+    _prompt = getattr(_raw, "prompt_tokens", None) if _raw else None
+    _completion = getattr(_raw, "completion_tokens", None) if _raw else None
+    if _prompt is None and _completion is None:
+        _est = estimate_messages_tokens_rough(api_messages)
+        _comp_text = "".join(content_parts) if content_parts else ""
+        usage_obj = SimpleNamespace(
+            prompt_tokens=_est,
+            completion_tokens=estimate_tokens_rough(_comp_text),
+        )
+    return usage_obj
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestStreamingTokenEstimation:
+    def test_fallback_estimates_when_usage_none(self):
+        """When usage_obj is None the block must estimate both token fields."""
+        api_messages = [{"role": "user", "content": "hello world"}]
+        content_parts = ["Hello! How can I help you today?"]
+
+        result = _apply_token_fallback(None, api_messages, content_parts)
+
+        # Estimation must produce non-zero prompt tokens
+        assert result.prompt_tokens > 0, "prompt_tokens should be estimated from messages"
+        # Completion should be estimated from the response text, not a char count
+        assert result.completion_tokens > 0, "completion_tokens should be estimated from text"
+        # Smoke-check: completion_tokens should be in the same rough ballpark as
+        # the actual response (a few words), not proportional to a 500-char string
+        assert result.completion_tokens < 10, (
+            "completion_tokens looks like a char-count, not an estimate"
+        )
+
+    def test_preserves_valid_zero_usage(self):
+        """When usage has prompt_tokens=0 (cache hit) the 0 must be preserved.
+
+        The fix uses `is None` checks instead of truthiness so that a real
+        prompt_tokens=0 value (common with cache hits on MiniMax/Kimi) is NOT
+        overwritten by the estimation path.
+        """
+        api_messages = [{"role": "user", "content": "hello world"}]
+        content_parts = ["Hello! How can I help you today?"]
+
+        # Simulate a cache hit: provider reports 0 prompt tokens, 5 completion
+        usage_with_zero = SimpleNamespace(prompt_tokens=0, completion_tokens=5)
+        result = _apply_token_fallback(usage_with_zero, api_messages, content_parts)
+
+        assert result.prompt_tokens == 0, (
+            "prompt_tokens=0 (cache hit) must NOT be overwritten with an estimate"
+        )
+        assert result.completion_tokens == 5, (
+            "completion_tokens should pass through unchanged"
+        )
+
+    def test_preserves_valid_nonzero_usage(self):
+        """When both token fields are non-None they must pass through unchanged."""
+        api_messages = [{"role": "user", "content": "hello world"}]
+        content_parts = ["Hello! How can I help you today?"]
+
+        usage_with_values = SimpleNamespace(prompt_tokens=100, completion_tokens=50)
+        result = _apply_token_fallback(usage_with_values, api_messages, content_parts)
+
+        assert result.prompt_tokens == 100, (
+            "prompt_tokens should pass through unchanged"
+        )
+        assert result.completion_tokens == 50, (
+            "completion_tokens should pass through unchanged"
+        )
+
+    def test_empty_content_parts_still_estimates_completion(self):
+        """Even with empty content, completion_tokens must be estimated (not 0 or error)."""
+        api_messages = [{"role": "user", "content": "hello world"}]
+        content_parts = []
+
+        result = _apply_token_fallback(None, api_messages, content_parts)
+
+        assert result.prompt_tokens > 0, "prompt_tokens must still be estimated"
+        # Empty text → 0 tokens from estimate_tokens_rough
+        assert result.completion_tokens == 0, (
+            "completion_tokens for empty content should be 0"
+        )
+
+    def test_is_none_check_discriminates_from_zero(self):
+        """Explicitly verify the fix: None vs 0 are not the same check.
+
+        The critical distinction is:
+        - usage=None → both getattr calls return None → fallback branch entered
+        - usage=SimpleNamespace(prompt_tokens=0, ...) → getattr returns 0 (not None)
+          → fallback NOT entered, 0 is preserved
+        """
+        # usage=None with real messages → fallback triggered, estimate > 0
+        result_none = _apply_token_fallback(None, [{"role": "user", "content": "hello"}], ["hi"])
+        assert result_none.prompt_tokens > 0, "fallback should estimate when usage is None"
+
+        # usage with prompt_tokens=0 (not None) → preserved, not overwritten
+        result_zero = _apply_token_fallback(
+            SimpleNamespace(prompt_tokens=0, completion_tokens=1),
+            [{"role": "user", "content": "hello"}],
+            ["hi"],
+        )
+        assert result_zero.prompt_tokens == 0, (
+            "prompt_tokens=0 must NOT be overwritten — is None check catches this"
+        )

--- a/tests/run_agent/test_streaming_token_estimation.py
+++ b/tests/run_agent/test_streaming_token_estimation.py
@@ -1,0 +1,90 @@
+"""Regression tests for streaming token estimation fallback.
+
+Tests the fix for providers that don't send usage data in stream chunks
+(MiniMax, Kimi, etc.).  Verifies the `is None` check (not falsiness) is
+used so that valid zero values (e.g. cache hits with prompt_tokens=0)
+are preserved instead of being overwritten with estimated values.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from run_agent import apply_streaming_token_fallback
+
+
+class TestStreamingTokenEstimation:
+    def test_fallback_estimates_when_usage_none(self):
+        """When usage_obj is None the block must estimate both token fields."""
+        api_messages = [{"role": "user", "content": "hello world"}]
+        content_parts = ["Hello! How can I help you today?"]
+
+        result = apply_streaming_token_fallback(None, api_messages, content_parts)
+
+        assert result.prompt_tokens > 0, "prompt_tokens should be estimated from messages"
+        assert result.completion_tokens > 0, "completion_tokens should be estimated from text"
+        assert result.completion_tokens < 10, (
+            "completion_tokens looks like a char-count, not an estimate"
+        )
+
+    def test_preserves_valid_zero_usage(self):
+        """When usage has prompt_tokens=0 (cache hit) the 0 must be preserved.
+
+        The fix uses `is None` checks instead of truthiness so that a real
+        prompt_tokens=0 value (common with cache hits on MiniMax/Kimi) is NOT
+        overwritten by the estimation path.
+        """
+        api_messages = [{"role": "user", "content": "hello world"}]
+        content_parts = ["Hello! How can I help you today?"]
+
+        usage_with_zero = SimpleNamespace(prompt_tokens=0, completion_tokens=5)
+        result = apply_streaming_token_fallback(usage_with_zero, api_messages, content_parts)
+
+        assert result.prompt_tokens == 0, (
+            "prompt_tokens=0 (cache hit) must NOT be overwritten with an estimate"
+        )
+        assert result.completion_tokens == 5, (
+            "completion_tokens should pass through unchanged"
+        )
+
+    def test_preserves_valid_nonzero_usage(self):
+        """When both token fields are non-None they must pass through unchanged."""
+        api_messages = [{"role": "user", "content": "hello world"}]
+        content_parts = ["Hello! How can I help you today?"]
+
+        usage_with_values = SimpleNamespace(prompt_tokens=100, completion_tokens=50)
+        result = apply_streaming_token_fallback(usage_with_values, api_messages, content_parts)
+
+        assert result.prompt_tokens == 100
+        assert result.completion_tokens == 50
+
+    def test_empty_content_parts_still_estimates_completion(self):
+        """Even with empty content, completion_tokens must be estimated (not 0 or error)."""
+        api_messages = [{"role": "user", "content": "hello world"}]
+
+        result = apply_streaming_token_fallback(None, api_messages, [])
+
+        assert result.prompt_tokens > 0, "prompt_tokens must still be estimated"
+        assert result.completion_tokens == 0, (
+            "completion_tokens for empty content should be 0"
+        )
+
+    def test_is_none_check_discriminates_from_zero(self):
+        """Explicitly verify: None vs 0 are not the same check.
+
+        - usage=None → fallback triggered, estimate > 0
+        - usage with prompt_tokens=0 → 0 preserved, not overwritten
+        """
+        result_none = apply_streaming_token_fallback(
+            None, [{"role": "user", "content": "hello"}], ["hi"]
+        )
+        assert result_none.prompt_tokens > 0, "fallback should estimate when usage is None"
+
+        result_zero = apply_streaming_token_fallback(
+            SimpleNamespace(prompt_tokens=0, completion_tokens=1),
+            [{"role": "user", "content": "hello"}],
+            ["hi"],
+        )
+        assert result_zero.prompt_tokens == 0, (
+            "prompt_tokens=0 must NOT be overwritten — is None check catches this"
+        )


### PR DESCRIPTION
## What does this PR do?

Some streaming providers do not report token usage metadata, leaving usage accounting unavailable for those completions. This PR estimates token usage from streamed content when usage metadata is absent, while preserving reported-usage behavior when providers do return it.

## Related Issue

Related to streaming token accounting for providers that omit usage metadata.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add fallback token estimation in `agent/chat_completion_helpers.py` for non-reporting streaming providers.
- Preserve provider-reported usage metadata when available.
- Add focused regression coverage for estimated and reported usage paths.

## How to Test

1. Check out this PR branch.
2. Run: `.venv/bin/python -m pytest -o 'addopts=' tests/run_agent/test_streaming_token_estimation.py -q`
3. Expected result: 5 passed

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — focused pytest passed; full suite was not run in this salvage pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux container / Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused verification:

```text
`.venv/bin/python -m pytest -o 'addopts=' tests/run_agent/test_streaming_token_estimation.py -q` — 5 passed
```
