### PR TITLE
fix: move kimi-k2.5 to thinking models

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -107,11 +107,11 @@ _FIXED_TEMPERATURE_MODELS: Dict[str, float] = {
 # the standard chat API and third parties) are NOT clamped.
 # Source: https://platform.kimi.ai/docs/guide/kimi-k2-5-quickstart
 _KIMI_INSTANT_MODELS: frozenset = frozenset({
-    "kimi-k2.5",
     "kimi-k2-turbo-preview",
     "kimi-k2-0905-preview",
 })
 _KIMI_THINKING_MODELS: frozenset = frozenset({
+    "kimi-k2.5",
     "kimi-k2-thinking",
     "kimi-k2-thinking-turbo",
 })

--- a/tests/run_agent/test_provider_parity.py
+++ b/tests/run_agent/test_provider_parity.py
@@ -263,6 +263,17 @@ class TestBuildApiKwargsKimiFixedTemperature:
         kwargs = agent._build_api_kwargs(messages)
         assert kwargs["temperature"] == 0.6
 
+    def test_kimi_k2_5_is_thinking_model(self, monkeypatch):
+        agent = _make_agent(
+            monkeypatch,
+            "kimi-coding",
+            base_url="https://api.kimi.com/coding/v1",
+            model="kimi-k2.5",
+        )
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert kwargs["temperature"] == 1.0
+
 
 class TestBuildApiKwargsAIGateway:
     def test_uses_chat_completions_format(self, monkeypatch):


### PR DESCRIPTION
Fixes #12745

`kimi-k2.5` was incorrectly classified in `_KIMI_INSTANT_MODELS` (temperature=0.6). The Moonshot API requires `temperature=1.0` for this model (thinking mode), so it belongs in `_KIMI_THINKING_MODELS`.

**Changes:**
- Moved `kimi-k2.5` from `_KIMI_INSTANT_MODELS` to `_KIMI_THINKING_MODELS` in `agent/auxiliary_client.py`
- Added test verifying `kimi-k2.5` is classified as a thinking model