### PR TITLE
fix(anthropic): preserve dots in Bedrock inference profile IDs

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -831,18 +831,39 @@ def read_hermes_oauth_credentials() -> Optional[Dict[str, Any]]:
 # ---------------------------------------------------------------------------
 
 
+_BEDROCK_PROFILE_PREFIXES = ("global.", "us.", "eu.", "ap.", "jp.")
+_BEDROCK_PROVIDER_SEGMENTS = (".anthropic.", ".meta.", ".amazon.", ".cohere.")
+
+
+def _is_bedrock_inference_profile(model: str) -> bool:
+    """Return True if *model* looks like a Bedrock inference profile ID.
+
+    Bedrock profiles use dots as namespace separators (e.g.
+    ``global.anthropic.claude-sonnet-4-6``), which must NOT be replaced
+    with hyphens.
+    """
+    lower = model.lower()
+    if any(lower.startswith(p) for p in _BEDROCK_PROFILE_PREFIXES):
+        return True
+    if any(seg in lower for seg in _BEDROCK_PROVIDER_SEGMENTS):
+        return True
+    return False
+
+
 def normalize_model_name(model: str, preserve_dots: bool = False) -> str:
     """Normalize a model name for the Anthropic API.
 
     - Strips 'anthropic/' prefix (OpenRouter format, case-insensitive)
     - Converts dots to hyphens in version numbers (OpenRouter uses dots,
       Anthropic uses hyphens: claude-opus-4.6 → claude-opus-4-6), unless
-      preserve_dots is True (e.g. for Alibaba/DashScope: qwen3.5-plus).
+      preserve_dots is True (e.g. for Alibaba/DashScope: qwen3.5-plus)
+      or the name is a Bedrock inference profile (dots are namespace
+      separators, not version separators).
     """
     lower = model.lower()
     if lower.startswith("anthropic/"):
         model = model[len("anthropic/"):]
-    if not preserve_dots:
+    if not preserve_dots and not _is_bedrock_inference_profile(model):
         # OpenRouter uses dots for version separators (claude-opus-4.6),
         # Anthropic uses hyphens (claude-opus-4-6). Convert dots to hyphens.
         model = model.replace(".", "-")

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -481,6 +481,19 @@ class TestNormalizeModelName:
         assert normalize_model_name("anthropic/qwen3.5-plus", preserve_dots=True) == "qwen3.5-plus"
         assert normalize_model_name("qwen3.5-flash", preserve_dots=True) == "qwen3.5-flash"
 
+    def test_bedrock_inference_profile_dots_preserved(self):
+        """Bedrock inference profile IDs use dots as namespace separators. Fixes #12727."""
+        assert normalize_model_name("global.anthropic.claude-sonnet-4-6") == "global.anthropic.claude-sonnet-4-6"
+        assert normalize_model_name("us.anthropic.claude-opus-4-6") == "us.anthropic.claude-opus-4-6"
+        assert normalize_model_name("eu.anthropic.claude-sonnet-4-6") == "eu.anthropic.claude-sonnet-4-6"
+        assert normalize_model_name("ap.anthropic.claude-sonnet-4-6") == "ap.anthropic.claude-sonnet-4-6"
+        assert normalize_model_name("jp.amazon.nova-pro-v1") == "jp.amazon.nova-pro-v1"
+
+    def test_openrouter_dots_still_converted(self):
+        """OpenRouter version dots should still be converted to hyphens."""
+        assert normalize_model_name("claude-opus-4.6") == "claude-opus-4-6"
+        assert normalize_model_name("anthropic/claude-sonnet-4.5") == "claude-sonnet-4-5"
+
 
 # ---------------------------------------------------------------------------
 # Tool conversion


### PR DESCRIPTION
Fixes #12727

## Problem
`normalize_model_name()` replaces all dots with hyphens, breaking Bedrock inference profile IDs like `global.anthropic.claude-sonnet-4-6` → `global-anthropic-claude-sonnet-4-6`.

## Solution
Added `_is_bedrock_inference_profile()` helper that detects Bedrock inference profile patterns (region prefixes + provider segments). When detected, dot-to-hyphen replacement is skipped. OpenRouter models continue normalizing as before.

## Tests
Added tests for both cases. All 122 tests pass.