### PR TITLE
fix: use _message_thread_id_for_send() in send_model_picker() for forum topics

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1228,13 +1228,13 @@ class TelegramAdapter(BasePlatformAdapter):
                 f"Select a provider:"
             )
 
-            thread_id = metadata.get("thread_id") if metadata else None
+            thread_id = self._metadata_thread_id(metadata)
             msg = await self._bot.send_message(
                 chat_id=int(chat_id),
                 text=text,
                 parse_mode=ParseMode.MARKDOWN,
                 reply_markup=keyboard,
-                message_thread_id=int(thread_id) if thread_id else None,
+                message_thread_id=self._message_thread_id_for_send(thread_id),
                 **self._link_preview_kwargs(),
             )
 


### PR DESCRIPTION
## Problem

In `send_model_picker()`, the code directly read `metadata.get("thread_id")` and passed `int(thread_id)` as `message_thread_id` to `send_message()`. This bypassed `_message_thread_id_for_send()`, which contains special handling for Telegram forum General topics (thread_id == "1" should be sent as `None`). As a result, sending the model picker in a forum General topic caused Telegram to return "Message thread not found".

## Solution

Replace the raw metadata access with `self._metadata_thread_id(metadata)` and use `self._message_thread_id_for_send(thread_id)` when calling `send_message()`. This aligns `send_model_picker()` with all other send methods in the adapter, ensuring consistent forum topic handling.

## Verification

- Code review confirmed the two-line change matches the pattern already used in `send()`, `send_exec_approval()`, and `send_typing()`.
- No other callers of `send_message()` in the adapter bypass `_message_thread_id_for_send()`.

Closes #12839.