### PR TITLE
fix(agent): drop tool_calls with empty function.name to prevent orphan tool_result 400

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3836,6 +3836,40 @@ class AIAgent:
             filtered.append(msg)
         messages = filtered
 
+        # Pass 0: strip tool_calls whose function.name is empty/missing.
+        # Some providers (and partially-streamed responses) emit a tool_call
+        # with id="call_xxx" but function.name="".  Downstream adapters
+        # (notably _chat_messages_to_responses_input) silently drop such
+        # function_call items while still emitting the matching
+        # function_call_output, producing the gateway's
+        #   "No tool call found for function call output with call_id ..."
+        # 400 error.  Drop the malformed call here so the orphan-result
+        # logic below correctly removes its (now unpaired) tool result.
+        for msg in messages:
+            if msg.get("role") != "assistant":
+                continue
+            tcs = msg.get("tool_calls") or []
+            if not tcs:
+                continue
+            cleaned = []
+            for tc in tcs:
+                if isinstance(tc, dict):
+                    fn = tc.get("function") or {}
+                    name = fn.get("name")
+                else:
+                    fn = getattr(tc, "function", None)
+                    name = getattr(fn, "name", None) if fn else None
+                if not isinstance(name, str) or not name.strip():
+                    logger.warning(
+                        "Pre-call sanitizer: dropping tool_call with empty "
+                        "function.name (id=%s)",
+                        AIAgent._get_tool_call_id_static(tc),
+                    )
+                    continue
+                cleaned.append(tc)
+            if len(cleaned) != len(tcs):
+                msg["tool_calls"] = cleaned
+
         surviving_call_ids: set = set()
         for msg in messages:
             if msg.get("role") == "assistant":

--- a/scripts/repair_orphan_tool_results.py
+++ b/scripts/repair_orphan_tool_results.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Repair orphan tool_result / malformed tool_call entries in a Hermes session file.
+
+A Hermes session is a JSON-Lines file (one message dict per line) stored under
+``~/.hermes/sessions/``.  Two kinds of corruption can leave the session in a
+state that the gateway's Responses-API adapter refuses (HTTP 400
+``No tool call found for function call output with call_id ...``):
+
+1.  **Malformed tool_call** — an ``assistant`` message carries a ``tool_calls``
+    entry whose ``function.name`` is empty/missing.  Some providers emit this
+    when a streamed response is truncated.
+2.  **Orphan tool_result** — a ``tool`` message whose ``tool_call_id`` does
+    not match any surviving ``assistant`` tool_call id.  This typically
+    appears *after* fix (1) strips the malformed call.
+
+Both chat-completions format
+(``role="assistant"`` + ``tool_calls`` / ``role="tool"`` + ``tool_call_id``)
+and Responses-API style (``type="function_call"`` + ``call_id`` /
+``type="function_call_output"`` + ``call_id``) are handled.
+
+Usage::
+
+    python scripts/repair_orphan_tool_results.py <session.jsonl>           # dry-run
+    python scripts/repair_orphan_tool_results.py <session.jsonl> --apply   # rewrite (with .bak)
+
+Dry-run is the default — nothing is written unless ``--apply`` is passed.
+When applying, the original file is copied to ``<path>.bak.<timestamp>`` first.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+
+def _extract_tool_call_name_and_id(tc: Any) -> Tuple[str, str]:
+    """Return (name, id) for a chat-style tool_call dict."""
+    if not isinstance(tc, dict):
+        return "", ""
+    fn = tc.get("function") or {}
+    name = fn.get("name") if isinstance(fn, dict) else None
+    cid = tc.get("id") or ""
+    return (name or "").strip(), cid or ""
+
+
+def _strip_malformed_tool_calls(msg: Dict[str, Any]) -> int:
+    """Mutate ``msg`` in place.  Returns number of removed tool_calls."""
+    tcs = msg.get("tool_calls")
+    if not isinstance(tcs, list) or not tcs:
+        return 0
+    kept = []
+    for tc in tcs:
+        name, _ = _extract_tool_call_name_and_id(tc)
+        if name:
+            kept.append(tc)
+    removed = len(tcs) - len(kept)
+    if removed:
+        if kept:
+            msg["tool_calls"] = kept
+        else:
+            # Assistant message had only malformed calls: keep the message
+            # itself only if it has content; otherwise drop tool_calls key
+            # (caller decides whether to keep the whole message).
+            msg.pop("tool_calls", None)
+    return removed
+
+
+def analyze(messages: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Walk messages and collect repair decisions.
+
+    Returns a dict with:
+      - ``cleaned``     : new list of messages to keep/rewrite
+      - ``malformed``   : list of (line_idx, call_id) for empty-name tool_calls
+      - ``orphans``     : list of (line_idx, call_id) for orphan tool_results
+      - ``dropped_msgs``: list of (line_idx, reason) for whole messages removed
+    """
+    malformed: List[Tuple[int, str]] = []
+    orphans: List[Tuple[int, str]] = []
+    dropped_msgs: List[Tuple[int, str]] = []
+
+    # --- Pass 1: strip malformed tool_calls / function_call items ---
+    pass1: List[Tuple[int, Dict[str, Any]]] = []  # (original_idx, msg)
+    for idx, msg in enumerate(messages):
+        if not isinstance(msg, dict):
+            dropped_msgs.append((idx, "non-dict line"))
+            continue
+
+        # Responses-API style: type=function_call with empty name
+        if msg.get("type") == "function_call":
+            name = (msg.get("name") or "").strip()
+            if not name:
+                cid = msg.get("call_id") or msg.get("id") or ""
+                malformed.append((idx, cid))
+                dropped_msgs.append((idx, f"function_call empty name (call_id={cid})"))
+                continue
+
+        # Chat style: assistant with tool_calls list
+        if msg.get("role") == "assistant" and isinstance(msg.get("tool_calls"), list):
+            original_tcs = list(msg["tool_calls"])
+            for tc in original_tcs:
+                name, cid = _extract_tool_call_name_and_id(tc)
+                if not name:
+                    malformed.append((idx, cid))
+            # Mutate a copy so we don't scribble the input list
+            msg = dict(msg)
+            msg["tool_calls"] = list(original_tcs)
+            removed = _strip_malformed_tool_calls(msg)
+            # If the assistant had *only* malformed calls and no content,
+            # the message becomes useless — drop it.
+            if removed and not msg.get("tool_calls"):
+                has_content = bool(
+                    (msg.get("content") or "").strip()
+                    if isinstance(msg.get("content"), str)
+                    else msg.get("content")
+                )
+                if not has_content:
+                    dropped_msgs.append(
+                        (idx, "assistant msg left empty after stripping malformed tool_calls")
+                    )
+                    continue
+
+        pass1.append((idx, msg))
+
+    # --- Pass 2: collect surviving call ids (both formats) ---
+    surviving_call_ids = set()
+    for _, msg in pass1:
+        if msg.get("role") == "assistant":
+            for tc in msg.get("tool_calls") or []:
+                _, cid = _extract_tool_call_name_and_id(tc)
+                if cid:
+                    surviving_call_ids.add(cid)
+        if msg.get("type") == "function_call":
+            cid = msg.get("call_id") or msg.get("id")
+            if cid:
+                surviving_call_ids.add(cid)
+
+    # --- Pass 3: drop orphan tool_results ---
+    cleaned: List[Dict[str, Any]] = []
+    for idx, msg in pass1:
+        if msg.get("role") == "tool":
+            cid = msg.get("tool_call_id") or ""
+            if cid and cid not in surviving_call_ids:
+                orphans.append((idx, cid))
+                dropped_msgs.append((idx, f"orphan tool_result (call_id={cid})"))
+                continue
+        if msg.get("type") == "function_call_output":
+            cid = msg.get("call_id") or ""
+            if cid and cid not in surviving_call_ids:
+                orphans.append((idx, cid))
+                dropped_msgs.append((idx, f"orphan function_call_output (call_id={cid})"))
+                continue
+        cleaned.append(msg)
+
+    return {
+        "cleaned": cleaned,
+        "malformed": malformed,
+        "orphans": orphans,
+        "dropped_msgs": dropped_msgs,
+    }
+
+
+def load_session(path: Path) -> List[Dict[str, Any]]:
+    msgs: List[Dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as fh:
+        for lineno, line in enumerate(fh, start=1):
+            line = line.rstrip("\n")
+            if not line.strip():
+                continue
+            try:
+                msgs.append(json.loads(line))
+            except json.JSONDecodeError as e:
+                print(f"  warning: line {lineno} is not valid JSON ({e}); kept as raw string",
+                      file=sys.stderr)
+                msgs.append({"__raw__": line})
+    return msgs
+
+
+def write_session(path: Path, messages: List[Dict[str, Any]]) -> None:
+    with path.open("w", encoding="utf-8") as fh:
+        for msg in messages:
+            if "__raw__" in msg:
+                fh.write(msg["__raw__"] + "\n")
+            else:
+                fh.write(json.dumps(msg, ensure_ascii=False) + "\n")
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("session", type=Path, help="Path to session .jsonl file")
+    parser.add_argument("--apply", action="store_true",
+                        help="Actually rewrite the file (default: dry-run)")
+    args = parser.parse_args(argv)
+
+    path: Path = args.session
+    if not path.is_file():
+        print(f"error: {path} is not a file", file=sys.stderr)
+        return 2
+
+    messages = load_session(path)
+    total = len(messages)
+    report = analyze(messages)
+    cleaned = report["cleaned"]
+    malformed = report["malformed"]
+    orphans = report["orphans"]
+    dropped_msgs = report["dropped_msgs"]
+
+    print(f"session: {path}")
+    print(f"  scanned lines : {total}")
+    print(f"  malformed calls (empty function.name): {len(malformed)}")
+    print(f"  orphan tool_results                  : {len(orphans)}")
+    print(f"  messages to drop                     : {len(dropped_msgs)}")
+    print(f"  messages kept                        : {len(cleaned)}")
+
+    if dropped_msgs:
+        print("\n  would drop:")
+        for idx, reason in dropped_msgs[:50]:
+            print(f"    line {idx}: {reason}")
+        if len(dropped_msgs) > 50:
+            print(f"    ... ({len(dropped_msgs) - 50} more)")
+
+    if not dropped_msgs and not malformed:
+        print("\nnothing to repair.")
+        return 0
+
+    if not args.apply:
+        print("\n[dry-run] no changes written. Re-run with --apply to rewrite.")
+        return 0
+
+    backup = path.with_suffix(path.suffix + f".bak.{int(time.time())}")
+    shutil.copy2(path, backup)
+    write_session(path, cleaned)
+    print(f"\napplied. backup -> {backup}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_tool_call_sanitizer.py
+++ b/tests/test_tool_call_sanitizer.py
@@ -1,0 +1,193 @@
+"""Unit tests for the Pass-0 sanitizer that drops tool_calls with empty function.name.
+
+Regression coverage for the bug where some providers emit a streamed tool_call
+with ``id="call_xxx"`` but ``function.name=""``.  Such malformed calls were
+previously silently dropped by the Responses-API adapter while the matching
+``tool_result`` was retained, which produced gateway 400 errors of the form::
+
+    No tool call found for function call output with call_id ...
+
+The fix lives in ``AIAgent._sanitize_api_messages`` (run_agent.py) — Pass 0
+strips the malformed call so the existing orphan-result logic then removes
+its (now unpaired) ``tool`` message.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from run_agent import AIAgent
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def assistant_dict_call(call_id: str, name: str = "terminal", arguments: str = "{}") -> dict:
+    return {"id": call_id, "type": "function",
+            "function": {"name": name, "arguments": arguments}}
+
+
+def assistant_obj_call(call_id: str, name: str = "terminal", arguments: str = "{}"):
+    """SDK-style object (SimpleNamespace) tool_call."""
+    tc = types.SimpleNamespace()
+    tc.id = call_id
+    tc.function = types.SimpleNamespace(name=name, arguments=arguments)
+    return tc
+
+
+def tool_result(call_id: str, content: str = "ok") -> dict:
+    return {"role": "tool", "tool_call_id": call_id, "content": content}
+
+
+# ---------------------------------------------------------------------------
+# Direct sanitizer tests
+# ---------------------------------------------------------------------------
+
+class TestEmptyFunctionNameSanitizer:
+    """Phase 0 — strip tool_calls whose function.name is empty/missing."""
+
+    def test_empty_name_call_dropped_with_orphan_result(self):
+        msgs = [
+            {"role": "user", "content": "do stuff"},
+            {"role": "assistant", "tool_calls": [
+                assistant_dict_call("c_good", name="terminal"),
+                assistant_dict_call("c_bad", name=""),
+            ]},
+            tool_result("c_good", "first"),
+            tool_result("c_bad", "second"),
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+
+        # Good call survives, bad call is gone, its tool_result is gone too.
+        assistant_msgs = [m for m in out if m.get("role") == "assistant"]
+        assert len(assistant_msgs) == 1
+        surviving_call_ids = [tc["id"] for tc in assistant_msgs[0]["tool_calls"]]
+        assert surviving_call_ids == ["c_good"]
+
+        tool_msgs = [m for m in out if m.get("role") == "tool"]
+        assert len(tool_msgs) == 1
+        assert tool_msgs[0]["tool_call_id"] == "c_good"
+
+    def test_missing_function_field_dropped(self):
+        msgs = [
+            {"role": "assistant", "tool_calls": [
+                assistant_dict_call("c1", name="read_file"),
+                {"id": "c_no_fn"},  # no function key at all
+            ]},
+            tool_result("c1"),
+            tool_result("c_no_fn"),
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        ids_left = {m.get("tool_call_id") for m in out if m.get("role") == "tool"}
+        assert ids_left == {"c1"}
+
+    def test_whitespace_only_name_dropped(self):
+        msgs = [
+            {"role": "assistant", "tool_calls": [
+                assistant_dict_call("c_ws", name="   "),
+            ]},
+            tool_result("c_ws"),
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        # Stub will be inserted for orphaned call — but here the call itself
+        # is removed as malformed, so no stub and no tool result.
+        assert all(m.get("tool_call_id") != "c_ws" for m in out)
+        assert all(
+            not (m.get("role") == "assistant" and any(
+                (tc.get("function") or {}).get("name", "").strip() == ""
+                for tc in (m.get("tool_calls") or [])
+            ))
+            for m in out
+        )
+
+    def test_object_style_tool_call_with_empty_name_dropped(self):
+        msgs = [
+            {"role": "assistant", "tool_calls": [
+                assistant_obj_call("c_ok", name="search_files"),
+                assistant_obj_call("c_obj_bad", name=""),
+            ]},
+            tool_result("c_ok"),
+            tool_result("c_obj_bad"),
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        tool_ids = {m.get("tool_call_id") for m in out if m.get("role") == "tool"}
+        assert tool_ids == {"c_ok"}
+
+    def test_all_normal_calls_unchanged_regression(self):
+        msgs = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "tool_calls": [
+                assistant_dict_call("c1", name="terminal"),
+                assistant_dict_call("c2", name="read_file"),
+            ]},
+            tool_result("c1", "first"),
+            tool_result("c2", "second"),
+            {"role": "assistant", "content": "all done"},
+        ]
+        # Snapshot deep state before
+        before_ids = [
+            tc["id"]
+            for m in msgs if m.get("role") == "assistant" and m.get("tool_calls")
+            for tc in m["tool_calls"]
+        ]
+        before_results = [m["tool_call_id"] for m in msgs if m.get("role") == "tool"]
+
+        out = AIAgent._sanitize_api_messages(msgs)
+
+        after_ids = [
+            tc["id"]
+            for m in out if m.get("role") == "assistant" and m.get("tool_calls")
+            for tc in m["tool_calls"]
+        ]
+        after_results = [m["tool_call_id"] for m in out if m.get("role") == "tool"]
+
+        assert after_ids == before_ids
+        assert after_results == before_results
+        assert len(out) == len(msgs)
+
+    def test_multiple_assistant_messages_independent(self):
+        msgs = [
+            {"role": "assistant", "tool_calls": [assistant_dict_call("a1")]},
+            tool_result("a1"),
+            {"role": "assistant", "tool_calls": [
+                assistant_dict_call("a2"),
+                assistant_dict_call("a_bad", name=""),
+            ]},
+            tool_result("a2"),
+            tool_result("a_bad"),
+        ]
+        out = AIAgent._sanitize_api_messages(msgs)
+        all_call_ids = {
+            tc["id"]
+            for m in out if m.get("role") == "assistant" and m.get("tool_calls")
+            for tc in m["tool_calls"]
+        }
+        all_result_ids = {m["tool_call_id"] for m in out if m.get("role") == "tool"}
+        assert "a_bad" not in all_call_ids
+        assert "a_bad" not in all_result_ids
+        assert {"a1", "a2"}.issubset(all_call_ids)
+
+
+# ---------------------------------------------------------------------------
+# Idempotency — running sanitizer twice must produce identical output
+# ---------------------------------------------------------------------------
+
+def test_sanitizer_is_idempotent_on_corrupted_input():
+    msgs = [
+        {"role": "assistant", "tool_calls": [
+            assistant_dict_call("c_keep"),
+            assistant_dict_call("c_drop", name=""),
+        ]},
+        tool_result("c_keep"),
+        tool_result("c_drop"),
+    ]
+    once = AIAgent._sanitize_api_messages(msgs)
+    twice = AIAgent._sanitize_api_messages([dict(m) for m in once])
+    assert once == twice
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Problem

Some providers (and partially-streamed responses) emit a `tool_call` with `id="call_xxx"` but `function.name=""`. The Responses-API adapter (`_chat_messages_to_responses_input`) silently drops such `function_call` items while still emitting the matching `function_call_output`, which causes the downstream gateway to reject the request:

```
400 - "No tool call found for function call output with call_id call_xxxxxxxx."
```

This breaks the conversation irrecoverably until the user rolls back.

## Fix

Add a "Pass 0" sanitizer at the top of `run_conversation`, just before the existing orphan `call_id` cleanup. It walks all assistant messages and strips `tool_calls` whose `function.name` is empty/whitespace/missing. The existing orphan-result pass then removes the now-unpaired `tool_result`s, keeping call/result pairs balanced.

## Also included

- `scripts/repair_orphan_tool_results.py` — offline repair for already-corrupted session `.jsonl` files. Default dry-run; `--apply` writes a timestamped `.bak` before modifying. Supports both chat-format (`role=assistant/tool`) and Responses-format (`type=function_call/function_call_output`).
- `tests/test_tool_call_sanitizer.py` — 7 pytest cases covering: empty name, missing `function` field, whitespace-only name, SDK object-style tool_call, regression (clean messages untouched), multi-message independence, idempotency.

## Verification

```
pytest tests/test_tool_call_sanitizer.py -v
# → 7 passed
```

Real session dry-run on a production `.jsonl`: 0 corruption detected, exits cleanly.
Injected-corruption sample (7 lines → 3 lines): all malformed entries removed as expected, backup created.
