### PR TITLE
fix(gateway): harden macOS PID detection

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -6,6 +6,7 @@ Handles: hermes gateway [run|start|stop|restart|status|install|uninstall|setup]
 
 import asyncio
 import os
+import re
 import shutil
 import signal
 import subprocess
@@ -59,6 +60,34 @@ class GatewayRuntimeSnapshot:
     def has_process_service_mismatch(self) -> bool:
         return self.service_installed and self.running and not self.service_running
 
+def _parse_launchctl_pid(output: str, label: str) -> int | None:
+    """Extract a launchd-managed PID from either tabular or plist-style output."""
+    stripped = output.strip()
+    if not stripped:
+        return None
+
+    for line in stripped.splitlines():
+        parts = line.split()
+        if len(parts) >= 3 and parts[2] == label:
+            try:
+                pid = int(parts[0])
+            except ValueError:
+                continue
+            return pid if pid > 0 else None
+
+    plist_label = re.search(r'"Label"\s*=\s*"([^"]+)"\s*;', stripped)
+    if plist_label and plist_label.group(1) != label:
+        return None
+
+    plist_pid = re.search(r'"PID"\s*=\s*(\d+)\s*;', stripped)
+    if not plist_pid:
+        return None
+
+    pid = int(plist_pid.group(1))
+    return pid if pid > 0 else None
+
+
+
 def _get_service_pids() -> set:
     """Return PIDs currently managed by systemd or launchd gateway services.
 
@@ -106,16 +135,9 @@ def _get_service_pids() -> set:
                 capture_output=True, text=True, timeout=5,
             )
             if result.returncode == 0:
-                # Output: "PID\tStatus\tLabel" header, then one data line
-                for line in result.stdout.strip().splitlines():
-                    parts = line.split()
-                    if len(parts) >= 3 and parts[2] == label:
-                        try:
-                            pid = int(parts[0])
-                            if pid > 0:
-                                pids.add(pid)
-                        except ValueError:
-                            pass
+                pid = _parse_launchctl_pid(result.stdout, label)
+                if pid is not None:
+                    pids.add(pid)
         except (FileNotFoundError, subprocess.TimeoutExpired):
             pass
 
@@ -245,8 +267,11 @@ def _scan_gateway_pids(exclude_pids: set[int], all_profiles: bool = False) -> li
                             pass
                     current_cmd = ""
         else:
+            ps_cmd = ["ps", "-A", "-ww", "-o", "pid=,command="] if is_macos() else [
+                "ps", "-A", "eww", "-o", "pid=,command="
+            ]
             result = subprocess.run(
-                ["ps", "-A", "eww", "-o", "pid=,command="],
+                ps_cmd,
                 capture_output=True,
                 text=True,
                 timeout=10,

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -252,10 +252,11 @@ def test_install_linux_gateway_from_setup_system_choice_as_root_installs(monkeyp
 def test_find_gateway_pids_falls_back_to_pid_file_when_process_scan_fails(monkeypatch):
     monkeypatch.setattr(gateway, "_get_service_pids", lambda: set())
     monkeypatch.setattr(gateway, "is_windows", lambda: False)
+    monkeypatch.setattr(gateway, "is_macos", lambda: True)
     monkeypatch.setattr("gateway.status.get_running_pid", lambda: 321)
 
     def fake_run(cmd, **kwargs):
-        if cmd[:4] == ["ps", "-A", "eww", "-o"]:
+        if cmd == ["ps", "-A", "-ww", "-o", "pid=,command="]:
             return SimpleNamespace(returncode=1, stdout="", stderr="ps failed")
         raise AssertionError(f"Unexpected command: {cmd}")
 

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -719,6 +719,33 @@ class TestGetServicePids:
         pids = gateway_cli._get_service_pids()
         assert 67890 in pids
 
+    def test_returns_launchd_pid_from_plist_style_output(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "is_linux", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
+
+        def fake_run(cmd, **kwargs):
+            joined = " ".join(str(c) for c in cmd)
+            if "launchctl" in joined and "list" in joined:
+                return subprocess.CompletedProcess(
+                    cmd,
+                    0,
+                    stdout=(
+                        "{\n"
+                        "\t\"Label\" = \"ai.hermes.gateway\";\n"
+                        "\t\"PID\" = 7817;\n"
+                        "\t\"LastExitStatus\" = 19200;\n"
+                        "};\n"
+                    ),
+                    stderr="",
+                )
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        pids = gateway_cli._get_service_pids()
+        assert 7817 in pids
+
     def test_returns_empty_when_no_services(self, monkeypatch):
         monkeypatch.setattr(gateway_cli, "is_linux", lambda: False)
         monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
@@ -818,6 +845,33 @@ class TestFindGatewayPidsExclude:
         pids = gateway_cli.find_gateway_pids()
 
         assert pids == [100]
+
+
+class TestScanGatewayPids:
+    def test_uses_macos_safe_ps_args(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "is_windows", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        monkeypatch.setattr("os.getpid", lambda: 999)
+
+        seen = []
+
+        def fake_run(cmd, **kwargs):
+            seen.append(cmd)
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout=(
+                    "100 /Users/brenner/.hermes/hermes-agent/venv/bin/python -m hermes_cli.main gateway run --replace\n"
+                ),
+                stderr="",
+            )
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        pids = gateway_cli._scan_gateway_pids(set())
+
+        assert pids == [100]
+        assert seen == [["ps", "-A", "-ww", "-o", "pid=,command="]]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This hardens macOS gateway PID discovery so Hermes stops producing false negatives when a launchd-managed gateway is alive.

Specifically, this PR:
- parses both legacy tabular and newer plist-style `launchctl list <label>` output in `_get_service_pids()`
- uses macOS-safe `ps` arguments for manual gateway process discovery while preserving the existing non-macOS path
- adds regression coverage for plist-style launchctl output and the macOS process-scan path
- updates an existing PID-file fallback test to match the macOS-safe `ps` invocation

## Problem

On the affected macOS install, these commands disagreed:
- `hermes gateway status`
- `hermes cron status`

`launchctl` showed the gateway loaded and running with a real PID, but `find_gateway_pids()` returned no processes, so `hermes cron status` incorrectly claimed the gateway was not running.

## Root cause

There were two macOS-specific detection bugs:

1. `_get_service_pids()` only understood older tabular `launchctl list <label>` output, but newer macOS returns plist-style output like:
   ```text
   {
       "Label" = "ai.hermes.gateway";
       "PID" = 7817;
   };
   ```

2. `_scan_gateway_pids()` used `ps -A eww -o pid=,command=` for every non-Windows platform. That works on Linux, but the macOS `ps` on the repro machine rejects that invocation.

## What changed

### launchd PID parsing

Added `_parse_launchctl_pid()` and used it from `_get_service_pids()` so Hermes now accepts both:
- legacy tabular `launchctl list` output
- plist-style `launchctl list` output from newer macOS

### macOS-safe process scanning

`_scan_gateway_pids()` now chooses:
- macOS: `ps -A -ww -o pid=,command=`
- non-macOS: existing `ps -A eww -o pid=,command=` path

## Tests

Run locally:
- `pytest tests/hermes_cli/test_gateway.py tests/hermes_cli/test_update_gateway_restart.py -q`

Result:
- `61 passed`

## Notes

I found two existing open PRs in similar territory (#11293 and #10636). I'm opening this because I reproduced the bug locally against a live macOS launchd install, implemented the fix against current `main`, and validated it in the current test layout.
