### PR TITLE
fix(cli): model validation fails for anthropic_messages and Cloudflare-protected endpoints

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2716,10 +2716,15 @@ def _model_flow_named_custom(config, provider_info):
 
     name = provider_info["name"]
     base_url = provider_info["base_url"]
+    api_mode = provider_info.get("api_mode", "")
     api_key = provider_info.get("api_key", "")
     key_env = provider_info.get("key_env", "")
     saved_model = provider_info.get("model", "")
     provider_key = (provider_info.get("provider_key") or "").strip()
+
+    # Resolve key from env var if api_key not set directly
+    if not api_key and key_env:
+        api_key = os.environ.get(key_env, "")
 
     print(f"  Provider: {name}")
     print(f"  URL:      {base_url}")
@@ -2728,7 +2733,10 @@ def _model_flow_named_custom(config, provider_info):
     print()
 
     print("Fetching available models...")
-    models = fetch_api_models(api_key, base_url, timeout=8.0)
+    models = fetch_api_models(
+        api_key, base_url, timeout=8.0,
+        api_mode=api_mode or None,
+    )
 
     if models:
         default_idx = 0

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -691,6 +691,7 @@ def switch_model(
             target_provider,
             api_key=api_key,
             base_url=base_url,
+            api_mode=api_mode or None,
         )
     except Exception as e:
         validation = {

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1737,8 +1737,15 @@ def probe_api_models(
     api_key: Optional[str],
     base_url: Optional[str],
     timeout: float = 5.0,
+    api_mode: Optional[str] = None,
 ) -> dict[str, Any]:
-    """Probe an OpenAI-compatible ``/models`` endpoint with light URL heuristics."""
+    """Probe a ``/models`` endpoint with light URL heuristics.
+
+    For ``anthropic_messages`` mode, uses ``x-api-key`` and
+    ``anthropic-version`` headers (Anthropic's native auth) instead of
+    ``Authorization: Bearer``.  The response shape (``data[].id``) is
+    identical, so the same parser works for both.
+    """
     normalized = (base_url or "").strip().rstrip("/")
     if not normalized:
         return {
@@ -1769,8 +1776,11 @@ def probe_api_models(
         candidates.append((alternate_base, True))
 
     tried: list[str] = []
-    headers: dict[str, str] = {}
-    if api_key:
+    headers: dict[str, str] = {"User-Agent": "Hermes/1.0"}
+    if api_key and api_mode == "anthropic_messages":
+        headers["x-api-key"] = api_key
+        headers["anthropic-version"] = "2023-06-01"
+    elif api_key:
         headers["Authorization"] = f"Bearer {api_key}"
     if normalized.startswith(COPILOT_BASE_URL):
         headers.update(copilot_default_headers())
@@ -1832,13 +1842,14 @@ def fetch_api_models(
     api_key: Optional[str],
     base_url: Optional[str],
     timeout: float = 5.0,
+    api_mode: Optional[str] = None,
 ) -> Optional[list[str]]:
     """Fetch the list of available model IDs from the provider's ``/models`` endpoint.
 
     Returns a list of model ID strings, or ``None`` if the endpoint could not
     be reached (network error, timeout, auth failure, etc.).
     """
-    return probe_api_models(api_key, base_url, timeout=timeout).get("models")
+    return probe_api_models(api_key, base_url, timeout=timeout, api_mode=api_mode).get("models")
 
 
 # ---------------------------------------------------------------------------
@@ -1966,6 +1977,7 @@ def validate_requested_model(
     *,
     api_key: Optional[str] = None,
     base_url: Optional[str] = None,
+    api_mode: Optional[str] = None,
 ) -> dict[str, Any]:
     """
     Validate a ``/model`` value for the active provider.
@@ -2007,7 +2019,11 @@ def validate_requested_model(
         }
 
     if normalized == "custom":
-        probe = probe_api_models(api_key, base_url)
+        # Try probing with correct auth for the api_mode.
+        if api_mode == "anthropic_messages":
+            probe = probe_api_models(api_key, base_url, api_mode=api_mode)
+        else:
+            probe = probe_api_models(api_key, base_url)
         api_models = probe.get("models")
         if api_models is not None:
             if requested_for_lookup in set(api_models):
@@ -2056,12 +2072,17 @@ def validate_requested_model(
             f"Note: could not reach this custom endpoint's model listing at `{probe.get('probed_url')}`. "
             f"Hermes will still save `{requested}`, but the endpoint should expose `/models` for verification."
         )
+        if api_mode == "anthropic_messages":
+            message += (
+                "\n  Many Anthropic-compatible proxies do not implement the Models API "
+                "(GET /v1/models).  The model name has been accepted without verification."
+            )
         if probe.get("suggested_base_url"):
             message += f"\n  If this server expects `/v1`, try base URL: `{probe.get('suggested_base_url')}`"
 
         return {
-            "accepted": False,
-            "persist": False,
+            "accepted": api_mode == "anthropic_messages",
+            "persist": True,
             "recognized": False,
             "message": message,
         }
@@ -2148,6 +2169,41 @@ def validate_requested_model(
                     "\n  The model may still work if it exists on the server."
                 ),
             }
+
+    # Anthropic Messages API: many proxies don't implement /v1/models.
+    # Try probing with correct auth; if it fails, accept with a warning.
+    if api_mode == "anthropic_messages":
+        api_models = fetch_api_models(api_key, base_url, api_mode=api_mode)
+        if api_models is not None:
+            if requested_for_lookup in set(api_models):
+                return {
+                    "accepted": True,
+                    "persist": True,
+                    "recognized": True,
+                    "message": None,
+                }
+            auto = get_close_matches(requested_for_lookup, api_models, n=1, cutoff=0.9)
+            if auto:
+                return {
+                    "accepted": True,
+                    "persist": True,
+                    "recognized": True,
+                    "corrected_model": auto[0],
+                    "message": f"Auto-corrected `{requested}` → `{auto[0]}`",
+                }
+        # Probe failed or model not found — accept anyway (proxy likely
+        # doesn't implement the Anthropic Models API).
+        return {
+            "accepted": True,
+            "persist": True,
+            "recognized": False,
+            "message": (
+                f"Note: could not verify `{requested}` against this endpoint's "
+                f"model listing.  Many Anthropic-compatible proxies do not "
+                f"implement GET /v1/models.  The model name has been accepted "
+                f"without verification."
+            ),
+        }
 
     # Probe the live API to check if the model actually exists
     api_models = fetch_api_models(api_key, base_url)


### PR DESCRIPTION
## Summary

The `/model` command fails to switch to providers using `api_mode: anthropic_messages`
and to some OpenAI-compatible endpoints behind Cloudflare, because `validate_requested_model()`
always probes with `Authorization: Bearer` (OpenAI-style auth) via `urllib.request`
without a `User-Agent` header.

## Root causes

1. **Anthropic Models API uses different auth**: Anthropic's `GET /v1/models`
   requires `x-api-key` + `anthropic-version` headers, not `Authorization: Bearer`.
   The response shape (`data[].id`) is identical to OpenAI, but the probe always
   failed with auth errors.

2. **Cloudflare blocks requests without User-Agent**: `urllib.request` does not
   set a `User-Agent` header by default. Some third-party OpenAI-compatible
   endpoints behind Cloudflare return 403, causing the probe to fail even though
   the endpoint works fine with normal HTTP clients.

3. **Hard rejection on probe failure**: When the `/models` probe failed for
   `anthropic_messages` providers, `validate_requested_model()` returned
   `accepted: False`, blocking the model switch entirely. Many Anthropic-compatible
   proxies do not implement the Models API at all, so this was a permanent block.

## Changes

### `hermes_cli/models.py`

- **`probe_api_models()`**: Added `api_mode` parameter. When `api_mode ==
  "anthropic_messages"`, sends `x-api-key` and `anthropic-version` headers
  instead of `Authorization: Bearer`. Always sets `User-Agent: Hermes/1.0`.
- **`fetch_api_models()`**: Propagates `api_mode` to `probe_api_models()`.
- **`validate_requested_model()`**: Added `api_mode` parameter.
  - For `anthropic_messages` mode: attempts probe with correct Anthropic auth.
    If the proxy implements the Models API (like the official Anthropic endpoint),
    the model is verified normally. If the probe fails (common for third-party
    proxies), the model is still **accepted** with an informational warning
    instead of being rejected.
  - Custom provider `"custom"` branch: same logic — tries Anthropic auth first,
    falls back to accept on failure.

### `hermes_cli/model_switch.py`

- **`switch_model()`**: Passes `api_mode` through to `validate_requested_model()`.

## How to test

1. Configure a custom provider with `api_mode: anthropic_messages` in
   `~/.hermes/config.yaml` under `custom_providers`.
2. Run `/model <model-name>` with that provider — it should accept and switch.
3. Configure a custom provider with a Cloudflare-protected OpenAI-compatible
   endpoint — the `/model` probe should now succeed.
4. Existing tests: `pytest tests/hermes_cli/ -v` passes (614 passed; 2
   pre-existing failures unrelated to this change).

## Platforms tested

- Linux (ARM64, Orange Pi 4 Pro)
- Python 3.11