### PR TITLE
docs(providers): drop stale 'TODO: Phase 4' from get_provider docstring

### DIFF
--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -322,12 +322,16 @@ def normalize_provider(name: str) -> str:
 
 
 def get_provider(name: str) -> Optional[ProviderDef]:
-    """Look up a provider by id or alias, merging all data sources.
+    """Look up a built-in provider by id or alias.
 
     Resolution order:
       1. Hermes overlays (for providers not in models.dev: nous, openai-codex, etc.)
       2. models.dev catalog + Hermes overlay
-      3. User-defined providers from config (TODO: Phase 4)
+
+    User-defined providers from config.yaml (``providers:`` / ``custom_providers:``)
+    are resolved by :func:`resolve_provider_full`, which layers ``resolve_user_provider``
+    and ``resolve_custom_provider`` on top of this function. Callers that need
+    user-config support should use ``resolve_provider_full`` instead.
 
     Returns a fully-resolved ProviderDef or None.
     """


### PR DESCRIPTION
## Summary
User-defined providers from config.yaml are already resolved — they live in `resolve_provider_full()` (which layers `resolve_user_provider` and `resolve_custom_provider` on top of `get_provider`). The `TODO: Phase 4` comment in `get_provider()`'s docstring is just stale. Refresh it to reflect current reality and point future readers at the right entry point.

No behaviour change.

Closes #12309.

## Context
Raised by @hamperhead in #12309 and proposed as a code change in #12292. The proposed implementation had several issues (wrong import — `ProviderDef` isn't in `agent.models_dev`; wrong config schema; duplicated existing `resolve_user_provider` logic; hardcoded `Path.home()` breaks profiles; YAML read on every hot-path call; unrelated test assertion deletion). Closing #12292 with credit; this docstring refresh is the actual follow-up.