### PR TITLE
fix(model_metadata): add Ollama-style naming for Gemma 4 context length

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -123,10 +123,16 @@ DEFAULT_CONTEXT_LENGTHS = {
     "gpt-4": 128000,
     # Google
     "gemini": 1048576,
-    # Gemma (open models served via AI Studio)
-    "gemma-4-31b": 256000,
-    "gemma-3": 131072,
-    "gemma": 8192,  # fallback for older gemma models
+	# Gemma (open models served via AI Studio, Ollama Cloud, etc.)
+	# Gemma 4 family (256K context) — include Ollama-style naming
+	"gemma-4-31b": 262144,
+	"gemma-4-27b": 262144,
+	"gemma4": 262144, # Ollama-style: gemma4:31b-cloud, gemma4:27b
+	# Gemma 3 family (128K context) — include Ollama-style naming
+	"gemma-3": 131072,
+	"gemma3": 131072, # Ollama-style: gemma3:27b, gemma3:12b
+	# Older Gemma models (8K context)
+	"gemma": 8192, # fallback for older gemma models
     # DeepSeek
     "deepseek": 128000,
     # Meta

--- a/tests/hermes_cli/test_gemini_provider.py
+++ b/tests/hermes_cli/test_gemini_provider.py
@@ -176,11 +176,18 @@ class TestGeminiContextLength:
         with patch("agent.models_dev.lookup_models_dev_context", return_value=None), \
              patch("agent.model_metadata.fetch_model_metadata", return_value={}):
             ctx = get_model_context_length("gemma-4-31b-it", provider="gemini")
-        assert ctx == 256000
+        assert ctx == 262144  # 256K context (256 * 1024)
 
     def test_gemini_3_context(self):
         ctx = get_model_context_length("gemini-3.1-pro-preview", provider="gemini")
         assert ctx == 1048576
+    def test_gemma4_ollama_style_context(self):
+        """Test Ollama Cloud naming style (gemma4:31b-cloud)."""
+        with patch("agent.models_dev.lookup_models_dev_context", return_value=None), \
+            patch("agent.model_metadata.fetch_model_metadata", return_value={}):
+            ctx = get_model_context_length("gemma4:31b-cloud")
+            assert ctx == 262144  # 256K context
+
 
 
 # ── Agent Init (no SyntaxError) ──


### PR DESCRIPTION
## Summary

Fixes #12976 - Gemma 4 models were incorrectly resolving to 8K context instead of 256K when used via Ollama Cloud.

## Problem

The `DEFAULT_CONTEXT_LENGTHS` dict in `agent/model_metadata.py` uses substring matching to find context lengths. Ollama Cloud names Gemma 4 as `gemma4:31b-cloud`, which:
1. Does NOT match `"gemma-4-31b"` (has hyphen, Ollama doesn't)
2. DOES match `"gemma"` (generic fallback for older models)
3. Returns 8192 instead of 262144

## Solution

Added Ollama-style naming entries:
- `"gemma4": 262144` - matches `gemma4:31b-cloud`, `gemma4:27b`
- `"gemma-4-27b": 262144` - explicit 27B variant
- `"gemma3": 131072` - Ollama-style for Gemma 3

Also fixed incorrect value: `256000` -> `262144` (actual 256K = 256 * 1024)

## Testing

- Updated existing test to expect correct 262144 value
- Added new test `test_gemma4_ollama_style_context` for Ollama naming
- All 3 context length tests pass locally

## Files Changed

- `agent/model_metadata.py` - Add Gemma 4/3 Ollama-style keys
- `tests/hermes_cli/test_gemini_provider.py` - Update tests