### PR TITLE
feat(gateway/discord): add strict_mention config option

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -614,6 +614,8 @@ def load_gateway_config() -> GatewayConfig:
             if isinstance(discord_cfg, dict):
                 if "require_mention" in discord_cfg and not os.getenv("DISCORD_REQUIRE_MENTION"):
                     os.environ["DISCORD_REQUIRE_MENTION"] = str(discord_cfg["require_mention"]).lower()
+                if "strict_mention" in discord_cfg and not os.getenv("DISCORD_STRICT_MENTION"):
+                    os.environ["DISCORD_STRICT_MENTION"] = str(discord_cfg["strict_mention"]).lower()
                 frc = discord_cfg.get("free_response_channels")
                 if frc is not None and not os.getenv("DISCORD_FREE_RESPONSE_CHANNELS"):
                     if isinstance(frc, list):

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -916,6 +916,16 @@ class DiscordAdapter(BasePlatformAdapter):
                 except Exception as e:
                     logger.debug("Could not fetch reply-to message: %s", e)
 
+            # Extract mentioned user IDs from content to allow Discord to
+            # actually trigger notifications for <@ID> patterns.  Without
+            # allowed_mentions, Discord renders them as plain text.
+            mentioned_user_ids = re.findall(r"<@!?(\d+)>", content)
+            allowed_mentions = None
+            if mentioned_user_ids:
+                allowed_mentions = discord.AllowedMentions(
+                    users=[discord.Object(id=int(uid)) for uid in mentioned_user_ids]
+                )
+
             for i, chunk in enumerate(chunks):
                 if self._reply_to_mode == "all":
                     chunk_reference = reference
@@ -925,6 +935,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     msg = await channel.send(
                         content=chunk,
                         reference=chunk_reference,
+                        allowed_mentions=allowed_mentions,
                     )
                 except Exception as e:
                     err_text = str(e)
@@ -947,6 +958,7 @@ class DiscordAdapter(BasePlatformAdapter):
                         msg = await channel.send(
                             content=chunk,
                             reference=None,
+                            allowed_mentions=allowed_mentions,
                         )
                     else:
                         raise
@@ -2488,6 +2500,20 @@ class DiscordAdapter(BasePlatformAdapter):
             return bool(configured)
         return os.getenv("DISCORD_REQUIRE_MENTION", "true").lower() not in ("false", "0", "no", "off")
 
+    def _discord_strict_mention(self) -> bool:
+        """Return whether @mention is always required, even in bot-joined threads.
+
+        When strict_mention is enabled, the bot-thread mention bypass is disabled.
+        This is useful in multi-participant threads where the bot should not
+        respond to messages directed at other participants.
+        """
+        configured = self.config.extra.get("strict_mention")
+        if configured is not None:
+            if isinstance(configured, str):
+                return configured.lower() in ("true", "1", "yes", "on")
+            return bool(configured)
+        return os.getenv("DISCORD_STRICT_MENTION", "false").lower() in ("true", "1", "yes", "on")
+
     def _discord_free_response_channels(self) -> set:
         """Return Discord channel IDs where no bot mention is required."""
         raw = self.config.extra.get("free_response_channels")
@@ -2948,6 +2974,7 @@ class DiscordAdapter(BasePlatformAdapter):
         #
         # Config (all settable via discord.* in config.yaml or DISCORD_* env vars):
         #   discord.require_mention: Require @mention in server channels (default: true)
+        #   discord.strict_mention: Always require @mention, even in bot threads (default: false)
         #   discord.free_response_channels: Channel IDs where bot responds without mention
         #   discord.ignored_channels: Channel IDs where bot NEVER responds (even when mentioned)
         #   discord.allowed_channels: If set, bot ONLY responds in these channels (whitelist)
@@ -2987,6 +3014,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 channel_ids.add(parent_channel_id)
 
             require_mention = self._discord_require_mention()
+            strict_mention = self._discord_strict_mention()
             # Voice-linked text channels act as free-response while voice is active.
             # Only the exact bound channel gets the exemption, not sibling threads.
             voice_linked_ids = {str(ch_id) for ch_id in self._voice_text_channels.values()}
@@ -2996,7 +3024,10 @@ class DiscordAdapter(BasePlatformAdapter):
 
             # Skip the mention check if the message is in a thread where
             # the bot has previously participated (auto-created or replied in).
-            in_bot_thread = is_thread and thread_id in self._threads
+            # When strict_mention is enabled, this bypass is disabled — @mention
+            # is always required, which is useful in multi-participant threads
+            # where the bot should not respond to messages directed at others.
+            in_bot_thread = (not strict_mention) and is_thread and thread_id in self._threads
 
             if require_mention and not is_free_channel and not in_bot_thread:
                 if self._client.user not in message.mentions:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -154,6 +154,27 @@ if _config_path.exists():
                         os.environ[_env_var] = json.dumps(_val)
                     else:
                         os.environ[_env_var] = str(_val)
+        # Discord config — bridge to DISCORD_* env vars so the platform adapter
+        # can read them via os.getenv() like it expects.
+        _discord_cfg = _cfg.get("discord", {})
+        if _discord_cfg and isinstance(_discord_cfg, dict):
+            _discord_env_map = {
+                "require_mention": "DISCORD_REQUIRE_MENTION",
+                "strict_mention": "DISCORD_STRICT_MENTION",
+                "free_response_channels": "DISCORD_FREE_RESPONSE_CHANNELS",
+                "auto_thread": "DISCORD_AUTO_THREAD",
+                "reactions": "DISCORD_REACTIONS",
+                "allowed_channels": "DISCORD_ALLOWED_CHANNELS",
+                "ignored_channels": "DISCORD_IGNORED_CHANNELS",
+                "no_thread_channels": "DISCORD_NO_THREAD_CHANNELS",
+            }
+            for _cfg_key, _env_var in _discord_env_map.items():
+                if _cfg_key in _discord_cfg:
+                    _val = _discord_cfg[_cfg_key]
+                    if isinstance(_val, list):
+                        os.environ[_env_var] = ",".join(str(v) for v in _val)
+                    else:
+                        os.environ[_env_var] = str(_val)
         # Compression config is read directly from config.yaml by run_agent.py
         # and auxiliary_client.py — no env var bridging needed.
         # Auxiliary model/direct-endpoint overrides (vision, web_extract).

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -717,6 +717,7 @@ DEFAULT_CONFIG = {
     # Discord platform settings (gateway mode)
     "discord": {
         "require_mention": True,       # Require @mention to respond in server channels
+        "strict_mention": False,       # If True, always require @mention even in threads bot has participated in
         "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
         "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
         "auto_thread": True,           # Auto-create threads on @mention in channels (like Slack)


### PR DESCRIPTION
## Summary

Add `discord.strict_mention` config option that, when enabled, always requires @mention even in threads the bot has previously participated in.

## Problem

By default, once the bot joins a Discord thread, it responds to **all** messages in that thread without requiring @mention. This is fine for 1-on-1 conversations, but problematic in **multi-participant threads** where the bot should not respond to messages directed at other participants.

In team channels with multiple agents or users, the bot currently "eavesdrops" on every message and jumps in unprompted — even when the message is clearly directed at someone else.

## Solution

New `strict_mention` option (default: `false` — no behavior change for existing users):

| strict_mention | Behavior |
|---|---|
| `false` (default) | Bot responds freely in threads it has joined (current behavior) |
| `true` | Bot always requires @mention, even in threads it has joined |

This only affects server channels. DMs and `free_response_channels` are unaffected.

## Changes

- **`gateway/platforms/discord.py`**: Add `_discord_strict_mention()` helper method (follows `_discord_require_mention` pattern). When `strict_mention=true`, the `in_bot_thread` mention bypass is disabled.
- **`gateway/config.py`**: Bridge `discord.strict_mention` → `DISCORD_STRICT_MENTION` env var.
- **`gateway/run.py`**: Add Discord config env var bridging for `strict_mention` and other Discord settings.
- **`hermes_cli/config.py`**: Add `strict_mention: False` to `DEFAULT_CONFIG["discord"]`.

Also includes: `allowed_mentions` fix for Discord user notification rendering (`<@ID>` patterns in bot responses now actually trigger Discord notifications).

## Configuration

```yaml
# config.yaml
discord:
  require_mention: true
  strict_mention: true   # Always require @mention, even in bot-joined threads
```

Or via env var:
```bash
DISCORD_STRICT_MENTION=true
```

## Testing

- Verified on live Discord gateway: with `strict_mention=true`, bot only responds when @mentioned in multi-participant threads
- `free_response_channels` (e.g. #agent-hermes) continue to work without @mention
- DMs unaffected