### PR TITLE
fix(agent): handle dict-typed message fields in error classifier (#11233)

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -237,6 +237,22 @@ _SERVER_DISCONNECT_PATTERNS = [
 ]
 
 
+# ── Helpers ───────────────────────────────────────────────────────────────
+
+def _safe_lower(val) -> str:
+    """Return .lower() for strings, str() for other types, or '' for None.
+
+    Some providers return dict-typed ``message`` fields in error bodies
+    (e.g. Pydantic validation errors).  Calling ``.lower()`` on those would
+    raise ``AttributeError``.
+    """
+    if val is None:
+        return ""
+    if isinstance(val, str):
+        return val.lower()
+    return str(val).lower()
+
+
 # ── Classification pipeline ─────────────────────────────────────────────
 
 def classify_api_error(
@@ -290,7 +306,7 @@ def classify_api_error(
     if isinstance(body, dict):
         _err_obj = body.get("error", {})
         if isinstance(_err_obj, dict):
-            _body_msg = (_err_obj.get("message") or "").lower()
+            _body_msg = _safe_lower(_err_obj.get("message"))
             # Parse metadata.raw for wrapped provider errors
             _metadata = _err_obj.get("metadata", {})
             if isinstance(_metadata, dict):
@@ -302,11 +318,11 @@ def classify_api_error(
                         if isinstance(_inner, dict):
                             _inner_err = _inner.get("error", {})
                             if isinstance(_inner_err, dict):
-                                _metadata_msg = (_inner_err.get("message") or "").lower()
+                                _metadata_msg = _safe_lower(_inner_err.get("message"))
                     except (json.JSONDecodeError, TypeError):
                         pass
         if not _body_msg:
-            _body_msg = (body.get("message") or "").lower()
+            _body_msg = _safe_lower(body.get("message"))
     # Combine all message sources for pattern matching
     parts = [_raw_msg]
     if _body_msg and _body_msg not in _raw_msg:
@@ -606,10 +622,10 @@ def _classify_400(
     if isinstance(body, dict):
         err_obj = body.get("error", {})
         if isinstance(err_obj, dict):
-            err_body_msg = (err_obj.get("message") or "").strip().lower()
+            err_body_msg = _safe_lower(err_obj.get("message")).strip()
         # Responses API (and some providers) use flat body: {"message": "..."}
         if not err_body_msg:
-            err_body_msg = (body.get("message") or "").strip().lower()
+            err_body_msg = _safe_lower(body.get("message")).strip()
     is_generic = len(err_body_msg) < 30 or err_body_msg in ("error", "")
     is_large = approx_tokens > context_length * 0.4 or approx_tokens > 80000 or num_messages > 80
 

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -9,6 +9,7 @@ from agent.error_classifier import (
     _extract_error_body,
     _extract_error_code,
     _classify_402,
+    _safe_lower,
 )
 
 
@@ -849,3 +850,73 @@ class TestAdversarialEdgeCases:
         )
         result = classify_api_error(e, provider="openrouter")
         assert result.reason == FailoverReason.model_not_found
+
+
+# ── Test: dict-typed message fields (#11233) ─────────────────────────────
+
+class TestDictMessageField:
+    """classify_api_error must not crash when error bodies contain dict-typed
+    ``message`` fields, which some providers (e.g. Pydantic validation
+    frameworks) return instead of plain strings."""
+
+    def test_safe_lower_string(self):
+        assert _safe_lower("Hello World") == "hello world"
+
+    def test_safe_lower_none(self):
+        assert _safe_lower(None) == ""
+
+    def test_safe_lower_dict(self):
+        result = _safe_lower({"code": "rate_limit", "msg": "slow down"})
+        assert isinstance(result, str)
+        assert "rate_limit" in result
+
+    def test_safe_lower_int(self):
+        assert _safe_lower(42) == "42"
+
+    def test_flat_body_dict_message(self):
+        """body.message is a dict — should not raise AttributeError."""
+        e = MockAPIError(
+            "Bad Request",
+            status_code=400,
+            body={"message": {"reason": "validation", "details": "invalid field"}},
+        )
+        result = classify_api_error(e)
+        assert isinstance(result, ClassifiedError)
+
+    def test_nested_error_dict_message(self):
+        """body.error.message is a dict — should not raise AttributeError."""
+        e = MockAPIError(
+            "Bad Request",
+            status_code=400,
+            body={"error": {"message": {"code": "invalid_request", "info": "bad param"}}},
+        )
+        result = classify_api_error(e)
+        assert isinstance(result, ClassifiedError)
+
+    def test_metadata_raw_inner_dict_message(self):
+        """Nested metadata.raw → inner error.message is a dict."""
+        import json
+        inner = json.dumps({"error": {"message": {"type": "provider_error"}}})
+        e = MockAPIError(
+            "Provider returned error",
+            status_code=400,
+            body={
+                "error": {
+                    "message": "Provider returned error",
+                    "metadata": {"raw": inner},
+                }
+            },
+        )
+        result = classify_api_error(e, provider="openrouter")
+        assert isinstance(result, ClassifiedError)
+
+    def test_classify_400_dict_message_no_crash(self):
+        """_classify_by_status also handles dict message in body."""
+        e = MockAPIError(
+            "Bad Request",
+            status_code=400,
+            body={"message": {"error": "context_length_exceeded"}},
+        )
+        result = classify_api_error(e, approx_tokens=150000, context_length=128000)
+        assert isinstance(result, ClassifiedError)
+


### PR DESCRIPTION
## What changed and why

Some API providers (Pydantic validation frameworks, LM Studio, etc.) return structured error bodies where the `message` field is a dict rather than a string. Calling `.lower()` on these values raises `AttributeError`, crashing the error handling pipeline and hiding the original API error.

**Root cause:** Five sites in `error_classifier.py` used the pattern `(value or "").lower()` which fails when `value` is a non-falsy, non-string type (e.g. a dict).

**Fix:** Add `_safe_lower()` helper that handles None (returns `""`), strings (lowercases normally), and other types (stringifies then lowercases). Applied to all five call sites.

Closes #11233

## How to test

1. Trigger an API error from a provider that returns dict-typed message fields:
   ```python
   body = {"error": {"message": {"code": "invalid_request", "info": "bad param"}}}
   ```
2. Verify `classify_api_error()` returns a `ClassifiedError` instead of raising `AttributeError`

**Automated:** 8 new tests in `tests/agent/test_error_classifier.py`:
- `_safe_lower` unit tests: string, None, dict, int
- Integration tests: flat body dict message, nested error dict, metadata.raw inner dict, `_classify_400` dict message

## Platform tested

- macOS (Darwin 24.6.0)