### PR TITLE
fix(session_search): restore same-session context when message ids are interleaved

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1126,10 +1126,37 @@ class SessionDB:
             try:
                 with self._lock:
                     ctx_cursor = self._conn.execute(
-                        """SELECT role, content FROM messages
-                           WHERE session_id = ? AND id >= ? - 1 AND id <= ? + 1
-                           ORDER BY id""",
-                        (match["session_id"], match["id"], match["id"]),
+                        """WITH target AS (
+                               SELECT session_id, timestamp, id
+                               FROM messages
+                               WHERE id = ?
+                           )
+                           SELECT role, content
+                           FROM (
+                               SELECT m.id, m.timestamp, m.role, m.content
+                               FROM messages m
+                               JOIN target t ON t.session_id = m.session_id
+                               WHERE (m.timestamp < t.timestamp)
+                                  OR (m.timestamp = t.timestamp AND m.id < t.id)
+                               ORDER BY m.timestamp DESC, m.id DESC
+                               LIMIT 1
+                           )
+                           UNION ALL
+                           SELECT role, content
+                           FROM messages
+                           WHERE id = ?
+                           UNION ALL
+                           SELECT role, content
+                           FROM (
+                               SELECT m.id, m.timestamp, m.role, m.content
+                               FROM messages m
+                               JOIN target t ON t.session_id = m.session_id
+                               WHERE (m.timestamp > t.timestamp)
+                                  OR (m.timestamp = t.timestamp AND m.id > t.id)
+                               ORDER BY m.timestamp ASC, m.id ASC
+                               LIMIT 1
+                           )""",
+                        (match["id"], match["id"]),
                     )
                     context_msgs = [
                         {"role": r["role"], "content": (r["content"] or "")[:200]}

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -334,6 +334,25 @@ class TestFTS5Search:
         assert isinstance(results[0]["context"], list)
         assert len(results[0]["context"]) > 0
 
+    def test_search_context_uses_session_neighbors_when_ids_are_interleaved(self, db):
+        db.create_session(session_id="s1", source="cli")
+        db.create_session(session_id="s2", source="cli")
+
+        db.append_message("s1", role="user", content="before needle")
+        db.append_message("s2", role="user", content="other session message")
+        db.append_message("s1", role="assistant", content="needle match")
+        db.append_message("s2", role="assistant", content="another other session message")
+        db.append_message("s1", role="user", content="after needle")
+
+        results = db.search_messages('"needle match"')
+        needle_result = next(r for r in results if r["session_id"] == "s1" and "needle match" in r["snippet"])
+
+        assert [msg["content"] for msg in needle_result["context"]] == [
+            "before needle",
+            "needle match",
+            "after needle",
+        ]
+
     def test_search_special_chars_do_not_crash(self, db):
         """FTS5 special characters in queries must not raise OperationalError."""
         db.create_session(session_id="s1", source="cli")


### PR DESCRIPTION
## Summary

Fixes a `session_search` context bug in `SessionDB.search_messages()`.

Previously, surrounding context for a search hit was collected with a global
`messages.id ± 1` lookup. Because `messages.id` is global across all sessions,
interleaved inserts from other sessions could break context reconstruction and
cause `session_search` to return incomplete or misleading neighbors.

This change makes context selection session-aware:
- fetch the previous message from the same `session_id`
- include the matched message itself
- fetch the next message from the same `session_id`

When timestamps are equal, `id` is used as a stable tie-breaker.

## Root Cause

`messages.id` is an autoincrement key for the whole table, not a per-session
sequence. Using `id >= match_id - 1 AND id <= match_id + 1` assumes local
adjacency that does not actually exist once messages from multiple sessions are
interleaved.

## User Impact

This improves `session_search` result quality by ensuring the returned context
actually reflects the matched conversation thread, even when multiple sessions
are writing to the database concurrently.

## Changes

- Added a regression test covering interleaved message inserts across sessions
- Replaced the global `id ± 1` context lookup with same-session neighbor queries

## Testing

Passed:

- `uv run pytest tests/test_hermes_state.py -q -n 4 -k "search_context_uses_session_neighbors_when_ids_are_interleaved or search_returns_context"`
- `uv run pytest tests/test_hermes_state.py -q -n 4 -k "search_"`


