### PR TITLE
fix(run_agent): improve memory/skill nudge trigger logic

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -9103,17 +9103,11 @@ class AIAgent:
         # Preserve the original user message (no nudge injection).
         original_user_message = persist_user_message if persist_user_message is not None else user_message
 
-        # Track memory nudge trigger (turn-based, checked here).
-        # Skill trigger is checked AFTER the agent loop completes, based on
-        # how many tool iterations THIS turn used.
-        _should_review_memory = False
+        # Track memory nudge trigger (turn-based).
         if (self._memory_nudge_interval > 0
                 and "memory" in self.valid_tool_names
                 and self._memory_store):
             self._turns_since_memory += 1
-            if self._turns_since_memory >= self._memory_nudge_interval:
-                _should_review_memory = True
-                self._turns_since_memory = 0
 
         # Add user message
         user_msg = {"role": "user", "content": user_message}
@@ -12111,13 +12105,20 @@ class AIAgent:
         # Clear stream callback so it doesn't leak into future calls
         self._stream_callback = None
 
+        # Check memory trigger NOW — turn-based.
+        _should_review_memory = False
+        if (self._memory_nudge_interval > 0
+                and self._turns_since_memory >= self._memory_nudge_interval
+                and "memory" in self.valid_tool_names):
+            if self._turns_since_memory >= self._memory_nudge_interval:
+                _should_review_memory = True
+
         # Check skill trigger NOW — based on how many tool iterations THIS turn used.
         _should_review_skills = False
         if (self._skill_nudge_interval > 0
                 and self._iters_since_skill >= self._skill_nudge_interval
                 and "skill_manage" in self.valid_tool_names):
             _should_review_skills = True
-            self._iters_since_skill = 0
 
         # External memory provider: sync the completed turn + queue next prefetch.
         # Use original_user_message (clean input) — user_message may contain
@@ -12132,6 +12133,11 @@ class AIAgent:
         # Background memory/skill review — runs AFTER the response is delivered
         # so it never competes with the user's task for model attention.
         if final_response and not interrupted and (_should_review_memory or _should_review_skills):
+            # Only reset memory/skill nudge counters when we actually trigger the review.
+            if _should_review_memory:
+                self._turns_since_memory = 0
+            if _should_review_skills:
+                self._iters_since_skill = 0
             try:
                 self._spawn_background_review(
                     messages_snapshot=list(messages),

--- a/tests/run_agent/test_memory_skill_nudge_trigger.py
+++ b/tests/run_agent/test_memory_skill_nudge_trigger.py
@@ -1,0 +1,175 @@
+"""Tests for memory/skill nudge trigger logic — ensuring counters are only reset when review is actually triggered."""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+from run_agent import AIAgent
+
+
+def _make_minimal_agent() -> AIAgent:
+    """Return an AIAgent constructed with the absolute minimum args.
+    
+    We skip __init__ entirely and only set up the attributes needed
+    for testing nudge trigger logic.
+    """
+    agent = AIAgent.__new__(AIAgent)  # skip __init__ entirely
+    
+    # Set up nudge-related attributes
+    agent._memory_nudge_interval = 2
+    agent._skill_nudge_interval = 3
+    agent._turns_since_memory = 0
+    agent._iters_since_skill = 0
+    agent.valid_tool_names = {"memory", "skill_manage"}
+    agent._memory_store = MagicMock()
+    
+    return agent
+
+
+def _check_memory_nudge_trigger(agent: AIAgent) -> bool:
+    """Check if memory nudge should trigger - mirrors real code in run_agent.py."""
+    if (agent._memory_nudge_interval > 0
+            and agent._turns_since_memory >= agent._memory_nudge_interval
+            and "memory" in agent.valid_tool_names):
+        return True
+    return False
+
+
+def _check_skill_nudge_trigger(agent: AIAgent) -> bool:
+    """Check if skill nudge should trigger - mirrors real code in run_agent.py."""
+    if (agent._skill_nudge_interval > 0
+            and agent._iters_since_skill >= agent._skill_nudge_interval
+            and "skill_manage" in agent.valid_tool_names):
+        return True
+    return False
+
+
+def _increment_memory_counter(agent: AIAgent):
+    """Increment memory counter at turn start - mirrors real code in run_agent.py."""
+    if (agent._memory_nudge_interval > 0
+            and "memory" in agent.valid_tool_names
+            and agent._memory_store):
+        agent._turns_since_memory += 1
+
+
+def _reset_counters_if_needed(agent: AIAgent, final_response, interrupted, 
+                              should_review_memory, should_review_skills):
+    """Reset counters - mirrors real code in run_agent.py."""
+    if final_response and not interrupted and (should_review_memory or should_review_skills):
+        if should_review_memory:
+            agent._turns_since_memory = 0
+        if should_review_skills:
+            agent._iters_since_skill = 0
+
+
+class TestNudgeTriggerLogic:
+    """Tests for memory/skill nudge trigger logic."""
+
+    def test_memory_nudge_complete_flow(self):
+        """Test complete memory nudge flow: increment at turn start, check at turn end, reset only on review."""
+        agent = _make_minimal_agent()
+        
+        # Start with counter 0
+        assert agent._turns_since_memory == 0
+        
+        # --- Turn 1 ---
+        _increment_memory_counter(agent)
+        assert agent._turns_since_memory == 1
+        
+        should_review = _check_memory_nudge_trigger(agent)
+        assert should_review is False
+        
+        # --- Turn 2 ---
+        _increment_memory_counter(agent)
+        assert agent._turns_since_memory == 2
+        
+        should_review = _check_memory_nudge_trigger(agent)
+        assert should_review is True
+        
+        # --- Reset on success ---
+        _reset_counters_if_needed(agent, "Success response", False, should_review, False)
+        assert agent._turns_since_memory == 0
+
+    def test_skill_nudge_complete_flow(self):
+        """Test complete skill nudge flow: check at turn end, reset only on review."""
+        agent = _make_minimal_agent()
+        
+        # At interval
+        agent._iters_since_skill = 3
+        should_review = _check_skill_nudge_trigger(agent)
+        assert should_review is True
+        
+        # Reset on success
+        _reset_counters_if_needed(agent, "Success response", False, False, should_review)
+        assert agent._iters_since_skill == 0
+        
+        # Below interval
+        agent._iters_since_skill = 2
+        should_review = _check_skill_nudge_trigger(agent)
+        assert should_review is False
+        
+        # No reset
+        _reset_counters_if_needed(agent, "Success response", False, False, should_review)
+        assert agent._iters_since_skill == 2
+
+    def test_both_nudges_triggered_together(self):
+        """Test when both memory and skill nudges trigger together."""
+        agent = _make_minimal_agent()
+        agent._turns_since_memory = 2
+        agent._iters_since_skill = 3
+        
+        should_review_memory = _check_memory_nudge_trigger(agent)
+        should_review_skills = _check_skill_nudge_trigger(agent)
+        
+        assert should_review_memory is True
+        assert should_review_skills is True
+        
+        # Reset both together
+        _reset_counters_if_needed(agent, "Success response", False, 
+                                 should_review_memory, should_review_skills)
+        
+        assert agent._turns_since_memory == 0
+        assert agent._iters_since_skill == 0
+
+    def test_counters_preserved_when_memory_tool_unavailable(self):
+        """Test that memory nudge doesn't trigger when memory tool is unavailable."""
+        agent = _make_minimal_agent()
+        agent.valid_tool_names = {"skill_manage"}  # remove memory tool
+        agent._turns_since_memory = 2
+        
+        should_review = _check_memory_nudge_trigger(agent)
+        assert should_review is False
+        
+        # Counter should NOT reset
+        _reset_counters_if_needed(agent, "Success response", False, should_review, False)
+        assert agent._turns_since_memory == 2
+
+    def test_counters_preserved_on_interruption_or_failure(self):
+        """Test that counters are preserved when conversation is interrupted or fails."""
+        agent = _make_minimal_agent()
+        agent._turns_since_memory = 2
+        agent._iters_since_skill = 3
+        should_review_memory = True
+        should_review_skills = True
+        
+        # --- Scenario 1: Interrupted ---
+        _reset_counters_if_needed(agent, "Partial response", True, 
+                                 should_review_memory, should_review_skills)
+        assert agent._turns_since_memory == 2
+        assert agent._iters_since_skill == 3
+        
+        # --- Scenario 2: No final response (failed) ---
+        _reset_counters_if_needed(agent, None, False, 
+                                 should_review_memory, should_review_skills)
+        assert agent._turns_since_memory == 2
+        assert agent._iters_since_skill == 3
+        
+        # --- Scenario 3: Success (for comparison) ---
+        _reset_counters_if_needed(agent, "Success response", False, 
+                                 should_review_memory, should_review_skills)
+        assert agent._turns_since_memory == 0
+        assert agent._iters_since_skill == 0


### PR DESCRIPTION
## Bugs Fixed
1. Duplicate memory reviews occur when _should_review_memory is true while the agent is calling a memory tool within the tool execution loop.
2. When a memory/skill review opportunity is lost due to an empty final_response or an interruption, the memory/skill nudge counters need to restart accumulation.

## What does this PR do?

This PR improves the memory/skill nudge trigger logic by:
1. Preventing duplicate nudges : Because the _should_review_memory check is now placed after tool calls, counter resets won't cause duplicate nudges when the agent calls memory tools.
2. Resetting nudge counters only when review is actually triggered : Counters are now only reset when we are certain to spawn a background review process, ensuring that nudge opportunities aren't lost due to interruptions or failures that would require restarting accumulation.

This approach is correct because it ensures:
1.  There's no duplicate memory reviews occur.
2. Nudge opportunities aren't lost due to interruptions or conversation failures—no need to restart accumulation from scratch.
3. The code has clearer, more intuitive semantics.
4. Memory and skill nudge behavior is consistent.


## Type of Change

- [✅] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [✅] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)


## Changes Made

- `run_agent.py`: Moved memory nudge trigger check from conversation start to end
- `run_agent.py`: Moved memory/skill counter reset logic to only happen when background review is actually spawned
Aligned memory nudge logic with skill nudge logic for consistency
- `tests/run_agent/test_memory_skill_nudge_trigger.py`: Added comprehensive unit tests for the new logic


## How to Test

1. Normal nudge trigger test :
   - Set _memory_nudge_interval = 2 (in code or via config)
   - Have 2 conversation turns
   - Verify memory nudge triggers after the second turn
3. User-initiated memory tool test :
   - Set _memory_nudge_interval = 2
   - Have 1 conversation turn (counter = 1)
   - In the second turn, manually call the memory tool (counter resets to 0)
   - Verify no duplicate memory nudge is triggered
6. Conversation interruption test :
   - Set _memory_nudge_interval = 2
   - Have 1 conversation turn (counter = 1)
   - Start a second turn but interrupt/fail it
   - Verify the counter remains intact and nudge triggers on next successful turn

## Checklist

### Code

- [✅] I've read the [Contributing Guide]([hermes-agent/[CONTRIBUTING.md](http://contributing.md/) at main · NousResearch/hermes-agent]([hermes-agent/CONTRIBUTING.md at main · NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)))
- [✅] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [✅] I searched for [existing PRs]([Pull requests · NousResearch/hermes-agent]([Pull requests · NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent/pulls))) to make sure this isn't a duplicate
- [✅] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [✅] I've run `pytest tests/ -q` and all tests pass
- [✅] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [✅] I've tested on my platform: macOS

### Documentation & Housekeeping

- [N/A] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [N/A] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [N/A] I've updated `[[CONTRIBUTING.md](http://contributing.md/)](http://contributing.md/)` or `[[AGENTS.md](http://agents.md/)](http://agents.md/)` if I changed architecture or workflows — or N/A
- [N/A] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide]([hermes-agent/[CONTRIBUTING.md](http://contributing.md/) at main · NousResearch/hermes-agent]([hermes-agent/CONTRIBUTING.md at main · NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility))) — or N/A
- [N/A] I've updated tool descriptions/schemas if I changed tool behavior — or N/A- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 