### PR TITLE
fix(gemini): sanitize tool schemas for Google providers

### DIFF
--- a/agent/gemini_cloudcode_adapter.py
+++ b/agent/gemini_cloudcode_adapter.py
@@ -39,6 +39,7 @@ from typing import Any, Dict, Iterator, List, Optional
 import httpx
 
 from agent import google_oauth
+from agent.gemini_schema import sanitize_gemini_tool_parameters
 from agent.google_code_assist import (
     CODE_ASSIST_ENDPOINT,
     FREE_TIER_ID,
@@ -205,7 +206,7 @@ def _translate_tools_to_gemini(tools: Any) -> List[Dict[str, Any]]:
             decl["description"] = str(fn["description"])
         params = fn.get("parameters")
         if isinstance(params, dict):
-            decl["parameters"] = params
+            decl["parameters"] = sanitize_gemini_tool_parameters(params)
         declarations.append(decl)
     if not declarations:
         return []

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -27,6 +27,8 @@ from typing import Any, Dict, Iterator, List, Optional
 
 import httpx
 
+from agent.gemini_schema import sanitize_gemini_tool_parameters
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_GEMINI_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
@@ -253,7 +255,7 @@ def _translate_tools_to_gemini(tools: Any) -> List[Dict[str, Any]]:
             decl["description"] = description
         parameters = fn.get("parameters")
         if isinstance(parameters, dict):
-            decl["parameters"] = parameters
+            decl["parameters"] = sanitize_gemini_tool_parameters(parameters)
         declarations.append(decl)
     return [{"functionDeclarations": declarations}] if declarations else []
 

--- a/agent/gemini_schema.py
+++ b/agent/gemini_schema.py
@@ -1,0 +1,85 @@
+"""Helpers for translating OpenAI-style tool schemas to Gemini's schema subset."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+# Gemini's ``FunctionDeclaration.parameters`` field accepts the ``Schema``
+# object, which is only a subset of OpenAPI 3.0 / JSON Schema.  Strip fields
+# outside that subset before sending Hermes tool schemas to Google.
+_GEMINI_SCHEMA_ALLOWED_KEYS = {
+    "type",
+    "format",
+    "title",
+    "description",
+    "nullable",
+    "enum",
+    "maxItems",
+    "minItems",
+    "properties",
+    "required",
+    "minProperties",
+    "maxProperties",
+    "minLength",
+    "maxLength",
+    "pattern",
+    "example",
+    "anyOf",
+    "propertyOrdering",
+    "default",
+    "items",
+    "minimum",
+    "maximum",
+}
+
+
+def sanitize_gemini_schema(schema: Any) -> Dict[str, Any]:
+    """Return a Gemini-compatible copy of a tool parameter schema.
+
+    Hermes tool schemas are OpenAI-flavored JSON Schema and may contain keys
+    such as ``$schema`` or ``additionalProperties`` that Google's Gemini
+    ``Schema`` object rejects.  This helper preserves the documented Gemini
+    subset and recursively sanitizes nested ``properties`` / ``items`` /
+    ``anyOf`` definitions.
+    """
+
+    if not isinstance(schema, dict):
+        return {}
+
+    cleaned: Dict[str, Any] = {}
+    for key, value in schema.items():
+        if key not in _GEMINI_SCHEMA_ALLOWED_KEYS:
+            continue
+        if key == "properties":
+            if not isinstance(value, dict):
+                continue
+            props: Dict[str, Any] = {}
+            for prop_name, prop_schema in value.items():
+                if not isinstance(prop_name, str):
+                    continue
+                props[prop_name] = sanitize_gemini_schema(prop_schema)
+            cleaned[key] = props
+            continue
+        if key == "items":
+            cleaned[key] = sanitize_gemini_schema(value)
+            continue
+        if key == "anyOf":
+            if not isinstance(value, list):
+                continue
+            cleaned[key] = [
+                sanitize_gemini_schema(item)
+                for item in value
+                if isinstance(item, dict)
+            ]
+            continue
+        cleaned[key] = value
+    return cleaned
+
+
+def sanitize_gemini_tool_parameters(parameters: Any) -> Dict[str, Any]:
+    """Normalize tool parameters to a valid Gemini object schema."""
+
+    cleaned = sanitize_gemini_schema(parameters)
+    if not cleaned:
+        return {"type": "object", "properties": {}}
+    return cleaned

--- a/tests/agent/test_gemini_cloudcode.py
+++ b/tests/agent/test_gemini_cloudcode.py
@@ -652,6 +652,42 @@ class TestBuildGeminiRequest:
         assert decls[0]["description"] == "foo"
         assert decls[0]["parameters"] == {"type": "object"}
 
+    def test_tools_strip_json_schema_only_fields_from_parameters(self):
+        from agent.gemini_cloudcode_adapter import build_gemini_request
+
+        req = build_gemini_request(
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[
+                {"type": "function", "function": {
+                    "name": "fn1",
+                    "description": "foo",
+                    "parameters": {
+                        "$schema": "https://json-schema.org/draft/2020-12/schema",
+                        "type": "object",
+                        "additionalProperties": False,
+                        "properties": {
+                            "city": {
+                                "type": "string",
+                                "$schema": "ignored",
+                                "description": "City name",
+                                "additionalProperties": False,
+                            }
+                        },
+                        "required": ["city"],
+                    },
+                }},
+            ],
+        )
+        params = req["tools"][0]["functionDeclarations"][0]["parameters"]
+        assert "$schema" not in params
+        assert "additionalProperties" not in params
+        assert params["type"] == "object"
+        assert params["required"] == ["city"]
+        assert params["properties"]["city"] == {
+            "type": "string",
+            "description": "City name",
+        }
+
     def test_tool_choice_auto(self):
         from agent.gemini_cloudcode_adapter import build_gemini_request
 

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -85,6 +85,46 @@ def test_build_native_request_uses_original_function_name_for_tool_result():
     assert tool_response["name"] == "get_weather"
 
 
+def test_build_native_request_strips_json_schema_only_fields_from_tool_parameters():
+    from agent.gemini_native_adapter import build_gemini_request
+
+    request = build_gemini_request(
+        messages=[{"role": "user", "content": "Hello"}],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "lookup_weather",
+                    "description": "Weather lookup",
+                    "parameters": {
+                        "$schema": "https://json-schema.org/draft/2020-12/schema",
+                        "type": "object",
+                        "additionalProperties": False,
+                        "properties": {
+                            "city": {
+                                "type": "string",
+                                "$schema": "ignored",
+                                "description": "City name",
+                            }
+                        },
+                        "required": ["city"],
+                    },
+                },
+            }
+        ],
+        tool_choice=None,
+    )
+
+    params = request["tools"][0]["functionDeclarations"][0]["parameters"]
+    assert "$schema" not in params
+    assert "additionalProperties" not in params
+    assert params["type"] == "object"
+    assert params["properties"]["city"] == {
+        "type": "string",
+        "description": "City name",
+    }
+
+
 def test_translate_native_response_surfaces_reasoning_and_tool_calls():
     from agent.gemini_native_adapter import translate_gemini_response
 


### PR DESCRIPTION
## What does this PR do?

Sanitizes Hermes tool parameter schemas before sending them to Google's Gemini function-calling endpoints.

Both `google-gemini-cli` (Code Assist OAuth) and the native `gemini` provider were forwarding OpenAI-style JSON Schema tool parameters directly into Gemini `functionDeclarations[].parameters`. Real Hermes tool schemas can include keys like `$schema` and `additionalProperties`, and Google rejects those with `INVALID_ARGUMENT` / unknown-field errors.

This change adds a shared Gemini schema sanitizer and routes both Gemini adapters through it so unsupported keys are stripped before request construction.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Added `agent/gemini_schema.py` with a shared sanitizer for Gemini-compatible schema subsets.
- Updated `agent/gemini_cloudcode_adapter.py` to sanitize tool `parameters` before building Code Assist `functionDeclarations`.
- Updated `agent/gemini_native_adapter.py` to use the same sanitizer for the native Gemini API path.
- Added regression coverage in `tests/agent/test_gemini_cloudcode.py` for `$schema` / `additionalProperties` leaks.
- Added regression coverage in `tests/agent/test_gemini_native_adapter.py` for the same schema leak on the native path.

## How to Test

1. Run `scripts/run_tests.sh tests/agent/test_gemini_cloudcode.py tests/agent/test_gemini_native_adapter.py`
2. Verify both new regression tests pass and the Gemini adapter suites stay green.
3. Run `scripts/run_tests.sh` for the full hermetic suite.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu / WSL-like Linux environment

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused verification:

- `scripts/run_tests.sh tests/agent/test_gemini_cloudcode.py tests/agent/test_gemini_native_adapter.py`
- Result: `92 passed in 2.12s`

Full hermetic suite:

- `scripts/run_tests.sh`
- Result: `18 failed, 13370 passed, 36 skipped, 202 warnings in 299.66s`

Failures observed in the full suite:

- `tests/gateway/test_dingtalk.py::TestCardLifecycle::test_final_reply_finalizes_card`
- `tests/gateway/test_dingtalk.py::TestCardLifecycle::test_intermediate_send_stays_streaming`
- `tests/gateway/test_dingtalk.py::TestCardLifecycle::test_done_fires_only_when_reply_to_is_set`
- `tests/gateway/test_dingtalk.py::TestCardLifecycle::test_edit_message_finalize_fires_done`
- `tests/gateway/test_dingtalk.py::TestCardLifecycle::test_edit_message_finalize_false_tracks_sibling`
- `tests/gateway/test_dingtalk.py::TestCardLifecycle::test_next_send_auto_closes_sibling_streaming_cards`
- `tests/gateway/test_dingtalk.py::TestDingTalkAdapterAICards::test_send_uses_ai_card_if_configured`
- `tests/gateway/test_discord_bot_filter.py::TestDiscordBotFilter::test_default_is_none`
- `tests/gateway/test_api_server.py::TestAdapterInit::test_default_config`
- `tests/hermes_cli/test_backup.py::TestProfileRestoration::test_import_creates_profile_wrappers`
- `tests/gateway/test_approve_deny_commands.py::TestBlockingApprovalE2E::test_blocking_approval_approve_once`
- `tests/gateway/test_approve_deny_commands.py::TestBlockingApprovalE2E::test_blocking_approval_deny`
- `tests/hermes_cli/test_gemini_provider.py::TestGeminiModelCatalog::test_provider_models_exist`
- `tests/tools/test_modal_sandbox_fixes.py::TestToolResolution::test_terminal_and_file_toolsets_resolve_all_tools`
- `tests/tools/test_modal_sandbox_fixes.py::TestToolResolution::test_terminal_tool_present`
- `tests/tools/test_tirith_security.py::TestDiskFailureMarker::test_cosign_missing_marker_clears_when_cosign_appears`
- `tests/tools/test_command_guards.py::TestTirithWarnSafe::test_warn_session_approved`
- `tests/tools/test_command_guards.py::TestCombinedWarnings::test_combined_cli_session_approves_both`

The targeted Gemini adapter coverage added in this PR is green; the full-suite failures are in other parts of the repo and are recorded here as observed during the required full run.
