### PR TITLE
fix(cli): smart arrow-key navigation for multiline input

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9179,23 +9179,51 @@ class HermesCLI:
             event.app.current_buffer.reset()
             event.app.invalidate()
 
-        # --- History navigation: up/down browse history in normal input mode ---
-        # The TextArea is multiline, so by default up/down only move the cursor.
-        # Buffer.auto_up/auto_down handle both: cursor movement when multi-line,
-        # history browsing when on the first/last line (or single-line input).
+        # --- Smart arrow-key navigation for multiline input ---
+        # Up arrow:  move cursor to previous line; on first line, jump to start;
+        #            if already at start, browse previous history entry.
+        # Down arrow: move cursor to next line; on last line, jump to end;
+        #            if already at end, browse next history entry.
+        # This matches the behavior of Codex and Claude Code CLI.
         _normal_input = Condition(
             lambda: not self._clarify_state and not self._approval_state and not self._sudo_state and not self._secret_state and not self._model_picker_state
         )
 
         @kb.add('up', filter=_normal_input)
         def history_up(event):
-            """Up arrow: browse history when on first line, else move cursor up."""
-            event.app.current_buffer.auto_up(count=event.arg)
+            """Up arrow: move up a line; on first line go to start, then history."""
+            buf = event.app.current_buffer
+            cursor_row = buf.document.cursor_position_row
+            if cursor_row > 0:
+                buf.cursor_up(count=event.arg)
+            else:
+                # On first (or only) line
+                col = buf.document.cursor_position_col
+                if col > 0:
+                    # Not at start yet — move cursor to beginning of line
+                    buf.cursor_position = buf.document.get_start_of_line_position(after_whitespace=False)
+                else:
+                    # Already at start of first line — browse history
+                    buf.history_backward()
 
         @kb.add('down', filter=_normal_input)
         def history_down(event):
-            """Down arrow: browse history when on last line, else move cursor down."""
-            event.app.current_buffer.auto_down(count=event.arg)
+            """Down arrow: move down a line; on last line go to end, then history."""
+            buf = event.app.current_buffer
+            cursor_row = buf.document.cursor_position_row
+            line_count = buf.document.line_count
+            if cursor_row < line_count - 1:
+                buf.cursor_down(count=event.arg)
+            else:
+                # On last (or only) line
+                col = buf.document.cursor_position_col
+                line_len = len(buf.document.current_line_after_cursor) + col
+                if col < line_len:
+                    # Not at end yet — move cursor to end of line
+                    buf.cursor_position = buf.document.get_end_of_line_position()
+                else:
+                    # Already at end of last line — browse history
+                    buf.history_forward()
 
         @kb.add('c-c')
         def handle_ctrl_c(event):


### PR DESCRIPTION
## Problem

The current `auto_up`/`auto_down` behavior in the multiline CLI input is inconsistent — it toggles between cursor movement and history browsing depending on cursor position, which can feel jarring and unpredictable.

## Fix

Replace `auto_up`/`auto_down` with explicit smart navigation that matches the behavior of **Codex** and **Claude Code CLI**:

**Up arrow:**
1. If cursor is not on the first line → move cursor up one line
2. If on the first line and cursor is not at start → jump cursor to beginning of line
3. If on the first line and cursor is already at start → browse previous history entry

**Down arrow:**
1. If cursor is not on the last line → move cursor down one line
2. If on the last line and cursor is not at end → jump cursor to end of line
3. If on the last line and cursor is already at end → browse next history entry

This gives users fine-grained cursor control in multiline input while preserving seamless history access at the boundaries.

## Behavior comparison

| Scenario | Before (`auto_up`/`auto_down`) | After (this PR) | Codex / Claude Code |
|---|---|---|---|
| Up in middle of multiline | Move cursor up | Move cursor up | Same |
| Up on first line, mid-line | History browse | Jump to line start | Same |
| Up on first line, at col 0 | History browse | History browse | Same |
| Down in middle of multiline | Move cursor down | Move cursor down | Same |
| Down on last line, mid-line | History browse | Jump to line end | Same |
| Down on last line, at end | History browse | History browse | Same |
| Single-line input, Up | History browse | Go to start → History | Same |
| Single-line input, Down | History browse | Go to end → History | Same |

## Testing

Manual testing in the CLI:
- [x] Multiline input: Up/Down moves cursor between lines
- [x] First line, mid-text: Up jumps to start
- [x] First line, at start: Up browses history
- [x] Last line, mid-text: Down jumps to end
- [x] Last line, at end: Down browses history
- [x] Single-line input: Up → start → history; Down → end → history