### PR TITLE
fix(docs): unbreak docs-site-checks — ascii-guard diagram + MDX `<1%`

### DIFF
--- a/website/docs/guides/github-pr-review-agent.md
+++ b/website/docs/guides/github-pr-review-agent.md
@@ -13,12 +13,15 @@ description: "Build an automated AI code reviewer that monitors your repos, revi
 **What you'll build:**
 
 ```
-┌──────────────┐     ┌───────────────┐     ┌──────────────┐     ┌──────────────┐
-│  Cron Timer  │────▶│  Hermes Agent │────▶│  GitHub API  │────▶│  Review to   │
-│  (every 2h)  │     │  + gh CLI     │     │  (PR diffs)  │     │  Telegram/   │
-│              │     │  + skill      │     │              │     │  Discord/    │
-│              │     │  + memory     │     │              │     │  local file  │
-└──────────────┘     └───────────────┘     └──────────────┘     └──────────────┘
+┌───────────────────────────────────────────────────────────────────┐
+│                                                                   │
+│   Cron Timer  ──▶  Hermes Agent  ──▶  GitHub API  ──▶  Review     │
+│   (every 2h)       + gh CLI           (PR diffs)       delivery   │
+│                    + skill                             (Telegram, │
+│                    + memory                            Discord,   │
+│                                                        local)     │
+│                                                                   │
+└───────────────────────────────────────────────────────────────────┘
 ```
 
 This guide uses **cron jobs** to poll for PRs on a schedule — no server or public endpoint needed. Works behind NAT and firewalls.

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -110,7 +110,7 @@ The largest optional category — covers the full ML pipeline from data curation
 | **llava** | Large Language and Vision Assistant — visual instruction tuning and image-based conversations combining CLIP vision with LLaMA language models. |
 | **modal** | Serverless GPU cloud platform for running ML workloads. On-demand GPU access without infrastructure management, ML model deployment as APIs, or batch jobs with automatic scaling. |
 | **nemo-curator** | GPU-accelerated data curation for LLM training. Fuzzy deduplication (16x faster), quality filtering (30+ heuristics), semantic dedup, PII redaction. Scales with RAPIDS. |
-| **peft-fine-tuning** | Parameter-efficient fine-tuning for LLMs using LoRA, QLoRA, and 25+ methods. Train <1% of parameters with minimal accuracy loss for 7B–70B models on limited GPU memory. HuggingFace's official PEFT library. |
+| **peft-fine-tuning** | Parameter-efficient fine-tuning for LLMs using LoRA, QLoRA, and 25+ methods. Train `<1%` of parameters with minimal accuracy loss for 7B–70B models on limited GPU memory. HuggingFace's official PEFT library. |
 | **pinecone** | Managed vector database for production AI. Auto-scaling, hybrid search (dense + sparse), metadata filtering, and low latency (under 100ms p95). |
 | **pytorch-fsdp** | Expert guidance for Fully Sharded Data Parallel training with PyTorch FSDP — parameter sharding, mixed precision, CPU offloading, FSDP2. |
 | **pytorch-lightning** | High-level PyTorch framework with Trainer class, automatic distributed training (DDP/FSDP/DeepSpeed), callbacks, and minimal boilerplate. |


### PR DESCRIPTION
## Summary

Two independent `docs-site-checks` failures were blocking every PR as `action_required`. Fixed both.

## Changes

- `website/docs/guides/github-pr-review-agent.md` — the intro diagram used 4 side-by-side boxes in one row, which ascii-guard cannot parse (reads the whole line as one 80-wide box and flags the inner borders as "extra characters"). Rewrote as a single 69-char outer box with four labeled regions separated by arrows. Same semantic content.
- `website/docs/reference/optional-skills-catalog.md` — `Train <1% of parameters` on line 113 was parsed by MDX as the start of a JSX tag (`1` isn't a valid tag-name start, so compilation failed). Wrapped in backticks so MDX treats it as literal code text.

Full docs tree scanned for other `<digit>` patterns outside backticks/fences — none found.

## Validation

| | Before | After |
|---|---|---|
| `ascii-guard lint website/docs` | 3 errors on github-pr-review-agent.md | 0 errors |
| `npm run build` (MDX compilation) | Failed on optional-skills-catalog.md:113:110 | Passes |
| `docs-site-checks` CI | fail (action_required) | **pass** |

Discovered while investigating the spurious `docs-site-checks` failure on PR #12969. The CI log attributed the ascii-guard error to `wecom.md` due to output buffering reordering `Checking` and `✗` lines — a known quirk documented in the `ascii-guard-lint-fixing` skill. Running the linter locally pointed at the real source.