### PR TITLE
fix(cli): handle multimodal interrupt payloads in re-queue

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8688,9 +8688,24 @@ class HermesCLI:
                             all_parts.append(extra)
                     except queue.Empty:
                         break
-                combined = "\n".join(all_parts)
+
+                # Normalize multimodal payloads: (text, images) tuples come from
+                # interrupt messages that contain pasted/attached images.
+                # Split text and images so we can combine text with join while
+                # preserving image attachments.
+                texts = []
+                images = []
+                for part in all_parts:
+                    if isinstance(part, tuple):
+                        texts.append(str(part[0]) if part else "")
+                        if len(part) > 1:
+                            images.extend(part[1])
+                    else:
+                        texts.append(str(part))
+
+                combined = ("\n".join(texts), images) if images else "\n".join(texts)
                 n = len(all_parts)
-                preview = combined[:50] + ("..." if len(combined) > 50 else "")
+                preview = "\n".join(texts)[:50] + ("..." if len("\n".join(texts)) > 50 else "")
                 if n > 1:
                     print(f"\n⚡ Sending {n} messages after interrupt: '{preview}'")
                 else:


### PR DESCRIPTION
## Summary
When a multimodal interrupt payload (e.g. pasted/attached images) is queued after Ctrl+C, the requeue logic in `HermesCLI` crashes because it tries to `"\n".join()` a list containing `(text, images)` tuples.

## Problem
The interrupt queue can contain tuples when the incoming message has image attachments. The existing code does:

```python
combined = "\n".join(all_parts)
```

This fails with a `TypeError` when `all_parts` contains tuples.

## Fix
Normalize multimodal payloads before joining:
- Split text and images from tuples
- Combine text parts with `\n` as before
- Preserve image attachments by returning `(combined_text, images)` when images are present
- Update the preview logic to use only the text portion

## Testing
- Manually tested with interrupt requeue containing pasted images
- Flat text interrupts continue to work unchanged
