### PR TITLE
feat: support wildcard '*' in terminal.env_passthrough to disable env blocklist

### DIFF
--- a/tools/env_passthrough.py
+++ b/tools/env_passthrough.py
@@ -81,12 +81,14 @@ def _load_config_passthrough() -> frozenset[str]:
 def is_env_passthrough(var_name: str) -> bool:
     """Check whether *var_name* is allowed to pass through to sandboxes.
 
-    Returns ``True`` if the variable was registered by a skill or listed in
-    the user's ``tools.env_passthrough`` config.
+    Returns ``True`` if the variable was registered by a skill, listed in
+    the user's ``terminal.env_passthrough`` config, or if the config
+    contains ``"*"`` (pass through everything — for trusted/self-use agents).
     """
     if var_name in _get_allowed():
         return True
-    return var_name in _load_config_passthrough()
+    cfg = _load_config_passthrough()
+    return "*" in cfg or var_name in cfg
 
 
 def get_all_passthrough() -> frozenset[str]:


### PR DESCRIPTION
## Summary

For trusted/self-use agents, setting `terminal.env_passthrough: ['*']` in config.yaml passes all environment variables through to subprocesses, bypassing the provider env blocklist.

## Motivation

The current env blocklist prevents agents from accessing credentials needed to do useful work (e.g. `GH_TOKEN`, `HASS_TOKEN`). While this is appropriate for multi-tenant or externally-facing deployments, self-use agents operated by their owner don't benefit from this restriction — credential isolation is better handled at the agent instance level.

This gives users an opt-in escape hatch without removing the default security posture.

## Changes

- `tools/env_passthrough.py`: `is_env_passthrough()` now checks for `"*"` in the config passthrough set. When present, all variables pass through regardless of the blocklist.

## Usage

```yaml
# config.yaml
terminal:
  env_passthrough:
    - '*'
```

## Test plan

- Default behavior unchanged — without `*`, blocklist works as before
- With `['*']`, previously-blocked vars (e.g. `GH_TOKEN`, `OPENAI_API_KEY`) are visible in subprocesses