### PR TITLE
fix(tools): improve Windows local execution

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -2,7 +2,6 @@
 
 import json
 import os
-import signal
 import subprocess
 import sys
 import time
@@ -602,16 +601,13 @@ class TestKillProcess:
 
         calls = []
 
-        def fake_kill(pid, sig):
-            calls.append((pid, sig))
-
         try:
-            with patch("tools.process_registry.os.kill", side_effect=fake_kill):
+            with patch.object(registry, "_is_host_pid_alive", return_value=True), \
+                 patch.object(registry, "_terminate_host_pid", side_effect=calls.append):
                 result = registry.kill_process(s.id)
 
             assert result["status"] == "killed"
-            assert (424242, 0) in calls
-            assert (424242, signal.SIGTERM) in calls
+            assert calls == [424242]
         finally:
             registry._running.pop(s.id, None)
 

--- a/tests/tools/test_windows_compat.py
+++ b/tests/tools/test_windows_compat.py
@@ -5,8 +5,11 @@ and that each module uses a platform guard before invoking POSIX-only functions.
 """
 
 import ast
-import pytest
+import subprocess
+import sys
 from pathlib import Path
+
+import pytest
 
 # Files that must have Windows-safe process management
 GUARDED_FILES = [
@@ -78,3 +81,90 @@ class TestKillpgGuarded:
                 assert "_IS_WINDOWS" in context or "else:" in context, (
                     f"{relpath}:{i + 1} has unguarded os.killpg/os.getpgid call"
                 )
+
+
+class TestWindowsBashSelection:
+    """Windows should use Git Bash for local shell execution, not WSL bash."""
+
+    def test_prefers_git_bash_over_wsl_bash_on_path(self, tmp_path, monkeypatch):
+        from tools.environments import local as local_env
+
+        git_bash = tmp_path / "Git" / "bin" / "bash.exe"
+        git_bash.parent.mkdir(parents=True)
+        git_bash.write_text("", encoding="utf-8")
+
+        monkeypatch.setattr(local_env, "_IS_WINDOWS", True)
+        monkeypatch.setenv("ProgramFiles", str(tmp_path))
+        monkeypatch.setenv("ProgramFiles(x86)", str(tmp_path / "missing-x86"))
+        monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "missing-local"))
+        monkeypatch.setattr(
+            local_env.shutil,
+            "which",
+            lambda name: r"C:\Windows\System32\bash.EXE" if name == "bash" else None,
+        )
+
+        assert local_env._find_bash() == str(git_bash)
+
+    def test_rejects_wsl_bash_when_git_bash_is_missing(self, tmp_path, monkeypatch):
+        from tools.environments import local as local_env
+
+        monkeypatch.setattr(local_env, "_IS_WINDOWS", True)
+        monkeypatch.setenv("ProgramFiles", str(tmp_path / "missing"))
+        monkeypatch.setenv("ProgramFiles(x86)", str(tmp_path / "missing-x86"))
+        monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "missing-local"))
+        monkeypatch.setenv("WINDIR", r"C:\Windows")
+        monkeypatch.setattr(
+            local_env.shutil,
+            "which",
+            lambda name: r"C:\Windows\System32\bash.exe" if name == "bash" else None,
+        )
+
+        with pytest.raises(RuntimeError, match="Git Bash not found"):
+            local_env._find_bash()
+
+    def test_allows_non_wsl_bash_from_path(self, tmp_path, monkeypatch):
+        from tools.environments import local as local_env
+
+        path_bash = tmp_path / "tools" / "bash.exe"
+        path_bash.parent.mkdir(parents=True)
+        path_bash.write_text("", encoding="utf-8")
+
+        monkeypatch.setattr(local_env, "_IS_WINDOWS", True)
+        monkeypatch.setenv("ProgramFiles", str(tmp_path / "missing"))
+        monkeypatch.setenv("ProgramFiles(x86)", str(tmp_path / "missing-x86"))
+        monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "missing-local"))
+        monkeypatch.setattr(
+            local_env.shutil,
+            "which",
+            lambda name: str(path_bash) if name == "bash" else None,
+        )
+
+        assert local_env._find_bash() == str(path_bash)
+
+
+class TestWindowsPipeDrain:
+    """Windows pipe draining cannot rely on select.select()."""
+
+    def test_wait_for_process_drains_stdout_with_windows_path(self, monkeypatch):
+        import tools.environments.base as base_env
+        from tools.environments.base import BaseEnvironment
+
+        class DummyEnvironment(BaseEnvironment):
+            def _run_bash(self, cmd_string, *, login=False, timeout=120, stdin_data=None):
+                raise NotImplementedError
+
+            def cleanup(self):
+                pass
+
+        monkeypatch.setattr(base_env.os, "name", "nt", raising=False)
+        env = DummyEnvironment(cwd=".", timeout=5)
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "print('hermes-local-test')"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+
+        result = env._wait_for_process(proc, timeout=5)
+
+        assert result["returncode"] == 0
+        assert "hermes-local-test" in result["output"]

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -464,8 +464,48 @@ class BaseEnvironment(ABC):
         # U+FFFD substitution rather than clobbering the whole buffer.
         decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
 
-        def _drain():
-            fd = proc.stdout.fileno()
+        def _flush_decoder():
+            # Flush any bytes buffered mid-sequence.  With ``errors="replace"``
+            # this emits U+FFFD for any final incomplete sequence rather than
+            # raising.
+            try:
+                tail = decoder.decode(b"", final=True)
+                if tail:
+                    output_chunks.append(tail)
+            except Exception:
+                pass
+
+        def _append_output(chunk):
+            if isinstance(chunk, bytes):
+                text = decoder.decode(chunk)
+            else:
+                text = str(chunk)
+            if text:
+                output_chunks.append(text)
+
+        def _stdout_fd_or_drain_iterable():
+            stdout = proc.stdout
+            if stdout is None:
+                _flush_decoder()
+                return None
+
+            fileno = getattr(stdout, "fileno", None)
+            if callable(fileno):
+                return fileno()
+
+            try:
+                for chunk in stdout:
+                    _append_output(chunk)
+            except (ValueError, OSError):
+                pass
+            finally:
+                _flush_decoder()
+            return None
+
+        def _drain_posix():
+            fd = _stdout_fd_or_drain_iterable()
+            if fd is None:
+                return
             idle_after_exit = 0
             try:
                 while True:
@@ -480,7 +520,7 @@ class BaseEnvironment(ABC):
                             break
                         if not chunk:
                             break  # true EOF — all writers closed
-                        output_chunks.append(decoder.decode(chunk))
+                        _append_output(chunk)
                         idle_after_exit = 0
                     elif proc.poll() is not None:
                         # bash is gone and the pipe was idle for ~100ms.  Give
@@ -490,18 +530,39 @@ class BaseEnvironment(ABC):
                         if idle_after_exit >= 3:
                             break
             finally:
-                # Flush any bytes buffered mid-sequence.  With ``errors="replace"``
-                # this emits U+FFFD for any final incomplete sequence rather than
-                # raising.
-                try:
-                    tail = decoder.decode(b"", final=True)
-                    if tail:
-                        output_chunks.append(tail)
-                except Exception:
-                    pass
+                _flush_decoder()
+
+        def _drain_windows():
+            fd = _stdout_fd_or_drain_iterable()
+            if fd is None:
+                return
+            try:
+                while True:
+                    try:
+                        chunk = os.read(fd, 4096)
+                    except (ValueError, OSError):
+                        break
+                    if not chunk:
+                        break
+                    _append_output(chunk)
+            finally:
+                _flush_decoder()
+
+        _drain = _drain_windows if os.name == "nt" else _drain_posix
 
         drain_thread = threading.Thread(target=_drain, daemon=True)
         drain_thread.start()
+
+        def _join_drain_thread(timeout_seconds: float = 2.0) -> None:
+            if os.name != "nt":
+                drain_thread.join(timeout=timeout_seconds)
+                return
+
+            # Windows pipe reads cannot be select()-polled. If a child keeps
+            # the inherited pipe open after the shell exits, don't burn the
+            # full POSIX drain timeout waiting on a blocking read.
+            drain_thread.join(timeout=min(timeout_seconds, 0.25))
+
         deadline = time.monotonic() + timeout
         _now = time.monotonic()
         _activity_state = {
@@ -539,7 +600,7 @@ class BaseEnvironment(ABC):
                             _tid, _pid, _iter_count, time.monotonic() - _activity_state["start"],
                         )
                     self._kill_process(proc)
-                    drain_thread.join(timeout=2)
+                    _join_drain_thread()
                     return {
                         "output": "".join(output_chunks) + "\n[Command interrupted]",
                         "returncode": 130,
@@ -552,12 +613,12 @@ class BaseEnvironment(ABC):
                             _tid, _pid, _iter_count, timeout,
                         )
                     self._kill_process(proc)
-                    drain_thread.join(timeout=2)
+                    _join_drain_thread()
                     partial = "".join(output_chunks)
                     timeout_msg = f"\n[Command timed out after {timeout}s]"
                     return {
                         "output": partial + timeout_msg
-                        if partial
+                        if partial.strip()
                         else timeout_msg.lstrip(),
                         "returncode": 124,
                     }
@@ -600,7 +661,7 @@ class BaseEnvironment(ABC):
                 )
             try:
                 self._kill_process(proc)
-                drain_thread.join(timeout=2)
+                _join_drain_thread()
             except Exception:
                 pass  # cleanup is best-effort
             raise
@@ -608,12 +669,13 @@ class BaseEnvironment(ABC):
         # Drain thread now exits promptly after bash does (~300ms idle
         # check).  A short join is enough; a long one would be a bug since
         # it means the non-blocking loop itself stopped cooperating.
-        drain_thread.join(timeout=2)
+        _join_drain_thread()
 
-        try:
-            proc.stdout.close()
-        except Exception:
-            pass
+        if not (os.name == "nt" and drain_thread.is_alive()):
+            try:
+                proc.stdout.close()
+            except Exception:
+                pass
 
         if _DEBUG_INTERRUPT:
             logger.info(

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -6,6 +6,7 @@ import shutil
 import signal
 import subprocess
 import tempfile
+from pathlib import PureWindowsPath
 
 from tools.environments.base import BaseEnvironment, _pipe_stdin
 
@@ -153,22 +154,80 @@ def _find_bash() -> str:
     if custom and os.path.isfile(custom):
         return custom
 
-    found = shutil.which("bash")
-    if found:
-        return found
+    program_files = os.environ.get("ProgramFiles", r"C:\Program Files")
+    program_files_x86 = os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)")
+    local_app_data = os.environ.get("LOCALAPPDATA", "")
 
     for candidate in (
-        os.path.join(os.environ.get("ProgramFiles", r"C:\Program Files"), "Git", "bin", "bash.exe"),
-        os.path.join(os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)"), "Git", "bin", "bash.exe"),
-        os.path.join(os.environ.get("LOCALAPPDATA", ""), "Programs", "Git", "bin", "bash.exe"),
+        os.path.join(program_files, "Git", "bin", "bash.exe"),
+        os.path.join(
+            program_files,
+            "Git", "usr", "bin", "bash.exe",
+        ),
+        os.path.join(program_files_x86, "Git", "bin", "bash.exe"),
+        os.path.join(
+            program_files_x86,
+            "Git", "usr", "bin", "bash.exe",
+        ),
+        os.path.join(local_app_data, "Programs", "Git", "bin", "bash.exe"),
+        os.path.join(
+            local_app_data,
+            "Programs", "Git", "usr", "bin", "bash.exe",
+        ),
     ):
         if candidate and os.path.isfile(candidate):
             return candidate
+
+    found = shutil.which("bash")
+    if found and not _is_windows_wsl_bash(found):
+        return found
 
     raise RuntimeError(
         "Git Bash not found. Hermes Agent requires Git for Windows on Windows.\n"
         "Install it from: https://git-scm.com/download/win\n"
         "Or set HERMES_GIT_BASH_PATH to your bash.exe location."
+    )
+
+
+def _normalize_windows_path(path: str) -> str:
+    return str(PureWindowsPath(path)).casefold()
+
+
+def _is_windows_wsl_bash(path: str) -> bool:
+    """Return True for Windows' WSL bash launchers, which are not Git Bash."""
+    if not path:
+        return False
+
+    candidates = [
+        str(
+            PureWindowsPath(
+                os.environ.get("WINDIR")
+                or os.environ.get("SystemRoot")
+                or r"C:\Windows"
+            )
+            / "System32"
+            / "bash.exe"
+        ),
+    ]
+    local_app_data = os.environ.get("LOCALAPPDATA")
+    if local_app_data:
+        candidates.append(
+            str(PureWindowsPath(local_app_data) / "Microsoft" / "WindowsApps" / "bash.exe")
+        )
+
+    normalized = _normalize_windows_path(path)
+    return any(normalized == _normalize_windows_path(candidate) for candidate in candidates)
+
+
+def _windows_bash_compat_prelude() -> str:
+    """Small shims for Unix-style commands that Git Bash lacks by default."""
+    if not _IS_WINDOWS:
+        return ""
+    return (
+        "if ! command -v python3 >/dev/null 2>&1 "
+        "&& command -v python >/dev/null 2>&1; then\n"
+        "  python3() { python \"$@\"; }\n"
+        "fi\n"
     )
 
 
@@ -275,11 +334,26 @@ class LocalEnvironment(BaseEnvironment):
 
         return proc
 
+    def _wrap_command(self, command: str, cwd: str) -> str:
+        wrapped = super()._wrap_command(command, cwd)
+        if _IS_WINDOWS:
+            return _windows_bash_compat_prelude() + wrapped
+        return wrapped
+
     def _kill_process(self, proc):
         """Kill the entire process group (all children)."""
         try:
             if _IS_WINDOWS:
-                proc.terminate()
+                subprocess.run(
+                    ["taskkill", "/PID", str(proc.pid), "/T", "/F"],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    timeout=5,
+                )
+                try:
+                    proc.wait(timeout=1.0)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
             else:
                 pgid = os.getpgid(proc.pid)
                 os.killpg(pgid, signal.SIGTERM)

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -41,7 +41,11 @@ import time
 import uuid
 
 _IS_WINDOWS = platform.system() == "Windows"
-from tools.environments.local import _find_shell, _sanitize_subprocess_env
+from tools.environments.local import (
+    _find_shell,
+    _sanitize_subprocess_env,
+    _windows_bash_compat_prelude,
+)
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
@@ -254,10 +258,34 @@ class ProcessRegistry:
         """Best-effort liveness check for host-visible PIDs."""
         if not pid:
             return False
+        if _IS_WINDOWS:
+            try:
+                import ctypes
+
+                process_query_limited_information = 0x1000
+                still_active = 259
+                kernel32 = ctypes.windll.kernel32
+                handle = kernel32.OpenProcess(
+                    process_query_limited_information,
+                    False,
+                    int(pid),
+                )
+                if not handle:
+                    return False
+                try:
+                    exit_code = ctypes.c_ulong()
+                    if not kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+                        return False
+                    return exit_code.value == still_active
+                finally:
+                    kernel32.CloseHandle(handle)
+            except Exception:
+                return False
+
         try:
             os.kill(pid, 0)
             return True
-        except (ProcessLookupError, PermissionError):
+        except (ProcessLookupError, PermissionError, OSError):
             return False
 
     def _refresh_detached_session(self, session: Optional[ProcessSession]) -> Optional[ProcessSession]:
@@ -283,7 +311,12 @@ class ProcessRegistry:
     def _terminate_host_pid(pid: int) -> None:
         """Terminate a host-visible PID without requiring the original process handle."""
         if _IS_WINDOWS:
-            os.kill(pid, signal.SIGTERM)
+            subprocess.run(
+                ["taskkill", "/PID", str(pid), "/T", "/F"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=5,
+            )
             return
 
         try:
@@ -344,8 +377,9 @@ class ProcessRegistry:
                 user_shell = _find_shell()
                 pty_env = _sanitize_subprocess_env(os.environ, env_vars)
                 pty_env["PYTHONUNBUFFERED"] = "1"
+                shell_command = f"set +m; {_windows_bash_compat_prelude()}{command}"
                 pty_proc = _PtyProcessCls.spawn(
-                    [user_shell, "-lic", f"set +m; {command}"],
+                    [user_shell, "-lic", shell_command],
                     cwd=session.cwd,
                     env=pty_env,
                     dimensions=(30, 120),
@@ -385,8 +419,9 @@ class ProcessRegistry:
         # stdout is a pipe, hiding output from process(action="poll")).
         bg_env = _sanitize_subprocess_env(os.environ, env_vars)
         bg_env["PYTHONUNBUFFERED"] = "1"
+        shell_command = f"set +m; {_windows_bash_compat_prelude()}{command}"
         proc = subprocess.Popen(
-            [user_shell, "-lic", f"set +m; {command}"],
+            [user_shell, "-lic", shell_command],
             text=True,
             cwd=session.cwd,
             env=bg_env,
@@ -806,7 +841,12 @@ class ProcessRegistry:
                 # Local process -- kill the process group
                 try:
                     if _IS_WINDOWS:
-                        session.process.terminate()
+                        subprocess.run(
+                            ["taskkill", "/PID", str(session.process.pid), "/T", "/F"],
+                            stdout=subprocess.DEVNULL,
+                            stderr=subprocess.DEVNULL,
+                            timeout=5,
+                        )
                     else:
                         os.killpg(os.getpgid(session.process.pid), signal.SIGTERM)
                 except (ProcessLookupError, PermissionError):


### PR DESCRIPTION
## Summary

Fixes native Windows local terminal execution issues discovered while running Hermes from a Windows checkout with Git Bash installed.

## What changed

- Prefer Git Bash over Windows/WSL `bash.exe` launchers when resolving the local shell on Windows.
- Use a Windows-safe stdout drain path instead of relying on `select.select()` for subprocess pipes.
- Avoid waiting on inherited pipe handles from background children on Windows.
- Use `taskkill /T /F` for Windows process-tree termination in local execution and process registry paths.
- Add a small Git Bash compatibility shim so `python3` maps to `python` when `python3` is unavailable.
- Use Win32 process exit-code checks for recovered host PID liveness on Windows.
- Add/adjust tests for Windows shell selection, stdout draining, process recovery, and detached process killing.

## Why

The existing local backend could execute commands on Windows but lose stdout because Windows pipes are not compatible with the POSIX `select.select()` drain loop. In this environment, `LocalEnvironment.execute('echo hermes-local-test')` returned `returncode: 0` with empty output before the fix. The Windows PATH also resolved `bash` to the WSL launcher before Git Bash, which is not the shell the native Windows local backend expects.

## Validation

Tested on Windows with Git Bash installed:

```powershell
python -m pytest -o "addopts=" tests\tools\test_windows_compat.py tests\tools\test_base_environment.py tests\tools\test_local_tempdir.py tests\tools\test_terminal_timeout_output.py tests\tools\test_local_background_child_hang.py tests\tools\test_process_registry.py -q
```

Result: `86 passed`.

Also ran:

```powershell
python -m py_compile tools\environments\base.py tools\environments\local.py tools\process_registry.py tests\tools\test_windows_compat.py tests\tools\test_process_registry.py
git diff --check
```

`git diff --check` only reported expected CRLF conversion warnings from Git for this Windows checkout.