### PR TITLE
fix(whatsapp): add permanent messaging-history.set handler for backfill

### DIFF
--- a/docs/plans/whatsapp-ultimate-hermes.md
+++ b/docs/plans/whatsapp-ultimate-hermes.md
@@ -1,0 +1,773 @@
+# WhatsApp Ultimate — Hermes Integration Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Build a fully-featured WhatsApp platform adapter for Hermes combining: Hermes's existing Baileys bridge + wacli's local SQLite/FTS5 storage + OpenClaw's whatsapp-ultimate features (polls, reactions, group management, voice notes, stickers).
+
+**Architecture:**
+
+```
+WhatsApp Servers
+       ↕ (Baileys Web WebSocket)
+Node.js Bridge (bridge.js)
+  - Full Baileys API (group management, polls, reactions, etc.)
+  - SQLite + FTS5 local message storage (like wacli)
+  - HTTP endpoints for Python adapter
+       ↕ (HTTP REST)
+Python Adapter (whatsapp.py)
+  - All WhatsApp features exposed as Python methods
+  - Connects to Hermes gateway like any other platform
+       ↕
+Hermes Gateway → Agent tools → User
+```
+
+**Tech Stack:**
+- Baileys v7 (existing, already installed)
+- better-sqlite3 (Node.js SQLite + FTS5)
+- Python adapter (existing, extending)
+- Hermes gateway platform adapter (existing, extending)
+
+**Key Files:**
+- `~/.hermes/hermes-agent/scripts/whatsapp-bridge/bridge.js` — Node.js bridge (ENHANCE)
+- `~/.hermes/hermes-agent/gateway/platforms/whatsapp.py` — Python adapter (ENHANCE)
+- `~/.hermes/hermes-agent/scripts/whatsapp-bridge/package.json` — Add better-sqlite3 dependency
+
+---
+
+## Phase 1: Bridge Enhancements (bridge.js)
+
+### Task 1: Add SQLite + FTS5 local storage to bridge
+
+**Objective:** Store all messages in local SQLite for search and history
+
+**File:** `~/.hermes/hermes-agent/scripts/whatsapp-bridge/bridge.js`
+
+**Step 1: Add better-sqlite3 import at top of bridge.js**
+```javascript
+import Database from 'better-sqlite3';
+import path from 'path';
+import { mkdirSync, existsSync } from 'fs';
+```
+
+**Step 2: Add DB initialization after socket creation**
+```javascript
+const DB_DIR = path.join(process.env.HOME || '~', '.hermes', 'whatsapp');
+mkdirSync(DB_DIR, { recursive: true });
+const db = new Database(path.join(DB_DIR, 'messages.db'));
+
+// Enable FTS5
+db.exec(`
+  CREATE TABLE IF NOT EXISTS messages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    msg_id TEXT UNIQUE,
+    chat_jid TEXT,
+    sender_jid TEXT,
+    from_me INTEGER,
+    text TEXT,
+    media_type TEXT,
+    media_caption TEXT,
+    timestamp INTEGER,
+    raw_json TEXT
+  );
+  CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
+    text, media_caption, chat_jid, sender_jid,
+    content='messages', content_rowid='id'
+  );
+  CREATE TABLE IF NOT EXISTS chats (
+    jid TEXT PRIMARY KEY,
+    name TEXT,
+    kind TEXT,
+    last_message_ts INTEGER
+  );
+  CREATE TRIGGER IF NOT EXISTS messages_ai AFTER INSERT ON messages BEGIN
+    INSERT INTO messages_fts(rowid, text, media_caption, chat_jid, sender_jid)
+    VALUES (new.id, new.text, new.media_caption, new.chat_jid, new.sender_jid);
+  END;
+`);
+
+// Prepared statements
+const insertMsg = db.prepare(`
+  INSERT OR IGNORE INTO messages (msg_id, chat_jid, sender_jid, from_me, text, media_type, media_caption, timestamp, raw_json)
+  VALUES (@msg_id, @chat_jid, @sender_jid, @from_me, @text, @media_type, @media_caption, @timestamp, @raw_json)
+`);
+const insertChat = db.prepare(`
+  INSERT OR IGNORE INTO chats (jid, name, kind, last_message_ts) VALUES (@jid, @name, @kind, @last_message_ts)
+`);
+const updateChatTs = db.prepare(`UPDATE chats SET last_message_ts = ? WHERE jid = ?`);
+```
+
+**Step 3: Save every incoming/outgoing message to DB**
+In the `sock.ev.on('messages.upsert')` handler, after pushing to `messageQueue`, also:
+```javascript
+// Save to SQLite
+try {
+  insertMsg.run({
+    msg_id: msg.key.id,
+    chat_jid: chatId,
+    sender_jid: senderId,
+    from_me: msg.key.fromMe ? 1 : 0,
+    text: textContent || '',
+    media_type: msg.message?.imageMessage ? 'image' : msg.message?.videoMessage ? 'video' : msg.message?.documentMessage ? 'document' : msg.message?.audioMessage ? 'audio' : null,
+    media_caption: msg.message?.imageMessage?.caption || msg.message?.videoMessage?.caption || null,
+    timestamp: msg.messageTimestamp,
+    raw_json: JSON.stringify(msg),
+  });
+  insertChat.run({ jid: chatId, name: chatId.replace(/@.*/, ''), kind: isGroup ? 'group' : 'dm', last_message_ts: msg.messageTimestamp });
+} catch (e) {
+  // Ignore dupes (UNIQUE constraint)
+}
+```
+
+**Step 4: Verify**
+Run: `curl http://127.0.0.1:<bridge_port>/messages` after receiving a message
+Run: SQLite browser — `SELECT COUNT(*) FROM messages` should increase
+
+---
+
+### Task 2: Add FTS5 search endpoint to bridge
+
+**Objective:** Enable fast full-text search of message history
+
+**File:** `~/.hermes/hermes-agent/scripts/whatsapp-bridge/bridge.js`
+
+**Add new endpoint after `/chat/:id`:**
+```javascript
+// Search messages (full-text)
+app.get('/search', (req, res) => {
+  const { q, chat, limit = 50 } = req.query;
+  if (!q) return res.status(400).json({ error: 'q (query) required' });
+
+  let sql = `
+    SELECT m.*, snippets(messages_fts, 0, '[', ']', '...', 15) as snippet
+    FROM messages_fts f
+    JOIN messages m ON m.id = f.rowid
+    WHERE messages_fts MATCH ?
+  `;
+  const params = [q];
+
+  if (chat) {
+    sql += ` AND m.chat_jid = ?`;
+    params.push(chat);
+  }
+
+  sql += ` ORDER BY rank LIMIT ?`;
+  params.push(parseInt(limit));
+
+  try {
+    const rows = db.prepare(sql).all(...params);
+    res.json({ results: rows, count: rows.length });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+```
+
+**Verify:** `curl "http://127.0.0.1:<port>/search?q=hello&limit=5"`
+
+---
+
+### Task 3: Add backfill endpoint to bridge
+
+**Objective:** Allow Hermes to trigger history backfill on demand
+
+**File:** `~/.hermes/hermes-agent/scripts/whatsapp-bridge/bridge.js`
+
+**Add new endpoint:**
+```javascript
+// Trigger history backfill for a specific chat
+app.post('/backfill', async (req, res) => {
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected' });
+  }
+  const { chatJid, count = 50 } = req.body;
+  if (!chatJid) return res.status(400).json({ error: 'chatJid required' });
+
+  try {
+    // Baileys sends history sync events automatically on cold start
+    // For on-demand backfill, we request sync from the primary device
+    const result = await sock.requestHistoryForChat(chatJid, count);
+    res.json({ success: true, requested: count });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+```
+
+**Note:** If `requestHistoryForChat` doesn't exist in Baileys v7, fall back to:
+```javascript
+// Alternative: just reconnect to trigger full history sync
+await sock柜.reconnect();
+res.json({ success: true, note: 'reconnected to trigger history sync' });
+```
+
+---
+
+### Task 4: Add group management endpoints to bridge
+
+**Objective:** Expose full Baileys group API via HTTP
+
+**File:** `~/.hermes/hermes-agent/scripts/whatsapp-bridge/bridge.js`
+
+**Add all these endpoints after `/backfill`:**
+
+```javascript
+// Create group
+app.post('/group/create', async (req, res) => {
+  if (!sock) return res.status(503).json({ error: 'Not connected' });
+  const { name, participants = [] } = req.body;
+  if (!name) return res.status(400).json({ error: 'name required' });
+  try {
+    const meta = await sock.groupCreate(name, participants);
+    res.json({ success: true, groupJid: meta.id, metadata: meta });
+  } catch (e) { res.status(500).json({ error: e.message }); }
+});
+
+// Rename group
+app.post('/group/rename', async (req, res) => {
+  if (!sock) return res.status(503).json({ error: 'Not connected' });
+  const { groupJid, name } = req.body;
+  try {
+    await sock.groupUpdateSubject(groupJid, name);
+    res.json({ success: true });
+  } catch (e) { res.status(500).json({ error: e.message }); }
+});
+
+// Set group description
+app.post('/group/description', async (req, res) => {
+  if (!sock) return res.status(503).json({ error: 'Not connected' });
+  const { groupJid, description } = req.body;
+  try {
+    await sock.groupUpdateDescription(groupJid, description || '');
+    res.json({ success: true });
+  } catch (e) { res.status(500).json({ error: e.message }); }
+});
+
+// Add participants
+app.post('/group/participants/add', async (req, res) => {
+  if (!sock) return res.status(503).json({ error: 'Not connected' });
+  const { groupJid, participants } = req.body;
+  try {
+    const result = await sock.groupParticipantsUpdate(groupJid, participants, 'add');
+    res.json({ success: true, result });
+  } catch (e) { res.status(500).json({ error: e.message }); }
+});
+
+// Remove participants
+app.post('/group/participants/remove', async (req, res) => {
+  if (!sock) return res.status(503).json({ error: 'Not connected' });
+  const { groupJid, participants } = req.body;
+  try {
+    const result = await sock.groupParticipantsUpdate(groupJid, participants, 'remove');
+    res.json({ success: true, result });
+  } catch (e) { res.status(500).json({ error: e.message }); }
+});
+
+// Promote participants (to admin)
+app.post('/group/participants/promote', async (req, res) => {
+  if (!sock) return res.status(503).json({ error: 'Not connected' });
+  const { groupJid, participants } = req.body;
+  try {
+    const result = await sock.groupParticipantsUpdate(groupJid, participants, 'promote');
+    res.json({ success: true, result });
+  } catch (e) { res.status(500).json({ error: e.message }); }
+});
+
+// Demote participants (remove admin)
+app.post('/group/participants/demote', async (req, res) => {
+  if (!sock) return res.status(503).json({ error: 'Not connected' });
+  const { groupJid, participants } = req.body;
+  try {
+    const result = await sock.groupParticipantsUpdate(groupJid, participants, 'demote');
+    res.json({ success: true, result });
+  } catch (e) { res.status(500).json({ error: e.message }); }
+});
+
+// Get invite link
+app.get('/group/invite/:jid', async (req, res) => {
+  if (!sock) return res.status(503).json({ error: 'Not connected' });
+  try {
+    const code = await sock.groupInviteCode(req.params.jid);
+    res.json({ success: true, code, link: `https://chat.whatsapp.com/${code}` });
+  } catch (e) { res.status(500).json({ error: e.message }); }
+});
+
+// Revoke invite link
+app.post('/group/invite/revoke', async (req, res) => {
+  if (!sock) return res.status(503).json({ error: 'Not connected' });
+  const { groupJid } = req.body;
+  try {
+    const code = await sock.groupRevokeInvite(groupJid);
+    res.json({ success: true, code, link: `https://chat.whatsapp.com/${code}` });
+  } catch (e) { res.status(500).json({ error: e.message }); }
+});
+
+// Leave group
+app.post('/group/leave', async (req, res) => {
+  if (!sock) return res.status(503).json({ error: 'Not connected' });
+  const { groupJid } = req.body;
+  try {
+    await sock.groupLeave(groupJid);
+    res.json({ success: true });
+  } catch (e) { res.status(500).json({ error: e.message }); }
+});
+
+// Get group info
+app.get('/group/info/:jid', async (req, res) => {
+  if (!sock) return res.status(503).json({ error: 'Not connected' });
+  try {
+    const meta = await sock.groupMetadata(req.params.jid);
+    res.json(meta);
+  } catch (e) { res.status(500).json({ error: e.message }); }
+});
+
+// List all groups
+app.get('/groups', async (req, res) => {
+  if (!sock) return res.status(503).json({ error: 'Not connected' });
+  try {
+    const groups = await sock.groupFetchAllParticipating();
+    res.json({ groups: Object.values(groups) });
+  } catch (e) { res.status(500).json({ error: e.message }); }
+});
+
+// Set group icon
+app.post('/group/icon', async (req, res) => {
+  if (!sock) return res.status(503).json({ error: 'Not connected' });
+  const { groupJid, filePath } = req.body;
+  try {
+    if (!existsSync(filePath)) return res.status(404).json({ error: 'File not found' });
+    const buffer = readFileSync(filePath);
+    await sock.updateProfilePicture(groupJid, buffer);
+    res.json({ success: true });
+  } catch (e) { res.status(500).json({ error: e.message }); }
+});
+```
+
+---
+
+### Task 5: Add reactions endpoint to bridge
+
+**Objective:** Send and receive message reactions
+
+**File:** `~/.hermes/hermes-agent/scripts/whatsapp-bridge/bridge.js`
+
+**Add after `/edit`:**
+```javascript
+// Send reaction
+app.post('/react', async (req, res) => {
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected to WhatsApp' });
+  }
+  const { chatId, messageId, emoji } = req.body;
+  if (!chatId || !messageId || !emoji) {
+    return res.status(400).json({ error: 'chatId, messageId, and emoji are required' });
+  }
+  try {
+    const key = { remoteJid: chatId, id: messageId, fromMe: false };
+    await sock.sendMessage(chatId, { text: emoji }, { quoted: key });
+    res.json({ success: true });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+```
+
+**Note:** Baileys v7 reactions use `sendMessage` with a reaction payload. If `text: emoji` with `quoted: key` doesn't work, try:
+```javascript
+await sock.sendMessage(chatId, {
+  reactionMessage: { key, text: emoji }
+});
+```
+
+---
+
+### Task 6: Add poll endpoint to bridge
+
+**Objective:** Create WhatsApp polls
+
+**File:** `~/.hermes/hermes-agent/scripts/whatsapp-bridge/bridge.js`
+
+**Add after `/react`:**
+```javascript
+// Send poll
+app.post('/poll', async (req, res) => {
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected to WhatsApp' });
+  }
+  const { chatId, question, options, selectableCount = 1 } = req.body;
+  if (!chatId || !question || !options || options.length < 2) {
+    return res.status(400).json({ error: 'chatId, question, and at least 2 options required' });
+  }
+  try {
+    const sent = await sock.sendMessage(chatId, {
+      poll: {
+        name: question,
+        selectableCount: selectableCount,
+        values: options,
+      }
+    });
+    res.json({ success: true, messageId: sent?.key?.id });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+```
+
+---
+
+### Task 7: Add voice note and sticker support to bridge
+
+**Objective:** Send voice notes (OGG/Opus) and stickers (WebP)
+
+**File:** `~/.hermes/hermes-agent/scripts/whatsapp-bridge/bridge.js`
+
+**Add to `/send-media` switch case for audio handling (already exists but ensure ptt support):**
+
+The existing `/send-media` already handles audio with `ptt: true` for ogg/opus. Ensure the voice note path works:
+
+**Add sticker send** (new endpoint after `/poll`):
+```javascript
+// Send sticker
+app.post('/sticker', async (req, res) => {
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected to WhatsApp' });
+  }
+  const { chatId, filePath } = req.body;
+  if (!chatId || !filePath) {
+    return res.status(400).json({ error: 'chatId and filePath required' });
+  }
+  try {
+    if (!existsSync(filePath)) {
+      return res.status(404).json({ error: `File not found: ${filePath}` });
+    }
+    const buffer = readFileSync(filePath);
+    await sock.sendMessage(chatId, { sticker: buffer, mimetype: 'image/webp' });
+    res.json({ success: true });
+  } catch (e) {
+    res.status(500).json({ error: e.message });
+  }
+});
+```
+
+---
+
+### Task 8: Install better-sqlite3 in bridge
+
+**Objective:** Add SQLite dependency to the bridge's node_modules
+
+**File:** `~/.hermes/hermes-agent/scripts/whatsapp-bridge/package.json`
+
+**Add dependency:**
+```json
+"better-sqlite3": "^11.0.0"
+```
+
+**Run:**
+```bash
+cd ~/.hermes/hermes-agent/scripts/whatsapp-bridge && npm install better-sqlite3
+```
+
+**Verify:** `ls node_modules/better-sqlite3`
+
+---
+
+## Phase 2: Python Adapter Enhancements (whatsapp.py)
+
+### Task 9: Add all new Python methods to WhatsApp adapter
+
+**Objective:** Expose bridge features as Python async methods
+
+**File:** `~/.hermes/hermes-agent/gateway/platforms/whatsapp.py`
+
+**Add after the existing `send` method:**
+
+```python
+async def search_messages(self, query: str, chat_jid: str = None, limit: int = 50) -> Dict[str, Any]:
+    """Full-text search of local WhatsApp message history."""
+    params = {"q": query, "limit": str(limit)}
+    if chat_jid:
+        params["chat"] = chat_jid
+    async with aiohttp.ClientSession() as session:
+        async with session.get(f"{self._bridge_url}/search", params=params) as resp:
+            return await resp.json()
+
+async def backfill_chat(self, chat_jid: str, count: int = 50) -> Dict[str, Any]:
+    """Request history backfill for a specific chat."""
+    async with aiohttp.ClientSession() as session:
+        async with session.post(f"{self._bridge_url}/backfill", json={"chatJid": chat_jid, "count": count}) as resp:
+            return await resp.json()
+
+async def create_group(self, name: str, participants: List[str]) -> Dict[str, Any]:
+    """Create a WhatsApp group."""
+    async with aiohttp.ClientSession() as session:
+        async with session.post(f"{self._bridge_url}/group/create", json={"name": name, "participants": participants}) as resp:
+            return await resp.json()
+
+async def rename_group(self, group_jid: str, name: str) -> Dict[str, Any]:
+    async with aiohttp.ClientSession() as session:
+        async with session.post(f"{self._bridge_url}/group/rename", json={"groupJid": group_jid, "name": name}) as resp:
+            return await resp.json()
+
+async def set_group_description(self, group_jid: str, description: str) -> Dict[str, Any]:
+    async with aiohttp.ClientSession() as session:
+        async with session.post(f"{self._bridge_url}/group/description", json={"groupJid": group_jid, "description": description}) as resp:
+            return await resp.json()
+
+async def add_group_participants(self, group_jid: str, participants: List[str]) -> Dict[str, Any]:
+    async with aiohttp.ClientSession() as session:
+        async with session.post(f"{self._bridge_url}/group/participants/add", json={"groupJid": group_jid, "participants": participants}) as resp:
+            return await resp.json()
+
+async def remove_group_participants(self, group_jid: str, participants: List[str]) -> Dict[str, Any]:
+    async with aiohttp.ClientSession() as session:
+        async with session.post(f"{self._bridge_url}/group/participants/remove", json={"groupJid": group_jid, "participants": participants}) as resp:
+            return await resp.json()
+
+async def promote_group_participants(self, group_jid: str, participants: List[str]) -> Dict[str, Any]:
+    async with aiohttp.ClientSession() as session:
+        async with session.post(f"{self._bridge_url}/group/participants/promote", json={"groupJid": group_jid, "participants": participants}) as resp:
+            return await resp.json()
+
+async def demote_group_participants(self, group_jid: str, participants: List[str]) -> Dict[str, Any]:
+    async with aiohttp.ClientSession() as session:
+        async with session.post(f"{self._bridge_url}/group/participants/demote", json={"groupJid": group_jid, "participants": participants}) as resp:
+            return await resp.json()
+
+async def get_group_invite_link(self, group_jid: str) -> Dict[str, Any]:
+    async with aiohttp.ClientSession() as session:
+        async with session.get(f"{self._bridge_url}/group/invite/{group_jid}") as resp:
+            return await resp.json()
+
+async def revoke_group_invite_link(self, group_jid: str) -> Dict[str, Any]:
+    async with aiohttp.ClientSession() as session:
+        async with session.post(f"{self._bridge_url}/group/invite/revoke", json={"groupJid": group_jid}) as resp:
+            return await resp.json()
+
+async def leave_group(self, group_jid: str) -> Dict[str, Any]:
+    async with aiohttp.ClientSession() as session:
+        async with session.post(f"{self._bridge_url}/group/leave", json={"groupJid": group_jid}) as resp:
+            return await resp.json()
+
+async def get_group_info(self, group_jid: str) -> Dict[str, Any]:
+    async with aiohttp.ClientSession() as session:
+        async with session.get(f"{self._bridge_url}/group/info/{group_jid}") as resp:
+            return await resp.json()
+
+async def list_groups(self) -> Dict[str, Any]:
+    async with aiohttp.ClientSession() as session:
+        async with session.get(f"{self._bridge_url}/groups") as resp:
+            return await resp.json()
+
+async def set_group_icon(self, group_jid: str, file_path: str) -> Dict[str, Any]:
+    async with aiohttp.ClientSession() as session:
+        async with session.post(f"{self._bridge_url}/group/icon", json={"groupJid": group_jid, "filePath": file_path}) as resp:
+            return await resp.json()
+
+async def send_reaction(self, chat_jid: str, message_id: str, emoji: str) -> Dict[str, Any]:
+    """Send a reaction emoji to a specific message."""
+    async with aiohttp.ClientSession() as session:
+        async with session.post(f"{self._bridge_url}/react", json={"chatId": chat_jid, "messageId": message_id, "emoji": emoji}) as resp:
+            return await resp.json()
+
+async def send_poll(self, chat_jid: str, question: str, options: List[str], selectable_count: int = 1) -> Dict[str, Any]:
+    """Send a poll to a chat."""
+    async with aiohttp.ClientSession() as session:
+        async with session.post(f"{self._bridge_url}/poll", json={
+            "chatId": chat_jid, "question": question, "options": options, "selectableCount": selectable_count
+        }) as resp:
+            return await resp.json()
+
+async def send_sticker(self, chat_jid: str, file_path: str) -> Dict[str, Any]:
+    """Send a WebP sticker to a chat."""
+    async with aiohttp.ClientSession() as session:
+        async with session.post(f"{self._bridge_url}/sticker", json={"chatId": chat_jid, "filePath": file_path}) as resp:
+            return await resp.json()
+```
+
+**Note:** Ensure `aiohttp` is imported at the top of `whatsapp.py`. If not:
+```python
+import aiohttp
+```
+
+---
+
+### Task 10: Expose WhatsApp tools to the agent
+
+**Objective:** Register WhatsApp-specific methods as Hermes tools so the agent can call them
+
+**File:** `~/.hermes/hermes-agent/gateway/platforms/whatsapp.py`
+
+**In the `WhatsAppPlatform.__init__` or after the existing tool registration, add:**
+
+```python
+# Register WhatsApp-specific tools
+self._register_tool("whatsapp_search", self.search_messages, {
+    "query": {"type": "string", "description": "Search query"},
+    "chat_jid": {"type": "string", "description": "Optional: filter to specific chat JID"},
+    "limit": {"type": "integer", "description": "Max results (default 50)"}
+})
+
+self._register_tool("whatsapp_backfill", self.backfill_chat, {
+    "chat_jid": {"type": "string", "description": "Chat JID to backfill"},
+    "count": {"type": "integer", "description": "Number of messages to request"}
+})
+
+self._register_tool("whatsapp_create_group", self.create_group, {
+    "name": {"type": "string", "description": "Group name"},
+    "participants": {"type": "array", "items": {"type": "string"}, "description": "Participant JIDs"}
+})
+
+self._register_tool("whatsapp_rename_group", self.rename_group, {
+    "group_jid": {"type": "string"},
+    "name": {"type": "string"}
+})
+
+self._register_tool("whatsapp_set_description", self.set_group_description, {
+    "group_jid": {"type": "string"},
+    "description": {"type": "string"}
+})
+
+self._register_tool("whatsapp_add_participants", self.add_group_participants, {
+    "group_jid": {"type": "string"},
+    "participants": {"type": "array", "items": {"type": "string"}}
+})
+
+self._register_tool("whatsapp_remove_participants", self.remove_group_participants, {
+    "group_jid": {"type": "string"},
+    "participants": {"type": "array", "items": {"type": "string"}}
+})
+
+self._register_tool("whatsapp_promote_participants", self.promote_group_participants, {
+    "group_jid": {"type": "string"},
+    "participants": {"type": "array", "items": {"type": "string"}}
+})
+
+self._register_tool("whatsapp_get_invite_link", self.get_group_invite_link, {
+    "group_jid": {"type": "string"}
+})
+
+self._register_tool("whatsapp_revoke_invite", self.revoke_group_invite_link, {
+    "group_jid": {"type": "string"}
+})
+
+self._register_tool("whatsapp_leave_group", self.leave_group, {
+    "group_jid": {"type": "string"}
+})
+
+self._register_tool("whatsapp_get_group_info", self.get_group_info, {
+    "group_jid": {"type": "string"}
+})
+
+self._register_tool("whatsapp_list_groups", self.list_groups, {})
+
+self._register_tool("whatsapp_send_reaction", self.send_reaction, {
+    "chat_jid": {"type": "string"},
+    "message_id": {"type": "string"},
+    "emoji": {"type": "string"}
+})
+
+self._register_tool("whatsapp_send_poll", self.send_poll, {
+    "chat_jid": {"type": "string"},
+    "question": {"type": "string"},
+    "options": {"type": "array", "items": {"type": "string"}},
+    "selectable_count": {"type": "integer"}
+})
+
+self._register_tool("whatsapp_send_sticker", self.send_sticker, {
+    "chat_jid": {"type": "string"},
+    "file_path": {"type": "string"}
+})
+```
+
+**Note:** The `_register_tool` pattern should match how other tools are registered in the adapter. If the existing adapter doesn't have a `_register_tool` method, add tools to the gateway's tool registry via the standard Hermes tool registration mechanism.
+
+---
+
+### Task 11: Add a WhatsAppUltimate skill document
+
+**Objective:** Document all the new WhatsApp features for the agent
+
+**File:** `~/.hermes/skills/social-media/whatsapp-ultimate/SKILL.md`
+
+**Create skill directory and file:**
+```bash
+mkdir -p ~/.hermes/skills/social-media/whatsapp-ultimate
+```
+
+**Content should include:**
+- All features (group management, polls, reactions, search, etc.)
+- JID format reference
+- Example tool calls
+- Tips (voice notes = OGG/Opus, stickers = WebP 512x512, etc.)
+
+---
+
+## Phase 3: Testing & Integration
+
+### Task 12: Restart gateway and verify all endpoints work
+
+**Step 1: Restart the bridge (restart the gateway)**
+```bash
+sudo systemctl restart hermes-gateway
+sleep 5
+journalctl -u hermes-gateway -f
+```
+
+**Step 2: Test health**
+```bash
+curl http://127.0.0.1:<bridge_port>/health
+```
+
+**Step 3: Test search**
+```bash
+curl "http://127.0.0.1:<bridge_port>/search?q=hello"
+```
+
+**Step 4: Test group creation (from Hermes chat)**
+```
+Create a WhatsApp group called "AI Agents Test" with myself
+```
+
+### Task 13: Test full workflow
+
+From Hermes chat (Telegram or web dashboard):
+1. "Search my WhatsApp messages for 'meeting'"
+2. "Create a group called X with +91XXXXXXXXX"
+3. "Send a poll to that group: 'Which time? Options: 3pm, 4pm, 5pm'"
+4. "Add +91XXXXXXXXX to the group"
+5. "What's the invite link for the group?"
+6. "Search for messages with attachments"
+
+---
+
+## Implementation Order
+
+1. **Task 8** — Install better-sqlite3 (dependency, needed first)
+2. **Task 1** — Add SQLite + FTS5 to bridge (foundation)
+3. **Task 2** — Add search endpoint
+4. **Task 3** — Add backfill endpoint
+5. **Task 4** — Add group management endpoints
+6. **Task 5** — Add reactions endpoint
+7. **Task 6** — Add poll endpoint
+8. **Task 7** — Add sticker endpoint
+9. **Task 9** — Add Python methods
+10. **Task 10** — Register tools with agent
+11. **Task 11** — Write skill doc
+12. **Task 12-13** — Test everything
+
+---
+
+## Verification Checklist
+
+After implementation:
+- [ ] `curl /health` returns connected
+- [ ] Messages stored in SQLite (`sqlite3 ~/.hermes/whatsapp/messages.db "SELECT COUNT(*) FROM messages"`)
+- [ ] Search returns results: `curl "/search?q=hello"`
+- [ ] Group creation works from Hermes chat
+- [ ] Poll creation works from Hermes chat
+- [ ] Reactions work
+- [ ] Voice notes send (as OGG)
+- [ ] Stickers send (as WebP)
+- [ ] Backfill triggers history sync
+- [ ] All groups listed: `curl /groups`
+- [ ] Invite link generated
+- [ ] Agent can use all tools via natural language

--- a/docs/skills/whatsapp-ultimate/SKILL.md
+++ b/docs/skills/whatsapp-ultimate/SKILL.md
@@ -1,0 +1,287 @@
+---
+name: whatsapp-ultimate
+description: Full-featured WhatsApp integration for Hermes Agent — local SQLite storage, full-text search, group management, polls, reactions, stickers, backfill, and more.
+version: 1.0.0
+author: Pratik Golechha ( NousResearch/hermes-agent#12605 )
+tags: [whatsapp, messaging, groups, polls, reactions, search, local-storage]
+hermes:
+  platform: whatsapp
+  features:
+    - local_storage
+    - full_text_search
+    - backfill
+    - group_management
+    - polls
+    - reactions
+    - stickers
+    - voice_notes
+    - unsend
+---
+
+# WhatsApp Ultimate
+
+A comprehensive WhatsApp platform integration for Hermes Agent. Extends the base WhatsApp bridge with **local SQLite storage**, **full-text search**, **group management**, **polls**, **reactions**, **stickers**, and more.
+
+## Features
+
+### Local Message Storage
+Every incoming/outgoing WhatsApp message is automatically persisted to a local SQLite database (`~/.hermes/whatsapp/messages.db`) with FTS5 full-text search indexing.
+
+### Full-Text Search
+Search all WhatsApp message history instantly using FTS5. Filter by chat or search across all chats.
+
+### Message Backfill
+On-demand history sync — fetch any amount of historical messages from WhatsApp servers and store them locally for offline search.
+
+### Group Management (Full)
+- Create groups with name and participants
+- Rename groups (change subject)
+- Set/update group description
+- Add/remove participants
+- Promote participants to admin
+- Get invite links
+- Revoke invite links
+- Leave groups
+
+### Advanced Messaging
+- **Polls**: Send interactive polls to groups or DMs — members vote directly in WhatsApp
+- **Reactions**: Send emoji reactions to any message
+- **Stickers**: Send .webp sticker files
+- **Unsend**: Delete sent messages for everyone
+
+## Prerequisites
+
+- Hermes Agent with WhatsApp bridge enabled
+- WhatsApp connected via QR code scan (one-time)
+- Node.js 18+ for the bridge
+- `better-sqlite3` npm package (auto-installed)
+
+## Configuration
+
+In your `config.yaml`:
+
+```yaml
+platforms:
+  whatsapp:
+    enabled: true
+    bridge_port: 3000          # default
+    session_path: ~/.hermes/whatsapp/session
+    mode: self-chat            # or "bot" for a separate bot number
+    reply_prefix: "⚙ *Hermes Agent*\n────────────\n"  # optional
+```
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `WHATSAPP_ENABLED` | `false` | Enable WhatsApp platform |
+| `WHATSAPP_MODE` | `self-chat` | `self-chat` (your number) or `bot` (separate number) |
+| `WHATSAPP_BRIDGE_PORT` | `3000` | Bridge HTTP server port |
+| `WHATSAPP_ALLOWED_USERS` | `*` | Comma-separated list of allowed phone numbers |
+| `WHATSAPP_REPLY_PREFIX` | (none) | Prefix added to outgoing messages |
+| `WHATSAPP_REQUIRE_MENTION` | `false` | Require @mention in groups to respond |
+
+## Connecting WhatsApp
+
+1. Enable WhatsApp in `config.yaml`
+2. Start/restart the gateway: `hermes restart`
+3. Watch the gateway log: `journalctl -u hermes-gateway -f`
+4. Scan the QR code shown in the logs with WhatsApp on your phone
+5. Done — WhatsApp is now connected
+
+## Available Tools
+
+### Search & Storage
+
+#### `whatsapp_search`
+Search message history using full-text search.
+
+```
+whatsapp_search(query="project update", chat_id=None, limit=50)
+```
+
+#### `whatsapp_backfill`
+Fetch historical messages from WhatsApp into local storage.
+
+```
+whatsapp_backfill(chat_id="123456789@g.us", limit=100)
+```
+
+### Group Management
+
+#### `whatsapp_list_groups`
+List all WhatsApp groups with metadata.
+
+```
+whatsapp_list_groups()
+→ { groups: [{ jid, name, description, size, owner, ... }] }
+```
+
+#### `whatsapp_create_group`
+Create a new WhatsApp group.
+
+```
+whatsapp_create_group(name="Project Team", participants=["+1234567890"])
+→ { success: true, groupJid: "..." }
+```
+
+#### `whatsapp_group_rename`
+Rename a group (change subject).
+
+```
+whatsapp_group_rename(chat_id="123456789@g.us", name="New Name")
+```
+
+#### `whatsapp_group_description`
+Set the group description.
+
+```
+whatsapp_group_description(chat_id="123456789@g.us", description="Team discussions")
+```
+
+#### `whatsapp_group_participants_add`
+Add participants to a group.
+
+```
+whatsapp_group_participants_add(chat_id="123456789@g.us", participants=["+1987654321"])
+```
+
+#### `whatsapp_group_participants_remove`
+Remove participants from a group.
+
+```
+whatsapp_group_participants_remove(chat_id="123456789@g.us", participants=["+1987654321"])
+```
+
+#### `whatsapp_group_participants_promote`
+Promote participants to admin.
+
+```
+whatsapp_group_participants_promote(chat_id="123456789@g.us", participants=["+1987654321"])
+```
+
+#### `whatsapp_group_invite_link`
+Get the group invite link.
+
+```
+whatsapp_group_invite_link(chat_id="123456789@g.us")
+→ { invite_link: "https://chat.whatsapp.com/..." }
+```
+
+#### `whatsapp_group_invite_link_revoke`
+Revoke current invite link and generate a new one.
+
+```
+whatsapp_group_invite_link_revoke(chat_id="123456789@g.us")
+→ { invite_link: "https://chat.whatsapp.com/..." }
+```
+
+#### `whatsapp_group_leave`
+Leave a group.
+
+```
+whatsapp_group_leave(chat_id="123456789@g.us")
+```
+
+### Advanced Messaging
+
+#### `whatsapp_send_reaction`
+React to a message with an emoji.
+
+```
+whatsapp_send_reaction(chat_id="123456789@g.us", message_id="xyz", emoji="👍")
+```
+
+#### `whatsapp_send_poll`
+Send a poll. Members vote directly in WhatsApp.
+
+```
+whatsapp_send_poll(
+    chat_id="123456789@g.us",
+    question="Which day works best for the meeting?",
+    options=["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"],
+    multiple_answers=False
+)
+```
+
+#### `whatsapp_send_sticker`
+Send a .webp sticker file.
+
+```
+whatsapp_send_sticker(chat_id="123456789@s.whatsapp.net", file_path="/path/to/sticker.webp")
+```
+
+#### `whatsapp_unsend_message`
+Delete a sent message for everyone (within 24h limit).
+
+```
+whatsapp_unsend_message(chat_id="123456789@s.whatsapp.net", message_id="xyz")
+```
+
+## Example Agent Prompts
+
+**Search history:**
+> "Search my WhatsApp chats for mentions of the project deadline"
+
+**Create a group:**
+> "Create a WhatsApp group called 'Weekend Plans' with +1234567890 and +0987654321"
+
+**Send a poll:**
+> "Create a poll in the family group asking 'What's for dinner?' with options Pizza, Tacos, Sushi"
+
+**React to a message:**
+> "React 👍 to the last message in the team group"
+
+**Get group invite:**
+> "Get the invite link for the project team group"
+
+## Architecture
+
+```
+WhatsApp → Baileys (Node.js bridge.js) → Python adapter (whatsapp.py) → Hermes Agent
+                    ↓
+              SQLite + FTS5
+           (~/.hermes/whatsapp/messages.db)
+```
+
+### Bridge Endpoints (Node.js)
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/search` | GET | FTS5 full-text search |
+| `/backfill` | POST | Fetch and store history |
+| `/groups` | GET | List all groups |
+| `/group/create` | POST | Create group |
+| `/group/rename` | POST | Change subject |
+| `/group/description` | POST | Set description |
+| `/group/participants/add` | POST | Add participants |
+| `/group/participants/remove` | POST | Remove participants |
+| `/group/participants/promote` | POST | Promote to admin |
+| `/group/invite-link` | GET | Get invite link |
+| `/group/invite-link/revoke` | POST | Revoke link |
+| `/group/leave` | POST | Leave group |
+| `/react` | POST | Emoji reaction |
+| `/poll` | POST | Create poll |
+| `/sticker` | POST | Send sticker |
+| `/message` | DELETE | Unsend message |
+
+## Troubleshooting
+
+### QR code not showing
+Check the bridge log: `tail -f ~/.hermes/whatsapp/bridge.log`
+
+### "Not connected to WhatsApp"
+The bridge process may have crashed. Restart the gateway: `hermes restart`
+
+### Search returns no results
+Make sure messages have been received since the upgrade. Use `whatsapp_backfill` to populate old messages.
+
+### better-sqlite3 build errors
+```bash
+cd ~/.hermes/hermes-agent/scripts/whatsapp-bridge
+npm install --build-from-source better-sqlite3
+```
+
+## Contributing
+
+This feature is part of [PR #12605](https://github.com/NousResearch/hermes-agent/pull/12605) — "feat(whatsapp): WhatsApp Ultimate". See the plan in `docs/plans/whatsapp-ultimate-hermes.md` for full implementation details.

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -824,7 +824,281 @@ class WhatsAppAdapter(BasePlatformAdapter):
             logger.debug("Could not get WhatsApp chat info for %s: %s", chat_id, e)
         
         return {"name": chat_id, "type": "dm"}
-    
+
+    async def whatsapp_search(self, query: str, chat_id: Optional[str] = None, limit: int = 50) -> Dict[str, Any]:
+        """Search messages via FTS5 in local SQLite storage."""
+        if not self._running or not self._http_session:
+            return {"error": "Not connected"}
+        if await self._check_managed_bridge_exit():
+            return {"error": "Bridge exited"}
+        try:
+            import aiohttp
+            params = {"q": query, "limit": str(limit)}
+            if chat_id:
+                params["chat_id"] = chat_id
+            async with self._http_session.get(
+                f"http://127.0.0.1:{self._bridge_port}/search",
+                params=params,
+                timeout=aiohttp.ClientTimeout(total=15)
+            ) as resp:
+                return await resp.json()
+        except Exception as e:
+            return {"error": str(e)}
+
+    async def whatsapp_backfill(self, chat_id: str, limit: int = 50) -> Dict[str, Any]:
+        """Backfill historical messages from WhatsApp into local SQLite storage."""
+        if not self._running or not self._http_session:
+            return {"error": "Not connected"}
+        if await self._check_managed_bridge_exit():
+            return {"error": "Bridge exited"}
+        try:
+            import aiohttp
+            async with self._http_session.post(
+                f"http://127.0.0.1:{self._bridge_port}/backfill",
+                json={"chat_id": chat_id, "limit": limit},
+                timeout=aiohttp.ClientTimeout(total=60)
+            ) as resp:
+                return await resp.json()
+        except Exception as e:
+            return {"error": str(e)}
+
+    async def whatsapp_list_groups(self) -> Dict[str, Any]:
+        """List all WhatsApp groups with metadata."""
+        if not self._running or not self._http_session:
+            return {"error": "Not connected"}
+        if await self._check_managed_bridge_exit():
+            return {"error": "Bridge exited"}
+        try:
+            import aiohttp
+            async with self._http_session.get(
+                f"http://127.0.0.1:{self._bridge_port}/groups",
+                timeout=aiohttp.ClientTimeout(total=15)
+            ) as resp:
+                return await resp.json()
+        except Exception as e:
+            return {"error": str(e)}
+
+    async def whatsapp_create_group(self, name: str, participants: list[str]) -> Dict[str, Any]:
+        """Create a WhatsApp group."""
+        if not self._running or not self._http_session:
+            return {"error": "Not connected"}
+        if await self._check_managed_bridge_exit():
+            return {"error": "Bridge exited"}
+        try:
+            import aiohttp
+            async with self._http_session.post(
+                f"http://127.0.0.1:{self._bridge_port}/group/create",
+                json={"name": name, "participants": participants},
+                timeout=aiohttp.ClientTimeout(total=15)
+            ) as resp:
+                return await resp.json()
+        except Exception as e:
+            return {"error": str(e)}
+
+    async def whatsapp_group_rename(self, chat_id: str, name: str) -> Dict[str, Any]:
+        """Rename a WhatsApp group (change subject)."""
+        if not self._running or not self._http_session:
+            return {"error": "Not connected"}
+        if await self._check_managed_bridge_exit():
+            return {"error": "Bridge exited"}
+        try:
+            import aiohttp
+            async with self._http_session.post(
+                f"http://127.0.0.1:{self._bridge_port}/group/rename",
+                json={"chat_id": chat_id, "name": name},
+                timeout=aiohttp.ClientTimeout(total=15)
+            ) as resp:
+                return await resp.json()
+        except Exception as e:
+            return {"error": str(e)}
+
+    async def whatsapp_group_description(self, chat_id: str, description: str) -> Dict[str, Any]:
+        """Set a WhatsApp group's description."""
+        if not self._running or not self._http_session:
+            return {"error": "Not connected"}
+        if await self._check_managed_bridge_exit():
+            return {"error": "Bridge exited"}
+        try:
+            import aiohttp
+            async with self._http_session.post(
+                f"http://127.0.0.1:{self._bridge_port}/group/description",
+                json={"chat_id": chat_id, "description": description},
+                timeout=aiohttp.ClientTimeout(total=15)
+            ) as resp:
+                return await resp.json()
+        except Exception as e:
+            return {"error": str(e)}
+
+    async def whatsapp_group_participants_add(self, chat_id: str, participants: list[str]) -> Dict[str, Any]:
+        """Add participants to a WhatsApp group."""
+        if not self._running or not self._http_session:
+            return {"error": "Not connected"}
+        if await self._check_managed_bridge_exit():
+            return {"error": "Bridge exited"}
+        try:
+            import aiohttp
+            async with self._http_session.post(
+                f"http://127.0.0.1:{self._bridge_port}/group/participants/add",
+                json={"chat_id": chat_id, "participants": participants},
+                timeout=aiohttp.ClientTimeout(total=15)
+            ) as resp:
+                return await resp.json()
+        except Exception as e:
+            return {"error": str(e)}
+
+    async def whatsapp_group_participants_remove(self, chat_id: str, participants: list[str]) -> Dict[str, Any]:
+        """Remove participants from a WhatsApp group."""
+        if not self._running or not self._http_session:
+            return {"error": "Not connected"}
+        if await self._check_managed_bridge_exit():
+            return {"error": "Bridge exited"}
+        try:
+            import aiohttp
+            async with self._http_session.post(
+                f"http://127.0.0.1:{self._bridge_port}/group/participants/remove",
+                json={"chat_id": chat_id, "participants": participants},
+                timeout=aiohttp.ClientTimeout(total=15)
+            ) as resp:
+                return await resp.json()
+        except Exception as e:
+            return {"error": str(e)}
+
+    async def whatsapp_group_participants_promote(self, chat_id: str, participants: list[str]) -> Dict[str, Any]:
+        """Promote participants to admin in a WhatsApp group."""
+        if not self._running or not self._http_session:
+            return {"error": "Not connected"}
+        if await self._check_managed_bridge_exit():
+            return {"error": "Bridge exited"}
+        try:
+            import aiohttp
+            async with self._http_session.post(
+                f"http://127.0.0.1:{self._bridge_port}/group/participants/promote",
+                json={"chat_id": chat_id, "participants": participants},
+                timeout=aiohttp.ClientTimeout(total=15)
+            ) as resp:
+                return await resp.json()
+        except Exception as e:
+            return {"error": str(e)}
+
+    async def whatsapp_group_invite_link(self, chat_id: str) -> Dict[str, Any]:
+        """Get the invite link for a WhatsApp group."""
+        if not self._running or not self._http_session:
+            return {"error": "Not connected"}
+        if await self._check_managed_bridge_exit():
+            return {"error": "Bridge exited"}
+        try:
+            import aiohttp
+            async with self._http_session.get(
+                f"http://127.0.0.1:{self._bridge_port}/group/invite-link",
+                params={"chat_id": chat_id},
+                timeout=aiohttp.ClientTimeout(total=15)
+            ) as resp:
+                return await resp.json()
+        except Exception as e:
+            return {"error": str(e)}
+
+    async def whatsapp_group_invite_link_revoke(self, chat_id: str) -> Dict[str, Any]:
+        """Revoke and regenerate the invite link for a WhatsApp group."""
+        if not self._running or not self._http_session:
+            return {"error": "Not connected"}
+        if await self._check_managed_bridge_exit():
+            return {"error": "Bridge exited"}
+        try:
+            import aiohttp
+            async with self._http_session.post(
+                f"http://127.0.0.1:{self._bridge_port}/group/invite-link/revoke",
+                json={"chat_id": chat_id},
+                timeout=aiohttp.ClientTimeout(total=15)
+            ) as resp:
+                return await resp.json()
+        except Exception as e:
+            return {"error": str(e)}
+
+    async def whatsapp_group_leave(self, chat_id: str) -> Dict[str, Any]:
+        """Leave a WhatsApp group."""
+        if not self._running or not self._http_session:
+            return {"error": "Not connected"}
+        if await self._check_managed_bridge_exit():
+            return {"error": "Bridge exited"}
+        try:
+            import aiohttp
+            async with self._http_session.post(
+                f"http://127.0.0.1:{self._bridge_port}/group/leave",
+                json={"chat_id": chat_id},
+                timeout=aiohttp.ClientTimeout(total=15)
+            ) as resp:
+                return await resp.json()
+        except Exception as e:
+            return {"error": str(e)}
+
+    async def whatsapp_send_reaction(self, chat_id: str, message_id: str, emoji: str) -> Dict[str, Any]:
+        """Send an emoji reaction to a specific message."""
+        if not self._running or not self._http_session:
+            return {"error": "Not connected"}
+        if await self._check_managed_bridge_exit():
+            return {"error": "Bridge exited"}
+        try:
+            import aiohttp
+            async with self._http_session.post(
+                f"http://127.0.0.1:{self._bridge_port}/react",
+                json={"chat_id": chat_id, "message_id": message_id, "emoji": emoji},
+                timeout=aiohttp.ClientTimeout(total=10)
+            ) as resp:
+                return await resp.json()
+        except Exception as e:
+            return {"error": str(e)}
+
+    async def whatsapp_send_poll(self, chat_id: str, question: str, options: list[str], multiple_answers: bool = False) -> Dict[str, Any]:
+        """Send a poll to a WhatsApp chat."""
+        if not self._running or not self._http_session:
+            return {"error": "Not connected"}
+        if await self._check_managed_bridge_exit():
+            return {"error": "Bridge exited"}
+        try:
+            import aiohttp
+            async with self._http_session.post(
+                f"http://127.0.0.1:{self._bridge_port}/poll",
+                json={"chat_id": chat_id, "question": question, "options": options, "multiple_answers": multiple_answers},
+                timeout=aiohttp.ClientTimeout(total=15)
+            ) as resp:
+                return await resp.json()
+        except Exception as e:
+            return {"error": str(e)}
+
+    async def whatsapp_send_sticker(self, chat_id: str, file_path: str) -> Dict[str, Any]:
+        """Send a .webp sticker to a WhatsApp chat."""
+        if not self._running or not self._http_session:
+            return {"error": "Not connected"}
+        if await self._check_managed_bridge_exit():
+            return {"error": "Bridge exited"}
+        try:
+            import aiohttp
+            async with self._http_session.post(
+                f"http://127.0.0.1:{self._bridge_port}/sticker",
+                json={"chat_id": chat_id, "file_path": file_path},
+                timeout=aiohttp.ClientTimeout(total=30)
+            ) as resp:
+                return await resp.json()
+        except Exception as e:
+            return {"error": str(e)}
+
+    async def whatsapp_unsend_message(self, chat_id: str, message_id: str) -> Dict[str, Any]:
+        """Unsend (delete for everyone) a message."""
+        if not self._running or not self._http_session:
+            return {"error": "Not connected"}
+        if await self._check_managed_bridge_exit():
+            return {"error": "Bridge exited"}
+        try:
+            import aiohttp
+            async with self._http_session.delete(
+                f"http://127.0.0.1:{self._bridge_port}/message",
+                json={"chat_id": chat_id, "message_id": message_id},
+                timeout=aiohttp.ClientTimeout(total=10)
+            ) as resp:
+                return await resp.json()
+        except Exception as e:
+            return {"error": str(e)}
+
     async def _poll_messages(self) -> None:
         """Poll the bridge for incoming messages."""
         import aiohttp

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1946,16 +1946,37 @@ def _setup_whatsapp():
     existing = get_env_value("WHATSAPP_ENABLED")
     if existing:
         print_info("WhatsApp: already enabled")
+        ultimate_existing = get_env_value("WHATSAPP_ULTIMATE")
+        print_info(f"WhatsApp mode: {'Ultimate' if ultimate_existing == 'true' else 'Standard'}")
         return
 
     print_info("WhatsApp connects via a built-in bridge (Baileys).")
     print_info("Requires Node.js. Run 'hermes whatsapp' for guided setup.")
     print()
+
+    # Ask which mode: Standard vs Ultimate
+    mode_desc = [
+        "Standard — send/receive only, no local message storage",
+        "Ultimate  — SQLite storage, FTS5 search, group mgmt, polls, reactions",
+    ]
+    mode_idx = prompt_choice(
+        "Which WhatsApp mode?",
+        ["Standard (lightweight)", "WhatsApp Ultimate (full-featured)"],
+        default=0,
+        description=mode_desc,
+    )
+    is_ultimate = mode_idx == 1
+
     if prompt_yes_no("Enable WhatsApp now?", True):
         save_env_value("WHATSAPP_ENABLED", "true")
-        print_success("WhatsApp enabled")
-        print_info("Run 'hermes whatsapp' to choose your mode (separate bot number")
-        print_info("or personal self-chat) and pair via QR code.")
+        if is_ultimate:
+            save_env_value("WHATSAPP_ULTIMATE", "true")
+            print_success("WhatsApp enabled (Ultimate mode)")
+        else:
+            # Clear any stale Ultimate flag
+            save_env_value("WHATSAPP_ULTIMATE", "false")
+            print_success("WhatsApp enabled (Standard mode)")
+        print_info("Run 'hermes whatsapp' to pair via QR code.")
 
 
 def _setup_weixin():

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -649,6 +649,8 @@ app.get('/search', (req, res) => {
 });
 
 // ─── Backfill endpoint ──────────────────────────────────────────────
+// Baileys v7 uses fetchMessageHistory(count, oldestMsgKey, oldestMsgTimestamp)
+// which requires a starting message. We use the oldest stored message as anchor.
 app.post('/backfill', async (req, res) => {
   if (!WHATSAPP_ULTIMATE) {
     return res.status(403).json({ error: 'Backfill requires WHATSAPP_ULTIMATE=true. Run "hermes setup" to enable.' });
@@ -656,34 +658,50 @@ app.post('/backfill', async (req, res) => {
   if (!sock || connectionState !== 'connected') {
     return res.status(503).json({ error: 'Not connected to WhatsApp' });
   }
-  
+
   const { chat_id, limit = 50 } = req.body;
   if (!chat_id) return res.status(400).json({ error: 'chat_id is required' });
-  
+
+  if (!db) return res.status(503).json({ error: 'SQLite not available' });
+
   try {
-    // Baileys v7: chatFetch takes (jid, { requests })
-    const conversation = await sock.chatFetch(chat_id, {
-      requests: [{ limit: parseInt(limit), type: 'messages' }],
-    });
-    // conversation is a map of jid -> { messages: [] }
-    const messages = conversation?.[chat_id]?.messages || [];
+    // Find oldest stored message for this chat to use as anchor
+    const oldest = db.prepare(
+      'SELECT id, timestamp FROM messages WHERE chat_id = ? ORDER BY timestamp ASC LIMIT 1'
+    ).get(chat_id);
+
+    let oldestMsgKey = null;
+    let oldestMsgTimestamp = Math.floor(Date.now() / 1000); // default: now
+
+    if (oldest) {
+      oldestMsgKey = { remoteJid: chat_id, id: oldest.id, fromMe: false };
+      oldestMsgTimestamp = oldest.timestamp;
+    }
+
+    // Baileys v7: fetchMessageHistory(count, oldestMsgKey, oldestMsgTimestamp)
+    // Requests older messages from the phone relative to the anchor
+    const fetchedMessages = await sock.fetchMessageHistory(
+      parseInt(limit),
+      oldestMsgKey,
+      oldestMsgTimestamp
+    );
+
     let stored = 0;
-    
-    for (const msg of messages) {
+    for (const msg of fetchedMessages || []) {
       if (!msg?.key?.id) continue;
       const chatId = msg.key.remoteJid;
       if (!chatId) continue;
-      
+
       const isGroup = chatId.endsWith('@g.us');
       const senderId = msg.key.participant || chatId;
       const senderNumber = senderId.replace(/@.*/, '');
       const messageContent = getMessageContent(msg);
-      
+
       let body = '';
       let hasMedia = false;
       let mediaType = '';
       const mediaUrls = [];
-      
+
       if (messageContent.conversation) body = messageContent.conversation;
       else if (messageContent.extendedTextMessage?.text) body = messageContent.extendedTextMessage.text;
       else if (messageContent.imageMessage) {
@@ -698,10 +716,10 @@ app.post('/backfill', async (req, res) => {
         body = messageContent.documentMessage.caption || '';
         hasMedia = true; mediaType = 'document';
       }
-      
+
       if (hasMedia && !body) body = `[${mediaType} received]`;
       if (!body && !hasMedia) continue;
-      
+
       const event = {
         messageId: msg.key.id,
         chatId,
@@ -718,12 +736,12 @@ app.post('/backfill', async (req, res) => {
         botIds: [],
         timestamp: msg.messageTimestamp,
       };
-      
+
       storeMessage(event);
       stored++;
     }
-    
-    res.json({ success: true, stored, total: messages.length });
+
+    res.json({ success: true, stored, total: fetchedMessages?.length || 0, anchor: oldestMsgKey ? 'used oldest stored message as anchor' : 'no anchor (no stored messages)' });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
@@ -998,8 +1016,10 @@ app.post('/react', async (req, res) => {
   if (!chat_id || !message_id || !emoji) {
     return res.status(400).json({ error: 'chat_id, message_id, and emoji are required' });
   }
-  
+
   try {
+    // Baileys v7: sendMessage with react uses { react: { text, key } }
+    // The key must match the target message
     const key = { remoteJid: chat_id, id: message_id, fromMe: false };
     await sock.sendMessage(chat_id, { react: { text: emoji, key } });
     res.json({ success: true });
@@ -1017,18 +1037,18 @@ app.post('/poll', async (req, res) => {
   if (!chat_id || !question || !options?.length || options.length < 2) {
     return res.status(400).json({ error: 'chat_id, question, and at least 2 options are required' });
   }
-  
+
   try {
-    const pollMessage = {
-      pollCreationMessage: {
+    // Baileys v7: sendMessage with poll uses high-level { poll: { name, values, selectableCount } }
+    // normalizeMessage converts this to the correct proto format
+    await sock.sendMessage(chat_id, {
+      poll: {
         name: question,
-        options: options.map(text => ({ optionName: text })),
-        withMyStatus: false,
-        multipleAnswers: !!multiple_answers,
+        values: options,
+        selectableCount: multiple_answers ? options.length : 1,
       }
-    };
-    const sent = await sock.sendMessage(chat_id, pollMessage);
-    res.json({ success: true, messageId: sent?.key?.id });
+    });
+    res.json({ success: true });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -28,6 +28,87 @@ import { randomBytes } from 'crypto';
 import qrcode from 'qrcode-terminal';
 import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
 
+import Database from 'better-sqlite3';
+
+// SQLite storage directory
+const DB_DIR = path.join(process.env.HOME || '~', '.hermes', 'whatsapp');
+mkdirSync(DB_DIR, { recursive: true });
+const DB_PATH = path.join(DB_DIR, 'messages.db');
+
+let db = null;
+
+function initDb() {
+  db = new Database(DB_PATH);
+  db.pragma('journal_mode = WAL');
+  
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS messages (
+      id TEXT PRIMARY KEY,
+      chat_id TEXT NOT NULL,
+      sender_id TEXT,
+      sender_name TEXT,
+      chat_name TEXT,
+      is_group INTEGER DEFAULT 0,
+      body TEXT,
+      has_media INTEGER DEFAULT 0,
+      media_type TEXT,
+      media_urls TEXT,
+      timestamp INTEGER NOT NULL,
+      stored_at INTEGER DEFAULT (unixepoch())
+    );
+    
+    CREATE INDEX IF NOT EXISTS idx_messages_chat ON messages(chat_id);
+    CREATE INDEX IF NOT EXISTS idx_messages_timestamp ON messages(timestamp);
+    
+    CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
+      body,
+      content='messages',
+      content_rowid='rowid'
+    );
+    
+    CREATE TRIGGER IF NOT EXISTS messages_ai AFTER INSERT ON messages BEGIN
+      INSERT INTO messages_fts(rowid, body) VALUES (new.rowid, new.body);
+    END;
+    
+    CREATE TRIGGER IF NOT EXISTS messages_ad AFTER DELETE ON messages BEGIN
+      INSERT INTO messages_fts(messages_fts, rowid, body) VALUES('delete', old.rowid, old.body);
+    END;
+    
+    CREATE TRIGGER IF NOT EXISTS messages_au AFTER UPDATE ON messages BEGIN
+      INSERT INTO messages_fts(messages_fts, rowid, body) VALUES('delete', old.rowid, old.body);
+      INSERT INTO messages_fts(rowid, body) VALUES (new.rowid, new.body);
+    END;
+  `);
+  
+  console.log('[bridge] SQLite initialized at', DB_PATH);
+}
+
+function storeMessage(event) {
+  if (!db || !event.messageId) return;
+  try {
+    const stmt = db.prepare(`
+      INSERT OR REPLACE INTO messages 
+      (id, chat_id, sender_id, sender_name, chat_name, is_group, body, has_media, media_type, media_urls, timestamp)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+    stmt.run(
+      event.messageId,
+      event.chatId,
+      event.senderId || null,
+      event.senderName || null,
+      event.chatName || null,
+      event.isGroup ? 1 : 0,
+      event.body || null,
+      event.hasMedia ? 1 : 0,
+      event.mediaType || null,
+      JSON.stringify(event.mediaUrls || []),
+      event.timestamp || Math.floor(Date.now() / 1000)
+    );
+  } catch (err) {
+    console.error('[bridge] DB store error:', err.message);
+  }
+}
+
 // Parse CLI args
 const args = process.argv.slice(2);
 function getArg(name, defaultVal) {
@@ -119,6 +200,7 @@ const MAX_RECENT_IDS = 50;
 
 let sock = null;
 let connectionState = 'disconnected';
+initDb();
 
 async function startSocket() {
   const { state, saveCreds } = await useMultiFileAuthState(SESSION_DIR);
@@ -361,6 +443,7 @@ async function startSocket() {
       };
 
       messageQueue.push(event);
+      storeMessage(event);
       if (messageQueue.length > MAX_QUEUE_SIZE) {
         messageQueue.shift();
       }
@@ -505,20 +588,400 @@ app.post('/send-media', async (req, res) => {
   }
 });
 
+// ─── Search endpoint ───────────────────────────────────────────────
+app.get('/search', (req, res) => {
+  const { q, chat_id, limit = 50 } = req.query;
+  if (!q || !db) return res.status(400).json({ error: 'q is required' });
+  
+  try {
+    let rows;
+    if (chat_id) {
+      const stmt = db.prepare(`
+        SELECT m.* FROM messages m
+        JOIN messages_fts fts ON m.rowid = fts.rowid
+        WHERE messages_fts MATCH ? AND m.chat_id = ?
+        ORDER BY m.timestamp DESC LIMIT ?
+      `);
+      rows = stmt.all(q, chat_id, parseInt(limit));
+    } else {
+      const stmt = db.prepare(`
+        SELECT m.* FROM messages m
+        JOIN messages_fts fts ON m.rowid = fts.rowid
+        WHERE messages_fts MATCH ?
+        ORDER BY m.timestamp DESC LIMIT ?
+      `);
+      rows = stmt.all(q, parseInt(limit));
+    }
+    
+    const results = rows.map(r => ({
+      messageId: r.id,
+      chatId: r.chat_id,
+      senderId: r.sender_id,
+      senderName: r.sender_name,
+      chatName: r.chat_name,
+      isGroup: !!r.is_group,
+      body: r.body,
+      hasMedia: !!r.has_media,
+      mediaType: r.media_type,
+      mediaUrls: JSON.parse(r.media_urls || '[]'),
+      timestamp: r.timestamp,
+    }));
+    
+    res.json({ results, count: results.length });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ─── Backfill endpoint ──────────────────────────────────────────────
+app.post('/backfill', async (req, res) => {
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected to WhatsApp' });
+  }
+  
+  const { chat_id, limit = 50 } = req.body;
+  if (!chat_id) return res.status(400).json({ error: 'chat_id is required' });
+  
+  try {
+    const conversation = await sock.fetchMessagesFromWhatsApp(chat_id, limit);
+    let stored = 0;
+    
+    for (const msg of (conversation || [])) {
+      if (!msg?.key?.id) continue;
+      const chatId = msg.key.remoteJid;
+      if (!chatId) continue;
+      
+      const isGroup = chatId.endsWith('@g.us');
+      const senderId = msg.key.participant || chatId;
+      const senderNumber = senderId.replace(/@.*/, '');
+      const messageContent = getMessageContent(msg);
+      
+      let body = '';
+      let hasMedia = false;
+      let mediaType = '';
+      const mediaUrls = [];
+      
+      if (messageContent.conversation) body = messageContent.conversation;
+      else if (messageContent.extendedTextMessage?.text) body = messageContent.extendedTextMessage.text;
+      else if (messageContent.imageMessage) {
+        body = messageContent.imageMessage.caption || '';
+        hasMedia = true; mediaType = 'image';
+      } else if (messageContent.videoMessage) {
+        body = messageContent.videoMessage.caption || '';
+        hasMedia = true; mediaType = 'video';
+      } else if (messageContent.audioMessage || messageContent.pttMessage) {
+        hasMedia = true; mediaType = messageContent.pttMessage ? 'ptt' : 'audio';
+      } else if (messageContent.documentMessage) {
+        body = messageContent.documentMessage.caption || '';
+        hasMedia = true; mediaType = 'document';
+      }
+      
+      if (hasMedia && !body) body = `[${mediaType} received]`;
+      if (!body && !hasMedia) continue;
+      
+      const event = {
+        messageId: msg.key.id,
+        chatId,
+        senderId,
+        senderName: msg.pushName || senderNumber,
+        chatName: isGroup ? chatId.split('@')[0] : (msg.pushName || senderNumber),
+        isGroup,
+        body,
+        hasMedia,
+        mediaType,
+        mediaUrls,
+        mentionedIds: [],
+        quotedParticipant: '',
+        botIds: [],
+        timestamp: msg.messageTimestamp,
+      };
+      
+      storeMessage(event);
+      stored++;
+    }
+    
+    res.json({ success: true, stored, total: conversation?.length || 0 });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ─── Group management endpoints ─────────────────────────────────────
+app.post('/group/create', async (req, res) => {
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected to WhatsApp' });
+  }
+  const { name, participants = [] } = req.body;
+  if (!name) return res.status(400).json({ error: 'name is required' });
+  
+  try {
+    const groupJid = await sock.createGroup(name, participants);
+    res.json({ success: true, groupJid });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get('/groups', async (req, res) => {
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected to WhatsApp' });
+  }
+  try {
+    const groups = await sock.groupFetchAllParticipating();
+    const result = Object.entries(groups).map(([jid, meta]) => ({
+      jid,
+      name: meta.subject || jid,
+      description: meta.desc?.toString() || '',
+      size: meta.size,
+      created: meta.creation,
+      owner: meta.owner,
+      restrict: meta.restrict,
+      announce: meta.announce,
+    }));
+    res.json({ groups: result });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/group/rename', async (req, res) => {
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected to WhatsApp' });
+  }
+  const { chat_id, name } = req.body;
+  if (!chat_id || !name) return res.status(400).json({ error: 'chat_id and name are required' });
+  
+  try {
+    await sock.groupUpdateSubject(chat_id, name);
+    res.json({ success: true });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/group/description', async (req, res) => {
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected to WhatsApp' });
+  }
+  const { chat_id, description } = req.body;
+  if (!chat_id) return res.status(400).json({ error: 'chat_id is required' });
+  
+  try {
+    await sock.groupUpdateDescription(chat_id, description || '');
+    res.json({ success: true });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/group/participants/add', async (req, res) => {
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected to WhatsApp' });
+  }
+  const { chat_id, participants } = req.body;
+  if (!chat_id || !participants?.length) {
+    return res.status(400).json({ error: 'chat_id and participants[] are required' });
+  }
+  
+  try {
+    await sock.groupParticipantsUpdate(chat_id, participants, 'add');
+    res.json({ success: true });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/group/participants/remove', async (req, res) => {
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected to WhatsApp' });
+  }
+  const { chat_id, participants } = req.body;
+  if (!chat_id || !participants?.length) {
+    return res.status(400).json({ error: 'chat_id and participants[] are required' });
+  }
+  
+  try {
+    await sock.groupParticipantsUpdate(chat_id, participants, 'remove');
+    res.json({ success: true });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/group/participants/promote', async (req, res) => {
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected to WhatsApp' });
+  }
+  const { chat_id, participants } = req.body;
+  if (!chat_id || !participants?.length) {
+    return res.status(400).json({ error: 'chat_id and participants[] are required' });
+  }
+  
+  try {
+    await sock.groupParticipantsUpdate(chat_id, participants, 'promote');
+    res.json({ success: true });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get('/group/invite-link', async (req, res) => {
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected to WhatsApp' });
+  }
+  const { chat_id } = req.query;
+  if (!chat_id) return res.status(400).json({ error: 'chat_id is required' });
+  
+  try {
+    const code = await sock.groupInviteCode(chat_id);
+    res.json({ invite_link: `https://chat.whatsapp.com/${code}` });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/group/invite-link/revoke', async (req, res) => {
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected to WhatsApp' });
+  }
+  const { chat_id } = req.body;
+  if (!chat_id) return res.status(400).json({ error: 'chat_id is required' });
+  
+  try {
+    const code = await sock.groupRevokeInvite(chat_id);
+    res.json({ invite_link: `https://chat.whatsapp.com/${code}` });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/group/leave', async (req, res) => {
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected to WhatsApp' });
+  }
+  const { chat_id } = req.body;
+  if (!chat_id) return res.status(400).json({ error: 'chat_id is required' });
+  
+  try {
+    await sock.groupLeave(chat_id);
+    res.json({ success: true });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ─── Reaction endpoint ──────────────────────────────────────────────
+app.post('/react', async (req, res) => {
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected to WhatsApp' });
+  }
+  const { chat_id, message_id, emoji } = req.body;
+  if (!chat_id || !message_id || !emoji) {
+    return res.status(400).json({ error: 'chat_id, message_id, and emoji are required' });
+  }
+  
+  try {
+    const key = { remoteJid: chat_id, id: message_id, fromMe: false };
+    await sock.sendMessage(chat_id, { react: { text: emoji, key } });
+    res.json({ success: true });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ─── Poll endpoint ─────────────────────────────────────────────────
+app.post('/poll', async (req, res) => {
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected to WhatsApp' });
+  }
+  const { chat_id, question, options, multiple_answers = false } = req.body;
+  if (!chat_id || !question || !options?.length || options.length < 2) {
+    return res.status(400).json({ error: 'chat_id, question, and at least 2 options are required' });
+  }
+  
+  try {
+    const pollMessage = {
+      pollCreationMessage: {
+        name: question,
+        options: options.map(text => ({ optionName: text })),
+        withMyStatus: false,
+        multipleAnswers: !!multiple_answers,
+      }
+    };
+    const sent = await sock.sendMessage(chat_id, pollMessage);
+    res.json({ success: true, messageId: sent?.key?.id });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ─── Sticker endpoint ──────────────────────────────────────────────
+app.post('/sticker', async (req, res) => {
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected to WhatsApp' });
+  }
+  const { chat_id, file_path } = req.body;
+  if (!chat_id || !file_path) {
+    return res.status(400).json({ error: 'chat_id and file_path are required' });
+  }
+  
+  try {
+    if (!existsSync(file_path)) {
+      return res.status(404).json({ error: `File not found: ${file_path}` });
+    }
+    
+    const buffer = readFileSync(file_path);
+    const ext = file_path.toLowerCase().split('.').pop();
+    
+    let sticker;
+    if (ext === 'webp') {
+      sticker = { sticker: buffer };
+    } else {
+      return res.status(400).json({ error: 'Only .webp files are supported for stickers. Convert image to .webp first.' });
+    }
+    
+    sticker.sticker.mimetype = 'image/webp';
+    const sent = await sock.sendMessage(chat_id, sticker);
+    res.json({ success: true, messageId: sent?.key?.id });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// ─── Unsend (delete for everyone) endpoint ─────────────────────────
+app.delete('/message', async (req, res) => {
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected to WhatsApp' });
+  }
+  const { chat_id, message_id } = req.body;
+  if (!chat_id || !message_id) {
+    return res.status(400).json({ error: 'chat_id and message_id are required' });
+  }
+  
+  try {
+    const key = { remoteJid: chat_id, id: message_id };
+    await sock.sendMessage(chat_id, { delete: key });
+    res.json({ success: true });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // Typing indicator
 app.post('/typing', async (req, res) => {
   if (!sock || connectionState !== 'connected') {
-    return res.status(503).json({ error: 'Not connected' });
+    return res.status(503).json({ error: 'Not connected to WhatsApp' });
   }
-
-  const { chatId } = req.body;
-  if (!chatId) return res.status(400).json({ error: 'chatId required' });
-
+  const { chat_id, is_typing } = req.body;
+  if (!chat_id) return res.status(400).json({ error: 'chat_id is required' });
+  
   try {
-    await sock.sendPresenceUpdate('composing', chatId);
+    await sock.sendMessage(chat_id, {
+      presence: is_typing !== false ? 'composing' : 'paused'
+    });
     res.json({ success: true });
   } catch (err) {
-    res.json({ success: false });
+    res.status(500).json({ error: err.message });
   }
 });
 

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -460,6 +460,175 @@ async function startSocket() {
       }
     }
   });
+
+  // Permanent handler for backfill / history-sync messages.
+  // fetchMessageHistory() triggers a PDO request; the phone responds via
+  // WebSocket with a HISTORY_SYNC_NOTIFICATION → process-message.ts emits
+  // "messaging-history.set" with { messages, syncType, peerDataRequestSessionId }.
+  // This is a SEPARATE event from messages.upsert and was missing from the bridge.
+  sock.ev.on('messaging-history.set', async ({ messages }) => {
+    if (!messages?.length) return;
+
+    const botIds = Array.from(new Set([
+      normalizeWhatsAppId(sock.user?.id),
+      normalizeWhatsAppId(sock.user?.lid),
+    ].filter(Boolean)));
+
+    for (const msg of messages) {
+      if (!msg?.message) continue;
+
+      const chatId = msg.key.remoteJid;
+      if (WHATSAPP_DEBUG) {
+        try {
+          console.log(JSON.stringify({
+            event: 'history-sync',
+            fromMe: !!msg.key.fromMe,
+            chatId,
+            senderId: msg.key.participant || chatId,
+            messageKeys: Object.keys(msg.message || {}),
+          }));
+        } catch {}
+      }
+
+      const senderId = msg.key.participant || chatId;
+      const isGroup = chatId.endsWith('@g.us');
+      const senderNumber = senderId.replace(/@.*/, '');
+
+      // Skip messages sent BY the bot (fromMe echo-backs)
+      if (msg.key.fromMe) continue;
+
+      // Check allowlist for messages from others (resolve LID ↔ phone aliases)
+      if (!matchesAllowedUser(senderId, ALLOWED_USERS, SESSION_DIR)) {
+        if (WHATSAPP_DEBUG) {
+          try {
+            console.log(JSON.stringify({
+              event: 'history-sync-ignored',
+              reason: 'allowlist_mismatch',
+              chatId,
+              senderId,
+            }));
+          } catch {}
+        }
+        continue;
+      }
+
+      // Extract body and media using the same logic as messages.upsert
+      const messageContent = getMessageContent(msg);
+      const contextInfo = getContextInfo(messageContent);
+      const mentionedIds = Array.from(new Set((contextInfo?.mentionedJid || []).map(normalizeWhatsAppId).filter(Boolean)));
+      const quotedParticipant = normalizeWhatsAppId(contextInfo?.participant || contextInfo?.remoteJid || '');
+
+      let body = '';
+      let hasMedia = false;
+      let mediaType = '';
+      const mediaUrls = [];
+
+      if (messageContent.conversation) {
+        body = messageContent.conversation;
+      } else if (messageContent.extendedTextMessage?.text) {
+        body = messageContent.extendedTextMessage.text;
+      } else if (messageContent.imageMessage) {
+        body = messageContent.imageMessage.caption || '';
+        hasMedia = true;
+        mediaType = 'image';
+        try {
+          const buf = await downloadMediaMessage(msg, 'buffer', {}, { logger, reuploadRequest: sock.updateMediaMessage });
+          const mime = messageContent.imageMessage.mimetype || 'image/jpeg';
+          const extMap = { 'image/jpeg': '.jpg', 'image/png': '.png', 'image/webp': '.webp', 'image/gif': '.gif' };
+          const ext = extMap[mime] || '.jpg';
+          mkdirSync(IMAGE_CACHE_DIR, { recursive: true });
+          const filePath = path.join(IMAGE_CACHE_DIR, `img_${randomBytes(6).toString('hex')}${ext}`);
+          writeFileSync(filePath, buf);
+          mediaUrls.push(filePath);
+        } catch (err) {
+          console.error('[bridge] history-sync: failed to download image:', err.message);
+        }
+      } else if (messageContent.videoMessage) {
+        body = messageContent.videoMessage.caption || '';
+        hasMedia = true;
+        mediaType = 'video';
+        try {
+          const buf = await downloadMediaMessage(msg, 'buffer', {}, { logger, reuploadRequest: sock.updateMediaMessage });
+          const mime = messageContent.videoMessage.mimetype || 'video/mp4';
+          const ext = mime.includes('mp4') ? '.mp4' : '.mkv';
+          mkdirSync(DOCUMENT_CACHE_DIR, { recursive: true });
+          const filePath = path.join(DOCUMENT_CACHE_DIR, `vid_${randomBytes(6).toString('hex')}${ext}`);
+          writeFileSync(filePath, buf);
+          mediaUrls.push(filePath);
+        } catch (err) {
+          console.error('[bridge] history-sync: failed to download video:', err.message);
+        }
+      } else if (messageContent.audioMessage || messageContent.pttMessage) {
+        hasMedia = true;
+        mediaType = messageContent.pttMessage ? 'ptt' : 'audio';
+        try {
+          const audioMsg = messageContent.pttMessage || messageContent.audioMessage;
+          const buf = await downloadMediaMessage(msg, 'buffer', {}, { logger, reuploadRequest: sock.updateMediaMessage });
+          const mime = audioMsg.mimetype || 'audio/ogg';
+          const ext = mime.includes('ogg') ? '.ogg' : mime.includes('mp4') ? '.m4a' : '.ogg';
+          mkdirSync(AUDIO_CACHE_DIR, { recursive: true });
+          const filePath = path.join(AUDIO_CACHE_DIR, `aud_${randomBytes(6).toString('hex')}${ext}`);
+          writeFileSync(filePath, buf);
+          mediaUrls.push(filePath);
+        } catch (err) {
+          console.error('[bridge] history-sync: failed to download audio:', err.message);
+        }
+      } else if (messageContent.documentMessage) {
+        body = messageContent.documentMessage.caption || '';
+        hasMedia = true;
+        mediaType = 'document';
+        const fileName = messageContent.documentMessage.fileName || 'document';
+        try {
+          const buf = await downloadMediaMessage(msg, 'buffer', {}, { logger, reuploadRequest: sock.updateMediaMessage });
+          mkdirSync(DOCUMENT_CACHE_DIR, { recursive: true });
+          const safeFileName = path.basename(fileName).replace(/[^a-zA-Z0-9._-]/g, '_');
+          const filePath = path.join(DOCUMENT_CACHE_DIR, `doc_${randomBytes(6).toString('hex')}_${safeFileName}`);
+          writeFileSync(filePath, buf);
+          mediaUrls.push(filePath);
+        } catch (err) {
+          console.error('[bridge] history-sync: failed to download document:', err.message);
+        }
+      }
+
+      // For media without caption, use a placeholder so the API message is never empty
+      if (hasMedia && !body) {
+        body = `[${mediaType} received]`;
+      }
+
+      // Skip empty messages
+      if (!body && !hasMedia) {
+        if (WHATSAPP_DEBUG) {
+          try {
+            console.log(JSON.stringify({ event: 'history-sync-ignored', reason: 'empty', chatId }));
+          } catch {}
+        }
+        continue;
+      }
+
+      const event = {
+        messageId: msg.key.id,
+        chatId,
+        senderId,
+        senderName: msg.pushName || senderNumber,
+        chatName: isGroup ? (chatId.split('@')[0]) : (msg.pushName || senderNumber),
+        isGroup,
+        body,
+        hasMedia,
+        mediaType,
+        mediaUrls,
+        mentionedIds,
+        quotedParticipant,
+        botIds,
+        timestamp: msg.messageTimestamp,
+      };
+
+      messageQueue.push(event);
+      storeMessage(event);
+      if (messageQueue.length > MAX_QUEUE_SIZE) {
+        messageQueue.shift();
+      }
+    }
+  });
 }
 
 // HTTP server
@@ -649,8 +818,10 @@ app.get('/search', (req, res) => {
 });
 
 // ─── Backfill endpoint ──────────────────────────────────────────────
-// Baileys v7 uses fetchMessageHistory(count, oldestMsgKey, oldestMsgTimestamp)
-// which requires a starting message. We use the oldest stored message as anchor.
+// fetchMessageHistory sends a PDO request to the phone and returns a
+// peerDataRequestSessionId string. The phone then streams history back
+// via WebSocket as a 'messaging-history.set' event — NOT messages.upsert.
+// We set up a temporary handler to catch it.
 app.post('/backfill', async (req, res) => {
   if (!WHATSAPP_ULTIMATE) {
     return res.status(403).json({ error: 'Backfill requires WHATSAPP_ULTIMATE=true. Run "hermes setup" to enable.' });
@@ -661,106 +832,134 @@ app.post('/backfill', async (req, res) => {
 
   const { chat_id, limit = 50 } = req.body;
   if (!chat_id) return res.status(400).json({ error: 'chat_id is required' });
-
   if (!db) return res.status(503).json({ error: 'SQLite not available' });
 
-  try {
-    // Find oldest stored message for this chat to use as anchor
-    const oldest = db.prepare(
-      'SELECT id, timestamp FROM messages WHERE chat_id = ? ORDER BY timestamp ASC LIMIT 1'
-    ).get(chat_id);
+  // Find newest stored message to use as anchor for fetchMessageHistory
+  const newest = db.prepare(
+    'SELECT id, timestamp FROM messages WHERE chat_id = ? ORDER BY timestamp DESC LIMIT 1'
+  ).get(chat_id);
 
-    let oldestMsgKey = null;
-    let oldestMsgTimestamp = Math.floor(Date.now() / 1000); // default: now
+  if (!newest) {
+    return res.json({
+      success: false,
+      error: 'No anchor message. Send/receive a message first to create an anchor, then backfill.',
+      stored: 0,
+    });
+  }
 
-    if (oldest) {
-      oldestMsgKey = { remoteJid: chat_id, id: oldest.id, fromMe: false };
-      oldestMsgTimestamp = oldest.timestamp;
-    }
+  // Count messages BEFORE the fetch
+  const countBefore = db.prepare('SELECT COUNT(*) as c FROM messages WHERE chat_id = ?').get(chat_id)?.c || 0;
+  console.log('[bridge] backfill: countBefore =', countBefore, 'for', chat_id);
 
-    // Baileys v7: fetchMessageHistory(count, oldestMsgKey, oldestMsgTimestamp)
-    // Requires a valid oldestMsgKey — crashes if null is passed.
-    // If no anchor exists, skip backfill and tell user to receive messages first.
-    if (!oldest) {
-      return res.json({
-        success: false,
-        error: 'No anchor message found. Receive some messages first in this chat, then try backfill again.',
-        stored: 0,
-      });
-    }
+  // Collect messages from the messaging-history.set event
+  let fetchedMessages = [];
+  let peerId = null;
+  let historySetReceived = false;
 
-    // Baileys v7: fetchMessageHistory(count, oldestMsgKey, oldestMsgTimestamp)
-    // Requests older messages from the phone relative to the anchor
-    const fetchedMessages = await sock.fetchMessageHistory(
-      parseInt(limit),
-      { remoteJid: chat_id, id: oldest.id, fromMe: false },
-      oldest.timestamp
-    );
+  const historyHandler = ({ messages, syncType, peerDataRequestSessionId }) => {
+    console.log('[bridge] messaging-history.set received! syncType:', syncType, 'peerDataRequestSessionId:', peerDataRequestSessionId, 'messages count:', messages?.length);
+    historySetReceived = true;
+    peerId = peerDataRequestSessionId;
 
-    let stored = 0;
-    for (const msg of fetchedMessages || []) {
-      if (!msg?.key?.id) continue;
-      const chatId = msg.key.remoteJid;
-      if (!chatId) continue;
+    // Filter to only messages from the target chat
+    const chatMessages = (messages || []).filter(msg => msg?.key?.remoteJid === chat_id);
+    console.log('[bridge] messaging-history.set: total', messages?.length, 'messages,', chatMessages.length, 'from chat', chat_id);
 
-      const isGroup = chatId.endsWith('@g.us');
-      const senderId = msg.key.participant || chatId;
-      const senderNumber = senderId.replace(/@.*/, '');
-      const messageContent = getMessageContent(msg);
+    for (const msg of chatMessages) {
+      if (!msg?.message) continue;
 
+      // Extract body (same logic as in messages.upsert handler)
       let body = '';
       let hasMedia = false;
       let mediaType = '';
       const mediaUrls = [];
+      const content = msg.message;
 
-      if (messageContent.conversation) body = messageContent.conversation;
-      else if (messageContent.extendedTextMessage?.text) body = messageContent.extendedTextMessage.text;
-      else if (messageContent.imageMessage) {
-        body = messageContent.imageMessage.caption || '';
-        hasMedia = true; mediaType = 'image';
-      } else if (messageContent.videoMessage) {
-        body = messageContent.videoMessage.caption || '';
-        hasMedia = true; mediaType = 'video';
-      } else if (messageContent.audioMessage || messageContent.pttMessage) {
-        hasMedia = true; mediaType = messageContent.pttMessage ? 'ptt' : 'audio';
-      } else if (messageContent.documentMessage) {
-        body = messageContent.documentMessage.caption || '';
-        hasMedia = true; mediaType = 'document';
-      }
+      const conversation = content.conversation || content.extendedTextMessage?.text ||
+        content.imageMessage?.caption || content.videoMessage?.caption ||
+        content.documentMessage?.caption || content.audioMessage?.caption ||
+        (content.listMessage ? '(list)' : '');
 
-      if (hasMedia && !body) body = `[${mediaType} received]`;
+      if (conversation) body = conversation;
+      else if (content.imageMessage) { hasMedia = true; mediaType = 'image'; }
+      else if (content.videoMessage) { hasMedia = true; mediaType = 'video'; }
+      else if (content.audioMessage || content.pttMessage) { hasMedia = true; mediaType = 'ptt'; }
+      else if (content.documentMessage) { hasMedia = true; mediaType = 'document'; }
+
       if (!body && !hasMedia) continue;
 
+      const senderId = msg.key.participant || msg.key.remoteJid;
       const event = {
         messageId: msg.key.id,
-        chatId,
+        chatId: msg.key.remoteJid,
         senderId,
-        senderName: msg.pushName || senderNumber,
-        chatName: isGroup ? chatId.split('@')[0] : (msg.pushName || senderNumber),
-        isGroup,
+        senderName: msg.pushName || senderId.replace(/@.*/, ''),
+        chatName: chat_id.split('@')[0],
+        isGroup: chat_id.endsWith('@g.us'),
         body,
         hasMedia,
         mediaType,
         mediaUrls,
         mentionedIds: [],
         quotedParticipant: '',
-        botIds: [],
         timestamp: msg.messageTimestamp,
       };
 
+      fetchedMessages.push(event);
       storeMessage(event);
-      stored++;
     }
+  };
 
-    res.json({ success: true, stored, total: fetchedMessages?.length || 0, anchor: oldestMsgKey ? 'used oldest stored message as anchor' : 'no anchor (no stored messages)' });
-  } catch (err) {
-    res.status(500).json({ error: err.message });
+  // Attach the handler BEFORE firing fetch so we don't race
+  sock.ev.on('messaging-history.set', historyHandler);
+
+  // Fire the PDO fetch — returns peerDataRequestSessionId string
+  let fetchError = null;
+  let requestId = null;
+  try {
+    requestId = await sock.fetchMessageHistory(
+      parseInt(limit),
+      { remoteJid: chat_id, id: newest.id, fromMe: false },
+      newest.timestamp
+    );
+    console.log('[bridge] fetchMessageHistory returned requestId:', requestId, '(type:', typeof requestId, ')');
+  } catch (e) {
+    console.log('[bridge] fetchMessageHistory error:', e.message);
+    fetchError = e.message;
   }
+
+  // Wait up to 30 seconds for messaging-history.set to fire
+  // (phone must be active and connected for this to work)
+  const waitMs = 30_000;
+  const start = Date.now();
+  while (!historySetReceived && Date.now() - start < waitMs) {
+    await new Promise(r => setTimeout(r, 500));
+  }
+  console.log('[bridge] backfill wait done:', historySetReceived ? 'event received' : 'timeout (phone may be offline)');
+
+  // Always remove handler to prevent memory leaks
+  sock.ev.off('messaging-history.set', historyHandler);
+
+  const countAfter = db.prepare('SELECT COUNT(*) as c FROM messages WHERE chat_id = ?').get(chat_id)?.c || 0;
+  const stored = countAfter - countBefore;
+
+  res.json({
+    success: true,
+    stored,
+    total: stored,
+    fetched: fetchedMessages.length,
+    requestId,
+    peerDataRequestSessionId: peerId,
+    method: 'messaging-history.set',
+    note: historySetReceived
+      ? 'Phone responded — history delivered via messaging-history.set event.'
+      : 'Phone did not respond. Ensure WhatsApp is open and the device is online.',
+  });
 });
 
 // ─── Group management endpoints ─────────────────────────────────────
 // All group operations use sock.query() directly — Baileys v7 separates
-// group methods into makeGroupsSocket which is NOT part of makeWASocket chain.
+// makeGroupsSocket from the main WASocket chain.
 
 // Low-level group IQ query helper
 async function groupQuery(jid, type, content) {

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -18,7 +18,7 @@
  *   node bridge.js --port 3000 --session ~/.hermes/whatsapp/session
  */
 
-import { makeWASocket, useMultiFileAuthState, DisconnectReason, fetchLatestBaileysVersion, downloadMediaMessage } from '@whiskeysockets/baileys';
+import { makeWASocket, useMultiFileAuthState, DisconnectReason, fetchLatestBaileysVersion, downloadMediaMessage, generateMessageIDV2, jidNormalizedUser } from '@whiskeysockets/baileys';
 import express from 'express';
 import { Boom } from '@hapi/boom';
 import pino from 'pino';
@@ -26,6 +26,7 @@ import path from 'path';
 import { mkdirSync, readFileSync, writeFileSync, existsSync, readdirSync } from 'fs';
 import { randomBytes } from 'crypto';
 import qrcode from 'qrcode-terminal';
+import QRCode from 'qrcode';
 import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
 
 import Database from 'better-sqlite3';
@@ -206,6 +207,7 @@ const MAX_RECENT_IDS = 50;
 
 let sock = null;
 let connectionState = 'disconnected';
+let lastQrData = null; // raw QR string for /qr-image endpoint
 if (WHATSAPP_ULTIMATE) {
   initDb();
 }
@@ -237,6 +239,7 @@ async function startSocket() {
     const { connection, lastDisconnect, qr } = update;
 
     if (qr) {
+      lastQrData = qr;
       console.log('\n📱 Scan this QR code with WhatsApp on your phone:\n');
       qrcode.generate(qr, { small: true });
       console.log('\nWaiting for scan...\n');
@@ -658,10 +661,15 @@ app.post('/backfill', async (req, res) => {
   if (!chat_id) return res.status(400).json({ error: 'chat_id is required' });
   
   try {
-    const conversation = await sock.fetchMessagesFromWhatsApp(chat_id, limit);
+    // Baileys v7: chatFetch takes (jid, { requests })
+    const conversation = await sock.chatFetch(chat_id, {
+      requests: [{ limit: parseInt(limit), type: 'messages' }],
+    });
+    // conversation is a map of jid -> { messages: [] }
+    const messages = conversation?.[chat_id]?.messages || [];
     let stored = 0;
     
-    for (const msg of (conversation || [])) {
+    for (const msg of messages) {
       if (!msg?.key?.id) continue;
       const chatId = msg.key.remoteJid;
       if (!chatId) continue;
@@ -715,23 +723,75 @@ app.post('/backfill', async (req, res) => {
       stored++;
     }
     
-    res.json({ success: true, stored, total: conversation?.length || 0 });
+    res.json({ success: true, stored, total: messages.length });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
 });
 
 // ─── Group management endpoints ─────────────────────────────────────
+// All group operations use sock.query() directly — Baileys v7 separates
+// group methods into makeGroupsSocket which is NOT part of makeWASocket chain.
+
+// Low-level group IQ query helper
+async function groupQuery(jid, type, content) {
+  return sock.query({
+    tag: 'iq',
+    attrs: { type, xmlns: 'w:g2', to: jid },
+    content,
+  });
+}
+
+// Parse group metadata from WhatsApp binary response
+function parseGroupMetadata(result) {
+  const groupNode = result?.content?.[0];
+  if (!groupNode) return null;
+  const getChild = (tag) => groupNode.content?.find(n => n.tag === tag) || groupNode.attrs?.[tag];
+  const getText = (tag) => {
+    const n = getChild(tag);
+    return n?.content ? Buffer.from(n.content[0]).toString('utf-8') : (n?.attrs?.value || '');
+  };
+  const participants = (groupNode.content || [])
+    .filter(n => n.tag === 'participant')
+    .map(n => ({ id: n.attrs.jid, admin: n.attrs.type === 'admin' ? 'admin' : null }));
+
+  return {
+    id: groupNode.attrs.id ? `${groupNode.attrs.id}@g.us` : jid,
+    subject: groupNode.attrs.subject || getText('subject'),
+    subjectOwner: groupNode.attrs.s_o,
+    subjectTime: Number(groupNode.attrs.s_t || 0),
+    description: getText('description'),
+    size: participants.length,
+    creation: Number(groupNode.attrs.creation || 0),
+    owner: groupNode.attrs.creator ? jidNormalizedUser(groupNode.attrs.creator) : undefined,
+    restrict: !!getChild('locked'),
+    announce: !!getChild('announcement'),
+    participants,
+    ephemeralExpiration: getChild('ephemeral')?.attrs?.expiration,
+  };
+}
+
 app.post('/group/create', async (req, res) => {
   if (!sock || connectionState !== 'connected') {
     return res.status(503).json({ error: 'Not connected to WhatsApp' });
   }
   const { name, participants = [] } = req.body;
   if (!name) return res.status(400).json({ error: 'name is required' });
-  
+
   try {
-    const groupJid = await sock.createGroup(name, participants);
-    res.json({ success: true, groupJid });
+    const key = generateMessageIDV2();
+    const result = await groupQuery('@g.us', 'set', [
+      {
+        tag: 'create',
+        attrs: { subject: name, key },
+        content: participants.map(jid => ({
+          tag: 'participant',
+          attrs: { jid }
+        }))
+      }
+    ]);
+    const meta = parseGroupMetadata(result);
+    res.json({ success: true, groupJid: meta?.id || result });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
@@ -742,18 +802,32 @@ app.get('/groups', async (req, res) => {
     return res.status(503).json({ error: 'Not connected to WhatsApp' });
   }
   try {
-    const groups = await sock.groupFetchAllParticipating();
-    const result = Object.entries(groups).map(([jid, meta]) => ({
+    const result = await sock.query({
+      tag: 'iq',
+      attrs: { to: '@g.us', xmlns: 'w:g2', type: 'get' },
+      content: [{ tag: 'participating', attrs: {}, content: [{ tag: 'participants', attrs: {} }, { tag: 'description', attrs: {} }] }]
+    });
+    const data = {};
+    const groupsChild = result?.content?.find(n => n.tag === 'groups');
+    if (groupsChild) {
+      for (const groupNode of groupsChild.content || []) {
+        if (groupNode.tag === 'group') {
+          const meta = parseGroupMetadata({ content: [groupNode] });
+          if (meta) data[meta.id] = meta;
+        }
+      }
+    }
+    const groupsList = Object.entries(data).map(([jid, meta]) => ({
       jid,
       name: meta.subject || jid,
-      description: meta.desc?.toString() || '',
+      description: meta.description || '',
       size: meta.size,
       created: meta.creation,
       owner: meta.owner,
       restrict: meta.restrict,
       announce: meta.announce,
     }));
-    res.json({ groups: result });
+    res.json({ groups: groupsList });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
@@ -765,9 +839,11 @@ app.post('/group/rename', async (req, res) => {
   }
   const { chat_id, name } = req.body;
   if (!chat_id || !name) return res.status(400).json({ error: 'chat_id and name are required' });
-  
+
   try {
-    await sock.groupUpdateSubject(chat_id, name);
+    await groupQuery(chat_id, 'set', [
+      { tag: 'subject', attrs: {}, content: Buffer.from(name, 'utf-8') }
+    ]);
     res.json({ success: true });
   } catch (err) {
     res.status(500).json({ error: err.message });
@@ -780,9 +856,12 @@ app.post('/group/description', async (req, res) => {
   }
   const { chat_id, description } = req.body;
   if (!chat_id) return res.status(400).json({ error: 'chat_id is required' });
-  
+
   try {
-    await sock.groupUpdateDescription(chat_id, description || '');
+    const content = description
+      ? [{ tag: 'description', attrs: { id: generateMessageIDV2().slice(0, 12) }, content: [{ tag: 'body', attrs: {}, content: Buffer.from(description, 'utf-8') }] }]
+      : [{ tag: 'description', attrs: { delete: 'true' } }];
+    await groupQuery(chat_id, 'set', content);
     res.json({ success: true });
   } catch (err) {
     res.status(500).json({ error: err.message });
@@ -797,9 +876,15 @@ app.post('/group/participants/add', async (req, res) => {
   if (!chat_id || !participants?.length) {
     return res.status(400).json({ error: 'chat_id and participants[] are required' });
   }
-  
+
   try {
-    await sock.groupParticipantsUpdate(chat_id, participants, 'add');
+    await groupQuery(chat_id, 'set', [
+      {
+        tag: 'add',
+        attrs: {},
+        content: participants.map(jid => ({ tag: 'participant', attrs: { jid } }))
+      }
+    ]);
     res.json({ success: true });
   } catch (err) {
     res.status(500).json({ error: err.message });
@@ -814,9 +899,15 @@ app.post('/group/participants/remove', async (req, res) => {
   if (!chat_id || !participants?.length) {
     return res.status(400).json({ error: 'chat_id and participants[] are required' });
   }
-  
+
   try {
-    await sock.groupParticipantsUpdate(chat_id, participants, 'remove');
+    await groupQuery(chat_id, 'set', [
+      {
+        tag: 'remove',
+        attrs: {},
+        content: participants.map(jid => ({ tag: 'participant', attrs: { jid } }))
+      }
+    ]);
     res.json({ success: true });
   } catch (err) {
     res.status(500).json({ error: err.message });
@@ -831,9 +922,15 @@ app.post('/group/participants/promote', async (req, res) => {
   if (!chat_id || !participants?.length) {
     return res.status(400).json({ error: 'chat_id and participants[] are required' });
   }
-  
+
   try {
-    await sock.groupParticipantsUpdate(chat_id, participants, 'promote');
+    await groupQuery(chat_id, 'set', [
+      {
+        tag: 'promote',
+        attrs: {},
+        content: participants.map(jid => ({ tag: 'participant', attrs: { jid } }))
+      }
+    ]);
     res.json({ success: true });
   } catch (err) {
     res.status(500).json({ error: err.message });
@@ -846,9 +943,12 @@ app.get('/group/invite-link', async (req, res) => {
   }
   const { chat_id } = req.query;
   if (!chat_id) return res.status(400).json({ error: 'chat_id is required' });
-  
+
   try {
-    const code = await sock.groupInviteCode(chat_id);
+    const result = await groupQuery(chat_id, 'get', [{ tag: 'invite', attrs: {} }]);
+    const inviteNode = result?.content?.find(n => n.tag === 'invite');
+    const code = inviteNode?.attrs?.code;
+    if (!code) return res.status(404).json({ error: 'No invite code found' });
     res.json({ invite_link: `https://chat.whatsapp.com/${code}` });
   } catch (err) {
     res.status(500).json({ error: err.message });
@@ -861,10 +961,12 @@ app.post('/group/invite-link/revoke', async (req, res) => {
   }
   const { chat_id } = req.body;
   if (!chat_id) return res.status(400).json({ error: 'chat_id is required' });
-  
+
   try {
-    const code = await sock.groupRevokeInvite(chat_id);
-    res.json({ invite_link: `https://chat.whatsapp.com/${code}` });
+    const result = await groupQuery(chat_id, 'set', [{ tag: 'revoke', attrs: {}, content: [{ tag: 'invite', attrs: {} }] }]);
+    const inviteNode = result?.content?.find(n => n.tag === 'invite') || result?.content?.[0];
+    const code = inviteNode?.attrs?.code;
+    res.json({ success: true, invite_link: code ? `https://chat.whatsapp.com/${code}` : null });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
@@ -876,9 +978,11 @@ app.post('/group/leave', async (req, res) => {
   }
   const { chat_id } = req.body;
   if (!chat_id) return res.status(400).json({ error: 'chat_id is required' });
-  
+
   try {
-    await sock.groupLeave(chat_id);
+    await groupQuery('@g.us', 'set', [
+      { tag: 'leave', attrs: {}, content: [{ tag: 'group', attrs: { id: chat_id.replace('@g.us', '') } }] }
+    ]);
     res.json({ success: true });
   } catch (err) {
     res.status(500).json({ error: err.message });
@@ -1032,6 +1136,29 @@ app.get('/health', (req, res) => {
     queueLength: messageQueue.length,
     uptime: process.uptime(),
   });
+});
+
+// QR code as PNG image (for scanning when bridge is run in background)
+app.get('/qr-image', async (req, res) => {
+  if (!lastQrData) {
+    return res.status(404).json({ error: 'No QR code available. Bridge may already be connected or QR expired.' });
+  }
+  try {
+    const png = await QRCode.toBuffer(lastQrData, { type: 'png', width: 400, margin: 2 });
+    res.set('Content-Type', 'image/png');
+    res.set('Cache-Control', 'no-store');
+    res.send(png);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// Debug: list available socket methods
+app.get('/debug/methods', (req, res) => {
+  if (!sock) return res.status(503).json({ error: 'Not connected' });
+  const proto = Object.getPrototypeOf(sock);
+  const ownMethods = Object.getOwnPropertyNames(proto).filter(m => !m.startsWith('_') && typeof sock[m] === 'function');
+  res.json({ methods: ownMethods.sort() });
 });
 
 // Start

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -679,11 +679,22 @@ app.post('/backfill', async (req, res) => {
     }
 
     // Baileys v7: fetchMessageHistory(count, oldestMsgKey, oldestMsgTimestamp)
+    // Requires a valid oldestMsgKey — crashes if null is passed.
+    // If no anchor exists, skip backfill and tell user to receive messages first.
+    if (!oldest) {
+      return res.json({
+        success: false,
+        error: 'No anchor message found. Receive some messages first in this chat, then try backfill again.',
+        stored: 0,
+      });
+    }
+
+    // Baileys v7: fetchMessageHistory(count, oldestMsgKey, oldestMsgTimestamp)
     // Requests older messages from the phone relative to the anchor
     const fetchedMessages = await sock.fetchMessageHistory(
       parseInt(limit),
-      oldestMsgKey,
-      oldestMsgTimestamp
+      { remoteJid: chat_id, id: oldest.id, fromMe: false },
+      oldest.timestamp
     );
 
     let stored = 0;
@@ -764,24 +775,45 @@ async function groupQuery(jid, type, content) {
 function parseGroupMetadata(result) {
   const groupNode = result?.content?.[0];
   if (!groupNode) return null;
-  const getChild = (tag) => groupNode.content?.find(n => n.tag === tag) || groupNode.attrs?.[tag];
+
+  // content can be an Array, Map, or have numeric keys — normalize to array
+  const contentArr = Array.isArray(groupNode.content)
+    ? groupNode.content
+    : (groupNode.content instanceof Map
+      ? Array.from(groupNode.content.values())
+      : []);
+
+  const getChild = (tag) => {
+    const found = contentArr.find(n => n && n.tag === tag);
+    if (found) return found;
+    // also check attrs (some values stored directly in attrs)
+    return groupNode.attrs?.[tag] ? { attrs: groupNode.attrs, tag } : null;
+  };
   const getText = (tag) => {
     const n = getChild(tag);
-    return n?.content ? Buffer.from(n.content[0]).toString('utf-8') : (n?.attrs?.value || '');
+    if (!n) return '';
+    // content can be Buffer, string, or nested node
+    if (n.content) {
+      const c = Array.isArray(n.content) ? n.content[0] : n.content;
+      if (Buffer.isBuffer(c)) return c.toString('utf-8');
+      if (typeof c === 'string') return c;
+      if (c && typeof c === 'object' && c.toString) return c.toString();
+    }
+    return n.attrs?.value || '';
   };
-  const participants = (groupNode.content || [])
-    .filter(n => n.tag === 'participant')
-    .map(n => ({ id: n.attrs.jid, admin: n.attrs.type === 'admin' ? 'admin' : null }));
+  const participants = contentArr
+    .filter(n => n && n.tag === 'participant')
+    .map(n => ({ id: String(n.attrs?.jid || ''), admin: n.attrs?.type === 'admin' ? 'admin' : null }));
 
   return {
-    id: groupNode.attrs.id ? `${groupNode.attrs.id}@g.us` : jid,
-    subject: groupNode.attrs.subject || getText('subject'),
-    subjectOwner: groupNode.attrs.s_o,
-    subjectTime: Number(groupNode.attrs.s_t || 0),
+    id: groupNode.attrs?.id ? `${groupNode.attrs.id}@g.us` : jid,
+    subject: groupNode.attrs?.subject || getText('subject'),
+    subjectOwner: groupNode.attrs?.s_o,
+    subjectTime: Number(groupNode.attrs?.s_t || 0),
     description: getText('description'),
     size: participants.length,
-    creation: Number(groupNode.attrs.creation || 0),
-    owner: groupNode.attrs.creator ? jidNormalizedUser(groupNode.attrs.creator) : undefined,
+    creation: Number(groupNode.attrs?.creation || 0),
+    owner: groupNode.attrs?.creator ? jidNormalizedUser(groupNode.attrs.creator) : undefined,
     restrict: !!getChild('locked'),
     announce: !!getChild('announcement'),
     participants,
@@ -836,16 +868,20 @@ app.get('/groups', async (req, res) => {
       }
     }
     const groupsList = Object.entries(data).map(([jid, meta]) => ({
-      jid,
-      name: meta.subject || jid,
-      description: meta.description || '',
-      size: meta.size,
-      created: meta.creation,
-      owner: meta.owner,
-      restrict: meta.restrict,
-      announce: meta.announce,
+      jid: String(jid || ''),
+      name: String(meta.subject || jid || ''),
+      description: String(meta.description || ''),
+      size: Number(meta.size || 0),
+      created: Number(meta.creation || 0),
+      owner: meta.owner ? String(meta.owner) : null,
+      restrict: Boolean(meta.restrict),
+      announce: Boolean(meta.announce),
     }));
-    res.json({ groups: groupsList });
+    try {
+      res.json({ groups: groupsList });
+    } catch (e) {
+      res.status(500).json({ error: 'Serialization failed: ' + e.message });
+    }
   } catch (err) {
     res.status(500).json({ error: err.message });
   }

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -122,6 +122,12 @@ const WHATSAPP_DEBUG =
   typeof process.env.WHATSAPP_DEBUG === 'string' &&
   ['1', 'true', 'yes', 'on'].includes(process.env.WHATSAPP_DEBUG.toLowerCase());
 
+// When true: SQLite storage, FTS5 search, group mgmt, polls, reactions, stickers
+const WHATSAPP_ULTIMATE =
+  typeof process !== 'undefined' &&
+  process.env &&
+  ['1', 'true', 'yes', 'on'].includes(String(process.env.WHATSAPP_ULTIMATE || '').toLowerCase());
+
 const PORT = parseInt(getArg('port', '3000'), 10);
 const SESSION_DIR = getArg('session', path.join(process.env.HOME || '~', '.hermes', 'whatsapp', 'session'));
 const IMAGE_CACHE_DIR = path.join(process.env.HOME || '~', '.hermes', 'image_cache');
@@ -200,7 +206,9 @@ const MAX_RECENT_IDS = 50;
 
 let sock = null;
 let connectionState = 'disconnected';
-initDb();
+if (WHATSAPP_ULTIMATE) {
+  initDb();
+}
 
 async function startSocket() {
   const { state, saveCreds } = await useMultiFileAuthState(SESSION_DIR);
@@ -590,8 +598,12 @@ app.post('/send-media', async (req, res) => {
 
 // ─── Search endpoint ───────────────────────────────────────────────
 app.get('/search', (req, res) => {
+  if (!WHATSAPP_ULTIMATE) {
+    return res.status(403).json({ error: 'Search requires WHATSAPP_ULTIMATE=true. Run "hermes setup" to enable.' });
+  }
   const { q, chat_id, limit = 50 } = req.query;
-  if (!q || !db) return res.status(400).json({ error: 'q is required' });
+  if (!q) return res.status(400).json({ error: 'q is required' });
+  if (!db) return res.status(503).json({ error: 'Database not initialized. Is WHATSAPP_ULTIMATE=true?' });
   
   try {
     let rows;
@@ -635,6 +647,9 @@ app.get('/search', (req, res) => {
 
 // ─── Backfill endpoint ──────────────────────────────────────────────
 app.post('/backfill', async (req, res) => {
+  if (!WHATSAPP_ULTIMATE) {
+    return res.status(403).json({ error: 'Backfill requires WHATSAPP_ULTIMATE=true. Run "hermes setup" to enable.' });
+  }
   if (!sock || connectionState !== 'connected') {
     return res.status(503).json({ error: 'Not connected to WhatsApp' });
   }
@@ -1028,7 +1043,8 @@ if (PAIR_ONLY) {
   startSocket();
 } else {
   app.listen(PORT, '127.0.0.1', () => {
-    console.log(`🌉 WhatsApp bridge listening on port ${PORT} (mode: ${WHATSAPP_MODE})`);
+    const ultimateTag = WHATSAPP_ULTIMATE ? ' 🌟 Ultimate' : '';
+    console.log(`🌉 WhatsApp bridge listening on port ${PORT} (mode: ${WHATSAPP_MODE}${ultimateTag})`);
     console.log(`📁 Session stored in: ${SESSION_DIR}`);
     if (ALLOWED_USERS.size > 0) {
       console.log(`🔒 Allowed users: ${Array.from(ALLOWED_USERS).join(', ')}`);

--- a/scripts/whatsapp-bridge/package-lock.json
+++ b/scripts/whatsapp-bridge/package-lock.json
@@ -8,10 +8,14 @@
       "name": "hermes-whatsapp-bridge",
       "version": "1.0.0",
       "dependencies": {
-        "@whiskeysockets/baileys": "WhiskeySockets/Baileys#fix/abprops-abt-fetch",
+        "@whiskeysockets/baileys": "WhiskeySockets/Baileys#01047debd81beb20da7b7779b08edcb06aa03770",
+        "better-sqlite3": "^11.10.0",
         "express": "^4.21.0",
         "pino": "^9.0.0",
         "qrcode-terminal": "^0.12.0"
+      },
+      "devDependencies": {
+        "@types/better-sqlite3": "^7.6.0"
       }
     },
     "node_modules/@borewit/text-codec": {
@@ -714,6 +718,16 @@
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
       "license": "MIT"
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/long": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
@@ -806,6 +820,57 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
+      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "node_modules/body-parser": {
       "version": "1.20.4",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
@@ -828,6 +893,30 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/bytes": {
@@ -881,6 +970,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -932,6 +1027,30 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -956,7 +1075,6 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -988,6 +1106,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/es-define-property": {
@@ -1040,6 +1167,15 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/express": {
       "version": "4.22.1",
@@ -1105,6 +1241,12 @@
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/finalhandler": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
@@ -1140,6 +1282,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -1186,6 +1334,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -1297,6 +1451,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/ipaddr.js": {
@@ -1449,6 +1609,33 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -1509,6 +1696,12 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -1516,6 +1709,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/object-inspect": {
@@ -1549,6 +1754,15 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/p-queue": {
@@ -1631,6 +1845,33 @@
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
       "license": "MIT"
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/process-warning": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
@@ -1682,6 +1923,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/qified": {
@@ -1749,6 +2000,35 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/real-require": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
@@ -1798,7 +2078,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -1974,6 +2253,51 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/sonic-boom": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
@@ -2001,6 +2325,24 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/strtok3": {
       "version": "10.3.5",
       "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
@@ -2015,6 +2357,34 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/thread-stream": {
@@ -2058,6 +2428,18 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -2108,6 +2490,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -2137,6 +2525,12 @@
       "resolved": "https://registry.npmjs.org/win-guid/-/win-guid-0.2.1.tgz",
       "integrity": "sha512-gEIQU4mkgl2OPeoNrWflcJFJ3Ae2BPd4eCsHHA/XikslkIVms/nHhvnvzIZV7VLmBvtFlDOzLt9rrZT+n6D67A==",
       "license": "MIT"
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.19.0",

--- a/scripts/whatsapp-bridge/package-lock.json
+++ b/scripts/whatsapp-bridge/package-lock.json
@@ -12,6 +12,7 @@
         "better-sqlite3": "^11.10.0",
         "express": "^4.21.0",
         "pino": "^9.0.0",
+        "qrcode": "^1.5.4",
         "qrcode-terminal": "^0.12.0"
       },
       "devDependencies": {
@@ -796,6 +797,30 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -970,11 +995,49 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
+    },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -1025,6 +1088,15 @@
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/decompress-response": {
@@ -1079,6 +1151,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -1097,6 +1175,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -1265,6 +1349,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -1296,6 +1393,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -1468,6 +1574,15 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/keyv": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
@@ -1523,6 +1638,18 @@
       "bin": {
         "pbjs": "bin/pbjs",
         "pbts": "bin/pbts"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/long": {
@@ -1765,6 +1892,33 @@
         "wrappy": "1"
       }
     },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/p-queue": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.1.0.tgz",
@@ -1793,6 +1947,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -1800,6 +1963,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-to-regexp": {
@@ -1844,6 +2016,15 @@
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
       "license": "MIT"
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
     },
     "node_modules/prebuild-install": {
       "version": "7.1.3",
@@ -1947,6 +2128,23 @@
         "node": ">=20"
       }
     },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/qrcode-terminal": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
@@ -2037,6 +2235,21 @@
       "engines": {
         "node": ">= 12.13.0"
       }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -2129,6 +2342,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -2334,6 +2553,32 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -2520,11 +2765,31 @@
       "integrity": "sha512-6KBRNvxg6WMIwZ/euA8qVzj16qxMBzLllfmaJIP1JGAAfSvwn6nr8JDOMXeqpXPEOl71UfOG+79JwKEoT2b1Fw==",
       "license": "MIT"
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
     "node_modules/win-guid": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/win-guid/-/win-guid-0.2.1.tgz",
       "integrity": "sha512-gEIQU4mkgl2OPeoNrWflcJFJ3Ae2BPd4eCsHHA/XikslkIVms/nHhvnvzIZV7VLmBvtFlDOzLt9rrZT+n6D67A==",
       "license": "MIT"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
@@ -2551,6 +2816,47 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     }
   }

--- a/scripts/whatsapp-bridge/package.json
+++ b/scripts/whatsapp-bridge/package.json
@@ -9,8 +9,12 @@
   },
   "dependencies": {
     "@whiskeysockets/baileys": "WhiskeySockets/Baileys#01047debd81beb20da7b7779b08edcb06aa03770",
+    "better-sqlite3": "^11.10.0",
     "express": "^4.21.0",
-    "qrcode-terminal": "^0.12.0",
-    "pino": "^9.0.0"
+    "pino": "^9.0.0",
+    "qrcode-terminal": "^0.12.0"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.0"
   }
 }

--- a/scripts/whatsapp-bridge/package.json
+++ b/scripts/whatsapp-bridge/package.json
@@ -12,6 +12,7 @@
     "better-sqlite3": "^11.10.0",
     "express": "^4.21.0",
     "pino": "^9.0.0",
+    "qrcode": "^1.5.4",
     "qrcode-terminal": "^0.12.0"
   },
   "devDependencies": {

--- a/tools/whatsapp_tools.py
+++ b/tools/whatsapp_tools.py
@@ -1,0 +1,611 @@
+"""WhatsApp Ultimate tools — extended WhatsApp features via the local Baileys bridge.
+
+These tools expose group management, polls, reactions, search, and other advanced
+WhatsApp features that go beyond basic send/receive.
+"""
+
+import aiohttp
+import logging
+import os
+from typing import Any, Dict, List, Optional
+
+from tools.registry import registry, tool_error
+
+logger = logging.getLogger(__name__)
+
+_BRIDGE_PORT = int(os.getenv("WHATSAPP_BRIDGE_PORT", "3000"))
+_BRIDGE_URL = f"http://127.0.0.1:{_BRIDGE_PORT}"
+
+
+def _error(msg: str) -> Dict[str, Any]:
+    return {"error": msg}
+
+
+async def _bridge_get(path: str, params: Optional[Dict] = None, timeout: float = 15) -> Dict[str, Any]:
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                f"{_BRIDGE_URL}{path}",
+                params=params or {},
+                timeout=aiohttp.ClientTimeout(total=timeout),
+            ) as resp:
+                return await resp.json()
+    except Exception as e:
+        return _error(str(e))
+
+
+async def _bridge_post(path: str, json: Dict, timeout: float = 15) -> Dict[str, Any]:
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                f"{_BRIDGE_URL}{path}",
+                json=json,
+                timeout=aiohttp.ClientTimeout(total=timeout),
+            ) as resp:
+                return await resp.json()
+    except Exception as e:
+        return _error(str(e))
+
+
+async def _bridge_delete(path: str, json: Dict, timeout: float = 10) -> Dict[str, Any]:
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.delete(
+                f"{_BRIDGE_URL}{path}",
+                json=json,
+                timeout=aiohttp.ClientTimeout(total=timeout),
+            ) as resp:
+                return await resp.json()
+    except Exception as e:
+        return _error(str(e))
+
+
+# -----------------------------------------------------------------------
+# Tool functions
+# -----------------------------------------------------------------------
+
+async def whatsapp_search(query: str, chat_id: Optional[str] = None, limit: int = 50) -> Dict[str, Any]:
+    """Search WhatsApp messages using full-text search.
+    
+    Searches the local message history (stored in SQLite with FTS5) for messages
+    matching the query string. Optionally filter to a specific chat.
+    
+    Args:
+        query: Search term (supports FTS5 query syntax)
+        chat_id: Optional — restrict search to this WhatsApp chat
+        limit: Maximum results to return (default 50)
+    """
+    params = {"q": query, "limit": str(limit)}
+    if chat_id:
+        params["chat_id"] = chat_id
+    return await _bridge_get("/search", params)
+
+
+async def whatsapp_backfill(chat_id: str, limit: int = 50) -> Dict[str, Any]:
+    """Backfill historical messages from WhatsApp into local storage.
+    
+    Fetches old messages from WhatsApp servers and stores them in the local
+    SQLite database for search and history access.
+    
+    Args:
+        chat_id: WhatsApp chat ID to backfill (e.g. "123456789@s.whatsapp.net" or group JID)
+        limit: Maximum messages to fetch (default 50, max 10000)
+    """
+    return await _bridge_post("/backfill", {"chat_id": chat_id, "limit": limit}, timeout=60)
+
+
+async def whatsapp_list_groups() -> Dict[str, Any]:
+    """List all WhatsApp groups the account participates in.
+    
+    Returns group JIDs, names, descriptions, participant counts, and settings.
+    """
+    return await _bridge_get("/groups")
+
+
+async def whatsapp_create_group(name: str, participants: List[str]) -> Dict[str, Any]:
+    """Create a new WhatsApp group.
+    
+    Args:
+        name: Group subject/title
+        participants: List of phone numbers or WhatsApp IDs to add initially
+    """
+    return await _bridge_post("/group/create", {"name": name, "participants": participants})
+
+
+async def whatsapp_group_rename(chat_id: str, name: str) -> Dict[str, Any]:
+    """Rename a WhatsApp group (change the subject/title).
+    
+    Args:
+        chat_id: The group JID
+        name: New group subject
+    """
+    return await _bridge_post("/group/rename", {"chat_id": chat_id, "name": name})
+
+
+async def whatsapp_group_description(chat_id: str, description: str) -> Dict[str, Any]:
+    """Set a WhatsApp group's description.
+    
+    Args:
+        chat_id: The group JID
+        description: New group description (can be empty to clear)
+    """
+    return await _bridge_post("/group/description", {"chat_id": chat_id, "description": description})
+
+
+async def whatsapp_group_participants_add(chat_id: str, participants: List[str]) -> Dict[str, Any]:
+    """Add participants to a WhatsApp group.
+    
+    Args:
+        chat_id: The group JID
+        participants: List of phone numbers or WhatsApp IDs to add
+    """
+    return await _bridge_post("/group/participants/add", {"chat_id": chat_id, "participants": participants})
+
+
+async def whatsapp_group_participants_remove(chat_id: str, participants: List[str]) -> Dict[str, Any]:
+    """Remove participants from a WhatsApp group.
+    
+    Args:
+        chat_id: The group JID
+        participants: List of phone numbers or WhatsApp IDs to remove
+    """
+    return await _bridge_post("/group/participants/remove", {"chat_id": chat_id, "participants": participants})
+
+
+async def whatsapp_group_participants_promote(chat_id: str, participants: List[str]) -> Dict[str, Any]:
+    """Promote participants to admin in a WhatsApp group.
+    
+    Args:
+        chat_id: The group JID
+        participants: List of phone numbers or WhatsApp IDs to promote
+    """
+    return await _bridge_post("/group/participants/promote", {"chat_id": chat_id, "participants": participants})
+
+
+async def whatsapp_group_invite_link(chat_id: str) -> Dict[str, Any]:
+    """Get the invite link for a WhatsApp group.
+    
+    Args:
+        chat_id: The group JID
+    
+    Returns:
+        invite_link: The group invite URL
+    """
+    return await _bridge_get("/group/invite-link", {"chat_id": chat_id})
+
+
+async def whatsapp_group_invite_link_revoke(chat_id: str) -> Dict[str, Any]:
+    """Revoke the current invite link and generate a new one for a WhatsApp group.
+    
+    Args:
+        chat_id: The group JID
+    
+    Returns:
+        invite_link: The new group invite URL
+    """
+    return await _bridge_post("/group/invite-link/revoke", {"chat_id": chat_id})
+
+
+async def whatsapp_group_leave(chat_id: str) -> Dict[str, Any]:
+    """Leave a WhatsApp group.
+    
+    Args:
+        chat_id: The group JID to leave
+    """
+    return await _bridge_post("/group/leave", {"chat_id": chat_id})
+
+
+async def whatsapp_send_reaction(chat_id: str, message_id: str, emoji: str) -> Dict[str, Any]:
+    """Send an emoji reaction to a specific message.
+    
+    Args:
+        chat_id: The chat JID where the message is
+        message_id: The message ID to react to
+        emoji: Single emoji character (e.g. "👍", "❤️", "😂")
+    """
+    return await _bridge_post("/react", {"chat_id": chat_id, "message_id": message_id, "emoji": emoji})
+
+
+async def whatsapp_send_poll(chat_id: str, question: str, options: List[str], multiple_answers: bool = False) -> Dict[str, Any]:
+    """Send a poll to a WhatsApp chat.
+    
+    Args:
+        chat_id: The chat JID
+        question: Poll question/title
+        options: List of poll options (minimum 2, maximum 10)
+        multiple_answers: Allow multiple selections per voter (default False)
+    """
+    return await _bridge_post("/poll", {
+        "chat_id": chat_id,
+        "question": question,
+        "options": options,
+        "multiple_answers": multiple_answers,
+    })
+
+
+async def whatsapp_send_sticker(chat_id: str, file_path: str) -> Dict[str, Any]:
+    """Send a .webp sticker to a WhatsApp chat.
+    
+    Args:
+        chat_id: The chat JID
+        file_path: Absolute path to a .webp sticker file
+    """
+    return await _bridge_post("/sticker", {"chat_id": chat_id, "file_path": file_path})
+
+
+async def whatsapp_unsend_message(chat_id: str, message_id: str) -> Dict[str, Any]:
+    """Unsend (delete for everyone) a message you sent.
+    
+    Args:
+        chat_id: The chat JID where the message is
+        message_id: The message ID to delete
+    """
+    return await _bridge_delete("/message", {"chat_id": chat_id, "message_id": message_id})
+
+
+# -----------------------------------------------------------------------
+# Schema definitions
+# -----------------------------------------------------------------------
+
+_WHATSAPP_SCHEMAS = [
+    {
+        "name": "whatsapp_search",
+        "description": "Search WhatsApp messages using full-text search. Searches the local message history stored in SQLite with FTS5. Optionally filter to a specific chat.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Search term (supports FTS5 query syntax)"},
+                "chat_id": {"type": "string", "description": "Optional — restrict search to this WhatsApp chat ID"},
+                "limit": {"type": "integer", "description": "Maximum results to return (default 50)", "default": 50},
+            },
+            "required": ["query"],
+        },
+    },
+    {
+        "name": "whatsapp_backfill",
+        "description": "Backfill historical messages from WhatsApp into local SQLite storage for search and history access.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "chat_id": {"type": "string", "description": "WhatsApp chat ID to backfill"},
+                "limit": {"type": "integer", "description": "Maximum messages to fetch (default 50)", "default": 50},
+            },
+            "required": ["chat_id"],
+        },
+    },
+    {
+        "name": "whatsapp_list_groups",
+        "description": "List all WhatsApp groups the account participates in. Returns group JIDs, names, descriptions, and participant counts.",
+        "parameters": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "whatsapp_create_group",
+        "description": "Create a new WhatsApp group with a name and optional initial participants.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string", "description": "Group subject/title"},
+                "participants": {"type": "array", "items": {"type": "string"}, "description": "List of phone numbers or WhatsApp IDs to add initially"},
+            },
+            "required": ["name"],
+        },
+    },
+    {
+        "name": "whatsapp_group_rename",
+        "description": "Rename a WhatsApp group (change the subject/title).",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "chat_id": {"type": "string", "description": "The group JID"},
+                "name": {"type": "string", "description": "New group subject"},
+            },
+            "required": ["chat_id", "name"],
+        },
+    },
+    {
+        "name": "whatsapp_group_description",
+        "description": "Set or update a WhatsApp group's description.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "chat_id": {"type": "string", "description": "The group JID"},
+                "description": {"type": "string", "description": "New group description (can be empty to clear)"},
+            },
+            "required": ["chat_id"],
+        },
+    },
+    {
+        "name": "whatsapp_group_participants_add",
+        "description": "Add participants to a WhatsApp group.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "chat_id": {"type": "string", "description": "The group JID"},
+                "participants": {"type": "array", "items": {"type": "string"}, "description": "List of phone numbers or WhatsApp IDs to add"},
+            },
+            "required": ["chat_id", "participants"],
+        },
+    },
+    {
+        "name": "whatsapp_group_participants_remove",
+        "description": "Remove participants from a WhatsApp group.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "chat_id": {"type": "string", "description": "The group JID"},
+                "participants": {"type": "array", "items": {"type": "string"}, "description": "List of phone numbers or WhatsApp IDs to remove"},
+            },
+            "required": ["chat_id", "participants"],
+        },
+    },
+    {
+        "name": "whatsapp_group_participants_promote",
+        "description": "Promote participants to admin in a WhatsApp group.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "chat_id": {"type": "string", "description": "The group JID"},
+                "participants": {"type": "array", "items": {"type": "string"}, "description": "List of phone numbers or WhatsApp IDs to promote to admin"},
+            },
+            "required": ["chat_id", "participants"],
+        },
+    },
+    {
+        "name": "whatsapp_group_invite_link",
+        "description": "Get the invite link for a WhatsApp group.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "chat_id": {"type": "string", "description": "The group JID"},
+            },
+            "required": ["chat_id"],
+        },
+    },
+    {
+        "name": "whatsapp_group_invite_link_revoke",
+        "description": "Revoke the current invite link and generate a new one for a WhatsApp group.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "chat_id": {"type": "string", "description": "The group JID"},
+            },
+            "required": ["chat_id"],
+        },
+    },
+    {
+        "name": "whatsapp_group_leave",
+        "description": "Leave a WhatsApp group.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "chat_id": {"type": "string", "description": "The group JID to leave"},
+            },
+            "required": ["chat_id"],
+        },
+    },
+    {
+        "name": "whatsapp_send_reaction",
+        "description": "Send an emoji reaction to a specific message.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "chat_id": {"type": "string", "description": "The chat JID where the message is"},
+                "message_id": {"type": "string", "description": "The message ID to react to"},
+                "emoji": {"type": "string", "description": "Single emoji character (e.g. '👍', '❤️', '😂')"},
+            },
+            "required": ["chat_id", "message_id", "emoji"],
+        },
+    },
+    {
+        "name": "whatsapp_send_poll",
+        "description": "Send a poll to a WhatsApp chat where group members can vote.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "chat_id": {"type": "string", "description": "The chat JID"},
+                "question": {"type": "string", "description": "Poll question/title"},
+                "options": {"type": "array", "items": {"type": "string"}, "description": "List of poll options (minimum 2, maximum 10)"},
+                "multiple_answers": {"type": "boolean", "description": "Allow multiple selections per voter", "default": False},
+            },
+            "required": ["chat_id", "question", "options"],
+        },
+    },
+    {
+        "name": "whatsapp_send_sticker",
+        "description": "Send a .webp sticker to a WhatsApp chat.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "chat_id": {"type": "string", "description": "The chat JID"},
+                "file_path": {"type": "string", "description": "Absolute path to a .webp sticker file"},
+            },
+            "required": ["chat_id", "file_path"],
+        },
+    },
+    {
+        "name": "whatsapp_unsend_message",
+        "description": "Unsend (delete for everyone) a message you sent. Only works for your own messages.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "chat_id": {"type": "string", "description": "The chat JID where the message is"},
+                "message_id": {"type": "string", "description": "The message ID to delete"},
+            },
+            "required": ["chat_id", "message_id"],
+        },
+    },
+]
+
+_WHATSAPP_SCHEMA_MAP = {s["name"]: s for s in _WHATSAPP_SCHEMAS}
+
+# -----------------------------------------------------------------------
+# Registry
+# -----------------------------------------------------------------------
+
+registry.register(
+    name="whatsapp_search",
+    toolset="hermes-whatsapp",
+    schema=_WHATSAPP_SCHEMA_MAP["whatsapp_search"],
+    handler=lambda args, **kw: whatsapp_search(
+        query=args.get("query"),
+        chat_id=args.get("chat_id"),
+        limit=args.get("limit", 50),
+    ),
+    emoji="🔍",
+)
+
+registry.register(
+    name="whatsapp_backfill",
+    toolset="hermes-whatsapp",
+    schema=_WHATSAPP_SCHEMA_MAP["whatsapp_backfill"],
+    handler=lambda args, **kw: whatsapp_backfill(
+        chat_id=args.get("chat_id"),
+        limit=args.get("limit", 50),
+    ),
+    emoji="📥",
+)
+
+registry.register(
+    name="whatsapp_list_groups",
+    toolset="hermes-whatsapp",
+    schema=_WHATSAPP_SCHEMA_MAP["whatsapp_list_groups"],
+    handler=lambda args, **kw: whatsapp_list_groups(),
+    emoji="👥",
+)
+
+registry.register(
+    name="whatsapp_create_group",
+    toolset="hermes-whatsapp",
+    schema=_WHATSAPP_SCHEMA_MAP["whatsapp_create_group"],
+    handler=lambda args, **kw: whatsapp_create_group(
+        name=args.get("name"),
+        participants=args.get("participants", []),
+    ),
+    emoji="🆕",
+)
+
+registry.register(
+    name="whatsapp_group_rename",
+    toolset="hermes-whatsapp",
+    schema=_WHATSAPP_SCHEMA_MAP["whatsapp_group_rename"],
+    handler=lambda args, **kw: whatsapp_group_rename(
+        chat_id=args.get("chat_id"),
+        name=args.get("name"),
+    ),
+    emoji="✏️",
+)
+
+registry.register(
+    name="whatsapp_group_description",
+    toolset="hermes-whatsapp",
+    schema=_WHATSAPP_SCHEMA_MAP["whatsapp_group_description"],
+    handler=lambda args, **kw: whatsapp_group_description(
+        chat_id=args.get("chat_id"),
+        description=args.get("description", ""),
+    ),
+    emoji="📝",
+)
+
+registry.register(
+    name="whatsapp_group_participants_add",
+    toolset="hermes-whatsapp",
+    schema=_WHATSAPP_SCHEMA_MAP["whatsapp_group_participants_add"],
+    handler=lambda args, **kw: whatsapp_group_participants_add(
+        chat_id=args.get("chat_id"),
+        participants=args.get("participants", []),
+    ),
+    emoji="➕",
+)
+
+registry.register(
+    name="whatsapp_group_participants_remove",
+    toolset="hermes-whatsapp",
+    schema=_WHATSAPP_SCHEMA_MAP["whatsapp_group_participants_remove"],
+    handler=lambda args, **kw: whatsapp_group_participants_remove(
+        chat_id=args.get("chat_id"),
+        participants=args.get("participants", []),
+    ),
+    emoji="➖",
+)
+
+registry.register(
+    name="whatsapp_group_participants_promote",
+    toolset="hermes-whatsapp",
+    schema=_WHATSAPP_SCHEMA_MAP["whatsapp_group_participants_promote"],
+    handler=lambda args, **kw: whatsapp_group_participants_promote(
+        chat_id=args.get("chat_id"),
+        participants=args.get("participants", []),
+    ),
+    emoji="⬆️",
+)
+
+registry.register(
+    name="whatsapp_group_invite_link",
+    toolset="hermes-whatsapp",
+    schema=_WHATSAPP_SCHEMA_MAP["whatsapp_group_invite_link"],
+    handler=lambda args, **kw: whatsapp_group_invite_link(chat_id=args.get("chat_id")),
+    emoji="🔗",
+)
+
+registry.register(
+    name="whatsapp_group_invite_link_revoke",
+    toolset="hermes-whatsapp",
+    schema=_WHATSAPP_SCHEMA_MAP["whatsapp_group_invite_link_revoke"],
+    handler=lambda args, **kw: whatsapp_group_invite_link_revoke(chat_id=args.get("chat_id")),
+    emoji="🔄",
+)
+
+registry.register(
+    name="whatsapp_group_leave",
+    toolset="hermes-whatsapp",
+    schema=_WHATSAPP_SCHEMA_MAP["whatsapp_group_leave"],
+    handler=lambda args, **kw: whatsapp_group_leave(chat_id=args.get("chat_id")),
+    emoji="🚪",
+)
+
+registry.register(
+    name="whatsapp_send_reaction",
+    toolset="hermes-whatsapp",
+    schema=_WHATSAPP_SCHEMA_MAP["whatsapp_send_reaction"],
+    handler=lambda args, **kw: whatsapp_send_reaction(
+        chat_id=args.get("chat_id"),
+        message_id=args.get("message_id"),
+        emoji=args.get("emoji"),
+    ),
+    emoji="😀",
+)
+
+registry.register(
+    name="whatsapp_send_poll",
+    toolset="hermes-whatsapp",
+    schema=_WHATSAPP_SCHEMA_MAP["whatsapp_send_poll"],
+    handler=lambda args, **kw: whatsapp_send_poll(
+        chat_id=args.get("chat_id"),
+        question=args.get("question"),
+        options=args.get("options", []),
+        multiple_answers=args.get("multiple_answers", False),
+    ),
+    emoji="📊",
+)
+
+registry.register(
+    name="whatsapp_send_sticker",
+    toolset="hermes-whatsapp",
+    schema=_WHATSAPP_SCHEMA_MAP["whatsapp_send_sticker"],
+    handler=lambda args, **kw: whatsapp_send_sticker(
+        chat_id=args.get("chat_id"),
+        file_path=args.get("file_path"),
+    ),
+    emoji="🎨",
+)
+
+registry.register(
+    name="whatsapp_unsend_message",
+    toolset="hermes-whatsapp",
+    schema=_WHATSAPP_SCHEMA_MAP["whatsapp_unsend_message"],
+    handler=lambda args, **kw: whatsapp_unsend_message(
+        chat_id=args.get("chat_id"),
+        message_id=args.get("message_id"),
+    ),
+    emoji="🗑️",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -309,8 +309,25 @@ TOOLSETS = {
     },
     
     "hermes-whatsapp": {
-        "description": "WhatsApp bot toolset - similar to Telegram (personal messaging, more trusted)",
-        "tools": _HERMES_CORE_TOOLS,
+        "description": "WhatsApp bot toolset - similar to Telegram (personal messaging, more trusted). Includes group management, polls, reactions, search, backfill, and stickers.",
+        "tools": _HERMES_CORE_TOOLS + [
+            "whatsapp_search",
+            "whatsapp_backfill",
+            "whatsapp_list_groups",
+            "whatsapp_create_group",
+            "whatsapp_group_rename",
+            "whatsapp_group_description",
+            "whatsapp_group_participants_add",
+            "whatsapp_group_participants_remove",
+            "whatsapp_group_participants_promote",
+            "whatsapp_group_invite_link",
+            "whatsapp_group_invite_link_revoke",
+            "whatsapp_group_leave",
+            "whatsapp_send_reaction",
+            "whatsapp_send_poll",
+            "whatsapp_send_sticker",
+            "whatsapp_unsend_message",
+        ],
         "includes": []
     },
     


### PR DESCRIPTION
## What changed and why

Backfill messages returned by `fetchMessageHistory()` arrive via the `messaging-history.set` event emitted from Baileys' `process-message.ts` — **not** `messages.upsert`. The bridge was only listening to `messages.upsert`, so backfill messages were silently dropped.

The new permanent handler (`sock.ev.on('messaging-history.set', ...)`) mirrors the `messages.upsert` logic:

- Skips `fromMe` echo-backs
- Enforces allowlist (with LID ↔ phone alias resolution)
- Extracts body, media (image/video/audio/document), mentions, quoted replies
- Pushes normalized events to `messageQueue` and SQLite (when `WHATSAPP_ULTIMATE=true`)

## How to test

1. Start the bridge with `WHATSAPP_ULTIMATE=true WHATSAPP_MODE=self-chat node bridge.js --port 18792`
2. Send/receive a message in a chat to create an anchor
3. `POST /backfill` with `{ chat_id: "<your-chat-id>", limit: 50 }`
4. Verify messages appear in SQLite: `SELECT COUNT(*) FROM messages WHERE chat_id = '<chat-id>'`
5. Or poll `GET /messages` — backfill messages should appear in the queue

## What platforms were tested

- Linux (primary dev environment)
- WhatsApp backfill only works when the phone is online and WhatsApp is open