### PR TITLE
fix(config): treat explicit false values in HERMES_MANAGED as unmanaged

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -68,6 +68,7 @@ from hermes_cli.default_soul import DEFAULT_SOUL_MD
 # =============================================================================
 
 _MANAGED_TRUE_VALUES = ("true", "1", "yes")
+_MANAGED_FALSE_VALUES = ("false", "0", "no", "off")
 _MANAGED_SYSTEM_NAMES = {
     "brew": "Homebrew",
     "homebrew": "Homebrew",
@@ -81,6 +82,8 @@ def get_managed_system() -> Optional[str]:
     raw = os.getenv("HERMES_MANAGED", "").strip()
     if raw:
         normalized = raw.lower()
+        if normalized in _MANAGED_FALSE_VALUES:
+            return None
         if normalized in _MANAGED_TRUE_VALUES:
             return "NixOS"
         return _MANAGED_SYSTEM_NAMES.get(normalized, raw)

--- a/tests/hermes_cli/test_managed_installs.py
+++ b/tests/hermes_cli/test_managed_installs.py
@@ -1,9 +1,12 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
 from hermes_cli.config import (
     format_managed_message,
     get_managed_system,
+    is_managed,
     recommended_update_command,
 )
 from hermes_cli.main import cmd_update
@@ -42,6 +45,15 @@ def test_cmd_update_blocks_managed_homebrew(monkeypatch, capsys):
     captured = capsys.readouterr()
     assert "managed by Homebrew" in captured.err
     assert "brew upgrade hermes-agent" in captured.err
+
+
+@pytest.mark.parametrize("false_value", ["false", "0", "no", "off", "FALSE", "False"])
+def test_get_managed_system_false_values(monkeypatch, false_value):
+    monkeypatch.setenv("HERMES_MANAGED", false_value)
+
+    assert get_managed_system() is None
+    assert not is_managed()
+    assert recommended_update_command() == "hermes update"
 
 
 def test_optional_skill_source_honors_env_override(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Fixes a bug where `HERMES_MANAGED=false` (and other common false-like strings) was incorrectly treated as a real managed-system name, causing `is_managed()` to return `True` and blocking update/config commands.

## Root Cause

`get_managed_system()` only normalized known *true* values (`true`, `1`, `yes`) but passed everything else through as a literal string. This meant `false` became the \"managed system\" named `false`.

## Changes

- Added `_MANAGED_FALSE_VALUES = (\"false\", \"0\", \"no\", \"off\")` in `hermes_cli/config.py`
- Check false values before true values in `get_managed_system()` — returns `None` for any explicit false value
- Added parametrized regression tests covering `false`, `0`, `no`, `off`, `FALSE`, and `False`

## Testing

```bash
pytest tests/hermes_cli/test_managed_installs.py -v
# 11 passed (including 6 new regression tests)
```

Fixes #12864