### PR TITLE
fix: add base_url_env_var to Anthropic ProviderConfig

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -201,6 +201,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         auth_type="api_key",
         inference_base_url="https://api.anthropic.com",
         api_key_env_vars=("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"),
+        base_url_env_var="ANTHROPIC_BASE_URL",
     ),
     "alibaba": ProviderConfig(
         id="alibaba",


### PR DESCRIPTION
## Problem

The Anthropic `ProviderConfig` in `PROVIDER_REGISTRY` is the only standard API-key provider missing `base_url_env_var`. This causes the credential pool to hardcode `base_url` to `https://api.anthropic.com`, ignoring `ANTHROPIC_BASE_URL` from the environment.

When using a proxy (LiteLLM, custom gateway, etc.), subagent delegation fails with **401 authentication_error** because:
1. `_seed_from_env()` creates pool entries with the hardcoded `base_url`
2. On error recovery, `_swap_credential()` overwrites the child agent's proxy URL with the pool entry's `api.anthropic.com`
3. The proxy API key is sent to real Anthropic → rejected

## Fix

One-line change: add `base_url_env_var="ANTHROPIC_BASE_URL"` to the Anthropic `ProviderConfig`, aligning it with the 20+ other providers that already have this field set (alibaba, gemini, deepseek, xai, etc.).

## Context

- PR #1516 attempted this fix but was closed for bundling unrelated features. The maintainer's review explicitly recommended using the `base_url_env_var` field on `ProviderConfig`.
- PR #1673 added a runtime check in `runtime_provider.py` but did **not** add `base_url_env_var` to `ProviderConfig`, leaving the credential pool seeding bug unresolved.

## Testing

Verified in a Docker environment with `ANTHROPIC_BASE_URL=http://host.docker.internal:8900`:
- Before fix: credential pool entries seeded with `base_url: https://api.anthropic.com` → delegation 401
- After fix: pool entries correctly use `base_url: http://host.docker.internal:8900` → delegation succeeds