### PR TITLE
fix: normalize empty tool args for shared dispatch

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -368,7 +368,11 @@ def coerce_tool_args(tool_name: str, args: Dict[str, Any]) -> Dict[str, Any]:
     Handles ``"type": "integer"``, ``"type": "number"``, ``"type": "boolean"``,
     and union types (``"type": ["integer", "string"]``).
     """
-    if not args or not isinstance(args, dict):
+    if args is None:
+        return {}
+    if not isinstance(args, dict):
+        return {}
+    if not args:
         return args
 
     schema = registry.get_schema(tool_name)
@@ -452,6 +456,7 @@ def handle_function_call(
     user_task: Optional[str] = None,
     enabled_tools: Optional[List[str]] = None,
     skip_pre_tool_call_hook: bool = False,
+    **_compat_kwargs: Any,
 ) -> str:
     """
     Main function call dispatcher that routes calls to the tool registry.
@@ -469,7 +474,8 @@ def handle_function_call(
     Returns:
         Function result as a JSON string.
     """
-    # Coerce string arguments to their schema-declared types (e.g. "42"→42)
+    # Normalize zero-arg tool calls to an empty dict before hooks or handlers
+    # see them, then coerce string arguments to schema-declared types.
     function_args = coerce_tool_args(function_name, function_args)
 
     try:

--- a/tests/run_agent/test_tool_arg_coercion.py
+++ b/tests/run_agent/test_tool_arg_coercion.py
@@ -198,7 +198,7 @@ class TestCoerceToolArgs:
         assert coerce_tool_args("test_tool", {}) == {}
 
     def test_none_args(self):
-        assert coerce_tool_args("test_tool", None) is None
+        assert coerce_tool_args("test_tool", None) == {}
 
     def test_preserves_non_string_values(self):
         """Lists, dicts, and other non-string values are never touched."""

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -74,6 +74,63 @@ class TestHandleFunctionCall:
             ),
         ]
 
+    def test_honcho_compat_kwargs_are_accepted(self):
+        with patch("model_tools.registry.dispatch", return_value='{"ok":true}') as mock_dispatch:
+            result = handle_function_call(
+                "web_search",
+                {"q": "test"},
+                task_id="task-1",
+                honcho_manager=object(),
+                honcho_session_key="gateway-session",
+            )
+
+        assert result == '{"ok":true}'
+        mock_dispatch.assert_called_once_with(
+            "web_search",
+            {"q": "test"},
+            task_id="task-1",
+            user_task=None,
+        )
+
+    def test_none_args_are_normalized_before_hooks_and_dispatch(self):
+        with (
+            patch("model_tools.registry.dispatch", return_value='{"ok":true}') as mock_dispatch,
+            patch("hermes_cli.plugins.get_pre_tool_call_block_message", return_value=None) as mock_block,
+            patch("hermes_cli.plugins.invoke_hook") as mock_invoke_hook,
+        ):
+            result = handle_function_call(
+                "web_search",
+                None,
+                task_id="task-1",
+                tool_call_id="call-1",
+                session_id="session-1",
+            )
+
+        assert result == '{"ok":true}'
+        mock_block.assert_called_once_with(
+            "web_search",
+            {},
+            task_id="task-1",
+            session_id="session-1",
+            tool_call_id="call-1",
+        )
+        mock_dispatch.assert_called_once_with(
+            "web_search",
+            {},
+            task_id="task-1",
+            user_task=None,
+        )
+        assert mock_invoke_hook.call_args_list == [
+            call(
+                "post_tool_call",
+                tool_name="web_search",
+                args={},
+                result='{"ok":true}',
+                task_id="task-1",
+                session_id="session-1",
+                tool_call_id="call-1",
+            ),
+        ]
 
 # =========================================================================
 # Agent loop tools
@@ -174,6 +231,39 @@ class TestPreToolCallBlocking:
         # is not called — invoke_hook fires directly in the skip=True branch.
         assert "pre_tool_call" in hook_calls
         assert "post_tool_call" in hook_calls
+
+    def test_skip_flag_normalizes_none_args_for_observer_hook(self, monkeypatch):
+        hook_calls = []
+
+        def fake_invoke_hook(hook_name, **kwargs):
+            hook_calls.append((hook_name, kwargs))
+            return []
+
+        monkeypatch.setattr("hermes_cli.plugins.invoke_hook", fake_invoke_hook)
+        monkeypatch.setattr("model_tools.registry.dispatch",
+                            lambda *a, **kw: json.dumps({"ok": True}))
+
+        result = json.loads(handle_function_call("web_search", None, task_id="t1",
+                                                 skip_pre_tool_call_hook=True))
+
+        assert result == {"ok": True}
+        assert hook_calls == [
+            ("pre_tool_call", {
+                "tool_name": "web_search",
+                "args": {},
+                "task_id": "t1",
+                "session_id": "",
+                "tool_call_id": "",
+            }),
+            ("post_tool_call", {
+                "tool_name": "web_search",
+                "args": {},
+                "result": json.dumps({"ok": True}),
+                "task_id": "t1",
+                "session_id": "",
+                "tool_call_id": "",
+            }),
+        ]
 
 
 # =========================================================================

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -47,6 +47,21 @@ class TestRegisterAndDispatch:
         result = json.loads(reg.dispatch("echo", {"msg": "hi"}))
         assert result == {"msg": "hi"}
 
+    def test_dispatch_normalizes_none_args_to_empty_dict(self):
+        reg = ToolRegistry()
+
+        def echo_handler(args, **kw):
+            return json.dumps(args)
+
+        reg.register(
+            name="echo",
+            toolset="core",
+            schema=_make_schema("echo"),
+            handler=echo_handler,
+        )
+        result = json.loads(reg.dispatch("echo", None))
+        assert result == {}
+
 
 class TestGetDefinitions:
     def test_returns_openai_format(self):

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -20,9 +20,14 @@ import json
 import logging
 import threading
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Set
+from typing import Any, Callable, Dict, List, Optional, Set
 
 logger = logging.getLogger(__name__)
+
+
+def _normalize_tool_args(args: Any) -> dict:
+    """Normalize tool-call args to the dict shape expected by handlers."""
+    return args if isinstance(args, dict) else {}
 
 
 def _is_registry_register_call(node: ast.AST) -> bool:
@@ -299,11 +304,12 @@ class ToolRegistry:
         entry = self.get_entry(name)
         if not entry:
             return json.dumps({"error": f"Unknown tool: {name}"})
+        normalized_args = _normalize_tool_args(args)
         try:
             if entry.is_async:
                 from model_tools import _run_async
-                return _run_async(entry.handler(args, **kwargs))
-            return entry.handler(args, **kwargs)
+                return _run_async(entry.handler(normalized_args, **kwargs))
+            return entry.handler(normalized_args, **kwargs)
         except Exception as e:
             logger.exception("Tool %s dispatch error: %s", name, e)
             return json.dumps({"error": f"Tool execution failed: {type(e).__name__}: {e}"})


### PR DESCRIPTION
## Summary
- normalize non-dict tool-call args to `{}` in the shared registry dispatch path
- normalize `handle_function_call()` args before plugin hooks and tool dispatch
- add regression coverage for `args=None` in registry dispatch and hook/skip-hook flows
- align the run-agent tool-arg coercion expectation with the normalized empty-dict behavior now used by shared dispatch

## Verification
- `python -m pytest tests/tools/test_registry.py tests/test_model_tools.py tests/run_agent/test_tool_arg_coercion.py -q`
- `python -m pytest /home/david/.hermes/plugins/hadto/tests/test_self_improvement.py -q -k "registered_handlers_tolerate_null_args or self_improvement_benchmark_scores_positive_and_persists_history or self_improvement_pipeline_repairs_delegate_conflicts_and_upserts_top_issue"`
- isolated runtime fixture checks for `self_improvement_evidence_gate`, `self_improvement_benchmark(persist=true)`, and `self_improvement_pipeline(persist=true, auto_repair_linear=true, auto_close_resolved=true)` via `handle_function_call(...)`