### PR TITLE
fix(openviking): viking_read fails on file URIs — route to /content/read

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -576,7 +576,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
             resp = self._client.get("/api/v1/fs/stat", params={"uri": uri})
             return resp.get("result", {}).get("isDir", False)
         except Exception:
-            # 如果 stat 失败，尝试 ls 来判断（目录可以 ls，文件不行）
+            # Fallback: try ls to distinguish (directories succeed, files fail)
             try:
                 resp = self._client.get("/api/v1/fs/ls", params={"uri": uri})
                 return resp.get("result") is not None
@@ -592,7 +592,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
         is_dir = self._is_directory(uri)
 
         if is_dir:
-            # 目录级别：按 level 调用对应端点（abstract/overview 仅支持目录）
+            # Directory: use abstract/overview endpoints (directory-only)
             if level == "abstract":
                 resp = self._client.get("/api/v1/content/abstract", params={"uri": uri})
             elif level == "full":
@@ -600,7 +600,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
             else:  # overview
                 resp = self._client.get("/api/v1/content/overview", params={"uri": uri})
         else:
-            # 文件级别：统一走 /content/read
+            # File: always use /content/read
             resp = self._client.get("/api/v1/content/read", params={"uri": uri})
 
         result = resp.get("result", "")

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -570,19 +570,38 @@ class OpenVikingMemoryProvider(MemoryProvider):
             "total": result.get("total", len(formatted)),
         }, ensure_ascii=False)
 
+    def _is_directory(self, uri: str) -> bool:
+        """Check if a viking:// URI points to a directory via stat."""
+        try:
+            resp = self._client.get("/api/v1/fs/stat", params={"uri": uri})
+            return resp.get("result", {}).get("isDir", False)
+        except Exception:
+            # 如果 stat 失败，尝试 ls 来判断（目录可以 ls，文件不行）
+            try:
+                resp = self._client.get("/api/v1/fs/ls", params={"uri": uri})
+                return resp.get("result") is not None
+            except Exception:
+                return False
+
     def _tool_read(self, args: dict) -> str:
         uri = args.get("uri", "")
         if not uri:
             return tool_error("uri is required")
 
         level = args.get("level", "overview")
-        # Map our level names to OpenViking GET endpoints
-        if level == "abstract":
-            resp = self._client.get("/api/v1/content/abstract", params={"uri": uri})
-        elif level == "full":
+        is_dir = self._is_directory(uri)
+
+        if is_dir:
+            # 目录级别：按 level 调用对应端点（abstract/overview 仅支持目录）
+            if level == "abstract":
+                resp = self._client.get("/api/v1/content/abstract", params={"uri": uri})
+            elif level == "full":
+                resp = self._client.get("/api/v1/content/overview", params={"uri": uri})
+            else:  # overview
+                resp = self._client.get("/api/v1/content/overview", params={"uri": uri})
+        else:
+            # 文件级别：统一走 /content/read
             resp = self._client.get("/api/v1/content/read", params={"uri": uri})
-        else:  # overview
-            resp = self._client.get("/api/v1/content/overview", params={"uri": uri})
 
         result = resp.get("result", "")
         # result is a plain string from the content endpoints


### PR DESCRIPTION
## Summary

`viking_read` routes file URIs to `/api/v1/content/abstract` and `/api/v1/content/overview`, but these endpoints only accept directory URIs, causing all file-level reads to return 412 Precondition Failed.

## Root Cause

OpenViking API endpoint design:
- `/api/v1/content/abstract` — accepts **directory** URIs only
- `/api/v1/content/overview` — accepts **directory** URIs only
- `/api/v1/content/read` — accepts **file** URIs only

The original code did not distinguish between URI types, so file URIs with `level=abstract|overview` always hit 412.

## Fix

1. Add `_is_directory()` method to detect URI type via `/api/v1/fs/stat`
2. **File URIs** → route to `/api/v1/content/read` (ignore level parameter)
3. **Directory URIs** → route to `/content/abstract` or `/content/overview` by level

## Test Plan

- [x] File URI + level=abstract → calls `/content/read`, returns file content
- [x] File URI + level=overview → calls `/content/read`, returns file content
- [x] Directory URI + level=overview → calls `/content/overview`, returns directory summary

Closes #4740
Closes #10124
Closes #12755