### PR TITLE
feat(cli): fire on_clarify plugin hook when clarify tool runs

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -62,6 +62,7 @@ VALID_HOOKS: Set[str] = {
     "on_session_end",
     "on_session_finalize",
     "on_session_reset",
+    "on_clarify",
 }
 
 ENTRY_POINTS_GROUP = "hermes_agent.plugins"

--- a/run_agent.py
+++ b/run_agent.py
@@ -7923,6 +7923,9 @@ class AIAgent:
                 question=function_args.get("question", ""),
                 choices=function_args.get("choices"),
                 callback=self.clarify_callback,
+                session_id=self.session_id or "",
+                model=self.model or "",
+                platform=getattr(self, "platform", None) or "",
             )
         elif function_name == "delegate_task":
             from tools.delegate_tool import delegate_task as _delegate_task
@@ -8439,6 +8442,9 @@ class AIAgent:
                     question=function_args.get("question", ""),
                     choices=function_args.get("choices"),
                     callback=self.clarify_callback,
+                    session_id=self.session_id or "",
+                    model=self.model or "",
+                    platform=getattr(self, "platform", None) or "",
                 )
                 tool_duration = time.time() - tool_start_time
                 if self._should_emit_quiet_tool_messages():

--- a/tests/tools/test_clarify_hook.py
+++ b/tests/tools/test_clarify_hook.py
@@ -1,0 +1,117 @@
+"""Tests for the on_clarify plugin hook triggered inside clarify_tool."""
+
+import json
+from typing import List, Optional
+from unittest.mock import patch, call
+
+import pytest
+
+from tools.clarify_tool import clarify_tool
+
+
+class TestOnClarifyHookInvocation:
+    """Verify that the on_clarify hook fires inside clarify_tool after validation."""
+
+    def test_hook_fires_after_validation_with_normalized_choices(self):
+        """Hook should fire with trimmed, normalized choices, not raw input."""
+        with patch("hermes_cli.plugins.invoke_hook") as mock_invoke:
+            result = json.loads(clarify_tool(
+                "  Test?  ",
+                choices=["  A  ", "  B  ", "  C  ", "  D  ", "  E  ", "  F  "],
+                callback=lambda q, c: "answer",
+                session_id="s1",
+                model="m1",
+                platform="cli",
+            ))
+
+        assert mock_invoke.called
+        kw = mock_invoke.call_args.kwargs
+        assert kw["question"] == "Test?"
+        # Only 4 (MAX_CHOICES), stripped
+        assert len(kw["choices"]) == 4
+        assert kw["choices"] == ["A", "B", "C", "D"]
+        assert kw["session_id"] == "s1"
+        assert kw["model"] == "m1"
+        assert kw["platform"] == "cli"
+
+    def test_hook_does_not_fire_on_empty_question(self):
+        """Hook should NOT fire when question is empty."""
+        with patch("hermes_cli.plugins.invoke_hook") as mock_invoke:
+            result = json.loads(clarify_tool(
+                "",
+                choices=["A"],
+                callback=lambda q, c: "answer",
+                session_id="s1",
+                model="m1",
+                platform="cli",
+            ))
+
+        assert "error" in result
+        mock_invoke.assert_not_called()
+
+    def test_hook_does_not_fire_when_callback_is_none(self):
+        """Hook should NOT fire when no callback is available."""
+        with patch("hermes_cli.plugins.invoke_hook") as mock_invoke:
+            result = json.loads(clarify_tool(
+                "Question?",
+                choices=["A"],
+                callback=None,
+                session_id="s1",
+                model="m1",
+                platform="cli",
+            ))
+
+        assert "error" in result
+        mock_invoke.assert_not_called()
+
+    def test_hook_does_not_fire_on_invalid_choices_type(self):
+        """Hook should NOT fire when choices is not a list."""
+        with patch("hermes_cli.plugins.invoke_hook") as mock_invoke:
+            result = json.loads(clarify_tool(
+                "Question?",
+                choices="not-a-list",
+                callback=lambda q, c: "answer",
+                session_id="s1",
+                model="m1",
+                platform="cli",
+            ))
+
+        assert "error" in result
+        mock_invoke.assert_not_called()
+
+    def test_hook_failure_does_not_break_tool(self):
+        """clarify_tool should still work when the hook raises."""
+        with patch("hermes_cli.plugins.invoke_hook", side_effect=RuntimeError("plugin bug")):
+            result = json.loads(clarify_tool(
+                "Question?",
+                callback=lambda q, c: "answer",
+                session_id="s1",
+                model="m1",
+                platform="cli",
+            ))
+
+        # Tool should still work despite hook failure
+        assert result["user_response"] == "answer"
+
+    def test_on_clarify_in_valid_hooks(self):
+        """on_clarify must be in VALID_HOOKS to be accepted without warning."""
+        from hermes_cli.plugins import VALID_HOOKS
+
+        assert "on_clarify" in VALID_HOOKS
+
+    def test_hook_fires_with_open_ended_question(self):
+        """Hook should fire with choices=None for open-ended questions."""
+        with patch("hermes_cli.plugins.invoke_hook") as mock_invoke:
+            result = json.loads(clarify_tool(
+                "What do you think?",
+                choices=None,
+                callback=lambda q, c: "my thoughts",
+                session_id="s1",
+                model="m1",
+                platform="cli",
+            ))
+
+        assert mock_invoke.called
+        kw = mock_invoke.call_args.kwargs
+        assert kw["choices"] is None
+        assert result["choices_offered"] is None

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -12,7 +12,10 @@ a thin dispatcher that delegates to a platform-provided callback.
 """
 
 import json
+import logging
 from typing import List, Optional, Callable
+
+logger = logging.getLogger(__name__)
 
 
 # Maximum number of predefined choices the agent can offer.
@@ -24,6 +27,9 @@ def clarify_tool(
     question: str,
     choices: Optional[List[str]] = None,
     callback: Optional[Callable] = None,
+    session_id: str = "",
+    model: str = "",
+    platform: str = "",
 ) -> str:
     """
     Ask the user a question, optionally with multiple-choice options.
@@ -35,6 +41,9 @@ def clarify_tool(
         callback: Platform-provided function that handles the actual UI
                   interaction. Signature: callback(question, choices) -> str.
                   Injected by the agent runner (cli.py / gateway).
+        session_id: Current session identifier (for plugin hooks).
+        model: Current model identifier (for plugin hooks).
+        platform: Platform name (for plugin hooks).
 
     Returns:
         JSON string with the user's response.
@@ -59,6 +68,22 @@ def clarify_tool(
             {"error": "Clarify tool is not available in this execution context."},
             ensure_ascii=False,
         )
+
+    # Fire on_clarify hook for plugins (e.g. desktop notifications).
+    # This hook is fire-and-forget — intentionally has no post_clarify
+    # counterpart, as notification toasts auto-dismiss.
+    try:
+        from hermes_cli.plugins import invoke_hook as _invoke_hook
+        _invoke_hook(
+            "on_clarify",
+            question=question,
+            choices=choices,
+            session_id=session_id,
+            model=model,
+            platform=platform,
+        )
+    except Exception as exc:
+        logger.warning("on_clarify hook failed: %s", exc)
 
     try:
         user_response = callback(question, choices)
@@ -135,7 +160,11 @@ registry.register(
     handler=lambda args, **kw: clarify_tool(
         question=args.get("question", ""),
         choices=args.get("choices"),
-        callback=kw.get("callback")),
+        callback=kw.get("callback"),
+        session_id=kw.get("session_id", ""),
+        model=kw.get("model", ""),
+        platform=kw.get("platform", ""),
+    ),
     check_fn=check_clarify_requirements,
     emoji="❓",
 )

--- a/website/docs/developer-guide/agent-loop.md
+++ b/website/docs/developer-guide/agent-loop.md
@@ -134,6 +134,10 @@ When the model returns tool calls:
   - Exception: tools marked as interactive (e.g., `clarify`) force sequential execution
   - Results are reinserted in the original tool call order regardless of completion order
 
+:::note
+`clarify` additionally fires a tool-specific plugin hook — `on_clarify` — from inside `tools/clarify_tool.py`, after input validation and before blocking on the user's response. See [Event Hooks → `on_clarify`](/docs/user-guide/features/hooks#on_clarify).
+:::
+
 ### Execution Flow
 
 ```text

--- a/website/docs/guides/build-a-hermes-plugin.md
+++ b/website/docs/guides/build-a-hermes-plugin.md
@@ -415,6 +415,7 @@ Each hook is documented in full on the **[Event Hooks reference](/docs/user-guid
 |------|-----------|-------------------|---------|
 | [`pre_tool_call`](/docs/user-guide/features/hooks#pre_tool_call) | Before any tool executes | `tool_name: str, args: dict, task_id: str` | ignored |
 | [`post_tool_call`](/docs/user-guide/features/hooks#post_tool_call) | After any tool returns | `tool_name: str, args: dict, result: str, task_id: str` | ignored |
+| [`on_clarify`](/docs/user-guide/features/hooks#on_clarify) | Before the `clarify` tool blocks on user input (after validation) | `question: str, choices: list[str] \| None, session_id: str, model: str, platform: str` | ignored |
 | [`pre_llm_call`](/docs/user-guide/features/hooks#pre_llm_call) | Once per turn, before the tool-calling loop | `session_id: str, user_message: str, conversation_history: list, is_first_turn: bool, model: str, platform: str` | [context injection](#pre_llm_call-context-injection) |
 | [`post_llm_call`](/docs/user-guide/features/hooks#post_llm_call) | Once per turn, after the tool-calling loop (successful turns only) | `session_id: str, user_message: str, assistant_response: str, conversation_history: list, model: str, platform: str` | ignored |
 | [`on_session_start`](/docs/user-guide/features/hooks#on_session_start) | New session created (first turn only) | `session_id: str, model: str, platform: str` | ignored |

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -239,6 +239,7 @@ def register(ctx):
 |------|-----------|---------|
 | [`pre_tool_call`](#pre_tool_call) | Before any tool executes | ignored |
 | [`post_tool_call`](#post_tool_call) | After any tool returns | ignored |
+| [`on_clarify`](#on_clarify) | Before the `clarify` tool blocks on user input | ignored |
 | [`pre_llm_call`](#pre_llm_call) | Once per turn, before the tool-calling loop | context injection |
 | [`post_llm_call`](#post_llm_call) | Once per turn, after the tool-calling loop | ignored |
 | [`on_session_start`](#on_session_start) | New session created (first turn only) | ignored |
@@ -344,6 +345,53 @@ def track_metrics(tool_name, result, **kwargs):
 
 def register(ctx):
     ctx.register_hook("post_tool_call", track_metrics)
+```
+
+---
+
+### `on_clarify`
+
+Fires inside the `clarify` tool, **after input validation** and **before** the tool blocks waiting for the user's answer. Use this when you want to react specifically to "the agent is about to ask the user a question" — for example, surfacing a desktop notification when the CLI window is minimized.
+
+This hook does **not** fire for:
+- Malformed `clarify` calls (empty question, missing callback, invalid `choices` type) — they short-circuit to an error before the hook runs.
+- Any other tool — this hook is specific to `clarify`. For general tool observation, use [`pre_tool_call`](#pre_tool_call) / [`post_tool_call`](#post_tool_call).
+
+**Callback signature:**
+
+```python
+def my_callback(question: str, choices: list[str] | None, session_id: str,
+                model: str, platform: str, **kwargs):
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `question` | `str` | The validated, whitespace-stripped question the user will see |
+| `choices` | `list[str]` or `None` | Normalized multiple-choice list (stripped; trimmed to at most `MAX_CHOICES`). `None` for open-ended questions. |
+| `session_id` | `str` | Session identifier |
+| `model` | `str` | Model identifier |
+| `platform` | `str` | Where the session is running: `"cli"`, `"telegram"`, etc. |
+
+**Fires:** In `tools/clarify_tool.py`, inside `clarify_tool()`, after validation passes and before the platform callback blocks on user input. Fire-and-forget — there is no `post_clarify` counterpart because notification toasts typically auto-dismiss.
+
+**Return value:** Ignored.
+
+**Use cases:** Desktop notifications when the agent is blocked on input, analytics on how often the agent asks for clarification, audit logs.
+
+**Example — desktop notification (macOS):**
+
+```python
+import subprocess
+
+def notify_clarify(question, choices, **kwargs):
+    preview = question if len(question) < 80 else question[:77] + "..."
+    subprocess.run([
+        "osascript", "-e",
+        f'display notification "{preview}" with title "Hermes needs input"',
+    ], check=False)
+
+def register(ctx):
+    ctx.register_hook("on_clarify", notify_clarify)
 ```
 
 ---

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -107,6 +107,7 @@ Plugins can register callbacks for these lifecycle events. See the **[Event Hook
 |------|-----------|
 | [`pre_tool_call`](/docs/user-guide/features/hooks#pre_tool_call) | Before any tool executes |
 | [`post_tool_call`](/docs/user-guide/features/hooks#post_tool_call) | After any tool returns |
+| [`on_clarify`](/docs/user-guide/features/hooks#on_clarify) | Before the `clarify` tool blocks on user input |
 | [`pre_llm_call`](/docs/user-guide/features/hooks#pre_llm_call) | Once per turn, before the LLM loop — can return `{"context": "..."}` to [inject context into the user message](/docs/user-guide/features/hooks#pre_llm_call) |
 | [`post_llm_call`](/docs/user-guide/features/hooks#post_llm_call) | Once per turn, after the LLM loop (successful turns only) |
 | [`on_session_start`](/docs/user-guide/features/hooks#on_session_start) | New session created (first turn only) |


### PR DESCRIPTION
## What does this PR do?

Fires the new `on_clarify` plugin hook when the agent invokes the `clarify` tool, so plugins (e.g. a desktop-notifier) can alert the user when the agent is blocked waiting for input.

The hook is invoked **inside `tools/clarify_tool.py`** after input validation — not at the agent dispatcher — so:
- It fires only when the tool will actually block on a callback; malformed calls (empty question, missing callback, wrong `choices` type) short-circuit before the hook is called, so plugins don't get spurious notifications for no-op errors.
- It sees the normalized `choices` (stripped + trimmed to `MAX_CHOICES`) that the user will actually be shown, not the raw model output.
- Both the concurrent and sequential tool-dispatch paths in `run_agent.py` share the same fire-site by construction.

Plugin exceptions are caught and logged as warnings, never propagate to the tool.

For reference, this is the Hermes analogue of Claude Code's `AskUserQuestion` hook (see [Claude Code hooks](https://code.claude.com/docs/en/hooks)).

## Related Issue

Fixes #12815

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/plugins.py`: add `on_clarify` to `VALID_HOOKS`.
- `tools/clarify_tool.py`: extend signature with `session_id`/`model`/`platform` (default `""`, backward-compatible); fire `on_clarify` after validation and before the platform callback; propagate the new kwargs through the registry handler.
- `run_agent.py`: pass `session_id`/`model`/`platform` into `clarify_tool` from both the concurrent (`_invoke_tool`) and sequential (`_execute_tool_calls_sequential`) dispatch paths.
- `tests/tools/test_clarify_hook.py`: 7 new tests covering normalized kwargs, validation gating (empty question, missing callback, invalid `choices` type), hook-failure isolation, open-ended questions, and `VALID_HOOKS` registration.
- `website/docs/user-guide/features/hooks.md`: add `on_clarify` row to the Quick reference table and a full section with signature, fire-site, use cases, and a macOS desktop-notification example.
- `website/docs/user-guide/features/plugins.md`: add `on_clarify` to the "Available hooks" summary table.
- `website/docs/guides/build-a-hermes-plugin.md`: add `on_clarify` row (with callback signature) to the hook reference table.
- `website/docs/developer-guide/agent-loop.md`: note `on_clarify` fires from inside `clarify_tool` alongside the interactive-tool exception.

## How to Test

1. Run the new and existing clarify tests together:
   ```
   pytest tests/tools/test_clarify_hook.py tests/tools/test_clarify_tool.py -q
   ```
   Expected: 27 passed.
2. To exercise the hook end-to-end, register a dummy plugin hook and invoke `clarify`:
   ```python
   ctx.register_hook("on_clarify", lambda **kw: print("NOTIFY", kw["question"]))
   ```
   Then in a Hermes session ask the agent to use the `clarify` tool. Expected: `NOTIFY ...` prints before the prompt renders. Invalid args (empty `question`) should NOT trigger the print.
3. Confirm that plugin exceptions don't break the tool: have the hook raise `RuntimeError`; the tool should still collect the user's answer.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(cli): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — added `on_clarify` section in `hooks.md`; added rows in `plugins.md`, `build-a-hermes-plugin.md`, and a note in `agent-loop.md`; extended `clarify_tool` docstring with the new kwargs; fire-and-forget semantics noted inline.
- [x] N/A — no config keys added.
- [x] N/A — no architecture / workflow change.
- [x] Cross-platform: pure-Python additions, no OS-specific code.
- [x] N/A — tool schema for `clarify` unchanged; new kwargs are plumbing between agent and tool, not part of the model-facing schema.

## Screenshots / Logs

```
$ pytest tests/tools/test_clarify_hook.py tests/tools/test_clarify_tool.py -q
...........................                                              [100%]
27 passed in 1.61s
```
