### PR TITLE
fix: honor configured cwd during snapshot init

### DIFF
--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -130,6 +130,29 @@ class TestEmbedStdinHeredoc:
 
 
 class TestInitSessionFailure:
+    def test_bootstrap_cds_into_configured_cwd_before_snapshot(self):
+        env = _TestableEnv(cwd="/tmp/project")
+
+        calls = []
+
+        def mock_run_bash(cmd, *, login=False, timeout=120, stdin_data=None):
+            calls.append({"cmd": cmd, "login": login, "timeout": timeout})
+            return MagicMock()
+
+        def mock_wait_for_process(proc, timeout=None):
+            return {"output": f"\n{env._cwd_marker}/tmp/project{env._cwd_marker}\n"}
+
+        env._run_bash = mock_run_bash
+        env._wait_for_process = mock_wait_for_process
+
+        env.init_session()
+
+        assert len(calls) == 1
+        assert calls[0]["login"] is True
+        assert "cd /tmp/project || exit 126" in calls[0]["cmd"]
+        assert env.cwd == "/tmp/project"
+        assert env._snapshot_ready is True
+
     def test_snapshot_ready_false_on_failure(self):
         env = _TestableEnv()
 

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -334,8 +334,14 @@ class BaseEnvironment(ABC):
         ``_snapshot_ready = True`` so subsequent commands source the snapshot
         instead of running with ``bash -l``.
         """
+        quoted_cwd = (
+            shlex.quote(self.cwd)
+            if self.cwd != "~" and not self.cwd.startswith("~/")
+            else self.cwd
+        )
         # Full capture: env vars, functions (filtered), aliases, shell options.
         bootstrap = (
+            f"cd {quoted_cwd} || exit 126\n"
             f"export -p > {self._snapshot_path}\n"
             f"declare -f | grep -vE '^_[^_]' >> {self._snapshot_path}\n"
             f"alias -p >> {self._snapshot_path}\n"
@@ -760,4 +766,3 @@ class BaseEnvironment(ABC):
         from tools.terminal_tool import _transform_sudo_command
 
         return _transform_sudo_command(command)
-


### PR DESCRIPTION
  ## Summary
  - cd into the configured cwd before creating the local shell snapshot
  - prevent launchd WorkingDirectory from overriding the messaging workspace
  - add a regression test covering snapshot init with an explicit cwd

  ## Verification
  - /Users/kaizhou/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/tools/test_base_environment.py