### PR TITLE
fix(mcp): respect ssl_verify config for StreamableHTTP servers

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -950,6 +950,7 @@ class MCPServerTask:
         url = config["url"]
         headers = dict(config.get("headers") or {})
         connect_timeout = config.get("connect_timeout", _DEFAULT_CONNECT_TIMEOUT)
+        ssl_verify = config.get("ssl_verify", True)
 
         # OAuth 2.1 PKCE: build httpx.Auth handler using the MCP SDK.
         # If OAuth setup fails (e.g. non-interactive environment without
@@ -978,6 +979,7 @@ class MCPServerTask:
             client_kwargs: dict = {
                 "follow_redirects": True,
                 "timeout": httpx.Timeout(float(connect_timeout), read=300.0),
+                "verify": ssl_verify,
             }
             if headers:
                 client_kwargs["headers"] = headers
@@ -1001,6 +1003,7 @@ class MCPServerTask:
             _http_kwargs: dict = {
                 "headers": headers,
                 "timeout": float(connect_timeout),
+                "verify": ssl_verify,
             }
             if _oauth_auth is not None:
                 _http_kwargs["auth"] = _oauth_auth


### PR DESCRIPTION
## Problem

When an MCP server config has `ssl_verify: false` set in `config.yaml` (needed for local dev environments with self-signed certs — ServBay, LocalWP, MAMP, etc.), the value was read from the config but **never actually passed to the httpx client**.

This caused `[SSL: CERTIFICATE_VERIFY_FAILED]` errors at Hermes startup, the MCP server silently failing all 3 connection attempts, and the tools never appearing — even though the config looked correct.

## Fix

Read `ssl_verify` from the server config block and pass it as the `verify` kwarg in both HTTP code paths:

- **New API** (`mcp >= 1.24.0`): `httpx.AsyncClient(verify=ssl_verify)`
- **Legacy API** (`mcp < 1.24.0`): `streamablehttp_client(..., verify=ssl_verify)`

Default is `True` (no change in behavior for existing configs without the key).

## Testing

Verified against a local ServBay WordPress install (`dev.afocal.com`) with a self-signed cert. Before the fix: SSL errors on every startup. After: both `wordpress` and `elementor` MCP servers connect and register their tools successfully.

## Config example this enables

```yaml
mcp_servers:
  wordpress:
    url: https://dev.example.com/wp-json/mcp/mcp-adapter-default-server
    headers:
      Authorization: Basic <token>
    ssl_verify: false   # was silently ignored before this fix
```