### PR TITLE
fix(steer): drain /steer between individual tool calls, not at batch end

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10384,6 +10384,16 @@ class GatewayRunner:
                     pending = pending_event.text or _build_media_placeholder(pending_event)
                     logger.debug("Processing queued message after agent completion: '%s...'", pending[:40])
 
+            # Leftover /steer: if a steer arrived after the last tool batch
+            # (e.g. during the final API call), the agent couldn't inject it
+            # and returned it in result["pending_steer"]. Deliver it as the
+            # next user turn so it isn't silently dropped.
+            if result and not pending and not pending_event:
+                _leftover_steer = result.get("pending_steer")
+                if _leftover_steer:
+                    pending = _leftover_steer
+                    logger.debug("Delivering leftover /steer as next turn: '%s...'", pending[:40])
+
             # Safety net: if the pending text is a slash command (e.g. "/stop",
             # "/new"), discard it — commands should never be passed to the agent
             # as user input.  The primary fix is in base.py (commands bypass the

--- a/run_agent.py
+++ b/run_agent.py
@@ -8404,6 +8404,11 @@ class AIAgent:
             }
             messages.append(tool_msg)
 
+            # ── Per-tool /steer drain ───────────────────────────────────
+            # Same as the sequential path: drain between each collected
+            # result so the steer lands as early as possible.
+            self._apply_pending_steer_to_tool_results(messages, 1)
+
         # ── Per-turn aggregate budget enforcement ─────────────────────────
         num_tools = len(parsed_calls)
         if num_tools > 0:
@@ -8766,6 +8771,12 @@ class AIAgent:
                 "tool_call_id": tool_call.id
             }
             messages.append(tool_msg)
+
+            # ── Per-tool /steer drain ───────────────────────────────────
+            # Drain pending steer BETWEEN individual tool calls so the
+            # injection lands as soon as a tool finishes — not after the
+            # entire batch.  The model sees it on the next API iteration.
+            self._apply_pending_steer_to_tool_results(messages, 1)
 
             if not self.quiet_mode:
                 if self.verbose_logging:


### PR DESCRIPTION
## Summary
/steer now injects between individual tool calls within a batch instead of waiting for the entire batch to complete.

## Problem
User report from Utku: /steer behaved identically to /queue — the message wasn't delivered until the agent was completely done (5-6 minute wait). The steer text was only drained after `_execute_tool_calls_sequential()` / `_execute_tool_calls_concurrent()` returned, so any long-running tool in the batch blocked the injection.

## Changes
- **run_agent.py**: Call `_apply_pending_steer_to_tool_results(messages, 1)` after each individual tool result is appended in both the sequential and concurrent execution paths. The end-of-batch drain stays as a no-op safety net.
- **gateway/run.py**: Handle leftover steers (`result["pending_steer"]`) in the post-run dequeue — if a steer arrives during the final API call (no tool batch to drain into), deliver it as the next user turn instead of silently dropping it.

## Before / After

| | Before | After |
|---|---|---|
| Steer during Tool 2 of 5 | Waits for Tools 3-5 to finish | Injected into Tool 2's result immediately |
| Steer during final API call | Silently dropped (gateway) | Delivered as next user turn |

## Validation
- All 23 existing steer tests pass
- E2E test confirms per-tool drain injects into the correct tool result