### PR TITLE
fix(tui): guard empty idle queue drain to stop idle OOM

### DIFF
--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -386,7 +386,12 @@ export function useMainApp(gw: GatewayClient) {
   // and error paths never emit message.complete, so anything enqueued while
   // `!sleep` / a failed turn was running would stay stuck forever.
   useEffect(() => {
-    if (!ui.sid || ui.busy || composerRefs.queueEditRef.current !== null) {
+    if (
+      !ui.sid ||
+      ui.busy ||
+      composerRefs.queueEditRef.current !== null ||
+      composerRefs.queueRef.current.length === 0
+    ) {
       return
     }
 


### PR DESCRIPTION
## What does this PR do?

Fixes a TUI OOM that could still happen while sitting idle at the `ready` prompt.

The queue-drain effect in `ui-tui/src/app/useMainApp.ts` could still call `composerActions.dequeue()` when the queue was empty. In the local repro, that empty dequeue was enough to keep the idle loop churning until the TUI eventually hit a JS heap OOM.

This change adds a single guard so the drain effect returns early when `composerRefs.queueRef.current.length === 0`.

## Related Issue

Fixes #12682

Follow-up to #12754 (`fix(tui): bound retained state against idle OOM`).

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- Add an empty-queue guard to the idle queue-drain effect in `ui-tui/src/app/useMainApp.ts`

## How to Test

1. Run `hermes --tui --dev`.
2. Let the TUI reach the normal `ready` state and sit idle with an empty queue.
3. On the unpatched build, this repro OOMed locally in roughly 50-55 seconds.
4. Apply this patch and repeat the same repro.
5. Confirm the TUI stays up past the previous failure window.
6. Run `npm --prefix ui-tui run type-check`.

## Screenshots / Logs

Local repro:
- Before: ready-state idle repro OOMed in ~50-55s
- After: same repro stayed stable past ~15min