### PR TITLE
fix(gateway): add Signal message type classification for documents

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -492,6 +492,8 @@ class SignalAdapter(BasePlatformAdapter):
                 msg_type = MessageType.VOICE
             elif any(mt.startswith("image/") for mt in media_types):
                 msg_type = MessageType.PHOTO
+            elif any(mt.startswith("application/") or mt.startswith("text/") for mt in media_types):
+                msg_type = MessageType.DOCUMENT
 
         # Parse timestamp from envelope data (milliseconds since epoch)
         ts_ms = envelope_data.get("timestamp", 0)

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -664,53 +664,96 @@ def _make_dm_envelope(sender: str, attachments: list, text: str = "") -> dict:
 
 
 class TestSignalInboundMessageTypeClassification:
-    """_handle_envelope must set MessageType.DOCUMENT for application/* attachments.
+    """_handle_envelope must set MessageType.DOCUMENT for application/* and text/* attachments.
 
     Before the fix, PDFs and other documents left msg_type as MessageType.TEXT,
     so run.py's document-context injection (which gates on MessageType.DOCUMENT)
     silently dropped the file and the agent never saw it.
     """
 
-    @pytest.mark.asyncio
-    async def test_pdf_attachment_sets_document_type(self, monkeypatch):
-        """A PDF attachment (application/pdf) must produce MessageType.DOCUMENT, not TEXT."""
-        from gateway.platforms.base import MessageType
-
+    async def _dispatch_single_attachment(self, monkeypatch, content_type: str,
+                                          att_id: str, fetch_path: str, fetch_ext: str):
+        """Helper: run _handle_envelope with one attachment and return the dispatched event."""
         envelope = _make_dm_envelope(
             sender="+15559876543",
             attachments=[{
-                "contentType": "application/pdf",
-                "id": "6zLO3b-6Yf3zVWeLDctA.pdf",
-                "size": 508237,
-                "filename": "report.pdf",
+                "contentType": content_type,
+                "id": att_id,
+                "size": 1024,
+                "filename": None,
                 "width": None,
                 "height": None,
                 "caption": None,
                 "uploadTimestamp": 1700000000000,
             }],
-            text="here's the doc",
         )
-
         adapter = _make_signal_adapter(monkeypatch)
         adapter._rpc, _ = _stub_rpc(None)
-
         dispatched = []
 
         async def _fake_handle_message(event):
             dispatched.append(event)
 
         adapter.handle_message = _fake_handle_message
-        adapter._fetch_attachment = AsyncMock(return_value=("/tmp/report.pdf", ".pdf"))
-
+        adapter._fetch_attachment = AsyncMock(return_value=(fetch_path, fetch_ext))
         await adapter._handle_envelope(envelope)
-
         assert dispatched, "_handle_envelope did not dispatch any event"
-        event = dispatched[0]
+        return dispatched[0]
+
+    @pytest.mark.asyncio
+    async def test_pdf_attachment_sets_document_type(self, monkeypatch):
+        """A PDF attachment (application/pdf) must produce MessageType.DOCUMENT, not TEXT."""
+        from gateway.platforms.base import MessageType
+
+        event = await self._dispatch_single_attachment(
+            monkeypatch,
+            content_type="application/pdf",
+            att_id="6zLO3b-6Yf3zVWeLDctA.pdf",
+            fetch_path="/tmp/report.pdf",
+            fetch_ext=".pdf",
+        )
+
         assert event.message_type == MessageType.DOCUMENT, (
             f"Expected DOCUMENT, got {event.message_type}. "
             "PDFs must be classified as DOCUMENT so run.py injects file context."
         )
         assert "/tmp/report.pdf" in event.media_urls
+
+    @pytest.mark.asyncio
+    async def test_text_plain_attachment_sets_document_type(self, monkeypatch):
+        """A text/plain attachment must produce MessageType.DOCUMENT, not TEXT."""
+        from gateway.platforms.base import MessageType
+
+        event = await self._dispatch_single_attachment(
+            monkeypatch,
+            content_type="text/plain",
+            att_id="notes.txt",
+            fetch_path="/tmp/notes.txt",
+            fetch_ext=".txt",
+        )
+
+        assert event.message_type == MessageType.DOCUMENT, (
+            f"Expected DOCUMENT, got {event.message_type}. "
+            "text/plain must be classified as DOCUMENT so run.py injects file context."
+        )
+
+    @pytest.mark.asyncio
+    async def test_text_html_attachment_sets_document_type(self, monkeypatch):
+        """A text/html attachment must produce MessageType.DOCUMENT (covers the text/* wildcard)."""
+        from gateway.platforms.base import MessageType
+
+        event = await self._dispatch_single_attachment(
+            monkeypatch,
+            content_type="text/html",
+            att_id="page.html",
+            fetch_path="/tmp/page.html",
+            fetch_ext=".html",
+        )
+
+        assert event.message_type == MessageType.DOCUMENT, (
+            f"Expected DOCUMENT, got {event.message_type}. "
+            "text/html must be classified as DOCUMENT so run.py injects file context."
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -641,6 +641,79 @@ class TestSignalMediaExtraction:
 
 
 # ---------------------------------------------------------------------------
+# Inbound attachment message type classification
+# ---------------------------------------------------------------------------
+
+def _make_dm_envelope(sender: str, attachments: list, text: str = "") -> dict:
+    """Build a minimal signal-cli DM envelope with the given attachments."""
+    return {
+        "envelope": {
+            "sourceNumber": sender,
+            "sourceName": "Test User",
+            "sourceUuid": "aaaaaaaa-0000-0000-0000-000000000001",
+            "timestamp": 1700000000000,
+            "dataMessage": {
+                "timestamp": 1700000000000,
+                "message": text,
+                "expiresInSeconds": 0,
+                "viewOnce": False,
+                "attachments": attachments,
+            },
+        }
+    }
+
+
+class TestSignalInboundMessageTypeClassification:
+    """_handle_envelope must set MessageType.DOCUMENT for application/* attachments.
+
+    Before the fix, PDFs and other documents left msg_type as MessageType.TEXT,
+    so run.py's document-context injection (which gates on MessageType.DOCUMENT)
+    silently dropped the file and the agent never saw it.
+    """
+
+    @pytest.mark.asyncio
+    async def test_pdf_attachment_sets_document_type(self, monkeypatch):
+        """A PDF attachment (application/pdf) must produce MessageType.DOCUMENT, not TEXT."""
+        from gateway.platforms.base import MessageType
+
+        envelope = _make_dm_envelope(
+            sender="+15559876543",
+            attachments=[{
+                "contentType": "application/pdf",
+                "id": "6zLO3b-6Yf3zVWeLDctA.pdf",
+                "size": 508237,
+                "filename": "report.pdf",
+                "width": None,
+                "height": None,
+                "caption": None,
+                "uploadTimestamp": 1700000000000,
+            }],
+            text="here's the doc",
+        )
+
+        adapter = _make_signal_adapter(monkeypatch)
+        adapter._rpc, _ = _stub_rpc(None)
+
+        dispatched = []
+
+        async def _fake_handle_message(event):
+            dispatched.append(event)
+
+        adapter.handle_message = _fake_handle_message
+        adapter._fetch_attachment = AsyncMock(return_value=("/tmp/report.pdf", ".pdf"))
+
+        await adapter._handle_envelope(envelope)
+
+        assert dispatched, "_handle_envelope did not dispatch any event"
+        event = dispatched[0]
+        assert event.message_type == MessageType.DOCUMENT, (
+            f"Expected DOCUMENT, got {event.message_type}. "
+            "PDFs must be classified as DOCUMENT so run.py injects file context."
+        )
+        assert "/tmp/report.pdf" in event.media_urls
+
+
+# ---------------------------------------------------------------------------
 # send_document now routes through _send_attachment (#5105 bonus)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What does this PR do?

Add missing Signal adapter `DOCUMENT` message type for non-image/non-audio attachments.


## Related Issue

Fixes https://github.com/NousResearch/hermes-agent/issues/12845

## Type of Change

<!-- Check the one that applies. -->

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Changed `src/gateway/platforms/signal.py` to include support for `application/*` and `text/*` MIME types.

## How to Test

1. Send a PDF via Note-to-Self
2. Document context injection is triggered
3. Agent correctly reads and summarizes the file

## Checklist

### Code

- [X] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [X] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [X] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [X] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [X] I've run `pytest tests/ -q` and all tests pass
- [X] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [X] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [N/A] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [N/A] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [N/A] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [N/A] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [N/A] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
DEBUG gateway.platforms.signal: Signal: Note to Self attachments: [{'contentType': 'application/pdf', 'filename': '1-s2.0-S0090429520315314-main.pdf', 'id': '6zLO3b-6Yf3zVWeLDctA.pdf', 'size': 508237, ...}]
DEBUG gateway.platforms.signal: Signal: message from +1********** in +1**********: What's this?
INFO  gateway.run: inbound message: platform=signal user=####### chat=+1********** msg="What's this?"
DEBUG gateway.run: run_agent resolved: model=claude-sonnet-4.6 provider=copilot
DEBUG gateway.run: Created new agent for session agent:main:signal:dm:+1**********
DEBUG gateway.platforms.signal: Signal: message from +1********** in +1**********: /approve
INFO  gateway.run: User approved 1 dangerous command(s) via /approve
INFO  gateway.run: response ready: platform=signal chat=+1********** time=27.2s api_calls=3 response=234 chars
INFO  gateway.platforms.base: [Signal] Sending response (234 chars) to +1**********
```

