### PR TITLE
fix: include api.moonshot.cn in public API temperature override (#12745)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -155,7 +155,7 @@ def _fixed_temperature_for_model(
 
     # Public Moonshot API has a stricter contract for some models than the
     # Coding Plan endpoint — check it first so it wins on conflict.
-    if base_url and "api.moonshot.ai" in base_url.lower():
+    if base_url and ("api.moonshot.ai" in base_url.lower() or "api.moonshot.cn" in base_url.lower()):
         public = _KIMI_PUBLIC_API_OVERRIDES.get(bare)
         if public is not None:
             logger.debug(

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -845,6 +845,8 @@ class TestKimiForCodingTemperature:
             "https://api.moonshot.ai/v1",
             "https://api.moonshot.ai/v1/",
             "https://API.MOONSHOT.AI/v1",
+            "https://api.moonshot.cn/v1",
+            "https://api.moonshot.cn/v1/",
         ],
     )
     def test_kimi_k2_5_public_api_forces_temperature_1(self, base_url):


### PR DESCRIPTION
## Problem

`kimi-k2.5` on `api.moonshot.cn/v1` fails with HTTP 400: `invalid temperature: only 1 is allowed for this model`.

The existing public API override only matches `api.moonshot.ai`, but Moonshot also serves the same API at `api.moonshot.cn`. Users in China typically use the `.cn` domain.

Fixes #12745

## Changes

- `agent/auxiliary_client.py`: Added `api.moonshot.cn` to the public API domain check in `_fixed_temperature_for_model()`
- `tests/agent/test_auxiliary_client.py`: Added `api.moonshot.cn` test cases to the parametrized test

## Testing

All 5 parametrized cases pass:
```
5 passed in 3.51s
```