### PR TITLE
fix(acp): implement ext_method to handle ping gracefully

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -844,3 +844,13 @@ class HermesACPAgent(acp.Agent):
         self.session_manager.save_session(session_id)
         logger.info("Session %s: config option %s updated", session_id, config_id)
         return SetSessionConfigOptionResponse(config_options=[])
+
+    # ---- Extension method handling --------------------------------------------
+
+    async def ext_method(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        """Handle unknown ACP extension methods gracefully.
+
+        Returns an empty result so clients receive a valid JSON-RPC response
+        instead of a method_not_found error with noisy traceback.
+        """
+        return {}

--- a/tests/acp/test_ext_method.py
+++ b/tests/acp/test_ext_method.py
@@ -1,0 +1,37 @@
+"""Tests for HermesACPAgent.ext_method extension method handling."""
+
+import pytest
+from acp_adapter.server import HermesACPAgent
+
+
+class TestExtMethod:
+    """Test suite for ACP extension method handling."""
+
+    def test_hermes_acp_agent_has_ext_method(self):
+        """Test that HermesACPAgent has an ext_method method."""
+        agent = HermesACPAgent()
+        assert hasattr(agent, "ext_method"), "HermesACPAgent should have ext_method method"
+        assert callable(agent.ext_method), "ext_method should be callable"
+
+    @pytest.mark.asyncio
+    async def test_ext_method_ping_returns_empty_dict(self):
+        """Test that calling ext_method with 'ping' returns empty dict without error."""
+        agent = HermesACPAgent()
+        result = await agent.ext_method("ping", {})
+        assert result == {}, "ext_method('ping', {}) should return {}"
+
+    @pytest.mark.asyncio
+    async def test_ext_method_unknown_method_returns_empty_dict(self):
+        """Test that calling ext_method with any unknown method returns empty dict."""
+        agent = HermesACPAgent()
+        result = await agent.ext_method("some_unknown_method", {"key": "value"})
+        assert result == {}, "ext_method with unknown method should return {}"
+
+    @pytest.mark.asyncio
+    async def test_ext_method_with_various_unknown_methods(self):
+        """Test that ext_method gracefully handles various unknown extension methods."""
+        agent = HermesACPAgent()
+        unknown_methods = ["ping", "health", "status", "custom_extension", "_internal"]
+        for method in unknown_methods:
+            result = await agent.ext_method(method, {})
+            assert result == {}, f"ext_method('{method}', {{}}) should return {{}}"


### PR DESCRIPTION
## What changed

The ACP adapter server now overrides `ext_method()` to return an empty dict (`{}`) for unknown ACP extension methods (e.g., `ping`), instead of raising `method_not_found` errors that produce noisy tracebacks in logs.

**Before:** Unknown extension methods like `ping` caused `method_not_found` errors and stack traces in the agent logs during ACP sessions.

**After:** Unknown extension methods are handled gracefully by returning an empty response, preventing log noise and allowing ACP sessions to proceed normally.

## How to test

1. Start an ACP session with a server that sends `ping` extension methods
2. Verify no `method_not_found` errors appear in logs
3. Run the test suite:
   ```bash
   pytest tests/acp/test_ext_method.py -v
   ```

## Platforms tested

- Linux (Docker container, Python 3.11)

Closes #12529