### PR TITLE
fix(tools): keep SSH ControlMaster socket path under macOS 104-byte limit

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -106,6 +106,7 @@ AUTHOR_MAP = {
     "hakanerten02@hotmail.com": "teyrebaz33",
     "linux2010@users.noreply.github.com": "Linux2010",
     "elmatadorgh@users.noreply.github.com": "elmatadorgh",
+    "alexazzjjtt@163.com": "alexzhu0",
     "ruzzgarcn@gmail.com": "Ruzzgar",
     "alireza78.crypto@gmail.com": "alireza78a",
     "brooklyn.bb.nicholson@gmail.com": "brooklynnicholson",

--- a/tests/tools/test_ssh_environment.py
+++ b/tests/tools/test_ssh_environment.py
@@ -67,6 +67,74 @@ class TestBuildSSHCommand:
         assert env._build_ssh_command()[-1] == "u@h"
 
 
+class TestControlSocketPath:
+    """Regression tests for issue #11840.
+
+    macOS caps Unix domain socket paths at 104 bytes (sun_path). SSH
+    appends a 16-byte random suffix to the control socket path when
+    operating in ControlMaster mode. An IPv6 host embedded in the
+    filename plus the deeply-nested macOS $TMPDIR easily blows past
+    the limit, causing every tool call to fail immediately.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _mock_connection(self, monkeypatch):
+        monkeypatch.setattr("tools.environments.ssh.subprocess.run",
+                            lambda *a, **k: subprocess.CompletedProcess([], 0))
+        monkeypatch.setattr("tools.environments.ssh.subprocess.Popen",
+                            lambda *a, **k: MagicMock(stdout=iter([]),
+                                                      stderr=iter([]),
+                                                      stdin=MagicMock()))
+        monkeypatch.setattr("tools.environments.base.time.sleep", lambda _: None)
+
+    # SSH appends ``.XXXXXXXXXXXXXXXX`` (17 bytes) to the ControlPath in
+    # ControlMaster mode; the macOS sun_path field is 104 bytes including
+    # the NUL terminator, so the usable path length is 103 bytes.
+    _SSH_CONTROLMASTER_SUFFIX = 17
+    _MAX_SUN_PATH = 103
+
+    def test_fits_under_macos_socket_limit_with_ipv6_host(self, monkeypatch):
+        """A realistic macOS $TMPDIR + IPv6 host must still produce a
+        control socket path that fits once SSH appends its ControlMaster
+        suffix (see issue #11840)."""
+        # Simulate the macOS $TMPDIR shape from the issue traceback —
+        # 48 bytes, the typical length of ``/var/folders/XX/YYYYYYYYY/T``.
+        fake_tmp = "/var/folders/2t/wbkw5yb158jc3zhswgl7tz9c0000gn/T"
+        monkeypatch.setattr("tools.environments.ssh.tempfile.gettempdir",
+                            lambda: fake_tmp)
+        # The simulated path doesn't exist on the test host — skip the
+        # real mkdir so __init__ can proceed.
+        from pathlib import Path as _Path
+        monkeypatch.setattr(_Path, "mkdir", lambda *a, **k: None)
+
+        env = SSHEnvironment(
+            host="9373:9b91:4480:558d:708e:e601:24e8:d8d0",
+            user="hermes",
+            port=22,
+        )
+
+        total_len = len(str(env.control_socket)) + self._SSH_CONTROLMASTER_SUFFIX
+        assert total_len <= self._MAX_SUN_PATH, (
+            f"control socket path would exceed the {self._MAX_SUN_PATH}-byte "
+            f"Unix domain socket limit once SSH appends its 16-byte suffix: "
+            f"{env.control_socket} (+{self._SSH_CONTROLMASTER_SUFFIX} = {total_len})"
+        )
+
+    def test_path_is_deterministic_across_instances(self):
+        """Same (user, host, port) must yield the same control socket so
+        ControlMaster reuse works across reconnects."""
+        first = SSHEnvironment(host="example.com", user="alice", port=2222)
+        second = SSHEnvironment(host="example.com", user="alice", port=2222)
+        assert first.control_socket == second.control_socket
+
+    def test_path_differs_for_different_targets(self):
+        """Different (user, host, port) triples must produce different paths."""
+        base = SSHEnvironment(host="h", user="u", port=22).control_socket
+        assert SSHEnvironment(host="h", user="u", port=23).control_socket != base
+        assert SSHEnvironment(host="h", user="v", port=22).control_socket != base
+        assert SSHEnvironment(host="g", user="u", port=22).control_socket != base
+
+
 class TestTerminalToolConfig:
     def test_ssh_persistent_default_true(self, monkeypatch):
         """SSH persistent defaults to True (via TERMINAL_PERSISTENT_SHELL)."""

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -1,5 +1,6 @@
 """SSH remote execution environment with ControlMaster connection persistence."""
 
+import hashlib
 import logging
 import os
 import shlex
@@ -47,7 +48,18 @@ class SSHEnvironment(BaseEnvironment):
 
         self.control_dir = Path(tempfile.gettempdir()) / "hermes-ssh"
         self.control_dir.mkdir(parents=True, exist_ok=True)
-        self.control_socket = self.control_dir / f"{user}@{host}:{port}.sock"
+        # Keep the socket filename short and deterministic so the full path
+        # stays under the 104-byte sun_path limit that macOS enforces on
+        # Unix domain sockets. A raw ``user@host:port`` — especially with an
+        # IPv6 host — plus the 16-byte random suffix SSH appends in
+        # ControlMaster mode easily exceeds the limit under macOS's
+        # deeply-nested $TMPDIR (e.g. /var/folders/xx/yy/T/). Hashing the
+        # triple keeps the path stable across reconnects so ControlMaster
+        # reuse still works.
+        _socket_id = hashlib.sha256(
+            f"{user}@{host}:{port}".encode()
+        ).hexdigest()[:16]
+        self.control_socket = self.control_dir / f"{_socket_id}.sock"
         _ensure_ssh_available()
         self._establish_connection()
         self._remote_home = self._detect_remote_home()


### PR DESCRIPTION
## Summary
SSH ControlMaster socket paths no longer blow past the 104-byte `sun_path` limit on macOS when connecting to IPv6 hosts. Previously the socket filename embedded `user@host:port` literally, and with macOS's deep `$TMPDIR` (`/var/folders/XX/YYYYYYYY/T/`) plus an expanded IPv6 address plus SSH's 16-byte ControlMaster suffix, the full path hit ~131 bytes — ~28 bytes over the limit — failing every tool call with `unix_listener: path "..." too long for Unix domain socket`.

Closes #11840.

## Changes
- `tools/environments/ssh.py`: replace the literal `f"{user}@{host}:{port}.sock"` filename with a 16-char SHA-256 hex digest of the connection identity. Deterministic (ControlMaster reuse still works), short (~21-byte filename), and collision-resistant at 64 bits.
- `tests/tools/test_ssh_environment.py`: 3 regression tests. Crucially, the length check accounts for SSH's 16-byte ControlMaster suffix (plus the dot separator): `len(path) + 17 <= 103`, which is the real invariant — not just `len(path) < 104`.

## Validation
| | Before | After |
|---|---|---|
| IPv6 host + macOS `$TMPDIR` socket path | ~131 bytes (over limit, fails) | ~65 bytes + 17 suffix = 82 bytes (under 103) |
| Full `test_ssh_environment.py` | 11 pass, 11 skipped | 14 pass, 11 skipped |
| Regression guard | — | Ipv6-length test fails when fix reverted |

## Credit
- @alexzhu0 (#11987) — source fix and the one set of regression tests that correctly accounts for SSH's 16-byte ControlMaster suffix in the length assertion (`+17 <= 103`), not just a bare `< 104`. Cherry-picked with original authorship preserved.

Duplicate PRs being closed with credit: #12738 (@Tranquil-Flow), #12711 (@Linux2010), #12480 (@Sanjays2402), #12433 (@Linux2010). #11851 (@kagura-agent) was already closed — will add an acknowledgment there too.
