### PR TITLE
fix(gateway): enable linger on systemd user-service repair path

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1431,6 +1431,8 @@ def systemd_install(force: bool = False, system: bool = False, run_as_user: str 
             refresh_systemd_unit_if_needed(system=system)
             _run_systemctl(["enable", get_service_name()], system=system, check=True, timeout=30)
             print(f"✓ {_service_scope_label(system).capitalize()} service definition updated")
+            if not system:
+                _ensure_linger_enabled()
             return
         print(f"Service already installed at: {unit_path}")
         print("Use --force to reinstall")

--- a/tests/hermes_cli/test_gateway_linger.py
+++ b/tests/hermes_cli/test_gateway_linger.py
@@ -123,3 +123,69 @@ def test_systemd_install_calls_linger_helper(monkeypatch, tmp_path, capsys):
     ]
     assert helper_calls == [True]
     assert "User service installed and enabled" in out
+
+
+def test_systemd_install_repair_path_calls_linger_helper(monkeypatch, tmp_path):
+    # The repair branch used to early-return before the linger helper ran, so
+    # upgrades on headless hosts left the service dead after the user logged
+    # out. Pin that repair now behaves like fresh-install on user scope.
+    unit_path = tmp_path / "hermes-gateway.service"
+    unit_path.write_text("old unit\n", encoding="utf-8")
+
+    monkeypatch.setattr(gateway, "get_systemd_unit_path", lambda system=False: unit_path)
+    monkeypatch.setattr(gateway, "systemd_unit_is_current", lambda system=False: False)
+    monkeypatch.setattr(
+        gateway, "generate_systemd_unit", lambda system=False, run_as_user=None: "new unit\n"
+    )
+
+    calls = []
+
+    def fake_run(cmd, check=False, **kwargs):
+        calls.append((cmd, check))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    helper_calls = []
+    monkeypatch.setattr(gateway.subprocess, "run", fake_run)
+    monkeypatch.setattr(gateway, "_ensure_linger_enabled", lambda: helper_calls.append(True))
+
+    gateway.systemd_install(force=False)
+
+    assert unit_path.read_text(encoding="utf-8") == "new unit\n"
+    assert [cmd for cmd, _ in calls] == [
+        ["systemctl", "--user", "daemon-reload"],
+        ["systemctl", "--user", "enable", gateway.get_service_name()],
+    ]
+    assert helper_calls == [True]
+
+
+def test_systemd_install_repair_path_system_scope_skips_linger(monkeypatch, tmp_path):
+    # Linger is a per-user-session concept; system-scope units run under PID 1
+    # and must never touch it. Guards against mirroring the user-scope fix in
+    # the wrong branch of systemd_install().
+    unit_path = tmp_path / "hermes-gateway.service"
+    unit_path.write_text("old unit\n", encoding="utf-8")
+
+    monkeypatch.setattr(gateway, "get_systemd_unit_path", lambda system=False: unit_path)
+    monkeypatch.setattr(gateway, "systemd_unit_is_current", lambda system=False: False)
+    monkeypatch.setattr(
+        gateway, "generate_systemd_unit", lambda system=False, run_as_user=None: "new unit\n"
+    )
+    monkeypatch.setattr(gateway, "_require_root_for_system_service", lambda _action: None)
+
+    calls = []
+
+    def fake_run(cmd, check=False, **kwargs):
+        calls.append((cmd, check))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    helper_calls = []
+    monkeypatch.setattr(gateway.subprocess, "run", fake_run)
+    monkeypatch.setattr(gateway, "_ensure_linger_enabled", lambda: helper_calls.append(True))
+
+    gateway.systemd_install(force=False, system=True)
+
+    assert helper_calls == []
+    assert [cmd for cmd, _ in calls] == [
+        ["systemctl", "daemon-reload"],
+        ["systemctl", "enable", gateway.get_service_name()],
+    ]


### PR DESCRIPTION
Closes #12863.

## Summary
- The repair branch in `systemd_install()` returns as soon as it rewrites an outdated unit and re-runs `systemctl enable`, bypassing `_ensure_linger_enabled()`. On headless Linux the command reports success, but the repaired user service still stops at logout.
- Call `_ensure_linger_enabled()` before the early return when the install is user-scoped, mirroring the fresh-install path.

## What changed
- `hermes_cli/gateway.py`: in the repair branch, call `_ensure_linger_enabled()` when `system=False` before returning.
- `tests/hermes_cli/test_gateway_linger.py`: add two regression tests covering the repair path:
  - `test_systemd_install_repair_path_calls_linger_helper` — user scope must call the linger helper.
  - `test_systemd_install_repair_path_system_scope_skips_linger` — system scope must not call it.

## Verification
Without the fix, the new user-scope test fails with `assert [] == [True]` (helper never invoked). With the fix, both new tests pass and the rest of the gateway suite is green:

```
uv run pytest tests/hermes_cli/test_gateway_linger.py tests/hermes_cli/test_gateway_service.py tests/hermes_cli/test_gateway.py
# 124 passed
```

## Test plan
- [x] New regression tests pass locally.
- [x] Reverse-check: new repair-path user-scope test fails on `main` without this fix.
- [x] Full `test_gateway_linger.py`, `test_gateway_service.py`, and `test_gateway.py` pass.