### PR TITLE
fix(memory): recover from malformed memory edit args

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -167,6 +167,20 @@ def _oneline(text: str) -> str:
     return " ".join(text.split())
 
 
+def _memory_lookup_preview(args: dict) -> str:
+    """Return the best available identifier preview for memory replace/remove."""
+    raw_old_text = args.get("old_text")
+    old_text = _oneline("" if raw_old_text is None else str(raw_old_text))
+    if old_text:
+        return old_text
+    if args.get("action") == "remove":
+        raw_content = args.get("content")
+        content = _oneline("" if raw_content is None else str(raw_content))
+        if content:
+            return content
+    return "<missing old_text>"
+
+
 def build_tool_preview(tool_name: str, args: dict, max_len: int | None = None) -> str | None:
     """Build a short preview of a tool call's primary argument for display.
 
@@ -225,9 +239,11 @@ def build_tool_preview(tool_name: str, args: dict, max_len: int | None = None) -
             content = _oneline(args.get("content", ""))
             return f"+{target}: \"{content[:25]}{'...' if len(content) > 25 else ''}\""
         elif action == "replace":
-            return f"~{target}: \"{_oneline(args.get('old_text', '')[:20])}\""
+            preview = _memory_lookup_preview(args)
+            return f"~{target}: \"{preview[:20]}{'...' if len(preview) > 20 else ''}\""
         elif action == "remove":
-            return f"-{target}: \"{_oneline(args.get('old_text', '')[:20])}\""
+            preview = _memory_lookup_preview(args)
+            return f"-{target}: \"{preview[:20]}{'...' if len(preview) > 20 else ''}\""
         return action
 
     if tool_name == "send_message":
@@ -939,9 +955,9 @@ def get_cute_tool_message(
         if action == "add":
             return _wrap(f"┊ 🧠 memory    +{target}: \"{_trunc(args.get('content', ''), 30)}\"  {dur}")
         elif action == "replace":
-            return _wrap(f"┊ 🧠 memory    ~{target}: \"{_trunc(args.get('old_text', ''), 20)}\"  {dur}")
+            return _wrap(f"┊ 🧠 memory    ~{target}: \"{_trunc(_memory_lookup_preview(args), 20)}\"  {dur}")
         elif action == "remove":
-            return _wrap(f"┊ 🧠 memory    -{target}: \"{_trunc(args.get('old_text', ''), 20)}\"  {dur}")
+            return _wrap(f"┊ 🧠 memory    -{target}: \"{_trunc(_memory_lookup_preview(args), 20)}\"  {dur}")
         return _wrap(f"┊ 🧠 memory    {action}  {dur}")
     if tool_name == "skills_list":
         return _wrap(f"┊ 📚 skills    list {args.get('category', 'all')}  {dur}")

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -8,6 +8,7 @@ from agent.display import (
     build_tool_preview,
     capture_local_edit_snapshot,
     extract_edit_diff,
+    get_cute_tool_message,
     _render_inline_unified_diff,
     _summarize_rendered_diff_sections,
     render_edit_diff_with_delta,
@@ -83,6 +84,18 @@ class TestBuildToolPreview:
         assert result is not None
         assert "user" in result
 
+    def test_memory_tool_remove_uses_content_fallback_preview(self):
+        result = build_tool_preview("memory", {"action": "remove", "target": "memory", "content": "stale note"})
+        assert result == '-memory: "stale note"'
+
+    def test_memory_tool_replace_marks_missing_old_text(self):
+        result = build_tool_preview("memory", {"action": "replace", "target": "memory", "content": "new note"})
+        assert result == '~memory: "<missing old_text>"'
+
+    def test_memory_tool_null_old_text_marks_missing(self):
+        result = build_tool_preview("memory", {"action": "remove", "target": "memory", "old_text": None})
+        assert result == '-memory: "<missing old_text>"'
+
     def test_session_search_preview(self):
         result = build_tool_preview("session_search", {"query": "find something"})
         assert result is not None
@@ -93,6 +106,18 @@ class TestBuildToolPreview:
         assert build_tool_preview("terminal", 0) is None
         assert build_tool_preview("terminal", "") is None
         assert build_tool_preview("terminal", []) is None
+
+    def test_cute_memory_remove_uses_content_fallback_preview(self):
+        result = get_cute_tool_message("memory", {"action": "remove", "target": "memory", "content": "stale note"}, 0.0)
+        assert '-memory: "stale note"' in result
+
+    def test_cute_memory_replace_marks_missing_old_text(self):
+        result = get_cute_tool_message("memory", {"action": "replace", "target": "memory", "content": "new note"}, 0.0)
+        assert '~memory: "<missing old_text>"' in result
+
+    def test_cute_memory_null_old_text_marks_missing(self):
+        result = get_cute_tool_message("memory", {"action": "remove", "target": "memory", "old_text": None}, 0.0)
+        assert '-memory: "<missing old_text>"' in result
 
 
 class TestEditDiffPreview:

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -182,6 +182,13 @@ class TestMemoryStoreRemove:
         result = store.remove("memory", "  ")
         assert result["success"] is False
 
+    def test_read_returns_live_entries(self, store):
+        store.add("memory", "persistent fact")
+        result = store.read("memory")
+        assert result["success"] is True
+        assert result["entries"] == ["persistent fact"]
+        assert result["entry_count"] == 1
+
 
 class TestMemoryStorePersistence:
     def test_save_and_load_roundtrip(self, tmp_path, monkeypatch):
@@ -201,7 +208,7 @@ class TestMemoryStorePersistence:
         monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
         # Write file with duplicates
         mem_file = tmp_path / "MEMORY.md"
-        mem_file.write_text("duplicate entry\n§\nduplicate entry\n§\nunique entry")
+        mem_file.write_text("duplicate entry\n§\nduplicate entry\n§\nunique entry", encoding="utf-8")
 
         store = MemoryStore()
         store.load_from_disk()
@@ -251,7 +258,50 @@ class TestMemoryToolDispatcher:
     def test_replace_requires_old_text(self, store):
         result = json.loads(memory_tool(action="replace", content="new", store=store))
         assert result["success"] is False
+        assert "guidance" in result
 
     def test_remove_requires_old_text(self, store):
+        store.add("memory", "delete me later")
         result = json.loads(memory_tool(action="remove", store=store))
         assert result["success"] is False
+        assert "guidance" in result
+        assert result["current_entries"] == ["delete me later"]
+
+    def test_remove_uses_content_as_fallback_identifier(self, store):
+        store.add("memory", "delete me later")
+        result = json.loads(memory_tool(action="remove", content="delete me", store=store))
+        assert result["success"] is True
+        assert result["entries"] == []
+
+    def test_read_via_tool(self, store):
+        store.add("user", "Prefers concise replies")
+        result = json.loads(memory_tool(action="read", target="user", store=store))
+        assert result["success"] is True
+        assert result["entries"] == ["Prefers concise replies"]
+
+    def test_replace_accepts_new_content_alias(self, store):
+        store.add("memory", "Python 3.11 project")
+        result = json.loads(
+            memory_tool(
+                action="replace",
+                old_text="3.11",
+                new_content="Python 3.12 project",
+                store=store,
+            )
+        )
+        assert result["success"] is True
+        assert result["entries"] == ["Python 3.12 project"]
+
+    def test_replace_prefers_nonempty_new_content_when_content_is_blank(self, store):
+        store.add("memory", "Python 3.11 project")
+        result = json.loads(
+            memory_tool(
+                action="replace",
+                old_text="3.11",
+                content="",
+                new_content="Python 3.12 project",
+                store=store,
+            )
+        )
+        assert result["success"] is True
+        assert result["entries"] == ["Python 3.12 project"]

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -57,6 +57,27 @@ def get_memory_dir() -> Path:
 ENTRY_DELIMITER = "\n§\n"
 
 
+def _memory_live_state(store: "MemoryStore", target: str) -> Dict[str, Any]:
+    """Return repair-friendly live state for memory tool errors."""
+    snapshot = store.read(target)
+    return {
+        "current_entries": snapshot["entries"],
+        "usage": snapshot["usage"],
+        "entry_count": snapshot["entry_count"],
+    }
+
+
+def _first_nonempty_text(*values: Optional[str]) -> Optional[str]:
+    """Return the first non-empty string after trimming, else None."""
+    for value in values:
+        if value is None:
+            continue
+        text = value.strip()
+        if text:
+            return text
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Memory content scanning — lightweight check for injection/exfiltration
 # in content that gets injected into the system prompt.
@@ -356,6 +377,12 @@ class MemoryStore:
 
         return self._success_response(target, "Entry removed.")
 
+    def read(self, target: str) -> Dict[str, Any]:
+        """Return the current live entries for a target."""
+        with self._file_lock(self._path_for(target)):
+            self._reload_target(target)
+            return self._success_response(target, "Current entries.")
+
     def format_for_system_prompt(self, target: str) -> Optional[str]:
         """
         Return the frozen snapshot for system prompt injection.
@@ -465,6 +492,7 @@ def memory_tool(
     target: str = "memory",
     content: str = None,
     old_text: str = None,
+    new_content: str = None,
     store: Optional[MemoryStore] = None,
 ) -> str:
     """
@@ -478,25 +506,53 @@ def memory_tool(
     if target not in ("memory", "user"):
         return tool_error(f"Invalid target '{target}'. Use 'memory' or 'user'.", success=False)
 
+    action = (action or "").strip().lower()
+    replacement_content = _first_nonempty_text(content, new_content)
+    lookup_text = _first_nonempty_text(old_text)
+    if action == "remove" and not lookup_text:
+        lookup_text = _first_nonempty_text(content)
+
     if action == "add":
         if not content:
             return tool_error("Content is required for 'add' action.", success=False)
         result = store.add(target, content)
 
     elif action == "replace":
-        if not old_text:
-            return tool_error("old_text is required for 'replace' action.", success=False)
-        if not content:
+        if not lookup_text:
+            error = {
+                "success": False,
+                "error": "old_text is required for 'replace' action.",
+                "guidance": (
+                    "Call action='read' first to inspect current entries, then "
+                    "retry with old_text set to a short unique substring."
+                ),
+            }
+            error.update(_memory_live_state(store, target))
+            return json.dumps(error, ensure_ascii=False)
+        if not replacement_content:
             return tool_error("content is required for 'replace' action.", success=False)
-        result = store.replace(target, old_text, content)
+        result = store.replace(target, lookup_text, replacement_content)
 
     elif action == "remove":
-        if not old_text:
-            return tool_error("old_text is required for 'remove' action.", success=False)
-        result = store.remove(target, old_text)
+        if not lookup_text:
+            error = {
+                "success": False,
+                "error": "old_text is required for 'remove' action.",
+                "guidance": (
+                    "Call action='read' first to inspect current entries, then "
+                    "retry with old_text set to a short unique substring. "
+                    "For remove, content is also accepted as a fallback identifier."
+                ),
+            }
+            error.update(_memory_live_state(store, target))
+            return json.dumps(error, ensure_ascii=False)
+        result = store.remove(target, lookup_text)
+
+    elif action == "read":
+        result = store.read(target)
 
     else:
-        return tool_error(f"Unknown action '{action}'. Use: add, replace, remove", success=False)
+        return tool_error(f"Unknown action '{action}'. Use: add, replace, remove, read", success=False)
 
     return json.dumps(result, ensure_ascii=False)
 
@@ -532,7 +588,8 @@ MEMORY_SCHEMA = {
         "- 'user': who the user is -- name, role, preferences, communication style, pet peeves\n"
         "- 'memory': your notes -- environment facts, project conventions, tool quirks, lessons learned\n\n"
         "ACTIONS: add (new entry), replace (update existing -- old_text identifies it), "
-        "remove (delete -- old_text identifies it).\n\n"
+        "remove (delete -- old_text identifies it, with content accepted as a fallback "
+        "identifier), read (inspect current live entries).\n\n"
         "SKIP: trivial/obvious info, things easily re-discovered, raw data dumps, and temporary task state."
     ),
     "parameters": {
@@ -540,7 +597,7 @@ MEMORY_SCHEMA = {
         "properties": {
             "action": {
                 "type": "string",
-                "enum": ["add", "replace", "remove"],
+                "enum": ["add", "replace", "remove", "read"],
                 "description": "The action to perform."
             },
             "target": {
@@ -550,11 +607,15 @@ MEMORY_SCHEMA = {
             },
             "content": {
                 "type": "string",
-                "description": "The entry content. Required for 'add' and 'replace'."
+                "description": "Entry content. Required for 'add'; replacement content for 'replace'; optional fallback identifier for 'remove'."
             },
             "old_text": {
                 "type": "string",
-                "description": "Short unique substring identifying the entry to replace or remove."
+                "description": "Short unique substring identifying the entry to replace or remove. Preferred for both actions."
+            },
+            "new_content": {
+                "type": "string",
+                "description": "Optional alias for replacement content when action='replace'."
             },
         },
         "required": ["action", "target"],
@@ -574,6 +635,7 @@ registry.register(
         target=args.get("target", "memory"),
         content=args.get("content"),
         old_text=args.get("old_text"),
+        new_content=args.get("new_content"),
         store=kw.get("store")),
     check_fn=check_memory_requirements,
     emoji="🧠",


### PR DESCRIPTION
## Summary                                                                                                                                                        
                                                                                                                                                                    
  Fix the memory tool so malformed `replace` and `remove` calls no longer fail immediately with misleading `🧠 memory ... [error]` output, especially when the model
  puts the lookup text in the wrong field.                                                                                                                          
                                                                                                                                                                    
  Fixes #12456.                                                                                                                                                     
                                                                                                                                                                    
  ## Problem                                                                                                                                                        
                                                                                                                                                                    
  Memory edits could fail instantly with output like:                                                                                                               
                                                                                                                                                                    
  `🧠 memory -memory: "" 0.0s [error]`                                                                                                                              
                                                                                                                                                                    
  This mainly happened when the model produced malformed but common arguments:                                                                                      
                                                                                                                                                                    
  - `remove` sent the lookup text in `content` instead of `old_text`                                                                                                
  - `replace` sent `new_content` while leaving `content` blank                                                                                                      
  - CLI previews rendered missing identifiers as `""` or `"None"`, which made the failure mode harder to understand                                                 
                                                                                                                                                                    
  That made the model more likely to loop on bad memory calls instead of recovering.                                                                                
                                                                                                                                                                    
  ## What Changed                                                                                                                                                   
                                                                                                                                                                    
  - Added `memory.read` to inspect current live entries                                                                                                             
  - Made `remove` accept `content` as a fallback identifier when `old_text` is missing                                                                              
  - Made `replace` accept `new_content` as an alias for replacement text                                                                                            
  - Preferred the first non-empty replacement value, so blank `content` no longer blocks a valid `new_content`                                                      
  - Returned richer repair-oriented errors for missing identifiers:                                                                                                 
    - `guidance`                                                                                                                                                    
    - `current_entries`                                                                                                                                             
    - `usage`                                                                                                                                                       
    - `entry_count`                                                                                                                                                 
  - Improved CLI memory previews so missing identifiers render as `<missing old_text>` instead of `""` or `"None"`                                                  
                                                                                                                                                                    
  ## Why                                                                                                                                                            
                                                                                                                                                                    
  The reported failure pattern came from the memory tool rejecting slightly malformed arguments at `0.0s`, then surfacing an unhelpful preview line. With these     
  changes, the common malformed cases now either succeed directly or fail with enough structured context for the model to self-correct.                             
                                                                                                                                                                    
  This removes the main cause of the repeated `🧠 memory ... [error]` loop reported in #12456.                                                                      
                                                                                                                                                                    
  ## Testing                                                                                                                                                        
                                                                                                                                                                    
  bash                                                                                                                                                           
  python -m pytest tests/tools/test_memory_tool.py tests/agent/test_display.py tests/run_agent/test_run_agent.py -k memory -q                                       
                                                                                                                                                                    
                                                                                                                                                  
 ## Notes                                                                                                                                                          
                                                                                                                                                                    
 This patch fixes the malformed memory-call failure mode from #12456.                                                                                              
                                                                                                                                                                    
  The separate symptom where Hermes can still appear to pause for a long time may involve the flush_memories or auxiliary timeout path, which is not changed in this PR.                                                            