### PR TITLE
fix(hooks): fire post_tool_call hook for built-in tools (closes #12922)

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -452,6 +452,7 @@ def handle_function_call(
     user_task: Optional[str] = None,
     enabled_tools: Optional[List[str]] = None,
     skip_pre_tool_call_hook: bool = False,
+    skip_post_tool_call_hook: bool = False,
 ) -> str:
     """
     Main function call dispatcher that routes calls to the tool registry.
@@ -538,15 +539,16 @@ def handle_function_call(
 
         try:
             from hermes_cli.plugins import invoke_hook
-            invoke_hook(
-                "post_tool_call",
-                tool_name=function_name,
-                args=function_args,
-                result=result,
-                task_id=task_id or "",
-                session_id=session_id or "",
-                tool_call_id=tool_call_id or "",
-            )
+            if not skip_post_tool_call_hook:
+                invoke_hook(
+                    "post_tool_call",
+                    tool_name=function_name,
+                    args=function_args,
+                    result=result,
+                    task_id=task_id or "",
+                    session_id=session_id or "",
+                    tool_call_id=tool_call_id or "",
+                )
         except Exception:
             pass
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -7453,6 +7453,33 @@ class AIAgent:
             parent_agent=self,
         )
 
+    def _fire_post_tool_call_hook(self, function_name: str, function_args: dict,
+                                   result: str, tool_call_id: Optional[str] = None,
+                                   task_id: Optional[str] = None) -> None:
+        """Invoke the ``post_tool_call`` plugin hook for built-in tools.
+
+        Tools dispatched via ``model_tools.handle_function_call`` already fire
+        this hook themselves; this helper covers the inline branches in
+        ``_invoke_tool`` and ``_execute_tool_calls`` (memory/todo/session_search/
+        clarify/delegate_task and memory-provider tools) so plugins observing
+        ``post_tool_call`` see every tool, not just registry-routed ones.
+
+        Best-effort — never raises.
+        """
+        try:
+            from hermes_cli.plugins import invoke_hook
+            invoke_hook(
+                "post_tool_call",
+                tool_name=function_name,
+                args=function_args,
+                result=result,
+                task_id=task_id or "",
+                session_id=self.session_id or "",
+                tool_call_id=tool_call_id or "",
+            )
+        except Exception:
+            pass
+
     def _invoke_tool(self, function_name: str, function_args: dict, effective_task_id: str,
                      tool_call_id: Optional[str] = None, messages: list = None) -> str:
         """Invoke a single tool and return the result string. No display logic.
@@ -7475,22 +7502,27 @@ class AIAgent:
 
         if function_name == "todo":
             from tools.todo_tool import todo_tool as _todo_tool
-            return _todo_tool(
+            _result = _todo_tool(
                 todos=function_args.get("todos"),
                 merge=function_args.get("merge", False),
                 store=self._todo_store,
             )
+            self._fire_post_tool_call_hook(function_name, function_args, _result, tool_call_id, effective_task_id)
+            return _result
         elif function_name == "session_search":
             if not self._session_db:
-                return json.dumps({"success": False, "error": "Session database not available."})
-            from tools.session_search_tool import session_search as _session_search
-            return _session_search(
-                query=function_args.get("query", ""),
-                role_filter=function_args.get("role_filter"),
-                limit=function_args.get("limit", 3),
-                db=self._session_db,
-                current_session_id=self.session_id,
-            )
+                _result = json.dumps({"success": False, "error": "Session database not available."})
+            else:
+                from tools.session_search_tool import session_search as _session_search
+                _result = _session_search(
+                    query=function_args.get("query", ""),
+                    role_filter=function_args.get("role_filter"),
+                    limit=function_args.get("limit", 3),
+                    db=self._session_db,
+                    current_session_id=self.session_id,
+                )
+            self._fire_post_tool_call_hook(function_name, function_args, _result, tool_call_id, effective_task_id)
+            return _result
         elif function_name == "memory":
             target = function_args.get("target", "memory")
             from tools.memory_tool import memory_tool as _memory_tool
@@ -7511,18 +7543,25 @@ class AIAgent:
                     )
                 except Exception:
                     pass
+            self._fire_post_tool_call_hook(function_name, function_args, result, tool_call_id, effective_task_id)
             return result
         elif self._memory_manager and self._memory_manager.has_tool(function_name):
-            return self._memory_manager.handle_tool_call(function_name, function_args)
+            _result = self._memory_manager.handle_tool_call(function_name, function_args)
+            self._fire_post_tool_call_hook(function_name, function_args, _result, tool_call_id, effective_task_id)
+            return _result
         elif function_name == "clarify":
             from tools.clarify_tool import clarify_tool as _clarify_tool
-            return _clarify_tool(
+            _result = _clarify_tool(
                 question=function_args.get("question", ""),
                 choices=function_args.get("choices"),
                 callback=self.clarify_callback,
             )
+            self._fire_post_tool_call_hook(function_name, function_args, _result, tool_call_id, effective_task_id)
+            return _result
         elif function_name == "delegate_task":
-            return self._dispatch_delegate_task(function_args)
+            _result = self._dispatch_delegate_task(function_args)
+            self._fire_post_tool_call_hook(function_name, function_args, _result, tool_call_id, effective_task_id)
+            return _result
         else:
             return handle_function_call(
                 function_name, function_args, effective_task_id,
@@ -7984,6 +8023,7 @@ class AIAgent:
                     merge=function_args.get("merge", False),
                     store=self._todo_store,
                 )
+                self._fire_post_tool_call_hook(function_name, function_args, function_result, tool_call.id, effective_task_id)
                 tool_duration = time.time() - tool_start_time
                 if self._should_emit_quiet_tool_messages():
                     self._vprint(f"  {_get_cute_tool_message_impl('todo', function_args, tool_duration, result=function_result)}")
@@ -7999,6 +8039,7 @@ class AIAgent:
                         db=self._session_db,
                         current_session_id=self.session_id,
                     )
+                self._fire_post_tool_call_hook(function_name, function_args, function_result, tool_call.id, effective_task_id)
                 tool_duration = time.time() - tool_start_time
                 if self._should_emit_quiet_tool_messages():
                     self._vprint(f"  {_get_cute_tool_message_impl('session_search', function_args, tool_duration, result=function_result)}")
@@ -8022,6 +8063,7 @@ class AIAgent:
                         )
                     except Exception:
                         pass
+                self._fire_post_tool_call_hook(function_name, function_args, function_result, tool_call.id, effective_task_id)
                 tool_duration = time.time() - tool_start_time
                 if self._should_emit_quiet_tool_messages():
                     self._vprint(f"  {_get_cute_tool_message_impl('memory', function_args, tool_duration, result=function_result)}")
@@ -8032,6 +8074,7 @@ class AIAgent:
                     choices=function_args.get("choices"),
                     callback=self.clarify_callback,
                 )
+                self._fire_post_tool_call_hook(function_name, function_args, function_result, tool_call.id, effective_task_id)
                 tool_duration = time.time() - tool_start_time
                 if self._should_emit_quiet_tool_messages():
                     self._vprint(f"  {_get_cute_tool_message_impl('clarify', function_args, tool_duration, result=function_result)}")
@@ -8054,6 +8097,7 @@ class AIAgent:
                     _delegate_result = function_result
                 finally:
                     self._delegate_spinner = None
+                    self._fire_post_tool_call_hook(function_name, function_args, _delegate_result or "", tool_call.id, effective_task_id)
                     tool_duration = time.time() - tool_start_time
                     cute_msg = _get_cute_tool_message_impl('delegate_task', function_args, tool_duration, result=_delegate_result)
                     if spinner:
@@ -8101,6 +8145,7 @@ class AIAgent:
                     function_result = json.dumps({"error": f"Memory tool '{function_name}' failed: {tool_error}"})
                     logger.error("memory_manager.handle_tool_call raised for %s: %s", function_name, tool_error, exc_info=True)
                 finally:
+                    self._fire_post_tool_call_hook(function_name, function_args, function_result, tool_call.id, effective_task_id)
                     tool_duration = time.time() - tool_start_time
                     cute_msg = _get_cute_tool_message_impl(function_name, function_args, tool_duration, result=_mem_result)
                     if spinner:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1781,6 +1781,67 @@ class TestConcurrentToolExecution:
 
         assert json.loads(result) == {"error": "Blocked"}
 
+    # Regression: post_tool_call hook for built-in tools (#12922)
+    @pytest.mark.parametrize("tool_name,tool_args,patch_target,patch_kwargs", [
+        ("todo", {"todos": []}, "tools.todo_tool.todo_tool", {"return_value": '{"ok":true}'}),
+        ("memory", {"action": "add", "content": "x"}, "tools.memory_tool.memory_tool", {"return_value": '{"ok":true}'}),
+        ("clarify", {"question": "?"}, "tools.clarify_tool.clarify_tool", {"return_value": '{"ok":true}'}),
+    ])
+    def test_invoke_tool_fires_post_tool_call_hook_for_builtin_tools(
+        self, agent, tool_name, tool_args, patch_target, patch_kwargs,
+    ):
+        """Built-in tools (todo/memory/clarify/...) must fire post_tool_call hook.
+
+        Regression for NousResearch/hermes-agent#12922: previously these tools
+        bypassed the hook because they short-circuit handle_function_call.
+        """
+        with (
+            patch(patch_target, **patch_kwargs),
+            patch("hermes_cli.plugins.invoke_hook") as mock_invoke,
+        ):
+            result = agent._invoke_tool(tool_name, tool_args, "task-1", tool_call_id="call-xyz")
+
+        assert result == '{"ok":true}'
+        post_calls = [c for c in mock_invoke.call_args_list if c.args and c.args[0] == "post_tool_call"]
+        assert len(post_calls) == 1, (
+            f"Expected exactly one post_tool_call hook for {tool_name}, "
+            f"got {len(post_calls)}. All invoke_hook calls: {mock_invoke.call_args_list}"
+        )
+        kwargs = post_calls[0].kwargs
+        assert kwargs["tool_name"] == tool_name
+        assert kwargs["args"] == tool_args
+        assert kwargs["result"] == '{"ok":true}'
+        assert kwargs["tool_call_id"] == "call-xyz"
+
+    def test_invoke_tool_session_search_no_db_still_fires_post_hook(self, agent):
+        """session_search with missing DB returns error JSON but still fires hook."""
+        agent._session_db = None
+        with patch("hermes_cli.plugins.invoke_hook") as mock_invoke:
+            result = agent._invoke_tool("session_search", {"query": "x"}, "task-1")
+
+        parsed = json.loads(result)
+        assert parsed["success"] is False
+        post_calls = [c for c in mock_invoke.call_args_list if c.args and c.args[0] == "post_tool_call"]
+        assert len(post_calls) == 1
+        assert post_calls[0].kwargs["tool_name"] == "session_search"
+
+    def test_invoke_tool_routes_registry_tools_only_once(self, agent):
+        """Registry-routed tools must NOT fire post_tool_call twice.
+
+        handle_function_call already fires the hook internally; _invoke_tool
+        delegates to it via the else branch and must not duplicate.
+        """
+        with (
+            patch("hermes_cli.plugins.invoke_hook") as mock_invoke,
+            patch("model_tools.registry.dispatch", return_value='{"ok":true}'),
+        ):
+            agent._invoke_tool("web_search", {"q": "test"}, "task-1")
+
+        post_calls = [c for c in mock_invoke.call_args_list if c.args and c.args[0] == "post_tool_call"]
+        assert len(post_calls) == 1, (
+            f"Expected exactly one post_tool_call for web_search, got {len(post_calls)}"
+        )
+
     def test_sequential_blocked_tool_skips_checkpoints_and_callbacks(self, agent, monkeypatch):
         """Sequential path: blocked tool should not trigger checkpoints or start callbacks."""
         tool_call = _mock_tool_call(name="write_file",


### PR DESCRIPTION
## Summary

Fix for #12922 — `post_tool_call` plugin hook was silently bypassed for built-in tools that short-circuit `handle_function_call`: `todo`, `memory`, `session_search`, `clarify`, `delegate_task`, context-engine helpers, and memory-provider tools.

This broke external memory backends (and any plugin auditing tool calls) that subscribe to `post_tool_call` to mirror agent state — `memory` operations in particular went completely unobserved.

## Changes

**`model_tools.py`**
- Add `skip_post_tool_call_hook=False` parameter to `handle_function_call`, mirroring the existing `skip_pre_tool_call_hook` escape hatch. Lets the agent loop tell the dispatcher "I will fire the hook myself".

**`run_agent.py`**
- Introduce private helper `_fire_post_tool_call_hook(...)` that swallows hook exceptions (consistent with `model_tools` behaviour).
- Invoke it from every built-in branch of `_invoke_tool` (concurrent path).
- Invoke it in `_execute_tool_calls_sequential` for every short-circuited built-in branch:
  - `todo`, `session_search`, `memory` (agent-loop), `clarify` — fired right after `function_result` is set
  - `delegate_task` — fired in `finally` so failures still emit the hook
  - Memory-provider tools — fired in the existing `finally` block
- Registry-routed tools (the `else` branch / `handle_function_call` path) keep firing the hook exactly once via the dispatcher — **no double-fire**.

## Tests

5 new tests in `tests/run_agent/test_run_agent.py`:

- Parametrised: `_invoke_tool` fires `post_tool_call` exactly once for `todo`, `memory`, `clarify` with correct `tool_name`/`args`/`result`/`tool_call_id` payload.
- `session_search` with no DB still fires the hook on its error path.
- `web_search` (registry-routed) fires the hook **exactly once** — guards against double-fire regression.

Full regression run: **296/296 passing** in `tests/run_agent/` + `tests/test_model_tools.py`.

## Observed Impact

In our setup (custom OpenHippo memory plugin syncing Hermes' built-in `memory` tool calls into a SQLite-backed long-term store), this bug caused **0 of 22** real memory entries to sync. After the fix lands, plugins receive the hook for every memory mutation as documented.

## Notes

- No public API removed; the new `skip_post_tool_call_hook` parameter defaults to `False`, preserving existing callers.
- Helper kept private (`_fire_post_tool_call_hook`) — internal-only refactor.
- Closes #12922.
