### PR TITLE
feat(delegate_task): per-subagent model/provider overrides + model observability plugin

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2155,13 +2155,12 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     agent = None
 
     # Mark this as a cron session so the approval system can apply cron_mode.
-    # This env var is process-wide and persists for the lifetime of the
-    # scheduler process — every job this process runs is a cron job.
-    os.environ["HERMES_CRON_SESSION"] = "1"
+    # Cron ticks may run in-process with live gateway conversations, so this
+    # marker is context-local rather than process-global os.environ state.
+    from gateway.session_context import set_session_vars, clear_session_vars, _VAR_MAP
 
     # Use ContextVars for per-job session/delivery state so parallel jobs
     # don't clobber each other's targets (os.environ is process-global).
-    from gateway.session_context import set_session_vars, clear_session_vars, _VAR_MAP
 
     # Cron execution is an internal scheduler context, not a live inbound
     # gateway message. Do not seed HERMES_SESSION_* contextvars from the
@@ -2188,6 +2187,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         platform="",
         chat_id="",
         chat_name="",
+        cron_session="1",
     )
     _cron_delivery_vars = (
         "HERMES_CRON_AUTO_DELIVER_PLATFORM",

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -217,6 +217,23 @@ def clear_session_vars(tokens: list) -> None:
         pass
 
 
+def get_raw_session_value(name: str) -> str | None:
+    """Return the raw context-local value for a session env var.
+
+    Returns ``None`` when the ContextVar has never been set in this context.
+    Unlike ``get_session_env()``, this never falls back to ``os.environ``.
+    Callers use this when they must distinguish explicit context state from a
+    stale process-global environment value.
+    """
+    var = _VAR_MAP.get(name)
+    if var is None:
+        return None
+    value = var.get()
+    if value is _UNSET:
+        return None
+    return value
+
+
 def get_session_env(name: str, default: str = "") -> str:
     """Read a session context variable by its legacy ``HERMES_SESSION_*`` name.
 

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -83,6 +83,10 @@ _SESSION_MESSAGE_ID: ContextVar = ContextVar("HERMES_SESSION_MESSAGE_ID", defaul
 # propagates that into this contextvar at session-bind time.
 _SESSION_ASYNC_DELIVERY: ContextVar = ContextVar("HERMES_SESSION_ASYNC_DELIVERY", default=_UNSET)
 
+# Cron execution marker. Cron jobs can run inside the long-lived gateway
+# process, so cron identity must be context-local instead of process-global.
+_CRON_SESSION: ContextVar = ContextVar("HERMES_CRON_SESSION", default=_UNSET)
+
 # Cron auto-delivery vars — set per-job in run_job() so concurrent jobs
 # don't clobber each other's delivery targets.
 _CRON_AUTO_DELIVER_PLATFORM: ContextVar = ContextVar("HERMES_CRON_AUTO_DELIVER_PLATFORM", default=_UNSET)
@@ -100,6 +104,7 @@ _VAR_MAP = {
     "HERMES_SESSION_KEY": _SESSION_KEY,
     "HERMES_SESSION_ID": _SESSION_ID,
     "HERMES_SESSION_MESSAGE_ID": _SESSION_MESSAGE_ID,
+    "HERMES_CRON_SESSION": _CRON_SESSION,
     "HERMES_CRON_AUTO_DELIVER_PLATFORM": _CRON_AUTO_DELIVER_PLATFORM,
     "HERMES_CRON_AUTO_DELIVER_CHAT_ID": _CRON_AUTO_DELIVER_CHAT_ID,
     "HERMES_CRON_AUTO_DELIVER_THREAD_ID": _CRON_AUTO_DELIVER_THREAD_ID,
@@ -134,6 +139,7 @@ def set_session_vars(
     message_id: str = "",
     cwd: str = "",
     async_delivery: bool = True,
+    cron_session: str = "",
 ) -> list:
     """Set all session context variables and return reset tokens.
 
@@ -162,6 +168,7 @@ def set_session_vars(
         _SESSION_ID.set(session_id),
         _SESSION_MESSAGE_ID.set(message_id),
         _SESSION_ASYNC_DELIVERY.set(bool(async_delivery)),
+        _CRON_SESSION.set(cron_session),
     ]
     try:
         from agent.runtime_cwd import set_session_cwd
@@ -194,6 +201,7 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_KEY,
         _SESSION_ID,
         _SESSION_MESSAGE_ID,
+        _CRON_SESSION,
     ):
         var.set("")
     # Reset async-delivery capability to the "never set" sentinel rather than a

--- a/plugins/model_observability/__init__.py
+++ b/plugins/model_observability/__init__.py
@@ -1,0 +1,466 @@
+"""Model Observability Plugin v2 — evidence-based model tracking + enforcement.
+
+Subscribes to four hooks:
+
+1. post_api_request (v1, unchanged)
+   Fires after every LLM API call (parent + subagents). Writes a JSONL record
+   to ~/.hermes/logs/model_usage.jsonl.
+
+2. on_session_start (v1, unchanged)
+   Writes a session boundary marker to the JSONL log.
+
+3. pre_tool_call (v2, NEW)
+   Fires BEFORE delegate_task executes. Serves two purposes:
+     a) Scoping anchor: captures the JSONL log byte offset so transform_tool_result
+        reads only records written by THIS delegation's children.
+     b) Missing-pin detection: flags whether the caller specified a model.
+   Always returns None — never blocks (soft enforcement only).
+   Also evicts TTL-expired stash entries on each fire.
+
+4. transform_tool_result (v2, NEW)
+   Fires after delegate_task completes, before the result goes back to the LLM.
+   Reads the stash entry set by pre_tool_call, reads only JSONL entries past
+   the saved byte offset (perfect scoping — no prior-session bleed), builds
+   an observability block, and injects it into the result string.
+   - If missing_pin=True: notes auto-router resolution (soft warning, no ⚠️)
+   - If match=False on an explicitly pinned model: injects a prominent WARNING
+   Pops the stash entry after use to prevent memory leak.
+
+Timing guarantee (verified from delegate_tool.py):
+   delegate_task uses ThreadPoolExecutor and blocks (while pending:) until ALL
+   child futures complete. Each child's post_api_request (JSONL write) fires
+   inside _run_single_child on the worker thread before that future resolves.
+   By the time transform_tool_result fires in the parent, all subagent JSONL
+   writes are complete. No race condition.
+
+Record schema (one JSON object per line in model_usage.jsonl):
+    ts             — ISO 8601 UTC timestamp
+    session_id     — parent session ID
+    task_id        — delegated task ID (None for parent calls)
+    agent_type     — "parent" | "subagent"
+    model_request  — model the agent was configured with (what we asked for)
+    model_response — model field echoed back in API response (what answered)
+    provider       — provider the agent was configured with
+    api_mode       — e.g. "chat_completions", "anthropic_messages"
+    api_call       — which API call within this agent's lifetime (1-indexed)
+    duration_s     — wall clock duration of this single API call
+    finish_reason  — stop / tool_calls / length / etc.
+    tokens_in      — prompt token count
+    tokens_out     — completion token count
+    assistant_chars — length of assistant text output
+    tool_calls     — number of tool calls in this response
+    platform       — cli / telegram / discord / etc.
+    match          — True if model_request == model_response (normalized)
+
+Query with: python3 ~/.hermes/scripts/model_usage.py
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# Resolve log path once. ~/.hermes/logs/ is the established convention.
+LOG_PATH = Path(os.path.expanduser("~/.hermes/logs/model_usage.jsonl"))
+
+# Thread lock for concurrent subagent writes.
+_write_lock = threading.Lock()
+
+# Stash for pre_tool_call → transform_tool_result coordination.
+# Key: tool_call_id (str)
+# Value: {"offset": int, "missing_pin": bool, "ts": float (monotonic)}
+_delegate_stash: dict[str, dict] = {}
+_stash_lock = threading.Lock()
+
+# Stash entries older than this are evicted as dead-letter cleanup.
+_STASH_TTL_S: float = 120.0
+
+
+# ---------------------------------------------------------------------------
+# Internal utilities
+# ---------------------------------------------------------------------------
+
+def _normalize_model(model: Any) -> str:
+    """Lowercase + strip for case-insensitive comparison."""
+    if not model:
+        return ""
+    return str(model).strip().lower()
+
+
+def _models_match(req: Any, resp: Any) -> bool:
+    """True if the requested model and the response model are effectively the same.
+
+    Two cases we treat as a match:
+    1. Exact equality after normalize (the common case).
+    2. The response model is a date-versioned alias of the requested model —
+       e.g. "anthropic/claude-sonnet-4.6" vs "anthropic/claude-4.6-sonnet-20260217",
+       or "openai/gpt-5.1-codex" vs "openai/gpt-5.1-codex-20251113".
+       Detection heuristic: the response model starts with the requested model
+       string (after stripping any provider prefix), OR the requested model
+       string appears as a substring of the response model after the last '/'.
+
+    Intentionally NOT a match:
+    - openrouter/auto → <anything>  (auto-router resolution is real signal)
+    - genuinely different models
+    """
+    r = _normalize_model(req)
+    s = _normalize_model(resp)
+
+    if not r or not s:
+        return False
+
+    if r in ("openrouter/auto", "auto"):
+        return False
+
+    if r == s:
+        return True
+
+    def _bare(m: str) -> str:
+        return m.rsplit("/", 1)[-1] if "/" in m else m
+
+    r_bare = _bare(r)
+    s_bare = _bare(s)
+
+    import re
+
+    # Date-suffix heuristic
+    if s_bare.startswith(r_bare) and len(s_bare) > len(r_bare):
+        suffix = s_bare[len(r_bare):]
+        if re.match(r"^-\d{6,}", suffix):
+            return True
+
+    if r_bare.startswith(s_bare) and len(r_bare) > len(s_bare):
+        suffix = r_bare[len(s_bare):]
+        if re.match(r"^-\d{6,}", suffix):
+            return True
+
+    # Token-set heuristic: handles Anthropic's name reordering
+    def _non_date_tokens(name: str) -> frozenset:
+        parts = re.split(r"[.-]", name)
+        return frozenset(p for p in parts if p and not re.fullmatch(r"\d{6,}", p))
+
+    if _non_date_tokens(r_bare) == _non_date_tokens(s_bare) and _non_date_tokens(r_bare):
+        return True
+
+    return False
+
+
+def _extract_tokens(usage: Any) -> tuple[int, int]:
+    """Pull prompt/completion tokens from the usage dict robustly."""
+    if not isinstance(usage, dict):
+        return 0, 0
+    tokens_in = usage.get("prompt_tokens") or usage.get("input_tokens") or 0
+    tokens_out = usage.get("completion_tokens") or usage.get("output_tokens") or 0
+    try:
+        return int(tokens_in), int(tokens_out)
+    except (ValueError, TypeError):
+        return 0, 0
+
+
+def _log_byte_offset() -> int:
+    """Return the current byte size of LOG_PATH, or 0 if it doesn't exist."""
+    try:
+        return LOG_PATH.stat().st_size
+    except (OSError, FileNotFoundError):
+        return 0
+
+
+def _read_log_from_offset(offset: int) -> list[dict]:
+    """Read JSONL records written after the given byte offset."""
+    try:
+        if not LOG_PATH.exists():
+            return []
+        with open(LOG_PATH, "rb") as f:
+            f.seek(offset)
+            lines = f.read().decode("utf-8", errors="replace").splitlines()
+        records = []
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError:
+                pass
+        return records
+    except Exception:
+        return []
+
+
+def _is_auto_router(model_request: str) -> bool:
+    return _normalize_model(model_request) in ("openrouter/auto", "auto", "")
+
+
+def _is_pareto_router(model_request: str) -> bool:
+    return _normalize_model(model_request) in ("openrouter/pareto-code", "pareto-code")
+
+
+def _detect_missing_pin(args: Any) -> bool:
+    """Return True if delegate_task was called without a model pin."""
+    if not isinstance(args, dict):
+        return True
+    # Single-task form: check top-level "model"
+    if "goal" in args or "context" in args:
+        return not bool(args.get("model"))
+    # Batch form: check each task
+    tasks = args.get("tasks")
+    if isinstance(tasks, list):
+        return any(not isinstance(t, dict) or not t.get("model") for t in tasks)
+    # Empty or unrecognized args
+    return True
+
+
+def _evict_expired_stash() -> None:
+    """Remove stash entries older than _STASH_TTL_S."""
+    now = time.monotonic()
+    with _stash_lock:
+        expired = [k for k, v in _delegate_stash.items()
+                   if now - v.get("ts", 0) > _STASH_TTL_S]
+        for k in expired:
+            del _delegate_stash[k]
+
+
+# ---------------------------------------------------------------------------
+# Hook: post_api_request (v1, unchanged)
+# ---------------------------------------------------------------------------
+
+def _on_post_api_request(**kwargs: Any) -> None:
+    """Write a JSONL record for one LLM API call."""
+    try:
+        task_id = kwargs.get("task_id") or None
+        model_request = kwargs.get("model") or ""
+        model_response = kwargs.get("response_model") or ""
+        provider = kwargs.get("provider") or ""
+
+        tokens_in, tokens_out = _extract_tokens(kwargs.get("usage"))
+
+        record = {
+            "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            "session_id": kwargs.get("session_id") or "",
+            "task_id": task_id,
+            "agent_type": "subagent" if task_id else "parent",
+            "model_request": model_request,
+            "model_response": model_response,
+            "provider": provider,
+            "api_mode": kwargs.get("api_mode") or "",
+            "api_call": kwargs.get("api_call_count") or 0,
+            "duration_s": round(float(kwargs.get("api_duration") or 0.0), 3),
+            "finish_reason": kwargs.get("finish_reason") or "",
+            "tokens_in": tokens_in,
+            "tokens_out": tokens_out,
+            "assistant_chars": int(kwargs.get("assistant_content_chars") or 0),
+            "tool_calls": int(kwargs.get("assistant_tool_call_count") or 0),
+            "platform": kwargs.get("platform") or "",
+            "match": _models_match(model_request, model_response),
+        }
+
+        line = json.dumps(record, ensure_ascii=False)
+        LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with _write_lock:
+            with open(LOG_PATH, "a", encoding="utf-8") as f:
+                f.write(line + "\n")
+    except Exception as exc:
+        logger.debug("model_observability write failed: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Hook: on_session_start (v1, unchanged)
+# ---------------------------------------------------------------------------
+
+def _on_session_start(**kwargs: Any) -> None:
+    """Write a session boundary marker so logs are groupable."""
+    try:
+        record = {
+            "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            "event": "session_start",
+            "session_id": kwargs.get("session_id") or "",
+            "platform": kwargs.get("platform") or "",
+            "model": kwargs.get("model") or "",
+            "provider": kwargs.get("provider") or "",
+        }
+        LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with _write_lock:
+            with open(LOG_PATH, "a", encoding="utf-8") as f:
+                f.write(json.dumps(record, ensure_ascii=False) + "\n")
+    except Exception as exc:
+        logger.debug("model_observability session_start write failed: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Hook: pre_tool_call (v2, NEW)
+# ---------------------------------------------------------------------------
+
+def _on_pre_tool_call(**kwargs: Any) -> Optional[dict]:
+    """Scoping anchor + missing-pin detection for delegate_task.
+
+    Always returns None — never blocks or warns directly.
+    Side effects only: stashes byte offset + missing_pin flag keyed on tool_call_id,
+    and evicts expired stash entries.
+    """
+    try:
+        _evict_expired_stash()
+
+        tool_name = kwargs.get("tool_name") or ""
+        if tool_name != "delegate_task":
+            return None
+
+        tool_call_id = kwargs.get("tool_call_id") or ""
+        args = kwargs.get("args") or {}
+
+        offset = _log_byte_offset()
+        missing_pin = _detect_missing_pin(args)
+
+        with _stash_lock:
+            _delegate_stash[tool_call_id] = {
+                "offset": offset,
+                "missing_pin": missing_pin,
+                "ts": time.monotonic(),
+            }
+    except Exception as exc:
+        logger.debug("model_observability pre_tool_call failed: %s", exc)
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Hook: transform_tool_result (v2, NEW)
+# ---------------------------------------------------------------------------
+
+def _on_transform_tool_result(**kwargs: Any) -> Optional[str]:
+    """Enrich delegate_task results with model observability data.
+
+    Reads the stash entry set by pre_tool_call, reads only JSONL entries past
+    the saved byte offset, builds an observability block, and injects it into
+    the result string. Pops the stash entry after use.
+
+    Returns the enriched result string, or None to leave the result unchanged.
+    """
+    try:
+        tool_name = kwargs.get("tool_name") or ""
+        if tool_name != "delegate_task":
+            return None
+
+        tool_call_id = kwargs.get("tool_call_id") or ""
+        original_result = kwargs.get("result") or ""
+
+        # Retrieve and pop stash entry
+        with _stash_lock:
+            stash_entry = _delegate_stash.pop(tool_call_id, None)
+
+        if stash_entry is None:
+            # pre_tool_call didn't fire (e.g. plugin loaded mid-session) — degrade gracefully
+            return None
+
+        offset = stash_entry["offset"]
+        missing_pin = stash_entry["missing_pin"]
+
+        # Read only records written after the scoping anchor
+        records = _read_log_from_offset(offset)
+        subagent_records = [
+            r for r in records
+            if isinstance(r, dict) and r.get("agent_type") == "subagent"
+        ]
+
+        if not subagent_records:
+            # No subagent calls — delegation may have failed before children ran,
+            # or no children wrote JSONL. Inject a minimal note if pin was missing,
+            # but never a false mismatch warning.
+            if missing_pin:
+                block = "\n\n[model_observability] No model pin specified. No subagent telemetry available."
+                return original_result + block
+            return None
+
+        # Classify records
+        mismatches = [
+            r for r in subagent_records
+            if (
+                not r.get("match", True)
+                and not _is_auto_router(r.get("model_request", ""))
+                and not _is_pareto_router(r.get("model_request", ""))
+            )
+        ]
+        auto_resolutions = [
+            r for r in subagent_records
+            if not r.get("match", True) and _is_auto_router(r.get("model_request", ""))
+        ]
+        pareto_resolutions = [
+            r for r in subagent_records
+            if not r.get("match", True) and _is_pareto_router(r.get("model_request", ""))
+        ]
+        matched = [
+            r for r in subagent_records
+            if r.get("match", True)
+        ]
+
+        # Build observability block
+        lines = ["\n\n[model_observability]"]
+
+        # Aggregate stats
+        total_tokens_in = sum(r.get("tokens_in", 0) for r in subagent_records)
+        total_tokens_out = sum(r.get("tokens_out", 0) for r in subagent_records)
+        total_duration = sum(r.get("duration_s", 0.0) for r in subagent_records)
+        lines.append(
+            f"  subagents: {len(subagent_records)} | "
+            f"tokens in: {total_tokens_in:,} | tokens out: {total_tokens_out:,} | "
+            f"duration: {total_duration:.1f}s"
+        )
+
+        # Matched pins
+        if matched:
+            unique_matched = sorted({r.get("model_request", "") for r in matched})
+            lines.append(f"  ✓ matched: {', '.join(unique_matched)}")
+
+        # Auto-router resolutions (informational, no warning)
+        if auto_resolutions:
+            for r in auto_resolutions:
+                lines.append(
+                    f"  → auto-router resolved to: {r.get('model_response', 'unknown')}"
+                )
+
+        # Pareto-router resolutions (informational, no warning)
+        if pareto_resolutions:
+            for r in pareto_resolutions:
+                lines.append(
+                    f"  → pareto-router resolved to: {r.get('model_response', 'unknown')}"
+                )
+
+        # Missing pin warning (soft)
+        if missing_pin and not mismatches:
+            lines.append("  ℹ no model pin specified — auto-router was used")
+
+        # Override mismatches (prominent WARNING)
+        if mismatches:
+            lines.append("  ⚠️ WARNING: model override mismatch detected")
+            for r in mismatches:
+                lines.append(
+                    f"    requested: {r.get('model_request', '?')} "
+                    f"→ actual: {r.get('model_response', '?')}"
+                )
+
+        block = "\n".join(lines)
+        return original_result + block
+
+    except Exception as exc:
+        logger.debug("model_observability transform_tool_result failed: %s", exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Plugin entry point
+# ---------------------------------------------------------------------------
+
+def register(ctx) -> None:
+    """Entry point called by the plugin manager at load time."""
+    ctx.register_hook("post_api_request", _on_post_api_request)
+    ctx.register_hook("on_session_start", _on_session_start)
+    ctx.register_hook("pre_tool_call", _on_pre_tool_call)
+    ctx.register_hook("transform_tool_result", _on_transform_tool_result)
+    logger.info("model_observability plugin v2 registered (log: %s)", LOG_PATH)

--- a/plugins/model_observability/plugin.yaml
+++ b/plugins/model_observability/plugin.yaml
@@ -1,0 +1,10 @@
+name: model_observability
+version: 1.1.0
+description: "Log every LLM API call with requested model, returned model, provider, tokens, and duration. Enriches delegate_task results with router-aware observability metadata. Writes JSONL to ~/.hermes/logs/model_usage.jsonl."
+author: Jordan
+requires_env: []
+hooks:
+  - post_api_request
+  - on_session_start
+  - pre_tool_call
+  - transform_tool_result

--- a/run_agent.py
+++ b/run_agent.py
@@ -5345,6 +5345,8 @@ class AIAgent:
             acp_command=function_args.get("acp_command"),
             acp_args=function_args.get("acp_args"),
             role=function_args.get("role"),
+model=function_args.get("model"),
+            provider=function_args.get("provider"),
             background=(not _is_subagent),
             parent_agent=self,
         )

--- a/scripts/refresh_openrouter_models.py
+++ b/scripts/refresh_openrouter_models.py
@@ -1,0 +1,470 @@
+#!/usr/bin/env python3
+"""
+refresh_openrouter_models.py
+
+Weekly script for keeping the subagent-model-routing skill current.
+
+Hits the OpenRouter /api/v1/models endpoint, compares the live catalog against
+your configured whitelists, and produces a read-only advisory digest for review.
+
+USAGE — run as a Hermes cron job script:
+
+    cronjob(
+        action="create",
+        name="OpenRouter Model Refresh",
+        script="refresh_openrouter_models.py",       # path relative to ~/.hermes/scripts/
+        schedule="0 11 * * 0",                        # every Sunday at 11 AM
+        model={"model": "openrouter/auto", "provider": "openrouter"},
+        deliver="origin",
+        prompt=CRON_PROMPT_TEMPLATE,                  # see bottom of this file
+    )
+
+The script's stdout is injected into the cron prompt as context. The cron agent
+reads the output and produces a digest for the operator. It does NOT write any
+files — all changes require explicit operator approval.
+
+SETUP:
+    1. Copy this file to ~/.hermes/scripts/refresh_openrouter_models.py
+    2. Customize the WHITELISTS dict below for your use case
+    3. Create the cron job (see usage above)
+    4. Set OPENROUTER_API_KEY in your environment
+
+REQUIREMENTS:
+    - Python 3.10+ (stdlib only, no dependencies)
+    - OPENROUTER_API_KEY environment variable
+
+MAINTENANCE — HOW TO KEEP EVERYTHING IN SYNC:
+
+    There are THREE locations that must stay consistent:
+
+    1. ~/.hermes/scripts/refresh_openrouter_models.py         ← THIS FILE (cron runs this)
+    2. ~/.hermes/hermes-agent-feat/scripts/refresh_openrouter_models.py  ← feat branch copy
+    3. ~/.hermes/skills/autonomous-ai-agents/subagent-model-routing/SKILL.md  ← human-readable mirror
+
+    CANONICAL SOURCE OF TRUTH: This file's WHITELISTS dict.
+
+    UPDATE FLOW (approved changes only — never edit whitelists speculatively):
+    1. Cron delivers a read-only digest to Jordan on Sundays
+    2. Jordan approves specific changes in a follow-up session
+    3. Agent patches WHITELISTS in THIS file first
+    4. Agent patches the skill's tier tables and WHITELISTS section to match (same session)
+    5. Agent copies this file AND the skill to the feat branch:
+           cp ~/.hermes/scripts/refresh_openrouter_models.py \
+              ~/.hermes/hermes-agent-feat/scripts/refresh_openrouter_models.py
+           cp ~/.hermes/skills/autonomous-ai-agents/subagent-model-routing/SKILL.md \
+              ~/.hermes/hermes-agent-feat/skills/autonomous-ai-agents/subagent-model-routing/SKILL.md
+    6. Steps 3–5 must happen atomically in one session. A partial update
+       (script only, or skill only, or feat branch not synced) leaves the
+       system inconsistent.
+
+    WHY TWO SCRIPT LOCATIONS:
+    - The Hermes cron sandbox only executes scripts inside ~/.hermes/scripts/
+      (symlinks that resolve outside are blocked by path traversal guard)
+    - The feat branch (hermes-agent-feat) is a separate git repo tracking
+      the PR. It must stay in sync so the PR reflects current whitelist state.
+    - These two files are NOT linked — copies must be explicit after every edit.
+
+    POST-MERGE (when PR #12794 lands in upstream main):
+    - Update the copy step above to use ~/.hermes/hermes-agent/scripts/ instead
+    - The feat worktree can then be deleted
+"""
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+PRICE_CACHE_PATH = Path.home() / ".hermes/caches/openrouter_prices_last.json"
+PRICE_CHANGE_THRESHOLD = 0.20  # 20% delta triggers a flag
+
+# ---------------------------------------------------------------------------
+# WHITELISTS — CUSTOMIZE THESE FOR YOUR USE CASE
+#
+# Define which models are allowed in each routing tier. The tier names and
+# model selections here are examples — rename, add, or remove tiers to match
+# your operational needs.
+#
+# Keep these in sync with:
+#   - Your subagent-model-routing skill's whitelist/tier tables
+#   - Any account-level OpenRouter whitelist settings you've configured
+#
+# When the cron reports changes and you approve them, update BOTH this dict
+# AND the skill's tier tables atomically in the same session.
+# ---------------------------------------------------------------------------
+
+WHITELISTS: dict[str, list[str]] = {
+    # PREMIUM: Orchestrator-level, synthesis, judgment, reviews
+    "premium": [
+        "x-ai/grok-4.20",
+        "x-ai/grok-4.20-multi-agent",
+        "x-ai/grok-4.3",
+        "anthropic/claude-opus-4.7",
+        "anthropic/claude-sonnet-4.6",
+        "google/gemini-2.5-pro",
+        "openai/gpt-5.5",
+        "google/gemini-3.1-pro-preview",
+    ],
+    # STANDARD: Regular delegation — business ops, analysis, general tasks
+    "standard": [
+        "anthropic/claude-haiku-4.5",
+        "openai/gpt-5.4-mini",
+        "deepseek/deepseek-v4-pro",
+        "moonshotai/kimi-k2.6",
+        "minimax/minimax-m2.7",
+        "z-ai/glm-5.1",
+    ],
+    # CODING: Code writing, review, and modification tasks only (may overlap other tiers)
+    "coding": [
+        "x-ai/grok-code-fast-1",
+        "qwen/qwen3-coder-flash",
+        "openai/gpt-5.1-codex-mini",
+        "openai/gpt-5.1-codex",
+        "deepseek/deepseek-v4-pro",
+        "moonshotai/kimi-k2.6",
+        "minimax/minimax-m2.7",
+        "z-ai/glm-5.1",
+        "anthropic/claude-sonnet-4.6",
+        "openai/gpt-5.5",
+        "anthropic/claude-opus-4.7",
+    ],
+    # BUDGET: Cron jobs, automated extraction, simple parsing
+    "budget": [
+        "google/gemini-2.5-flash",
+        "google/gemini-2.5-flash-lite",
+        "x-ai/grok-4.1-fast",
+        "openai/gpt-5-nano",
+        "deepseek/deepseek-v4-flash",
+    ],
+}
+
+# ---------------------------------------------------------------------------
+# TRACKED PROVIDERS — new model discovery scope
+# Only models from these providers will appear in the "new models" section.
+# Add or remove providers to match what you care about.
+# ---------------------------------------------------------------------------
+
+TRACKED_PROVIDERS: set[str] = {
+    "anthropic",
+    "google",
+    "openai",
+    "x-ai",
+    "mistralai",
+    "deepseek",
+    "qwen",
+    "meta-llama",
+}
+
+# PRICE_CHANGE_THRESHOLD: reserved for a future pricing-delta feature.
+# The script currently reports a live pricing snapshot but does not compare
+# against a baseline (previous run or skill file). Implementing delta tracking
+# would require persisting previous prices to disk between runs. Not yet
+# implemented — when added, use this threshold (20%) to filter noise.
+
+# ---------------------------------------------------------------------------
+# Implementation — no customization needed below this line
+# ---------------------------------------------------------------------------
+
+# Validate whitelist exclusivity:
+# budget / standard / premium must be mutually exclusive.
+# coding is allowed to overlap with any tier.
+_EXCLUSIVE_TIERS = {"budget", "standard", "premium"}
+_exclusive_seen: dict[str, str] = {}
+_overlap_errors: list[str] = []
+for _tier in _EXCLUSIVE_TIERS:
+    for _mid in WHITELISTS.get(_tier, []):
+        if _mid in _exclusive_seen:
+            _overlap_errors.append(
+                f"  '{_mid}' appears in both '{_exclusive_seen[_mid]}' and '{_tier}'"
+            )
+        else:
+            _exclusive_seen[_mid] = _tier
+if _overlap_errors:
+    raise ValueError(
+        "WHITELIST OVERLAP DETECTED — budget/standard/premium must be mutually exclusive:\n"
+        + "\n".join(_overlap_errors)
+        + "\n(coding is exempt — it may overlap any tier)"
+    )
+
+# Flatten all unique models across all whitelists
+ALL_WHITELISTED: set[str] = set()
+for _models in WHITELISTS.values():
+    ALL_WHITELISTED.update(_models)
+
+
+def fetch_models(api_key: str, order: str | None = None) -> list[dict]:
+    """Fetch model list from OpenRouter /api/v1/models."""
+    url = "https://openrouter.ai/api/v1/models"
+    if order:
+        url += "?" + urllib.parse.urlencode({"order": order})
+    req = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "HTTP-Referer": "https://hermes-agent.local",
+            "X-Title": "Hermes Model Refresh",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            raw = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as e:
+        raise RuntimeError(f"OpenRouter API returned {e.code}: {e.reason}") from e
+    except Exception as e:
+        raise RuntimeError(f"Failed to fetch models: {e}") from e
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(
+            f"OpenRouter returned malformed JSON (offset {e.pos}): {e.msg}\n"
+            f"Response snippet: {raw[:200]!r}"
+        ) from e
+    return data.get("data", [])
+
+
+def parse_price(pricing: dict, key: str) -> float | None:
+    """Parse a pricing field to float (price per token)."""
+    val = pricing.get(key)
+    if val is None:
+        return None
+    try:
+        return float(val)
+    except (ValueError, TypeError):
+        return None
+
+
+def price_per_million(price_per_token: float | None) -> str:
+    if price_per_token is None:
+        return "unknown"
+    return f"${price_per_token * 1_000_000:.2f}"
+
+
+def load_price_cache() -> dict:
+    """Load previous run's price snapshot. Returns empty dict if none exists."""
+    try:
+        return json.loads(PRICE_CACHE_PATH.read_text())
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+
+
+def save_price_cache(prices: dict) -> None:
+    """Persist current run's prices for next week's delta comparison."""
+    PRICE_CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    PRICE_CACHE_PATH.write_text(json.dumps(prices, indent=2))
+
+
+def fmt_ctx(ctx) -> str:
+    c = int(ctx) if ctx else 0
+    if not c:
+        return "unknown"
+    return f"{c // 1000}K" if c >= 1000 else "< 1K"
+
+
+def main() -> None:
+    api_key = os.getenv("OPENROUTER_API_KEY")
+    if not api_key:
+        print("ERROR: OPENROUTER_API_KEY not set", file=sys.stderr)
+        sys.exit(1)
+
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    print(f"OpenRouter Model Refresh — {now}")
+    print("=" * 60)
+
+    # Fetch with top-weekly ordering: returns full catalog ranked by weekly usage.
+    try:
+        models = fetch_models(api_key, order="top-weekly")
+    except RuntimeError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Sanity checks — fewer than 50 almost certainly means truncation.
+    if len(models) <= 50:
+        print(
+            f"WARNING: Only {len(models)} models returned — expected >50; "
+            "aborting to avoid false MISSING positives.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if len(models) < 300:
+        print(
+            f"WARNING: Only {len(models)} models returned — OpenRouter usually has 300+; "
+            "possible truncation.",
+            file=sys.stderr,
+        )
+
+    live_ids = {m["id"] for m in models if "id" in m}
+    live_by_id = {m["id"]: m for m in models if "id" in m}
+
+    # Load previous price snapshot for delta comparison
+    prev_prices = load_price_cache()
+    if prev_prices:
+        print(f"📅 Price baseline: {prev_prices.get('_run_date', 'unknown')}")
+    else:
+        print("📅 Price baseline: none (first run — delta tracking starts next week)")
+    print()
+
+    # Precompute per-model whitelist membership for O(1) lookup.
+    whitelist_by_model: dict[str, list[str]] = {}
+    for wl_name, wl_models in WHITELISTS.items():
+        for mid in wl_models:
+            whitelist_by_model.setdefault(mid, []).append(wl_name)
+
+    print(f"Total models available on OpenRouter: {len(models)}")
+    print()
+
+    # ------------------------------------------------------------------
+    # 1. Missing — whitelisted models no longer in live catalog
+    # ------------------------------------------------------------------
+    missing = [m for m in ALL_WHITELISTED if m not in live_ids]
+    if missing:
+        print("⚠️  MISSING — Whitelisted models NOT found in live catalog:")
+        for m in sorted(missing):
+            in_lists = [k for k, v in WHITELISTS.items() if m in v]
+            print(f"  - {m}  [in: {', '.join(in_lists)}]")
+    else:
+        print("✅ All whitelisted models found in live catalog.")
+    print()
+
+    # ------------------------------------------------------------------
+    # 2. Pricing snapshot for all whitelisted models
+    # ------------------------------------------------------------------
+    print("💰 PRICING SNAPSHOT — Current prices for whitelisted models:")
+    print(f"  {'Model':<40} {'In ($/Mi)':>12} {'Out ($/Mi)':>12}  {'Context':>10}")
+    print(f"  {'-'*40} {'-'*12} {'-'*12}  {'-'*10}")
+    for model_id in sorted(ALL_WHITELISTED):
+        if model_id not in live_by_id:
+            print(f"  {model_id:<40} {'MISSING':>12} {'MISSING':>12}  {'':>10}")
+            continue
+        m = live_by_id[model_id]
+        pricing = m.get("pricing", {})
+        p_in = parse_price(pricing, "prompt")
+        p_out = parse_price(pricing, "completion")
+        ctx = m.get("context_length", 0)
+        print(
+            f"  {model_id:<40} {price_per_million(p_in):>12} "
+            f"{price_per_million(p_out):>12}  {fmt_ctx(ctx):>10}"
+        )
+    print()
+
+    # ------------------------------------------------------------------
+    # 2b. Pricing deltas vs previous run
+    # ------------------------------------------------------------------
+    current_prices: dict = {"_run_date": now}
+    price_changes = []
+    for model_id in sorted(ALL_WHITELISTED):
+        m = live_by_id.get(model_id)
+        if not m:
+            continue
+        pricing = m.get("pricing", {})
+        p_in = parse_price(pricing, "prompt")
+        p_out = parse_price(pricing, "completion")
+        current_prices[model_id] = {"in": p_in, "out": p_out}
+
+        if prev_prices and model_id in prev_prices:
+            old = prev_prices[model_id]
+            for label, old_val, new_val in [
+                ("in", old.get("in"), p_in),
+                ("out", old.get("out"), p_out),
+            ]:
+                if old_val and new_val and abs(new_val - old_val) / old_val >= PRICE_CHANGE_THRESHOLD:
+                    direction = "▲" if new_val > old_val else "▼"
+                    pct = abs(new_val - old_val) / old_val * 100
+                    price_changes.append(
+                        f"  {direction} {model_id} [{label}]: "
+                        f"{price_per_million(old_val)} → {price_per_million(new_val)} "
+                        f"({pct:.0f}%)"
+                    )
+
+    if prev_prices:
+        if price_changes:
+            print(f"💸 PRICING CHANGES vs {prev_prices.get('_run_date', 'last run')} (>{PRICE_CHANGE_THRESHOLD*100:.0f}% delta):")
+            for line in price_changes:
+                print(line)
+        else:
+            print("✅ No significant pricing changes vs last run.")
+        print()
+
+    # ------------------------------------------------------------------
+    # 3. New models from tracked providers not yet in any whitelist
+    # ------------------------------------------------------------------
+    new_models = []
+    for m in models:
+        mid = m["id"]
+        if mid in ALL_WHITELISTED:
+            continue
+        provider = mid.split("/")[0] if "/" in mid else ""
+        if provider not in TRACKED_PROVIDERS:
+            continue
+        pricing = m.get("pricing", {})
+        p_in = parse_price(pricing, "prompt")
+        p_out = parse_price(pricing, "completion")
+        ctx = m.get("context_length", 0)
+        new_models.append((mid, p_in, p_out, ctx))
+
+    if new_models:
+        print(f"🆕 NEW MODELS from tracked providers not in any whitelist ({len(new_models)}):")
+        print(f"  {'Model':<45} {'In ($/Mi)':>12} {'Out ($/Mi)':>12}  {'Context':>10}")
+        print(f"  {'-'*45} {'-'*12} {'-'*12}  {'-'*10}")
+        for mid, p_in, p_out, ctx in sorted(new_models, key=lambda x: x[0]):
+            print(
+                f"  {mid:<45} {price_per_million(p_in):>12} "
+                f"{price_per_million(p_out):>12}  {fmt_ctx(ctx):>10}"
+            )
+    else:
+        print("✅ No new models from tracked providers outside whitelists.")
+    print()
+
+    # ------------------------------------------------------------------
+    # 4. Whitelist membership summary
+    # ------------------------------------------------------------------
+    print("📋 WHITELIST SUMMARY:")
+    for name, models_list in WHITELISTS.items():
+        live_count = sum(1 for m in models_list if m in live_ids)
+        print(f"  {name}: {live_count}/{len(models_list)} models live")
+    print()
+
+    # ------------------------------------------------------------------
+    # 5. Top 15 trending models this week
+    # ------------------------------------------------------------------
+    print("🔥 TOP 15 TRENDING MODELS — Most used on OpenRouter this week:")
+    print(
+        f"  {'Rank':<5} {'Model':<45} {'In ($/Mi)':>10} {'Out ($/Mi)':>11}"
+        f"  {'Context':>8}  In Whitelist?"
+    )
+    print(f"  {'-'*5} {'-'*45} {'-'*10} {'-'*11}  {'-'*8}  {'-'*13}")
+    for rank, m in enumerate(models[:15], 1):
+        mid = m["id"]
+        pricing = m.get("pricing", {})
+        p_in = parse_price(pricing, "prompt")
+        p_out = parse_price(pricing, "completion")
+        ctx = m.get("context_length", 0)
+        in_wl = whitelist_by_model.get(mid, [])
+        wl_str = ", ".join(in_wl) if in_wl else "—"
+        print(
+            f"  #{rank:<4} {mid:<45} {price_per_million(p_in):>10} "
+            f"{price_per_million(p_out):>11}  {fmt_ctx(ctx):>8}  {wl_str}"
+        )
+    print()
+
+    print("=" * 60)
+    print("Agent instructions:")
+    print("1. Report any MISSING models — they may need replacing.")
+    print("2. Highlight compelling NEW models worth adding to a whitelist.")
+    print("3. Note significant pricing changes vs. skill documentation.")
+    print("4. If whitelist changes are warranted, propose specific edits.")
+    print("5. Flag trending models NOT in whitelists that appear cost-competitive.")
+    print()
+    print("⛔ DO NOT write any files. Present findings only.")
+    print("   All changes require operator approval in a subsequent session.")
+    print("   When approved: patch BOTH this script's WHITELISTS dict AND")
+    print("   the skill's tier tables atomically in the same session.")
+
+    # Persist current prices for next run's delta comparison
+    save_price_cache(current_prices)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/refresh_openrouter_models.py
+++ b/scripts/refresh_openrouter_models.py
@@ -118,24 +118,35 @@ WHITELISTS: dict[str, list[str]] = {
         "z-ai/glm-5.1",
     ],
     # CODING: Code writing, review, and modification tasks only (may overlap other tiers)
+    # Ranked by OpenRouter Pareto Code Router (Artificial Analysis coding percentiles, 020626)
+    # HIGH tier (min_coding_score >= 0.66): strongest coders, highest cost
+    # MEDIUM tier (0.33 <= min_coding_score < 0.66): solid coders, mid cost
+    # LOW tier (min_coding_score < 0.33): lighter coders, lowest cost
+    # Router slug: openrouter/pareto-code (pass min_coding_score via pareto-router plugin)
     "coding": [
-        "x-ai/grok-code-fast-1",
-        "qwen/qwen3-coder-flash",
-        "openai/gpt-5.1-codex-mini",
-        "openai/gpt-5.1-codex",
-        "deepseek/deepseek-v4-pro",
-        "moonshotai/kimi-k2.6",
-        "minimax/minimax-m2.7",
-        "z-ai/glm-5.1",
-        "anthropic/claude-sonnet-4.6",
+        # HIGH
         "openai/gpt-5.5",
+        "google/gemini-3.1-pro-preview",
         "anthropic/claude-opus-4.7",
+        "deepseek/deepseek-v4-pro",
+        # MEDIUM
+        "openai/gpt-5.4-mini",
+        "anthropic/claude-sonnet-4.6",
+        "moonshotai/kimi-k2.6",
+        "x-ai/grok-4.3",
+        # LOW
+        "xiaomi/mimo-v2.5-pro",
+        "qwen/qwen3.6-max-preview",
+        "z-ai/glm-5.1",
+        "deepseek/deepseek-v4-flash",
+        "anthropic/claude-haiku-4.5",
+        "x-ai/grok-build-0.1",
     ],
     # BUDGET: Cron jobs, automated extraction, simple parsing
     "budget": [
         "google/gemini-2.5-flash",
         "google/gemini-2.5-flash-lite",
-        "x-ai/grok-4.1-fast",
+        "google/gemini-3.1-flash-lite",
         "openai/gpt-5-nano",
         "deepseek/deepseek-v4-flash",
     ],

--- a/skills/autonomous-ai-agents/subagent-model-routing/SKILL.md
+++ b/skills/autonomous-ai-agents/subagent-model-routing/SKILL.md
@@ -7,7 +7,7 @@ tags: [delegation, cost, models, routing, auto-router]
 
 # Subagent Model Routing
 
-> **Last updated:** 100526 | **Source:** `~/.hermes/scripts/refresh_openrouter_models.py → WHITELISTS`
+> **Last updated:** 020626 | **Source:** `~/.hermes/scripts/refresh_openrouter_models.py → WHITELISTS`
 > If today is >10 days past the date above, verify pricing before high-stakes decisions.
 
 Load this skill every time you use `delegate_task` without an explicit model.
@@ -26,11 +26,11 @@ Budget/standard/premium are mutually exclusive. Coding overlaps all.
 `moonshotai/kimi-k2.6` | `minimax/minimax-m2.7` | `z-ai/glm-5.1`
 
 **BUDGET** — cron jobs, extraction, parsing (account default)
-`google/gemini-2.5-flash` | `google/gemini-2.5-flash-lite` | `x-ai/grok-4.1-fast`
+`google/gemini-2.5-flash` | `google/gemini-2.5-flash-lite` | `google/gemini-3.1-flash-lite`
 `openai/gpt-5-nano` | `deepseek/deepseek-v4-flash`
 
 **CODING** — anything touching code (overlaps permitted)
-Ranked by [OpenRouter Pareto Code Router](https://openrouter.ai/openrouter/pareto-code/router/) (Artificial Analysis coding percentiles, 100526).
+Ranked by [OpenRouter Pareto Code Router](https://openrouter.ai/openrouter/pareto-code/router/) (Artificial Analysis coding percentiles, 020626).
 Router slug: `openrouter/pareto-code` — see Pareto Router section below for usage.
 
 *HIGH tier* (`min_coding_score >= 0.66`) — strongest coders, highest cost:
@@ -40,7 +40,7 @@ Router slug: `openrouter/pareto-code` — see Pareto Router section below for us
 `openai/gpt-5.4-mini` | `anthropic/claude-sonnet-4.6` | `moonshotai/kimi-k2.6` | `x-ai/grok-4.3`
 
 *LOW tier* (`score < 0.33`) — lighter coders, lowest cost:
-`xiaomi/mimo-v2.5-pro` | `qwen/qwen3.6-max-preview` | `z-ai/glm-5.1` | `deepseek/deepseek-v4-flash` | `anthropic/claude-haiku-4.5`
+`xiaomi/mimo-v2.5-pro` | `qwen/qwen3.6-max-preview` | `z-ai/glm-5.1` | `deepseek/deepseek-v4-flash` | `anthropic/claude-haiku-4.5` | `x-ai/grok-build-0.1`
 
 > **Slug verified 100526:** MiMo-V2.5-Pro is Xiaomi, NOT Minimax. Display name in OR UI was misleading. `xiaomi/mimo-v2.5-pro` ✅ — `minimax/mimo-v2.5-pro` ❌. Always verify OR slugs via live API when vendor name isn't obvious from the model card.
 

--- a/skills/autonomous-ai-agents/subagent-model-routing/SKILL.md
+++ b/skills/autonomous-ai-agents/subagent-model-routing/SKILL.md
@@ -1,0 +1,236 @@
+---
+name: subagent-model-routing
+description: Model selection guide for delegate_task and cron jobs. Tiers are LLM decision guides (not API constraints).
+version: 3
+tags: [delegation, cost, models, routing, auto-router]
+---
+
+# Subagent Model Routing
+
+> **Last updated:** 100526 | **Sources:** `~/.hermes/scripts/refresh_openrouter_models.py → WHITELISTS` + OpenRouter Pareto Code Router / Artificial Analysis coding percentiles
+> If today is >10 days past the date above, verify pricing before high-stakes decisions.
+
+Load this skill every time you use `delegate_task` without an explicit model.
+
+## Tiers
+
+Budget/standard/premium are mutually exclusive. Coding overlaps all.
+
+**PREMIUM** — synthesis, judgment, reviews
+`x-ai/grok-4.20` | `x-ai/grok-4.20-multi-agent` | `x-ai/grok-4.3`
+`anthropic/claude-opus-4.7` | `anthropic/claude-sonnet-4.6`
+`google/gemini-2.5-pro` | `google/gemini-3.1-pro-preview` | `openai/gpt-5.5`
+
+**STANDARD** — ops, analysis, general delegation
+`anthropic/claude-haiku-4.5` | `openai/gpt-5.4-mini` | `deepseek/deepseek-v4-pro`
+`moonshotai/kimi-k2.6` | `minimax/minimax-m2.7` | `z-ai/glm-5.1`
+
+**BUDGET** — cron jobs, extraction, parsing (account default)
+`google/gemini-2.5-flash` | `google/gemini-2.5-flash-lite` | `x-ai/grok-4.1-fast`
+`openai/gpt-5-nano` | `deepseek/deepseek-v4-flash`
+
+**CODING** — anything touching code (overlaps permitted)
+Use `openrouter/pareto-code` by default for coding delegation. It routes across OpenRouter's Pareto-efficient coding frontier; set the global quality floor with `openrouter.min_coding_score`.
+
+*HIGH tier* (`min_coding_score >= 0.66`) — strongest coders, highest cost:
+`openai/gpt-5.5` | `google/gemini-3.1-pro-preview` | `anthropic/claude-opus-4.7` | `deepseek/deepseek-v4-pro`
+
+*MEDIUM tier* (`0.33 <= score < 0.66`) — solid coders, mid cost:
+`openai/gpt-5.4-mini` | `anthropic/claude-sonnet-4.6` | `moonshotai/kimi-k2.6` | `x-ai/grok-4.3`
+
+*LOW tier* (`score < 0.33`) — lighter coders, lowest cost:
+`xiaomi/mimo-v2.5-pro` | `qwen/qwen3.6-max-preview` | `z-ai/glm-5.1` | `deepseek/deepseek-v4-flash` | `anthropic/claude-haiku-4.5`
+
+> **Slug verified 100526:** MiMo-V2.5-Pro is Xiaomi, NOT Minimax. Display name in OR UI was misleading. Good: `xiaomi/mimo-v2.5-pro`; bad: `minimax/mimo-v2.5-pro`. Always verify OR slugs via live API when vendor name isn't obvious from the model card.
+
+## Pareto Router (`openrouter/pareto-code`)
+
+OpenRouter's curated coding router selects a model from the Pareto-efficient quality/cost frontier. No router fee; you pay only for the underlying model.
+
+**Status (100526): ✅ NATIVELY SUPPORTED** — Hermes wires `min_coding_score` automatically via the OpenRouter plugin when model is `openrouter/pareto-code`. PR #22838 shipped in the +80 commit sync.
+
+**Active config (100526):**
+```yaml
+delegation:
+  model: openrouter/pareto-code   # default for all delegate_task calls
+
+openrouter:
+  min_coding_score: 0.33          # Medium tier floor — Sonnet 4.6 / Grok 4.3 / Kimi K2.6 range
+```
+
+**Score is a floor, not a target** — OpenRouter picks the cheapest available coding model that meets or exceeds the quality bar.
+- `0.66+` → HIGH only (Opus 4.7, GPT-5.5, Gemini 3.1 Pro)
+- `0.33–0.65` → MEDIUM or better (Sonnet 4.6, Grok 4.3, Kimi K2.6)
+- `< 0.33` → any tier
+
+**Per-task score override is NOT supported.** One global `min_coding_score` applies to all delegation batches. Use explicit model pinning (`model: "anthropic/claude-opus-4.7"`) for tasks needing a different tier in the same batch.
+
+**Aux tasks are independent** — `openrouter.min_coding_score` does NOT propagate to auxiliary tasks (compression, vision, session_search, etc.). Wire separately via `extra_body` if needed:
+```yaml
+auxiliary:
+  compression:
+    provider: openrouter
+    model: openrouter/pareto-code
+    extra_body:
+      plugins:
+        - id: pareto-router
+          min_coding_score: 0.5
+```
+
+**Usage:**
+```python
+# delegate_task — inherits min_coding_score from config automatically
+delegate_task(goal="...", model="openrouter/pareto-code", provider="openrouter")
+```
+
+Response `model` shows which concrete model was used. `min_coding_score` is silently dropped for non-`openrouter/pareto-code` models, so it is safe to leave configured globally.
+
+## Routing Matrix
+
+| Task | Model | Tier |
+|------|-------|------|
+| Extraction / parsing / summarization | gemini-2.5-flash | budget |
+| Web research | gemini-2.5-flash | budget |
+| Simple file ops / renames | gpt-5-nano | budget |
+| New script / feature | openrouter/pareto-code (MEDIUM) | coding |
+| Refactor / complex integration | explicit premium pin, or temporarily raise Pareto floor to HIGH | coding |
+| Code review | explicit premium coding pin + grok-4.3 second opinion | coding + premium |
+| Business ops / analysis | claude-haiku-4.5 | standard |
+| Reasoning / math | deepseek-v4-pro or gpt-5.4-mini | standard |
+| Intelligence synthesis | grok-4.20 | premium |
+| Architecture judgment | gpt-5.5 or grok-4.3 | premium |
+| Legal research (Mexican/labor law) | grok-4.3 | premium ← confirmed 050526: LFT PTU, STPS, SAT |
+| Domain law research (any jurisdiction) | grok-4.3 | premium — Grok outperforms on law questions |
+
+## Per-Call Model Pinning (030526 — verified working)
+
+Per-task model pinning works on the feat branch (PR #12794). Pass `model` at the task level:
+
+```python
+delegate_task(tasks=[
+    {"goal": "...", "model": "anthropic/claude-haiku-4.5", "toolsets": [...]},
+    {"goal": "...", "model": "anthropic/claude-opus-4.7",  "toolsets": [...]},
+])
+```
+
+**Verified live (030526):** Three tasks with distinct pins ran on their correct models. The `model_observability` plugin confirmed `match: true` for each pinned task via JSONL evidence.
+
+**Note:** This requires the gateway to run from `hermes-agent-feat/` (feat branch). Upstream main does NOT have `model` in the `delegate_task` signature — pins are silently discarded there. Until PR #12794 merges, `delegation.model` in `config.yaml` is the only routing lever on upstream main.
+
+## Hard Rules
+
+0. **NEVER second-guess a model slug the user provides.** If Jordan says "use grok-4.3" or any other slug, do NOT say the model doesn't exist. Load this skill and `openrouter-expert`, verify the whitelist, then attempt execution. He almost certainly knows it exists. Only flag if the API call actually fails. (Canonical failure 050526: told Jordan grok-4.3 didn't exist — it was in the premium tier the entire time.)
+1. **Grok (ALL variants):** reasoning, intelligence synthesis, and **legal/domain research**. Never code, never general tasks. Confirmed strong: LFT labor law, STPS/SAT compliance, jurisdiction-specific statutes.
+2. **Coding tasks:** coding-tier models ONLY. General models invent abstractions instead of following integration requirements.
+3. **Adversarial code review:** use a different coding model (different training DNA), not a reasoning model.
+4. **Mixed providers in one batch:** always `provider="openrouter"`. Native providers only serve their own models.
+5. **Never self-select Premium autonomously** without exhausting cheaper options. Cost difference is 10–40×.
+6. **Escalating past Standard when user is present:** offer the tradeoff before acting.
+7. **No `openrouter/auto` for cron jobs** where tool execution is mandatory — it can route to a model that fabricates output instead of calling tools. Pin a specific model.
+8. **Rule 0 is not aspirational — it has fired twice.** If you are reading this and Jordan just named a model slug you don't recognize, stop reading, open a terminal, run `curl -s 'https://openrouter.ai/api/v1/models' | python3 -c "import json,sys; [print(m['id']) for m in json.load(sys.stdin)['data']]" | grep <slug>`, and confirm before saying anything.
+
+## When Not to Delegate
+
+- Task is 3 tool calls or fewer
+- Task needs 3+ existing codebase functions/patterns already in your context — write it directly
+- Two prior delegations already failed on the same task
+- Task requires your session state or ongoing conversation context
+
+## Ephemeral Subagents vs. Persistent Profiles — Do NOT Conflate
+
+`delegate_task` spawns **ephemeral anonymous subagents** — they live for one task, have no memory, no SOUL.md, no accumulated context. They are cheap throwaway workers.
+
+**Persistent profiles** are a fundamentally different concept: a named profile with its own `config.yaml`, `SOUL.md`, memory store, cron schedule, and identity that accumulates context across sessions.
+
+**Common mistake (caught 040526):** Connecting `delegate_task`'s per-task model routing to the design of persistent multi-agent profiles (e.g., a Librarian profile or Ops profile). PR #12794 adds model overrides to ephemeral subagents only. A persistent profile running in the gateway as its own named agent is a completely separate architectural decision that has nothing to do with delegate_task's model parameter.
+
+**Rule:** When discussing multi-agent architecture — which profiles to create, what each specialist accumulates over time — do not reference `delegate_task` or PR #12794 as the mechanism. Those are for ephemeral fan-out only.
+
+## Syntax
+
+```python
+# Single task
+delegate_task(goal="...", model="anthropic/claude-haiku-4.5", provider="openrouter")
+
+# Batch — mixed models
+delegate_task(
+    provider="openrouter",
+    tasks=[
+        {"goal": "implement feature", "model": "openai/gpt-5.1-codex-mini"},
+        {"goal": "review output",     "model": "x-ai/grok-4.20"},
+    ]
+)
+
+# Cron job model pin
+cronjob(action="create", model={"model": "google/gemini-2.5-flash", "provider": "openrouter"}, ...)
+```
+
+## Provider Rules
+
+- Omit `provider` only when all tasks share the same provider as the parent session
+- `provider="openrouter"` for mixed-provider batches or any OpenRouter model
+- `provider="anthropic"` for Anthropic-only batches (better latency, prompt caching)
+- Per-task `provider` override does NOT exist — top-level `provider` applies to all tasks in a batch
+
+## Escalation Ladder
+
+```
+1. Handle yourself       free — no context transfer cost
+2. Budget                default starting point
+3. Standard              when budget underperforms or task warrants reliability
+4. Coding                mandatory for any code writing/modification
+5. Premium               review, synthesis, architecture — after cheaper options exhausted
+```
+
+## Observability
+
+Every `delegate_task` result includes an `observability` field:
+```json
+{
+  "models_used": {"google/gemini-2.5-flash": 8},
+  "models_requested": {"openrouter/auto": 8},
+  "api_calls": 8,
+  "tokens": {"input": 24312, "output": 1847},
+  "auto_router_resolutions": {"openrouter/auto": {"google/gemini-2.5-flash": 8}},
+  "override_mismatches": []
+}
+```
+
+If `override_mismatches` is non-empty → alert Jordan immediately. A model override was silently dropped and the task ran on the wrong model.
+
+## Aux Slot Routing (v0.13.0+)
+
+These are gateway-internal slots — not `delegate_task` params — but they follow the same routing logic and slug conventions.
+
+| Slot | Current model | Rationale |
+|---|---|---|
+| `triage_specifier` | `anthropic/claude-haiku-4.5` | Kanban task dispatch; judgment-lite routing decisions |
+| `curator` | `anthropic/claude-haiku-4.5` | Skill archive/prune; monitor for over-aggressive pruning — bump to `sonnet-4.6` if needed |
+| `vision` | `google/gemini-2.5-flash` | Powers `video_analyze` + screenshot analysis |
+
+**`triage_specifier` watch note (070526):** This is the model that reads an incoming Kanban task and decides which worker profile picks it up, what toolsets it gets, and how to scope it. Haiku is appropriate for structured routing decisions. If the first real Kanban board shows mis-dispatch (wrong worker, wrong toolset, wrong scope), bump to `anthropic/claude-sonnet-4.6` immediately — don't wait for a second failure.
+
+## Known Limitations
+
+- No per-task `provider` in batches. Workaround: use `provider="openrouter"` for mixed batches — it serves all providers.
+- OpenRouter uses dot notation for Anthropic slugs: `claude-haiku-4.5` not `claude-haiku-4-5`. Hyphens will silently fail or fall back to the main model. Always verify a new slug via live API before writing it into config, code, or cron — canonical verification command:
+  ```bash
+  curl -s 'https://openrouter.ai/api/v1/models' | python3 -c "import json,sys; [print(m['id']) for m in json.load(sys.stdin)['data']]" | grep <slug>
+  ```
+  Canonical failure (080526): attempted `anthropic/claude-haiku-4-5` (hyphen) — corrected to `anthropic/claude-haiku-4.5` (dot) after live check.
+
+## Whitelist Maintenance
+
+**Canonical source:** `~/.hermes/scripts/refresh_openrouter_models.py → WHITELISTS`
+
+The refresh cron runs every Sunday 11 AM, delivers a read-only digest, and requires operator approval before any changes are applied. When approving changes, patch **both** the script's `WHITELISTS` dict and this skill's tier tables atomically in the same session. Also copy the updated script to the feat branch — see the MAINTENANCE section inside the script for the exact commands.
+
+**Tier exclusivity is enforced by the script itself.** The `WHITELISTS` dict has a validator that raises at import time if any model appears in more than one of budget/standard/premium. Coding is explicitly exempt. If you add a model, ensure it belongs to exactly one non-coding tier.
+
+**Price delta tracking uses a local cache.** The script writes `~/.hermes/caches/openrouter_prices_last.json` after each run and diffs against it the following week. Section 2b of the report shows changes ≥20% with direction arrows. No external persistence needed — the cache is the baseline.
+
+**OpenRouter response caching (030526):** Default TTL is 300s and is on by default — no config needed. Decision: leave at 300s. Dynamic cron prompts (briefings, intel) never hit the cache because they include fresh dates/content; 300s captures legitimate repeat aux calls within a session. Longer TTLs offer marginal savings but more exposure to the beta feature's edge cases. Do not increase unless cost audits show a clear win.
+
+**Do not embed a `CRON_PROMPT_TEMPLATE` in the refresh script.** The live prompt lives in `jobs.json` (job `6d0271a4d5cb`). A template in the script is a diverging copy with no enforcement mechanism — it goes stale silently and misleads future agents reading the script. The script's job is data collection; the prompt belongs in the scheduler.
+
+> See `references/routing-rationale.md` for case studies, QA history, whitelist change log, and slug verification protocol.

--- a/skills/autonomous-ai-agents/subagent-model-routing/SKILL.md
+++ b/skills/autonomous-ai-agents/subagent-model-routing/SKILL.md
@@ -7,7 +7,7 @@ tags: [delegation, cost, models, routing, auto-router]
 
 # Subagent Model Routing
 
-> **Last updated:** 100526 | **Sources:** `~/.hermes/scripts/refresh_openrouter_models.py → WHITELISTS` + OpenRouter Pareto Code Router / Artificial Analysis coding percentiles
+> **Last updated:** 100526 | **Source:** `~/.hermes/scripts/refresh_openrouter_models.py → WHITELISTS`
 > If today is >10 days past the date above, verify pricing before high-stakes decisions.
 
 Load this skill every time you use `delegate_task` without an explicit model.
@@ -30,7 +30,8 @@ Budget/standard/premium are mutually exclusive. Coding overlaps all.
 `openai/gpt-5-nano` | `deepseek/deepseek-v4-flash`
 
 **CODING** — anything touching code (overlaps permitted)
-Use `openrouter/pareto-code` by default for coding delegation. It routes across OpenRouter's Pareto-efficient coding frontier; set the global quality floor with `openrouter.min_coding_score`.
+Ranked by [OpenRouter Pareto Code Router](https://openrouter.ai/openrouter/pareto-code/router/) (Artificial Analysis coding percentiles, 100526).
+Router slug: `openrouter/pareto-code` — see Pareto Router section below for usage.
 
 *HIGH tier* (`min_coding_score >= 0.66`) — strongest coders, highest cost:
 `openai/gpt-5.5` | `google/gemini-3.1-pro-preview` | `anthropic/claude-opus-4.7` | `deepseek/deepseek-v4-pro`
@@ -41,11 +42,11 @@ Use `openrouter/pareto-code` by default for coding delegation. It routes across 
 *LOW tier* (`score < 0.33`) — lighter coders, lowest cost:
 `xiaomi/mimo-v2.5-pro` | `qwen/qwen3.6-max-preview` | `z-ai/glm-5.1` | `deepseek/deepseek-v4-flash` | `anthropic/claude-haiku-4.5`
 
-> **Slug verified 100526:** MiMo-V2.5-Pro is Xiaomi, NOT Minimax. Display name in OR UI was misleading. Good: `xiaomi/mimo-v2.5-pro`; bad: `minimax/mimo-v2.5-pro`. Always verify OR slugs via live API when vendor name isn't obvious from the model card.
+> **Slug verified 100526:** MiMo-V2.5-Pro is Xiaomi, NOT Minimax. Display name in OR UI was misleading. `xiaomi/mimo-v2.5-pro` ✅ — `minimax/mimo-v2.5-pro` ❌. Always verify OR slugs via live API when vendor name isn't obvious from the model card.
 
 ## Pareto Router (`openrouter/pareto-code`)
 
-OpenRouter's curated coding router selects a model from the Pareto-efficient quality/cost frontier. No router fee; you pay only for the underlying model.
+OpenRouter's curated coding router — automatically selects a model from the Pareto-efficient quality/cost frontier. No fee added; you pay only for the underlying model.
 
 **Status (100526): ✅ NATIVELY SUPPORTED** — Hermes wires `min_coding_score` automatically via the OpenRouter plugin when model is `openrouter/pareto-code`. PR #22838 shipped in the +80 commit sync.
 
@@ -58,7 +59,7 @@ openrouter:
   min_coding_score: 0.33          # Medium tier floor — Sonnet 4.6 / Grok 4.3 / Kimi K2.6 range
 ```
 
-**Score is a floor, not a target** — OpenRouter picks the cheapest available coding model that meets or exceeds the quality bar.
+**Score is a floor, not a target** — "cheapest model that meets or exceeds this quality bar."
 - `0.66+` → HIGH only (Opus 4.7, GPT-5.5, Gemini 3.1 Pro)
 - `0.33–0.65` → MEDIUM or better (Sonnet 4.6, Grok 4.3, Kimi K2.6)
 - `< 0.33` → any tier
@@ -81,9 +82,20 @@ auxiliary:
 ```python
 # delegate_task — inherits min_coding_score from config automatically
 delegate_task(goal="...", model="openrouter/pareto-code", provider="openrouter")
+
+# Or set per-session score inline (when config.yaml supports it)
+# The plugin emits: extra_body.plugins = [{id: "pareto-router", min_coding_score: X}]
 ```
 
-Response `model` shows which concrete model was used. `min_coding_score` is silently dropped for non-`openrouter/pareto-code` models, so it is safe to leave configured globally.
+**How it works:**
+- Set `model = "openrouter/pareto-code"` and Hermes does the rest
+- `min_coding_score` maps to tier: `>= 0.66` → HIGH, `0.33–0.65` → MEDIUM, `< 0.33` → LOW
+- Falls back to next-closest tier if all candidates are unavailable
+- Response `model` field shows which model was actually used
+- Score is silently dropped on any other model — safe to leave configured globally
+- `min_coding_score` does NOT propagate to aux calls by design
+
+**When to use:** Any coding task where you want OpenRouter to pick the best available model at your cost floor, rather than pinning a specific model that may degrade or disappear. Especially good for cron coding tasks where model availability varies.
 
 ## Routing Matrix
 
@@ -93,8 +105,9 @@ Response `model` shows which concrete model was used. `min_coding_score` is sile
 | Web research | gemini-2.5-flash | budget |
 | Simple file ops / renames | gpt-5-nano | budget |
 | New script / feature | openrouter/pareto-code (MEDIUM) | coding |
-| Refactor / complex integration | explicit premium pin, or temporarily raise Pareto floor to HIGH | coding |
-| Code review | explicit premium coding pin + grok-4.3 second opinion | coding + premium |
+| Small focused code review | anthropic/claude-haiku-4.5 with exact touched-file prompt | budget/standard |
+| Refactor / complex integration | openrouter/pareto-code (HIGH) | coding |
+| Code review | openrouter/pareto-code (HIGH) + grok-4.3 second opinion | coding + premium |
 | Business ops / analysis | claude-haiku-4.5 | standard |
 | Reasoning / math | deepseek-v4-pro or gpt-5.4-mini | standard |
 | Intelligence synthesis | grok-4.20 | premium |
@@ -128,6 +141,18 @@ delegate_task(tasks=[
 6. **Escalating past Standard when user is present:** offer the tradeoff before acting.
 7. **No `openrouter/auto` for cron jobs** where tool execution is mandatory — it can route to a model that fabricates output instead of calling tools. Pin a specific model.
 8. **Rule 0 is not aspirational — it has fired twice.** If you are reading this and Jordan just named a model slug you don't recognize, stop reading, open a terminal, run `curl -s 'https://openrouter.ai/api/v1/models' | python3 -c "import json,sys; [print(m['id']) for m in json.load(sys.stdin)['data']]" | grep <slug>`, and confirm before saying anything.
+
+## Focused Review Retry Pattern
+
+If a code-review delegation times out or starts exploring the whole repo, do not treat that as a code finding. Retry once with a narrower prompt:
+
+- exact touched file list
+- "read only these files"
+- "run at most the focused tests"
+- `PASS` / `REQUEST_CHANGES` output only
+- use `anthropic/claude-haiku-4.5` for small focused reviews unless the diff is architecture-critical
+
+Use the heavier Pareto/high-tier review only when the diff is broad, phase-gating, security-sensitive, or prior focused review found real issues.
 
 ## When Not to Delegate
 

--- a/skills/autonomous-ai-agents/subagent-model-routing/SKILL.md
+++ b/skills/autonomous-ai-agents/subagent-model-routing/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: subagent-model-routing
 description: Model selection guide for delegate_task and cron jobs. Tiers are LLM decision guides (not API constraints).
-version: 3
+version: 4
 tags: [delegation, cost, models, routing, auto-router]
 ---
 
@@ -43,6 +43,52 @@ Router slug: `openrouter/pareto-code` — see Pareto Router section below for us
 `xiaomi/mimo-v2.5-pro` | `qwen/qwen3.6-max-preview` | `z-ai/glm-5.1` | `deepseek/deepseek-v4-flash` | `anthropic/claude-haiku-4.5`
 
 > **Slug verified 100526:** MiMo-V2.5-Pro is Xiaomi, NOT Minimax. Display name in OR UI was misleading. `xiaomi/mimo-v2.5-pro` ✅ — `minimax/mimo-v2.5-pro` ❌. Always verify OR slugs via live API when vendor name isn't obvious from the model card.
+
+## GPT-5.3-Codex-Spark Implementer Lane (verified 2026-05-25)
+
+Verified live through Hermes/OpenAI Codex OAuth:
+
+```bash
+hermes chat -q 'Reply with exactly: SPARK_OK' --provider openai-codex --model gpt-5.3-codex-spark --toolsets '' --quiet
+# → SPARK_OK
+```
+
+Use `gpt-5.3-codex-spark` only as a **bounded code implementation worker** when the main lane has already planned the issue and provided exact context. This is for exploiting Jordan's separate Codex Spark usage bucket without moving planning/judgment off GPT-5.5.
+
+Route Spark to:
+- scoped issue-slice implementation in an isolated worktree;
+- boilerplate, small refactors, UI/layout/style edits;
+- applying one explicit step from a stronger model's plan;
+- TDD loops with focused tests and tight touched-file bounds.
+
+Do **not** route Spark to:
+- architecture, design, spec coherence, or product judgment;
+- root-cause debugging with unknown cause;
+- migrations, security-sensitive changes, or irreversible data model work;
+- final code review or adversarial review;
+- long autonomous runs where it must decide the plan itself.
+
+### Current live enforcement (2026-05-26)
+
+Jordan's gateway is dogfooding the delegate model/provider override feature branch. The live schema now supports top-level `provider`, top-level `model`, and per-task `model`.
+
+For coding implementer subagents, enforce Spark explicitly:
+
+```python
+delegate_task(
+    goal="Implement bounded issue slice ...",
+    context="WORKTREE: /absolute/path\n...",
+    provider="openai-codex",
+    model="gpt-5.3-codex-spark",
+    toolsets=["terminal", "file"],
+)
+```
+
+Per-task `provider` does **not** exist. If all children in a batch are Spark implementers, use the top-level provider/model once. If a batch mixes reviewer models, use `provider="openrouter"` plus provider-prefixed per-task `model` strings, or separate the implementation and review batches.
+
+Always inspect `delegate_task` observability after the first real Spark implementation in a session. Requested/actual model mismatch means runtime drift or routing failure; stop and diagnose before continuing.
+
+If the live schema ever lacks these fields again, do not rewrite doctrine as if the feature is absent. Diagnose runtime drift: launchd may be running `/Users/jj/.hermes/hermes-agent` while the feature branch lives in `/Users/jj/.hermes/hermes-agent-feat`.
 
 ## Pareto Router (`openrouter/pareto-code`)
 
@@ -117,18 +163,23 @@ delegate_task(goal="...", model="openrouter/pareto-code", provider="openrouter")
 
 ## Per-Call Model Pinning (030526 — verified working)
 
-Per-task model pinning works on the feat branch (PR #12794). Pass `model` at the task level:
+Per-task model pinning works only when the live `delegate_task` tool schema exposes model/provider fields. Before relying on pins, inspect the current schema in the tool definition for `model` and `provider` at the same level you intend to use them. If those fields are absent, extra JSON keys are silently ignored and the task runs on the configured default (often `openrouter/pareto-code`).
+
+**Feature-branch vs live-runtime distinction:** If Jordan says this functionality was explicitly built, do not answer as if the feature does not exist. Diagnose the mismatch: compare the *running/live tool schema* against the repo branch/commit that contains the implementation. The correct phrasing is usually “the feature exists on `<branch/commit>`, but this gateway/session is exposing an older schema,” not “delegate_task cannot do this.” This prevents turning a deployment/branch drift problem into false doctrine.
 
 ```python
+# Only valid when the live schema supports per-task `model`:
 delegate_task(tasks=[
     {"goal": "...", "model": "anthropic/claude-haiku-4.5", "toolsets": [...]},
     {"goal": "...", "model": "anthropic/claude-opus-4.7",  "toolsets": [...]},
 ])
 ```
 
-**Verified live (030526):** Three tasks with distinct pins ran on their correct models. The `model_observability` plugin confirmed `match: true` for each pinned task via JSONL evidence.
+**Verified live (030526):** Three tasks with distinct pins ran on their correct models when the feat branch schema exposed the field. The `model_observability` plugin confirmed `match: true` for each pinned task via JSONL evidence.
 
-**Note:** This requires the gateway to run from `hermes-agent-feat/` (feat branch). Upstream main does NOT have `model` in the `delegate_task` signature — pins are silently discarded there. Until PR #12794 merges, `delegation.model` in `config.yaml` is the only routing lever on upstream main.
+**Regression/pitfall observed 220526:** In a session where the live `delegate_task` schema did **not** expose `model` inside batch tasks, requested task pins were ignored and the observability result showed `model: openrouter/pareto-code`. Treat this as a schema mismatch, not a model failure. If the task truly requires a frontier/premium model, either use a supported top-level model override if present in the live schema, or do not claim the task was run on the pinned model.
+
+**Note:** This requires the gateway to run from a version whose `delegate_task` signature includes model/provider override fields. Upstream/main or older tool schemas may not have them — pins are silently discarded there. Until the live schema confirms support, `delegation.model` in `config.yaml` is the only reliable routing lever.
 
 ## Hard Rules
 

--- a/skills/autonomous-ai-agents/subagent-model-routing/references/openrouter-refresh-architecture-030526.md
+++ b/skills/autonomous-ai-agents/subagent-model-routing/references/openrouter-refresh-architecture-030526.md
@@ -1,0 +1,55 @@
+# OpenRouter Model Refresh — Architecture Decisions (030526)
+
+## Three-Location Sync Problem
+
+`refresh_openrouter_models.py` must exist in three places:
+
+| Location | Purpose | How updated |
+|---|---|---|
+| `~/.hermes/scripts/refresh_openrouter_models.py` | Cron executes this | `cp` from feat branch after every edit |
+| `~/.hermes/hermes-agent-feat/scripts/refresh_openrouter_models.py` | Feat branch source | Edit here first |
+| `subagent-model-routing/SKILL.md` WHITELISTS section | Human-readable mirror | Patched atomically with script |
+
+**Why not a symlink:** The cron sandbox (`scheduler.py → _run_job_script()`) calls `path.resolve()` which follows symlinks. A symlink pointing outside `~/.hermes/scripts/` is blocked with a path traversal error. Real file copies only.
+
+**Why the feat branch is source of truth:** The script is a declared dependency of PR #12794. Whitelist changes must land there to keep the PR current. Post-merge, the copy step targets `~/.hermes/hermes-agent/scripts/` instead.
+
+## Price Cache (added 030526)
+
+`~/.hermes/caches/openrouter_prices_last.json` — written at end of each run, read at start of next for delta comparison. Schema:
+
+```json
+{
+  "_run_date": "2026-05-03 20:42 UTC",
+  "google/gemini-2.5-flash": {"in": 0.0000003, "out": 0.0000025},
+  ...
+}
+```
+
+Threshold: 20% change triggers a flag. First run seeds the cache with no delta output ("delta tracking starts next week").
+
+**Why not parse the skill's pricing tables:** The skill tables are human-readable narrative, not a reliable machine-parseable baseline. They have inconsistent formats across sections and aren't exhaustive. The JSON sidecar is stdlib, self-healing (resets with every approved update), and zero-dependency.
+
+## CRON_PROMPT_TEMPLATE removed (030526)
+
+The template was removed from the script because:
+- The live prompt lives in `jobs.json` (job `6d0271a4d5cb`) — that's the real one
+- The template was a diverging copy with no enforcement
+- Any agent reading the script would get a misleading picture of what the cron actually says
+- The script's MAINTENANCE docstring already explains the full architecture
+
+To inspect the live prompt: `python3 -c "import json; jobs=json.load(open('/Users/jj/.hermes/cron/jobs.json')); print(next(j['prompt'] for j in jobs['jobs'] if j['id']=='6d0271a4d5cb'))"`
+
+## Whitelist Tier Exclusivity
+
+`budget / standard / premium` are mutually exclusive. `coding` may overlap any of them. Enforced at script import time:
+
+```python
+_EXCLUSIVE_TIERS = {"budget", "standard", "premium"}
+# raises ValueError on overlap with clear error message naming the offending model
+# coding is explicitly exempt
+```
+
+## Overlap Validation Rationale
+
+Before 030526 the same model appeared in up to 4 lists simultaneously (e.g. `mistralai/devstral-small` in full/standard/coding/budget). The auto-router uses these lists for routing decisions — duplicates caused ambiguous precedence and made the lists meaningless as tiers. The restructure assigns each model a single home except coding (intentional overlap for specialist access from any tier).

--- a/skills/autonomous-ai-agents/subagent-model-routing/references/routing-rationale.md
+++ b/skills/autonomous-ai-agents/subagent-model-routing/references/routing-rationale.md
@@ -1,0 +1,113 @@
+# Subagent Model Routing — Rationale & History
+
+Supporting context for `subagent-model-routing/SKILL.md`. Not loaded automatically — reference when debugging routing decisions or reviewing past lessons.
+
+---
+
+## Why Model Selection Matters
+
+`delegate_task` supports `model` and `provider` overrides. When omitted, subagents inherit `delegation.model` from `config.yaml` (typically `openrouter/auto`). The auto-router is a reasonable default, but:
+
+- Coding tasks on general-purpose models consistently produce off-target code — the model invents its own abstractions instead of following integration requirements
+- Simple extraction tasks on premium models waste 10–50× the cost for no quality benefit
+- Mixed-provider batches fail silently if the wrong provider is set at the top level
+
+## Cost Comparison (illustrative)
+
+Tonight's session (actual): 9 Opus subagents ≈ $150
+Same work with proper routing:
+  - 3 code reviews × gemini-2.5-pro ≈ $5–8
+  - 6 execution tasks × grok-4.1-fast ≈ $1–2
+  - Total: ~$10 instead of $150 (15× cheaper)
+
+**Jordan's principle (180426):** "Affordability is important, but effectiveness is important as well. If a model doesn't do the task correctly, or requires a lot of reruns, use a more capable model. Choose the cheapest model that will RELIABLY succeed on the FIRST try."
+
+## 180426 Case Study — Orchestrator-Direct Beats Delegation for Code
+
+Three scripts needed: `fetch_and_file_corte.py`, `fetch_and_file_invoices.py`, `scan_and_cache_emails.py`. All required tight integration with existing `daily_briefing.py` patterns.
+
+Two subagent delegations failed:
+- Subagent 1 (Sonnet): Created a generic "CortePDFHandler" class — missed the himalaya/IMAP integration entirely
+- Subagent 2 (Sonnet via Gemini Flash): Created "court document" and "pending cases" infrastructure — misunderstood "Corte" as legal court, not the daily sales summary
+
+Orchestrator wrote all 3 scripts directly in ~10 minutes. All worked on first run.
+
+**Rule:** If a script needs to call 3+ existing functions from the codebase, or reference specific file paths/constants/patterns from an existing monolith, write it directly. Context transfer cost exceeds delegation benefit.
+
+## 280426 — openrouter/auto Fabrication Failure
+
+The auto-router selected a model for the daily briefing cron that read the prompt and *wrote prose about what the script would have returned* instead of executing `terminal()`. No error raised. Output file created. Status showed `ok`.
+
+**Diagnostic:** Token counts were 4,667 in vs 91,618 in on a healthy run — the model never saw script output because it never ran the script.
+
+**Fix:** Convert mandatory-tool-call cron jobs to pre-runners (script runs deterministically before agent, output injected into prompt). Or pin a specific reliable model. Never use `openrouter/auto` where tool execution is mandatory.
+
+## QA Status (verified 200426)
+
+- ✅ No override → config default (openrouter/auto → budget tier)
+- ✅ Top-level model+provider override → lands on correct model
+- ✅ Batch with per-task model override → each subagent routes correctly
+- ✅ Cross-provider routing (anthropic main → openrouter subagent)
+- ✅ Max concurrency (3 parallel subagents with different models)
+- ✅ Failure modes: bogus model name, invalid provider
+- ✅ Cron jobs honor model pin
+- ✅ Unit tests pass
+- ⏳ Nous Portal subagent from non-Nous parent — not yet verified
+
+**Known issue:** `exit_reason` reports `"max_iterations"` when a subagent fails with an API error on its first call. Pre-existing bug in `delegate_tool.py`, not caused by our patch.
+
+## Root Cause of Original Dispatch Bug (200426)
+
+`run_agent.py` had TWO hardcoded dispatch sites for `delegate_task` that bypassed the registry's handler lambda. The schema could expose new parameters; those dispatch sites passed a fixed parameter list to `_delegate_task()`. Fix required patching BOTH:
+1. `tools/delegate_tool.py` — schema + handler lambda + credential resolution + signature
+2. `run_agent.py` — both direct-dispatch call sites to forward `model`, `provider`, `acp_command`, `acp_args`
+
+Note: upstream's existing `acp_command` schema param was silently broken the same way. This is a legit upstream dispatch-path bug.
+
+**As of upstream consolidation (200426):** `run_agent.py` dispatch sites were consolidated into `_dispatch_delegate_task()`. All new params only need to be added there. `TestRunAgentDispatchForwarding` guards this.
+
+## Surgical Revert-and-Rebuild Workflow
+
+When a framework patch is broken/unverified, don't layer fixes — revert to upstream clean, then rebuild with verification.
+
+1. Inventory modified files: `git status` + `git diff <file>`
+2. Separate patches: BROKEN vs DEPENDENT vs PROVEN
+3. Back up and revert broken + dependent: `git checkout HEAD -- <files>`
+4. Strip dead metadata from runtime state (jobs.json, config)
+5. Stash proven patches, pull upstream, pop back
+6. Verify parse: `python -c "import py_compile; py_compile.compile(f, doraise=True)"`
+7. Rebuild feature with observability-first verification
+8. Build the verification query BEFORE restart
+9. Restart gateway, run test, grep log. Binary pass/fail.
+10. If verification fails → revert same session. Never leave unverified patches overnight.
+
+## Codex CLI Sandboxing Limitation (180426)
+
+The `codex` CLI tool operates in its own sandboxed working directory. It cannot access files in `~/.hermes/scripts/` or other user home directories. Use `delegate_task` with Sonnet/Grok and `toolsets: ["terminal", "file"]` instead.
+
+## Large-Scale Refactor Pattern (180426)
+
+2060-line monolith → 383-line orchestrator + 9 modules completed in ~2 hours. Every module was written by the orchestrator — zero successful code-generation delegations for the extraction itself. Subagents were used only for reviews.
+
+**Rule for refactors:** If extracting from a monolith where modules need to import shared helpers, reference the same constants, and maintain the same output format — do it yourself. Delegate the reviews, not the implementation.
+
+## Auto Router Technical Notes
+
+- Model ID: `openrouter/auto`
+- Powered by: NotDiamond (third-party meta-routing AI)
+- Pricing: standard rate of whichever model is selected — no premium
+- Response includes `model` field — always shows what was actually chosen
+- Account-level whitelist: OpenRouter Settings UI → Plugin Settings → Auto Router (currently unrestricted)
+- Per-call whitelist via `plugins` param — not yet implemented for delegate_task
+
+## OpenRouter Model ID Notation
+
+OpenRouter uses **dot notation**: `claude-haiku-4.5`, `claude-sonnet-4.6`, `claude-opus-4.7`
+Anthropic native API uses **hyphen notation**: `claude-haiku-4-5`
+
+LLM training data is biased toward Anthropic native notation, which leaks into OpenRouter config writes. The live API lookup must happen every time a slug is written:
+
+```bash
+curl -s 'https://openrouter.ai/api/v1/models' | python3 -c \
+  "import json,sys; [print(m['id']) for m in json.load(sys.stdin)['data'] if 'claude' in m['id'].lower()]"
+```

--- a/tests/gateway/test_session_env.py
+++ b/tests/gateway/test_session_env.py
@@ -139,6 +139,30 @@ def test_get_session_env_falls_back_to_os_environ(monkeypatch):
     assert get_session_env("HERMES_SESSION_PLATFORM") == ""
 
 
+def test_live_session_masks_stale_cron_env(monkeypatch):
+    """Gateway session context should hide stale process-level cron markers."""
+    monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+
+    assert get_session_env("HERMES_CRON_SESSION") == "1"
+
+    tokens = set_session_vars(platform="discord", session_key="live-session")
+    assert get_session_env("HERMES_CRON_SESSION") == ""
+
+    clear_session_vars(tokens)
+    assert get_session_env("HERMES_CRON_SESSION") == ""
+
+
+def test_cron_session_contextvar_overrides_absent_env(monkeypatch):
+    """Cron identity can be scoped to the current context without os.environ."""
+    monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+
+    tokens = set_session_vars(cron_session="1")
+    assert get_session_env("HERMES_CRON_SESSION") == "1"
+
+    clear_session_vars(tokens)
+    assert get_session_env("HERMES_CRON_SESSION") == ""
+
+
 def test_get_session_env_default_when_nothing_set(monkeypatch):
     """get_session_env returns default when neither contextvar nor env is set."""
     monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)

--- a/tests/plugins/test_model_observability_v2.py
+++ b/tests/plugins/test_model_observability_v2.py
@@ -1,0 +1,847 @@
+"""Tests for the redesigned model_observability plugin v2.
+
+Architecture under test:
+    pre_tool_call       → scoping anchor + missing-pin flag
+                          Stashes {offset, missing_pin} keyed on tool_call_id.
+                          NEVER returns block; never directly warns the agent.
+                          Also evicts TTL-expired stash entries.
+
+    transform_tool_result → reads stash by tool_call_id, reads only JSONL entries
+                            past the stash offset (scoping anchor), builds observability
+                            block and injects into the result string. If missing_pin=True,
+                            notes auto-router resolution. If match=False on a pinned
+                            model, injects a prominent WARNING. Pops stash entry after use.
+
+    post_api_request    → JSONL write (unchanged from v1). Regression suite.
+
+Hook contracts (from hermes_cli/plugins.py):
+    pre_tool_call:  return {"action": "block", "message": "..."} to block,
+                    or None to pass through. Framework ignores everything else.
+                    We always return None — hook is for side effects only.
+    transform_tool_result: return string to replace result, or None to leave it.
+    post_api_request:  observer only, return value ignored.
+
+Key design decisions:
+    - pre_tool_call stash is keyed on tool_call_id
+    - Stash entries older than TTL are evicted on each pre_tool_call fire
+    - byte-offset scoping means multiple delegate_task calls in one session
+      never cross-contaminate each other
+    - tool_call_id is threaded through both hooks, enabling exact scoping
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+PLUGIN_PATH = Path(__file__).resolve().parents[3] / "plugins" / "model_observability" / "__init__.py"
+
+
+def _load_plugin(tmp_path: Path):
+    """Load the plugin module in isolation with a tmp log dir.
+
+    LOG_PATH is patched BEFORE exec_module by injecting it via a
+    module-level attribute seed so future register() calls also see it.
+    """
+    log_path = tmp_path / "model_usage.jsonl"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+
+    spec = importlib.util.spec_from_file_location(
+        f"model_observability_{id(tmp_path)}", PLUGIN_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    # Redirect after exec — safe because no top-level code opens the file,
+    # but we explicitly test _load_plugin isolation in TestLoadPluginIsolation.
+    mod.LOG_PATH = log_path
+    return mod
+
+
+def _read_log(log_path: Path) -> list[dict]:
+    if not log_path.exists():
+        return []
+    return [json.loads(line) for line in log_path.read_text().splitlines() if line.strip()]
+
+
+def _write_log_entries(log_path: Path, records: list[dict]) -> None:
+    """Append records to the log (does not truncate existing content)."""
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(log_path, "a") as f:
+        for r in records:
+            f.write(json.dumps(r) + "\n")
+
+
+def _write_log(log_path: Path, records: list[dict]) -> None:
+    """Overwrite the log with exactly these records."""
+    log_path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+
+
+def _subagent_record(session_id: str, task_id: str, model_req: str, model_resp: str,
+                     match: bool = True, tokens_in: int = 100, tokens_out: int = 30,
+                     duration_s: float = 0.5) -> dict:
+    return {
+        "session_id": session_id,
+        "task_id": task_id,
+        "agent_type": "subagent",
+        "model_request": model_req,
+        "model_response": model_resp,
+        "match": match,
+        "tokens_in": tokens_in,
+        "tokens_out": tokens_out,
+        "duration_s": duration_s,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def plugin(tmp_path):
+    return _load_plugin(tmp_path)
+
+
+@pytest.fixture
+def log_path(plugin):
+    return plugin.LOG_PATH
+
+
+# ===========================================================================
+# 0. Plugin isolation — _load_plugin redirect happens before any writes
+# ===========================================================================
+
+class TestLoadPluginIsolation:
+
+    def test_log_path_points_to_tmp_not_real_home(self, plugin, log_path, tmp_path):
+        """LOG_PATH must be inside tmp_path, never the real ~/.hermes/logs/."""
+        assert str(log_path).startswith(str(tmp_path))
+        assert ".hermes/logs" not in str(log_path)
+
+    def test_writes_go_to_tmp_log(self, plugin, log_path):
+        plugin._on_post_api_request(
+            task_id=None, session_id="s1", platform="test",
+            model="anthropic/claude-haiku-4.5", provider="openrouter",
+            api_mode="chat_completions", api_call_count=1,
+            api_duration=1.0, finish_reason="stop",
+            usage={"prompt_tokens": 10, "completion_tokens": 5},
+            response_model="anthropic/claude-haiku-4.5",
+            assistant_content_chars=20, assistant_tool_call_count=0,
+        )
+        assert log_path.exists()
+        real_log = Path.home() / ".hermes" / "logs" / "model_usage.jsonl"
+        if real_log.exists():
+            real_entries = _read_log(real_log)
+            tmp_entries = _read_log(log_path)
+            # tmp log has our entry; real log was not touched by this test
+            assert len(tmp_entries) == 1
+            # Real log entries won't have been written by this isolated module instance
+
+
+# ===========================================================================
+# 1. pre_tool_call — scoping anchor + missing-pin detection
+# ===========================================================================
+
+class TestPreToolCallScopingAnchor:
+
+    def test_returns_none_for_non_delegate_task_tools(self, plugin, log_path):
+        """pre_tool_call must always return None for non-delegation tools."""
+        result = plugin._on_pre_tool_call(
+            tool_name="web_search",
+            args={"query": "test"},
+            task_id="",
+            session_id="s1",
+            tool_call_id="tc1",
+        )
+        assert result is None
+
+    def test_returns_none_for_delegate_task_with_model_pinned(self, plugin, log_path):
+        """pre_tool_call must ALWAYS return None — it's a side-effect hook, not a blocker."""
+        result = plugin._on_pre_tool_call(
+            tool_name="delegate_task",
+            args={"goal": "task", "model": "anthropic/claude-haiku-4.5"},
+            task_id="",
+            session_id="s1",
+            tool_call_id="tc1",
+        )
+        assert result is None
+
+    def test_returns_none_for_delegate_task_without_model(self, plugin, log_path):
+        """Even with missing pin, pre_tool_call returns None — never blocks or warns directly."""
+        result = plugin._on_pre_tool_call(
+            tool_name="delegate_task",
+            args={"goal": "task"},
+            task_id="",
+            session_id="s1",
+            tool_call_id="tc1",
+        )
+        assert result is None
+
+    def test_never_returns_block(self, plugin, log_path):
+        """Hard requirement: soft enforcement only. block is permanently off."""
+        for args in [
+            {},
+            {"goal": "task"},
+            {"tasks": [{"goal": "a"}, {"goal": "b"}]},
+        ]:
+            result = plugin._on_pre_tool_call(
+                tool_name="delegate_task",
+                args=args,
+                task_id="",
+                session_id="s1",
+                tool_call_id="tc-block-test",
+            )
+            assert result is None or result.get("action") != "block"
+
+    def test_stashes_byte_offset_for_tool_call_id(self, plugin, log_path):
+        """After pre_tool_call fires, the stash must contain a byte offset for this tool_call_id."""
+        # Write some entries first so offset is nonzero
+        _write_log_entries(log_path, [
+            _subagent_record("s1", "prior-task", "a/model", "a/model")
+        ])
+
+        plugin._on_pre_tool_call(
+            tool_name="delegate_task",
+            args={"goal": "task", "model": "anthropic/claude-haiku-4.5"},
+            task_id="",
+            session_id="s1",
+            tool_call_id="tc1",
+        )
+        assert "tc1" in plugin._delegate_stash
+        assert plugin._delegate_stash["tc1"]["offset"] > 0
+
+    def test_stashes_missing_pin_false_when_model_present(self, plugin, log_path):
+        plugin._on_pre_tool_call(
+            tool_name="delegate_task",
+            args={"goal": "task", "model": "anthropic/claude-haiku-4.5"},
+            task_id="",
+            session_id="s1",
+            tool_call_id="tc1",
+        )
+        assert plugin._delegate_stash["tc1"]["missing_pin"] is False
+
+    def test_stashes_missing_pin_true_when_model_absent(self, plugin, log_path):
+        plugin._on_pre_tool_call(
+            tool_name="delegate_task",
+            args={"goal": "task"},
+            task_id="",
+            session_id="s1",
+            tool_call_id="tc1",
+        )
+        assert plugin._delegate_stash["tc1"]["missing_pin"] is True
+
+    def test_stashes_missing_pin_false_when_all_batch_tasks_pinned(self, plugin, log_path):
+        plugin._on_pre_tool_call(
+            tool_name="delegate_task",
+            args={"tasks": [
+                {"goal": "a", "model": "anthropic/claude-haiku-4.5"},
+                {"goal": "b", "model": "openai/gpt-5-nano"},
+            ]},
+            task_id="",
+            session_id="s1",
+            tool_call_id="tc1",
+        )
+        assert plugin._delegate_stash["tc1"]["missing_pin"] is False
+
+    def test_stashes_missing_pin_true_when_any_batch_task_unpinned(self, plugin, log_path):
+        plugin._on_pre_tool_call(
+            tool_name="delegate_task",
+            args={"tasks": [
+                {"goal": "a", "model": "anthropic/claude-haiku-4.5"},
+                {"goal": "b"},  # missing model
+            ]},
+            task_id="",
+            session_id="s1",
+            tool_call_id="tc1",
+        )
+        assert plugin._delegate_stash["tc1"]["missing_pin"] is True
+
+    def test_stash_zero_offset_when_log_empty(self, plugin, log_path):
+        """If log doesn't exist yet, offset should be 0."""
+        log_path.unlink(missing_ok=True)
+        plugin._on_pre_tool_call(
+            tool_name="delegate_task",
+            args={"goal": "task"},
+            task_id="",
+            session_id="s1",
+            tool_call_id="tc1",
+        )
+        assert plugin._delegate_stash["tc1"]["offset"] == 0
+
+    def test_evicts_expired_stash_entries(self, plugin, log_path):
+        """Stash entries older than TTL are evicted on the next pre_tool_call fire."""
+        # Manually insert an expired entry
+        plugin._delegate_stash["old-tc"] = {
+            "offset": 0,
+            "missing_pin": False,
+            "ts": time.monotonic() - plugin._STASH_TTL_S - 1,
+        }
+        plugin._on_pre_tool_call(
+            tool_name="delegate_task",
+            args={"goal": "task"},
+            task_id="",
+            session_id="s1",
+            tool_call_id="tc-new",
+        )
+        assert "old-tc" not in plugin._delegate_stash
+        assert "tc-new" in plugin._delegate_stash
+
+    def test_non_delegate_tool_does_not_add_to_stash(self, plugin, log_path):
+        plugin._on_pre_tool_call(
+            tool_name="terminal",
+            args={"command": "ls"},
+            task_id="",
+            session_id="s1",
+            tool_call_id="tc1",
+        )
+        assert "tc1" not in plugin._delegate_stash
+
+
+# ===========================================================================
+# 2. transform_tool_result — observability enrichment + scoping
+# ===========================================================================
+
+class TestTransformToolResult:
+
+    def _fire_pre(self, plugin, log_path, tool_call_id: str, args: dict,
+                  pre_existing_records: list[dict] | None = None) -> None:
+        """Helper: optionally write pre-existing records, then fire pre_tool_call."""
+        if pre_existing_records:
+            _write_log_entries(log_path, pre_existing_records)
+        plugin._on_pre_tool_call(
+            tool_name="delegate_task",
+            args=args,
+            task_id="",
+            session_id="s1",
+            tool_call_id=tool_call_id,
+        )
+
+    def _fire_transform(self, plugin, log_path, tool_call_id: str,
+                        args: dict, result: str,
+                        new_records: list[dict] | None = None) -> str | None:
+        """Helper: optionally write new records (simulating subagent writes), then fire transform."""
+        if new_records:
+            _write_log_entries(log_path, new_records)
+        return plugin._on_transform_tool_result(
+            tool_name="delegate_task",
+            args=args,
+            result=result,
+            task_id="",
+            session_id="s1",
+            tool_call_id=tool_call_id,
+            duration_ms=1000,
+        )
+
+    # ── basic pass-through ──────────────────────────────────────────────────
+
+    def test_ignores_non_delegate_task_tools(self, plugin, log_path):
+        result = plugin._on_transform_tool_result(
+            tool_name="web_search",
+            args={"query": "test"},
+            result='{"data": []}',
+            task_id="",
+            session_id="s1",
+            tool_call_id="tc1",
+            duration_ms=100,
+        )
+        assert result is None
+
+    # ── warning surfaces via transform, not pre_tool_call ──────────────────
+
+    def test_missing_pin_warning_surfaces_in_transform_result(self, plugin, log_path):
+        """The missing-pin flag set by pre_tool_call must appear in the transform result."""
+        self._fire_pre(plugin, log_path, "tc1", args={"goal": "task"})  # no model pin
+        # Subagent resolves via auto-router
+        result = self._fire_transform(
+            plugin, log_path, "tc1",
+            args={"goal": "task"},
+            result='{"summary": "done"}',
+            new_records=[_subagent_record("s1", "subagent-0-abc",
+                                          "openrouter/auto", "google/gemini-2.5-flash",
+                                          match=False)],
+        )
+        assert result is not None
+        assert isinstance(result, str)
+        # Must warn that no model was pinned
+        lower = result.lower()
+        assert "no model" in lower or "unpinned" in lower or "unspecified" in lower or "pin" in lower
+
+    def test_missing_pin_warning_does_not_appear_when_model_pinned(self, plugin, log_path):
+        """No missing-pin warning when a model was explicitly pinned."""
+        self._fire_pre(plugin, log_path, "tc1",
+                       args={"goal": "task", "model": "anthropic/claude-haiku-4.5"})
+        result = self._fire_transform(
+            plugin, log_path, "tc1",
+            args={"goal": "task", "model": "anthropic/claude-haiku-4.5"},
+            result='{"summary": "done"}',
+            new_records=[_subagent_record("s1", "subagent-0-abc",
+                                          "anthropic/claude-haiku-4.5",
+                                          "anthropic/claude-haiku-4.5",
+                                          match=True)],
+        )
+        if result is not None:
+            lower = result.lower()
+            assert "no model" not in lower and "unpinned" not in lower
+
+    # ── override mismatch warning ───────────────────────────────────────────
+
+    def test_injects_prominent_warning_when_override_dropped(self, plugin, log_path):
+        """Pinned model requested but different model answered → prominent WARNING."""
+        self._fire_pre(plugin, log_path, "tc1",
+                       args={"goal": "task", "model": "anthropic/claude-opus-4.7"})
+        result = self._fire_transform(
+            plugin, log_path, "tc1",
+            args={"goal": "task", "model": "anthropic/claude-opus-4.7"},
+            result='{"summary": "done"}',
+            new_records=[_subagent_record("s1", "subagent-0-abc",
+                                          "anthropic/claude-opus-4.7",
+                                          "google/gemini-2.5-flash",
+                                          match=False)],
+        )
+        assert result is not None
+        assert "WARNING" in result or "⚠️" in result or "mismatch" in result.lower()
+        assert "anthropic/claude-opus-4.7" in result
+        assert "google/gemini-2.5-flash" in result
+
+    def test_auto_router_resolution_noted_not_warned(self, plugin, log_path):
+        """Auto-router resolution (no pin) is noted informatively, not as a warning."""
+        self._fire_pre(plugin, log_path, "tc1", args={"goal": "task"})
+        result = self._fire_transform(
+            plugin, log_path, "tc1",
+            args={"goal": "task"},
+            result='{"summary": "done"}',
+            new_records=[_subagent_record("s1", "subagent-0-abc",
+                                          "openrouter/auto", "google/gemini-2.5-flash",
+                                          match=False)],
+        )
+        assert result is not None
+        assert "google/gemini-2.5-flash" in result
+        # No mismatch warning — auto-router resolution is expected
+        assert "WARNING" not in result and "⚠️" not in result
+
+    def test_pareto_router_resolution_noted_not_warned(self, plugin, log_path):
+        """Pareto router resolves to a concrete model; that is expected, not an override drop."""
+        self._fire_pre(plugin, log_path, "tc1",
+                       args={"goal": "task", "model": "openrouter/pareto-code"})
+        result = self._fire_transform(
+            plugin, log_path, "tc1",
+            args={"goal": "task", "model": "openrouter/pareto-code"},
+            result='{"summary": "done"}',
+            new_records=[_subagent_record("s1", "subagent-0-abc",
+                                          "openrouter/pareto-code", "anthropic/claude-sonnet-4.6",
+                                          match=False)],
+        )
+        assert result is not None
+        assert "pareto-router resolved to: anthropic/claude-sonnet-4.6" in result
+        assert "WARNING" not in result and "⚠️" not in result
+
+    # ── scoping: prior delegations must not bleed in ────────────────────────
+
+    def test_prior_delegation_records_do_not_bleed_into_current(self, plugin, log_path):
+        """Records from a prior delegate_task call in the same session must be filtered out.
+
+        Only records written AFTER the pre_tool_call offset are reported.
+        """
+        PRIOR_MODEL = "openai/o3"
+        CURRENT_MODEL = "anthropic/claude-haiku-4.5"
+
+        # Simulate a prior delegation that already ran and wrote records
+        prior_records = [_subagent_record("s1", "subagent-0-prior",
+                                          PRIOR_MODEL, PRIOR_MODEL, match=True)]
+        self._fire_pre(plugin, log_path, "tc2",
+                       args={"goal": "second task", "model": CURRENT_MODEL},
+                       pre_existing_records=prior_records)
+
+        # Now the current delegation writes its records
+        result = self._fire_transform(
+            plugin, log_path, "tc2",
+            args={"goal": "second task", "model": CURRENT_MODEL},
+            result='{"summary": "done"}',
+            new_records=[_subagent_record("s1", "subagent-0-current",
+                                          CURRENT_MODEL, CURRENT_MODEL, match=True)],
+        )
+        assert result is not None
+        # Prior model must NOT appear — scoping anchored it out
+        assert PRIOR_MODEL not in result
+
+    def test_parent_calls_and_session_start_filtered_out(self, plugin, log_path):
+        """Parent API calls and session_start events are not subagent records — filter them."""
+        # Write a session_start and a parent call, then fire pre
+        existing = [
+            {"event": "session_start", "session_id": "s1", "model": "anthropic/claude-sonnet-4.6"},
+            {"session_id": "s1", "task_id": None, "agent_type": "parent",
+             "model_request": "anthropic/claude-sonnet-4.6",
+             "model_response": "anthropic/claude-sonnet-4.6",
+             "match": True, "tokens_in": 1000, "tokens_out": 200, "duration_s": 3.0},
+        ]
+        self._fire_pre(plugin, log_path, "tc1",
+                       args={"goal": "task", "model": "anthropic/claude-haiku-4.5"},
+                       pre_existing_records=existing)
+        result = self._fire_transform(
+            plugin, log_path, "tc1",
+            args={"goal": "task", "model": "anthropic/claude-haiku-4.5"},
+            result='{"summary": "done"}',
+            new_records=[_subagent_record("s1", "subagent-0-abc",
+                                          "anthropic/claude-haiku-4.5",
+                                          "anthropic/claude-haiku-4.5", match=True)],
+        )
+        if result is not None:
+            # Parent call model (sonnet) must not appear as a mismatch
+            assert "WARNING" not in result and "⚠️" not in result
+
+    # ── stash lifecycle ─────────────────────────────────────────────────────
+
+    def test_stash_entry_popped_after_transform(self, plugin, log_path):
+        """transform_tool_result must clean up its stash entry — no leak."""
+        self._fire_pre(plugin, log_path, "tc1", args={"goal": "task"})
+        assert "tc1" in plugin._delegate_stash
+
+        self._fire_transform(
+            plugin, log_path, "tc1",
+            args={"goal": "task"},
+            result='{"summary": "done"}',
+        )
+        assert "tc1" not in plugin._delegate_stash
+
+    def test_transform_without_pre_tool_call_does_not_crash(self, plugin, log_path):
+        """If no stash entry exists (pre never fired), degrade gracefully — no crash."""
+        result = plugin._on_transform_tool_result(
+            tool_name="delegate_task",
+            args={"goal": "task"},
+            result='{"summary": "done"}',
+            task_id="",
+            session_id="s1",
+            tool_call_id="tc-no-stash",
+            duration_ms=500,
+        )
+        assert result is None or isinstance(result, str)
+
+    # ── mixed batch: match + mismatch + auto-router in one call ────────────
+
+    def test_mixed_batch_warning_only_for_mismatch(self, plugin, log_path):
+        """Batch: task A matched, task B mismatched, task C auto-routed.
+        WARNING appears for B only; C is noted without warning; A is silent/healthy."""
+        self._fire_pre(plugin, log_path, "tc1", args={"tasks": [
+            {"goal": "a", "model": "anthropic/claude-haiku-4.5"},
+            {"goal": "b", "model": "anthropic/claude-opus-4.7"},
+            {"goal": "c"},  # auto-router
+        ]})
+        records = [
+            _subagent_record("s1", "subagent-0-abc",
+                             "anthropic/claude-haiku-4.5",
+                             "anthropic/claude-haiku-4.5", match=True),
+            _subagent_record("s1", "subagent-1-abc",
+                             "anthropic/claude-opus-4.7",
+                             "google/gemini-2.5-flash", match=False),   # MISMATCH
+            _subagent_record("s1", "subagent-2-abc",
+                             "openrouter/auto",
+                             "openai/gpt-5-nano", match=False),          # auto
+        ]
+        result = self._fire_transform(
+            plugin, log_path, "tc1",
+            args={"tasks": [
+                {"goal": "a", "model": "anthropic/claude-haiku-4.5"},
+                {"goal": "b", "model": "anthropic/claude-opus-4.7"},
+                {"goal": "c"},
+            ]},
+            result='[{"summary": "a"}, {"summary": "b"}, {"summary": "c"}]',
+            new_records=records,
+        )
+        assert result is not None
+        # Must warn on B's mismatch
+        assert "WARNING" in result or "⚠️" in result or "mismatch" in result.lower()
+        assert "anthropic/claude-opus-4.7" in result
+        assert "google/gemini-2.5-flash" in result
+
+    # ── failed delegation ───────────────────────────────────────────────────
+
+    def test_handles_failed_delegation_no_jsonl_written(self, plugin, log_path):
+        """If delegate_task errored before children ran, no subagent JSONL was written.
+        Plugin must pass through gracefully (return None or minimal note), no false warning."""
+        self._fire_pre(plugin, log_path, "tc1",
+                       args={"goal": "task", "model": "anthropic/claude-haiku-4.5"})
+        # No new records written (children never ran)
+        result = plugin._on_transform_tool_result(
+            tool_name="delegate_task",
+            args={"goal": "task", "model": "anthropic/claude-haiku-4.5"},
+            result='{"error": "max_spawn_depth exceeded"}',
+            task_id="",
+            session_id="s1",
+            tool_call_id="tc1",
+            duration_ms=10,
+        )
+        # Must not inject a mismatch warning — nothing ran
+        if result is not None:
+            assert "WARNING" not in result and "⚠️" not in result
+
+    # ── data integrity ──────────────────────────────────────────────────────
+
+    def test_original_result_content_preserved(self, plugin, log_path):
+        """The original result data must be preserved in the enriched output."""
+        self._fire_pre(plugin, log_path, "tc1",
+                       args={"goal": "task", "model": "anthropic/claude-haiku-4.5"})
+        result = self._fire_transform(
+            plugin, log_path, "tc1",
+            args={"goal": "task", "model": "anthropic/claude-haiku-4.5"},
+            result='{"summary": "expected content", "status": "ok"}',
+            new_records=[_subagent_record("s1", "subagent-0-abc",
+                                          "anthropic/claude-haiku-4.5",
+                                          "anthropic/claude-haiku-4.5", match=True)],
+        )
+        if result is not None:
+            assert "expected content" in result
+
+    def test_multiple_subagent_calls_all_models_reported(self, plugin, log_path):
+        """Batch across 3 tasks with different models — all three models appear in output."""
+        self._fire_pre(plugin, log_path, "tc1", args={"tasks": [
+            {"goal": f"task {i}", "model": f"model-{i}/test"} for i in range(3)
+        ]})
+        records = [
+            _subagent_record("s1", f"subagent-{i}-abc",
+                             f"model-{i}/test", f"model-{i}/test", match=True)
+            for i in range(3)
+        ]
+        result = self._fire_transform(
+            plugin, log_path, "tc1",
+            args={"tasks": [{"goal": f"task {i}", "model": f"model-{i}/test"} for i in range(3)]},
+            result='[{"summary": "a"}, {"summary": "b"}, {"summary": "c"}]',
+            new_records=records,
+        )
+        if result is not None:
+            for i in range(3):
+                assert f"model-{i}/test" in result
+
+    # ── resilience ──────────────────────────────────────────────────────────
+
+    def test_handles_missing_log_file_gracefully(self, plugin, log_path):
+        """JSONL log file doesn't exist — no crash."""
+        log_path.unlink(missing_ok=True)
+        self._fire_pre(plugin, log_path, "tc1", args={"goal": "task"})
+        result = plugin._on_transform_tool_result(
+            tool_name="delegate_task",
+            args={"goal": "task"},
+            result='{"summary": "done"}',
+            task_id="",
+            session_id="s1",
+            tool_call_id="tc1",
+            duration_ms=500,
+        )
+        assert result is None or isinstance(result, str)
+
+    def test_never_raises_on_bad_args(self, plugin, log_path):
+        """Garbage args must never crash the agent loop."""
+        plugin._on_transform_tool_result(
+            tool_name="delegate_task",
+            args=None,
+            result=None,
+            task_id=None,
+            session_id=None,
+            tool_call_id=None,
+            duration_ms="bad",
+        )
+        # must not raise
+
+
+# ===========================================================================
+# 3. post_api_request — regression suite (existing behavior must not break)
+# ===========================================================================
+
+class TestPostApiRequestRegression:
+
+    def test_writes_jsonl_record_for_subagent_call(self, plugin, log_path):
+        plugin._on_post_api_request(
+            task_id="subagent-0-abc",
+            session_id="s1",
+            platform="telegram",
+            model="anthropic/claude-haiku-4.5",
+            provider="openrouter",
+            api_mode="chat_completions",
+            api_call_count=1,
+            api_duration=1.5,
+            finish_reason="stop",
+            usage={"prompt_tokens": 100, "completion_tokens": 50},
+            response_model="anthropic/claude-haiku-4.5",
+            assistant_content_chars=200,
+            assistant_tool_call_count=0,
+        )
+        records = _read_log(log_path)
+        assert len(records) == 1
+        r = records[0]
+        assert r["task_id"] == "subagent-0-abc"
+        assert r["agent_type"] == "subagent"
+        assert r["model_request"] == "anthropic/claude-haiku-4.5"
+        assert r["model_response"] == "anthropic/claude-haiku-4.5"
+        assert r["match"] is True
+
+    def test_writes_jsonl_record_for_parent_call(self, plugin, log_path):
+        plugin._on_post_api_request(
+            task_id=None,
+            session_id="s1",
+            platform="telegram",
+            model="anthropic/claude-sonnet-4.6",
+            provider="openrouter",
+            api_mode="chat_completions",
+            api_call_count=1,
+            api_duration=2.0,
+            finish_reason="stop",
+            usage={"prompt_tokens": 200, "completion_tokens": 80},
+            response_model="anthropic/claude-sonnet-4.6",
+            assistant_content_chars=500,
+            assistant_tool_call_count=2,
+        )
+        records = _read_log(log_path)
+        assert len(records) == 1
+        assert records[0]["agent_type"] == "parent"
+        assert records[0]["task_id"] is None
+
+    def test_match_false_for_mismatched_models(self, plugin, log_path):
+        plugin._on_post_api_request(
+            task_id="subagent-0-abc",
+            session_id="s1",
+            platform="telegram",
+            model="anthropic/claude-opus-4.7",
+            provider="openrouter",
+            api_mode="chat_completions",
+            api_call_count=1,
+            api_duration=3.0,
+            finish_reason="stop",
+            usage={"prompt_tokens": 500, "completion_tokens": 200},
+            response_model="google/gemini-2.5-flash",
+            assistant_content_chars=800,
+            assistant_tool_call_count=0,
+        )
+        records = _read_log(log_path)
+        assert records[0]["match"] is False
+
+    def test_match_true_for_date_versioned_alias(self, plugin, log_path):
+        """Anthropic returns date-versioned aliases — must still match."""
+        plugin._on_post_api_request(
+            task_id="subagent-0-abc",
+            session_id="s1",
+            platform="telegram",
+            model="anthropic/claude-sonnet-4.6",
+            provider="openrouter",
+            api_mode="chat_completions",
+            api_call_count=1,
+            api_duration=1.8,
+            finish_reason="stop",
+            usage={"prompt_tokens": 300, "completion_tokens": 90},
+            response_model="anthropic/claude-4.6-sonnet-20260217",
+            assistant_content_chars=400,
+            assistant_tool_call_count=1,
+        )
+        records = _read_log(log_path)
+        assert records[0]["match"] is True
+
+    def test_auto_router_always_match_false(self, plugin, log_path):
+        """openrouter/auto → anything is a resolution, never a match."""
+        plugin._on_post_api_request(
+            task_id="subagent-0-abc",
+            session_id="s1",
+            platform="telegram",
+            model="openrouter/auto",
+            provider="openrouter",
+            api_mode="chat_completions",
+            api_call_count=1,
+            api_duration=1.1,
+            finish_reason="stop",
+            usage={"prompt_tokens": 150, "completion_tokens": 40},
+            response_model="google/gemini-2.5-flash",
+            assistant_content_chars=100,
+            assistant_tool_call_count=0,
+        )
+        records = _read_log(log_path)
+        assert records[0]["match"] is False
+
+    def test_thread_safe_concurrent_writes(self, plugin, log_path):
+        """Concurrent subagent writes must not corrupt the log."""
+        errors = []
+
+        def write_record(i):
+            try:
+                plugin._on_post_api_request(
+                    task_id=f"subagent-{i}-abc",
+                    session_id="s1",
+                    platform="telegram",
+                    model="anthropic/claude-haiku-4.5",
+                    provider="openrouter",
+                    api_mode="chat_completions",
+                    api_call_count=1,
+                    api_duration=0.5,
+                    finish_reason="stop",
+                    usage={"prompt_tokens": 100, "completion_tokens": 30},
+                    response_model="anthropic/claude-haiku-4.5",
+                    assistant_content_chars=80,
+                    assistant_tool_call_count=0,
+                )
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=write_record, args=(i,)) for i in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        records = _read_log(log_path)
+        assert len(records) == 20
+
+    def test_never_raises_on_bad_kwargs(self, plugin, log_path):
+        """plugin must never crash the agent loop, even with garbage kwargs."""
+        plugin._on_post_api_request(
+            task_id=None,
+            session_id=None,
+            platform=None,
+            model=None,
+            provider=None,
+            api_mode=None,
+            api_call_count=None,
+            api_duration="not_a_float",
+            finish_reason=None,
+            usage="bad_type",
+            response_model=None,
+            assistant_content_chars="bad",
+            assistant_tool_call_count="bad",
+        )
+
+    def test_session_start_writes_boundary_marker(self, plugin, log_path):
+        plugin._on_session_start(
+            session_id="s1",
+            platform="telegram",
+            model="anthropic/claude-sonnet-4.6",
+            provider="openrouter",
+        )
+        records = _read_log(log_path)
+        assert len(records) == 1
+        assert records[0].get("event") == "session_start"
+        assert records[0]["session_id"] == "s1"
+
+
+# ===========================================================================
+# 4. register — hook registration contract
+# ===========================================================================
+
+class TestRegister:
+
+    def test_registers_four_hooks(self, plugin):
+        """register() must subscribe all four hooks: pre_tool_call,
+        transform_tool_result, post_api_request, on_session_start."""
+        ctx = MagicMock()
+        plugin.register(ctx)
+        hook_names = [call.args[0] for call in ctx.register_hook.call_args_list]
+        assert "post_api_request" in hook_names
+        assert "on_session_start" in hook_names
+        assert "pre_tool_call" in hook_names
+        assert "transform_tool_result" in hook_names
+        assert len(set(hook_names)) == 4  # no duplicates

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1943,3 +1943,48 @@ class TestTirithImportErrorFailOpenPolicy:
                         result = check_all_command_guards("echo hello", "local")
 
         assert result.get("approved") is True
+
+
+def test_execute_code_ask_ignores_stale_cron_env_and_context(monkeypatch):
+    """A stale cron marker must not make user-present execute_code look unattended."""
+    from gateway.session_context import clear_session_vars, set_session_vars
+    from tools import approval as mod
+
+    session_key = "test-exec-ask-cron-stale"
+    saved = {
+        k: os.environ.get(k)
+        for k in (
+            "HERMES_CRON_SESSION",
+            "HERMES_EXEC_ASK",
+            "HERMES_GATEWAY_SESSION",
+            "HERMES_SESSION_KEY",
+            "HERMES_YOLO_MODE",
+            "HERMES_INTERACTIVE",
+        )
+    }
+    tokens = set_session_vars(cron_session="1", session_key=session_key)
+    try:
+        os.environ["HERMES_CRON_SESSION"] = "1"
+        os.environ["HERMES_EXEC_ASK"] = "1"
+        os.environ["HERMES_SESSION_KEY"] = session_key
+        os.environ.pop("HERMES_GATEWAY_SESSION", None)
+        os.environ.pop("HERMES_YOLO_MODE", None)
+        os.environ.pop("HERMES_INTERACTIVE", None)
+        monkeypatch.setattr(mod, "_get_approval_mode", lambda: "manual")
+        monkeypatch.setattr(mod, "_get_cron_approval_mode", lambda: "deny")
+
+        assert mod._is_cron_approval_context() is False
+        result = mod.check_execute_code_guard("print('ok')", "local")
+
+        assert result["approved"] is False
+        assert result.get("status") == "pending_approval"
+        assert result.get("approval_pending") is True
+        assert "Cron jobs run without a user present" not in result.get("message", "")
+    finally:
+        clear_session_vars(tokens)
+        mod._pending.pop(session_key, None)
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v

--- a/tests/tools/test_cron_approval_mode.py
+++ b/tests/tools/test_cron_approval_mode.py
@@ -16,10 +16,15 @@ def _clear_approval_state():
     approval_module._permanent_approved.clear()
     approval_module.clear_session("default")
     approval_module.clear_session("test-session")
+    from gateway.session_context import _UNSET, _VAR_MAP
+    for var in _VAR_MAP.values():
+        var.set(_UNSET)
     yield
     approval_module._permanent_approved.clear()
     approval_module.clear_session("default")
     approval_module.clear_session("test-session")
+    for var in _VAR_MAP.values():
+        var.set(_UNSET)
 
 
 # ---------------------------------------------------------------------------
@@ -200,6 +205,61 @@ class TestCronDenyModeAllGuards:
             result = check_all_command_guards("echo hello", "local")
             assert result["approved"]
 
+    def test_contextvar_cron_session_blocks_without_process_env(self, monkeypatch):
+        """A real cron context should use cron_mode even without process env."""
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+        monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+
+        from gateway.session_context import set_session_vars, clear_session_vars
+        from unittest.mock import patch as mock_patch
+
+        tokens = set_session_vars(cron_session="1")
+        try:
+            with mock_patch("tools.approval._get_cron_approval_mode", return_value="deny"):
+                result = check_all_command_guards("rm -rf /tmp/stuff", "local")
+                assert not result["approved"]
+                assert "BLOCKED" in result["message"]
+                assert "cron_mode" in result["message"]
+        finally:
+            clear_session_vars(tokens)
+
+    def test_live_gateway_command_uses_gateway_despite_stale_cron_env(self, monkeypatch):
+        """A stale process cron flag must not reclassify live gateway turns."""
+        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+        monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+
+        from gateway.session_context import set_session_vars, clear_session_vars
+        from unittest.mock import patch as mock_patch
+
+        session_key = "agent:main:discord:dm:live-user"
+        notified = []
+
+        def notify(data):
+            notified.append(data)
+            approval_module.resolve_gateway_approval(session_key, "once")
+
+        tokens = set_session_vars(platform="discord", chat_id="live-chat", session_key=session_key)
+        approval_module.register_gateway_notify(session_key, notify)
+        try:
+            with (
+                mock_patch("tools.approval._get_approval_mode", return_value="manual"),
+                mock_patch("tools.approval._get_cron_approval_mode", return_value="deny"),
+            ):
+                result = check_all_command_guards("rm -rf /tmp/stuff", "local")
+                assert result["approved"] is True
+                assert result.get("user_approved") is True
+                assert len(notified) == 1
+                assert "cron" not in (result.get("message") or "").lower()
+        finally:
+            approval_module.unregister_gateway_notify(session_key)
+            clear_session_vars(tokens)
+
     def test_combined_guard_approve_mode(self, monkeypatch):
         monkeypatch.setenv("HERMES_CRON_SESSION", "1")
         monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
@@ -268,26 +328,24 @@ class TestCronModeInteractions:
 
 
 class TestCronWithGatewayOrigin:
-    """Cron jobs originating from a gateway platform must NOT be treated as gateway.
+    """Cron jobs with platform metadata must NOT be treated as gateway.
 
-    cron/scheduler.py binds HERMES_SESSION_PLATFORM via contextvars for
-    delivery routing (so cron output lands back in the origin chat). The
-    API-server approvals work (PR #20311) made check_dangerous_command treat
-    any contextvar-bound platform as a gateway session. That would route
-    cron-from-telegram/discord/etc. through submit_pending with no listener,
-    hanging the job instead of respecting approvals.cron_mode.
+    If a cron context ever carries platform metadata for delivery or logging,
+    the explicit cron context marker must still win over gateway approval
+    routing. Otherwise cron-from-telegram/discord/etc. could submit a pending
+    approval with no listener instead of respecting approvals.cron_mode.
     """
 
     def test_cron_with_telegram_origin_uses_cron_mode_not_gateway(self, monkeypatch):
-        """Cron + contextvar platform=telegram + cron_mode=deny → BLOCKED, not pending."""
-        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        """Cron + platform=telegram + cron_mode=deny → BLOCKED, not pending."""
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
         monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
         monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
         monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
         monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
 
         from gateway.session_context import set_session_vars, clear_session_vars
-        tokens = set_session_vars(platform="telegram", chat_id="123")
+        tokens = set_session_vars(platform="telegram", chat_id="123", cron_session="1")
         try:
             from unittest.mock import patch as mock_patch
             with mock_patch("tools.approval._get_cron_approval_mode", return_value="deny"):
@@ -301,15 +359,15 @@ class TestCronWithGatewayOrigin:
             clear_session_vars(tokens)
 
     def test_cron_with_telegram_origin_approve_mode_allows(self, monkeypatch):
-        """Cron + contextvar platform=telegram + cron_mode=approve → allowed via cron path."""
-        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        """Cron + platform=telegram + cron_mode=approve → allowed via cron path."""
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
         monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
         monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
         monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
         monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
 
         from gateway.session_context import set_session_vars, clear_session_vars
-        tokens = set_session_vars(platform="discord", chat_id="456")
+        tokens = set_session_vars(platform="discord", chat_id="456", cron_session="1")
         try:
             from unittest.mock import patch as mock_patch
             with mock_patch("tools.approval._get_cron_approval_mode", return_value="approve"):
@@ -322,14 +380,14 @@ class TestCronWithGatewayOrigin:
 
     def test_cron_with_telegram_origin_combined_guard_uses_cron_mode(self, monkeypatch):
         """check_all_command_guards must also honor cron_mode over gateway classification."""
-        monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
         monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
         monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
         monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
         monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
 
         from gateway.session_context import set_session_vars, clear_session_vars
-        tokens = set_session_vars(platform="telegram", chat_id="789")
+        tokens = set_session_vars(platform="telegram", chat_id="789", cron_session="1")
         try:
             from unittest.mock import patch as mock_patch
             with mock_patch("tools.approval._get_cron_approval_mode", return_value="deny"):

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -32,7 +32,8 @@ from tools.delegate_tool import (
     _strip_blocked_tools,
     _resolve_child_credential_pool,
     _resolve_delegation_credentials,
-    _inherit_parent_base_url,
+_inherit_parent_base_url,
+    _warn_model_provider_mismatch,
 )
 
 
@@ -970,6 +971,44 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertIsNone(creds["api_key"])
 
 
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_provider_resolves_full_credentials(self, mock_resolve):
+        """When delegation.provider is set, full credentials are resolved."""
+        mock_resolve.return_value = {
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "sk-or-test-resolved-key",
+            "api_mode": "chat_completions",
+        }
+        parent = _make_mock_parent(depth=0)
+        cfg = {"model": "google/gemini-3-flash-preview", "provider": "openrouter"}
+        creds = _resolve_delegation_credentials(cfg, parent)
+        self.assertEqual(creds["model"], "google/gemini-3-flash-preview")
+        self.assertEqual(creds["provider"], "openrouter")
+        self.assertEqual(creds["base_url"], "https://openrouter.ai/api/v1")
+        self.assertEqual(creds["api_key"], "sk-or-test-resolved-key")
+        self.assertEqual(creds["api_mode"], "chat_completions")
+        mock_resolve.assert_called_once_with(requested="openrouter", target_model="google/gemini-3-flash-preview")
+
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_provider_resolution_uses_runtime_model_when_config_model_missing(self, mock_resolve):
+        """Named providers should propagate their runtime default model to children."""
+        mock_resolve.return_value = {
+            "provider": "custom",
+            "base_url": "https://my-server.example/v1",
+            "api_key": "sk-test-key",
+            "api_mode": "chat_completions",
+            "model": "server-default-model",
+        }
+        parent = _make_mock_parent(depth=0)
+        cfg = {"provider": "custom:my-server", "model": ""}
+
+        creds = _resolve_delegation_credentials(cfg, parent)
+
+        self.assertEqual(creds["model"], "server-default-model")
+        self.assertEqual(creds["provider"], "custom:my-server")
+        self.assertEqual(creds["base_url"], "https://my-server.example/v1")
+        mock_resolve.assert_called_once_with(requested="custom:my-server", target_model=None)
 
     def test_direct_endpoint_uses_configured_base_url_and_api_key(self):
         parent = _make_mock_parent(depth=0)
@@ -1075,6 +1114,22 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertIsNone(creds["api_key"])
         self.assertEqual(creds["provider"], "custom")
 
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_nous_provider_resolves_nous_credentials(self, mock_resolve):
+        """Nous provider resolves Nous Portal base_url and api_key."""
+        mock_resolve.return_value = {
+            "provider": "nous",
+            "base_url": "https://inference-api.nousresearch.com/v1",
+            "api_key": "nous-agent-key-xyz",
+            "api_mode": "chat_completions",
+        }
+        parent = _make_mock_parent(depth=0)
+        cfg = {"model": "hermes-3-llama-3.1-8b", "provider": "nous"}
+        creds = _resolve_delegation_credentials(cfg, parent)
+        self.assertEqual(creds["provider"], "nous")
+        self.assertEqual(creds["base_url"], "https://inference-api.nousresearch.com/v1")
+        self.assertEqual(creds["api_key"], "nous-agent-key-xyz")
+        mock_resolve.assert_called_once_with(requested="nous", target_model="hermes-3-llama-3.1-8b")
 
     @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
     def test_provider_resolution_failure_raises_valueerror(self, mock_resolve):
@@ -2867,6 +2922,468 @@ class TestFallbackModelInheritance(unittest.TestCase):
 
         _, kwargs = MockAgent.call_args
         self.assertIsNone(kwargs["fallback_model"])
+
+
+class TestModelProviderOverride(unittest.TestCase):
+    """Per-call model/provider override (200426).
+
+    The schema exposes `model` and `provider` at top-level and `model` per-task.
+    These flow through `_resolve_delegation_credentials()` (top-level only) and
+    `_build_child_agent(model=...)` (per-task), so subagents can be routed to
+    a specific model independent of the config default.
+    """
+
+    def test_schema_exposes_model_and_provider_top_level(self):
+        """Top-level schema MUST expose `model` and `provider`."""
+        props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+        self.assertIn("model", props)
+        self.assertIn("provider", props)
+        self.assertEqual(props["model"]["type"], "string")
+        self.assertEqual(props["provider"]["type"], "string")
+
+    def test_schema_exposes_model_per_task(self):
+        """Per-task schema MUST expose `model` (provider intentionally omitted; documented limitation)."""
+        task_props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]["tasks"]["items"]["properties"]
+        self.assertIn("model", task_props)
+        self.assertNotIn("provider", task_props,
+            "Per-task `provider` not yet supported — workaround: use provider='openrouter' at top level")
+
+    def test_resolve_credentials_no_override(self):
+        """Without overrides, returns config defaults (None when nothing configured)."""
+        parent = _make_mock_parent()
+        with patch("tools.delegate_tool._load_config", return_value={}):
+            creds = _resolve_delegation_credentials({}, parent)
+        self.assertIsNone(creds["model"])
+        self.assertIsNone(creds["provider"])
+
+    def test_resolve_credentials_model_override_beats_config(self):
+        """model_override should take precedence over cfg['model']."""
+        parent = _make_mock_parent()
+        cfg = {"model": "config/default-model"}
+        creds = _resolve_delegation_credentials(
+            cfg, parent, model_override="anthropic/claude-opus-4-7"
+        )
+        self.assertEqual(creds["model"], "anthropic/claude-opus-4-7")
+
+    def test_resolve_credentials_provider_override_drives_runtime(self):
+        """provider_override should take precedence over cfg['provider'] AND drive credential lookup."""
+        parent = _make_mock_parent()
+        cfg = {"provider": "config-provider"}
+        fake_runtime = {
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "***",
+            "api_mode": "chat_completions",
+        }
+        with patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value=fake_runtime) as mock_resolve:
+            creds = _resolve_delegation_credentials(
+                cfg, parent, provider_override="openrouter"
+            )
+        mock_resolve.assert_called_once_with(requested="openrouter", target_model=None)
+        self.assertEqual(creds["provider"], "openrouter")
+        self.assertEqual(creds["base_url"], "https://openrouter.ai/api/v1")
+
+    def test_resolve_credentials_invalid_provider_raises_valueerror(self):
+        """Unknown provider override should raise ValueError with helpful message."""
+        parent = _make_mock_parent()
+        with patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            side_effect=Exception("Unknown provider 'totally-fake'"),
+        ):
+            with self.assertRaises(ValueError) as ctx:
+                _resolve_delegation_credentials(
+                    {}, parent, provider_override="totally-fake"
+                )
+        self.assertIn("totally-fake", str(ctx.exception))
+        self.assertIn("Available providers", str(ctx.exception))
+
+    def test_delegate_task_invalid_provider_returns_tool_error(self):
+        """Bad provider override should bubble up as a tool_error, not a crash."""
+        parent = _make_mock_parent()
+        with patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            side_effect=Exception("Unknown provider 'totally-fake'"),
+        ):
+            result = json.loads(delegate_task(
+                goal="should never run",
+                provider="totally-fake",
+                parent_agent=parent,
+            ))
+        self.assertIn("error", result)
+        self.assertIn("totally-fake", result["error"])
+
+    @patch("tools.delegate_tool._build_child_agent")
+    @patch("tools.delegate_tool._run_single_child")
+    def test_delegate_task_top_level_model_override_threads_through(
+        self, mock_run, mock_build
+    ):
+        """Top-level model='X' should reach _build_child_agent(model='X')."""
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed",
+            "summary": "ok", "api_calls": 1, "duration_seconds": 0.1,
+        }
+        mock_build.return_value = MagicMock()
+        parent = _make_mock_parent()
+
+        delegate_task(
+            goal="test override",
+            model="anthropic/claude-opus-4-7",
+            provider=None,
+            parent_agent=parent,
+        )
+        build_kwargs = mock_build.call_args[1]
+        self.assertEqual(build_kwargs["model"], "anthropic/claude-opus-4-7")
+
+    @patch("tools.delegate_tool._build_child_agent")
+    @patch("tools.delegate_tool._run_single_child")
+    def test_delegate_task_per_task_model_overrides_top_level(
+        self, mock_run, mock_build
+    ):
+        """In a batch, per-task model should override the top-level model for that task."""
+        mock_run.side_effect = [
+            {"task_index": 0, "status": "completed", "summary": "A", "api_calls": 1, "duration_seconds": 0.1},
+            {"task_index": 1, "status": "completed", "summary": "B", "api_calls": 1, "duration_seconds": 0.1},
+        ]
+        mock_build.return_value = MagicMock()
+        parent = _make_mock_parent()
+
+        delegate_task(
+            model="anthropic/claude-opus-4-7",  # batch default
+            tasks=[
+                {"goal": "use opus (inherits)"},
+                {"goal": "use haiku (override)", "model": "anthropic/claude-haiku-4-5"},
+            ],
+            parent_agent=parent,
+        )
+        self.assertEqual(mock_build.call_count, 2)
+        first_kwargs = mock_build.call_args_list[0][1]
+        second_kwargs = mock_build.call_args_list[1][1]
+        self.assertEqual(first_kwargs["model"], "anthropic/claude-opus-4-7")
+        self.assertEqual(second_kwargs["model"], "anthropic/claude-haiku-4-5")
+
+    def test_delegate_task_no_override_falls_back_to_config(self):
+        """With no override, _resolve_delegation_credentials returns cfg['model']."""
+        parent = _make_mock_parent()
+        cfg = {"model": "config/default-model"}
+        creds = _resolve_delegation_credentials(cfg, parent)
+        self.assertEqual(creds["model"], "config/default-model")
+
+
+class TestModelProviderMismatchWarning(unittest.TestCase):
+    """_warn_model_provider_mismatch emits a logger.warning on cross-provider
+    per-task model assignments, and stays silent for valid cases.
+    """
+
+    def test_warns_on_foreign_model_prefix(self):
+        """x-ai/... model with anthropic provider should warn."""
+        with self.assertLogs("tools.delegate_tool", level="WARNING") as cm:
+            _warn_model_provider_mismatch("x-ai/grok-4.1-fast", "anthropic", 0)
+        self.assertTrue(any("x-ai/grok-4.1-fast" in line for line in cm.output))
+        self.assertTrue(any("anthropic" in line for line in cm.output))
+
+    def test_no_warning_for_matching_prefix(self):
+        """anthropic/claude-haiku with anthropic provider should not warn."""
+        import logging
+        with self.assertNoLogs("tools.delegate_tool", level="WARNING"):
+            _warn_model_provider_mismatch("anthropic/claude-haiku-4-5", "anthropic", 0)
+
+    def test_no_warning_when_openrouter_resolved(self):
+        """Aggregator providers (openrouter, opencode, etc.) accept provider-prefixed
+        model strings as a feature — no warning should fire for them."""
+        with self.assertNoLogs("tools.delegate_tool", level="WARNING"):
+            _warn_model_provider_mismatch("x-ai/grok-4.1-fast", "openrouter", 0)
+        with self.assertNoLogs("tools.delegate_tool", level="WARNING"):
+            _warn_model_provider_mismatch("anthropic/claude-haiku-4-5", "openrouter", 0)
+        # opencode is also an aggregator in the providers registry
+        with self.assertNoLogs("tools.delegate_tool", level="WARNING"):
+            _warn_model_provider_mismatch("x-ai/grok-4.1-fast", "opencode", 0)
+
+    def test_no_warning_without_slash(self):
+        """Bare model name (no provider prefix) should not warn."""
+        with self.assertNoLogs("tools.delegate_tool", level="WARNING"):
+            _warn_model_provider_mismatch("grok-4.1-fast", "anthropic", 0)
+
+    def test_no_warning_when_task_model_none(self):
+        """None task_model should not warn."""
+        with self.assertNoLogs("tools.delegate_tool", level="WARNING"):
+            _warn_model_provider_mismatch(None, "anthropic", 0)
+
+    def test_no_warning_when_provider_none(self):
+        """None resolved_provider (inherit from parent) should not warn."""
+        with self.assertNoLogs("tools.delegate_tool", level="WARNING"):
+            _warn_model_provider_mismatch("x-ai/grok-4.1-fast", None, 0)
+
+    def test_no_warning_auto_with_openrouter(self):
+        """model='auto' with provider='openrouter' is valid — OpenRouter's own routing model."""
+        with self.assertNoLogs("tools.delegate_tool", level="WARNING"):
+            _warn_model_provider_mismatch("auto", "openrouter", 0)
+
+    def test_no_warning_openrouter_auto_with_openrouter(self):
+        """model='openrouter/auto' with provider='openrouter' is valid."""
+        with self.assertNoLogs("tools.delegate_tool", level="WARNING"):
+            _warn_model_provider_mismatch("openrouter/auto", "openrouter", 0)
+
+    def test_warns_auto_with_non_openrouter_provider(self):
+        """model='auto' with provider='anthropic' should warn — 'auto' is OpenRouter-only."""
+        with self.assertLogs("tools.delegate_tool", level="WARNING") as cm:
+            _warn_model_provider_mismatch("auto", "anthropic", 0)
+        self.assertTrue(any("auto" in line for line in cm.output))
+        self.assertTrue(any("anthropic" in line for line in cm.output))
+
+    def test_warns_openrouter_auto_with_non_openrouter_provider(self):
+        """model='openrouter/auto' with provider='anthropic' should warn."""
+        with self.assertLogs("tools.delegate_tool", level="WARNING") as cm:
+            _warn_model_provider_mismatch("openrouter/auto", "anthropic", 0)
+        self.assertTrue(any("openrouter/auto" in line for line in cm.output))
+
+    @patch("tools.delegate_tool._build_child_agent")
+    @patch("tools.delegate_tool._run_single_child")
+    def test_warning_fires_in_delegate_task_batch(self, mock_run, mock_build):
+        """End-to-end: mismatch warning fires during delegate_task batch dispatch."""
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed",
+            "summary": "ok", "api_calls": 1, "duration_seconds": 0.1,
+        }
+        mock_build.return_value = MagicMock()
+        parent = _make_mock_parent()
+
+        fake_runtime = {
+            "provider": "anthropic",
+            "base_url": "https://api.anthropic.com/v1",
+            "api_key": "sk-ant-test",
+            "api_mode": "anthropic_messages",
+        }
+        with patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value=fake_runtime,
+        ):
+            with self.assertLogs("tools.delegate_tool", level="WARNING") as cm:
+                delegate_task(
+                    provider="anthropic",
+                    tasks=[{"goal": "run something", "model": "x-ai/grok-4.1-fast"}],
+                    parent_agent=parent,
+                )
+        self.assertTrue(any("x-ai/grok-4.1-fast" in line for line in cm.output))
+
+
+class TestRunAgentDispatchForwarding(unittest.TestCase):
+    """Regression guard: _dispatch_delegate_task() must forward all schema params.
+
+    Upstream replaced the two hardcoded dispatch sites (pre-200426) with a
+    single _dispatch_delegate_task() helper. This test verifies that helper
+    forwards every param we depend on — model, provider, role, acp_command,
+    acp_args — so future schema additions only need one change to reach all
+    invocation paths.
+
+    Uses mock-based verification rather than source-text inspection so the test
+    stays stable across argument reordering, reformatting, and minor refactors.
+    """
+
+    @patch("tools.delegate_tool.delegate_task")
+    def test_dispatch_helper_forwards_model_provider_role_acp(self, mock_delegate):
+        """_dispatch_delegate_task must forward model=, provider=, role=, acp_command=, acp_args=."""
+        import importlib
+        import run_agent as ra
+
+        mock_delegate.return_value = {"results": [], "total_duration_seconds": 0.1}
+
+        function_args = {
+            "goal": "test goal",
+            "model": "openai/gpt-5.1-codex",
+            "provider": "openrouter",
+            "role": "orchestrator",
+            "acp_command": "claude",
+            "acp_args": ["--acp", "--stdio"],
+        }
+
+        # Instantiate AIAgent without __init__ and call _dispatch_delegate_task
+        # directly — tests the real forwarding path, not source text.
+        agent = ra.AIAgent.__new__(ra.AIAgent)
+        agent._dispatch_delegate_task(function_args=function_args)
+
+        self.assertTrue(mock_delegate.called, "_dispatch_delegate_task did not call delegate_task")
+        call_kwargs = mock_delegate.call_args.kwargs
+
+        required = {
+            "model": "openai/gpt-5.1-codex",
+            "provider": "openrouter",
+            "role": "orchestrator",
+            "acp_command": "claude",
+            "acp_args": ["--acp", "--stdio"],
+        }
+        for key, expected in required.items():
+            self.assertIn(
+                key, call_kwargs,
+                f"_dispatch_delegate_task is missing '{key}=' — add "
+                f"`{key}=function_args.get('{key}')` to keep schema params from "
+                f"being silently dropped across all invocation paths."
+            )
+            self.assertEqual(
+                call_kwargs[key], expected,
+                f"_dispatch_delegate_task forwarded wrong value for '{key}': "
+                f"expected {expected!r}, got {call_kwargs[key]!r}"
+            )
+
+
+class TestOpenRouterAutoModelSmoke(unittest.TestCase):
+    """Smoke tests for the OpenRouter-centric use case with model='openrouter/auto'.
+
+    Regression target: upstream commit 83bbe9b45 fixed api_mode computation by
+    threading target_model through resolve_runtime_provider. This test verifies
+    that our model_override path in _resolve_delegation_credentials also threads
+    the override model correctly — so that a parent on any provider that passes
+    model='openrouter/auto' and provider='openrouter' always gets
+    api_mode='chat_completions', not a stale anthropic_messages or None.
+
+    The critical code path:
+        delegate_task(model="openrouter/auto", provider="openrouter")
+            → _resolve_delegation_credentials(cfg={}, parent, model_override="openrouter/auto",
+                                               provider_override="openrouter")
+            → resolve_runtime_provider(requested="openrouter",
+                                       target_model="openrouter/auto")   ← must receive override
+            → returns api_mode="chat_completions"
+    """
+
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_auto_model_override_passes_target_model_to_resolver(self, mock_resolve):
+        """model_override='openrouter/auto' must be forwarded as target_model to
+        resolve_runtime_provider, not silently dropped.
+
+        If target_model is not forwarded, resolve_runtime_provider falls back to
+        model_cfg.get('default'), which could be a native-provider model (e.g.
+        claude-opus-4) that triggers anthropic_messages api_mode — breaking the
+        OpenRouter child with a 404 or auth error.
+        """
+        mock_resolve.return_value = {
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "sk-or-test",
+            "api_mode": "chat_completions",
+        }
+        parent = _make_mock_parent(depth=0)
+        cfg = {}  # no static delegation config — everything from call-site overrides
+
+        creds = _resolve_delegation_credentials(
+            cfg, parent,
+            model_override="openrouter/auto",
+            provider_override="openrouter",
+        )
+
+        # resolve_runtime_provider must be called with target_model="openrouter/auto"
+        mock_resolve.assert_called_once_with(
+            requested="openrouter",
+            target_model="openrouter/auto",
+        )
+        # Credential bundle must reflect the resolver's return value
+        self.assertEqual(creds["api_mode"], "chat_completions")
+        self.assertEqual(creds["provider"], "openrouter")
+        self.assertEqual(creds["model"], "openrouter/auto")
+
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_auto_model_override_api_mode_is_chat_completions(self, mock_resolve):
+        """api_mode returned for openrouter/auto must always be chat_completions.
+
+        OpenRouter is an aggregator — it only speaks chat_completions. If the
+        resolver were to return anthropic_messages (e.g. because the fallback
+        model_cfg.default is a Claude model), the child would receive an
+        anthropic_messages transport and strip /v1 from the base URL, causing a 404.
+        """
+        mock_resolve.return_value = {
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "sk-or-test",
+            "api_mode": "chat_completions",
+        }
+        parent = _make_mock_parent(depth=0)
+        cfg = {}
+
+        creds = _resolve_delegation_credentials(
+            cfg, parent,
+            model_override="openrouter/auto",
+            provider_override="openrouter",
+        )
+
+        self.assertEqual(
+            creds["api_mode"], "chat_completions",
+            "OpenRouter with model='openrouter/auto' must produce api_mode='chat_completions'. "
+            "Got anthropic_messages — likely target_model is not being forwarded to "
+            "resolve_runtime_provider, causing it to infer api_mode from the stale "
+            "parent model config instead of the requested openrouter/auto model.",
+        )
+
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_per_task_model_override_does_not_affect_other_tasks(self, mock_resolve):
+        """Top-level model='openrouter/auto' + per-task model override coexist correctly.
+
+        When one task specifies model='anthropic/claude-haiku-4-5' and another
+        omits model (falling back to the top-level 'openrouter/auto'), credentials
+        are resolved once at the top level. The per-task model is substituted at
+        _build_child_agent call time via task_model = t.get('model') or creds['model'].
+
+        This test verifies that the top-level credential resolution with
+        model_override='openrouter/auto' correctly sets creds['model'] to 'openrouter/auto'
+        so per-task fallback works as expected.
+        """
+        mock_resolve.return_value = {
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "sk-or-test",
+            "api_mode": "chat_completions",
+        }
+        parent = _make_mock_parent(depth=0)
+        cfg = {}
+
+        creds = _resolve_delegation_credentials(
+            cfg, parent,
+            model_override="openrouter/auto",
+            provider_override="openrouter",
+        )
+
+        # creds['model'] is the fallback used by tasks that don't specify a per-task model
+        self.assertEqual(
+            creds["model"], "openrouter/auto",
+            "creds['model'] must equal the model_override so tasks without a "
+            "per-task model correctly inherit 'openrouter/auto' as the fallback.",
+        )
+        # api_mode is shared across all tasks — must stay chat_completions
+        self.assertEqual(creds["api_mode"], "chat_completions")
+
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_model_override_takes_precedence_over_config_model(self, mock_resolve):
+        """Call-site model_override must win over delegation.model in config.yaml.
+
+        A user may have delegation.model='anthropic/claude-sonnet-4' in config.yaml
+        as a static default. When they call delegate_task(model='openrouter/auto'),
+        the call-site value must take precedence — not be silently ignored.
+        """
+        mock_resolve.return_value = {
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "sk-or-test",
+            "api_mode": "chat_completions",
+        }
+        parent = _make_mock_parent(depth=0)
+        # Simulate config.yaml with a static delegation.model
+        cfg = {"model": "anthropic/claude-sonnet-4", "provider": ""}
+
+        creds = _resolve_delegation_credentials(
+            cfg, parent,
+            model_override="openrouter/auto",
+            provider_override="openrouter",
+        )
+
+        # Override must win
+        self.assertEqual(
+            creds["model"], "openrouter/auto",
+            "model_override='openrouter/auto' must take precedence over "
+            "cfg['model']='anthropic/claude-sonnet-4'. The call-site param "
+            "is not being applied — check the configured_model resolution in "
+            "_resolve_delegation_credentials.",
+        )
+        mock_resolve.assert_called_once_with(
+            requested="openrouter",
+            target_model="openrouter/auto",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/tools/test_delegate_tool_observability.py
+++ b/tests/tools/test_delegate_tool_observability.py
@@ -1,0 +1,39 @@
+from tools.delegate_tool import _build_observability
+
+
+def test_build_observability_treats_pareto_code_as_router_resolution():
+    obs = _build_observability([
+        {
+            "model_request": "openrouter/pareto-code",
+            "model_response": "anthropic/claude-sonnet-4.6",
+            "match": False,
+            "tokens_in": 10,
+            "tokens_out": 5,
+            "duration_s": 0.25,
+        }
+    ])
+
+    assert obs is not None
+    assert obs["pareto_router_resolutions"] == {
+        "openrouter/pareto-code": {"anthropic/claude-sonnet-4.6": 1}
+    }
+    assert "override_mismatches" not in obs
+
+
+def test_build_observability_still_warns_on_real_override_mismatch():
+    obs = _build_observability([
+        {
+            "model_request": "anthropic/claude-opus-4.7",
+            "model_response": "google/gemini-2.5-flash",
+            "match": False,
+            "tokens_in": 10,
+            "tokens_out": 5,
+            "duration_s": 0.25,
+        }
+    ])
+
+    assert obs is not None
+    assert obs["override_mismatches"] == [
+        {"requested": "anthropic/claude-opus-4.7", "actual": "google/gemini-2.5-flash"}
+    ]
+    assert "pareto_router_resolutions" not in obs

--- a/tests/tools/test_execute_code_approval_cluster.py
+++ b/tests/tools/test_execute_code_approval_cluster.py
@@ -195,6 +195,21 @@ def test_guard_live_gateway_ignores_stale_cron_env(monkeypatch, gw_session):
         clear_session_vars(tokens)
 
 
+def test_guard_exec_ask_ignores_stale_cron_env_without_context(monkeypatch, gw_session):
+    """Gateway execute_code ask mode must beat stale cron env even without ContextVars."""
+    monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+    monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+    monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+    monkeypatch.setattr(A, "_get_approval_mode", lambda: "manual")
+    monkeypatch.setattr(A, "_get_cron_approval_mode", lambda: "deny")
+
+    _register_resolver(gw_session, "once")
+    res = A.check_execute_code_guard("import os; print(1)", "local")
+    assert res["approved"] is True
+    assert res.get("user_approved") is True
+    assert res.get("outcome") != "blocked"
+
+
 def test_guard_gateway_user_approves_is_one_shot(gw_session):
     _register_resolver(gw_session, "once")
     res = A.check_execute_code_guard("import os; print(1)", "local")

--- a/tests/tools/test_execute_code_approval_cluster.py
+++ b/tests/tools/test_execute_code_approval_cluster.py
@@ -25,6 +25,14 @@ from tools import approval as A
 from tools.thread_context import propagate_context_to_thread
 
 
+@pytest.fixture(autouse=True)
+def _reset_session_contextvars():
+    yield
+    from gateway.session_context import _UNSET, _VAR_MAP
+    for var in _VAR_MAP.values():
+        var.set(_UNSET)
+
+
 # ---------------------------------------------------------------------------
 # 1. Context + callback propagation helper
 # ---------------------------------------------------------------------------
@@ -165,6 +173,26 @@ def test_guard_cron_deny_blocks(monkeypatch):
     res = A.check_execute_code_guard("import os", "local")
     assert res["approved"] is False
     assert res["outcome"] == "blocked"
+
+
+def test_guard_live_gateway_ignores_stale_cron_env(monkeypatch, gw_session):
+    """Stale process cron env must not block live gateway execute_code approval."""
+    from gateway.session_context import clear_session_vars, set_session_vars
+
+    monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+    monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+    monkeypatch.setattr(A, "_get_approval_mode", lambda: "manual")
+    monkeypatch.setattr(A, "_get_cron_approval_mode", lambda: "deny")
+
+    tokens = set_session_vars(platform="discord", chat_id="live-chat", session_key=gw_session)
+    try:
+        _register_resolver(gw_session, "once")
+        res = A.check_execute_code_guard("import os; print(1)", "local")
+        assert res["approved"] is True
+        assert res.get("user_approved") is True
+        assert res.get("outcome") != "blocked"
+    finally:
+        clear_session_vars(tokens)
 
 
 def test_guard_gateway_user_approves_is_one_shot(gw_session):

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -139,15 +139,33 @@ def _is_cron_approval_context() -> bool:
     Prefer the context-local marker set by ``cron.scheduler.run_job`` so a
     scheduler tick in the long-lived gateway process cannot poison later live
     Discord/Telegram/etc. sessions through process-global ``os.environ``.
-    The env fallback is kept for standalone cron/test callers that do not bind
-    session contextvars.
+
+    Keep the env fallback for standalone cron/test callers, but do not let a
+    stale process-global HERMES_CRON_SESSION override explicit user-present
+    gateway/execute-code approval markers. Gateway startup sets
+    HERMES_EXEC_ASK=1 so live chat turns can ask the user; stale cron env must
+    not convert those turns back into unattended cron.
     """
     try:
-        from gateway.session_context import get_session_env
+        from gateway.session_context import get_raw_session_value, get_session_env
 
-        return is_truthy_value(get_session_env("HERMES_CRON_SESSION", ""))
+        raw_cron = get_raw_session_value("HERMES_CRON_SESSION")
+        if raw_cron is not None:
+            return is_truthy_value(raw_cron)
+
+        if env_var_enabled("HERMES_CRON_SESSION"):
+            if env_var_enabled("HERMES_EXEC_ASK") or env_var_enabled("HERMES_GATEWAY_SESSION"):
+                return False
+            if get_session_env("HERMES_SESSION_PLATFORM", ""):
+                return False
+            return True
+        return False
     except Exception:
-        return env_var_enabled("HERMES_CRON_SESSION")
+        if not env_var_enabled("HERMES_CRON_SESSION"):
+            return False
+        if env_var_enabled("HERMES_EXEC_ASK") or env_var_enabled("HERMES_GATEWAY_SESSION"):
+            return False
+        return True
 
 
 def _is_gateway_approval_context() -> bool:

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -149,13 +149,18 @@ def _is_cron_approval_context() -> bool:
     try:
         from gateway.session_context import get_raw_session_value, get_session_env
 
+        # User-present approval surfaces must win over any cron marker.
+        if env_var_enabled("HERMES_EXEC_ASK") or env_var_enabled("HERMES_GATEWAY_SESSION"):
+            return False
+
+        # Explicit context-local cron identity wins over platform origin.
+        # Cron jobs can carry HERMES_SESSION_PLATFORM for delivery/provenance;
+        # that must not make them look like live user gateway turns.
         raw_cron = get_raw_session_value("HERMES_CRON_SESSION")
         if raw_cron is not None:
             return is_truthy_value(raw_cron)
 
         if env_var_enabled("HERMES_CRON_SESSION"):
-            if env_var_enabled("HERMES_EXEC_ASK") or env_var_enabled("HERMES_GATEWAY_SESSION"):
-                return False
             if get_session_env("HERMES_SESSION_PLATFORM", ""):
                 return False
             return True

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -133,6 +133,23 @@ def _get_session_platform() -> str:
         return os.getenv("HERMES_SESSION_PLATFORM", "") or ""
 
 
+def _is_cron_approval_context() -> bool:
+    """True when this approval decision belongs to a cron job.
+
+    Prefer the context-local marker set by ``cron.scheduler.run_job`` so a
+    scheduler tick in the long-lived gateway process cannot poison later live
+    Discord/Telegram/etc. sessions through process-global ``os.environ``.
+    The env fallback is kept for standalone cron/test callers that do not bind
+    session contextvars.
+    """
+    try:
+        from gateway.session_context import get_session_env
+
+        return is_truthy_value(get_session_env("HERMES_CRON_SESSION", ""))
+    except Exception:
+        return env_var_enabled("HERMES_CRON_SESSION")
+
+
 def _is_gateway_approval_context() -> bool:
     """True when this call is inside a gateway/API session.
 
@@ -147,7 +164,7 @@ def _is_gateway_approval_context() -> bool:
     fall through to the gateway branch would submit a pending approval
     with no listener and block the job indefinitely.
     """
-    if env_var_enabled("HERMES_CRON_SESSION"):
+    if _is_cron_approval_context():
         return False
     if env_var_enabled("HERMES_GATEWAY_SESSION"):
         return True
@@ -1349,7 +1366,7 @@ def check_dangerous_command(command: str, env_type: str,
 
     if not is_cli and not is_gateway:
         # Cron sessions: respect cron_mode config
-        if env_var_enabled("HERMES_CRON_SESSION"):
+        if _is_cron_approval_context():
             if _get_cron_approval_mode() == "deny":
                 return {
                     "approved": False,
@@ -1612,7 +1629,7 @@ def check_all_command_guards(command: str, env_type: str,
     # flows, we do not block on approvals and we skip external guard work.
     if not is_cli and not is_gateway and not is_ask:
         # Cron sessions: respect cron_mode config
-        if env_var_enabled("HERMES_CRON_SESSION"):
+        if _is_cron_approval_context():
             if _get_cron_approval_mode() == "deny":
                 # Run detection to get a description for the block message
                 is_dangerous, _pk, description = detect_dangerous_command(command)
@@ -1939,7 +1956,7 @@ def check_execute_code_guard(code: str, env_type: str,
     is_ask = env_var_enabled("HERMES_EXEC_ASK")
 
     # Cron: no user is present to approve arbitrary code.
-    if env_var_enabled("HERMES_CRON_SESSION"):
+    if _is_cron_approval_context():
         if _get_cron_approval_mode() == "deny":
             return {
                 "approved": False,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -28,6 +28,7 @@ from concurrent.futures import (
     ThreadPoolExecutor,
     TimeoutError as FuturesTimeoutError,
 )
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from toolsets import TOOLSETS
@@ -39,6 +40,135 @@ _RUNTIME_PROVIDER_CUSTOM = "custom"
 from tools import file_state
 from tools.terminal_tool import set_approval_callback as _set_subagent_approval_cb
 from utils import base_url_hostname, is_truthy_value
+
+_MODEL_USAGE_LOG = Path.home() / ".hermes" / "logs" / "model_usage.jsonl"
+
+
+def _read_observability(task_id: str) -> Dict[str, Any] | None:
+    """Read model_usage.jsonl and return a compact observability dict for task_id.
+
+    Reads model routing evidence from the model_observability plugin log
+    (plugins/model_observability/). If the log file is absent (first run,
+    log rotated, or plugin disabled), returns None silently — delegate_task
+    still succeeds and the 'observability' field is omitted from the result.
+
+    Returns None if the log doesn't exist, task_id is falsy, or has no entries.
+    Called via _read_observability_batch() — do not call directly in hot paths.
+    """
+    if not task_id:
+        return None
+    if not _MODEL_USAGE_LOG.exists():
+        logger.debug("observability log not found at %s — plugin may not be installed", _MODEL_USAGE_LOG)
+        return None
+    entries = []
+    try:
+        with _MODEL_USAGE_LOG.open() as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    e = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if e.get("task_id") == task_id:
+                    entries.append(e)
+    except OSError:
+        return None
+    return _build_observability(entries)
+
+
+def _load_observability_log() -> Dict[str, list]:
+    """Read the full model_usage.jsonl log once and return entries keyed by task_id.
+
+    Used by the batch enrichment block to avoid reading the log N times for an
+    N-task batch. Returns an empty dict if the log doesn't exist or can't be read.
+    """
+    if not _MODEL_USAGE_LOG.exists():
+        logger.debug("observability log not found at %s — plugin may not be installed", _MODEL_USAGE_LOG)
+        return {}
+    log_by_task: Dict[str, list] = {}
+    try:
+        with _MODEL_USAGE_LOG.open() as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    e = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                tid = e.get("task_id")
+                if tid:
+                    log_by_task.setdefault(tid, []).append(e)
+    except OSError:
+        return {}
+    return log_by_task
+
+
+def _build_observability(entries: list) -> Dict[str, Any] | None:
+    """Build a compact observability dict from a list of log entries for one task."""
+    if not entries:
+        return None
+
+    from collections import Counter
+    total_calls = len(entries)
+    tokens_in = sum(e.get("tokens_in", 0) for e in entries)
+    tokens_out = sum(e.get("tokens_out", 0) for e in entries)
+    duration_s = round(sum(e.get("duration_s", 0.0) for e in entries), 2)
+    response_models = Counter(e.get("model_response", "unknown") for e in entries)
+    request_models = Counter(e.get("model_request", "unknown") for e in entries)
+
+    # Router resolutions: requested → list of resolved models (preserves all)
+    # Key = requested router model (e.g. "openrouter/auto" or
+    # "openrouter/pareto-code"), value = Counter of what resolved.
+    auto_resolutions: Dict[str, Any] = {}
+    pareto_resolutions: Dict[str, Any] = {}
+    for e in entries:
+        req = e.get("model_request", "")
+        resp = e.get("model_response", "unknown")
+        if req.endswith("/auto"):
+            auto_resolutions.setdefault(req, Counter())
+            auto_resolutions[req][resp] += 1
+        elif req in {"openrouter/pareto-code", "pareto-code"}:
+            pareto_resolutions.setdefault(req, Counter())
+            pareto_resolutions[req][resp] += 1
+    # Flatten Counters to dicts for JSON serialization
+    auto_resolutions = {k: dict(v) for k, v in auto_resolutions.items()}
+    pareto_resolutions = {k: dict(v) for k, v in pareto_resolutions.items()}
+
+    # Real mismatches (non-auto, non-alias)
+    mismatches = []
+    for e in entries:
+        req = e.get("model_request", "")
+        resp = e.get("model_response", "")
+        # match=False means confirmed mismatch per model_observability plugin contract.
+        # Default True (not a mismatch) when field is absent — plugin always sets it explicitly.
+        if req.endswith("/auto") or req in {"openrouter/pareto-code", "pareto-code"} or e.get("match", True):
+            continue
+        req_slug = req.split("/", 1)[-1] if "/" in req else req
+        resp_slug = resp.split("/", 1)[-1] if "/" in resp else resp
+        req_parts = set(req_slug.replace("-", " ").split())
+        resp_parts = set(resp_slug.replace("-", " ").split())
+        if len(req_parts & resp_parts) >= 2:
+            continue  # cosmetic alias
+        mismatches.append({"requested": req, "actual": resp})
+
+    obs: Dict[str, Any] = {
+        "models_used": dict(response_models.most_common()),
+        "models_requested": dict(request_models.most_common()),
+        "api_calls": total_calls,
+        "tokens": {"input": tokens_in, "output": tokens_out},
+        "duration_seconds": duration_s,
+    }
+    if auto_resolutions:
+        obs["auto_router_resolutions"] = auto_resolutions
+    if pareto_resolutions:
+        obs["pareto_router_resolutions"] = pareto_resolutions
+    if mismatches:
+        obs["override_mismatches"] = mismatches
+    return obs
+
 
 
 # Tools that children must never have access to
@@ -144,6 +274,10 @@ _MIN_SPAWN_DEPTH = 1
 # No upper ceiling on spawn depth — like max_concurrent_children, depth has a
 # floor of 1 and no ceiling. Deeper trees multiply API cost, so the default
 # stays flat (MAX_DEPTH = 1); raising the config knob is an explicit opt-in.
+
+# Model names that are only meaningful on OpenRouter (meta-routing or
+# aggregator-specific). Used by _warn_model_provider_mismatch.
+_OPENROUTER_ONLY_MODELS: frozenset = frozenset({"auto"})
 
 
 # ---------------------------------------------------------------------------
@@ -364,6 +498,105 @@ def _normalize_role(r: Optional[str]) -> str:
         return r_norm
     logger.warning("Unknown delegate_task role=%r, coercing to 'leaf'", r)
     return "leaf"
+
+
+def _warn_model_provider_mismatch(
+    task_model: Optional[str],
+    resolved_provider: Optional[str],
+    task_index: int,
+) -> None:
+    """Emit a warning when a per-task model is incompatible with the
+    resolved provider credentials.
+
+    Two cases are checked:
+
+    1. Provider-prefixed model string (e.g. 'x-ai/grok-4.1-fast') with a
+       non-matching resolved provider (e.g. 'anthropic'). The child will call
+       the wrong endpoint and receive an opaque invalid-model error.
+
+    2. OpenRouter-specific bare model names (e.g. 'auto', 'openrouter/auto')
+       used with a non-OpenRouter provider. 'auto' is OpenRouter's meta-routing
+       model and is meaningless on any other provider.
+
+    OpenRouter and other registered aggregator providers are excluded from
+    the prefix-mismatch check because they accept provider-prefixed model
+    strings as a feature.
+
+    Only warning-level — does not block execution.
+    """
+    if not task_model or not resolved_provider:
+        return
+
+    # --- Case 2: OpenRouter-specific bare model names ---
+    # 'auto' (and 'openrouter/auto') are only valid on OpenRouter.
+    # Normalize by stripping an 'openrouter/' prefix first.
+    bare_model = task_model.strip().lower()
+    if bare_model.startswith("openrouter/"):
+        bare_model = bare_model[len("openrouter/"):]
+    if bare_model in _OPENROUTER_ONLY_MODELS:
+        try:
+            from hermes_cli.model_normalize import _normalize_provider_alias
+            from hermes_cli.providers import is_aggregator
+            norm_resolved = _normalize_provider_alias(resolved_provider)
+            # Aggregators (openrouter, opencode, etc.) are all valid targets
+            # for OpenRouter-only models — skip silently.
+            if is_aggregator(norm_resolved) or norm_resolved == "":
+                return
+        except Exception:
+            # Alias resolution unavailable — fall back to raw string comparison.
+            # Unlike Case 1, a raw comparison is safe here: the only valid
+            # resolved provider for 'auto' is openrouter, always spelled the
+            # same way. Case 1 can't safely skip by raw comparison because
+            # provider aliases (xai vs x-ai, etc.) would produce false positives.
+            norm_resolved = (resolved_provider or "").strip().lower()
+            if norm_resolved in ("openrouter", ""):
+                return
+        logger.warning(
+            "delegate_task task[%d]: per-task model=%r is an OpenRouter-specific "
+            "model and is not valid on provider=%r. Use provider='openrouter' to "
+            "route through OpenRouter, or choose a model supported by %r.",
+            task_index, task_model, resolved_provider, resolved_provider,
+        )
+        return  # handled — don't fall through to prefix check
+
+    # --- Case 1: Provider-prefixed model strings ---
+    if "/" not in task_model:
+        return
+
+    model_prefix = task_model.split("/", 1)[0].strip().lower()
+    if not model_prefix:
+        return
+
+    try:
+        from hermes_cli.model_normalize import _normalize_provider_alias
+        norm_prefix = _normalize_provider_alias(model_prefix)
+        norm_resolved = _normalize_provider_alias(resolved_provider)
+    except Exception:
+        return  # normalisation unavailable — skip silently
+
+    # Aggregator providers (openrouter, opencode, vercel, etc.) accept
+    # provider-prefixed model strings as a feature — routing x-ai/... through
+    # openrouter is valid and intentional. Use the canonical registry check
+    # rather than a hardcoded list so new aggregators are covered automatically.
+    try:
+        from hermes_cli.providers import is_aggregator
+        if is_aggregator(norm_resolved):
+            return
+    except Exception:
+        # Fallback: openrouter is the most common aggregator
+        if norm_resolved in ("openrouter",):
+            return
+
+    if norm_prefix and norm_resolved and norm_prefix != norm_resolved:
+        logger.warning(
+            "delegate_task task[%d]: per-task model=%r has provider prefix %r "
+            "but credentials were resolved for provider=%r. The child agent will "
+            "call %r's endpoint with a foreign model name, which usually returns "
+            "an invalid-model error. To route tasks to different providers, set "
+            "provider='openrouter' at the top level and use provider-prefixed "
+            "model strings per task (e.g. 'anthropic/claude-haiku-4-5').",
+            task_index, task_model, model_prefix, resolved_provider, resolved_provider,
+        )
 
 
 def _get_max_concurrent_children() -> int:
@@ -1921,6 +2154,7 @@ def _run_single_child(
                 )
                 else 0.0
             ),
+            "_task_id": child_task_id,
         }
         if status == "failed":
             entry["error"] = result.get("error", "Subagent did not produce a response.")
@@ -2130,6 +2364,8 @@ def delegate_task(
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
     role: Optional[str] = None,
+    model: Optional[str] = None,
+    provider: Optional[str] = None,
     background: Optional[bool] = None,
     parent_agent=None,
 ) -> str:
@@ -2208,7 +2444,11 @@ def delegate_task(
     # used by CLI/gateway startup.  When unconfigured, returns None values so
     # children inherit from the parent.
     try:
-        creds = _resolve_delegation_credentials(cfg, parent_agent)
+        creds = _resolve_delegation_credentials(
+            cfg, parent_agent,
+            model_override=model,
+            provider_override=provider,
+        )
     except ValueError as exc:
         return tool_error(str(exc))
 
@@ -2273,17 +2513,20 @@ def delegate_task(
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
+            task_model = t.get("model") or creds["model"]
+            # Warn early if a per-task model prefix is incompatible with the
+            # resolved provider (e.g. model='x-ai/...' but provider='anthropic').
+            if t.get("model"):
+                # creds["provider"] may be None when no provider is configured
+                # (child inherits from parent); mismatch check is skipped in
+                # that case — see _warn_model_provider_mismatch docstring.
+                _warn_model_provider_mismatch(t["model"], creds["provider"], i)
             child = _build_child_agent(
-                task_index=i,
-                goal=t["goal"],
-                context=t.get("context"),
+                task_index=i, goal=t["goal"], context=t.get("context"),
                 toolsets=t.get("toolsets") or toolsets,
-                model=creds["model"],
-                max_iterations=effective_max_iter,
-                task_count=n_tasks,
-                parent_agent=parent_agent,
-                override_provider=creds["provider"],
-                override_base_url=creds["base_url"],
+                model=task_model,
+                max_iterations=effective_max_iter, task_count=n_tasks, parent_agent=parent_agent,
+                override_provider=creds["provider"], override_base_url=creds["base_url"],
                 override_api_key=creds["api_key"],
                 override_api_mode=creds["api_mode"],
                 override_acp_command=t.get("acp_command")
@@ -2533,6 +2776,19 @@ def delegate_task(
 
         total_duration = round(time.monotonic() - overall_start, 2)
 
+# Enrich each result with task_id and inline observability data from the
+        # model_usage.jsonl log. Read the log once for the whole batch (O(1) lookup
+        # per result), then attach ground-truth routing data to each entry so the
+        # LLM sees it in the tool return without needing to run a separate script.
+        _obs_log = _load_observability_log()
+        for entry in results:
+            tid = entry.pop("_task_id", None)
+            if tid:
+                entry["task_id"] = tid
+                obs = _build_observability(_obs_log.get(tid, []))
+                if obs:
+                    entry["observability"] = obs
+
         return {
             "results": results,
             "total_duration_seconds": total_duration,
@@ -2744,7 +3000,12 @@ def _resolve_child_credential_pool(
     return None
 
 
-def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
+def _resolve_delegation_credentials(
+    cfg: dict,
+    parent_agent,
+    model_override: Optional[str] = None,
+    provider_override: Optional[str] = None,
+) -> dict:
     """Resolve credentials for subagent delegation.
 
     If ``delegation.base_url`` is configured, subagents use that direct
@@ -2763,10 +3024,24 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     If neither base_url nor provider is configured, returns None values so the
     child inherits everything from the parent agent.
 
+    Per-call overrides:
+    - model_override: if set, takes precedence over cfg["model"]. Routes this
+      specific delegation to a different model.
+    - provider_override: if set, takes precedence over cfg["provider"]. Routes
+      this specific delegation to a different provider (e.g. openrouter).
+
     Raises ValueError with a user-friendly message on credential failure.
     """
-    configured_model = str(cfg.get("model") or "").strip() or None
-    configured_provider = str(cfg.get("provider") or "").strip() or None
+    configured_model = (
+        (model_override and str(model_override).strip())
+        or str(cfg.get("model") or "").strip()
+        or None
+    )
+    configured_provider = (
+        (provider_override and str(provider_override).strip())
+        or str(cfg.get("provider") or "").strip()
+        or None
+    )
     configured_base_url = str(cfg.get("base_url") or "").strip() or None
     configured_api_key = str(cfg.get("api_key") or "").strip() or None
     configured_api_mode = str(cfg.get("api_mode") or "").strip().lower() or None
@@ -2987,7 +3262,13 @@ def _build_top_level_description() -> str:
         "delegation.orchestrator_enabled=false.\n"
         "- Subagent model is NOT selectable per call: children inherit the parent model (plus its fallback chain) unless you pin all subagents to a model via delegation.provider / delegation.model in config.yaml.\n"
         "- Each subagent gets its own terminal session (separate working directory and state).\n"
-        "- Results are always returned as an array, one entry per task."
+        "- Results are always returned as an array, one entry per task.\n"
+        "\n"
+        "MODEL SELECTION: If the user has not explicitly specified a model or provider "
+        "for this delegation, load the 'subagent-model-routing' skill before filling "
+        "in the 'model' and 'provider' parameters. That skill contains the routing "
+        "decision matrix, tier tables, and known failure modes. Using the wrong model "
+        "silently degrades output quality or wastes cost with no error."
     )
 
 
@@ -3143,6 +3424,14 @@ DELEGATE_TASK_SCHEMA = {
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
                         },
+                        "model": {
+                            "type": "string",
+                            "description": (
+                                "Per-task model override (e.g. 'anthropic/claude-haiku-4-5'). "
+                                "Overrides the top-level model for this task only. "
+                                "See the 'subagent-model-routing' skill for selection guidance."
+                            ),
+                        },
                     },
                     "required": ["goal"],
                 },
@@ -3190,6 +3479,36 @@ DELEGATE_TASK_SCHEMA = {
                     "Leave empty unless acp_command is explicitly provided."
                 ),
             },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Model for the subagent(s). Format: '<provider>/<model>' "
+                    "(e.g. 'anthropic/claude-haiku-4-5', 'x-ai/grok-4.1-fast', "
+                    "'openrouter/auto'). When omitted, subagents use "
+                    "delegation.model from config. Applies to all tasks in the "
+                    "batch unless a per-task model is set. "
+                    "Load the 'subagent-model-routing' skill to select the right "
+                    "model — task type, cost tier, and capability requirements all "
+                    "affect which model to use. Wrong model = silent quality "
+                    "degradation or wasted cost."
+                ),
+            },
+            "provider": {
+                "type": "string",
+                "description": (
+                    "Provider for the subagent(s) (e.g. 'openrouter', "
+                    "'anthropic'). Usually omitted — provider is inferred from "
+                    "the model prefix and parent config. Set explicitly when "
+                    "routing through a specific provider. "
+                    "IMPORTANT: provider is resolved once per call and shared "
+                    "across all tasks in the batch — you cannot mix native "
+                    "providers in one batch. For mixed-provider batches, use "
+                    "provider='openrouter' with provider-prefixed model strings "
+                    "per task (e.g. 'anthropic/claude-haiku-4-5' and "
+                    "'x-ai/grok-4.1-fast' in the same batch). "
+                    "See the 'subagent-model-routing' skill for routing rules."
+                ),
+            },
         },
         "required": [],
     },
@@ -3231,6 +3550,8 @@ registry.register(
         role=args.get("role"),
         background=_model_background_value(args, kw.get("parent_agent")),
         parent_agent=kw.get("parent_agent"),
+        model=args.get("model"),
+        provider=args.get("provider"),
     ),
     check_fn=check_delegate_requirements,
     emoji="🔀",


### PR DESCRIPTION
# feat(delegate_task): per-subagent model/provider overrides + model observability plugin

## Summary

Two related additions:

1. **Per-subagent model/provider overrides** — adds `model` and `provider` parameters to `delegate_task`, allowing the calling agent to route individual subagents (or each task in a batch) to a specific model, independent of `delegation.model` in config.

2. **`model_observability` plugin v2** — verifies that requested models actually reach the subagent. Surfaces ground-truth routing data (requested vs actual model, mismatch warnings, auto-router resolutions, Pareto-router resolutions) directly in `delegate_task` results via `transform_tool_result`.

These two components are designed together: the override exposes the parameter, the plugin verifies it was honored.

## Components

Three pieces that form a complete system:

**Patch (`tools/delegate_tool.py`, `run_agent.py`)** — exposes the capability. Adds `model` and `provider` to the `delegate_task` schema and threads them through `_dispatch_delegate_task()`. Without this, any `model` arg passed by the LLM is silently discarded.

**Skill (`skills/autonomous-ai-agents/subagent-model-routing/SKILL.md`)** — tells the agent how to use it. Defines the routing decision matrix: which models belong in which tier, which tasks warrant which tier, and when to specify a model pin vs. let the auto-router decide. The skill is what turns the new parameter from "available" to "used correctly."

**Plugin (`plugins/model_observability/`)** — verifies it worked. Intercepts every `delegate_task` call, compares requested vs. actual model for each subagent, and injects the result back into the tool output before the LLM sees it. If a pin was silently dropped, the agent knows immediately rather than discovering it through degraded output quality.

## Motivation

`_build_child_agent()` already accepted `model=...` (used by `cron/scheduler.py`) but the parameter was never plumbed through the tool schema or dispatch path. The result: any `model` arg passed by the LLM was silently discarded, and every subagent inherited `delegation.model` from config regardless of what the caller specified.

The observability plugin was built specifically to detect this class of silent failure. On `main` (without this patch), the plugin reports a mismatch on every delegation — confirmed by live instrumentation. On this branch, it reports clean matches for explicit pins and correctly distinguishes router resolutions from override mismatches.

## Rebase note (2026-04-26)

Rebased onto `main` after upstream merged:

- **`48ecb98f`** — `_dispatch_delegate_task()` helper consolidating the two hardcoded dispatch sites this PR originally patched. We accepted that refactor entirely and add `model=`/`provider=` to the single dispatch method instead.
- **`9c9d9b7d`** — `FileStateRegistry` for concurrent subagent write safety.

`TestRunAgentDispatchForwarding` updated to verify `_dispatch_delegate_task()` directly.

## API

### Single-agent override

```jsonc
{
  "model": "anthropic/claude-haiku-4.5",
  "goal": "..."
}
```

### Batch — per-task overrides

```jsonc
{
  "model": "anthropic/claude-opus-4.7",  // default for tasks that do not specify
  "tasks": [
    {"goal": "...", "model": "anthropic/claude-haiku-4.5"},  // overrides default
    {"goal": "..."}                                           // uses default above
  ]
}
```

### Routing through OpenRouter (multi-provider batch)

`provider` is resolved once per `delegate_task` call, so per-task provider routing is not supported. To route tasks to different providers in a single batch, use `provider="openrouter"` at the top level — OpenRouter accepts provider-prefixed model strings and handles the downstream routing:

```jsonc
{
  "provider": "openrouter",
  "tasks": [
    {"goal": "...", "model": "anthropic/claude-haiku-4.5"},
    {"goal": "...", "model": "x-ai/grok-4.1-fast"},
    {"goal": "...", "model": "google/gemini-2.5-flash"}
  ]
}
```

### Router requests

Router-style model IDs are requests for a routing policy, not concrete model pins:

- `openrouter/auto` → report as `auto_router_resolutions`
- `openrouter/pareto-code` → report as `pareto_router_resolutions`

These are expected to return a different concrete backend model. That is not an override mismatch.

### Precedence

1. Per-task `model` (batch only)
2. Top-level `model` argument
3. `delegation.model` from `config.yaml`
4. Parent agent inherit

### Error behavior

Model slugs are not validated locally — an unrecognized slug passes through and the provider returns an opaque invalid-model error. The `model_observability` plugin will log the attempt regardless. The `_warn_model_provider_mismatch()` guard catches the most common misconfiguration (provider-prefixed model string used with a non-aggregator provider) and logs a warning before the call fires.

## Model Observability Plugin v2

### Design

Four hooks, one enforcement chain:

**`pre_tool_call`** — scoping anchor only (always returns `None`).  
Before `delegate_task` executes, captures the current JSONL byte offset and whether a model pin was specified. Stored in a `tool_call_id`-keyed stash. This is not a warning hook — the framework only enforces `block` from `pre_tool_call`. Its sole purpose is to give `transform_tool_result` a precise log read boundary, preventing bleed from prior delegations in the same session. Stash entries evict after 120s TTL.

**`transform_tool_result`** — enrichment and soft enforcement.  
After `delegate_task` returns, reads JSONL entries past the saved offset (scoped to this call only), computes requested-vs-actual per subagent, and injects an observability block before the result reaches the LLM:

```text
✓ sa-0: anthropic/claude-haiku-4.5 → anthropic/claude-4.5-haiku-20251001 [MATCH]
⚠ sa-1: requested anthropic/claude-opus-4.7 → actual google/gemini-2.5-flash [MISMATCH — override silently dropped]
→ sa-2: no model specified → auto-router resolved to google/gemini-2.5-flash-lite
→ sa-3: pareto-router resolved to deepseek/deepseek-v4-pro-20260423
```

**`post_api_request`** — JSONL logging backbone.  
Logs every LLM API call to `~/.hermes/logs/model_usage.jsonl`. Read by the other hooks.

**`on_session_start`** — session boundary marker.  
Writes a boundary record so log readers can distinguish gateway incarnations and session-scoped runs.

All failure modes (missing log, failed delegation, stale stash, bad args) degrade silently — the plugin never interrupts the agent loop.

### Why `pre_tool_call` as a scoping anchor rather than filtering by `session_id`

Filtering by session + subagent type still returns all delegations from the session. A long-running session with multiple `delegate_task` calls would aggregate unrelated records. The byte-offset approach costs one `stat()` call and gives exact per-invocation scoping with no false positives.

### Live verification (2026-05-03)

Tested end-to-end with the gateway running from this branch:

| Task | Requested | Actual | Result |
|------|-----------|--------|--------|
| 0 | `anthropic/claude-haiku-4.5` | `anthropic/claude-4.5-haiku-20251001` | ✅ match |
| 1 | `anthropic/claude-opus-4.7` | `anthropic/claude-4.7-opus-20260416` | ✅ match |
| 2 | `openrouter/auto` | `google/gemini-2.5-flash-lite` | ✅ auto-router noted, no warning |

Same test on `main` (without this patch): all three tasks report `MISMATCH` — confirming the patch is the differentiator.

### Pareto router verification (2026-05-13)

After upstream added the OpenRouter Pareto Code router, the plugin needed to treat `openrouter/pareto-code` as a router request rather than a concrete model pin.

Live smoke after gateway restart:

- Request: `model="openrouter/pareto-code"`, `provider="openrouter"`
- Task id: `sa-0-7780e3fa`
- Actual backend: `deepseek/deepseek-v4-pro-20260423`
- Result: inline `observability` contains `pareto_router_resolutions`
- Result: no `override_mismatches`

Reader-script output agreed:

```text
Pareto-router: yes → deepseek/deepseek-v4-pro-20260423 ×1
```

## Tests

Original PR coverage:

- `tests/plugins/test_model_observability_v2.py` — plugin lifecycle, hook registration, scoping, enrichment, mismatch/auto-router behavior, log isolation, edge cases
- `tests/tools/test_delegate.py` — delegate coverage including credential resolution, model/provider overrides, mismatch guard, OpenRouter auto smoke, and dispatch forwarding

Latest verification after Pareto-router compatibility update:

```bash
python -m pytest -o addopts='' \
  tests/plugins/test_model_observability_v2.py \
  tests/tools/test_delegate_tool_observability.py -q
# 41 passed

python -m pytest -o addopts='' tests/plugins -q --tb=short
# 587 passed
```

## Files changed

- `tools/delegate_tool.py` — schema fields, handler, `_resolve_delegation_credentials()` overrides, `delegate_task()` signature, observability enrichment helpers, router-aware inline metadata
- `run_agent.py` — `model=`/`provider=` forwarded through `_dispatch_delegate_task()`
- `plugins/model_observability/__init__.py` + `plugin.yaml` — v2 plugin, 4 hooks, auto/Pareto-router classification
- `tests/plugins/test_model_observability_v2.py` — plugin regression tests, including Pareto-router resolution behavior
- `tests/tools/test_delegate.py` — delegate model/provider coverage
- `tests/tools/test_delegate_tool_observability.py` — inline observability metadata regression tests
- `scripts/refresh_openrouter_models.py` — weekly model catalog maintenance script (price delta tracking, tier exclusivity validation)
- `skills/autonomous-ai-agents/subagent-model-routing/SKILL.md` — agent-optimized routing skill

## Backwards compatibility

All new parameters are optional. No behavior change when omitted. Observability enrichment degrades gracefully when log is absent.

Router requests are explicitly treated as router requests: `openrouter/auto` and `openrouter/pareto-code` may return concrete backend model names without being classified as override failures.

## Prior art

#3172 (ReqX), #6771 (GusBot69), and #12715 (ViFigueiredo) all attempt per-call model overrides and remain open. None have been rebased onto the `_dispatch_delegate_task()` dispatch refactor (`48ecb98f`) that landed in main after they were submitted — all three would have merge conflicts against current main on their current branches. This PR is the only open implementation rebased onto that refactor.

The skill's escalation patterns are adapted from #3172 — credit to ReqX for that framing.
