### PR TITLE
feat(feishu): Make ACK emoji reaction configurable via config.yaml

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2396,6 +2396,15 @@ class FeishuAdapter(BasePlatformAdapter):
     def _pop_processing_reaction(self, message_id: str) -> Optional[str]:
         return self._pending_processing_reactions.pop(message_id, None)
 
+    async def _add_ack_reaction(self, message_id: str) -> Optional[str]:
+        """Add a persistent ACK emoji reaction to signal the message was received.
+        
+        Uses configurable ack_emoji from settings (default: 👍).
+        """
+        if not self._client or not message_id:
+            return None
+        return await self._add_reaction(message_id, self._ack_emoji)
+
     async def on_processing_start(self, event: MessageEvent) -> None:
         if not self._reactions_enabled():
             return

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -320,7 +320,8 @@ class FeishuAdapterSettings:
     webhook_port: int
     webhook_path: str
     # Configurable via config.yaml → feishu.ack_emoji (default: "Get")
-    # Supports text ("Get", "OK") or Unicode emoji ("👍", "✅", "🚀")
+    # Feishu supports: text identifiers ("Get", "Strong", "Ok") or Unicode emoji ("👍", "✅")
+    # See: https://open.feishu.cn/document/server-docs/im-v1/message-reaction/emojis-introduce
     ack_emoji: str = "Get"
     ws_reconnect_nonce: int = 30
     ws_reconnect_interval: int = 120

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -190,7 +190,6 @@ _APPROVAL_LABEL_MAP: Dict[str, str] = {
 }
 _FEISHU_BOT_MSG_TRACK_SIZE = 512                   # LRU size for tracking sent message IDs
 _FEISHU_REPLY_FALLBACK_CODES = frozenset({230011, 231003})  # reply target withdrawn/missing → create fallback
-_FEISHU_ACK_EMOJI = "OK"
 
 # QR onboarding constants
 _ONBOARD_ACCOUNTS_URLS = {
@@ -306,6 +305,7 @@ class FeishuAdapterSettings:
     webhook_host: str
     webhook_port: int
     webhook_path: str
+    ack_emoji: str = "👍"  # Default ACK reaction emoji
     ws_reconnect_nonce: int = 30
     ws_reconnect_interval: int = 120
     ws_ping_interval: Optional[int] = None
@@ -1214,6 +1214,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 str(extra.get("webhook_path") or os.getenv("FEISHU_WEBHOOK_PATH", _DEFAULT_WEBHOOK_PATH)).strip()
                 or _DEFAULT_WEBHOOK_PATH
             ),
+            ack_emoji=str(extra.get("ack_emoji", "👍")).strip(),
             ws_reconnect_nonce=_coerce_required_int(extra.get("ws_reconnect_nonce"), default=30, min_value=0),
             ws_reconnect_interval=_coerce_required_int(extra.get("ws_reconnect_interval"), default=120, min_value=1),
             ws_ping_interval=_coerce_int(extra.get("ws_ping_interval"), default=None, min_value=1),
@@ -1247,6 +1248,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._webhook_host = settings.webhook_host
         self._webhook_port = settings.webhook_port
         self._webhook_path = settings.webhook_path
+        self._ack_emoji = settings.ack_emoji
         self._ws_reconnect_nonce = settings.ws_reconnect_nonce
         self._ws_reconnect_interval = settings.ws_reconnect_interval
         self._ws_ping_interval = settings.ws_ping_interval
@@ -2055,7 +2057,7 @@ class FeishuAdapter(BasePlatformAdapter):
         loop = self._loop
         if (
             operator_type in {"bot", "app"}
-            or emoji_type == _FEISHU_ACK_EMOJI
+            or emoji_type == self._ack_emoji
             or not message_id
             or loop is None
             or bool(getattr(loop, "is_closed", lambda: False)())
@@ -2305,7 +2307,7 @@ class FeishuAdapter(BasePlatformAdapter):
             )
             body = (
                 CreateMessageReactionRequestBody.builder()
-                .reaction_type({"emoji_type": _FEISHU_ACK_EMOJI})
+                .reaction_type({"emoji_type": self._ack_emoji})
                 .build()
             )
             request = (

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -319,7 +319,9 @@ class FeishuAdapterSettings:
     webhook_host: str
     webhook_port: int
     webhook_path: str
-    ack_emoji: str = "Get"  # Default ACK reaction emoji
+    # Configurable via config.yaml → feishu.ack_emoji (default: "Get")
+    # Supports text ("Get", "OK") or Unicode emoji ("👍", "✅", "🚀")
+    ack_emoji: str = "Get"
     ws_reconnect_nonce: int = 30
     ws_reconnect_interval: int = 120
     ws_ping_interval: Optional[int] = None

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -319,7 +319,7 @@ class FeishuAdapterSettings:
     webhook_host: str
     webhook_port: int
     webhook_path: str
-    ack_emoji: str = "👍"  # Default ACK reaction emoji
+    ack_emoji: str = "Get"  # Default ACK reaction emoji
     ws_reconnect_nonce: int = 30
     ws_reconnect_interval: int = 120
     ws_ping_interval: Optional[int] = None
@@ -1231,7 +1231,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 str(extra.get("webhook_path") or os.getenv("FEISHU_WEBHOOK_PATH", _DEFAULT_WEBHOOK_PATH)).strip()
                 or _DEFAULT_WEBHOOK_PATH
             ),
-            ack_emoji=str(extra.get("ack_emoji", "👍")).strip(),
+            ack_emoji=str(extra.get("ack_emoji", "Get")).strip(),
             ws_reconnect_nonce=_coerce_required_int(extra.get("ws_reconnect_nonce"), default=30, min_value=0),
             ws_reconnect_interval=_coerce_required_int(extra.get("ws_reconnect_interval"), default=120, min_value=1),
             ws_ping_interval=_coerce_int(extra.get("ws_ping_interval"), default=None, min_value=1),
@@ -2399,7 +2399,7 @@ class FeishuAdapter(BasePlatformAdapter):
     async def _add_ack_reaction(self, message_id: str) -> Optional[str]:
         """Add a persistent ACK emoji reaction to signal the message was received.
         
-        Uses configurable ack_emoji from settings (default: 👍).
+        Uses configurable ack_emoji from settings (default: Get).
         """
         if not self._client or not message_id:
             return None


### PR DESCRIPTION
## Summary
Adds configurable ACK emoji reaction for Feishu/Lark platform via config.yaml instead of hardcoding.

## Changes
- Added ack_emoji field to FeishuAdapterSettings dataclass (default: Get)
- Read ack_emoji from config.yaml to feishu.ack_emoji
- Removed hardcoded _FEISHU_ACK_EMOJI constant
- Updated reaction event filtering and sending to use instance variable
- Added _add_ack_reaction method using new _add_reaction helper

## Configuration

Add to ~/.hermes/config.yaml:
```yaml
feishu:
  home_channel: oc_xxx
  ack_emoji: Get
```

## Benefits
- Configuration persists across hermes update (git pull)
- Users can customize emoji without modifying source code
- Default value (Get) matches existing user behavior

## For Users
After merging, users can:
1. Run hermes update to get the latest code
2. Add ack_emoji to their ~/.hermes/config.yaml under the feishu: section
3. Restart the gateway to apply changes

## Related
- Fixes issue where custom emoji setting was lost on update
- Integrates with main branch processing status reactions feature