### PR TITLE
fix(cli): normalize disabled skills config parsing

### DIFF
--- a/hermes_cli/skills_config.py
+++ b/hermes_cli/skills_config.py
@@ -26,14 +26,26 @@ PLATFORMS = {k: info.label for k, info in _PLATFORMS.items() if k != "api_server
 
 def get_disabled_skills(config: dict, platform: Optional[str] = None) -> Set[str]:
     """Return disabled skill names. Platform-specific list falls back to global."""
-    skills_cfg = config.get("skills", {})
-    global_disabled = set(skills_cfg.get("disabled", []))
+    skills_cfg = config.get("skills")
+    if not isinstance(skills_cfg, dict):
+        skills_cfg = {}
+
+    global_disabled = _normalize_string_set(skills_cfg.get("disabled"))
     if platform is None:
         return global_disabled
-    platform_disabled = skills_cfg.get("platform_disabled", {}).get(platform)
+    platform_disabled = (skills_cfg.get("platform_disabled") or {}).get(platform)
     if platform_disabled is None:
         return global_disabled
-    return set(platform_disabled)
+    return _normalize_string_set(platform_disabled)
+
+
+def _normalize_string_set(values) -> Set[str]:
+    """Normalize config values into a cleaned set of strings."""
+    if values is None:
+        return set()
+    if isinstance(values, str):
+        values = [values]
+    return {str(v).strip() for v in values if str(v).strip()}
 
 
 def save_disabled_skills(config: dict, disabled: Set[str], platform: Optional[str] = None):

--- a/tests/hermes_cli/test_skills_config.py
+++ b/tests/hermes_cli/test_skills_config.py
@@ -39,6 +39,15 @@ class TestGetDisabledSkills:
         from hermes_cli.skills_config import get_disabled_skills
         assert get_disabled_skills({"skills": {"disabled": []}}) == set()
 
+    def test_disabled_scalar_is_treated_as_single_skill(self):
+        from hermes_cli.skills_config import get_disabled_skills
+        config = {"skills": {"disabled": "my-skill"}}
+        assert get_disabled_skills(config) == {"my-skill"}
+
+    def test_null_skills_returns_empty_set(self):
+        from hermes_cli.skills_config import get_disabled_skills
+        assert get_disabled_skills({"skills": None}) == set()
+
 
 # ---------------------------------------------------------------------------
 # save_disabled_skills


### PR DESCRIPTION
## Summary
- 修复 `get_disabled_skills()` 对异常配置结构的健壮性：`skills: null` 不再崩溃。
- 修复 `skills.disabled` 为字符串时被拆成字符集合的问题，统一按单个技能名处理。
- 增加回归测试覆盖上述两种场景，避免后续回归。

## Test plan
- [x] `python -m pytest tests/hermes_cli/test_skills_config.py -q -n 4`

Closes #13026