### PR TITLE
fix(tui): guard empty idle queue drain to stop idle OOM

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -229,6 +229,7 @@ AUTHOR_MAP = {
     "ygd58@users.noreply.github.com": "ygd58",
     "vominh1919@users.noreply.github.com": "vominh1919",
     "iamagenius00@users.noreply.github.com": "iamagenius00",
+    "9219265+cresslank@users.noreply.github.com": "cresslank",
     "trevmanthony@gmail.com": "trevthefoolish",
     "ziliangpeng@users.noreply.github.com": "ziliangpeng",
     "centripetal-star@users.noreply.github.com": "centripetal-star",

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -386,7 +386,12 @@ export function useMainApp(gw: GatewayClient) {
   // and error paths never emit message.complete, so anything enqueued while
   // `!sleep` / a failed turn was running would stay stuck forever.
   useEffect(() => {
-    if (!ui.sid || ui.busy || composerRefs.queueEditRef.current !== null) {
+    if (
+      !ui.sid ||
+      ui.busy ||
+      composerRefs.queueEditRef.current !== null ||
+      composerRefs.queueRef.current.length === 0
+    ) {
       return
     }
 


### PR DESCRIPTION
TUI no longer OOMs while sitting idle at the `ready` prompt.

Follow-up to #12754. The queue-drain `useEffect` in `ui-tui/src/app/useMainApp.ts` could still call `composerActions.dequeue()` when the queue was empty, which kept the idle rerender/dequeue path alive until V8 hit its ~4GB limit (~50-55s on cresslank's repro).

## Changes
- `ui-tui/src/app/useMainApp.ts`: return early from the drain effect when `composerRefs.queueRef.current.length === 0`
- `scripts/release.py`: add cresslank to AUTHOR_MAP

## Validation
| | Before | After |
|---|---|---|
| Idle `ready` (cresslank's repro) | OOM at ~50-55s | Stable >30min |
| Independent confirmation (@e-shizz) | crash | fix |
| `npm --prefix ui-tui run type-check` | — | clean |

Salvages #12822 (@cresslank). Authorship preserved via cherry-pick; rebase-merge.

Closes #12682.
