### PR TITLE
fix: move kimi-k2.5 from instant to thinking models

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -107,11 +107,11 @@ _FIXED_TEMPERATURE_MODELS: Dict[str, float] = {
 # the standard chat API and third parties) are NOT clamped.
 # Source: https://platform.kimi.ai/docs/guide/kimi-k2-5-quickstart
 _KIMI_INSTANT_MODELS: frozenset = frozenset({
-    "kimi-k2.5",
     "kimi-k2-turbo-preview",
     "kimi-k2-0905-preview",
 })
 _KIMI_THINKING_MODELS: frozenset = frozenset({
+    "kimi-k2.5",
     "kimi-k2-thinking",
     "kimi-k2-thinking-turbo",
 })


### PR DESCRIPTION
## Problem

\kimi-k2.5\ was incorrectly classified in \_KIMI_INSTANT_MODELS\ (temperature=0.6), but Moonshot's API requires temperature=1.0 (thinking mode) for this model. This causes HTTP 400: \invalid temperature: only 1 is allowed for this model\.

## Fix

Move \kimi-k2.5\ from \_KIMI_INSTANT_MODELS\ to \_KIMI_THINKING_MODELS\.

One-line change in \gent/auxiliary_client.py\.

Reference: https://platform.kimi.ai/docs/guide/kimi-k2-5-quickstart

Fixes #12745