### PR TITLE
fix(matrix): improve fresh-room detection and harden sync/timestamp handling

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -231,9 +231,10 @@ class MatrixAdapter(BasePlatformAdapter):
         self._closing = False
         self._startup_ts: float = 0.0
 
-        # Positive DM cache: room_id -> True once we have authoritative
-        # evidence the room is a DM. We avoid negative caching because fresh
-        # Matrix rooms can have incomplete local membership state.
+        # Authoritative DM cache: room_id -> bool once we have a reliable
+        # answer from m.direct or complete membership data. We avoid writing
+        # negative entries from mere m.direct absence because fresh rooms may
+        # appear there late.
         self._dm_rooms: Dict[str, bool] = {}
         # Set of room IDs we've joined
         self._joined_rooms: Set[str] = set()
@@ -327,6 +328,22 @@ class MatrixAdapter(BasePlatformAdapter):
         if isinstance(raw, (list, tuple, set)):
             return {str(item).strip() for item in raw if str(item).strip()}
         return {part.strip() for part in str(raw).split(",") if part.strip()}
+
+    @staticmethod
+    def _normalize_event_timestamp(raw_ts: Any) -> float:
+        """Normalize Matrix event timestamps to Unix seconds.
+
+        mautrix payloads have historically exposed timestamps in milliseconds,
+        while newer releases expose seconds. Accept both to keep startup-grace
+        filtering stable across SDK versions.
+        """
+        try:
+            event_ts = float(raw_ts)
+        except (TypeError, ValueError):
+            return 0.0
+        if event_ts <= 0:
+            return 0.0
+        return event_ts / 1000.0 if event_ts >= 10_000_000_000 else event_ts
 
     # ------------------------------------------------------------------
     # E2EE helpers
@@ -664,11 +681,7 @@ class MatrixAdapter(BasePlatformAdapter):
                 rooms_join = sync_data.get("rooms", {}).get("join", {})
                 self._joined_rooms.clear()
                 self._joined_rooms.update(rooms_join.keys())
-                # Store the next_batch token so incremental syncs start
-                # from where the initial sync left off.
                 nb = sync_data.get("next_batch")
-                if nb:
-                    await client.sync_store.put_next_batch(nb)
                 logger.info(
                     "Matrix: initial sync complete, joined %d rooms",
                     len(self._joined_rooms),
@@ -678,12 +691,16 @@ class MatrixAdapter(BasePlatformAdapter):
 
                 # Dispatch events from the initial sync so the OlmMachine
                 # receives to-device key shares queued while we were offline.
-                try:
-                    tasks = client.handle_sync(sync_data)
-                    if tasks:
-                        await asyncio.gather(*tasks)
-                except Exception as exc:
-                    logger.warning("Matrix: initial sync event dispatch error: %s", exc)
+                if await self._dispatch_sync_payload(
+                    client,
+                    sync_data,
+                    context="initial sync",
+                ):
+                    # Persist the initial sync token only after dispatch
+                    # succeeded, otherwise the background sync would skip the
+                    # same events on the next poll.
+                    if nb:
+                        await client.sync_store.put_next_batch(nb)
             else:
                 logger.warning(
                     "Matrix: initial sync returned unexpected type %s",
@@ -1128,6 +1145,28 @@ class MatrixAdapter(BasePlatformAdapter):
     # Sync loop
     # ------------------------------------------------------------------
 
+    async def _dispatch_sync_payload(
+        self,
+        client: Any,
+        sync_data: dict,
+        *,
+        context: str,
+    ) -> bool:
+        """Dispatch a sync payload and report whether all handlers succeeded."""
+        try:
+            tasks = client.handle_sync(sync_data)
+            logger.debug(
+                "Matrix: %s handle_sync queued %d task(s)",
+                context,
+                len(tasks) if tasks else 0,
+            )
+            if tasks:
+                await asyncio.gather(*tasks)
+            return True
+        except Exception as exc:
+            logger.warning("Matrix: %s event dispatch error: %s", context, exc)
+            return False
+
     async def _sync_loop(self) -> None:
         """Continuously sync with the homeserver."""
         client = self._client
@@ -1194,25 +1233,18 @@ class MatrixAdapter(BasePlatformAdapter):
                         "set" if next_batch else "none",
                     )
 
-                    # Advance the sync token so the next request is
-                    # incremental instead of a full initial sync.
                     nb = sync_data.get("next_batch")
-                    if nb:
-                        next_batch = nb
-                        await client.sync_store.put_next_batch(nb)
-
-                    # Dispatch events to registered handlers so that
-                    # _on_room_message / _on_reaction / _on_invite fire.
-                    try:
-                        tasks = client.handle_sync(sync_data)
-                        logger.debug(
-                            "Matrix: handle_sync queued %d task(s)",
-                            len(tasks) if tasks else 0,
-                        )
-                        if tasks:
-                            await asyncio.gather(*tasks)
-                    except Exception as exc:
-                        logger.warning("Matrix: sync event dispatch error: %s", exc)
+                    if await self._dispatch_sync_payload(
+                        client,
+                        sync_data,
+                        context="sync",
+                    ):
+                        # Advance the sync token only after every queued
+                        # handler completed successfully. Otherwise the next
+                        # sync would skip events we failed to dispatch.
+                        if nb:
+                            next_batch = nb
+                            await client.sync_store.put_next_batch(nb)
                 else:
                     logger.debug(
                         "Matrix: sync returned non-dict payload of type %s",
@@ -1276,7 +1308,7 @@ class MatrixAdapter(BasePlatformAdapter):
             or getattr(event, "server_timestamp", None)
             or 0
         )
-        event_ts = raw_ts / 1000.0 if raw_ts else 0.0
+        event_ts = self._normalize_event_timestamp(raw_ts)
         if event_ts and event_ts < self._startup_ts - _STARTUP_GRACE_SECONDS:
             return
 
@@ -2026,32 +2058,29 @@ class MatrixAdapter(BasePlatformAdapter):
 
     async def _is_dm_room(self, room_id: str) -> bool:
         """Check if a room is a DM."""
-        if self._dm_rooms.get(room_id, False):
-            logger.debug("Matrix: DM detection for %s via cache: True", room_id)
-            return True
+        cached = self._dm_rooms.get(room_id)
+        if cached is not None:
+            logger.debug("Matrix: DM detection for %s via cache: %s", room_id, cached)
+            return cached
 
         # Prefer authoritative local membership state when available.
         state_store = getattr(self._client, "state_store", None) if self._client else None
         if state_store and hasattr(state_store, "get_members"):
             try:
-                has_full_member_list = True
-                source = "state_store_legacy"
+                has_full_member_list = False
                 if hasattr(state_store, "has_full_member_list"):
                     has_full_member_list = await state_store.has_full_member_list(room_id)
-                    source = "state_store_full"
                 if has_full_member_list:
                     members = await state_store.get_members(room_id)
                     member_count = len(members or [])
                     is_dm = member_count == 2
                     logger.debug(
-                        "Matrix: DM detection for %s via %s (members=%d): %s",
+                        "Matrix: DM detection for %s via state_store_full (members=%d): %s",
                         room_id,
-                        source,
                         member_count,
                         is_dm,
                     )
-                    if is_dm:
-                        self._dm_rooms[room_id] = True
+                    self._dm_rooms[room_id] = is_dm
                     return is_dm
             except Exception as exc:
                 logger.debug(
@@ -2073,8 +2102,7 @@ class MatrixAdapter(BasePlatformAdapter):
                     member_count,
                     is_dm,
                 )
-                if is_dm:
-                    self._dm_rooms[room_id] = True
+                self._dm_rooms[room_id] = is_dm
                 return is_dm
             except Exception as exc:
                 logger.debug(

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -113,6 +113,7 @@ _CRYPTO_DB_PATH = _STORE_DIR / "crypto.db"
 
 # Grace period: ignore messages older than this many seconds before startup.
 _STARTUP_GRACE_SECONDS = 5
+_SYNC_RETRY_DELAY_SECONDS = 5
 
 
 _E2EE_INSTALL_HINT = (
@@ -1245,6 +1246,12 @@ class MatrixAdapter(BasePlatformAdapter):
                         if nb:
                             next_batch = nb
                             await client.sync_store.put_next_batch(nb)
+                    else:
+                        # Keep the current token so we can retry the same
+                        # batch, but back off to avoid hammering /sync when a
+                        # handler is persistently failing.
+                        await asyncio.sleep(_SYNC_RETRY_DELAY_SECONDS)
+                        continue
                 else:
                     logger.debug(
                         "Matrix: sync returned non-dict payload of type %s",
@@ -1274,8 +1281,12 @@ class MatrixAdapter(BasePlatformAdapter):
                         "Matrix: permanent auth error: %s — stopping sync", exc
                     )
                     return
-                logger.warning("Matrix: sync error: %s — retrying in 5s", exc)
-                await asyncio.sleep(5)
+                logger.warning(
+                    "Matrix: sync error: %s — retrying in %ss",
+                    exc,
+                    _SYNC_RETRY_DELAY_SECONDS,
+                )
+                await asyncio.sleep(_SYNC_RETRY_DELAY_SECONDS)
 
     # ------------------------------------------------------------------
     # Event callbacks

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -1178,6 +1178,13 @@ class MatrixAdapter(BasePlatformAdapter):
         if self._is_duplicate_event(event_id):
             return
 
+        logger.debug(
+            "Matrix: received event %s from %s in %s",
+            event_id or "(unknown)",
+            sender or "(unknown)",
+            room_id or "(unknown)",
+        )
+
         # Startup grace: ignore old messages from initial sync.
         raw_ts = (
             getattr(event, "timestamp", None)
@@ -1266,6 +1273,14 @@ class MatrixAdapter(BasePlatformAdapter):
             in_bot_thread = bool(thread_id and thread_id in self._threads)
             if self._require_mention and not is_free_room and not in_bot_thread:
                 if not is_mentioned:
+                    logger.debug(
+                        "Matrix: ignoring unmentioned event %s in %s "
+                        "(require_mention=true, free_room=%s, bot_thread=%s)",
+                        event_id or "(unknown)",
+                        room_id or "(unknown)",
+                        is_free_room,
+                        in_bot_thread,
+                    )
                     return None
 
         # DM mention-thread.
@@ -1917,19 +1932,59 @@ class MatrixAdapter(BasePlatformAdapter):
 
     async def _is_dm_room(self, room_id: str) -> bool:
         """Check if a room is a DM."""
-        if self._dm_rooms.get(room_id, False):
-            return True
-        # Fallback: check member count via state store.
+        cached = self._dm_rooms.get(room_id)
+        if cached is not None:
+            return cached
+        # Only trust the state store when it confirms the member list is
+        # complete. Freshly joined rooms may have partial membership there.
         state_store = (
             getattr(self._client, "state_store", None) if self._client else None
         )
         if state_store:
             try:
-                members = await state_store.get_members(room_id)
-                if members and len(members) == 2:
-                    return True
-            except Exception:
-                pass
+                has_full_member_list = getattr(state_store, "has_full_member_list", None)
+                state_store_complete = False
+                if has_full_member_list:
+                    state_store_complete = bool(await has_full_member_list(room_id))
+
+                if state_store_complete:
+                    members = await state_store.get_members(room_id)
+                    is_dm = len(members) == 2
+                    self._dm_rooms[room_id] = is_dm
+                    logger.debug(
+                        "Matrix: DM detection for %s resolved via state_store_full -> %s",
+                        room_id,
+                        "dm" if is_dm else "group",
+                    )
+                    return is_dm
+            except Exception as exc:
+                logger.debug(
+                    "Matrix: state_store DM detection failed for %s: %s",
+                    room_id,
+                    exc,
+                )
+
+        # Freshly joined 1:1 rooms are often missing from m.direct on the bot
+        # account. Fall back to the joined-members API so a new DM isn't
+        # misclassified as a group room that requires an explicit mention.
+        if self._client and hasattr(self._client, "get_joined_members"):
+            try:
+                joined_members = await self._client.get_joined_members(RoomID(room_id))
+                if joined_members:
+                    is_dm = len(joined_members) == 2
+                    self._dm_rooms[room_id] = is_dm
+                    logger.debug(
+                        "Matrix: DM detection for %s resolved via joined_members -> %s",
+                        room_id,
+                        "dm" if is_dm else "group",
+                    )
+                    return is_dm
+            except Exception as exc:
+                logger.debug(
+                    "Matrix: get_joined_members(%s) failed during DM detection: %s",
+                    room_id,
+                    exc,
+                )
         return False
 
     async def _refresh_dm_cache(self) -> None:
@@ -1956,7 +2011,12 @@ class MatrixAdapter(BasePlatformAdapter):
             if isinstance(rooms, list):
                 dm_room_ids.update(str(r) for r in rooms)
 
-        self._dm_rooms = {rid: (rid in dm_room_ids) for rid in self._joined_rooms}
+        # m.direct is reliable as a positive DM signal, but not as a negative
+        # one: fresh 1:1 rooms often appear here late or never. Only cache
+        # rooms that are explicitly marked as DMs.
+        for rid in self._joined_rooms:
+            if rid in dm_room_ids:
+                self._dm_rooms[rid] = True
 
     # ------------------------------------------------------------------
     # Mention detection helpers

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -231,7 +231,9 @@ class MatrixAdapter(BasePlatformAdapter):
         self._closing = False
         self._startup_ts: float = 0.0
 
-        # Cache: room_id → bool (is DM)
+        # Positive DM cache: room_id -> True once we have authoritative
+        # evidence the room is a DM. We avoid negative caching because fresh
+        # Matrix rooms can have incomplete local membership state.
         self._dm_rooms: Dict[str, bool] = {}
         # Set of room IDs we've joined
         self._joined_rooms: Set[str] = set()
@@ -247,22 +249,27 @@ class MatrixAdapter(BasePlatformAdapter):
         # Thread participation tracking (for require_mention bypass)
         self._threads = ThreadParticipationTracker("matrix")
 
-        # Mention/thread gating — parsed once from env vars.
-        self._require_mention: bool = os.getenv(
-            "MATRIX_REQUIRE_MENTION", "true"
-        ).lower() not in ("false", "0", "no")
-        free_rooms_raw = os.getenv("MATRIX_FREE_RESPONSE_ROOMS", "")
-        self._free_rooms: Set[str] = {
-            r.strip() for r in free_rooms_raw.split(",") if r.strip()
-        }
-        self._auto_thread: bool = os.getenv("MATRIX_AUTO_THREAD", "true").lower() in (
-            "true",
-            "1",
-            "yes",
+        # Mention/thread gating. Match the other adapters by honoring
+        # config.extra first, then env vars.
+        self._require_mention: bool = self._config_bool(
+            "require_mention",
+            env_var="MATRIX_REQUIRE_MENTION",
+            default=True,
         )
-        self._dm_mention_threads: bool = os.getenv(
-            "MATRIX_DM_MENTION_THREADS", "false"
-        ).lower() in ("true", "1", "yes")
+        free_rooms_raw = config.extra.get("free_response_rooms")
+        if free_rooms_raw is None:
+            free_rooms_raw = os.getenv("MATRIX_FREE_RESPONSE_ROOMS", "")
+        self._free_rooms: Set[str] = self._string_set(free_rooms_raw)
+        self._auto_thread: bool = self._config_bool(
+            "auto_thread",
+            env_var="MATRIX_AUTO_THREAD",
+            default=True,
+        )
+        self._dm_mention_threads: bool = self._config_bool(
+            "dm_mention_threads",
+            env_var="MATRIX_DM_MENTION_THREADS",
+            default=False,
+        )
 
         # Reactions: configurable via MATRIX_REACTIONS (default: true).
         self._reactions_enabled: bool = os.getenv(
@@ -293,6 +300,33 @@ class MatrixAdapter(BasePlatformAdapter):
         self._processed_events.append(event_id)
         self._processed_events_set.add(event_id)
         return False
+
+    def _config_bool(self, key: str, *, env_var: str, default: bool) -> bool:
+        """Read a boolean from config.extra first, then the environment."""
+        raw = self.config.extra.get(key)
+        if raw is None:
+            raw = os.getenv(env_var)
+        if raw is None:
+            return default
+        if isinstance(raw, bool):
+            return raw
+        if isinstance(raw, str):
+            value = raw.strip().lower()
+            if value in ("true", "1", "yes", "on"):
+                return True
+            if value in ("false", "0", "no", "off"):
+                return False
+            return default if value == "" else bool(raw)
+        return bool(raw)
+
+    @staticmethod
+    def _string_set(raw: Any) -> Set[str]:
+        """Normalize a comma-separated string or list-like value to a set."""
+        if raw is None:
+            return set()
+        if isinstance(raw, (list, tuple, set)):
+            return {str(item).strip() for item in raw if str(item).strip()}
+        return {part.strip() for part in str(raw).split(",") if part.strip()}
 
     # ------------------------------------------------------------------
     # E2EE helpers
@@ -1111,7 +1145,14 @@ class MatrixAdapter(BasePlatformAdapter):
                 _sync_msg = getattr(sync_data, "message", None)
                 if _sync_msg and isinstance(_sync_msg, str):
                     _lower = _sync_msg.lower()
-                    if "m_unknown_token" in _lower or "unknown_token" in _lower:
+                    if (
+                        "m_unknown_token" in _lower
+                        or "unknown_token" in _lower
+                        or "token is not active" in _lower
+                        or "invalid access token" in _lower
+                        or "access token has expired" in _lower
+                        or "soft logout" in _lower
+                    ):
                         logger.error(
                             "Matrix: permanent auth error from sync: %s — stopping",
                             _sync_msg,
@@ -1124,6 +1165,35 @@ class MatrixAdapter(BasePlatformAdapter):
                     if rooms_join:
                         self._joined_rooms.update(rooms_join.keys())
 
+                    timeline_events = 0
+                    encrypted_events = 0
+                    message_events = 0
+                    for room_data in rooms_join.values():
+                        events = (
+                            room_data.get("timeline", {}).get("events", [])
+                            if isinstance(room_data, dict)
+                            else []
+                        )
+                        timeline_events += len(events)
+                        for evt in events:
+                            if not isinstance(evt, dict):
+                                continue
+                            evt_type = evt.get("type")
+                            if evt_type == "m.room.encrypted":
+                                encrypted_events += 1
+                            elif evt_type == "m.room.message":
+                                message_events += 1
+
+                    logger.debug(
+                        "Matrix: sync received joined_rooms=%d timeline_events=%d "
+                        "message_events=%d encrypted_events=%d since=%s",
+                        len(rooms_join),
+                        timeline_events,
+                        message_events,
+                        encrypted_events,
+                        "set" if next_batch else "none",
+                    )
+
                     # Advance the sync token so the next request is
                     # incremental instead of a full initial sync.
                     nb = sync_data.get("next_batch")
@@ -1135,10 +1205,19 @@ class MatrixAdapter(BasePlatformAdapter):
                     # _on_room_message / _on_reaction / _on_invite fire.
                     try:
                         tasks = client.handle_sync(sync_data)
+                        logger.debug(
+                            "Matrix: handle_sync queued %d task(s)",
+                            len(tasks) if tasks else 0,
+                        )
                         if tasks:
                             await asyncio.gather(*tasks)
                     except Exception as exc:
                         logger.warning("Matrix: sync event dispatch error: %s", exc)
+                else:
+                    logger.debug(
+                        "Matrix: sync returned non-dict payload of type %s",
+                        type(sync_data).__name__,
+                    )
 
             except asyncio.CancelledError:
                 return
@@ -1152,6 +1231,12 @@ class MatrixAdapter(BasePlatformAdapter):
                     or "403" in err_str
                     or "unauthorized" in err_str
                     or "forbidden" in err_str
+                    or "m_unknown_token" in err_str
+                    or "unknown_token" in err_str
+                    or "token is not active" in err_str
+                    or "invalid access token" in err_str
+                    or "access token has expired" in err_str
+                    or "soft logout" in err_str
                 ):
                     logger.error(
                         "Matrix: permanent auth error: %s — stopping sync", exc
@@ -1207,6 +1292,14 @@ class MatrixAdapter(BasePlatformAdapter):
             msgtype = content.get("msgtype", "")
         else:
             msgtype = ""
+
+        logger.debug(
+            "Matrix: received event %s in %s from %s (msgtype=%s)",
+            event_id or "?",
+            room_id or "?",
+            sender or "?",
+            msgtype or "?",
+        )
 
         # Determine source content dict for relation/thread extraction.
         if isinstance(content, dict):
@@ -1274,10 +1367,11 @@ class MatrixAdapter(BasePlatformAdapter):
             if self._require_mention and not is_free_room and not in_bot_thread:
                 if not is_mentioned:
                     logger.debug(
-                        "Matrix: ignoring unmentioned event %s in %s "
-                        "(require_mention=true, free_room=%s, bot_thread=%s)",
+                        "Matrix: dropped event %s in %s due to require_mention "
+                        "(is_dm=%s, free_room=%s, in_bot_thread=%s)",
                         event_id or "(unknown)",
-                        room_id or "(unknown)",
+                        room_id,
+                        is_dm,
                         is_free_room,
                         in_bot_thread,
                     )
@@ -1932,56 +2026,59 @@ class MatrixAdapter(BasePlatformAdapter):
 
     async def _is_dm_room(self, room_id: str) -> bool:
         """Check if a room is a DM."""
-        cached = self._dm_rooms.get(room_id)
-        if cached is not None:
-            return cached
-        # Only trust the state store when it confirms the member list is
-        # complete. Freshly joined rooms may have partial membership there.
-        state_store = (
-            getattr(self._client, "state_store", None) if self._client else None
-        )
-        if state_store:
-            try:
-                has_full_member_list = getattr(state_store, "has_full_member_list", None)
-                state_store_complete = False
-                if has_full_member_list:
-                    state_store_complete = bool(await has_full_member_list(room_id))
+        if self._dm_rooms.get(room_id, False):
+            logger.debug("Matrix: DM detection for %s via cache: True", room_id)
+            return True
 
-                if state_store_complete:
+        # Prefer authoritative local membership state when available.
+        state_store = getattr(self._client, "state_store", None) if self._client else None
+        if state_store and hasattr(state_store, "get_members"):
+            try:
+                has_full_member_list = True
+                source = "state_store_legacy"
+                if hasattr(state_store, "has_full_member_list"):
+                    has_full_member_list = await state_store.has_full_member_list(room_id)
+                    source = "state_store_full"
+                if has_full_member_list:
                     members = await state_store.get_members(room_id)
-                    is_dm = len(members) == 2
-                    self._dm_rooms[room_id] = is_dm
+                    member_count = len(members or [])
+                    is_dm = member_count == 2
                     logger.debug(
-                        "Matrix: DM detection for %s resolved via state_store_full -> %s",
+                        "Matrix: DM detection for %s via %s (members=%d): %s",
                         room_id,
-                        "dm" if is_dm else "group",
+                        source,
+                        member_count,
+                        is_dm,
                     )
+                    if is_dm:
+                        self._dm_rooms[room_id] = True
                     return is_dm
             except Exception as exc:
                 logger.debug(
-                    "Matrix: state_store DM detection failed for %s: %s",
+                    "Matrix: DM detection via state_store failed for %s: %s",
                     room_id,
                     exc,
                 )
 
-        # Freshly joined 1:1 rooms are often missing from m.direct on the bot
-        # account. Fall back to the joined-members API so a new DM isn't
-        # misclassified as a group room that requires an explicit mention.
+        # Fresh rooms can have incomplete local membership data right after
+        # join; ask the server directly before deciding the room is not a DM.
         if self._client and hasattr(self._client, "get_joined_members"):
             try:
-                joined_members = await self._client.get_joined_members(RoomID(room_id))
-                if joined_members:
-                    is_dm = len(joined_members) == 2
-                    self._dm_rooms[room_id] = is_dm
-                    logger.debug(
-                        "Matrix: DM detection for %s resolved via joined_members -> %s",
-                        room_id,
-                        "dm" if is_dm else "group",
-                    )
-                    return is_dm
+                members = await self._client.get_joined_members(RoomID(room_id))
+                member_count = len(members or {})
+                is_dm = member_count == 2
+                logger.debug(
+                    "Matrix: DM detection for %s via joined_members (members=%d): %s",
+                    room_id,
+                    member_count,
+                    is_dm,
+                )
+                if is_dm:
+                    self._dm_rooms[room_id] = True
+                return is_dm
             except Exception as exc:
                 logger.debug(
-                    "Matrix: get_joined_members(%s) failed during DM detection: %s",
+                    "Matrix: DM detection via joined_members failed for %s: %s",
                     room_id,
                     exc,
                 )
@@ -2011,12 +2108,8 @@ class MatrixAdapter(BasePlatformAdapter):
             if isinstance(rooms, list):
                 dm_room_ids.update(str(r) for r in rooms)
 
-        # m.direct is reliable as a positive DM signal, but not as a negative
-        # one: fresh 1:1 rooms often appear here late or never. Only cache
-        # rooms that are explicitly marked as DMs.
-        for rid in self._joined_rooms:
-            if rid in dm_room_ids:
-                self._dm_rooms[rid] = True
+        for room_id in dm_room_ids:
+            self._dm_rooms[room_id] = True
 
     # ------------------------------------------------------------------
     # Mention detection helpers

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -142,9 +142,6 @@ def _make_fake_mautrix():
         async def get_member_profiles(self, room_id):
             return {}
 
-        async def has_full_member_list(self, room_id):
-            return False
-
     class MemorySyncStore:
         pass
 
@@ -1298,8 +1295,8 @@ class TestMatrixSyncLoop:
         mock_sync_store.put_next_batch.assert_awaited_once_with("s1234")
 
     @pytest.mark.asyncio
-    async def test_sync_loop_does_not_store_token_when_dispatch_task_fails(self):
-        """Failed dispatch must not advance next_batch or we would skip events."""
+    async def test_sync_loop_dispatch_failure_retries_after_backoff(self):
+        """Failed dispatch must not advance next_batch and should back off."""
         adapter = _make_adapter()
         adapter._closing = False
 
@@ -1325,10 +1322,12 @@ class TestMatrixSyncLoop:
         fake_client.handle_sync = MagicMock(return_value=[_failing_task()])
         adapter._client = fake_client
 
-        await adapter._sync_loop()
+        with patch("gateway.platforms.matrix.asyncio.sleep", AsyncMock()) as mock_sleep:
+            await adapter._sync_loop()
 
         fake_client.handle_sync.assert_called_once()
         mock_sync_store.put_next_batch.assert_not_awaited()
+        mock_sleep.assert_awaited_once_with(5)
 
     @pytest.mark.asyncio
     async def test_connect_initial_sync_does_not_store_token_when_dispatch_fails(self):

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -506,6 +506,45 @@ class TestMatrixDmDetection:
         mock_client.get_joined_members.assert_awaited_once()
         assert self.adapter._dm_rooms["!fresh:ex.org"] is True
 
+    @pytest.mark.asyncio
+    async def test_is_dm_room_caches_group_false_from_full_member_list(self):
+        """A full local member list may authoritatively cache a non-DM room."""
+        state_store = MagicMock()
+        state_store.has_full_member_list = AsyncMock(return_value=True)
+        state_store.get_members = AsyncMock(
+            return_value=["@alice:ex.org", "@bot:ex.org", "@bob:ex.org"]
+        )
+
+        mock_client = MagicMock()
+        mock_client.state_store = state_store
+        mock_client.get_joined_members = AsyncMock()
+        self.adapter._client = mock_client
+
+        assert await self.adapter._is_dm_room("!group:ex.org") is False
+        assert self.adapter._dm_rooms["!group:ex.org"] is False
+        mock_client.get_joined_members.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_is_dm_room_caches_group_false_from_joined_members(self):
+        """Server-side joined_members fallback may also cache a non-DM room."""
+        state_store = MagicMock()
+        state_store.has_full_member_list = AsyncMock(return_value=False)
+        state_store.get_members = AsyncMock(return_value=["@bot:ex.org"])
+
+        mock_client = MagicMock()
+        mock_client.state_store = state_store
+        mock_client.get_joined_members = AsyncMock(
+            return_value={
+                "@alice:ex.org": MagicMock(),
+                "@bot:ex.org": MagicMock(),
+                "@bob:ex.org": MagicMock(),
+            }
+        )
+        self.adapter._client = mock_client
+
+        assert await self.adapter._is_dm_room("!group-fresh:ex.org") is False
+        assert self.adapter._dm_rooms["!group-fresh:ex.org"] is False
+
 
 # ---------------------------------------------------------------------------
 # Reply fallback stripping
@@ -1209,13 +1248,14 @@ class TestMatrixDeviceIdConfig:
 
 class TestMatrixSyncLoop:
     @pytest.mark.asyncio
-    async def test_sync_loop_dispatches_events_and_stores_token(self):
-        """_sync_loop should call handle_sync() and persist next_batch."""
+    async def test_sync_loop_dispatches_events_before_storing_token(self):
+        """_sync_loop should only persist next_batch after dispatch succeeds."""
         adapter = _make_adapter()
         adapter._encryption = True
         adapter._closing = False
 
         call_count = 0
+        dispatch_steps = []
 
         async def _sync_once(**kwargs):
             nonlocal call_count
@@ -1228,13 +1268,27 @@ class TestMatrixSyncLoop:
 
         mock_sync_store = MagicMock()
         mock_sync_store.get_next_batch = AsyncMock(return_value=None)
-        mock_sync_store.put_next_batch = AsyncMock()
+
+        async def _put_next_batch(token):
+            dispatch_steps.append(("put_next_batch", token))
+            assert dispatch_steps == [
+                ("handle_sync", None),
+                ("task", None),
+                ("put_next_batch", "s1234"),
+            ]
+
+        mock_sync_store.put_next_batch = AsyncMock(side_effect=_put_next_batch)
+
+        async def _dispatch_task():
+            dispatch_steps.append(("task", None))
 
         fake_client = MagicMock()
         fake_client.sync = AsyncMock(side_effect=_sync_once)
         fake_client.crypto = mock_crypto
         fake_client.sync_store = mock_sync_store
-        fake_client.handle_sync = MagicMock(return_value=[])
+        fake_client.handle_sync = MagicMock(
+            side_effect=lambda payload: dispatch_steps.append(("handle_sync", None)) or [_dispatch_task()]
+        )
         adapter._client = fake_client
 
         await adapter._sync_loop()
@@ -1242,6 +1296,103 @@ class TestMatrixSyncLoop:
         fake_client.sync.assert_awaited_once()
         fake_client.handle_sync.assert_called_once()
         mock_sync_store.put_next_batch.assert_awaited_once_with("s1234")
+
+    @pytest.mark.asyncio
+    async def test_sync_loop_does_not_store_token_when_dispatch_task_fails(self):
+        """Failed dispatch must not advance next_batch or we would skip events."""
+        adapter = _make_adapter()
+        adapter._closing = False
+
+        call_count = 0
+
+        async def _sync_once(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 1:
+                adapter._closing = True
+            return {"rooms": {"join": {"!room:example.org": {}}}, "next_batch": "s1234"}
+
+        async def _failing_task():
+            raise RuntimeError("boom")
+
+        mock_sync_store = MagicMock()
+        mock_sync_store.get_next_batch = AsyncMock(return_value=None)
+        mock_sync_store.put_next_batch = AsyncMock()
+
+        fake_client = MagicMock()
+        fake_client.sync = AsyncMock(side_effect=_sync_once)
+        fake_client.sync_store = mock_sync_store
+        fake_client.handle_sync = MagicMock(return_value=[_failing_task()])
+        adapter._client = fake_client
+
+        await adapter._sync_loop()
+
+        fake_client.handle_sync.assert_called_once()
+        mock_sync_store.put_next_batch.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_connect_initial_sync_does_not_store_token_when_dispatch_fails(self):
+        """connect() should not persist the initial sync token before dispatch succeeds."""
+        from gateway.platforms.matrix import MatrixAdapter
+
+        config = PlatformConfig(
+            enabled=True,
+            token="syt_test_access_token",
+            extra={
+                "homeserver": "https://matrix.example.org",
+                "user_id": "@bot:example.org",
+                "encryption": False,
+            },
+        )
+        adapter = MatrixAdapter(config)
+
+        class FakeWhoamiResponse:
+            def __init__(self, user_id, device_id):
+                self.user_id = user_id
+                self.device_id = device_id
+
+        fake_mautrix_mods = _make_fake_mautrix()
+
+        async def _failing_task():
+            raise RuntimeError("boom")
+
+        mock_sync_store = MagicMock()
+        mock_sync_store.put_next_batch = AsyncMock()
+
+        mock_client = MagicMock()
+        mock_client.mxid = "@bot:example.org"
+        mock_client.device_id = None
+        mock_client.state_store = MagicMock()
+        mock_client.sync_store = mock_sync_store
+        mock_client.crypto = None
+        mock_client.whoami = AsyncMock(
+            return_value=FakeWhoamiResponse("@bot:example.org", "DEV123")
+        )
+        mock_client.sync = AsyncMock(
+            return_value={
+                "rooms": {"join": {"!room:server": {}}},
+                "next_batch": "s1234",
+            }
+        )
+        mock_client.add_event_handler = MagicMock()
+        mock_client.add_dispatcher = MagicMock()
+        mock_client.handle_sync = MagicMock(return_value=[_failing_task()])
+        mock_client.api = MagicMock()
+        mock_client.api.token = "syt_test_access_token"
+        mock_client.api.session = MagicMock()
+        mock_client.api.session.close = AsyncMock()
+
+        fake_mautrix_mods["mautrix.client"].Client = MagicMock(return_value=mock_client)
+
+        with patch.dict("sys.modules", fake_mautrix_mods):
+            with patch.object(adapter, "_refresh_dm_cache", AsyncMock()):
+                with patch.object(adapter, "_sync_loop", AsyncMock(return_value=None)):
+                    assert await adapter.connect() is True
+
+        mock_client.handle_sync.assert_called_once()
+        mock_sync_store.put_next_batch.assert_not_awaited()
+
+        await adapter.disconnect()
 
 
 class TestMatrixUploadAndSend:

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -139,6 +139,9 @@ def _make_fake_mautrix():
         async def get_member_profiles(self, room_id):
             return {}
 
+        async def has_full_member_list(self, room_id):
+            return False
+
     class MemorySyncStore:
         pass
 
@@ -445,7 +448,7 @@ class TestMatrixDmDetection:
 
     @pytest.mark.asyncio
     async def test_refresh_dm_cache_with_m_direct(self):
-        """_refresh_dm_cache should populate _dm_rooms from m.direct data."""
+        """_refresh_dm_cache should only positively mark rooms in m.direct."""
         self.adapter._joined_rooms = {"!room_a:ex.org", "!room_b:ex.org", "!room_c:ex.org"}
 
         mock_client = MagicMock()
@@ -461,7 +464,65 @@ class TestMatrixDmDetection:
 
         assert self.adapter._dm_rooms["!room_a:ex.org"] is True
         assert self.adapter._dm_rooms["!room_b:ex.org"] is True
-        assert self.adapter._dm_rooms["!room_c:ex.org"] is False
+        assert "!room_c:ex.org" not in self.adapter._dm_rooms
+
+    @pytest.mark.asyncio
+    async def test_is_dm_room_falls_back_to_joined_members(self):
+        """Fresh rooms not in m.direct should still be recognized as DMs."""
+        mock_state_store = MagicMock()
+        mock_state_store.has_full_member_list = AsyncMock(return_value=False)
+        mock_state_store.get_members = AsyncMock(return_value=[])
+
+        mock_client = MagicMock()
+        mock_client.state_store = mock_state_store
+        mock_client.get_joined_members = AsyncMock(
+            return_value={
+                "@bot:ex.org": MagicMock(),
+                "@alice:ex.org": MagicMock(),
+            }
+        )
+        self.adapter._client = mock_client
+
+        assert await self.adapter._is_dm_room("!fresh_dm:ex.org") is True
+        assert self.adapter._dm_rooms["!fresh_dm:ex.org"] is True
+
+    @pytest.mark.asyncio
+    async def test_is_dm_room_ignores_partial_state_store_and_falls_back(self):
+        """An incomplete state store must not negative-cache a fresh DM."""
+        mock_state_store = MagicMock()
+        mock_state_store.has_full_member_list = AsyncMock(return_value=False)
+        mock_state_store.get_members = AsyncMock(return_value=["@bot:ex.org"])
+
+        mock_client = MagicMock()
+        mock_client.state_store = mock_state_store
+        mock_client.get_joined_members = AsyncMock(
+            return_value={
+                "@bot:ex.org": MagicMock(),
+                "@alice:ex.org": MagicMock(),
+            }
+        )
+        self.adapter._client = mock_client
+
+        assert await self.adapter._is_dm_room("!partial_dm:ex.org") is True
+        assert self.adapter._dm_rooms["!partial_dm:ex.org"] is True
+
+    @pytest.mark.asyncio
+    async def test_is_dm_room_full_member_list_can_cache_group_false(self):
+        """A complete state-store member list may authoritatively cache group rooms."""
+        mock_state_store = MagicMock()
+        mock_state_store.has_full_member_list = AsyncMock(return_value=True)
+        mock_state_store.get_members = AsyncMock(
+            return_value=["@bot:ex.org", "@alice:ex.org", "@bob:ex.org"]
+        )
+
+        mock_client = MagicMock()
+        mock_client.state_store = mock_state_store
+        mock_client.get_joined_members = AsyncMock()
+        self.adapter._client = mock_client
+
+        assert await self.adapter._is_dm_room("!group:ex.org") is False
+        assert self.adapter._dm_rooms["!group:ex.org"] is False
+        mock_client.get_joined_members.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------
@@ -1237,9 +1298,10 @@ class TestMatrixUploadAndSend:
         mock_client.send_message_event = AsyncMock(return_value="$event")
         adapter._client = mock_client
 
-        result = await adapter._upload_and_send(
-            "!room:example.org", b"secret", "secret.txt", "text/plain", "m.file",
-        )
+        with patch.dict("sys.modules", _make_fake_mautrix()):
+            result = await adapter._upload_and_send(
+                "!room:example.org", b"secret", "secret.txt", "text/plain", "m.file",
+            )
 
         assert result.success is True
         # Should have uploaded ciphertext, not plaintext

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -136,6 +136,9 @@ def _make_fake_mautrix():
         async def get_members(self, room_id):
             return []
 
+        async def has_full_member_list(self, room_id):
+            return False
+
         async def get_member_profiles(self, room_id):
             return {}
 
@@ -448,7 +451,7 @@ class TestMatrixDmDetection:
 
     @pytest.mark.asyncio
     async def test_refresh_dm_cache_with_m_direct(self):
-        """_refresh_dm_cache should only positively mark rooms in m.direct."""
+        """_refresh_dm_cache should add positive DM cache entries only."""
         self.adapter._joined_rooms = {"!room_a:ex.org", "!room_b:ex.org", "!room_c:ex.org"}
 
         mock_client = MagicMock()
@@ -467,62 +470,41 @@ class TestMatrixDmDetection:
         assert "!room_c:ex.org" not in self.adapter._dm_rooms
 
     @pytest.mark.asyncio
-    async def test_is_dm_room_falls_back_to_joined_members(self):
-        """Fresh rooms not in m.direct should still be recognized as DMs."""
-        mock_state_store = MagicMock()
-        mock_state_store.has_full_member_list = AsyncMock(return_value=False)
-        mock_state_store.get_members = AsyncMock(return_value=[])
+    async def test_is_dm_room_uses_full_member_list_when_authoritative(self):
+        """Authoritative state-store membership should be trusted."""
+        state_store = MagicMock()
+        state_store.has_full_member_list = AsyncMock(return_value=True)
+        state_store.get_members = AsyncMock(return_value=["@alice:ex.org", "@bot:ex.org"])
 
         mock_client = MagicMock()
-        mock_client.state_store = mock_state_store
-        mock_client.get_joined_members = AsyncMock(
-            return_value={
-                "@bot:ex.org": MagicMock(),
-                "@alice:ex.org": MagicMock(),
-            }
-        )
-        self.adapter._client = mock_client
-
-        assert await self.adapter._is_dm_room("!fresh_dm:ex.org") is True
-        assert self.adapter._dm_rooms["!fresh_dm:ex.org"] is True
-
-    @pytest.mark.asyncio
-    async def test_is_dm_room_ignores_partial_state_store_and_falls_back(self):
-        """An incomplete state store must not negative-cache a fresh DM."""
-        mock_state_store = MagicMock()
-        mock_state_store.has_full_member_list = AsyncMock(return_value=False)
-        mock_state_store.get_members = AsyncMock(return_value=["@bot:ex.org"])
-
-        mock_client = MagicMock()
-        mock_client.state_store = mock_state_store
-        mock_client.get_joined_members = AsyncMock(
-            return_value={
-                "@bot:ex.org": MagicMock(),
-                "@alice:ex.org": MagicMock(),
-            }
-        )
-        self.adapter._client = mock_client
-
-        assert await self.adapter._is_dm_room("!partial_dm:ex.org") is True
-        assert self.adapter._dm_rooms["!partial_dm:ex.org"] is True
-
-    @pytest.mark.asyncio
-    async def test_is_dm_room_full_member_list_can_cache_group_false(self):
-        """A complete state-store member list may authoritatively cache group rooms."""
-        mock_state_store = MagicMock()
-        mock_state_store.has_full_member_list = AsyncMock(return_value=True)
-        mock_state_store.get_members = AsyncMock(
-            return_value=["@bot:ex.org", "@alice:ex.org", "@bob:ex.org"]
-        )
-
-        mock_client = MagicMock()
-        mock_client.state_store = mock_state_store
+        mock_client.state_store = state_store
         mock_client.get_joined_members = AsyncMock()
         self.adapter._client = mock_client
 
-        assert await self.adapter._is_dm_room("!group:ex.org") is False
-        assert self.adapter._dm_rooms["!group:ex.org"] is False
+        assert await self.adapter._is_dm_room("!room_a:ex.org") is True
         mock_client.get_joined_members.assert_not_awaited()
+        assert self.adapter._dm_rooms["!room_a:ex.org"] is True
+
+    @pytest.mark.asyncio
+    async def test_is_dm_room_falls_back_to_joined_members_for_fresh_rooms(self):
+        """Fresh rooms should use joined_members when local state is incomplete."""
+        state_store = MagicMock()
+        state_store.has_full_member_list = AsyncMock(return_value=False)
+        state_store.get_members = AsyncMock(return_value=["@bot:ex.org"])
+
+        mock_client = MagicMock()
+        mock_client.state_store = state_store
+        mock_client.get_joined_members = AsyncMock(
+            return_value={
+                "@alice:ex.org": MagicMock(),
+                "@bot:ex.org": MagicMock(),
+            }
+        )
+        self.adapter._client = mock_client
+
+        assert await self.adapter._is_dm_room("!fresh:ex.org") is True
+        mock_client.get_joined_members.assert_awaited_once()
+        assert self.adapter._dm_rooms["!fresh:ex.org"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_matrix_mention.py
+++ b/tests/gateway/test_matrix_mention.py
@@ -83,6 +83,29 @@ def _make_event(
     )
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("timestamp_scale", ("seconds", "milliseconds"))
+async def test_recent_timestamp_not_dropped_by_startup_grace(timestamp_scale):
+    adapter = _make_adapter(extra={"require_mention": False})
+    adapter._background_read_receipt = MagicMock()
+    _set_dm(adapter)
+
+    now = time.time()
+    raw_ts = int(now) if timestamp_scale == "seconds" else int(now * 1000)
+    adapter._startup_ts = now - 1
+    event = SimpleNamespace(
+        sender="@alice:example.org",
+        event_id=f"$evt-{timestamp_scale}",
+        room_id="!room1:example.org",
+        timestamp=raw_ts,
+        content={"body": "hello", "msgtype": "m.text"},
+    )
+
+    await adapter._on_room_message(event)
+
+    adapter.handle_message.assert_awaited_once()
+
+
 # ---------------------------------------------------------------------------
 # Mention detection helpers
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_matrix_mention.py
+++ b/tests/gateway/test_matrix_mention.py
@@ -278,6 +278,61 @@ async def test_require_mention_dm_always_responds(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_fresh_two_member_room_without_m_direct_responds_like_dm(monkeypatch):
+    """Freshly joined 1:1 rooms should not require an explicit mention."""
+    monkeypatch.delenv("MATRIX_REQUIRE_MENTION", raising=False)
+    monkeypatch.delenv("MATRIX_FREE_RESPONSE_ROOMS", raising=False)
+    monkeypatch.setenv("MATRIX_AUTO_THREAD", "false")
+
+    adapter = _make_adapter()
+    adapter._client = MagicMock()
+    adapter._client.state_store = MagicMock()
+    adapter._client.state_store.has_full_member_list = AsyncMock(return_value=False)
+    adapter._client.state_store.get_members = AsyncMock(return_value=[])
+    adapter._client.get_joined_members = AsyncMock(
+        return_value={
+            "@hermes:example.org": MagicMock(),
+            "@alice:example.org": MagicMock(),
+        }
+    )
+    event = _make_event("hello without mention")
+
+    await adapter._on_room_message(event)
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_non_m_direct_room_does_not_block_joined_members_dm_fallback(monkeypatch):
+    """A room absent from m.direct should still behave like a DM when membership says so."""
+    monkeypatch.delenv("MATRIX_REQUIRE_MENTION", raising=False)
+    monkeypatch.delenv("MATRIX_FREE_RESPONSE_ROOMS", raising=False)
+    monkeypatch.setenv("MATRIX_AUTO_THREAD", "false")
+
+    adapter = _make_adapter()
+    adapter._joined_rooms = {"!room1:example.org"}
+    adapter._client = MagicMock()
+    adapter._client.get_account_data = AsyncMock(
+        return_value={"@someone:example.org": ["!other:example.org"]}
+    )
+    adapter._client.state_store = MagicMock()
+    adapter._client.state_store.has_full_member_list = AsyncMock(return_value=False)
+    adapter._client.state_store.get_members = AsyncMock(return_value=["@hermes:example.org"])
+    adapter._client.get_joined_members = AsyncMock(
+        return_value={
+            "@hermes:example.org": MagicMock(),
+            "@alice:example.org": MagicMock(),
+        }
+    )
+
+    await adapter._refresh_dm_cache()
+    assert "!room1:example.org" not in adapter._dm_rooms
+
+    event = _make_event("hello without mention")
+    await adapter._on_room_message(event)
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_dm_strips_full_mxid(monkeypatch):
     """DMs strip the full MXID from body when require_mention is on (default)."""
     monkeypatch.delenv("MATRIX_REQUIRE_MENTION", raising=False)

--- a/tests/gateway/test_matrix_mention.py
+++ b/tests/gateway/test_matrix_mention.py
@@ -16,17 +16,21 @@ from gateway.config import PlatformConfig
 # needing real mautrix APIs mock them individually.
 
 
-def _make_adapter(tmp_path=None):
+def _make_adapter(tmp_path=None, extra=None):
     """Create a MatrixAdapter with mocked config."""
     from gateway.platforms.matrix import MatrixAdapter
+
+    merged_extra = {
+        "homeserver": "https://matrix.example.org",
+        "user_id": "@hermes:example.org",
+    }
+    if extra:
+        merged_extra.update(extra)
 
     config = PlatformConfig(
         enabled=True,
         token="syt_test_token",
-        extra={
-            "homeserver": "https://matrix.example.org",
-            "user_id": "@hermes:example.org",
-        },
+        extra=merged_extra,
     )
     adapter = MatrixAdapter(config)
     adapter._text_batch_delay_seconds = 0  # disable batching for tests
@@ -444,6 +448,20 @@ async def test_require_mention_disabled_skips_stripping(monkeypatch):
     adapter.handle_message.assert_awaited_once()
     msg = adapter.handle_message.await_args.args[0]
     assert msg.text == "@hermes:example.org help me"
+
+
+@pytest.mark.asyncio
+async def test_require_mention_disabled_via_config_extra(monkeypatch):
+    """config.extra should disable mention gating even without env vars."""
+    monkeypatch.delenv("MATRIX_REQUIRE_MENTION", raising=False)
+    monkeypatch.delenv("MATRIX_FREE_RESPONSE_ROOMS", raising=False)
+    monkeypatch.setenv("MATRIX_AUTO_THREAD", "false")
+
+    adapter = _make_adapter(extra={"require_mention": False})
+    event = _make_event("hello without mention")
+
+    await adapter._on_room_message(event)
+    adapter.handle_message.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_matrix_voice.py
+++ b/tests/gateway/test_matrix_voice.py
@@ -88,6 +88,7 @@ def _make_audio_event(
 def _make_state_store(member_count: int = 2):
     """Create a mock state store with get_members/get_member support."""
     store = MagicMock()
+    store.has_full_member_list = AsyncMock(return_value=True)
     # get_members returns a list of member user IDs
     members = [MagicMock() for _ in range(member_count)]
     store.get_members = AsyncMock(return_value=members)


### PR DESCRIPTION
## Summary

Fixes #12614 by covering the three Matrix issues that together made fresh setups look "connected but not receiving messages", plus an additional sync-dispatch retry hardening change to avoid tight `/sync` retry loops when event dispatch fails:

- fresh 1:1 rooms could be misclassified as normal rooms
- sync/auth handling could obscure the real failure mode and advance sync state too aggressively
- startup-grace filtering assumed Matrix event timestamps were always in milliseconds

This PR started as the fresh-DM negative-cache fix, then expanded as the issue was reproduced and narrowed down against a real `matrix.org` account.

Huge thanks to @Schnurzel700 for the original fresh-environment report, the follow-up clarification that the bug still reproduced with `MATRIX_REQUIRE_MENTION=false`, the timestamp-unit diagnosis in `_on_room_message`, and the real-world verification on `matrix.org` after the fix.

## Problem

On a completely fresh Matrix setup, Hermes could:

- join rooms successfully
- stay apparently connected
- log no usable inbound message handling
- fail to respond to DMs or room messages

There turned out to be more than one contributing cause:

- fresh DM detection could decide "not a DM" too early from incomplete local state or missing `m.direct` data
- Matrix mention/thread settings were not consistently honoring `config.extra`
- permanent auth failures such as `M_UNKNOWN_TOKEN` / `Token is not active` could be treated as retryable sync errors
- the startup grace check in `_on_room_message` assumed `mautrix` timestamps were milliseconds, while newer `mautrix` builds can expose seconds
- sync tokens could be persisted before queued event handlers had actually completed, which risks skipping events if dispatch fails

## What changed

### Fresh-room / DM detection

- treat `m.direct` as a positive DM signal only
- stop writing negative DM cache entries for rooms merely absent from `m.direct`
- only trust `state_store.get_members()` when `has_full_member_list(room_id)` is true
- fall back to `get_joined_members()` for fresh rooms with incomplete local membership state
- cache authoritative `False` results only when they come from a complete member list or `get_joined_members()`, so normal rooms do not re-run membership detection on every message
- add debug logs for DM detection source (`cache`, `state_store_full`, `joined_members`)

### Config gating / diagnostics

- honor Matrix mention/thread settings from `config.extra` before env vars:
  - `require_mention`
  - `free_response_rooms`
  - `auto_thread`
  - `dm_mention_threads`
- add debug logs for:
  - sync payload summaries (`joined_rooms`, `timeline_events`, `message_events`, `encrypted_events`)
  - queued sync-dispatch task counts
  - received Matrix events
  - require-mention drops
- treat `M_UNKNOWN_TOKEN`, `Token is not active`, expired/invalid access-token messages, and soft-logout failures as permanent auth errors that stop sync instead of retrying forever

### Timestamp + sync safety

- normalize incoming Matrix event timestamps so both second-based and millisecond-based `mautrix` payloads pass the startup-grace check correctly
- persist `next_batch` only after initial-sync and incremental-sync event dispatch succeeds, so a dispatch failure cannot silently skip events on the next sync
- back off before retrying the same sync batch when dispatch fails, so Hermes does not hammer `/sync` or replay the same batch in a tight loop

### Tests

- add regression coverage for second-based and millisecond-based Matrix timestamps in startup-grace filtering
- add coverage for authoritative DM `False` caching from full member lists and `get_joined_members()`
- add coverage that sync tokens are written only after dispatch succeeds, and not written when dispatch fails
- add coverage that failed sync dispatch backs off before retrying the same batch
- keep the Matrix voice test aligned with the stricter DM detection path

## Real Matrix Verification

During reproduction against a real `matrix.org` account with stable credentials:

- initial sync completed successfully
- inbound DM events reached `/sync`
- events entered `_on_room_message`
- Hermes logged inbound messages and sent Matrix replies

In addition, @Schnurzel700 validated the timestamp fix against real `matrix.org` encrypted DMs and group rooms.

## Tests Run

```bash
.\\venv\\Scripts\\python.exe -m pytest tests/gateway/test_matrix.py tests/gateway/test_matrix_mention.py tests/gateway/test_matrix_voice.py -q
```
