### PR TITLE
fix(bedrock): preserve dots in Bedrock model IDs during normalization

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -831,6 +831,22 @@ def read_hermes_oauth_credentials() -> Optional[Dict[str, Any]]:
 # ---------------------------------------------------------------------------
 
 
+def _is_bedrock_model_id(model: str) -> bool:
+    """Return True if the model string is a Bedrock-native model identifier.
+
+    Bedrock IDs use dots as structural separators (e.g.
+    ``global.anthropic.claude-opus-4-6-v1``, ``anthropic.claude-sonnet-4-6``).
+    These must NOT have their dots replaced with hyphens.
+    """
+    lower = model.lower()
+    for prefix in ("global.", "us.", "eu.", "ap.", "apac.", "jp."):
+        if lower.startswith(prefix):
+            return True
+    if lower.startswith("anthropic.claude"):
+        return True
+    return False
+
+
 def normalize_model_name(model: str, preserve_dots: bool = False) -> str:
     """Normalize a model name for the Anthropic API.
 
@@ -838,13 +854,15 @@ def normalize_model_name(model: str, preserve_dots: bool = False) -> str:
     - Converts dots to hyphens in version numbers (OpenRouter uses dots,
       Anthropic uses hyphens: claude-opus-4.6 → claude-opus-4-6), unless
       preserve_dots is True (e.g. for Alibaba/DashScope: qwen3.5-plus).
+    - Preserves dots in Bedrock model IDs where dots are structural
+      separators (e.g. global.anthropic.claude-opus-4-6-v1).
     """
     lower = model.lower()
     if lower.startswith("anthropic/"):
         model = model[len("anthropic/"):]
+    if _is_bedrock_model_id(model):
+        return model
     if not preserve_dots:
-        # OpenRouter uses dots for version separators (claude-opus-4.6),
-        # Anthropic uses hyphens (claude-opus-4-6). Convert dots to hyphens.
         model = model.replace(".", "-")
     return model
 

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -19,6 +19,7 @@ from agent.anthropic_adapter import (
     convert_tools_to_anthropic,
     is_claude_code_token_valid,
     normalize_anthropic_response,
+    _is_bedrock_model_id,
     normalize_model_name,
     read_claude_code_credentials,
     resolve_anthropic_token,
@@ -480,6 +481,42 @@ class TestNormalizeModelName:
         assert normalize_model_name("qwen3.5-plus", preserve_dots=True) == "qwen3.5-plus"
         assert normalize_model_name("anthropic/qwen3.5-plus", preserve_dots=True) == "qwen3.5-plus"
         assert normalize_model_name("qwen3.5-flash", preserve_dots=True) == "qwen3.5-flash"
+
+    def test_preserves_dots_in_bedrock_model_ids(self):
+        """Bedrock model IDs use dots as structural separators, not version delimiters."""
+        assert normalize_model_name("global.anthropic.claude-opus-4-6-v1") == "global.anthropic.claude-opus-4-6-v1"
+        assert normalize_model_name("global.anthropic.claude-opus-4-7") == "global.anthropic.claude-opus-4-7"
+        assert normalize_model_name("global.anthropic.claude-sonnet-4-6") == "global.anthropic.claude-sonnet-4-6"
+        assert normalize_model_name("apac.anthropic.claude-sonnet-4-20250514-v1:0") == "apac.anthropic.claude-sonnet-4-20250514-v1:0"
+        assert normalize_model_name("us.anthropic.claude-opus-4-6-v1") == "us.anthropic.claude-opus-4-6-v1"
+        assert normalize_model_name("eu.anthropic.claude-sonnet-4-6") == "eu.anthropic.claude-sonnet-4-6"
+        assert normalize_model_name("anthropic.claude-opus-4-6-v1") == "anthropic.claude-opus-4-6-v1"
+
+
+class TestIsBedrockModelId:
+    def test_global_prefix(self):
+        assert _is_bedrock_model_id("global.anthropic.claude-opus-4-6-v1") is True
+
+    def test_regional_prefixes(self):
+        assert _is_bedrock_model_id("us.anthropic.claude-opus-4-6-v1") is True
+        assert _is_bedrock_model_id("eu.anthropic.claude-sonnet-4-6") is True
+        assert _is_bedrock_model_id("ap.anthropic.claude-sonnet-4-6") is True
+        assert _is_bedrock_model_id("apac.anthropic.claude-sonnet-4-20250514-v1:0") is True
+        assert _is_bedrock_model_id("jp.anthropic.claude-opus-4-7") is True
+
+    def test_foundation_model_prefix(self):
+        assert _is_bedrock_model_id("anthropic.claude-opus-4-6-v1") is True
+        assert _is_bedrock_model_id("anthropic.claude-sonnet-4-6") is True
+
+    def test_non_bedrock_ids(self):
+        assert _is_bedrock_model_id("claude-opus-4-6") is False
+        assert _is_bedrock_model_id("claude-opus-4.6") is False
+        assert _is_bedrock_model_id("anthropic/claude-opus-4.6") is False
+        assert _is_bedrock_model_id("qwen3.5-plus") is False
+
+    def test_case_insensitive(self):
+        assert _is_bedrock_model_id("Global.Anthropic.Claude-Opus-4-6-v1") is True
+        assert _is_bedrock_model_id("GLOBAL.ANTHROPIC.CLAUDE-OPUS-4-6-V1") is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

  `normalize_model_name()` unconditionally replaces all dots with hyphens, which breaks Bedrock model IDs where dots are structural separators (e.g.
  `global.anthropic.claude-opus-4-6-v1` becomes the invalid `global-anthropic-claude-opus-4-6-v1`). This causes **all** Claude models on Bedrock to fail with `ValidationException: The
  provided model identifier is invalid`, while Nova models (which use the `bedrock_converse` path) work fine.

  This PR adds a `_is_bedrock_model_id()` helper to detect Bedrock-native IDs by their regional/vendor prefixes and skips dot-to-hyphen conversion for them.

  ### Root Cause

  `normalize_model_name()` was designed for OpenRouter-style names (`claude-opus-4.6` → `claude-opus-4-6`) but did not account for Bedrock-native IDs where dots delimit
  region/vendor/model hierarchy.

  ## Related Issue

  - #10774 — Auto-detect Bedrock inference profile prefix for Claude models
  - #7164 — normalize_model_name() breaks model names for custom base URLs

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [ ] ✨ New feature (non-breaking change that adds functionality)
  - [ ] 🔒 Security fix
  - [ ] 📝 Documentation update
  - [ ] ✅ Tests (adding or improving test coverage)
  - [ ] ♻️  Refactor (no behavior change)
  - [ ] 🎯 New skill (bundled or hub)

  ## Changes Made

  - `agent/anthropic_adapter.py`: Added `_is_bedrock_model_id()` helper that detects Bedrock model ID patterns by regional prefixes (`global.`, `us.`, `eu.`, `ap.`, `apac.`, `jp.`) and
   foundation model prefix (`anthropic.claude`)
  - `agent/anthropic_adapter.py`: Modified `normalize_model_name()` to return early (preserving dots) when `_is_bedrock_model_id()` returns True
  - `tests/agent/test_anthropic_adapter.py`: Added `TestIsBedrockModelId` class and `test_preserves_dots_in_bedrock_model_ids` test method (6 new test cases)

  ## How to Test

  1. Configure Hermes with Bedrock provider (e.g. region `ap-northeast-2`)
  2. Set model to any Claude inference profile (e.g. `global.anthropic.claude-opus-4-6-v1`)
  3. Send any message

  **Before fix:** `ValidationException: The provided model identifier is invalid.`
  **After fix:** Normal response from Claude via AnthropicBedrock SDK

  ### Affected Model ID Patterns

  | Pattern | Example | Dots are... |
  |---------|---------|-------------|
  | Global inference profile | `global.anthropic.claude-opus-4-6-v1` | structural (preserved ✓) |
  | Regional inference profile | `apac.anthropic.claude-sonnet-4-20250514-v1:0` | structural (preserved ✓) |
  | Foundation model | `anthropic.claude-opus-4-6-v1` | structural (preserved ✓) |
  | OpenRouter format | `claude-opus-4.6` | version separator (converted → `claude-opus-4-6` ✓) |
  | Aggregator slug | `anthropic/claude-sonnet-4.6` | version separator (converted → `claude-sonnet-4-6` ✓) |

  ## Checklist

  ### Code

  - [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
  - [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
  - [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
  - [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
  - [x] I've run `pytest tests/ -q` and all tests pass
  - [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
  - [x] I've tested on my platform: Amazon Linux 2023 (EC2, ap-northeast-2, Python 3.11.14)

  ### Documentation & Housekeeping

  - [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
  - [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
  - [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
  - [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility
  guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
  - [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

  ## Screenshots / Logs

  ### Error log (before fix)
  ERROR root: API call failed after 3 retries. An error occurred (ValidationException)
    when calling the ConverseStream operation: The provided model identifier is invalid.
    | provider=bedrock model=global.anthropic.claude-opus-4-7 msgs=2 tokens=~3,106

  ### Test results (after fix)
  $ venv/bin/python -m pytest tests/agent/test_anthropic_adapter.py -q
  126 passed in 5.12s

  ### Verification
  ```python
  >>> from agent.anthropic_adapter import normalize_model_name
  >>> normalize_model_name("global.anthropic.claude-opus-4-6-v1")
  'global.anthropic.claude-opus-4-6-v1'  # dots preserved ✓
  >>> normalize_model_name("claude-opus-4.6")
  'claude-opus-4-6'  # still converts OpenRouter format ✓
  >>> normalize_model_name("anthropic/claude-sonnet-4.6")
  'claude-sonnet-4-6'  # still strips prefix and converts ✓