### PR TITLE
fix(doctor): catch OpenRouter 402/429 and validate model/provider config

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -277,6 +277,79 @@ def run_doctor(args):
     config_path = HERMES_HOME / 'config.yaml'
     if config_path.exists():
         check_ok(f"{_DHH}/config.yaml exists")
+
+        # Validate model.provider and model.default values
+        try:
+            import yaml as _yaml
+            cfg = _yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+            model_section = cfg.get("model") or {}
+            provider_raw = (model_section.get("provider") or "").strip()
+            provider = provider_raw.lower()
+            default_model = (model_section.get("default") or model_section.get("model") or "").strip()
+
+            known_providers: set = set()
+            try:
+                from hermes_cli.auth import PROVIDER_REGISTRY
+                known_providers = set(PROVIDER_REGISTRY.keys()) | {"openrouter", "custom", "auto"}
+            except Exception:
+                pass
+            try:
+                from hermes_cli.auth import resolve_provider as _resolve_provider
+            except Exception:
+                _resolve_provider = None
+
+            canonical_provider = provider
+            if provider and _resolve_provider is not None and provider != "auto":
+                try:
+                    canonical_provider = _resolve_provider(provider)
+                except Exception:
+                    canonical_provider = None
+
+            if provider and provider != "auto":
+                if canonical_provider is None or (known_providers and canonical_provider not in known_providers):
+                    known_list = ", ".join(sorted(known_providers)) if known_providers else "(unavailable)"
+                    check_fail(
+                        f"model.provider '{provider_raw}' is not a recognised provider",
+                        f"(known: {known_list})",
+                    )
+                    issues.append(
+                        f"model.provider '{provider_raw}' is unknown. "
+                        f"Valid providers: {known_list}. "
+                        f"Fix: run 'hermes config set model.provider <valid_provider>'"
+                    )
+
+            # Warn if model is set to a provider-prefixed name on a provider that doesn't use them
+            if default_model and "/" in default_model and canonical_provider and canonical_provider not in ("openrouter", "custom", "auto", "ai-gateway", "kilocode", "opencode-zen", "huggingface", "nous"):
+                check_warn(
+                    f"model.default '{default_model}' uses a vendor/model slug but provider is '{provider_raw}'",
+                    "(vendor-prefixed slugs belong to aggregators like openrouter)",
+                )
+                issues.append(
+                    f"model.default '{default_model}' is vendor-prefixed but model.provider is '{provider_raw}'. "
+                    "Either set model.provider to 'openrouter', or drop the vendor prefix."
+                )
+
+            # Check credentials for the configured provider
+            if canonical_provider and canonical_provider not in ("auto", "custom"):
+                try:
+                    from hermes_cli.auth import get_auth_status
+                    status = get_auth_status(canonical_provider) or {}
+                    configured = bool(status.get("configured") or status.get("logged_in") or status.get("api_key"))
+                    if not configured:
+                        check_fail(
+                            f"model.provider '{canonical_provider}' is set but not authenticated",
+                            "(check ~/.hermes/.env or run 'hermes setup')",
+                        )
+                        issues.append(
+                            f"No credentials found for provider '{canonical_provider}'. "
+                            f"Run 'hermes setup' or set the provider's API key in {_DHH}/.env, "
+                            f"or switch providers with 'hermes config set model.provider <name>'"
+                        )
+                except Exception:
+                    pass
+
+        except Exception as e:
+            check_warn("Could not validate model/provider config", f"({e})")
     else:
         fallback_config = PROJECT_ROOT / 'cli-config.yaml'
         if fallback_config.exists():
@@ -778,6 +851,16 @@ def run_doctor(args):
             elif response.status_code == 401:
                 print(f"\r  {color('✗', Colors.RED)} OpenRouter API {color('(invalid API key)', Colors.DIM)}                ")
                 issues.append("Check OPENROUTER_API_KEY in .env")
+            elif response.status_code == 402:
+                print(f"\r  {color('✗', Colors.RED)} OpenRouter API {color('(out of credits — payment required)', Colors.DIM)}")
+                issues.append(
+                    "OpenRouter account has insufficient credits. "
+                    "Fix: run 'hermes config set model.provider <provider>' to switch providers, "
+                    "or fund your OpenRouter account at https://openrouter.ai/settings/credits"
+                )
+            elif response.status_code == 429:
+                print(f"\r  {color('✗', Colors.RED)} OpenRouter API {color('(rate limited)', Colors.DIM)}                ")
+                issues.append("OpenRouter rate limit hit — consider switching to a different provider or waiting")
             else:
                 print(f"\r  {color('✗', Colors.RED)} OpenRouter API {color(f'(HTTP {response.status_code})', Colors.DIM)}                ")
         except Exception as e:

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -329,22 +329,29 @@ def run_doctor(args):
                     "Either set model.provider to 'openrouter', or drop the vendor prefix."
                 )
 
-            # Check credentials for the configured provider
-            if canonical_provider and canonical_provider not in ("auto", "custom"):
+            # Check credentials for the configured provider.
+            # Limit to API-key providers in PROVIDER_REGISTRY — other provider
+            # types (OAuth, SDK, openrouter/anthropic/custom/auto) have their
+            # own env-var checks elsewhere in doctor, and get_auth_status()
+            # returns a bare {logged_in: False} for anything it doesn't
+            # explicitly dispatch, which would produce false positives.
+            if canonical_provider and canonical_provider not in ("auto", "custom", "openrouter"):
                 try:
-                    from hermes_cli.auth import get_auth_status
-                    status = get_auth_status(canonical_provider) or {}
-                    configured = bool(status.get("configured") or status.get("logged_in") or status.get("api_key"))
-                    if not configured:
-                        check_fail(
-                            f"model.provider '{canonical_provider}' is set but not authenticated",
-                            "(check ~/.hermes/.env or run 'hermes setup')",
-                        )
-                        issues.append(
-                            f"No credentials found for provider '{canonical_provider}'. "
-                            f"Run 'hermes setup' or set the provider's API key in {_DHH}/.env, "
-                            f"or switch providers with 'hermes config set model.provider <name>'"
-                        )
+                    from hermes_cli.auth import PROVIDER_REGISTRY, get_auth_status
+                    pconfig = PROVIDER_REGISTRY.get(canonical_provider)
+                    if pconfig and getattr(pconfig, "auth_type", "") == "api_key":
+                        status = get_auth_status(canonical_provider) or {}
+                        configured = bool(status.get("configured") or status.get("logged_in") or status.get("api_key"))
+                        if not configured:
+                            check_fail(
+                                f"model.provider '{canonical_provider}' is set but no API key is configured",
+                                "(check ~/.hermes/.env or run 'hermes setup')",
+                            )
+                            issues.append(
+                                f"No credentials found for provider '{canonical_provider}'. "
+                                f"Run 'hermes setup' or set the provider's API key in {_DHH}/.env, "
+                                f"or switch providers with 'hermes config set model.provider <name>'"
+                            )
                 except Exception:
                     pass
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -293,6 +293,7 @@ AUTHOR_MAP = {
     "jarvischer@gmail.com": "maxchernin",
     "levantam.98.2324@gmail.com": "LVT382009",
     "zhurongcheng@rcrai.com": "heykb",
+    "withapurpose37@gmail.com": "StefanIsMe",
 }
 
 


### PR DESCRIPTION
Salvages #3171 — @StefanIsMe's fix for two silent `hermes doctor` gaps.

## Summary
`hermes doctor` now flags two failure modes it previously hid:
- OpenRouter HTTP 402 (out of credits) and 429 (rate-limited) — now surface as ✗ with a fix hint, instead of falling into the generic 'HTTP <code>' else branch with no actionable issue.
- `model.provider` / `model.default` in `config.yaml` — validated against `PROVIDER_REGISTRY` and `resolve_provider()`; unknown provider names (e.g. a stale `'main'`) fail red at check time instead of crashing at first use.

## Changes
- `hermes_cli/doctor.py`: +83 lines. Two new `elif` branches in the OpenRouter health check (402, 429) + a new config-validation block after the `config.yaml exists` check.
- `scripts/release.py`: AUTHOR_MAP entry for StefanIsMe.

## Salvage notes
Contributor's branch was 2303 commits behind main and called `get_provider_credentials()` — a function that doesn't exist on current `auth.py` (wrapped in bare `except Exception: pass`, so the credential-check limb was silently dead). Follow-up commit rewrites that limb against the current API:
- Reads the canonical provider via `resolve_provider()` so aliases (`glm`, `moonshot`, `x.ai`, …) validate correctly.
- Uses `get_auth_status()` for credential detection, limited to API-key providers in `PROVIDER_REGISTRY` — avoids false-positive 'not authenticated' failures for openrouter / anthropic / custom / auto.
- Drops the hardcoded fallback provider list (was already stale — missing gemini, bedrock, arcee, nvidia) and the stale honcho-section revert from the cherry-pick.

## Validation
- py_compile ✓
- `tests/hermes_cli/test_doctor*.py`: 31 passed
- E2E with isolated HERMES_HOME (6 scenarios):
  - bogus `provider: main` → ✗ fail with full provider list
  - `provider: minimax, default: anthropic/…` → ⚠ vendor-prefix warning + ✗ missing key
  - `provider: openrouter` + `OPENROUTER_API_KEY` set → clean pass
  - `provider: minimax` + `MINIMAX_API_KEY` set → clean pass
  - `provider: custom` → silent (correct; custom skips cred check)
  - `model: {}` → silent (correct; nothing to validate)

Closes #3171 via salvage (Stefan's commit preserved in git log).