### PR TITLE
fix: treat falsey HERMES_MANAGED values as unmanaged

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -68,6 +68,7 @@ from hermes_cli.default_soul import DEFAULT_SOUL_MD
 # =============================================================================
 
 _MANAGED_TRUE_VALUES = ("true", "1", "yes")
+_MANAGED_FALSE_VALUES = ("false", "0", "no", "off")
 _MANAGED_SYSTEM_NAMES = {
     "brew": "Homebrew",
     "homebrew": "Homebrew",
@@ -81,6 +82,8 @@ def get_managed_system() -> Optional[str]:
     raw = os.getenv("HERMES_MANAGED", "").strip()
     if raw:
         normalized = raw.lower()
+        if normalized in _MANAGED_FALSE_VALUES:
+            return None
         if normalized in _MANAGED_TRUE_VALUES:
             return "NixOS"
         return _MANAGED_SYSTEM_NAMES.get(normalized, raw)

--- a/tests/hermes_cli/test_managed_installs.py
+++ b/tests/hermes_cli/test_managed_installs.py
@@ -1,9 +1,12 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
 from hermes_cli.config import (
     format_managed_message,
     get_managed_system,
+    is_managed,
     recommended_update_command,
 )
 from hermes_cli.main import cmd_update
@@ -42,6 +45,33 @@ def test_cmd_update_blocks_managed_homebrew(monkeypatch, capsys):
     captured = capsys.readouterr()
     assert "managed by Homebrew" in captured.err
     assert "brew upgrade hermes-agent" in captured.err
+
+
+@pytest.mark.parametrize("falsey_value", ["false", "False", "FALSE", "0", "no", "off", "OFF"])
+def test_get_managed_system_returns_none_for_falsey_values(monkeypatch, falsey_value):
+    """Falsey env values like 'false', '0', 'no', 'off' should disable managed mode.
+
+    Regression test for https://github.com/NousResearch/hermes-agent/issues/12864
+    """
+    monkeypatch.setenv("HERMES_MANAGED", falsey_value)
+
+    assert get_managed_system() is None
+    assert is_managed() is False
+    assert recommended_update_command() == "hermes update"
+
+
+def test_format_managed_message_not_triggered_for_false(monkeypatch):
+    """format_managed_message should not be reachable when HERMES_MANAGED=false.
+
+    Regression test for https://github.com/NousResearch/hermes-agent/issues/12864
+    """
+    monkeypatch.setenv("HERMES_MANAGED", "false")
+
+    # is_managed() must be False, so managed-guarded code paths never execute
+    assert is_managed() is False
+    assert get_managed_system() is None
+    # Verify update command falls back to the default unmanaged path
+    assert recommended_update_command() == "hermes update"
 
 
 def test_optional_skill_source_honors_env_override(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Closes #12864.

`get_managed_system()` treats any non-empty `HERMES_MANAGED` value as a package manager name unless it matches the small `_MANAGED_TRUE_VALUES` set (`"true"`, `"1"`, `"yes"`). Falsey strings like `"false"`, `"0"`, `"no"`, and `"off"` fall through to the catch-all `return raw` path, returning the literal string (e.g. `"false"`) as a manager name. This makes `is_managed()` return `True` and blocks guarded commands like `hermes update`.

## Root Cause

```python
def get_managed_system():
    raw = os.getenv("HERMES_MANAGED", "").strip()
    if raw:                                    # any non-empty string is truthy
        normalized = raw.lower()
        if normalized in _MANAGED_TRUE_VALUES:  # "false" not in ("true", "1", "yes")
            return "NixOS"
        return _MANAGED_SYSTEM_NAMES.get(normalized, raw)  # → returns "false"
```

## Fix

Added `_MANAGED_FALSE_VALUES = ("false", "0", "no", "off")` and check it **before** the truthy and system-name branches. When matched, return `None` (unmanaged).

3 lines of production code across 1 file.

## Tests

- **Parametrized test**: 7 falsey string variants (`"false"`, `"False"`, `"FALSE"`, `"0"`, `"no"`, `"off"`, `"OFF"`) all verify `get_managed_system() is None`, `is_managed() is False`, and `recommended_update_command() == "hermes update"`.
- **Integration test**: verifies the managed message path is unreachable when `HERMES_MANAGED=false`.

All 13 tests in `test_managed_installs.py` pass (5 existing + 8 new).