### PR TITLE
feat(whatsapp): implement send_voice for native audio message delivery

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -773,6 +773,17 @@ class WhatsAppAdapter(BasePlatformAdapter):
         """Send a video natively via bridge — plays inline in WhatsApp."""
         return await self._send_media_to_bridge(chat_id, video_path, "video", caption)
 
+    async def send_voice(
+        self,
+        chat_id: str,
+        audio_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Send an audio file as a WhatsApp voice message via bridge."""
+        return await self._send_media_to_bridge(chat_id, audio_path, "audio", caption)
+
     async def send_document(
         self,
         chat_id: str,


### PR DESCRIPTION
## Summary
Cherry-pick of #12513 by @sprmn24 onto current main.

Adds `send_voice` to the WhatsApp adapter, routing through `_send_media_to_bridge` with `media_type='audio'`. Matches the existing `send_video` / `send_document` pattern. Without this, TTS/audio responses fell back to the base class which sends the file path as text.

## Changes
- `gateway/platforms/whatsapp.py`: added `send_voice` method (11 lines)

## Validation
Clean cherry-pick, no conflicts. Method slots in between `send_video` and `send_document` exactly as intended.