### PR TITLE
fix(cli): prevent duplicate custom providers from slug mismatch (#12293)

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1095,6 +1095,12 @@ def list_authenticated_providers(
                 "api_url": api_url,
             })
             seen_slugs.add(ep_name.lower())
+            # Also add the custom:-prefixed slug so that Section 4's
+            # ``custom_provider_slug(display_name)`` check finds it and skips
+            # the duplicate entry (issue #12293).
+            _cp_slug = custom_provider_slug(display_name)
+            if _cp_slug and _cp_slug.lower() != ep_name.lower():
+                seen_slugs.add(_cp_slug.lower())
             _pair = (
                 str(display_name).strip().lower(),
                 str(api_url).strip().rstrip("/").lower(),

--- a/tests/hermes_cli/test_duplicate_custom_provider_slug.py
+++ b/tests/hermes_cli/test_duplicate_custom_provider_slug.py
@@ -1,0 +1,162 @@
+"""Regression tests for duplicate custom provider entries (issue #12293).
+
+Section 3 (user_providers) and Section 4 (custom_providers) used different
+slug formats when tracking duplicates. Section 3 added the plain key
+(e.g. "modal-direct") while Section 4 generated a "custom:"-prefixed slug
+(e.g. "custom:modal-direct"), causing the same provider to appear twice.
+
+The _section3_emitted_pairs dedup provides a partial workaround when both
+name and base_url match, but the seen_slugs check is the authoritative
+defense — and it was broken because of the slug format mismatch.
+"""
+
+import hermes_cli.providers as providers_mod
+from hermes_cli.model_switch import list_authenticated_providers
+
+
+def _no_external_calls(monkeypatch):
+    """Monkeypatch external API calls for isolation."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+
+
+class TestDuplicateCustomProviderSlug:
+    """Verify that the same provider in user_providers and custom_providers
+    produces only one entry in the /model list."""
+
+    def test_no_duplicate_when_base_url_missing_from_user_providers(self, monkeypatch):
+        """When user_providers entry has no base_url, _section3_emitted_pairs
+        can't catch the duplicate (pair requires both name and url).
+        Only the seen_slugs slug-based check prevents the duplicate.
+
+        This is the core regression test for issue #12293.
+        Without the fix, Section 4 generates custom:-prefixed slug which
+        doesn't match the plain slug Section 3 added.
+        """
+        _no_external_calls(monkeypatch)
+
+        providers = list_authenticated_providers(
+            current_provider="openrouter",
+            user_providers={
+                "modal-direct": {
+                    "name": "Modal Direct",
+                    # No base_url — _section3_emitted_pairs won't capture this
+                    "model": "llama3",
+                },
+            },
+            custom_providers=[
+                {
+                    "name": "Modal Direct",
+                    "base_url": "https://api.us-west-2.modal.direct/v1",
+                    "model": "qwen3",
+                },
+            ],
+            max_models=50,
+        )
+
+        modal_rows = [p for p in providers if p["name"] == "Modal Direct"]
+        assert len(modal_rows) == 1, (
+            f"Expected 1 Modal Direct row, got {len(modal_rows)}: "
+            f"{[r['slug'] for r in modal_rows]}"
+        )
+
+    def test_matching_name_and_url_no_duplicate(self, monkeypatch):
+        """When user_providers and custom_providers share the same
+        display name and base URL, only one picker row should appear."""
+        _no_external_calls(monkeypatch)
+
+        providers = list_authenticated_providers(
+            current_provider="openrouter",
+            user_providers={
+                "modal-direct": {
+                    "name": "Modal Direct",
+                    "base_url": "https://api.us-west-2.modal.direct/v1",
+                    "model": "llama3",
+                },
+            },
+            custom_providers=[
+                {
+                    "name": "Modal Direct",
+                    "base_url": "https://api.us-west-2.modal.direct/v1",
+                    "model": "qwen3",
+                },
+            ],
+            max_models=50,
+        )
+
+        modal_rows = [p for p in providers if p["name"] == "Modal Direct"]
+        assert len(modal_rows) == 1, (
+            f"Expected 1 Modal Direct row, got {len(modal_rows)}: "
+            f"{[r['slug'] for r in modal_rows]}"
+        )
+
+    def test_distinct_providers_both_appear(self, monkeypatch):
+        """When user_providers and custom_providers have genuinely different
+        providers, both should appear."""
+        _no_external_calls(monkeypatch)
+
+        providers = list_authenticated_providers(
+            current_provider="openrouter",
+            user_providers={
+                "my-local": {
+                    "name": "My Local",
+                    "base_url": "http://localhost:1234/v1",
+                    "model": "llama3",
+                },
+            },
+            custom_providers=[
+                {
+                    "name": "Cloud Provider",
+                    "base_url": "https://api.mistral.ai/v1",
+                    "model": "mistral-large",
+                },
+            ],
+            max_models=50,
+        )
+
+        names = [p["name"] for p in providers]
+        assert "My Local" in names
+        assert "Cloud Provider" in names
+        assert len(providers) == 2
+
+    def test_custom_providers_only_still_works(self, monkeypatch):
+        """When only custom_providers is passed (no user_providers),
+        entries should still appear normally."""
+        _no_external_calls(monkeypatch)
+
+        providers = list_authenticated_providers(
+            current_provider="openrouter",
+            user_providers={},
+            custom_providers=[
+                {
+                    "name": "Standalone",
+                    "base_url": "https://api.standalone.example/v1",
+                    "model": "model-a",
+                },
+            ],
+            max_models=50,
+        )
+
+        names = [p["name"] for p in providers]
+        assert "Standalone" in names
+
+    def test_user_providers_only_still_works(self, monkeypatch):
+        """When only user_providers is passed (no custom_providers),
+        entries should still appear normally."""
+        _no_external_calls(monkeypatch)
+
+        providers = list_authenticated_providers(
+            current_provider="openrouter",
+            user_providers={
+                "my-provider": {
+                    "name": "My Provider",
+                    "base_url": "https://api.my-provider.example/v1",
+                    "model": "model-a",
+                },
+            },
+            custom_providers=None,
+            max_models=50,
+        )
+
+        names = [p["name"] for p in providers]
+        assert "My Provider" in names


### PR DESCRIPTION
## What changed and why

The `/model` picker showed duplicate entries when the same provider appeared in both `user_providers` and `custom_providers` config sections.

**Root cause:** Section 3 (`user_providers`) added the plain dict key (e.g. `"modal-direct"`) to `seen_slugs`, while Section 4 (`custom_providers`) generated a `"custom:"`-prefixed slug via `custom_provider_slug()` (e.g. `"custom:modal-direct"`). The prefix mismatch meant the slug-based dedup check in Section 4 never matched, producing duplicate rows.

The `_section3_emitted_pairs` (name+URL) dedup provides a partial defense but only works when both name AND `base_url` are present. When `user_providers` lacks a `base_url`, duplicates slip through entirely.

**Fix:** After Section 3 adds the plain slug to `seen_slugs`, also add the `custom:`-prefixed version so Section 4's lookup finds it. Uses the existing `custom_provider_slug()` helper (single source of truth for slug format).

Closes #12293

## How to test

1. Add the same provider to both `user_providers` and `custom_providers` in `config.yaml` (with or without `base_url` in `user_providers`)
2. Run `/model` — should show exactly one entry, not two

**Automated:** 5 new tests in `tests/hermes_cli/test_duplicate_custom_provider_slug.py`:
- Core regression: `user_providers` without `base_url` (the exact gap)
- Matching name+URL dedup
- Distinct providers both appear
- Custom-only and user-only backward compatibility

## Platform tested

- macOS (Darwin 24.6.0)