### PR TITLE
fix(session): validate and repair tool_call arguments before persisting

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2974,6 +2974,30 @@ class AIAgent:
                     ]
                 elif isinstance(msg.get("tool_calls"), list):
                     tool_calls_data = msg["tool_calls"]
+                
+                # Validate tool_calls JSON before persisting (#12731)
+                # Detect truncated/corrupted arguments and repair or reject them
+                if tool_calls_data:
+                    validated_tool_calls = []
+                    for tc in tool_calls_data:
+                        if isinstance(tc, dict) and "function" in tc:
+                            args = tc["function"].get("arguments", "")
+                            if args:
+                                try:
+                                    json.loads(args)
+                                except (json.JSONDecodeError, TypeError):
+                                    # Arguments are invalid JSON — try to repair
+                                    repaired = _repair_tool_call_arguments(args, tc["function"].get("name", "?"))
+                                    tc = {**tc, "function": {**tc["function"], "arguments": repaired}}
+                                    logger.warning(
+                                        "Repaired corrupted tool_call arguments for %s before session flush",
+                                        tc["function"].get("name", "?"),
+                                    )
+                            validated_tool_calls.append(tc)
+                        else:
+                            validated_tool_calls.append(tc)
+                    tool_calls_data = validated_tool_calls
+                
                 self._session_db.append_message(
                     session_id=self.session_id,
                     role=role,


### PR DESCRIPTION
## Summary

Fixes #12731 - Session compression was corrupting tool_call JSON arguments when the conversation was interrupted mid-tool-call (e.g., by a slash command).

## Problem

The `arguments` field in tool_calls was being truncated to exactly 214 characters (`200 + "...[truncated]"`), producing invalid JSON that caused all subsequent API calls to fail with errors like:

```
Error code: 400 - {'error': {'message': "'content' is a required property...
```

## Root Cause Analysis

While the `_truncate_tool_call_args_json` function in `context_compressor.py` correctly preserves JSON validity when truncating, corrupted arguments can still enter the session through other paths:

1. Provider malformation (Minimax via OpenRouter reported in the issue)
2. Interrupt timing - when a slash command interrupts a streaming tool call
3. Race conditions during message persistence

## Fix

Added validation in `_flush_messages_to_session_db` to detect and repair corrupted tool_call arguments before persisting to SQLite. Uses the existing `_repair_tool_call_arguments` helper to fix malformed JSON.

The validation:
1. Checks each tool_call's `arguments` field for valid JSON
2. If invalid, attempts repair using `_repair_tool_call_arguments`
3. Logs warnings when repairs are made
4. Ensures only valid JSON is persisted to the database

## Testing

- All existing tests pass (17 tests in `test_repair_tool_call_arguments.py`)
- Compression persistence tests pass (6 tests)
- No regressions introduced

## Test Plan

1. Run existing test suite: `pytest tests/run_agent/test_repair_tool_call_arguments.py tests/run_agent/test_compression_persistence.py`
2. Manual test: Start a session with a provider, trigger a tool call, interrupt with slash command, verify session continues correctly