### PR TITLE
approval: block live self-gateway restarts from messaging turns

### DIFF
--- a/tests/tools/test_command_guards.py
+++ b/tests/tools/test_command_guards.py
@@ -39,7 +39,14 @@ def _clean_state():
     approval_module._pending.clear()
     approval_module._permanent_approved.clear()
     saved = {}
-    for k in ("HERMES_INTERACTIVE", "HERMES_GATEWAY_SESSION", "HERMES_EXEC_ASK", "HERMES_YOLO_MODE"):
+    for k in (
+        "HERMES_INTERACTIVE",
+        "HERMES_GATEWAY_SESSION",
+        "HERMES_EXEC_ASK",
+        "HERMES_YOLO_MODE",
+        "HERMES_SESSION_PLATFORM",
+        "HERMES_HOME",
+    ):
         if k in os.environ:
             saved[k] = os.environ.pop(k)
     yield
@@ -48,7 +55,14 @@ def _clean_state():
     approval_module._permanent_approved.clear()
     for k, v in saved.items():
         os.environ[k] = v
-    for k in ("HERMES_INTERACTIVE", "HERMES_GATEWAY_SESSION", "HERMES_EXEC_ASK", "HERMES_YOLO_MODE"):
+    for k in (
+        "HERMES_INTERACTIVE",
+        "HERMES_GATEWAY_SESSION",
+        "HERMES_EXEC_ASK",
+        "HERMES_YOLO_MODE",
+        "HERMES_SESSION_PLATFORM",
+        "HERMES_HOME",
+    ):
         os.environ.pop(k, None)
 
 
@@ -164,6 +178,38 @@ class TestTirithAllowDangerous:
         cb.assert_called_once()
         # allow_permanent should be True (no tirith warning)
         assert cb.call_args[1]["allow_permanent"] is True
+
+    @patch(_TIRITH_PATCH, return_value=_tirith_result("allow"))
+    def test_live_discord_self_gateway_restart_is_hard_blocked(self, mock_tirith):
+        os.environ["HERMES_SESSION_PLATFORM"] = "discord"
+        os.environ["HERMES_HOME"] = "/home/tester/.hermes/profiles/satori-hermes"
+        result = check_all_command_guards(
+            "systemctl --user restart hermes-gateway-satori-hermes.service",
+            "local",
+        )
+        assert result["approved"] is False
+        assert result.get("status") == "blocked"
+        assert "do not stop or restart that same live gateway synchronously" in result["message"].lower()
+
+    @patch(_TIRITH_PATCH, return_value=_tirith_result("allow"))
+    def test_live_discord_other_gateway_restart_only_needs_normal_approval(self, mock_tirith):
+        os.environ["HERMES_SESSION_PLATFORM"] = "discord"
+        os.environ["HERMES_HOME"] = "/home/tester/.hermes/profiles/satori-hermes"
+        result = check_all_command_guards(
+            "systemctl --user restart hermes-gateway-other.service",
+            "local",
+        )
+        assert result["approved"] is False
+        assert result.get("status") == "approval_required"
+        assert "stop/restart system service" in result["description"]
+
+    @patch(_TIRITH_PATCH, return_value=_tirith_result("allow"))
+    def test_live_discord_surface_uses_session_platform_for_other_dangerous_commands(self, mock_tirith):
+        os.environ["HERMES_SESSION_PLATFORM"] = "discord"
+        result = check_all_command_guards("rm -rf /tmp/demo", "local")
+        assert result["approved"] is False
+        assert result.get("status") == "approval_required"
+        assert result["description"] in {"recursive delete", "delete in root path"}
 
 
 # ---------------------------------------------------------------------------

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -184,6 +184,40 @@ def _normalize_command_for_detection(command: str) -> str:
     return command
 
 
+def _is_live_messaging_surface() -> bool:
+    from gateway.session_context import get_session_env
+
+    return bool(
+        os.getenv("HERMES_GATEWAY_SESSION")
+        or get_session_env("HERMES_SESSION_PLATFORM")
+    )
+
+
+def _current_gateway_unit() -> str:
+    from hermes_cli.gateway import get_service_name
+
+    service_name = (get_service_name() or "").strip()
+    if not service_name:
+        return ""
+    return f"{service_name}.service"
+
+
+def _is_live_self_gateway_interruption(command: str) -> bool:
+    if not _is_live_messaging_surface():
+        return False
+    current_unit = _current_gateway_unit()
+    if not current_unit:
+        return False
+    normalized = _normalize_command_for_detection(command).lower()
+    if current_unit.lower() not in normalized:
+        return False
+    return bool(re.search(
+        r'\bsystemctl\b[^\n]*\b(?:stop|restart|reload-or-restart|try-restart)\b',
+        normalized,
+        re.IGNORECASE | re.DOTALL,
+    ))
+
+
 def detect_dangerous_command(command: str) -> tuple:
     """Check if a command matches any dangerous patterns.
 
@@ -624,7 +658,7 @@ def check_dangerous_command(command: str, env_type: str,
         return {"approved": True, "message": None}
 
     is_cli = os.getenv("HERMES_INTERACTIVE")
-    is_gateway = os.getenv("HERMES_GATEWAY_SESSION")
+    is_gateway = _is_live_messaging_surface()
 
     if not is_cli and not is_gateway:
         # Cron sessions: respect cron_mode config
@@ -731,8 +765,25 @@ def check_all_command_guards(command: str, env_type: str,
     if os.getenv("HERMES_YOLO_MODE") or is_current_session_yolo_enabled() or approval_mode == "off":
         return {"approved": True, "message": None}
 
+    if _is_live_self_gateway_interruption(command):
+        from gateway.session_context import get_session_env
+
+        platform = (get_session_env("HERMES_SESSION_PLATFORM") or "gateway").strip().lower()
+        current_unit = _current_gateway_unit()
+        return {
+            "approved": False,
+            "status": "blocked",
+            "pattern_key": "stop/restart system service",
+            "description": "interrupt current hermes gateway service from live messaging turn",
+            "message": (
+                f"BLOCKED: This {platform} turn is running through {current_unit}. "
+                "Do not stop or restart that same live gateway synchronously. "
+                "Use a detached or staged handoff instead."
+            ),
+        }
+
     is_cli = os.getenv("HERMES_INTERACTIVE")
-    is_gateway = os.getenv("HERMES_GATEWAY_SESSION")
+    is_gateway = _is_live_messaging_surface()
     is_ask = os.getenv("HERMES_EXEC_ASK")
 
     # Preserve the existing non-interactive behavior: outside CLI/gateway/ask


### PR DESCRIPTION
## Summary
- treat `HERMES_SESSION_PLATFORM` as a live messaging surface in approval guards
- block synchronous stop/restart of the currently serving Hermes gateway from that same live turn
- add regression tests for self-gateway interruption and non-self gateway behavior

## Why
A live messaging turn should not be able to synchronously stop or restart the gateway that is currently serving that turn. That self-interrupts the session and is a generic safety issue, not a Spark-specific one.

## Test Plan
- pytest -q tests/tools/test_command_guards.py
