### PR TITLE
fix(gateway): don't claim text document content is inlined when it isn't

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3830,8 +3830,8 @@ class GatewayRunner:
                 if mtype.startswith("text/"):
                     context_note = (
                         f"[The user sent a text document: '{display_name}'. "
-                        f"Its content has been included below. "
-                        f"The file is also saved at: {path}]"
+                        f"The file is saved at: {path}. "
+                        f"Use the read_file tool to read its content.]"
                     )
                 else:
                     context_note = (


### PR DESCRIPTION
When a text document attachment arrives, the prompt claims "Its
content has been included below" — but no enrichment step actually
inlines text content. (Pictures are enriched via
``_enrich_message_with_vision`` and audio via
``_enrich_message_with_transcription``; the text branch has no
counterpart.) The LLM reads the false claim, looks for content it
never receives, and often reports "file not found" to the user
despite the file being on disk.

Replace the misleading wording with an explicit instruction to call
the ``read_file`` tool. Matches the pattern used on the non-text
branch directly below.

Two-line wording change. No new dependencies, no behavioural change
beyond nudging the model toward the existing ``read_file`` path.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

