### PR TITLE
fix(cli): hide idle stopwatch (⏲ 0s) in status bar

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2276,7 +2276,7 @@ class HermesCLI:
             parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label]
             parts.append(duration_label)
             prompt_elapsed = snapshot.get("prompt_elapsed")
-            if prompt_elapsed:
+            if prompt_elapsed and prompt_elapsed != "⏲ 0s":
                 parts.append(prompt_elapsed)
             return self._trim_status_bar_text(" │ ".join(parts), width)
         except Exception:
@@ -2339,7 +2339,7 @@ class HermesCLI:
                     ]
                     # Position 7: per-prompt elapsed timer (live or frozen)
                     prompt_elapsed = snapshot.get("prompt_elapsed")
-                    if prompt_elapsed:
+                    if prompt_elapsed and prompt_elapsed != "⏲ 0s":
                         frags.append(("class:status-bar-dim", " │ "))
                         frags.append(("class:status-bar-dim", prompt_elapsed))
                     frags.append(("class:status-bar", " "))


### PR DESCRIPTION
## Summary
When Hermes CLI is left idle (no prompt running), the status bar permanently shows `⏲ 0s` stopwatch segment. This PR adds a check to skip rendering the segment when the elapsed value is zero / the idle string.

## Fix
Added `and prompt_elapsed != "⏲ 0s"` condition at two locations in `cli.py`:
- Line ~2279: `_build_status_bar_text()` method
- Line ~2342: `_get_status_bar_fragments()` method

## Testing
- [x] Code compiles without errors (lint passed)
- [ ] Tested locally - Mas Gun can verify by leaving CLI idle

Closes #13020