### PR TITLE
fix(agent): preserve env proxies for custom httpx transports

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4666,6 +4666,36 @@ class AIAgent:
             return bool(getattr(http_client, "is_closed", False))
         return False
 
+    @staticmethod
+    def _resolve_httpx_env_proxy(base_url: str) -> Optional[str]:
+        """Preserve env proxy support when Hermes injects a custom transport."""
+        if base_url and is_local_endpoint(base_url):
+            return None
+        return (
+            os.getenv("HTTPS_PROXY")
+            or os.getenv("https_proxy")
+            or os.getenv("HTTP_PROXY")
+            or os.getenv("http_proxy")
+            or None
+        )
+
+    def _build_keepalive_http_transport(self, httpx_module: Any, socket_module: Any, base_url: str) -> Any:
+        sock_opts = [(socket_module.SOL_SOCKET, socket_module.SO_KEEPALIVE, 1)]
+        if hasattr(socket_module, "TCP_KEEPIDLE"):
+            # Linux
+            sock_opts.append((socket_module.IPPROTO_TCP, socket_module.TCP_KEEPIDLE, 30))
+            sock_opts.append((socket_module.IPPROTO_TCP, socket_module.TCP_KEEPINTVL, 10))
+            sock_opts.append((socket_module.IPPROTO_TCP, socket_module.TCP_KEEPCNT, 3))
+        elif hasattr(socket_module, "TCP_KEEPALIVE"):
+            # macOS (uses TCP_KEEPALIVE instead of TCP_KEEPIDLE)
+            sock_opts.append((socket_module.IPPROTO_TCP, socket_module.TCP_KEEPALIVE, 30))
+
+        transport_kwargs = {"socket_options": sock_opts}
+        proxy = self._resolve_httpx_env_proxy(base_url)
+        if proxy:
+            transport_kwargs["proxy"] = proxy
+        return httpx_module.HTTPTransport(**transport_kwargs)
+
     def _create_openai_client(self, client_kwargs: dict, *, reason: str, shared: bool) -> Any:
         from agent.auxiliary_client import _validate_base_url, _validate_proxy_env_urls
         # Treat client_kwargs as read-only. Callers pass self._client_kwargs (or shallow
@@ -4727,17 +4757,9 @@ class AIAgent:
             try:
                 import httpx as _httpx
                 import socket as _socket
-                _sock_opts = [(_socket.SOL_SOCKET, _socket.SO_KEEPALIVE, 1)]
-                if hasattr(_socket, "TCP_KEEPIDLE"):
-                    # Linux
-                    _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPIDLE, 30))
-                    _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPINTVL, 10))
-                    _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPCNT, 3))
-                elif hasattr(_socket, "TCP_KEEPALIVE"):
-                    # macOS (uses TCP_KEEPALIVE instead of TCP_KEEPIDLE)
-                    _sock_opts.append((_socket.IPPROTO_TCP, _socket.TCP_KEEPALIVE, 30))
+                _base_url = str(client_kwargs.get("base_url") or self.base_url or "")
                 client_kwargs["http_client"] = _httpx.Client(
-                    transport=_httpx.HTTPTransport(socket_options=_sock_opts),
+                    transport=self._build_keepalive_http_transport(_httpx, _socket, _base_url),
                 )
             except Exception:
                 pass  # Fall through to default transport if socket opts fail

--- a/tests/run_agent/test_create_openai_client_kwargs_isolation.py
+++ b/tests/run_agent/test_create_openai_client_kwargs_isolation.py
@@ -15,10 +15,8 @@ from unittest.mock import MagicMock, patch
 from run_agent import AIAgent
 
 
-@patch("run_agent.OpenAI")
-def test_create_openai_client_does_not_mutate_input_kwargs(mock_openai):
-    mock_openai.return_value = MagicMock()
-    agent = AIAgent(
+def _make_agent():
+    return AIAgent(
         api_key="test-key",
         base_url="https://openrouter.ai/api/v1",
         model="test/model",
@@ -26,6 +24,12 @@ def test_create_openai_client_does_not_mutate_input_kwargs(mock_openai):
         skip_context_files=True,
         skip_memory=True,
     )
+
+
+@patch("run_agent.OpenAI")
+def test_create_openai_client_does_not_mutate_input_kwargs(mock_openai):
+    mock_openai.return_value = MagicMock()
+    agent = _make_agent()
 
     kwargs = {"api_key": "test-key", "base_url": "https://api.example.com/v1"}
     snapshot = dict(kwargs)
@@ -35,3 +39,18 @@ def test_create_openai_client_does_not_mutate_input_kwargs(mock_openai):
     assert kwargs == snapshot, (
         f"_create_openai_client mutated input kwargs; expected {snapshot}, got {kwargs}"
     )
+
+
+def test_httpx_env_proxy_resolves_https_proxy(monkeypatch):
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7890")
+
+    assert (
+        AIAgent._resolve_httpx_env_proxy("https://chatgpt.com/backend-api/codex")
+        == "http://127.0.0.1:7890"
+    )
+
+
+def test_httpx_env_proxy_skips_local_endpoints(monkeypatch):
+    monkeypatch.setenv("HTTPS_PROXY", "http://127.0.0.1:7890")
+
+    assert AIAgent._resolve_httpx_env_proxy("http://127.0.0.1:11434/v1") is None


### PR DESCRIPTION
## What does this PR do?

Fixes OpenAI-compatible requests ignoring `HTTPS_PROXY` / `HTTP_PROXY` when Hermes injects a custom `httpx.HTTPTransport` for TCP keepalive socket options.

`httpx` normally reads environment proxies, but passing a custom transport bypasses that default behavior. This change preserves the existing keepalive transport while explicitly carrying the configured env proxy for non-local endpoints.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Added `_resolve_httpx_env_proxy()` to preserve `HTTPS_PROXY` / `HTTP_PROXY` for non-local endpoints.
- Added `_build_keepalive_http_transport()` to keep keepalive transport construction encapsulated.
- Updated OpenAI client construction to use the helper.
- Added tests for proxy resolution and local endpoint exclusion.

## How to Test

1. Configure `HTTPS_PROXY=http://127.0.0.1:7890` or `HTTP_PROXY=http://127.0.0.1:7890`.
2. Use an OpenAI/Codex provider endpoint that requires the proxy.
3. Run:

```bash
pytest tests/run_agent/test_create_openai_client_kwargs_isolation.py tests/run_agent/test_create_openai_client_reuse.py tests/agent/test_proxy_and_url_validation.py
```

Result locally:

```text
19 passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Local targeted test output:

```text
19 passed, 6 warnings
```
