### PR TITLE
fix(gateway): pass session_key (not session_id) to active-process check during prune

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -926,12 +926,18 @@ class SessionStore:
                     continue
                 # Never prune sessions with an active background process
                 # attached — the user may still be waiting on output.
+                # The callback is keyed by session_key (see process_registry.
+                # has_active_for_session); passing session_id here used to
+                # never match, so active sessions got pruned anyway.
                 if self._has_active_processes_fn is not None:
                     try:
-                        if self._has_active_processes_fn(entry.session_id):
+                        if self._has_active_processes_fn(entry.session_key):
                             continue
-                    except Exception:
-                        pass
+                    except Exception as exc:
+                        logger.debug(
+                            "has_active_processes_fn raised during prune for %s: %s",
+                            entry.session_key, exc,
+                        )
                 if entry.updated_at < cutoff:
                     removed_keys.append(key)
             for key in removed_keys:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -301,6 +301,7 @@ AUTHOR_MAP = {
     "withapurpose37@gmail.com": "StefanIsMe",
     "261797239+lumenradley@users.noreply.github.com": "lumenradley",
     "166376523+sjz-ks@users.noreply.github.com": "sjz-ks",
+    "haileymarshall005@gmail.com": "haileymarshall",
 }
 
 

--- a/tests/gateway/test_session_store_prune.py
+++ b/tests/gateway/test_session_store_prune.py
@@ -117,11 +117,20 @@ class TestPruneBasics:
         assert "idle" not in store._entries
 
     def test_prune_skips_entries_with_active_processes(self, tmp_path):
-        """Sessions with active bg processes aren't pruned even if old."""
-        active_session_ids = {"sid_active"}
+        """Sessions with active bg processes aren't pruned even if old.
 
-        def _has_active(session_id: str) -> bool:
-            return session_id in active_session_ids
+        The callback is keyed by session_key — matching what
+        process_registry.has_active_for_session() actually consumes in
+        gateway/run.py.  Prior to the fix this test passed the callback a
+        session_id, which silently matched an implementation bug where
+        prune_old_entries was also passing session_id; real-world usage
+        (via process_registry) takes a session_key and never matched, so
+        active sessions were still being pruned.
+        """
+        active_session_keys = {"active"}
+
+        def _has_active(session_key: str) -> bool:
+            return session_key in active_session_keys
 
         store = _make_store(tmp_path, has_active_processes_fn=_has_active)
         store._entries["active"] = _entry(
@@ -136,6 +145,26 @@ class TestPruneBasics:
         assert removed == 1
         assert "active" in store._entries
         assert "idle" not in store._entries
+
+    def test_prune_active_check_uses_session_key_not_session_id(self, tmp_path):
+        """Regression guard: a callback that only recognises session_ids must
+        NOT protect entries during prune.  This pins the fix so a future
+        refactor can't silently revert to passing session_id again.
+        """
+        def _recognises_only_ids(identifier: str) -> bool:
+            return identifier.startswith("sid_")
+
+        store = _make_store(tmp_path, has_active_processes_fn=_recognises_only_ids)
+        store._entries["active"] = _entry(
+            "active", age_days=1000, session_id="sid_active"
+        )
+
+        removed = store.prune_old_entries(max_age_days=90)
+
+        # Entry is pruned because the callback receives "active" (session_key),
+        # not "sid_active" (session_id), so _recognises_only_ids returns False.
+        assert removed == 1
+        assert "active" not in store._entries
 
     def test_prune_does_not_write_disk_when_no_removals(self, tmp_path):
         """If nothing is evictable, _save() should NOT be called."""


### PR DESCRIPTION
Salvage of #12145 (@haileymarshall) onto current main.

## Summary
`SessionStore.prune_old_entries` passed `entry.session_id` to its active-process guard, but the callback (`process_registry.has_active_for_session`) compares against `session_key`. The two live in different namespaces, so the guard never fired — sessions with live background processes were pruned anyway, orphaning their output when it finally came back.

The two sibling call sites in the same file (`_is_session_expired`, `_should_reset`) already pass `session_key`; prune was the only outlier.

## Changes
- `gateway/session.py`: pass `entry.session_key` to `_has_active_processes_fn`; demote silent `except: pass` to a debug log.
- `tests/gateway/test_session_store_prune.py`: existing `test_prune_skips_entries_with_active_processes` validated the buggy interface (mock keyed by session_id) so it passed tautologically — rewritten against the real callback contract. New regression test `test_prune_active_check_uses_session_key_not_session_id` pins the fix.
- `scripts/release.py`: add @haileymarshall to AUTHOR_MAP.

## Validation
18/18 in tests/gateway/test_session_store_prune.py pass, including the new regression guard.

Closes #12145. Contributor authorship preserved via cherry-pick.