### PR TITLE
fix: tolerate non-utf8 filenames in file discovery

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -474,20 +474,25 @@ def _iter_visible_entries(path: Path, cwd: Path, limit: int) -> list[Path]:
     return output
 
 
+def _decode_fs_lines(data: bytes) -> list[str]:
+    """Decode subprocess file listings using filesystem semantics."""
+    return [os.fsdecode(line) for line in data.splitlines() if line]
+
+
 def _rg_files(path: Path, cwd: Path, limit: int) -> list[Path] | None:
     try:
         result = subprocess.run(
             ["rg", "--files", str(path.relative_to(cwd))],
             cwd=cwd,
             capture_output=True,
-            text=True,
+            text=False,
             timeout=10,
         )
     except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
         return None
     if result.returncode != 0:
         return None
-    files = [Path(line.strip()) for line in result.stdout.splitlines() if line.strip()]
+    files = [Path(line) for line in _decode_fs_lines(result.stdout)]
     return files[:limit]
 
 

--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -527,6 +527,11 @@ def _iter_visible_entries(path: Path, cwd: Path, limit: int) -> list[Path]:
     return output
 
 
+def _decode_fs_lines(data: bytes) -> list[str]:
+    """Decode subprocess file listings using filesystem semantics."""
+    return [os.fsdecode(line) for line in data.splitlines() if line]
+
+
 def _rg_files(path: Path, cwd: Path, limit: int) -> list[Path] | None:
     _popen_kwargs = {"creationflags": windows_hide_flags()} if IS_WINDOWS else {}
     try:
@@ -534,7 +539,7 @@ def _rg_files(path: Path, cwd: Path, limit: int) -> list[Path] | None:
             ["rg", "--files", str(path.relative_to(cwd))],
             cwd=cwd,
             capture_output=True,
-            text=True,
+            text=False,
             timeout=10,
             stdin=subprocess.DEVNULL,
             **_popen_kwargs,
@@ -543,7 +548,7 @@ def _rg_files(path: Path, cwd: Path, limit: int) -> list[Path] | None:
         return None
     if result.returncode != 0:
         return None
-    files = [Path(line.strip()) for line in result.stdout.splitlines() if line.strip()]
+    files = [Path(line) for line in _decode_fs_lines(result.stdout)]
     return files[:limit]
 
 

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1660,11 +1660,14 @@ class SlashCommandCompleter(Completer):
                 continue
             try:
                 proc = subprocess.run(
-                    cmd, capture_output=True, text=True, timeout=2,
-                    cwd=cwd, encoding="utf-8", errors="replace",
+                    cmd,
+                    capture_output=True,
+                    text=False,
+                    timeout=2,
+                    cwd=cwd,
                 )
-                if proc.returncode == 0 and proc.stdout and proc.stdout.strip():
-                    raw = proc.stdout.strip().split("\n")
+                raw = _decode_fs_lines(proc.stdout)
+                if proc.returncode == 0 and raw:
                     # Store relative paths
                     for p in raw[:5000]:
                         rel = os.path.relpath(p, cwd) if os.path.isabs(p) else p
@@ -2130,6 +2133,11 @@ class SlashCommandAutoSuggest(AutoSuggest):
         if self._history:
             return self._history.get_suggestion(buffer, document)
         return None
+
+
+def _decode_fs_lines(data: bytes) -> list[str]:
+    """Decode subprocess file listings using filesystem semantics."""
+    return [os.fsdecode(line) for line in data.splitlines() if line]
 
 
 def _file_size_label(path: str) -> str:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -991,11 +991,14 @@ class SlashCommandCompleter(Completer):
                 continue
             try:
                 proc = subprocess.run(
-                    cmd, capture_output=True, text=True, timeout=2,
+                    cmd,
+                    capture_output=True,
+                    text=False,
+                    timeout=2,
                     cwd=cwd,
                 )
-                if proc.returncode == 0 and proc.stdout.strip():
-                    raw = proc.stdout.strip().split("\n")
+                raw = _decode_fs_lines(proc.stdout)
+                if proc.returncode == 0 and raw:
                     # Store relative paths
                     for p in raw[:5000]:
                         rel = os.path.relpath(p, cwd) if os.path.isabs(p) else p
@@ -1322,6 +1325,14 @@ class SlashCommandAutoSuggest(AutoSuggest):
         if self._history:
             return self._history.get_suggestion(buffer, document)
         return None
+
+
+def _decode_fs_lines(data: bytes) -> list[str]:
+    """Decode subprocess file listings using filesystem semantics.
+
+    This preserves non-UTF-8 filenames via surrogateescape instead of raising.
+    """
+    return [os.fsdecode(line) for line in data.splitlines() if line]
 
 
 def _file_size_label(path: str) -> str:

--- a/tests/agent/test_context_references.py
+++ b/tests/agent/test_context_references.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import os
+import shutil
 import subprocess
 from pathlib import Path
 from unittest.mock import patch
@@ -205,6 +207,33 @@ def test_binary_and_missing_files_become_warnings(sample_repo: Path):
     assert len(result.warnings) == 2
     assert "binary" in result.message.lower()
     assert "not found" in result.message.lower()
+
+
+@pytest.mark.skipif(shutil.which("rg") is None, reason="rg is required for folder listing tests")
+def test_folder_listing_handles_non_utf8_filenames(tmp_path: Path):
+    from agent.context_references import preprocess_context_references
+
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    (workspace / "visible.txt").write_text("hello\n", encoding="utf-8")
+
+    bad_path = os.fsencode(workspace) + b"/bad-\xff.txt"
+    fd = os.open(bad_path, os.O_WRONLY | os.O_CREAT, 0o644)
+    try:
+        os.write(fd, b"x")
+    finally:
+        os.close(fd)
+
+    result = preprocess_context_references(
+        "Check @folder:.",
+        cwd=workspace,
+        context_length=100_000,
+    )
+
+    assert result.expanded
+    assert "visible.txt" in result.message
+    assert "bad-" in result.message
+    assert not result.blocked
 
 
 def test_soft_budget_warns_and_hard_budget_refuses(sample_repo: Path):

--- a/tests/agent/test_context_references.py
+++ b/tests/agent/test_context_references.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import os
+import shutil
 import subprocess
 from pathlib import Path
 from unittest.mock import patch
@@ -224,6 +226,28 @@ def test_binary_file_yields_actionable_block_not_a_dead_warning(sample_repo: Pat
     assert "not supported" not in result.message.lower()
     # And it must point the agent at the file so it can act on it with tools.
     assert str(sample_repo / "blob.bin") in result.message
+
+
+@pytest.mark.skipif(shutil.which("rg") is None, reason="rg is required for folder listing tests")
+def test_folder_listing_round_trips_non_utf8_filename(tmp_path: Path):
+    from agent.context_references import preprocess_context_references
+
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    (workspace / "visible.txt").write_text("hello\n", encoding="utf-8")
+    bad_path = os.fsencode(workspace) + b"/bad-\xff.txt"
+    fd = os.open(bad_path, os.O_WRONLY | os.O_CREAT, 0o644)
+    try:
+        os.write(fd, b"x")
+    finally:
+        os.close(fd)
+
+    result = preprocess_context_references("Check @folder:.", cwd=workspace, context_length=100_000)
+
+    assert result.expanded
+    assert "visible.txt" in result.message
+    assert os.fsencode(result.message).find(b"bad-\xff.txt") >= 0
+    assert not result.blocked
 
 
 def test_soft_budget_warns_and_hard_budget_refuses(sample_repo: Path):

--- a/tests/hermes_cli/test_path_completion.py
+++ b/tests/hermes_cli/test_path_completion.py
@@ -1,6 +1,7 @@
 """Tests for file path autocomplete in the CLI completer."""
 
 import os
+import shutil
 from unittest.mock import MagicMock
 
 import pytest
@@ -205,6 +206,31 @@ class TestIntegration:
         names = _display_names(completions)
         # /etc/hosts should exist on Linux
         assert any("host" in n.lower() for n in names)
+
+    @pytest.mark.skipif(shutil.which("rg") is None, reason="rg is required for project file cache tests")
+    def test_bare_at_completion_handles_non_utf8_filenames(self, completer, tmp_path):
+        good = tmp_path / "good.txt"
+        good.write_text("ok", encoding="utf-8")
+
+        bad_path = os.fsencode(tmp_path) + b"/bad-\xff.txt"
+        fd = os.open(bad_path, os.O_WRONLY | os.O_CREAT, 0o644)
+        try:
+            os.write(fd, b"x")
+        finally:
+            os.close(fd)
+
+        old_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            doc = Document("@", cursor_position=1)
+            event = MagicMock()
+            completions = list(completer.get_completions(doc, event))
+            texts = [completion.text for completion in completions]
+            assert "@file:good.txt" in texts
+            bad_ref = next(text for text in texts if text.startswith("@file:bad-"))
+            assert os.fsencode(bad_ref.removeprefix("@file:")) == b"bad-\xff.txt"
+        finally:
+            os.chdir(old_cwd)
 
 
 class TestFileSizeLabel:

--- a/tests/hermes_cli/test_path_completion.py
+++ b/tests/hermes_cli/test_path_completion.py
@@ -1,6 +1,7 @@
 """Tests for file path autocomplete in the CLI completer."""
 
 import os
+import shutil
 from unittest.mock import MagicMock
 
 import pytest
@@ -162,6 +163,30 @@ class TestIntegration:
         names = _display_names(completions)
         # /etc/hosts should exist on Linux
         assert any("host" in n.lower() for n in names)
+
+    @pytest.mark.skipif(shutil.which("rg") is None, reason="rg is required for project file cache tests")
+    def test_bare_at_completion_handles_non_utf8_filenames(self, completer, tmp_path):
+        good = tmp_path / "good.txt"
+        good.write_text("ok", encoding="utf-8")
+
+        bad_path = os.fsencode(tmp_path) + b"/bad-\xff.txt"
+        fd = os.open(bad_path, os.O_WRONLY | os.O_CREAT, 0o644)
+        try:
+            os.write(fd, b"x")
+        finally:
+            os.close(fd)
+
+        old_cwd = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            doc = Document("@", cursor_position=1)
+            event = MagicMock()
+            completions = list(completer.get_completions(doc, event))
+            texts = [completion.text for completion in completions]
+            assert "@file:good.txt" in texts
+            assert any(text.startswith("@file:bad-") for text in texts)
+        finally:
+            os.chdir(old_cwd)
 
 
 class TestFileSizeLabel:

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -17,6 +17,24 @@ from hermes_cli.browser_connect import ChromeDebugLaunch
 from tui_gateway import server
 
 
+def test_tui_repo_file_listing_round_trips_non_utf8_git_paths(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    bad_path = os.fsencode(repo) + b"/bad-\xff.txt"
+    fd = os.open(bad_path, os.O_WRONLY | os.O_CREAT, 0o644)
+    try:
+        os.write(fd, b"x")
+    finally:
+        os.close(fd)
+
+    with server._fuzzy_cache_lock:
+        server._fuzzy_cache.pop(str(repo), None)
+    files = server._list_repo_files(str(repo))
+
+    assert any(os.fsencode(path) == b"bad-\xff.txt" for path in files)
+
+
 def test_session_create_rejects_at_active_session_limit(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -12450,7 +12450,7 @@ def _list_repo_files(root: str) -> list[str]:
             creationflags=_creationflags,
         )
         if top_result.returncode == 0:
-            top = top_result.stdout.decode("utf-8", "replace").strip()
+            top = os.fsdecode(top_result.stdout).strip()
             list_result = subprocess.run(
                 [
                     "git",
@@ -12469,7 +12469,7 @@ def _list_repo_files(root: str) -> list[str]:
                 creationflags=_creationflags,
             )
             if list_result.returncode == 0:
-                for p in list_result.stdout.decode("utf-8", "replace").split("\0"):
+                for p in os.fsdecode(list_result.stdout).split("\0"):
                     if not p:
                         continue
                     rel = os.path.relpath(os.path.join(top, p), root).replace(


### PR DESCRIPTION
## Summary
- make CLI project file discovery tolerate non-UTF-8 filenames during bare `@` completion
- apply the same filesystem-safe decoding to context reference folder discovery
- add regression tests covering non-UTF-8 filenames in both code paths

## Why
Some repositories contain filenames that are valid on the filesystem but not valid UTF-8. Hermes should not crash when scanning those trees for `@` file completion or folder context references.

## Root cause
`subprocess.run(..., text=True)` decoded `rg --files` output as strict UTF-8. If the working tree contained non-UTF-8 filenames, Hermes raised `UnicodeDecodeError` while building completions or folder listings.

## Behavior before
- bare `@` completion could crash on mixed-encoding trees
- folder context discovery could fail when `rg --files` returned non-UTF-8 names

## Behavior after
- file discovery subprocess calls use `text=False`
- each output line is decoded with `os.fsdecode(...)`, preserving filesystem semantics via surrogateescape
- Hermes keeps normal behavior for UTF-8 paths while tolerating mixed-encoding trees without crashing

## How to test
- `python -m pytest tests/hermes_cli/test_path_completion.py tests/agent/test_context_references.py -o 'addopts=' -q`
- In a repository containing at least one non-UTF-8 filename, verify that:
  - bare `@` completion no longer crashes
  - folder/context reference expansion still works

## Platforms tested
- Linux (local Hermes development environment on omarchy)

## Related issues / PRs
- Related to #8901 and #10879 as another example of strict UTF-8 assumptions causing `UnicodeDecodeError` in real-world environments.
- Similar in problem family to #8898 / #9145, which harden OpenClaw migration against non-UTF-8 files; this PR is specifically scoped to CLI file discovery and context reference expansion.
- Distinct from Windows/stdin/config encoding fixes like #10979, #11990, and #8415 because this bug is about filesystem filename bytes returned from subprocess file listing, not about stdio or config file decoding.

## Notes
- This PR is intentionally scoped to filesystem-safe decoding in file discovery and the corresponding regression coverage.
