### PR TITLE
fix glm-5.1 model normalization

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -777,10 +777,15 @@ def normalize_model_name(model: str, preserve_dots: bool = False) -> str:
     - Converts dots to hyphens in version numbers (OpenRouter uses dots,
       Anthropic uses hyphens: claude-opus-4.6 → claude-opus-4-6), unless
       preserve_dots is True (e.g. for Alibaba/DashScope: qwen3.5-plus).
+    - Preserves dotted GLM model IDs and normalizes them to lowercase
+      (e.g. GLM-5.1 → glm-5.1) for BigModel-compatible Anthropic endpoints.
     """
     lower = model.lower()
     if lower.startswith("anthropic/"):
         model = model[len("anthropic/"):]
+        lower = model.lower()
+    if lower.startswith("glm-"):
+        return lower
     if not preserve_dots:
         # OpenRouter uses dots for version separators (claude-opus-4.6),
         # Anthropic uses hyphens (claude-opus-4-6). Convert dots to hyphens.

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -486,6 +486,12 @@ class TestNormalizeModelName:
         assert normalize_model_name("anthropic/qwen3.5-plus", preserve_dots=True) == "qwen3.5-plus"
         assert normalize_model_name("qwen3.5-flash", preserve_dots=True) == "qwen3.5-flash"
 
+    def test_preserve_and_lowercase_glm_model_ids(self):
+        """BigModel GLM model IDs keep dots and use lowercase codes."""
+        assert normalize_model_name("GLM-5.1") == "glm-5.1"
+        assert normalize_model_name("anthropic/GLM-5.1") == "glm-5.1"
+        assert normalize_model_name("GLM-5-Turbo") == "glm-5-turbo"
+
 
 # ---------------------------------------------------------------------------
 # Tool conversion


### PR DESCRIPTION
## Summary
- preserve dotted GLM model ids when normalizing Anthropc-compatible model names
- normalize GLM ids to lowercase so BigModel Anthropic-compatible requests use `glm-5.1`
- add regression coverage for GLM model normalization

## Validation
- `source venv/bin/activate && pytest tests/agent/test_anthropic_adapter.py -q`
- `source venv/bin/activate && pytest tests/run_agent/test_run_agent.py -q -k bigmodel_anthropic_endpoint_preserves_dots`
