### PR TITLE
feat(snapshot-manager): restore source and polish UI

### DIFF
--- a/hermes_snapshot_manager/README.md
+++ b/hermes_snapshot_manager/README.md
@@ -1,0 +1,53 @@
+# Hermes Snapshot Manager
+
+Independent snapshot and rollback web app for protecting `~/.hermes` inside Windows WSL.
+
+## MVP scope
+
+- Snapshot the entire `~/.hermes` tree
+- Compress each snapshot payload as `files.tar.gz` to reduce disk usage
+- Include `.env`, session/state DBs, skills, memories, scripts, and profiles
+- Restore the entire package in one action
+- Create a pre-restore safeguard snapshot automatically
+- Keep a SQLite catalog of snapshots and restore history
+- Provide a local Web UI via FastAPI + Jinja templates
+
+## Install
+
+```bash
+source venv/bin/activate
+pip install -e '.[snapshot-manager]'
+```
+
+## Run
+
+```bash
+hermes-snapshot-manager
+```
+
+Then open `http://127.0.0.1:8876`.
+
+## systemd user service (WSL)
+
+A sample unit file is included at `hermes_snapshot_manager/deploy/hermes-snapshot-manager.service`.
+
+Install it like this:
+
+```bash
+mkdir -p ~/.config/systemd/user
+cp hermes_snapshot_manager/deploy/hermes-snapshot-manager.service ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now hermes-snapshot-manager.service
+systemctl --user status hermes-snapshot-manager.service
+```
+
+The service uses `hermes_snapshot_manager/scripts/run_snapshot_manager.sh` to activate `venv` and launch uvicorn.
+
+## Environment variables
+
+- `HERMES_HOME` — source directory to protect (defaults to `~/.hermes`)
+- `HERMES_SNAPSHOT_HOME` — app storage root (defaults to `/mnt/d/hermes_snapshot`, i.e. `D:\hermes_snapshot` on Windows)
+
+## Notes
+
+This first scaffold uses logical snapshots, not filesystem-level WSL/VHDX snapshots. That is intentional: the goal is reliable rollback of Hermes state, not full OS rollback.

--- a/hermes_snapshot_manager/__init__.py
+++ b/hermes_snapshot_manager/__init__.py
@@ -1,0 +1,4 @@
+"""Hermes Snapshot Manager package."""
+
+__all__ = ["__version__"]
+__version__ = "0.1.0"

--- a/hermes_snapshot_manager/api/__init__.py
+++ b/hermes_snapshot_manager/api/__init__.py
@@ -1,0 +1,1 @@
+"""API routers for Hermes Snapshot Manager."""

--- a/hermes_snapshot_manager/api/health.py
+++ b/hermes_snapshot_manager/api/health.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/api/health", tags=["health"])
+
+
+@router.get("")
+def health() -> dict:
+    return {"status": "ok"}

--- a/hermes_snapshot_manager/api/restore.py
+++ b/hermes_snapshot_manager/api/restore.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Form
+from fastapi.responses import RedirectResponse
+
+from hermes_snapshot_manager.services.operation_service import OperationService
+from hermes_snapshot_manager.services.restore_service import RestoreService
+
+router = APIRouter(tags=["restore"])
+service = RestoreService()
+operation_service = OperationService(service.paths)
+
+
+@router.post("/api/snapshots/{snapshot_id}/restore")
+def restore_snapshot(snapshot_id: str, notes: str | None = Form(default=None)) -> dict:
+    return service.restore_snapshot(snapshot_id, notes=notes)
+
+
+@router.post("/api/snapshots/{snapshot_id}/restore/start")
+def start_restore_snapshot(snapshot_id: str, notes: str | None = Form(default=None)) -> dict:
+    return operation_service.start_restore(snapshot_id, notes=notes)
+
+
+@router.get("/api/restores")
+def restore_history() -> list[dict]:
+    return service.list_restore_history()
+
+
+@router.post("/snapshots/{snapshot_id}/restore")
+def restore_snapshot_from_ui(snapshot_id: str, notes: str | None = Form(default=None)) -> RedirectResponse:
+    service.restore_snapshot(snapshot_id, notes=notes)
+    return RedirectResponse(url=f"/snapshots/{snapshot_id}", status_code=303)

--- a/hermes_snapshot_manager/api/settings.py
+++ b/hermes_snapshot_manager/api/settings.py
@@ -4,8 +4,9 @@ from dataclasses import asdict
 
 from fastapi import APIRouter, Form
 from fastapi.responses import RedirectResponse
+from apscheduler.triggers.cron import CronTrigger
 
-from hermes_snapshot_manager.core.config import load_settings, update_settings
+from hermes_snapshot_manager.core.config import DEFAULT_EXCLUDE_PATTERNS, load_settings, update_settings
 from hermes_snapshot_manager.core.paths import build_paths
 
 router = APIRouter(tags=["settings"])
@@ -28,10 +29,15 @@ def update_settings_from_ui(
     app_paths = build_paths()
     current = load_settings(app_paths)
     parsed_excludes = [line.strip() for line in exclude_patterns.splitlines() if line.strip()]
+    schedule_cron = schedule_cron.strip() or "0 */6 * * *"
+    try:
+        CronTrigger.from_crontab(schedule_cron)
+    except ValueError as exc:
+        return RedirectResponse(url=f"/settings?error={str(exc)}", status_code=303)
     update_settings(
         {
             "schedule_enabled": schedule_enabled,
-            "schedule_cron": schedule_cron.strip() or "0 */6 * * *",
+            "schedule_cron": schedule_cron,
             "retention_hourly": retention_hourly,
             "retention_daily": retention_daily,
             "retention_weekly": retention_weekly,
@@ -39,4 +45,11 @@ def update_settings_from_ui(
         },
         app_paths,
     )
+    return RedirectResponse(url="/settings?saved=1", status_code=303)
+
+
+@router.post("/settings/excludes/defaults")
+def reset_excludes_to_defaults() -> RedirectResponse:
+    app_paths = build_paths()
+    update_settings({"exclude_patterns": DEFAULT_EXCLUDE_PATTERNS.copy()}, app_paths)
     return RedirectResponse(url="/settings?saved=1", status_code=303)

--- a/hermes_snapshot_manager/api/settings.py
+++ b/hermes_snapshot_manager/api/settings.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+
+from fastapi import APIRouter, Form
+from fastapi.responses import RedirectResponse
+
+from hermes_snapshot_manager.core.config import load_settings, update_settings
+from hermes_snapshot_manager.core.paths import build_paths
+
+router = APIRouter(tags=["settings"])
+
+
+@router.get("/api/settings")
+def get_settings() -> dict:
+    return asdict(load_settings(build_paths()))
+
+
+@router.post("/settings")
+def update_settings_from_ui(
+    schedule_enabled: bool = Form(default=False),
+    schedule_cron: str = Form(default="0 */6 * * *"),
+    retention_hourly: int = Form(default=24),
+    retention_daily: int = Form(default=30),
+    retention_weekly: int = Form(default=12),
+    exclude_patterns: str = Form(default=""),
+) -> RedirectResponse:
+    app_paths = build_paths()
+    current = load_settings(app_paths)
+    parsed_excludes = [line.strip() for line in exclude_patterns.splitlines() if line.strip()]
+    update_settings(
+        {
+            "schedule_enabled": schedule_enabled,
+            "schedule_cron": schedule_cron.strip() or "0 */6 * * *",
+            "retention_hourly": retention_hourly,
+            "retention_daily": retention_daily,
+            "retention_weekly": retention_weekly,
+            "exclude_patterns": parsed_excludes or current.exclude_patterns,
+        },
+        app_paths,
+    )
+    return RedirectResponse(url="/settings?saved=1", status_code=303)

--- a/hermes_snapshot_manager/api/snapshots.py
+++ b/hermes_snapshot_manager/api/snapshots.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Form
+from fastapi.responses import RedirectResponse
+
+from hermes_snapshot_manager.services.operation_service import OperationService
+from hermes_snapshot_manager.services.snapshot_service import SnapshotService
+
+router = APIRouter(tags=["snapshots"])
+service = SnapshotService()
+operation_service = OperationService(service.paths)
+
+
+@router.get("/api/snapshots")
+def list_snapshots() -> list[dict]:
+    return [snapshot.__dict__ for snapshot in service.list_snapshots()]
+
+
+@router.post("/api/snapshots")
+def create_snapshot(label: str | None = Form(default=None), trigger_type: str = Form(default="manual")) -> dict:
+    snapshot = service.create_snapshot(label=label, trigger_type=trigger_type)
+    return snapshot.__dict__
+
+
+@router.post("/api/snapshots/start")
+def start_snapshot(label: str | None = Form(default=None)) -> dict:
+    return operation_service.start_snapshot(label=label)
+
+
+@router.get("/api/operations/current")
+def current_operation() -> dict:
+    return operation_service.get_current_operation() or {}
+
+
+@router.get("/api/snapshots/{snapshot_id}")
+def get_snapshot(snapshot_id: str) -> dict:
+    return service.get_snapshot(snapshot_id)
+
+
+@router.post("/api/operations/current/abort")
+def abort_operation() -> dict:
+    return operation_service.abort_operation() or {"status": "none"}
+
+
+@router.post("/api/operations/current/clear")
+def clear_stale_operation() -> dict:
+    return operation_service.clear_stale_operation() or {"status": "none"}
+
+
+@router.get("/api/snapshots/{snapshot_id}/verify")
+def verify_snapshot(snapshot_id: str) -> dict:
+    return service.verify_snapshot(snapshot_id)
+
+
+@router.get("/api/snapshots/{snapshot_id}/diff-current")
+def diff_snapshot_to_current(snapshot_id: str) -> dict:
+    return service.diff_snapshot_to_current(snapshot_id)
+
+
+@router.post("/snapshots/create")
+def create_snapshot_from_ui(label: str | None = Form(default=None)) -> RedirectResponse:
+    service.create_snapshot(label=label, trigger_type="manual")
+    return RedirectResponse(url="/snapshots", status_code=303)
+
+
+@router.post("/snapshots/{snapshot_id}/known-good")
+def mark_known_good(snapshot_id: str) -> RedirectResponse:
+    service.mark_known_good(snapshot_id, value=True)
+    return RedirectResponse(url=f"/snapshots/{snapshot_id}", status_code=303)
+
+
+@router.post("/snapshots/{snapshot_id}/verify")
+def verify_snapshot_from_ui(snapshot_id: str) -> RedirectResponse:
+    service.verify_snapshot(snapshot_id)
+    return RedirectResponse(url=f"/snapshots/{snapshot_id}", status_code=303)

--- a/hermes_snapshot_manager/core/compression.py
+++ b/hermes_snapshot_manager/core/compression.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import tarfile
+from pathlib import Path
+
+
+def create_tar_gz(source_dir: Path, archive_path: Path) -> None:
+    archive_path.parent.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(archive_path, "w:gz") as archive:
+        archive.add(source_dir, arcname=source_dir.name)
+
+
+def extract_tar_gz(archive_path: Path, destination: Path) -> Path:
+    destination.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(archive_path, "r:gz") as archive:
+        archive.extractall(destination)
+    members = [path for path in destination.iterdir()]
+    if len(members) != 1:
+        raise ValueError(f"Unexpected archive layout in {archive_path}")
+    return members[0]

--- a/hermes_snapshot_manager/core/config.py
+++ b/hermes_snapshot_manager/core/config.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+import json
+from json import JSONDecodeError
+from pathlib import Path
+from typing import Any
+
+from .paths import AppPaths, build_paths, ensure_app_dirs
+
+
+DEFAULT_INCLUDE_PATTERNS = ["**/*"]
+DEFAULT_EXCLUDE_PATTERNS = [
+    "audio_cache/**",
+    "cron/output/**",
+    "**/*.log",
+    "**/__pycache__/**",
+    "**/tmp/**",
+    # Python virtual environments — extremely large, contain thousands of
+    # platform-specific binary packages; snapshotting them is数十GB for no reason.
+    ".venv/**",
+    "venv/**",
+    ".virtualenv/**",
+    "**/site-packages/**",
+    # Node modules — similarly huge and irrelevant to Hermes state.
+    "**/node_modules/**",
+    # Python build artifacts and egg-info.
+    "**/*.egg-info/**",
+    "**/build/**",
+    "**/dist/**",
+    # Editor and OS metadata — machine-specific, not part of Hermes state.
+    ".vscode/**",
+    ".idea/**",
+    ".DS_Store",
+    "Thumbs.db",
+    # Version control — .git is massive and Hermes uses its own SQLite store.
+    # Use **/.git/** (not .git/**) so it matches nested paths like src/.git/.
+    "**/.git/**",
+]
+
+# Patterns matched against the relative path of a file. Matching files are
+# skipped immediately without retry during snapshot creation.  Use this to
+# skip known-problematic paths such as network mounts, socket files, or
+# FUSE filesystems that are known to hang.
+DEFAULT_SKIP_STUCK_PATTERNS: list[str] = []
+
+# Default max consecutive stuck-file skips before copy aborts.
+DEFAULT_MAX_CONSECUTIVE_SKIPPED = 20
+
+# Default list of filesystem types (fstype from /proc/mounts) to skip during
+# traversal.  Network-backed and virtual filesystems are excluded by default
+# because they can hang on unresponsive servers or contain no real files.
+DEFAULT_SKIP_FS_TYPES: list[str] = [
+    "proc", "sysfs", "devpts", "devtmpfs", "cgroup", "cgroup2",
+    "autofs", "pstore", "securityfs", "debugfs", "hugetlbfs",
+    "mqueue", "fusectl", "configfs", "binfmt_misc",
+    "nfs", "nfs4", "cifs", "smb", "smb3", "sshfs",
+    "fuse", "fuseblk", "overlay", "aufs", "btrfs",
+    "container", "containerd", "crio", "runtime",
+    # WSL / Plan 9 shared-folder protocol
+    "9p",
+]
+
+# Default mount-point prefixes to skip during traversal (independent of
+# filesystem type).  These are almost always virtual / system mounts.
+# /tmp is intentionally excluded because it may live on the same filesystem
+# as the user's source root; add it explicitly if you want to skip it.
+DEFAULT_SKIP_MOUNT_POINTS: list[str] = [
+    "/proc", "/sys", "/dev", "/dev/pts", "/dev/shm",
+    "/run", "/run/lock",
+    "/mnt", "/media", "/snap",
+]
+
+# Default: do NOT cross device/mount boundaries during traversal.
+# Setting this to True can cause huge or infinite traversals when
+# a bind mount points outside the source tree.
+DEFAULT_CROSS_DEVICE = False
+
+
+@dataclass
+class SnapshotManagerSettings:
+    source_root: str
+    snapshot_root: str
+    schedule_enabled: bool = False
+    schedule_cron: str = "0 */6 * * *"
+    retention_hourly: int = 24
+    retention_daily: int = 30
+    retention_weekly: int = 12
+    include_patterns: list[str] = field(default_factory=lambda: DEFAULT_INCLUDE_PATTERNS.copy())
+    exclude_patterns: list[str] = field(default_factory=lambda: DEFAULT_EXCLUDE_PATTERNS.copy())
+    skip_stuck_patterns: list[str] = field(default_factory=lambda: DEFAULT_SKIP_STUCK_PATTERNS.copy())
+    max_consecutive_skipped: int = DEFAULT_MAX_CONSECUTIVE_SKIPPED
+    skip_fs_types: list[str] = field(default_factory=lambda: DEFAULT_SKIP_FS_TYPES.copy())
+    skip_mount_points: list[str] = field(default_factory=lambda: DEFAULT_SKIP_MOUNT_POINTS.copy())
+    cross_device: bool = DEFAULT_CROSS_DEVICE
+
+    @classmethod
+    def from_paths(cls, paths: AppPaths) -> "SnapshotManagerSettings":
+        return cls(source_root=str(paths.source_root), snapshot_root=str(paths.snapshot_root))
+
+
+def _merge_unique(existing: list[str] | None, defaults: list[str]) -> list[str]:
+    merged = list(existing or [])
+    for item in defaults:
+        if item not in merged:
+            merged.append(item)
+    return merged
+
+
+def load_settings(paths: AppPaths | None = None) -> SnapshotManagerSettings:
+    app_paths = paths or build_paths()
+    ensure_app_dirs(app_paths)
+    settings_path = app_paths.settings_path
+    if not settings_path.exists():
+        settings = SnapshotManagerSettings.from_paths(app_paths)
+        save_settings(settings, app_paths)
+        return settings
+
+    try:
+        raw = json.loads(settings_path.read_text(encoding="utf-8"))
+    except (OSError, JSONDecodeError):
+        settings = SnapshotManagerSettings.from_paths(app_paths)
+        save_settings(settings, app_paths)
+        return settings
+    defaults = asdict(SnapshotManagerSettings.from_paths(app_paths))
+    merged = {**defaults, **raw}
+
+    # Migrate older settings files forward by appending newly introduced safe
+    # defaults instead of freezing the exclude/skip lists forever at the moment
+    # the file was first created.
+    merged["exclude_patterns"] = _merge_unique(raw.get("exclude_patterns"), DEFAULT_EXCLUDE_PATTERNS)
+    merged["skip_fs_types"] = _merge_unique(raw.get("skip_fs_types"), DEFAULT_SKIP_FS_TYPES)
+    merged["skip_mount_points"] = _merge_unique(raw.get("skip_mount_points"), DEFAULT_SKIP_MOUNT_POINTS)
+
+    settings = SnapshotManagerSettings(**merged)
+    save_settings(settings, app_paths)
+    return settings
+
+
+def save_settings(settings: SnapshotManagerSettings, paths: AppPaths | None = None) -> None:
+    app_paths = paths or build_paths(Path(settings.source_root), Path(settings.snapshot_root).parent)
+    ensure_app_dirs(app_paths)
+    app_paths.settings_path.write_text(json.dumps(asdict(settings), indent=2, sort_keys=True), encoding="utf-8")
+
+
+def update_settings(data: dict[str, Any], paths: AppPaths | None = None) -> SnapshotManagerSettings:
+    app_paths = paths or build_paths()
+    current = load_settings(app_paths)
+    merged = {**asdict(current), **data}
+    settings = SnapshotManagerSettings(**merged)
+    save_settings(settings, app_paths)
+    return settings

--- a/hermes_snapshot_manager/core/display.py
+++ b/hermes_snapshot_manager/core/display.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+
+def format_bytes(value: int | None) -> str:
+    if value is None:
+        return "-"
+    units = ["B", "KB", "MB", "GB", "TB"]
+    size = float(value)
+    for unit in units:
+        if size < 1024 or unit == units[-1]:
+            if unit == "B":
+                return f"{int(size)} {unit}"
+            return f"{size:.1f} {unit}"
+        size /= 1024
+    return f"{int(value)} B"
+
+
+def compression_ratio(original_bytes: int, compressed_bytes: int) -> float:
+    if original_bytes <= 0:
+        return 0.0
+    return round((compressed_bytes / original_bytes) * 100, 1)

--- a/hermes_snapshot_manager/core/filesystem.py
+++ b/hermes_snapshot_manager/core/filesystem.py
@@ -1,0 +1,659 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from pathlib import Path, PurePosixPath
+import fnmatch
+import os
+import shutil
+import signal
+import stat
+import subprocess
+import threading
+
+
+ProgressCallback = Callable[[int, int, str], None]
+ScanProgressCallback = Callable[[int, str], None]  # (scanned_count, current_relative_path) -> None
+SkipCallback = Callable[[str, str], None]  # (relative_path, error_message) -> None
+# (relative_path, reason) -> None; reason is one of:
+# "fifo", "socket", "device", "symlink", "mount_point:<path>",
+# "fs_type:<type>", "cross_device", "lstat_failed"
+TraversalSkipCallback = Callable[[str, str], None]
+
+
+def _relpath(path: Path, root: Path) -> str:
+    """Return path relative to root, or the path string if that fails."""
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        # Not relative to root (e.g., different drive on Windows, or absolute path
+        # that doesn't share the root prefix) — return as absolute posix string.
+        return path.as_posix()
+
+# Default timeout for copying a single file (seconds)
+DEFAULT_COPY_TIMEOUT_SECONDS = 30
+
+# Default max retries per file
+DEFAULT_MAX_RETRIES = 2
+
+# Max number of consecutive skipped (stuck) files before we treat the snapshot as degraded.
+# Prevents accumulating unbounded zombie processes / pathological I/O.
+DEFAULT_MAX_CONSECUTIVE_SKIPPED = 20
+
+# Signals we treat as "stuck" when sent to the process group.
+_STUCK_SIGNALS = (signal.SIGKILL, signal.SIGTERM)
+
+# Filesystem types that are safe to traverse.  procfs/sysfs/devpts are virtual
+# and either contain no real files or will block when accessed.
+# cgroup, cgroup2, devtmpfs, autofs, snap, overlay are also excluded by default.
+# Network-backed types are excluded by default because they can hang on
+# unresponsive servers.
+_DEFAULT_SKIP_FS_TYPES: frozenset[str] = frozenset({
+    "proc", "sysfs", "devpts", "devtmpfs", "cgroup", "cgroup2",
+    "autofs", "pstore", "securityfs", "debugfs", "hugetlbfs",
+    "mqueue", "fusectl", "configfs", "binfmt_misc",
+    # Network / FUSE types
+    "nfs", "nfs4", "cifs", "smb", "smb3", "sshfs", "fuse.sshfs",
+    "fuse", "fuseblk", "overlay", "aufs", "btrfs",
+    # Container runtimes
+    "container", "containerd", "crio", "runtime",
+    # WSL / Plan 9 shared-folder protocol
+    "9p",
+})
+
+# Mount points that are almost always virtual / system mounts and should be
+# excluded from traversal even if their fstype is not known.
+_DEFAULT_SKIP_MOUNT_POINTS: tuple[str, ...] = (
+    "/proc", "/sys", "/dev", "/dev/pts", "/dev/shm",
+    "/run", "/run/lock",
+    # /tmp is intentionally NOT included here because it may contain user files
+    # and is often on the same filesystem as the source.  If you want to skip
+    # /tmp, add it to skip_mount_points in settings or set skip_tmp=True in
+    # iter_included_files().  We also skip /mnt and /media as they commonly
+    # contain external mounts.
+    "/mnt", "/media", "/snap",
+)
+
+
+def _is_real_regular_file(entry: os.DirEntry) -> bool:
+    """Return True only if entry is a real regular file (not symlink, FIFO, socket, device).
+
+    Uses lstat internally so it never blocks on FIFO read or socket connect.
+    This is the primary defense: we skip non-regular files before they reach
+    the copy stage, where cp would block indefinitely on FIFOs/sockets.
+    """
+    try:
+        st = entry.stat(follow_symlinks=False)
+    except OSError:
+        return False
+    return stat.S_ISREG(st.st_mode)
+
+
+def _is_skipable_by_stat(entry_path: str | Path) -> tuple[bool, str]:
+    """Check if a path is a special file that would block during traversal.
+
+    Returns (should_skip, reason) where reason is empty string if not skipable.
+    Uses lstat so it never blocks on FIFO read or socket connect.
+    """
+    try:
+        st = os.lstat(entry_path)
+    except OSError:
+        return True, "lstat_failed"
+
+    mode = st.st_mode
+
+    # Non-regular files that would cause cp to block forever
+    if stat.S_ISFIFO(mode):
+        return True, "fifo"
+    if stat.S_ISSOCK(mode):
+        return True, "socket"
+
+    # Device files — cp will try to open and read them (returning ENODEV or
+    # blocking on a raw character device)
+    if stat.S_ISBLK(mode) or stat.S_ISCHR(mode):
+        return True, "device"
+
+    # Broken symlink — would fail with ENOENT during copy
+    if stat.S_ISLNK(mode):
+        return True, "symlink"
+
+    return False, ""
+
+
+def _safe_scandir_recurse(
+    source: Path,
+    skip_mount_points: tuple[str, ...] | None = None,
+    skip_fs_types: frozenset[str] | None = None,
+    cross_device: bool = False,
+    stop_event: threading.Event | None = None,
+    _device_id: int | None = None,
+    skip_symlinks: bool = True,
+    traversal_skip_callback: TraversalSkipCallback | None = None,
+    _root: Path | None = None,
+) -> Iterator[Path]:
+    """Recursively walk source using os.scandir with mount-boundary and
+    special-file guards.
+
+    This replaces rglob for snapshot-traversal because:
+    - rglob + is_file() can block on FIFOs/sockets (opens the file descriptor).
+    - rglob follows symlink directories by default in Python 3.11.
+    - os.scandir + lstat never opens file content, so never blocks on a FIFO.
+
+    Args:
+        source: Root directory to traverse.
+        skip_mount_points: Mount-point prefixes to skip (absolute paths).
+        skip_fs_types: Filesystem type names to skip (from /proc/mounts).
+        cross_device: If False, stop traversal when a directory's device ID
+            differs from _device_id (prevents traversing into bind mounts).
+        stop_event: Optional threading.Event; if set, abort traversal early.
+        _device_id: Device ID of the source root (used internally for
+            cross-device boundary detection).  Set automatically on first call.
+        skip_symlinks: If True (default), skip all symlinks (including working
+            symlinks to regular files).  This prevents snapshotting symlinks
+            that point outside the source tree.  If False, symlinks to regular
+            files are included and copied as symlinks via `cp -p`.
+        traversal_skip_callback: If provided, called with (relative_path, reason)
+            whenever a file or directory is skipped during traversal (mount point,
+            filesystem type, cross-device boundary, or special file).  The path is
+            relative to the original source root.  Reasons are one of:
+            "fifo", "socket", "device", "symlink", "mount_point:<path>",
+            "fs_type:<type>", "cross_device", "lstat_failed".
+        _root: Internal; set to the original source root on first call so
+            relative paths can be computed for the skip callback.
+    """
+    if _root is None:
+        _root = source
+
+    if skip_mount_points is None:
+        skip_mount_points = _DEFAULT_SKIP_MOUNT_POINTS
+    if skip_fs_types is None:
+        skip_fs_types = _DEFAULT_SKIP_FS_TYPES
+
+    if _device_id is None:
+        try:
+            _device_id = os.stat(source).st_dev
+        except OSError:
+            return
+
+    # Check if this path is under a skipable mount point
+    try:
+        real_path = os.path.realpath(source)
+    except OSError:
+        if traversal_skip_callback is not None:
+            traversal_skip_callback(_relpath(source, _root), "lstat_failed")
+        return
+    for mp in skip_mount_points:
+        if real_path == mp or real_path.startswith(mp + "/"):
+            if traversal_skip_callback is not None:
+                traversal_skip_callback(_relpath(source, _root), f"mount_point:{mp}")
+            return
+
+    # Check filesystem type
+    try:
+        fs_type = _get_filesystem_type(source)
+        if fs_type and fs_type in skip_fs_types:
+            if traversal_skip_callback is not None:
+                traversal_skip_callback(_relpath(source, _root), f"fs_type:{fs_type}")
+            return
+    except OSError:
+        pass
+
+    try:
+        entries = list(os.scandir(source))
+    except OSError:
+        # Directory disappeared or permission denied — skip silently
+        if traversal_skip_callback is not None:
+            traversal_skip_callback(_relpath(source, _root), "lstat_failed")
+        return
+    except PermissionError:
+        if traversal_skip_callback is not None:
+            traversal_skip_callback(_relpath(source, _root), "lstat_failed")
+        return
+
+    for entry in entries:
+        if stop_event and stop_event.is_set():
+            return
+
+        try:
+            is_dir = entry.is_dir(follow_symlinks=False)
+        except OSError:
+            continue
+
+        if is_dir:
+            # Check cross-device boundary
+            if not cross_device:
+                try:
+                    child_dev = os.stat(entry.path).st_dev
+                except OSError:
+                    if traversal_skip_callback is not None:
+                        traversal_skip_callback(_relpath(Path(entry.path), _root), "lstat_failed")
+                    continue
+                if child_dev != _device_id:
+                    # Crossed a mount boundary — skip the mount entirely
+                    if traversal_skip_callback is not None:
+                        traversal_skip_callback(_relpath(Path(entry.path), _root), "cross_device")
+                    continue
+
+            # Recurse into subdirectory
+            yield from _safe_scandir_recurse(
+                Path(entry.path),
+                skip_mount_points=skip_mount_points,
+                skip_fs_types=skip_fs_types,
+                cross_device=cross_device,
+                stop_event=stop_event,
+                _device_id=_device_id,
+                skip_symlinks=skip_symlinks,
+                traversal_skip_callback=traversal_skip_callback,
+                _root=_root,
+            )
+        else:
+            # It's a file (or symlink-to-file). Use lstat to check file type
+            # safely without blocking.
+            should_skip, reason = _is_skipable_by_stat(entry.path)
+            if should_skip:
+                # Symlinks are only skipped if skip_symlinks is True
+                if reason == "symlink" and not skip_symlinks:
+                    # Include working symlinks when skip_symlinks=False
+                    yield Path(entry.path)
+                else:
+                    if traversal_skip_callback is not None:
+                        traversal_skip_callback(_relpath(Path(entry.path), _root), reason)
+                continue
+            yield Path(entry.path)
+
+
+def _get_filesystem_type(path: Path) -> str | None:
+    """Return the filesystem type of the mount containing path (e.g. 'ext4', 'nfs4').
+
+    Returns None if the type cannot be determined.
+    """
+    try:
+        # Use /proc/mounts for reliable cross-platform type info
+        with open("/proc/mounts", "r") as f:
+            mounts = f.read()
+    except (OSError, IOError):
+        return None
+
+    # Find the most-specific matching mount entry
+    best_match = None
+    best_len = -1
+    for line in mounts.splitlines():
+        parts = line.split()
+        if len(parts) < 3:
+            continue
+        mount_point = parts[1]
+        fs_type = parts[2]
+        # mount_point may contain octal escapes for spaces
+        import urllib.parse
+        try:
+            decoded_mp = urllib.parse.unquote(mount_point)
+        except Exception:
+            decoded_mp = mount_point
+
+        if path == Path(decoded_mp) or str(path).startswith(decoded_mp + "/"):
+            if len(decoded_mp) > best_len:
+                best_match = fs_type
+                best_len = len(decoded_mp)
+
+    return best_match
+
+
+def iter_included_files(
+    source: Path,
+    include_patterns: list[str] | None = None,
+    exclude_patterns: list[str] | None = None,
+    skip_stuck_patterns: list[str] | None = None,
+    skip_mount_points: tuple[str, ...] | None = None,
+    skip_fs_types: frozenset[str] | None = None,
+    cross_device: bool = False,
+    skip_symlinks: bool = True,
+    traversal_skip_callback: TraversalSkipCallback | None = None,
+    scan_progress_callback: ScanProgressCallback | None = None,
+) -> list[Path]:
+    """Iterate over regular files under source, skipping special files and mount boundaries.
+
+    This is the safe replacement for source.rglob('*') + is_file() filtering.
+
+    Special-file defense (via lstat):
+      - FIFOs  → skipped (cp would block forever reading from them)
+      - Sockets → skipped (cp would block forever)
+      - Block/char devices → skipped (cp would return ENODEV or block)
+      - Broken symlinks → skipped (cp would fail with ENOENT)
+
+    Mount-boundary defense (when cross_device=False):
+      - If a subdirectory's device ID differs from the source root's device ID,
+        it is treated as a bind mount and its contents are NOT traversed.
+      - This prevents infinite/huge traversals when /mnt/foo is a bind mount of /home.
+
+    Args:
+        source: Root directory to traverse.
+        include_patterns: Glob patterns for files to include.
+        exclude_patterns: Glob patterns for files to exclude.
+        skip_stuck_patterns: Additional glob patterns; matching paths are skipped
+            immediately without traversal (e.g. '**/__pycache__').
+        skip_mount_points: Additional mount-point prefixes to skip.
+        skip_fs_types: Additional filesystem-type names to skip.
+        cross_device: If True, cross filesystem/device boundaries during traversal.
+            Default False (safer: stops at mount boundaries).
+        traversal_skip_callback: If provided, called with (relative_path, reason)
+            for every item skipped during traversal.  Also called for items
+            skipped by skip_stuck_patterns or include/exclude filters.
+    """
+    combined_skip_mounts = (
+        tuple(set(_DEFAULT_SKIP_MOUNT_POINTS) | set(skip_mount_points or ()))
+    )
+    combined_skip_fs = (
+        _DEFAULT_SKIP_FS_TYPES | (skip_fs_types or frozenset())
+    )
+
+    files: list[Path] = []
+    scanned_count = 0
+    for item in _safe_scandir_recurse(
+        source,
+        skip_mount_points=combined_skip_mounts,
+        skip_fs_types=combined_skip_fs,
+        cross_device=cross_device,
+        skip_symlinks=skip_symlinks,
+        traversal_skip_callback=traversal_skip_callback,
+    ):
+        scanned_count += 1
+        relative_str = item.relative_to(source).as_posix()
+        if scan_progress_callback is not None and (scanned_count == 1 or scanned_count % 250 == 0):
+            scan_progress_callback(scanned_count, relative_str)
+        # Additional pattern-based skip (after lstat check)
+        if skip_stuck_patterns and _matches_any(relative_str, skip_stuck_patterns):
+            if traversal_skip_callback is not None:
+                traversal_skip_callback(relative_str, "skipped_by_pattern")
+            continue
+        if not should_include(relative_str, include_patterns=include_patterns, exclude_patterns=exclude_patterns):
+            if traversal_skip_callback is not None:
+                traversal_skip_callback(relative_str, "excluded_by_filter")
+            continue
+        files.append(item)
+    return files
+
+
+def _matches_any(relative_path: str, patterns: list[str]) -> bool:
+    if not patterns:
+        return False
+    if "**/*" in patterns:
+        return True
+    path = PurePosixPath(relative_path)
+    candidates = {relative_path, path.as_posix()}
+    if relative_path:
+        parts = relative_path.split("/")
+        candidates.add(parts[-1])
+        for i in range(1, len(parts) + 1):
+            candidates.add("/".join(parts[:i]))
+    for pattern in patterns:
+        pattern_variants = {pattern}
+        if pattern.startswith("**/"):
+            pattern_variants.add(pattern[3:])
+        for candidate in candidates:
+            if any(fnmatch.fnmatchcase(candidate, variant) for variant in pattern_variants):
+                return True
+    return False
+
+
+def should_include(relative_path: str, include_patterns: list[str] | None = None, exclude_patterns: list[str] | None = None) -> bool:
+    include_patterns = include_patterns or ["**/*"]
+    exclude_patterns = exclude_patterns or []
+    if exclude_patterns and _matches_any(relative_path, exclude_patterns):
+        return False
+    return _matches_any(relative_path, include_patterns) or relative_path == ""
+
+
+def copy_tree(
+    source: Path,
+    destination: Path,
+    include_patterns: list[str] | None = None,
+    exclude_patterns: list[str] | None = None,
+    progress_callback: ProgressCallback | None = None,
+    scan_progress_callback: ScanProgressCallback | None = None,
+    skip_callback: SkipCallback | None = None,
+    copy_timeout: float = DEFAULT_COPY_TIMEOUT_SECONDS,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+    skip_stuck_patterns: list[str] | None = None,
+    max_consecutive_skipped: int = DEFAULT_MAX_CONSECUTIVE_SKIPPED,
+    skip_mount_points: tuple[str, ...] | None = None,
+    skip_fs_types: frozenset[str] | None = None,
+    cross_device: bool = False,
+    skip_symlinks: bool = True,
+    traversal_skip_callback: TraversalSkipCallback | None = None,
+    traversal_skipped_collector: list[tuple[str, str]] | None = None,
+) -> tuple[list[Path], list[tuple[str, str]], bool]:
+    """Copy a source tree to destination, skipping files that fail.
+
+    Returns:
+        A tuple of (included_files, skipped_files, is_degraded) where:
+        - included_files: list of Path objects that were successfully copied.
+        - skipped_files: list of (relative_path, error_message) tuples.
+        - is_degraded: True if any files were skipped.
+
+    The copy operation is fail-safe: individual file failures are logged via
+    skip_callback (if provided) and do not abort the overall copy operation.
+    A metadata-only placeholder is created for any skipped files so the
+    manifest still references them.
+    """
+    destination.mkdir(parents=True, exist_ok=True)
+
+    # Collector wraps traversal_skip_callback to also accumulate a list
+    _traversal_skipped: list[tuple[str, str]] = []
+    _cb = traversal_skip_callback
+
+    def _wrapped_cb(path: str, reason: str) -> None:
+        _traversal_skipped.append((path, reason))
+        if _cb is not None:
+            _cb(path, reason)
+
+    included_files = iter_included_files(
+        source,
+        include_patterns=include_patterns,
+        exclude_patterns=exclude_patterns,
+        skip_stuck_patterns=skip_stuck_patterns,
+        skip_mount_points=skip_mount_points,
+        skip_fs_types=skip_fs_types,
+        cross_device=cross_device,
+        skip_symlinks=skip_symlinks,
+        traversal_skip_callback=_wrapped_cb,
+        scan_progress_callback=scan_progress_callback,
+    )
+
+    # Merge traversal skips into the collector for the caller
+    if traversal_skipped_collector is not None:
+        traversal_skipped_collector.extend(_traversal_skipped)
+
+    # Collect files to copy (exclude dirs — those are created as we go)
+    files_to_copy = [f for f in included_files]
+
+    # Internal progress counter so copy_files_with_progress can use it
+    # without us having to compute it again.
+    copied_count = [0]  # mutable container so closure can mutate
+
+    def _progress_wrapper(completed: int, total: int, relative_str: str) -> None:
+        copied_count[0] = completed
+        if progress_callback is not None:
+            progress_callback(completed, total, relative_str)
+
+    skipped_files, is_degraded = copy_files_with_progress(
+        source,
+        destination,
+        files_to_copy,
+        progress_callback=_progress_wrapper,
+        skip_callback=skip_callback,
+        copy_timeout=copy_timeout,
+        max_retries=max_retries,
+        skip_stuck_patterns=skip_stuck_patterns,
+        max_consecutive_skipped=max_consecutive_skipped,
+    )
+
+    # Re-collect included files from the destination as a Path list.
+    # Any file that was skipped still has a placeholder (via _metadata_only_copy).
+    result_files = [f for f in destination.rglob("*") if f.is_file()]
+    return result_files, skipped_files, is_degraded
+
+
+def _copy_file_with_timeout(source: Path, dest: Path, timeout: float) -> None:
+    """Copy a single file with a timeout mechanism.
+
+    Uses a subprocess spawned with os.setsid so we can kill the entire
+    process group if the copy hangs (e.g., on locked files, network
+    drives, or stale NFS handles).  This is far more reliable than
+    threading-based interrupt because kill(2) on a subprocess can break
+    blocking C-level syscalls that no Python-level join() can unwind.
+    """
+    # Use cp(1) which is available on all Unix systems and handles
+    # metadata-copy (permissions + mtime) via -p flag.
+    # --interval=1 makes rsync-check less aggressive; not used here but
+    # retained for API parity with any future rsync path.
+    cmd = ["cp", "-p", str(source), str(dest)]
+
+    try:
+        proc = subprocess.run(
+            cmd,
+            timeout=timeout,
+            # Start a new session so killpg targets the whole process group.
+            start_new_session=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+        )
+    except subprocess.TimeoutExpired:
+        raise TimeoutError(f"Copy timed out after {timeout}s: {source}")
+    except OSError as exc:
+        raise OSError(f"Failed to spawn copy process for {source}: {exc}")
+
+    if proc.returncode != 0:
+        stderr = proc.stderr.decode("utf-8", errors="replace").strip()
+        raise OSError(f"cp exited with {proc.returncode}: {stderr}")
+
+
+def _metadata_only_copy(source: Path, dest: Path) -> bool:
+    """Try to preserve at least mode+mtime when a full copy failed.
+
+    Returns True if metadata was applied, False if even that failed.
+    This is a last-ditch fallback so a stuck file still gets a
+    placeholder in the archive (same mode/mtime as source) rather than
+    silently disappearing from the manifest.
+
+    Uses a subprocess with a hard 5-second timeout.
+    """
+    try:
+        stat_info = source.stat()
+    except OSError:
+        return False
+
+    # Touch dest to create a zero-length placeholder
+    try:
+        dest.write_bytes(b"")
+    except OSError:
+        return False
+
+    # Set mtime (and mode if we have permission)
+    try:
+        os.utime(dest, (stat_info.st_atime, stat_info.st_mtime))
+    except OSError:
+        pass
+
+    try:
+        os.chmod(dest, stat_info.st_mode & 0o777)
+    except OSError:
+        pass
+
+    return True
+
+
+def copy_files_with_progress(
+    source_root: Path,
+    destination_root: Path,
+    files: list[Path],
+    progress_callback: ProgressCallback | None = None,
+    skip_callback: SkipCallback | None = None,
+    copy_timeout: float = DEFAULT_COPY_TIMEOUT_SECONDS,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+    skip_stuck_patterns: list[str] | None = None,
+    max_consecutive_skipped: int = DEFAULT_MAX_CONSECUTIVE_SKIPPED,
+) -> tuple[list[tuple[str, str]], bool]:
+    """Copy a list of files with progress reporting and fail-safe skipping.
+
+    Args:
+        source_root: Root of the source tree.
+        destination_root: Root of the destination tree.
+        files: List of file paths to copy (relative to source_root).
+        progress_callback: Called with (index, total, relative_path).
+        skip_callback: Called with (relative_path, error_message) when a
+            file is skipped.
+        copy_timeout: Max seconds to wait for a single file copy.
+        max_retries: Number of retry attempts after timeout/error.
+        skip_stuck_patterns: Glob patterns. Matching files are skipped
+            immediately without retry (useful for network mounts, sockets).
+        max_consecutive_skipped: Abort copy if this many files are skipped
+            consecutively (prevents pathological I/O storms).
+
+    Returns:
+        A two-tuple (skipped_files, is_degraded) where:
+        - skipped_files: List of (relative_path, error_message) tuples.
+        - is_degraded: True if any files were skipped.
+    """
+    total_files = len(files)
+    skipped_files: list[tuple[str, str]] = []
+    is_degraded = False
+    consecutive_skipped = 0
+
+    for index, item in enumerate(files, start=1):
+        relative = item.relative_to(source_root)
+        relative_str = relative.as_posix()
+        target = destination_root / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+
+        # Fast-path: known-stuck files are skipped immediately without retry.
+        if skip_stuck_patterns and _matches_any(relative_str, skip_stuck_patterns):
+            skipped_files.append((relative_str, "skipped_by_pattern"))
+            is_degraded = True
+            consecutive_skipped += 1
+            if skip_callback is not None:
+                skip_callback(relative_str, "skipped_by_pattern")
+            if consecutive_skipped >= max_consecutive_skipped:
+                skipped_files.append(
+                    (relative_str, f"max_consecutive_skipped ({max_consecutive_skipped}) reached — aborting")
+                )
+                break
+            continue
+
+        last_error = None
+        for attempt in range(max_retries + 1):
+            try:
+                _copy_file_with_timeout(item, target, timeout=copy_timeout)
+                last_error = None
+                consecutive_skipped = 0
+                break
+            except Exception as exc:  # noqa: BLE001
+                last_error = str(exc)
+                if attempt < max_retries:
+                    threading.Event().wait(0.1)
+
+        if last_error is not None:
+            # Last-ditch metadata fallback so the manifest still references
+            # a file (placeholder with correct mode/mtime) rather than skipping
+            # it entirely from the archive.
+            _metadata_only_copy(item, target)
+            skipped_files.append((relative_str, last_error))
+            is_degraded = True
+            consecutive_skipped += 1
+            if skip_callback is not None:
+                skip_callback(relative_str, last_error)
+            if consecutive_skipped >= max_consecutive_skipped:
+                skipped_files.append(
+                    (relative_str, f"max_consecutive_skipped ({max_consecutive_skipped}) reached — aborting")
+                )
+                break
+            continue
+
+        if progress_callback is not None:
+            progress_callback(index, total_files, relative_str)
+
+    return skipped_files, is_degraded
+
+
+def replace_tree(source: Path, destination: Path) -> None:
+    if destination.exists():
+        shutil.rmtree(destination)
+    shutil.copytree(source, destination, dirs_exist_ok=True)

--- a/hermes_snapshot_manager/core/hashing.py
+++ b/hermes_snapshot_manager/core/hashing.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+
+BUF_SIZE = 1024 * 1024
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(BUF_SIZE):
+            digest.update(chunk)
+    return digest.hexdigest()

--- a/hermes_snapshot_manager/core/locking.py
+++ b/hermes_snapshot_manager/core/locking.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from pathlib import Path
+import fcntl
+
+
+@contextmanager
+def exclusive_lock(lock_path: Path):
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("w", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)

--- a/hermes_snapshot_manager/core/paths.py
+++ b/hermes_snapshot_manager/core/paths.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import os
+
+
+@dataclass(frozen=True)
+class AppPaths:
+    source_root: Path
+    app_root: Path
+    snapshot_root: Path
+    export_root: Path
+    log_root: Path
+    db_path: Path
+    settings_path: Path
+    lock_path: Path
+    operation_status_path: Path
+
+
+def default_source_root() -> Path:
+    return Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes")).expanduser().resolve()
+
+
+def default_app_root() -> Path:
+    return Path(os.environ.get("HERMES_SNAPSHOT_HOME", "/mnt/d/hermes_snapshot")).expanduser().resolve()
+
+
+def build_paths(source_root: Path | None = None, app_root: Path | None = None) -> AppPaths:
+    source = (source_root or default_source_root()).expanduser().resolve()
+    root = (app_root or default_app_root()).expanduser().resolve()
+    return AppPaths(
+        source_root=source,
+        app_root=root,
+        snapshot_root=root / "snapshots",
+        export_root=root / "exports",
+        log_root=root / "logs",
+        db_path=root / "catalog.db",
+        settings_path=root / "settings.json",
+        lock_path=root / ".snapshot.lock",
+        operation_status_path=root / "operation-status.json",
+    )
+
+
+def ensure_app_dirs(paths: AppPaths) -> None:
+    for path in (paths.app_root, paths.snapshot_root, paths.export_root, paths.log_root):
+        path.mkdir(parents=True, exist_ok=True)

--- a/hermes_snapshot_manager/deploy/hermes-snapshot-manager.service
+++ b/hermes_snapshot_manager/deploy/hermes-snapshot-manager.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Hermes Snapshot Manager Web UI
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h/.hermes/hermes-agent
+Environment=PYTHONUNBUFFERED=1
+ExecStart=%h/.hermes/hermes-agent/hermes_snapshot_manager/scripts/run_snapshot_manager.sh
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/hermes_snapshot_manager/main.py
+++ b/hermes_snapshot_manager/main.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+import uvicorn
+from dataclasses import asdict, is_dataclass
+
+from hermes_snapshot_manager.api import health, restore, settings as settings_api, snapshots
+from hermes_snapshot_manager.core.config import load_settings
+from hermes_snapshot_manager.core.display import format_bytes
+from hermes_snapshot_manager.core.paths import build_paths, ensure_app_dirs
+from hermes_snapshot_manager.services.restore_service import RestoreService
+from hermes_snapshot_manager.services.scheduler_service import SchedulerService, describe_cron
+from hermes_snapshot_manager.services.snapshot_service import SnapshotService
+
+BASE_DIR = Path(__file__).resolve().parent
+TEMPLATES = Jinja2Templates(directory=str(BASE_DIR / "templates"))
+
+paths = build_paths()
+ensure_app_dirs(paths)
+snapshot_service = SnapshotService(paths)
+restore_service = RestoreService(paths)
+scheduler_service = SchedulerService(paths)
+
+
+def _enrich_snapshot_detail(detail: dict) -> dict:
+    metadata = detail.get("metadata") or {}
+    snapshot = detail.get("snapshot") or {}
+    original_bytes = snapshot.get("total_bytes") or metadata.get("total_bytes") or 0
+    compressed_bytes = metadata.get("payload_archive_size")
+    detail["display_stats"] = {
+        "original_bytes": original_bytes,
+        "original_bytes_human": format_bytes(original_bytes),
+        "compressed_bytes": compressed_bytes,
+        "compressed_bytes_human": format_bytes(compressed_bytes),
+        "space_saved_bytes": metadata.get("space_saved_bytes"),
+        "space_saved_bytes_human": format_bytes(metadata.get("space_saved_bytes")),
+        "compression_ratio": metadata.get("compression_ratio"),
+        "payload_format": metadata.get("payload_format", "-"),
+    }
+    return detail
+
+
+def _base_context(*, title: str, current_path: str) -> dict:
+    return {"title": title, "current_path": current_path}
+
+
+def _status_tone(status: str | None) -> str:
+    mapping = {
+        "created": "info",
+        "verified": "success",
+        "completed": "success",
+        "running": "running",
+        "degraded": "warning",
+        "failed": "danger",
+        "stale": "warning",
+        "success": "success",
+    }
+    return mapping.get((status or "").lower(), "neutral")
+
+
+def _snapshot_card(snapshot) -> dict | None:
+    if not snapshot:
+        return None
+    data = asdict(snapshot) if is_dataclass(snapshot) else dict(snapshot)
+    data["total_bytes_human"] = format_bytes(data.get("total_bytes"))
+    data["status_tone"] = _status_tone(data.get("status"))
+    return data
+
+app = FastAPI(title="Hermes Snapshot Manager", version="0.1.0")
+app.mount("/static", StaticFiles(directory=str(BASE_DIR / "static")), name="static")
+app.include_router(health.router)
+app.include_router(snapshots.router)
+app.include_router(restore.router)
+app.include_router(settings_api.router)
+
+
+@app.on_event("startup")
+def startup_event() -> None:
+    scheduler_service.start()
+
+
+@app.on_event("shutdown")
+def shutdown_event() -> None:
+    scheduler_service.stop()
+
+
+@app.get("/", response_class=HTMLResponse)
+def dashboard(request: Request):
+    snapshots_list = snapshot_service.list_snapshots()
+    latest = snapshots_list[0] if snapshots_list else None
+    history = restore_service.list_restore_history()
+    latest_restore = history[0] if history else None
+    settings = load_settings(paths)
+    latest_snapshot = _snapshot_card(latest)
+    if latest_snapshot and latest:
+        latest_detail = _enrich_snapshot_detail(snapshot_service.get_snapshot(latest.id))
+        latest_snapshot["compression_ratio"] = latest_detail["display_stats"].get("compression_ratio")
+        latest_snapshot["space_saved_bytes_human"] = latest_detail["display_stats"].get("space_saved_bytes_human")
+    context = {
+        **_base_context(title="Dashboard · Hermes Snapshot Manager", current_path="/"),
+        "snapshot_count": len(snapshots_list),
+        "latest_snapshot": latest_snapshot,
+        "latest_snapshots": [_snapshot_card(item) for item in snapshots_list[:5]],
+        "latest_restore": latest_restore,
+        "latest_restore_tone": _status_tone(None if not latest_restore else latest_restore.get("result")),
+        "restore_count": len(history),
+        "paths": paths,
+        "settings": settings,
+        "schedule_summary": {
+            **scheduler_service.next_run_info(),
+            "cron_description": describe_cron(settings.schedule_cron),
+        },
+    }
+    return TEMPLATES.TemplateResponse(request, "dashboard.html", context)
+
+
+@app.get("/snapshots", response_class=HTMLResponse)
+def snapshots_page(request: Request):
+    return TEMPLATES.TemplateResponse(
+        request,
+        "snapshots.html",
+        {**_base_context(title="Snapshots · Hermes Snapshot Manager", current_path="/snapshots"), "snapshots": [_snapshot_card(item) for item in snapshot_service.list_snapshots()]},
+    )
+
+
+@app.get("/snapshots/{snapshot_id}", response_class=HTMLResponse)
+def snapshot_detail(request: Request, snapshot_id: str):
+    detail = _enrich_snapshot_detail(snapshot_service.get_snapshot(snapshot_id))
+    verification = snapshot_service.verify_snapshot(snapshot_id)
+    diff = snapshot_service.diff_snapshot_to_current(snapshot_id)
+    detail["snapshot"]["status_tone"] = _status_tone(detail["snapshot"].get("status"))
+    return TEMPLATES.TemplateResponse(
+        request,
+        "snapshot_detail.html",
+        {**_base_context(title=f"Snapshot {snapshot_id} · Hermes Snapshot Manager", current_path="/snapshots"), **detail, "verification": verification, "diff": diff},
+    )
+
+
+@app.get("/restores", response_class=HTMLResponse)
+def restore_history_page(request: Request):
+    return TEMPLATES.TemplateResponse(
+        request,
+        "restore_history.html",
+        {**_base_context(title="Restore History · Hermes Snapshot Manager", current_path="/restores"), "history": restore_service.list_restore_history()},
+    )
+
+
+@app.get("/settings", response_class=HTMLResponse)
+def settings_page(request: Request):
+    settings = load_settings(paths)
+    schedule_summary = {
+        **scheduler_service.next_run_info(),
+        "cron_description": describe_cron(settings.schedule_cron),
+        "exclude_patterns_text": "\n".join(settings.exclude_patterns),
+    }
+    return TEMPLATES.TemplateResponse(
+        request,
+        "settings.html",
+        {**_base_context(title="Settings · Hermes Snapshot Manager", current_path="/settings"), "settings": settings, "schedule_summary": schedule_summary},
+    )
+
+
+def main() -> None:
+    uvicorn.run("hermes_snapshot_manager.main:app", host="127.0.0.1", port=8876, reload=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/hermes_snapshot_manager/scripts/run_snapshot_manager.sh
+++ b/hermes_snapshot_manager/scripts/run_snapshot_manager.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+source venv/bin/activate
+exec uvicorn hermes_snapshot_manager.main:app --host 127.0.0.1 --port 8876

--- a/hermes_snapshot_manager/services/manifest_service.py
+++ b/hermes_snapshot_manager/services/manifest_service.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from typing import Iterable
+
+from hermes_snapshot_manager.core.hashing import sha256_file
+
+
+ISO = "%Y-%m-%dT%H:%M:%SZ"
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).strftime(ISO)
+
+
+def build_manifest(snapshot_id: str, source_root: Path, files_root: Path, label: str | None, trigger_type: str, file_paths: Iterable[Path]) -> dict:
+    files: list[dict] = []
+    for path in sorted(file_paths):
+        stat = path.stat()
+        files.append(
+            {
+                "path": str(path.relative_to(files_root)),
+                "sha256": sha256_file(path),
+                "size": stat.st_size,
+                "mtime": stat.st_mtime,
+                "mode": oct(stat.st_mode & 0o777),
+                "file_type": "file" if path.is_file() else "other",
+            }
+        )
+    return {
+        "snapshot_id": snapshot_id,
+        "created_at": utc_now(),
+        "source_root": str(source_root),
+        "label": label,
+        "trigger_type": trigger_type,
+        "files": files,
+    }
+
+
+def write_manifest(manifest: dict, output_path: Path) -> str:
+    raw = json.dumps(manifest, indent=2, sort_keys=True)
+    output_path.write_text(raw, encoding="utf-8")
+    return sha256_file(output_path)

--- a/hermes_snapshot_manager/services/operation_service.py
+++ b/hermes_snapshot_manager/services/operation_service.py
@@ -1,0 +1,464 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+import shutil
+import threading
+import uuid
+
+from hermes_snapshot_manager.core.paths import AppPaths, build_paths, ensure_app_dirs
+from hermes_snapshot_manager.services.restore_service import RestoreService
+from hermes_snapshot_manager.services.snapshot_service import SnapshotService
+
+# seconds after which a running operation is considered stale
+STALE_THRESHOLD_SECONDS = 90
+
+# seconds after which a completed or failed operation record is automatically
+# cleared from disk.  Prevents UI clutter from old operations that finished
+# (successfully or not) and are no longer relevant.  The operation state file
+# is deleted so get_current_operation() returns None for expired records.
+COMPLETED_OPERATION_EXPIRY_SECONDS = 3600  # 1 hour
+
+
+class OperationService:
+    def __init__(self, paths: AppPaths | None = None):
+        self.paths = paths or build_paths()
+        ensure_app_dirs(self.paths)
+        self.snapshot_service = SnapshotService(self.paths)
+        self.restore_service = RestoreService(self.paths)
+        self._state_lock = threading.Lock()
+        self._heartbeat_thread: threading.Thread | None = None
+        self._running_operation_id: str | None = None
+        # Clear any expired completed/failed operations on startup so the UI
+        # never shows stale records from a previous session.
+        self.get_current_operation()
+
+    # -------------------------------------------------------------------------
+    # Persistence
+    # -------------------------------------------------------------------------
+
+    def _read_state(self) -> dict | None:
+        if not self.paths.operation_status_path.exists():
+            return None
+        return json.loads(self.paths.operation_status_path.read_text(encoding="utf-8"))
+
+    def _write_state(self, state: dict | None) -> None:
+        if state is None:
+            if self.paths.operation_status_path.exists():
+                self.paths.operation_status_path.unlink()
+            return
+        self.paths.operation_status_path.write_text(
+            json.dumps(state, indent=2, sort_keys=True), encoding="utf-8"
+        )
+
+    # -------------------------------------------------------------------------
+    # Stale / expired detection
+    # -------------------------------------------------------------------------
+
+    def _is_stale(self, state: dict) -> bool:
+        """Return True when a running operation has not updated its heartbeat
+        within the stale threshold."""
+        if state.get("status") != "running":
+            return False
+        last_hb = state.get("last_heartbeat")
+        if not last_hb:
+            # No heartbeat ever written — check started_at as fallback
+            started_str = state.get("started_at", "")
+            try:
+                started = datetime.strptime(started_str, "%Y-%m-%dT%H:%M:%SZ").replace(
+                    tzinfo=timezone.utc
+                )
+            except ValueError:
+                return True  # malformed date = assume stale
+            age = (datetime.now(timezone.utc) - started).total_seconds()
+            return age > STALE_THRESHOLD_SECONDS
+        try:
+            last = datetime.strptime(last_hb, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+        except ValueError:
+            return True
+        age = (datetime.now(timezone.utc) - last).total_seconds()
+        return age > STALE_THRESHOLD_SECONDS
+
+    def _is_expired_completed(self, state: dict) -> bool:
+        """Return True when a completed or failed operation has been finished
+        for longer than COMPLETED_OPERATION_EXPIRY_SECONDS and should be
+        auto-cleared to keep the UI clean."""
+        if state.get("status") not in ("completed", "failed"):
+            return False
+        finished_str = state.get("finished_at")
+        if not finished_str:
+            return False
+        try:
+            finished = datetime.strptime(finished_str, "%Y-%m-%dT%H:%M:%SZ").replace(
+                tzinfo=timezone.utc
+            )
+        except ValueError:
+            return True  # malformed date = clear it
+        age = (datetime.now(timezone.utc) - finished).total_seconds()
+        return age > COMPLETED_OPERATION_EXPIRY_SECONDS
+
+    def get_current_operation(self) -> dict | None:
+        with self._state_lock:
+            state = self._read_state()
+            if not state:
+                return None
+            # Auto-clear expired completed/failed operations.
+            if self._is_expired_completed(state):
+                self._write_state(None)
+                return None
+            if self._is_stale(state):
+                state = dict(state)
+                state["status"] = "stale"
+            return state
+
+    # -------------------------------------------------------------------------
+    # Partial snapshot cleanup
+    # -------------------------------------------------------------------------
+
+    def _cleanup_incomplete_snapshot_dirs(self) -> None:
+        """Remove any snapshot directories that were left behind by a crashed
+        or interrupted snapshot run (i.e. directories that exist but have no
+        completed metadata.json or manifest.json).
+
+        Safe to call concurrently: OSError from concurrent rmtree races is
+        swallowed so that multiple /api/operations/current/clear or
+        start_snapshot calls racing on the same incomplete dir never produce
+        a 500.
+        """
+        if not self.paths.snapshot_root.exists():
+            return
+        for entry in self.paths.snapshot_root.iterdir():
+            try:
+                if not entry.is_dir():
+                    continue
+                has_metadata = (entry / "metadata.json").exists()
+                has_manifest = (entry / "manifest.json").exists()
+                # If neither is present, this directory is an incomplete leftover
+                if not has_metadata and not has_manifest:
+                    shutil.rmtree(entry, ignore_errors=True)
+            except OSError:
+                # Directory was removed by a concurrent cleanup thread between
+                # the iterdir() yield and the is_dir() / rmtree() call — safe to ignore.
+                pass
+
+    # -------------------------------------------------------------------------
+    # Heartbeat thread
+    # -------------------------------------------------------------------------
+
+    def _start_heartbeat(self, operation_id: str) -> None:
+        def heartbeat_loop():
+            while True:
+                if self._running_operation_id != operation_id:
+                    break
+                with self._state_lock:
+                    self._update_state_nolock(operation_id, last_heartbeat=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"))
+                threading.Event().wait(10)
+
+        t = threading.Thread(target=heartbeat_loop, daemon=True)
+        t.start()
+        self._heartbeat_thread = t
+
+    def _stop_heartbeat(self) -> None:
+        self._running_operation_id = None
+        # The thread is daemon so it will die naturally; signal it to exit
+        if self._heartbeat_thread is not None:
+            self._heartbeat_thread.join(timeout=1.5)
+            self._heartbeat_thread = None
+
+    # -------------------------------------------------------------------------
+    # State mutation helpers
+    # -------------------------------------------------------------------------
+
+    def _update_state_nolock(self, operation_id: str, **updates) -> None:
+        """Must be called while holding _state_lock."""
+        state = self._read_state()
+        if not state or state.get("id") != operation_id:
+            return
+        state.update(updates)
+        self._write_state(state)
+
+    def _update_state(self, operation_id: str, **updates) -> None:
+        with self._state_lock:
+            self._update_state_nolock(operation_id, **updates)
+
+    def _build_progress_callback(
+        self, operation_id: str, stage: str, start_percent: int, end_percent: int, noun: str
+    ):
+        def callback(completed: int, total: int, current_item: str) -> None:
+            # Guard: completed can exceed total due to rglob re-counting destination
+            # files after symlink/skipped-placeholder divergence. Clamp to total so
+            # progress never regresses and the UI never shows "80849/80378".
+            # Also guard against total==0 (ZeroDivisionError) and negative completed.
+            safe_completed = max(0, min(completed, total)) if total > 0 else 0
+            percent = (
+                end_percent
+                if total <= 0
+                else start_percent + int((safe_completed / total) * (end_percent - start_percent))
+            )
+            message = f"{noun}: {safe_completed}/{total}"
+            self._update_state(
+                operation_id,
+                progress=min(percent, end_percent),
+                stage=stage,
+                message=message,
+                current_item=current_item,
+                last_heartbeat=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            )
+
+        return callback
+
+    def _build_skip_callback(self, operation_id: str):
+        def callback(relative_path: str, error_message: str) -> None:
+            with self._state_lock:
+                state = self._read_state()
+                if not state or state.get("id") != operation_id:
+                    return
+                skipped_count = int(state.get("skipped_files_count") or 0) + 1
+                skipped_files = list(state.get("skipped_files") or [])
+                skipped_files.append({"path": relative_path, "error": error_message})
+                state.update(
+                    {
+                        "skipped_files_count": skipped_count,
+                        "last_skipped_file": relative_path,
+                        "message": f"Skipped file ({skipped_count}): {relative_path}",
+                        "skipped_files": skipped_files[-20:],
+                        "last_heartbeat": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    }
+                )
+                self._write_state(state)
+
+        return callback
+
+    def _build_traversal_skip_callback(self, operation_id: str):
+        """Build a TraversalSkipCallback that records traversal-stage skips."""
+        def callback(relative_path: str, reason: str) -> None:
+            with self._state_lock:
+                state = self._read_state()
+                if not state or state.get("id") != operation_id:
+                    return
+                count = int(state.get("traversal_skipped_count") or 0) + 1
+                skipped = list(state.get("traversal_skipped") or [])
+                skipped.append({"path": relative_path, "reason": reason})
+                state.update(
+                    {
+                        "traversal_skipped_count": count,
+                        "last_traversal_skipped": relative_path,
+                        "message": f"Skipped during traversal ({count}): {relative_path} — {reason}",
+                        "traversal_skipped": skipped[-20:],
+                        "last_heartbeat": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    }
+                )
+                self._write_state(state)
+
+        return callback
+
+    # -------------------------------------------------------------------------
+    # Abort / Resume / Clear
+    # -------------------------------------------------------------------------
+
+    def abort_operation(self) -> dict | None:
+        """Mark the current operation as aborted and clean up partial state."""
+        with self._state_lock:
+            state = self._read_state()
+            if not state:
+                return None
+            self._stop_heartbeat()
+            self._write_state(None)
+        # Clean up any incomplete snapshot directories
+        self._cleanup_incomplete_snapshot_dirs()
+        return {"status": "aborted", "id": state["id"]}
+
+    def clear_stale_operation(self) -> dict | None:
+        """Clear a stale operation record and remove partial snapshot dirs."""
+        with self._state_lock:
+            state = self._read_state()
+            if not state:
+                return None
+            if state.get("status") not in ("stale", "running"):
+                return None
+            self._stop_heartbeat()
+            self._write_state(None)
+        self._cleanup_incomplete_snapshot_dirs()
+        return {"status": "cleared", "id": state["id"]}
+
+    # -------------------------------------------------------------------------
+    # Operations
+    # -------------------------------------------------------------------------
+
+    def _begin_operation(
+        self, kind: str, target_id: str | None = None, detail: str | None = None
+    ) -> dict:
+        with self._state_lock:
+            existing = self._read_state()
+            if existing:
+                # Auto-clear expired completed/failed operations so they don't
+                # block new runs.
+                if self._is_expired_completed(existing):
+                    self._write_state(None)
+                # Auto-clear stale running operations so they don't block new runs
+                elif existing.get("status") in ("running", "stale") and self._is_stale(existing):
+                    self._stop_heartbeat()
+                    self._write_state(None)
+                    self._cleanup_incomplete_snapshot_dirs()
+                else:
+                    raise RuntimeError(f"Another operation is already running: {existing['id']}")
+
+            operation_id = f"op-{kind}-{uuid.uuid4().hex[:8]}"
+            now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+            state = {
+                "id": operation_id,
+                "kind": kind,
+                "status": "running",
+                "progress": 0,
+                "stage": "queued",
+                "message": f"Queued {kind} operation",
+                "detail": detail,
+                "target_id": target_id,
+                "started_at": now,
+                "last_heartbeat": now,
+                "finished_at": None,
+                "result": None,
+                "error": None,
+                "skipped_files_count": 0,
+                "last_skipped_file": None,
+                "skipped_files": [],
+                "traversal_skipped_count": 0,
+                "last_traversal_skipped": None,
+                "traversal_skipped": [],
+            }
+            self._write_state(state)
+            self._running_operation_id = operation_id
+            return state
+
+    def start_snapshot(self, label: str | None = None) -> dict:
+        # Always try to clean up leftovers from crashed runs first
+        self._cleanup_incomplete_snapshot_dirs()
+        state = self._begin_operation("snapshot", detail=label)
+        operation_id = state["id"]
+
+        def run() -> None:
+            try:
+                self._start_heartbeat(operation_id)
+                self._update_state(
+                    operation_id,
+                    progress=5,
+                    stage="preparing",
+                    message="Preparing snapshot",
+                    last_heartbeat=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                )
+                snapshot = self.snapshot_service.create_snapshot(
+                    label=label,
+                    trigger_type="manual",
+                    progress_callback=self._build_progress_callback(
+                        operation_id, "copying_files", 10, 80, "Copying files"
+                    ),
+                    stage_callback=lambda stage, progress, message: self._update_state(
+                        operation_id,
+                        stage=stage,
+                        progress=progress,
+                        message=message,
+                        last_heartbeat=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    ),
+                    skip_callback=self._build_skip_callback(operation_id),
+                    traversal_skip_callback=self._build_traversal_skip_callback(operation_id),
+                )
+                current_state = self.get_current_operation() or {}
+                skipped_count = int(current_state.get("skipped_files_count") or 0)
+                traversal_count = int(current_state.get("traversal_skipped_count") or 0)
+                parts = []
+                if skipped_count:
+                    parts.append(f"{skipped_count} skipped file(s)")
+                if traversal_count:
+                    parts.append(f"{traversal_count} traversal skip(s)")
+                completion_message = (
+                    "Snapshot completed with " + ", ".join(parts)
+                    if parts else "Snapshot completed"
+                )
+                self._update_state(
+                    operation_id,
+                    status="completed",
+                    progress=100,
+                    stage="completed",
+                    message=completion_message,
+                    result={
+                        "snapshot_id": snapshot.id,
+                        "skipped_files_count": skipped_count,
+                        "traversal_skipped_count": traversal_count,
+                    },
+                    finished_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    last_heartbeat=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                )
+            except Exception as exc:
+                self._update_state(
+                    operation_id,
+                    status="failed",
+                    stage="failed",
+                    message="Snapshot failed",
+                    error=str(exc),
+                    finished_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    last_heartbeat=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                )
+            finally:
+                self._stop_heartbeat()
+
+        threading.Thread(target=run, daemon=True).start()
+        return {"operation_id": operation_id, "status": "running"}
+
+    def start_restore(self, snapshot_id: str, notes: str | None = None) -> dict:
+        state = self._begin_operation("restore", target_id=snapshot_id, detail=notes)
+        operation_id = state["id"]
+
+        def run() -> None:
+            try:
+                self._start_heartbeat(operation_id)
+                self._update_state(
+                    operation_id,
+                    progress=5,
+                    stage="preparing",
+                    message="Preparing restore",
+                    last_heartbeat=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                )
+                result = self.restore_service.restore_snapshot(
+                    snapshot_id,
+                    notes=notes,
+                    pre_snapshot_progress_callback=self._build_progress_callback(
+                        operation_id, "creating_pre_restore_snapshot", 10, 45, "Creating safeguard snapshot"
+                    ),
+                    restore_progress_callback=self._build_progress_callback(
+                        operation_id, "restoring_files", 55, 95, "Restoring files"
+                    ),
+                    stage_callback=lambda stage, progress, message: self._update_state(
+                        operation_id,
+                        stage=stage,
+                        progress=progress,
+                        message=message,
+                        last_heartbeat=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    ),
+                )
+                self._update_state(
+                    operation_id,
+                    status="completed",
+                    progress=100,
+                    stage="completed",
+                    message="Restore completed",
+                    result=result,
+                    finished_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    last_heartbeat=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                )
+            except Exception as exc:
+                self._update_state(
+                    operation_id,
+                    status="failed",
+                    stage="failed",
+                    message="Restore failed",
+                    error=str(exc),
+                    finished_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    last_heartbeat=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                )
+            finally:
+                self._stop_heartbeat()
+
+        threading.Thread(target=run, daemon=True).start()
+        return {"operation_id": operation_id, "status": "running"}
+
+

--- a/hermes_snapshot_manager/services/restore_service.py
+++ b/hermes_snapshot_manager/services/restore_service.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import datetime, timezone
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+
+from hermes_snapshot_manager.core.filesystem import ProgressCallback, copy_files_with_progress
+from hermes_snapshot_manager.core.locking import exclusive_lock
+from hermes_snapshot_manager.core.paths import AppPaths, build_paths
+from hermes_snapshot_manager.services.snapshot_service import SnapshotService
+from hermes_snapshot_manager.storage.db import connect
+
+StageCallback = Callable[[str, int, str], None]
+
+
+class RestoreService:
+    def __init__(self, paths: AppPaths | None = None):
+        self.paths = paths or build_paths()
+        self.snapshot_service = SnapshotService(self.paths)
+
+    def _copy_snapshot_into_place(
+        self,
+        snapshot_dir: Path,
+        destination: Path,
+        progress_callback: ProgressCallback | None = None,
+    ) -> None:
+        destination.mkdir(parents=True, exist_ok=True)
+        files = [path for path in snapshot_dir.rglob("*") if path.is_file()]
+        copy_files_with_progress(snapshot_dir, destination, files, progress_callback=progress_callback)
+
+    def _find_active_hermes_processes(self) -> list[str]:
+        try:
+            result = subprocess.run(
+                ["ps", "-eo", "pid=,args="],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except Exception:
+            return []
+        markers = ("run_agent.py", "hermes ", "hermes-agent", "hermes_snapshot_manager.main:app")
+        current_pid = str(Path('/proc/self').resolve().name) if Path('/proc/self').exists() else None
+        lines: list[str] = []
+        for line in result.stdout.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            if current_pid and stripped.startswith(f"{current_pid} "):
+                continue
+            if any(marker in stripped for marker in markers):
+                lines.append(stripped)
+        return lines
+
+    def _find_active_sqlite_sidecars(self) -> list[str]:
+        matches: list[str] = []
+        for suffix in ("-wal", "-journal", "-shm"):
+            for path in self.paths.source_root.rglob(f"*{suffix}"):
+                if path.is_file():
+                    matches.append(str(path.relative_to(self.paths.source_root)))
+        return sorted(matches)
+
+    def _record_restore_attempt(
+        self,
+        snapshot_id: str,
+        result: str,
+        pre_restore_snapshot_id: str | None,
+        notes: str | None,
+    ) -> None:
+        with connect(self.paths.db_path) as conn:
+            conn.execute(
+                "INSERT INTO restore_history (snapshot_id, restored_at, result, pre_restore_snapshot_id, notes) VALUES (?,?,?,?,?)",
+                (snapshot_id, datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"), result, pre_restore_snapshot_id, notes),
+            )
+            conn.commit()
+
+    def restore_snapshot(
+        self,
+        snapshot_id: str,
+        notes: str | None = None,
+        pre_snapshot_progress_callback: ProgressCallback | None = None,
+        restore_progress_callback: ProgressCallback | None = None,
+        stage_callback: StageCallback | None = None,
+    ) -> dict:
+        archive_path = self.snapshot_service._payload_archive_path(snapshot_id)
+        if not archive_path.exists():
+            raise FileNotFoundError(f"Snapshot payload archive missing: {archive_path}")
+
+        if stage_callback is not None:
+            stage_callback("checking_safety", 5, "Checking restore safety")
+        active_processes = self._find_active_hermes_processes()
+        if active_processes:
+            raise RuntimeError(f"Cannot restore with active Hermes processes: {active_processes}")
+
+        sqlite_sidecars = self._find_active_sqlite_sidecars()
+        if sqlite_sidecars:
+            raise RuntimeError(f"Cannot restore while SQLite activity is present: {sqlite_sidecars}")
+
+        if stage_callback is not None:
+            stage_callback("verifying_snapshot", 8, "Verifying snapshot before restore")
+        verification = self.snapshot_service.verify_snapshot(snapshot_id)
+        if not verification["ok"]:
+            raise ValueError(f"Snapshot {snapshot_id} failed verification")
+
+        with exclusive_lock(self.paths.lock_path):
+            if stage_callback is not None:
+                stage_callback("creating_pre_restore_snapshot", 10, "Creating safeguard snapshot")
+            pre_restore = self.snapshot_service._create_snapshot_unlocked(
+                label=f"pre-restore:{snapshot_id}",
+                trigger_type="pre_restore",
+                notes=f"Automatic safeguard before restoring {snapshot_id}",
+                progress_callback=pre_snapshot_progress_callback,
+            )
+            backup_target = self.paths.source_root.parent / f"{self.paths.source_root.name}.restore-backup"
+            if backup_target.exists():
+                shutil.rmtree(backup_target)
+            if self.paths.source_root.exists():
+                shutil.move(str(self.paths.source_root), str(backup_target))
+            try:
+                with tempfile.TemporaryDirectory(prefix=f"snapshot-restore-{snapshot_id}-") as temp_dir:
+                    extracted_root = self.snapshot_service._extract_payload(snapshot_id, Path(temp_dir))
+                    if stage_callback is not None:
+                        stage_callback("restoring_files", 55, "Restoring files")
+                    if restore_progress_callback is not None:
+                        self._copy_snapshot_into_place(extracted_root, self.paths.source_root, progress_callback=restore_progress_callback)
+                    else:
+                        self._copy_snapshot_into_place(extracted_root, self.paths.source_root)
+            except Exception as exc:
+                if self.paths.source_root.exists():
+                    shutil.rmtree(self.paths.source_root)
+                if backup_target.exists():
+                    shutil.move(str(backup_target), str(self.paths.source_root))
+                failure_notes = f"{notes or ''}\nrestore_error={exc}".strip()
+                self._record_restore_attempt(snapshot_id, "failed", pre_restore.id, failure_notes)
+                raise
+            else:
+                if backup_target.exists():
+                    shutil.rmtree(backup_target)
+                self._record_restore_attempt(snapshot_id, "success", pre_restore.id, notes)
+        return {"restored_snapshot_id": snapshot_id, "pre_restore_snapshot_id": pre_restore.id, "result": "success"}
+
+    def list_restore_history(self) -> list[dict]:
+        with connect(self.paths.db_path) as conn:
+            rows = conn.execute(
+                "SELECT id, snapshot_id, restored_at, result, pre_restore_snapshot_id, notes FROM restore_history ORDER BY id DESC"
+            ).fetchall()
+        return [dict(row) for row in rows]

--- a/hermes_snapshot_manager/services/retention_service.py
+++ b/hermes_snapshot_manager/services/retention_service.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from hermes_snapshot_manager.services.snapshot_service import SnapshotService
+
+
+class RetentionService:
+    def __init__(self, snapshot_service: SnapshotService):
+        self.snapshot_service = snapshot_service
+
+    def cleanup(self) -> dict:
+        snapshots = self.snapshot_service.list_snapshots()
+        keep = self.snapshot_service.settings.retention_daily
+        protected = {snapshot.id for snapshot in snapshots[:keep]}
+        protected.update(snapshot.id for snapshot in snapshots if snapshot.is_known_good)
+
+        deleted: list[str] = []
+        for snapshot in snapshots:
+            if snapshot.id in protected:
+                continue
+            self.snapshot_service.delete_snapshot(snapshot.id)
+            deleted.append(snapshot.id)
+        return {"deleted": deleted, "retained": len(snapshots) - len(deleted), "protected": sorted(protected)}

--- a/hermes_snapshot_manager/services/scheduler_service.py
+++ b/hermes_snapshot_manager/services/scheduler_service.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.cron import CronTrigger
+from datetime import datetime, timezone
+
+from hermes_snapshot_manager.core.config import load_settings
+from hermes_snapshot_manager.core.paths import AppPaths, build_paths
+from hermes_snapshot_manager.services.retention_service import RetentionService
+from hermes_snapshot_manager.services.snapshot_service import SnapshotService
+
+
+class SchedulerService:
+    def __init__(self, paths: AppPaths | None = None):
+        self.paths = paths or build_paths()
+        self.settings = load_settings(self.paths)
+        self.snapshot_service = SnapshotService(self.paths, self.settings)
+        self.retention_service = RetentionService(self.snapshot_service)
+        self.scheduler = BackgroundScheduler(timezone="UTC")
+
+    def refresh_settings(self):
+        self.settings = load_settings(self.paths)
+        self.snapshot_service.settings = self.settings
+        return self.settings
+
+    def describe_schedule(self) -> str:
+        return describe_cron(self.refresh_settings().schedule_cron)
+
+    def next_run_info(self) -> dict:
+        settings = self.refresh_settings()
+        if not settings.schedule_enabled:
+            return {
+                "enabled": False,
+                "description": "Automatic snapshots are off",
+                "next_run_utc": None,
+                "next_run_relative": "Scheduling disabled",
+            }
+        trigger = CronTrigger.from_crontab(settings.schedule_cron, timezone="UTC")
+        now = datetime.now(timezone.utc)
+        next_run = trigger.get_next_fire_time(previous_fire_time=None, now=now)
+        return {
+            "enabled": True,
+            "description": describe_cron(settings.schedule_cron),
+            "next_run_utc": None if next_run is None else next_run.strftime("%Y-%m-%d %H:%M UTC"),
+            "next_run_relative": _humanize_future_delta(next_run, now),
+        }
+
+    def start(self) -> None:
+        settings = self.refresh_settings()
+        if not settings.schedule_enabled:
+            return
+        trigger = CronTrigger.from_crontab(settings.schedule_cron)
+        self.scheduler.add_job(self.snapshot_service.create_snapshot, trigger=trigger, kwargs={"trigger_type": "scheduled"}, id="snapshot-job", replace_existing=True)
+        self.scheduler.add_job(self.retention_service.cleanup, trigger=trigger, id="retention-job", replace_existing=True)
+        self.scheduler.start()
+
+    def stop(self) -> None:
+        if self.scheduler.running:
+            self.scheduler.shutdown(wait=False)
+
+
+def _humanize_future_delta(target: datetime | None, now: datetime | None = None) -> str:
+    if target is None:
+        return "No future run"
+    baseline = now or datetime.now(timezone.utc)
+    seconds = max(int((target - baseline).total_seconds()), 0)
+    minutes, _ = divmod(seconds, 60)
+    hours, minutes = divmod(minutes, 60)
+    days, hours = divmod(hours, 24)
+    pieces = []
+    if days:
+        pieces.append(f"{days}d")
+    if hours:
+        pieces.append(f"{hours}h")
+    if minutes:
+        pieces.append(f"{minutes}m")
+    return "in <1m" if not pieces else "in " + " ".join(pieces[:2])
+
+
+def describe_cron(cron: str) -> str:
+    parts = cron.split()
+    if len(parts) != 5:
+        return "Custom cron schedule"
+    minute, hour, day_of_month, month, day_of_week = parts
+    if minute == "0" and hour.startswith("*/") and day_of_month == month == day_of_week == "*":
+        return f"Every {hour[2:]} hours"
+    if day_of_month == month == day_of_week == "*" and minute.isdigit() and hour.isdigit():
+        return f"Daily at {int(hour):02d}:{int(minute):02d} UTC"
+    if day_of_month == month == "*" and day_of_week.isdigit() and minute.isdigit() and hour.isdigit():
+        weekday_names = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
+        return f"{weekday_names[int(day_of_week)]} at {int(hour):02d}:{int(minute):02d} UTC"
+    return "Custom cron schedule"

--- a/hermes_snapshot_manager/services/snapshot_service.py
+++ b/hermes_snapshot_manager/services/snapshot_service.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+import shutil
+import tempfile
+import uuid
+
+from hermes_snapshot_manager.core.compression import create_tar_gz, extract_tar_gz
+from hermes_snapshot_manager.core.config import SnapshotManagerSettings, load_settings
+from hermes_snapshot_manager.core.display import compression_ratio
+from hermes_snapshot_manager.core.filesystem import ProgressCallback, SkipCallback, TraversalSkipCallback, copy_tree, should_include
+from hermes_snapshot_manager.core.hashing import sha256_file
+from hermes_snapshot_manager.core.locking import exclusive_lock
+from hermes_snapshot_manager.core.paths import AppPaths, build_paths, ensure_app_dirs
+from hermes_snapshot_manager.storage.db import connect, init_db
+from hermes_snapshot_manager.storage.models import SnapshotSummary
+from hermes_snapshot_manager.services.manifest_service import build_manifest, write_manifest
+
+StageCallback = Callable[[str, int, str], None]
+
+
+class SnapshotService:
+    def __init__(self, paths: AppPaths | None = None, settings: SnapshotManagerSettings | None = None):
+        self.paths = paths or build_paths()
+        self.settings = settings or load_settings(self.paths)
+        ensure_app_dirs(self.paths)
+        init_db(self.paths.db_path)
+
+    def _payload_archive_path(self, snapshot_id: str) -> Path:
+        return self.paths.snapshot_root / snapshot_id / "files.tar.gz"
+
+    def _extract_payload(self, snapshot_id: str, destination: Path) -> Path:
+        archive_path = self._payload_archive_path(snapshot_id)
+        if not archive_path.exists():
+            raise FileNotFoundError(f"Snapshot payload archive missing: {archive_path}")
+        extracted_root = extract_tar_gz(archive_path, destination)
+        return extracted_root
+
+    def create_snapshot(
+        self,
+        label: str | None = None,
+        trigger_type: str = "manual",
+        notes: str | None = None,
+        progress_callback: ProgressCallback | None = None,
+        stage_callback: StageCallback | None = None,
+        skip_callback: SkipCallback | None = None,
+        traversal_skip_callback: TraversalSkipCallback | None = None,
+    ) -> SnapshotSummary:
+        # Reload settings for every snapshot so changes made from the settings UI
+        # apply to the very next run without requiring a service restart.
+        self.settings = load_settings(self.paths)
+        with exclusive_lock(self.paths.lock_path):
+            return self._create_snapshot_unlocked(
+                label=label,
+                trigger_type=trigger_type,
+                notes=notes,
+                progress_callback=progress_callback,
+                stage_callback=stage_callback,
+                skip_callback=skip_callback,
+            )
+
+    def _create_snapshot_unlocked(
+        self,
+        label: str | None = None,
+        trigger_type: str = "manual",
+        notes: str | None = None,
+        progress_callback: ProgressCallback | None = None,
+        stage_callback: StageCallback | None = None,
+        skip_callback: SkipCallback | None = None,
+        traversal_skip_callback: TraversalSkipCallback | None = None,
+    ) -> SnapshotSummary:
+        if not self.paths.source_root.exists():
+            raise FileNotFoundError(f"Hermes source root does not exist: {self.paths.source_root}")
+
+        if stage_callback is not None:
+            stage_callback("preparing", 5, "Preparing snapshot")
+
+        created_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%SZ")
+        snapshot_id = f"{created_at}_{uuid.uuid4().hex[:6]}"
+        snapshot_dir = self.paths.snapshot_root / snapshot_id
+        files_root = snapshot_dir / "files" / ".hermes"
+        metadata_path = snapshot_dir / "metadata.json"
+        manifest_path = snapshot_dir / "manifest.json"
+        archive_path = snapshot_dir / "files.tar.gz"
+        skipped_log_path = snapshot_dir / "skipped-files.json"
+
+        if snapshot_dir.exists():
+            raise FileExistsError(f"Snapshot path already exists: {snapshot_dir}")
+        files_root.mkdir(parents=True, exist_ok=False)
+        _traversal_skipped_collector: list[tuple[str, str]] = []
+        _included_files, skipped_files, is_degraded = copy_tree(
+            self.paths.source_root,
+            files_root,
+            include_patterns=self.settings.include_patterns,
+            exclude_patterns=self.settings.exclude_patterns,
+            progress_callback=progress_callback,
+            scan_progress_callback=(
+                None
+                if stage_callback is None
+                else lambda scanned_count, current_item: stage_callback(
+                    "scanning_files",
+                    8,
+                    f"Scanning files to include: {scanned_count} checked · {current_item}",
+                )
+            ),
+            skip_callback=skip_callback,
+            skip_stuck_patterns=self.settings.skip_stuck_patterns,
+            max_consecutive_skipped=self.settings.max_consecutive_skipped,
+            skip_fs_types=frozenset(self.settings.skip_fs_types),
+            skip_mount_points=tuple(self.settings.skip_mount_points),
+            cross_device=self.settings.cross_device,
+            traversal_skip_callback=traversal_skip_callback,
+            traversal_skipped_collector=_traversal_skipped_collector,
+        )
+        # Write a dedicated traversal-skipped log so it survives restart and is
+        # readable from the snapshot directory.
+        if _traversal_skipped_collector:
+            traversal_skipped_log_path = snapshot_dir / "traversal-skipped.json"
+            traversal_skipped_log_path.write_text(
+                json.dumps(
+                    [{"path": path, "reason": reason} for path, reason in _traversal_skipped_collector],
+                    indent=2,
+                    sort_keys=True,
+                ),
+                encoding="utf-8",
+            )
+        if skipped_files:
+            skipped_log_path.write_text(
+                json.dumps(
+                    [
+                        {"path": relative_path, "error": error_message}
+                        for relative_path, error_message in skipped_files
+                    ],
+                    indent=2,
+                    sort_keys=True,
+                ),
+                encoding="utf-8",
+            )
+        # Determine snapshot status: degraded if any files were skipped.
+        snapshot_status = "degraded" if is_degraded else "created"
+        if stage_callback is not None:
+            stage_callback("building_manifest", 80, "Building manifest")
+        file_paths = [path for path in files_root.rglob("*") if path.is_file()]
+        manifest = build_manifest(snapshot_id, self.paths.source_root, files_root, label, trigger_type, file_paths)
+        manifest_sha = write_manifest(manifest, manifest_path)
+        if stage_callback is not None:
+            stage_callback("compressing_payload", 90, "Compressing snapshot payload")
+        create_tar_gz(files_root, archive_path)
+        shutil.rmtree(files_root.parent)
+        total_files = len(manifest["files"])
+        total_bytes = sum(item["size"] for item in manifest["files"])
+        traversal_log_name = "traversal-skipped.json" if _traversal_skipped_collector else None
+        metadata = {
+            "id": snapshot_id,
+            "created_at": manifest["created_at"],
+            "label": label,
+            "trigger_type": trigger_type,
+            "status": snapshot_status,
+            "source_root": str(self.paths.source_root),
+            "total_files": total_files,
+            "total_bytes": total_bytes,
+            "manifest_sha256": manifest_sha,
+            "notes": notes,
+            "payload_format": "tar.gz",
+            "payload_archive": archive_path.name,
+            "payload_archive_size": archive_path.stat().st_size,
+            "compression_ratio": compression_ratio(total_bytes, archive_path.stat().st_size),
+            "space_saved_bytes": max(total_bytes - archive_path.stat().st_size, 0),
+            "skipped_files_count": len(skipped_files),
+            "skipped_files_log": skipped_log_path.name if skipped_files else None,
+            "traversal_skipped_count": len(_traversal_skipped_collector),
+            "traversal_skipped_log": traversal_log_name,
+            "is_degraded": is_degraded,
+        }
+        metadata_path.write_text(json.dumps(metadata, indent=2, sort_keys=True), encoding="utf-8")
+        if stage_callback is not None:
+            stage_callback("recording_catalog", 95, "Recording snapshot in catalog")
+        with connect(self.paths.db_path) as conn:
+            conn.execute(
+                """
+                INSERT INTO snapshots (id, created_at, label, trigger_type, status, source_root, total_files, total_bytes, manifest_sha256, notes)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    snapshot_id,
+                    metadata["created_at"],
+                    label,
+                    trigger_type,
+                    snapshot_status,
+                    str(self.paths.source_root),
+                    total_files,
+                    total_bytes,
+                    manifest_sha,
+                    notes,
+                ),
+            )
+            conn.executemany(
+                """
+                INSERT INTO snapshot_files (snapshot_id, relative_path, sha256, size, mtime, mode, file_type)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                [
+                    (
+                        snapshot_id,
+                        item["path"],
+                        item["sha256"],
+                        item["size"],
+                        item["mtime"],
+                        item["mode"],
+                        item["file_type"],
+                    )
+                    for item in manifest["files"]
+                ],
+            )
+            conn.commit()
+
+        return SnapshotSummary(
+            id=snapshot_id,
+            created_at=metadata["created_at"],
+            label=label,
+            trigger_type=trigger_type,
+            status=snapshot_status,
+            total_files=total_files,
+            total_bytes=total_bytes,
+            is_known_good=False,
+        )
+
+    def list_snapshots(self) -> list[SnapshotSummary]:
+        with connect(self.paths.db_path) as conn:
+            rows = conn.execute(
+                """
+                SELECT id, created_at, label, trigger_type, status, total_files, total_bytes, is_known_good
+                FROM snapshots
+                ORDER BY created_at DESC, rowid DESC
+                """
+            ).fetchall()
+        return [SnapshotSummary(**dict(row)) for row in rows]
+
+    def get_snapshot(self, snapshot_id: str) -> dict:
+        with connect(self.paths.db_path) as conn:
+            snapshot = conn.execute("SELECT * FROM snapshots WHERE id = ?", (snapshot_id,)).fetchone()
+            if snapshot is None:
+                raise KeyError(f"Unknown snapshot: {snapshot_id}")
+            files = conn.execute(
+                "SELECT relative_path, sha256, size, mtime, mode, file_type FROM snapshot_files WHERE snapshot_id = ? ORDER BY relative_path",
+                (snapshot_id,),
+            ).fetchall()
+        manifest_path = self.paths.snapshot_root / snapshot_id / "manifest.json"
+        metadata_path = self.paths.snapshot_root / snapshot_id / "metadata.json"
+        return {
+            "snapshot": dict(snapshot),
+            "files": [dict(row) for row in files],
+            "manifest": json.loads(manifest_path.read_text(encoding="utf-8")) if manifest_path.exists() else None,
+            "metadata": json.loads(metadata_path.read_text(encoding="utf-8")) if metadata_path.exists() else None,
+        }
+
+    def verify_snapshot(self, snapshot_id: str) -> dict:
+        detail = self.get_snapshot(snapshot_id)
+        missing_files: list[str] = []
+        changed_files: list[str] = []
+        with tempfile.TemporaryDirectory(prefix=f"snapshot-verify-{snapshot_id}-") as temp_dir:
+            payload_root = self._extract_payload(snapshot_id, Path(temp_dir))
+            for item in detail["files"]:
+                path = payload_root / item["relative_path"]
+                if not path.exists():
+                    missing_files.append(item["relative_path"])
+                    continue
+                if sha256_file(path) != item["sha256"]:
+                    changed_files.append(item["relative_path"])
+        ok = not missing_files and not changed_files
+        with connect(self.paths.db_path) as conn:
+            conn.execute("UPDATE snapshots SET status = ? WHERE id = ?", ("verified" if ok else "failed", snapshot_id))
+            conn.commit()
+        return {"ok": ok, "missing_files": missing_files, "changed_files": changed_files}
+
+    def diff_snapshot_to_current(self, snapshot_id: str) -> dict:
+        detail = self.get_snapshot(snapshot_id)
+        snapshot_map = {item["relative_path"]: item["sha256"] for item in detail["files"]}
+        current_map: dict[str, str] = {}
+        for path in self.paths.source_root.rglob("*"):
+            if not path.is_file():
+                continue
+            relative = path.relative_to(self.paths.source_root).as_posix()
+            if not should_include(relative, self.settings.include_patterns, self.settings.exclude_patterns):
+                continue
+            current_map[relative] = sha256_file(path)
+        snapshot_paths = set(snapshot_map)
+        current_paths = set(current_map)
+        return {
+            "added": sorted(current_paths - snapshot_paths),
+            "removed": sorted(snapshot_paths - current_paths),
+            "changed": sorted(path for path in snapshot_paths & current_paths if snapshot_map[path] != current_map[path]),
+        }
+
+    def mark_known_good(self, snapshot_id: str, value: bool = True) -> None:
+        with connect(self.paths.db_path) as conn:
+            conn.execute("UPDATE snapshots SET is_known_good = ? WHERE id = ?", (1 if value else 0, snapshot_id))
+            conn.commit()
+
+    def delete_snapshot(self, snapshot_id: str) -> None:
+        snapshot_dir = self.paths.snapshot_root / snapshot_id
+        with exclusive_lock(self.paths.lock_path):
+            if snapshot_dir.exists():
+                shutil.rmtree(snapshot_dir)
+            with connect(self.paths.db_path) as conn:
+                conn.execute("DELETE FROM snapshots WHERE id = ?", (snapshot_id,))
+                conn.commit()

--- a/hermes_snapshot_manager/static/app.css
+++ b/hermes_snapshot_manager/static/app.css
@@ -1,0 +1,98 @@
+:root {
+  color-scheme: dark;
+  --bg: #07111f;
+  --bg-accent: radial-gradient(circle at top left, rgba(86, 124, 255, 0.22), transparent 32%), radial-gradient(circle at top right, rgba(24, 198, 255, 0.14), transparent 24%), linear-gradient(180deg, #091120 0%, #060c17 100%);
+  --panel: rgba(11, 20, 37, 0.88);
+  --panel-2: rgba(17, 29, 51, 0.96);
+  --panel-3: rgba(23, 37, 63, 0.95);
+  --text: #eef4ff;
+  --muted: #9ca8c7;
+  --accent: #8ca8ff;
+  --danger: #ff8c9e;
+  --border: rgba(132, 156, 219, 0.18);
+  --shadow: 0 24px 80px rgba(3, 9, 20, 0.45);
+}
+* { box-sizing: border-box; }
+html, body { min-height: 100%; }
+body { margin: 0; font-family: Inter, ui-sans-serif, system-ui, sans-serif; background: var(--bg-accent); color: var(--text); }
+a { color: inherit; }
+code { color: #dbe6ff; font-family: Consolas, monospace; font-size: 0.92em; }
+.page-shell { min-height: 100vh; padding: 24px; }
+.hero-header, .card { backdrop-filter: blur(20px); }
+.hero-header { max-width: 1240px; margin: 0 auto 20px; padding: 24px 28px; border-radius: 28px; border: 1px solid var(--border); background: linear-gradient(180deg, rgba(17, 29, 51, 0.88), rgba(7, 15, 28, 0.9)); box-shadow: var(--shadow); }
+.hero-header__content { display: flex; align-items: center; gap: 18px; margin-bottom: 18px; }
+.brand-mark { width: 56px; height: 56px; border-radius: 18px; display: grid; place-items: center; font-weight: 800; color: #06101e; background: linear-gradient(135deg, #8ca8ff, #6ee7ff); }
+.eyebrow { margin: 0 0 8px; color: var(--accent); font-size: 0.78rem; font-weight: 700; letter-spacing: 0.11em; text-transform: uppercase; }
+.subtitle { color: var(--muted); margin: 8px 0 0; line-height: 1.6; }
+.topnav { display: flex; flex-wrap: wrap; gap: 10px; }
+.topnav a { text-decoration: none; color: var(--muted); padding: 10px 14px; border-radius: 999px; }
+.topnav a:hover, .topnav a.active { color: var(--text); border-color: rgba(140, 168, 255, 0.25); background: rgba(140, 168, 255, 0.12); }
+.container { max-width: 1240px; margin: 0 auto; }
+.grid, .hero-grid, .stat-grid, .key-value-grid, .diff-columns { display: grid; gap: 18px; }
+.hero-grid, .two-up, .snapshot-top-grid { grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); }
+.card { background: linear-gradient(180deg, rgba(13, 23, 41, 0.92), rgba(8, 15, 28, 0.94)); border: 1px solid var(--border); border-radius: 24px; padding: 24px; margin-bottom: 18px; box-shadow: var(--shadow); }
+.hero-card--primary { background: linear-gradient(180deg, rgba(24, 38, 68, 0.98), rgba(11, 20, 37, 0.92)); }
+.section-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 14px; margin-bottom: 16px; }
+.stat-grid { grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); margin-top: 18px; }
+.stat-tile, .record-card, .list-row, .schedule-mode-panel, .preset-option, .inset-card { border: 1px solid rgba(140, 168, 255, 0.14); background: rgba(18, 31, 54, 0.7); border-radius: 18px; }
+.stat-tile { padding: 16px; }
+.stat-label, .key-label, .help-text, .table-subtitle, .callout-text { color: var(--muted); font-size: 0.92rem; }
+.stat-value { display: block; margin-top: 8px; font-size: 1.8rem; }
+.stat-value--small { font-size: 1.2rem; }
+.chip-row, .inline-actions, .operation-actions, .button-row, .list-filters, .preset-grid { display: flex; flex-wrap: wrap; gap: 10px; }
+.chip { display: inline-flex; align-items: center; gap: 6px; padding: 10px 14px; border-radius: 999px; border: 1px solid rgba(140, 168, 255, 0.18); background: rgba(16, 28, 49, 0.72); color: var(--text); }
+input, button, textarea, select { width: 100%; margin-top: 8px; padding: 13px 14px; border-radius: 14px; border: 1px solid rgba(140, 168, 255, 0.18); background: var(--panel-3); color: var(--text); font: inherit; }
+textarea { resize: vertical; min-height: 160px; }
+button, .button-link { cursor: pointer; background: linear-gradient(135deg, var(--accent), #6ee7ff); color: #05101d; font-weight: 800; text-decoration: none; justify-content: center; }
+.button-link--secondary { background: rgba(140, 168, 255, 0.12); color: var(--text); border: 1px solid rgba(140, 168, 255, 0.24); }
+.button-link--ghost { background: transparent; color: var(--muted); border: 1px dashed rgba(140, 168, 255, 0.22); }
+.button-link { display: inline-flex; align-items: center; }
+.checkbox { display: flex; gap: 0.5rem; align-items: center; }
+.checkbox input { width: auto; margin: 0; }
+.preset-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); }
+.preset-option { padding: 12px 14px; }
+.preset-option input { width: auto; margin-right: 8px; }
+.inline-control { display: flex; gap: 10px; align-items: center; }
+.inline-control input { margin-top: 0; }
+.inset-card { padding: 14px; margin: 14px 0; }
+.key-value-grid { grid-template-columns: repeat(auto-fit, minmax(170px, 1fr)); margin-top: 16px; }
+.key-value-grid.compact { grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); }
+.key-value-grid > div { padding: 14px; border-radius: 16px; background: rgba(15, 27, 48, 0.68); border: 1px solid rgba(140, 168, 255, 0.12); }
+.key-value-grid strong { display: block; margin-top: 8px; }
+.record-card, .list-row { display: flex; align-items: center; justify-content: space-between; gap: 14px; padding: 16px; }
+.list-stack { display: grid; gap: 12px; }
+.list-row { text-decoration: none; color: inherit; }
+.list-row__meta { display: flex; flex-wrap: wrap; gap: 12px; align-items: center; color: var(--muted); }
+.table-shell { overflow-x: auto; border-radius: 18px; border: 1px solid rgba(140, 168, 255, 0.14); }
+table { width: 100%; border-collapse: collapse; }
+th, td { text-align: left; padding: 14px 16px; border-top: 1px solid rgba(140, 168, 255, 0.1); vertical-align: top; }
+thead th { color: var(--muted); font-weight: 700; border-top: 0; background: rgba(12, 20, 36, 0.86); }
+.diff-columns { grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); }
+.empty-state { color: var(--muted); padding: 18px 0; }
+.hidden { display: none !important; }
+.success-banner { border-color: rgba(66, 214, 164, 0.28); }
+.card.danger { border-color: rgba(255, 140, 158, 0.26); }
+.pill { display: inline-flex; align-items: center; justify-content: center; min-height: 32px; padding: 7px 12px; border-radius: 999px; border: 1px solid rgba(140, 168, 255, 0.18); background: rgba(140, 168, 255, 0.12); color: var(--text); }
+.pill-info { background: rgba(140, 168, 255, 0.14); border-color: rgba(140, 168, 255, 0.24); }
+.pill-success { background: rgba(66, 214, 164, 0.14); border-color: rgba(66, 214, 164, 0.24); color: #d4ffe9; }
+.pill-warning, .pill.stale { background: rgba(248, 193, 93, 0.16); border-color: rgba(248, 193, 93, 0.25); color: #ffe1a2; }
+.pill-danger { background: rgba(255, 140, 158, 0.14); border-color: rgba(255, 140, 158, 0.24); color: #ffd6de; }
+.pill-running { background: rgba(110, 231, 255, 0.14); border-color: rgba(110, 231, 255, 0.24); color: #d7fbff; }
+.pill-neutral { background: rgba(156, 168, 199, 0.14); border-color: rgba(156, 168, 199, 0.22); }
+.operation-progress__header, .progress-meta-row { display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
+.metric-value { margin: 0; font-size: 1.7rem; font-weight: 800; }
+.progress-bar-shell { width: 100%; height: 18px; margin-top: 16px; background: rgba(15, 27, 48, 0.88); border: 1px solid rgba(140, 168, 255, 0.12); border-radius: 999px; overflow: hidden; }
+@keyframes _bar_stripes { 0% { background-position: 0 0; } 100% { background-position: 40px 0; } }
+@keyframes _bar_shimmer { 0% { opacity: 0.6; } 50% { opacity: 1; } 100% { opacity: 0.6; } }
+@keyframes _bar_complete { 0% { box-shadow: 0 0 0 0 rgba(110, 231, 183, 0.5); } 70% { box-shadow: 0 0 0 6px rgba(110, 231, 183, 0); } 100% { box-shadow: 0 0 0 0 rgba(110, 231, 183, 0); } }
+.progress-bar-fill { height: 100%; width: 0; background: linear-gradient(90deg, #6d96ff, #9fd0ff); transition: width 0.25s ease; position: relative; overflow: hidden; }
+.progress-bar-fill.running { background-image: linear-gradient(-45deg, rgba(255,255,255,0.18) 25%, transparent 25%, transparent 50%, rgba(255,255,255,0.18) 50%, rgba(255,255,255,0.18) 75%, transparent 75%); background-size: 40px 40px; animation: _bar_stripes 0.6s linear infinite, _bar_shimmer 1.4s ease-in-out infinite; background-color: #6d96ff; }
+.progress-bar-fill.completed { background: linear-gradient(90deg, #34d399, #6ee7b7); animation: _bar_complete 0.8s ease-out forwards; }
+.progress-bar-fill.failed { background: linear-gradient(90deg, #6b7280, #9ca3af); }
+.progress-bar-fill.stale { background: linear-gradient(90deg, #f59e0b, #fcd34d); }
+.progress-detail { word-break: break-word; color: #d4e0ff; }
+.progress-error { color: var(--danger); white-space: pre-wrap; }
+.btn-retry, .btn-abort { width: auto !important; padding: 10px 16px !important; font-size: 0.92rem; }
+.btn-retry { background: linear-gradient(135deg, #f8c15d, #ffd87e) !important; color: #0c1321 !important; }
+.btn-abort { background: linear-gradient(135deg, #ff8c9e, #ffb0bc) !important; color: #0c1321 !important; }
+@media (max-width: 760px) { .page-shell { padding: 16px; } .hero-header, .card { padding: 18px; border-radius: 20px; } .hero-header__content, .section-heading, .record-card, .list-row, .progress-meta-row, .inline-control { flex-direction: column; align-items: flex-start; } .topnav { width: 100%; } }

--- a/hermes_snapshot_manager/static/app.css
+++ b/hermes_snapshot_manager/static/app.css
@@ -40,6 +40,7 @@ code { color: #dbe6ff; font-family: Consolas, monospace; font-size: 0.92em; }
 .stat-value { display: block; margin-top: 8px; font-size: 1.8rem; }
 .stat-value--small { font-size: 1.2rem; }
 .chip-row, .inline-actions, .operation-actions, .button-row, .list-filters, .preset-grid { display: flex; flex-wrap: wrap; gap: 10px; }
+.inline-actions > * { flex: 1; }
 .chip { display: inline-flex; align-items: center; gap: 6px; padding: 10px 14px; border-radius: 999px; border: 1px solid rgba(140, 168, 255, 0.18); background: rgba(16, 28, 49, 0.72); color: var(--text); }
 input, button, textarea, select { width: 100%; margin-top: 8px; padding: 13px 14px; border-radius: 14px; border: 1px solid rgba(140, 168, 255, 0.18); background: var(--panel-3); color: var(--text); font: inherit; }
 textarea { resize: vertical; min-height: 160px; }
@@ -52,6 +53,10 @@ button, .button-link { cursor: pointer; background: linear-gradient(135deg, var(
 .preset-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); }
 .preset-option { padding: 12px 14px; }
 .preset-option input { width: auto; margin-right: 8px; }
+.exclude-editor { display: grid; gap: 12px; margin-top: 8px; }
+.exclude-editor__toolbar, .exclude-editor__presets, .table-footer { display: flex; flex-wrap: wrap; gap: 10px; justify-content: space-between; align-items: center; }
+.exclude-row { display: grid; grid-template-columns: 1fr auto; gap: 10px; }
+.exclude-row input { margin-top: 0; }
 .inline-control { display: flex; gap: 10px; align-items: center; }
 .inline-control input { margin-top: 0; }
 .inset-card { padding: 14px; margin: 14px 0; }
@@ -71,6 +76,8 @@ thead th { color: var(--muted); font-weight: 700; border-top: 0; background: rgb
 .empty-state { color: var(--muted); padding: 18px 0; }
 .hidden { display: none !important; }
 .success-banner { border-color: rgba(66, 214, 164, 0.28); }
+.toast-banner { position: sticky; top: 16px; z-index: 20; transition: opacity 0.25s ease, transform 0.25s ease; }
+.validation-error { color: #ffd6de; }
 .card.danger { border-color: rgba(255, 140, 158, 0.26); }
 .pill { display: inline-flex; align-items: center; justify-content: center; min-height: 32px; padding: 7px 12px; border-radius: 999px; border: 1px solid rgba(140, 168, 255, 0.18); background: rgba(140, 168, 255, 0.12); color: var(--text); }
 .pill-info { background: rgba(140, 168, 255, 0.14); border-color: rgba(140, 168, 255, 0.24); }

--- a/hermes_snapshot_manager/static/app.js
+++ b/hermes_snapshot_manager/static/app.js
@@ -118,6 +118,9 @@
     const descriptionPreview = document.getElementById("schedule-description-preview");
     const panels = Array.from(form.querySelectorAll("[data-mode-panel]"));
     const currentCron = form.dataset.currentCron || hiddenCronInput?.value || "0 */6 * * *";
+    const excludeEditor = form.querySelector("[data-exclude-editor]");
+    const excludeRows = form.querySelector("[data-exclude-rows]");
+    const excludeTextarea = form.querySelector("[data-exclude-textarea]");
 
     function inferModeFromCron(cron) {
       const hourly = cron.match(/^0 \*\/(\d{1,2}) \* \* \*$/);
@@ -142,6 +145,10 @@
       return "Custom cron schedule";
     }
 
+    function validCron(cron) {
+      return /^\S+\s+\S+\s+\S+\s+\S+\s+\S+$/.test(cron.trim());
+    }
+
     function selectedMode() {
       return modeInputs.find((input) => input.checked)?.value || "every_hours";
     }
@@ -160,6 +167,29 @@
       return hours === 24 ? "0 0 * * *" : `0 */${hours} * * *`;
     }
 
+    function createExcludeRow(value = "") {
+      const row = document.createElement("div");
+      row.className = "exclude-row";
+      row.innerHTML = `<input type="text" value="${value.replaceAll('"', '&quot;')}" placeholder="sessions/**" /><button type="button" class="button-link button-link--ghost">Remove</button>`;
+      const input = row.querySelector("input");
+      const removeButton = row.querySelector("button");
+      input.addEventListener("input", syncExcludeTextarea);
+      removeButton.addEventListener("click", () => {
+        row.remove();
+        syncExcludeTextarea();
+      });
+      excludeRows?.appendChild(row);
+      return row;
+    }
+
+    function syncExcludeTextarea() {
+      if (!excludeTextarea || !excludeRows) return;
+      const values = Array.from(excludeRows.querySelectorAll("input"))
+        .map((input) => input.value.trim())
+        .filter(Boolean);
+      excludeTextarea.value = values.join("\n");
+    }
+
     const inferred = inferModeFromCron(currentCron);
     modeInputs.forEach((input) => { input.checked = input.value === inferred.mode; });
     if (inferred.hours && everyHoursInput) everyHoursInput.value = inferred.hours;
@@ -168,13 +198,35 @@
     if (inferred.time && weeklyTimeInput && inferred.mode === "weekly") weeklyTimeInput.value = inferred.time;
     if (customCronInput) customCronInput.value = currentCron;
 
+    if (excludeRows && excludeTextarea) {
+      const initialPatterns = excludeTextarea.value.split("\n").map((item) => item.trim()).filter(Boolean);
+      if (initialPatterns.length === 0) createExcludeRow("");
+      initialPatterns.forEach((pattern) => createExcludeRow(pattern));
+      excludeEditor?.querySelectorAll("[data-exclude-add]").forEach((button) => button.addEventListener("click", () => createExcludeRow("")));
+      excludeEditor?.querySelectorAll("[data-exclude-preset]").forEach((button) => button.addEventListener("click", () => {
+        const pattern = button.dataset.excludePreset || "";
+        const existing = Array.from(excludeRows.querySelectorAll("input")).map((input) => input.value.trim());
+        if (!existing.includes(pattern)) createExcludeRow(pattern);
+        syncExcludeTextarea();
+      }));
+      excludeEditor?.querySelectorAll("[data-exclude-restore-defaults]").forEach((button) => button.addEventListener("click", () => {
+        excludeRows.innerHTML = "";
+        ["audio_cache/**", "cron/output/**", "**/*.log", "**/__pycache__/**", "**/tmp/**", ".venv/**", "venv/**", ".virtualenv/**", "**/site-packages/**", "**/node_modules/**", "**/*.egg-info/**", "**/build/**", "**/dist/**", ".vscode/**", ".idea/**", ".DS_Store", "Thumbs.db", "**/.git/**"].forEach((pattern) => createExcludeRow(pattern));
+        syncExcludeTextarea();
+      }));
+      syncExcludeTextarea();
+    }
+
     function renderMode() {
       const mode = selectedMode();
       panels.forEach((panel) => panel.classList.toggle("hidden", panel.dataset.modePanel !== mode));
       const cron = computeCron(mode);
       if (hiddenCronInput) hiddenCronInput.value = cron;
       if (preview) preview.innerHTML = `<code>${cron}</code>`;
-      if (descriptionPreview) descriptionPreview.textContent = describeCron(cron);
+      if (descriptionPreview) {
+        descriptionPreview.textContent = validCron(cron) ? describeCron(cron) : "Cron must have 5 fields";
+        descriptionPreview.classList.toggle("validation-error", !validCron(cron));
+      }
     }
 
     modeInputs.forEach((input) => input.addEventListener("change", renderMode));
@@ -189,33 +241,68 @@
   function setupSnapshotTable() {
     const table = document.getElementById("snapshots-table");
     const filterInput = document.getElementById("snapshot-filter");
+    const statusFilter = document.getElementById("snapshot-status-filter");
     const sortSelect = document.getElementById("snapshot-sort");
-    if (!table || !filterInput || !sortSelect) return;
+    const prevButton = document.getElementById("snapshots-prev-page");
+    const nextButton = document.getElementById("snapshots-next-page");
+    const pageIndicator = document.getElementById("snapshots-page-indicator");
+    const summary = document.getElementById("snapshots-table-summary");
+    const noResults = document.getElementById("snapshots-no-results");
+    if (!table || !filterInput || !sortSelect || !statusFilter) return;
     const tbody = table.querySelector("tbody");
     const rows = Array.from(tbody.querySelectorAll("tr[data-filter-text]"));
+    let currentPage = 1;
+    const pageSize = 10;
 
-    function applyTableState() {
+    function currentFilteredRows() {
       const query = filterInput.value.trim().toLowerCase();
-      const sortMode = sortSelect.value;
-      const visibleRows = rows.filter((row) => row.dataset.filterText.toLowerCase().includes(query));
-      visibleRows.sort((a, b) => {
+      const status = statusFilter.value;
+      const filtered = rows.filter((row) => {
+        const matchesQuery = row.dataset.filterText.toLowerCase().includes(query);
+        const matchesStatus = status === "all" || (row.dataset.status || "") === status;
+        return matchesQuery && matchesStatus;
+      });
+      filtered.sort((a, b) => {
         const createdA = Date.parse(a.dataset.created || "") || 0;
         const createdB = Date.parse(b.dataset.created || "") || 0;
         const sizeA = Number(a.dataset.size || 0);
         const sizeB = Number(b.dataset.size || 0);
-        if (sortMode === "created_asc") return createdA - createdB;
-        if (sortMode === "size_desc") return sizeB - sizeA;
-        if (sortMode === "size_asc") return sizeA - sizeB;
+        if (sortSelect.value === "created_asc") return createdA - createdB;
+        if (sortSelect.value === "size_desc") return sizeB - sizeA;
+        if (sortSelect.value === "size_asc") return sizeA - sizeB;
         return createdB - createdA;
       });
-      rows.forEach((row) => row.remove());
-      visibleRows.forEach((row) => tbody.appendChild(row));
-      rows.forEach((row) => { row.classList.toggle("hidden", !visibleRows.includes(row)); });
+      return filtered;
     }
 
-    filterInput.addEventListener("input", applyTableState);
+    function applyTableState() {
+      const filtered = currentFilteredRows();
+      const totalPages = Math.max(1, Math.ceil(filtered.length / pageSize));
+      currentPage = Math.min(currentPage, totalPages);
+      const start = (currentPage - 1) * pageSize;
+      const visibleSet = new Set(filtered.slice(start, start + pageSize));
+      rows.forEach((row) => {
+        row.classList.toggle("hidden", !visibleSet.has(row));
+        if (visibleSet.has(row)) tbody.appendChild(row);
+      });
+      if (summary) summary.textContent = filtered.length ? `Showing ${Math.min(start + 1, filtered.length)}-${Math.min(start + pageSize, filtered.length)} of ${filtered.length} snapshots` : "No snapshots match the current filters";
+      if (pageIndicator) pageIndicator.textContent = `Page ${currentPage} / ${totalPages}`;
+      if (prevButton) prevButton.disabled = currentPage <= 1;
+      if (nextButton) nextButton.disabled = currentPage >= totalPages;
+      if (noResults) noResults.classList.toggle("hidden", filtered.length !== 0);
+    }
+
+    filterInput.addEventListener("input", () => { currentPage = 1; applyTableState(); });
+    statusFilter.addEventListener("change", () => { currentPage = 1; applyTableState(); });
     sortSelect.addEventListener("change", applyTableState);
+    prevButton?.addEventListener("click", () => { currentPage = Math.max(1, currentPage - 1); applyTableState(); });
+    nextButton?.addEventListener("click", () => { currentPage += 1; applyTableState(); });
     applyTableState();
+  }
+
+  const saveBanner = document.getElementById("settings-save-banner");
+  if (saveBanner) {
+    window.setTimeout(() => saveBanner.classList.add("hidden"), 2400);
   }
 
   setupScheduleForm();

--- a/hermes_snapshot_manager/static/app.js
+++ b/hermes_snapshot_manager/static/app.js
@@ -1,0 +1,225 @@
+(() => {
+  const progressCard = document.getElementById("operation-progress");
+  if (!progressCard) return;
+
+  const kindEl = document.getElementById("operation-progress-kind");
+  const barEl = document.getElementById("operation-progress-bar");
+  const percentEl = document.getElementById("operation-progress-percent");
+  const messageEl = document.getElementById("operation-progress-message");
+  const detailEl = document.getElementById("operation-progress-detail");
+  const errorEl = document.getElementById("operation-progress-error");
+  const actionEl = document.getElementById("operation-progress-action");
+  let pollTimer = null;
+
+  function toneForStatus(status) {
+    if (status === "completed") return "success";
+    if (status === "failed") return "danger";
+    if (status === "running") return "running";
+    if (status === "stale") return "stale";
+    return "neutral";
+  }
+
+  function renderState(state) {
+    const hasState = state && Object.keys(state).length > 0;
+    if (!hasState) {
+      progressCard.classList.add("hidden");
+      return;
+    }
+
+    progressCard.classList.remove("hidden");
+    const progress = Number(state.progress || 0);
+    const status = state.status || "idle";
+    kindEl.textContent = `${state.kind || "operation"} · ${status}`;
+    kindEl.className = status === "stale" ? "pill stale" : `pill pill-${toneForStatus(status)}`;
+    barEl.classList.remove("running", "completed", "failed", "stale");
+    if (["running", "completed", "failed", "stale"].includes(status)) barEl.classList.add(status);
+    barEl.style.width = `${progress}%`;
+    percentEl.textContent = `${progress}%`;
+    messageEl.textContent = state.message || "Working…";
+    const skippedSummary = Number(state.skipped_files_count || 0) > 0 ? `Skipped files: ${state.skipped_files_count}` : "";
+    detailEl.textContent = [state.current_item || state.detail || "", skippedSummary].filter(Boolean).join(" · ");
+    errorEl.textContent = state.error || "";
+
+    if (actionEl) {
+      actionEl.innerHTML = "";
+      if (status === "stale") {
+        const retryBtn = document.createElement("button");
+        retryBtn.type = "button";
+        retryBtn.className = "btn-retry";
+        retryBtn.textContent = "Resume / Retry";
+        retryBtn.addEventListener("click", async () => {
+          await fetch("/api/operations/current/clear", { method: "POST" });
+          await fetchCurrentOperation();
+        });
+        actionEl.appendChild(retryBtn);
+      } else if (status === "running") {
+        const abortBtn = document.createElement("button");
+        abortBtn.type = "button";
+        abortBtn.className = "btn-abort";
+        abortBtn.textContent = "Abort";
+        abortBtn.addEventListener("click", async () => {
+          await fetch("/api/operations/current/abort", { method: "POST" });
+          await fetchCurrentOperation();
+        });
+        actionEl.appendChild(abortBtn);
+      }
+    }
+  }
+
+  async function fetchCurrentOperation() {
+    try {
+      const response = await fetch("/api/operations/current", { cache: "no-store" });
+      renderState(await response.json());
+    } catch (error) {
+      errorEl.textContent = `Connection error: ${error.message}`;
+      progressCard.classList.remove("hidden");
+    }
+  }
+
+  function ensurePolling() {
+    if (pollTimer !== null) return;
+    pollTimer = window.setInterval(fetchCurrentOperation, 1000);
+  }
+
+  document.querySelectorAll(".js-operation-form").forEach((form) => {
+    form.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const button = form.querySelector("button[type='submit']");
+      if (button) button.disabled = true;
+      progressCard.classList.remove("hidden");
+      messageEl.textContent = `Starting ${form.dataset.operationKind || "operation"}…`;
+      detailEl.textContent = "";
+      errorEl.textContent = "";
+      try {
+        const response = await fetch(form.action, { method: "POST", body: new FormData(form) });
+        const payload = await response.json();
+        if (!response.ok) throw new Error(payload.error || payload.detail || response.statusText);
+        ensurePolling();
+        await fetchCurrentOperation();
+      } catch (error) {
+        errorEl.textContent = String(error);
+        if (button) button.disabled = false;
+      }
+    });
+  });
+
+  function setupScheduleForm() {
+    const form = document.querySelector(".js-schedule-form");
+    if (!form) return;
+
+    const modeInputs = Array.from(form.querySelectorAll("input[name='schedule_mode']"));
+    const everyHoursInput = form.querySelector("input[name='schedule_every_hours']");
+    const dailyTimeInput = form.querySelector("input[name='schedule_daily_time']");
+    const weeklyDayInput = form.querySelector("select[name='schedule_weekly_day']");
+    const weeklyTimeInput = form.querySelector("input[name='schedule_weekly_time']");
+    const customCronInput = form.querySelector("#schedule-cron-custom");
+    const hiddenCronInput = form.querySelector("input[name='schedule_cron']");
+    const preview = document.getElementById("schedule-cron-preview");
+    const descriptionPreview = document.getElementById("schedule-description-preview");
+    const panels = Array.from(form.querySelectorAll("[data-mode-panel]"));
+    const currentCron = form.dataset.currentCron || hiddenCronInput?.value || "0 */6 * * *";
+
+    function inferModeFromCron(cron) {
+      const hourly = cron.match(/^0 \*\/(\d{1,2}) \* \* \*$/);
+      if (hourly) return { mode: "every_hours", hours: hourly[1] };
+      const daily = cron.match(/^([0-5]?\d) ([0-1]?\d|2[0-3]) \* \* \*$/);
+      if (daily) return { mode: "daily", time: `${daily[2].padStart(2, "0")}:${daily[1].padStart(2, "0")}` };
+      const weekly = cron.match(/^([0-5]?\d) ([0-1]?\d|2[0-3]) \* \* ([0-6])$/);
+      if (weekly) return { mode: "weekly", day: weekly[3], time: `${weekly[2].padStart(2, "0")}:${weekly[1].padStart(2, "0")}` };
+      return { mode: "custom" };
+    }
+
+    function describeCron(cron) {
+      const hourly = cron.match(/^0 \*\/(\d{1,2}) \* \* \*$/);
+      if (hourly) return `Every ${hourly[1]} hours`;
+      const daily = cron.match(/^([0-5]?\d) ([0-1]?\d|2[0-3]) \* \* \*$/);
+      if (daily) return `Daily at ${daily[2].padStart(2, "0")}:${daily[1].padStart(2, "0")} UTC`;
+      const weekly = cron.match(/^([0-5]?\d) ([0-1]?\d|2[0-3]) \* \* ([0-6])$/);
+      if (weekly) {
+        const weekdayNames = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+        return `${weekdayNames[Number(weekly[3])]} at ${weekly[2].padStart(2, "0")}:${weekly[1].padStart(2, "0")} UTC`;
+      }
+      return "Custom cron schedule";
+    }
+
+    function selectedMode() {
+      return modeInputs.find((input) => input.checked)?.value || "every_hours";
+    }
+
+    function computeCron(mode) {
+      if (mode === "daily") {
+        const [hour, minute] = (dailyTimeInput?.value || "03:00").split(":");
+        return `${Number(minute)} ${Number(hour)} * * *`;
+      }
+      if (mode === "weekly") {
+        const [hour, minute] = (weeklyTimeInput?.value || "08:00").split(":");
+        return `${Number(minute)} ${Number(hour)} * * ${weeklyDayInput?.value || "1"}`;
+      }
+      if (mode === "custom") return (customCronInput?.value || currentCron).trim() || currentCron;
+      const hours = Math.max(1, Math.min(24, Number(everyHoursInput?.value || 6)));
+      return hours === 24 ? "0 0 * * *" : `0 */${hours} * * *`;
+    }
+
+    const inferred = inferModeFromCron(currentCron);
+    modeInputs.forEach((input) => { input.checked = input.value === inferred.mode; });
+    if (inferred.hours && everyHoursInput) everyHoursInput.value = inferred.hours;
+    if (inferred.time && dailyTimeInput && inferred.mode === "daily") dailyTimeInput.value = inferred.time;
+    if (inferred.day && weeklyDayInput) weeklyDayInput.value = inferred.day;
+    if (inferred.time && weeklyTimeInput && inferred.mode === "weekly") weeklyTimeInput.value = inferred.time;
+    if (customCronInput) customCronInput.value = currentCron;
+
+    function renderMode() {
+      const mode = selectedMode();
+      panels.forEach((panel) => panel.classList.toggle("hidden", panel.dataset.modePanel !== mode));
+      const cron = computeCron(mode);
+      if (hiddenCronInput) hiddenCronInput.value = cron;
+      if (preview) preview.innerHTML = `<code>${cron}</code>`;
+      if (descriptionPreview) descriptionPreview.textContent = describeCron(cron);
+    }
+
+    modeInputs.forEach((input) => input.addEventListener("change", renderMode));
+    everyHoursInput?.addEventListener("input", renderMode);
+    dailyTimeInput?.addEventListener("input", renderMode);
+    weeklyDayInput?.addEventListener("change", renderMode);
+    weeklyTimeInput?.addEventListener("input", renderMode);
+    customCronInput?.addEventListener("input", renderMode);
+    renderMode();
+  }
+
+  function setupSnapshotTable() {
+    const table = document.getElementById("snapshots-table");
+    const filterInput = document.getElementById("snapshot-filter");
+    const sortSelect = document.getElementById("snapshot-sort");
+    if (!table || !filterInput || !sortSelect) return;
+    const tbody = table.querySelector("tbody");
+    const rows = Array.from(tbody.querySelectorAll("tr[data-filter-text]"));
+
+    function applyTableState() {
+      const query = filterInput.value.trim().toLowerCase();
+      const sortMode = sortSelect.value;
+      const visibleRows = rows.filter((row) => row.dataset.filterText.toLowerCase().includes(query));
+      visibleRows.sort((a, b) => {
+        const createdA = Date.parse(a.dataset.created || "") || 0;
+        const createdB = Date.parse(b.dataset.created || "") || 0;
+        const sizeA = Number(a.dataset.size || 0);
+        const sizeB = Number(b.dataset.size || 0);
+        if (sortMode === "created_asc") return createdA - createdB;
+        if (sortMode === "size_desc") return sizeB - sizeA;
+        if (sortMode === "size_asc") return sizeA - sizeB;
+        return createdB - createdA;
+      });
+      rows.forEach((row) => row.remove());
+      visibleRows.forEach((row) => tbody.appendChild(row));
+      rows.forEach((row) => { row.classList.toggle("hidden", !visibleRows.includes(row)); });
+    }
+
+    filterInput.addEventListener("input", applyTableState);
+    sortSelect.addEventListener("change", applyTableState);
+    applyTableState();
+  }
+
+  setupScheduleForm();
+  setupSnapshotTable();
+  fetchCurrentOperation();
+  ensurePolling();
+})();

--- a/hermes_snapshot_manager/storage/db.py
+++ b/hermes_snapshot_manager/storage/db.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS snapshots (
+    id TEXT PRIMARY KEY,
+    created_at TEXT NOT NULL,
+    label TEXT,
+    trigger_type TEXT NOT NULL,
+    status TEXT NOT NULL,
+    source_root TEXT NOT NULL,
+    total_files INTEGER NOT NULL,
+    total_bytes INTEGER NOT NULL,
+    manifest_sha256 TEXT NOT NULL,
+    is_known_good INTEGER NOT NULL DEFAULT 0,
+    notes TEXT
+);
+
+CREATE TABLE IF NOT EXISTS snapshot_files (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    snapshot_id TEXT NOT NULL,
+    relative_path TEXT NOT NULL,
+    sha256 TEXT NOT NULL,
+    size INTEGER NOT NULL,
+    mtime REAL NOT NULL,
+    mode TEXT NOT NULL,
+    file_type TEXT NOT NULL,
+    FOREIGN KEY(snapshot_id) REFERENCES snapshots(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS restore_history (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    snapshot_id TEXT NOT NULL,
+    restored_at TEXT NOT NULL,
+    result TEXT NOT NULL,
+    pre_restore_snapshot_id TEXT,
+    notes TEXT,
+    FOREIGN KEY(snapshot_id) REFERENCES snapshots(id) ON DELETE CASCADE
+);
+"""
+
+
+def connect(db_path: Path) -> sqlite3.Connection:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    return conn
+
+
+def init_db(db_path: Path) -> None:
+    with connect(db_path) as conn:
+        conn.executescript(SCHEMA)
+        conn.commit()

--- a/hermes_snapshot_manager/storage/models.py
+++ b/hermes_snapshot_manager/storage/models.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class SnapshotSummary:
+    id: str
+    created_at: str
+    label: str | None
+    trigger_type: str
+    status: str
+    total_files: int
+    total_bytes: int
+    is_known_good: bool
+
+
+@dataclass(slots=True)
+class RestoreRecord:
+    id: int
+    snapshot_id: str
+    restored_at: str
+    result: str
+    pre_restore_snapshot_id: str | None
+    notes: str | None

--- a/hermes_snapshot_manager/templates/base.html
+++ b/hermes_snapshot_manager/templates/base.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{{ title or 'Hermes Snapshot Manager' }}</title>
+    <link rel="stylesheet" href="/static/app.css" />
+  </head>
+  <body>
+    <div class="page-shell">
+      <header class="hero-header">
+        <div class="hero-header__content">
+          <div class="brand-mark">HS</div>
+          <div>
+            <p class="eyebrow">Rollback safety for WSL</p>
+            <h1>Hermes Snapshot Manager</h1>
+            <p class="subtitle">Independent rollback protection for <code>~/.hermes</code> with fast snapshots, restore history, and scheduled protection.</p>
+          </div>
+        </div>
+        <nav class="topnav">
+          <a href="/" class="{% if current_path == '/' %}active{% endif %}">Dashboard</a>
+          <a href="/snapshots" class="{% if current_path == '/snapshots' %}active{% endif %}">Snapshots</a>
+          <a href="/restores" class="{% if current_path == '/restores' %}active{% endif %}">Restores</a>
+          <a href="/settings" class="{% if current_path == '/settings' %}active{% endif %}">Settings</a>
+        </nav>
+      </header>
+      <main class="container">
+        <section id="operation-progress" class="card operation-progress hidden" aria-live="polite">
+          <div class="operation-progress__header">
+            <div>
+              <p class="eyebrow">Live operation</p>
+              <h2>Current operation</h2>
+            </div>
+            <span id="operation-progress-kind" class="pill">idle</span>
+          </div>
+          <div class="progress-bar-shell">
+            <div id="operation-progress-bar" class="progress-bar-fill" style="width: 0%"></div>
+          </div>
+          <div class="progress-meta-row">
+            <p id="operation-progress-percent" class="metric-value">0%</p>
+            <p id="operation-progress-message" class="subtitle">Waiting…</p>
+          </div>
+          <p id="operation-progress-detail" class="progress-detail"></p>
+          <p id="operation-progress-error" class="progress-error"></p>
+          <div id="operation-progress-action" class="operation-actions"></div>
+        </section>
+        {% block content %}{% endblock %}
+      </main>
+    </div>
+    <script src="/static/app.js"></script>
+  </body>
+</html>

--- a/hermes_snapshot_manager/templates/dashboard.html
+++ b/hermes_snapshot_manager/templates/dashboard.html
@@ -1,0 +1,92 @@
+{% extends 'base.html' %}
+{% block content %}
+<section class="hero-grid">
+  <article class="card hero-card hero-card--primary">
+    <p class="eyebrow">System overview</p>
+    <h2>Snapshot protection at a glance</h2>
+    <p class="subtitle">Create known-good rollback points, monitor restore history, and keep scheduled backups under control.</p>
+    <div class="stat-grid">
+      <div class="stat-tile"><span class="stat-label">Snapshots</span><strong class="stat-value">{{ snapshot_count }}</strong></div>
+      <div class="stat-tile"><span class="stat-label">Restores</span><strong class="stat-value">{{ restore_count }}</strong></div>
+      <div class="stat-tile"><span class="stat-label">Schedule</span><strong class="stat-value">{{ 'On' if settings.schedule_enabled else 'Off' }}</strong></div>
+      <div class="stat-tile"><span class="stat-label">Next run</span><strong class="stat-value stat-value--small">{{ schedule_summary.next_run_relative }}</strong></div>
+    </div>
+    <div class="chip-row">
+      <span class="chip">Source: <code>{{ paths.source_root }}</code></span>
+      <span class="chip">Store: <code>{{ paths.snapshot_root }}</code></span>
+      <span class="chip">Schedule: {{ schedule_summary.description }}</span>
+    </div>
+  </article>
+
+  <article class="card quick-action-card">
+    <p class="eyebrow">Quick action</p>
+    <h2>Create a fresh snapshot</h2>
+    <p class="subtitle">Use a short label so you can spot the rollback point later.</p>
+    <form method="post" action="/api/snapshots/start" class="js-operation-form stacked-form" data-operation-kind="snapshot" data-redirect="/snapshots">
+      <label for="snapshot-label">Label</label>
+      <input id="snapshot-label" type="text" name="label" placeholder="before-upgrade" />
+      <button type="submit">Create snapshot</button>
+    </form>
+    <div class="inline-actions">
+      <a class="button-link button-link--secondary" href="/snapshots">Browse snapshots</a>
+      <a class="button-link button-link--ghost" href="/settings">Tune schedule</a>
+    </div>
+  </article>
+</section>
+
+<section class="grid two-up">
+  <article class="card">
+    <div class="section-heading">
+      <div><p class="eyebrow">Latest snapshot</p><h2>Most recent recovery point</h2></div>
+      <a href="/snapshots" class="text-link">View all</a>
+    </div>
+    {% if latest_snapshot %}
+    <div class="record-card">
+      <div class="record-card__main">
+        <strong>{{ latest_snapshot.label or latest_snapshot.id }}</strong>
+        <p class="subtitle">{{ latest_snapshot.created_at }}</p>
+      </div>
+      <span class="pill pill-{{ latest_snapshot.status_tone }}">{{ latest_snapshot.status }}</span>
+    </div>
+    <div class="key-value-grid compact">
+      <div><span class="key-label">Files</span><strong>{{ latest_snapshot.total_files }}</strong></div>
+      <div><span class="key-label">Size</span><strong>{{ latest_snapshot.total_bytes_human }}</strong></div>
+      <div><span class="key-label">Compression</span><strong>{{ latest_snapshot.compression_ratio if latest_snapshot.compression_ratio is not none else '-' }}{% if latest_snapshot.compression_ratio is not none %}%{% endif %}</strong></div>
+      <div><span class="key-label">Saved</span><strong>{{ latest_snapshot.space_saved_bytes_human or '-' }}</strong></div>
+    </div>
+    <a class="button-link button-link--secondary" href="/snapshots/{{ latest_snapshot.id }}">Open details</a>
+    {% else %}<p class="empty-state">No snapshots yet. Create one from the quick action card.</p>{% endif %}
+  </article>
+
+  <article class="card {% if latest_restore and latest_restore.result != 'success' %}danger{% endif %}">
+    <div class="section-heading">
+      <div><p class="eyebrow">Restore history</p><h2>Recent restore status</h2></div>
+      <a href="/restores" class="text-link">Audit trail</a>
+    </div>
+    {% if latest_restore %}
+    <div class="record-card">
+      <div class="record-card__main"><strong>{{ latest_restore.result }}</strong><p class="subtitle">{{ latest_restore.restored_at }}</p></div>
+      <span class="pill pill-{{ latest_restore_tone }}">{{ latest_restore.snapshot_id }}</span>
+    </div>
+    {% if latest_restore.notes %}<p class="callout-text">{{ latest_restore.notes }}</p>{% endif %}
+    {% else %}<p class="empty-state">No restore attempts recorded yet.</p>{% endif %}
+  </article>
+</section>
+
+<section class="card">
+  <div class="section-heading">
+    <div><p class="eyebrow">Recent snapshots</p><h2>Newest recovery points</h2></div>
+    <a href="/snapshots" class="text-link">Full library</a>
+  </div>
+  {% if latest_snapshots %}
+  <div class="list-stack">
+    {% for snapshot in latest_snapshots %}
+    <a class="list-row" href="/snapshots/{{ snapshot.id }}">
+      <div><strong>{{ snapshot.label or snapshot.id }}</strong><p class="subtitle">{{ snapshot.created_at }}</p></div>
+      <div class="list-row__meta"><span>{{ snapshot.total_files }} files</span><span>{{ snapshot.total_bytes_human }}</span><span class="pill pill-{{ snapshot.status_tone }}">{{ snapshot.status }}</span></div>
+    </a>
+    {% endfor %}
+  </div>
+  {% else %}<p class="empty-state">Nothing here yet.</p>{% endif %}
+</section>
+{% endblock %}

--- a/hermes_snapshot_manager/templates/restore_history.html
+++ b/hermes_snapshot_manager/templates/restore_history.html
@@ -1,0 +1,29 @@
+{% extends 'base.html' %}
+{% block content %}
+<section class="card page-header-card">
+  <p class="eyebrow">Audit trail</p>
+  <h2>Restore history</h2>
+  <p class="subtitle">Every restore attempt, its outcome, and any attached notes are listed here.</p>
+</section>
+<section class="card">
+  <div class="table-shell">
+    <table>
+      <thead><tr><th>ID</th><th>Snapshot</th><th>Result</th><th>When</th><th>Pre-restore snapshot</th><th>Notes</th></tr></thead>
+      <tbody>
+        {% for row in history %}
+        <tr>
+          <td>{{ row.id }}</td>
+          <td><code>{{ row.snapshot_id }}</code></td>
+          <td><span class="pill pill-{{ 'success' if row.result == 'success' else 'danger' }}">{{ row.result }}</span></td>
+          <td>{{ row.restored_at }}</td>
+          <td><code>{{ row.pre_restore_snapshot_id or '-' }}</code></td>
+          <td><code>{{ row.notes or '-' }}</code></td>
+        </tr>
+        {% else %}
+        <tr><td colspan="6">No restore attempts yet.</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</section>
+{% endblock %}

--- a/hermes_snapshot_manager/templates/settings.html
+++ b/hermes_snapshot_manager/templates/settings.html
@@ -1,9 +1,15 @@
 {% extends 'base.html' %}
 {% block content %}
 {% if request.query_params.get('saved') == '1' %}
-<section class="card success-banner">
+<section class="card success-banner toast-banner" id="settings-save-banner">
   <strong>Settings saved.</strong>
   <p class="subtitle">Schedule and retention changes will apply to the next run.</p>
+</section>
+{% endif %}
+{% if request.query_params.get('error') %}
+<section class="card danger" id="settings-error-banner">
+  <strong>Could not save settings.</strong>
+  <p class="subtitle">{{ request.query_params.get('error') }}</p>
 </section>
 {% endif %}
 <section class="grid two-up">
@@ -52,8 +58,25 @@
       <label>Weekly retention</label>
       <input type="number" name="retention_weekly" value="{{ settings.retention_weekly }}" min="1" />
       <label>Exclude patterns</label>
-      <textarea name="exclude_patterns" rows="8">{{ schedule_summary.exclude_patterns_text }}</textarea>
-      <button type="submit">Save settings</button>
+      <div class="exclude-editor" data-exclude-editor>
+        <div class="exclude-editor__toolbar">
+          <button type="button" class="button-link button-link--secondary" data-exclude-add>Add pattern</button>
+          <button type="button" class="button-link button-link--ghost" data-exclude-restore-defaults>Restore defaults</button>
+        </div>
+        <div class="exclude-editor__presets">
+          <button type="button" class="chip-button" data-exclude-preset="sessions/**">sessions/**</button>
+          <button type="button" class="chip-button" data-exclude-preset="checkpoints/**">checkpoints/**</button>
+          <button type="button" class="chip-button" data-exclude-preset="cache/**">cache/**</button>
+          <button type="button" class="chip-button" data-exclude-preset="browser_screenshots/**">browser_screenshots/**</button>
+        </div>
+        <div class="exclude-editor__rows" data-exclude-rows></div>
+        <textarea name="exclude_patterns" rows="8" class="hidden" data-exclude-textarea>{{ schedule_summary.exclude_patterns_text }}</textarea>
+      </div>
+      <p class="help-text">One pattern per line. Bulky directories can be pruned before copy starts.</p>
+      <div class="inline-actions">
+        <button type="submit">Save settings</button>
+        <button type="button" class="button-link button-link--ghost" data-exclude-restore-defaults>Reset excludes</button>
+      </div>
     </form>
   </article>
   <article class="card">

--- a/hermes_snapshot_manager/templates/settings.html
+++ b/hermes_snapshot_manager/templates/settings.html
@@ -1,0 +1,74 @@
+{% extends 'base.html' %}
+{% block content %}
+{% if request.query_params.get('saved') == '1' %}
+<section class="card success-banner">
+  <strong>Settings saved.</strong>
+  <p class="subtitle">Schedule and retention changes will apply to the next run.</p>
+</section>
+{% endif %}
+<section class="grid two-up">
+  <article class="card">
+    <p class="eyebrow">Scheduling</p>
+    <h2>Make cron easier to configure</h2>
+    <p class="subtitle">Pick a friendly schedule preset, then tweak the cron expression only if you need something custom.</p>
+    <form method="post" action="/settings" class="js-schedule-form" data-current-cron="{{ settings.schedule_cron }}">
+      <label class="checkbox"><input type="checkbox" name="schedule_enabled" {% if settings.schedule_enabled %}checked{% endif %} /> Enable automatic snapshots</label>
+      <div class="preset-grid">
+        <label class="preset-option"><input type="radio" name="schedule_mode" value="every_hours" checked /> <span>Every few hours</span></label>
+        <label class="preset-option"><input type="radio" name="schedule_mode" value="daily" /> <span>Daily at a set time</span></label>
+        <label class="preset-option"><input type="radio" name="schedule_mode" value="weekly" /> <span>Weekly routine</span></label>
+        <label class="preset-option"><input type="radio" name="schedule_mode" value="custom" /> <span>Custom cron</span></label>
+      </div>
+      <div class="schedule-mode-panel" data-mode-panel="every_hours">
+        <label>Run every</label>
+        <div class="inline-control"><input type="number" name="schedule_every_hours" min="1" max="24" value="6" /><span>hours</span></div>
+      </div>
+      <div class="schedule-mode-panel hidden" data-mode-panel="daily">
+        <label>Run at</label>
+        <input type="time" name="schedule_daily_time" value="03:00" />
+      </div>
+      <div class="schedule-mode-panel hidden" data-mode-panel="weekly">
+        <label>Weekday</label>
+        <select name="schedule_weekly_day">
+          <option value="1">Monday</option><option value="2">Tuesday</option><option value="3">Wednesday</option><option value="4">Thursday</option><option value="5">Friday</option><option value="6">Saturday</option><option value="0">Sunday</option>
+        </select>
+        <label>Run at</label>
+        <input type="time" name="schedule_weekly_time" value="08:00" />
+      </div>
+      <div class="schedule-mode-panel hidden" data-mode-panel="custom">
+        <label>Cron expression</label>
+        <input id="schedule-cron-custom" type="text" value="{{ settings.schedule_cron }}" placeholder="0 */6 * * *" />
+      </div>
+      <input type="hidden" name="schedule_cron" value="{{ settings.schedule_cron }}" />
+      <div class="card inset-card">
+        <p class="eyebrow">Generated cron</p>
+        <strong id="schedule-cron-preview"><code>{{ settings.schedule_cron }}</code></strong>
+        <p id="schedule-description-preview" class="subtitle">{{ schedule_summary.cron_description }}</p>
+      </div>
+      <label>Hourly retention</label>
+      <input type="number" name="retention_hourly" value="{{ settings.retention_hourly }}" min="1" />
+      <label>Daily retention</label>
+      <input type="number" name="retention_daily" value="{{ settings.retention_daily }}" min="1" />
+      <label>Weekly retention</label>
+      <input type="number" name="retention_weekly" value="{{ settings.retention_weekly }}" min="1" />
+      <label>Exclude patterns</label>
+      <textarea name="exclude_patterns" rows="8">{{ schedule_summary.exclude_patterns_text }}</textarea>
+      <button type="submit">Save settings</button>
+    </form>
+  </article>
+  <article class="card">
+    <p class="eyebrow">Schedule summary</p>
+    <h2>What will happen</h2>
+    <div class="key-value-grid compact">
+      <div><span class="key-label">Description</span><strong>{{ schedule_summary.description }}</strong></div>
+      <div><span class="key-label">Next run</span><strong>{{ schedule_summary.next_run_relative }}</strong></div>
+      <div><span class="key-label">UTC time</span><strong>{{ schedule_summary.next_run_utc or '-' }}</strong></div>
+      <div><span class="key-label">Current cron</span><strong><code>{{ settings.schedule_cron }}</code></strong></div>
+    </div>
+    <h3>Active excludes</h3>
+    <div class="chip-row">
+      {% for pattern in settings.exclude_patterns %}<span class="chip"><code>{{ pattern }}</code></span>{% endfor %}
+    </div>
+  </article>
+</section>
+{% endblock %}

--- a/hermes_snapshot_manager/templates/snapshot_detail.html
+++ b/hermes_snapshot_manager/templates/snapshot_detail.html
@@ -1,0 +1,57 @@
+{% extends 'base.html' %}
+{% block content %}
+<section class="grid two-up snapshot-top-grid">
+  <article class="card">
+    <div class="section-heading">
+      <div><p class="eyebrow">Snapshot summary</p><h2>{{ snapshot.label or snapshot.id }}</h2></div>
+      <span class="pill pill-{{ snapshot.status_tone }}">{{ snapshot.status }}</span>
+    </div>
+    <div class="key-value-grid">
+      <div><span class="key-label">ID</span><strong><code>{{ snapshot.id }}</code></strong></div>
+      <div><span class="key-label">Created</span><strong>{{ snapshot.created_at }}</strong></div>
+      <div><span class="key-label">Type</span><strong>{{ snapshot.trigger_type }}</strong></div>
+      <div><span class="key-label">Known good</span><strong>{{ 'Yes' if snapshot.is_known_good else 'No' }}</strong></div>
+      <div><span class="key-label">Files</span><strong>{{ snapshot.total_files }}</strong></div>
+      <div><span class="key-label">Original size</span><strong>{{ display_stats.original_bytes_human }}</strong></div>
+      <div><span class="key-label">Compressed size</span><strong>{{ display_stats.compressed_bytes_human }}</strong></div>
+      <div><span class="key-label">Saved</span><strong>{{ display_stats.space_saved_bytes_human }}</strong></div>
+      <div><span class="key-label">Compression ratio</span><strong>{{ display_stats.compression_ratio }}%</strong></div>
+      <div><span class="key-label">Payload format</span><strong>{{ display_stats.payload_format }}</strong></div>
+    </div>
+    <div class="button-row">
+      <form method="post" action="/snapshots/{{ snapshot.id }}/known-good"><button type="submit">Mark known good</button></form>
+      <form method="post" action="/snapshots/{{ snapshot.id }}/verify"><button type="submit">Verify snapshot</button></form>
+    </div>
+  </article>
+  <article class="card danger">
+    <p class="eyebrow">Danger zone</p>
+    <h2>Restore entire package</h2>
+    <p class="subtitle">This replaces the entire <code>~/.hermes</code> tree and creates a pre-restore safeguard snapshot first.</p>
+    <form method="post" action="/api/snapshots/{{ snapshot.id }}/restore/start" class="js-operation-form" data-operation-kind="restore" data-redirect="/snapshots/{{ snapshot.id }}">
+      <label>Notes</label>
+      <input type="text" name="notes" placeholder="rollback after broken update" />
+      <button type="submit">Restore entire package</button>
+    </form>
+  </article>
+</section>
+<section class="grid two-up">
+  <article class="card">
+    <h2>Verification</h2>
+    {% if verification %}
+    <div class="key-value-grid compact">
+      <div><span class="key-label">OK</span><strong>{{ 'Yes' if verification.ok else 'No' }}</strong></div>
+      <div><span class="key-label">Missing</span><strong>{{ verification.missing_files|length }}</strong></div>
+      <div><span class="key-label">Changed</span><strong>{{ verification.changed_files|length }}</strong></div>
+    </div>
+    {% else %}<p class="empty-state">Run verification to confirm stored file hashes still match.</p>{% endif %}
+  </article>
+  <article class="card">
+    <h2>Diff vs current</h2>
+    <div class="key-value-grid compact">
+      <div><span class="key-label">Added</span><strong>{{ diff.added|length }}</strong></div>
+      <div><span class="key-label">Removed</span><strong>{{ diff.removed|length }}</strong></div>
+      <div><span class="key-label">Changed</span><strong>{{ diff.changed|length }}</strong></div>
+    </div>
+  </article>
+</section>
+{% endblock %}

--- a/hermes_snapshot_manager/templates/snapshots.html
+++ b/hermes_snapshot_manager/templates/snapshots.html
@@ -9,6 +9,13 @@
     </div>
     <div class="list-filters">
       <input id="snapshot-filter" type="search" placeholder="Filter by label or snapshot id" data-filter-table="snapshots-table" />
+      <select id="snapshot-status-filter">
+        <option value="all">All statuses</option>
+        <option value="created">Created</option>
+        <option value="verified">Verified</option>
+        <option value="degraded">Degraded</option>
+        <option value="failed">Failed</option>
+      </select>
       <select id="snapshot-sort" data-sort-table="snapshots-table">
         <option value="created_desc">Newest first</option>
         <option value="created_asc">Oldest first</option>
@@ -26,7 +33,7 @@
       </thead>
       <tbody>
         {% for snapshot in snapshots %}
-        <tr data-filter-text="{{ (snapshot.label or '') ~ ' ' ~ snapshot.id }}" data-created="{{ snapshot.created_at }}" data-size="{{ snapshot.total_bytes }}">
+        <tr data-filter-text="{{ (snapshot.label or '') ~ ' ' ~ snapshot.id }}" data-created="{{ snapshot.created_at }}" data-size="{{ snapshot.total_bytes }}" data-status="{{ snapshot.status }}">
           <td><a href="/snapshots/{{ snapshot.id }}"><strong>{{ snapshot.label or snapshot.id }}</strong></a><div class="table-subtitle"><code>{{ snapshot.id }}</code></div></td>
           <td>{{ snapshot.created_at }}</td>
           <td>{{ snapshot.trigger_type }}</td>
@@ -41,5 +48,14 @@
       </tbody>
     </table>
   </div>
+  <div class="table-footer">
+    <p class="help-text" id="snapshots-table-summary">Showing all snapshots</p>
+    <div class="inline-actions compact-actions">
+      <button type="button" class="button-link button-link--secondary" id="snapshots-prev-page">Previous</button>
+      <span class="chip" id="snapshots-page-indicator">Page 1</span>
+      <button type="button" class="button-link button-link--secondary" id="snapshots-next-page">Next</button>
+    </div>
+  </div>
+  <p class="empty-state hidden" id="snapshots-no-results">No snapshots match the current filters.</p>
 </section>
 {% endblock %}

--- a/hermes_snapshot_manager/templates/snapshots.html
+++ b/hermes_snapshot_manager/templates/snapshots.html
@@ -1,0 +1,45 @@
+{% extends 'base.html' %}
+{% block content %}
+<section class="card page-header-card">
+  <div class="section-heading">
+    <div>
+      <p class="eyebrow">Snapshot library</p>
+      <h2>All snapshots</h2>
+      <p class="subtitle">Browse every recovery point, compare sizes, and jump straight to restore details.</p>
+    </div>
+    <div class="list-filters">
+      <input id="snapshot-filter" type="search" placeholder="Filter by label or snapshot id" data-filter-table="snapshots-table" />
+      <select id="snapshot-sort" data-sort-table="snapshots-table">
+        <option value="created_desc">Newest first</option>
+        <option value="created_asc">Oldest first</option>
+        <option value="size_desc">Largest first</option>
+        <option value="size_asc">Smallest first</option>
+      </select>
+    </div>
+  </div>
+</section>
+<section class="card">
+  <div class="table-shell">
+    <table id="snapshots-table">
+      <thead>
+        <tr><th>Snapshot</th><th>Created</th><th>Type</th><th>Files</th><th>Size</th><th>Status</th><th>Known good</th></tr>
+      </thead>
+      <tbody>
+        {% for snapshot in snapshots %}
+        <tr data-filter-text="{{ (snapshot.label or '') ~ ' ' ~ snapshot.id }}" data-created="{{ snapshot.created_at }}" data-size="{{ snapshot.total_bytes }}">
+          <td><a href="/snapshots/{{ snapshot.id }}"><strong>{{ snapshot.label or snapshot.id }}</strong></a><div class="table-subtitle"><code>{{ snapshot.id }}</code></div></td>
+          <td>{{ snapshot.created_at }}</td>
+          <td>{{ snapshot.trigger_type }}</td>
+          <td>{{ snapshot.total_files }}</td>
+          <td>{{ snapshot.total_bytes_human }}</td>
+          <td><span class="pill pill-{{ snapshot.status_tone }}">{{ snapshot.status }}</span></td>
+          <td>{{ 'Yes' if snapshot.is_known_good else 'No' }}</td>
+        </tr>
+        {% else %}
+        <tr><td colspan="7">No snapshots yet.</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</section>
+{% endblock %}

--- a/tests/test_hermes_snapshot_manager_polish.py
+++ b/tests/test_hermes_snapshot_manager_polish.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from hermes_snapshot_manager.core.config import load_settings
+from hermes_snapshot_manager.core.paths import build_paths
+from hermes_snapshot_manager.main import app
+from hermes_snapshot_manager.services.scheduler_service import describe_cron
+
+
+def test_settings_page_has_schedule_builder_and_saved_banner(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    snapshot_home = tmp_path / ".hermes-snapshot-manager"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_SNAPSHOT_HOME", str(snapshot_home))
+
+    client = TestClient(app)
+    response = client.get("/settings?saved=1")
+
+    assert response.status_code == 200
+    assert "Make cron easier to configure" in response.text
+    assert "Weekly routine" in response.text
+    assert "Settings saved." in response.text
+
+
+def test_settings_post_updates_retention_and_excludes(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    snapshot_home = tmp_path / ".hermes-snapshot-manager"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_SNAPSHOT_HOME", str(snapshot_home))
+
+    client = TestClient(app)
+    response = client.post(
+        "/settings",
+        data={
+            "schedule_enabled": "on",
+            "schedule_cron": "0 8 * * 1",
+            "retention_hourly": "12",
+            "retention_daily": "14",
+            "retention_weekly": "8",
+            "exclude_patterns": "cache/**\nsessions/**\n",
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/settings?saved=1"
+
+    settings = load_settings(build_paths())
+    assert settings.schedule_enabled is True
+    assert settings.retention_hourly == 12
+    assert settings.retention_daily == 14
+    assert settings.retention_weekly == 8
+    assert "cache/**" in settings.exclude_patterns
+    assert "sessions/**" in settings.exclude_patterns
+
+
+def test_describe_cron_humanizes_common_patterns():
+    assert describe_cron("0 */6 * * *") == "Every 6 hours"
+    assert describe_cron("0 3 * * *") == "Daily at 03:00 UTC"
+    assert describe_cron("0 8 * * 1") == "Monday at 08:00 UTC"

--- a/tests/test_hermes_snapshot_manager_polish.py
+++ b/tests/test_hermes_snapshot_manager_polish.py
@@ -22,6 +22,8 @@ def test_settings_page_has_schedule_builder_and_saved_banner(tmp_path, monkeypat
     assert "Make cron easier to configure" in response.text
     assert "Weekly routine" in response.text
     assert "Settings saved." in response.text
+    assert "Add pattern" in response.text
+    assert "Reset excludes" in response.text
 
 
 def test_settings_post_updates_retention_and_excludes(tmp_path, monkeypatch):
@@ -61,3 +63,54 @@ def test_describe_cron_humanizes_common_patterns():
     assert describe_cron("0 */6 * * *") == "Every 6 hours"
     assert describe_cron("0 3 * * *") == "Daily at 03:00 UTC"
     assert describe_cron("0 8 * * 1") == "Monday at 08:00 UTC"
+
+
+def test_invalid_cron_rejects_save(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    snapshot_home = tmp_path / ".hermes-snapshot-manager"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_SNAPSHOT_HOME", str(snapshot_home))
+
+    client = TestClient(app)
+    response = client.post(
+        "/settings",
+        data={
+            "schedule_enabled": "on",
+            "schedule_cron": "not a cron",
+            "retention_hourly": "12",
+            "retention_daily": "14",
+            "retention_weekly": "8",
+            "exclude_patterns": "cache/**\n",
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"].startswith("/settings?error=")
+
+
+def test_snapshots_page_has_filters_and_pagination(tmp_path, monkeypatch):
+    from hermes_snapshot_manager.core.config import SnapshotManagerSettings
+    from hermes_snapshot_manager.services.snapshot_service import SnapshotService
+    from hermes_snapshot_manager.main import snapshot_service as main_snapshot_service
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    snapshot_home = tmp_path / ".hermes-snapshot-manager"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_SNAPSHOT_HOME", str(snapshot_home))
+
+    settings = SnapshotManagerSettings(source_root=str(hermes_home), snapshot_root=str(snapshot_home / "snapshots"))
+    service = SnapshotService(build_paths(), settings=settings)
+    (hermes_home / "config.yaml").write_text("model: one\n", encoding="utf-8")
+    service.create_snapshot(label="ui")
+    monkeypatch.setattr("hermes_snapshot_manager.main.snapshot_service", service)
+
+    client = TestClient(app)
+    response = client.get("/snapshots")
+
+    assert response.status_code == 200
+    assert "All statuses" in response.text
+    assert "Page 1" in response.text
+    assert "No snapshots match the current filters." in response.text


### PR DESCRIPTION
## Summary\n- restore the snapshot manager source tree from a known-good snapshot\n- modernize the dashboard, snapshot pages, and restore history UI\n- add a richer schedule builder with human-readable cron previews and retention controls\n- add client-side filtering/sorting for the snapshots table\n\n## Validation\n- python -m pytest -n0 tests/test_hermes_snapshot_manager_polish.py -q\n\n## Notes\n- branch pushed from fork because upstream push permissions are not available on this machine