### PR TITLE
fix(gateway): auto-reset session on format errors (MiniMax 2013)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4096,6 +4096,34 @@ class GatewayRunner:
                     "Your next message will start a fresh session."
                 )
 
+            # When the agent fails with a format error (e.g. MiniMax API error
+            # 2013: invalid function arguments), the session may be in a corrupt
+            # state that will fail repeatedly on every message.  Detect this and
+            # auto-reset the session to break the stuck loop, then alert the user.
+            _err_str = (agent_result.get("error") or "").lower()
+            _is_format_loop = (
+                agent_result.get("failed")
+                and (
+                    "2013" in _err_str
+                    or "invalid function arguments" in _err_str
+                    or ("format" in _err_str and "error" in _err_str)
+                )
+            )
+            if _is_format_loop and session_entry and session_key:
+                logger.warning(
+                    "Auto-resetting session %s after format error: %s",
+                    session_entry.session_id,
+                    agent_result.get("error", "")[:300],
+                )
+                self.session_store.reset_session(session_key)
+                self._evict_cached_agent(session_key)
+                self._session_model_overrides.pop(session_key, None)
+                response = (response or "") + (
+                    "\n\n🔄 Session auto-reset — the previous request triggered a "
+                    "format error (e.g. MiniMax error 2013). The conversation has "
+                    "been cleared. Your next message will start fresh."
+                )
+
             ts = datetime.now().isoformat()
             
             # If this is a fresh session (no history), write the full tool


### PR DESCRIPTION
## Problem

When the MiniMax API returns a format error (HTTP 2013: invalid function arguments), the gateway session enters a fail loop — each new message tries to process the same corrupted context, fails again, and accumulates more messages. The session never recovers on its own.

## Root Cause

The gateway has an auto-reset mechanism for `compression_exhausted` (context too large), but no equivalent recovery path for format-level errors. Sessions that hit this error become permanently stuck until manually reset by the user.

## Solution

Detect format errors in `gateway/run.py` and auto-reset the session, similar to the existing `compression_exhausted` recovery:

- Trigger on: MiniMax error `2013`, OpenAI `invalid function arguments`, or generic `format` + `error` in error string
- Actions: `session_store.reset_session()` + `evict_cached_agent()` + clear model override
- User notification: append "🔄 Session auto-reset — the previous request triggered a format error..."

## Testing

Manual: provoke a 2013 error and verify the session resets and user receives the notification message.