### PR TITLE
fix(tui): visual-row Up/Down navigation and cross-newline Left/Right in the input area

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3389,6 +3389,171 @@ def _estimate_tui_input_height(
     return min(max(visual_lines, 1), max(1, int(max_height or 1)))
 
 
+def _cli_cwidth(text: str) -> int:
+    """Terminal cell width for ``text``, matching classic input layout."""
+    try:
+        from prompt_toolkit.utils import get_cwidth
+
+        return get_cwidth(text or "")
+    except Exception:
+        return len(text or "")
+
+
+def _build_input_visual_rows(
+    text: str,
+    window_width: int,
+    prompt_width: int,
+) -> list[tuple[int, int, int]]:
+    """Build exclusive visual-row ranges for classic soft-wrapped input.
+
+    Each entry is ``(row_start, row_end, loglineno)`` where ``row_end`` is
+    exclusive over buffer indices. Wrapping uses display-cell widths via
+    ``get_cwidth`` so CJK / wide glyphs match prompt_toolkit layout.
+    """
+    win_w = max(1, int(window_width or 1))
+    prompt_w = max(0, int(prompt_width or 0))
+    logical_lines = (text or "").split("\n")
+    rows: list[tuple[int, int, int]] = []
+    char_idx = 0
+
+    for loglineno, line in enumerate(logical_lines):
+        first_row_cells = (win_w - prompt_w) if loglineno == 0 else win_w
+        first_row_cells = max(1, first_row_cells)
+        line_start = char_idx
+
+        if not line:
+            rows.append((line_start, line_start, loglineno))
+        else:
+            offset = 0
+            is_first_row = True
+            while offset < len(line):
+                avail = first_row_cells if is_first_row else win_w
+                is_first_row = False
+                r_start = line_start + offset
+                width = 0
+                consumed = 0
+                while offset + consumed < len(line):
+                    cw = max(1, _cli_cwidth(line[offset + consumed]))
+                    if width > 0 and width + cw > avail:
+                        break
+                    width += cw
+                    consumed += 1
+                    if width >= avail:
+                        break
+                if consumed == 0:
+                    consumed = 1
+                r_end = r_start + consumed
+                rows.append((r_start, r_end, loglineno))
+                offset += consumed
+
+        char_idx += len(line) + 1  # +1 for the '\n' separator
+
+    return rows or [(0, 0, 0)]
+
+
+def _find_input_visual_row(
+    rows: list[tuple[int, int, int]],
+    pos: int,
+    text_len: int,
+) -> int:
+    """Locate the visual row for ``pos`` using non-overlapping membership.
+
+    Ranges are half-open ``[start, end)``. The cursor may also sit on:
+    - an empty logical line (``start == end``),
+    - the end of a logical line's last visual row (``pos == end`` before ``\\n`` / EOF),
+    - EOF (``pos == text_len``) on the final row.
+    Wrap boundaries belong to the next row (``pos == next_start``).
+    """
+    if not rows:
+        return 0
+
+    pos = max(0, min(int(pos), int(text_len)))
+
+    for i, (r_start, r_end, loglineno) in enumerate(rows):
+        if r_start == r_end and pos == r_start:
+            return i
+        if r_start <= pos < r_end:
+            return i
+
+        is_last = i == len(rows) - 1
+        next_start = rows[i + 1][0] if not is_last else text_len + 1
+        next_log = rows[i + 1][2] if not is_last else loglineno + 1
+        at_line_end = pos == r_end and (is_last or next_start > r_end or next_log != loglineno)
+        if at_line_end:
+            return i
+
+    return len(rows) - 1
+
+
+def _pos_at_row_display_col(text: str, row_start: int, row_end: int, display_col: int) -> int:
+    """Map a display column within a visual row to a buffer index in ``[start, end]``."""
+    if row_start >= row_end:
+        return row_start
+
+    target = max(0, int(display_col))
+    width = 0
+    i = row_start
+    while i < row_end:
+        cw = max(1, _cli_cwidth(text[i]))
+        if width + cw > target:
+            break
+        width += cw
+        i += 1
+        if width >= target:
+            break
+    return i
+
+
+def _visual_row_move_cursor(
+    text: str,
+    pos: int,
+    direction: int,
+    window_width: int,
+    prompt_width: int,
+) -> int | None:
+    """Return the cursor index after one visual-row step, or ``None`` for history.
+
+    ``direction`` is ``-1`` (up) or ``+1`` (down). Screen-column preference is
+    preserved across the prompt-bearing first visual row.
+    """
+    rows = _build_input_visual_rows(text, window_width, prompt_width)
+    text_len = len(text or "")
+    pos = max(0, min(int(pos), text_len))
+    cur_row_idx = _find_input_visual_row(rows, pos, text_len)
+    r_start, r_end, loglineno = rows[cur_row_idx]
+    prompt_w = max(0, int(prompt_width or 0))
+    content_col = _cli_cwidth(text[r_start:pos]) if pos > r_start else 0
+    screen_col = content_col + (prompt_w if cur_row_idx == 0 else 0)
+    max_logical = rows[-1][2]
+
+    if direction < 0:
+        if cur_row_idx == 0:
+            return None
+        prev_start, prev_end, _prev_log = rows[cur_row_idx - 1]
+        dest_idx = cur_row_idx - 1
+        dest_col = max(0, screen_col - (prompt_w if dest_idx == 0 else 0))
+        return _pos_at_row_display_col(text, prev_start, prev_end, dest_col)
+
+    if loglineno == max_logical and cur_row_idx == len(rows) - 1:
+        return None
+    if cur_row_idx >= len(rows) - 1:
+        return None
+
+    next_start, next_end, _next_log = rows[cur_row_idx + 1]
+    dest_idx = cur_row_idx + 1
+    dest_col = max(0, screen_col - (prompt_w if dest_idx == 0 else 0))
+    return _pos_at_row_display_col(text, next_start, next_end, dest_col)
+
+
+def _history_forward_preserve_draft_cursor(buf, count: int = 1) -> None:
+    """Step history forward without forcing the cursor to the end of the buffer.
+
+    When prompt_toolkit restores the unsubmitted draft, its saved cursor
+    position must be kept so the user returns to where they were editing.
+    """
+    buf.history_forward(count=count)
+
+
 def _collect_query_images(query: str | None, image_arg: str | None = None) -> tuple[str, list[Path]]:
     """Collect local image attachments for single-query CLI flows."""
     message = query or ""
@@ -15194,8 +15359,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             first logical line.
 
             The first visual row therefore holds window_width - prompt_width
-            buffer characters; every other visual row holds window_width."""
-            from prompt_toolkit.utils import get_cwidth
+            display cells of buffer content; every other visual row holds
+            window_width cells."""
             info = input_area.window.render_info
             if info is not None and info.window_width > 0:
                 win_w = info.window_width
@@ -15206,87 +15371,25 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
                     cols = 80
                 win_w = max(1, cols)
             try:
-                prompt_w = get_cwidth(self._get_tui_prompt_text())
+                prompt_w = _cli_cwidth(self._get_tui_prompt_text())
             except Exception:
                 prompt_w = 2
             return win_w, max(0, prompt_w)
 
         def _visual_move(buf, direction: int) -> bool:
-            """Move the cursor up (direction=-1) or down (direction=+1) by one
-            visual row within the soft-wrapped, possibly multi-line input.
-
-            Each visual row is represented as (row_start, row_end, loglineno)
-            where row_start/row_end are buffer indices (row_end exclusive of
-            the trailing newline) and loglineno is the logical line index.
-
-            History recall is triggered by loglineno:
-              UP:   return False when loglineno == 0 (on the first logical line)
-              DOWN: return False when loglineno == max_logical_lines
-
-            The prompt prefix occupies prompt_w screen columns on visual row 0
-            only, so hpos is adjusted when crossing the row-0 / row-1 boundary.
-            """
+            """Move the cursor up/down one visual row. Return False for history."""
             win_w, prompt_w = _get_window_width()
-            pos = buf.cursor_position
-            text = buf.text
-            logical_lines = text.split('\n')
-            max_logical_lines = len(logical_lines) - 1  # 0-based index of last
-
-            # Build list of visual rows: (row_start, row_end, loglineno)
-            rows = []
-            char_idx = 0
-            for loglineno, line in enumerate(logical_lines):
-                first_row_w = (win_w - prompt_w) if loglineno == 0 else win_w
-                first_row_w = max(1, first_row_w)
-                line_start = char_idx
-                line_len = len(line)
-                if line_len == 0:
-                    rows.append((line_start, line_start, loglineno))
-                else:
-                    offset = 0
-                    while offset < line_len:
-                        rw = first_row_w if offset == 0 else win_w
-                        r_start = line_start + offset
-                        r_end = min(r_start + rw, line_start + line_len)
-                        rows.append((r_start, r_end, loglineno))
-                        offset += rw
-                char_idx += line_len + 1  # +1 for the '\n'
-
-            # Find the visual row the cursor is currently on.
-            cur_row_idx = len(rows) - 1
-            for i, (r_start, r_end, _) in enumerate(rows):
-                if r_start <= pos <= r_end:
-                    cur_row_idx = i
-                    break
-
-            r_start, r_end, loglineno = rows[cur_row_idx]
-            hpos = pos - r_start  # horizontal position within current visual row
-
-            if direction == -1:  # UP
-                # History recall when on the first logical line.
-                if loglineno == 0 and cur_row_idx == 0:
-                    return False
-                if cur_row_idx == 0:
-                    # Shouldn't happen (loglineno > 0 but cur_row_idx == 0),
-                    # but guard anyway.
-                    return False
-                prev_start, prev_end, prev_loglineno = rows[cur_row_idx - 1]
-                # Crossing from visual row 1 to visual row 0: subtract prompt_w
-                # because visual row 0 has the prompt prefix.
-                target_hpos = max(0, hpos - prompt_w) if cur_row_idx == 1 else hpos
-                buf.cursor_position = prev_start + min(target_hpos, prev_end - prev_start)
-                return True
-            else:  # DOWN
-                # History recall when on the last logical line.
-                if loglineno == max_logical_lines and cur_row_idx == len(rows) - 1:
-                    return False
-                if cur_row_idx == len(rows) - 1:
-                    return False
-                next_start, next_end, next_loglineno = rows[cur_row_idx + 1]
-                # Crossing from visual row 0 to visual row 1: add prompt_w.
-                target_hpos = (hpos + prompt_w) if cur_row_idx == 0 else hpos
-                buf.cursor_position = next_start + min(target_hpos, next_end - next_start)
-                return True
+            next_pos = _visual_row_move_cursor(
+                buf.text,
+                buf.cursor_position,
+                direction,
+                win_w,
+                prompt_w,
+            )
+            if next_pos is None:
+                return False
+            buf.cursor_position = next_pos
+            return True
 
         @kb.add('up', filter=_normal_input, eager=True)
         def smart_up(event):
@@ -15306,8 +15409,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             automatically restored."""
             buf = event.app.current_buffer
             if not _visual_move(buf, +1):
-                buf.history_forward(count=event.arg)
-                buf.cursor_position = len(buf.text)
+                _history_forward_preserve_draft_cursor(buf, count=event.arg)
 
         @kb.add('right', filter=_normal_input, eager=True)
         def smart_right(event):

--- a/cli.py
+++ b/cli.py
@@ -3545,13 +3545,53 @@ def _visual_row_move_cursor(
     return _pos_at_row_display_col(text, next_start, next_end, dest_col)
 
 
-def _history_forward_preserve_draft_cursor(buf, count: int = 1) -> None:
-    """Step history forward without forcing the cursor to the end of the buffer.
+def _buffer_on_working_draft(buf) -> bool:
+    """True when ``buf`` is on the editable working draft (not a history entry)."""
+    try:
+        return buf.working_index >= len(buf._working_lines) - 1
+    except Exception:
+        return True
 
-    When prompt_toolkit restores the unsubmitted draft, its saved cursor
-    position must be kept so the user returns to where they were editing.
+
+def _remember_draft_history_cursor(
+    slot: dict[str, int | None],
+    cursor: int,
+    *,
+    on_draft: bool,
+    suppress: bool,
+) -> None:
+    """Update the saved draft cursor unless Up/Down history navigation is in progress.
+
+    Climbing Up through soft-wrapped / hard-newline rows moves the live cursor to
+    the top of the draft before ``history_backward`` runs. Those intermediate
+    positions must not overwrite the last real edit location.
+    """
+    if suppress or not on_draft:
+        return
+    slot["pos"] = max(0, int(cursor))
+
+
+def _history_forward_restore_draft_cursor(
+    buf,
+    count: int = 1,
+    draft_cursor: int | None = None,
+) -> None:
+    """Step history forward, restoring ``draft_cursor`` when landing on the draft.
+
+    prompt_toolkit's ``history_forward`` always places the cursor at the end of
+    the first line (``cursor_position = 0`` then ``get_end_of_line_position()``).
+    That is fine while browsing history, but when Down returns to the unsubmitted
+    draft it would erase the user's edit position — so we re-apply a cursor saved
+    from the last edit on the draft (not the position after climbing to row 0).
     """
     buf.history_forward(count=count)
+    if draft_cursor is None or not _buffer_on_working_draft(buf):
+        return
+    buf.cursor_position = min(max(0, int(draft_cursor)), len(buf.text))
+
+
+# Backwards-compatible alias used by older call sites / tests.
+_history_forward_preserve_draft_cursor = _history_forward_restore_draft_cursor
 
 
 def _collect_query_images(query: str | None, image_arg: str | None = None) -> tuple[str, list[Path]]:
@@ -15391,6 +15431,24 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             buf.cursor_position = next_pos
             return True
 
+        # Saved edit cursor on the working draft; restored when Down returns
+        # from history. prompt_toolkit does not preserve this itself, and
+        # climbing Up through rows must not overwrite it with position 0.
+        draft_history_cursor: dict[str, int | None] = {"pos": None}
+        suppress_draft_cursor_track = {"on": False}
+
+        def _track_draft_cursor(_buffer=None) -> None:
+            buf = input_area.buffer
+            _remember_draft_history_cursor(
+                draft_history_cursor,
+                buf.cursor_position,
+                on_draft=_buffer_on_working_draft(buf),
+                suppress=suppress_draft_cursor_track["on"],
+            )
+
+        input_area.buffer.on_cursor_position_changed += _track_draft_cursor
+        _track_draft_cursor()
+
         @kb.add('up', filter=_normal_input, eager=True)
         def smart_up(event):
             """Move cursor up one visual row within the soft-wrapped input, or
@@ -15398,8 +15456,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             row.  The unsubmitted draft is preserved in prompt_toolkit's
             working_index and is restored when stepping back down past the most
             recent entry."""
-            if not _visual_move(event.app.current_buffer, -1):
-                event.app.current_buffer.history_backward(count=event.arg)
+            buf = event.app.current_buffer
+            suppress_draft_cursor_track["on"] = True
+            try:
+                if not _visual_move(buf, -1):
+                    buf.history_backward(count=event.arg)
+            finally:
+                suppress_draft_cursor_track["on"] = False
 
         @kb.add('down', filter=_normal_input, eager=True)
         def smart_down(event):
@@ -15409,7 +15472,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             automatically restored."""
             buf = event.app.current_buffer
             if not _visual_move(buf, +1):
-                _history_forward_preserve_draft_cursor(buf, count=event.arg)
+                suppress_draft_cursor_track["on"] = True
+                try:
+                    _history_forward_restore_draft_cursor(
+                        buf,
+                        count=event.arg,
+                        draft_cursor=draft_history_cursor["pos"],
+                    )
+                finally:
+                    suppress_draft_cursor_track["on"] = False
 
         @kb.add('right', filter=_normal_input, eager=True)
         def smart_right(event):

--- a/cli.py
+++ b/cli.py
@@ -14014,23 +14014,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             _idx = 9 if _num == 0 else _num - 1
             kb.add(str(_num), filter=Condition(lambda: bool(self._slash_confirm_state)))(_make_slash_confirm_number_handler(_idx))
 
-        # --- History navigation: up/down browse history in normal input mode ---
-        # The TextArea is multiline, so by default up/down only move the cursor.
-        # Buffer.auto_up/auto_down handle both: cursor movement when multi-line,
-        # history browsing when on the first/last line (or single-line input).
-        _normal_input = Condition(
-            lambda: not self._clarify_state and not self._approval_state and not self._slash_confirm_state and not self._sudo_state and not self._secret_state and not self._model_picker_state
-        )
-
-        @kb.add('up', filter=_normal_input)
-        def history_up(event):
-            """Up arrow: browse history when on first line, else move cursor up."""
-            event.app.current_buffer.auto_up(count=event.arg)
-
-        @kb.add('down', filter=_normal_input)
-        def history_down(event):
-            """Down arrow: browse history when on last line, else move cursor down."""
-            event.app.current_buffer.auto_down(count=event.arg)
+        # Smart Up/Down for soft-wrapped input are registered after input_area
+        # is created (below), where input_area.window.render_info is available.
 
         @kb.add('c-l')
         def handle_ctrl_l(event):
@@ -15179,6 +15164,164 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
 
         # Allow wrapper CLIs to register extra keybindings.
         self._register_extra_tui_keybindings(kb, input_area=input_area)
+
+        # --- Smart Up/Down/Left/Right: visual-row navigation in the input area ---
+        #
+        # prompt_toolkit's auto_up/auto_down use document.cursor_position_row,
+        # which counts only hard newlines (\n). On a long soft-wrapped prompt
+        # with no hard newlines, cursor_position_row is always 0, so auto_up
+        # immediately steps to history instead of moving the cursor up one visual
+        # row. The bindings below fix this by computing cursor movement from the
+        # rendered screen layout.
+        #
+        # smart_right/smart_left replace the default bindings so that the cursor
+        # can cross hard-newline boundaries; next/previous word already did
+        # this correctly.
+        #
+        # input_area must be in scope here so that input_area.window.render_info
+        # is accessible at key-press time (render_info is None before first render).
+        _normal_input = Condition(
+            lambda: not self._clarify_state and not self._approval_state and not self._slash_confirm_state and not self._sudo_state and not self._secret_state and not self._model_picker_state
+        )
+
+        def _get_window_width() -> tuple[int, int]:
+            """Return (window_width, prompt_width) for the input area.
+
+            window_width is the full content-area width reported by
+            prompt_toolkit (terminal columns minus any left/right margins).
+            prompt_width is the display width of the prompt prefix (e.g. "› ")
+            which BeforeInput prepends only to the first visual row of the
+            first logical line.
+
+            The first visual row therefore holds window_width - prompt_width
+            buffer characters; every other visual row holds window_width."""
+            from prompt_toolkit.utils import get_cwidth
+            info = input_area.window.render_info
+            if info is not None and info.window_width > 0:
+                win_w = info.window_width
+            else:
+                try:
+                    cols = shutil.get_terminal_size((80, 24)).columns
+                except Exception:
+                    cols = 80
+                win_w = max(1, cols)
+            try:
+                prompt_w = get_cwidth(self._get_tui_prompt_text())
+            except Exception:
+                prompt_w = 2
+            return win_w, max(0, prompt_w)
+
+        def _visual_move(buf, direction: int) -> bool:
+            """Move the cursor up (direction=-1) or down (direction=+1) by one
+            visual row within the soft-wrapped, possibly multi-line input.
+
+            Each visual row is represented as (row_start, row_end, loglineno)
+            where row_start/row_end are buffer indices (row_end exclusive of
+            the trailing newline) and loglineno is the logical line index.
+
+            History recall is triggered by loglineno:
+              UP:   return False when loglineno == 0 (on the first logical line)
+              DOWN: return False when loglineno == max_logical_lines
+
+            The prompt prefix occupies prompt_w screen columns on visual row 0
+            only, so hpos is adjusted when crossing the row-0 / row-1 boundary.
+            """
+            win_w, prompt_w = _get_window_width()
+            pos = buf.cursor_position
+            text = buf.text
+            logical_lines = text.split('\n')
+            max_logical_lines = len(logical_lines) - 1  # 0-based index of last
+
+            # Build list of visual rows: (row_start, row_end, loglineno)
+            rows = []
+            char_idx = 0
+            for loglineno, line in enumerate(logical_lines):
+                first_row_w = (win_w - prompt_w) if loglineno == 0 else win_w
+                first_row_w = max(1, first_row_w)
+                line_start = char_idx
+                line_len = len(line)
+                if line_len == 0:
+                    rows.append((line_start, line_start, loglineno))
+                else:
+                    offset = 0
+                    while offset < line_len:
+                        rw = first_row_w if offset == 0 else win_w
+                        r_start = line_start + offset
+                        r_end = min(r_start + rw, line_start + line_len)
+                        rows.append((r_start, r_end, loglineno))
+                        offset += rw
+                char_idx += line_len + 1  # +1 for the '\n'
+
+            # Find the visual row the cursor is currently on.
+            cur_row_idx = len(rows) - 1
+            for i, (r_start, r_end, _) in enumerate(rows):
+                if r_start <= pos <= r_end:
+                    cur_row_idx = i
+                    break
+
+            r_start, r_end, loglineno = rows[cur_row_idx]
+            hpos = pos - r_start  # horizontal position within current visual row
+
+            if direction == -1:  # UP
+                # History recall when on the first logical line.
+                if loglineno == 0 and cur_row_idx == 0:
+                    return False
+                if cur_row_idx == 0:
+                    # Shouldn't happen (loglineno > 0 but cur_row_idx == 0),
+                    # but guard anyway.
+                    return False
+                prev_start, prev_end, prev_loglineno = rows[cur_row_idx - 1]
+                # Crossing from visual row 1 to visual row 0: subtract prompt_w
+                # because visual row 0 has the prompt prefix.
+                target_hpos = max(0, hpos - prompt_w) if cur_row_idx == 1 else hpos
+                buf.cursor_position = prev_start + min(target_hpos, prev_end - prev_start)
+                return True
+            else:  # DOWN
+                # History recall when on the last logical line.
+                if loglineno == max_logical_lines and cur_row_idx == len(rows) - 1:
+                    return False
+                if cur_row_idx == len(rows) - 1:
+                    return False
+                next_start, next_end, next_loglineno = rows[cur_row_idx + 1]
+                # Crossing from visual row 0 to visual row 1: add prompt_w.
+                target_hpos = (hpos + prompt_w) if cur_row_idx == 0 else hpos
+                buf.cursor_position = next_start + min(target_hpos, next_end - next_start)
+                return True
+
+        @kb.add('up', filter=_normal_input, eager=True)
+        def smart_up(event):
+            """Move cursor up one visual row within the soft-wrapped input, or
+            step to the previous history entry when already on the first visual
+            row.  The unsubmitted draft is preserved in prompt_toolkit's
+            working_index and is restored when stepping back down past the most
+            recent entry."""
+            if not _visual_move(event.app.current_buffer, -1):
+                event.app.current_buffer.history_backward(count=event.arg)
+
+        @kb.add('down', filter=_normal_input, eager=True)
+        def smart_down(event):
+            """Move cursor down one visual row within the soft-wrapped input,
+            or step to the next history entry when already on the last visual
+            row.  At the most recent entry the unsubmitted draft is
+            automatically restored."""
+            buf = event.app.current_buffer
+            if not _visual_move(buf, +1):
+                buf.history_forward(count=event.arg)
+                buf.cursor_position = len(buf.text)
+
+        @kb.add('right', filter=_normal_input, eager=True)
+        def smart_right(event):
+            """Right arrow: move one character right, crossing hard newlines."""
+            buf = event.app.current_buffer
+            if buf.cursor_position < len(buf.text):
+                buf.cursor_position += 1
+
+        @kb.add('left', filter=_normal_input, eager=True)
+        def smart_left(event):
+            """Left arrow: move one character left, crossing hard newlines."""
+            buf = event.app.current_buffer
+            if buf.cursor_position > 0:
+                buf.cursor_position -= 1
 
         # Layout: interactive prompt widgets + ruled input at bottom.
         # The sudo, approval, and clarify widgets appear above the input when

--- a/cli.py
+++ b/cli.py
@@ -8866,24 +8866,16 @@ class HermesCLI:
             self._close_model_picker()
             event.app.current_buffer.reset()
             event.app.invalidate()
-
-        # --- History navigation: up/down browse history in normal input mode ---
-        # The TextArea is multiline, so by default up/down only move the cursor.
-        # Buffer.auto_up/auto_down handle both: cursor movement when multi-line,
-        # history browsing when on the first/last line (or single-line input).
+        # --- History navigation: Up/Down in normal input mode ---
+        # prompt_toolkit's auto_up/auto_down only check hard newlines (\n), so
+        # they treat a long soft-wrapped line as a single text row and immediately
+        # step to history on the first Up keypress, even when the cursor is
+        # not at the first text row of the prompt.  The render_info-aware
+        # smart Up/Down bindings are registered below, after input_area is
+        # created, so that input_area.window.render_info is accessible.
         _normal_input = Condition(
             lambda: not self._clarify_state and not self._approval_state and not self._sudo_state and not self._secret_state and not self._model_picker_state
         )
-
-        @kb.add('up', filter=_normal_input)
-        def history_up(event):
-            """Up arrow: browse history when on first line, else move cursor up."""
-            event.app.current_buffer.auto_up(count=event.arg)
-
-        @kb.add('down', filter=_normal_input)
-        def history_down(event):
-            """Down arrow: browse history when on last line, else move cursor down."""
-            event.app.current_buffer.auto_down(count=event.arg)
 
         @kb.add('c-c')
         def handle_ctrl_c(event):
@@ -9771,6 +9763,161 @@ class HermesCLI:
 
         # Allow wrapper CLIs to register extra keybindings.
         self._register_extra_tui_keybindings(kb, input_area=input_area)
+
+        # --- Smart Up/Down/Left/Right: visual-row navigation in the input area ---
+        #
+        # prompt_toolkit's auto_up/auto_down use document.cursor_position_row,
+        # which counts only hard newlines (\n). On a long soft-wrapped prompt
+        # with no hard newlines, cursor_position_row is always 0, so auto_up
+        # immediately steps to history instead of moving the cursor up one visual
+        # row. The bindings below fix this by computing cursor movement from the
+        # rendered screen layout.
+        #
+        # smart_right/smart_left replace the default bindings so that the cursor
+        # can cross hard-newline boundaries; next/previous word already did
+        # this correctly, by the way.
+        #
+        # input_area must be in scope here so that input_area.window.render_info
+        # is accessible at key-press time (render_info is None before first render).
+
+        def _get_window_width() -> tuple[int, int]:
+            """Return (window_width, prompt_width) for the input area.
+
+            window_width is the full content-area width reported by
+            prompt_toolkit (terminal columns minus any left/right margins).
+            prompt_width is the display width of the prompt prefix (e.g. "› ")
+            which BeforeInput prepends only to the first visual row of the
+            first logical line.
+
+            The first visual row therefore holds window_width - prompt_width
+            buffer characters; every other visual row holds window_width."""
+            from prompt_toolkit.utils import get_cwidth
+            info = input_area.window.render_info
+            if info is not None and info.window_width > 0:
+                win_w = info.window_width
+            else:
+                try:
+                    cols = shutil.get_terminal_size((80, 24)).columns
+                except Exception:
+                    cols = 80
+                win_w = max(1, cols)
+            try:
+                prompt_w = get_cwidth(self._get_tui_prompt_text())
+            except Exception:
+                prompt_w = 2
+            return win_w, max(0, prompt_w)
+
+        def _visual_move(buf, direction: int) -> bool:
+            """Move the cursor up (direction=-1) or down (direction=+1) by one
+            visual row within the soft-wrapped, possibly multi-line input.
+
+            Each visual row is represented as (row_start, row_end, loglineno)
+            where row_start/row_end are buffer indices (row_end exclusive of
+            the trailing newline) and loglineno is the logical line index.
+
+            History recall is triggered by loglineno:
+              UP:   return False when loglineno == 0 (on the first logical line)
+              DOWN: return False when loglineno == max_logical_lines
+
+            The prompt prefix occupies prompt_w screen columns on visual row 0
+            only, so hpos is adjusted when crossing the row-0 / row-1 boundary.
+            """
+            win_w, prompt_w = _get_window_width()
+            pos = buf.cursor_position
+            text = buf.text
+            logical_lines = text.split('\n')
+            max_logical_lines = len(logical_lines) - 1  # 0-based index of last
+
+            # Build list of visual rows: (row_start, row_end, loglineno)
+            rows = []
+            char_idx = 0
+            for loglineno, line in enumerate(logical_lines):
+                first_row_w = (win_w - prompt_w) if loglineno == 0 else win_w
+                first_row_w = max(1, first_row_w)
+                line_start = char_idx
+                line_len = len(line)
+                if line_len == 0:
+                    rows.append((line_start, line_start, loglineno))
+                else:
+                    offset = 0
+                    while offset < line_len:
+                        rw = first_row_w if offset == 0 else win_w
+                        r_start = line_start + offset
+                        r_end = min(r_start + rw, line_start + line_len)
+                        rows.append((r_start, r_end, loglineno))
+                        offset += rw
+                char_idx += line_len + 1  # +1 for the '\n'
+
+            # Find the visual row the cursor is currently on.
+            cur_row_idx = len(rows) - 1
+            for i, (r_start, r_end, _) in enumerate(rows):
+                if r_start <= pos <= r_end:
+                    cur_row_idx = i
+                    break
+
+            r_start, r_end, loglineno = rows[cur_row_idx]
+            hpos = pos - r_start  # horizontal position within current visual row
+
+            if direction == -1:  # UP
+                # History recall when on the first logical line.
+                if loglineno == 0 and cur_row_idx == 0:
+                    return False
+                if cur_row_idx == 0:
+                    # Shouldn't happen (loglineno > 0 but cur_row_idx == 0),
+                    # but guard anyway.
+                    return False
+                prev_start, prev_end, prev_loglineno = rows[cur_row_idx - 1]
+                # Crossing from visual row 1 to visual row 0: subtract prompt_w
+                # because visual row 0 has the prompt prefix.
+                target_hpos = max(0, hpos - prompt_w) if cur_row_idx == 1 else hpos
+                buf.cursor_position = prev_start + min(target_hpos, prev_end - prev_start)
+                return True
+            else:  # DOWN
+                # History recall when on the last logical line.
+                if loglineno == max_logical_lines and cur_row_idx == len(rows) - 1:
+                    return False
+                if cur_row_idx == len(rows) - 1:
+                    return False
+                next_start, next_end, next_loglineno = rows[cur_row_idx + 1]
+                # Crossing from visual row 0 to visual row 1: add prompt_w.
+                target_hpos = (hpos + prompt_w) if cur_row_idx == 0 else hpos
+                buf.cursor_position = next_start + min(target_hpos, next_end - next_start)
+                return True
+
+        @kb.add('up', filter=_normal_input, eager=True)
+        def smart_up(event):
+            """Move cursor up one visual row within the soft-wrapped input, or
+            step to the previous history entry when already on the first visual
+            row.  The unsubmitted draft is preserved in prompt_toolkit's
+            working_index and is restored when stepping back down past the most
+            recent entry."""
+            if not _visual_move(event.app.current_buffer, -1):
+                event.app.current_buffer.history_backward(count=event.arg)
+
+        @kb.add('down', filter=_normal_input, eager=True)
+        def smart_down(event):
+            """Move cursor down one visual row within the soft-wrapped input,
+            or step to the next history entry when already on the last visual
+            row.  At the most recent entry the unsubmitted draft is
+            automatically restored."""
+            buf = event.app.current_buffer
+            if not _visual_move(buf, +1):
+                buf.history_forward(count=event.arg)
+                buf.cursor_position = len(buf.text)
+
+        @kb.add('right', filter=_normal_input, eager=True)
+        def smart_right(event):
+            """Right arrow: move one character right, crossing hard newlines."""
+            buf = event.app.current_buffer
+            if buf.cursor_position < len(buf.text):
+                buf.cursor_position += 1
+
+        @kb.add('left', filter=_normal_input, eager=True)
+        def smart_left(event):
+            """Left arrow: move one character left, crossing hard newlines."""
+            buf = event.app.current_buffer
+            if buf.cursor_position > 0:
+                buf.cursor_position -= 1
 
         # Layout: interactive prompt widgets + ruled input at bottom.
         # The sudo, approval, and clarify widgets appear above the input when

--- a/tests/cli/test_cli_visual_row_nav.py
+++ b/tests/cli/test_cli_visual_row_nav.py
@@ -1,0 +1,98 @@
+"""Tests for classic-CLI visual-row Up/Down navigation helpers."""
+
+from __future__ import annotations
+
+import cli as cli_mod
+
+
+class _FakeBuffer:
+    def __init__(self, text: str = "draft text", cursor: int = 3):
+        self.text = text
+        self.cursor_position = cursor
+        self.forward_calls = 0
+
+    def history_forward(self, count: int = 1) -> None:
+        self.forward_calls += count
+        # prompt_toolkit restores the working draft + its saved cursor here.
+        self.text = "draft text"
+        self.cursor_position = 3
+
+
+def test_build_rows_soft_wrap_uses_exclusive_ends_without_overlap():
+    # prompt takes 2 cells → first visual row holds 3 content cells at width 5.
+    rows = cli_mod._build_input_visual_rows("abcdefghij", window_width=5, prompt_width=2)
+    assert rows == [(0, 3, 0), (3, 8, 0), (8, 10, 0)]
+
+    # Wrap boundary belongs to the next row, not both.
+    assert cli_mod._find_input_visual_row(rows, 3, 10) == 1
+    assert cli_mod._find_input_visual_row(rows, 2, 10) == 0
+
+
+def test_build_rows_hard_newlines_and_empty_line():
+    text = "hi\n\nbye"
+    rows = cli_mod._build_input_visual_rows(text, window_width=80, prompt_width=2)
+    assert rows == [(0, 2, 0), (3, 3, 1), (4, 7, 2)]
+
+    # Cursor on the newline after "hi" maps to end of that logical line.
+    assert cli_mod._find_input_visual_row(rows, 2, len(text)) == 0
+    # Empty middle line.
+    assert cli_mod._find_input_visual_row(rows, 3, len(text)) == 1
+    # EOF sits on the last row.
+    assert cli_mod._find_input_visual_row(rows, len(text), len(text)) == 2
+
+
+def test_cjk_wrapping_uses_display_cell_width():
+    # Ten CJK chars = 20 cells. With prompt width 2 and width 14:
+    # first row content cells = 12 → 6 CJK chars; remainder 4 chars on row 2.
+    text = "你" * 10
+    rows = cli_mod._build_input_visual_rows(text, window_width=14, prompt_width=2)
+    assert rows == [(0, 6, 0), (6, 10, 0)]
+
+    # len()-based wrapping would have put 12 code points on row 0; display
+    # width must keep the wrap at 6 characters.
+    assert cli_mod._find_input_visual_row(rows, 6, len(text)) == 1
+
+
+def test_visual_move_soft_wrap_preserves_screen_column():
+    text = "abcdefghij"
+    # Cursor on 'e' (index 4) in the second visual row.
+    # Screen column on row 1 is content col 1.
+    down_from_b = cli_mod._visual_row_move_cursor(text, 1, +1, 5, 2)
+    # 'b' is content col 1 on prompt row → screen col 3 → row1 content col 3 → 'g'
+    assert down_from_b == 6
+
+    up_from_g = cli_mod._visual_row_move_cursor(text, 6, -1, 5, 2)
+    assert up_from_g == 1
+
+
+def test_visual_move_hard_newline_and_history_boundaries():
+    text = "hello\nworld"
+    # From col 2 of "hello" down to col 2 of "world" (screen-aware via prompt).
+    # content col 2 on row 0 → screen 4 → dest content col 4 → index 10 ('d' end-ish)
+    moved = cli_mod._visual_row_move_cursor(text, 2, +1, 80, 2)
+    assert moved == 10
+
+    assert cli_mod._visual_row_move_cursor(text, 1, -1, 80, 2) is None
+    assert cli_mod._visual_row_move_cursor(text, 8, +1, 80, 2) is None
+
+
+def test_visual_move_cjk_targets_matching_display_column():
+    text = "你" * 10
+    # Index 7 is the 8th CJK char → second visual row, content display col 2.
+    up = cli_mod._visual_row_move_cursor(text, 7, -1, 14, 2)
+    # screen col = 2; on prompt row content col = 0 → first CJK char.
+    assert up == 0
+
+    down = cli_mod._visual_row_move_cursor(text, 1, +1, 14, 2)
+    # content col 2 (你你), screen col 4 → second-row content col 4 → index 8.
+    assert down == 8
+
+
+def test_history_forward_preserves_draft_cursor():
+    buf = _FakeBuffer(text="history entry", cursor=0)
+    # Simulate returning to the draft: history_forward restores text+cursor,
+    # and our helper must not overwrite the restored cursor to len(text).
+    cli_mod._history_forward_preserve_draft_cursor(buf, count=1)
+    assert buf.forward_calls == 1
+    assert buf.text == "draft text"
+    assert buf.cursor_position == 3

--- a/tests/cli/test_cli_visual_row_nav.py
+++ b/tests/cli/test_cli_visual_row_nav.py
@@ -6,16 +6,30 @@ import cli as cli_mod
 
 
 class _FakeBuffer:
-    def __init__(self, text: str = "draft text", cursor: int = 3):
+    def __init__(
+        self,
+        text: str = "history entry",
+        cursor: int = 0,
+        *,
+        working_index: int = 0,
+        working_line_count: int = 2,
+        draft_text: str = "draft text",
+    ):
         self.text = text
         self.cursor_position = cursor
+        self.working_index = working_index
+        self._working_lines = [""] * max(1, working_line_count)
+        self._draft_text = draft_text
         self.forward_calls = 0
 
     def history_forward(self, count: int = 1) -> None:
         self.forward_calls += count
-        # prompt_toolkit restores the working draft + its saved cursor here.
-        self.text = "draft text"
-        self.cursor_position = 3
+        # Mirror prompt_toolkit: jump to end of the first line of the new entry.
+        self.working_index = min(self.working_index + count, len(self._working_lines) - 1)
+        if self.working_index >= len(self._working_lines) - 1:
+            self.text = self._draft_text
+        first_line = self.text.split("\n", 1)[0]
+        self.cursor_position = len(first_line)
 
 
 def test_build_rows_soft_wrap_uses_exclusive_ends_without_overlap():
@@ -88,11 +102,42 @@ def test_visual_move_cjk_targets_matching_display_column():
     assert down == 8
 
 
-def test_history_forward_preserves_draft_cursor():
-    buf = _FakeBuffer(text="history entry", cursor=0)
-    # Simulate returning to the draft: history_forward restores text+cursor,
-    # and our helper must not overwrite the restored cursor to len(text).
-    cli_mod._history_forward_preserve_draft_cursor(buf, count=1)
+def test_history_forward_restores_saved_draft_cursor():
+    # Mid-line draft cursor must survive Up→history→Down→draft.
+    buf = _FakeBuffer(text="history entry", cursor=0, working_index=0, working_line_count=2)
+    cli_mod._history_forward_restore_draft_cursor(buf, count=1, draft_cursor=6)
     assert buf.forward_calls == 1
     assert buf.text == "draft text"
-    assert buf.cursor_position == 3
+    assert buf.cursor_position == 6
+
+
+def test_history_forward_restores_cursor_on_multiline_draft():
+    # prompt_toolkit alone would park at end-of-first-line (0 for a leading blank).
+    buf = _FakeBuffer(
+        text="history entry",
+        cursor=0,
+        working_index=0,
+        working_line_count=2,
+        draft_text="\n\ntrailing",
+    )
+    cli_mod._history_forward_restore_draft_cursor(buf, count=1, draft_cursor=2)
+    assert buf.cursor_position == 2
+
+
+def test_history_forward_leaves_history_entry_cursor_alone():
+    buf = _FakeBuffer(text="old\nentry", cursor=0, working_index=0, working_line_count=3)
+    # Still browsing history (not yet on draft) — do not override pt's placement.
+    cli_mod._history_forward_restore_draft_cursor(buf, count=1, draft_cursor=9)
+    assert buf.working_index == 1
+    assert buf.cursor_position == len("old")  # end of first line after forward
+
+
+def test_remember_draft_cursor_ignores_climb_to_history():
+    slot: dict[str, int | None] = {"pos": 12}
+    # Climbing Up through rows suppresses tracking so position 0 cannot clobber.
+    cli_mod._remember_draft_history_cursor(slot, 0, on_draft=True, suppress=True)
+    assert slot["pos"] == 12
+    cli_mod._remember_draft_history_cursor(slot, 0, on_draft=True, suppress=False)
+    assert slot["pos"] == 0
+    cli_mod._remember_draft_history_cursor(slot, 5, on_draft=False, suppress=False)
+    assert slot["pos"] == 0


### PR DESCRIPTION
## What does this PR do?

I tend to write long prompts for the LLM, and using Hermes Agent was frustrating
because I couldn't move the cursor freely within the input area. I found that the
TUI area is a multiline `TextArea` with soft-wrap enabled.

The previous `Up`/`Down` bindings called `Buffer.auto_up()` / `Buffer.auto_down()`,
which use `document.cursor_position_row` to decide whether to move the cursor or
step to history. `cursor_position_row` counts only hard newlines (`\n`), so on a
long soft-wrapped prompt with no hard newlines it is always `0`. As a result,
pressing `Up` on any row of a wrapped prompt immediately stepped to history instead
of moving the cursor up one visual row. Other AI CLIs — notably Gemini CLI —
handle this correctly.

Additionally, `Right`/`Left` arrow stopped at hard-newline boundaries because
`get_cursor_right_position` / `get_cursor_left_position` are clamped to the
current logical line.

## Related Issue

No existing issue found — this PR is the first report of this bug.

## Type of Change

- ✅ 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

Replace the four affected bindings with `smart_up`, `smart_down`, `smart_right`,
and `smart_left`. All additions are in one contiguous block in `cli.py`; nothing
else in the codebase is touched. The core logic to review is `_visual_move`
(~50 lines of code, excluding comments).

`_visual_move` builds a list of visual rows from the buffer text, using
`render_info.window_width` for the wrap width and `_get_tui_prompt_text()` for
the prompt prefix width (the `BeforeInput` processor shifts the first visual row
right by `prompt_w` columns, so the first row holds `window_width - prompt_w`
buffer characters while all subsequent rows hold `window_width`). It then:

1. Locates the cursor's current visual row and horizontal position (`hpos`).
2. Moves to the adjacent visual row at the same `hpos`, clamped to that row's
   length.
3. Adjusts `hpos` by `±prompt_w` when crossing the visual-row-0 / visual-row-1
   boundary to keep the screen column consistent.
4. Returns `False` (triggering history recall) only when the cursor is on the
   first visual row of the first logical line (`Up`) or the last visual row of the
   last logical line (`Down`).

`smart_right` / `smart_left` are one-liners that increment/decrement
`buf.cursor_position` with a bounds check, allowing the cursor to cross hard
newlines naturally.

### Smart Up/Down Arrow Navigation in the Prompt Input Area — Behavior Table

| Key | Cursor position | Action |
|-----|----------------|--------|
| ↑ Up | NOT on the first text row (or text rows are scrolled above) | Move cursor up one text row |
| ↑ Up | On the first text row, nothing scrolled above | Step to previous history entry (draft preserved) |
| ↓ Down | NOT on the last text row (or text rows are scrolled below) | Move cursor down one text row |
| ↓ Down | On the last text row, nothing scrolled below | Step to next history entry (last entry: restore draft) |

> **Note:** When stepping to history, the user's unsubmitted draft is automatically
> preserved in prompt\_toolkit's `working_index` and is restored when stepping
> back down past the most recent entry. This matches the behavior of fish, zsh,
> and Gemini CLI.

| File | Removed | Added |
|------|---------|-------|
| `cli.py` | 15 lines | 159 lines |

## How to Test

1. Start the CLI: `python cli.py`
2. Type a long prompt that soft-wraps across at least 3 visual rows (do not press Enter).
3. Press `Up`. The cursor should move up one visual row within your draft.
4. Press `Up` until the cursor is on the first visual row.
5. Press `Up` again. The prompt should step to the previous history entry.
6. Press `Down`. Your unsubmitted draft should be restored exactly as you left it.
7. Type a prompt with a hard newline (`Ctrl+J`), then use `Right`/`Left` to confirm the cursor crosses the newline boundary.

## Checklist

### Code
- ✅ I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- ✅ My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- ✅ I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- ✅ My PR contains only changes related to this fix (no unrelated commits)
- ✅ I've run `pytest tests/ -q` and all tests pass
- ⬜ I've added tests for my changes — the fix is in interactive TUI key bindings; automated testing requires a running terminal emulator and is not covered by the existing pytest suite
- ✅ I've tested on my platform: macOS

### Documentation & Housekeeping
- ✅ I've updated relevant documentation — N/A (no public API or config change)
- ✅ I've updated `cli-config.yaml.example` — N/A
- ✅ I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- ✅ I've considered cross-platform impact — the fix relies purely on prompt\_toolkit's `WindowRenderInfo` and `buf.cursor_position`, which are platform-independent
- ✅ I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

Platform tested on: macOS (should work identically on Linux as it relies purely
on prompt\_toolkit's internal `WindowRenderInfo`).

https://github.com/user-attachments/assets/640b8174-011c-4757-b244-d247cf2957bc
