### PR TITLE
fix(agent): fall back when rg is blocked for @folder references

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -483,9 +483,7 @@ def _rg_files(path: Path, cwd: Path, limit: int) -> list[Path] | None:
             text=True,
             timeout=10,
         )
-    except FileNotFoundError:
-        return None
-    except subprocess.TimeoutExpired:
+    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
         return None
     if result.returncode != 0:
         return None

--- a/tests/agent/test_context_references.py
+++ b/tests/agent/test_context_references.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import subprocess
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -121,6 +122,31 @@ def test_expand_file_range_and_folder_listing(sample_repo: Path):
     assert "main.py" in result.message
     assert "helper.py" in result.message
     assert result.injected_tokens > 0
+    assert not result.warnings
+
+
+def test_folder_listing_falls_back_when_rg_is_blocked(sample_repo: Path):
+    from agent.context_references import preprocess_context_references
+
+    real_run = subprocess.run
+
+    def blocked_rg(*args, **kwargs):
+        cmd = args[0] if args else kwargs.get("args")
+        if isinstance(cmd, list) and cmd and cmd[0] == "rg":
+            raise PermissionError("rg blocked by policy")
+        return real_run(*args, **kwargs)
+
+    with patch("agent.context_references.subprocess.run", side_effect=blocked_rg):
+        result = preprocess_context_references(
+            "Review @folder:src/",
+            cwd=sample_repo,
+            context_length=100_000,
+        )
+
+    assert result.expanded
+    assert "src/" in result.message
+    assert "main.py" in result.message
+    assert "helper.py" in result.message
     assert not result.warnings
 
 


### PR DESCRIPTION
## Summary
Salvage of #11791 by @Ruzzgar — cherry-picked onto current main.

Broadens exception handling in `_rg_files()` so `@folder:` context expansion falls back to `os.walk` when `rg` is installed but blocked by policy (AppLocker, endpoint restrictions). `PermissionError` is a subclass of `OSError`, so catching `OSError` covers it plus any other launch-related OS errors.

## Changes
- `agent/context_references.py`: Collapse two `except` clauses into `except (FileNotFoundError, OSError, subprocess.TimeoutExpired)`
- `tests/agent/test_context_references.py`: Add regression test simulating `rg` blocked by `PermissionError`

## Validation
- `tests/agent/test_context_references.py`: 14/14 passed