### PR TITLE
fix(agent): skip fallback cascade for model-output tool call errors

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -85,6 +85,22 @@ class ClassifiedError:
 
 # ── Provider-specific patterns ──────────────────────────────────────────
 
+# Patterns that indicate model-output errors (malformed tool calls, invalid
+# JSON in arguments).  These are *not* infrastructure problems — a different
+# provider will NOT fix them, so fallback is wasteful.  See issue #12770.
+_MODEL_OUTPUT_ERROR_PATTERNS = [
+    "invalid tool call arguments",
+    "invalid tool_call",
+    "malformed tool call",
+    "invalid json in tool",
+    "could not parse tool",
+    "tool input did not match",
+    "failed to parse tool",
+    "tool_use block is not valid json",
+    "is not valid json",
+    "unterminated string",
+]
+
 # Patterns that indicate billing exhaustion (not transient rate limit)
 _BILLING_PATTERNS = [
     "insufficient credits",
@@ -620,7 +636,17 @@ def _classify_400(
             should_compress=True,
         )
 
-    # Non-retryable format error
+    # Model-output errors (e.g. malformed tool call arguments) — the
+    # model itself produced bad JSON.  Another provider will NOT fix this,
+    # so falling back only wastes 20-60s per cascade.  (#12770)
+    if any(p in error_msg for p in _MODEL_OUTPUT_ERROR_PATTERNS):
+        return result_fn(
+            FailoverReason.format_error,
+            retryable=False,
+            should_fallback=False,
+        )
+
+    # Non-retryable format error (unknown cause — fallback may help)
     return result_fn(
         FailoverReason.format_error,
         retryable=False,

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -534,6 +534,73 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.format_error
         assert result.retryable is False
 
+    # ── Model-output errors: should NOT fallback (#12770) ──
+
+    def test_400_invalid_tool_call_arguments_no_fallback(self):
+        """400 with 'invalid tool call arguments' → format_error, no fallback.
+
+        The model generated malformed JSON in tool call arguments.
+        Another provider will produce different (not better) output,
+        so cascading through all fallback providers wastes 20-60s.
+        """
+        e = MockAPIError(
+            "invalid tool call arguments",
+            status_code=400,
+            body={"error": {"message": "invalid tool call arguments"}},
+        )
+        result = classify_api_error(e, approx_tokens=5000)
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+        assert result.should_fallback is False
+
+    def test_400_tool_use_not_valid_json_no_fallback(self):
+        """400 with 'tool_use block is not valid json' → no fallback."""
+        e = MockAPIError(
+            "tool_use block is not valid json",
+            status_code=400,
+            body={"error": {"message": "tool_use block is not valid json"}},
+        )
+        result = classify_api_error(e, approx_tokens=5000)
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+        assert result.should_fallback is False
+
+    def test_400_unterminated_string_no_fallback(self):
+        """400 with 'unterminated string' → no fallback."""
+        e = MockAPIError(
+            "unterminated string in tool call arguments",
+            status_code=400,
+            body={"error": {"message": "unterminated string in tool call arguments"}},
+        )
+        result = classify_api_error(e, approx_tokens=5000)
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+        assert result.should_fallback is False
+
+    def test_400_failed_to_parse_tool_no_fallback(self):
+        """400 with 'failed to parse tool' → no fallback."""
+        e = MockAPIError(
+            "failed to parse tool call: unexpected end of input",
+            status_code=400,
+            body={"error": {"message": "failed to parse tool call: unexpected end of input"}},
+        )
+        result = classify_api_error(e, approx_tokens=5000)
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+        assert result.should_fallback is False
+
+    def test_400_non_tool_error_still_fallback(self):
+        """400 with generic non-tool-related message → still allows fallback."""
+        e = MockAPIError(
+            "invalid request: unknown parameter 'foo'",
+            status_code=400,
+            body={"error": {"message": "invalid request: unknown parameter 'foo'"}},
+        )
+        result = classify_api_error(e, approx_tokens=5000)
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+        assert result.should_fallback is True
+
     def test_400_flat_body_descriptive_not_context_overflow(self):
         """Responses API flat body with descriptive error + large session → format error.
 


### PR DESCRIPTION
Fixes #12770

## Problem

When the API returns a 400 error with messages like `"invalid tool call arguments"`, the error classifier falls through to the generic `format_error` path with `should_fallback=True`. This triggers a full cascade through ALL fallback providers (4-5 sequential API calls), wasting 20-60 seconds per occurrence.

The root cause is a **model-output problem** — the model generated malformed JSON in tool call arguments — not an infrastructure issue. A different provider will produce different (not better) output.

## Fix

Added `_MODEL_OUTPUT_ERROR_PATTERNS` — a pattern list matching common API error messages for malformed tool calls — checked before the generic `format_error` fallthrough in `_classify_400()`.

When a model-output error is detected:
- `should_fallback = False` — stop the cascade immediately
- `retryable = False` — the same model will likely produce the same malformed output

Non-tool-related 400 errors continue to allow fallback as before.

### Patterns matched

| Pattern | Typical source |
|---|---|
| `invalid tool call arguments` | OpenAI / OpenRouter |
| `tool_use block is not valid json` | Anthropic |
| `unterminated string` | JSON parse errors |
| `failed to parse tool` | Various providers |
| `is not valid json` | Generic JSON validation |
| `could not parse tool` / `tool input did not match` | Provider-specific |

### Impact

From the issue report, this pattern was observed 7 times in a single session, each cascade burning 4-5 sequential API calls × ~5-15s = **20-60s wasted per occurrence**. With this fix, the error is classified immediately and the cascade is skipped.

## Tests

Added 5 regression tests in `tests/agent/test_error_classifier.py`:
- `test_400_invalid_tool_call_arguments_no_fallback`
- `test_400_tool_use_not_valid_json_no_fallback`
- `test_400_unterminated_string_no_fallback`
- `test_400_failed_to_parse_tool_no_fallback`
- `test_400_non_tool_error_still_fallback` — confirms non-tool 400s still allow fallback

All 102 tests pass (97 existing + 5 new).