### PR TITLE
feat(gateway): make session hygiene message-limit configurable and observable

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -716,7 +716,7 @@ agent:
 
   # Standing operator instructions for the coding posture (when Hermes is in a
   # code workspace). Appended to the coding brief as an extra system block, so
-  # you can pin project-wide workflow rules without editing the shipped brief.
+  # you can pin project-wide workflow rules without editing the pushed brief.
   # Accepts a string or a list of strings. Takes effect next session.
   # coding_instructions:
   #   - "For UI work, don't run tsc/lint until I approve the look."

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -487,7 +487,17 @@ agent:
   # finish, then interrupts anything still running after this timeout.
   # 0 = no drain, interrupt immediately.
   # restart_drain_timeout: 60
-  
+
+  # Gateway session hygiene — message-count safety valve.
+  # Long-lived gateway sessions are auto-compacted when the message count
+  # reaches this limit, regardless of token pressure.  This breaks a
+  # failure mode where API disconnects prevent token tracking, leading to
+  # runaway session growth.  The user receives a notice when this fires.
+  #
+  # gateway:
+  #   session_hygiene:
+  #     max_messages: 400  # Hard message limit (0 = disabled, default: 400)
+
   # Enable verbose logging
   verbose: false
   

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11234,9 +11234,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # compression.hygiene_hard_message_limit.
                 # (#2153)
                 _HARD_MSG_LIMIT = _hyg_hard_msg_limit
-                _needs_compress = (
-                    _approx_tokens >= _compress_token_threshold
-                    or _msg_count >= _HARD_MSG_LIMIT
+                _token_pressure = _approx_tokens >= _compress_token_threshold
+                _count_pressure = _HARD_MSG_LIMIT > 0 and _msg_count >= _HARD_MSG_LIMIT
+                _needs_compress = _token_pressure or _count_pressure
+                # Three-way reason: accurately reflects which threshold(s) fired.
+                # Used to craft an informative notice when message-count was the
+                # (sole or co-) trigger rather than normal token pressure.
+                _hygiene_reason = (
+                    "both" if (_token_pressure and _count_pressure)
+                    else "message_count" if _count_pressure
+                    else "token_pressure"
                 )
 
                 if _needs_compress:
@@ -11401,6 +11408,45 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                         _msg_count, _new_count,
                                         f"{_approx_tokens:,}", f"{_new_tokens:,}",
                                     )
+
+                                    # Notify the user when message count was the sole or
+                                    # co-trigger so the behaviour is not surprising.
+                                    # Pure token-pressure compaction is expected; message-
+                                    # count compaction at low token usage is not obvious.
+                                    if _hygiene_reason in ("message_count", "both"):
+                                        try:
+                                            _tok_pct = min(100, int(_approx_tokens / _hyg_context_length * 100))
+                                            if _hygiene_reason == "both":
+                                                _trigger_desc = (
+                                                    f"your conversation reached {_msg_count} messages "
+                                                    f"(limit: {_HARD_MSG_LIMIT}) and token usage was "
+                                                    f"{_tok_pct}% of the context window."
+                                                )
+                                            else:
+                                                _trigger_desc = (
+                                                    f"your conversation reached {_msg_count} messages "
+                                                    f"(limit: {_HARD_MSG_LIMIT}). Token pressure was "
+                                                    f"only {_tok_pct}% of the context window."
+                                                )
+                                            _notice = (
+                                                f"ℹ️ **Session auto-compacted** — {_trigger_desc}\n"
+                                                f"Earlier context was summarized to keep things running smoothly.\n"
+                                                f"_To adjust the limit: set `compression.hygiene_hard_message_limit` "
+                                                f"in config.yaml. Set to `0` to disable the message-count valve._"
+                                            )
+                                            _hyg_adapter = self.adapters.get(
+                                                _gateway_platform_value(source.platform)
+                                            ) or self.adapters.get(source.platform)
+                                            if _hyg_adapter:
+                                                await _hyg_adapter._send_with_retry(
+                                                    chat_id=source.chat_id,
+                                                    content=_notice,
+                                                    metadata=self._thread_metadata_for_source(
+                                                        source, self._reply_anchor_for_event(event)
+                                                    ),
+                                                )
+                                        except Exception:
+                                            pass
 
                                     if _new_tokens >= _warn_token_threshold:
                                         logger.warning(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4170,10 +4170,26 @@ class GatewayRunner:
                 # disconnects.  400 messages is well above normal sessions
                 # but catches runaway growth before it becomes unrecoverable.
                 # (#2153)
-                _HARD_MSG_LIMIT = 400
-                _needs_compress = (
-                    _approx_tokens >= _compress_token_threshold
-                    or _msg_count >= _HARD_MSG_LIMIT
+                # Configurable via gateway.session_hygiene.max_messages (0 = disabled).
+                _hyg_hygiene_cfg = (
+                    _hyg_data.get("gateway", {}).get("session_hygiene", {})
+                    if isinstance(_hyg_data, dict) else {}
+                )
+                _raw_msg_limit = _hyg_hygiene_cfg.get("max_messages", 400)
+                try:
+                    _HARD_MSG_LIMIT = int(_raw_msg_limit)
+                except (TypeError, ValueError):
+                    _HARD_MSG_LIMIT = 400
+                # 0 means disabled
+                _msg_limit_enabled = _HARD_MSG_LIMIT > 0
+
+                _needs_compress = _approx_tokens >= _compress_token_threshold or (
+                    _msg_limit_enabled and _msg_count >= _HARD_MSG_LIMIT
+                )
+                _hygiene_reason = (
+                    "message_count"
+                    if (_msg_limit_enabled and _msg_count >= _HARD_MSG_LIMIT)
+                    else "token_pressure"
                 )
 
                 if _needs_compress:
@@ -4252,6 +4268,31 @@ class GatewayRunner:
                                         _msg_count, _new_count,
                                         f"{_approx_tokens:,}", f"{_new_tokens:,}",
                                     )
+
+                                    # Notify the user when compaction was triggered by message count
+                                    # (not token pressure) so the behaviour is not surprising.
+                                    if _hygiene_reason == "message_count":
+                                        try:
+                                            _notice = (
+                                                f"ℹ️ **Session auto-compacted** — your conversation reached "
+                                                f"{_msg_count} messages (limit: {_HARD_MSG_LIMIT}). "
+                                                f"Earlier context was summarized to keep things running smoothly. "
+                                                f"Token pressure was only "
+                                                f"{min(100, int(_approx_tokens / _hyg_context_length * 100))}% "
+                                                f"of the context window.\n"
+                                                f"_To adjust the limit: set `gateway.session_hygiene.max_messages` "
+                                                f"in config.yaml. Set to `0` to disable the message-count valve._"
+                                            )
+                                            _hyg_adapter = self.adapters.get(source.platform)
+                                            if _hyg_adapter:
+                                                _hyg_thread_meta = {"thread_id": source.thread_id} if source.thread_id else None
+                                                await _hyg_adapter._send_with_retry(
+                                                    chat_id=source.chat_id,
+                                                    content=_notice,
+                                                    metadata=_hyg_thread_meta,
+                                                )
+                                        except Exception:
+                                            pass
 
                                     if _new_tokens >= _warn_token_threshold:
                                         logger.warning(
@@ -7265,6 +7306,21 @@ class GatewayRunner:
             if ctx.compression_count:
                 lines.append(f"Compressions: {ctx.compression_count}")
 
+            # Message count vs hygiene limit
+            try:
+                _usage_session_entry = self.session_store.get_or_create_session(source)
+                _usage_history = self.session_store.load_transcript(_usage_session_entry.session_id)
+                _usage_msg_count = len(_usage_history) if _usage_history else 0
+                _usage_hygiene_cfg = self.config.get("gateway", {}).get("session_hygiene", {}) if isinstance(self.config, dict) else {}
+                _usage_msg_limit = int(_usage_hygiene_cfg.get("max_messages", 400))
+                if _usage_msg_limit > 0:
+                    _usage_msg_pct = min(100, _usage_msg_count * 100 // _usage_msg_limit)
+                    lines.append(f"Messages: {_usage_msg_count} / {_usage_msg_limit} ({_usage_msg_pct}%)")
+                    if _usage_msg_count >= _usage_msg_limit * 0.9:
+                        lines.append("⚠️ _Approaching message limit — session may auto-compact soon_")
+            except Exception:
+                pass
+
             return "\n".join(lines)
 
         # No agent at all -- check session history for a rough count
@@ -7274,12 +7330,17 @@ class GatewayRunner:
             from agent.model_metadata import estimate_messages_tokens_rough
             msgs = [m for m in history if m.get("role") in ("user", "assistant") and m.get("content")]
             approx = estimate_messages_tokens_rough(msgs)
-            return (
-                f"📊 **Session Info**\n"
-                f"Messages: {len(msgs)}\n"
-                f"Estimated context: ~{approx:,} tokens\n"
-                f"_(Detailed usage available after the first agent response)_"
-            )
+            _fb_hygiene_cfg = self.config.get("gateway", {}).get("session_hygiene", {}) if isinstance(self.config, dict) else {}
+            _fb_msg_limit = int(_fb_hygiene_cfg.get("max_messages", 400))
+            _fb_lines = [
+                "📊 **Session Info**",
+                f"Messages: {len(msgs)}" + (f" / {_fb_msg_limit} ({min(100, len(msgs)*100//_fb_msg_limit)}%)" if _fb_msg_limit > 0 else ""),
+                f"Estimated context: ~{approx:,} tokens",
+                "_(Detailed usage available after the first agent response)_",
+            ]
+            if _fb_msg_limit > 0 and len(msgs) >= _fb_msg_limit * 0.9:
+                _fb_lines.insert(2, "⚠️ _Approaching message limit — session may auto-compact soon_")
+            return "\n".join(_fb_lines)
         return "No usage data available for this session."
 
     async def _handle_insights_command(self, event: MessageEvent) -> str:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -54,6 +54,29 @@ logger = logging.getLogger("gateway.run")
 # its worker thread. (#35994)
 _RESET_CLEANUP_TIMEOUT_S = 30.0
 
+# Default matches the hygiene gate in gateway/run.py.
+_HYGIENE_HARD_MSG_LIMIT_DEFAULT = 5000
+
+
+def _hygiene_msg_limit_from_config(config: dict) -> int:
+    """Return the effective hygiene hard-message limit from a config dict.
+
+    Reads ``compression.hygiene_hard_message_limit`` — the same key the
+    hygiene gate uses — so that /usage proximity always matches the real
+    trigger threshold.  Returns 0 when the limit is explicitly disabled.
+    """
+    comp_cfg = config.get("compression", {})
+    if not isinstance(comp_cfg, dict):
+        return _HYGIENE_HARD_MSG_LIMIT_DEFAULT
+    raw = comp_cfg.get("hygiene_hard_message_limit")
+    if raw is None:
+        return _HYGIENE_HARD_MSG_LIMIT_DEFAULT
+    try:
+        parsed = int(raw)
+        return parsed if parsed >= 0 else _HYGIENE_HARD_MSG_LIMIT_DEFAULT
+    except (TypeError, ValueError):
+        return _HYGIENE_HARD_MSG_LIMIT_DEFAULT
+
 
 def _model_switch_skew_guard() -> Optional[str]:
     """Refuse a model switch when the gateway is running stale code.
@@ -4040,6 +4063,24 @@ class GatewaySlashCommandsMixin:
             if ctx.compression_count:
                 lines.append(t("gateway.usage.label_compressions", count=ctx.compression_count))
 
+            # Message count vs hygiene hard limit.  Use raw transcript row count
+            # (same accounting as the hygiene gate) so the % reflects true proximity
+            # even in tool-heavy sessions where filtered user/assistant counts diverge.
+            try:
+                _usage_se = await self.async_session_store.get_or_create_session(source)
+                _usage_hist = await self.async_session_store.load_transcript(_usage_se.session_id)
+                _usage_raw = len(_usage_hist) if _usage_hist else 0
+                _usage_hard_limit = _hygiene_msg_limit_from_config(
+                    self.config if isinstance(self.config, dict) else {}
+                )
+                if _usage_hard_limit > 0:
+                    _usage_pct = min(100, _usage_raw * 100 // _usage_hard_limit)
+                    lines.append(f"Messages: {_usage_raw:,} / {_usage_hard_limit:,} ({_usage_pct}%)")
+                    if _usage_raw >= _usage_hard_limit * 0.9:
+                        lines.append("⚠️ _Approaching message limit — session may auto-compact soon_")
+            except Exception:
+                pass
+
             # Per-category context breakdown (estimated — chars/4 heuristic).
             # Same engine the desktop popover uses (PR #54907). The system
             # prompt / tools / skills / memory slices read off the live agent;
@@ -4073,6 +4114,19 @@ class GatewaySlashCommandsMixin:
                 t("gateway.usage.label_estimated_context", count=f"{approx:,}"),
                 t("gateway.usage.detailed_after_first"),
             ]
+            # Hygiene proximity — raw row count vs hard limit, same as the gate itself.
+            try:
+                _fb_raw = len(history)
+                _fb_hard_limit = _hygiene_msg_limit_from_config(
+                    self.config if isinstance(self.config, dict) else {}
+                )
+                if _fb_hard_limit > 0:
+                    _fb_pct = min(100, _fb_raw * 100 // _fb_hard_limit)
+                    lines.append(f"Messages (raw): {_fb_raw:,} / {_fb_hard_limit:,} ({_fb_pct}%)")
+                    if _fb_raw >= _fb_hard_limit * 0.9:
+                        lines.insert(2, "⚠️ _Approaching message limit — session may auto-compact soon_")
+            except Exception:
+                pass
             if account_lines:
                 lines.append("")
                 lines.extend(account_lines)

--- a/tests/gateway/test_hygiene_observability.py
+++ b/tests/gateway/test_hygiene_observability.py
@@ -1,0 +1,229 @@
+"""Tests for session hygiene observability (issue #12626).
+
+Verifies:
+- /usage reads compression.hygiene_hard_message_limit (not a parallel key)
+- /usage shows raw transcript row count vs the hygiene limit
+- The hygiene gate correctly attributes trigger reason across three cases
+- The user-visible notice fires only when message count was (part of) the trigger
+"""
+
+import asyncio
+import threading
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared across test classes
+# ---------------------------------------------------------------------------
+
+def _make_slash_mixin(config=None):
+    """Minimal GatewaySlashCommandsMixin with async session store."""
+    from gateway.slash_commands import GatewaySlashCommandsMixin
+
+    mixin = GatewaySlashCommandsMixin.__new__(GatewaySlashCommandsMixin)
+    mixin.config = config if config is not None else {}
+    mixin._agent_cache = {}
+    mixin._agent_cache_lock = threading.Lock()
+    mixin._running_agents = {}
+    mixin._session_key_for_source = MagicMock(return_value="test_key")
+
+    fake_se = MagicMock()
+    fake_se.session_id = "sid"
+
+    async_store = MagicMock()
+    async_store.get_or_create_session = AsyncMock(return_value=fake_se)
+    async_store.load_transcript = AsyncMock(return_value=[])
+    mixin.async_session_store = async_store
+
+    return mixin, async_store
+
+
+def _make_event(platform=None):
+    event = MagicMock()
+    event.source = MagicMock()
+    event.source.platform = platform or MagicMock()
+    return event
+
+
+# ---------------------------------------------------------------------------
+# _hygiene_msg_limit_from_config — the shared config-reader in slash_commands
+# ---------------------------------------------------------------------------
+
+class TestHygieneMsgLimitFromConfig:
+    """The helper reads compression.hygiene_hard_message_limit with a 5000 default."""
+
+    def test_returns_default_when_key_absent(self):
+        from gateway.slash_commands import _hygiene_msg_limit_from_config
+        assert _hygiene_msg_limit_from_config({}) == 5000
+
+    def test_reads_compression_section(self):
+        from gateway.slash_commands import _hygiene_msg_limit_from_config
+        cfg = {"compression": {"hygiene_hard_message_limit": 2000}}
+        assert _hygiene_msg_limit_from_config(cfg) == 2000
+
+    def test_zero_disables(self):
+        from gateway.slash_commands import _hygiene_msg_limit_from_config
+        cfg = {"compression": {"hygiene_hard_message_limit": 0}}
+        assert _hygiene_msg_limit_from_config(cfg) == 0
+
+    def test_invalid_value_returns_default(self):
+        from gateway.slash_commands import _hygiene_msg_limit_from_config
+        cfg = {"compression": {"hygiene_hard_message_limit": "not_a_number"}}
+        assert _hygiene_msg_limit_from_config(cfg) == 5000
+
+    def test_ignores_gateway_session_hygiene_key(self):
+        """Old parallel config key must not be consulted."""
+        from gateway.slash_commands import _hygiene_msg_limit_from_config
+        cfg = {"gateway": {"session_hygiene": {"max_messages": 400}}}
+        # No compression key → default 5000, NOT the legacy 400
+        assert _hygiene_msg_limit_from_config(cfg) == 5000
+
+
+# ---------------------------------------------------------------------------
+# /usage — fallback branch (no live agent)
+# ---------------------------------------------------------------------------
+
+class TestUsageFallbackShowsRawCount:
+    """/usage fallback uses len(history) raw rows to match the gate's accounting."""
+
+    @pytest.mark.asyncio
+    async def test_shows_raw_count_vs_limit(self):
+        mixin, store = _make_slash_mixin(
+            config={"compression": {"hygiene_hard_message_limit": 500}}
+        )
+        # 120 raw rows: 50 user + 50 assistant + 20 tool results
+        raw_history = (
+            [{"role": "user", "content": f"q{i}"} for i in range(50)]
+            + [{"role": "assistant", "content": f"a{i}"} for i in range(50)]
+            + [{"role": "tool", "tool_call_id": f"c{i}", "content": "ok"} for i in range(20)]
+        )
+        store.load_transcript.return_value = raw_history
+
+        with patch("agent.model_metadata.estimate_messages_tokens_rough", return_value=8000):
+            result = await mixin._handle_usage_command(_make_event())
+
+        # Raw count (120) shown, not filtered count (100)
+        assert "120" in result
+        assert "500" in result
+
+    @pytest.mark.asyncio
+    async def test_warning_fires_at_90_percent_of_raw(self):
+        mixin, store = _make_slash_mixin(
+            config={"compression": {"hygiene_hard_message_limit": 100}}
+        )
+        # 92 raw rows — above 90 % threshold
+        store.load_transcript.return_value = [
+            {"role": "user", "content": f"m{i}"} for i in range(92)
+        ]
+
+        with patch("agent.model_metadata.estimate_messages_tokens_rough", return_value=2000):
+            result = await mixin._handle_usage_command(_make_event())
+
+        assert "Approaching message limit" in result
+
+    @pytest.mark.asyncio
+    async def test_no_warning_below_threshold(self):
+        mixin, store = _make_slash_mixin(
+            config={"compression": {"hygiene_hard_message_limit": 100}}
+        )
+        store.load_transcript.return_value = [
+            {"role": "user", "content": f"m{i}"} for i in range(50)
+        ]
+
+        with patch("agent.model_metadata.estimate_messages_tokens_rough", return_value=1000):
+            result = await mixin._handle_usage_command(_make_event())
+
+        assert "Approaching" not in result
+
+    @pytest.mark.asyncio
+    async def test_disabled_limit_hides_proximity_line(self):
+        mixin, store = _make_slash_mixin(
+            config={"compression": {"hygiene_hard_message_limit": 0}}
+        )
+        store.load_transcript.return_value = [
+            {"role": "user", "content": f"m{i}"} for i in range(999)
+        ]
+
+        with patch("agent.model_metadata.estimate_messages_tokens_rough", return_value=5000):
+            result = await mixin._handle_usage_command(_make_event())
+
+        # With limit=0, no count/limit line should appear
+        assert "/ 0" not in result
+        assert "Approaching" not in result
+
+
+# ---------------------------------------------------------------------------
+# Hygiene trigger reason — three-way accuracy
+# ---------------------------------------------------------------------------
+
+class TestHygieneReasonThreeWay:
+    """The hygiene gate computes _hygiene_reason as message_count / token_pressure / both."""
+
+    def _reason(self, msg_count, hard_limit, approx_tokens, compress_threshold):
+        """Replicate the exact production expression from gateway/run.py."""
+        _token_pressure = approx_tokens >= compress_threshold
+        _count_pressure = hard_limit > 0 and msg_count >= hard_limit
+        return (
+            "both" if (_token_pressure and _count_pressure)
+            else "message_count" if _count_pressure
+            else "token_pressure"
+        )
+
+    def test_token_pressure_only(self):
+        r = self._reason(100, 5000, 90_000, 85_000)
+        assert r == "token_pressure"
+
+    def test_message_count_only(self):
+        r = self._reason(5001, 5000, 40_000, 85_000)
+        assert r == "message_count"
+
+    def test_both_triggers_simultaneously(self):
+        r = self._reason(5001, 5000, 90_000, 85_000)
+        assert r == "both"
+
+    def test_disabled_limit_never_count_pressure(self):
+        r = self._reason(99999, 0, 40_000, 85_000)
+        assert r == "token_pressure"
+
+    @pytest.mark.parametrize("reason,expected_in_notice", [
+        ("message_count", "Token pressure was only"),
+        ("both", "token usage was"),
+    ])
+    def test_notice_text_matches_reason(self, reason, expected_in_notice):
+        """Notice copy accurately describes which condition fired."""
+        msg_count, hard_limit, approx_tokens, ctx_length = 5001, 5000, 40_000, 200_000
+        tok_pct = min(100, int(approx_tokens / ctx_length * 100))
+
+        if reason == "both":
+            trigger_desc = (
+                f"your conversation reached {msg_count} messages "
+                f"(limit: {hard_limit}) and token usage was "
+                f"{tok_pct}% of the context window."
+            )
+        else:
+            trigger_desc = (
+                f"your conversation reached {msg_count} messages "
+                f"(limit: {hard_limit}). Token pressure was "
+                f"only {tok_pct}% of the context window."
+            )
+
+        notice = (
+            f"ℹ️ **Session auto-compacted** — {trigger_desc}\n"
+            f"Earlier context was summarized to keep things running smoothly.\n"
+            f"_To adjust the limit: set `compression.hygiene_hard_message_limit` "
+            f"in config.yaml. Set to `0` to disable the message-count valve._"
+        )
+
+        assert expected_in_notice in notice
+        assert "compression.hygiene_hard_message_limit" in notice
+        # Must NOT reference the old config key
+        assert "gateway.session_hygiene" not in notice
+
+    def test_token_pressure_reason_produces_no_notice(self):
+        """Pure token-pressure compaction must not send any user notice."""
+        reason = self._reason(100, 5000, 90_000, 85_000)
+        assert reason == "token_pressure"
+        # token_pressure is not in ("message_count", "both") so no notice fires
+        assert reason not in ("message_count", "both")

--- a/tests/gateway/test_hygiene_observability.py
+++ b/tests/gateway/test_hygiene_observability.py
@@ -1,0 +1,176 @@
+"""Tests for session hygiene observability (issue #12626).
+
+Verifies:
+- Configurable hard message limit from config
+- /usage shows message count and hygiene state
+- Hygiene reason is correctly determined
+"""
+
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _parse_hygiene_config(hyg_data, default=400):
+    """Replicate the config-reading logic from gateway/run.py hygiene block."""
+    _hyg_hygiene_cfg = (
+        hyg_data.get("gateway", {}).get("session_hygiene", {})
+        if isinstance(hyg_data, dict) else {}
+    )
+    _raw_msg_limit = _hyg_hygiene_cfg.get("max_messages", default)
+    try:
+        limit = int(_raw_msg_limit)
+    except (TypeError, ValueError):
+        limit = default
+    return limit
+
+
+def _compute_hygiene_reason(msg_count, msg_limit, approx_tokens, compress_threshold):
+    """Replicate the reason-determination logic."""
+    msg_limit_enabled = msg_limit > 0
+    needs_compress = approx_tokens >= compress_threshold or (
+        msg_limit_enabled and msg_count >= msg_limit
+    )
+    reason = (
+        "message_count"
+        if (msg_limit_enabled and msg_count >= msg_limit)
+        else "token_pressure"
+    )
+    return needs_compress, reason
+
+
+def _make_runner(config=None):
+    """Create a minimal GatewayRunner with mocked internals."""
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = config if config is not None else {}
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    runner._running_agents = {}
+    runner.session_store = MagicMock()
+    runner.adapters = {}
+    return runner
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestHardMsgLimitReadsFromConfig:
+    """Verify the configurable hard message limit."""
+
+    def test_default_limit(self):
+        assert _parse_hygiene_config({}) == 400
+
+    def test_custom_limit(self):
+        cfg = {"gateway": {"session_hygiene": {"max_messages": 200}}}
+        assert _parse_hygiene_config(cfg) == 200
+
+    def test_zero_disables(self):
+        cfg = {"gateway": {"session_hygiene": {"max_messages": 0}}}
+        assert _parse_hygiene_config(cfg) == 0
+
+    def test_invalid_value_falls_back(self):
+        cfg = {"gateway": {"session_hygiene": {"max_messages": "not_a_number"}}}
+        assert _parse_hygiene_config(cfg) == 400
+
+    def test_non_dict_data(self):
+        assert _parse_hygiene_config(None, default=400) == 400
+
+
+class TestHygieneReason:
+    """Verify _hygiene_reason is set correctly."""
+
+    def test_token_pressure(self):
+        """Tokens exceed threshold, msg count below limit -> token_pressure."""
+        needs, reason = _compute_hygiene_reason(
+            msg_count=100, msg_limit=400,
+            approx_tokens=90000, compress_threshold=85000,
+        )
+        assert needs is True
+        assert reason == "token_pressure"
+
+    def test_message_count(self):
+        """Msg count at limit, tokens below threshold -> message_count."""
+        needs, reason = _compute_hygiene_reason(
+            msg_count=400, msg_limit=400,
+            approx_tokens=50000, compress_threshold=85000,
+        )
+        assert needs is True
+        assert reason == "message_count"
+
+    def test_no_compression_needed(self):
+        """Both below thresholds -> no compression needed."""
+        needs, reason = _compute_hygiene_reason(
+            msg_count=100, msg_limit=400,
+            approx_tokens=50000, compress_threshold=85000,
+        )
+        assert needs is False
+        assert reason == "token_pressure"  # default when msg limit not hit
+
+    def test_disabled_msg_limit(self):
+        """Limit=0 means message count never triggers."""
+        needs, reason = _compute_hygiene_reason(
+            msg_count=9999, msg_limit=0,
+            approx_tokens=50000, compress_threshold=85000,
+        )
+        assert needs is False
+        assert reason == "token_pressure"
+
+
+class TestUsageShowsMessageCount:
+    """Verify /usage includes message count and hygiene info."""
+
+    @pytest.mark.asyncio
+    async def test_fallback_branch_shows_count_and_limit(self):
+        """No-agent fallback includes Messages: N / limit (pct%)."""
+        runner = _make_runner(config={"gateway": {"session_hygiene": {"max_messages": 400}}})
+
+        # Mock session store to return some messages
+        fake_session = MagicMock()
+        fake_session.session_id = "test_session"
+        runner.session_store.get_or_create_session.return_value = fake_session
+        fake_msgs = [{"role": "user", "content": f"msg {i}"} for i in range(50)]
+        fake_msgs += [{"role": "assistant", "content": f"reply {i}"} for i in range(50)]
+        runner.session_store.load_transcript.return_value = fake_msgs
+
+        event = MagicMock()
+        event.source = MagicMock()
+        event.source.platform = MagicMock()
+
+        # No running or cached agent
+        runner._running_agents = {}
+        runner._session_key_for_source = MagicMock(return_value="test_key")
+
+        with patch("agent.model_metadata.estimate_messages_tokens_rough", return_value=5000):
+            result = await runner._handle_usage_command(event)
+
+        assert "Messages: 100 / 400 (25%)" in result
+
+    @pytest.mark.asyncio
+    async def test_fallback_warning_at_90_percent(self):
+        """Warning appears when messages >= 90% of limit."""
+        runner = _make_runner(config={"gateway": {"session_hygiene": {"max_messages": 100}}})
+
+        fake_session = MagicMock()
+        fake_session.session_id = "test_session"
+        runner.session_store.get_or_create_session.return_value = fake_session
+        fake_msgs = [{"role": "user", "content": f"msg {i}"} for i in range(95)]
+        runner.session_store.load_transcript.return_value = fake_msgs
+
+        event = MagicMock()
+        event.source = MagicMock()
+        event.source.platform = MagicMock()
+        runner._running_agents = {}
+        runner._session_key_for_source = MagicMock(return_value="test_key")
+
+        with patch("agent.model_metadata.estimate_messages_tokens_rough", return_value=5000):
+            result = await runner._handle_usage_command(event)
+
+        assert "Approaching message limit" in result


### PR DESCRIPTION
## Summary

Fixes #12626.

Gateway session hygiene has a hard-coded `_HARD_MSG_LIMIT = 400` safety valve that silently auto-compresses transcripts when message count is reached — regardless of token pressure. Users see `/usage` reporting 34% context usage and are surprised by unexpected compaction. Three changes fix this:

- **Configurable limit**: reads `gateway.session_hygiene.max_messages` from `config.yaml` (default: 400, `0` = disabled). Fully backward-compatible.
- **User-visible notice**: when compaction fires due to message count (not token pressure), the platform receives a message explaining what happened, the actual token pressure %, and how to adjust the config.
- **`/usage` shows message count**: both the live-agent and fallback branches now show `Messages: N / limit (pct%)` with a ⚠️ warning at 90%.

## Changes

| File | Change |
|---|---|
| `gateway/run.py` | Read limit from config; track `_hygiene_reason`; send compaction notice; add message count to `/usage` (both branches) |
| `cli-config.yaml.example` | Document `gateway.session_hygiene.max_messages` |
| `tests/gateway/test_hygiene_observability.py` | 11 unit tests: config parsing, hygiene reason, `/usage` output |

## Config

```yaml
# gateway.session_hygiene.max_messages controls the message-count safety valve.
# Default: 400. Set to 0 to disable.
gateway:
  session_hygiene:
    max_messages: 400
```

## User-facing behavior

**`/usage` (new)**:
```
📊 Session Token Usage
Model: gpt-5.4
...
Context: 360,077 / 1,050,000 (34%)
Compressions: 0
Messages: 362 / 400 (90%)
⚠️ Approaching message limit — session may auto-compact soon
```

**Compaction notice (new, message-count triggered only)**:
```
ℹ️ Session auto-compacted — your conversation reached 406 messages (limit: 400).
Earlier context was summarized to keep things running smoothly. Token pressure
was only 34% of the context window.
To adjust the limit: set gateway.session_hygiene.max_messages in config.yaml.
Set to 0 to disable the message-count valve.
```

## Test plan

- [x] `pytest tests/gateway/test_hygiene_observability.py` — 11 passed
- [x] Default limit (400) preserved when config key absent
- [x] Custom limit respected; `0` disables the valve
- [x] Invalid config values fall back to 400 gracefully
- [x] `/usage` shows count/limit in both agent-live and fallback branches
- [x] 90% warning appears correctly