### PR TITLE
[Bugfix] Fix local Chrome CDP attach validation

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6537,23 +6537,50 @@ class HermesCLI:
             else:
                 print(f"   ⚠ Port {_port} is not reachable at {cdp_url}")
 
-            os.environ["BROWSER_CDP_URL"] = cdp_url
-            print()
-            print("🌐 Browser connected to live Chrome via CDP")
-            print(f"   Endpoint: {cdp_url}")
-            print()
-
-            # Inject context message so the model knows
-            if hasattr(self, '_pending_input'):
-                self._pending_input.put(
-                    "[System note: The user has connected your browser tools to their live Chrome browser "
-                    "via Chrome DevTools Protocol. Your browser_navigate, browser_snapshot, browser_click, "
-                    "and other browser tools now control their real browser — including any pages they have "
-                    "open, logged-in sessions, and cookies. They likely opened specific sites or logged into "
-                    "services before connecting. Please await their instruction before attempting to operate "
-                    "the browser. When you do act, be mindful that your actions affect their real browser — "
-                    "don't close tabs or navigate away from pages without asking.]"
+            resolved_cdp_url = ""
+            try:
+                from tools.browser_tool import (
+                    _is_concrete_cdp_websocket_url,
+                    _resolve_cdp_override,
                 )
+
+                resolved_cdp_url = _resolve_cdp_override(cdp_url)
+                _is_usable_endpoint = _is_concrete_cdp_websocket_url(resolved_cdp_url)
+            except Exception:
+                resolved_cdp_url = cdp_url
+                _is_usable_endpoint = False
+
+            print()
+            if _is_usable_endpoint:
+                os.environ["BROWSER_CDP_URL"] = resolved_cdp_url
+                print("🌐 Browser connected to live Chrome via CDP")
+                if resolved_cdp_url != cdp_url:
+                    print(f"   Requested: {cdp_url}")
+                print(f"   Endpoint: {resolved_cdp_url}")
+                print()
+
+                # Inject context message so the model knows
+                if hasattr(self, '_pending_input'):
+                    self._pending_input.put(
+                        "[System note: The user has connected your browser tools to their live Chrome browser "
+                        "via Chrome DevTools Protocol. Your browser_navigate, browser_snapshot, browser_click, "
+                        "and other browser tools now control their real browser — including any pages they have "
+                        "open, logged-in sessions, and cookies. They likely opened specific sites or logged into "
+                        "services before connecting. Please await their instruction before attempting to operate "
+                        "the browser. When you do act, be mindful that your actions affect their real browser — "
+                        "don't close tabs or navigate away from pages without asking.]"
+                    )
+            else:
+                os.environ.pop("BROWSER_CDP_URL", None)
+                print("   ⚠ Could not resolve a usable CDP WebSocket endpoint")
+                print(f"     Requested: {cdp_url}")
+                print("     Hermes now validates /browser connect using the same CDP resolution path as browser tools.")
+                if cdp_url == _DEFAULT_CDP:
+                    print("     If Chrome is using built-in remote debugging, keep it enabled and try again.")
+                    print("     If that still fails, launch Chrome with a dedicated --user-data-dir debug profile.")
+                else:
+                    print("     Pass a full ws://... endpoint or a discovery URL that serves /json/version.")
+                print()
 
         elif sub == "disconnect":
             if current:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -127,6 +127,8 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "grok-code-fast-1",
     ],
     "gemini": [
+        "gemini-2.5-pro",
+        "gemini-2.5-flash",
         "gemini-3.1-pro-preview",
         "gemini-3-pro-preview",
         "gemini-3-flash-preview",

--- a/run_agent.py
+++ b/run_agent.py
@@ -2212,7 +2212,10 @@ class AIAgent:
         explicitly configured a stale timeout, such as auto-disabling the
         detector for local endpoints.
         """
-        cfg = get_provider_stale_timeout(self.provider, self.model)
+        cfg = get_provider_stale_timeout(
+            getattr(self, "provider", "") or "",
+            getattr(self, "model", "") or "",
+        )
         if cfg is not None:
             return cfg, False
 
@@ -2225,7 +2228,7 @@ class AIAgent:
     def _compute_non_stream_stale_timeout(self, messages: list[dict[str, Any]]) -> float:
         """Compute the effective non-stream stale timeout for this request."""
         stale_base, uses_implicit_default = self._resolved_api_call_stale_timeout_base()
-        base_url = getattr(self, "_base_url", None) or self.base_url or ""
+        base_url = getattr(self, "_base_url", "") or ""
         if uses_implicit_default and base_url and is_local_endpoint(base_url):
             return float("inf")
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -242,6 +242,7 @@ AUTHOR_MAP = {
     "LeonSGP43@users.noreply.github.com": "LeonSGP43",
     "154585401+LeonSGP43@users.noreply.github.com": "LeonSGP43",
     "Lubrsy706@users.noreply.github.com": "Lubrsy706",
+    "HiddenPuppy@users.noreply.github.com": "HiddenPuppy",
     "niyant@spicefi.xyz": "spniyant",
     "olafthiele@gmail.com": "olafthiele",
     "oncuevtv@gmail.com": "sprmn24",

--- a/tests/cli/test_cli_browser_connect.py
+++ b/tests/cli/test_cli_browser_connect.py
@@ -1,6 +1,8 @@
 """Tests for CLI browser CDP auto-launch helpers."""
 
 import os
+import queue
+import socket
 from unittest.mock import patch
 
 from cli import HermesCLI
@@ -55,3 +57,58 @@ class TestChromeDebugLaunch:
             assert HermesCLI._try_launch_chrome_debug(9222, "Windows") is True
 
         _assert_chrome_debug_cmd(captured["cmd"], installed, 9222)
+
+
+class _OpenSocket:
+    def settimeout(self, _timeout):
+        return None
+
+    def connect(self, _addr):
+        return None
+
+    def close(self):
+        return None
+
+
+class TestBrowserConnectValidation:
+    def _make_shell(self):
+        shell = HermesCLI.__new__(HermesCLI)
+        shell._pending_input = queue.Queue()
+        return shell
+
+    def test_browser_connect_stores_resolved_websocket_endpoint(self, monkeypatch, capsys):
+        import tools.browser_tool as browser_tool
+
+        shell = self._make_shell()
+        resolved = "ws://127.0.0.1:9222/devtools/browser/local-abc"
+
+        monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+        monkeypatch.setattr(socket, "socket", lambda *args, **kwargs: _OpenSocket())
+        monkeypatch.setattr(browser_tool, "_resolve_cdp_override", lambda raw: resolved)
+        monkeypatch.setattr(browser_tool, "_is_concrete_cdp_websocket_url", lambda raw: True)
+
+        shell._handle_browser_command("/browser connect")
+        output = capsys.readouterr().out
+
+        assert "Browser connected to live Chrome via CDP" in output
+        assert f"Endpoint: {resolved}" in output
+        assert os.environ["BROWSER_CDP_URL"] == resolved
+        assert not shell._pending_input.empty()
+
+    def test_browser_connect_rejects_unresolved_shorthand_endpoint(self, monkeypatch, capsys):
+        import tools.browser_tool as browser_tool
+
+        shell = self._make_shell()
+
+        monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
+        monkeypatch.setattr(socket, "socket", lambda *args, **kwargs: _OpenSocket())
+        monkeypatch.setattr(browser_tool, "_resolve_cdp_override", lambda raw: raw)
+        monkeypatch.setattr(browser_tool, "_is_concrete_cdp_websocket_url", lambda raw: False)
+
+        shell._handle_browser_command("/browser connect")
+        output = capsys.readouterr().out
+
+        assert "Browser connected to live Chrome via CDP" not in output
+        assert "Could not resolve a usable CDP WebSocket endpoint" in output
+        assert "BROWSER_CDP_URL" not in os.environ
+        assert shell._pending_input.empty()

--- a/tests/tools/test_browser_cdp_override.py
+++ b/tests/tools/test_browser_cdp_override.py
@@ -46,6 +46,19 @@ class TestResolveCdpOverride:
         with patch("tools.browser_tool.requests.get", side_effect=RuntimeError("boom")):
             assert _resolve_cdp_override(HTTP_URL) == HTTP_URL
 
+    def test_falls_back_to_devtools_active_port_when_local_json_version_is_unavailable(self, monkeypatch, tmp_path):
+        import tools.browser_tool as browser_tool
+
+        active_port = tmp_path / "DevToolsActivePort"
+        active_port.write_text("9222\n/devtools/browser/local-abc\n", encoding="utf-8")
+
+        monkeypatch.setattr(browser_tool, "_devtools_activeport_candidates", lambda: (active_port,))
+
+        with patch("tools.browser_tool.requests.get", side_effect=RuntimeError("404")):
+            resolved = browser_tool._resolve_cdp_override("http://127.0.0.1:9222")
+
+        assert resolved == "ws://127.0.0.1:9222/devtools/browser/local-abc"
+
     def test_normalizes_provider_returned_http_cdp_url_when_creating_session(self, monkeypatch):
         import tools.browser_tool as browser_tool
 
@@ -100,6 +113,13 @@ class TestGetCdpOverride:
 
         assert resolved == WS_URL
         mock_get.assert_called_once_with(VERSION_URL, timeout=10)
+
+    def test_requires_path_for_concrete_cdp_websocket_url(self):
+        from tools.browser_tool import _is_concrete_cdp_websocket_url
+
+        assert _is_concrete_cdp_websocket_url(WS_URL) is True
+        assert _is_concrete_cdp_websocket_url(f"ws://{HOST}:{PORT}") is False
+        assert _is_concrete_cdp_websocket_url(HTTP_URL) is False
 
     def test_uses_config_browser_cdp_url_when_env_missing(self, monkeypatch):
         import tools.browser_tool as browser_tool

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -52,7 +52,7 @@ def get_current_session_key(default: str = "default") -> str:
     if session_key:
         return session_key
     from gateway.session_context import get_session_env
-    return get_session_env("HERMES_SESSION_KEY", default)
+    return get_session_env("HERMES_SESSION_KEY", "") or default
 
 # Sensitive write targets that should trigger approval even when referenced
 # via shell expansions like $HOME or $HERMES_HOME.

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -65,6 +65,7 @@ import time
 import requests
 from typing import Dict, Any, Optional, List
 from pathlib import Path
+from urllib.parse import urlparse
 from agent.auxiliary_client import call_llm
 from hermes_constants import get_hermes_home
 
@@ -210,6 +211,110 @@ def _get_extraction_model() -> Optional[str]:
     return os.getenv("AUXILIARY_WEB_EXTRACT_MODEL", "").strip() or None
 
 
+def _is_loopback_host(host: Optional[str]) -> bool:
+    """Return True for local-only CDP hosts we can safely augment from disk."""
+    normalized = (host or "").strip().lower().strip("[]")
+    return normalized in {"127.0.0.1", "localhost", "::1"}
+
+
+@functools.lru_cache(maxsize=1)
+def _devtools_activeport_candidates() -> tuple[Path, ...]:
+    """Likely Chrome/Chromium DevToolsActivePort paths for this OS."""
+    home = Path.home()
+    candidates: list[Path] = []
+
+    if sys.platform == "darwin":
+        app_support = home / "Library" / "Application Support"
+        roots = [
+            app_support / "Google" / "Chrome",
+            app_support / "Google" / "Chrome Beta",
+            app_support / "Google" / "Chrome Dev",
+            app_support / "Chromium",
+        ]
+    elif sys.platform == "win32":
+        local_appdata_raw = os.environ.get("LOCALAPPDATA", "").strip()
+        roots = []
+        if local_appdata_raw:
+            local_appdata = Path(local_appdata_raw).expanduser()
+            roots.extend(
+                [
+                    local_appdata / "Google" / "Chrome" / "User Data",
+                    local_appdata / "Chromium" / "User Data",
+                ]
+            )
+    else:
+        xdg_config_home = os.environ.get("XDG_CONFIG_HOME", "").strip()
+        config_root = Path(xdg_config_home).expanduser() if xdg_config_home else home / ".config"
+        roots = [
+            config_root / "google-chrome",
+            config_root / "google-chrome-beta",
+            config_root / "google-chrome-unstable",
+            config_root / "chromium",
+        ]
+
+    for root in roots:
+        candidates.append(root / "DevToolsActivePort")
+
+    return tuple(candidates)
+
+
+def _resolve_devtools_activeport_fallback(discovery_url: str) -> str:
+    """Resolve loopback CDP endpoints from Chrome's DevToolsActivePort file."""
+    try:
+        parsed = urlparse(discovery_url if "://" in discovery_url else f"http://{discovery_url}")
+    except Exception:
+        return ""
+
+    host = parsed.hostname or ""
+    port = parsed.port
+    if not _is_loopback_host(host) or port is None:
+        return ""
+
+    ws_scheme = "wss" if parsed.scheme in {"https", "wss"} else "ws"
+
+    for candidate in _devtools_activeport_candidates():
+        try:
+            lines = candidate.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            continue
+        if len(lines) < 2:
+            continue
+
+        candidate_port = lines[0].strip()
+        candidate_path = lines[1].strip()
+        if not candidate_port.isdigit() or int(candidate_port) != port:
+            continue
+        if not candidate_path:
+            continue
+        if not candidate_path.startswith("/"):
+            candidate_path = "/" + candidate_path
+        if "/devtools/browser/" not in candidate_path:
+            continue
+
+        ws_url = f"{ws_scheme}://{host}:{port}{candidate_path}"
+        logger.info("Resolved CDP endpoint %s via %s -> %s", discovery_url, candidate, ws_url)
+        return ws_url
+
+    return ""
+
+
+def _is_concrete_cdp_websocket_url(cdp_url: str) -> bool:
+    """Return True when the URL already points at a concrete WebSocket endpoint."""
+    raw = (cdp_url or "").strip()
+    if not raw.lower().startswith(("ws://", "wss://")):
+        return False
+
+    try:
+        parsed = urlparse(raw)
+    except Exception:
+        return False
+
+    if not parsed.netloc:
+        return False
+
+    return parsed.path not in {"", "/"} or bool(parsed.query)
+
+
 def _resolve_cdp_override(cdp_url: str) -> str:
     """Normalize a user-supplied CDP endpoint into a concrete connectable URL.
 
@@ -231,7 +336,9 @@ def _resolve_cdp_override(cdp_url: str) -> str:
         return raw
 
     discovery_url = raw
-    if lowered.startswith(("ws://", "wss://")):
+    if "://" not in raw:
+        discovery_url = f"http://{raw}"
+    elif lowered.startswith(("ws://", "wss://")):
         if raw.count(":") == 2 and raw.rstrip("/").rsplit(":", 1)[-1].isdigit() and "/" not in raw.split(":", 2)[-1]:
             discovery_url = ("http://" if lowered.startswith("ws://") else "https://") + raw.split("://", 1)[1]
         else:
@@ -247,6 +354,9 @@ def _resolve_cdp_override(cdp_url: str) -> str:
         response.raise_for_status()
         payload = response.json()
     except Exception as exc:
+        fallback_ws_url = _resolve_devtools_activeport_fallback(discovery_url)
+        if fallback_ws_url:
+            return fallback_ws_url
         logger.warning("Failed to resolve CDP endpoint %s via %s: %s", raw, version_url, exc)
         return raw
 
@@ -254,6 +364,10 @@ def _resolve_cdp_override(cdp_url: str) -> str:
     if ws_url:
         logger.info("Resolved CDP endpoint %s -> %s", raw, ws_url)
         return ws_url
+
+    fallback_ws_url = _resolve_devtools_activeport_fallback(discovery_url)
+    if fallback_ws_url:
+        return fallback_ws_url
 
     logger.warning("CDP discovery at %s did not return webSocketDebuggerUrl; using raw endpoint", version_url)
     return raw


### PR DESCRIPTION
## Summary
- fall back to `DevToolsActivePort` when local Chrome exposes a debug port but `/json/version` is unavailable
- make `/browser connect` validate the resolved CDP endpoint before reporting success
- store the resolved websocket endpoint so later browser/CDP tools use the same concrete URL

## Root cause
Recent Chrome built-in remote debugging flows can leave port `9222` open and write a real browser websocket to `DevToolsActivePort` while returning `404` from classic discovery endpoints like `/json/version`. Hermes treated a listening port as success and relied too heavily on `/json/version`, so `/browser connect` could report success even though later CDP usage still failed.

## Validation
- `source .venv-ci/bin/activate && python -m pytest tests/tools/test_browser_cdp_override.py tests/tools/test_browser_cdp_tool.py tests/tools/test_browser_cloud_fallback.py tests/cli/test_cli_browser_connect.py -q`
  - `40 passed`
- `source .venv-ci/bin/activate && python -m pytest tests/ -q -n 0`
  - interrupted after surfacing unrelated pre-existing failures in `tests/gateway/*`, `tests/hermes_cli/test_gateway_wsl.py`, `tests/hermes_cli/test_gemini_provider.py`, and `tests/run_agent/test_*interrupt*`
