### PR TITLE
fix: remove codex spark model support

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -116,7 +116,6 @@ DEFAULT_CONTEXT_LENGTHS = {
     "gpt-5.4-nano": 400000,           # 400k (not 1.05M like full 5.4)
     "gpt-5.4-mini": 400000,           # 400k (not 1.05M like full 5.4)
     "gpt-5.4": 1050000,               # GPT-5.4, GPT-5.4 Pro (1.05M context)
-    "gpt-5.3-codex-spark": 128000,    # Spark variant has reduced 128k context
     "gpt-5.1-chat": 128000,           # Chat variant has 128k context
     "gpt-5": 400000,                  # GPT-5.x base, mini, codex variants (400k)
     "gpt-4.1": 1047576,

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -24,7 +24,6 @@ _FORWARD_COMPAT_TEMPLATE_MODELS: List[tuple[str, tuple[str, ...]]] = [
     ("gpt-5.4-mini", ("gpt-5.3-codex", "gpt-5.2-codex")),
     ("gpt-5.4", ("gpt-5.3-codex", "gpt-5.2-codex")),
     ("gpt-5.3-codex", ("gpt-5.2-codex",)),
-    ("gpt-5.3-codex-spark", ("gpt-5.3-codex", "gpt-5.2-codex")),
 ]
 
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -225,7 +225,6 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "gpt-5.4-pro",
         "gpt-5.4",
         "gpt-5.3-codex",
-        "gpt-5.3-codex-spark",
         "gpt-5.2",
         "gpt-5.2-codex",
         "gpt-5.1",

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -54,7 +54,7 @@ def test_get_codex_model_ids_falls_back_to_curated_defaults(tmp_path, monkeypatc
 
     assert models[: len(DEFAULT_CODEX_MODELS)] == DEFAULT_CODEX_MODELS
     assert "gpt-5.4" in models
-    assert "gpt-5.3-codex-spark" in models
+    assert "gpt-5.3-codex-spark" not in models
 
 
 def test_get_codex_model_ids_adds_forward_compat_models_from_templates(monkeypatch):
@@ -65,7 +65,7 @@ def test_get_codex_model_ids_adds_forward_compat_models_from_templates(monkeypat
 
     models = get_codex_model_ids(access_token="codex-access-token")
 
-    assert models == ["gpt-5.2-codex", "gpt-5.4-mini", "gpt-5.4", "gpt-5.3-codex", "gpt-5.3-codex-spark"]
+    assert models == ["gpt-5.2-codex", "gpt-5.4-mini", "gpt-5.4", "gpt-5.3-codex"]
 
 
 def test_model_command_uses_runtime_access_token_for_codex_list(monkeypatch):


### PR DESCRIPTION
## Summary
- remove `gpt-5.3-codex-spark` from Codex forward-compat synthesis so it no longer appears as a synthetic fallback model
- drop the unsupported slug from the curated provider catalogs and context metadata
- update Codex model tests to assert Spark is no longer surfaced

## Test plan
- `python3 -m py_compile hermes_cli/codex_models.py hermes_cli/models.py agent/model_metadata.py tests/hermes_cli/test_codex_models.py`
- E2E import/verification against the worktree with an isolated `CODEX_HOME`:
  - `get_codex_model_ids()` no longer returns `gpt-5.3-codex-spark`
  - synthetic API fallback from `gpt-5.2-codex` no longer adds Spark
  - `opencode-zen` catalog no longer lists Spark
  - `DEFAULT_CONTEXT_LENGTHS` no longer contains Spark
