### PR TITLE
feat(cli): add ZenMux as built-in provider

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -31,6 +31,7 @@ model:
   #   "kilocode"     - KiloCode gateway (requires: KILOCODE_API_KEY)
   #   "azure-foundry" - Microsoft Foundry / Azure OpenAI (API key or Entra ID)
   #   "lmstudio"     - LM Studio local server (optional: LM_API_KEY, defaults to http://127.0.0.1:1234/v1)
+  #   "zenmux"       - ZenMux (200+ models, unified API key) (requires: ZENMUX_API_KEY)
   #
   # Local servers (LM Studio, Ollama, vLLM, llama.cpp):
   #   "custom"       - Any other OpenAI-compatible endpoint. Set base_url below.

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -423,6 +423,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("OLLAMA_API_KEY",),
         base_url_env_var="OLLAMA_BASE_URL",
     ),
+    "zenmux": ProviderConfig(
+        id="zenmux",
+        name="ZenMux",
+        auth_type="api_key",
+        inference_base_url="https://zenmux.ai/api/v1",
+        api_key_env_vars=("ZENMUX_API_KEY",),
+        base_url_env_var="ZENMUX_BASE_URL",
+    ),
     "bedrock": ProviderConfig(
         id="bedrock",
         name="AWS Bedrock",

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1517,6 +1517,7 @@ def resolve_provider(
         "go": "opencode-go", "opencode-go-sub": "opencode-go",
         "kilo": "kilocode", "kilo-code": "kilocode", "kilo-gateway": "kilocode",
         "lmstudio": "lmstudio", "lm-studio": "lmstudio", "lm_studio": "lmstudio",
+        "zenmux.ai": "zenmux",
         # Local server aliases — route through the generic custom provider
         "ollama": "custom", "ollama_cloud": "ollama-cloud",
         "vllm": "custom", "llamacpp": "custom",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2603,6 +2603,7 @@ def select_provider_and_model(args=None):
         "ollama-cloud",
         "tencent-tokenhub",
         "lmstudio",
+        "zenmux",
     } or _is_profile_api_key_provider(selected_provider):
         _model_flow_api_key_provider(config, selected_provider, current_model)
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -451,6 +451,15 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "moonshotai/Kimi-K2-Thinking",
         "moonshotai/Kimi-K2.6",
     ],
+    "zenmux": [
+        "anthropic/claude-opus-4.7",
+        "anthropic/claude-sonnet-4.6",
+        "openai/gpt-5.4",
+        "google/gemini-3-flash-preview",
+        "deepseek/deepseek-chat",
+        "x-ai/grok-4-fast",
+        "qwen/qwen3.6-plus",
+    ],
     # AWS Bedrock — static fallback list used when dynamic discovery is
     # unavailable (no boto3, no credentials, or API error).  The agent
     # prefers live discovery via ListFoundationModels + ListInferenceProfiles.
@@ -925,6 +934,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("kilocode",       "Kilo Code",                "Kilo Code (Kilo Gateway API)"),
     ProviderEntry("opencode-zen",   "OpenCode Zen",             "OpenCode Zen (Curated models, pay-as-you-go)"),
     ProviderEntry("opencode-go",    "OpenCode Go",              "OpenCode Go (Open models subscription)"),
+    ProviderEntry("zenmux",         "ZenMux",                   "ZenMux (200+ models, unified API key — zenmux.ai)"),
     ProviderEntry("bedrock",        "AWS Bedrock",              "AWS Bedrock (Claude, Nova, Llama, DeepSeek; IAM or API key)"),
     ProviderEntry("azure-foundry",  "Azure Foundry",            "Azure Foundry (OpenAI-style or Anthropic-style endpoint, your Azure AI deployment)"),
     ProviderEntry("qwen-oauth",     "Qwen OAuth (Portal)",      "Qwen OAuth (Reuses local Qwen CLI login)"),
@@ -1134,6 +1144,7 @@ _PROVIDER_ALIASES = {
     "lm_studio": "lmstudio",
     "ollama": "custom",  # bare "ollama" = local; use "ollama-cloud" for cloud
     "ollama_cloud": "ollama-cloud",
+    "zenmux.ai": "zenmux",
 }
 
 

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -212,6 +212,11 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         transport="bedrock_converse",
         auth_type="aws_sdk",
     ),
+    "zenmux": HermesOverlay(
+        transport="openai_chat",
+        is_aggregator=True,
+        base_url_env_var="ZENMUX_BASE_URL",
+    ),
 }
 
 
@@ -348,6 +353,9 @@ ALIASES: Dict[str, str] = {
     # gmi
     "gmi-cloud": "gmi",
     "gmicloud": "gmi",
+
+    # zenmux
+    "zenmux.ai": "zenmux",
 
     # Local server aliases → virtual "local" concept (resolved via user config)
     "lmstudio": "lmstudio",

--- a/tests/hermes_cli/test_zenmux_provider.py
+++ b/tests/hermes_cli/test_zenmux_provider.py
@@ -1,0 +1,148 @@
+"""Tests for ZenMux provider support — OpenAI-compatible aggregator."""
+
+import pytest
+
+from hermes_cli.auth import (
+    PROVIDER_REGISTRY,
+    resolve_provider,
+    get_api_key_provider_status,
+    resolve_api_key_provider_credentials,
+)
+
+
+_OTHER_PROVIDER_KEYS = (
+    "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "DEEPSEEK_API_KEY",
+    "GOOGLE_API_KEY", "GEMINI_API_KEY", "DASHSCOPE_API_KEY",
+    "XAI_API_KEY", "KIMI_API_KEY", "KIMI_CN_API_KEY",
+    "MINIMAX_API_KEY", "MINIMAX_CN_API_KEY", "AI_GATEWAY_API_KEY",
+    "KILOCODE_API_KEY", "HF_TOKEN", "GLM_API_KEY", "ZAI_API_KEY",
+    "XIAOMI_API_KEY", "COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN",
+    "ARCEEAI_API_KEY", "OLLAMA_API_KEY",
+)
+
+
+# =============================================================================
+# Provider Registry
+# =============================================================================
+
+
+class TestZenmuxProviderRegistry:
+    def test_registered(self):
+        assert "zenmux" in PROVIDER_REGISTRY
+
+    def test_name(self):
+        assert PROVIDER_REGISTRY["zenmux"].name == "ZenMux"
+
+    def test_auth_type(self):
+        assert PROVIDER_REGISTRY["zenmux"].auth_type == "api_key"
+
+    def test_inference_base_url(self):
+        assert PROVIDER_REGISTRY["zenmux"].inference_base_url == "https://zenmux.ai/api/v1"
+
+    def test_api_key_env_vars(self):
+        assert PROVIDER_REGISTRY["zenmux"].api_key_env_vars == ("ZENMUX_API_KEY",)
+
+    def test_base_url_env_var(self):
+        assert PROVIDER_REGISTRY["zenmux"].base_url_env_var == "ZENMUX_BASE_URL"
+
+
+# =============================================================================
+# Aliases
+# =============================================================================
+
+
+class TestZenmuxAliases:
+    def test_alias_zenmux_ai(self, monkeypatch):
+        for key in _OTHER_PROVIDER_KEYS + ("OPENROUTER_API_KEY",):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("ZENMUX_API_KEY", "zm-test-12345")
+        assert resolve_provider("zenmux.ai") == "zenmux"
+
+    def test_normalize_provider_models_py(self):
+        from hermes_cli.models import normalize_provider
+        assert normalize_provider("zenmux.ai") == "zenmux"
+
+    def test_normalize_provider_providers_py(self):
+        from hermes_cli.providers import normalize_provider
+        assert normalize_provider("zenmux.ai") == "zenmux"
+
+
+# =============================================================================
+# Credentials
+# =============================================================================
+
+
+class TestZenmuxCredentials:
+    def test_status_configured(self, monkeypatch):
+        monkeypatch.setenv("ZENMUX_API_KEY", "zm-test")
+        status = get_api_key_provider_status("zenmux")
+        assert status["configured"]
+
+    def test_status_not_configured(self, monkeypatch):
+        monkeypatch.delenv("ZENMUX_API_KEY", raising=False)
+        status = get_api_key_provider_status("zenmux")
+        assert not status["configured"]
+
+    def test_openrouter_key_does_not_make_zenmux_configured(self, monkeypatch):
+        monkeypatch.delenv("ZENMUX_API_KEY", raising=False)
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-test")
+        status = get_api_key_provider_status("zenmux")
+        assert not status["configured"]
+
+    def test_resolve_credentials(self, monkeypatch):
+        monkeypatch.setenv("ZENMUX_API_KEY", "zm-direct-key")
+        monkeypatch.delenv("ZENMUX_BASE_URL", raising=False)
+        creds = resolve_api_key_provider_credentials("zenmux")
+        assert creds["api_key"] == "zm-direct-key"
+        assert creds["base_url"] == "https://zenmux.ai/api/v1"
+
+    def test_custom_base_url_override(self, monkeypatch):
+        monkeypatch.setenv("ZENMUX_API_KEY", "zm-x")
+        monkeypatch.setenv("ZENMUX_BASE_URL", "https://custom.zenmux.example/v1")
+        creds = resolve_api_key_provider_credentials("zenmux")
+        assert creds["base_url"] == "https://custom.zenmux.example/v1"
+
+
+# =============================================================================
+# Model catalog
+# =============================================================================
+
+
+class TestZenmuxModelCatalog:
+    def test_static_model_list(self):
+        from hermes_cli.models import _PROVIDER_MODELS
+        assert "zenmux" in _PROVIDER_MODELS
+        models = _PROVIDER_MODELS["zenmux"]
+        assert len(models) >= 1
+
+    def test_canonical_provider_entry(self):
+        from hermes_cli.models import CANONICAL_PROVIDERS
+        slugs = [p.slug for p in CANONICAL_PROVIDERS]
+        assert "zenmux" in slugs
+
+
+# =============================================================================
+# providers.py overlay + aliases
+# =============================================================================
+
+
+class TestZenmuxProvidersModule:
+    def test_overlay_exists(self):
+        from hermes_cli.providers import HERMES_OVERLAYS
+        assert "zenmux" in HERMES_OVERLAYS
+        overlay = HERMES_OVERLAYS["zenmux"]
+        assert overlay.transport == "openai_chat"
+        assert overlay.is_aggregator is True
+        assert overlay.base_url_env_var == "ZENMUX_BASE_URL"
+
+    def test_get_provider(self):
+        from hermes_cli.providers import get_provider
+        pdef = get_provider("zenmux")
+        assert pdef is not None
+        assert pdef.id == "zenmux"
+        assert pdef.transport == "openai_chat"
+        assert pdef.is_aggregator is True
+
+    def test_determine_api_mode(self):
+        from hermes_cli.providers import determine_api_mode
+        assert determine_api_mode("zenmux") == "chat_completions"


### PR DESCRIPTION
## What does this PR do?

Add ZenMux (https://zenmux.ai) as a first-class built-in provider in the `hermes model` selector.

Previously, users had to manually configure ZenMux as a "Custom endpoint" by entering the URL and API key. Now they can select it directly from the provider menu — same experience as OpenRouter, DeepSeek, or Vercel AI Gateway.

ZenMux is an OpenAI-compatible API aggregator supporting 200+ models with a unified API key.

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/models.py`: Add `ProviderEntry` to `CANONICAL_PROVIDERS`, curated 7-model fallback list to `_PROVIDER_MODELS`, alias `zenmux.ai` to `_PROVIDER_ALIASES`
- `hermes_cli/auth.py`: Add `ProviderConfig` to `PROVIDER_REGISTRY` (base URL: `https://zenmux.ai/api/v1`, env var: `ZENMUX_API_KEY`), add `zenmux.ai` alias to `resolve_provider()` internal alias dict
- `hermes_cli/providers.py`: Add `HermesOverlay` to `HERMES_OVERLAYS` (`is_aggregator=True`, `transport=openai_chat`), add alias to `ALIASES`
- `hermes_cli/main.py`: Add `"zenmux"` to the generic `_model_flow_api_key_provider` routing tuple
- `cli-config.yaml.example`: Add ZenMux to provider documentation comments
- `tests/hermes_cli/test_zenmux_provider.py`: 19 tests covering registry, aliases, credentials, model catalog, overlay, and API mode

## How to Test

1. `python -m hermes_cli.main model` → ZenMux appears as "ZenMux (200+ models, unified API key — zenmux.ai)" in the provider list
2. Select ZenMux → prompts for `ZENMUX_API_KEY` → shows base URL `https://zenmux.ai/api/v1` → fetches live model list via `/v1/models`
3. Select a model → start conversation → verify model responds correctly
4. Verify alias: `python -c "from hermes_cli.providers import normalize_provider; assert normalize_provider('zenmux.ai') == 'zenmux'"`
5. Run tests: `pytest tests/hermes_cli/test_zenmux_provider.py -v` (19 passed)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (19 tests in `test_zenmux_provider.py`)
- [x] I've tested on my platform: macOS 15 (Darwin 24.4.0), Python 3.11

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — pure data registration, no UI changes. ZenMux reuses the existing generic `_model_flow_api_key_provider` flow identical to other aggregators (OpenRouter, Vercel AI Gateway, KiloCode, etc.).
