### PR TITLE
fix(docker): pass docker_mount_cwd_to_workspace and docker_forward_env to container_config in file_tools

### DIFF
--- a/tests/tools/test_file_tools_container_config.py
+++ b/tests/tools/test_file_tools_container_config.py
@@ -1,0 +1,65 @@
+"""Tests for docker container_config key propagation in file_tools."""
+
+from unittest.mock import patch, MagicMock
+import tools.file_tools as file_tools
+
+
+def _make_env_config(**overrides):
+    base = {
+        "env_type": "docker",
+        "docker_image": "test-image:latest",
+        "singularity_image": "docker://test",
+        "modal_image": "test",
+        "daytona_image": "test",
+        "cwd": "/workspace",
+        "host_cwd": None,
+        "timeout": 180,
+        "container_cpu": 2,
+        "container_memory": 4096,
+        "container_disk": 20480,
+        "container_persistent": False,
+        "docker_volumes": [],
+        "docker_mount_cwd_to_workspace": True,
+        "docker_forward_env": ["MY_SECRET", "API_KEY"],
+    }
+    base.update(overrides)
+    return base
+
+
+class TestFileToolsContainerConfig:
+    def _run(self, env_config, task_id):
+        captured = {}
+        mock_env = MagicMock()
+
+        def fake_create_env(**kwargs):
+            captured.update(kwargs)
+            return mock_env
+
+        with patch("tools.terminal_tool._get_env_config", return_value=env_config),              patch("tools.terminal_tool._task_env_overrides", {}),              patch("tools.terminal_tool._active_environments", {}),              patch("tools.terminal_tool._creation_locks", {}),              patch("tools.terminal_tool._creation_locks_lock", __import__("threading").Lock()),              patch("tools.terminal_tool._create_environment", side_effect=fake_create_env),              patch("tools.terminal_tool._start_cleanup_thread"),              patch("tools.terminal_tool._check_disk_usage_warning"),              patch("tools.file_tools._file_ops_cache", {}),              patch("tools.file_tools._file_ops_lock", __import__("threading").Lock()):
+            file_tools._get_file_ops(task_id)
+
+        return captured.get("container_config", {})
+
+    def test_docker_mount_cwd_to_workspace_passed(self):
+        """docker_mount_cwd_to_workspace is forwarded to container_config."""
+        cc = self._run(_make_env_config(docker_mount_cwd_to_workspace=True), "t1")
+        assert cc.get("docker_mount_cwd_to_workspace") is True
+
+    def test_docker_forward_env_passed(self):
+        """docker_forward_env is forwarded to container_config."""
+        cc = self._run(_make_env_config(docker_forward_env=["MY_SECRET"]), "t2")
+        assert cc.get("docker_forward_env") == ["MY_SECRET"]
+
+    def test_docker_mount_cwd_defaults_to_false(self):
+        """docker_mount_cwd_to_workspace defaults to False when absent from config."""
+        cfg = _make_env_config()
+        del cfg["docker_mount_cwd_to_workspace"]
+        cc = self._run(cfg, "t3")
+        assert cc.get("docker_mount_cwd_to_workspace") is False
+
+    def test_docker_forward_env_defaults_to_empty_list(self):
+        """docker_forward_env defaults to [] when absent from config."""
+        cfg = _make_env_config()
+        del cfg["docker_forward_env"]
+        cc = self._run(cfg, "t4")
+        assert cc.get("docker_forward_env") == []

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -278,6 +278,8 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                     "container_disk": config.get("container_disk", 51200),
                     "container_persistent": config.get("container_persistent", True),
                     "docker_volumes": config.get("docker_volumes", []),
+                    "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
+                    "docker_forward_env": config.get("docker_forward_env", []),
                 }
 
             ssh_config = None


### PR DESCRIPTION
## Summary
File tools (`read_file`, `write_file`, `search_files`, `patch`) now respect `docker_mount_cwd_to_workspace` and `docker_forward_env` when the terminal backend is Docker/Singularity/Modal/Daytona. Previously these two keys were present in `terminal_tool.py`'s `container_config` but missing from `file_tools.py`'s — so file tools silently ignored them and users saw "file not found" on files that exist in the host cwd.

Closes #2672.

## Changes
- `tools/file_tools.py`: add `docker_mount_cwd_to_workspace` and `docker_forward_env` to the `container_config` dict in `_get_file_ops()`, matching `terminal_tool.py`.
- `tests/tools/test_file_tools_container_config.py`: 4 regression tests verifying both keys are forwarded and defaulted correctly.

## Validation
| | Before | After |
|---|---|---|
| `docker_mount_cwd_to_workspace=true` respected by file tools | ✗ | ✓ |
| `docker_forward_env` respected by file tools | ✗ | ✓ |
| Regression tests | — | 4/4 pass; all 4 fail when fix is reverted |

## Credit
Salvaged from @teyrebaz33's #2688 — cherry-picked with original authorship preserved. Closing duplicate PRs #2674 (@Mibayy, first submitter with same 2-line fix), #2697 (@JasonOA888), #2729 (@amethystani), #11888 (@Linux2010) with credit pointing here.
