### PR TITLE
docs: fix fallback behavior description — per-turn, not per-session

### DIFF
--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -94,8 +94,8 @@ When triggered, Hermes:
 
 The switch is seamless — your conversation history, tool calls, and context are preserved. The agent continues from exactly where it left off, just using a different model.
 
-:::info One-Shot
-Fallback activates **at most once** per session. If the fallback provider also fails, normal error handling takes over (retries, then error message). This prevents cascading failover loops.
+:::info Per-Turn, Not Per-Session
+Fallback is **turn-scoped**: each new user message starts with the primary model restored. If the primary fails mid-turn, fallback activates for that turn only. On the next message, Hermes tries the primary again. Within a single turn, fallback activates at most once — if the fallback also fails, normal error handling takes over (retries, then error message). This prevents cascading failover loops within a turn while giving the primary model a fresh chance every turn.
 :::
 
 ### Examples
@@ -336,7 +336,7 @@ See [Scheduled Tasks (Cron)](/docs/user-guide/features/cron) for full configurat
 
 | Feature | Fallback Mechanism | Config Location |
 |---------|-------------------|----------------|
-| Main agent model | `fallback_model` in config.yaml — one-shot failover on errors | `fallback_model:` (top-level) |
+| Main agent model | `fallback_model` in config.yaml — per-turn failover on errors (primary restored each turn) | `fallback_model:` (top-level) |
 | Vision | Auto-detection chain + internal OpenRouter retry | `auxiliary.vision` |
 | Web extraction | Auto-detection chain + internal OpenRouter retry | `auxiliary.web_extract` |
 | Context compression | Auto-detection chain, degrades to no-summary if unavailable | `auxiliary.compression` |


### PR DESCRIPTION
## Problem

The "One-Shot" info box on the Fallback Providers page states:

> Fallback activates **at most once** per session.

This is inaccurate. The actual implementation is **per-turn**, not per-session.

## Source Code Evidence

Three methods in `run_agent.py` establish this behavior:

1. **Snapshot** (line ~1671): `_primary_runtime` saves the primary model/provider at init
2. **Restore** (line ~6454): `_restore_primary_runtime()` resets model/provider back to primary, sets `_fallback_activated = False`
3. **Call site** (line ~8681): `_restore_primary_runtime()` is called at the top of every `run_conversation()` invocation

This means every new user message gets a fresh attempt with the primary model. If it fails mid-turn, fallback activates for that turn only. Next message — primary is restored again.

## Changes

- Updated the info box from "One-Shot" / "at most once per session" to accurately describe per-turn restoration
- Updated the summary table row to match
