### PR TITLE
fix(docker): forward configured environment variables to sandbox containers

### DIFF
--- a/tests/tools/test_docker_forward_env.py
+++ b/tests/tools/test_docker_forward_env.py
@@ -1,0 +1,190 @@
+"""Tests for docker_forward_env configuration forwarding to Docker containers.
+
+Bug #12534: Docker sandbox never receives env vars from docker_forward_env config.
+The environment variables listed in terminal.docker_forward_env config were read
+but never actually passed to the container creation call.
+"""
+import subprocess
+import pytest
+
+from tools.environments import docker as docker_env
+
+
+def _mock_subprocess_run(monkeypatch):
+    """Mock subprocess.run to intercept docker run -d and docker version calls.
+
+    Returns a list of captured (cmd, kwargs) tuples for inspection.
+    """
+    calls = []
+
+    def _run(cmd, **kwargs):
+        calls.append((list(cmd) if isinstance(cmd, list) else cmd, kwargs))
+        if isinstance(cmd, list) and len(cmd) >= 2:
+            if cmd[1] == "version":
+                return subprocess.CompletedProcess(cmd, 0, stdout="Docker version", stderr="")
+            if cmd[1] == "run":
+                return subprocess.CompletedProcess(cmd, 0, stdout="fake-container-id\n", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", _run)
+    return calls
+
+
+def _make_dummy_env(forward_env=None, env=None, **kwargs):
+    """Helper to construct DockerEnvironment with docker_forward_env support."""
+    return docker_env.DockerEnvironment(
+        image=kwargs.get("image", "python:3.11"),
+        cwd=kwargs.get("cwd", "/root"),
+        timeout=kwargs.get("timeout", 60),
+        cpu=kwargs.get("cpu", 0),
+        memory=kwargs.get("memory", 0),
+        disk=kwargs.get("disk", 0),
+        persistent_filesystem=kwargs.get("persistent_filesystem", False),
+        task_id=kwargs.get("task_id", "test-task"),
+        volumes=kwargs.get("volumes", []),
+        network=kwargs.get("network", True),
+        host_cwd=kwargs.get("host_cwd"),
+        auto_mount_cwd=kwargs.get("auto_mount_cwd", False),
+        forward_env=forward_env,
+        env=env,
+    )
+
+
+def _has_env_flag(run_cmd, key, value):
+    """Check if -e key=value appears as consecutive args in run_cmd."""
+    for i, arg in enumerate(run_cmd):
+        if arg == "-e" and i + 1 < len(run_cmd):
+            if run_cmd[i + 1] == f"{key}={value}":
+                return True
+    return False
+
+
+def test_docker_forward_env_includes_configured_vars_in_container_run(
+    monkeypatch,
+):
+    """docker_forward_env vars that exist in host env should be passed to docker run -e.
+
+    This tests the fix for bug #12534 where docker_forward_env was read but
+    never actually forwarded to the container creation call.
+    """
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+
+    # Set up environment variables that will be "forwarded"
+    monkeypatch.setenv("HOME", "/home/testuser")
+    monkeypatch.setenv("PATH", "/usr/local/bin:/usr/bin:/bin")
+    monkeypatch.setenv("MY_VAR", "my_value")
+
+    calls = _mock_subprocess_run(monkeypatch)
+
+    # Create environment with docker_forward_env
+    _make_dummy_env(
+        forward_env=["HOME", "PATH", "MY_VAR"],
+    )
+
+    # Find the docker run call
+    run_calls = [
+        c for c in calls
+        if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"
+    ]
+    assert run_calls, "docker run should have been called"
+    run_cmd = run_calls[0][0]
+
+    # Verify all forward_env vars appear as -e flags in the docker run command
+    assert _has_env_flag(run_cmd, "HOME", "/home/testuser"), f"HOME should be forwarded: {run_cmd}"
+    assert _has_env_flag(run_cmd, "PATH", "/usr/local/bin:/usr/bin:/bin"), f"PATH should be forwarded: {run_cmd}"
+    assert _has_env_flag(run_cmd, "MY_VAR", "my_value"), f"MY_VAR should be forwarded: {run_cmd}"
+
+
+def test_docker_forward_env_skips_missing_vars(monkeypatch):
+    """docker_forward_env vars that don't exist in host env should be silently skipped.
+
+    Missing environment variables should not cause errors or be passed as empty strings.
+    """
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+
+    # Set up some env vars but not all
+    monkeypatch.setenv("HOME", "/home/testuser")
+    monkeypatch.setenv("PATH", "/usr/local/bin:/usr/bin:/bin")
+    # MY_VAR is intentionally NOT set
+    monkeypatch.delenv("MY_VAR", raising=False)
+
+    calls = _mock_subprocess_run(monkeypatch)
+
+    # Create environment with docker_forward_env that includes a missing var
+    _make_dummy_env(
+        forward_env=["HOME", "PATH", "MY_VAR"],
+    )
+
+    # Find the docker run call
+    run_calls = [
+        c for c in calls
+        if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"
+    ]
+    assert run_calls, "docker run should have been called"
+    run_cmd = run_calls[0][0]
+
+    # HOME and PATH should be forwarded
+    assert _has_env_flag(run_cmd, "HOME", "/home/testuser")
+    assert _has_env_flag(run_cmd, "PATH", "/usr/local/bin:/usr/bin:/bin")
+
+    # MY_VAR should NOT appear (it doesn't exist in host env)
+    assert not _has_env_flag(run_cmd, "MY_VAR", ""), \
+        f"MY_VAR should not be forwarded when missing from host env: {run_cmd}"
+
+
+def test_docker_forward_env_empty_list_forwards_nothing(monkeypatch):
+    """When docker_forward_env is empty, no additional env vars should be forwarded."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setenv("HOME", "/home/testuser")
+
+    calls = _mock_subprocess_run(monkeypatch)
+
+    # Create environment with empty docker_forward_env
+    _make_dummy_env(
+        forward_env=[],
+    )
+
+    # Find the docker run call
+    run_calls = [
+        c for c in calls
+        if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"
+    ]
+    assert run_calls, "docker run should have been called"
+    run_cmd = run_calls[0][0]
+
+    # With empty forward_env, HOME should NOT appear in -e flags
+    # (it's not in docker_env, only in forward_env which is empty)
+    assert not _has_env_flag(run_cmd, "HOME", "/home/testuser"), \
+        f"HOME should not be forwarded with empty forward_env: {run_cmd}"
+
+
+def test_docker_env_and_docker_forward_env_both_forwarded(monkeypatch):
+    """Both docker_env and docker_forward_env should be passed to container.
+
+    docker_env provides explicit key-value pairs, docker_forward_env provides
+    host env vars to relay. Both should appear in the docker run command.
+    """
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setenv("HOST_VAR", "from_host")
+
+    calls = _mock_subprocess_run(monkeypatch)
+
+    # Create environment with both docker_env (explicit) and docker_forward_env (host relay)
+    _make_dummy_env(
+        env={"EXPLICIT_VAR": "explicit_value"},
+        forward_env=["HOST_VAR"],
+    )
+
+    # Find the docker run call
+    run_calls = [
+        c for c in calls
+        if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"
+    ]
+    assert run_calls, "docker run should have been called"
+    run_cmd = run_calls[0][0]
+
+    # Both should appear
+    assert _has_env_flag(run_cmd, "EXPLICIT_VAR", "explicit_value"), \
+        f"docker_env var missing: {run_cmd}"
+    assert _has_env_flag(run_cmd, "HOST_VAR", "from_host"), \
+        f"docker_forward_env var missing: {run_cmd}"

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -788,9 +788,17 @@ class DockerEnvironment(BaseEnvironment):
 
         # Explicit environment variables (docker_env config) — set at container
         # creation so they're available to all processes (including entrypoint).
+        # Note: docker_forward_env vars are also injected by _build_init_env_args()
+        # during init_session, but setting them here ensures they are part of the
+        # container's native environment (visible to non-bash processes and
+        # docker inspect).
         env_args = []
         for key in sorted(self._env):
             env_args.extend(["-e", f"{key}={self._env[key]}"])
+        for key in sorted(self._forward_env):
+            value = os.environ.get(key)
+            if value is not None:
+                env_args.extend(["-e", f"{key}={value}"])
 
         # Optional: run the container as the host user so files written into
         # bind-mounted dirs (/workspace, /root, docker_volumes entries) are

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -791,14 +791,14 @@ class DockerEnvironment(BaseEnvironment):
         # Note: docker_forward_env vars are also injected by _build_init_env_args()
         # during init_session, but setting them here ensures they are part of the
         # container's native environment (visible to non-bash processes and
-        # docker inspect).
+        # docker inspect). The forward-env dict delegates to the same
+        # shell-first, ~/.hermes/.env fallback semantics as _build_init_env_args()
+        # so both injection points agree on which values win.
         env_args = []
         for key in sorted(self._env):
             env_args.extend(["-e", f"{key}={self._env[key]}"])
-        for key in sorted(self._forward_env):
-            value = os.environ.get(key)
-            if value is not None:
-                env_args.extend(["-e", f"{key}={value}"])
+        for key, value in self._build_forward_env_dict().items():
+            env_args.extend(["-e", f"{key}={value}"])
 
         # Optional: run the container as the host user so files written into
         # bind-mounted dirs (/workspace, /root, docker_volumes entries) are
@@ -1025,6 +1025,30 @@ class DockerEnvironment(BaseEnvironment):
         # Initialize session snapshot inside the container
         self.init_session()
 
+    def _build_forward_env_dict(self) -> dict[str, str]:
+        """Return {key: value} for the set of host env vars to forward into the container.
+
+        Resolution order per key:
+          1. Shell env (``os.environ``) — non-empty wins.
+          2. ``~/.hermes/.env`` (via ``_load_hermes_env_vars()``).
+
+        Only ``docker_forward_env`` keys are honoured here (explicit opt-in
+        means we ignore the implicit passthrough set and the
+        ``_HERMES_PROVIDER_ENV_BLOCKLIST``). This mirrors the per-key fallback
+        semantics used by ``_build_init_env_args()`` so the container's native
+        -e flags match the snapshot injected at init_session time.
+        """
+        forward_keys: set[str] = set(self._forward_env)
+        hermes_env = _load_hermes_env_vars() if forward_keys else {}
+        resolved: dict[str, str] = {}
+        for key in sorted(forward_keys):
+            value = os.getenv(key)
+            if not value:
+                value = hermes_env.get(key)
+            if value:
+                resolved[key] = value
+        return resolved
+
     def _build_init_env_args(self) -> list[str]:
         """Build -e KEY=VALUE args for injecting host env vars into init_session.
 
@@ -1033,7 +1057,6 @@ class DockerEnvironment(BaseEnvironment):
         """
         exec_env: dict[str, str] = dict(self._env)
 
-        explicit_forward_keys = set(self._forward_env)
         passthrough_keys: set[str] = set()
         try:
             from tools.env_passthrough import get_all_passthrough
@@ -1048,6 +1071,7 @@ class DockerEnvironment(BaseEnvironment):
         _implicit_forward = {
             k for k in passthrough_keys if not _is_hermes_internal_secret(k)
         }
+        explicit_forward_keys = set(self._forward_env)
         forward_keys = explicit_forward_keys | (_implicit_forward - _HERMES_PROVIDER_ENV_BLOCKLIST)
         hermes_env = _load_hermes_env_vars() if forward_keys else {}
         for key in sorted(forward_keys):

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -411,9 +411,17 @@ class DockerEnvironment(BaseEnvironment):
 
         # Explicit environment variables (docker_env config) — set at container
         # creation so they're available to all processes (including entrypoint).
+        # Note: docker_forward_env vars are also injected by _build_init_env_args()
+        # during init_session, but setting them here ensures they are part of the
+        # container's native environment (visible to non-bash processes and
+        # docker inspect).
         env_args = []
         for key in sorted(self._env):
             env_args.extend(["-e", f"{key}={self._env[key]}"])
+        for key in sorted(self._forward_env):
+            value = os.environ.get(key)
+            if value is not None:
+                env_args.extend(["-e", f"{key}={value}"])
 
         logger.info(f"Docker volume_args: {volume_args}")
         all_run_args = list(_SECURITY_ARGS) + writable_args + resource_args + volume_args + env_args


### PR DESCRIPTION
## What does this PR do?

Environment variables listed in `docker_forward_env` config are now forwarded to sandbox containers at creation time via `docker run -e`, in addition to the existing `docker exec -e` forwarding during `init_session()`.

**Before:** The `docker_forward_env` config keys were read but never injected into the container's native environment. Only `_build_init_env_args()` forwarded them via `docker exec`, which made vars visible only to bash subprocesses — not to processes started via `docker run` or inspectable via `docker inspect`.

**After:** Forwarded env vars are available in the container from the moment of creation, visible to all processes and inspectable via `docker inspect`. The two mechanisms serve distinct purposes:
- `docker run -e` — persistent, visible to all processes in the container
- `docker exec -e` — session-scoped, visible only to the init subprocess

## Related Issue

Closes #12534

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Docker sandbox creation now passes `docker_forward_env` keys through `docker run -e` so they live in the container's native environment
- Existing `docker exec -e` forwarding during `init_session()` retained for session-scoped use
- `tests/tools/test_docker_forward_env.py` — coverage for the new run-time forwarding behavior

## How to Test

1. Add env vars to `docker_forward_env` in `config.yaml`:
   ```yaml
   docker_forward_env:
     - MY_API_KEY
   ```
2. Set `MY_API_KEY=secret` in your host `.env`
3. Start a Docker sandbox and verify the var is available:
   ```bash
   docker inspect <container> | grep MY_API_KEY
   ```
4. Run the test suite:
   ```bash
   pytest tests/tools/test_docker_forward_env.py -v
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (Docker container, Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — see commit description and PR diff.
