### PR TITLE
fix(gemini): list Gemini 3 preview models in gemini/google-gemini-cli pickers

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2351,7 +2351,7 @@ def _model_flow_google_gemini_cli(_config, current_model=""):
         return
 
     models = list(_PROVIDER_MODELS.get("google-gemini-cli") or [])
-    default = current_model or (models[0] if models else "gemini-2.5-flash")
+    default = current_model or (models[0] if models else "gemini-3-flash-preview")
     selected = _prompt_model_selection(models, current_model=default)
     if selected:
         _save_model_choice(selected)

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -128,16 +128,14 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     ],
     "gemini": [
         "gemini-3.1-pro-preview",
+        "gemini-3-pro-preview",
         "gemini-3-flash-preview",
         "gemini-3.1-flash-lite-preview",
-        "gemini-2.5-pro",
-        "gemini-2.5-flash",
-        "gemini-2.5-flash-lite",
     ],
     "google-gemini-cli": [
-        "gemini-2.5-pro",
-        "gemini-2.5-flash",
-        "gemini-2.5-flash-lite",
+        "gemini-3.1-pro-preview",
+        "gemini-3-pro-preview",
+        "gemini-3-flash-preview",
     ],
     "zai": [
         "glm-5.1",

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -89,8 +89,8 @@ _DEFAULT_PROVIDER_MODELS = {
         "grok-code-fast-1",
     ],
     "gemini": [
-        "gemini-3.1-pro-preview", "gemini-3-flash-preview", "gemini-3.1-flash-lite-preview",
-        "gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.5-flash-lite",
+        "gemini-3.1-pro-preview", "gemini-3-pro-preview",
+        "gemini-3-flash-preview", "gemini-3.1-flash-lite-preview",
     ],
     "zai": ["glm-5.1", "glm-5", "glm-4.7", "glm-4.5", "glm-4.5-flash"],
     "kimi-coding": ["kimi-k2.5", "kimi-k2-thinking", "kimi-k2-turbo-preview"],


### PR DESCRIPTION
## Summary
Gemini CLI (Cloud Code Assist) and native Gemini pickers now offer the Gemini 3 preview IDs that actually work against the backend, instead of only gemini-2.5-*.

User report: picking `gemini-3.1-pro` as a custom name on `google-gemini-cli` returned `HTTP 404: Requested entity was not found` from `cloudcode-pa.googleapis.com`. Root cause: our picker never listed any Gemini 3 option, so users had to guess names — and Code Assist's actual IDs are `-preview`-suffixed.

## Changes
- `hermes_cli/models.py` — replace gemini-2.5-* with gemini-3.1-pro-preview, gemini-3-pro-preview, gemini-3-flash-preview (+ gemini-3.1-flash-lite-preview on native `gemini`).
- `hermes_cli/setup.py` — same update for the setup-wizard catalog.
- `hermes_cli/main.py` — fallback default `gemini-2.5-flash` → `gemini-3-flash-preview`.
- `copilot` picker untouched (that's Microsoft's model menu; `gemini-2.5-pro` is still valid there).
- Adapter/pricing constants untouched (harmless historical defaults; pricing still correct for past 2.5 sessions).

## Validation
```
tests/agent/test_gemini_cloudcode.py
tests/hermes_cli/test_model_validation.py
tests/cli/test_cli_init.py
→ 170 passed in 7.14s
```

Picker sanity check:
```
google-gemini-cli: ['gemini-3.1-pro-preview', 'gemini-3-pro-preview', 'gemini-3-flash-preview']
gemini:            ['gemini-3.1-pro-preview', 'gemini-3-pro-preview', 'gemini-3-flash-preview', 'gemini-3.1-flash-lite-preview']
```

## Caveat
Access to Gemini 3 on Code Assist still depends on the user's Google tier (non-business AI Ultra, paid Gemini API key, or waitlist approval) and `previewFeatures` being enabled in their Gemini CLI settings. Users without access will now get a clearer "model not available" response instead of "you picked a name we never listed."