### PR TITLE
fix(update): handle UnicodeDecodeError in post-update config migration prompt

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -10165,6 +10165,17 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     )
                 except EOFError:
                     response = "n"
+                except UnicodeDecodeError:
+                    # input() can raise UnicodeDecodeError when the terminal
+                    # encoding cannot decode the byte sequence (e.g. a
+                    # non-UTF-8 locale on Linux or an embedded terminal).
+                    # Treat it as a skip: the user can run
+                    # 'hermes config migrate' manually.
+                    print(
+                        "  ⚠ Could not read input (UnicodeDecodeError). "
+                        "Run 'hermes config migrate' manually if needed."
+                    )
+                    response = "n"
 
             if response in {"", "y", "yes", "auto"}:
                 print()

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4226,6 +4226,10 @@ def cmd_update(args):
                     response = input("Would you like to configure them now? [Y/n]: ").strip().lower()
                 except EOFError:
                     response = "n"
+                except UnicodeDecodeError:
+                    print("  ℹ Unreadable terminal input — skipping config migration prompt.")
+                    print("    Run 'hermes config migrate' later to apply any new config/env options.")
+                    response = "n"
             
             if response in ('', 'y', 'yes'):
                 print()

--- a/tests/hermes_cli/test_update_yes_flag.py
+++ b/tests/hermes_cli/test_update_yes_flag.py
@@ -132,6 +132,48 @@ class TestUpdateYesConfigMigration:
             assert any("configure them now" in p for p in prompts)
 
 
+    def test_unicode_decode_error_in_tty_skips_and_prints_hint(
+        self,
+        mock_run,
+        _mock_which,
+        _mock_missing_env,
+        _mock_missing_cfg,
+        _mock_version,
+        mock_migrate,
+        capsys,
+    ):
+        """UnicodeDecodeError from input() in a TTY must not crash the update.
+
+        When the terminal encoding cannot decode the user's input (e.g. a
+        non-UTF-8 locale or an embedded terminal), input() raises
+        UnicodeDecodeError. Without the fix the exception propagates and
+        aborts the update; with it the command continues via the 'n' skip
+        branch and prints a manual-migration hint.
+        """
+        mock_run.side_effect = _make_run_side_effect(
+            branch="main", verify_ok=True, commit_count="1"
+        )
+        mock_migrate.return_value = {"env_added": [], "config_added": []}
+
+        args = SimpleNamespace(yes=False)
+
+        import sys as _sys
+
+        with patch(
+            "builtins.input",
+            side_effect=UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid byte"),
+        ), patch.object(_sys.stdin, "isatty", return_value=True), patch.object(
+            _sys.stdout, "isatty", return_value=True
+        ):
+            # Must not raise; update continues through the skip branch.
+            cmd_update(args)
+
+        captured = capsys.readouterr()
+        assert "hermes config migrate" in captured.out, (
+            "Expected manual-migration hint in output when UnicodeDecodeError occurs"
+        )
+
+
 class TestUpdateYesStashRestore:
     """--yes auto-restores the pre-update autostash without prompting."""
 


### PR DESCRIPTION
## Problem

input() can raise UnicodeDecodeError when the terminal encoding cannot decode the byte sequence. Without this fix the exception escapes the existing EOFError handler and crashes the update at the migration prompt.

## Fix

Extend the except clause at hermes_cli/main.py:10162 to also catch UnicodeDecodeError. Handler prints an actionable hermes config migrate hint and falls through to the skip branch (response=n).

## Verification

Added test_unicode_decode_error_in_tty_skips_and_prints_hint to tests/hermes_cli/test_update_yes_flag.py: builtins.input raises UnicodeDecodeError with both streams reporting TTYs, asserts cmd_update completes without raising, and asserts hermes config migrate appears in stdout (maintainer-suggested coverage).

Fixes #12884