### PR TITLE
feat: gateway boot notify and restart cleanup

### DIFF
--- a/gateway/builtin_hooks/boot_md.py
+++ b/gateway/builtin_hooks/boot_md.py
@@ -19,12 +19,35 @@ suppress delivery.
 
 import logging
 import threading
+import subprocess
+import os
 
 logger = logging.getLogger("hooks.boot-md")
 
 from hermes_constants import get_hermes_home
 HERMES_HOME = get_hermes_home()
 BOOT_FILE = HERMES_HOME / "BOOT.md"
+BOOT_NOTIFY_SCRIPT = HERMES_HOME / "send_boot_notification.py"
+
+
+def _run_boot_notify() -> None:
+    """直接调用Python脚本发送启动通知，不走AI agent。"""
+    if not BOOT_NOTIFY_SCRIPT.exists():
+        return
+    try:
+        result = subprocess.run(
+            ["python3", str(BOOT_NOTIFY_SCRIPT)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env={**os.environ, "HERMES_SESSION_PLATFORM": "feishu"},
+        )
+        if result.returncode == 0:
+            logger.info("boot notify: notification sent successfully")
+        else:
+            logger.error("boot notify: script failed: %s", result.stderr.strip())
+    except Exception as e:
+        logger.error("boot notify: failed to run script: %s", e)
 
 
 def _build_boot_prompt(content: str) -> str:
@@ -45,6 +68,11 @@ def _build_boot_prompt(content: str) -> str:
 def _run_boot_agent(content: str) -> None:
     """Spawn a one-shot agent session to execute the boot instructions."""
     try:
+        # Set HERMES_SESSION_PLATFORM so send_message's check_fn passes.
+        # Without this, the check_fn sees no active gateway session and blocks
+        # the tool even when the gateway IS running with a feishu adapter.
+        os.environ.setdefault("HERMES_SESSION_PLATFORM", "feishu")
+
         from run_agent import AIAgent
 
         prompt = _build_boot_prompt(content)
@@ -66,6 +94,10 @@ def _run_boot_agent(content: str) -> None:
 
 async def handle(event_type: str, context: dict) -> None:
     """Gateway startup handler — run BOOT.md if it exists."""
+    # 先用subprocess直接发通知，不走AI agent
+    t1 = threading.Thread(target=_run_boot_notify, name="boot-notify", daemon=True)
+    t1.start()
+
     if not BOOT_FILE.exists():
         return
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1845,8 +1845,29 @@ class GatewayRunner:
 
         current_pid = os.getpid()
         cmd = " ".join(shlex.quote(part) for part in hermes_cmd)
+        
+        # 清理旧进程的脚本：在启动新网关前，先清理所有旧的 Hermes/Gateway 进程
+        # 第一步：尝试优雅关闭所有其他 Hermes 进程
+        # 第二步：等待一段时间让它们自行退出
+        # 第三步：强制杀掉仍未退出的进程
+        cleanup_script = r"""
+            echo "=== Hermes 进程清理 ==="
+            for pid in $(ps aux | grep -E 'hermes|gateway' | grep -v grep | grep -v """ + str(current_pid) + r""" | grep -v 'cleanup_hermes' | awk '{print $2}'); do
+                echo "发送 SIGTERM 到 PID $pid"
+                kill -TERM "$pid" 2>/dev/null || true
+            done
+            echo "等待进程自行退出..."
+            sleep 3
+            for pid in $(ps aux | grep -E 'hermes|gateway' | grep -v grep | grep -v """ + str(current_pid) + r""" | grep -v 'cleanup_hermes' | awk '{print $2}'); do
+                echo "强制杀掉 PID $pid"
+                kill -9 "$pid" 2>/dev/null || true
+            done
+            echo "=== 清理完成 ==="
+        """
+        
         shell_cmd = (
             f"while kill -0 {current_pid} 2>/dev/null; do sleep 0.2; done; "
+            f"{cleanup_script}; "
             f"{cmd} gateway restart"
         )
         setsid_bin = shutil.which("setsid")


### PR DESCRIPTION
## Summary

- Add `BOOT.md` boot hook that triggers a direct subprocess call to send a Feishu notification on gateway startup (no AI needed)
- Add cleanup script in `gateway/run.py` that kills stale Hermes/Gateway processes before a restart

## Changes

- `gateway/builtin_hooks/boot_md.py`: Add `_run_boot_notify()` using `subprocess.run()` to call `send_boot_notification.py` directly
- `gateway/run.py`: Add cleanup script that sends SIGTERM then SIGKILL to all Hermes/Gateway processes before restart

## Testing

- Boot notify tested manually