### PR TITLE
docs(agent): align _build_system_prompt layer comments with implement…

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3706,12 +3706,14 @@ class AIAgent:
         """
         # Layers (in order):
         #   1. Agent identity — SOUL.md when available, else DEFAULT_AGENT_IDENTITY
-        #   2. User / gateway system prompt (if provided)
-        #   3. Persistent memory (frozen snapshot)
-        #   4. Skills guidance (if skills tools are loaded)
-        #   5. Context files (AGENTS.md, .cursorrules — SOUL.md excluded here when used as identity)
-        #   6. Current date & time (frozen at build time)
-        #   7. Platform-specific formatting hint
+        #   2. Tool-aware guidance (memory/session_search/skills behavior)
+        #   3. Optional model/tool guidance (tool-use enforcement, model-specific ops prompts)
+        #   4. User / gateway system prompt (if provided)
+        #   5. Persistent snapshots (memory + user profile) and external memory-provider block
+        #   6. Skills index prompt (if skills tools are loaded)
+        #   7. Context files (AGENTS.md, .cursorrules — SOUL.md excluded here when used as identity)
+        #   8. Conversation metadata (time, optional session/model/provider)
+        #   9. Environment and platform hints
 
         # Try SOUL.md as primary identity (unless context files are skipped)
         _soul_loaded = False


### PR DESCRIPTION
## What does this PR do?

This PR updates the inline layer-order comment in `AIAgent._build_system_prompt()` so it matches the current implementation in `run_agent.py`.

This is a documentation-only change (no runtime behavior change).

## Related Issue

N/A

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- Updated `_build_system_prompt()` layer-order comment in `run_agent.py`
- Included currently active layers (tool-aware guidance, model/tool guidance, memory provider block, env/platform hints)

## How to Test

1. Open `run_agent.py`
2. Navigate to `AIAgent._build_system_prompt()`
3. Verify the comment order aligns with the actual `prompt_parts.append(...)` flow below it
