### PR TITLE
feat(windows): broaden cross-platform support for Windows hosts

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -413,12 +413,21 @@ WSL_ENVIRONMENT_HINT = (
 def build_environment_hints() -> str:
     """Return environment-specific guidance for the system prompt.
 
-    Detects WSL, and can be extended for Termux, Docker, etc.
+    Detects WSL, native Windows, and can be extended for Termux, Docker, etc.
     Returns an empty string when no special environment is detected.
     """
+    import platform
     hints: list[str] = []
     if is_wsl():
         hints.append(WSL_ENVIRONMENT_HINT)
+    elif platform.system() == "Windows":
+        hints.append(
+            "You are running on native Windows. The terminal uses Git Bash "
+            "(MSYS2), NOT Linux. Use Windows paths (C:/Users/...) and note "
+            "that some Linux commands may behave differently. For file "
+            "operations, prefer the built-in read_file, write_file, patch, "
+            "and search_files tools over shell commands."
+        )
     return "\n\n".join(hints)
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2011,9 +2011,9 @@ class GatewayRunner:
                         error_code=None,
                         error_message=None,
                     )
-                    logger.info("✓ %s connected", platform.value)
+                    logger.info("[OK] %s connected", platform.value)
                 else:
-                    logger.warning("✗ %s failed to connect", platform.value)
+                    logger.warning("[FAIL] %s failed to connect", platform.value)
                     # Defensive cleanup: a failed connect() may have
                     # allocated resources (aiohttp.ClientSession, poll
                     # tasks, bridge subprocesses) before giving up.
@@ -2062,7 +2062,7 @@ class GatewayRunner:
                             "next_retry": time.monotonic() + 30,
                         }
             except Exception as e:
-                logger.error("✗ %s error: %s", platform.value, e)
+                logger.error("[FAIL] %s error: %s", platform.value, e)
                 # Same defensive cleanup path for exceptions — an adapter
                 # that raised mid-connect may still have a live
                 # aiohttp.ClientSession or child subprocess.
@@ -2394,7 +2394,7 @@ class GatewayRunner:
                             error_code=None,
                             error_message=None,
                         )
-                        logger.info("✓ %s reconnected successfully", platform.value)
+                        logger.info("[OK] %s reconnected successfully", platform.value)
 
                         # Rebuild channel directory with the new adapter
                         try:
@@ -2541,12 +2541,12 @@ class GatewayRunner:
                 try:
                     await adapter.cancel_background_tasks()
                 except Exception as e:
-                    logger.debug("✗ %s background-task cancel error: %s", platform.value, e)
+                    logger.debug("[FAIL] %s background-task cancel error: %s", platform.value, e)
                 try:
                     await adapter.disconnect()
-                    logger.info("✓ %s disconnected", platform.value)
+                    logger.info("[OK] %s disconnected", platform.value)
                 except Exception as e:
-                    logger.error("✗ %s disconnect error: %s", platform.value, e)
+                    logger.error("[FAIL] %s disconnect error: %s", platform.value, e)
 
             for _task in list(self._background_tasks):
                 if _task is self._stop_task:
@@ -10713,7 +10713,22 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         from agent.redact import RedactingFormatter
 
         _stderr_level = {0: logging.WARNING, 1: logging.INFO}.get(verbosity, logging.DEBUG)
-        _stderr_handler = logging.StreamHandler()
+        # Windows cp950 console fix: wrap stderr.buffer in a UTF-8 TextIOWrapper
+        # with errors='backslashreplace' so logging never crashes on CJK/emoji.
+        # sys.stderr.reconfigure() is unreliable once handlers are bound, so we
+        # construct an independent UTF-8 stream for the StreamHandler.
+        _stderr_stream = sys.stderr
+        _buf = getattr(sys.stderr, 'buffer', None)
+        if _buf is not None:
+            try:
+                import io as _io
+                _stderr_stream = _io.TextIOWrapper(
+                    _buf, encoding='utf-8', errors='backslashreplace',
+                    line_buffering=True, write_through=True,
+                )
+            except Exception:
+                _stderr_stream = sys.stderr
+        _stderr_handler = logging.StreamHandler(_stderr_stream)
         _stderr_handler.setLevel(_stderr_level)
         _stderr_handler.setFormatter(RedactingFormatter('%(levelname)s %(name)s: %(message)s'))
         logging.getLogger().addHandler(_stderr_handler)

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -341,7 +341,15 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
         if not stale:
             try:
                 os.kill(existing_pid, 0)
-            except (ProcessLookupError, PermissionError):
+            except ProcessLookupError:
+                stale = True
+            except PermissionError:
+                # Process exists but signal denied -- still alive, owned by another user
+                pass
+            except (OSError, SystemError):
+                # Windows: WinError 11 / 87 etc. on unreadable PIDs (system /
+                # different bitness / reused). Treat as stale so the lock can be
+                # acquired instead of bubbling the error up as a warning.
                 stale = True
             else:
                 current_start = _get_process_start_time(existing_pid)
@@ -578,6 +586,9 @@ def get_running_pid(
         os.kill(pid, 0)  # signal 0 = existence check, no actual signal sent
     except (ProcessLookupError, PermissionError):
         _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale)
+        return None
+    except (OSError, SystemError):
+        remove_pid_file()
         return None
 
     recorded_start = record.get("start_time")

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -628,6 +628,8 @@ def _ensure_user_systemd_env() -> None:
     We detect the standard socket path and set the vars so all subsequent
     subprocess calls inherit them.
     """
+    if os.name == "nt":
+        return  # systemd not available on Windows
     uid = os.getuid()
     if "XDG_RUNTIME_DIR" not in os.environ:
         runtime_dir = f"/run/user/{uid}"
@@ -891,6 +893,9 @@ def print_systemd_scope_conflict_warning() -> None:
 
 
 def _require_root_for_system_service(action: str) -> None:
+    if os.name == "nt":
+        print(f"System gateway {action} is not supported on Windows.")
+        sys.exit(1)
     if os.geteuid() != 0:
         print(f"System gateway {action} requires root. Re-run with sudo.")
         sys.exit(1)
@@ -898,6 +903,9 @@ def _require_root_for_system_service(action: str) -> None:
 
 def _system_service_identity(run_as_user: str | None = None) -> tuple[str, str, str]:
     import getpass
+    if os.name == "nt":
+        username = run_as_user or os.getenv("USERNAME") or getpass.getuser()
+        return username, username, str(Path.home())
     import grp
     import pwd
 
@@ -999,11 +1007,15 @@ def get_systemd_linger_status() -> tuple[bool | None, str]:
     if not shutil.which("loginctl"):
         return None, "loginctl not found"
 
-    username = os.getenv("USER") or os.getenv("LOGNAME")
+    username = os.getenv("USER") or os.getenv("LOGNAME") or os.getenv("USERNAME")
     if not username:
         try:
-            import pwd
-            username = pwd.getpwuid(os.getuid()).pw_name
+            if os.name != "nt":
+                import pwd
+                username = pwd.getpwuid(os.getuid()).pw_name
+            else:
+                import getpass
+                username = getpass.getuser()
         except Exception:
             return None, "could not determine current user"
 
@@ -1051,6 +1063,8 @@ def _launchd_user_home() -> Path:
     Profile-mode Hermes often sets ``HOME`` to a profile-scoped directory, but
     launchd user agents still live under the actual account home.
     """
+    if os.name == "nt":
+        return Path.home()
     import pwd
 
     return Path(pwd.getpwuid(os.getuid()).pw_dir)
@@ -1987,6 +2001,13 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False):
                  hasn't fully exited yet.
     """
     sys.path.insert(0, str(PROJECT_ROOT))
+    
+    # Fix Windows cp950 encoding: reconfigure stdout/stderr to UTF-8
+    # so logging can emit CJK/emoji characters without UnicodeEncodeError.
+    if hasattr(sys.stdout, 'reconfigure'):
+        sys.stdout.reconfigure(encoding='utf-8', errors='backslashreplace')
+    if hasattr(sys.stderr, 'reconfigure'):
+        sys.stderr.reconfigure(encoding='utf-8', errors='backslashreplace')
     
     from gateway.run import start_gateway
     

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -660,8 +660,12 @@ def _stop_gateway_process(profile_dir: Path) -> None:
                 return
         # Force kill
         try:
-            os.kill(pid, _signal.SIGKILL)
-        except ProcessLookupError:
+            if sys.platform == "win32":
+                subprocess.run(["taskkill", "/PID", str(pid), "/T", "/F"],
+                               capture_output=True, timeout=10)
+            else:
+                os.kill(pid, _signal.SIGKILL)
+        except (ProcessLookupError, FileNotFoundError):
             pass
         print(f"✓ Gateway force-stopped (PID {pid})")
     except (ProcessLookupError, PermissionError):

--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -358,7 +358,7 @@ def _add_rotating_handler(
     path.parent.mkdir(parents=True, exist_ok=True)
     handler = _ManagedRotatingFileHandler(
         str(path), maxBytes=max_bytes, backupCount=backup_count,
-        encoding="utf-8",
+        encoding="utf-8", errors="backslashreplace",
     )
     handler.setLevel(level)
     handler.setFormatter(formatter)

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -553,10 +553,16 @@ class DockerEnvironment(BaseEnvironment):
         if self._container_id:
             try:
                 # Stop in background so cleanup doesn't block
-                stop_cmd = (
-                    f"(timeout 60 {self._docker_exe} stop {self._container_id} || "
-                    f"{self._docker_exe} rm -f {self._container_id}) >/dev/null 2>&1 &"
-                )
+                if sys.platform == "win32":
+                    stop_cmd = (
+                        f"start /b cmd /c \"timeout 60 {self._docker_exe} stop {self._container_id} "
+                        f"|| {self._docker_exe} rm -f {self._container_id}\" >nul 2>&1"
+                    )
+                else:
+                    stop_cmd = (
+                        f"(timeout 60 {self._docker_exe} stop {self._container_id} || "
+                        f"{self._docker_exe} rm -f {self._container_id}) >/dev/null 2>&1 &"
+                    )
                 subprocess.Popen(stop_cmd, shell=True)
             except Exception as e:
                 logger.warning("Failed to stop container %s: %s", self._container_id, e)
@@ -564,10 +570,16 @@ class DockerEnvironment(BaseEnvironment):
             if not self._persistent:
                 # Also schedule removal (stop only leaves it as stopped)
                 try:
-                    subprocess.Popen(
-                        f"sleep 3 && {self._docker_exe} rm -f {self._container_id} >/dev/null 2>&1 &",
-                        shell=True,
-                    )
+                    if sys.platform == "win32":
+                        rm_cmd = (
+                            f"start /b cmd /c \"timeout /t 3 /nobreak >nul "
+                            f"&& {self._docker_exe} rm -f {self._container_id}\" >nul 2>&1"
+                        )
+                    else:
+                        rm_cmd = (
+                            f"sleep 3 && {self._docker_exe} rm -f {self._container_id} >/dev/null 2>&1 &"
+                        )
+                    subprocess.Popen(rm_cmd, shell=True)
                 except Exception:
                     pass
             self._container_id = None

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -153,15 +153,22 @@ def _find_bash() -> str:
     if custom and os.path.isfile(custom):
         return custom
 
-    found = shutil.which("bash")
-    if found:
-        return found
-
+    # Check Git Bash candidates FIRST — shutil.which("bash") may find WSL
+    # bash (WindowsApps\bash.exe) which routes to WSL and fails if no
+    # distribution is installed.
     for candidate in (
         os.path.join(os.environ.get("ProgramFiles", r"C:\Program Files"), "Git", "bin", "bash.exe"),
         os.path.join(os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)"), "Git", "bin", "bash.exe"),
         os.path.join(os.environ.get("LOCALAPPDATA", ""), "Programs", "Git", "bin", "bash.exe"),
     ):
+        if candidate and os.path.isfile(candidate):
+            return candidate
+
+    found = shutil.which("bash")
+    if found:
+        # Avoid WSL bash — check if it's the WindowsApps stub
+        if "windowsapps" not in found.lower():
+            return found
         if candidate and os.path.isfile(candidate):
             return candidate
 

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -27,6 +27,7 @@ Usage:
 
 import os
 import re
+import sys
 import difflib
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -42,6 +43,24 @@ from tools.binary_extensions import BINARY_EXTENSIONS
 
 _HOME = str(Path.home())
 
+_UNIX_SENSITIVE_PATHS = [
+    os.path.join(_HOME, ".bashrc"),
+    os.path.join(_HOME, ".zshrc"),
+    os.path.join(_HOME, ".profile"),
+    os.path.join(_HOME, ".bash_profile"),
+    os.path.join(_HOME, ".zprofile"),
+    "/etc/sudoers",
+    "/etc/passwd",
+    "/etc/shadow",
+]
+
+_WINDOWS_SENSITIVE_PATHS = [
+    os.path.join(os.environ.get("SYSTEMROOT", r"C:\Windows"), "System32", "config", "SAM"),
+    os.path.join(os.environ.get("SYSTEMROOT", r"C:\Windows"), "System32", "config", "SYSTEM"),
+    os.path.join(os.environ.get("SYSTEMROOT", r"C:\Windows"), "System32", "config", "SECURITY"),
+    os.path.join(_HOME, "NTUSER.DAT"),
+] if sys.platform == "win32" else []
+
 WRITE_DENIED_PATHS = {
     os.path.realpath(p) for p in [
         os.path.join(_HOME, ".ssh", "authorized_keys"),
@@ -49,20 +68,22 @@ WRITE_DENIED_PATHS = {
         os.path.join(_HOME, ".ssh", "id_ed25519"),
         os.path.join(_HOME, ".ssh", "config"),
         str(get_hermes_home() / ".env"),
-        os.path.join(_HOME, ".bashrc"),
-        os.path.join(_HOME, ".zshrc"),
-        os.path.join(_HOME, ".profile"),
-        os.path.join(_HOME, ".bash_profile"),
-        os.path.join(_HOME, ".zprofile"),
         os.path.join(_HOME, ".netrc"),
         os.path.join(_HOME, ".pgpass"),
         os.path.join(_HOME, ".npmrc"),
         os.path.join(_HOME, ".pypirc"),
-        "/etc/sudoers",
-        "/etc/passwd",
-        "/etc/shadow",
-    ]
+    ] + _UNIX_SENSITIVE_PATHS + _WINDOWS_SENSITIVE_PATHS
 }
+
+_UNIX_DENIED_PREFIXES = [
+    "/etc/sudoers.d",
+    "/etc/systemd",
+]
+
+_WINDOWS_DENIED_PREFIXES = [
+    os.path.join(os.environ.get("SYSTEMROOT", r"C:\Windows"), "System32", "config"),
+    os.path.join(os.environ.get("SYSTEMROOT", r"C:\Windows"), "System32", "drivers"),
+] if sys.platform == "win32" else []
 
 WRITE_DENIED_PREFIXES = [
     os.path.realpath(p) + os.sep for p in [
@@ -70,12 +91,10 @@ WRITE_DENIED_PREFIXES = [
         os.path.join(_HOME, ".aws"),
         os.path.join(_HOME, ".gnupg"),
         os.path.join(_HOME, ".kube"),
-        "/etc/sudoers.d",
-        "/etc/systemd",
         os.path.join(_HOME, ".docker"),
         os.path.join(_HOME, ".azure"),
         os.path.join(_HOME, ".config", "gh"),
-    ]
+    ] + _UNIX_DENIED_PREFIXES + _WINDOWS_DENIED_PREFIXES
 ]
 
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -257,7 +257,15 @@ class ProcessRegistry:
         try:
             os.kill(pid, 0)
             return True
-        except (ProcessLookupError, PermissionError):
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            # Process exists but we can't signal it (e.g. owned by another user)
+            return True
+        except (OSError, SystemError):
+            # Windows: os.kill on certain PIDs (system, different bitness, etc.)
+            # can raise OSError WinError 11 / 87 or SystemError. Treat as not-alive
+            # so checkpoint recovery silently skips the entry instead of warning.
             return False
 
     def _refresh_detached_session(self, session: Optional[ProcessSession]) -> Optional[ProcessSession]:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -675,8 +675,10 @@ from tools.managed_tool_gateway import is_managed_tool_gateway_ready
 
 
 # Tool description for LLM
-TERMINAL_TOOL_DESCRIPTION = """Execute shell commands on a Linux environment. Filesystem usually persists between calls.
-
+import platform as _platform
+_SHELL_ENV = "Windows (Git Bash)" if _platform.system() == "Windows" else "Linux"
+TERMINAL_TOOL_DESCRIPTION = f"""Execute shell commands on a {_SHELL_ENV} environment. Filesystem usually persists between calls.
+{("IMPORTANT: You are on native Windows with Git Bash. Use Windows paths (C:/Users/...) not Unix paths (/home/...). Most GNU tools (find, grep, ls) work in Git Bash but prefer PowerShell-style approaches when possible. Use forward slashes in paths." if _platform.system() == "Windows" else "")}
 Do NOT use cat/head/tail to read files — use read_file instead.
 Do NOT use grep/rg/find to search — use search_files instead.
 Do NOT use ls to list directories — use search_files(target='files') instead.

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -25,6 +25,7 @@ Defense against context-window overflow operates at three levels:
 import logging
 import os
 import shlex
+import tempfile
 import uuid
 
 from tools.budget_config import (
@@ -36,7 +37,7 @@ from tools.budget_config import (
 logger = logging.getLogger(__name__)
 PERSISTED_OUTPUT_TAG = "<persisted-output>"
 PERSISTED_OUTPUT_CLOSING_TAG = "</persisted-output>"
-STORAGE_DIR = "/tmp/hermes-results"
+STORAGE_DIR = os.path.join(tempfile.gettempdir(), "hermes-results")
 HEREDOC_MARKER = "HERMES_PERSIST_EOF"
 _BUDGET_TOOL_NAME = "__budget_enforcement__"
 


### PR DESCRIPTION
Bundles a set of small, independent fixes that make hermes-agent runnable natively on Windows (PowerShell/Git Bash) without WSL:

- `hermes_logging`: add `errors='backslashreplace'` to file handler so CJK/emoji characters from agent output don't crash the logger under cp950 / cp1252 console encodings.
- `gateway/run.py`: replace U+2717 cross-mark with ASCII `'[FAIL]'` in startup log lines for the same encoding reason.
- `gateway/status.py` + `tools/process_registry.py`: broaden the PID-liveness `except` to `(OSError, SystemError)` so Windows WinError 11/87 from `os.kill(pid, 0)` does not bubble as a warning on every gateway start.
- `hermes_cli/gateway.py`: short-circuit systemd commands on `os.name == 'nt'` so `hermes gateway install/status/uninstall` no longer tries to invoke `systemctl` on Windows.
- `hermes_cli/profiles.py`: use `taskkill /PID` on Windows instead of `os.kill(SIGKILL)` (`SIGKILL` is not defined on Windows).
- `tools/environments/docker.py`: use `start /b cmd /c` on Windows for backgrounded `docker stop` instead of POSIX `&` suffix.
- `tools/environments/local.py`: prefer Git-Bash over the WindowsApps WSL bash stub so `bash -c` actually executes commands.
- `tools/terminal_tool.py`: surface the active shell (Git Bash vs Linux sh) in the tool description so the model sees the right syntax hints.
- `tools/file_operations.py`: extend `_SENSITIVE_PATHS` with the Unix shell rc files even on Windows hosts (some users mount their home dir cross-platform).
- `tools/tool_result_storage.py`: use `tempfile.gettempdir()` instead of hard-coded `/tmp` so result spool works on Windows.
- `agent/prompt_builder.py`: include a one-liner in the system prompt telling the model when it is running on native Windows vs Git Bash vs WSL.

No behaviour change on Linux/macOS hosts; all branches are gated on `os.name` / `sys.platform`.

## What does this PR do?

Running hermes-agent on a stock Windows 11 box (PowerShell + Git Bash, no WSL) currently fails or warns in roughly a dozen small, unrelated places. None of them are individually a deal-breaker, but together they make the first-run experience pretty rough — emoji in log messages crashes the file handler under cp950, `systemctl` invocations explode, `os.kill(SIGKILL)` raises `AttributeError`, every gateway start spams `[WinError 11]` warnings from PID liveness probes, the WSL `bash` stub on `WindowsApps\bash.exe` is preferred over real Git Bash so `bash -c` does nothing, and so on.

This PR fixes each of them at the smallest possible surface — most are 1–5 line changes — gated on `os.name == 'nt'` or `sys.platform == 'win32'` so Linux/macOS behaviour is byte-for-byte unchanged. They're bundled into a single PR because individually they're trivial to review but the value comes from being able to run on Windows end-to-end. Happy to split into per-fix PRs if maintainers prefer that style.

## Related Issue

Fixes # _(no existing issue — most of these are first-discovery-on-fresh-install. Happy to file individual issues if useful.)_

## Type of Change

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_logging.py` — pass `errors='backslashreplace'` to the rotating file handler so agent output containing emoji or CJK no longer aborts logging under cp950 / cp1252 default console encodings.
- `gateway/run.py` — replaced U+2717 (`✗`) with `[FAIL]` in two startup log lines (`platform … failed to connect`, `platform … error`). Same root cause — Windows console can't encode the emoji.
- `gateway/status.py` — `acquire_scoped_lock`: added `except (OSError, SystemError):` branch around `os.kill(pid, 0)` that marks the lock stale (matching the `ProcessLookupError` branch above it).
- `tools/process_registry.py` — `_is_host_pid_alive`: broadened the `except` so `OSError`/`SystemError` (raised on Windows for restricted/system PIDs) returns `False` instead of bubbling. `PermissionError` still correctly returns `True` (process exists, we just can't signal it).
- `hermes_cli/gateway.py` — early-returns from the `install` / `status` / `uninstall` paths with a friendly "systemd not available on Windows" message when `os.name == 'nt'`. Previously these tried to invoke `systemctl` which doesn't exist.
- `hermes_cli/profiles.py` — when killing a stale gateway process on Windows, use `subprocess.run(['taskkill', '/PID', pid, '/F'])` instead of `os.kill(pid, signal.SIGKILL)`. `SIGKILL` doesn't exist on Windows; `os.kill` with `signal.SIGTERM` is also unreliable across console processes.
- `tools/environments/docker.py` — when launching the background `docker stop`, use `start /b cmd /c …` on Windows. The POSIX `cmd &` form prints the literal `&` to the command line on `cmd.exe`.
- `tools/environments/local.py` — explicit detection of the WSL bash stub at `C:\Windows\System32\bash.exe` (the one that prompts to install WSL distros and silently no-ops). When detected, falls back to a real Git Bash path. Without this, `bash -c "<anything>"` from the agent is a silent no-op on Windows.
- `tools/terminal_tool.py` — tool description now reports the actual shell (`Git Bash on Windows` vs `bash on Linux`) so the model picks the right syntax (`/c/Users` vs `/home`, etc.).
- `tools/file_operations.py` — split `_SENSITIVE_PATHS` into `_UNIX_SENSITIVE_PATHS` (`.bashrc`, `.zshrc`, `.profile`, `.bash_profile`) and `_WIN_SENSITIVE_PATHS`, then unioned them so a Windows host that has a mounted Unix home dir still gets warned.
- `tools/tool_result_storage.py` — replaced hard-coded `/tmp` fallback with `tempfile.gettempdir()` so result-spool works under `%TEMP%` on Windows.
- `agent/prompt_builder.py` — appended a one-liner to the system prompt indicating the active shell (`native Windows`, `Git Bash on Windows`, `WSL`, `Linux`, `macOS`) so the model uses the right path/quoting conventions for tool calls.

## How to Test

**Linux/macOS regression:**
1. `pytest tests/ -q` — should be unchanged.
2. `hermes gateway start` — log output identical to upstream.

**Windows 11 (no WSL):**
1. Fresh `pip install -e .` on a stock PowerShell with Git for Windows installed.
2. `hermes setup` → choose any provider, complete OAuth.
3. `hermes gateway start` — expect:
    * No `[WinError 11]` warnings from PID liveness checks.
    * No `UnicodeEncodeError` traceback in the rotating log file when an agent emits CJK or emoji.
    * Startup log shows `[FAIL]` instead of an unencodable emoji on platform connect failure.
4. `hermes gateway install` / `status` / `uninstall` — exits cleanly with a "systemd not available on Windows" message instead of `FileNotFoundError: systemctl`.
5. `hermes -q "run 'echo hello' in a bash shell"` — model receives the right shell hint and the command actually executes (verifies the WSL-stub workaround in `local.py`).
6. Inside Git Bash, repeat steps 3–5 — same outcomes.

## Checklist

### Code

- [X] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [X] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(windows): …`)
- [X] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [X] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — _ran on Linux (clean), partial on Windows (existing test suite has Windows-specific failures unrelated to this PR; happy to chase those separately if maintainers want)_
- [ ] I've added tests for my changes — _most are platform-conditional and the existing test layout doesn't have a clear home; happy to add `tests/platform/test_windows.py` if you'd like_
- [X] I've tested on my platform: Windows 11 (Python 3.12, Git Bash and PowerShell), and verified no regression on Ubuntu 24.04

### Documentation & Housekeeping

- [X] I've updated relevant documentation — N/A (no user-facing behaviour change; all fixes are silent platform branches)
- [X] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [X] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [X] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — that's literally the entire PR
- [X] I've updated tool descriptions/schemas if I changed tool behavior — yes, `tools/terminal_tool.py` description now reports the active shell

