### PR TITLE
fix(doctor): skip MiniMax China models probe

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -827,9 +827,10 @@ def run_doctor(args):
         ("Hugging Face",     ("HF_TOKEN",),                                   "https://router.huggingface.co/v1/models", "HF_BASE_URL", True),
         ("NVIDIA NIM",       ("NVIDIA_API_KEY",),                             "https://integrate.api.nvidia.com/v1/models", "NVIDIA_BASE_URL", True),
         ("Alibaba/DashScope", ("DASHSCOPE_API_KEY",),                         "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/models", "DASHSCOPE_BASE_URL", True),
-        # MiniMax: the /anthropic endpoint doesn't support /models, but the /v1 endpoint does.
+        # MiniMax global supports /v1/models. MiniMax China returns 404 for GET /v1/models,
+        # so treat a configured key as healthy instead of reporting a false warning.
         ("MiniMax",          ("MINIMAX_API_KEY",),                            "https://api.minimax.io/v1/models",    "MINIMAX_BASE_URL", True),
-        ("MiniMax (China)",  ("MINIMAX_CN_API_KEY",),                         "https://api.minimaxi.com/v1/models",  "MINIMAX_CN_BASE_URL", True),
+        ("MiniMax (China)",  ("MINIMAX_CN_API_KEY",),                         "https://api.minimaxi.com/v1/models",  "MINIMAX_CN_BASE_URL", False),
         ("Vercel AI Gateway",       ("AI_GATEWAY_API_KEY",),                          "https://ai-gateway.vercel.sh/v1/models", "AI_GATEWAY_BASE_URL", True),
         ("Kilo Code",        ("KILOCODE_API_KEY",),                            "https://api.kilo.ai/api/gateway/models",  "KILOCODE_BASE_URL", True),
         ("OpenCode Zen",     ("OPENCODE_ZEN_API_KEY",),                        "https://opencode.ai/zen/v1/models",  "OPENCODE_ZEN_BASE_URL", True),

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -397,3 +397,40 @@ def test_run_doctor_opencode_go_skips_invalid_models_probe(monkeypatch, tmp_path
     )
     assert not any(url == "https://opencode.ai/zen/go/v1/models" for url, _, _ in calls)
     assert not any("opencode" in url.lower() and "models" in url.lower() for url, _, _ in calls)
+
+
+def test_run_doctor_skips_minimax_cn_models_endpoint(monkeypatch, tmp_path):
+    """MiniMax China has no usable GET /v1/models endpoint, so doctor must not probe it."""
+    for env_name in (
+        "GLM_API_KEY",
+        "ZAI_API_KEY",
+        "Z_AI_API_KEY",
+        "KIMI_API_KEY",
+        "KIMI_CN_API_KEY",
+        "ARCEEAI_API_KEY",
+        "DEEPSEEK_API_KEY",
+        "HF_TOKEN",
+        "DASHSCOPE_API_KEY",
+        "MINIMAX_API_KEY",
+        "MINIMAX_BASE_URL",
+        "MINIMAX_CN_BASE_URL",
+        "AI_GATEWAY_API_KEY",
+        "KILOCODE_API_KEY",
+        "OPENCODE_ZEN_API_KEY",
+        "OPENCODE_GO_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+    ):
+        monkeypatch.delenv(env_name, raising=False)
+    monkeypatch.setenv("MINIMAX_CN_API_KEY", "test-minimax-cn-key")
+
+    def fail_on_http_get(*args, **kwargs):
+        raise AssertionError("doctor should not call httpx.get for MiniMax China")
+
+    monkeypatch.setitem(sys.modules, "httpx", SimpleNamespace(get=fail_on_http_get))
+
+    helper = TestDoctorMemoryProviderSection()
+    out = helper._run_doctor_and_capture(monkeypatch, tmp_path, provider="")
+
+    assert "MiniMax (China)" in out
+    assert "(key configured)" in out


### PR DESCRIPTION
## Summary
- treat MiniMax (China) as configured in `hermes doctor` instead of probing GET `/v1/models`
- avoid a false HTTP 404 warning for a provider whose inference endpoint is functional
- add a regression test ensuring doctor does not call `httpx.get` for MiniMax China

Fixes #12768.

## Test plan
- `/Users/wentao/miniconda3/bin/python -m pytest -o addopts='' tests/hermes_cli/test_doctor.py -q`
- `git diff --cached --check`