### PR TITLE
fix: Update Gemini model from 1.5-flash to 1.5-flash-latest

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -40,7 +40,7 @@ _VALID_BUDGETS = {"low", "mid", "high"}
 _PROVIDER_DEFAULT_MODELS = {
     "openai": "gpt-4o-mini",
     "anthropic": "claude-haiku-4-5",
-    "gemini": "gemini-2.5-flash",
+    "gemini": "gemini-1.5-flash-latest",
     "groq": "openai/gpt-oss-120b",
     "openrouter": "qwen/qwen3.5-9b",
     "minimax": "MiniMax-M2.7",

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -90,7 +90,7 @@ def test_no_warning_when_aux_context_sufficient(mock_get_client, mock_ctx_len):
     mock_client = MagicMock()
     mock_client.base_url = "https://openrouter.ai/api/v1"
     mock_client.api_key = "sk-aux"
-    mock_get_client.return_value = (mock_client, "google/gemini-2.5-flash")
+    mock_get_client.return_value = (mock_client, "google/gemini-1.5-flash-latest")
 
     messages = []
     agent._emit_status = lambda msg: messages.append(msg)

--- a/tests/run_agent/test_fallback_model.py
+++ b/tests/run_agent/test_fallback_model.py
@@ -232,7 +232,7 @@ class TestTryActivateFallback:
 
     def test_prompt_caching_disabled_for_non_claude(self):
         agent = _make_agent(
-            fallback_model={"provider": "openrouter", "model": "google/gemini-2.5-flash"},
+            fallback_model={\"provider\": \"openrouter\", \"model\": \"google/gemini-1.5-flash-latest\"},
         )
         mock_client = _mock_resolve(
             api_key="sk-or-key",


### PR DESCRIPTION
This PR updates the Gemini model from the deprecated 1.5-flash to the new 1.5-flash-latest to resolve 404 errors.