### PR TITLE
fix(discord): restore thread creation for free response channels

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3012,7 +3012,7 @@ class DiscordAdapter(BasePlatformAdapter):
         if not is_thread and not isinstance(message.channel, discord.DMChannel):
             no_thread_channels_raw = os.getenv("DISCORD_NO_THREAD_CHANNELS", "")
             no_thread_channels = {ch.strip() for ch in no_thread_channels_raw.split(",") if ch.strip()}
-            skip_thread = bool(channel_ids & no_thread_channels) or is_free_channel
+            skip_thread = bool(channel_ids & no_thread_channels)
             auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in ("true", "1", "yes")
             is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
             if auto_thread and not skip_thread and not is_voice_linked_channel and not is_reply_message:

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -427,16 +427,63 @@ async def test_discord_voice_linked_channel_skips_mention_requirement_and_auto_t
 
 
 @pytest.mark.asyncio
-async def test_discord_free_channel_skips_auto_thread(adapter, monkeypatch):
-    """Free-response channels must NOT auto-create threads — bot replies inline.
+async def test_discord_free_channel_auto_threads(adapter, monkeypatch):
+    """Free-response channels must auto-create threads for responses.
 
-    Without this, every message in a free-response channel would spin off a
-    thread (since the channel bypasses the @mention gate), defeating the
-    lightweight-chat purpose of free-response mode.
+    Free-response channels bypass the @mention gate so users can chat without
+    mentioning the bot, but responses should still be threaded to keep the
+    channel tidy — each conversation gets its own thread, just like regular
+    @mention interactions.
     """
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
     monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "789")
     monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)  # default true
+
+    fake_thread = FakeThread(channel_id=999, parent=FakeTextChannel(channel_id=789))
+    adapter._auto_create_thread = AsyncMock(return_value=fake_thread)
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=789),
+        content="free chat message",
+    )
+
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_awaited_once()
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_type == "thread"
+
+
+@pytest.mark.asyncio
+async def test_discord_free_channel_no_thread_when_auto_thread_disabled(adapter, monkeypatch):
+    """Free-response channels respect DISCORD_AUTO_THREAD=false."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "789")
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+
+    adapter._auto_create_thread = AsyncMock()
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=789),
+        content="free chat message",
+    )
+
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_not_awaited()
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_type == "group"
+
+
+@pytest.mark.asyncio
+async def test_discord_free_channel_no_thread_override(adapter, monkeypatch):
+    """A channel in both free-response AND no-thread lists skips threading."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "789")
+    monkeypatch.setenv("DISCORD_NO_THREAD_CHANNELS", "789")
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
 
     adapter._auto_create_thread = AsyncMock()
 


### PR DESCRIPTION
## Problem

Fixes #12750 — Discord free response channels no longer respond in threads; they reply inline in the channel instead.

## Root Cause

Commit 93fe4b35 added `is_free_channel` to the `skip_thread` condition, which prevented auto-threading in free response channels. Free response channels should only skip the @mention requirement, not thread creation.

## Fix

Remove `is_free_channel` from the `skip_thread` check so free response channels auto-thread normally. Users can still disable threading per-channel via `DISCORD_NO_THREAD_CHANNELS`.

## Tests

- `test_discord_free_channel_auto_threads` — verifies free channels create threads
- `test_discord_free_channel_no_thread_when_auto_thread_disabled` — respects DISCORD_AUTO_THREAD=false
- `test_discord_free_channel_no_thread_override` — respects DISCORD_NO_THREAD_CHANNELS override

All 22 tests in `test_discord_free_response.py` pass.