### PR TITLE
fix(model-picker): dedup overlapping providers: dict and custom_providers: list entries

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1035,6 +1035,13 @@ def list_authenticated_providers(
         seen_slugs.add(_cp.slug.lower())
 
     # --- 3. User-defined endpoints from config ---
+    # Track (name, base_url) of what section 3 emits so section 4 can skip
+    # any overlapping ``custom_providers:`` entries.  Callers typically pass
+    # both (gateway/CLI invoke ``get_compatible_custom_providers()`` which
+    # merges ``providers:`` into the list) — without this, the same endpoint
+    # produces two picker rows: one bare-slug ("openrouter") from section 3
+    # and one "custom:openrouter" from section 4, both labelled identically.
+    _section3_emitted_pairs: set = set()
     if user_providers and isinstance(user_providers, dict):
         for ep_name, ep_cfg in user_providers.items():
             if not isinstance(ep_cfg, dict):
@@ -1088,6 +1095,12 @@ def list_authenticated_providers(
                 "api_url": api_url,
             })
             seen_slugs.add(ep_name.lower())
+            _pair = (
+                str(display_name).strip().lower(),
+                str(api_url).strip().rstrip("/").lower(),
+            )
+            if _pair[0] and _pair[1]:
+                _section3_emitted_pairs.add(_pair)
 
     # --- 4. Saved custom providers from config ---
     # Each ``custom_providers`` entry represents one model under a named
@@ -1145,6 +1158,17 @@ def list_authenticated_providers(
 
         for slug, grp in groups.items():
             if slug.lower() in seen_slugs:
+                continue
+            # Skip if section 3 already emitted this endpoint under its
+            # ``providers:`` dict key — matches on (display_name, base_url),
+            # the tuple section 4 groups by.  Prevents two picker rows
+            # labelled identically when callers pass both ``user_providers``
+            # and a compatibility-merged ``custom_providers`` list.
+            _pair_key = (
+                str(grp["name"]).strip().lower(),
+                str(grp["api_url"]).strip().rstrip("/").lower(),
+            )
+            if _pair_key[0] and _pair_key[1] and _pair_key in _section3_emitted_pairs:
                 continue
             results.append({
                 "slug": slug,

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -304,6 +304,54 @@ def test_list_authenticated_providers_dedupes_when_user_and_custom_overlap(monke
     assert matches[0]["models"] == ["gpt-5.4", "grok-4.20-beta"]
 
 
+def test_list_authenticated_providers_no_duplicate_labels_across_schemas(monkeypatch):
+    """Regression: same endpoint in both ``providers:`` dict AND ``custom_providers:``
+    list (e.g. via ``get_compatible_custom_providers()``) must not emit two picker
+    rows with identical display names.
+
+    Before the fix, section 3 emitted bare-slug rows ("openrouter") and section 4
+    emitted ``custom:openrouter`` rows for the same endpoint — both labelled
+    identically, bypassing ``seen_slugs`` dedup because the slug shapes differ.
+    """
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    shared_entries = [
+        ("endpoint-a", "http://a.local/v1"),
+        ("endpoint-b", "http://b.local/v1"),
+        ("endpoint-c", "http://c.local/v1"),
+    ]
+
+    user_providers = {
+        name: {"name": name, "base_url": url, "model": "m1"}
+        for name, url in shared_entries
+    }
+    custom_providers = [
+        {"name": name, "base_url": url, "model": "m1"}
+        for name, url in shared_entries
+    ]
+
+    providers = list_authenticated_providers(
+        current_provider="none",
+        user_providers=user_providers,
+        custom_providers=custom_providers,
+        max_models=50,
+    )
+
+    user_rows = [p for p in providers if p.get("source") == "user-config"]
+    # Expect one row per shared entry — not two.
+    assert len(user_rows) == len(shared_entries), (
+        f"Expected {len(shared_entries)} rows, got {len(user_rows)}: "
+        f"{[(p['slug'], p['name']) for p in user_rows]}"
+    )
+
+    # And zero duplicate display labels.
+    labels = [p["name"].lower() for p in user_rows]
+    assert len(labels) == len(set(labels)), (
+        f"Duplicate labels across picker rows: {labels}"
+    )
+
+
 # =============================================================================
 # Tests for _get_named_custom_provider with providers: dict
 # =============================================================================


### PR DESCRIPTION
## Summary
`/model` picker stops showing duplicate rows when the same endpoint exists in both config schemas.

## Root cause
`list_authenticated_providers()` has two overlapping input sources:
- Section 3 iterates `providers:` dict (v12+ keyed schema) → emits bare-name slugs
- Section 4 iterates `custom_providers:` list (legacy schema) → emits `custom:<name>` slugs

Callers (gateway, CLI, tui_gateway) pass both. `get_compatible_custom_providers()` already merges `providers:` into the custom_providers list, so every `providers:` entry gets emitted twice under two different slug shapes, bypassing the `seen_slugs` dedup entirely. Users see the same endpoint twice with identical display labels — e.g. `zai (0)` appearing in rows 7 and 9 of the Telegram picker (#from community report).

## Changes
- `hermes_cli/model_switch.py`: section 3 records `(name, base_url)` of emitted entries in `_section3_emitted_pairs`; section 4 skips groups whose pair was already emitted.
- `tests/hermes_cli/test_user_providers_model_switch.py`: regression test `test_list_authenticated_providers_no_duplicate_labels_across_schemas`.

## Validation
| | Before | After |
|---|---|---|
| Overlapping config (6 entries in both schemas) | 13 picker rows, 6 duplicate labels | 9 rows, 0 duplicate labels |
| Only `providers:` dict | 1 row | 1 row |
| Only `custom_providers:` list | 1 row | 1 row |
| Distinct entries in both | 2 rows | 2 rows |
| `tests/hermes_cli/ -k 'model_switch or list_authenticated or model_picker or model_command or custom_provider'` | | 88 passed |