### PR TITLE
fix: Anthropic max_tokens + Feishu channel_prompt + Discord free_response

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -578,6 +578,20 @@ platform_toolsets:
 # Run `hermes chat --list-toolsets` to see all toolsets and their tools.
 # Run `hermes chat --list-tools` to see every individual tool with descriptions.
 # ─────────────────────────────────────────────────────────────────────────────
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Discord-specific settings (optional)
+# ─────────────────────────────────────────────────────────────────────────────
+# platforms:
+#   discord:
+#     reply_to_mode: "first"  # off | first | all
+#     extra:
+#       # Channels where bot responds without @mention (thread-friendly)
+#       # Supports both channel IDs and thread IDs
+#       free_response_channels:
+#         - "1234567890123456789"  # Channel ID
+#         - "9876543210987654321"  # Thread ID (parent channel also works)
+#       # Or use env var: DISCORD_FREE_RESPONSE_CHANNELS=123,456,789
 #
 # INDIVIDUAL TOOLSETS (compose your own):
 #   web          - web_search, web_extract

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -633,12 +633,18 @@ class DiscordAdapter(BasePlatformAdapter):
                     if _other_bots_mentioned and not _self_mentioned:
                         return
                     # If humans are mentioned but we're not → not for us
-                    # (preserves old DISCORD_IGNORE_NO_MENTION=true behavior)
+                    # (preserves old DISCORD_IGNORE_NO_MENTION=true behavior).
+                    # BUT: don't gate out free_response_channels — those are
+                    # explicitly configured to receive messages without @mention.
                     _ignore_no_mention = os.getenv(
                         "DISCORD_IGNORE_NO_MENTION", "true"
                     ).lower() in ("true", "1", "yes")
                     if _ignore_no_mention and not _self_mentioned and not _other_bots_mentioned:
-                        return
+                        _free_channels_raw = os.getenv("DISCORD_FREE_RESPONSE_CHANNELS", "")
+                        _free_channels = {ch.strip() for ch in _free_channels_raw.split(",") if ch.strip()}
+                        _channel_id = str(message.channel.id)
+                        if _channel_id not in _free_channels:
+                            return
 
                 await self._handle_message(message)
 

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -640,10 +640,19 @@ class DiscordAdapter(BasePlatformAdapter):
                         "DISCORD_IGNORE_NO_MENTION", "true"
                     ).lower() in ("true", "1", "yes")
                     if _ignore_no_mention and not _self_mentioned and not _other_bots_mentioned:
-                        _free_channels_raw = os.getenv("DISCORD_FREE_RESPONSE_CHANNELS", "")
-                        _free_channels = {ch.strip() for ch in _free_channels_raw.split(",") if ch.strip()}
+                        # Get free_response_channels from config.yaml first, then env var
+                        _free_channels_config = self.config.extra.get("free_response_channels", [])
+                        if _free_channels_config:
+                            _free_channels = {str(ch).strip() for ch in _free_channels_config if str(ch).strip()}
+                        else:
+                            _free_channels_raw = os.getenv("DISCORD_FREE_RESPONSE_CHANNELS", "")
+                            _free_channels = {ch.strip() for ch in _free_channels_raw.split(",") if ch.strip()}
+                        
+                        # Check both channel ID and parent channel ID (for threads)
                         _channel_id = str(message.channel.id)
-                        if _channel_id not in _free_channels:
+                        _parent_id = str(getattr(message.channel, 'parent_id', '') or '')
+                        
+                        if _channel_id not in _free_channels and _parent_id not in _free_channels:
                             return
 
                 await self._handle_message(message)

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2128,6 +2128,7 @@ class FeishuAdapter(BasePlatformAdapter):
             source=source,
             raw_message=data,
             message_id=message_id,
+            channel_prompt=self._resolve_channel_prompt(chat_id),
             timestamp=datetime.now(),
         )
         logger.info("[Feishu] Routing reaction %s:%s on bot message %s as synthetic event", action, emoji_type, message_id)
@@ -2190,6 +2191,7 @@ class FeishuAdapter(BasePlatformAdapter):
             source=source,
             raw_message=data,
             message_id=token or str(uuid.uuid4()),
+            channel_prompt=self._resolve_channel_prompt(chat_id),
             timestamp=datetime.now(),
         )
         logger.info("[Feishu] Routing card action %r from %s in %s as synthetic command", action_tag, open_id, chat_id)
@@ -2292,6 +2294,11 @@ class FeishuAdapter(BasePlatformAdapter):
         """Reset the anomaly counter for remote_ip after a successful request."""
         self._webhook_anomaly_counts.pop(remote_ip, None)
 
+    def _resolve_channel_prompt(self, chat_id: str, parent_id: str | None = None) -> str | None:
+        """Resolve a Feishu per-channel prompt, matching Discord/Slack behaviour."""
+        from gateway.platforms.base import resolve_channel_prompt
+        return resolve_channel_prompt(self.config.extra or {}, chat_id, parent_id)
+
     # =========================================================================
     # Inbound processing pipeline
     # =========================================================================
@@ -2352,6 +2359,7 @@ class FeishuAdapter(BasePlatformAdapter):
             media_types=media_types,
             reply_to_message_id=reply_to_message_id,
             reply_to_text=reply_to_text,
+            channel_prompt=self._resolve_channel_prompt(chat_id),
             timestamp=datetime.now(),
         )
         await self._dispatch_inbound_event(normalized)

--- a/run_agent.py
+++ b/run_agent.py
@@ -6716,18 +6716,19 @@ class AIAgent:
             # (the documented max output for qwen3-coder models) so the
             # model has adequate output budget for tool calls.
             api_kwargs.update(self._max_tokens_param(65536))
-        elif (self._is_openrouter_url() or "nousresearch" in self._base_url_lower) and "claude" in (self.model or "").lower():
-            # OpenRouter and Nous Portal translate requests to Anthropic's
-            # Messages API, which requires max_tokens as a mandatory field.
-            # When we omit it, the proxy picks a default that can be too
-            # low — the model spends its output budget on thinking and has
-            # almost nothing left for the actual response (especially large
-            # tool calls like write_file).  Sending the model's real output
-            # limit ensures full capacity.
+        else:
+            # For any Anthropic-compatible model (Claude, MiniMax, etc.),
+            # always send max_tokens regardless of which proxy serves it.
+            # OpenRouter/Nous translate to Messages API (mandatory field),
+            # but other proxies (AWS Bedrock, NVIDIA, LiteLLM, corporate
+            # gateways) also need it — they default to 4096 output tokens,
+            # which easily exhausts on thinking + large tool calls.
             try:
-                from agent.anthropic_adapter import _get_anthropic_max_output
-                _model_output_limit = _get_anthropic_max_output(self.model)
-                api_kwargs["max_tokens"] = _model_output_limit
+                from agent.anthropic_adapter import _get_anthropic_max_output, _ANTHROPIC_OUTPUT_LIMITS
+                _model_lower = (self.model or "").lower().replace(".", "-")
+                if any(key in _model_lower for key in _ANTHROPIC_OUTPUT_LIMITS):
+                    _model_output_limit = _get_anthropic_max_output(self.model)
+                    api_kwargs["max_tokens"] = _model_output_limit
             except Exception:
                 pass  # fail open — let the proxy pick its default
 


### PR DESCRIPTION
## Fixes #12790: Anthropic max_tokens fallback for all proxies

The `max_tokens` fallback in `_build_api_kwargs()` only fired when the base URL was OpenRouter or Nous Portal. Any other chat-completions proxy (AWS Bedrock, NVIDIA, LiteLLM, vLLM, corporate gateways) serving Claude models would silently bypass the fallback, shipping requests without `max_tokens` set. Proxies like AWS Bedrock default to **4096 output tokens**, which easily exhausts on thinking tokens + large tool calls like `write_file` or `patch`.

**Fix:** Changed the condition from URL-gated to model-gated. If the model is in `_ANTHROPIC_OUTPUT_LIMITS` (Claude, MiniMax), `max_tokens` is always set regardless of which proxy serves it.

## Fixes #12805: Feishu adapter missing channel_prompt resolution

The Feishu platform adapter did not implement per-channel prompt resolution (`_resolve_channel_prompt`), unlike Discord and Slack which both support this feature. This means `channel_prompts` config in `config.yaml` was silently ignored for Feishu.

**Fix:** Added `_resolve_channel_prompt()` method matching the Discord/Slack pattern. Passes `channel_prompt` to all three `MessageEvent` construction sites (main message, reaction routing, card action routing).

## Fixes #12750: Discord free_response_channels not working

The `on_message` handler checked `DISCORD_IGNORE_NO_MENTION` (default: `true`) **before** `_handle_message` was called. When a message had no @mention (human or bot), it returned early — never reaching the `free_response_channels` logic inside `_handle_message`. This meant free response channels could never receive unmentioned messages.

**Fix:** In the `DISCORD_IGNORE_NO_MENTION` gate at `on_message`, check the channel against `DISCORD_FREE_RESPONSE_CHANNELS` before returning early. Configured channels are exempted from the ignore-no-mention filter.

---
**Discussed in:** #12790, #12805, #12750