### PR TITLE
fix(vision): honor auxiliary.vision.temperature from config

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -209,6 +209,7 @@ AUTHOR_MAP = {
     "kagura.chen28@gmail.com": "kagura-agent",
     "1342088860@qq.com": "youngDoo",
     "kamil@gwozdz.me": "kamil-gwozdz",
+    "skmishra1991@gmail.com": "bugkill3r",
     "karamusti912@gmail.com": "MustafaKara7",
     "kira@ariaki.me": "kira-ariaki",
     "knopki@duck.com": "knopki",

--- a/tests/tools/test_browser_camofox.py
+++ b/tests/tools/test_browser_camofox.py
@@ -260,6 +260,72 @@ class TestCamofoxGetImages:
         assert result["images"][0]["src"] == "https://x.com/img.png"
 
 
+class TestCamofoxVisionConfig:
+    @patch("tools.browser_camofox.requests.post")
+    @patch("tools.browser_camofox._get")
+    @patch("tools.browser_camofox._get_raw")
+    def test_camofox_vision_uses_configured_temperature_and_timeout(self, mock_get_raw, mock_get, mock_post, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        mock_post.return_value = _mock_response(json_data={"tabId": "tab11", "url": "https://x.com"})
+        camofox_navigate("https://x.com", task_id="t11")
+
+        snapshot_text = '- button "Submit"\n'
+        raw_resp = MagicMock()
+        raw_resp.content = b"fakepng"
+        mock_get_raw.return_value = raw_resp
+        mock_get.return_value = {"snapshot": snapshot_text}
+
+        mock_response = MagicMock()
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Camofox screenshot analysis"
+        mock_response.choices = [mock_choice]
+
+        with (
+            patch("tools.browser_camofox.open", create=True) as mock_open,
+            patch("agent.auxiliary_client.call_llm", return_value=mock_response) as mock_llm,
+            patch("hermes_cli.config.load_config", return_value={"auxiliary": {"vision": {"temperature": 1, "timeout": 45}}}),
+        ):
+            mock_open.return_value.__enter__.return_value.read.return_value = b"fakepng"
+            result = json.loads(camofox_vision("what is on the page?", annotate=True, task_id="t11"))
+
+        assert result["success"] is True
+        assert result["analysis"] == "Camofox screenshot analysis"
+        assert mock_llm.call_args.kwargs["temperature"] == 1.0
+        assert mock_llm.call_args.kwargs["timeout"] == 45.0
+
+    @patch("tools.browser_camofox.requests.post")
+    @patch("tools.browser_camofox._get")
+    @patch("tools.browser_camofox._get_raw")
+    def test_camofox_vision_defaults_temperature_when_config_omits_it(self, mock_get_raw, mock_get, mock_post, monkeypatch):
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        mock_post.return_value = _mock_response(json_data={"tabId": "tab12", "url": "https://x.com"})
+        camofox_navigate("https://x.com", task_id="t12")
+
+        snapshot_text = '- button "Submit"\n'
+        raw_resp = MagicMock()
+        raw_resp.content = b"fakepng"
+        mock_get_raw.return_value = raw_resp
+        mock_get.return_value = {"snapshot": snapshot_text}
+
+        mock_response = MagicMock()
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Default camofox screenshot analysis"
+        mock_response.choices = [mock_choice]
+
+        with (
+            patch("tools.browser_camofox.open", create=True) as mock_open,
+            patch("agent.auxiliary_client.call_llm", return_value=mock_response) as mock_llm,
+            patch("hermes_cli.config.load_config", return_value={"auxiliary": {"vision": {}}}),
+        ):
+            mock_open.return_value.__enter__.return_value.read.return_value = b"fakepng"
+            result = json.loads(camofox_vision("what is on the page?", annotate=True, task_id="t12"))
+
+        assert result["success"] is True
+        assert result["analysis"] == "Default camofox screenshot analysis"
+        assert mock_llm.call_args.kwargs["temperature"] == 0.1
+        assert mock_llm.call_args.kwargs["timeout"] == 120.0
+
+
 # ---------------------------------------------------------------------------
 # Routing integration — verify browser_tool routes to camofox
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_browser_console.py
+++ b/tests/tools/test_browser_console.py
@@ -3,6 +3,7 @@
 import json
 import os
 import sys
+from pathlib import Path
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -192,6 +193,63 @@ class TestBrowserVisionAnnotate:
                 args = mock_cmd.call_args[0]
                 cmd_args = args[2] if len(args) > 2 else []
                 assert "--annotate" in cmd_args
+
+
+class TestBrowserVisionConfig:
+    def _setup_screenshot(self, tmp_path):
+        shots_dir = tmp_path / "browser_screenshots"
+        shots_dir.mkdir()
+        screenshot = shots_dir / "shot.png"
+        screenshot.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
+        return shots_dir, screenshot
+
+    def test_browser_vision_uses_configured_temperature_and_timeout(self, tmp_path):
+        from tools.browser_tool import browser_vision
+
+        shots_dir, screenshot = self._setup_screenshot(tmp_path)
+        mock_response = MagicMock()
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Annotated screenshot analysis"
+        mock_response.choices = [mock_choice]
+
+        with (
+            patch("hermes_constants.get_hermes_dir", return_value=shots_dir),
+            patch("tools.browser_tool._cleanup_old_screenshots"),
+            patch("tools.browser_tool._run_browser_command", return_value={"success": True, "data": {"path": str(screenshot)}}),
+            patch("tools.browser_tool._get_vision_model", return_value="test-model"),
+            patch("hermes_cli.config.load_config", return_value={"auxiliary": {"vision": {"temperature": 1, "timeout": 45}}}),
+            patch("tools.browser_tool.call_llm", return_value=mock_response) as mock_llm,
+        ):
+            result = json.loads(browser_vision("what is on the page?", task_id="test"))
+
+        assert result["success"] is True
+        assert result["analysis"] == "Annotated screenshot analysis"
+        assert mock_llm.call_args.kwargs["temperature"] == 1.0
+        assert mock_llm.call_args.kwargs["timeout"] == 45.0
+
+    def test_browser_vision_defaults_temperature_when_config_omits_it(self, tmp_path):
+        from tools.browser_tool import browser_vision
+
+        shots_dir, screenshot = self._setup_screenshot(tmp_path)
+        mock_response = MagicMock()
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Default screenshot analysis"
+        mock_response.choices = [mock_choice]
+
+        with (
+            patch("hermes_constants.get_hermes_dir", return_value=shots_dir),
+            patch("tools.browser_tool._cleanup_old_screenshots"),
+            patch("tools.browser_tool._run_browser_command", return_value={"success": True, "data": {"path": str(screenshot)}}),
+            patch("tools.browser_tool._get_vision_model", return_value="test-model"),
+            patch("hermes_cli.config.load_config", return_value={"auxiliary": {"vision": {}}}),
+            patch("tools.browser_tool.call_llm", return_value=mock_response) as mock_llm,
+        ):
+            result = json.loads(browser_vision("what is on the page?", task_id="test"))
+
+        assert result["success"] is True
+        assert result["analysis"] == "Default screenshot analysis"
+        assert mock_llm.call_args.kwargs["temperature"] == 0.1
+        assert mock_llm.call_args.kwargs["timeout"] == 120.0
 
 
 # ── auto-recording config ────────────────────────────────────────────

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -366,6 +366,66 @@ class TestErrorLoggingExcInfo:
             assert warning_records[0].exc_info is not None
 
 
+class TestVisionConfig:
+    @pytest.mark.asyncio
+    async def test_vision_uses_configured_temperature_and_timeout(self, tmp_path):
+        img = tmp_path / "test.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
+
+        mock_response = MagicMock()
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Configured image analysis"
+        mock_response.choices = [mock_choice]
+
+        with (
+            patch("hermes_cli.config.load_config", return_value={
+                "auxiliary": {"vision": {"temperature": 1, "timeout": 77}}
+            }),
+            patch(
+                "tools.vision_tools._image_to_base64_data_url",
+                return_value="data:image/png;base64,abc",
+            ),
+            patch(
+                "tools.vision_tools.async_call_llm",
+                new_callable=AsyncMock,
+                return_value=mock_response,
+            ) as mock_llm,
+        ):
+            result = json.loads(await vision_analyze_tool(str(img), "describe this", "test/model"))
+
+        assert result["success"] is True
+        assert mock_llm.await_args.kwargs["temperature"] == 1.0
+        assert mock_llm.await_args.kwargs["timeout"] == 77.0
+
+    @pytest.mark.asyncio
+    async def test_vision_defaults_temperature_when_config_omits_it(self, tmp_path):
+        img = tmp_path / "test.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
+
+        mock_response = MagicMock()
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Default image analysis"
+        mock_response.choices = [mock_choice]
+
+        with (
+            patch("hermes_cli.config.load_config", return_value={"auxiliary": {"vision": {}}}),
+            patch(
+                "tools.vision_tools._image_to_base64_data_url",
+                return_value="data:image/png;base64,abc",
+            ),
+            patch(
+                "tools.vision_tools.async_call_llm",
+                new_callable=AsyncMock,
+                return_value=mock_response,
+            ) as mock_llm,
+        ):
+            result = json.loads(await vision_analyze_tool(str(img), "describe this", "test/model"))
+
+        assert result["success"] is True
+        assert mock_llm.await_args.kwargs["temperature"] == 0.1
+        assert mock_llm.await_args.kwargs["timeout"] == 120.0
+
+
 class TestVisionSafetyGuards:
     @pytest.mark.asyncio
     async def test_local_non_image_file_rejected_before_llm_call(self, tmp_path):

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -545,9 +545,12 @@ def camofox_vision(question: str, annotate: bool = False,
         try:
             from hermes_cli.config import load_config
             _cfg = load_config()
-            _vision_timeout = int(_cfg.get("auxiliary", {}).get("vision", {}).get("timeout", 120))
+            _vision_cfg = _cfg.get("auxiliary", {}).get("vision", {})
+            _vision_timeout = float(_vision_cfg.get("timeout", 120))
+            _vision_temperature = float(_vision_cfg.get("temperature", 0.1))
         except Exception:
-            _vision_timeout = 120
+            _vision_timeout = 120.0
+            _vision_temperature = 0.1
 
         response = call_llm(
             messages=[{
@@ -563,6 +566,7 @@ def camofox_vision(question: str, annotate: bool = False,
                 ],
             }],
             task="vision",
+            temperature=_vision_temperature,
             timeout=_vision_timeout,
         )
         analysis = (response.choices[0].message.content or "").strip() if response.choices else ""

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2098,16 +2098,21 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
         logger.debug("browser_vision: analysing screenshot (%d bytes)",
                      len(_screenshot_bytes))
 
-        # Read vision timeout from config (auxiliary.vision.timeout), default 120s.
+        # Read vision timeout/temperature from config (auxiliary.vision.*).
         # Local vision models (llama.cpp, ollama) can take well over 30s for
-        # screenshot analysis, so the default must be generous.
+        # screenshot analysis, so the default timeout must be generous.
         vision_timeout = 120.0
+        vision_temperature = 0.1
         try:
             from hermes_cli.config import load_config
             _cfg = load_config()
-            _vt = _cfg.get("auxiliary", {}).get("vision", {}).get("timeout")
+            _vision_cfg = _cfg.get("auxiliary", {}).get("vision", {})
+            _vt = _vision_cfg.get("timeout")
             if _vt is not None:
                 vision_timeout = float(_vt)
+            _vtemp = _vision_cfg.get("temperature")
+            if _vtemp is not None:
+                vision_temperature = float(_vtemp)
         except Exception:
             pass
 
@@ -2123,7 +2128,7 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
                 }
             ],
             "max_tokens": 2000,
-            "temperature": 0.1,
+            "temperature": vision_temperature,
             "timeout": vision_timeout,
         }
         if vision_model:

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -553,18 +553,23 @@ async def vision_analyze_tool(
         # Read timeout from config.yaml (auxiliary.vision.timeout), default 120s.
         # Local vision models (llama.cpp, ollama) can take well over 30s.
         vision_timeout = 120.0
+        vision_temperature = 0.1
         try:
             from hermes_cli.config import load_config
             _cfg = load_config()
-            _vt = _cfg.get("auxiliary", {}).get("vision", {}).get("timeout")
+            _vision_cfg = _cfg.get("auxiliary", {}).get("vision", {})
+            _vt = _vision_cfg.get("timeout")
             if _vt is not None:
                 vision_timeout = float(_vt)
+            _vtemp = _vision_cfg.get("temperature")
+            if _vtemp is not None:
+                vision_temperature = float(_vtemp)
         except Exception:
             pass
         call_kwargs = {
             "task": "vision",
             "messages": messages,
-            "temperature": 0.1,
+            "temperature": vision_temperature,
             "max_tokens": 2000,
             "timeout": vision_timeout,
         }


### PR DESCRIPTION
Salvage of #4967 by @bugkill3r onto current `main`.

## Summary
- make `vision_analyze_tool()` read `auxiliary.vision.temperature` from `config.yaml`
- make `browser_vision()` mirror the same temperature/timeout config bridge so screenshot analysis does not bypass the setting
- make `camofox_vision()` honor the same config so the routed browser path stays consistent too
- preserve the existing `0.1` default when the user has not configured vision temperature
- add regression tests for configured and default behavior across all three local vision entry points
- add `skmishra1991@gmail.com -> bugkill3r` to `AUTHOR_MAP` for contributor audit

## Why
The direct vision tool hardcoded `temperature=0.1`, which breaks providers like Kimi/Moonshot vision models that require `temperature=1`. During review I found the same drift in both browser screenshot-analysis paths, so this salvage fixes all local vision entry points together rather than leaving a hidden bypass.

## Validation
- targeted pytest: 6 passed
  - `tests/tools/test_vision_tools.py`
  - `tests/tools/test_browser_console.py`
  - `tests/tools/test_browser_camofox.py`
  - `tests/agent/test_vision_resolved_args.py`
- isolated E2E import check with real `config.yaml`:
  - `vision_analyze_tool()` forwarded `temperature=1.0`, `timeout=45.0`
  - `browser_vision()` forwarded `temperature=1.0`, `timeout=45.0`
  - `camofox_vision()` forwarded `temperature=1.0`, `timeout=45.0`

Contributor authorship preserved via cherry-pick.

Closes #4661
Refs #4967
