### PR TITLE
fix: anchor /plan storage to get_hermes_home() to avoid redundant .hermes dirs

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from hermes_constants import display_hermes_home
+from hermes_constants import display_hermes_home, get_hermes_home
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +41,7 @@ def build_plan_path(
         slug = "-".join(part for part in slug.split("-")[:8] if part)[:48].strip("-")
     slug = slug or "conversation-plan"
     timestamp = (now or datetime.now()).strftime("%Y-%m-%d_%H%M%S")
-    return Path(".hermes") / "plans" / f"{timestamp}-{slug}.md"
+    return get_hermes_home() / "plans" / f"{timestamp}-{slug}.md"
 
 
 def _load_skill_payload(skill_identifier: str, task_id: str | None = None) -> tuple[dict[str, Any], Path | None, str] | None:

--- a/skills/software-development/plan/SKILL.md
+++ b/skills/software-development/plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plan
-description: Plan mode for Hermes — inspect context, write a markdown plan into the active workspace's `.hermes/plans/` directory, and do not execute the work.
+description: Plan mode for Hermes — inspect context, write a markdown plan into the `~/.hermes/plans/` directory, and do not execute the work.
 version: 1.0.0
 author: Hermes Agent
 license: MIT
@@ -22,7 +22,7 @@ For this turn, you are planning only.
 - Do not edit project files except the plan markdown file.
 - Do not run mutating terminal commands, commit, push, or perform external actions.
 - You may inspect the repo or other context with read-only commands/tools when needed.
-- Your deliverable is a markdown plan saved inside the active workspace under `.hermes/plans/`.
+- Your deliverable is a markdown plan saved under `~/.hermes/plans/`.
 
 ## Output requirements
 
@@ -41,13 +41,13 @@ If the task is code-related, include exact file paths, likely test targets, and 
 
 ## Save location
 
-Save the plan with `write_file` under:
-- `.hermes/plans/YYYY-MM-DD_HHMMSS-<slug>.md`
+Save the plan with `write_file` using an absolute path anchored to your home directory:
+- `~/.hermes/plans/YYYY-MM-DD_HHMMSS-<slug>.md`
 
-Treat that as relative to the active working directory / backend workspace. Hermes file tools are backend-aware, so using this relative path keeps the plan with the workspace on local, docker, ssh, modal, and daytona backends.
+Using this absolute home path ensures plans are consolidated in your persistent state directory rather than polluting individual project workspaces.
 
 If the runtime provides a specific target path, use that exact path.
-If not, create a sensible timestamped filename yourself under `.hermes/plans/`.
+If not, create a sensible timestamped filename yourself under `~/.hermes/plans/`.
 
 ## Interaction style
 


### PR DESCRIPTION
This PR anchors the plan storage path to the global Hermes home directory instead of using a relative path. This prevents the creation of redundant `.hermes` directories within project workspaces that are already managed by Hermes.

**Changes**:
- Modified `agent/skill_commands.py` to use `get_hermes_home()` in `build_plan_path`.
- Updated `skills/software-development/plan/SKILL.md` to reflect the change to absolute home paths and explain the benefit (preventing workspace pollution).

**Verification**:
- Verified that `/plan` now saves to `~/.hermes/plans/` even when the CWD contains a `.hermes` folder.
- Verified that `skill_commands.py` passes syntax checks.