### PR TITLE
fix(acp): handle non-iterable conversation_history in ACP Copilot integration

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -372,6 +372,17 @@ def run_conversation(
         _msg_preview,
     )
 
+    # ACP Copilot and some adapter paths can pass a non-iterable
+    # (e.g. SimpleNamespace) instead of a list, which would crash on
+    # len()/list()/reversed() below.  Normalise once up-front so every
+    # downstream consumer sees a real list.
+    try:
+        from run_agent import normalize_conversation_history
+        conversation_history = normalize_conversation_history(conversation_history)
+    except Exception:
+        if conversation_history is None:
+            conversation_history = []
+
     # Initialize conversation (copy to avoid mutating the caller's list)
     messages = list(conversation_history) if conversation_history else []
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -285,6 +285,26 @@ def _qwen_portal_headers() -> dict:
     }
 
 
+def normalize_conversation_history(conversation_history):
+    """Normalize conversation_history to a list.
+
+    ACP Copilot and some adapter paths can pass a non-iterable
+    (e.g. SimpleNamespace) instead of a list, which would crash on
+    len(), list(), reversed(), etc.  Returns ``[]`` for None or
+    non-iterable inputs (the non-iterable case is logged).
+    """
+    if conversation_history is None:
+        return []
+    try:
+        return list(conversation_history)
+    except TypeError:
+        logger.warning(
+            "conversation_history is not iterable (%s) — treating as empty",
+            type(conversation_history).__name__,
+        )
+        return []
+
+
 class _StreamErrorEvent(Exception):
     """Synthesized provider error surfaced from a Responses ``error`` SSE frame.
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -585,6 +585,25 @@ def _qwen_portal_headers() -> dict:
     }
 
 
+def normalize_conversation_history(conversation_history):
+    """Normalize conversation_history to a list.
+
+    ACP Copilot and some adapter paths can pass a non-iterable
+    (e.g. SimpleNamespace) instead of a list, which would crash on
+    len(), list(), reversed(), etc.
+    """
+    if conversation_history is None:
+        return []
+    try:
+        return list(conversation_history)
+    except TypeError:
+        logger.warning(
+            "conversation_history is not iterable (%s) — treating as empty",
+            type(conversation_history).__name__,
+        )
+        return []
+
+
 class AIAgent:
     """
     AI Agent with tool calling capabilities.
@@ -8770,18 +8789,20 @@ class AIAgent:
         # calls so that nudge logic accumulates correctly in CLI mode.
         self.iteration_budget = IterationBudget(self.max_iterations)
 
+        conversation_history = normalize_conversation_history(conversation_history)
+
         # Log conversation turn start for debugging/observability
         _msg_preview = (user_message[:80] + "...") if len(user_message) > 80 else user_message
         _msg_preview = _msg_preview.replace("\n", " ")
         logger.info(
             "conversation turn: session=%s model=%s provider=%s platform=%s history=%d msg=%r",
             self.session_id or "none", self.model, self.provider or "unknown",
-            self.platform or "unknown", len(conversation_history or []),
+            self.platform or "unknown", len(conversation_history),
             _msg_preview,
         )
 
         # Initialize conversation (copy to avoid mutating the caller's list)
-        messages = list(conversation_history) if conversation_history else []
+        messages = list(conversation_history)
 
         # Hydrate todo store from conversation history (gateway creates a fresh
         # AIAgent per message, so the in-memory store is empty -- we need to

--- a/tests/run_agent/test_acp_copilot_namespace.py
+++ b/tests/run_agent/test_acp_copilot_namespace.py
@@ -1,0 +1,64 @@
+"""Regression tests for ACP Copilot conversation_history normalization.
+
+Verifies that non-iterable types (e.g. SimpleNamespace) passed as
+conversation_history are handled gracefully instead of crashing.
+
+See: issue #11732
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from run_agent import normalize_conversation_history
+
+
+class TestConversationHistoryNormalization:
+    """Tests for normalize_conversation_history()."""
+
+    def test_normalizes_simplenamespace(self, caplog):
+        """ACP Copilot can pass a SimpleNamespace instead of a list."""
+        ns = SimpleNamespace(foo="bar", baz=123)
+        result = normalize_conversation_history(ns)
+
+        assert result == []
+        assert any(
+            "SimpleNamespace" in record.message and "not iterable" in record.message
+            for record in caplog.records
+        )
+
+    def test_normalizes_none(self, caplog):
+        """Passing None should be treated as an empty list."""
+        result = normalize_conversation_history(None)
+        assert result == []
+        assert not any(
+            "not iterable" in record.message for record in caplog.records
+        )
+
+    def test_preserves_valid_list(self):
+        """A normal list of message dicts passes through unchanged."""
+        messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi there"},
+        ]
+        result = normalize_conversation_history(messages)
+        assert result == messages
+
+    def test_preserves_empty_list(self):
+        """An empty list remains an empty list."""
+        result = normalize_conversation_history([])
+        assert result == []
+
+    def test_normalizes_non_iterable_int(self, caplog):
+        """An int is not iterable and should be treated as empty with a warning."""
+        result = normalize_conversation_history(42)
+        assert result == []
+        assert any(
+            "int" in record.message and "not iterable" in record.message
+            for record in caplog.records
+        )
+
+    def test_string_becomes_list_of_chars(self):
+        """A bare string is iterable (chars) — list() works, documenting current behavior."""
+        result = normalize_conversation_history("hello")
+        assert result == list("hello")


### PR DESCRIPTION
## What does this PR do?

ACP Copilot and some adapter paths can pass a non-iterable (e.g. `SimpleNamespace`) as `conversation_history`, crashing on `len()`/`list()`/`reversed()`.

This PR extracts `normalize_conversation_history()` to gracefully coerce to list with a `logger.warning()` for non-iterables. `None` is silently treated as empty list; non-iterables log a warning with the type name.

## Related Issue

Fixes #11732

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Extract `normalize_conversation_history()` helper used in the ACP Copilot integration path
- `None` → silently treated as empty list
- Non-iterables → `[]` with `logger.warning()` naming the offending type
- Valid iterables pass through as a list

## How to Test

Tests import and call the real `normalize_conversation_history()` function:

1. `test_normalizes_simplenamespace` — SimpleNamespace → `[]` + warning
2. `test_normalizes_none` — None → `[]`, no warning
3. `test_preserves_valid_list` — normal list passes through unchanged
4. `test_preserves_empty_list` — `[]` stays `[]`
5. `test_normalizes_non_iterable_int` — `42` → `[]` + warning
6. `test_string_becomes_list_of_chars` — documents current behavior (string is iterable)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin 24.6.0, Python 3.14)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — see commit description and PR diff.
