### PR TITLE
fix: apply Anthropic max_tokens fallback to all chat_completions proxies

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2187,6 +2187,27 @@ class AIAgent:
             return {"max_completion_tokens": value}
         return {"max_tokens": value}
 
+    def _matches_anthropic_compatible_model(self) -> bool:
+        """Return True when ``self.model`` matches a known Anthropic-compatible
+        model in ``_ANTHROPIC_OUTPUT_LIMITS``.
+
+        Used to decide whether to inject an explicit ``max_tokens`` fallback
+        for chat_completions requests whose upstream proxy translates to
+        Anthropic's Messages API (which requires ``max_tokens`` as a mandatory
+        field).  The check is proxy-agnostic: any base_url is fine, only the
+        model name matters.  Unknown models return False so we don't risk
+        sending an oversized ``max_tokens`` to providers with their own
+        (possibly lower) ceilings.
+        """
+        if not self.model:
+            return False
+        try:
+            from agent.anthropic_adapter import _ANTHROPIC_OUTPUT_LIMITS
+        except Exception:
+            return False
+        m = self.model.lower().replace(".", "-")
+        return any(key in m for key in _ANTHROPIC_OUTPUT_LIMITS)
+
     def _has_content_after_think_block(self, content: str) -> bool:
         """
         Check if content has actual text after any reasoning/thinking blocks.
@@ -7207,14 +7228,28 @@ class AIAgent:
             # (the documented max output for qwen3-coder models) so the
             # model has adequate output budget for tool calls.
             api_kwargs.update(self._max_tokens_param(65536))
-        elif (self._is_openrouter_url() or "nousresearch" in self._base_url_lower) and "claude" in (self.model or "").lower():
-            # OpenRouter and Nous Portal translate requests to Anthropic's
-            # Messages API, which requires max_tokens as a mandatory field.
-            # When we omit it, the proxy picks a default that can be too
-            # low — the model spends its output budget on thinking and has
-            # almost nothing left for the actual response (especially large
-            # tool calls like write_file).  Sending the model's real output
-            # limit ensures full capacity.
+        elif self._matches_anthropic_compatible_model():
+            # Any Anthropic-compatible model served via a chat_completions
+            # proxy needs an explicit max_tokens — the upstream Messages API
+            # requires it as a mandatory field, and when omitted proxies pick
+            # their own defaults that can be too low:
+            #   • AWS Bedrock historically defaults to 4096 (reasoning + one
+            #     write_file tool call easily exceeds it → finish_reason=length
+            #     → continuation retries → rollback → user-visible truncation)
+            #   • OpenRouter and Nous Portal also pick low defaults
+            #   • Self-hosted LiteLLM / vLLM / custom gateways: unpredictable
+            #
+            # Previously this fallback was gated on the base_url being
+            # OpenRouter or Nous, which silently excluded every other proxy
+            # (Bedrock, NVIDIA inference, self-hosted gateways, …).  The
+            # gate is now the model name itself: if the model matches a
+            # known Anthropic-compatible entry in _ANTHROPIC_OUTPUT_LIMITS,
+            # we send the documented output limit regardless of which
+            # proxy URL serves it.
+            #
+            # Anthropic's own API uses api_mode='anthropic_messages' and
+            # never reaches this branch, so there is no conflict with the
+            # first-party SDK.
             try:
                 from agent.anthropic_adapter import _get_anthropic_max_output
                 _model_output_limit = _get_anthropic_max_output(self.model)

--- a/run_agent.py
+++ b/run_agent.py
@@ -3513,6 +3513,27 @@ class AIAgent:
             return {"max_completion_tokens": value}
         return {"max_tokens": value}
 
+    def _matches_anthropic_compatible_model(self) -> bool:
+        """Return True when ``self.model`` matches a known Anthropic-compatible
+        model in ``_ANTHROPIC_OUTPUT_LIMITS``.
+
+        Used to decide whether to inject an explicit ``max_tokens`` fallback
+        for chat_completions requests whose upstream proxy translates to
+        Anthropic's Messages API (which requires ``max_tokens`` as a mandatory
+        field).  The check is proxy-agnostic: any base_url is fine, only the
+        model name matters.  Unknown models return False so we don't risk
+        sending an oversized ``max_tokens`` to providers with their own
+        (possibly lower) ceilings.
+        """
+        if not self.model:
+            return False
+        try:
+            from agent.anthropic_adapter import _ANTHROPIC_OUTPUT_LIMITS
+        except Exception:
+            return False
+        m = self.model.lower().replace(".", "-")
+        return any(key in m for key in _ANTHROPIC_OUTPUT_LIMITS)
+
     def _has_content_after_think_block(self, content: str) -> bool:
         """
         Check if content has actual text after any reasoning/thinking blocks.
@@ -9316,9 +9337,30 @@ class AIAgent:
         if self.provider_data_collection:
             _prefs["data_collection"] = self.provider_data_collection
 
-        # Claude max-output override on aggregators
+        # Anthropic-compatible max-output override
+        #
+        # Any chat_completions proxy that translates to Anthropic's Messages
+        # API requires ``max_tokens`` as a mandatory field.  When omitted,
+        # proxies pick their own defaults that can be too low:
+        #   • AWS Bedrock historically defaults to 4096 (reasoning + one
+        #     write_file tool call easily exceeds it → finish_reason=length
+        #     → continuation retries → rollback → user-visible truncation)
+        #   • OpenRouter and Nous Portal also pick low defaults
+        #   • NVIDIA inference API, self-hosted LiteLLM / vLLM / custom
+        #     gateways: unpredictable, sometimes 4096 or smaller
+        #
+        # Previously this override was gated on the base_url being OpenRouter
+        # or Nous, which silently excluded every other proxy.  The gate is
+        # now the model name itself: if the model matches a known
+        # Anthropic-compatible entry in ``_ANTHROPIC_OUTPUT_LIMITS``, we
+        # send the documented output limit regardless of which proxy URL
+        # serves it.
+        #
+        # Anthropic's own API uses api_mode='anthropic_messages' and never
+        # reaches this code path, so there is no conflict with the
+        # first-party SDK.
         _ant_max = None
-        if (_is_or or _is_nous) and "claude" in (self.model or "").lower():
+        if self._matches_anthropic_compatible_model():
             try:
                 from agent.anthropic_adapter import _get_anthropic_max_output
                 _ant_max = _get_anthropic_max_output(self.model)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1049,6 +1049,76 @@ class TestBuildApiKwargs:
         kwargs = agent._build_api_kwargs(messages)
         assert kwargs["max_tokens"] == 65536
 
+    def test_openrouter_claude_uses_anthropic_max_output_fallback(self, agent):
+        """Regression guard: OpenRouter + Claude without explicit max_tokens
+        falls back to _get_anthropic_max_output."""
+        agent.base_url = "https://openrouter.ai/api/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "anthropic/claude-opus-4-6"
+        agent.max_tokens = None
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs.get("max_tokens") == 128_000
+
+    def test_custom_proxy_claude_uses_anthropic_max_output_fallback(self, agent):
+        """Any chat_completions proxy serving Claude (AWS Bedrock gateway,
+        NVIDIA inference API, self-hosted LiteLLM, etc.) should get the
+        real Anthropic max output cap as a floor — otherwise the upstream
+        proxy picks a surprise default (Bedrock historically = 4096) and
+        responses get truncated with finish_reason='length'."""
+        agent.base_url = "https://inference-api.nvidia.com/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "aws/anthropic/bedrock-claude-opus-4-7"
+        agent.max_tokens = None
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        # Must be set (not None) and well above Bedrock's 4096 default
+        assert kwargs.get("max_tokens") is not None
+        assert kwargs["max_tokens"] >= 32_000
+
+    def test_custom_proxy_minimax_uses_fallback(self, agent):
+        """The fallback is not Claude-specific: any Anthropic-compatible
+        model served via chat_completions benefits.  MiniMax's
+        Anthropic-compatible endpoints (listed in _ANTHROPIC_OUTPUT_LIMITS)
+        should also receive an explicit max_tokens regardless of proxy URL."""
+        agent.base_url = "https://example-proxy.internal/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "MiniMax-M2"
+        agent.max_tokens = None
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs.get("max_tokens") == 131_072
+
+    def test_custom_proxy_unknown_model_no_fallback(self, agent):
+        """Models not in _ANTHROPIC_OUTPUT_LIMITS (GPT-oss, Qwen served
+        via non-Portal URL, etc.) must NOT get the Anthropic fallback —
+        each provider has its own output ceiling and sending 128K to a
+        proxy that only supports 8K would trigger 'max_tokens too large'
+        errors."""
+        agent.base_url = "https://inference-api.nvidia.com/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "openai/gpt-oss-120b"
+        agent.max_tokens = None
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        # No max_tokens set — let the upstream proxy handle it
+        assert "max_tokens" not in kwargs
+
+    def test_fallback_condition_does_not_hardcode_claude_substring(self, agent):
+        """Meta-test: the fallback condition must dispatch on a known model
+        table, not on a hardcoded 'claude' substring.  Otherwise future
+        non-Claude Anthropic-compatible models (or Claude-branded models
+        with an unusual name) would silently regress.
+
+        This test asserts that the ``_matches_anthropic_compatible_model``
+        helper returns True for a known non-Claude Anthropic-compat entry
+        (MiniMax) — proving the check is table-driven, not string-driven.
+        """
+        agent.model = "MiniMax-M2.5"
+        assert agent._matches_anthropic_compatible_model() is True
+        agent.model = "some-future-model-without-claude-in-the-name"
+        assert agent._matches_anthropic_compatible_model() is False
+
     def test_ollama_think_false_on_effort_none(self, agent):
         """Custom (Ollama) provider with effort=none should inject think=false."""
         agent.provider = "custom"

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1457,6 +1457,80 @@ class TestBuildApiKwargs:
         kwargs = agent._build_api_kwargs(messages)
         assert kwargs["max_tokens"] == 65536
 
+    def test_openrouter_claude_uses_anthropic_max_output_fallback(self, agent):
+        """Regression guard: OpenRouter + Claude without explicit max_tokens
+        falls back to _get_anthropic_max_output."""
+        agent.base_url = "https://openrouter.ai/api/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "anthropic/claude-opus-4-6"
+        agent.max_tokens = None
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs.get("max_tokens") == 128_000
+
+    def test_custom_proxy_claude_uses_anthropic_max_output_fallback(self, agent):
+        """Any chat_completions proxy serving Claude (AWS Bedrock gateway,
+        NVIDIA inference API, self-hosted LiteLLM, etc.) should get the
+        real Anthropic max output cap as a floor — otherwise the upstream
+        proxy picks a surprise default (Bedrock historically = 4096) and
+        responses get truncated with finish_reason='length'."""
+        agent.base_url = "https://integrate.api.nvidia.com/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "aws/anthropic/bedrock-claude-opus-4-7"
+        agent.max_tokens = None
+        agent.provider = "custom"
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        # Must be set (not None) and well above Bedrock's 4096 default
+        assert kwargs.get("max_tokens") is not None
+        assert kwargs["max_tokens"] >= 32_000
+
+    def test_custom_proxy_minimax_uses_fallback(self, agent):
+        """The fallback is not Claude-specific: any Anthropic-compatible
+        model served via chat_completions benefits.  MiniMax's
+        Anthropic-compatible endpoints (listed in _ANTHROPIC_OUTPUT_LIMITS)
+        should also receive an explicit max_tokens regardless of proxy URL."""
+        agent.base_url = "https://example-proxy.internal/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "MiniMax-M2"
+        agent.max_tokens = None
+        agent.provider = "custom"
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs.get("max_tokens") == 131_072
+
+    def test_custom_proxy_unknown_non_anthropic_model_skips_fallback(self, agent):
+        """Models not in _ANTHROPIC_OUTPUT_LIMITS (GPT-oss served via a
+        non-OpenAI proxy, etc.) must NOT get the Anthropic 128K fallback.
+        Some proxies (NVIDIA NIM) apply their own lower default — that's a
+        separate code path; what matters here is that the Anthropic
+        table-driven fallback does not fire for these models."""
+        agent.base_url = "https://example-proxy.internal/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "openai/gpt-oss-120b"
+        agent.max_tokens = None
+        agent.provider = "custom"
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        # The Anthropic 128K fallback must not fire; the proxy-agnostic
+        # path leaves max_tokens unset for unknown models.
+        assert kwargs.get("max_tokens") != 128_000
+
+    def test_fallback_condition_does_not_hardcode_claude_substring(self, agent):
+        """Meta-test: the fallback condition must dispatch on a known model
+        table, not on a hardcoded 'claude' substring.  Otherwise future
+        non-Claude Anthropic-compatible models (or Claude-branded models
+        with an unusual name) would silently regress.
+
+        This test asserts that the ``_matches_anthropic_compatible_model``
+        helper returns True for a known non-Claude Anthropic-compat entry
+        (MiniMax) — proving the check is table-driven, not string-driven.
+        """
+        agent.model = "MiniMax-M2"
+        assert agent._matches_anthropic_compatible_model() is True
+        agent.model = "some-future-model-without-claude-in-the-name"
+        assert agent._matches_anthropic_compatible_model() is False
+
     def test_ollama_think_false_on_effort_none(self, agent):
         """Custom (Ollama) provider with effort=none should inject think=false."""
         agent.provider = "custom"


### PR DESCRIPTION
The fallback that injects an explicit max_tokens for Anthropic-compatible models was previously gated on the base_url being OpenRouter or Nousresearch. Any other chat_completions proxy (AWS Bedrock gateway, NVIDIA inference API, self-hosted LiteLLM, vLLM, corporate gateways, etc.) silently bypassed the fallback, shipping requests without max_tokens set.

Upstream proxies then picked their own defaults. AWS Bedrock historically defaults to 4096 — reasoning plus one write_file tool call easily exceeds that, producing finish_reason='length' → 3 continuation retries → rollback → the user-visible '⚠️ Response truncated due to output length limit' error.

The gate is now the model name itself: if the model matches a known Anthropic-compatible entry in _ANTHROPIC_OUTPUT_LIMITS, the documented output limit is sent regardless of which proxy URL serves it. The check is table-driven, not string-driven, so it also covers non-Claude Anthropic-compatible models (e.g. MiniMax) without hardcoding model family names.

Anthropic's first-party API uses api_mode='anthropic_messages' and does not reach this code path — no conflict with the native SDK.

Adds:
- _matches_anthropic_compatible_model() helper (proxy-agnostic model table lookup)
- 5 new TestBuildApiKwargs tests:
  * regression guard for existing OpenRouter+Claude behaviour
  * new scenario: custom proxy + Claude (NVIDIA Bedrock)
  * new scenario: custom proxy + MiniMax (non-Claude Anthropic-compat)
  * negative: unknown models must not receive the fallback
  * meta-test: condition must not hardcode 'claude' substring

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

