### PR TITLE
fix(tui): bound retained state against idle OOM

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/screen.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/screen.ts
@@ -121,6 +121,8 @@ const YELLOW_FG_CODE: AnsiCode = {
   endCode: '\x1b[39m'
 }
 
+const MAX_TRANSITION_CACHE = 32768
+
 export class StylePool {
   private ids = new Map<string, number>()
   private styles: AnsiCode[][] = []
@@ -160,7 +162,9 @@ export class StylePool {
   /**
    * Returns the pre-serialized ANSI string to transition from one style to
    * another. Cached by (fromId, toId) — zero allocations after first call
-   * for a given pair.
+   * for a given pair. Full-clear at MAX_TRANSITION_CACHE guards against
+   * unbounded growth from ever-expanding id spaces; cache repopulates from
+   * the next frame's actual transitions.
    */
   transition(fromId: number, toId: number): string {
     if (fromId === toId) {
@@ -171,6 +175,10 @@ export class StylePool {
     let str = this.transitionCache.get(key)
 
     if (str === undefined) {
+      if (this.transitionCache.size >= MAX_TRANSITION_CACHE) {
+        this.transitionCache.clear()
+      }
+
       str = ansiCodesToString(diffAnsiCodes(this.get(fromId), this.get(toId)))
       this.transitionCache.set(key, str)
     }

--- a/ui-tui/src/app/useComposerState.ts
+++ b/ui-tui/src/app/useComposerState.ts
@@ -16,6 +16,28 @@ import { pasteTokenLabel, stripTrailingPasteNewlines } from '../lib/text.js'
 import type { PasteSnippet, UseComposerStateOptions, UseComposerStateResult } from './interfaces.js'
 import { $isBlocked } from './overlayStore.js'
 
+const PASTE_SNIP_MAX_COUNT = 32
+const PASTE_SNIP_MAX_TOTAL_BYTES = 4 * 1024 * 1024
+
+const trimSnips = (snips: PasteSnippet[]): PasteSnippet[] => {
+  let total = 0
+  const out: PasteSnippet[] = []
+
+  for (let i = snips.length - 1; i >= 0; i--) {
+    const snip = snips[i]!
+    const size = snip.text.length
+
+    if (out.length >= PASTE_SNIP_MAX_COUNT || total + size > PASTE_SNIP_MAX_TOTAL_BYTES) {
+      break
+    }
+
+    total += size
+    out.unshift(snip)
+  }
+
+  return out.length === snips.length ? snips : out
+}
+
 export function useComposerState({ gw, onClipboardPaste, submitRef }: UseComposerStateOptions): UseComposerStateResult {
   const [input, setInput] = useState('')
   const [inputBuf, setInputBuf] = useState<string[]>([])
@@ -31,6 +53,7 @@ export function useComposerState({ gw, onClipboardPaste, submitRef }: UseCompose
   const clearIn = useCallback(() => {
     setInput('')
     setInputBuf([])
+    setPasteSnips([])
     setQueueEdit(null)
     setHistoryIdx(null)
     historyDraftRef.current = ''
@@ -68,7 +91,7 @@ export function useComposerState({ gw, onClipboardPaste, submitRef }: UseCompose
       const tail = cursor < value.length && !/\s/.test(value[cursor] ?? '') ? ' ' : ''
       const insert = `${lead}${label}${tail}`
 
-      setPasteSnips(prev => [...prev, { label, text: cleanedText }].slice(-32))
+      setPasteSnips(prev => trimSnips([...prev, { label, text: cleanedText }]))
 
       void gw
         .request<{ path?: string }>('paste.collapse', { text: cleanedText })

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -448,6 +448,7 @@ export function useMainApp(gw: GatewayClient) {
     const handler = (ev: GatewayEvent) => onEventRef.current(ev)
 
     const exitHandler = () => {
+      turnController.reset()
       patchUiState({ busy: false, sid: null, status: 'gateway exited' })
       turnController.pushActivity('gateway exited · /logs to inspect', 'error')
       sys('error: gateway exited')

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -7,9 +7,14 @@ import { createInterface } from 'node:readline'
 import type { GatewayEvent } from './gatewayTypes.js'
 
 const MAX_GATEWAY_LOG_LINES = 200
+const MAX_LOG_LINE_BYTES = 4096
+const MAX_BUFFERED_EVENTS = 2000
 const MAX_LOG_PREVIEW = 240
 const STARTUP_TIMEOUT_MS = Math.max(5000, parseInt(process.env.HERMES_TUI_STARTUP_TIMEOUT_MS ?? '15000', 10) || 15000)
 const REQUEST_TIMEOUT_MS = Math.max(30000, parseInt(process.env.HERMES_TUI_RPC_TIMEOUT_MS ?? '120000', 10) || 120000)
+
+const truncateLine = (line: string) =>
+  line.length > MAX_LOG_LINE_BYTES ? `${line.slice(0, MAX_LOG_LINE_BYTES)}… [truncated ${line.length} bytes]` : line
 
 const resolvePython = (root: string) => {
   const configured = process.env.HERMES_PYTHON?.trim() || process.env.PYTHON?.trim()
@@ -69,7 +74,9 @@ export class GatewayClient extends EventEmitter {
       return void this.emit('event', ev)
     }
 
-    this.bufferedEvents.push(ev)
+    if (this.bufferedEvents.push(ev) > MAX_BUFFERED_EVENTS) {
+      this.bufferedEvents.splice(0, this.bufferedEvents.length - MAX_BUFFERED_EVENTS)
+    }
   }
 
   start() {
@@ -121,7 +128,7 @@ export class GatewayClient extends EventEmitter {
 
     this.stderrRl = createInterface({ input: this.proc.stderr! })
     this.stderrRl.on('line', raw => {
-      const line = raw.trim()
+      const line = truncateLine(raw.trim())
 
       if (!line) {
         return
@@ -181,7 +188,7 @@ export class GatewayClient extends EventEmitter {
   }
 
   private pushLog(line: string) {
-    if (this.logs.push(line) > MAX_GATEWAY_LOG_LINES) {
+    if (this.logs.push(truncateLine(line)) > MAX_GATEWAY_LOG_LINES) {
       this.logs.splice(0, this.logs.length - MAX_GATEWAY_LOG_LINES)
     }
   }


### PR DESCRIPTION
## Why

Someone reported the TUI hitting V8's 2 GB heap limit after ~1 min of idle
with 0 tokens used. Their crash trace shows `Mark-Compact (reduce) 2045.6 →
2039.7 MB` — MC freed ~6 MB out of 2 GB. That's **pure retention, not
allocation churn**: something is reachable from a GC root and growing.

Narrowed four unbounded containers in `ui-tui/`. Guards here don't require
reproducing the bad payload — they're structural caps.

## Changes

### `GatewayClient.logs` + `gateway.stderr` line bytes
Old: `logs` cap = 200 **lines**, no byte cap. `createInterface('line')`
buffers until `\n`, so a chatty Python child (giant traceback, dumped
model-cache JSON, unflushed line) can hoard 100s of MB per line, AND the
same line gets wrapped into a `gateway.stderr` event. Truncate at 4 KB/line
with a `\`… [truncated N bytes]\`` marker.

### `GatewayClient.bufferedEvents`
Unbounded until the React mount effect calls `drain()`. If the gateway
event stream fires before mount completes (e.g. dynamic import latency on
`@hermes/ink`), events accumulate. Now capped at 2 000 with FIFO eviction.

### `useMainApp` gateway `exit` handler
Old handler set `status: 'gateway exited'` but didn't reset
`turnController`. A mid-stream crash left `bufRef` / `reasoningText` alive
forever (status shows \"ready\" later, memory stays pinned). Now calls
`turnController.reset()` first.

### `pasteSnips` byte cap + clear-on-submit
Old: 32-entry cap, no byte cap. 32 × many-MB pastes = GB retained. New:
32 entries **and** 4 MB total, plus `clearIn` clears the list so a submitted
paste doesn't linger across prompts.

### `StylePool.transitionCache`
Ink's style-transition cache was uncapped (other caches — `charCache`,
`lineWidth`, `inverseCache` — are capped). Full-clear at 32 k entries to
mirror `charCache`'s pattern.

## Test plan

- [x] \`npm run type-check\` clean
- [x] \`npm run lint\` clean
- [x] \`npm run test\` — 14 files / 92 tests passing
- [x] \`npm run build\` — \`@hermes/ink\` bundle rebuilt (396.5 kB)
- [x] \`npm run fmt\` (prettier) — no changes needed
- [ ] Reproducer: run \`NODE_OPTIONS=\"--max-old-space-size=4096 --heap-prof\"
  hermes tui\`, sit idle ~90 s, load the heapprofile into Chrome DevTools →
  confirm no container dominates retained size.

## Notes

- No protocol / RPC change; fully backward-compatible.
- The truncation marker preserves the original byte count so a future \`/logs\` viewer can still show that a giant line was seen.
- If the root cause is actually on Python's side (a stderr spew loop at idle), this PR stops it from killing the TUI while the underlying issue gets chased separately. Filing a follow-up to audit Python-side stderr volume at idle is recommended.