### PR TITLE
fix: keep send_message visible and actionable when gateway is down

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -63,6 +63,29 @@ def _ensure_slack_mock(monkeypatch):
 
 
 class TestSendMessageTool:
+    def setup_method(self):
+        self._gw_patch = patch("gateway.status.is_gateway_running", return_value=True)
+        self._gw_patch.start()
+
+    def teardown_method(self):
+        self._gw_patch.stop()
+
+    def test_gateway_not_running_returns_actionable_error(self):
+        self._gw_patch.stop()
+        dead_patch = patch("gateway.status.is_gateway_running", return_value=False)
+        dead_patch.start()
+        try:
+            result = json.loads(
+                send_message_tool(
+                    {"action": "send", "target": "telegram:-1001", "message": "hello"}
+                )
+            )
+            assert "error" in result
+            assert "hermes gateway start" in result["error"]
+        finally:
+            dead_patch.stop()
+            self._gw_patch.start()
+
     def test_cron_duplicate_target_is_skipped_and_explained(self):
         home = SimpleNamespace(chat_id="-1001")
         config, _telegram_cfg = _make_config()

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 _TELEGRAM_TOPIC_TARGET_RE = re.compile(r"^\s*(-?\d+)(?::(\d+))?\s*$")
 _FEISHU_TARGET_RE = re.compile(r"^\s*((?:oc|ou|on|chat|open)_[-A-Za-z0-9]+)(?::([-A-Za-z0-9_]+))?\s*$")
-_WEIXIN_TARGET_RE = re.compile(r"^\s*((?:wxid|gh|v\d+|wm|wb)_[A-Za-z0-9_-]+|[A-Za-z0-9._-]+@chatroom|filehelper)\s*$")
+_WEIXIN_TARGET_RE = re.compile(r"^\s*((?:wxid|gh|v\d+|wm|wb)_[A-Za-z0-9_-]+|[A-Za-z0-9._-]+@[A-Za-z0-9.]+|filehelper)\s*$")
 # Discord snowflake IDs are numeric, same regex pattern as Telegram topic targets.
 _NUMERIC_TOPIC_RE = _TELEGRAM_TOPIC_TARGET_RE
 _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".gif"}
@@ -138,6 +138,25 @@ def _handle_send(args):
     from tools.interrupt import is_interrupted
     if is_interrupted():
         return tool_error("Interrupted")
+
+    # For CLI sessions, check whether the gateway is running and surface an
+    # actionable error rather than silently failing.
+    from gateway.session_context import get_session_env
+    _session_platform = get_session_env("HERMES_SESSION_PLATFORM", "")
+    if not _session_platform or _session_platform == "local":
+        try:
+            from gateway.status import is_gateway_running
+            if not is_gateway_running():
+                return json.dumps({
+                    "error": (
+                        "The Hermes gateway is not running. "
+                        "Start it with: hermes gateway start\n"
+                        "Or run it in the foreground: hermes gateway run\n"
+                        "Then retry your send_message call."
+                    )
+                })
+        except Exception:
+            pass
 
     try:
         from gateway.config import load_gateway_config, Platform
@@ -1024,16 +1043,30 @@ async def _send_feishu(pconfig, chat_id, message, media_files=None, thread_id=No
 
 
 def _check_send_message():
-    """Gate send_message on gateway running (always available on messaging platforms)."""
+    """Show send_message whenever any platform is configured.
+
+    Previously this was gated on the gateway process being alive, which caused
+    the tool to disappear entirely when the gateway crashed — leaving the agent
+    with no way to discover the correct recovery path. Now the tool is always
+    visible when at least one platform is configured; the handler surfaces an
+    actionable error with restart instructions when the gateway is down.
+    """
     from gateway.session_context import get_session_env
     platform = get_session_env("HERMES_SESSION_PLATFORM", "")
     if platform and platform != "local":
         return True
     try:
-        from gateway.status import is_gateway_running
-        return is_gateway_running()
+        from gateway.config import load_gateway_config
+        config = load_gateway_config()
+        return any(p.enabled for p in config.platforms.values())
     except Exception:
-        return False
+        # Fall back to process check so the tool still appears in unconfigured
+        # environments where the gateway may have been started manually.
+        try:
+            from gateway.status import is_gateway_running
+            return is_gateway_running()
+        except Exception:
+            return False
 
 
 # --- Registry ---


### PR DESCRIPTION
## Problem

Two bugs in `send_message` for CLI sessions:

**Bug 1 — Tool disappears when gateway crashes**

`_check_send_message` gated tool *visibility* on `is_gateway_running()`. If the gateway crashed mid-session the tool was silently removed from the agent's tool list. The agent had no way to discover that a messaging path existed or how to recover, and would resort to incorrect approaches like modifying config files directly.

**Bug 2 — Weixin `@im.wechat` / `@im.bot` IDs not recognized**

`_WEIXIN_TARGET_RE` only matched `@chatroom` as a valid suffix. iLink personal account IDs (`…@im.wechat`) and bot IDs (`…@im.bot`) failed the regex, were silently downgraded to channel-name resolution, and could fail to send.

## Fix

- **`_check_send_message`**: show the tool whenever at least one platform is enabled in `config.yaml`, regardless of whether the gateway process is alive. Falls back to `is_gateway_running()` for unconfigured environments.
- **`_handle_send`**: when called from a CLI session and the gateway is not running, return an actionable error with restart instructions (`hermes gateway start`) instead of silently failing downstream.
- **`_WEIXIN_TARGET_RE`**: broaden `@chatroom` to `@[A-Za-z0-9.]+` to cover all iLink ID formats including `@im.wechat` and `@im.bot`.

## Tests

- Added `setup_method`/`teardown_method` to `TestSendMessageTool` so existing tests don't each need to mock `is_gateway_running` independently.
- Added `test_gateway_not_running_returns_actionable_error` to verify the new error path.

All 80 existing tests pass.