### PR TITLE
fix: resolve context_length from custom_providers on model switch

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -996,20 +996,18 @@ def get_model_context_length(
             context_length = matched.get("context_length")
             if isinstance(context_length, int):
                 return context_length
-        if not _is_known_provider_base_url(base_url):
-            # 3. Try querying local server directly
-            if is_local_endpoint(base_url):
-                local_ctx = _query_local_context_length(model, base_url)
-                if local_ctx and local_ctx > 0:
-                    save_context_length(model, base_url, local_ctx)
-                    return local_ctx
-            logger.info(
-                "Could not detect context length for model %r at %s — "
-                "defaulting to %s tokens (probe-down). Set model.context_length "
-                "in config.yaml to override.",
-                model, base_url, f"{DEFAULT_FALLBACK_CONTEXT:,}",
-            )
-            return DEFAULT_FALLBACK_CONTEXT
+        # 3. Try querying local server directly
+        if is_local_endpoint(base_url):
+            local_ctx = _query_local_context_length(model, base_url)
+            if local_ctx and local_ctx > 0:
+                save_context_length(model, base_url, local_ctx)
+                return local_ctx
+        # Endpoint didn't report context_length — fall through to
+        # models.dev / OpenRouter / hardcoded defaults instead of
+        # returning the 128K fallback immediately.  Proxy endpoints
+        # (e.g. LiteLLM, NewAPI) often omit context_length from
+        # /models but serve well-known models whose metadata is
+        # available in downstream registries.
 
     # 4. Anthropic /v1/models API (only for regular API keys, not OAuth)
     if provider == "anthropic" or (

--- a/run_agent.py
+++ b/run_agent.py
@@ -1493,9 +1493,6 @@ class AIAgent:
                 )
                 _config_context_length = None
 
-        # Store for reuse in switch_model (so config override persists across model switches)
-        self._config_context_length = _config_context_length
-
         # Check custom_providers per-model context_length
         if _config_context_length is None:
             try:
@@ -1534,6 +1531,11 @@ class AIAgent:
                                         file=sys.stderr,
                                     )
                     break
+
+        # Store for reuse in switch_model (so config override persists across
+        # model switches).  Must be set *after* the custom_providers lookup above
+        # so that per-model overrides from custom_providers are captured.
+        self._config_context_length = _config_context_length
         
         # Select context engine: config-driven (like memory providers).
         # 1. Check config.yaml context.engine setting
@@ -1871,6 +1873,54 @@ class AIAgent:
 
         # ── Update context compressor ──
         if hasattr(self, "context_compressor") and self.context_compressor:
+            # Re-resolve config_context_length for the *new* model from
+            # custom_providers.  The value stored at init time may belong to
+            # the previous model; we need the per-model override that matches
+            # the new (model, base_url) pair.
+            #
+            # Start from the top-level model.context_length (if any) — this is
+            # the global override that applies regardless of which custom
+            # provider is active.  Per-model overrides from custom_providers
+            # take precedence and are checked below.
+            _switch_config_ctx = None
+            try:
+                from hermes_cli.config import load_config as _load_switch_config
+                _sw_cfg = _load_switch_config()
+            except Exception:
+                _sw_cfg = {}
+            _sw_model_section = _sw_cfg.get("model", {})
+            if isinstance(_sw_model_section, dict):
+                _sw_top_ctx = _sw_model_section.get("context_length")
+                if _sw_top_ctx is not None:
+                    try:
+                        _switch_config_ctx = int(_sw_top_ctx)
+                    except (TypeError, ValueError):
+                        pass
+            try:
+                from hermes_cli.config import get_compatible_custom_providers
+                _sw_custom_providers = get_compatible_custom_providers(_sw_cfg)
+            except Exception:
+                _sw_custom_providers = _sw_cfg.get("custom_providers")
+                if not isinstance(_sw_custom_providers, list):
+                    _sw_custom_providers = []
+            for _sw_cp in _sw_custom_providers:
+                if not isinstance(_sw_cp, dict):
+                    continue
+                _sw_cp_url = (_sw_cp.get("base_url") or "").rstrip("/")
+                if _sw_cp_url and _sw_cp_url == self.base_url.rstrip("/"):
+                    _sw_models = _sw_cp.get("models", {})
+                    if isinstance(_sw_models, dict):
+                        _sw_model_cfg = _sw_models.get(self.model, {})
+                        if isinstance(_sw_model_cfg, dict):
+                            _sw_ctx = _sw_model_cfg.get("context_length")
+                            if _sw_ctx is not None:
+                                try:
+                                    _switch_config_ctx = int(_sw_ctx)
+                                except (TypeError, ValueError):
+                                    pass
+                    break
+            self._config_context_length = _switch_config_ctx
+
             from agent.model_metadata import get_model_context_length
             new_context_length = get_model_context_length(
                 self.model,

--- a/tests/agent/test_custom_endpoint_context_fallthrough.py
+++ b/tests/agent/test_custom_endpoint_context_fallthrough.py
@@ -1,0 +1,99 @@
+"""Tests that custom endpoints without context_length fall through to downstream lookups.
+
+When a custom endpoint's /models response omits context_length, the resolver
+should continue to models.dev / OpenRouter / hardcoded defaults instead of
+returning the 128K fallback immediately.
+"""
+
+from unittest.mock import patch, MagicMock
+
+from agent.model_metadata import get_model_context_length
+
+
+def test_custom_endpoint_no_context_falls_through_to_models_dev():
+    """Custom endpoint without context_length should fall through to models.dev."""
+    # Simulate /models returning a model entry without context_length
+    endpoint_metadata = {
+        "gemini-3.1-pro-preview": {"name": "gemini-3.1-pro-preview"},
+    }
+
+    with (
+        patch(
+            "agent.model_metadata.fetch_endpoint_model_metadata",
+            return_value=endpoint_metadata,
+        ),
+        patch("agent.model_metadata._is_custom_endpoint", return_value=True),
+        patch("agent.model_metadata._is_known_provider_base_url", return_value=False),
+        patch("agent.model_metadata.is_local_endpoint", return_value=False),
+        # models.dev should be consulted and return the correct value
+        patch(
+            "agent.models_dev.lookup_models_dev_context",
+            return_value=1048576,
+        ) as mock_models_dev,
+    ):
+        result = get_model_context_length(
+            "gemini-3.1-pro-preview",
+            base_url="https://proxy.example.com/v1",
+            api_key="sk-test",
+            provider="custom",
+        )
+
+    # Should have fallen through to models.dev instead of returning 128K
+    assert result == 1048576
+    mock_models_dev.assert_called()
+
+
+def test_custom_endpoint_with_context_returns_immediately():
+    """Custom endpoint that reports context_length should return it directly."""
+    endpoint_metadata = {
+        "my-model": {"name": "my-model", "context_length": 32768},
+    }
+
+    with (
+        patch(
+            "agent.model_metadata.fetch_endpoint_model_metadata",
+            return_value=endpoint_metadata,
+        ),
+        patch("agent.model_metadata._is_custom_endpoint", return_value=True),
+        patch("agent.model_metadata._is_known_provider_base_url", return_value=False),
+        patch("agent.model_metadata.is_local_endpoint", return_value=False),
+    ):
+        result = get_model_context_length(
+            "my-model",
+            base_url="https://proxy.example.com/v1",
+            api_key="sk-test",
+            provider="custom",
+        )
+
+    assert result == 32768
+
+
+def test_custom_endpoint_local_server_still_queried():
+    """Local custom endpoints should still try _query_local_context_length."""
+    endpoint_metadata = {
+        "my-model": {"name": "my-model"},  # no context_length
+    }
+
+    with (
+        patch(
+            "agent.model_metadata.fetch_endpoint_model_metadata",
+            return_value=endpoint_metadata,
+        ),
+        patch("agent.model_metadata._is_custom_endpoint", return_value=True),
+        patch("agent.model_metadata._is_known_provider_base_url", return_value=False),
+        patch("agent.model_metadata.is_local_endpoint", return_value=True),
+        patch(
+            "agent.model_metadata._query_local_context_length",
+            return_value=65536,
+        ) as mock_local,
+        patch("agent.model_metadata.save_context_length"),
+    ):
+        result = get_model_context_length(
+            "my-model",
+            base_url="http://localhost:8080/v1",
+            api_key="",
+            provider="custom",
+        )
+
+    assert result == 65536
+    mock_local.assert_called_once()

--- a/tests/run_agent/test_custom_provider_context_switch.py
+++ b/tests/run_agent/test_custom_provider_context_switch.py
@@ -1,0 +1,165 @@
+"""Tests that custom_providers per-model context_length is correctly resolved.
+
+Covers:
+- __init__ stores custom_providers per-model context_length in _config_context_length
+- switch_model re-resolves context_length from custom_providers for the new model
+"""
+
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+from agent.context_compressor import ContextCompressor
+
+
+_CUSTOM_PROVIDERS = [
+    {
+        "name": "smt-claude",
+        "base_url": "https://api.example.com:60000/",
+        "api_key": "sk-test-claude",
+        "api_mode": "anthropic_messages",
+        "model": "claude-opus-4.6",
+        "models": {
+            "claude-opus-4.6": {"context_length": 1000000},
+        },
+    },
+    {
+        "name": "smt-codex",
+        "base_url": "https://api.example.com:60000/v1",
+        "api_key": "sk-test-codex",
+        "api_mode": "chat_completions",
+        "model": "gemini-3.1-pro-preview",
+        "models": {
+            "gemini-3.1-pro-preview": {"context_length": 1000000},
+            "gpt-5.4": {"context_length": 1000000},
+        },
+    },
+]
+
+
+def _build_init_agent(model, base_url, custom_providers=None):
+    """Build an AIAgent via __init__ with custom_providers config."""
+    cfg = {
+        "model": {"default": model, "provider": "custom", "base_url": base_url},
+    }
+    if custom_providers is not None:
+        cfg["custom_providers"] = custom_providers
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("agent.model_metadata.get_model_context_length", return_value=128_000),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            model=model,
+            api_key="sk-test",
+            base_url=base_url,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    return agent
+
+
+def test_init_stores_custom_provider_context_length():
+    """__init__ should store per-model context_length from custom_providers."""
+    agent = _build_init_agent(
+        model="gemini-3.1-pro-preview",
+        base_url="https://api.example.com:60000/v1",
+        custom_providers=_CUSTOM_PROVIDERS,
+    )
+    assert agent._config_context_length == 1000000
+
+
+def test_init_no_custom_provider_match():
+    """When no custom_provider matches, _config_context_length stays None."""
+    agent = _build_init_agent(
+        model="some-unknown-model",
+        base_url="https://other-api.example.com/v1",
+        custom_providers=_CUSTOM_PROVIDERS,
+    )
+    assert agent._config_context_length is None
+
+
+# ── switch_model tests ──
+
+
+def _make_agent_for_switch(initial_model, initial_base_url, config_context_length=None):
+    """Build a minimal AIAgent with a context_compressor, skipping __init__."""
+    agent = AIAgent.__new__(AIAgent)
+    agent.model = initial_model
+    agent.provider = "custom"
+    agent.base_url = initial_base_url
+    agent.api_key = "sk-test"
+    agent.api_mode = "chat_completions"
+    agent.client = MagicMock()
+    agent.quiet_mode = True
+    agent._config_context_length = config_context_length
+    agent._primary_runtime = {}
+
+    compressor = ContextCompressor(
+        model=initial_model,
+        threshold_percent=0.50,
+        base_url=initial_base_url,
+        api_key="sk-test",
+        provider="custom",
+        quiet_mode=True,
+        config_context_length=config_context_length,
+    )
+    agent.context_compressor = compressor
+    return agent
+
+
+def test_switch_model_resolves_new_custom_provider_context():
+    """switch_model should re-resolve context_length from custom_providers for the new model."""
+    agent = _make_agent_for_switch(
+        initial_model="claude-opus-4.6",
+        initial_base_url="https://api.example.com:60000/",
+        config_context_length=1000000,
+    )
+
+    cfg = {"custom_providers": _CUSTOM_PROVIDERS}
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("agent.model_metadata.get_model_context_length", return_value=1000000) as mock_ctx,
+    ):
+        agent.switch_model(
+            "gemini-3.1-pro-preview",
+            "custom",
+            api_key="sk-test-codex",
+            base_url="https://api.example.com:60000/v1",
+        )
+
+    # _config_context_length should be updated to the new model's value
+    assert agent._config_context_length == 1000000
+    # get_model_context_length should have been called with the new config override
+    mock_ctx.assert_called_once()
+    assert mock_ctx.call_args.kwargs["config_context_length"] == 1000000
+
+
+def test_switch_model_clears_context_when_no_match():
+    """switch_model to a model not in custom_providers should fall back to None."""
+    agent = _make_agent_for_switch(
+        initial_model="gemini-3.1-pro-preview",
+        initial_base_url="https://api.example.com:60000/v1",
+        config_context_length=1000000,
+    )
+
+    cfg = {"custom_providers": _CUSTOM_PROVIDERS}
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("agent.model_metadata.get_model_context_length", return_value=128_000) as mock_ctx,
+    ):
+        agent.switch_model(
+            "unknown-model",
+            "custom",
+            api_key="sk-test",
+            base_url="https://other-api.example.com/v1",
+        )
+
+    # No custom_provider match — should be None (the initial _config_context_length
+    # of 1000000 should NOT persist for a different model)
+    assert agent._config_context_length is None
+    mock_ctx.assert_called_once()
+    assert mock_ctx.call_args.kwargs["config_context_length"] is None

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -42,14 +42,22 @@ def _make_agent_with_compressor(config_context_length=None) -> AIAgent:
 
 @patch("agent.model_metadata.get_model_context_length", return_value=131_072)
 def test_switch_model_preserves_config_context_length(mock_ctx_len):
-    """When switching models, config_context_length should be passed to get_model_context_length."""
+    """When switching models, config_context_length should be passed to get_model_context_length.
+
+    The top-level model.context_length from config.yaml is a global override
+    that applies to all models.  switch_model re-reads it from config so it
+    persists across model switches.
+    """
     agent = _make_agent_with_compressor(config_context_length=32_768)
 
     assert agent.context_compressor.model == "primary-model"
     assert agent.context_compressor.context_length == 32_768  # From config override
 
-    # Switch model
-    agent.switch_model("new-model", "openrouter", api_key="sk-new", base_url="https://openrouter.ai/api/v1")
+    # Mock load_config to return the top-level context_length override
+    cfg = {"model": {"context_length": 32_768}}
+    with patch("hermes_cli.config.load_config", return_value=cfg):
+        # Switch model
+        agent.switch_model("new-model", "openrouter", api_key="sk-new", base_url="https://openrouter.ai/api/v1")
 
     # Verify get_model_context_length was called with config_context_length
     mock_ctx_len.assert_called_once()
@@ -64,7 +72,11 @@ def test_switch_model_without_config_context_length():
     """When switching models without config override, config_context_length should be None."""
     agent = _make_agent_with_compressor(config_context_length=None)
 
-    with patch("agent.model_metadata.get_model_context_length", return_value=128_000) as mock_ctx_len:
+    cfg = {"model": {}}  # No context_length in config
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("agent.model_metadata.get_model_context_length", return_value=128_000) as mock_ctx_len,
+    ):
         # Switch model
         agent.switch_model("new-model", "openrouter", api_key="sk-new", base_url="https://openrouter.ai/api/v1")
 


### PR DESCRIPTION
## Summary

Three related bugs caused `custom_providers` per-model `context_length` overrides to be ignored, particularly when switching models at runtime via `/model`. This resulted in models like `gemini-3.1-pro-preview` (1M context) being incorrectly reported as 128K when served through proxy endpoints (LiteLLM, NewAPI, etc.).

## Root Cause

1. **`__init__` assignment order** (`run_agent.py`): `self._config_context_length` was assigned *before* the `custom_providers` lookup, so per-model overrides from `custom_providers` were never stored on the agent instance.

2. **`switch_model` stale value** (`run_agent.py`): When switching models, the old model's `_config_context_length` was reused instead of re-resolving from `custom_providers` for the new `(model, base_url)` pair.

3. **Early return on unknown endpoints** (`model_metadata.py`): When a custom endpoint's `/models` response omitted `context_length`, `get_model_context_length()` returned 128K immediately instead of falling through to models.dev / OpenRouter / hardcoded defaults.

## Changes

- **`run_agent.py`**: Move `self._config_context_length` assignment after the `custom_providers` lookup in `__init__`.
- **`run_agent.py`**: In `switch_model()`, re-resolve `config_context_length` from config.yaml (both top-level `model.context_length` and `custom_providers` per-model overrides) for the new model.
- **`agent/model_metadata.py`**: Remove the early `return DEFAULT_FALLBACK_CONTEXT` for unknown custom endpoints when `/models` lacks `context_length` — fall through to downstream registries instead.
- **Tests**: Updated existing `test_switch_model_context.py` and added new test files for both fixes.

## Test Plan

- All 30 related tests pass (context switch, compression feasibility, invalid context warnings, custom endpoint fallthrough).
- Manual verification: switching to `gemini-3.1-pro-preview` via a proxy endpoint now correctly reports 1M context.