### PR TITLE
fix(gateway): route watch notifications to correct Discord thread (#10411)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15404,6 +15404,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self.session_store._ensure_loaded()
                 entry = self.session_store._entries.get(session_key)
                 if entry and getattr(entry, "origin", None):
+                    # The persisted origin may lack thread_id when the
+                    # session was first created from a non-threaded
+                    # message in the parent channel.  The event dict
+                    # carries the correct thread_id from the watcher
+                    # metadata (set via session_context when the
+                    # background process was launched from a thread).
+                    _evt_thread = str(evt.get("thread_id") or "").strip() or None
+                    if _evt_thread and not getattr(entry.origin, "thread_id", None):
+                        return dataclasses.replace(entry.origin, thread_id=_evt_thread)
                     return entry.origin
             except Exception as exc:
                 logger.debug(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8197,6 +8197,22 @@ class GatewayRunner:
                 self.session_store._ensure_loaded()
                 entry = self.session_store._entries.get(session_key)
                 if entry and getattr(entry, "origin", None):
+                    # The persisted origin may lack thread_id when the
+                    # session was first created from a non-threaded
+                    # message in the parent channel.  The event dict
+                    # carries the correct thread_id from the watcher
+                    # metadata (set via session_context when the
+                    # background process was launched from a thread).
+                    _evt_thread = str(evt.get("thread_id") or "").strip() or None
+                    if _evt_thread and not getattr(entry.origin, "thread_id", None):
+                        return SessionSource(
+                            platform=entry.origin.platform,
+                            chat_id=entry.origin.chat_id,
+                            chat_type=entry.origin.chat_type,
+                            thread_id=_evt_thread,
+                            user_id=entry.origin.user_id,
+                            user_name=entry.origin.user_name,
+                        )
                     return entry.origin
             except Exception as exc:
                 logger.debug(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -24,6 +24,7 @@ import signal
 import tempfile
 import threading
 import time
+import dataclasses
 from collections import OrderedDict
 from contextvars import copy_context
 from pathlib import Path
@@ -8205,14 +8206,7 @@ class GatewayRunner:
                     # background process was launched from a thread).
                     _evt_thread = str(evt.get("thread_id") or "").strip() or None
                     if _evt_thread and not getattr(entry.origin, "thread_id", None):
-                        return SessionSource(
-                            platform=entry.origin.platform,
-                            chat_id=entry.origin.chat_id,
-                            chat_type=entry.origin.chat_type,
-                            thread_id=_evt_thread,
-                            user_id=entry.origin.user_id,
-                            user_name=entry.origin.user_name,
-                        )
+                        return dataclasses.replace(entry.origin, thread_id=_evt_thread)
                     return entry.origin
             except Exception as exc:
                 logger.debug(

--- a/tests/gateway/test_watch_notification_thread_routing.py
+++ b/tests/gateway/test_watch_notification_thread_routing.py
@@ -1,0 +1,240 @@
+"""Regression tests for watch_match notification thread routing (issue #10411).
+
+When a background process is started from a Discord thread, the watch_match
+notification should be routed back to that thread.  The session store origin
+may lack thread_id (if the session was first created from the parent channel),
+but the event dict carries thread_id from the watcher metadata.
+
+``_build_process_event_source`` must use the event's thread_id when the
+origin lacks one.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _build_runner(monkeypatch, tmp_path) -> GatewayRunner:
+    """Create a GatewayRunner with a fake config."""
+    import gateway.run as gateway_run
+
+    (tmp_path / "config.yaml").write_text(
+        "display:\n  background_process_notifications: all\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner = GatewayRunner(GatewayConfig())
+    adapter = SimpleNamespace(send=AsyncMock(), handle_message=AsyncMock())
+    runner.adapters[Platform.DISCORD] = adapter
+    return runner
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestWatchNotificationThreadRouting:
+    """Verify watch notifications route to the correct thread when the
+    session store origin lacks thread_id."""
+
+    @pytest.mark.asyncio
+    async def test_event_thread_id_used_when_origin_lacks_it(self, monkeypatch, tmp_path):
+        """When origin has no thread_id but the event does, use the event's."""
+        runner = _build_runner(monkeypatch, tmp_path)
+        adapter = runner.adapters[Platform.DISCORD]
+
+        # Session was first created from the parent channel (no thread_id)
+        runner.session_store._entries["agent:main:discord:group:123:456"] = SimpleNamespace(
+            origin=SessionSource(
+                platform=Platform.DISCORD,
+                chat_id="123",
+                chat_type="group",
+                thread_id=None,  # <-- Missing thread_id
+                user_id="789",
+                user_name="Emiliyan",
+            )
+        )
+
+        # Background process was started from thread 456
+        evt = {
+            "session_id": "proc_abc",
+            "session_key": "agent:main:discord:group:123:456",
+            "platform": "discord",
+            "chat_id": "123",
+            "thread_id": "456",  # <-- Correct thread from watcher metadata
+            "user_id": "789",
+            "user_name": "Emiliyan",
+        }
+
+        await runner._inject_watch_notification("[SYSTEM: Background process matched]", evt)
+
+        adapter.handle_message.assert_awaited_once()
+        synth_event = adapter.handle_message.await_args.args[0]
+        assert synth_event.source.thread_id == "456"
+
+    @pytest.mark.asyncio
+    async def test_origin_thread_id_preserved_when_present(self, monkeypatch, tmp_path):
+        """When origin already has thread_id, it should be used (not overridden)."""
+        runner = _build_runner(monkeypatch, tmp_path)
+        adapter = runner.adapters[Platform.DISCORD]
+
+        runner.session_store._entries["agent:main:discord:group:123:100"] = SimpleNamespace(
+            origin=SessionSource(
+                platform=Platform.DISCORD,
+                chat_id="123",
+                chat_type="group",
+                thread_id="100",  # <-- Already has thread_id
+                user_id="789",
+                user_name="Emiliyan",
+            )
+        )
+
+        evt = {
+            "session_id": "proc_abc",
+            "session_key": "agent:main:discord:group:123:100",
+            "platform": "discord",
+            "chat_id": "123",
+            "thread_id": "999",  # <-- Different thread in event
+            "user_id": "789",
+            "user_name": "Emiliyan",
+        }
+
+        await runner._inject_watch_notification("[SYSTEM: Background process matched]", evt)
+
+        adapter.handle_message.assert_awaited_once()
+        synth_event = adapter.handle_message.await_args.args[0]
+        # Origin's thread_id takes precedence
+        assert synth_event.source.thread_id == "100"
+
+    def test_build_source_patches_thread_id_from_event(self, monkeypatch, tmp_path):
+        """_build_process_event_source patches thread_id from event when origin lacks it."""
+        runner = _build_runner(monkeypatch, tmp_path)
+
+        runner.session_store._entries["agent:main:discord:group:123:456"] = SimpleNamespace(
+            origin=SessionSource(
+                platform=Platform.DISCORD,
+                chat_id="123",
+                chat_type="group",
+                thread_id=None,
+                user_id="789",
+                user_name="Emiliyan",
+            )
+        )
+
+        evt = {
+            "session_id": "proc_abc",
+            "session_key": "agent:main:discord:group:123:456",
+            "platform": "discord",
+            "chat_id": "123",
+            "thread_id": "456",
+            "user_id": "789",
+            "user_name": "Emiliyan",
+        }
+
+        source = runner._build_process_event_source(evt)
+
+        assert source is not None
+        assert source.thread_id == "456"
+        assert source.chat_id == "123"
+        assert source.platform == Platform.DISCORD
+
+    def test_build_source_no_event_thread_returns_origin_as_is(self, monkeypatch, tmp_path):
+        """When event also has no thread_id, origin is returned unchanged."""
+        runner = _build_runner(monkeypatch, tmp_path)
+
+        runner.session_store._entries["agent:main:discord:group:123"] = SimpleNamespace(
+            origin=SessionSource(
+                platform=Platform.DISCORD,
+                chat_id="123",
+                chat_type="group",
+                thread_id=None,
+                user_id="789",
+                user_name="Emiliyan",
+            )
+        )
+
+        evt = {
+            "session_id": "proc_abc",
+            "session_key": "agent:main:discord:group:123",
+        }
+
+        source = runner._build_process_event_source(evt)
+
+        assert source is not None
+        assert source.thread_id is None
+
+    def test_build_source_no_origin_uses_event_thread_id(self, monkeypatch, tmp_path):
+        """When no session store entry exists, event's thread_id is used directly."""
+        runner = _build_runner(monkeypatch, tmp_path)
+
+        evt = {
+            "session_id": "proc_abc",
+            "session_key": "agent:main:discord:group:123:456",
+            "platform": "discord",
+            "chat_id": "123",
+            "thread_id": "456",
+            "user_id": "789",
+            "user_name": "Emiliyan",
+        }
+
+        source = runner._build_process_event_source(evt)
+
+        assert source is not None
+        assert source.thread_id == "456"
+
+    def test_all_origin_fields_preserved_when_thread_patched(self, monkeypatch, tmp_path):
+        """All 11 SessionSource fields must survive when thread_id is patched.
+
+        Regression test: a manual SessionSource() constructor previously
+        dropped chat_name, chat_topic, user_id_alt, chat_id_alt, and is_bot.
+        Using dataclasses.replace() ensures all fields carry over.
+        """
+        runner = _build_runner(monkeypatch, tmp_path)
+
+        origin = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="123",
+            chat_name="general",
+            chat_type="group",
+            thread_id=None,
+            user_id="789",
+            user_name="Emiliyan",
+            chat_topic="Project discussion",
+            user_id_alt="alt-uuid-abc",
+            chat_id_alt="alt-group-xyz",
+            is_bot=False,
+        )
+        runner.session_store._entries["agent:main:discord:group:123:456"] = SimpleNamespace(
+            origin=origin,
+        )
+
+        evt = {
+            "session_id": "proc_abc",
+            "session_key": "agent:main:discord:group:123:456",
+            "thread_id": "456",
+        }
+
+        source = runner._build_process_event_source(evt)
+
+        assert source is not None
+        assert source.thread_id == "456"
+        assert source.platform == Platform.DISCORD
+        assert source.chat_id == "123"
+        assert source.chat_name == "general"
+        assert source.chat_type == "group"
+        assert source.user_id == "789"
+        assert source.user_name == "Emiliyan"
+        assert source.chat_topic == "Project discussion"
+        assert source.user_id_alt == "alt-uuid-abc"
+        assert source.chat_id_alt == "alt-group-xyz"
+        assert source.is_bot is False

--- a/tests/gateway/test_watch_notification_thread_routing.py
+++ b/tests/gateway/test_watch_notification_thread_routing.py
@@ -1,0 +1,193 @@
+"""Regression tests for watch_match notification thread routing (issue #10411).
+
+When a background process is started from a Discord thread, the watch_match
+notification should be routed back to that thread.  The session store origin
+may lack thread_id (if the session was first created from the parent channel),
+but the event dict carries thread_id from the watcher metadata.
+
+``_build_process_event_source`` must use the event's thread_id when the
+origin lacks one.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _build_runner(monkeypatch, tmp_path) -> GatewayRunner:
+    """Create a GatewayRunner with a fake config."""
+    import gateway.run as gateway_run
+
+    (tmp_path / "config.yaml").write_text(
+        "display:\n  background_process_notifications: all\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner = GatewayRunner(GatewayConfig())
+    adapter = SimpleNamespace(send=AsyncMock(), handle_message=AsyncMock())
+    runner.adapters[Platform.DISCORD] = adapter
+    return runner
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestWatchNotificationThreadRouting:
+    """Verify watch notifications route to the correct thread when the
+    session store origin lacks thread_id."""
+
+    @pytest.mark.asyncio
+    async def test_event_thread_id_used_when_origin_lacks_it(self, monkeypatch, tmp_path):
+        """When origin has no thread_id but the event does, use the event's."""
+        runner = _build_runner(monkeypatch, tmp_path)
+        adapter = runner.adapters[Platform.DISCORD]
+
+        # Session was first created from the parent channel (no thread_id)
+        runner.session_store._entries["agent:main:discord:group:123:456"] = SimpleNamespace(
+            origin=SessionSource(
+                platform=Platform.DISCORD,
+                chat_id="123",
+                chat_type="group",
+                thread_id=None,  # <-- Missing thread_id
+                user_id="789",
+                user_name="Emiliyan",
+            )
+        )
+
+        # Background process was started from thread 456
+        evt = {
+            "session_id": "proc_abc",
+            "session_key": "agent:main:discord:group:123:456",
+            "platform": "discord",
+            "chat_id": "123",
+            "thread_id": "456",  # <-- Correct thread from watcher metadata
+            "user_id": "789",
+            "user_name": "Emiliyan",
+        }
+
+        await runner._inject_watch_notification("[SYSTEM: Background process matched]", evt)
+
+        adapter.handle_message.assert_awaited_once()
+        synth_event = adapter.handle_message.await_args.args[0]
+        assert synth_event.source.thread_id == "456"
+
+    @pytest.mark.asyncio
+    async def test_origin_thread_id_preserved_when_present(self, monkeypatch, tmp_path):
+        """When origin already has thread_id, it should be used (not overridden)."""
+        runner = _build_runner(monkeypatch, tmp_path)
+        adapter = runner.adapters[Platform.DISCORD]
+
+        runner.session_store._entries["agent:main:discord:group:123:100"] = SimpleNamespace(
+            origin=SessionSource(
+                platform=Platform.DISCORD,
+                chat_id="123",
+                chat_type="group",
+                thread_id="100",  # <-- Already has thread_id
+                user_id="789",
+                user_name="Emiliyan",
+            )
+        )
+
+        evt = {
+            "session_id": "proc_abc",
+            "session_key": "agent:main:discord:group:123:100",
+            "platform": "discord",
+            "chat_id": "123",
+            "thread_id": "999",  # <-- Different thread in event
+            "user_id": "789",
+            "user_name": "Emiliyan",
+        }
+
+        await runner._inject_watch_notification("[SYSTEM: Background process matched]", evt)
+
+        adapter.handle_message.assert_awaited_once()
+        synth_event = adapter.handle_message.await_args.args[0]
+        # Origin's thread_id takes precedence
+        assert synth_event.source.thread_id == "100"
+
+    def test_build_source_patches_thread_id_from_event(self, monkeypatch, tmp_path):
+        """_build_process_event_source patches thread_id from event when origin lacks it."""
+        runner = _build_runner(monkeypatch, tmp_path)
+
+        runner.session_store._entries["agent:main:discord:group:123:456"] = SimpleNamespace(
+            origin=SessionSource(
+                platform=Platform.DISCORD,
+                chat_id="123",
+                chat_type="group",
+                thread_id=None,
+                user_id="789",
+                user_name="Emiliyan",
+            )
+        )
+
+        evt = {
+            "session_id": "proc_abc",
+            "session_key": "agent:main:discord:group:123:456",
+            "platform": "discord",
+            "chat_id": "123",
+            "thread_id": "456",
+            "user_id": "789",
+            "user_name": "Emiliyan",
+        }
+
+        source = runner._build_process_event_source(evt)
+
+        assert source is not None
+        assert source.thread_id == "456"
+        assert source.chat_id == "123"
+        assert source.platform == Platform.DISCORD
+
+    def test_build_source_no_event_thread_returns_origin_as_is(self, monkeypatch, tmp_path):
+        """When event also has no thread_id, origin is returned unchanged."""
+        runner = _build_runner(monkeypatch, tmp_path)
+
+        runner.session_store._entries["agent:main:discord:group:123"] = SimpleNamespace(
+            origin=SessionSource(
+                platform=Platform.DISCORD,
+                chat_id="123",
+                chat_type="group",
+                thread_id=None,
+                user_id="789",
+                user_name="Emiliyan",
+            )
+        )
+
+        evt = {
+            "session_id": "proc_abc",
+            "session_key": "agent:main:discord:group:123",
+        }
+
+        source = runner._build_process_event_source(evt)
+
+        assert source is not None
+        assert source.thread_id is None
+
+    def test_build_source_no_origin_uses_event_thread_id(self, monkeypatch, tmp_path):
+        """When no session store entry exists, event's thread_id is used directly."""
+        runner = _build_runner(monkeypatch, tmp_path)
+
+        evt = {
+            "session_id": "proc_abc",
+            "session_key": "agent:main:discord:group:123:456",
+            "platform": "discord",
+            "chat_id": "123",
+            "thread_id": "456",
+            "user_id": "789",
+            "user_name": "Emiliyan",
+        }
+
+        source = runner._build_process_event_source(evt)
+
+        assert source is not None
+        assert source.thread_id == "456"

--- a/tests/gateway/test_watch_notification_thread_routing.py
+++ b/tests/gateway/test_watch_notification_thread_routing.py
@@ -191,3 +191,50 @@ class TestWatchNotificationThreadRouting:
 
         assert source is not None
         assert source.thread_id == "456"
+
+    def test_all_origin_fields_preserved_when_thread_patched(self, monkeypatch, tmp_path):
+        """All 11 SessionSource fields must survive when thread_id is patched.
+
+        Regression test: a manual SessionSource() constructor previously
+        dropped chat_name, chat_topic, user_id_alt, chat_id_alt, and is_bot.
+        Using dataclasses.replace() ensures all fields carry over.
+        """
+        runner = _build_runner(monkeypatch, tmp_path)
+
+        origin = SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="123",
+            chat_name="general",
+            chat_type="group",
+            thread_id=None,
+            user_id="789",
+            user_name="Emiliyan",
+            chat_topic="Project discussion",
+            user_id_alt="alt-uuid-abc",
+            chat_id_alt="alt-group-xyz",
+            is_bot=False,
+        )
+        runner.session_store._entries["agent:main:discord:group:123:456"] = SimpleNamespace(
+            origin=origin,
+        )
+
+        evt = {
+            "session_id": "proc_abc",
+            "session_key": "agent:main:discord:group:123:456",
+            "thread_id": "456",
+        }
+
+        source = runner._build_process_event_source(evt)
+
+        assert source is not None
+        assert source.thread_id == "456"
+        assert source.platform == Platform.DISCORD
+        assert source.chat_id == "123"
+        assert source.chat_name == "general"
+        assert source.chat_type == "group"
+        assert source.user_id == "789"
+        assert source.user_name == "Emiliyan"
+        assert source.chat_topic == "Project discussion"
+        assert source.user_id_alt == "alt-uuid-abc"
+        assert source.chat_id_alt == "alt-group-xyz"
+        assert source.is_bot is False


### PR DESCRIPTION
## What does this PR do?

Background process watch notifications can lose the Discord thread context when the stored session origin does not carry the current event thread. This PR uses the event thread information as a fallback so watch notifications return to the thread where the process was started.

## Related Issue

Fixes #10411

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Preserve Discord thread routing for watch/process notifications in `gateway/run.py`.
- Add focused regression coverage for event-thread fallback routing.

## How to Test

1. Check out this PR branch.
2. Run: `.venv/bin/python -m pytest -o 'addopts=' tests/gateway/test_watch_notification_thread_routing.py -q`
3. Expected result: 6 passed

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — focused pytest passed; full suite was not run in this salvage pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux container / Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused verification:

```text
`.venv/bin/python -m pytest -o 'addopts=' tests/gateway/test_watch_notification_thread_routing.py -q` — 6 passed
```
