### PR TITLE
fix(file-ops): map Windows absolute paths for POSIX shells on Windows

### DIFF
--- a/tests/tools/test_file_operations_edge_cases.py
+++ b/tests/tools/test_file_operations_edge_cases.py
@@ -146,3 +146,51 @@ class TestCheckLintBracePaths:
 
         assert result.success is False
         assert "SyntaxError" in result.output
+
+
+class TestWindowsPathNormalization:
+    """Verify Windows absolute paths are mapped for POSIX shells."""
+
+    @pytest.fixture()
+    def ops(self):
+        obj = ShellFileOperations.__new__(ShellFileOperations)
+        obj.env = MagicMock()
+        obj.cwd = "/"
+        return obj
+
+    def test_wsl_style_cwd_maps_to_mnt(self, ops):
+        """WSL bash (``/mnt/<drive>/...`` cwd) should rewrite C:/ → /mnt/c/."""
+        ops.env.cwd = "/mnt/d/Hermes_Agent"
+        p = "C:/Users/alice/.hermes/cache/documents/a(1).md"
+        assert (
+            ops._normalize_windows_abs_path_for_posix_shell(p)
+            == "/mnt/c/Users/alice/.hermes/cache/documents/a(1).md"
+        )
+
+    def test_git_bash_style_cwd_maps_to_drive_root(self, ops):
+        r"""Git Bash / MSYS2 (``/<drive>/...`` cwd) should rewrite C:\ → /c/."""
+        ops.env.cwd = "/d/Hermes_Agent"
+        p = r"C:\Users\alice\.hermes\cache\documents\a(1).md"
+        assert (
+            ops._normalize_windows_abs_path_for_posix_shell(p)
+            == "/c/Users/alice/.hermes/cache/documents/a(1).md"
+        )
+
+    def test_non_posix_cwd_keeps_windows_path(self, ops):
+        """Native Windows cwd means the consumer is not bash — leave as-is."""
+        ops.env.cwd = r"D:\Hermes_Agent"
+        p = "C:/Users/alice/.hermes/cache/documents/a.md"
+        assert ops._normalize_windows_abs_path_for_posix_shell(p) == p
+
+    def test_posix_path_passes_through(self, ops):
+        """Already-POSIX paths should not be rewritten even under WSL cwd."""
+        ops.env.cwd = "/mnt/d/repo"
+        p = "/mnt/c/Users/alice/file.md"
+        assert ops._normalize_windows_abs_path_for_posix_shell(p) == p
+
+    def test_drive_letter_only(self, ops):
+        """Drive root without trailing path still maps cleanly."""
+        ops.env.cwd = "/mnt/d/repo"
+        assert ops._normalize_windows_abs_path_for_posix_shell("C:/") == "/mnt/c"
+        ops.env.cwd = "/d/repo"
+        assert ops._normalize_windows_abs_path_for_posix_shell("C:\\") == "/c"

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -469,9 +469,46 @@ class ShellFileOperations(FileOperations):
                         user_home = expand_result.stdout.strip()
                         suffix = path[1 + len(username):]  # e.g. "/rest/of/path"
                         return user_home + suffix
-        
+
+        return self._normalize_windows_abs_path_for_posix_shell(path)
+
+    def _normalize_windows_abs_path_for_posix_shell(self, path: str) -> str:
+        """Map a Windows absolute path to the form the active POSIX shell accepts.
+
+        Hermes runs every shell command through ``bash -c``. On Windows,
+        ``bash`` can resolve to WSL bash (``/mnt/<drive>/...`` roots) or
+        Git Bash / MSYS2 (``/<drive>/...`` roots). Neither can open a bare
+        ``C:/...`` path — they report "No such file or directory" even
+        though the file exists on the host filesystem.
+
+        Detect which shell is active by inspecting the live terminal cwd:
+
+          * ``/mnt/...`` prefix → WSL bash. Map ``C:/foo`` → ``/mnt/c/foo``.
+          * any other POSIX absolute cwd → Git Bash / MSYS2. Map
+            ``C:\\foo`` → ``/c/foo``.
+          * anything else (native Windows cwd, or no cwd info) → pass
+            through unchanged.
+
+        Both backslash and forward-slash drive-letter forms are accepted.
+        """
+        if not path:
+            return path
+
+        match = re.match(r"^([A-Za-z]):[\\/](.*)$", path)
+        if not match:
+            return path
+
+        shell_cwd = str(getattr(self.env, "cwd", None) or self.cwd or "")
+        drive = match.group(1).lower()
+        rest = match.group(2).replace("\\", "/").lstrip("/")
+
+        if shell_cwd.startswith("/mnt/"):
+            return f"/mnt/{drive}/{rest}" if rest else f"/mnt/{drive}"
+        if shell_cwd.startswith("/"):
+            return f"/{drive}/{rest}" if rest else f"/{drive}"
+
         return path
-    
+
     def _escape_shell_arg(self, arg: str) -> str:
         """Escape a string for safe use in shell commands."""
         # Use single quotes and escape any single quotes in the string


### PR DESCRIPTION
On Windows, ``ShellFileOperations`` runs every command through
``bash -c``, which may resolve to WSL bash or Git Bash / MSYS2.
Neither shell can open a bare Windows path like ``C:/Users/alice/x.md``
— WSL needs ``/mnt/c/Users/alice/x.md``, Git Bash needs
``/c/Users/alice/x.md``. Without this mapping every ``read_file``,
``search_files``, etc. reports "No such file or directory" on any
absolute Windows path the agent passes in, even when the file
clearly exists on the host filesystem.

Add ``_normalize_windows_abs_path_for_posix_shell`` at the tail of
``_expand_path``. It inspects the live terminal cwd to decide which
POSIX root to map to:

  * ``/mnt/...`` cwd       → WSL bash   → ``C:/foo`` becomes ``/mnt/c/foo``
  * any other POSIX cwd    → Git Bash   → ``C:\foo`` becomes ``/c/foo``
  * native Windows cwd     → pass through (consumer is not bash)

Both forward-slash and backslash drive-letter inputs are accepted;
drive letter is lower-cased; empty suffix (``C:/`` or ``C:\``) is
handled.

Tests in ``tests/tools/test_file_operations_edge_cases.py`` cover
all four cwd regimes plus the drive-only edge case.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

