### PR TITLE
feat(gateway): add configurable command_prefix to avoid platform conflicts

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -265,6 +265,18 @@ class GatewayConfig:
     # fresh session exactly as if the reset policy had fired.  0 = disabled.
     session_store_max_age_days: int = 90
 
+    # Command prefix: the character(s) that mark a message as a command.
+    # Defaults to "/" but can be changed globally or per-platform to avoid
+    # conflicts with native slash commands (e.g. Matrix, Mattermost).
+    command_prefix: str = "/"
+    platform_command_prefix: Dict[Platform, str] = field(default_factory=dict)
+
+    def get_command_prefix(self, platform: Optional[Platform] = None) -> str:
+        """Return the effective command prefix for a platform."""
+        if platform and platform in self.platform_command_prefix:
+            return self.platform_command_prefix[platform]
+        return self.command_prefix
+
     def get_connected_platforms(self) -> List[Platform]:
         """Return list of platforms that are enabled and configured."""
         connected = []
@@ -427,6 +439,13 @@ class GatewayConfig:
         except (TypeError, ValueError):
             session_store_max_age_days = 90
 
+        platform_command_prefix = {}
+        for pname, prefix in data.get("platform_command_prefix", {}).items():
+            try:
+                platform_command_prefix[Platform(pname)] = str(prefix)
+            except ValueError:
+                pass
+
         return cls(
             platforms=platforms,
             default_reset_policy=default_policy,
@@ -442,6 +461,8 @@ class GatewayConfig:
             unauthorized_dm_behavior=unauthorized_dm_behavior,
             streaming=StreamingConfig.from_dict(data.get("streaming", {})),
             session_store_max_age_days=session_store_max_age_days,
+            command_prefix=data.get("command_prefix", "/"),
+            platform_command_prefix=platform_command_prefix,
         )
 
     def get_unauthorized_dm_behavior(self, platform: Optional[Platform] = None) -> str:
@@ -527,6 +548,19 @@ def load_gateway_config() -> GatewayConfig:
 
             if "always_log_local" in yaml_cfg:
                 gw_data["always_log_local"] = yaml_cfg["always_log_local"]
+
+            # Command prefix configuration — supports a top-level key or
+            # nested under a ``gateway:`` section for clarity.
+            gw_section = yaml_cfg.get("gateway", {})
+            if not isinstance(gw_section, dict):
+                gw_section = {}
+            if "command_prefix" in gw_section:
+                gw_data["command_prefix"] = str(gw_section["command_prefix"])
+            elif "command_prefix" in yaml_cfg:
+                gw_data["command_prefix"] = str(yaml_cfg["command_prefix"])
+            pcp = gw_section.get("platform_command_prefix") or yaml_cfg.get("platform_command_prefix")
+            if isinstance(pcp, dict):
+                gw_data["platform_command_prefix"] = {str(k): str(v) for k, v in pcp.items()}
 
             if "unauthorized_dm_behavior" in yaml_cfg:
                 gw_data["unauthorized_dm_behavior"] = _normalize_unauthorized_dm_behavior(

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -703,25 +703,30 @@ class MessageEvent:
 
     # Timestamps
     timestamp: datetime = field(default_factory=datetime.now)
-    
+
+    # Command prefix used to detect slash-style commands.
+    # Set by the platform adapter from GatewayConfig.get_command_prefix().
+    command_prefix: str = "/"
+
     def is_command(self) -> bool:
         """Check if this is a command message (e.g., /new, /reset)."""
-        return self.text.startswith("/")
-    
+        return self.text.startswith(self.command_prefix)
+
     def get_command(self) -> Optional[str]:
         """Extract command name if this is a command message."""
         if not self.is_command():
             return None
-        # Split on space and get first word, strip the /
+        # Split on space and get first word, strip the prefix
         parts = self.text.split(maxsplit=1)
-        raw = parts[0][1:].lower() if parts else None
+        prefix_len = len(self.command_prefix)
+        raw = parts[0][prefix_len:].lower() if parts else None
         if raw and "@" in raw:
             raw = raw.split("@", 1)[0]
         # Reject file paths: valid command names never contain /
         if raw and "/" in raw:
             return None
         return raw
-    
+
     def get_command_args(self) -> str:
         """Get the arguments after a command."""
         if not self.is_command():
@@ -865,6 +870,7 @@ class BasePlatformAdapter(ABC):
     def __init__(self, config: PlatformConfig, platform: Platform):
         self.config = config
         self.platform = platform
+        self.command_prefix: str = "/"
         self._message_handler: Optional[MessageHandler] = None
         self._running = False
         self._fatal_error_code: Optional[str] = None

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -2354,7 +2354,7 @@ class DiscordAdapter(BasePlatformAdapter):
             chat_topic=chat_topic,
         )
 
-        msg_type = MessageType.COMMAND if text.startswith("/") else MessageType.TEXT
+        msg_type = MessageType.COMMAND if text.startswith(self.command_prefix) else MessageType.TEXT
         channel_id = str(interaction.channel_id)
         parent_id = str(getattr(getattr(interaction, "channel", None), "parent_id", "") or "")
         return MessageEvent(
@@ -2363,10 +2363,8 @@ class DiscordAdapter(BasePlatformAdapter):
             source=source,
             raw_message=interaction,
             channel_prompt=self._resolve_channel_prompt(channel_id, parent_id or None),
+            command_prefix=self.command_prefix,
         )
-
-    # ------------------------------------------------------------------
-    # Thread creation helpers
     # ------------------------------------------------------------------
 
     async def _handle_thread_create_slash(
@@ -2444,6 +2442,7 @@ class DiscordAdapter(BasePlatformAdapter):
             raw_message=interaction,
             auto_skill=_skills,
             channel_prompt=_channel_prompt,
+            command_prefix=self.command_prefix,
         )
         await self.handle_message(event)
 
@@ -3025,7 +3024,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
         # Determine message type
         msg_type = MessageType.TEXT
-        if message.content.startswith("/"):
+        if message.content.startswith(self.command_prefix):
             msg_type = MessageType.COMMAND
         elif message.attachments:
             # Check attachment types
@@ -3200,6 +3199,7 @@ class DiscordAdapter(BasePlatformAdapter):
             timestamp=message.created_at,
             auto_skill=_skills,
             channel_prompt=_channel_prompt,
+            command_prefix=self.command_prefix,
         )
 
         # Track thread participation so the bot won't require @mention for

--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -1347,7 +1347,7 @@ class MatrixAdapter(BasePlatformAdapter):
             body = "\n".join(stripped) if stripped else body
 
         msg_type = MessageType.TEXT
-        if body.startswith(("!", "/")):
+        if body.startswith(("!", "/", self.command_prefix)):
             msg_type = MessageType.COMMAND
 
         msg_event = MessageEvent(
@@ -1357,6 +1357,7 @@ class MatrixAdapter(BasePlatformAdapter):
             raw_message=source_content,
             message_id=event_id,
             reply_to_message_id=reply_to,
+            command_prefix=self.command_prefix,
         )
 
         if msg_type == MessageType.TEXT and self._text_batch_delay_seconds > 0:
@@ -1536,6 +1537,7 @@ class MatrixAdapter(BasePlatformAdapter):
             message_id=event_id,
             media_urls=media_urls,
             media_types=media_types,
+            command_prefix=self.command_prefix,
         )
 
         await self.handle_message(msg_event)

--- a/gateway/platforms/mattermost.py
+++ b/gateway/platforms/mattermost.py
@@ -659,7 +659,7 @@ class MattermostAdapter(BasePlatformAdapter):
         # Determine message type.
         file_ids = post.get("file_ids") or []
         msg_type = MessageType.TEXT
-        if message_text.startswith("/"):
+        if message_text.startswith(self.command_prefix):
             msg_type = MessageType.COMMAND
 
         # Download file attachments immediately (URLs require auth headers
@@ -733,6 +733,7 @@ class MattermostAdapter(BasePlatformAdapter):
             media_urls=media_urls if media_urls else None,
             media_types=media_types if media_types else None,
             channel_prompt=_channel_prompt,
+            command_prefix=self.command_prefix,
         )
 
         await self.handle_message(msg_event)

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -1086,7 +1086,7 @@ class SlackAdapter(BasePlatformAdapter):
 
         # Determine message type
         msg_type = MessageType.TEXT
-        if text.startswith("/"):
+        if text.startswith(self.command_prefix):
             msg_type = MessageType.COMMAND
 
         # Handle file attachments
@@ -1201,6 +1201,7 @@ class SlackAdapter(BasePlatformAdapter):
             media_types=media_types,
             reply_to_message_id=thread_ts if thread_ts != ts else None,
             channel_prompt=_channel_prompt,
+            command_prefix=self.command_prefix,
         )
 
         # Only react when bot is directly addressed (DM or @mention).
@@ -1537,9 +1538,10 @@ class SlackAdapter(BasePlatformAdapter):
 
         event = MessageEvent(
             text=text,
-            message_type=MessageType.COMMAND if text.startswith("/") else MessageType.TEXT,
+            message_type=MessageType.COMMAND if text.startswith(self.command_prefix) else MessageType.TEXT,
             source=source,
             raw_message=command,
+            command_prefix=self.command_prefix,
         )
 
         await self.handle_message(event)

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2975,6 +2975,7 @@ class TelegramAdapter(BasePlatformAdapter):
             auto_skill=topic_skill,
             channel_prompt=_channel_prompt,
             timestamp=message.date,
+            command_prefix=self.command_prefix,
         )
 
     # ── Message reactions (processing lifecycle) ──────────────────────────

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1986,6 +1986,7 @@ class GatewayRunner:
                 continue
             
             # Set up message + fatal error handlers
+            adapter.command_prefix = self.config.get_command_prefix(platform)
             adapter.set_message_handler(self._handle_message)
             adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
             adapter.set_session_store(self.session_store)

--- a/tests/test_command_prefix.py
+++ b/tests/test_command_prefix.py
@@ -1,0 +1,102 @@
+"""Tests for configurable command_prefix (issue #12688)."""
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent, MessageType
+
+
+# ── MessageEvent with default prefix ──
+
+class TestMessageEventDefaultPrefix:
+    def test_is_command_slash(self):
+        e = MessageEvent(text="/help")
+        assert e.is_command()
+
+    def test_is_command_plain_text(self):
+        e = MessageEvent(text="hello")
+        assert not e.is_command()
+
+    def test_get_command(self):
+        e = MessageEvent(text="/reset some args")
+        assert e.get_command() == "reset"
+
+    def test_get_command_args(self):
+        e = MessageEvent(text="/model gpt-4")
+        assert e.get_command_args() == "gpt-4"
+
+    def test_get_command_args_empty(self):
+        e = MessageEvent(text="/help")
+        assert e.get_command_args() == ""
+
+    def test_not_command_returns_full_text(self):
+        e = MessageEvent(text="just text")
+        assert e.get_command_args() == "just text"
+
+
+# ── MessageEvent with custom prefix ──
+
+class TestMessageEventCustomPrefix:
+    def test_is_command_bang(self):
+        e = MessageEvent(text="!help", command_prefix="!")
+        assert e.is_command()
+
+    def test_slash_not_command_with_bang_prefix(self):
+        e = MessageEvent(text="/help", command_prefix="!")
+        assert not e.is_command()
+
+    def test_get_command_bang(self):
+        e = MessageEvent(text="!reset args", command_prefix="!")
+        assert e.get_command() == "reset"
+
+    def test_get_command_args_bang(self):
+        e = MessageEvent(text="!model gpt-4", command_prefix="!")
+        assert e.get_command_args() == "gpt-4"
+
+    def test_backslash_prefix(self):
+        e = MessageEvent(text="\\help", command_prefix="\\")
+        assert e.is_command()
+        assert e.get_command() == "help"
+
+    def test_multi_char_prefix(self):
+        e = MessageEvent(text="!!help", command_prefix="!!")
+        assert e.is_command()
+        assert e.get_command() == "help"
+
+
+# ── GatewayConfig.get_command_prefix ──
+
+class TestGatewayConfigCommandPrefix:
+    def test_default_prefix(self):
+        cfg = GatewayConfig()
+        assert cfg.get_command_prefix() == "/"
+
+    def test_global_override(self):
+        cfg = GatewayConfig(command_prefix="!")
+        assert cfg.get_command_prefix() == "!"
+        assert cfg.get_command_prefix(Platform.SLACK) == "!"
+
+    def test_platform_override(self):
+        cfg = GatewayConfig(
+            command_prefix="/",
+            platform_command_prefix={Platform.MATRIX: "\\", Platform.MATTERMOST: "!"},
+        )
+        assert cfg.get_command_prefix() == "/"
+        assert cfg.get_command_prefix(Platform.MATRIX) == "\\"
+        assert cfg.get_command_prefix(Platform.MATTERMOST) == "!"
+        assert cfg.get_command_prefix(Platform.SLACK) == "/"
+
+    def test_from_dict_command_prefix(self):
+        cfg = GatewayConfig.from_dict({
+            "command_prefix": "!",
+            "platform_command_prefix": {"matrix": "\\"},
+        })
+        assert cfg.command_prefix == "!"
+        assert cfg.platform_command_prefix == {Platform.MATRIX: "\\"}
+        assert cfg.get_command_prefix(Platform.MATRIX) == "\\"
+        assert cfg.get_command_prefix(Platform.DISCORD) == "!"
+
+    def test_from_dict_defaults(self):
+        cfg = GatewayConfig.from_dict({})
+        assert cfg.command_prefix == "/"
+        assert cfg.platform_command_prefix == {}


### PR DESCRIPTION
## Summary

Closes #12688.

On Matrix and Mattermost, the `/` character is reserved by the platform for native slash commands, making Hermes gateway commands like `/reset`, `/model`, `/status` unreliable or unusable.

## Changes

Add a `command_prefix` config key with per-platform override support:

```yaml
gateway:
  command_prefix: "!"       # global default (default: /)
  platform_command_prefix:
    matrix: "\\"
    mattermost: "!"
```

### Modified files:
- **gateway/config.py** — Add `command_prefix` and `platform_command_prefix` fields to `GatewayConfig`, with `get_command_prefix(platform)` method and YAML parsing
- **gateway/platforms/base.py** — Use `command_prefix` in `MessageEvent.is_command` and `command_name` properties
- **gateway/platforms/{discord,matrix,mattermost,slack,telegram}.py** — Pass `command_prefix` through to `MessageEvent` construction
- **gateway/run.py** — Set `adapter.command_prefix` from config during platform init
- **tests/test_command_prefix.py** — 17 tests covering MessageEvent detection, GatewayConfig defaults/overrides, and config parsing

## Testing

All 17 new tests pass. No existing tests broken. Default remains `/` so existing setups are unaffected.