### PR TITLE
fix(kimi): include api.moonshot.cn in public temperature override

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -155,7 +155,7 @@ def _fixed_temperature_for_model(
 
     # Public Moonshot API has a stricter contract for some models than the
     # Coding Plan endpoint — check it first so it wins on conflict.
-    if base_url and "api.moonshot.ai" in base_url.lower():
+    if base_url and ("api.moonshot.ai" in base_url.lower() or "api.moonshot.cn" in base_url.lower()):
         public = _KIMI_PUBLIC_API_OVERRIDES.get(bare)
         if public is not None:
             logger.debug(

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -845,6 +845,8 @@ class TestKimiForCodingTemperature:
             "https://api.moonshot.ai/v1",
             "https://api.moonshot.ai/v1/",
             "https://API.MOONSHOT.AI/v1",
+            "https://api.moonshot.cn/v1",
+            "https://api.moonshot.cn/v1/",
         ],
     )
     def test_kimi_k2_5_public_api_forces_temperature_1(self, base_url):

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -928,6 +928,16 @@ class TestBuildApiKwargs:
 
         assert kwargs["temperature"] == 1.0
 
+    def test_public_moonshot_cn_kimi_k2_5_forces_temperature_1(self, agent):
+        agent.base_url = "https://api.moonshot.cn/v1"
+        agent._base_url_lower = agent.base_url.lower()
+        agent.model = "kimi-k2.5"
+        messages = [{"role": "user", "content": "hi"}]
+
+        kwargs = agent._build_api_kwargs(messages)
+
+        assert kwargs["temperature"] == 1.0
+
     def test_kimi_coding_endpoint_keeps_kimi_k2_5_at_0_6(self, agent):
         agent.base_url = "https://api.kimi.com/coding/v1"
         agent._base_url_lower = agent.base_url.lower()

--- a/tests/test_trajectory_compressor.py
+++ b/tests/test_trajectory_compressor.py
@@ -78,6 +78,30 @@ def test_generate_summary_public_moonshot_kimi_k2_5_forces_temperature_1():
     assert compressor.client.chat.completions.create.call_args.kwargs["temperature"] == 1.0
 
 
+def test_generate_summary_public_moonshot_cn_kimi_k2_5_forces_temperature_1():
+    config = CompressionConfig(
+        summarization_model="kimi-k2.5",
+        base_url="https://api.moonshot.cn/v1",
+        temperature=0.3,
+        summary_target_tokens=100,
+        max_retries=1,
+    )
+    compressor = TrajectoryCompressor.__new__(TrajectoryCompressor)
+    compressor.config = config
+    compressor.logger = MagicMock()
+    compressor._use_call_llm = False
+    compressor.client = MagicMock()
+    compressor.client.chat.completions.create.return_value = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="[CONTEXT SUMMARY]: summary"))]
+    )
+
+    metrics = TrajectoryMetrics()
+    result = compressor._generate_summary("tool output", metrics)
+
+    assert result.startswith("[CONTEXT SUMMARY]:")
+    assert compressor.client.chat.completions.create.call_args.kwargs["temperature"] == 1.0
+
+
 # ---------------------------------------------------------------------------
 # CompressionConfig
 # ---------------------------------------------------------------------------

--- a/tests/test_trajectory_compressor_async.py
+++ b/tests/test_trajectory_compressor_async.py
@@ -169,3 +169,32 @@ async def test_generate_summary_async_public_moonshot_kimi_k2_5_forces_temperatu
 
     assert result.startswith("[CONTEXT SUMMARY]:")
     assert async_client.chat.completions.create.call_args.kwargs["temperature"] == 1.0
+
+
+
+@pytest.mark.asyncio
+async def test_generate_summary_async_public_moonshot_cn_kimi_k2_5_forces_temperature_1():
+    from trajectory_compressor import CompressionConfig, TrajectoryCompressor, TrajectoryMetrics
+
+    config = CompressionConfig(
+        summarization_model="kimi-k2.5",
+        base_url="https://api.moonshot.cn/v1",
+        temperature=0.3,
+        summary_target_tokens=100,
+        max_retries=1,
+    )
+    compressor = TrajectoryCompressor.__new__(TrajectoryCompressor)
+    compressor.config = config
+    compressor.logger = MagicMock()
+    compressor._use_call_llm = False
+    async_client = MagicMock()
+    async_client.chat.completions.create = MagicMock(return_value=SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="[CONTEXT SUMMARY]: summary"))]
+    ))
+    compressor._get_async_client = MagicMock(return_value=async_client)
+
+    metrics = TrajectoryMetrics()
+    result = await compressor._generate_summary_async("tool output", metrics)
+
+    assert result.startswith("[CONTEXT SUMMARY]:")
+    assert async_client.chat.completions.create.call_args.kwargs["temperature"] == 1.0


### PR DESCRIPTION
Salvage of #12806 by @kagura-agent onto current `main`.

## Summary
- extend the public Moonshot temperature override to `api.moonshot.cn` as well as `api.moonshot.ai`
- preserve the existing Coding Plan behavior on `api.kimi.com/coding`
- add direct-call regression coverage for the China endpoint in `run_agent` and the trajectory compressor paths

## Why
Current `main` already routes `api.moonshot.cn` as a Moonshot/Kimi provider in other places, but `_fixed_temperature_for_model()` only treated `api.moonshot.ai` as the public endpoint. That left China users on `api.moonshot.cn/v1` still hitting:

`invalid temperature: only 1 is allowed for this model`

## Validation
- targeted pytest: 7 passed
  - `tests/agent/test_auxiliary_client.py`
  - `tests/run_agent/test_run_agent.py`
  - `tests/test_trajectory_compressor.py`
  - `tests/test_trajectory_compressor_async.py`
- isolated E2E import check:
  - `api.moonshot.cn/v1` -> `temperature=1.0`
  - `api.kimi.com/coding/v1` -> `temperature=0.6`

Contributor authorship preserved via cherry-pick.

Closes #12745
Refs #12835
