### PR TITLE
Prepare official Hermes fork for first safe Powerunits Railway deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,5 +52,4 @@ RUN uv venv && \
 # ---------- Runtime ----------
 ENV HERMES_WEB_DIST=/opt/hermes/hermes_cli/web_dist
 ENV HERMES_HOME=/opt/data
-VOLUME [ "/opt/data" ]
 ENTRYPOINT [ "/opt/hermes/docker/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,4 +52,5 @@ RUN uv venv && \
 # ---------- Runtime ----------
 ENV HERMES_WEB_DIST=/opt/hermes/hermes_cli/web_dist
 ENV HERMES_HOME=/opt/data
+ENV HERMES_POWERUNITS_RUNTIME_POLICY=first_safe_v1
 ENTRYPOINT [ "/opt/hermes/docker/entrypoint.sh" ]

--- a/docker/apply_powerunits_runtime_policy.py
+++ b/docker/apply_powerunits_runtime_policy.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""
+Apply Powerunits first-deployment runtime safety policy.
+
+This is intentionally narrow:
+- keep Hermes install intact for future phases
+- enforce a fail-closed platform/tool surface for first Railway deployment
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import yaml
+
+
+POLICY_ID = "first_safe_v1"
+
+ALLOWED_TELEGRAM_TOOLSETS = [
+    "memory",
+    "session_search",
+    "skills",
+    "todo",
+    "no_mcp",
+]
+
+DISABLED_PLATFORMS = [
+    "discord",
+    "whatsapp",
+    "slack",
+    "signal",
+    "homeassistant",
+    "email",
+    "sms",
+    "mattermost",
+    "matrix",
+    "dingtalk",
+    "feishu",
+    "wecom",
+    "wecom_callback",
+    "weixin",
+    "qqbot",
+    "webhook",
+    "api_server",
+    "bluebubbles",
+]
+
+
+def _load_yaml(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return data if isinstance(data, dict) else {}
+
+
+def _save_yaml(path: Path, data: dict) -> None:
+    path.write_text(
+        yaml.safe_dump(
+            data,
+            sort_keys=False,
+            allow_unicode=False,
+            default_flow_style=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+def apply_policy(config_path: Path) -> None:
+    cfg = _load_yaml(config_path)
+
+    # Enforce narrow, explicit platform toolset policy (fail-closed for gateway usage).
+    platform_toolsets = cfg.get("platform_toolsets")
+    if not isinstance(platform_toolsets, dict):
+        platform_toolsets = {}
+    platform_toolsets["telegram"] = list(ALLOWED_TELEGRAM_TOOLSETS)
+    for p in DISABLED_PLATFORMS:
+        platform_toolsets[p] = []
+    cfg["platform_toolsets"] = platform_toolsets
+
+    # Enforce platform exposure defaults: Telegram enabled, all others disabled.
+    platforms = cfg.get("platforms")
+    if not isinstance(platforms, dict):
+        platforms = {}
+    telegram_cfg = platforms.get("telegram")
+    if not isinstance(telegram_cfg, dict):
+        telegram_cfg = {}
+    telegram_cfg["enabled"] = True
+    platforms["telegram"] = telegram_cfg
+
+    for p in DISABLED_PLATFORMS:
+        plat_cfg = platforms.get(p)
+        if not isinstance(plat_cfg, dict):
+            plat_cfg = {}
+        plat_cfg["enabled"] = False
+        platforms[p] = plat_cfg
+    cfg["platforms"] = platforms
+
+    # Keep explicit manual approvals and deny dangerous cron execution in this phase.
+    approvals = cfg.get("approvals")
+    if not isinstance(approvals, dict):
+        approvals = {}
+    approvals["mode"] = "manual"
+    approvals["cron_mode"] = "deny"
+    cfg["approvals"] = approvals
+
+    # Ensure no inherited allowlist bypass exists.
+    cfg["command_allowlist"] = []
+
+    # Mark active policy for operator visibility.
+    powerunits = cfg.get("powerunits")
+    if not isinstance(powerunits, dict):
+        powerunits = {}
+    runtime_policy = powerunits.get("runtime_policy")
+    if not isinstance(runtime_policy, dict):
+        runtime_policy = {}
+    runtime_policy["id"] = POLICY_ID
+    runtime_policy["enforced"] = True
+    powerunits["runtime_policy"] = runtime_policy
+    cfg["powerunits"] = powerunits
+
+    _save_yaml(config_path, cfg)
+
+
+def main() -> int:
+    hermes_home = Path(os.getenv("HERMES_HOME", "/opt/data"))
+    config_path = hermes_home / "config.yaml"
+    apply_policy(config_path)
+    print(f"[powerunits-policy] applied {POLICY_ID} to {config_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -58,6 +58,11 @@ if [ ! -f "$HERMES_HOME/config.yaml" ]; then
     cp "$INSTALL_DIR/cli-config.yaml.example" "$HERMES_HOME/config.yaml"
 fi
 
+# Optional Powerunits first-deployment runtime policy (fail-closed defaults).
+if [ "${HERMES_POWERUNITS_RUNTIME_POLICY:-}" = "first_safe_v1" ]; then
+    python3 "$INSTALL_DIR/docker/apply_powerunits_runtime_policy.py"
+fi
+
 # SOUL.md
 if [ ! -f "$HERMES_HOME/SOUL.md" ]; then
     cp "$INSTALL_DIR/docker/SOUL.md" "$HERMES_HOME/SOUL.md"

--- a/docs/powerunits_railway_bootstrap_v1.md
+++ b/docs/powerunits_railway_bootstrap_v1.md
@@ -1,0 +1,143 @@
+# Powerunits Railway Bootstrap v1 (Official Hermes Fork)
+
+## Before editing context
+
+Dieses Repository ist jetzt der kanonische Hermes-Pfad fuer Powerunits (Powerunits-kontrollierter Fork von `NousResearch/hermes-agent`).
+
+Der Auftrag ist bewusst **minimaler Railway-Bootstrap** fuer einen sicheren internen Start, nicht Capability-Erweiterung oder tiefe Produktintegration.
+
+---
+
+## Part A - Deployability inspection (official repo findings)
+
+### Runtime entrypoint
+
+- Offizieller CLI-Entrypoint ist vorhanden:
+  - `pyproject.toml` -> `[project.scripts] hermes = "hermes_cli.main:main"`
+  - Wrapper-Skript `hermes` ruft ebenfalls `hermes_cli.main:main` auf.
+
+### Startmodus fuer Railway
+
+- Fuer Cloud/Container-Run ist im Repo klar der Foreground-Gateway-Modus vorgesehen:
+  - `hermes gateway run`
+  - In `hermes_cli/main.py` ist `gateway run` explizit als empfohlen fuer Docker-Umgebungen markiert.
+
+### Docker vs. non-Docker on Railway
+
+- Repo enthaelt bereits einen produktionsnahen `Dockerfile` mit:
+  - Python/Node-Abhaengigkeiten
+  - `ENTRYPOINT ["/opt/hermes/docker/entrypoint.sh"]`
+  - `HERMES_HOME=/opt/data`
+  - `VOLUME ["/opt/data"]`
+- Damit ist ein Docker-basierter Railway-Pfad in diesem Fork am klarsten und reproduzierbarsten.
+
+### Persistenzpfad
+
+- Offizieller Containerpfad ist `/opt/data` (nicht `/data`) laut Dockerfile + `docker/entrypoint.sh`.
+- `entrypoint.sh` bootstrapt dort `.env`, `config.yaml`, `SOUL.md`, Skills-Sync und startet dann `hermes`.
+
+### Runtime assumptions
+
+- Python-Anforderung: `>=3.11` (aus `pyproject.toml`).
+- Messaging/Telegram wird offiziell ueber Gateway unterstuetzt.
+
+### Bereits vorhandene deploy-relevante Dateien
+
+- `Dockerfile`
+- `docker/entrypoint.sh`
+- `.env.example`
+- `cli-config.yaml.example`
+- `pyproject.toml`
+
+Fazit: Repo ist bereits grundsaetzlich deploybar; es braucht vorrangig einen klaren Powerunits-Bootstrap-Contract.
+
+---
+
+## Part B - Minimal Railway bootstrap contract (Powerunits)
+
+1. **Source repo:** Powerunits-kontrollierter `hermes-agent` Fork.
+2. **Branch:** `powerunits-internal-setup` fuer initialen Rollout (danach kontrollierter Release-Branch oder `main`).
+3. **Railway scope:** separates Railway-Projekt + separater Hermes-Service.
+4. **Deploy path:** Dockerfile-basierter Deploy aus dem Fork.
+5. **Persistenz:** 1 Volume, gemountet auf `/opt/data`.
+6. **Startverhalten:** Foreground Gateway via `hermes gateway run` (durch Entrypoint + Command).
+7. **Telegram-first:** Telegram als einziges aktiviertes Messaging-Interface im ersten Schritt.
+8. **Provider setup:** genau ein LLM-Provider-Key fuer Start (z. B. OpenRouter/OpenAI/Anthropic), kein Multi-Provider-Overhead initial.
+9. **Internal-only posture:** erlaubte Nutzer explizit begrenzen; kein oeffentlicher Customer-Surface.
+10. **Keine gefaehrlichen Extras:** keine Shell/SSH/Docker-Exec-Backends, keine Browser-Automation, keine optionalen Tool-Integrationen.
+
+---
+
+## Part C - Minimal repo-side bootstrap changes
+
+### Was wirklich noetig war
+
+- Dieses Runbook unter `docs/powerunits_railway_bootstrap_v1.md`.
+
+### Was **nicht** zwingend noetig war (Stand v1)
+
+- Kein `railway.toml` erforderlich:
+  - Der Repo-Dockerfile ist bereits deployfaehig und definiert Entrypoint/State-Pfad.
+- Keine neue `.env.example.powerunits` erforderlich:
+  - `.env.example` existiert bereits; relevante Minimalvariablen werden unten klar eingegrenzt.
+
+Optional spaeter (nur wenn Betrieb es verlangt):
+
+- sehr kleine `railway.toml` zur expliziten Dokumentation von Build/Start/Healthcheck.
+
+---
+
+## Part D - Safety defaults (first internal rollout)
+
+Setze fuer den ersten Rollout folgende sicheren Defaults:
+
+1. Telegram only (keine weiteren Plattformen aktivieren).
+2. Zunaechst ein interner Benutzer / enge Allowlist.
+3. Keine optionalen Toolsets aktivieren.
+4. Keine write-faehigen DB-Credentials.
+5. Keine Infra/Admin-Tokens (Railway API, Cloud Control Plane).
+6. Keine Bucket/Object-Storage Credentials.
+7. Keine externen Control-Plane-Integrationen.
+8. Keine customer-facing Kommunikation oder Produkt-Einbettung.
+
+---
+
+## Minimum env contract (v1 bootstrap)
+
+Minimal noetige Variablen fuer den ersten Railway-Start:
+
+- `TELEGRAM_BOT_TOKEN` (required)
+- `TELEGRAM_ALLOWED_USERS` (required fuer internal-only gate)
+- genau **ein** Provider-Key (required), z. B.:
+  - `OPENROUTER_API_KEY` **oder**
+  - `OPENAI_API_KEY` **oder**
+  - `ANTHROPIC_API_KEY`
+- optional fuer Webhook-Betrieb:
+  - `TELEGRAM_WEBHOOK_URL`
+  - `TELEGRAM_WEBHOOK_SECRET`
+
+Hinweis:
+
+- Wenn Polling-Modus genutzt wird, ist keine oeffentliche Webhook-URL zwingend.
+- Keine weiteren Secrets initial setzen.
+
+---
+
+## Part E - Transition logic vs. third-party template
+
+Aktueller Third-Party-Template-Deploy bleibt nur temporaer als Vergleichsartefakt.
+
+Switch-Kriterium auf offiziellen Fork:
+
+- Hermes startet stabil auf Railway aus dem Fork
+- Telegram Nachrichtenaustausch funktioniert
+- Persistenz unter `/opt/data` bleibt ueber Redeploys erhalten
+- Safety-Defaults bleiben wirksam (internal-only, keine gefaehrlichen Extras)
+
+Dann Third-Party-Pfad als nicht-kanonisch stilllegen.
+
+---
+
+## Exact next recommendation
+
+`Switch Railway source from the third-party template to the Powerunits-controlled fork next`

--- a/docs/powerunits_railway_bootstrap_v1.md
+++ b/docs/powerunits_railway_bootstrap_v1.md
@@ -85,6 +85,10 @@ Optional spaeter (nur wenn Betrieb es verlangt):
 
 - sehr kleine `railway.toml` zur expliziten Dokumentation von Build/Start/Healthcheck.
 
+Railway-Kompatibilitaetshinweis:
+
+- Dockerfile-`VOLUME` wird auf Railway nicht akzeptiert; Persistenz wird ausschliesslich ueber Railway-Volume-Mount auf `/opt/data` hergestellt.
+
 ---
 
 ## Part D - Safety defaults (first internal rollout)
@@ -141,3 +145,11 @@ Dann Third-Party-Pfad als nicht-kanonisch stilllegen.
 ## Exact next recommendation
 
 `Switch Railway source from the third-party template to the Powerunits-controlled fork next`
+
+---
+
+## Switchover linkage (v2.3)
+
+Der konkrete First-Switchover-Ablauf (Source-Switch + Post-Deploy-Checks) ist dokumentiert in:
+
+- `docs/powerunits_railway_switchover_v1.md`

--- a/docs/powerunits_railway_bootstrap_v1.md
+++ b/docs/powerunits_railway_bootstrap_v1.md
@@ -104,6 +104,11 @@ Setze fuer den ersten Rollout folgende sicheren Defaults:
 7. Keine externen Control-Plane-Integrationen.
 8. Keine customer-facing Kommunikation oder Produkt-Einbettung.
 
+Ergaenzung fuer ersten Live-Rollout:
+
+- tiered runtime policy aktivieren/halten (`HERMES_POWERUNITS_RUNTIME_POLICY=first_safe_v1`),
+  damit die Telegram-Tooloberflaeche fail-closed eingeschraenkt bleibt.
+
 ---
 
 ## Minimum env contract (v1 bootstrap)

--- a/docs/powerunits_railway_build_fix_v1.md
+++ b/docs/powerunits_railway_build_fix_v1.md
@@ -1,0 +1,68 @@
+# Powerunits Railway Build Fix v1 (Docker `VOLUME` Compatibility)
+
+## Before editing context
+
+Ein v2.4-Runtime-Review ist verfrueht, solange der Build auf Railway nicht durchlaeuft.  
+Der aktuelle Task ist deshalb bewusst ein minimaler Railway-Kompatibilitaets-Patch.
+
+---
+
+## Part A - Exact blocker diagnosis
+
+Der Build-Blocker war eindeutig:
+
+- Datei: `Dockerfile`
+- Zeile/Instruktion: `VOLUME [ "/opt/data" ]`
+- Railway-Fehler: `The 'VOLUME' keyword is banned in Dockerfiles. Use Railway volumes instead.`
+
+Gleichzeitig bleibt Repo-seitig klar:
+
+- `HERMES_HOME=/opt/data` ist gesetzt (Dockerfile).
+- Entrypoint nutzt `HERMES_HOME="${HERMES_HOME:-/opt/data}"` und bootstrapt State dort.
+- `/opt/data` ist weiterhin der intendierte persistente Hermes-State-Pfad.
+
+Es wurde kein weiterer Railway-spezifischer harter Dockerfile-Blocker identifiziert.
+
+---
+
+## Part B - Minimal safe fix
+
+Angewandter Fix (minimal):
+
+- `VOLUME [ "/opt/data" ]` aus `Dockerfile` entfernt.
+
+Nicht veraendert:
+
+- `ENV HERMES_HOME=/opt/data`
+- `ENTRYPOINT [ "/opt/hermes/docker/entrypoint.sh" ]`
+- Entrypoint-Logik fuer State-Bootstrap unter `HERMES_HOME`
+
+Damit wird nur der Railway-Build-Blocker entfernt, ohne Runtime-/Scope-Ausbau.
+
+---
+
+## Part C - Post-fix deploy assumptions
+
+Nach dem Fix gilt:
+
+- Mount-Pfad bleibt `/opt/data`.
+- Persistenz erfolgt ueber Railway-Volume-Mount (platformseitig), nicht ueber Dockerfile-`VOLUME`.
+- Railway muss sicherstellen, dass ein persistentes Volume auf `/opt/data` gemountet ist.
+
+Keine weiteren manuellen Repo-Aenderungen sind dafuer noetig.
+
+---
+
+## Part D - Validation scope
+
+Leichte Validierung:
+
+- Dockerfile-Blocker-Instruktion entfernt.
+- `HERMES_HOME`-/Entrypoint-State-Pfad unveraendert auf `/opt/data`.
+- Keine Runtime-Logik, keine Tools, keine Integrationen erweitert.
+
+---
+
+## Part E - One exact next recommendation
+
+`Redeploy the Railway Hermes service from the Powerunits-controlled fork next`

--- a/docs/powerunits_railway_switchover_v1.md
+++ b/docs/powerunits_railway_switchover_v1.md
@@ -36,6 +36,7 @@ Exakte Reihenfolge fuer den ersten Source-Switch in Railway:
    - Service startet ohne Crashloop.
    - Gateway laeuft im Foreground-Modus.
    - Telegram-Interaktion mit erlaubtem User funktioniert.
+   - Runtime-Policy aktiv: `powerunits.runtime_policy.id = first_safe_v1` in `config.yaml`.
 
 ---
 

--- a/docs/powerunits_railway_switchover_v1.md
+++ b/docs/powerunits_railway_switchover_v1.md
@@ -1,0 +1,122 @@
+# Powerunits Railway Switchover v1 (Third-Party Template -> Official Fork)
+
+## Before editing context
+
+Das Repo ist bereits deploybar genug (Dockerfile, Entrypoint, `HERMES_HOME=/opt/data`, Gateway-Startpfad vorhanden).  
+Der richtige naechste Schritt ist daher **Switchover-Readiness**, nicht weitere Architektur- oder Capability-Arbeit.
+
+---
+
+## Part A - First switchover checklist
+
+Exakte Reihenfolge fuer den ersten Source-Switch in Railway:
+
+1. **Service auswaehlen**
+   - Bestehenden Hermes-Service im separaten Hermes-Railway-Projekt verwenden.
+   - Third-Party-Service nur als Vergleichsartefakt belassen.
+
+2. **Source Repo umstellen**
+   - Railway Source auf den Powerunits-kontrollierten `hermes-agent` Fork setzen.
+   - Branch fuer den ersten Switch: `powerunits-internal-setup`.
+
+3. **Volume beibehalten**
+   - Vorhandenes persistentes Volume nicht entfernen.
+   - Mount-Ziel fuer den offiziellen Containerpfad bestaetigen: `/opt/data`.
+   - Hinweis: Railway ignoriert Dockerfile-`VOLUME`; der Mount muss platformseitig gesetzt sein.
+
+4. **Env-Variablen kontrollieren**
+   - Nur Minimalvertrag setzen (siehe Part C).
+   - Unsichere/unnuetze Variablen aus Third-Party-Template nicht uebernehmen.
+
+5. **Deploy triggern**
+   - Nach Source-Umstellung manuellen Deploy ausloesen (oder Auto-Deploy auf Branch-Update).
+   - Build-/Start-Logs auf Entrypoint und Gateway-Start pruefen.
+
+6. **Erste Health-Verifikation**
+   - Service startet ohne Crashloop.
+   - Gateway laeuft im Foreground-Modus.
+   - Telegram-Interaktion mit erlaubtem User funktioniert.
+
+---
+
+## Part B - Runtime command verification
+
+### Verifikation im aktuellen Fork
+
+- Dockerfile setzt `ENTRYPOINT ["/opt/hermes/docker/entrypoint.sh"]`.
+- `entrypoint.sh` aktiviert venv, bootstrapt State unter `HERMES_HOME` (default `/opt/data`) und endet mit:
+  - `exec hermes "$@"`
+- Damit kann Railway den Runtime-Command direkt als:
+  - `gateway run`
+  verwenden (effektiver Prozess: `hermes gateway run`).
+
+### Repo-side Anpassung noetig?
+
+- **Nein, keine Code-/Config-Aenderung noetig** fuer den ersten Switchover.
+- Der bestehende Docker/Entrypoint-Pfad ist fuer den initialen Railway-Switch ausreichend.
+
+---
+
+## Part C - Minimal env contract for first live run
+
+Fuer den ersten produktionsnahen internen Lauf nur:
+
+- `TELEGRAM_BOT_TOKEN` (required)
+- `TELEGRAM_ALLOWED_USERS` (required)
+- genau **ein** Provider-Key (required), z. B.:
+  - `OPENROUTER_API_KEY` **oder**
+  - `OPENAI_API_KEY` **oder**
+  - `ANTHROPIC_API_KEY`
+
+Optional nur falls Webhook-Modus explizit genutzt wird:
+
+- `TELEGRAM_WEBHOOK_URL`
+- `TELEGRAM_WEBHOOK_SECRET`
+
+### Muss weiterhin unset bleiben
+
+- write-faehige DB-Credentials (z. B. `DATABASE_URL`)
+- Bucket/Object-Storage Credentials
+- Railway/Admin Control-Plane Tokens
+- GitHub write/admin Tokens
+- beliebige Powerunits-Produktionssecrets ausserhalb des Minimalvertrags
+
+---
+
+## Part D - First post-deploy validation
+
+Nach dem ersten Fork-Deploy:
+
+1. **Service boot**
+   - Container startet stabil, kein Restart-Loop.
+2. **Volume persistence**
+   - `/opt/data` bleibt ueber Redeploy hinweg erhalten.
+3. **Telegram pairing / interaction**
+   - Erlaubter interner User kann interagieren.
+4. **Access restriction**
+   - Nicht erlaubte User sind blockiert (Allowlist greift).
+5. **Optional tools**
+   - Keine optionalen Plattform-/Tool-Erweiterungen aktiv.
+6. **Dangerous capability check**
+   - Keine Broad-Tool/Infra-Control Erweiterungen ausgerollt.
+
+---
+
+## Part E - Template retirement rule
+
+Der Third-Party-Template-Pfad gilt als retire-faehing, wenn alle Kriterien erfuellt sind:
+
+- offizieller Fork-Deploy erfolgreich
+- Telegram-Interaktion erfolgreich
+- Persistenz unter `/opt/data` bestaetigt
+- kein fehlender Bootstrap-Baustein fuer den offiziellen Pfad
+
+Danach:
+
+- Third-Party-Template nicht mehr als kanonische Betriebsbasis verwenden.
+
+---
+
+## Part F - One exact next recommendation
+
+`Switch the Railway Hermes service to the Powerunits-controlled fork next`

--- a/docs/powerunits_runtime_policy_v1.md
+++ b/docs/powerunits_runtime_policy_v1.md
@@ -1,0 +1,116 @@
+# Powerunits Runtime Policy v1 (Tiered First-Deployment Safety)
+
+## Before editing context
+
+Der aktuelle Blocker ist Runtime-Over-Permissioning, nicht Build/Start.  
+Das Ziel ist daher kontrollierte Capability-Shaping fuer den ersten Live-Betrieb, nicht komplettes De-Powering von Hermes.
+
+---
+
+## Part A - Runtime surface diagnosis
+
+### Warum die breite Standardoberflaeche sichtbar ist
+
+- Standard-Toolsets fuer Messaging (z. B. `hermes-telegram`) sind sehr breit und enthalten u. a.:
+  - `terminal`/`process`
+  - Browser-Tools
+  - `execute_code`
+  - `delegate_task`
+  - Web-/Image-/MCP-nahe Funktionalitaet
+- Diese Defaults werden ueber `platform_toolsets` aufgeloest.
+- Gebuendelte Skills werden beim Start nach `HERMES_HOME/skills` synchronisiert.
+
+### Was sauber restriktierbar ist
+
+- Plattform-Toolsets pro Plattform (`platform_toolsets`) -> gut fuer fail-closed.
+- Plattform-Exposure (`platforms.<name>.enabled`) -> klar steuerbar.
+- Approval-Verhalten (`approvals`) und `command_allowlist`.
+
+### Was bewusst nicht tief umgebaut wurde
+
+- Keine Entfernung von Tool-Implementierungen.
+- Keine dauerhafte Entfernung von Skills.
+- Keine invasive Aenderung der Agent-Kernlogik.
+
+---
+
+## Part B - Tiered policy
+
+### 1) Allowed now
+
+- Telegram als einzige aktive Messaging-Plattform
+- Core Conversation + Memory
+- Session Search (read-only conversation recall)
+- Skills read/list/view
+- Todo/Plan-Orchestrierung ohne Mutations-Tools
+
+### 2) Installed but disabled / not exposed now
+
+- Browser-Tooling
+- Delegation/Subagents
+- Cron-Operations
+- GitHub-nahe Faehigkeiten
+- File write/patch pathways
+- Discord/Slack/Email/weitere Messaging-Plattformen
+- MCP-/weitere externe Integrationen
+- Web-Scraping/Search-Toolsets
+
+### 3) Forbidden now
+
+- Code execution
+- Shell/SSH/Docker exec
+- Write-faehige DB-Zugaenge
+- Infra/Deploy/Worker/Bucket control
+- Unrestricted filesystem mutation
+- Autonomous multi-step operational mutation paths
+
+---
+
+## Part C - Implemented smallest restriction mechanism
+
+Implementiert wurde eine kleine policy-basierte Laufzeit-Restriktion:
+
+1. Neues Policy-Skript:
+   - `docker/apply_powerunits_runtime_policy.py`
+2. Entrypoint-Hook:
+   - `docker/entrypoint.sh` ruft Policy an, wenn
+     - `HERMES_POWERUNITS_RUNTIME_POLICY=first_safe_v1`
+3. Docker Runtime default:
+   - `Dockerfile` setzt
+     - `HERMES_POWERUNITS_RUNTIME_POLICY=first_safe_v1`
+
+### Effekt der Policy
+
+- `platform_toolsets.telegram` wird auf eine enge Allowlist gesetzt:
+  - `memory`, `session_search`, `skills`, `todo`, `no_mcp`
+- Alle anderen relevanten Plattformen werden toolset-seitig auf `[]` gesetzt.
+- Plattform-Exposure:
+  - `platforms.telegram.enabled = true`
+  - andere Plattformen `enabled = false`
+- `approvals.mode = manual`, `approvals.cron_mode = deny`
+- `command_allowlist = []`
+
+Fail-closed:
+
+- Policy wird bei Containerstart wieder angewendet (keine einmalige Best-Effort-Konfiguration).
+
+---
+
+## Part D - Railway/runtime implications
+
+Nach diesem Repo-Change in Railway:
+
+1. Keine neuen Secrets erforderlich.
+2. Sicherstellen, dass der Service weiterhin:
+   - getrenntes Projekt/Service nutzt
+   - Volume auf `/opt/data` gemountet hat
+3. Env fuer Policy ist bereits im Dockerfile gesetzt:
+   - `HERMES_POWERUNITS_RUNTIME_POLICY=first_safe_v1`
+   - optional in Railway explizit sichtbar setzen/ueberschreiben, falls gewuenscht
+4. Telegram/Provider-Minimalvertrag unveraendert lassen.
+
+---
+
+## Part E - One exact next recommendation
+
+`Redeploy Hermes with the tiered first-safe runtime policy next`


### PR DESCRIPTION
## Summary

This PR prepares the Powerunits-controlled Hermes fork for the first safe Railway deployment path.

## What changed

- added Powerunits Railway bootstrap notes
- added Railway switchover runbook
- added Railway build compatibility fix
- added first-safe runtime policy
- documented the intended minimal Telegram-first internal deployment shape

## Why

The goal is to move away from the third-party Railway wrapper/template and use a Powerunits-controlled fork of the official Hermes repository.

This PR keeps the scope intentionally small:
- internal-only
- Telegram-first
- no DB integration yet
- no dangerous tool expansion
- no customer-facing deployment

## Expected outcome

After merge, this fork should be the canonical repo for the first Powerunits-safe Hermes Railway deployment and post-policy runtime verification.