### PR TITLE
feat: mention users for slack approvals and completions

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -608,6 +608,10 @@ def load_gateway_config() -> GatewayConfig:
                     if isinstance(frc, list):
                         frc = ",".join(str(v) for v in frc)
                     os.environ["SLACK_FREE_RESPONSE_CHANNELS"] = str(frc)
+                if "mention_on_approval_required" in slack_cfg and not os.getenv("SLACK_MENTION_ON_APPROVAL_REQUIRED"):
+                    os.environ["SLACK_MENTION_ON_APPROVAL_REQUIRED"] = str(slack_cfg["mention_on_approval_required"]).lower()
+                if "mention_on_completion" in slack_cfg and not os.getenv("SLACK_MENTION_ON_COMPLETION"):
+                    os.environ["SLACK_MENTION_ON_COMPLETION"] = str(slack_cfg["mention_on_completion"]).lower()
 
             # Discord settings → env vars (env vars take precedence)
             discord_cfg = yaml_cfg.get("discord", {})

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -1237,6 +1237,12 @@ class SlackAdapter(BasePlatformAdapter):
         try:
             cmd_preview = command[:2900] + "..." if len(command) > 2900 else command
             thread_ts = self._resolve_thread_ts(None, metadata)
+            mention_prefix = self._notification_mention_prefix(
+                (metadata or {}).get("user_id", ""),
+                extra_key="mention_on_approval_required",
+                env_var="SLACK_MENTION_ON_APPROVAL_REQUIRED",
+            )
+            block_mention_prefix = f"{mention_prefix.rstrip()}\n" if mention_prefix else ""
 
             blocks = [
                 {
@@ -1244,7 +1250,7 @@ class SlackAdapter(BasePlatformAdapter):
                     "text": {
                         "type": "mrkdwn",
                         "text": (
-                            f":warning: *Command Approval Required*\n"
+                            f"{block_mention_prefix}:warning: *Command Approval Required*\n"
                             f"```{cmd_preview}```\n"
                             f"Reason: {description}"
                         ),
@@ -1285,7 +1291,7 @@ class SlackAdapter(BasePlatformAdapter):
 
             kwargs: Dict[str, Any] = {
                 "channel": chat_id,
-                "text": f"⚠️ Command approval required: {cmd_preview[:100]}",
+                "text": f"{mention_prefix}⚠️ Command approval required: {cmd_preview[:100]}",
                 "blocks": blocks,
             }
             if thread_ts:
@@ -1695,3 +1701,21 @@ class SlackAdapter(BasePlatformAdapter):
         if isinstance(raw, str) and raw.strip():
             return {part.strip() for part in raw.split(",") if part.strip()}
         return set()
+
+    def _notification_mention_enabled(self, extra_key: str, env_var: str) -> bool:
+        """Return whether a Slack notification type should @mention the user."""
+        configured = self.config.extra.get(extra_key)
+        if configured is not None:
+            if isinstance(configured, str):
+                return configured.strip().lower() in ("true", "1", "yes", "on")
+            return bool(configured)
+        return os.getenv(env_var, "false").strip().lower() in ("true", "1", "yes", "on")
+
+    def _notification_mention_prefix(self, user_id: str, *, extra_key: str, env_var: str) -> str:
+        """Return a Slack user mention prefix for opted-in notifications."""
+        user_id = str(user_id or "").strip()
+        if not user_id:
+            return ""
+        if not self._notification_mention_enabled(extra_key, env_var):
+            return ""
+        return f"<@{user_id}> "

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8274,6 +8274,42 @@ class GatewayRunner:
         except Exception as e:
             logger.error("Watch notification injection error: %s", e)
 
+    def _prefix_platform_notification_mention(
+        self,
+        adapter,
+        platform_name: str,
+        message_text: str,
+        *,
+        user_id: str = "",
+        purpose: str = "",
+    ) -> str:
+        """Add platform-specific user mention prefixes for opted-in notifications."""
+        if platform_name != Platform.SLACK.value:
+            return message_text
+
+        mention_user_id = str(user_id or "").strip()
+        if not mention_user_id:
+            return message_text
+
+        extra = getattr(getattr(adapter, "config", None), "extra", {}) or {}
+        if purpose == "completion":
+            enabled = extra.get("mention_on_completion")
+            env_value = os.getenv("SLACK_MENTION_ON_COMPLETION", "")
+        else:
+            enabled = False
+            env_value = ""
+
+        if enabled is None:
+            enabled = env_value.strip().lower() in ("true", "1", "yes", "on")
+        elif isinstance(enabled, str):
+            enabled = enabled.strip().lower() in ("true", "1", "yes", "on")
+        else:
+            enabled = bool(enabled)
+
+        if not enabled:
+            return message_text
+        return f"<@{mention_user_id}> {message_text}"
+
     async def _run_process_watcher(self, watcher: dict) -> None:
         """
         Periodically check a background process and push updates to the user.
@@ -8401,6 +8437,13 @@ class GatewayRunner:
                     if adapter and chat_id:
                         try:
                             send_meta = {"thread_id": thread_id} if thread_id else None
+                            message_text = self._prefix_platform_notification_mention(
+                                adapter,
+                                platform_name,
+                                message_text,
+                                user_id=user_id,
+                                purpose="completion",
+                            )
                             await adapter.send(chat_id, message_text, metadata=send_meta)
                         except Exception as e:
                             logger.error("Watcher delivery error: %s", e)

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -50,15 +50,19 @@ def _build_runner(monkeypatch, tmp_path, mode: str) -> GatewayRunner:
     return runner
 
 
-def _watcher_dict(session_id="proc_test", thread_id=""):
+def _watcher_dict(session_id="proc_test", thread_id="", platform="telegram", user_id="", user_name=""):
     d = {
         "session_id": session_id,
         "check_interval": 0,
-        "platform": "telegram",
+        "platform": platform,
         "chat_id": "123",
     }
     if thread_id:
         d["thread_id"] = thread_id
+    if user_id:
+        d["user_id"] = user_id
+    if user_name:
+        d["user_name"] = user_name
     return d
 
 
@@ -243,6 +247,35 @@ async def test_no_thread_id_sends_no_metadata(monkeypatch, tmp_path):
     assert adapter.send.await_count == 1
     _, kwargs = adapter.send.call_args
     assert kwargs["metadata"] is None
+
+
+@pytest.mark.asyncio
+async def test_slack_completion_notification_mentions_requesting_user(monkeypatch, tmp_path):
+    """Slack completion notifications mention the originating user when enabled."""
+    import tools.process_registry as pr_module
+    from gateway.config import PlatformConfig
+
+    sessions = [SimpleNamespace(output_buffer="done\n", exited=True, exit_code=0)]
+    monkeypatch.setattr(pr_module, "process_registry", _FakeRegistry(sessions))
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+    runner = _build_runner(monkeypatch, tmp_path, "result")
+    runner.adapters.pop(Platform.TELEGRAM)
+    slack_adapter = SimpleNamespace(send=AsyncMock(), handle_message=AsyncMock())
+    slack_adapter.config = PlatformConfig(enabled=True, extra={"mention_on_completion": True})
+    runner.adapters[Platform.SLACK] = slack_adapter
+
+    await runner._run_process_watcher(
+        _watcher_dict(platform="slack", user_id="U_REQUESTER", user_name="harusame")
+    )
+
+    slack_adapter.send.assert_awaited_once()
+    sent_text = slack_adapter.send.await_args.args[1]
+    assert sent_text.startswith("<@U_REQUESTER> ")
+    assert "finished with exit code 0" in sent_text
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -299,6 +299,26 @@ class TestLoadGatewayConfig:
             "C01ABC": "Code review mode",
         }
 
+    def test_bridges_slack_mention_notification_env_vars_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "slack:\n"
+            "  mention_on_approval_required: true\n"
+            "  mention_on_completion: true\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("SLACK_MENTION_ON_APPROVAL_REQUIRED", raising=False)
+        monkeypatch.delenv("SLACK_MENTION_ON_COMPLETION", raising=False)
+
+        load_gateway_config()
+
+        assert os.environ.get("SLACK_MENTION_ON_APPROVAL_REQUIRED") == "true"
+        assert os.environ.get("SLACK_MENTION_ON_COMPLETION") == "true"
+
     def test_invalid_quick_commands_in_config_yaml_are_ignored(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1487,6 +1487,45 @@ class TestReplyBroadcast:
         assert kwargs.get("reply_broadcast") is True
 
 
+class TestUserMentions:
+    """Slack-specific mention prefix behavior for important notifications."""
+
+    @pytest.mark.asyncio
+    async def test_send_exec_approval_mentions_requesting_user_when_enabled(self, adapter):
+        adapter.config.extra["mention_on_approval_required"] = True
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "1234.5678"})
+
+        result = await adapter.send_exec_approval(
+            chat_id="C123",
+            command="rm -rf /important",
+            session_key="agent:main:slack:group:C123:1111",
+            description="dangerous deletion",
+            metadata={"user_id": "U_REQUESTER"},
+        )
+
+        assert result.success is True
+        kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
+        assert kwargs["text"].startswith("<@U_REQUESTER> ")
+        assert "Command approval required" in kwargs["text"]
+        assert kwargs["blocks"][0]["text"]["text"].startswith("<@U_REQUESTER>\n")
+
+    @pytest.mark.asyncio
+    async def test_send_exec_approval_skips_mention_when_disabled(self, adapter):
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "1234.5678"})
+
+        await adapter.send_exec_approval(
+            chat_id="C123",
+            command="rm -rf /important",
+            session_key="agent:main:slack:group:C123:1111",
+            description="dangerous deletion",
+            metadata={"user_id": "U_REQUESTER"},
+        )
+
+        kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
+        assert not kwargs["text"].startswith("<@U_REQUESTER>")
+        assert not kwargs["blocks"][0]["text"]["text"].startswith("<@U_REQUESTER>")
+
+
 # ---------------------------------------------------------------------------
 # TestFallbackPreservesThreadContext
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -153,7 +153,8 @@ class TestSlackApprovalAction:
     """Test the approval button click handler."""
 
     @pytest.mark.asyncio
-    async def test_resolves_approval(self):
+    async def test_resolves_approval(self, monkeypatch):
+        monkeypatch.delenv("SLACK_ALLOWED_USERS", raising=False)
         adapter = _make_adapter()
         adapter._approval_resolved["1234.5678"] = False
 
@@ -189,7 +190,8 @@ class TestSlackApprovalAction:
         assert "Approved once by norbert" in update_kwargs["text"]
 
     @pytest.mark.asyncio
-    async def test_prevents_double_click(self):
+    async def test_prevents_double_click(self, monkeypatch):
+        monkeypatch.delenv("SLACK_ALLOWED_USERS", raising=False)
         adapter = _make_adapter()
         adapter._approval_resolved["1234.5678"] = True  # Already resolved
 
@@ -212,7 +214,8 @@ class TestSlackApprovalAction:
         mock_resolve.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_deny_action(self):
+    async def test_deny_action(self, monkeypatch):
+        monkeypatch.delenv("SLACK_ALLOWED_USERS", raising=False)
         adapter = _make_adapter()
         adapter._approval_resolved["1.2"] = False
 


### PR DESCRIPTION
## Summary
- add opt-in Slack @mention support for approval-required messages
- add opt-in Slack @mention support for background process completion notifications
- bridge `slack.mention_on_approval_required` and `slack.mention_on_completion` from config.yaml to env-backed runtime config

## Test Plan
- `python -m pytest tests/gateway/test_slack.py::TestUserMentions tests/gateway/test_background_process_notifications.py tests/gateway/test_slack_approval_buttons.py tests/gateway/test_config.py::TestLoadGatewayConfig::test_bridges_slack_mention_notification_env_vars_from_config_yaml -q`
