### PR TITLE
feat(feishu): add require_mention config option for group chats

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -313,6 +313,7 @@ class FeishuAdapterSettings:
     admins: frozenset[str] = frozenset()
     default_group_policy: str = ""
     group_rules: Dict[str, FeishuGroupRule] = field(default_factory=dict)
+    require_mention: bool = True
 
 
 @dataclass
@@ -1165,6 +1166,9 @@ class FeishuAdapter(BasePlatformAdapter):
         # Default group policy (for groups not in group_rules)
         default_group_policy = str(extra.get("default_group_policy", "")).strip().lower()
 
+        # Whether @mention is required in group chats (default: True, backward-compatible)
+        require_mention = str(extra.get("require_mention", "true")).strip().lower() != "false"
+
         return FeishuAdapterSettings(
             app_id=str(extra.get("app_id") or os.getenv("FEISHU_APP_ID", "")).strip(),
             app_secret=str(extra.get("app_secret") or os.getenv("FEISHU_APP_SECRET", "")).strip(),
@@ -1221,6 +1225,7 @@ class FeishuAdapter(BasePlatformAdapter):
             admins=admins,
             default_group_policy=default_group_policy,
             group_rules=group_rules,
+            require_mention=require_mention,
         )
 
     def _apply_settings(self, settings: FeishuAdapterSettings) -> None:
@@ -1251,6 +1256,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._ws_reconnect_interval = settings.ws_reconnect_interval
         self._ws_ping_interval = settings.ws_ping_interval
         self._ws_ping_timeout = settings.ws_ping_timeout
+        self._require_mention = settings.require_mention
 
     def _build_event_handler(self) -> Any:
         if EventDispatcherHandler is None:
@@ -3277,6 +3283,9 @@ class FeishuAdapter(BasePlatformAdapter):
 
     def _should_accept_group_message(self, message: Any, sender_id: Any, chat_id: str = "") -> bool:
         """Require an explicit @mention before group messages enter the agent."""
+        # If require_mention is False, skip mention check but still enforce group policy.
+        if not self._require_mention:
+            return self._allow_group_message(sender_id, chat_id)
         if not self._allow_group_message(sender_id, chat_id):
             return False
         # @_all is Feishu's @everyone placeholder — always route to the bot.

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -3174,6 +3174,59 @@ class TestGroupMentionAtAll(unittest.TestCase):
         self.assertTrue(adapter._should_accept_group_message(message, allowed_sender, ""))
 
 
+class TestRequireMentionConfig(unittest.TestCase):
+    """Tests for the require_mention config option in Feishu group chats."""
+
+    @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "open"}, clear=True)
+    def test_require_mention_false_accepts_message_without_mention(self):
+        """When require_mention=false, group messages without @mention are accepted (if policy allows)."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig(extra={"require_mention": False}))
+        message = SimpleNamespace(content='{"text":"hello"}', mentions=[])
+        sender_id = SimpleNamespace(open_id="ou_anyone", user_id=None)
+        self.assertTrue(adapter._should_accept_group_message(message, sender_id, ""))
+
+    @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "allowlist", "FEISHU_ALLOWED_USERS": "ou_allowed"}, clear=True)
+    def test_require_mention_false_still_requires_group_policy(self):
+        """require_mention=false bypasses mention check but NOT group allowlist policy."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig(extra={"require_mention": False}))
+        message = SimpleNamespace(content='{"text":"hello"}', mentions=[])
+        # Non-allowlisted user with allowlist policy — should be blocked.
+        sender_id = SimpleNamespace(open_id="ou_stranger", user_id=None)
+        self.assertFalse(adapter._should_accept_group_message(message, sender_id, ""))
+
+    @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "open"}, clear=True)
+    def test_require_mention_true_default_requires_mention(self):
+        """Default require_mention=true still requires @mention (backward compatible)."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig(extra={"require_mention": True}))
+        message = SimpleNamespace(content='{"text":"hello"}', mentions=[])
+        sender_id = SimpleNamespace(open_id="ou_anyone", user_id=None)
+        self.assertFalse(adapter._should_accept_group_message(message, sender_id, ""))
+
+    @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "allowlist", "FEISHU_ALLOWED_USERS": "ou_allowed"}, clear=True)
+    def test_require_mention_false_with_allowlist_blocks_non_allowed_users(self):
+        """require_mention=false does not bypass allowlist policy."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig(extra={"require_mention": False}))
+        message = SimpleNamespace(content='{"text":"hello"}', mentions=[])
+        # Allowlisted user — should pass.
+        allowed_sender = SimpleNamespace(open_id="ou_allowed", user_id=None)
+        self.assertTrue(adapter._should_accept_group_message(message, allowed_sender, ""))
+        # Non-allowlisted user — should be blocked.
+        blocked_sender = SimpleNamespace(open_id="ou_stranger", user_id=None)
+        self.assertFalse(adapter._should_accept_group_message(message, blocked_sender, ""))
+
+
 @unittest.skipUnless(_HAS_LARK_OAPI, "lark-oapi not installed")
 class TestSenderNameResolution(unittest.TestCase):
     """Tests for _resolve_sender_name_from_api."""


### PR DESCRIPTION
## Feishu 群聊 `require_mention` 配置选项

允许在飞书群聊中关闭必须 @mention 机器人才能触发回复的限制。

### 使用方法

在 `~/.hermes/config.yaml` 中添加：

```yaml
platforms:
  feishu:
    extra:
      require_mention: false
```

然后 `hermes gateway restart` 重启网关即可。

### ⚠️ 重要前提：飞书应用权限

此配置依赖飞书平台级权限，**仅修改配置不够**。必须在 [飞书开放平台](https://open.feishu.cn) 给应用添加以下权限：

| 权限 | 说明 |
|------|------|
| `im:message.group_msg`（读取群组中所有消息） | 接收群聊中所有消息（不需要 @mention） |

如果只具备 `im:message.group_at_msg`（获取 @机器人的消息），飞书服务器本身不会把非 @mention 消息转发给应用，配置无效。

### 代码改动

- `FeishuAdapterSettings`：新增 `require_mention: bool = True` 字段
- `_load_settings()`：从 `extra` 读取 `require_mention`，默认为 `true`
- `_should_accept_group_message()`：`require_mention=False` 时跳过 @mention 检查但仍执行群策略

### 测试

4 个新增测试用例全部通过（118 passing）
