### PR TITLE
fix(file_tools): resolve relative paths against TERMINAL_CWD for worktree isolation (#12689)

### DIFF
--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -293,4 +293,36 @@ class TestSearchHints:
         assert "offset=100" in raw
 
 
+class TestResolvePath:
+    """Tests for _resolve_path: TERMINAL_CWD-aware path resolution."""
+
+    def test_absolute_path_ignores_terminal_cwd(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TERMINAL_CWD", "/some/worktree")
+        from tools.file_tools import _resolve_path
+        result = _resolve_path(str(tmp_path / "file.txt"))
+        assert result == (tmp_path / "file.txt").resolve()
+
+    def test_relative_path_uses_terminal_cwd(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+        from tools.file_tools import _resolve_path
+        result = _resolve_path("subdir/file.txt")
+        assert result == (tmp_path / "subdir" / "file.txt").resolve()
+
+    def test_relative_path_falls_back_to_cwd(self, monkeypatch):
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+        from tools.file_tools import _resolve_path
+        import os
+        from pathlib import Path
+        result = _resolve_path("file.txt")
+        assert result == Path(os.getcwd(), "file.txt").resolve()
+
+    def test_tilde_expanded_before_check(self, monkeypatch):
+        monkeypatch.setenv("TERMINAL_CWD", "/should/not/matter")
+        from tools.file_tools import _resolve_path
+        from pathlib import Path
+        result = _resolve_path("~/somefile")
+        # ~ expands to absolute, so TERMINAL_CWD should not be used
+        assert str(result).startswith(str(Path.home()))
+
+
 

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -14,6 +14,25 @@ from agent.redact import redact_sensitive_text
 logger = logging.getLogger(__name__)
 
 
+def _resolve_path(path: str) -> Path:
+    """Resolve a file path, respecting TERMINAL_CWD for worktree isolation.
+
+    When hermes is launched with -w (worktree mode), the TERMINAL_CWD env var
+    is set to the worktree path.  Relative paths should resolve against that
+    directory rather than the process CWD (os.getcwd()), which may point
+    elsewhere.
+
+    Falls back to normal Path.resolve() behaviour when TERMINAL_CWD is unset
+    or the path is already absolute.
+    """
+    p = Path(path).expanduser()
+    if not p.is_absolute():
+        terminal_cwd = os.environ.get("TERMINAL_CWD")
+        if terminal_cwd:
+            p = Path(terminal_cwd) / p
+    return p.resolve()
+
+
 _EXPECTED_WRITE_ERRNOS = {errno.EACCES, errno.EPERM, errno.EROFS}
 
 # ---------------------------------------------------------------------------
@@ -345,7 +364,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                 ),
             })
 
-        _resolved = Path(path).expanduser().resolve()
+        _resolved = _resolve_path(path)
 
         # ── Binary file guard ─────────────────────────────────────────
         # Block binary files by extension (no I/O).
@@ -553,7 +572,7 @@ def _update_read_timestamp(filepath: str, task_id: str) -> None:
     refreshes the stored timestamp to match the file's new state.
     """
     try:
-        resolved = str(Path(filepath).expanduser().resolve())
+        resolved = str(_resolve_path(filepath))
         current_mtime = os.path.getmtime(resolved)
     except (OSError, ValueError):
         return
@@ -572,7 +591,7 @@ def _check_file_staleness(filepath: str, task_id: str) -> str | None:
     or was never read.  Does not block — the write still proceeds.
     """
     try:
-        resolved = str(Path(filepath).expanduser().resolve())
+        resolved = str(_resolve_path(filepath))
     except (OSError, ValueError):
         return None
     with _read_tracker_lock:


### PR DESCRIPTION
## Problem

When Hermes is launched with `-w` (worktree mode), `TERMINAL_CWD` is correctly set to the worktree path, but file tools (`read_file`, `write_file`, `patch`) resolve relative paths using `Path(path).resolve()` which defaults to the process CWD — the main repository root. This causes file operations to leak out of the worktree.

Fixes #12689

## Changes

- **`tools/file_tools.py`**: Added `_resolve_path(path)` helper that resolves relative paths against `TERMINAL_CWD` env var when set, falling back to normal `Path.resolve()`. Applied to all file path resolution points.
- **`tests/tools/test_file_tools.py`**: 4 tests covering absolute path passthrough, relative path resolution via `TERMINAL_CWD`, fallback to `os.getcwd()`, and tilde expansion.

## Testing

```
4 passed in 1.77s
```