### PR TITLE
fix(retry): prevent attempt counter reset after primary transport recovery

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -10199,7 +10199,12 @@ class AIAgent:
                             api_error, retry_count=retry_count, max_retries=max_retries,
                         ):
                             primary_recovery_attempted = True
-                            retry_count = 0
+                            # Do NOT reset retry_count to 0 — that causes the
+                            # attempt counter to show (1/3), (2/3), (1/3), (2/3)
+                            # instead of a monotonically increasing sequence.
+                            # Grant one extra attempt beyond max_retries so the
+                            # rebuilt client gets exactly one shot (issue #12956).
+                            max_retries += 1
                             continue
                         # Try fallback before giving up entirely
                         self._emit_status(f"⚠️ Max retries ({max_retries}) exhausted — trying fallback...")


### PR DESCRIPTION
## Problem

When `_try_recover_primary_transport()` succeeded, `retry_count` was reset to `0`, causing the attempt counter to restart from `(1/3)` after already showing `(1/3)`, `(2/3)`:

```
⚠️ Retrying in 2.77s (attempt 1/3)...
⚠️ Retrying in 5.46s (attempt 2/3)...
⚠️ Retrying in 2.54s (attempt 1/3)...  ← resets!
⚠️ Retrying in 5.64s (attempt 2/3)...
⚠️ Max retries (3) exhausted — trying fallback...
```

## Fix

Instead of resetting `retry_count = 0`, increment `max_retries += 1`. This grants the rebuilt client exactly one extra attempt while keeping the displayed counter monotonic:

```
⚠️ Retrying in 2.77s (attempt 1/3)...
⚠️ Retrying in 5.46s (attempt 2/3)...
⚠️ Retrying in 2.54s (attempt 3/3)...
⚠️ Retrying in 5.64s (attempt 4/4)...  ← recovery attempt
⚠️ Max retries (4) exhausted — trying fallback...
```

Fixes #12956