### PR TITLE
  feat: add NetEase IM (NIM) channel integration for Hermes Gateway

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -343,19 +343,18 @@ def load_nim_config(
     platform: "PlatformConfig",
     environ: Dict[str, str] | None = None,
 ) -> NimResolvedConfig:
-    env = dict(os.environ) if environ is None else environ
     extra = dict(platform.extra or {})
     p2p_cfg = _coerce_mapping(extra.get("p2p"))
     team_cfg = _coerce_mapping(extra.get("team"))
     qchat_cfg = _coerce_mapping(extra.get("qchat"))
     advanced_cfg = _coerce_mapping(extra.get("advanced"))
 
-    nim_token = _first_non_empty(extra.get("nimToken"), extra.get("nim_token"), env.get("NIM_CREDENTIALS"))
+    nim_token = _first_non_empty(extra.get("nimToken"), extra.get("nim_token"))
     credentials = parse_nim_token(nim_token)
     if credentials is None:
-        app_key = _first_non_empty(extra.get("appKey"), extra.get("app_key"), env.get("NIM_APP_KEY"))
-        account = _first_non_empty(extra.get("account"), env.get("NIM_ACCOUNT"))
-        token = _first_non_empty(extra.get("token"), env.get("NIM_TOKEN"))
+        app_key = _first_non_empty(extra.get("appKey"), extra.get("app_key"))
+        account = _first_non_empty(extra.get("account"))
+        token = _first_non_empty(extra.get("token"))
         if app_key and account and token:
             credentials = NimCredentials(
                 app_key=str(app_key).strip(),
@@ -363,8 +362,8 @@ def load_nim_config(
                 token=str(token).strip(),
             )
 
-    legacy_p2p_allow = _parse_csv_list(_first_non_empty(extra.get("allowed_users"), env.get("NIM_ALLOWED_USERS")))
-    legacy_allow_all = _coerce_bool(extra.get("allow_all_users", env.get("NIM_ALLOW_ALL_USERS")), default=True)
+    legacy_p2p_allow = _parse_csv_list(_first_non_empty(extra.get("allowed_users")))
+    legacy_allow_all = _coerce_bool(extra.get("allow_all_users"), default=True)
     p2p_allow_from = _parse_csv_list(
         _first_non_empty(
             p2p_cfg.get("allowFrom"),
@@ -381,7 +380,7 @@ def load_nim_config(
         else:
             p2p_policy = "open"
 
-    legacy_team_allow = _parse_csv_list(_first_non_empty(extra.get("group_allowlist"), env.get("NIM_GROUP_ALLOWLIST")))
+    legacy_team_allow = _parse_csv_list(_first_non_empty(extra.get("group_allowlist")))
     team_allow_from = _parse_csv_list(
         _first_non_empty(
             team_cfg.get("allowFrom"),
@@ -390,7 +389,7 @@ def load_nim_config(
         )
     )
     team_policy = _normalize_nim_policy(
-        _first_non_empty(team_cfg.get("policy"), extra.get("group_policy"), env.get("NIM_GROUP_POLICY")),
+        _first_non_empty(team_cfg.get("policy"), extra.get("group_policy")),
         "open",
     )
     qchat_policy = _normalize_nim_policy(qchat_cfg.get("policy"), "open")
@@ -403,7 +402,6 @@ def load_nim_config(
             advanced_cfg.get("mediaMaxMb"),
             advanced_cfg.get("media_max_mb"),
             extra.get("media_max_mb"),
-            env.get("NIM_MEDIA_MAX_MB"),
         ),
         30,
     )
@@ -418,7 +416,7 @@ def load_nim_config(
         ),
     )
     debug = _coerce_bool(
-        _first_non_empty(advanced_cfg.get("debug"), extra.get("debug"), env.get("NIM_DEBUG")),
+        _first_non_empty(advanced_cfg.get("debug"), extra.get("debug")),
         default=False,
     )
     advanced: Dict[str, Any] = {
@@ -461,7 +459,7 @@ def load_nim_config(
         allow_all_users=p2p_policy == "open",
         group_policy=team_policy,
         group_allowlist=list(team_allow_from),
-        home_channel=str(_first_non_empty(extra.get("home_channel"), extra.get("homeChannel"), env.get("NIM_HOME_CHANNEL")) or "").strip() or None,
+        home_channel=str(_first_non_empty(extra.get("home_channel"), extra.get("homeChannel")) or "").strip() or None,
         bridge_command=_default_nim_bridge_command(),
         media_max_mb=media_max_mb,
         text_chunk_limit=text_chunk_limit,
@@ -500,20 +498,8 @@ def load_nim_instances(
     platform: "PlatformConfig",
     environ: Dict[str, str] | None = None,
 ) -> List[NimResolvedConfig]:
-    env = dict(os.environ) if environ is None else environ
     base_extra = dict(platform.extra or {})
     raw_instances = _coerce_nim_instances(base_extra.pop("instances", None))
-    env_instances = env.get("NIM_INSTANCES")
-    legacy_env = dict(env)
-    has_explicit_instances = bool(raw_instances)
-    if has_explicit_instances:
-        for key in ("NIM_CREDENTIALS", "NIM_APP_KEY", "NIM_ACCOUNT", "NIM_TOKEN", "NIM_HOME_CHANNEL"):
-            legacy_env.pop(key, None)
-    if env_instances is not None and env_instances.strip():
-        raw_instances = _coerce_nim_instances(env_instances)
-        has_explicit_instances = bool(raw_instances)
-        for key in ("NIM_CREDENTIALS", "NIM_APP_KEY", "NIM_ACCOUNT", "NIM_TOKEN", "NIM_HOME_CHANNEL"):
-            legacy_env.pop(key, None)
 
     instances: List[NimResolvedConfig] = []
     seen_names: set[str] = set()
@@ -535,16 +521,13 @@ def load_nim_instances(
         reply_to_mode=platform.reply_to_mode,
         extra=base_extra,
     )
-    legacy = load_nim_config(legacy_platform, legacy_env)
+    legacy = load_nim_config(legacy_platform, environ)
     if legacy.configured():
         _append_instance(legacy)
 
     for index, item in enumerate(raw_instances, start=1):
         instance_extra = {**base_extra, **item}
         enabled = _coerce_bool(instance_extra.get("enabled"), default=platform.enabled)
-        instance_env = dict(env)
-        for key in ("NIM_CREDENTIALS", "NIM_APP_KEY", "NIM_ACCOUNT", "NIM_TOKEN", "NIM_HOME_CHANNEL"):
-            instance_env.pop(key, None)
         instance_platform = PlatformConfig(
             enabled=enabled,
             token=platform.token,
@@ -553,7 +536,7 @@ def load_nim_instances(
             reply_to_mode=platform.reply_to_mode,
             extra=instance_extra,
         )
-        resolved = load_nim_config(instance_platform, instance_env)
+        resolved = load_nim_config(instance_platform, environ)
         if not resolved.configured():
             logger.warning("Ignoring unconfigured NIM instance entry: %s", instance_extra.get("instance_name") or instance_extra.get("name") or f"nim{index}")
             continue
@@ -867,13 +850,28 @@ class GatewayConfig:
 
         return False
     
-    def get_home_channel(self, platform: Platform) -> Optional[HomeChannel]:
+    def get_home_channel(
+        self,
+        platform: Platform,
+        source_chat_id: Optional[str] = None,
+    ) -> Optional[HomeChannel]:
         """Get the home channel for a platform."""
         config = self.platforms.get(platform)
         if config and config.home_channel:
             return config.home_channel
         if platform == Platform.NIM and config:
-            for instance in load_nim_instances(config):
+            instances = load_nim_instances(config)
+            if source_chat_id:
+                instance_name, _routed = decode_nim_chat_id(source_chat_id)
+                if instance_name:
+                    for instance in instances:
+                        if instance.instance_name == instance_name and instance.home_channel:
+                            return HomeChannel(
+                                platform=Platform.NIM,
+                                chat_id=instance.home_channel,
+                                name=f"NIM {instance.instance_name}",
+                            )
+            for instance in instances:
                 if instance.home_channel:
                     return HomeChannel(
                         platform=Platform.NIM,
@@ -1905,58 +1903,6 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                 thread_id=os.getenv("WEIXIN_HOME_CHANNEL_THREAD_ID") or None,
             )
 
-    # NIM
-    nim_token = os.getenv("NIM_CREDENTIALS")
-    nim_instances = os.getenv("NIM_INSTANCES", "").strip()
-    nim_app_key = os.getenv("NIM_APP_KEY")
-    nim_account = os.getenv("NIM_ACCOUNT")
-    nim_secret = os.getenv("NIM_TOKEN")
-    if nim_token or nim_instances or (nim_app_key and nim_account and nim_secret):
-        if Platform.NIM not in config.platforms:
-            config.platforms[Platform.NIM] = PlatformConfig()
-        config.platforms[Platform.NIM].enabled = True
-        extra = config.platforms[Platform.NIM].extra
-        existing_yaml_instances = _coerce_nim_instances(extra.get("instances"))
-        if nim_instances:
-            parsed_instances = _coerce_nim_instances(nim_instances)
-            if parsed_instances:
-                extra["instances"] = parsed_instances
-        if nim_token and not nim_instances and not existing_yaml_instances:
-            extra["nim_token"] = nim_token
-        if nim_app_key and not nim_instances and not existing_yaml_instances:
-            extra["app_key"] = nim_app_key
-        if nim_account and not nim_instances and not existing_yaml_instances:
-            extra["account"] = nim_account
-        if nim_secret and not nim_instances and not existing_yaml_instances:
-            extra["token"] = nim_secret
-        nim_group_policy = os.getenv("NIM_GROUP_POLICY", "").strip().lower()
-        if nim_group_policy:
-            extra["group_policy"] = nim_group_policy
-        nim_group_allowlist = os.getenv("NIM_GROUP_ALLOWLIST", "").strip()
-        if nim_group_allowlist:
-            extra["group_allowlist"] = _parse_csv_list(nim_group_allowlist)
-        nim_allowed_users = os.getenv("NIM_ALLOWED_USERS", "").strip()
-        if nim_allowed_users:
-            extra["allowed_users"] = _parse_csv_list(nim_allowed_users)
-        nim_allow_all_users = os.getenv("NIM_ALLOW_ALL_USERS", "").strip()
-        if nim_allow_all_users:
-            extra["allow_all_users"] = _coerce_bool(nim_allow_all_users, default=True)
-        nim_media_max_mb = os.getenv("NIM_MEDIA_MAX_MB", "").strip()
-        if nim_media_max_mb:
-            try:
-                extra["media_max_mb"] = int(nim_media_max_mb)
-            except ValueError:
-                pass
-        nim_debug = os.getenv("NIM_DEBUG", "").strip()
-        if nim_debug:
-            extra["debug"] = _coerce_bool(nim_debug, default=False)
-    nim_home = os.getenv("NIM_HOME_CHANNEL", "").strip()
-    if nim_home and Platform.NIM in config.platforms:
-        config.platforms[Platform.NIM].home_channel = HomeChannel(
-            platform=Platform.NIM,
-            chat_id=nim_home,
-            name=os.getenv("NIM_HOME_CHANNEL_NAME", "Home"),
-        )
     # BlueBubbles (iMessage)
     bluebubbles_server_url = os.getenv("BLUEBUBBLES_SERVER_URL")
     bluebubbles_password = os.getenv("BLUEBUBBLES_PASSWORD")

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -865,8 +865,16 @@ class GatewayConfig:
     def get_home_channel(self, platform: Platform) -> Optional[HomeChannel]:
         """Get the home channel for a platform."""
         config = self.platforms.get(platform)
-        if config:
+        if config and config.home_channel:
             return config.home_channel
+        if platform == Platform.NIM and config:
+            for instance in load_nim_instances(config):
+                if instance.home_channel:
+                    return HomeChannel(
+                        platform=Platform.NIM,
+                        chat_id=instance.home_channel,
+                        name=f"NIM {instance.instance_name}",
+                    )
         return None
     
     def get_reset_policy(

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -732,6 +732,11 @@ _PLATFORM_CONNECTED_CHECKERS: dict[Platform, Callable[[PlatformConfig], bool]] =
     Platform.WEIXIN: lambda cfg: bool(
         cfg.extra.get("account_id") and (cfg.token or cfg.extra.get("token"))
     ),
+    Platform.NIM: lambda cfg: bool(
+        load_nim_instances(cfg)
+        or cfg.extra.get("nim_token")
+        or cfg.extra.get("nimToken")
+    ),
     Platform.WHATSAPP: lambda cfg: True,  # bridge handles auth
     Platform.SIGNAL: lambda cfg: bool(cfg.extra.get("http_url")),
     Platform.EMAIL: lambda cfg: bool(cfg.extra.get("address")),

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -11,6 +11,8 @@ Handles loading and validating configuration for:
 import logging
 import os
 import json
+import re
+import shlex
 from pathlib import Path
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Any, Callable
@@ -105,6 +107,7 @@ class Platform(Enum):
     WECOM = "wecom"
     WECOM_CALLBACK = "wecom_callback"
     WEIXIN = "weixin"
+    NIM = "nim"
     BLUEBUBBLES = "bluebubbles"
     QQBOT = "qqbot"
     YUANBAO = "yuanbao"
@@ -179,6 +182,388 @@ class Platform(Enum):
 # Used to distinguish real platforms from arbitrary strings.
 _BUILTIN_PLATFORM_VALUES = frozenset(m.value for m in Platform.__members__.values())
 
+
+@dataclass(slots=True)
+class NimCredentials:
+    app_key: str
+    account: str
+    token: str
+
+
+@dataclass(slots=True)
+class NimResolvedConfig:
+    enabled: bool
+    credentials: NimCredentials | None
+    instance_name: str = "default"
+    route_prefix: str | None = None
+    p2p_policy: str = "open"
+    p2p_allow_from: List[str] = field(default_factory=list)
+    team_policy: str = "open"
+    team_allow_from: List[str] = field(default_factory=list)
+    qchat_policy: str = "open"
+    qchat_allow_from: List[str] = field(default_factory=list)
+    allowed_users: List[str] = field(default_factory=list)
+    allow_all_users: bool = True
+    group_policy: str = "open"
+    group_allowlist: List[str] = field(default_factory=list)
+    home_channel: str | None = None
+    bridge_command: List[str] = field(default_factory=list)
+    media_max_mb: int = 30
+    text_chunk_limit: int = 4000
+    debug: bool = False
+    advanced: Dict[str, Any] = field(default_factory=dict)
+    raw_extra: Dict[str, Any] = field(default_factory=dict)
+
+    def configured(self) -> bool:
+        return self.enabled and self.credentials is not None
+
+    def to_bridge_payload(self) -> Dict[str, Any]:
+        creds = self.credentials
+        return {
+            "enabled": self.enabled,
+            "credentials": {
+                "app_key": creds.app_key if creds else "",
+                "account": creds.account if creds else "",
+                "token": creds.token if creds else "",
+            },
+            "debug": self.debug,
+            "media_max_mb": self.media_max_mb,
+            "text_chunk_limit": self.text_chunk_limit,
+            "home_channel": self.home_channel,
+            "advanced": dict(self.advanced),
+        }
+
+
+def parse_nim_token(value: Any) -> NimCredentials | None:
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+    parts = raw.split("|", 2) if "|" in raw else raw.split("-", 2)
+    if len(parts) != 3 or any(not part for part in parts):
+        return None
+    return NimCredentials(app_key=parts[0], account=parts[1], token=parts[2])
+
+
+def _normalize_nim_instance_name(value: Any, fallback: str = "default") -> str:
+    raw = str(value or "").strip()
+    if not raw:
+        return fallback
+    normalized = re.sub(r"[^a-zA-Z0-9._-]+", "-", raw).strip("._-")
+    return normalized or fallback
+
+
+def encode_nim_chat_id(instance_name: str | None, chat_id: str) -> str:
+    raw_chat_id = str(chat_id or "").strip()
+    if not raw_chat_id:
+        return raw_chat_id
+    normalized = _normalize_nim_instance_name(instance_name or "", "")
+    if not normalized:
+        return raw_chat_id
+    prefix = f"{normalized}/"
+    return raw_chat_id if raw_chat_id.startswith(prefix) else f"{prefix}{raw_chat_id}"
+
+
+def decode_nim_chat_id(value: Any) -> tuple[str | None, str]:
+    raw = str(value or "").strip()
+    if not raw:
+        return None, ""
+    prefix, sep, remainder = raw.partition("/")
+    if not sep or not remainder:
+        return None, raw
+    normalized = _normalize_nim_instance_name(prefix, "")
+    if not normalized:
+        return None, raw
+    return normalized, remainder
+
+
+def _default_nim_bridge_dir() -> Path:
+    from nim_bot_py.bridge import NodeBridge
+
+    return NodeBridge.bridge_dir()
+
+
+def _default_nim_bridge_command() -> List[str]:
+    from nim_bot_py.bridge import NodeBridge
+
+    return NodeBridge.default_command()
+
+
+def _resolve_nim_bridge_command(value: Any) -> List[str]:
+    if value is None:
+        return _default_nim_bridge_command()
+    if isinstance(value, str):
+        parts = shlex.split(value)
+        return parts or _resolve_nim_bridge_command(None)
+    if isinstance(value, (list, tuple)):
+        parts = [str(item).strip() for item in value if str(item).strip()]
+        return parts or _resolve_nim_bridge_command(None)
+    raise TypeError("NIM bridge_command must be a string or sequence of strings")
+
+
+def _parse_csv_list(value: Any) -> List[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [item.strip() for item in value.split(",") if item.strip()]
+    if isinstance(value, (list, tuple, set)):
+        return [str(item).strip() for item in value if str(item).strip()]
+    return [str(value).strip()]
+
+
+def _coerce_mapping(value: Any) -> Dict[str, Any]:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _coerce_int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _first_non_empty(*values: Any) -> Any:
+    for value in values:
+        if value is None:
+            continue
+        if isinstance(value, str) and not value.strip():
+            continue
+        return value
+    return None
+
+
+def _normalize_nim_policy(value: Any, default: str = "open") -> str:
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"open", "allowlist", "disabled"}:
+            return normalized
+    return default
+
+
+def load_nim_config(
+    platform: "PlatformConfig",
+    environ: Dict[str, str] | None = None,
+) -> NimResolvedConfig:
+    env = dict(os.environ) if environ is None else environ
+    extra = dict(platform.extra or {})
+    p2p_cfg = _coerce_mapping(extra.get("p2p"))
+    team_cfg = _coerce_mapping(extra.get("team"))
+    qchat_cfg = _coerce_mapping(extra.get("qchat"))
+    advanced_cfg = _coerce_mapping(extra.get("advanced"))
+
+    nim_token = _first_non_empty(extra.get("nimToken"), extra.get("nim_token"), env.get("NIM_CREDENTIALS"))
+    credentials = parse_nim_token(nim_token)
+    if credentials is None:
+        app_key = _first_non_empty(extra.get("appKey"), extra.get("app_key"), env.get("NIM_APP_KEY"))
+        account = _first_non_empty(extra.get("account"), env.get("NIM_ACCOUNT"))
+        token = _first_non_empty(extra.get("token"), env.get("NIM_TOKEN"))
+        if app_key and account and token:
+            credentials = NimCredentials(
+                app_key=str(app_key).strip(),
+                account=str(account).strip(),
+                token=str(token).strip(),
+            )
+
+    legacy_p2p_allow = _parse_csv_list(_first_non_empty(extra.get("allowed_users"), env.get("NIM_ALLOWED_USERS")))
+    legacy_allow_all = _coerce_bool(extra.get("allow_all_users", env.get("NIM_ALLOW_ALL_USERS")), default=True)
+    p2p_allow_from = _parse_csv_list(
+        _first_non_empty(
+            p2p_cfg.get("allowFrom"),
+            p2p_cfg.get("allow_from"),
+            legacy_p2p_allow if legacy_p2p_allow else None,
+        )
+    )
+    p2p_policy = _normalize_nim_policy(p2p_cfg.get("policy"))
+    if "policy" not in p2p_cfg:
+        if legacy_allow_all:
+            p2p_policy = "open"
+        elif p2p_allow_from:
+            p2p_policy = "allowlist"
+        else:
+            p2p_policy = "open"
+
+    legacy_team_allow = _parse_csv_list(_first_non_empty(extra.get("group_allowlist"), env.get("NIM_GROUP_ALLOWLIST")))
+    team_allow_from = _parse_csv_list(
+        _first_non_empty(
+            team_cfg.get("allowFrom"),
+            team_cfg.get("allow_from"),
+            legacy_team_allow if legacy_team_allow else None,
+        )
+    )
+    team_policy = _normalize_nim_policy(
+        _first_non_empty(team_cfg.get("policy"), extra.get("group_policy"), env.get("NIM_GROUP_POLICY")),
+        "open",
+    )
+    qchat_policy = _normalize_nim_policy(qchat_cfg.get("policy"), "open")
+    qchat_allow_from = _parse_csv_list(
+        _first_non_empty(qchat_cfg.get("allowFrom"), qchat_cfg.get("allow_from"))
+    )
+
+    media_max_mb = _coerce_int(
+        _first_non_empty(
+            advanced_cfg.get("mediaMaxMb"),
+            advanced_cfg.get("media_max_mb"),
+            extra.get("media_max_mb"),
+            env.get("NIM_MEDIA_MAX_MB"),
+        ),
+        30,
+    )
+    text_chunk_limit = max(
+        1,
+        _coerce_int(
+            _first_non_empty(
+                advanced_cfg.get("textChunkLimit"),
+                advanced_cfg.get("text_chunk_limit"),
+            ),
+            4000,
+        ),
+    )
+    debug = _coerce_bool(
+        _first_non_empty(advanced_cfg.get("debug"), extra.get("debug"), env.get("NIM_DEBUG")),
+        default=False,
+    )
+    advanced: Dict[str, Any] = {
+        "mediaMaxMb": media_max_mb,
+        "textChunkLimit": text_chunk_limit,
+        "debug": debug,
+    }
+    for out_key, candidates in (
+        ("weblbsUrl", ("weblbsUrl", "weblbs_url")),
+        ("link_web", ("link_web",)),
+        ("nos_uploader", ("nos_uploader",)),
+        ("nos_downloader_v2", ("nos_downloader_v2",)),
+        ("nos_accelerate", ("nos_accelerate",)),
+        ("nos_accelerate_host", ("nos_accelerate_host",)),
+    ):
+        value = _first_non_empty(*(advanced_cfg.get(candidate) for candidate in candidates))
+        if value is not None:
+            advanced[out_key] = value
+    nos_ssl = _first_non_empty(advanced_cfg.get("nosSsl"), advanced_cfg.get("nos_ssl"))
+    if nos_ssl is not None:
+        advanced["nosSsl"] = _coerce_bool(nos_ssl, default=False)
+
+    instance_name = _normalize_nim_instance_name(
+        extra.get("instance_name") or extra.get("instanceName") or extra.get("name"),
+        "default",
+    )
+
+    return NimResolvedConfig(
+        instance_name=instance_name,
+        route_prefix=None,
+        enabled=platform.enabled,
+        credentials=credentials,
+        p2p_policy=p2p_policy,
+        p2p_allow_from=p2p_allow_from,
+        team_policy=team_policy,
+        team_allow_from=team_allow_from,
+        qchat_policy=qchat_policy,
+        qchat_allow_from=qchat_allow_from,
+        allowed_users=list(p2p_allow_from),
+        allow_all_users=p2p_policy == "open",
+        group_policy=team_policy,
+        group_allowlist=list(team_allow_from),
+        home_channel=str(_first_non_empty(extra.get("home_channel"), extra.get("homeChannel"), env.get("NIM_HOME_CHANNEL")) or "").strip() or None,
+        bridge_command=_default_nim_bridge_command(),
+        media_max_mb=media_max_mb,
+        text_chunk_limit=text_chunk_limit,
+        debug=debug,
+        advanced=advanced,
+        raw_extra=extra,
+    )
+
+
+def _coerce_nim_instances(value: Any) -> List[Dict[str, Any]]:
+    if value is None:
+        return []
+    raw = value
+    if isinstance(raw, str):
+        text = raw.strip()
+        if not text:
+            return []
+        try:
+            raw = json.loads(text)
+        except json.JSONDecodeError as exc:
+            logger.warning("Ignoring invalid NIM_INSTANCES JSON: %s", exc)
+            return []
+    if not isinstance(raw, list):
+        logger.warning("Ignoring NIM instances config: expected a list, got %s", type(raw).__name__)
+        return []
+    instances: List[Dict[str, Any]] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            logger.warning("Ignoring NIM instance entry: expected a mapping, got %s", type(item).__name__)
+            continue
+        instances.append(dict(item))
+    return instances
+
+
+def load_nim_instances(
+    platform: "PlatformConfig",
+    environ: Dict[str, str] | None = None,
+) -> List[NimResolvedConfig]:
+    env = dict(os.environ) if environ is None else environ
+    base_extra = dict(platform.extra or {})
+    raw_instances = _coerce_nim_instances(base_extra.pop("instances", None))
+    env_instances = env.get("NIM_INSTANCES")
+    legacy_env = dict(env)
+    if env_instances is not None and env_instances.strip():
+        raw_instances = _coerce_nim_instances(env_instances)
+        for key in ("NIM_CREDENTIALS", "NIM_APP_KEY", "NIM_ACCOUNT", "NIM_TOKEN", "NIM_HOME_CHANNEL"):
+            legacy_env.pop(key, None)
+
+    instances: List[NimResolvedConfig] = []
+    seen_names: set[str] = set()
+
+    def _append_instance(config_obj: NimResolvedConfig) -> None:
+        name = _normalize_nim_instance_name(config_obj.instance_name, "default")
+        if name in seen_names:
+            logger.warning("Ignoring duplicate NIM instance name: %s", name)
+            return
+        config_obj.instance_name = name
+        seen_names.add(name)
+        instances.append(config_obj)
+
+    legacy_platform = PlatformConfig(
+        enabled=platform.enabled,
+        token=platform.token,
+        api_key=platform.api_key,
+        home_channel=platform.home_channel,
+        reply_to_mode=platform.reply_to_mode,
+        extra=base_extra,
+    )
+    legacy = load_nim_config(legacy_platform, legacy_env)
+    if legacy.configured():
+        _append_instance(legacy)
+
+    for index, item in enumerate(raw_instances, start=1):
+        instance_extra = {**base_extra, **item}
+        enabled = _coerce_bool(instance_extra.get("enabled"), default=platform.enabled)
+        instance_env = dict(env)
+        for key in ("NIM_CREDENTIALS", "NIM_APP_KEY", "NIM_ACCOUNT", "NIM_TOKEN", "NIM_HOME_CHANNEL"):
+            instance_env.pop(key, None)
+        instance_platform = PlatformConfig(
+            enabled=enabled,
+            token=platform.token,
+            api_key=platform.api_key,
+            home_channel=None,
+            reply_to_mode=platform.reply_to_mode,
+            extra=instance_extra,
+        )
+        resolved = load_nim_config(instance_platform, instance_env)
+        if not resolved.configured():
+            logger.warning("Ignoring unconfigured NIM instance entry: %s", instance_extra.get("instance_name") or instance_extra.get("name") or f"nim{index}")
+            continue
+        if "instance_name" not in instance_extra and "instanceName" not in instance_extra and "name" not in instance_extra:
+            fallback_name = resolved.credentials.account if resolved.credentials else f"nim{index}"
+            resolved.instance_name = _normalize_nim_instance_name(fallback_name, f"nim{index}")
+        _append_instance(resolved)
+
+    multi_instance = len(instances) > 1
+    for item in instances:
+        item.route_prefix = f"{item.instance_name}/" if multi_instance else None
+        if item.route_prefix and item.home_channel:
+            item.home_channel = encode_nim_chat_id(item.instance_name, item.home_channel)
+
+    return instances
 
 @dataclass
 class HomeChannel:
@@ -720,6 +1105,35 @@ def load_gateway_config() -> GatewayConfig:
                     if merged_extra:
                         merged["extra"] = merged_extra
                     platforms_data[plat_name] = merged
+                gw_data["platforms"] = platforms_data
+            yaml_nim = yaml_cfg.get("nim")
+            if isinstance(yaml_nim, dict):
+                nim_platform = platforms_data.setdefault(Platform.NIM.value, {})
+                if not isinstance(nim_platform, dict):
+                    nim_platform = {}
+                    platforms_data[Platform.NIM.value] = nim_platform
+                nim_existing_extra = nim_platform.get("extra", {})
+                if not isinstance(nim_existing_extra, dict):
+                    nim_existing_extra = {}
+                nim_extra = {
+                    key: value
+                    for key, value in yaml_nim.items()
+                    if key not in {"enabled", "home_channel", "home_channel_name", "reply_to_mode"}
+                }
+                merged_extra = {**nim_existing_extra, **nim_extra}
+                if merged_extra:
+                    nim_platform["extra"] = merged_extra
+                if "enabled" in yaml_nim:
+                    nim_platform["enabled"] = _coerce_bool(yaml_nim.get("enabled"), True)
+                elif "enabled" not in nim_platform and _coerce_nim_instances(merged_extra.get("instances")):
+                    nim_platform["enabled"] = True
+                nim_home_channel = str(yaml_nim.get("home_channel") or "").strip()
+                if nim_home_channel:
+                    nim_platform["home_channel"] = {
+                        "platform": Platform.NIM.value,
+                        "chat_id": nim_home_channel,
+                        "name": str(yaml_nim.get("home_channel_name") or "Home"),
+                    }
                 gw_data["platforms"] = platforms_data
             for plat in Platform:
                 if plat == Platform.LOCAL:
@@ -1478,6 +1892,57 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                 thread_id=os.getenv("WEIXIN_HOME_CHANNEL_THREAD_ID") or None,
             )
 
+    # NIM
+    nim_token = os.getenv("NIM_CREDENTIALS")
+    nim_instances = os.getenv("NIM_INSTANCES", "").strip()
+    nim_app_key = os.getenv("NIM_APP_KEY")
+    nim_account = os.getenv("NIM_ACCOUNT")
+    nim_secret = os.getenv("NIM_TOKEN")
+    if nim_token or nim_instances or (nim_app_key and nim_account and nim_secret):
+        if Platform.NIM not in config.platforms:
+            config.platforms[Platform.NIM] = PlatformConfig()
+        config.platforms[Platform.NIM].enabled = True
+        extra = config.platforms[Platform.NIM].extra
+        if nim_instances:
+            parsed_instances = _coerce_nim_instances(nim_instances)
+            if parsed_instances:
+                extra["instances"] = parsed_instances
+        if nim_token and not nim_instances:
+            extra["nim_token"] = nim_token
+        if nim_app_key and not nim_instances:
+            extra["app_key"] = nim_app_key
+        if nim_account and not nim_instances:
+            extra["account"] = nim_account
+        if nim_secret and not nim_instances:
+            extra["token"] = nim_secret
+        nim_group_policy = os.getenv("NIM_GROUP_POLICY", "").strip().lower()
+        if nim_group_policy:
+            extra["group_policy"] = nim_group_policy
+        nim_group_allowlist = os.getenv("NIM_GROUP_ALLOWLIST", "").strip()
+        if nim_group_allowlist:
+            extra["group_allowlist"] = _parse_csv_list(nim_group_allowlist)
+        nim_allowed_users = os.getenv("NIM_ALLOWED_USERS", "").strip()
+        if nim_allowed_users:
+            extra["allowed_users"] = _parse_csv_list(nim_allowed_users)
+        nim_allow_all_users = os.getenv("NIM_ALLOW_ALL_USERS", "").strip()
+        if nim_allow_all_users:
+            extra["allow_all_users"] = _coerce_bool(nim_allow_all_users, default=True)
+        nim_media_max_mb = os.getenv("NIM_MEDIA_MAX_MB", "").strip()
+        if nim_media_max_mb:
+            try:
+                extra["media_max_mb"] = int(nim_media_max_mb)
+            except ValueError:
+                pass
+        nim_debug = os.getenv("NIM_DEBUG", "").strip()
+        if nim_debug:
+            extra["debug"] = _coerce_bool(nim_debug, default=False)
+    nim_home = os.getenv("NIM_HOME_CHANNEL", "").strip()
+    if nim_home and Platform.NIM in config.platforms:
+        config.platforms[Platform.NIM].home_channel = HomeChannel(
+            platform=Platform.NIM,
+            chat_id=nim_home,
+            name=os.getenv("NIM_HOME_CHANNEL_NAME", "Home"),
+        )
     # BlueBubbles (iMessage)
     bluebubbles_server_url = os.getenv("BLUEBUBBLES_SERVER_URL")
     bluebubbles_password = os.getenv("BLUEBUBBLES_PASSWORD")

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -505,8 +505,13 @@ def load_nim_instances(
     raw_instances = _coerce_nim_instances(base_extra.pop("instances", None))
     env_instances = env.get("NIM_INSTANCES")
     legacy_env = dict(env)
+    has_explicit_instances = bool(raw_instances)
+    if has_explicit_instances:
+        for key in ("NIM_CREDENTIALS", "NIM_APP_KEY", "NIM_ACCOUNT", "NIM_TOKEN", "NIM_HOME_CHANNEL"):
+            legacy_env.pop(key, None)
     if env_instances is not None and env_instances.strip():
         raw_instances = _coerce_nim_instances(env_instances)
+        has_explicit_instances = bool(raw_instances)
         for key in ("NIM_CREDENTIALS", "NIM_APP_KEY", "NIM_ACCOUNT", "NIM_TOKEN", "NIM_HOME_CHANNEL"):
             legacy_env.pop(key, None)
 
@@ -1911,17 +1916,18 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             config.platforms[Platform.NIM] = PlatformConfig()
         config.platforms[Platform.NIM].enabled = True
         extra = config.platforms[Platform.NIM].extra
+        existing_yaml_instances = _coerce_nim_instances(extra.get("instances"))
         if nim_instances:
             parsed_instances = _coerce_nim_instances(nim_instances)
             if parsed_instances:
                 extra["instances"] = parsed_instances
-        if nim_token and not nim_instances:
+        if nim_token and not nim_instances and not existing_yaml_instances:
             extra["nim_token"] = nim_token
-        if nim_app_key and not nim_instances:
+        if nim_app_key and not nim_instances and not existing_yaml_instances:
             extra["app_key"] = nim_app_key
-        if nim_account and not nim_instances:
+        if nim_account and not nim_instances and not existing_yaml_instances:
             extra["account"] = nim_account
-        if nim_secret and not nim_instances:
+        if nim_secret and not nim_instances and not existing_yaml_instances:
             extra["token"] = nim_secret
         nim_group_policy = os.getenv("NIM_GROUP_POLICY", "").strip().lower()
         if nim_group_policy:

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -394,8 +394,13 @@ def load_nim_instances(
     raw_instances = _coerce_nim_instances(base_extra.pop("instances", None))
     env_instances = env.get("NIM_INSTANCES")
     legacy_env = dict(env)
+    has_explicit_instances = bool(raw_instances)
+    if has_explicit_instances:
+        for key in ("NIM_CREDENTIALS", "NIM_APP_KEY", "NIM_ACCOUNT", "NIM_TOKEN", "NIM_HOME_CHANNEL"):
+            legacy_env.pop(key, None)
     if env_instances is not None and env_instances.strip():
         raw_instances = _coerce_nim_instances(env_instances)
+        has_explicit_instances = bool(raw_instances)
         for key in ("NIM_CREDENTIALS", "NIM_APP_KEY", "NIM_ACCOUNT", "NIM_TOKEN", "NIM_HOME_CHANNEL"):
             legacy_env.pop(key, None)
 
@@ -1645,17 +1650,18 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             config.platforms[Platform.NIM] = PlatformConfig()
         config.platforms[Platform.NIM].enabled = True
         extra = config.platforms[Platform.NIM].extra
+        existing_yaml_instances = _coerce_nim_instances(extra.get("instances"))
         if nim_instances:
             parsed_instances = _coerce_nim_instances(nim_instances)
             if parsed_instances:
                 extra["instances"] = parsed_instances
-        if nim_token and not nim_instances:
+        if nim_token and not nim_instances and not existing_yaml_instances:
             extra["nim_token"] = nim_token
-        if nim_app_key and not nim_instances:
+        if nim_app_key and not nim_instances and not existing_yaml_instances:
             extra["app_key"] = nim_app_key
-        if nim_account and not nim_instances:
+        if nim_account and not nim_instances and not existing_yaml_instances:
             extra["account"] = nim_account
-        if nim_secret and not nim_instances:
+        if nim_secret and not nim_instances and not existing_yaml_instances:
             extra["token"] = nim_secret
         nim_group_policy = os.getenv("NIM_GROUP_POLICY", "").strip().lower()
         if nim_group_policy:

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -706,14 +706,25 @@ class GatewayConfig:
                 config.extra.get("client_secret") or os.getenv("DINGTALK_CLIENT_SECRET")
             ):
                 connected.append(platform)
+            # NIM uses bridge credentials from config.extra or env vars
+            elif platform == Platform.NIM and load_nim_instances(config):
+                connected.append(platform)
         
         return connected
     
     def get_home_channel(self, platform: Platform) -> Optional[HomeChannel]:
         """Get the home channel for a platform."""
         config = self.platforms.get(platform)
-        if config:
+        if config and config.home_channel:
             return config.home_channel
+        if platform == Platform.NIM and config:
+            for instance in load_nim_instances(config):
+                if instance.home_channel:
+                    return HomeChannel(
+                        platform=Platform.NIM,
+                        chat_id=instance.home_channel,
+                        name=f"NIM {instance.instance_name}",
+                    )
         return None
     
     def get_reset_policy(

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -232,19 +232,18 @@ def load_nim_config(
     platform: "PlatformConfig",
     environ: Dict[str, str] | None = None,
 ) -> NimResolvedConfig:
-    env = dict(os.environ) if environ is None else environ
     extra = dict(platform.extra or {})
     p2p_cfg = _coerce_mapping(extra.get("p2p"))
     team_cfg = _coerce_mapping(extra.get("team"))
     qchat_cfg = _coerce_mapping(extra.get("qchat"))
     advanced_cfg = _coerce_mapping(extra.get("advanced"))
 
-    nim_token = _first_non_empty(extra.get("nimToken"), extra.get("nim_token"), env.get("NIM_CREDENTIALS"))
+    nim_token = _first_non_empty(extra.get("nimToken"), extra.get("nim_token"))
     credentials = parse_nim_token(nim_token)
     if credentials is None:
-        app_key = _first_non_empty(extra.get("appKey"), extra.get("app_key"), env.get("NIM_APP_KEY"))
-        account = _first_non_empty(extra.get("account"), env.get("NIM_ACCOUNT"))
-        token = _first_non_empty(extra.get("token"), env.get("NIM_TOKEN"))
+        app_key = _first_non_empty(extra.get("appKey"), extra.get("app_key"))
+        account = _first_non_empty(extra.get("account"))
+        token = _first_non_empty(extra.get("token"))
         if app_key and account and token:
             credentials = NimCredentials(
                 app_key=str(app_key).strip(),
@@ -252,8 +251,8 @@ def load_nim_config(
                 token=str(token).strip(),
             )
 
-    legacy_p2p_allow = _parse_csv_list(_first_non_empty(extra.get("allowed_users"), env.get("NIM_ALLOWED_USERS")))
-    legacy_allow_all = _coerce_bool(extra.get("allow_all_users", env.get("NIM_ALLOW_ALL_USERS")), default=True)
+    legacy_p2p_allow = _parse_csv_list(_first_non_empty(extra.get("allowed_users")))
+    legacy_allow_all = _coerce_bool(extra.get("allow_all_users"), default=True)
     p2p_allow_from = _parse_csv_list(
         _first_non_empty(
             p2p_cfg.get("allowFrom"),
@@ -270,7 +269,7 @@ def load_nim_config(
         else:
             p2p_policy = "open"
 
-    legacy_team_allow = _parse_csv_list(_first_non_empty(extra.get("group_allowlist"), env.get("NIM_GROUP_ALLOWLIST")))
+    legacy_team_allow = _parse_csv_list(_first_non_empty(extra.get("group_allowlist")))
     team_allow_from = _parse_csv_list(
         _first_non_empty(
             team_cfg.get("allowFrom"),
@@ -279,7 +278,7 @@ def load_nim_config(
         )
     )
     team_policy = _normalize_nim_policy(
-        _first_non_empty(team_cfg.get("policy"), extra.get("group_policy"), env.get("NIM_GROUP_POLICY")),
+        _first_non_empty(team_cfg.get("policy"), extra.get("group_policy")),
         "open",
     )
     qchat_policy = _normalize_nim_policy(qchat_cfg.get("policy"), "open")
@@ -292,7 +291,6 @@ def load_nim_config(
             advanced_cfg.get("mediaMaxMb"),
             advanced_cfg.get("media_max_mb"),
             extra.get("media_max_mb"),
-            env.get("NIM_MEDIA_MAX_MB"),
         ),
         30,
     )
@@ -307,7 +305,7 @@ def load_nim_config(
         ),
     )
     debug = _coerce_bool(
-        _first_non_empty(advanced_cfg.get("debug"), extra.get("debug"), env.get("NIM_DEBUG")),
+        _first_non_empty(advanced_cfg.get("debug"), extra.get("debug")),
         default=False,
     )
     advanced: Dict[str, Any] = {
@@ -350,7 +348,7 @@ def load_nim_config(
         allow_all_users=p2p_policy == "open",
         group_policy=team_policy,
         group_allowlist=list(team_allow_from),
-        home_channel=str(_first_non_empty(extra.get("home_channel"), extra.get("homeChannel"), env.get("NIM_HOME_CHANNEL")) or "").strip() or None,
+        home_channel=str(_first_non_empty(extra.get("home_channel"), extra.get("homeChannel")) or "").strip() or None,
         bridge_command=_default_nim_bridge_command(),
         media_max_mb=media_max_mb,
         text_chunk_limit=text_chunk_limit,
@@ -389,20 +387,8 @@ def load_nim_instances(
     platform: "PlatformConfig",
     environ: Dict[str, str] | None = None,
 ) -> List[NimResolvedConfig]:
-    env = dict(os.environ) if environ is None else environ
     base_extra = dict(platform.extra or {})
     raw_instances = _coerce_nim_instances(base_extra.pop("instances", None))
-    env_instances = env.get("NIM_INSTANCES")
-    legacy_env = dict(env)
-    has_explicit_instances = bool(raw_instances)
-    if has_explicit_instances:
-        for key in ("NIM_CREDENTIALS", "NIM_APP_KEY", "NIM_ACCOUNT", "NIM_TOKEN", "NIM_HOME_CHANNEL"):
-            legacy_env.pop(key, None)
-    if env_instances is not None and env_instances.strip():
-        raw_instances = _coerce_nim_instances(env_instances)
-        has_explicit_instances = bool(raw_instances)
-        for key in ("NIM_CREDENTIALS", "NIM_APP_KEY", "NIM_ACCOUNT", "NIM_TOKEN", "NIM_HOME_CHANNEL"):
-            legacy_env.pop(key, None)
 
     instances: List[NimResolvedConfig] = []
     seen_names: set[str] = set()
@@ -424,16 +410,13 @@ def load_nim_instances(
         reply_to_mode=platform.reply_to_mode,
         extra=base_extra,
     )
-    legacy = load_nim_config(legacy_platform, legacy_env)
+    legacy = load_nim_config(legacy_platform, environ)
     if legacy.configured():
         _append_instance(legacy)
 
     for index, item in enumerate(raw_instances, start=1):
         instance_extra = {**base_extra, **item}
         enabled = _coerce_bool(instance_extra.get("enabled"), default=platform.enabled)
-        instance_env = dict(env)
-        for key in ("NIM_CREDENTIALS", "NIM_APP_KEY", "NIM_ACCOUNT", "NIM_TOKEN", "NIM_HOME_CHANNEL"):
-            instance_env.pop(key, None)
         instance_platform = PlatformConfig(
             enabled=enabled,
             token=platform.token,
@@ -442,7 +425,7 @@ def load_nim_instances(
             reply_to_mode=platform.reply_to_mode,
             extra=instance_extra,
         )
-        resolved = load_nim_config(instance_platform, instance_env)
+        resolved = load_nim_config(instance_platform, environ)
         if not resolved.configured():
             logger.warning("Ignoring unconfigured NIM instance entry: %s", instance_extra.get("instance_name") or instance_extra.get("name") or f"nim{index}")
             continue
@@ -717,13 +700,28 @@ class GatewayConfig:
         
         return connected
     
-    def get_home_channel(self, platform: Platform) -> Optional[HomeChannel]:
+    def get_home_channel(
+        self,
+        platform: Platform,
+        source_chat_id: Optional[str] = None,
+    ) -> Optional[HomeChannel]:
         """Get the home channel for a platform."""
         config = self.platforms.get(platform)
         if config and config.home_channel:
             return config.home_channel
         if platform == Platform.NIM and config:
-            for instance in load_nim_instances(config):
+            instances = load_nim_instances(config)
+            if source_chat_id:
+                instance_name, _routed = decode_nim_chat_id(source_chat_id)
+                if instance_name:
+                    for instance in instances:
+                        if instance.instance_name == instance_name and instance.home_channel:
+                            return HomeChannel(
+                                platform=Platform.NIM,
+                                chat_id=instance.home_channel,
+                                name=f"NIM {instance.instance_name}",
+                            )
+            for instance in instances:
                 if instance.home_channel:
                     return HomeChannel(
                         platform=Platform.NIM,
@@ -1639,58 +1637,6 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                 name=os.getenv("WEIXIN_HOME_CHANNEL_NAME", "Home"),
             )
 
-    # NIM
-    nim_token = os.getenv("NIM_CREDENTIALS")
-    nim_instances = os.getenv("NIM_INSTANCES", "").strip()
-    nim_app_key = os.getenv("NIM_APP_KEY")
-    nim_account = os.getenv("NIM_ACCOUNT")
-    nim_secret = os.getenv("NIM_TOKEN")
-    if nim_token or nim_instances or (nim_app_key and nim_account and nim_secret):
-        if Platform.NIM not in config.platforms:
-            config.platforms[Platform.NIM] = PlatformConfig()
-        config.platforms[Platform.NIM].enabled = True
-        extra = config.platforms[Platform.NIM].extra
-        existing_yaml_instances = _coerce_nim_instances(extra.get("instances"))
-        if nim_instances:
-            parsed_instances = _coerce_nim_instances(nim_instances)
-            if parsed_instances:
-                extra["instances"] = parsed_instances
-        if nim_token and not nim_instances and not existing_yaml_instances:
-            extra["nim_token"] = nim_token
-        if nim_app_key and not nim_instances and not existing_yaml_instances:
-            extra["app_key"] = nim_app_key
-        if nim_account and not nim_instances and not existing_yaml_instances:
-            extra["account"] = nim_account
-        if nim_secret and not nim_instances and not existing_yaml_instances:
-            extra["token"] = nim_secret
-        nim_group_policy = os.getenv("NIM_GROUP_POLICY", "").strip().lower()
-        if nim_group_policy:
-            extra["group_policy"] = nim_group_policy
-        nim_group_allowlist = os.getenv("NIM_GROUP_ALLOWLIST", "").strip()
-        if nim_group_allowlist:
-            extra["group_allowlist"] = _parse_csv_list(nim_group_allowlist)
-        nim_allowed_users = os.getenv("NIM_ALLOWED_USERS", "").strip()
-        if nim_allowed_users:
-            extra["allowed_users"] = _parse_csv_list(nim_allowed_users)
-        nim_allow_all_users = os.getenv("NIM_ALLOW_ALL_USERS", "").strip()
-        if nim_allow_all_users:
-            extra["allow_all_users"] = _coerce_bool(nim_allow_all_users, default=True)
-        nim_media_max_mb = os.getenv("NIM_MEDIA_MAX_MB", "").strip()
-        if nim_media_max_mb:
-            try:
-                extra["media_max_mb"] = int(nim_media_max_mb)
-            except ValueError:
-                pass
-        nim_debug = os.getenv("NIM_DEBUG", "").strip()
-        if nim_debug:
-            extra["debug"] = _coerce_bool(nim_debug, default=False)
-    nim_home = os.getenv("NIM_HOME_CHANNEL", "").strip()
-    if nim_home and Platform.NIM in config.platforms:
-        config.platforms[Platform.NIM].home_channel = HomeChannel(
-            platform=Platform.NIM,
-            chat_id=nim_home,
-            name=os.getenv("NIM_HOME_CHANNEL_NAME", "Home"),
-        )
     # BlueBubbles (iMessage)
     bluebubbles_server_url = os.getenv("BLUEBUBBLES_SERVER_URL")
     bluebubbles_password = os.getenv("BLUEBUBBLES_PASSWORD")

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -11,6 +11,8 @@ Handles loading and validating configuration for:
 import logging
 import os
 import json
+import re
+import shlex
 from pathlib import Path
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Any
@@ -65,9 +67,392 @@ class Platform(Enum):
     WECOM = "wecom"
     WECOM_CALLBACK = "wecom_callback"
     WEIXIN = "weixin"
+    NIM = "nim"
     BLUEBUBBLES = "bluebubbles"
     QQBOT = "qqbot"
 
+
+@dataclass(slots=True)
+class NimCredentials:
+    app_key: str
+    account: str
+    token: str
+
+
+@dataclass(slots=True)
+class NimResolvedConfig:
+    enabled: bool
+    credentials: NimCredentials | None
+    instance_name: str = "default"
+    route_prefix: str | None = None
+    p2p_policy: str = "open"
+    p2p_allow_from: List[str] = field(default_factory=list)
+    team_policy: str = "open"
+    team_allow_from: List[str] = field(default_factory=list)
+    qchat_policy: str = "open"
+    qchat_allow_from: List[str] = field(default_factory=list)
+    allowed_users: List[str] = field(default_factory=list)
+    allow_all_users: bool = True
+    group_policy: str = "open"
+    group_allowlist: List[str] = field(default_factory=list)
+    home_channel: str | None = None
+    bridge_command: List[str] = field(default_factory=list)
+    media_max_mb: int = 30
+    text_chunk_limit: int = 4000
+    debug: bool = False
+    advanced: Dict[str, Any] = field(default_factory=dict)
+    raw_extra: Dict[str, Any] = field(default_factory=dict)
+
+    def configured(self) -> bool:
+        return self.enabled and self.credentials is not None
+
+    def to_bridge_payload(self) -> Dict[str, Any]:
+        creds = self.credentials
+        return {
+            "enabled": self.enabled,
+            "credentials": {
+                "app_key": creds.app_key if creds else "",
+                "account": creds.account if creds else "",
+                "token": creds.token if creds else "",
+            },
+            "debug": self.debug,
+            "media_max_mb": self.media_max_mb,
+            "text_chunk_limit": self.text_chunk_limit,
+            "home_channel": self.home_channel,
+            "advanced": dict(self.advanced),
+        }
+
+
+def parse_nim_token(value: Any) -> NimCredentials | None:
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+    parts = raw.split("|", 2) if "|" in raw else raw.split("-", 2)
+    if len(parts) != 3 or any(not part for part in parts):
+        return None
+    return NimCredentials(app_key=parts[0], account=parts[1], token=parts[2])
+
+
+def _normalize_nim_instance_name(value: Any, fallback: str = "default") -> str:
+    raw = str(value or "").strip()
+    if not raw:
+        return fallback
+    normalized = re.sub(r"[^a-zA-Z0-9._-]+", "-", raw).strip("._-")
+    return normalized or fallback
+
+
+def encode_nim_chat_id(instance_name: str | None, chat_id: str) -> str:
+    raw_chat_id = str(chat_id or "").strip()
+    if not raw_chat_id:
+        return raw_chat_id
+    normalized = _normalize_nim_instance_name(instance_name or "", "")
+    if not normalized:
+        return raw_chat_id
+    prefix = f"{normalized}/"
+    return raw_chat_id if raw_chat_id.startswith(prefix) else f"{prefix}{raw_chat_id}"
+
+
+def decode_nim_chat_id(value: Any) -> tuple[str | None, str]:
+    raw = str(value or "").strip()
+    if not raw:
+        return None, ""
+    prefix, sep, remainder = raw.partition("/")
+    if not sep or not remainder:
+        return None, raw
+    normalized = _normalize_nim_instance_name(prefix, "")
+    if not normalized:
+        return None, raw
+    return normalized, remainder
+
+
+def _default_nim_bridge_dir() -> Path:
+    from nim_bot_py.bridge import NodeBridge
+
+    return NodeBridge.bridge_dir()
+
+
+def _default_nim_bridge_command() -> List[str]:
+    from nim_bot_py.bridge import NodeBridge
+
+    return NodeBridge.default_command()
+
+
+def _resolve_nim_bridge_command(value: Any) -> List[str]:
+    if value is None:
+        return _default_nim_bridge_command()
+    if isinstance(value, str):
+        parts = shlex.split(value)
+        return parts or _resolve_nim_bridge_command(None)
+    if isinstance(value, (list, tuple)):
+        parts = [str(item).strip() for item in value if str(item).strip()]
+        return parts or _resolve_nim_bridge_command(None)
+    raise TypeError("NIM bridge_command must be a string or sequence of strings")
+
+
+def _parse_csv_list(value: Any) -> List[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [item.strip() for item in value.split(",") if item.strip()]
+    if isinstance(value, (list, tuple, set)):
+        return [str(item).strip() for item in value if str(item).strip()]
+    return [str(value).strip()]
+
+
+def _coerce_mapping(value: Any) -> Dict[str, Any]:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _coerce_int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _first_non_empty(*values: Any) -> Any:
+    for value in values:
+        if value is None:
+            continue
+        if isinstance(value, str) and not value.strip():
+            continue
+        return value
+    return None
+
+
+def _normalize_nim_policy(value: Any, default: str = "open") -> str:
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"open", "allowlist", "disabled"}:
+            return normalized
+    return default
+
+
+def load_nim_config(
+    platform: "PlatformConfig",
+    environ: Dict[str, str] | None = None,
+) -> NimResolvedConfig:
+    env = dict(os.environ) if environ is None else environ
+    extra = dict(platform.extra or {})
+    p2p_cfg = _coerce_mapping(extra.get("p2p"))
+    team_cfg = _coerce_mapping(extra.get("team"))
+    qchat_cfg = _coerce_mapping(extra.get("qchat"))
+    advanced_cfg = _coerce_mapping(extra.get("advanced"))
+
+    nim_token = _first_non_empty(extra.get("nimToken"), extra.get("nim_token"), env.get("NIM_CREDENTIALS"))
+    credentials = parse_nim_token(nim_token)
+    if credentials is None:
+        app_key = _first_non_empty(extra.get("appKey"), extra.get("app_key"), env.get("NIM_APP_KEY"))
+        account = _first_non_empty(extra.get("account"), env.get("NIM_ACCOUNT"))
+        token = _first_non_empty(extra.get("token"), env.get("NIM_TOKEN"))
+        if app_key and account and token:
+            credentials = NimCredentials(
+                app_key=str(app_key).strip(),
+                account=str(account).strip(),
+                token=str(token).strip(),
+            )
+
+    legacy_p2p_allow = _parse_csv_list(_first_non_empty(extra.get("allowed_users"), env.get("NIM_ALLOWED_USERS")))
+    legacy_allow_all = _coerce_bool(extra.get("allow_all_users", env.get("NIM_ALLOW_ALL_USERS")), default=True)
+    p2p_allow_from = _parse_csv_list(
+        _first_non_empty(
+            p2p_cfg.get("allowFrom"),
+            p2p_cfg.get("allow_from"),
+            legacy_p2p_allow if legacy_p2p_allow else None,
+        )
+    )
+    p2p_policy = _normalize_nim_policy(p2p_cfg.get("policy"))
+    if "policy" not in p2p_cfg:
+        if legacy_allow_all:
+            p2p_policy = "open"
+        elif p2p_allow_from:
+            p2p_policy = "allowlist"
+        else:
+            p2p_policy = "open"
+
+    legacy_team_allow = _parse_csv_list(_first_non_empty(extra.get("group_allowlist"), env.get("NIM_GROUP_ALLOWLIST")))
+    team_allow_from = _parse_csv_list(
+        _first_non_empty(
+            team_cfg.get("allowFrom"),
+            team_cfg.get("allow_from"),
+            legacy_team_allow if legacy_team_allow else None,
+        )
+    )
+    team_policy = _normalize_nim_policy(
+        _first_non_empty(team_cfg.get("policy"), extra.get("group_policy"), env.get("NIM_GROUP_POLICY")),
+        "open",
+    )
+    qchat_policy = _normalize_nim_policy(qchat_cfg.get("policy"), "open")
+    qchat_allow_from = _parse_csv_list(
+        _first_non_empty(qchat_cfg.get("allowFrom"), qchat_cfg.get("allow_from"))
+    )
+
+    media_max_mb = _coerce_int(
+        _first_non_empty(
+            advanced_cfg.get("mediaMaxMb"),
+            advanced_cfg.get("media_max_mb"),
+            extra.get("media_max_mb"),
+            env.get("NIM_MEDIA_MAX_MB"),
+        ),
+        30,
+    )
+    text_chunk_limit = max(
+        1,
+        _coerce_int(
+            _first_non_empty(
+                advanced_cfg.get("textChunkLimit"),
+                advanced_cfg.get("text_chunk_limit"),
+            ),
+            4000,
+        ),
+    )
+    debug = _coerce_bool(
+        _first_non_empty(advanced_cfg.get("debug"), extra.get("debug"), env.get("NIM_DEBUG")),
+        default=False,
+    )
+    advanced: Dict[str, Any] = {
+        "mediaMaxMb": media_max_mb,
+        "textChunkLimit": text_chunk_limit,
+        "debug": debug,
+    }
+    for out_key, candidates in (
+        ("weblbsUrl", ("weblbsUrl", "weblbs_url")),
+        ("link_web", ("link_web",)),
+        ("nos_uploader", ("nos_uploader",)),
+        ("nos_downloader_v2", ("nos_downloader_v2",)),
+        ("nos_accelerate", ("nos_accelerate",)),
+        ("nos_accelerate_host", ("nos_accelerate_host",)),
+    ):
+        value = _first_non_empty(*(advanced_cfg.get(candidate) for candidate in candidates))
+        if value is not None:
+            advanced[out_key] = value
+    nos_ssl = _first_non_empty(advanced_cfg.get("nosSsl"), advanced_cfg.get("nos_ssl"))
+    if nos_ssl is not None:
+        advanced["nosSsl"] = _coerce_bool(nos_ssl, default=False)
+
+    instance_name = _normalize_nim_instance_name(
+        extra.get("instance_name") or extra.get("instanceName") or extra.get("name"),
+        "default",
+    )
+
+    return NimResolvedConfig(
+        instance_name=instance_name,
+        route_prefix=None,
+        enabled=platform.enabled,
+        credentials=credentials,
+        p2p_policy=p2p_policy,
+        p2p_allow_from=p2p_allow_from,
+        team_policy=team_policy,
+        team_allow_from=team_allow_from,
+        qchat_policy=qchat_policy,
+        qchat_allow_from=qchat_allow_from,
+        allowed_users=list(p2p_allow_from),
+        allow_all_users=p2p_policy == "open",
+        group_policy=team_policy,
+        group_allowlist=list(team_allow_from),
+        home_channel=str(_first_non_empty(extra.get("home_channel"), extra.get("homeChannel"), env.get("NIM_HOME_CHANNEL")) or "").strip() or None,
+        bridge_command=_default_nim_bridge_command(),
+        media_max_mb=media_max_mb,
+        text_chunk_limit=text_chunk_limit,
+        debug=debug,
+        advanced=advanced,
+        raw_extra=extra,
+    )
+
+
+def _coerce_nim_instances(value: Any) -> List[Dict[str, Any]]:
+    if value is None:
+        return []
+    raw = value
+    if isinstance(raw, str):
+        text = raw.strip()
+        if not text:
+            return []
+        try:
+            raw = json.loads(text)
+        except json.JSONDecodeError as exc:
+            logger.warning("Ignoring invalid NIM_INSTANCES JSON: %s", exc)
+            return []
+    if not isinstance(raw, list):
+        logger.warning("Ignoring NIM instances config: expected a list, got %s", type(raw).__name__)
+        return []
+    instances: List[Dict[str, Any]] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            logger.warning("Ignoring NIM instance entry: expected a mapping, got %s", type(item).__name__)
+            continue
+        instances.append(dict(item))
+    return instances
+
+
+def load_nim_instances(
+    platform: "PlatformConfig",
+    environ: Dict[str, str] | None = None,
+) -> List[NimResolvedConfig]:
+    env = dict(os.environ) if environ is None else environ
+    base_extra = dict(platform.extra or {})
+    raw_instances = _coerce_nim_instances(base_extra.pop("instances", None))
+    env_instances = env.get("NIM_INSTANCES")
+    legacy_env = dict(env)
+    if env_instances is not None and env_instances.strip():
+        raw_instances = _coerce_nim_instances(env_instances)
+        for key in ("NIM_CREDENTIALS", "NIM_APP_KEY", "NIM_ACCOUNT", "NIM_TOKEN", "NIM_HOME_CHANNEL"):
+            legacy_env.pop(key, None)
+
+    instances: List[NimResolvedConfig] = []
+    seen_names: set[str] = set()
+
+    def _append_instance(config_obj: NimResolvedConfig) -> None:
+        name = _normalize_nim_instance_name(config_obj.instance_name, "default")
+        if name in seen_names:
+            logger.warning("Ignoring duplicate NIM instance name: %s", name)
+            return
+        config_obj.instance_name = name
+        seen_names.add(name)
+        instances.append(config_obj)
+
+    legacy_platform = PlatformConfig(
+        enabled=platform.enabled,
+        token=platform.token,
+        api_key=platform.api_key,
+        home_channel=platform.home_channel,
+        reply_to_mode=platform.reply_to_mode,
+        extra=base_extra,
+    )
+    legacy = load_nim_config(legacy_platform, legacy_env)
+    if legacy.configured():
+        _append_instance(legacy)
+
+    for index, item in enumerate(raw_instances, start=1):
+        instance_extra = {**base_extra, **item}
+        enabled = _coerce_bool(instance_extra.get("enabled"), default=platform.enabled)
+        instance_env = dict(env)
+        for key in ("NIM_CREDENTIALS", "NIM_APP_KEY", "NIM_ACCOUNT", "NIM_TOKEN", "NIM_HOME_CHANNEL"):
+            instance_env.pop(key, None)
+        instance_platform = PlatformConfig(
+            enabled=enabled,
+            token=platform.token,
+            api_key=platform.api_key,
+            home_channel=None,
+            reply_to_mode=platform.reply_to_mode,
+            extra=instance_extra,
+        )
+        resolved = load_nim_config(instance_platform, instance_env)
+        if not resolved.configured():
+            logger.warning("Ignoring unconfigured NIM instance entry: %s", instance_extra.get("instance_name") or instance_extra.get("name") or f"nim{index}")
+            continue
+        if "instance_name" not in instance_extra and "instanceName" not in instance_extra and "name" not in instance_extra:
+            fallback_name = resolved.credentials.account if resolved.credentials else f"nim{index}"
+            resolved.instance_name = _normalize_nim_instance_name(fallback_name, f"nim{index}")
+        _append_instance(resolved)
+
+    multi_instance = len(instances) > 1
+    for item in instances:
+        item.route_prefix = f"{item.instance_name}/" if multi_instance else None
+        if item.route_prefix and item.home_channel:
+            item.home_channel = encode_nim_chat_id(item.instance_name, item.home_channel)
+
+    return instances
 
 @dataclass
 class HomeChannel:
@@ -554,6 +939,35 @@ def load_gateway_config() -> GatewayConfig:
                     if merged_extra:
                         merged["extra"] = merged_extra
                     platforms_data[plat_name] = merged
+                gw_data["platforms"] = platforms_data
+            yaml_nim = yaml_cfg.get("nim")
+            if isinstance(yaml_nim, dict):
+                nim_platform = platforms_data.setdefault(Platform.NIM.value, {})
+                if not isinstance(nim_platform, dict):
+                    nim_platform = {}
+                    platforms_data[Platform.NIM.value] = nim_platform
+                nim_existing_extra = nim_platform.get("extra", {})
+                if not isinstance(nim_existing_extra, dict):
+                    nim_existing_extra = {}
+                nim_extra = {
+                    key: value
+                    for key, value in yaml_nim.items()
+                    if key not in {"enabled", "home_channel", "home_channel_name", "reply_to_mode"}
+                }
+                merged_extra = {**nim_existing_extra, **nim_extra}
+                if merged_extra:
+                    nim_platform["extra"] = merged_extra
+                if "enabled" in yaml_nim:
+                    nim_platform["enabled"] = _coerce_bool(yaml_nim.get("enabled"), True)
+                elif "enabled" not in nim_platform and _coerce_nim_instances(merged_extra.get("instances")):
+                    nim_platform["enabled"] = True
+                nim_home_channel = str(yaml_nim.get("home_channel") or "").strip()
+                if nim_home_channel:
+                    nim_platform["home_channel"] = {
+                        "platform": Platform.NIM.value,
+                        "chat_id": nim_home_channel,
+                        "name": str(yaml_nim.get("home_channel_name") or "Home"),
+                    }
                 gw_data["platforms"] = platforms_data
             for plat in Platform:
                 if plat == Platform.LOCAL:
@@ -1209,6 +1623,57 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                 name=os.getenv("WEIXIN_HOME_CHANNEL_NAME", "Home"),
             )
 
+    # NIM
+    nim_token = os.getenv("NIM_CREDENTIALS")
+    nim_instances = os.getenv("NIM_INSTANCES", "").strip()
+    nim_app_key = os.getenv("NIM_APP_KEY")
+    nim_account = os.getenv("NIM_ACCOUNT")
+    nim_secret = os.getenv("NIM_TOKEN")
+    if nim_token or nim_instances or (nim_app_key and nim_account and nim_secret):
+        if Platform.NIM not in config.platforms:
+            config.platforms[Platform.NIM] = PlatformConfig()
+        config.platforms[Platform.NIM].enabled = True
+        extra = config.platforms[Platform.NIM].extra
+        if nim_instances:
+            parsed_instances = _coerce_nim_instances(nim_instances)
+            if parsed_instances:
+                extra["instances"] = parsed_instances
+        if nim_token and not nim_instances:
+            extra["nim_token"] = nim_token
+        if nim_app_key and not nim_instances:
+            extra["app_key"] = nim_app_key
+        if nim_account and not nim_instances:
+            extra["account"] = nim_account
+        if nim_secret and not nim_instances:
+            extra["token"] = nim_secret
+        nim_group_policy = os.getenv("NIM_GROUP_POLICY", "").strip().lower()
+        if nim_group_policy:
+            extra["group_policy"] = nim_group_policy
+        nim_group_allowlist = os.getenv("NIM_GROUP_ALLOWLIST", "").strip()
+        if nim_group_allowlist:
+            extra["group_allowlist"] = _parse_csv_list(nim_group_allowlist)
+        nim_allowed_users = os.getenv("NIM_ALLOWED_USERS", "").strip()
+        if nim_allowed_users:
+            extra["allowed_users"] = _parse_csv_list(nim_allowed_users)
+        nim_allow_all_users = os.getenv("NIM_ALLOW_ALL_USERS", "").strip()
+        if nim_allow_all_users:
+            extra["allow_all_users"] = _coerce_bool(nim_allow_all_users, default=True)
+        nim_media_max_mb = os.getenv("NIM_MEDIA_MAX_MB", "").strip()
+        if nim_media_max_mb:
+            try:
+                extra["media_max_mb"] = int(nim_media_max_mb)
+            except ValueError:
+                pass
+        nim_debug = os.getenv("NIM_DEBUG", "").strip()
+        if nim_debug:
+            extra["debug"] = _coerce_bool(nim_debug, default=False)
+    nim_home = os.getenv("NIM_HOME_CHANNEL", "").strip()
+    if nim_home and Platform.NIM in config.platforms:
+        config.platforms[Platform.NIM].home_channel = HomeChannel(
+            platform=Platform.NIM,
+            chat_id=nim_home,
+            name=os.getenv("NIM_HOME_CHANNEL_NAME", "Home"),
+        )
     # BlueBubbles (iMessage)
     bluebubbles_server_url = os.getenv("BLUEBUBBLES_SERVER_URL")
     bluebubbles_password = os.getenv("BLUEBUBBLES_PASSWORD")

--- a/gateway/platforms/nim.py
+++ b/gateway/platforms/nim.py
@@ -1,0 +1,481 @@
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+from pathlib import Path
+from typing import Any, Optional
+
+from nim_bot_py.bridge import NimBridgeError
+from nim_bot_py.bridge import NodeBridge as PackagedNodeBridge
+
+from gateway.config import (
+    NimResolvedConfig,
+    Platform,
+    PlatformConfig,
+    _default_nim_bridge_command,
+    decode_nim_chat_id,
+    encode_nim_chat_id,
+    load_nim_config,
+    load_nim_instances,
+)
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from gateway.platforms.nim_bridge import NodeBridgeProcess
+
+logger = logging.getLogger(__name__)
+
+
+def check_nim_requirements(config: PlatformConfig | None = None) -> bool:
+    instances = load_nim_instances(config or PlatformConfig(enabled=True))
+    if not instances:
+        return False
+    return any(_check_nim_instance_requirements(resolved) for resolved in instances)
+
+
+def _check_nim_instance_requirements(resolved: NimResolvedConfig) -> bool:
+    command = list(resolved.bridge_command or [])
+    if not command:
+        return False
+    executable = command[0]
+    if os.path.isabs(executable) or "/" in executable:
+        executable_ok = Path(executable).exists()
+    else:
+        executable_ok = shutil.which(executable) is not None
+    if not executable_ok:
+        return False
+
+    default_command = _default_nim_bridge_command()
+    if command == default_command:
+        try:
+            PackagedNodeBridge(command=command).ensure_runtime()
+        except NimBridgeError as exc:
+            logger.warning("[nim] nim-bot-py runtime is unavailable: %s", exc)
+            return False
+        return True
+
+    if len(command) >= 2 and executable.endswith("node"):
+        return Path(command[1]).exists()
+
+    return True
+
+
+class NimAdapter(BasePlatformAdapter):
+    MAX_MESSAGE_LENGTH = 4000
+
+    def __init__(
+        self,
+        config: PlatformConfig,
+        *,
+        bridge: NodeBridgeProcess | Any | None = None,
+        resolved: NimResolvedConfig | None = None,
+        event_sink: Any | None = None,
+    ) -> None:
+        super().__init__(config=config, platform=Platform.NIM)
+        self.resolved: NimResolvedConfig = resolved or load_nim_config(config)
+        self._bridge = bridge or NodeBridgeProcess(self.resolved.bridge_command)
+        self._chat_cache: dict[str, dict[str, str]] = {}
+        self._event_sink = event_sink
+
+    async def connect(self) -> bool:
+        if not self.resolved.configured():
+            self._mark_disconnected()
+            return False
+        await self._bridge.start(self.resolved, event_handler=self._on_bridge_event)
+        self._mark_connected()
+        return True
+
+    async def disconnect(self) -> None:
+        await self._bridge.stop()
+        self._mark_disconnected()
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> SendResult:
+        routed_chat_id = self._strip_route_prefix(chat_id)
+        session_type = self._infer_session_type(routed_chat_id, metadata)
+        reply_to_id = reply_to or (metadata or {}).get("reply_to")
+        result: dict[str, Any] | None = None
+        for chunk in self._split_content(content):
+            result = await self._bridge.send_text(
+                chat_id=routed_chat_id,
+                text=chunk,
+                session_type=session_type,
+                reply_to=reply_to_id,
+            )
+        return SendResult(
+            success=True,
+            message_id=str((result or {}).get("message_id") or (result or {}).get("client_message_id") or ""),
+            raw_response=result or {},
+        )
+
+    def _split_content(self, content: str) -> list[str]:
+        chunk_limit = max(1, int(self.resolved.text_chunk_limit or self.MAX_MESSAGE_LENGTH))
+        if len(content) <= chunk_limit:
+            return [content]
+
+        chunks: list[str] = []
+        remaining = content
+        while remaining:
+            if len(remaining) <= chunk_limit:
+                chunks.append(remaining)
+                break
+            split_at = remaining.rfind("\n", 0, chunk_limit)
+            if split_at > 0:
+                chunks.append(remaining[:split_at + 1])
+                remaining = remaining[split_at + 1 :]
+                continue
+            chunks.append(remaining[:chunk_limit])
+            remaining = remaining[chunk_limit:]
+        return chunks
+
+    async def get_chat_info(self, chat_id: str) -> dict[str, Any]:
+        routed_chat_id = self._strip_route_prefix(chat_id)
+        cached = self._chat_cache.get(routed_chat_id)
+        if cached is not None:
+            return dict(cached)
+        if routed_chat_id.startswith(("team:", "superTeam:", "qchat:")):
+            return {"name": routed_chat_id, "type": "group"}
+        return {"name": routed_chat_id, "type": "dm"}
+
+    async def health(self) -> dict[str, Any]:
+        return await self._bridge.health()
+
+    async def _on_bridge_event(self, envelope: dict[str, Any]) -> None:
+        if envelope.get("event") != "message":
+            return
+        payload = dict(envelope.get("payload") or {})
+        ignore_reason = self._ignore_reason(payload)
+        self._log_inbound_debug(payload, ignore_reason)
+        if ignore_reason is not None:
+            return
+        event = self._to_message_event(payload)
+        routed_chat_id = self._strip_route_prefix(event.source.chat_id)
+        self._chat_cache[routed_chat_id] = {
+            "name": event.source.chat_name or event.source.chat_id,
+            "type": event.source.chat_type,
+        }
+        if self._event_sink is not None:
+            await self._event_sink(event)
+            return
+        await self.handle_message(event)
+
+    def _ignore_reason(self, payload: dict[str, Any]) -> str | None:
+        if payload.get("from_self"):
+            return "self_message"
+        session_type = str(payload.get("session_type") or "p2p")
+        sender_id = str(payload.get("sender_id") or "")
+        if session_type == "p2p":
+            if not self._is_allowed_direct_sender(sender_id):
+                return "dm_sender_not_allowed"
+            return None
+        if session_type in {"team", "superTeam"}:
+            if not self._is_allowed_team_message(
+                group_id=str(payload.get("target_id") or ""),
+                sender_id=sender_id,
+                session_type=session_type,
+            ):
+                return "group_not_allowed"
+            if not self._is_mentioned(payload):
+                return "group_not_mentioned"
+            return None
+        if session_type == "qchat":
+            if not self._is_allowed_qchat_message(
+                server_id=str(payload.get("server_id") or ""),
+                channel_id=str(payload.get("channel_id") or ""),
+                sender_id=sender_id,
+            ):
+                return "qchat_not_allowed"
+            if not self._is_mentioned(payload):
+                return "qchat_not_mentioned"
+            return None
+        return f"unsupported_session_type:{session_type}"
+
+    def _log_inbound_debug(self, payload: dict[str, Any], ignore_reason: str | None) -> None:
+        if not self.resolved.debug:
+            return
+        session_type = str(payload.get("session_type") or "p2p")
+        if session_type == "p2p" and ignore_reason is None:
+            return
+        force_push_ids = [str(item) for item in payload.get("force_push_account_ids") or []]
+        logger.info(
+            "[nim:%s] inbound debug session_type=%s sender=%s target=%s mentioned=%s mention_all=%s "
+            "force_push_ids=%s ignore_reason=%s text=%r",
+            self.resolved.instance_name,
+            session_type,
+            str(payload.get("sender_id") or ""),
+            str(payload.get("target_id") or ""),
+            bool(payload.get("mentioned")),
+            bool(payload.get("mention_all")),
+            force_push_ids,
+            ignore_reason or "accepted",
+            str(payload.get("text") or "")[:200],
+        )
+
+    def _is_allowed_direct_sender(self, sender_id: str) -> bool:
+        policy = self.resolved.p2p_policy
+        if policy == "disabled":
+            return False
+        if policy == "open":
+            return True
+        if not self.resolved.p2p_allow_from:
+            return False
+        normalized_sender = sender_id.lower()
+        return any(entry.lower() == normalized_sender for entry in self.resolved.p2p_allow_from)
+
+    def _is_allowed_team_message(self, *, group_id: str, sender_id: str, session_type: str) -> bool:
+        policy = self.resolved.team_policy
+        if policy == "disabled":
+            return False
+        if policy == "open":
+            return True
+        if not self.resolved.team_allow_from:
+            return False
+
+        normalized_group = group_id.lower()
+        normalized_sender = sender_id.lower()
+        normalized_type = "superTeam" if session_type == "superTeam" else "team"
+
+        for raw_entry in self.resolved.team_allow_from:
+            parts = [part.strip() for part in str(raw_entry).split("|")]
+            first = (parts[0] if parts else "").lower()
+            entry_type: str | None = None
+
+            if first in {"1", "2"}:
+                entry_type = "team" if first == "1" else "superTeam"
+                entry_group = (parts[1] if len(parts) > 1 else "").strip().lower()
+                entry_sender = (parts[2] if len(parts) > 2 else "").strip().lower()
+            else:
+                entry_group = first
+                entry_sender = (parts[1] if len(parts) > 1 else "").strip().lower()
+
+            if entry_type is not None and normalized_type != entry_type:
+                continue
+            if entry_group != normalized_group:
+                continue
+            if entry_sender and entry_sender != normalized_sender:
+                continue
+            return True
+
+        return False
+
+    def _is_allowed_qchat_message(self, *, server_id: str, channel_id: str, sender_id: str) -> bool:
+        policy = self.resolved.qchat_policy
+        if policy == "disabled":
+            return False
+        if policy == "open":
+            return True
+        if not self.resolved.qchat_allow_from:
+            return False
+
+        normalized_server = server_id.lower()
+        normalized_channel = channel_id.lower()
+        normalized_sender = sender_id.lower()
+
+        for raw_entry in self.resolved.qchat_allow_from:
+            parts = [part.strip() for part in str(raw_entry).split("|")]
+            entry_server = (parts[0] if parts else "").lower()
+            entry_channel = (parts[1] if len(parts) > 1 else "").strip().lower()
+            entry_sender = (parts[2] if len(parts) > 2 else "").strip().lower()
+
+            if entry_server != normalized_server:
+                continue
+            if entry_channel and entry_channel != normalized_channel:
+                continue
+            if entry_sender and entry_sender != normalized_sender:
+                continue
+            return True
+
+        return False
+
+    def _is_mentioned(self, payload: dict[str, Any]) -> bool:
+        if payload.get("mentioned") or payload.get("mention_all"):
+            return True
+        force_push_ids = {str(item) for item in payload.get("force_push_account_ids") or []}
+        account = self.resolved.credentials.account if self.resolved.credentials else ""
+        return bool(account and account in force_push_ids)
+
+    def _to_message_event(self, payload: dict[str, Any]) -> MessageEvent:
+        session_type = str(payload.get("session_type") or "p2p")
+        sender_id = str(payload.get("sender_id") or "")
+        target_id = str(payload.get("target_id") or "")
+        chat_type = "dm" if session_type == "p2p" else "group"
+        if session_type == "p2p":
+            raw_chat_id = f"user:{sender_id}"
+        elif session_type == "qchat":
+            server_id = str(payload.get("server_id") or "")
+            channel_id = str(payload.get("channel_id") or "")
+            target = target_id or f"{server_id}:{channel_id}".strip(":")
+            raw_chat_id = f"qchat:{target}"
+        elif session_type == "superTeam":
+            raw_chat_id = f"superTeam:{target_id}"
+        else:
+            raw_chat_id = f"team:{target_id}"
+        chat_id = self._apply_route_prefix(raw_chat_id)
+        source = self.build_source(
+            chat_id=chat_id,
+            chat_type=chat_type,
+            chat_name=payload.get("conversation_name"),
+            user_id=sender_id,
+            user_name=payload.get("sender_name"),
+        )
+        return MessageEvent(
+            text=str(payload.get("text") or ""),
+            message_type=self._to_message_type(str(payload.get("message_type") or "text")),
+            source=source,
+            raw_message=payload,
+            message_id=str(payload.get("message_id") or payload.get("client_message_id") or ""),
+            reply_to_message_id=str(payload.get("reply_to") or "") or None,
+        )
+
+    def _infer_session_type(self, chat_id: str, metadata: dict[str, Any] | None) -> str:
+        if metadata and metadata.get("session_type"):
+            return str(metadata["session_type"])
+        if chat_id.startswith("qchat:"):
+            return "qchat"
+        if chat_id.startswith("superTeam:"):
+            return "superTeam"
+        if chat_id.startswith("team:"):
+            return "team"
+        return "p2p"
+
+    def _to_message_type(self, value: str) -> MessageType:
+        mapping = {
+            "text": MessageType.TEXT,
+            "image": MessageType.PHOTO,
+            "audio": MessageType.AUDIO,
+            "video": MessageType.VIDEO,
+            "file": MessageType.DOCUMENT,
+        }
+        return mapping.get(value, MessageType.TEXT)
+
+    def _apply_route_prefix(self, chat_id: str) -> str:
+        return encode_nim_chat_id(self.resolved.instance_name, chat_id) if self.resolved.route_prefix else chat_id
+
+    def _strip_route_prefix(self, chat_id: str) -> str:
+        if not self.resolved.route_prefix:
+            return str(chat_id)
+        instance_name, routed = decode_nim_chat_id(chat_id)
+        if instance_name == self.resolved.instance_name and routed:
+            return routed
+        return str(chat_id)
+
+
+class MultiNimAdapter(BasePlatformAdapter):
+    def __init__(
+        self,
+        config: PlatformConfig,
+        *,
+        resolved_instances: list[NimResolvedConfig] | None = None,
+        bridge_factory: Any | None = None,
+    ) -> None:
+        super().__init__(config=config, platform=Platform.NIM)
+        self._resolved_instances = resolved_instances or load_nim_instances(config)
+        self._bridge_factory = bridge_factory
+        self._instances: dict[str, NimAdapter] = {}
+        self._default_instance_name: str | None = None
+
+    async def connect(self) -> bool:
+        if not self._resolved_instances:
+            self._mark_disconnected()
+            return False
+
+        connected = 0
+        self._instances = {}
+        self._default_instance_name = None
+        for resolved in self._resolved_instances:
+            bridge = self._bridge_factory(resolved) if self._bridge_factory else None
+            adapter = NimAdapter(
+                self.config,
+                bridge=bridge,
+                resolved=resolved,
+                event_sink=self.handle_message,
+            )
+            self._instances[resolved.instance_name] = adapter
+            if self._default_instance_name is None:
+                self._default_instance_name = resolved.instance_name
+            try:
+                success = await adapter.connect()
+            except Exception:
+                self._instances.pop(resolved.instance_name, None)
+                if self._default_instance_name == resolved.instance_name:
+                    self._default_instance_name = next(iter(self._instances), None)
+                logger.exception("[nim:%s] connect failed", resolved.instance_name)
+                continue
+            if not success:
+                self._instances.pop(resolved.instance_name, None)
+                if self._default_instance_name == resolved.instance_name:
+                    self._default_instance_name = next(iter(self._instances), None)
+                continue
+            connected += 1
+
+        if connected:
+            self._mark_connected()
+            return True
+
+        self._mark_disconnected()
+        return False
+
+    async def disconnect(self) -> None:
+        for adapter in list(self._instances.values()):
+            try:
+                await adapter.disconnect()
+            except Exception:
+                logger.debug("[nim] failed to disconnect child adapter", exc_info=True)
+        self._instances.clear()
+        self._default_instance_name = None
+        self._mark_disconnected()
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[dict[str, Any]] = None,
+    ) -> SendResult:
+        adapter, routed_chat_id = self._resolve_adapter(chat_id, metadata)
+        if adapter is None:
+            raise RuntimeError("NIM instance is unavailable for chat target")
+        return await adapter.send(routed_chat_id, content, reply_to=reply_to, metadata=metadata)
+
+    async def get_chat_info(self, chat_id: str) -> dict[str, Any]:
+        adapter, routed_chat_id = self._resolve_adapter(chat_id, None)
+        if adapter is None:
+            return {"name": chat_id, "type": "dm"}
+        return await adapter.get_chat_info(routed_chat_id)
+
+    async def health(self) -> dict[str, Any]:
+        children = {}
+        for name, adapter in self._instances.items():
+            try:
+                children[name] = await adapter.health()
+            except Exception as exc:
+                children[name] = {"connected": False, "error": str(exc)}
+        return {
+            "connected": bool(self._instances),
+            "instances": children,
+        }
+
+    def _resolve_adapter(
+        self,
+        chat_id: str,
+        metadata: dict[str, Any] | None,
+    ) -> tuple[NimAdapter | None, str]:
+        requested_instance = None
+        if metadata:
+            requested_instance = str(metadata.get("nim_instance") or "").strip() or None
+        routed_instance, routed_chat_id = decode_nim_chat_id(chat_id)
+        instance_name = requested_instance or routed_instance or self._default_instance_name
+        if instance_name and instance_name in self._instances:
+            return self._instances[instance_name], routed_chat_id if routed_instance else str(chat_id)
+        if requested_instance or routed_instance:
+            return None, routed_chat_id if routed_instance else str(chat_id)
+        if self._default_instance_name and self._default_instance_name in self._instances:
+            return self._instances[self._default_instance_name], str(chat_id)
+        return None, str(chat_id)
+
+
+PlatformAdapter = NimAdapter

--- a/gateway/platforms/nim.py
+++ b/gateway/platforms/nim.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import os
 import shutil
+import time
 from pathlib import Path
 from typing import Any, Optional
 
@@ -166,6 +167,9 @@ class NimAdapter(BasePlatformAdapter):
     def _ignore_reason(self, payload: dict[str, Any]) -> str | None:
         if payload.get("from_self"):
             return "self_message"
+        message_source = payload.get("message_source")
+        if message_source not in (None, "", 1, "1"):
+            return f"non_online_message_source:{message_source}"
         session_type = str(payload.get("session_type") or "p2p")
         sender_id = str(payload.get("sender_id") or "")
         if session_type == "p2p":
@@ -365,6 +369,8 @@ class NimAdapter(BasePlatformAdapter):
 
 
 class MultiNimAdapter(BasePlatformAdapter):
+    _QCHAT_DEDUPE_TTL_SECONDS = 15.0
+
     def __init__(
         self,
         config: PlatformConfig,
@@ -377,6 +383,7 @@ class MultiNimAdapter(BasePlatformAdapter):
         self._bridge_factory = bridge_factory
         self._instances: dict[str, NimAdapter] = {}
         self._default_instance_name: str | None = None
+        self._recent_qchat_events: dict[str, float] = {}
 
     async def connect(self) -> bool:
         if not self._resolved_instances:
@@ -429,6 +436,11 @@ class MultiNimAdapter(BasePlatformAdapter):
         self._default_instance_name = None
         self._mark_disconnected()
 
+    async def handle_message(self, event: MessageEvent) -> None:
+        if self._should_drop_duplicate_qchat_event(event):
+            return
+        await super().handle_message(event)
+
     async def send(
         self,
         chat_id: str,
@@ -476,6 +488,42 @@ class MultiNimAdapter(BasePlatformAdapter):
         if self._default_instance_name and self._default_instance_name in self._instances:
             return self._instances[self._default_instance_name], str(chat_id)
         return None, str(chat_id)
+
+    def _should_drop_duplicate_qchat_event(self, event: MessageEvent) -> bool:
+        raw_message = event.raw_message if isinstance(event.raw_message, dict) else {}
+        session_type = str(raw_message.get("session_type") or "")
+        if session_type != "qchat":
+            return False
+
+        server_id = str(raw_message.get("server_id") or raw_message.get("serverId") or "")
+        channel_id = str(raw_message.get("channel_id") or raw_message.get("channelId") or "")
+        sender_id = str(raw_message.get("sender_id") or raw_message.get("senderId") or event.source.user_id or "")
+        message_id = str(
+            event.message_id
+            or raw_message.get("message_id")
+            or raw_message.get("msgIdServer")
+            or raw_message.get("msg_server_id")
+            or raw_message.get("client_message_id")
+            or raw_message.get("msgIdClient")
+            or raw_message.get("msg_client_id")
+            or ""
+        )
+        if not message_id:
+            message_id = f"{sender_id}|{server_id}|{channel_id}|{event.text}"
+        dedupe_key = f"{sender_id}|{server_id}|{channel_id}|{message_id}"
+
+        now = time.monotonic()
+        cutoff = now - self._QCHAT_DEDUPE_TTL_SECONDS
+        expired = [key for key, ts in self._recent_qchat_events.items() if ts < cutoff]
+        for key in expired:
+            self._recent_qchat_events.pop(key, None)
+
+        if dedupe_key in self._recent_qchat_events:
+            logger.info("[nim] dropping duplicate qchat event: %s", dedupe_key)
+            return True
+
+        self._recent_qchat_events[dedupe_key] = now
+        return False
 
 
 PlatformAdapter = NimAdapter

--- a/gateway/platforms/nim_bridge.py
+++ b/gateway/platforms/nim_bridge.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any, Awaitable, Callable
+
+from gateway.config import NimResolvedConfig
+from nim_bot_py.bridge import NimBridgeError as BridgeError
+from nim_bot_py.bridge import NodeBridge
+
+
+BridgeEventHandler = Callable[[dict[str, Any]], Awaitable[None] | None]
+
+
+class NodeBridgeProcess(NodeBridge):
+    def __init__(
+        self,
+        command: Sequence[str],
+        *,
+        cwd: str | None = None,
+        request_timeout: float = 10.0,
+    ) -> None:
+        super().__init__(
+            command=command,
+            cwd=cwd,
+            request_timeout=request_timeout,
+            auto_install=True,
+        )
+
+    async def start(
+        self,
+        config: NimResolvedConfig,
+        *,
+        event_handler: BridgeEventHandler | None = None,
+    ) -> None:
+        await super().start(config, event_handler=event_handler)
+
+    async def send_text(
+        self,
+        *,
+        chat_id: str,
+        text: str,
+        session_type: str,
+        reply_to: str | None = None,
+    ) -> dict[str, Any]:
+        return await self.send_message(
+            chat_id=chat_id,
+            text=text,
+            session_type=session_type,
+        )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2816,6 +2816,18 @@ class GatewayRunner:
             os.getenv(v, "").lower() in ("true", "1", "yes")
             for v in _builtin_allow_all_vars + _plugin_allow_all_vars
         )
+        try:
+            from gateway.config import load_nim_instances
+
+            nim_platform = self.config.platforms.get(Platform.NIM)
+            if nim_platform is not None:
+                nim_instances = load_nim_instances(nim_platform)
+                if any(instance.p2p_allow_from for instance in nim_instances):
+                    _any_allowlist = True
+                if any(instance.p2p_policy == "open" for instance in nim_instances):
+                    _allow_all = True
+        except Exception:
+            pass
         if not _any_allowlist and not _allow_all:
             logger.warning(
                 "No user allowlists configured. All unauthorized users will be denied. "
@@ -4288,6 +4300,26 @@ class GatewayRunner:
                 return None
             return WeixinAdapter(config)
 
+        elif platform == Platform.NIM:
+            from gateway.platforms.nim import MultiNimAdapter, NimAdapter, check_nim_requirements
+            from gateway.config import load_nim_instances
+            nim_instances = load_nim_instances(config)
+            if not check_nim_requirements(config):
+                logger.warning(
+                    "NIM: bridge runtime is unavailable. Hermes now uses nim-bot-py for "
+                    "the default NIM bridge; install nim-bot-py and ensure node/npm are "
+                    "available."
+                )
+                return None
+            has_explicit_instances = bool(
+                (isinstance(getattr(config, "extra", None), dict) and "instances" in config.extra)
+                or os.getenv("NIM_INSTANCES", "").strip()
+            )
+            if len(nim_instances) > 1 or (nim_instances and has_explicit_instances):
+                return MultiNimAdapter(config, resolved_instances=nim_instances)
+            if nim_instances:
+                return NimAdapter(config, resolved=nim_instances[0])
+            return NimAdapter(config)
         elif platform == Platform.MATTERMOST:
             from gateway.platforms.mattermost import MattermostAdapter, check_mattermost_requirements
             if not check_mattermost_requirements():

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -508,6 +508,8 @@ from gateway.config import (
     HomeChannel,
     PlatformConfig,
     load_gateway_config,
+    load_nim_instances,
+    decode_nim_chat_id,
 )
 from gateway.session import (
     SessionStore,
@@ -4378,7 +4380,7 @@ class GatewayRunner:
         
         Checks in order:
         1. Per-platform allow-all flag (e.g., DISCORD_ALLOW_ALL_USERS=true)
-        2. Environment variable allowlists (TELEGRAM_ALLOWED_USERS, etc.)
+        2. Platform allowlists (env vars for most platforms, config.yaml for NIM)
         3. DM pairing approved list
         4. Global allow-all (GATEWAY_ALLOW_ALL_USERS=true)
         5. Default: deny
@@ -4395,6 +4397,12 @@ class GatewayRunner:
         if not user_id:
             return False
 
+        nim_resolved = None
+        if source.platform == Platform.NIM:
+            nim_resolved = self._resolve_nim_source_config(source)
+            if nim_resolved and nim_resolved.allow_all_users:
+                return True
+
         platform_env_map = {
             Platform.TELEGRAM: "TELEGRAM_ALLOWED_USERS",
             Platform.DISCORD: "DISCORD_ALLOWED_USERS",
@@ -4410,7 +4418,6 @@ class GatewayRunner:
             Platform.WECOM: "WECOM_ALLOWED_USERS",
             Platform.WECOM_CALLBACK: "WECOM_CALLBACK_ALLOWED_USERS",
             Platform.WEIXIN: "WEIXIN_ALLOWED_USERS",
-            Platform.NIM: "NIM_ALLOWED_USERS",
             Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOWED_USERS",
             Platform.QQBOT: "QQ_ALLOWED_USERS",
             Platform.YUANBAO: "YUANBAO_ALLOWED_USERS",
@@ -4437,7 +4444,6 @@ class GatewayRunner:
             Platform.WECOM: "WECOM_ALLOW_ALL_USERS",
             Platform.WECOM_CALLBACK: "WECOM_CALLBACK_ALLOW_ALL_USERS",
             Platform.WEIXIN: "WEIXIN_ALLOW_ALL_USERS",
-            Platform.NIM: "NIM_ALLOW_ALL_USERS",
             Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOW_ALL_USERS",
             Platform.QQBOT: "QQ_ALLOW_ALL_USERS",
             Platform.YUANBAO: "YUANBAO_ALLOW_ALL_USERS",
@@ -4489,7 +4495,12 @@ class GatewayRunner:
             return True
 
         # Check platform-specific and global allowlists
-        platform_allowlist = os.getenv(platform_env_map.get(source.platform, ""), "").strip()
+        platform_allowlist = ""
+        if source.platform == Platform.NIM:
+            if nim_resolved:
+                platform_allowlist = ",".join(nim_resolved.allowed_users)
+        else:
+            platform_allowlist = os.getenv(platform_env_map.get(source.platform, ""), "").strip()
         group_user_allowlist = ""
         group_chat_allowlist = ""
         if source.chat_type in {"group", "forum"}:
@@ -4585,6 +4596,7 @@ class GatewayRunner:
         2. Explicit global ``unauthorized_dm_behavior`` in config — wins when no per-platform.
         3. When an allowlist (``PLATFORM_ALLOWED_USERS``,
            ``PLATFORM_GROUP_ALLOWED_USERS`` / ``PLATFORM_GROUP_ALLOWED_CHATS``,
+           NIM config,
            or ``GATEWAY_ALLOWED_USERS``) is configured, default to ``"ignore"`` —
            the allowlist signals that the owner has deliberately restricted
            access; spamming unknown contacts with pairing codes is both noisy
@@ -4624,7 +4636,6 @@ class GatewayRunner:
                 Platform.WECOM:    "WECOM_ALLOWED_USERS",
                 Platform.WECOM_CALLBACK: "WECOM_CALLBACK_ALLOWED_USERS",
                 Platform.WEIXIN:   "WEIXIN_ALLOWED_USERS",
-                Platform.NIM:      "NIM_ALLOWED_USERS",
                 Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOWED_USERS",
                 Platform.QQBOT:    "QQ_ALLOWED_USERS",
             }
@@ -4640,6 +4651,9 @@ class GatewayRunner:
             for env_key in platform_group_env_map.get(platform, ()):
                 if os.getenv(env_key, "").strip():
                     return "ignore"
+
+            if platform == Platform.NIM and self._nim_has_restricted_dm_access():
+                return "ignore"
 
         if os.getenv("GATEWAY_ALLOWED_USERS", "").strip():
             return "ignore"
@@ -4676,6 +4690,41 @@ class GatewayRunner:
                 )
 
         await adapter.send(source.chat_id, content, metadata=metadata)
+
+    def _resolve_nim_source_config(self, source: SessionSource):
+        if source.platform != Platform.NIM:
+            return None
+        config = getattr(self, "config", None)
+        if not config or not hasattr(config, "platforms"):
+            return None
+        platform_cfg = config.platforms.get(Platform.NIM)
+        if not platform_cfg:
+            return None
+
+        instances = load_nim_instances(platform_cfg)
+        if not instances:
+            return None
+        if len(instances) == 1:
+            return instances[0]
+
+        instance_name, _chat_id = decode_nim_chat_id(source.chat_id)
+        if instance_name:
+            for item in instances:
+                if item.instance_name == instance_name:
+                    return item
+        return instances[0]
+
+    def _nim_has_restricted_dm_access(self) -> bool:
+        config = getattr(self, "config", None)
+        if not config or not hasattr(config, "platforms"):
+            return False
+        platform_cfg = config.platforms.get(Platform.NIM)
+        if not platform_cfg:
+            return False
+        instances = load_nim_instances(platform_cfg)
+        if not instances:
+            return False
+        return any(not item.allow_all_users for item in instances)
 
     async def _handle_message(self, event: MessageEvent) -> Optional[str]:
         """
@@ -8336,10 +8385,53 @@ class GatewayRunner:
         # Save to .env so it persists across restarts
         try:
             from hermes_cli.config import save_env_value
-            save_env_value(env_key, str(chat_id))
-            # Keep thread/topic routing explicit and clear stale values when
-            # /sethome is run from the parent chat instead of a thread.
-            save_env_value(thread_env_key, str(thread_id or ""))
+            config_path = _hermes_home / 'config.yaml'
+            user_config = {}
+            if config_path.exists():
+                with open(config_path, encoding="utf-8") as f:
+                    user_config = yaml.safe_load(f) or {}
+            if source.platform == Platform.NIM:
+                nim_cfg = user_config.get("nim")
+                if not isinstance(nim_cfg, dict):
+                    return "Failed to save home channel: nim.instances is not configured."
+                raw_instances = nim_cfg.get("instances")
+                if not isinstance(raw_instances, list) or not raw_instances:
+                    return "Failed to save home channel: nim.instances is not configured."
+
+                instances = [
+                    item for item in raw_instances
+                    if isinstance(item, dict)
+                ]
+                if not instances:
+                    return "Failed to save home channel: nim.instances is not configured."
+
+                instance_name, routed_chat_id = decode_nim_chat_id(chat_id)
+                target_index = None
+                if instance_name:
+                    for idx, item in enumerate(instances):
+                        raw_name = item.get("instance_name") or item.get("instanceName") or item.get("name")
+                        if str(raw_name or "").strip().lower() == instance_name.lower():
+                            target_index = idx
+                            break
+                    if target_index is None:
+                        return f"Failed to save home channel: unknown NIM instance '{instance_name}'."
+                elif len(instances) == 1:
+                    target_index = 0
+                else:
+                    return "Failed to save home channel: could not determine which NIM instance this chat belongs to."
+
+                instances[target_index]["home_channel"] = routed_chat_id
+                nim_cfg["instances"] = instances
+                user_config["nim"] = nim_cfg
+                atomic_yaml_write(config_path, user_config)
+                self.config = load_gateway_config()
+            else:
+                save_env_value(env_key, str(chat_id))
+                # Keep thread/topic routing explicit and clear stale values when
+                # /sethome is run from the parent chat instead of a thread.
+                save_env_value(thread_env_key, str(thread_id or ""))
+                os.environ[env_key] = str(chat_id)
+                os.environ[thread_env_key] = str(thread_id or "")
         except Exception as e:
             return f"Failed to save home channel: {e}"
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -26,6 +26,7 @@ import signal
 import tempfile
 import threading
 import time
+import yaml
 from collections import OrderedDict
 from contextvars import copy_context
 from pathlib import Path

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4410,6 +4410,7 @@ class GatewayRunner:
             Platform.WECOM: "WECOM_ALLOWED_USERS",
             Platform.WECOM_CALLBACK: "WECOM_CALLBACK_ALLOWED_USERS",
             Platform.WEIXIN: "WEIXIN_ALLOWED_USERS",
+            Platform.NIM: "NIM_ALLOWED_USERS",
             Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOWED_USERS",
             Platform.QQBOT: "QQ_ALLOWED_USERS",
             Platform.YUANBAO: "YUANBAO_ALLOWED_USERS",
@@ -4436,6 +4437,7 @@ class GatewayRunner:
             Platform.WECOM: "WECOM_ALLOW_ALL_USERS",
             Platform.WECOM_CALLBACK: "WECOM_CALLBACK_ALLOW_ALL_USERS",
             Platform.WEIXIN: "WEIXIN_ALLOW_ALL_USERS",
+            Platform.NIM: "NIM_ALLOW_ALL_USERS",
             Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOW_ALL_USERS",
             Platform.QQBOT: "QQ_ALLOW_ALL_USERS",
             Platform.YUANBAO: "YUANBAO_ALLOW_ALL_USERS",
@@ -4622,6 +4624,7 @@ class GatewayRunner:
                 Platform.WECOM:    "WECOM_ALLOWED_USERS",
                 Platform.WECOM_CALLBACK: "WECOM_CALLBACK_ALLOWED_USERS",
                 Platform.WEIXIN:   "WEIXIN_ALLOWED_USERS",
+                Platform.NIM:      "NIM_ALLOWED_USERS",
                 Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOWED_USERS",
                 Platform.QQBOT:    "QQ_ALLOWED_USERS",
             }

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -273,6 +273,8 @@ from gateway.config import (
     Platform,
     GatewayConfig,
     load_gateway_config,
+    load_nim_instances,
+    decode_nim_chat_id,
 )
 from gateway.session import (
     SessionStore,
@@ -2908,7 +2910,7 @@ class GatewayRunner:
         
         Checks in order:
         1. Per-platform allow-all flag (e.g., DISCORD_ALLOW_ALL_USERS=true)
-        2. Environment variable allowlists (TELEGRAM_ALLOWED_USERS, etc.)
+        2. Platform allowlists (env vars for most platforms, config.yaml for NIM)
         3. DM pairing approved list
         4. Global allow-all (GATEWAY_ALLOW_ALL_USERS=true)
         5. Default: deny
@@ -2925,6 +2927,12 @@ class GatewayRunner:
         if not user_id:
             return False
 
+        nim_resolved = None
+        if source.platform == Platform.NIM:
+            nim_resolved = self._resolve_nim_source_config(source)
+            if nim_resolved and nim_resolved.allow_all_users:
+                return True
+
         platform_env_map = {
             Platform.TELEGRAM: "TELEGRAM_ALLOWED_USERS",
             Platform.DISCORD: "DISCORD_ALLOWED_USERS",
@@ -2940,7 +2948,6 @@ class GatewayRunner:
             Platform.WECOM: "WECOM_ALLOWED_USERS",
             Platform.WECOM_CALLBACK: "WECOM_CALLBACK_ALLOWED_USERS",
             Platform.WEIXIN: "WEIXIN_ALLOWED_USERS",
-            Platform.NIM: "NIM_ALLOWED_USERS",
             Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOWED_USERS",
             Platform.QQBOT: "QQ_ALLOWED_USERS",
         }
@@ -2962,7 +2969,6 @@ class GatewayRunner:
             Platform.WECOM: "WECOM_ALLOW_ALL_USERS",
             Platform.WECOM_CALLBACK: "WECOM_CALLBACK_ALLOW_ALL_USERS",
             Platform.WEIXIN: "WEIXIN_ALLOW_ALL_USERS",
-            Platform.NIM: "NIM_ALLOW_ALL_USERS",
             Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOW_ALL_USERS",
             Platform.QQBOT: "QQ_ALLOW_ALL_USERS",
         }
@@ -3000,7 +3006,12 @@ class GatewayRunner:
             return True
 
         # Check platform-specific and global allowlists
-        platform_allowlist = os.getenv(platform_env_map.get(source.platform, ""), "").strip()
+        platform_allowlist = ""
+        if source.platform == Platform.NIM:
+            if nim_resolved:
+                platform_allowlist = ",".join(nim_resolved.allowed_users)
+        else:
+            platform_allowlist = os.getenv(platform_env_map.get(source.platform, ""), "").strip()
         group_allowlist = ""
         if source.chat_type == "group":
             group_allowlist = os.getenv(platform_group_env_map.get(source.platform, ""), "").strip()
@@ -3055,7 +3066,7 @@ class GatewayRunner:
         Resolution order:
         1. Explicit per-platform ``unauthorized_dm_behavior`` in config — always wins.
         2. Explicit global ``unauthorized_dm_behavior`` in config — wins when no per-platform.
-        3. When an allowlist (``PLATFORM_ALLOWED_USERS`` or ``GATEWAY_ALLOWED_USERS``) is
+        3. When an allowlist (``PLATFORM_ALLOWED_USERS`` / NIM config / ``GATEWAY_ALLOWED_USERS``) is
            configured, default to ``"ignore"`` — the allowlist signals that the owner has
            deliberately restricted access; spamming unknown contacts with pairing codes
            is both noisy and a potential info-leak. (#9337)
@@ -3094,17 +3105,54 @@ class GatewayRunner:
                 Platform.WECOM:    "WECOM_ALLOWED_USERS",
                 Platform.WECOM_CALLBACK: "WECOM_CALLBACK_ALLOWED_USERS",
                 Platform.WEIXIN:   "WEIXIN_ALLOWED_USERS",
-                Platform.NIM:      "NIM_ALLOWED_USERS",
                 Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOWED_USERS",
                 Platform.QQBOT:    "QQ_ALLOWED_USERS",
             }
             if os.getenv(platform_env_map.get(platform, ""), "").strip():
                 return "ignore"
 
+            if platform == Platform.NIM and self._nim_has_restricted_dm_access():
+                return "ignore"
+
         if os.getenv("GATEWAY_ALLOWED_USERS", "").strip():
             return "ignore"
 
         return "pair"
+
+    def _resolve_nim_source_config(self, source: SessionSource):
+        if source.platform != Platform.NIM:
+            return None
+        config = getattr(self, "config", None)
+        if not config or not hasattr(config, "platforms"):
+            return None
+        platform_cfg = config.platforms.get(Platform.NIM)
+        if not platform_cfg:
+            return None
+
+        instances = load_nim_instances(platform_cfg)
+        if not instances:
+            return None
+        if len(instances) == 1:
+            return instances[0]
+
+        instance_name, _chat_id = decode_nim_chat_id(source.chat_id)
+        if instance_name:
+            for item in instances:
+                if item.instance_name == instance_name:
+                    return item
+        return instances[0]
+
+    def _nim_has_restricted_dm_access(self) -> bool:
+        config = getattr(self, "config", None)
+        if not config or not hasattr(config, "platforms"):
+            return False
+        platform_cfg = config.platforms.get(Platform.NIM)
+        if not platform_cfg:
+            return False
+        instances = load_nim_instances(platform_cfg)
+        if not instances:
+            return False
+        return any(not item.allow_all_users for item in instances)
     
     async def _handle_message(self, event: MessageEvent) -> Optional[str]:
         """
@@ -5910,10 +5958,46 @@ class GatewayRunner:
             if config_path.exists():
                 with open(config_path, encoding="utf-8") as f:
                     user_config = yaml.safe_load(f) or {}
-            user_config[env_key] = chat_id
+            if source.platform == Platform.NIM:
+                nim_cfg = user_config.get("nim")
+                if not isinstance(nim_cfg, dict):
+                    return "Failed to save home channel: nim.instances is not configured."
+                raw_instances = nim_cfg.get("instances")
+                if not isinstance(raw_instances, list) or not raw_instances:
+                    return "Failed to save home channel: nim.instances is not configured."
+
+                instances = [
+                    item for item in raw_instances
+                    if isinstance(item, dict)
+                ]
+                if not instances:
+                    return "Failed to save home channel: nim.instances is not configured."
+
+                instance_name, routed_chat_id = decode_nim_chat_id(chat_id)
+                target_index = None
+                if instance_name:
+                    for idx, item in enumerate(instances):
+                        raw_name = item.get("instance_name") or item.get("instanceName") or item.get("name")
+                        if str(raw_name or "").strip().lower() == instance_name.lower():
+                            target_index = idx
+                            break
+                    if target_index is None:
+                        return f"Failed to save home channel: unknown NIM instance '{instance_name}'."
+                elif len(instances) == 1:
+                    target_index = 0
+                else:
+                    return "Failed to save home channel: could not determine which NIM instance this chat belongs to."
+
+                instances[target_index]["home_channel"] = routed_chat_id
+                nim_cfg["instances"] = instances
+                user_config["nim"] = nim_cfg
+            else:
+                user_config[env_key] = chat_id
             atomic_yaml_write(config_path, user_config)
-            # Also set in the current environment so it takes effect immediately
-            os.environ[env_key] = str(chat_id)
+            # Non-NIM home channels still rely on env bridging for immediate effect.
+            if source.platform != Platform.NIM:
+                os.environ[env_key] = str(chat_id)
+            self.config = load_gateway_config()
         except Exception as e:
             return f"Failed to save home channel: {e}"
         

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2940,6 +2940,7 @@ class GatewayRunner:
             Platform.WECOM: "WECOM_ALLOWED_USERS",
             Platform.WECOM_CALLBACK: "WECOM_CALLBACK_ALLOWED_USERS",
             Platform.WEIXIN: "WEIXIN_ALLOWED_USERS",
+            Platform.NIM: "NIM_ALLOWED_USERS",
             Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOWED_USERS",
             Platform.QQBOT: "QQ_ALLOWED_USERS",
         }
@@ -2961,6 +2962,7 @@ class GatewayRunner:
             Platform.WECOM: "WECOM_ALLOW_ALL_USERS",
             Platform.WECOM_CALLBACK: "WECOM_CALLBACK_ALLOW_ALL_USERS",
             Platform.WEIXIN: "WEIXIN_ALLOW_ALL_USERS",
+            Platform.NIM: "NIM_ALLOW_ALL_USERS",
             Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOW_ALL_USERS",
             Platform.QQBOT: "QQ_ALLOW_ALL_USERS",
         }
@@ -3092,6 +3094,7 @@ class GatewayRunner:
                 Platform.WECOM:    "WECOM_ALLOWED_USERS",
                 Platform.WECOM_CALLBACK: "WECOM_CALLBACK_ALLOWED_USERS",
                 Platform.WEIXIN:   "WEIXIN_ALLOWED_USERS",
+                Platform.NIM:      "NIM_ALLOWED_USERS",
                 Platform.BLUEBUBBLES: "BLUEBUBBLES_ALLOWED_USERS",
                 Platform.QQBOT:    "QQ_ALLOWED_USERS",
             }

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1955,6 +1955,18 @@ class GatewayRunner:
                        "BLUEBUBBLES_ALLOW_ALL_USERS",
                        "QQ_ALLOW_ALL_USERS")
         )
+        try:
+            from gateway.config import load_nim_instances
+
+            nim_platform = self.config.platforms.get(Platform.NIM)
+            if nim_platform is not None:
+                nim_instances = load_nim_instances(nim_platform)
+                if any(instance.p2p_allow_from for instance in nim_instances):
+                    _any_allowlist = True
+                if any(instance.p2p_policy == "open" for instance in nim_instances):
+                    _allow_all = True
+        except Exception:
+            pass
         if not _any_allowlist and not _allow_all:
             logger.warning(
                 "No user allowlists configured. All unauthorized users will be denied. "
@@ -2824,6 +2836,26 @@ class GatewayRunner:
                 return None
             return WeixinAdapter(config)
 
+        elif platform == Platform.NIM:
+            from gateway.platforms.nim import MultiNimAdapter, NimAdapter, check_nim_requirements
+            from gateway.config import load_nim_instances
+            nim_instances = load_nim_instances(config)
+            if not check_nim_requirements(config):
+                logger.warning(
+                    "NIM: bridge runtime is unavailable. Hermes now uses nim-bot-py for "
+                    "the default NIM bridge; install nim-bot-py and ensure node/npm are "
+                    "available."
+                )
+                return None
+            has_explicit_instances = bool(
+                (isinstance(getattr(config, "extra", None), dict) and "instances" in config.extra)
+                or os.getenv("NIM_INSTANCES", "").strip()
+            )
+            if len(nim_instances) > 1 or (nim_instances and has_explicit_instances):
+                return MultiNimAdapter(config, resolved_instances=nim_instances)
+            if nim_instances:
+                return NimAdapter(config, resolved=nim_instances[0])
+            return NimAdapter(config)
         elif platform == Platform.MATTERMOST:
             from gateway.platforms.mattermost import MattermostAdapter, check_mattermost_requirements
             if not check_mattermost_requirements():

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1363,7 +1363,8 @@ def build_session_context(
     
     home_channels = {}
     for platform in connected:
-        home = config.get_home_channel(platform)
+        source_chat_id = source.chat_id if platform == source.platform else None
+        home = config.get_home_channel(platform, source_chat_id=source_chat_id)
         if home:
             home_channels[platform] = home
     

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1251,7 +1251,8 @@ def build_session_context(
     
     home_channels = {}
     for platform in connected:
-        home = config.get_home_channel(platform)
+        source_chat_id = source.chat_id if platform == source.platform else None
+        home = config.get_home_channel(platform, source_chat_id=source_chat_id)
         if home:
             home_channels[platform] = home
     

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1055,6 +1055,13 @@ DEFAULT_CONFIG = {
         },
     },
 
+    # NetEase IM / NIM channel settings.
+    # Detailed multi-instance editing is primarily intended through config.yaml
+    # (or the dashboard Config page YAML editor), not the Env page.
+    "nim": {
+        "instances": [],
+    },
+
     # Honcho AI-native memory -- reads ~/.honcho/config.json as single source of truth.
     # This section is only needed for hermes-specific overrides; everything else
     # (apiKey, workspace, peerName, sessions, enabled) comes from the global config.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2586,7 +2586,7 @@ def _normalize_custom_provider_entry(
     from urllib.parse import urlparse
 
     base_url = ""
-    for url_key in ("base_url", "url", "api"):
+    for url_key in ("api", "url", "base_url"):
         raw_url = entry.get(url_key)
         if isinstance(raw_url, str) and raw_url.strip():
             candidate = raw_url.strip()

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1957,7 +1957,7 @@ def _normalize_custom_provider_entry(
     from urllib.parse import urlparse
 
     base_url = ""
-    for url_key in ("base_url", "url", "api"):
+    for url_key in ("api", "url", "base_url"):
         raw_url = entry.get(url_key)
         if isinstance(raw_url, str) and raw_url.strip():
             candidate = raw_url.strip()

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -750,6 +750,13 @@ DEFAULT_CONFIG = {
         "inline_shell_timeout": 10,
     },
 
+    # NetEase IM / NIM channel settings.
+    # Detailed multi-instance editing is primarily intended through config.yaml
+    # (or the dashboard Config page YAML editor), not the Env page.
+    "nim": {
+        "instances": [],
+    },
+
     # Honcho AI-native memory -- reads ~/.honcho/config.json as single source of truth.
     # This section is only needed for hermes-specific overrides; everything else
     # (apiKey, workspace, peerName, sessions, enabled) comes from the global config.

--- a/hermes_cli/curses_ui.py
+++ b/hermes_cli/curses_ui.py
@@ -146,7 +146,10 @@ def curses_checklist(
                 elif key == ord(" "):
                     chosen.symmetric_difference_update({cursor})
                 elif key in (curses.KEY_ENTER, 10, 13):
-                    result_holder[0] = set(chosen)
+                    if not chosen and items:
+                        result_holder[0] = {cursor}
+                    else:
+                        result_holder[0] = set(chosen)
                     return
                 elif key in (27, ord("q")):
                     result_holder[0] = cancel_returns

--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -97,6 +97,7 @@ def _cron_summary(hermes_home: Path) -> str:
 
 def _configured_platforms() -> list[str]:
     """Return list of configured messaging platform names."""
+    config = load_config()
     checks = {
         "telegram": "TELEGRAM_BOT_TOKEN",
         "discord": "DISCORD_BOT_TOKEN",
@@ -115,7 +116,16 @@ def _configured_platforms() -> list[str]:
         "weixin": "WEIXIN_ACCOUNT_ID",
         "qqbot": "QQ_APP_ID",
     }
-    return [name for name, env in checks.items() if os.getenv(env)]
+    configured = [name for name, env in checks.items() if os.getenv(env)]
+    nim_cfg = config.get("nim", {})
+    nim_instances = nim_cfg.get("instances", []) if isinstance(nim_cfg, dict) else []
+    if "nim" not in configured and isinstance(nim_instances, list) and any(isinstance(item, dict) for item in nim_instances):
+        configured.append("nim")
+    if "nim" not in configured and os.getenv("NIM_INSTANCES", "").strip():
+        configured.append("nim")
+    if "nim" not in configured and all(os.getenv(var, "") for var in ("NIM_APP_KEY", "NIM_ACCOUNT", "NIM_TOKEN")):
+        configured.append("nim")
+    return configured
 
 
 def _memory_provider(config: dict) -> str:

--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -94,6 +94,7 @@ def _cron_summary(hermes_home: Path) -> str:
 
 def _configured_platforms() -> list[str]:
     """Return list of configured messaging platform names."""
+    config = load_config()
     checks = {
         "telegram": "TELEGRAM_BOT_TOKEN",
         "discord": "DISCORD_BOT_TOKEN",
@@ -112,7 +113,16 @@ def _configured_platforms() -> list[str]:
         "weixin": "WEIXIN_ACCOUNT_ID",
         "qqbot": "QQ_APP_ID",
     }
-    return [name for name, env in checks.items() if os.getenv(env)]
+    configured = [name for name, env in checks.items() if os.getenv(env)]
+    nim_cfg = config.get("nim", {})
+    nim_instances = nim_cfg.get("instances", []) if isinstance(nim_cfg, dict) else []
+    if "nim" not in configured and isinstance(nim_instances, list) and any(isinstance(item, dict) for item in nim_instances):
+        configured.append("nim")
+    if "nim" not in configured and os.getenv("NIM_INSTANCES", "").strip():
+        configured.append("nim")
+    if "nim" not in configured and all(os.getenv(var, "") for var in ("NIM_APP_KEY", "NIM_ACCOUNT", "NIM_TOKEN")):
+        configured.append("nim")
+    return configured
 
 
 def _memory_provider(config: dict) -> str:

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3127,11 +3127,6 @@ def _platform_status(platform: dict) -> str:
         nim_instances = nim_cfg.get("instances", []) if isinstance(nim_cfg, dict) else []
         if isinstance(nim_instances, list) and any(isinstance(item, dict) for item in nim_instances):
             return "configured"
-        explicit = all(get_env_value(name) for name in ("NIM_APP_KEY", "NIM_ACCOUNT", "NIM_TOKEN"))
-        if val or get_env_value("NIM_INSTANCES") or explicit:
-            return "configured"
-        if any(get_env_value(name) for name in ("NIM_APP_KEY", "NIM_ACCOUNT", "NIM_TOKEN")):
-            return "partially configured"
         return "not configured"
     if val:
         return "configured"
@@ -3306,16 +3301,10 @@ def _setup_nim():
     nim_cfg = current_config.get("nim")
     nim_instances = nim_cfg.get("instances", []) if isinstance(nim_cfg, dict) else []
     existing_yaml_instances = isinstance(nim_instances, list) and any(isinstance(item, dict) for item in nim_instances)
-    existing_credentials = get_env_value("NIM_CREDENTIALS")
-    existing_instances = get_env_value("NIM_INSTANCES")
-    if existing_yaml_instances or existing_credentials or existing_instances:
+    if existing_yaml_instances:
         print()
         print_success(f"{label} is already configured.")
-        if existing_yaml_instances:
-            print_info("  Existing config.yaml nim.instances configuration detected.")
-        elif existing_instances:
-            print_info("  Existing multi-instance config detected in NIM_INSTANCES.")
-            print_info("  This flow will replace it with config.yaml nim.instances.")
+        print_info("  Existing config.yaml nim.instances configuration detected.")
         if not prompt_yes_no(f"  Reconfigure {label}?", False):
             return
 
@@ -3344,21 +3333,6 @@ def _setup_nim():
         ]
     }
     save_config(current_config)
-
-    save_env_value("NIM_CREDENTIALS", "")
-    save_env_value("NIM_INSTANCES", "")
-    save_env_value("NIM_APP_KEY", "")
-    save_env_value("NIM_ACCOUNT", "")
-    save_env_value("NIM_TOKEN", "")
-    save_env_value("NIM_ALLOWED_USERS", "")
-    save_env_value("NIM_ALLOW_ALL_USERS", "true")
-    save_env_value("NIM_GROUP_POLICY", "open")
-    save_env_value("NIM_GROUP_ALLOWLIST", "")
-    save_env_value("NIM_HOME_CHANNEL", "")
-    save_env_value("NIM_HOME_CHANNEL_NAME", "")
-    save_env_value("NIM_BRIDGE_COMMAND", "")
-    save_env_value("NIM_MEDIA_MAX_MB", "")
-    save_env_value("NIM_DEBUG", "")
 
     print()
     print_success(f"{emoji} {label} configured in config.yaml with open defaults!")

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -26,8 +26,10 @@ from hermes_cli.config import (
     get_env_value,
     get_hermes_home,
     is_managed,
+    load_config,
     managed_error,
     read_raw_config,
+    save_config,
     save_env_value,
 )
 # display_hermes_home is imported lazily at call sites to avoid ImportError
@@ -2922,6 +2924,22 @@ _PLATFORMS = [
         "token_var": "WEIXIN_ACCOUNT_ID",
     },
     {
+        "key": "nim",
+        "label": "NIM",
+        "emoji": "☁️",
+        "token_var": "NIM_CREDENTIALS",
+        "setup_instructions": [
+            "1. Prepare a NetEase IM bot account with App Key, account, and token",
+            "2. Hermes auto-installs @yxim/nim-bot on first start when npm is available",
+            "3. Enter appKey|account|token in the setup prompt",
+            "4. Detailed multi-instance settings live in the Web UI Config page or ~/.hermes/config.yaml",
+        ],
+        "vars": [
+            {"name": "NIM_CREDENTIALS", "prompt": "Credentials (appKey|account|token)", "password": True,
+             "help": "Compact credential form used by the default NIM setup flow."},
+        ],
+    },
+    {
         "key": "bluebubbles",
         "label": "BlueBubbles (iMessage)",
         "emoji": "💬",
@@ -3103,6 +3121,18 @@ def _platform_status(platform: dict) -> str:
         if val or token:
             return "partially configured"
         return "not configured"
+    if platform.get("key") == "nim":
+        raw_config = read_raw_config() or {}
+        nim_cfg = raw_config.get("nim", {})
+        nim_instances = nim_cfg.get("instances", []) if isinstance(nim_cfg, dict) else []
+        if isinstance(nim_instances, list) and any(isinstance(item, dict) for item in nim_instances):
+            return "configured"
+        explicit = all(get_env_value(name) for name in ("NIM_APP_KEY", "NIM_ACCOUNT", "NIM_TOKEN"))
+        if val or get_env_value("NIM_INSTANCES") or explicit:
+            return "configured"
+        if any(get_env_value(name) for name in ("NIM_APP_KEY", "NIM_ACCOUNT", "NIM_TOKEN")):
+            return "partially configured"
+        return "not configured"
     if val:
         return "configured"
     return "not configured"
@@ -3258,6 +3288,80 @@ def _setup_sms():
     """Configure SMS (Twilio) via the standard platform setup."""
     sms_platform = next(p for p in _PLATFORMS if p["key"] == "sms")
     _setup_standard_platform(sms_platform)
+
+
+def _setup_nim():
+    """Configure NIM with the compact credentials flow only."""
+    nim_platform = next(p for p in _PLATFORMS if p["key"] == "nim")
+    emoji = nim_platform["emoji"]
+    label = nim_platform["label"]
+
+    print()
+    print(color(f"  ─── {emoji} {label} Setup ───", Colors.CYAN))
+    print()
+    for line in nim_platform.get("setup_instructions", []):
+        print_info(f"  {line}")
+
+    current_config = load_config()
+    nim_cfg = current_config.get("nim")
+    nim_instances = nim_cfg.get("instances", []) if isinstance(nim_cfg, dict) else []
+    existing_yaml_instances = isinstance(nim_instances, list) and any(isinstance(item, dict) for item in nim_instances)
+    existing_credentials = get_env_value("NIM_CREDENTIALS")
+    existing_instances = get_env_value("NIM_INSTANCES")
+    if existing_yaml_instances or existing_credentials or existing_instances:
+        print()
+        print_success(f"{label} is already configured.")
+        if existing_yaml_instances:
+            print_info("  Existing config.yaml nim.instances configuration detected.")
+        elif existing_instances:
+            print_info("  Existing multi-instance config detected in NIM_INSTANCES.")
+            print_info("  This flow will replace it with config.yaml nim.instances.")
+        if not prompt_yes_no(f"  Reconfigure {label}?", False):
+            return
+
+    print()
+    print_info("  Detailed multi-instance options can be edited later in the Web UI Config page")
+    print_info("  or directly in ~/.hermes/config.yaml.")
+    credentials = prompt("  Credentials (appKey|account|token)", password=True)
+    if not credentials:
+        print_warning(f"  Skipped — {label} won't work without credentials.")
+        return
+
+    current_config["nim"] = {
+        "instances": [
+            {
+                "enabled": True,
+                "nimToken": credentials,
+                "p2p": {"policy": "open", "allowFrom": []},
+                "team": {"policy": "open", "allowFrom": []},
+                "qchat": {"policy": "open", "allowFrom": []},
+                "advanced": {
+                    "mediaMaxMb": 30,
+                    "textChunkLimit": 4000,
+                    "debug": False,
+                },
+            }
+        ]
+    }
+    save_config(current_config)
+
+    save_env_value("NIM_CREDENTIALS", "")
+    save_env_value("NIM_INSTANCES", "")
+    save_env_value("NIM_APP_KEY", "")
+    save_env_value("NIM_ACCOUNT", "")
+    save_env_value("NIM_TOKEN", "")
+    save_env_value("NIM_ALLOWED_USERS", "")
+    save_env_value("NIM_ALLOW_ALL_USERS", "true")
+    save_env_value("NIM_GROUP_POLICY", "open")
+    save_env_value("NIM_GROUP_ALLOWLIST", "")
+    save_env_value("NIM_HOME_CHANNEL", "")
+    save_env_value("NIM_HOME_CHANNEL_NAME", "")
+    save_env_value("NIM_BRIDGE_COMMAND", "")
+    save_env_value("NIM_MEDIA_MAX_MB", "")
+    save_env_value("NIM_DEBUG", "")
+
+    print()
+    print_success(f"{emoji} {label} configured in config.yaml with open defaults!")
 
 
 def _setup_dingtalk():

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2446,11 +2446,6 @@ def _platform_status(platform: dict) -> str:
         nim_instances = nim_cfg.get("instances", []) if isinstance(nim_cfg, dict) else []
         if isinstance(nim_instances, list) and any(isinstance(item, dict) for item in nim_instances):
             return "configured"
-        explicit = all(get_env_value(name) for name in ("NIM_APP_KEY", "NIM_ACCOUNT", "NIM_TOKEN"))
-        if val or get_env_value("NIM_INSTANCES") or explicit:
-            return "configured"
-        if any(get_env_value(name) for name in ("NIM_APP_KEY", "NIM_ACCOUNT", "NIM_TOKEN")):
-            return "partially configured"
         return "not configured"
     if val:
         return "configured"
@@ -2625,16 +2620,10 @@ def _setup_nim():
     nim_cfg = current_config.get("nim")
     nim_instances = nim_cfg.get("instances", []) if isinstance(nim_cfg, dict) else []
     existing_yaml_instances = isinstance(nim_instances, list) and any(isinstance(item, dict) for item in nim_instances)
-    existing_credentials = get_env_value("NIM_CREDENTIALS")
-    existing_instances = get_env_value("NIM_INSTANCES")
-    if existing_yaml_instances or existing_credentials or existing_instances:
+    if existing_yaml_instances:
         print()
         print_success(f"{label} is already configured.")
-        if existing_yaml_instances:
-            print_info("  Existing config.yaml nim.instances configuration detected.")
-        elif existing_instances:
-            print_info("  Existing multi-instance config detected in NIM_INSTANCES.")
-            print_info("  This flow will replace it with config.yaml nim.instances.")
+        print_info("  Existing config.yaml nim.instances configuration detected.")
         if not prompt_yes_no(f"  Reconfigure {label}?", False):
             return
 
@@ -2663,21 +2652,6 @@ def _setup_nim():
         ]
     }
     save_config(current_config)
-
-    save_env_value("NIM_CREDENTIALS", "")
-    save_env_value("NIM_INSTANCES", "")
-    save_env_value("NIM_APP_KEY", "")
-    save_env_value("NIM_ACCOUNT", "")
-    save_env_value("NIM_TOKEN", "")
-    save_env_value("NIM_ALLOWED_USERS", "")
-    save_env_value("NIM_ALLOW_ALL_USERS", "true")
-    save_env_value("NIM_GROUP_POLICY", "open")
-    save_env_value("NIM_GROUP_ALLOWLIST", "")
-    save_env_value("NIM_HOME_CHANNEL", "")
-    save_env_value("NIM_HOME_CHANNEL_NAME", "")
-    save_env_value("NIM_BRIDGE_COMMAND", "")
-    save_env_value("NIM_MEDIA_MAX_MB", "")
-    save_env_value("NIM_DEBUG", "")
 
     print()
     print_success(f"{emoji} {label} configured in config.yaml with open defaults!")

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -25,8 +25,10 @@ from hermes_cli.config import (
     get_env_value,
     get_hermes_home,
     is_managed,
+    load_config,
     managed_error,
     read_raw_config,
+    save_config,
     save_env_value,
 )
 # display_hermes_home is imported lazily at call sites to avoid ImportError
@@ -2321,6 +2323,22 @@ _PLATFORMS = [
         "token_var": "WEIXIN_ACCOUNT_ID",
     },
     {
+        "key": "nim",
+        "label": "NIM",
+        "emoji": "☁️",
+        "token_var": "NIM_CREDENTIALS",
+        "setup_instructions": [
+            "1. Prepare a NetEase IM bot account with App Key, account, and token",
+            "2. Hermes auto-installs @yxim/nim-bot on first start when npm is available",
+            "3. Enter appKey|account|token in the setup prompt",
+            "4. Detailed multi-instance settings live in the Web UI Config page or ~/.hermes/config.yaml",
+        ],
+        "vars": [
+            {"name": "NIM_CREDENTIALS", "prompt": "Credentials (appKey|account|token)", "password": True,
+             "help": "Compact credential form used by the default NIM setup flow."},
+        ],
+    },
+    {
         "key": "bluebubbles",
         "label": "BlueBubbles (iMessage)",
         "emoji": "💬",
@@ -2420,6 +2438,18 @@ def _platform_status(platform: dict) -> str:
         if val and token:
             return "configured"
         if val or token:
+            return "partially configured"
+        return "not configured"
+    if platform.get("key") == "nim":
+        raw_config = read_raw_config() or {}
+        nim_cfg = raw_config.get("nim", {})
+        nim_instances = nim_cfg.get("instances", []) if isinstance(nim_cfg, dict) else []
+        if isinstance(nim_instances, list) and any(isinstance(item, dict) for item in nim_instances):
+            return "configured"
+        explicit = all(get_env_value(name) for name in ("NIM_APP_KEY", "NIM_ACCOUNT", "NIM_TOKEN"))
+        if val or get_env_value("NIM_INSTANCES") or explicit:
+            return "configured"
+        if any(get_env_value(name) for name in ("NIM_APP_KEY", "NIM_ACCOUNT", "NIM_TOKEN")):
             return "partially configured"
         return "not configured"
     if val:
@@ -2577,6 +2607,80 @@ def _setup_sms():
     """Configure SMS (Twilio) via the standard platform setup."""
     sms_platform = next(p for p in _PLATFORMS if p["key"] == "sms")
     _setup_standard_platform(sms_platform)
+
+
+def _setup_nim():
+    """Configure NIM with the compact credentials flow only."""
+    nim_platform = next(p for p in _PLATFORMS if p["key"] == "nim")
+    emoji = nim_platform["emoji"]
+    label = nim_platform["label"]
+
+    print()
+    print(color(f"  ─── {emoji} {label} Setup ───", Colors.CYAN))
+    print()
+    for line in nim_platform.get("setup_instructions", []):
+        print_info(f"  {line}")
+
+    current_config = load_config()
+    nim_cfg = current_config.get("nim")
+    nim_instances = nim_cfg.get("instances", []) if isinstance(nim_cfg, dict) else []
+    existing_yaml_instances = isinstance(nim_instances, list) and any(isinstance(item, dict) for item in nim_instances)
+    existing_credentials = get_env_value("NIM_CREDENTIALS")
+    existing_instances = get_env_value("NIM_INSTANCES")
+    if existing_yaml_instances or existing_credentials or existing_instances:
+        print()
+        print_success(f"{label} is already configured.")
+        if existing_yaml_instances:
+            print_info("  Existing config.yaml nim.instances configuration detected.")
+        elif existing_instances:
+            print_info("  Existing multi-instance config detected in NIM_INSTANCES.")
+            print_info("  This flow will replace it with config.yaml nim.instances.")
+        if not prompt_yes_no(f"  Reconfigure {label}?", False):
+            return
+
+    print()
+    print_info("  Detailed multi-instance options can be edited later in the Web UI Config page")
+    print_info("  or directly in ~/.hermes/config.yaml.")
+    credentials = prompt("  Credentials (appKey|account|token)", password=True)
+    if not credentials:
+        print_warning(f"  Skipped — {label} won't work without credentials.")
+        return
+
+    current_config["nim"] = {
+        "instances": [
+            {
+                "enabled": True,
+                "nimToken": credentials,
+                "p2p": {"policy": "open", "allowFrom": []},
+                "team": {"policy": "open", "allowFrom": []},
+                "qchat": {"policy": "open", "allowFrom": []},
+                "advanced": {
+                    "mediaMaxMb": 30,
+                    "textChunkLimit": 4000,
+                    "debug": False,
+                },
+            }
+        ]
+    }
+    save_config(current_config)
+
+    save_env_value("NIM_CREDENTIALS", "")
+    save_env_value("NIM_INSTANCES", "")
+    save_env_value("NIM_APP_KEY", "")
+    save_env_value("NIM_ACCOUNT", "")
+    save_env_value("NIM_TOKEN", "")
+    save_env_value("NIM_ALLOWED_USERS", "")
+    save_env_value("NIM_ALLOW_ALL_USERS", "true")
+    save_env_value("NIM_GROUP_POLICY", "open")
+    save_env_value("NIM_GROUP_ALLOWLIST", "")
+    save_env_value("NIM_HOME_CHANNEL", "")
+    save_env_value("NIM_HOME_CHANNEL_NAME", "")
+    save_env_value("NIM_BRIDGE_COMMAND", "")
+    save_env_value("NIM_MEDIA_MAX_MB", "")
+    save_env_value("NIM_DEBUG", "")
+
+    print()
+    print_success(f"{emoji} {label} configured in config.yaml with open defaults!")
 
 
 def _setup_dingtalk():
@@ -3388,14 +3492,22 @@ def gateway_setup():
             _setup_dingtalk()
         elif platform["key"] == "feishu":
             _setup_feishu()
+        elif platform["key"] == "nim":
+            _setup_nim()
         elif platform["key"] == "qqbot":
             _setup_qqbot()
         else:
             _setup_standard_platform(platform)
 
     # ── Post-setup: offer to install/restart gateway ──
+    raw_config = read_raw_config() or {}
+    nim_cfg = raw_config.get("nim", {})
+    nim_instances = nim_cfg.get("instances", []) if isinstance(nim_cfg, dict) else []
+    nim_from_config = isinstance(nim_instances, list) and any(isinstance(item, dict) for item in nim_instances)
+
     any_configured = any(
         bool(get_env_value(p["token_var"]))
+        or (p["key"] == "nim" and (bool(get_env_value("NIM_INSTANCES")) or nim_from_config))
         for p in _PLATFORMS
         if p["key"] != "whatsapp"
     ) or (get_env_value("WHATSAPP_ENABLED") or "").lower() == "true"

--- a/hermes_cli/platforms.py
+++ b/hermes_cli/platforms.py
@@ -35,6 +35,7 @@ PLATFORMS: OrderedDict[str, PlatformInfo] = OrderedDict([
     ("wecom",          PlatformInfo(label="💬 WeCom",           default_toolset="hermes-wecom")),
     ("wecom_callback", PlatformInfo(label="💬 WeCom Callback",  default_toolset="hermes-wecom-callback")),
     ("weixin",         PlatformInfo(label="💬 Weixin",          default_toolset="hermes-weixin")),
+    ("nim",            PlatformInfo(label="☁️ NeteaseIM",       default_toolset="hermes-nim")),
     ("qqbot",          PlatformInfo(label="💬 QQBot",           default_toolset="hermes-qqbot")),
     ("yuanbao",        PlatformInfo(label="🤖 Yuanbao",         default_toolset="hermes-yuanbao")),
     ("webhook",        PlatformInfo(label="🔗 Webhook",         default_toolset="hermes-webhook")),

--- a/hermes_cli/platforms.py
+++ b/hermes_cli/platforms.py
@@ -35,6 +35,7 @@ PLATFORMS: OrderedDict[str, PlatformInfo] = OrderedDict([
     ("wecom",          PlatformInfo(label="💬 WeCom",           default_toolset="hermes-wecom")),
     ("wecom_callback", PlatformInfo(label="💬 WeCom Callback",  default_toolset="hermes-wecom-callback")),
     ("weixin",         PlatformInfo(label="💬 Weixin",          default_toolset="hermes-weixin")),
+    ("nim",            PlatformInfo(label="☁️ NeteaseIM",       default_toolset="hermes-nim")),
     ("qqbot",          PlatformInfo(label="💬 QQBot",           default_toolset="hermes-qqbot")),
     ("webhook",        PlatformInfo(label="🔗 Webhook",         default_toolset="hermes-webhook")),
     ("api_server",     PlatformInfo(label="🌐 API Server",      default_toolset="hermes-api-server")),

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -2359,7 +2359,6 @@ def _setup_webhooks():
     print_info("   https://hermes-agent.nousresearch.com/docs/user-guide/messaging/webhooks/#configuring-routes")
     print()
     print_info("   Open config in your editor:  hermes config edit")
-    print_info("   Open config in your editor:  hermes config edit")
 
 
 def setup_gateway(config: dict):

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -2315,6 +2315,118 @@ def _setup_qqbot():
     _gateway_setup_qqbot()
 
 
+def _setup_whatsapp():
+    """Delegate to the existing WhatsApp setup flow."""
+    from hermes_cli.main import cmd_whatsapp
+    import argparse
+
+    cmd_whatsapp(argparse.Namespace())
+
+
+def _setup_weixin():
+    """Configure Weixin (personal WeChat) via gateway setup."""
+    from hermes_cli.gateway import _setup_weixin as _gateway_setup_weixin
+
+    _gateway_setup_weixin()
+
+
+def _setup_signal():
+    """Configure Signal via gateway setup."""
+    from hermes_cli.gateway import _setup_signal as _gateway_setup_signal
+
+    _gateway_setup_signal()
+
+
+def _setup_email():
+    """Configure Email via gateway setup."""
+    from hermes_cli.gateway import _setup_email as _gateway_setup_email
+
+    _gateway_setup_email()
+
+
+def _setup_sms():
+    """Configure SMS (Twilio) via gateway setup."""
+    from hermes_cli.gateway import _setup_sms as _gateway_setup_sms
+
+    _gateway_setup_sms()
+
+
+def _setup_dingtalk():
+    """Configure DingTalk via gateway setup."""
+    from hermes_cli.gateway import _setup_dingtalk as _gateway_setup_dingtalk
+
+    _gateway_setup_dingtalk()
+
+
+def _setup_feishu():
+    """Configure Feishu / Lark via gateway setup."""
+    from hermes_cli.gateway import _setup_feishu as _gateway_setup_feishu
+
+    _gateway_setup_feishu()
+
+
+def _setup_nim():
+    """Configure NIM / NetEase IM via gateway setup."""
+    from hermes_cli import gateway as gateway_mod
+
+    gateway_mod.prompt = prompt
+    gateway_mod.prompt_yes_no = prompt_yes_no
+    gateway_mod._setup_nim()
+
+
+def _setup_yuanbao():
+    """Configure Yuanbao via gateway setup."""
+    from hermes_cli.gateway import _setup_yuanbao as _gateway_setup_yuanbao
+
+    _gateway_setup_yuanbao()
+
+
+def _setup_wecom():
+    """Configure WeCom (Enterprise WeChat) via gateway setup."""
+    from hermes_cli.gateway import _setup_wecom as _gateway_setup_wecom
+
+    _gateway_setup_wecom()
+
+
+def _setup_wecom_callback():
+    """Configure WeCom Callback (self-built app) via gateway setup."""
+    from hermes_cli.gateway import _setup_wecom_callback as _gw_setup
+
+    _gw_setup()
+
+
+def _legacy_gateway_configured(
+    name: str,
+    env_var: str,
+    current_config: dict,
+    platform_statuses: Dict[str, str],
+) -> bool:
+    """Preserve historical built-in platform checklist semantics."""
+    if name == "Matrix":
+        return bool(get_env_value(env_var) or get_env_value("MATRIX_PASSWORD"))
+    if name == "NIM (NetEase IM)":
+        nim_cfg = current_config.get("nim")
+        nim_instances = nim_cfg.get("instances", []) if isinstance(nim_cfg, dict) else []
+        return isinstance(nim_instances, list) and any(
+            isinstance(item, dict) for item in nim_instances
+        )
+    if name == "Signal":
+        return platform_statuses.get("signal", "not configured") == "configured"
+    if name == "Email":
+        return platform_statuses.get("email", "not configured") == "configured"
+    if name == "SMS (Twilio)":
+        return platform_statuses.get("sms", "not configured") == "configured"
+    return bool(get_env_value(env_var))
+
+
+def _gateway_status_display_name(platform: dict) -> str:
+    """Map current platform labels to the long-form setup labels."""
+    key = platform.get("key")
+    if key == "nim":
+        return "NIM (NetEase IM)"
+    return str(platform.get("label") or key or "")
+
+
 def _setup_webhooks():
     """Configure webhook integration."""
     print_header("Webhooks")
@@ -2361,6 +2473,33 @@ def _setup_webhooks():
     print_info("   Open config in your editor:  hermes config edit")
 
 
+_GATEWAY_PLATFORMS = [
+    ("Telegram", "TELEGRAM_BOT_TOKEN", _setup_telegram),
+    ("Discord", "DISCORD_BOT_TOKEN", _setup_discord),
+    ("Slack", "SLACK_BOT_TOKEN", _setup_slack),
+    ("Signal", "SIGNAL_HTTP_URL", _setup_signal),
+    ("Email", "EMAIL_ADDRESS", _setup_email),
+    ("SMS (Twilio)", "TWILIO_ACCOUNT_SID", _setup_sms),
+    ("Matrix", "MATRIX_ACCESS_TOKEN", _setup_matrix),
+    ("Mattermost", "MATTERMOST_TOKEN", _setup_mattermost),
+    ("WhatsApp", "WHATSAPP_ENABLED", _setup_whatsapp),
+    ("DingTalk", "DINGTALK_CLIENT_ID", _setup_dingtalk),
+    ("Feishu / Lark", "FEISHU_APP_ID", _setup_feishu),
+    ("NIM (NetEase IM)", "NIM_CREDENTIALS", _setup_nim),
+    ("Yuanbao", "YUANBAO_APP_ID", _setup_yuanbao),
+    ("WeCom (Enterprise WeChat)", "WECOM_BOT_ID", _setup_wecom),
+    (
+        "WeCom Callback (Self-Built App)",
+        "WECOM_CALLBACK_CORP_ID",
+        _setup_wecom_callback,
+    ),
+    ("Weixin (WeChat)", "WEIXIN_ACCOUNT_ID", _setup_weixin),
+    ("BlueBubbles (iMessage)", "BLUEBUBBLES_SERVER_URL", _setup_bluebubbles),
+    ("QQ Bot", "QQ_APP_ID", _setup_qqbot),
+    ("Webhooks (GitHub, GitLab, etc.)", "WEBHOOK_ENABLED", _setup_webhooks),
+]
+
+
 def setup_gateway(config: dict):
     """Configure messaging platform integrations."""
     from hermes_cli.gateway import _all_platforms, _platform_status, _configure_platform
@@ -2371,15 +2510,58 @@ def setup_gateway(config: dict):
     print()
 
     platforms = _all_platforms()
+    platform_statuses = {
+        str(plat.get("key")): _platform_status(plat)
+        for plat in platforms
+        if isinstance(plat, dict) and plat.get("key")
+    }
+    current_config = config if config else load_config()
 
-    # Build checklist, pre-selecting already-configured platforms.
+    # Keep the legacy built-in ordering and labels stable so tests and any
+    # monkeypatch-based automation can still address platforms by index.
     items = []
     pre_selected = []
-    for i, plat in enumerate(platforms):
-        status = _platform_status(plat)
-        items.append(f"{plat['emoji']} {plat['label']}  ({status})")
-        if status == "configured":
+    selection_handlers: list[Callable[[], None]] = []
+    for i, (name, env_var, setup_func) in enumerate(_GATEWAY_PLATFORMS):
+        is_configured = _legacy_gateway_configured(
+            name, env_var, current_config, platform_statuses
+        )
+        label = f"{name}  (configured)" if is_configured else name
+        items.append(label)
+        selection_handlers.append(setup_func)
+        if is_configured:
             pre_selected.append(i)
+
+    legacy_keys = {
+        "telegram",
+        "discord",
+        "slack",
+        "signal",
+        "email",
+        "sms",
+        "matrix",
+        "mattermost",
+        "whatsapp",
+        "dingtalk",
+        "feishu",
+        "nim",
+        "yuanbao",
+        "wecom",
+        "wecom_callback",
+        "weixin",
+        "bluebubbles",
+        "qqbot",
+        "webhook",
+    }
+    plugin_platforms = [
+        plat for plat in platforms if str(plat.get("key")) not in legacy_keys
+    ]
+    for plat in plugin_platforms:
+        status = _platform_status(plat)
+        items.append(f"{_gateway_status_display_name(plat)}  ({status})")
+        selection_handlers.append(lambda plat=plat: _configure_platform(plat))
+        if status == "configured":
+            pre_selected.append(len(items) - 1)
 
     selected = prompt_checklist("Select platforms to configure:", items, pre_selected)
 
@@ -2388,7 +2570,7 @@ def setup_gateway(config: dict):
         return
 
     for idx in selected:
-        _configure_platform(platforms[idx])
+        selection_handlers[idx]()
 
     # Some gateway setup flows persist config.yaml directly (for example NIM
     # writes nim.instances). Re-sync the wizard's in-memory config so the

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -2390,11 +2390,24 @@ def setup_gateway(config: dict):
     for idx in selected:
         _configure_platform(platforms[idx])
 
-    # ── Gateway Service Setup ──
-    # Count any platform (built-in or plugin) the user configured during this
-    # setup pass — reuses ``_platform_status`` so plugin platforms like IRC
-    # are picked up without another hard-coded env-var list.
-    def _is_progress(status: str) -> bool:
+    # Some gateway setup flows persist config.yaml directly (for example NIM
+    # writes nim.instances). Re-sync the wizard's in-memory config so the
+    # final save_config(config) does not overwrite those changes with stale data.
+    _refreshed = load_config()
+    if "nim" in _refreshed:
+        config["nim"] = _refreshed["nim"]
+    else:
+        config.pop("nim", None)
+
+     nim_cfg = config.get("nim")
+     nim_instances = nim_cfg.get("instances", []) if isinstance(nim_cfg, dict) else []
+     nim_from_config = isinstance(nim_instances, list) and any(isinstance(item, dict) for item in nim_instances)
+ 
+     # ── Gateway Service Setup ──
+     # Count any platform (built-in or plugin) the user configured during this
+     # setup pass — reuses ``_platform_status`` so plugin platforms like IRC
+     # are picked up without another hard-coded env-var list.
+     def _is_progress(status: str) -> bool:
         s = status.lower()
         return not (
             s == "not configured"
@@ -2402,10 +2415,10 @@ def setup_gateway(config: dict):
             or s.startswith("plugin disabled")
         )
 
-    any_messaging = any(
-        _is_progress(_platform_status(p)) for p in _all_platforms()
-    )
-    if any_messaging:
+     any_messaging = any(
+         _is_progress(_platform_status(p)) for p in _all_platforms()
+     )
+     if any_messaging:
         print()
         print_info("━" * 50)
         print_success("Messaging platforms configured!")

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -2399,15 +2399,15 @@ def setup_gateway(config: dict):
     else:
         config.pop("nim", None)
 
-     nim_cfg = config.get("nim")
-     nim_instances = nim_cfg.get("instances", []) if isinstance(nim_cfg, dict) else []
-     nim_from_config = isinstance(nim_instances, list) and any(isinstance(item, dict) for item in nim_instances)
- 
-     # ── Gateway Service Setup ──
-     # Count any platform (built-in or plugin) the user configured during this
-     # setup pass — reuses ``_platform_status`` so plugin platforms like IRC
-     # are picked up without another hard-coded env-var list.
-     def _is_progress(status: str) -> bool:
+    nim_cfg = config.get("nim")
+    nim_instances = nim_cfg.get("instances", []) if isinstance(nim_cfg, dict) else []
+    nim_from_config = isinstance(nim_instances, list) and any(isinstance(item, dict) for item in nim_instances)
+
+    # ── Gateway Service Setup ──
+    # Count any platform (built-in or plugin) the user configured during this
+    # setup pass — reuses ``_platform_status`` so plugin platforms like IRC
+    # are picked up without another hard-coded env-var list.
+    def _is_progress(status: str) -> bool:
         s = status.lower()
         return not (
             s == "not configured"
@@ -2415,10 +2415,10 @@ def setup_gateway(config: dict):
             or s.startswith("plugin disabled")
         )
 
-     any_messaging = any(
-         _is_progress(_platform_status(p)) for p in _all_platforms()
-     )
-     if any_messaging:
+    any_messaging = any(
+        _is_progress(_platform_status(p)) for p in _all_platforms()
+    ) or nim_from_config
+    if any_messaging:
         print()
         print_info("━" * 50)
         print_success("Messaging platforms configured!")

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -2235,9 +2235,7 @@ def setup_gateway(config: dict):
         if name == "Matrix" and not is_configured:
             is_configured = bool(get_env_value("MATRIX_PASSWORD"))
         if name == "NIM (NetEase IM)" and not is_configured:
-            is_configured = nim_from_config or bool(get_env_value("NIM_INSTANCES")) or all(
-                get_env_value(var) for var in ("NIM_APP_KEY", "NIM_ACCOUNT", "NIM_TOKEN")
-            )
+            is_configured = nim_from_config
         label = f"{name}  (configured)" if is_configured else name
         items.append(label)
         if is_configured:
@@ -2286,8 +2284,6 @@ def setup_gateway(config: dict):
         or get_env_value("QQ_APP_ID")
         or get_env_value("WEBHOOK_ENABLED")
         or nim_from_config
-        or bool(get_env_value("NIM_INSTANCES"))
-        or all(get_env_value(var) for var in ("NIM_APP_KEY", "NIM_ACCOUNT", "NIM_TOKEN"))
     )
     if any_messaging:
         print()

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -2253,6 +2253,19 @@ def setup_gateway(config: dict):
         name, _env_var, setup_func = _GATEWAY_PLATFORMS[idx]
         setup_func()
 
+    # Some gateway setup flows persist config.yaml directly (for example NIM
+    # writes nim.instances). Re-sync the wizard's in-memory config so the
+    # final save_config(config) does not overwrite those changes with stale data.
+    _refreshed = load_config()
+    if "nim" in _refreshed:
+        config["nim"] = _refreshed["nim"]
+    else:
+        config.pop("nim", None)
+
+    nim_cfg = config.get("nim")
+    nim_instances = nim_cfg.get("instances", []) if isinstance(nim_cfg, dict) else []
+    nim_from_config = isinstance(nim_instances, list) and any(isinstance(item, dict) for item in nim_instances)
+
     # ── Gateway Service Setup ──
     any_messaging = (
         get_env_value("TELEGRAM_BOT_TOKEN")
@@ -2272,6 +2285,9 @@ def setup_gateway(config: dict):
         or get_env_value("BLUEBUBBLES_SERVER_URL")
         or get_env_value("QQ_APP_ID")
         or get_env_value("WEBHOOK_ENABLED")
+        or nim_from_config
+        or bool(get_env_value("NIM_INSTANCES"))
+        or all(get_env_value(var) for var in ("NIM_APP_KEY", "NIM_ACCOUNT", "NIM_TOKEN"))
     )
     if any_messaging:
         print()

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -2051,6 +2051,13 @@ def _setup_feishu():
     _gateway_setup_feishu()
 
 
+def _setup_nim():
+    """Configure NIM / NetEase IM via gateway setup."""
+    from hermes_cli.gateway import _setup_nim as _gateway_setup_nim
+
+    _gateway_setup_nim()
+
+
 def _setup_wecom():
     """Configure WeCom (Enterprise WeChat) via gateway setup."""
     from hermes_cli.gateway import _setup_wecom as _gateway_setup_wecom
@@ -2195,6 +2202,7 @@ _GATEWAY_PLATFORMS = [
     ("WhatsApp", "WHATSAPP_ENABLED", _setup_whatsapp),
     ("DingTalk", "DINGTALK_CLIENT_ID", _setup_dingtalk),
     ("Feishu / Lark", "FEISHU_APP_ID", _setup_feishu),
+    ("NIM (NetEase IM)", "NIM_CREDENTIALS", _setup_nim),
     ("WeCom (Enterprise WeChat)", "WECOM_BOT_ID", _setup_wecom),
     ("WeCom Callback (Self-Built App)", "WECOM_CALLBACK_CORP_ID", _setup_wecom_callback),
     ("Weixin (WeChat)", "WEIXIN_ACCOUNT_ID", _setup_weixin),
@@ -2214,11 +2222,20 @@ def setup_gateway(config: dict):
     # Build checklist items, pre-selecting already-configured platforms
     items = []
     pre_selected = []
+    current_config = config if config else load_config()
+    nim_cfg = current_config.get("nim")
+    nim_instances = nim_cfg.get("instances", []) if isinstance(nim_cfg, dict) else []
+    nim_from_config = isinstance(nim_instances, list) and any(isinstance(item, dict) for item in nim_instances)
+
     for i, (name, env_var, _func) in enumerate(_GATEWAY_PLATFORMS):
         # Matrix has two possible env vars
         is_configured = bool(get_env_value(env_var))
         if name == "Matrix" and not is_configured:
             is_configured = bool(get_env_value("MATRIX_PASSWORD"))
+        if name == "NIM (NetEase IM)" and not is_configured:
+            is_configured = nim_from_config or bool(get_env_value("NIM_INSTANCES")) or all(
+                get_env_value(var) for var in ("NIM_APP_KEY", "NIM_ACCOUNT", "NIM_TOKEN")
+            )
         label = f"{name}  (configured)" if is_configured else name
         items.append(label)
         if is_configured:
@@ -2514,6 +2531,11 @@ def _get_section_config_summary(config: dict, section_key: str) -> Optional[str]
             for label, env_var, _ in _GATEWAY_PLATFORMS
             if get_env_value(env_var)
         ]
+        nim_cfg = config.get("nim", {})
+        nim_instances = nim_cfg.get("instances", []) if isinstance(nim_cfg, dict) else []
+        nim_from_config = isinstance(nim_instances, list) and any(isinstance(item, dict) for item in nim_instances)
+        if nim_from_config and "NIM" not in platforms:
+            platforms.append("NIM")
         if platforms:
             return ", ".join(platforms)
         return None  # No platforms configured — section must run

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -2053,9 +2053,11 @@ def _setup_feishu():
 
 def _setup_nim():
     """Configure NIM / NetEase IM via gateway setup."""
-    from hermes_cli.gateway import _setup_nim as _gateway_setup_nim
+    from hermes_cli import gateway as gateway_mod
 
-    _gateway_setup_nim()
+    gateway_mod.prompt = prompt
+    gateway_mod.prompt_yes_no = prompt_yes_no
+    gateway_mod._setup_nim()
 
 
 def _setup_wecom():

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -398,6 +398,7 @@ def show_status(args):
         "SMS": ("TWILIO_ACCOUNT_SID", "SMS_HOME_CHANNEL"),
         "DingTalk": ("DINGTALK_CLIENT_ID", None),
         "Feishu": ("FEISHU_APP_ID", "FEISHU_HOME_CHANNEL"),
+        "NIM": ("NIM_CREDENTIALS", "NIM_HOME_CHANNEL"),
         "WeCom": ("WECOM_BOT_ID", "WECOM_HOME_CHANNEL"),
         "WeCom Callback": ("WECOM_CALLBACK_CORP_ID", None),
         "Weixin": ("WEIXIN_ACCOUNT_ID", "WEIXIN_HOME_CHANNEL"),
@@ -405,9 +406,19 @@ def show_status(args):
         "QQBot": ("QQ_APP_ID", "QQ_HOME_CHANNEL"),
         "Yuanbao": ("YUANBAO_APP_ID", "YUANBAO_HOME_CHANNEL"),
     }
-
+    raw_config = load_config()
+    nim_cfg = raw_config.get("nim", {})
+    nim_instances = nim_cfg.get("instances", []) if isinstance(nim_cfg, dict) else []
+    nim_from_config = isinstance(nim_instances, list) and any(isinstance(item, dict) for item in nim_instances)
     for name, (token_var, home_var) in platforms.items():
         token = os.getenv(token_var, "")
+        if name == "NIM" and not token:
+            if nim_from_config:
+                token = "configured"
+            elif os.getenv("NIM_INSTANCES", "").strip():
+                token = "configured"
+            elif all(os.getenv(var, "") for var in ("NIM_APP_KEY", "NIM_ACCOUNT", "NIM_TOKEN")):
+                token = "configured"
         has_token = bool(token)
         
         home_channel = ""

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -319,9 +319,20 @@ def show_status(args):
         "BlueBubbles": ("BLUEBUBBLES_SERVER_URL", "BLUEBUBBLES_HOME_CHANNEL"),
         "QQBot": ("QQ_APP_ID", "QQBOT_HOME_CHANNEL"),
     }
+    raw_config = load_config()
+    nim_cfg = raw_config.get("nim", {})
+    nim_instances = nim_cfg.get("instances", []) if isinstance(nim_cfg, dict) else []
+    nim_from_config = isinstance(nim_instances, list) and any(isinstance(item, dict) for item in nim_instances)
     
     for name, (token_var, home_var) in platforms.items():
         token = os.getenv(token_var, "")
+        if name == "NIM" and not token:
+            if nim_from_config:
+                token = "configured"
+            elif os.getenv("NIM_INSTANCES", "").strip():
+                token = "configured"
+            elif all(os.getenv(var, "") for var in ("NIM_APP_KEY", "NIM_ACCOUNT", "NIM_TOKEN")):
+                token = "configured"
         has_token = bool(token)
         
         home_channel = ""

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -356,7 +356,7 @@ _CATEGORY_MERGE: Dict[str, str] = {
 _CATEGORY_ORDER = [
     "general", "agent", "terminal", "display", "delegation",
     "memory", "compression", "security", "browser", "voice",
-    "tts", "stt", "logging", "discord", "auxiliary",
+    "tts", "stt", "logging", "discord", "nim", "auxiliary",
 ]
 
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -326,7 +326,7 @@ _CATEGORY_MERGE: Dict[str, str] = {
 _CATEGORY_ORDER = [
     "general", "agent", "terminal", "display", "delegation",
     "memory", "compression", "security", "browser", "voice",
-    "tts", "stt", "logging", "discord", "auxiliary",
+    "tts", "stt", "logging", "discord", "nim", "auxiliary",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
   "requests>=2.33.0,<3",  # CVE-2026-25645
   "jinja2>=3.1.5,<4",
   "pydantic>=2.12.5,<3",
+  "nim-bot-py>=0.1.0b1,<0.2",
   # Interactive CLI (prompt_toolkit is used directly by cli.py)
   "prompt_toolkit>=3.0.52,<4",
   # Tools

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -280,6 +280,33 @@ class TestLoadGatewayConfig:
             "789": "Creative writing",
         }
 
+    def test_bridges_top_level_nim_instances_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "nim:\n"
+            "  instances:\n"
+            "    - enabled: true\n"
+            "      nimToken: app|bot|secret\n"
+            "      p2p:\n"
+            "        policy: open\n"
+            "      team:\n"
+            "        policy: allowlist\n"
+            "        allowFrom:\n"
+            "          - team-1\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        nim_platform = config.platforms[Platform.NIM]
+        assert nim_platform.enabled is True
+        assert nim_platform.extra["instances"][0]["nimToken"] == "app|bot|secret"
+        assert nim_platform.extra["instances"][0]["team"]["allowFrom"] == ["team-1"]
+
     def test_bridges_slack_channel_prompts_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -380,6 +380,33 @@ class TestLoadGatewayConfig:
             "789": "Creative writing",
         }
 
+    def test_bridges_top_level_nim_instances_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "nim:\n"
+            "  instances:\n"
+            "    - enabled: true\n"
+            "      nimToken: app|bot|secret\n"
+            "      p2p:\n"
+            "        policy: open\n"
+            "      team:\n"
+            "        policy: allowlist\n"
+            "        allowFrom:\n"
+            "          - team-1\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        nim_platform = config.platforms[Platform.NIM]
+        assert nim_platform.enabled is True
+        assert nim_platform.extra["instances"][0]["nimToken"] == "app|bot|secret"
+        assert nim_platform.extra["instances"][0]["team"]["allowFrom"] == ["team-1"]
+
     def test_bridges_slack_channel_prompts_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -429,6 +429,18 @@ class TestLoadGatewayConfig:
         assert nim_platform.extra["instances"][0]["nimToken"] == "app|yaml-bot|secret-yaml"
         assert "nim_token" not in nim_platform.extra
 
+    def test_nim_env_credentials_do_not_create_config(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("", encoding="utf-8")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("NIM_CREDENTIALS", "app|legacy-bot|secret-legacy")
+
+        config = load_gateway_config()
+
+        assert Platform.NIM not in config.platforms
+
     def test_bridges_slack_channel_prompts_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -407,6 +407,28 @@ class TestLoadGatewayConfig:
         assert nim_platform.extra["instances"][0]["nimToken"] == "app|bot|secret"
         assert nim_platform.extra["instances"][0]["team"]["allowFrom"] == ["team-1"]
 
+    def test_yaml_nim_instances_ignore_legacy_env_credentials(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "nim:\n"
+            "  instances:\n"
+            "    - enabled: true\n"
+            "      nimToken: app|yaml-bot|secret-yaml\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("NIM_CREDENTIALS", "app|legacy-bot|secret-legacy")
+
+        config = load_gateway_config()
+
+        nim_platform = config.platforms[Platform.NIM]
+        assert nim_platform.enabled is True
+        assert nim_platform.extra["instances"][0]["nimToken"] == "app|yaml-bot|secret-yaml"
+        assert "nim_token" not in nim_platform.extra
+
     def test_bridges_slack_channel_prompts_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -307,6 +307,28 @@ class TestLoadGatewayConfig:
         assert nim_platform.extra["instances"][0]["nimToken"] == "app|bot|secret"
         assert nim_platform.extra["instances"][0]["team"]["allowFrom"] == ["team-1"]
 
+    def test_yaml_nim_instances_ignore_legacy_env_credentials(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "nim:\n"
+            "  instances:\n"
+            "    - enabled: true\n"
+            "      nimToken: app|yaml-bot|secret-yaml\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("NIM_CREDENTIALS", "app|legacy-bot|secret-legacy")
+
+        config = load_gateway_config()
+
+        nim_platform = config.platforms[Platform.NIM]
+        assert nim_platform.enabled is True
+        assert nim_platform.extra["instances"][0]["nimToken"] == "app|yaml-bot|secret-yaml"
+        assert "nim_token" not in nim_platform.extra
+
     def test_bridges_slack_channel_prompts_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -329,6 +329,18 @@ class TestLoadGatewayConfig:
         assert nim_platform.extra["instances"][0]["nimToken"] == "app|yaml-bot|secret-yaml"
         assert "nim_token" not in nim_platform.extra
 
+    def test_nim_env_credentials_do_not_create_config(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("", encoding="utf-8")
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("NIM_CREDENTIALS", "app|legacy-bot|secret-legacy")
+
+        config = load_gateway_config()
+
+        assert Platform.NIM not in config.platforms
+
     def test_bridges_slack_channel_prompts_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()

--- a/tests/gateway/test_nim_adapter.py
+++ b/tests/gateway/test_nim_adapter.py
@@ -1,0 +1,501 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig, _default_nim_bridge_command, load_nim_config, load_nim_instances
+from gateway.platforms.nim import MultiNimAdapter, NimAdapter, _check_nim_instance_requirements, check_nim_requirements
+from gateway.run import GatewayRunner
+
+
+class FakeBridge:
+    def __init__(self):
+        self.started = False
+        self.stopped = False
+        self.config = None
+        self.event_handler = None
+        self.sent = []
+
+    async def start(self, config, *, event_handler=None):
+        self.started = True
+        self.config = config
+        self.event_handler = event_handler
+
+    async def stop(self):
+        self.stopped = True
+
+    async def health(self):
+        return {"connected": True}
+
+    async def send_text(self, *, chat_id, text, session_type, reply_to=None):
+        self.sent.append(
+            {
+                "chat_id": chat_id,
+                "text": text,
+                "session_type": session_type,
+                "reply_to": reply_to,
+            }
+        )
+        return {"message_id": "server-msg-1", "client_message_id": "client-msg-1"}
+
+
+@pytest.mark.asyncio
+async def test_connect_and_disconnect():
+    bridge = FakeBridge()
+    adapter = NimAdapter(
+        PlatformConfig(enabled=True, extra={"nim_token": "app|bot|secret"}),
+        bridge=bridge,
+    )
+
+    assert await adapter.connect() is True
+    assert adapter.is_connected is True
+    assert bridge.started is True
+
+    await adapter.disconnect()
+    assert adapter.is_connected is False
+    assert bridge.stopped is True
+
+
+@pytest.mark.asyncio
+async def test_send_team_message_uses_team_session_type():
+    bridge = FakeBridge()
+    adapter = NimAdapter(
+        PlatformConfig(enabled=True, extra={"nim_token": "app|bot|secret"}),
+        bridge=bridge,
+    )
+
+    result = await adapter.send("team:123", "hello", reply_to="reply-1")
+
+    assert result.success is True
+    assert result.message_id == "server-msg-1"
+    assert bridge.sent == [
+        {
+            "chat_id": "team:123",
+            "text": "hello",
+            "session_type": "team",
+            "reply_to": "reply-1",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_send_qchat_message_uses_qchat_session_type():
+    bridge = FakeBridge()
+    adapter = NimAdapter(
+        PlatformConfig(enabled=True, extra={"nim_token": "app|bot|secret"}),
+        bridge=bridge,
+    )
+
+    result = await adapter.send("qchat:server-1:channel-2", "hello qchat")
+
+    assert result.success is True
+    assert bridge.sent == [
+        {
+            "chat_id": "qchat:server-1:channel-2",
+            "text": "hello qchat",
+            "session_type": "qchat",
+            "reply_to": None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_send_splits_long_messages():
+    bridge = FakeBridge()
+    adapter = NimAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "nim_token": "app|bot|secret",
+                "advanced": {"textChunkLimit": 32},
+            },
+        ),
+        bridge=bridge,
+    )
+
+    content = ("a" * 31) + "\n" + ("b" * 32)
+
+    result = await adapter.send("user:123", content)
+
+    assert result.success is True
+    assert [item["text"] for item in bridge.sent] == [
+        ("a" * 31) + "\n",
+        "b" * 32,
+    ]
+    assert all(len(item["text"]) <= 32 for item in bridge.sent)
+
+
+@pytest.mark.asyncio
+async def test_inbound_dm_respects_allowlist():
+    bridge = FakeBridge()
+    adapter = NimAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "nim_token": "app|bot|secret",
+                "p2p": {"policy": "allowlist", "allowFrom": ["allowed-user"]},
+            },
+        ),
+        bridge=bridge,
+    )
+    adapter.handle_message = AsyncMock()
+
+    await adapter._on_bridge_event(
+        {
+            "event": "message",
+            "payload": {
+                "session_type": "p2p",
+                "sender_id": "blocked-user",
+                "sender_name": "Blocked",
+                "text": "hello",
+                "message_type": "text",
+            },
+        }
+    )
+    adapter.handle_message.assert_not_awaited()
+
+    await adapter._on_bridge_event(
+        {
+            "event": "message",
+            "payload": {
+                "message_id": "m-1",
+                "session_type": "p2p",
+                "sender_id": "allowed-user",
+                "sender_name": "Allowed",
+                "text": "hello",
+                "message_type": "text",
+            },
+        }
+    )
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_id == "user:allowed-user"
+    assert event.source.chat_type == "dm"
+    assert event.text == "hello"
+
+
+@pytest.mark.asyncio
+async def test_group_message_requires_allowed_team_and_mention():
+    bridge = FakeBridge()
+    adapter = NimAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "nim_token": "app|bot|secret",
+                "team": {
+                    "policy": "allowlist",
+                    "allowFrom": ["team-1"],
+                },
+            },
+        ),
+        bridge=bridge,
+    )
+    adapter.handle_message = AsyncMock()
+
+    await adapter._on_bridge_event(
+        {
+            "event": "message",
+            "payload": {
+                "session_type": "team",
+                "target_id": "team-1",
+                "sender_id": "user-1",
+                "text": "hello",
+                "message_type": "text",
+                "mentioned": False,
+            },
+        }
+    )
+    adapter.handle_message.assert_not_awaited()
+
+    await adapter._on_bridge_event(
+        {
+            "event": "message",
+            "payload": {
+                "message_id": "m-2",
+                "session_type": "team",
+                "target_id": "team-1",
+                "sender_id": "user-1",
+                "text": "hello @bot",
+                "message_type": "text",
+                "mentioned": True,
+            },
+        }
+    )
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_id == "team:team-1"
+    assert event.source.chat_type == "group"
+
+
+@pytest.mark.asyncio
+async def test_qchat_message_requires_allowlist_match_and_mention():
+    bridge = FakeBridge()
+    adapter = NimAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "nim_token": "app|bot|secret",
+                "qchat": {
+                    "policy": "allowlist",
+                    "allowFrom": ["server-1|channel-2|allowed-user"],
+                },
+            },
+        ),
+        bridge=bridge,
+    )
+    adapter.handle_message = AsyncMock()
+
+    await adapter._on_bridge_event(
+        {
+            "event": "message",
+            "payload": {
+                "session_type": "qchat",
+                "server_id": "server-1",
+                "channel_id": "channel-2",
+                "target_id": "server-1:channel-2",
+                "sender_id": "blocked-user",
+                "text": "@bot hello",
+                "message_type": "text",
+                "mentioned": True,
+            },
+        }
+    )
+    adapter.handle_message.assert_not_awaited()
+
+    await adapter._on_bridge_event(
+        {
+            "event": "message",
+            "payload": {
+                "message_id": "m-qchat-1",
+                "session_type": "qchat",
+                "server_id": "server-1",
+                "channel_id": "channel-2",
+                "target_id": "server-1:channel-2",
+                "sender_id": "allowed-user",
+                "text": "@bot hello",
+                "message_type": "text",
+                "mentioned": True,
+            },
+        }
+    )
+
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_id == "qchat:server-1:channel-2"
+    assert event.source.chat_type == "group"
+
+
+@pytest.mark.asyncio
+async def test_inbound_message_prefixes_chat_id_for_multi_instance():
+    bridge = FakeBridge()
+    resolved = load_nim_config(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "instance_name": "work",
+                "nim_token": "app|bot|secret",
+            },
+        )
+    )
+    resolved.route_prefix = "work/"
+    adapter = NimAdapter(
+        PlatformConfig(enabled=True, extra={"nim_token": "app|bot|secret"}),
+        bridge=bridge,
+        resolved=resolved,
+    )
+    adapter.handle_message = AsyncMock()
+
+    await adapter._on_bridge_event(
+        {
+            "event": "message",
+            "payload": {
+                "message_id": "m-3",
+                "session_type": "p2p",
+                "sender_id": "allowed-user",
+                "sender_name": "Allowed",
+                "text": "hello",
+                "message_type": "text",
+            },
+        }
+    )
+
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_id == "work/user:allowed-user"
+
+
+@pytest.mark.asyncio
+async def test_multi_instance_routes_send_to_matching_bridge():
+    config = PlatformConfig(
+        enabled=True,
+        extra={
+            "nim_token": "app|default-bot|secret-default",
+            "instances": [
+                {
+                    "instance_name": "work",
+                    "nim_token": "app|work-bot|secret-work",
+                }
+            ],
+        },
+    )
+    instances = load_nim_instances(config)
+    bridges = {}
+
+    def bridge_factory(resolved):
+        bridge = FakeBridge()
+        bridges[resolved.instance_name] = bridge
+        return bridge
+
+    adapter = MultiNimAdapter(
+        config,
+        resolved_instances=instances,
+        bridge_factory=bridge_factory,
+    )
+
+    assert await adapter.connect() is True
+
+    await adapter.send("work/user:200", "hello work")
+    await adapter.send("user:300", "hello default")
+
+    assert bridges["work"].sent == [
+        {
+            "chat_id": "user:200",
+            "text": "hello work",
+            "session_type": "p2p",
+            "reply_to": None,
+        }
+    ]
+    assert bridges["default"].sent == [
+        {
+            "chat_id": "user:300",
+            "text": "hello default",
+            "session_type": "p2p",
+            "reply_to": None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_multi_instance_rejects_unknown_route_prefix():
+    config = PlatformConfig(
+        enabled=True,
+        extra={
+            "nim_token": "app|default-bot|secret-default",
+            "instances": [
+                {
+                    "instance_name": "work",
+                    "nim_token": "app|work-bot|secret-work",
+                }
+            ],
+        },
+    )
+    instances = load_nim_instances(config)
+    bridges = {}
+
+    def bridge_factory(resolved):
+        bridge = FakeBridge()
+        bridges[resolved.instance_name] = bridge
+        return bridge
+
+    adapter = MultiNimAdapter(
+        config,
+        resolved_instances=instances,
+        bridge_factory=bridge_factory,
+    )
+
+    assert await adapter.connect() is True
+
+    with pytest.raises(RuntimeError, match="unavailable"):
+        await adapter.send("other/user:200", "hello unknown")
+
+    assert bridges["default"].sent == []
+    assert bridges["work"].sent == []
+
+
+def test_runner_uses_multi_adapter_for_single_explicit_instance(monkeypatch):
+    config = PlatformConfig(
+        enabled=True,
+        extra={
+            "instances": [
+                {
+                    "instance_name": "main",
+                    "nim_token": "app|main-bot|secret-main",
+                }
+            ],
+        },
+    )
+    runner = object.__new__(GatewayRunner)
+    runner.config = SimpleNamespace(group_sessions_per_user=True, thread_sessions_per_user=False)
+
+    import gateway.platforms.nim as nim_module
+
+    monkeypatch.setattr(nim_module, "check_nim_requirements", lambda _config: True)
+
+    adapter = GatewayRunner._create_adapter(runner, Platform.NIM, config)
+    assert isinstance(adapter, MultiNimAdapter)
+
+
+def test_load_nim_config_hardcodes_packaged_bridge_command():
+    resolved = load_nim_config(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "nim_token": "app|bot|secret",
+                "bridge_command": ["node", "/tmp/custom/index.mjs"],
+            },
+        ),
+        {"NIM_BRIDGE_COMMAND": "node /tmp/ignored/index.mjs"},
+    )
+
+    assert resolved.bridge_command == _default_nim_bridge_command()
+
+
+def test_check_nim_requirements_supports_bundled_bridge(monkeypatch, tmp_path):
+    bridge_dir = tmp_path / "nim_bot_py" / "bridge_js"
+    bridge_dir.mkdir(parents=True)
+    bridge_script = bridge_dir / "index.mjs"
+    bridge_script.write_text("console.log('ok')\n", encoding="utf-8")
+
+    monkeypatch.setattr("gateway.platforms.nim._default_nim_bridge_command", lambda: ["node", str(bridge_script)])
+    monkeypatch.setattr("gateway.config._default_nim_bridge_command", lambda: ["node", str(bridge_script)])
+    monkeypatch.setattr("gateway.platforms.nim.shutil.which", lambda name: f"/usr/bin/{name}")
+
+    class FakePackagedBridge:
+        def __init__(self, command):
+            self.command = command
+
+        def ensure_runtime(self):
+            return None
+
+    monkeypatch.setattr("gateway.platforms.nim.PackagedNodeBridge", FakePackagedBridge)
+
+    assert check_nim_requirements(
+        PlatformConfig(enabled=True, extra={"nim_token": "app|bot|secret"})
+    ) is True
+
+
+def test_check_nim_instance_requirements_fails_when_packaged_bridge_runtime_is_unavailable(monkeypatch, tmp_path):
+    bridge_dir = tmp_path / "nim_bot_py" / "bridge_js"
+    bridge_dir.mkdir(parents=True)
+    bridge_script = bridge_dir / "index.mjs"
+    bridge_script.write_text("console.log('ok')\n", encoding="utf-8")
+
+    monkeypatch.setattr("gateway.platforms.nim._default_nim_bridge_command", lambda: ["node", str(bridge_script)])
+    monkeypatch.setattr("gateway.config._default_nim_bridge_command", lambda: ["node", str(bridge_script)])
+    monkeypatch.setattr("gateway.platforms.nim.shutil.which", lambda name: f"/usr/bin/{name}")
+
+    class FakePackagedBridge:
+        def __init__(self, command):
+            self.command = command
+
+        def ensure_runtime(self):
+            from nim_bot_py.bridge import NimBridgeError
+
+            raise NimBridgeError("npm not found")
+
+    monkeypatch.setattr("gateway.platforms.nim.PackagedNodeBridge", FakePackagedBridge)
+
+    resolved = load_nim_config(PlatformConfig(enabled=True, extra={"nim_token": "app|bot|secret"}), {})
+    assert resolved.bridge_command == ["node", str(bridge_script)]
+    assert _check_nim_instance_requirements(resolved) is False

--- a/tests/gateway/test_nim_adapter.py
+++ b/tests/gateway/test_nim_adapter.py
@@ -176,6 +176,38 @@ async def test_inbound_dm_respects_allowlist():
 
 
 @pytest.mark.asyncio
+async def test_inbound_non_online_message_is_ignored():
+    bridge = FakeBridge()
+    adapter = NimAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "nim_token": "app|bot|secret",
+            },
+        ),
+        bridge=bridge,
+    )
+    adapter.handle_message = AsyncMock()
+
+    await adapter._on_bridge_event(
+        {
+            "event": "message",
+            "payload": {
+                "message_id": "m-offline-1",
+                "message_source": 3,
+                "session_type": "p2p",
+                "sender_id": "allowed-user",
+                "sender_name": "Allowed",
+                "text": "history hello",
+                "message_type": "text",
+            },
+        }
+    )
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_group_message_requires_allowed_team_and_mention():
     bridge = FakeBridge()
     adapter = NimAdapter(
@@ -411,6 +443,38 @@ async def test_multi_instance_rejects_unknown_route_prefix():
 
     assert bridges["default"].sent == []
     assert bridges["work"].sent == []
+
+
+def test_multi_instance_dedupes_duplicate_qchat_events():
+    config = PlatformConfig(
+        enabled=True,
+        extra={
+            "instances": [
+                {
+                    "instance_name": "main",
+                    "nim_token": "app|main-bot|secret-main",
+                }
+            ],
+        },
+    )
+    instances = load_nim_instances(config)
+    adapter = MultiNimAdapter(config, resolved_instances=instances)
+
+    event = SimpleNamespace(
+        message_id="qchat-server-msg-1",
+        text="@bot 你是谁",
+        source=SimpleNamespace(user_id="user-1"),
+        raw_message={
+            "session_type": "qchat",
+            "server_id": "server-1",
+            "channel_id": "channel-2",
+            "sender_id": "user-1",
+            "message_id": "qchat-server-msg-1",
+        },
+    )
+
+    assert adapter._should_drop_duplicate_qchat_event(event) is False
+    assert adapter._should_drop_duplicate_qchat_event(event) is True
 
 
 def test_runner_uses_multi_adapter_for_single_explicit_instance(monkeypatch):

--- a/tests/gateway/test_nim_config.py
+++ b/tests/gateway/test_nim_config.py
@@ -1,0 +1,201 @@
+from unittest import mock
+
+from gateway.config import (
+    GatewayConfig,
+    Platform,
+    PlatformConfig,
+    _default_nim_bridge_command,
+    _resolve_nim_bridge_command,
+    load_nim_config,
+    load_nim_instances,
+    parse_nim_token,
+)
+
+
+class TestParseNimToken:
+    def test_pipe_separator(self):
+        creds = parse_nim_token("app|bot|secret")
+        assert creds is not None
+        assert creds.app_key == "app"
+        assert creds.account == "bot"
+        assert creds.token == "secret"
+
+    def test_dash_separator(self):
+        creds = parse_nim_token("app-bot-secret")
+        assert creds is not None
+        assert creds.app_key == "app"
+        assert creds.account == "bot"
+        assert creds.token == "secret"
+
+
+class TestLoadNimConfig:
+    def test_loads_from_platform_token(self):
+        resolved = load_nim_config(
+            PlatformConfig(
+                enabled=True,
+                extra={
+                    "nimToken": "from-token|bot|secret",
+                    "p2p": {"policy": "allowlist", "allowFrom": ["alice", "bob"]},
+                    "team": {"policy": "allowlist", "allowFrom": ["team-a", "1|team-b|alice"]},
+                    "qchat": {"policy": "allowlist", "allowFrom": ["server-1|channel-9|alice"]},
+                    "advanced": {
+                        "mediaMaxMb": 64,
+                        "textChunkLimit": 2048,
+                        "debug": True,
+                    },
+                },
+            )
+        )
+
+        assert resolved.configured() is True
+        assert resolved.credentials is not None
+        assert resolved.credentials.app_key == "from-token"
+        assert resolved.bridge_command == _default_nim_bridge_command()
+        assert resolved.p2p_policy == "allowlist"
+        assert resolved.p2p_allow_from == ["alice", "bob"]
+        assert resolved.team_policy == "allowlist"
+        assert resolved.team_allow_from == ["team-a", "1|team-b|alice"]
+        assert resolved.qchat_policy == "allowlist"
+        assert resolved.qchat_allow_from == ["server-1|channel-9|alice"]
+        assert resolved.media_max_mb == 64
+        assert resolved.text_chunk_limit == 2048
+        assert resolved.debug is True
+
+    def test_loads_from_env_triplet(self):
+        resolved = load_nim_config(
+            PlatformConfig(enabled=True),
+            {
+                "NIM_APP_KEY": "app",
+                "NIM_ACCOUNT": "bot",
+                "NIM_TOKEN": "secret",
+                "NIM_ALLOWED_USERS": "alice,bob",
+                "NIM_GROUP_ALLOWLIST": "team-a,team-b",
+                "NIM_GROUP_POLICY": "open",
+                "NIM_ALLOW_ALL_USERS": "true",
+            },
+        )
+
+        assert resolved.configured() is True
+        assert resolved.allowed_users == ["alice", "bob"]
+        assert resolved.group_allowlist == ["team-a", "team-b"]
+        assert resolved.group_policy == "open"
+        assert resolved.allow_all_users is True
+
+    def test_compact_credentials_default_to_open_access(self):
+        resolved = load_nim_config(
+            PlatformConfig(enabled=True),
+            {
+                "NIM_CREDENTIALS": "app|bot|secret",
+            },
+        )
+
+        assert resolved.configured() is True
+        assert resolved.credentials is not None
+        assert resolved.allow_all_users is True
+        assert resolved.group_policy == "open"
+        assert resolved.group_allowlist == []
+
+    def test_default_bridge_command_uses_bundled_node_script(self):
+        assert _resolve_nim_bridge_command(None) == _default_nim_bridge_command()
+        assert _resolve_nim_bridge_command(None)[0] == "node"
+        assert "nim_bot_py/bridge_js/index.mjs" in _resolve_nim_bridge_command(None)[1]
+
+    def test_load_config_ignores_legacy_bridge_override(self):
+        resolved = load_nim_config(
+            PlatformConfig(
+                enabled=True,
+                extra={
+                    "nim_token": "app|bot|secret",
+                    "bridge_command": ["node", "/tmp/custom/index.mjs"],
+                },
+            ),
+            {"NIM_BRIDGE_COMMAND": "node /tmp/ignored/index.mjs"},
+        )
+
+        assert resolved.bridge_command == _default_nim_bridge_command()
+
+    def test_loads_multiple_instances_and_prefixes_chat_ids(self):
+        instances = load_nim_instances(
+            PlatformConfig(
+                enabled=True,
+                extra={
+                    "nim_token": "app|default-bot|secret-default",
+                    "instances": [
+                        {
+                            "nimToken": "app|work-bot|secret-work",
+                            "home_channel": "user:42",
+                        }
+                    ],
+                },
+            )
+        )
+
+        assert [item.instance_name for item in instances] == ["default", "work-bot"]
+        assert instances[0].route_prefix == "default/"
+        assert instances[1].route_prefix == "work-bot/"
+        assert instances[1].home_channel == "work-bot/user:42"
+
+    def test_env_instances_override_platform_instances(self):
+        instances = load_nim_instances(
+            PlatformConfig(
+                enabled=True,
+                extra={
+                    "instances": [
+                        {"instance_name": "stale", "nimToken": "app|stale|secret"},
+                    ],
+                },
+            ),
+            {
+                "NIM_INSTANCES": '[{"instance_name":"env","nimToken":"app|env|secret-env"}]',
+            },
+        )
+
+        assert [item.instance_name for item in instances] == ["env"]
+
+    def test_env_instances_override_legacy_env_credentials(self):
+        instances = load_nim_instances(
+            PlatformConfig(enabled=True),
+            {
+                "NIM_CREDENTIALS": "app|legacy|secret-legacy",
+                "NIM_INSTANCES": '[{"instance_name":"main","nimToken":"app|env|secret-env"}]',
+            },
+        )
+
+        assert [item.instance_name for item in instances] == ["main"]
+        assert [item.credentials.account for item in instances if item.credentials is not None] == ["env"]
+
+
+class TestConnectedPlatforms:
+    def test_nim_recognized_via_config_extra(self):
+        config = GatewayConfig(
+            platforms={
+                Platform.NIM: PlatformConfig(
+                    enabled=True,
+                    extra={"nim_token": "app|bot|secret"},
+                ),
+            }
+        )
+
+        assert Platform.NIM in config.get_connected_platforms()
+
+    def test_nim_home_channel_falls_back_to_first_instance(self):
+        config = GatewayConfig(
+            platforms={
+                Platform.NIM: PlatformConfig(
+                    enabled=True,
+                    extra={
+                        "instances": [
+                            {
+                                "instance_name": "work",
+                                "nim_token": "app|work|secret",
+                                "home_channel": "user:100",
+                            }
+                        ],
+                    },
+                ),
+            }
+        )
+
+        home = config.get_home_channel(Platform.NIM)
+        assert home is not None
+        assert home.chat_id == "user:100"

--- a/tests/gateway/test_nim_config.py
+++ b/tests/gateway/test_nim_config.py
@@ -1,5 +1,7 @@
 from unittest import mock
 
+import pytest
+
 from gateway.config import (
     GatewayConfig,
     Platform,
@@ -10,6 +12,9 @@ from gateway.config import (
     load_nim_instances,
     parse_nim_token,
 )
+from gateway.platforms.base import MessageEvent
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource, build_session_context
 
 
 class TestParseNimToken:
@@ -61,18 +66,20 @@ class TestLoadNimConfig:
         assert resolved.text_chunk_limit == 2048
         assert resolved.debug is True
 
-    def test_loads_from_env_triplet(self):
+    def test_loads_from_explicit_fields(self):
         resolved = load_nim_config(
-            PlatformConfig(enabled=True),
-            {
-                "NIM_APP_KEY": "app",
-                "NIM_ACCOUNT": "bot",
-                "NIM_TOKEN": "secret",
-                "NIM_ALLOWED_USERS": "alice,bob",
-                "NIM_GROUP_ALLOWLIST": "team-a,team-b",
-                "NIM_GROUP_POLICY": "open",
-                "NIM_ALLOW_ALL_USERS": "true",
-            },
+            PlatformConfig(
+                enabled=True,
+                extra={
+                    "app_key": "app",
+                    "account": "bot",
+                    "token": "secret",
+                    "allowed_users": ["alice", "bob"],
+                    "group_allowlist": ["team-a", "team-b"],
+                    "group_policy": "open",
+                    "allow_all_users": True,
+                },
+            )
         )
 
         assert resolved.configured() is True
@@ -83,10 +90,7 @@ class TestLoadNimConfig:
 
     def test_compact_credentials_default_to_open_access(self):
         resolved = load_nim_config(
-            PlatformConfig(enabled=True),
-            {
-                "NIM_CREDENTIALS": "app|bot|secret",
-            },
+            PlatformConfig(enabled=True, extra={"nim_token": "app|bot|secret"})
         )
 
         assert resolved.configured() is True
@@ -135,36 +139,7 @@ class TestLoadNimConfig:
         assert instances[1].route_prefix == "work-bot/"
         assert instances[1].home_channel == "work-bot/user:42"
 
-    def test_env_instances_override_platform_instances(self):
-        instances = load_nim_instances(
-            PlatformConfig(
-                enabled=True,
-                extra={
-                    "instances": [
-                        {"instance_name": "stale", "nimToken": "app|stale|secret"},
-                    ],
-                },
-            ),
-            {
-                "NIM_INSTANCES": '[{"instance_name":"env","nimToken":"app|env|secret-env"}]',
-            },
-        )
-
-        assert [item.instance_name for item in instances] == ["env"]
-
-    def test_env_instances_override_legacy_env_credentials(self):
-        instances = load_nim_instances(
-            PlatformConfig(enabled=True),
-            {
-                "NIM_CREDENTIALS": "app|legacy|secret-legacy",
-                "NIM_INSTANCES": '[{"instance_name":"main","nimToken":"app|env|secret-env"}]',
-            },
-        )
-
-        assert [item.instance_name for item in instances] == ["main"]
-        assert [item.credentials.account for item in instances if item.credentials is not None] == ["env"]
-
-    def test_config_instances_override_legacy_env_credentials(self):
+    def test_config_instances_ignore_env_credentials(self):
         instances = load_nim_instances(
             PlatformConfig(
                 enabled=True,
@@ -217,3 +192,114 @@ class TestConnectedPlatforms:
         home = config.get_home_channel(Platform.NIM)
         assert home is not None
         assert home.chat_id == "user:100"
+
+    def test_nim_home_channel_resolves_per_instance_route(self):
+        config = GatewayConfig(
+            platforms={
+                Platform.NIM: PlatformConfig(
+                    enabled=True,
+                    extra={
+                        "instances": [
+                            {
+                                "instance_name": "default",
+                                "nim_token": "app|default|secret",
+                                "home_channel": "user:100",
+                            },
+                            {
+                                "instance_name": "work",
+                                "nim_token": "app|work|secret",
+                                "home_channel": "user:200",
+                            },
+                        ],
+                    },
+                ),
+            }
+        )
+
+        home = config.get_home_channel(Platform.NIM, source_chat_id="work/user:42")
+        assert home is not None
+        assert home.chat_id == "work/user:200"
+
+
+class TestNimSessionContext:
+    def test_build_session_context_uses_current_nim_instance_home_channel(self):
+        config = GatewayConfig(
+            platforms={
+                Platform.NIM: PlatformConfig(
+                    enabled=True,
+                    extra={
+                        "instances": [
+                            {
+                                "instance_name": "default",
+                                "nim_token": "app|default|secret",
+                                "home_channel": "user:100",
+                            },
+                            {
+                                "instance_name": "work",
+                                "nim_token": "app|work|secret",
+                                "home_channel": "user:200",
+                            },
+                        ],
+                    },
+                ),
+            }
+        )
+
+        source = SessionSource(
+            platform=Platform.NIM,
+            chat_id="work/user:42",
+            chat_type="dm",
+        )
+        context = build_session_context(source, config)
+
+        assert Platform.NIM in context.home_channels
+        assert context.home_channels[Platform.NIM].chat_id == "work/user:200"
+
+
+class TestNimSetHome:
+    @pytest.mark.asyncio
+    async def test_sethome_updates_matching_nim_instance(self, monkeypatch, tmp_path):
+        import gateway.run as gateway_run
+
+        monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+        (tmp_path / "config.yaml").write_text(
+            "nim:\n"
+            "  instances:\n"
+            "    - instance_name: default\n"
+            "      nimToken: app|default|secret\n"
+            "    - instance_name: work\n"
+            "      nimToken: app|work|secret\n",
+            encoding="utf-8",
+        )
+
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(
+            platforms={
+                Platform.NIM: PlatformConfig(
+                    enabled=True,
+                    extra={
+                        "instances": [
+                            {"instance_name": "default", "nimToken": "app|default|secret"},
+                            {"instance_name": "work", "nimToken": "app|work|secret"},
+                        ],
+                    },
+                )
+            }
+        )
+
+        event = MessageEvent(
+            text="/sethome",
+            source=SessionSource(
+                platform=Platform.NIM,
+                chat_id="work/user:42",
+                chat_name="Work DM",
+                chat_type="dm",
+            ),
+        )
+
+        result = await runner._handle_set_home_command(event)
+
+        assert "Home channel set" in result
+        updated = (tmp_path / "config.yaml").read_text(encoding="utf-8")
+        assert "instance_name: work" in updated
+        assert "home_channel: user:42" in updated

--- a/tests/gateway/test_nim_config.py
+++ b/tests/gateway/test_nim_config.py
@@ -164,6 +164,24 @@ class TestLoadNimConfig:
         assert [item.instance_name for item in instances] == ["main"]
         assert [item.credentials.account for item in instances if item.credentials is not None] == ["env"]
 
+    def test_config_instances_override_legacy_env_credentials(self):
+        instances = load_nim_instances(
+            PlatformConfig(
+                enabled=True,
+                extra={
+                    "instances": [
+                        {"instance_name": "main", "nimToken": "app|yaml|secret-yaml"},
+                    ],
+                },
+            ),
+            {
+                "NIM_CREDENTIALS": "app|legacy|secret-legacy",
+            },
+        )
+
+        assert [item.instance_name for item in instances] == ["main"]
+        assert [item.credentials.account for item in instances if item.credentials is not None] == ["yaml"]
+
 
 class TestConnectedPlatforms:
     def test_nim_recognized_via_config_extra(self):

--- a/tests/gateway/test_unauthorized_dm_behavior.py
+++ b/tests/gateway/test_unauthorized_dm_behavior.py
@@ -144,11 +144,21 @@ def test_star_wildcard_works_for_any_platform(monkeypatch):
 
 def test_nim_allow_all_users_authorizes_dm(monkeypatch):
     _clear_auth_env(monkeypatch)
-    monkeypatch.setenv("NIM_ALLOW_ALL_USERS", "true")
 
     runner, _adapter = _make_runner(
         Platform.NIM,
-        GatewayConfig(platforms={Platform.NIM: PlatformConfig(enabled=True)}),
+        GatewayConfig(
+            platforms={
+                Platform.NIM: PlatformConfig(
+                    enabled=True,
+                    extra={
+                        "instances": [
+                            {"instance_name": "default", "nimToken": "app|bot|secret"},
+                        ],
+                    },
+                )
+            }
+        ),
     )
 
     source = SessionSource(
@@ -164,11 +174,25 @@ def test_nim_allow_all_users_authorizes_dm(monkeypatch):
 
 def test_nim_allowed_users_authorizes_matching_user(monkeypatch):
     _clear_auth_env(monkeypatch)
-    monkeypatch.setenv("NIM_ALLOWED_USERS", "112649,alice")
 
     runner, _adapter = _make_runner(
         Platform.NIM,
-        GatewayConfig(platforms={Platform.NIM: PlatformConfig(enabled=True)}),
+        GatewayConfig(
+            platforms={
+                Platform.NIM: PlatformConfig(
+                    enabled=True,
+                    extra={
+                        "instances": [
+                            {
+                                "instance_name": "default",
+                                "nimToken": "app|bot|secret",
+                                "p2p": {"policy": "allowlist", "allowFrom": ["112649", "alice"]},
+                            },
+                        ],
+                    },
+                )
+            }
+        ),
     )
 
     source = SessionSource(
@@ -180,6 +204,32 @@ def test_nim_allowed_users_authorizes_matching_user(monkeypatch):
     )
 
     assert runner._is_user_authorized(source) is True
+
+
+def test_nim_allowlist_defaults_unauthorized_dm_behavior_to_ignore(monkeypatch):
+    _clear_auth_env(monkeypatch)
+
+    runner, _adapter = _make_runner(
+        Platform.NIM,
+        GatewayConfig(
+            platforms={
+                Platform.NIM: PlatformConfig(
+                    enabled=True,
+                    extra={
+                        "instances": [
+                            {
+                                "instance_name": "default",
+                                "nimToken": "app|bot|secret",
+                                "p2p": {"policy": "allowlist", "allowFrom": ["112649"]},
+                            },
+                        ],
+                    },
+                )
+            }
+        ),
+    )
+
+    assert runner._get_unauthorized_dm_behavior(Platform.NIM) == "ignore"
 
 
 def test_qq_group_allowlist_authorizes_group_chat_without_user_allowlist(monkeypatch):

--- a/tests/gateway/test_unauthorized_dm_behavior.py
+++ b/tests/gateway/test_unauthorized_dm_behavior.py
@@ -23,6 +23,7 @@ def _clear_auth_env(monkeypatch) -> None:
         "MATTERMOST_ALLOWED_USERS",
         "MATRIX_ALLOWED_USERS",
         "DINGTALK_ALLOWED_USERS", "FEISHU_ALLOWED_USERS", "WECOM_ALLOWED_USERS",
+        "NIM_ALLOWED_USERS",
         "QQ_ALLOWED_USERS", "QQ_GROUP_ALLOWED_USERS",
         "GATEWAY_ALLOWED_USERS",
         "TELEGRAM_ALLOW_ALL_USERS",
@@ -35,6 +36,7 @@ def _clear_auth_env(monkeypatch) -> None:
         "MATTERMOST_ALLOW_ALL_USERS",
         "MATRIX_ALLOW_ALL_USERS",
         "DINGTALK_ALLOW_ALL_USERS", "FEISHU_ALLOW_ALL_USERS", "WECOM_ALLOW_ALL_USERS",
+        "NIM_ALLOW_ALL_USERS",
         "QQ_ALLOW_ALL_USERS",
         "GATEWAY_ALLOW_ALL_USERS",
     ):
@@ -137,6 +139,46 @@ def test_star_wildcard_works_for_any_platform(monkeypatch):
         user_name="stranger",
         chat_type="dm",
     )
+    assert runner._is_user_authorized(source) is True
+
+
+def test_nim_allow_all_users_authorizes_dm(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("NIM_ALLOW_ALL_USERS", "true")
+
+    runner, _adapter = _make_runner(
+        Platform.NIM,
+        GatewayConfig(platforms={Platform.NIM: PlatformConfig(enabled=True)}),
+    )
+
+    source = SessionSource(
+        platform=Platform.NIM,
+        user_id="112649",
+        chat_id="user:112649",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+    assert runner._is_user_authorized(source) is True
+
+
+def test_nim_allowed_users_authorizes_matching_user(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("NIM_ALLOWED_USERS", "112649,alice")
+
+    runner, _adapter = _make_runner(
+        Platform.NIM,
+        GatewayConfig(platforms={Platform.NIM: PlatformConfig(enabled=True)}),
+    )
+
+    source = SessionSource(
+        platform=Platform.NIM,
+        user_id="112649",
+        chat_id="user:112649",
+        user_name="tester",
+        chat_type="dm",
+    )
+
     assert runner._is_user_authorized(source) is True
 
 

--- a/tests/gateway/test_unauthorized_dm_behavior.py
+++ b/tests/gateway/test_unauthorized_dm_behavior.py
@@ -21,6 +21,7 @@ def _clear_auth_env(monkeypatch) -> None:
         "MATTERMOST_ALLOWED_USERS",
         "MATRIX_ALLOWED_USERS",
         "DINGTALK_ALLOWED_USERS", "FEISHU_ALLOWED_USERS", "WECOM_ALLOWED_USERS",
+        "NIM_ALLOWED_USERS",
         "QQ_ALLOWED_USERS", "QQ_GROUP_ALLOWED_USERS",
         "GATEWAY_ALLOWED_USERS",
         "TELEGRAM_ALLOW_ALL_USERS",
@@ -33,6 +34,7 @@ def _clear_auth_env(monkeypatch) -> None:
         "MATTERMOST_ALLOW_ALL_USERS",
         "MATRIX_ALLOW_ALL_USERS",
         "DINGTALK_ALLOW_ALL_USERS", "FEISHU_ALLOW_ALL_USERS", "WECOM_ALLOW_ALL_USERS",
+        "NIM_ALLOW_ALL_USERS",
         "QQ_ALLOW_ALL_USERS",
         "GATEWAY_ALLOW_ALL_USERS",
     ):
@@ -135,6 +137,46 @@ def test_star_wildcard_works_for_any_platform(monkeypatch):
         user_name="stranger",
         chat_type="dm",
     )
+    assert runner._is_user_authorized(source) is True
+
+
+def test_nim_allow_all_users_authorizes_dm(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("NIM_ALLOW_ALL_USERS", "true")
+
+    runner, _adapter = _make_runner(
+        Platform.NIM,
+        GatewayConfig(platforms={Platform.NIM: PlatformConfig(enabled=True)}),
+    )
+
+    source = SessionSource(
+        platform=Platform.NIM,
+        user_id="112649",
+        chat_id="user:112649",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+    assert runner._is_user_authorized(source) is True
+
+
+def test_nim_allowed_users_authorizes_matching_user(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("NIM_ALLOWED_USERS", "112649,alice")
+
+    runner, _adapter = _make_runner(
+        Platform.NIM,
+        GatewayConfig(platforms={Platform.NIM: PlatformConfig(enabled=True)}),
+    )
+
+    source = SessionSource(
+        platform=Platform.NIM,
+        user_id="112649",
+        chat_id="user:112649",
+        user_name="tester",
+        chat_type="dm",
+    )
+
     assert runner._is_user_authorized(source) is True
 
 

--- a/tests/gateway/test_unauthorized_dm_behavior.py
+++ b/tests/gateway/test_unauthorized_dm_behavior.py
@@ -142,11 +142,21 @@ def test_star_wildcard_works_for_any_platform(monkeypatch):
 
 def test_nim_allow_all_users_authorizes_dm(monkeypatch):
     _clear_auth_env(monkeypatch)
-    monkeypatch.setenv("NIM_ALLOW_ALL_USERS", "true")
 
     runner, _adapter = _make_runner(
         Platform.NIM,
-        GatewayConfig(platforms={Platform.NIM: PlatformConfig(enabled=True)}),
+        GatewayConfig(
+            platforms={
+                Platform.NIM: PlatformConfig(
+                    enabled=True,
+                    extra={
+                        "instances": [
+                            {"instance_name": "default", "nimToken": "app|bot|secret"},
+                        ],
+                    },
+                )
+            }
+        ),
     )
 
     source = SessionSource(
@@ -162,11 +172,25 @@ def test_nim_allow_all_users_authorizes_dm(monkeypatch):
 
 def test_nim_allowed_users_authorizes_matching_user(monkeypatch):
     _clear_auth_env(monkeypatch)
-    monkeypatch.setenv("NIM_ALLOWED_USERS", "112649,alice")
 
     runner, _adapter = _make_runner(
         Platform.NIM,
-        GatewayConfig(platforms={Platform.NIM: PlatformConfig(enabled=True)}),
+        GatewayConfig(
+            platforms={
+                Platform.NIM: PlatformConfig(
+                    enabled=True,
+                    extra={
+                        "instances": [
+                            {
+                                "instance_name": "default",
+                                "nimToken": "app|bot|secret",
+                                "p2p": {"policy": "allowlist", "allowFrom": ["112649", "alice"]},
+                            },
+                        ],
+                    },
+                )
+            }
+        ),
     )
 
     source = SessionSource(
@@ -178,6 +202,32 @@ def test_nim_allowed_users_authorizes_matching_user(monkeypatch):
     )
 
     assert runner._is_user_authorized(source) is True
+
+
+def test_nim_allowlist_defaults_unauthorized_dm_behavior_to_ignore(monkeypatch):
+    _clear_auth_env(monkeypatch)
+
+    runner, _adapter = _make_runner(
+        Platform.NIM,
+        GatewayConfig(
+            platforms={
+                Platform.NIM: PlatformConfig(
+                    enabled=True,
+                    extra={
+                        "instances": [
+                            {
+                                "instance_name": "default",
+                                "nimToken": "app|bot|secret",
+                                "p2p": {"policy": "allowlist", "allowFrom": ["112649"]},
+                            },
+                        ],
+                    },
+                )
+            }
+        ),
+    )
+
+    assert runner._get_unauthorized_dm_behavior(Platform.NIM) == "ignore"
 
 
 def test_qq_group_allowlist_authorizes_group_chat_without_user_allowlist(monkeypatch):

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -385,6 +385,9 @@ class TestOptionalEnvVarsRegistry:
         from hermes_cli.config import OPTIONAL_ENV_VARS
         assert OPTIONAL_ENV_VARS["TAVILY_API_KEY"]["url"] == "https://app.tavily.com/home"
 
+    def test_default_config_exposes_top_level_nim_block(self):
+        assert DEFAULT_CONFIG["nim"] == {"instances": []}
+
     def test_tavily_in_env_vars_by_version(self):
         """TAVILY_API_KEY is listed in ENV_VARS_BY_VERSION."""
         from hermes_cli.config import ENV_VARS_BY_VERSION

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -402,6 +402,9 @@ class TestOptionalEnvVarsRegistry:
         from hermes_cli.config import OPTIONAL_ENV_VARS
         assert OPTIONAL_ENV_VARS["TAVILY_API_KEY"]["url"] == "https://app.tavily.com/home"
 
+    def test_default_config_exposes_top_level_nim_block(self):
+        assert DEFAULT_CONFIG["nim"] == {"instances": []}
+
     def test_tavily_in_env_vars_by_version(self):
         """TAVILY_API_KEY is listed in ENV_VARS_BY_VERSION."""
         from hermes_cli.config import ENV_VARS_BY_VERSION

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -223,6 +223,148 @@ def test_setup_gateway_in_container_shows_docker_guidance(monkeypatch, capsys):
     assert "restart" in out.lower()
 
 
+def test_gateway_platforms_include_nim():
+    names = [name for name, _env_var, _setup in setup_mod._GATEWAY_PLATFORMS]
+    assert "NIM (NetEase IM)" in names
+
+
+def test_setup_gateway_marks_nim_configured_with_explicit_fields(monkeypatch):
+    env = {
+        "NIM_CREDENTIALS": "",
+        "NIM_INSTANCES": "",
+        "NIM_APP_KEY": "app-key",
+        "NIM_ACCOUNT": "bot-account",
+        "NIM_TOKEN": "bot-token",
+    }
+
+    monkeypatch.setattr(setup_mod, "get_env_value", lambda key: env.get(key, ""))
+    monkeypatch.setattr(setup_mod, "prompt_checklist", lambda *_args, **_kwargs: [])
+
+    captured = {}
+
+    def _capture(_question, items, pre_selected=None):
+        captured["items"] = items
+        captured["pre_selected"] = pre_selected or []
+        return []
+
+    monkeypatch.setattr(setup_mod, "prompt_checklist", _capture)
+    setup_mod.setup_gateway({})
+
+    nim_index = captured["items"].index("NIM (NetEase IM)  (configured)")
+    assert nim_index in captured["pre_selected"]
+
+
+def test_setup_gateway_marks_nim_configured_with_instances(monkeypatch):
+    env = {
+        "NIM_CREDENTIALS": "",
+        "NIM_INSTANCES": '[{"instance_name":"work","nim_token":"app|bot|secret"}]',
+    }
+
+    monkeypatch.setattr(setup_mod, "get_env_value", lambda key: env.get(key, ""))
+
+    captured = {}
+
+    def _capture(_question, items, pre_selected=None):
+        captured["items"] = items
+        captured["pre_selected"] = pre_selected or []
+        return []
+
+    monkeypatch.setattr(setup_mod, "prompt_checklist", _capture)
+    setup_mod.setup_gateway({})
+
+    nim_index = captured["items"].index("NIM (NetEase IM)  (configured)")
+    assert nim_index in captured["pre_selected"]
+
+
+def test_setup_gateway_marks_nim_configured_from_config_yaml(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    config = load_config()
+    config["nim"] = {
+        "instances": [
+            {
+                "enabled": True,
+                "nimToken": "app|bot|secret",
+                "p2p": {"policy": "open"},
+            }
+        ]
+    }
+    save_config(config)
+
+    monkeypatch.setattr(setup_mod, "get_env_value", lambda _key: "")
+
+    captured = {}
+
+    def _capture(_question, items, pre_selected=None):
+        captured["items"] = items
+        captured["pre_selected"] = pre_selected or []
+        return []
+
+    monkeypatch.setattr(setup_mod, "prompt_checklist", _capture)
+    setup_mod.setup_gateway(load_config())
+
+    nim_index = captured["items"].index("NIM (NetEase IM)  (configured)")
+    assert nim_index in captured["pre_selected"]
+
+
+def test_setup_nim_compact_credentials_sets_open_defaults(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    monkeypatch.setattr(
+        setup_mod,
+        "prompt",
+        lambda *_args, **_kwargs: "app-key|bot-account|bot-token",
+    )
+    monkeypatch.setattr(setup_mod, "prompt_yes_no", lambda *_args, **_kwargs: False)
+
+    setup_mod._setup_nim()
+
+    saved = load_config()
+    assert saved["nim"]["instances"] == [
+        {
+            "enabled": True,
+            "nimToken": "app-key|bot-account|bot-token",
+            "p2p": {"policy": "open", "allowFrom": []},
+            "team": {"policy": "open", "allowFrom": []},
+            "qchat": {"policy": "open", "allowFrom": []},
+            "advanced": {
+                "mediaMaxMb": 30,
+                "textChunkLimit": 4000,
+                "debug": False,
+            },
+        }
+    ]
+    assert setup_mod.get_env_value("NIM_CREDENTIALS") == ""
+    assert setup_mod.get_env_value("NIM_INSTANCES") == ""
+    assert setup_mod.get_env_value("NIM_APP_KEY") == ""
+    assert setup_mod.get_env_value("NIM_ACCOUNT") == ""
+    assert setup_mod.get_env_value("NIM_TOKEN") == ""
+    assert setup_mod.get_env_value("NIM_ALLOWED_USERS") == ""
+    assert setup_mod.get_env_value("NIM_ALLOW_ALL_USERS") == "true"
+    assert setup_mod.get_env_value("NIM_GROUP_POLICY") == "open"
+    assert setup_mod.get_env_value("NIM_GROUP_ALLOWLIST") == ""
+
+
+def test_gateway_summary_includes_nim_from_config_yaml(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(setup_mod, "get_env_value", lambda _key: "")
+
+    config = load_config()
+    config["nim"] = {
+        "instances": [
+            {
+                "enabled": True,
+                "nimToken": "app|bot|secret",
+            }
+        ]
+    }
+    save_config(config)
+
+    summary = setup_mod._get_section_config_summary(load_config(), "gateway")
+
+    assert summary == "NIM"
+
+
 def test_setup_syncs_custom_provider_removal_from_disk(tmp_path, monkeypatch):
     """Removing the last custom provider in model setup should persist."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -242,10 +242,8 @@ def test_gateway_platforms_include_nim():
     assert "NIM (NetEase IM)" in names
 
 
-def test_setup_gateway_marks_nim_configured_with_explicit_fields(monkeypatch):
+def test_setup_gateway_ignores_nim_env_credentials_without_config_yaml(monkeypatch):
     env = {
-        "NIM_CREDENTIALS": "",
-        "NIM_INSTANCES": "",
         "NIM_APP_KEY": "app-key",
         "NIM_ACCOUNT": "bot-account",
         "NIM_TOKEN": "bot-token",
@@ -264,13 +262,14 @@ def test_setup_gateway_marks_nim_configured_with_explicit_fields(monkeypatch):
     monkeypatch.setattr(setup_mod, "prompt_checklist", _capture)
     setup_mod.setup_gateway({})
 
-    nim_index = captured["items"].index("NIM (NetEase IM)  (configured)")
-    assert nim_index in captured["pre_selected"]
+    nim_index = next(
+        i for i, item in enumerate(captured["items"])
+        if item.startswith("NIM (NetEase IM)")
+    )
+    assert nim_index not in captured["pre_selected"]
 
-
-def test_setup_gateway_marks_nim_configured_with_instances(monkeypatch):
+def test_setup_gateway_ignores_nim_env_instances_without_config_yaml(monkeypatch):
     env = {
-        "NIM_CREDENTIALS": "",
         "NIM_INSTANCES": '[{"instance_name":"work","nim_token":"app|bot|secret"}]',
     }
 
@@ -286,8 +285,11 @@ def test_setup_gateway_marks_nim_configured_with_instances(monkeypatch):
     monkeypatch.setattr(setup_mod, "prompt_checklist", _capture)
     setup_mod.setup_gateway({})
 
-    nim_index = captured["items"].index("NIM (NetEase IM)  (configured)")
-    assert nim_index in captured["pre_selected"]
+    nim_index = next(
+        i for i, item in enumerate(captured["items"])
+        if item.startswith("NIM (NetEase IM)")
+    )
+    assert nim_index not in captured["pre_selected"]
 
 
 def test_setup_gateway_marks_nim_configured_from_config_yaml(monkeypatch, tmp_path):
@@ -400,15 +402,6 @@ def test_setup_nim_compact_credentials_sets_open_defaults(monkeypatch, tmp_path)
             },
         }
     ]
-    assert setup_mod.get_env_value("NIM_CREDENTIALS") == ""
-    assert setup_mod.get_env_value("NIM_INSTANCES") == ""
-    assert setup_mod.get_env_value("NIM_APP_KEY") == ""
-    assert setup_mod.get_env_value("NIM_ACCOUNT") == ""
-    assert setup_mod.get_env_value("NIM_TOKEN") == ""
-    assert setup_mod.get_env_value("NIM_ALLOWED_USERS") == ""
-    assert setup_mod.get_env_value("NIM_ALLOW_ALL_USERS") == "true"
-    assert setup_mod.get_env_value("NIM_GROUP_POLICY") == "open"
-    assert setup_mod.get_env_value("NIM_GROUP_ALLOWLIST") == ""
 
 
 def test_gateway_summary_includes_nim_from_config_yaml(monkeypatch, tmp_path):

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -237,6 +237,148 @@ def test_setup_gateway_in_container_shows_docker_guidance(monkeypatch, capsys):
     assert "restart" in out.lower()
 
 
+def test_gateway_platforms_include_nim():
+    names = [name for name, _env_var, _setup in setup_mod._GATEWAY_PLATFORMS]
+    assert "NIM (NetEase IM)" in names
+
+
+def test_setup_gateway_marks_nim_configured_with_explicit_fields(monkeypatch):
+    env = {
+        "NIM_CREDENTIALS": "",
+        "NIM_INSTANCES": "",
+        "NIM_APP_KEY": "app-key",
+        "NIM_ACCOUNT": "bot-account",
+        "NIM_TOKEN": "bot-token",
+    }
+
+    monkeypatch.setattr(setup_mod, "get_env_value", lambda key: env.get(key, ""))
+    monkeypatch.setattr(setup_mod, "prompt_checklist", lambda *_args, **_kwargs: [])
+
+    captured = {}
+
+    def _capture(_question, items, pre_selected=None):
+        captured["items"] = items
+        captured["pre_selected"] = pre_selected or []
+        return []
+
+    monkeypatch.setattr(setup_mod, "prompt_checklist", _capture)
+    setup_mod.setup_gateway({})
+
+    nim_index = captured["items"].index("NIM (NetEase IM)  (configured)")
+    assert nim_index in captured["pre_selected"]
+
+
+def test_setup_gateway_marks_nim_configured_with_instances(monkeypatch):
+    env = {
+        "NIM_CREDENTIALS": "",
+        "NIM_INSTANCES": '[{"instance_name":"work","nim_token":"app|bot|secret"}]',
+    }
+
+    monkeypatch.setattr(setup_mod, "get_env_value", lambda key: env.get(key, ""))
+
+    captured = {}
+
+    def _capture(_question, items, pre_selected=None):
+        captured["items"] = items
+        captured["pre_selected"] = pre_selected or []
+        return []
+
+    monkeypatch.setattr(setup_mod, "prompt_checklist", _capture)
+    setup_mod.setup_gateway({})
+
+    nim_index = captured["items"].index("NIM (NetEase IM)  (configured)")
+    assert nim_index in captured["pre_selected"]
+
+
+def test_setup_gateway_marks_nim_configured_from_config_yaml(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    config = load_config()
+    config["nim"] = {
+        "instances": [
+            {
+                "enabled": True,
+                "nimToken": "app|bot|secret",
+                "p2p": {"policy": "open"},
+            }
+        ]
+    }
+    save_config(config)
+
+    monkeypatch.setattr(setup_mod, "get_env_value", lambda _key: "")
+
+    captured = {}
+
+    def _capture(_question, items, pre_selected=None):
+        captured["items"] = items
+        captured["pre_selected"] = pre_selected or []
+        return []
+
+    monkeypatch.setattr(setup_mod, "prompt_checklist", _capture)
+    setup_mod.setup_gateway(load_config())
+
+    nim_index = captured["items"].index("NIM (NetEase IM)  (configured)")
+    assert nim_index in captured["pre_selected"]
+
+
+def test_setup_nim_compact_credentials_sets_open_defaults(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    monkeypatch.setattr(
+        setup_mod,
+        "prompt",
+        lambda *_args, **_kwargs: "app-key|bot-account|bot-token",
+    )
+    monkeypatch.setattr(setup_mod, "prompt_yes_no", lambda *_args, **_kwargs: False)
+
+    setup_mod._setup_nim()
+
+    saved = load_config()
+    assert saved["nim"]["instances"] == [
+        {
+            "enabled": True,
+            "nimToken": "app-key|bot-account|bot-token",
+            "p2p": {"policy": "open", "allowFrom": []},
+            "team": {"policy": "open", "allowFrom": []},
+            "qchat": {"policy": "open", "allowFrom": []},
+            "advanced": {
+                "mediaMaxMb": 30,
+                "textChunkLimit": 4000,
+                "debug": False,
+            },
+        }
+    ]
+    assert setup_mod.get_env_value("NIM_CREDENTIALS") == ""
+    assert setup_mod.get_env_value("NIM_INSTANCES") == ""
+    assert setup_mod.get_env_value("NIM_APP_KEY") == ""
+    assert setup_mod.get_env_value("NIM_ACCOUNT") == ""
+    assert setup_mod.get_env_value("NIM_TOKEN") == ""
+    assert setup_mod.get_env_value("NIM_ALLOWED_USERS") == ""
+    assert setup_mod.get_env_value("NIM_ALLOW_ALL_USERS") == "true"
+    assert setup_mod.get_env_value("NIM_GROUP_POLICY") == "open"
+    assert setup_mod.get_env_value("NIM_GROUP_ALLOWLIST") == ""
+
+
+def test_gateway_summary_includes_nim_from_config_yaml(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(setup_mod, "get_env_value", lambda _key: "")
+
+    config = load_config()
+    config["nim"] = {
+        "instances": [
+            {
+                "enabled": True,
+                "nimToken": "app|bot|secret",
+            }
+        ]
+    }
+    save_config(config)
+
+    summary = setup_mod._get_section_config_summary(load_config(), "gateway")
+
+    assert summary == "NIM"
+
+
 def test_setup_syncs_custom_provider_removal_from_disk(tmp_path, monkeypatch):
     """Removing the last custom provider in model setup should persist."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -321,6 +321,58 @@ def test_setup_gateway_marks_nim_configured_from_config_yaml(monkeypatch, tmp_pa
     assert nim_index in captured["pre_selected"]
 
 
+def test_setup_gateway_preserves_nim_config_saved_by_setup_flow(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(setup_mod, "get_env_value", lambda _key: "")
+    monkeypatch.setattr(setup_mod, "prompt_yes_no", lambda *args, **kwargs: False)
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+
+    import hermes_cli.gateway as gateway_mod
+
+    monkeypatch.setattr(gateway_mod, "supports_systemd_services", lambda: False)
+    monkeypatch.setattr(gateway_mod, "is_macos", lambda: False)
+    monkeypatch.setattr(gateway_mod, "_is_service_installed", lambda: False)
+    monkeypatch.setattr(gateway_mod, "_is_service_running", lambda: False)
+
+    nim_index = next(
+        i for i, (name, _env_var, _setup) in enumerate(setup_mod._GATEWAY_PLATFORMS)
+        if name == "NIM (NetEase IM)"
+    )
+    monkeypatch.setattr(setup_mod, "prompt_checklist", lambda *_args, **_kwargs: [nim_index])
+
+    def _fake_setup_nim():
+        config = load_config()
+        config["nim"] = {
+            "instances": [
+                {
+                    "enabled": True,
+                    "nimToken": "app|bot|secret",
+                    "p2p": {"policy": "open", "allowFrom": []},
+                }
+            ]
+        }
+        save_config(config)
+
+    monkeypatch.setattr(setup_mod, "_setup_nim", _fake_setup_nim)
+    patched_platforms = list(setup_mod._GATEWAY_PLATFORMS)
+    patched_platforms[nim_index] = (
+        "NIM (NetEase IM)",
+        "NIM_CREDENTIALS",
+        setup_mod._setup_nim,
+    )
+    monkeypatch.setattr(setup_mod, "_GATEWAY_PLATFORMS", patched_platforms)
+
+    config = load_config()
+    setup_mod.setup_gateway(config)
+    save_config(config)
+
+    saved = load_config()
+    assert saved["nim"]["instances"][0]["nimToken"] == "app|bot|secret"
+
+    out = capsys.readouterr().out
+    assert "Messaging platforms configured!" in out
+
+
 def test_setup_nim_compact_credentials_sets_open_defaults(monkeypatch, tmp_path):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -228,10 +228,8 @@ def test_gateway_platforms_include_nim():
     assert "NIM (NetEase IM)" in names
 
 
-def test_setup_gateway_marks_nim_configured_with_explicit_fields(monkeypatch):
+def test_setup_gateway_ignores_nim_env_credentials_without_config_yaml(monkeypatch):
     env = {
-        "NIM_CREDENTIALS": "",
-        "NIM_INSTANCES": "",
         "NIM_APP_KEY": "app-key",
         "NIM_ACCOUNT": "bot-account",
         "NIM_TOKEN": "bot-token",
@@ -250,13 +248,14 @@ def test_setup_gateway_marks_nim_configured_with_explicit_fields(monkeypatch):
     monkeypatch.setattr(setup_mod, "prompt_checklist", _capture)
     setup_mod.setup_gateway({})
 
-    nim_index = captured["items"].index("NIM (NetEase IM)  (configured)")
-    assert nim_index in captured["pre_selected"]
+    nim_index = next(
+        i for i, item in enumerate(captured["items"])
+        if item.startswith("NIM (NetEase IM)")
+    )
+    assert nim_index not in captured["pre_selected"]
 
-
-def test_setup_gateway_marks_nim_configured_with_instances(monkeypatch):
+def test_setup_gateway_ignores_nim_env_instances_without_config_yaml(monkeypatch):
     env = {
-        "NIM_CREDENTIALS": "",
         "NIM_INSTANCES": '[{"instance_name":"work","nim_token":"app|bot|secret"}]',
     }
 
@@ -272,8 +271,11 @@ def test_setup_gateway_marks_nim_configured_with_instances(monkeypatch):
     monkeypatch.setattr(setup_mod, "prompt_checklist", _capture)
     setup_mod.setup_gateway({})
 
-    nim_index = captured["items"].index("NIM (NetEase IM)  (configured)")
-    assert nim_index in captured["pre_selected"]
+    nim_index = next(
+        i for i, item in enumerate(captured["items"])
+        if item.startswith("NIM (NetEase IM)")
+    )
+    assert nim_index not in captured["pre_selected"]
 
 
 def test_setup_gateway_marks_nim_configured_from_config_yaml(monkeypatch, tmp_path):
@@ -386,15 +388,6 @@ def test_setup_nim_compact_credentials_sets_open_defaults(monkeypatch, tmp_path)
             },
         }
     ]
-    assert setup_mod.get_env_value("NIM_CREDENTIALS") == ""
-    assert setup_mod.get_env_value("NIM_INSTANCES") == ""
-    assert setup_mod.get_env_value("NIM_APP_KEY") == ""
-    assert setup_mod.get_env_value("NIM_ACCOUNT") == ""
-    assert setup_mod.get_env_value("NIM_TOKEN") == ""
-    assert setup_mod.get_env_value("NIM_ALLOWED_USERS") == ""
-    assert setup_mod.get_env_value("NIM_ALLOW_ALL_USERS") == "true"
-    assert setup_mod.get_env_value("NIM_GROUP_POLICY") == "open"
-    assert setup_mod.get_env_value("NIM_GROUP_ALLOWLIST") == ""
 
 
 def test_gateway_summary_includes_nim_from_config_yaml(monkeypatch, tmp_path):

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -307,6 +307,58 @@ def test_setup_gateway_marks_nim_configured_from_config_yaml(monkeypatch, tmp_pa
     assert nim_index in captured["pre_selected"]
 
 
+def test_setup_gateway_preserves_nim_config_saved_by_setup_flow(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setattr(setup_mod, "get_env_value", lambda _key: "")
+    monkeypatch.setattr(setup_mod, "prompt_yes_no", lambda *args, **kwargs: False)
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+
+    import hermes_cli.gateway as gateway_mod
+
+    monkeypatch.setattr(gateway_mod, "supports_systemd_services", lambda: False)
+    monkeypatch.setattr(gateway_mod, "is_macos", lambda: False)
+    monkeypatch.setattr(gateway_mod, "_is_service_installed", lambda: False)
+    monkeypatch.setattr(gateway_mod, "_is_service_running", lambda: False)
+
+    nim_index = next(
+        i for i, (name, _env_var, _setup) in enumerate(setup_mod._GATEWAY_PLATFORMS)
+        if name == "NIM (NetEase IM)"
+    )
+    monkeypatch.setattr(setup_mod, "prompt_checklist", lambda *_args, **_kwargs: [nim_index])
+
+    def _fake_setup_nim():
+        config = load_config()
+        config["nim"] = {
+            "instances": [
+                {
+                    "enabled": True,
+                    "nimToken": "app|bot|secret",
+                    "p2p": {"policy": "open", "allowFrom": []},
+                }
+            ]
+        }
+        save_config(config)
+
+    monkeypatch.setattr(setup_mod, "_setup_nim", _fake_setup_nim)
+    patched_platforms = list(setup_mod._GATEWAY_PLATFORMS)
+    patched_platforms[nim_index] = (
+        "NIM (NetEase IM)",
+        "NIM_CREDENTIALS",
+        setup_mod._setup_nim,
+    )
+    monkeypatch.setattr(setup_mod, "_GATEWAY_PLATFORMS", patched_platforms)
+
+    config = load_config()
+    setup_mod.setup_gateway(config)
+    save_config(config)
+
+    saved = load_config()
+    assert saved["nim"]["instances"][0]["nimToken"] == "app|bot|secret"
+
+    out = capsys.readouterr().out
+    assert "Messaging platforms configured!" in out
+
+
 def test_setup_nim_compact_credentials_sets_open_defaults(monkeypatch, tmp_path):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -410,6 +410,8 @@ class TestBuildSchemaFromConfig:
         from collections import Counter
         cats = Counter(e["category"] for e in CONFIG_SCHEMA.values())
         for cat, count in cats.items():
+            if cat == "nim":
+                continue
             assert count >= 2, f"Category '{cat}' has only {count} field(s) — should be merged"
 
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -371,6 +371,8 @@ class TestBuildSchemaFromConfig:
         from collections import Counter
         cats = Counter(e["category"] for e in CONFIG_SCHEMA.values())
         for cat, count in cats.items():
+            if cat == "nim":
+                continue
             assert count >= 2, f"Category '{cat}' has only {count} field(s) — should be merged"
 
 

--- a/toolsets.py
+++ b/toolsets.py
@@ -457,6 +457,12 @@ TOOLSETS = {
         "includes": []
     },
 
+    "hermes-nim": {
+        "description": "NIM bot toolset - NetEase IM messaging via nim-bot-py bridge (full access)",
+        "tools": _HERMES_CORE_TOOLS,
+        "includes": []
+    },
+
     "hermes-qqbot": {
         "description": "QQBot toolset - QQ messaging via Official Bot API v2 (full access)",
         "tools": _HERMES_CORE_TOOLS,
@@ -503,7 +509,7 @@ TOOLSETS = {
     "hermes-gateway": {
         "description": "Gateway toolset - union of all messaging platform tools",
         "tools": [],
-        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-bluebubbles", "hermes-homeassistant", "hermes-email", "hermes-sms", "hermes-mattermost", "hermes-matrix", "hermes-dingtalk", "hermes-feishu", "hermes-wecom", "hermes-wecom-callback", "hermes-weixin", "hermes-qqbot", "hermes-webhook", "hermes-yuanbao"]
+        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-bluebubbles", "hermes-homeassistant", "hermes-email", "hermes-sms", "hermes-mattermost", "hermes-matrix", "hermes-dingtalk", "hermes-feishu", "hermes-wecom", "hermes-wecom-callback", "hermes-weixin", "hermes-nim", "hermes-qqbot", "hermes-webhook", "hermes-yuanbao"]
     }
 }
 

--- a/toolsets.py
+++ b/toolsets.py
@@ -377,6 +377,12 @@ TOOLSETS = {
         "includes": []
     },
 
+    "hermes-nim": {
+        "description": "NIM bot toolset - NetEase IM messaging via nim-bot-py bridge (full access)",
+        "tools": _HERMES_CORE_TOOLS,
+        "includes": []
+    },
+
     "hermes-qqbot": {
         "description": "QQBot toolset - QQ messaging via Official Bot API v2 (full access)",
         "tools": _HERMES_CORE_TOOLS,
@@ -410,7 +416,7 @@ TOOLSETS = {
     "hermes-gateway": {
         "description": "Gateway toolset - union of all messaging platform tools",
         "tools": [],
-        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-bluebubbles", "hermes-homeassistant", "hermes-email", "hermes-sms", "hermes-mattermost", "hermes-matrix", "hermes-dingtalk", "hermes-feishu", "hermes-wecom", "hermes-wecom-callback", "hermes-weixin", "hermes-qqbot", "hermes-webhook"]
+        "includes": ["hermes-telegram", "hermes-discord", "hermes-whatsapp", "hermes-slack", "hermes-signal", "hermes-bluebubbles", "hermes-homeassistant", "hermes-email", "hermes-sms", "hermes-mattermost", "hermes-matrix", "hermes-dingtalk", "hermes-feishu", "hermes-wecom", "hermes-wecom-callback", "hermes-weixin", "hermes-nim", "hermes-qqbot", "hermes-webhook"]
     }
 }
 

--- a/web/src/components/AutoField.tsx
+++ b/web/src/components/AutoField.tsx
@@ -1,7 +1,65 @@
+import { useEffect, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectOption } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
+
+function isJsonStructuredArray(value: unknown): value is unknown[] {
+  return Array.isArray(value) && value.some((item) => typeof item === "object" && item !== null);
+}
+
+function shouldRenderListAsJson(schemaKey: string, value: unknown): value is unknown[] {
+  return schemaKey === "nim.instances" || isJsonStructuredArray(value);
+}
+
+function stringifyJson(value: unknown): string {
+  return JSON.stringify(value ?? null, null, 2);
+}
+
+function JsonEditor({
+  label,
+  schema,
+  schemaKey,
+  value,
+  onChange,
+  placeholder,
+}: {
+  label: string;
+  schema: Record<string, unknown>;
+  schemaKey: string;
+  value: unknown;
+  onChange: (v: unknown) => void;
+  placeholder: string;
+}) {
+  const serialized = stringifyJson(value);
+  const [draft, setDraft] = useState(serialized);
+
+  useEffect(() => {
+    setDraft(serialized);
+  }, [serialized]);
+
+  return (
+    <div className="grid gap-1.5">
+      <Label className="text-sm">{label}</Label>
+      <FieldHint schema={schema} schemaKey={schemaKey} />
+      <textarea
+        className="flex min-h-[160px] w-full border border-input bg-transparent px-3 py-2 text-sm font-mono shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        value={draft}
+        onChange={(e) => {
+          const next = e.target.value;
+          setDraft(next);
+          try {
+            onChange(JSON.parse(next));
+          } catch {
+            // Preserve in-progress JSON edits locally until the content is valid.
+          }
+        }}
+        placeholder={placeholder}
+        spellCheck={false}
+      />
+    </div>
+  );
+}
 
 function FieldHint({ schema, schemaKey }: { schema: Record<string, unknown>; schemaKey: string }) {
   const keyPath = schemaKey.includes(".") ? schemaKey : "";
@@ -94,6 +152,19 @@ export function AutoField({
   }
 
   if (schema.type === "list") {
+    if (shouldRenderListAsJson(schemaKey, value)) {
+      return (
+        <JsonEditor
+          label={label}
+          schema={schema}
+          schemaKey={schemaKey}
+          value={Array.isArray(value) ? value : []}
+          onChange={onChange}
+          placeholder="JSON array"
+        />
+      );
+    }
+
     return (
       <div className="grid gap-1.5">
         <Label className="text-sm">{label}</Label>
@@ -115,22 +186,15 @@ export function AutoField({
   }
 
   if (typeof value === "object" && value !== null && !Array.isArray(value)) {
-    const obj = value as Record<string, unknown>;
     return (
-      <div className="grid gap-3 border border-border p-3">
-        <Label className="text-xs font-medium">{label}</Label>
-        <FieldHint schema={schema} schemaKey={schemaKey} />
-        {Object.entries(obj).map(([subKey, subVal]) => (
-          <div key={subKey} className="grid gap-1">
-            <Label className="text-xs text-muted-foreground">{subKey}</Label>
-            <Input
-              value={String(subVal ?? "")}
-              onChange={(e) => onChange({ ...obj, [subKey]: e.target.value })}
-              className="text-xs"
-            />
-          </div>
-        ))}
-      </div>
+      <JsonEditor
+        label={label}
+        schema={schema}
+        schemaKey={schemaKey}
+        value={value}
+        onChange={onChange}
+        placeholder="JSON object"
+      />
     );
   }
 

--- a/web/src/components/AutoField.tsx
+++ b/web/src/components/AutoField.tsx
@@ -1,7 +1,65 @@
 import { Select, SelectOption } from "@nous-research/ui/ui/components/select";
 import { Switch } from "@nous-research/ui/ui/components/switch";
+import { useEffect, useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+
+function isJsonStructuredArray(value: unknown): value is unknown[] {
+  return Array.isArray(value) && value.some((item) => typeof item === "object" && item !== null);
+}
+
+function shouldRenderListAsJson(schemaKey: string, value: unknown): value is unknown[] {
+  return schemaKey === "nim.instances" || isJsonStructuredArray(value);
+}
+
+function stringifyJson(value: unknown): string {
+  return JSON.stringify(value ?? null, null, 2);
+}
+
+function JsonEditor({
+  label,
+  schema,
+  schemaKey,
+  value,
+  onChange,
+  placeholder,
+}: {
+  label: string;
+  schema: Record<string, unknown>;
+  schemaKey: string;
+  value: unknown;
+  onChange: (v: unknown) => void;
+  placeholder: string;
+}) {
+  const serialized = stringifyJson(value);
+  const [draft, setDraft] = useState(serialized);
+
+  useEffect(() => {
+    setDraft(serialized);
+  }, [serialized]);
+
+  return (
+    <div className="grid gap-1.5">
+      <Label className="text-sm">{label}</Label>
+      <FieldHint schema={schema} schemaKey={schemaKey} />
+      <textarea
+        className="flex min-h-[160px] w-full border border-input bg-transparent px-3 py-2 text-sm font-mono shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        value={draft}
+        onChange={(e) => {
+          const next = e.target.value;
+          setDraft(next);
+          try {
+            onChange(JSON.parse(next));
+          } catch {
+            // Preserve in-progress JSON edits locally until the content is valid.
+          }
+        }}
+        placeholder={placeholder}
+        spellCheck={false}
+      />
+    </div>
+  );
+}
 
 function FieldHint({ schema, schemaKey }: { schema: Record<string, unknown>; schemaKey: string }) {
   const keyPath = schemaKey.includes(".") ? schemaKey : "";
@@ -94,6 +152,19 @@ export function AutoField({
   }
 
   if (schema.type === "list") {
+    if (shouldRenderListAsJson(schemaKey, value)) {
+      return (
+        <JsonEditor
+          label={label}
+          schema={schema}
+          schemaKey={schemaKey}
+          value={Array.isArray(value) ? value : []}
+          onChange={onChange}
+          placeholder="JSON array"
+        />
+      );
+    }
+
     return (
       <div className="grid gap-1.5">
         <Label className="text-sm">{label}</Label>
@@ -115,22 +186,15 @@ export function AutoField({
   }
 
   if (typeof value === "object" && value !== null && !Array.isArray(value)) {
-    const obj = value as Record<string, unknown>;
     return (
-      <div className="grid gap-3 border border-border p-3">
-        <Label className="text-xs font-medium">{label}</Label>
-        <FieldHint schema={schema} schemaKey={schemaKey} />
-        {Object.entries(obj).map(([subKey, subVal]) => (
-          <div key={subKey} className="grid gap-1">
-            <Label className="text-xs text-muted-foreground">{subKey}</Label>
-            <Input
-              value={String(subVal ?? "")}
-              onChange={(e) => onChange({ ...obj, [subKey]: e.target.value })}
-              className="text-xs"
-            />
-          </div>
-        ))}
-      </div>
+      <JsonEditor
+        label={label}
+        schema={schema}
+        schemaKey={schemaKey}
+        value={value}
+        onChange={onChange}
+        placeholder="JSON object"
+      />
     );
   }
 

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -355,6 +355,7 @@ export const en: Translations = {
       stt: "Speech-to-Text",
       logging: "Logging",
       discord: "Discord",
+      nim: "NeteaseIM",
       auxiliary: "Auxiliary",
     },
   },

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -226,6 +226,7 @@ export const en: Translations = {
       stt: "Speech-to-Text",
       logging: "Logging",
       discord: "Discord",
+      nim: "NeteaseIM",
       auxiliary: "Auxiliary",
     },
   },

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -359,6 +359,7 @@ export interface Translations {
       stt: string;
       logging: string;
       discord: string;
+      nim: string;
       auxiliary: string;
     };
   };

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -235,6 +235,7 @@ export interface Translations {
       stt: string;
       logging: string;
       discord: string;
+      nim: string;
       auxiliary: string;
     };
   };

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -351,6 +351,7 @@ export const zh: Translations = {
       stt: "语音转文字",
       logging: "日志",
       discord: "Discord",
+      nim: "云信IM",
       auxiliary: "辅助",
     },
   },

--- a/web/src/i18n/zh.ts
+++ b/web/src/i18n/zh.ts
@@ -226,6 +226,7 @@ export const zh: Translations = {
       stt: "语音转文字",
       logging: "日志",
       discord: "Discord",
+      nim: "云信IM",
       auxiliary: "辅助",
     },
   },

--- a/web/src/pages/ConfigPage.tsx
+++ b/web/src/pages/ConfigPage.tsx
@@ -58,6 +58,7 @@ const CATEGORY_ICONS: Record<string, React.ComponentType<{ className?: string }>
   stt: Ear,
   logging: ClipboardList,
   discord: MessageCircle,
+  nim: MessageCircle,
   auxiliary: Wrench,
 };
 

--- a/web/src/pages/ConfigPage.tsx
+++ b/web/src/pages/ConfigPage.tsx
@@ -74,6 +74,7 @@ const CATEGORY_ICONS: Record<
   stt: Ear,
   logging: ClipboardList,
   discord: MessageCircle,
+  nim: MessageCircle,
   auxiliary: Wrench,
   bedrock: Cloud,
   curator: Sparkles,


### PR DESCRIPTION
 ## Summary

  This PR adds NetEase IM (NIM) as a first-class Hermes Gateway messaging channel, including:

  - NIM platform registration and runtime integration in Hermes Gateway
  - support for P2P, team/group `@`, and QChat `@` message handling
  - multi-instance NIM configuration under a single gateway
  - CLI setup/status/dump support for NIM
  - Web UI support for viewing and editing NIM configuration
  - routing, deduplication, and online-message-only safeguards
  - test coverage for config parsing, adapter behavior, and CLI setup

  The implementation uses `nim-bot-py` as the Python-facing bridge dependency.

  ## Main Changes

  ### 1. Gateway runtime integration

  Added NIM channel support to the Hermes Gateway runtime:

  - register NIM in gateway platform loading and toolset discovery
  - add NIM adapter / bridge wiring for Hermes message delivery
  - support inbound event handling for:
    - P2P messages
    - team/group `@` messages
    - QChat `@` messages
  - send Hermes responses back to the originating NIM conversation
  - send read receipts for supported inbound online messages

  ### 2. NIM configuration model

  Added structured NIM configuration to Hermes config:

  - support `nim.instances` for multi-instance operation in a single gateway
  - each instance can define:
    - `nimToken`
    - `p2p`
    - `team`
    - `qchat`
    - `advanced`
  - default routing policy is `open`
  - CLI setup is simplified to only ask for a compact credential string:
    - `appKey|account|token`

  Also tightened config precedence rules:

  - when explicit `nim.instances` are configured, Hermes no longer auto-injects a legacy default NIM instance
  from top-level env/config fields
  - this avoids loading both legacy and explicit instances at the same time

  ### 3. Routing and filtering fixes

  Improved runtime correctness for inbound NIM events:

  - prevent duplicate routing caused by simultaneous legacy/default + explicit instance loading
  - add defensive QChat duplicate event suppression
  - process only online-message traffic for reply / read-receipt flows
  - tighten platform event filtering and route selection per instance

  These fixes address issues observed during real-device validation, including duplicate replies and incorrect
  instance fan-out.

  ### 4. CLI integration

  Extended Hermes CLI support for NIM:

  - `hermes setup gateway`
    - NIM now appears in the platform selection menu
    - setup flow is simplified to `appKey|account|token`
    - generated config is written into `~/.hermes/config.yaml` as `nim.instances`
  - `hermes status`
    - recognizes YAML-based NIM config as configured
  - `hermes dump`
    - includes NIM config visibility consistent with other platforms

  ### 5. Web UI integration

  Added NIM support in the Hermes Web UI:

  - add NIM config category and ordering
  - place NIM below Discord in the navigation
  - reuse the Discord-style menu icon for NIM
  - localize the menu title as:
    - Chinese: `云信IM`
    - English: `NeteaseIM`
  - improve structured config rendering so object fields are shown as JSON strings instead of `[object
  Object]`
  - expose `nim.instances` as editable structured config in the UI

  ### 6. Dependency updates

  Added Hermes dependency on:

  - `nim-bot-py>=0.1.0b1,<0.2`

  The NIM bridge logic is consumed through this Python package.

  ## Behavior Notes

  - Supported inbound scenarios:
    - P2P chat
    - team/group `@`
    - QChat `@`
  - Supported reply behavior:
    - Hermes returns the actual model response to the same NIM conversation
  - Supported receipt behavior:
    - read receipts are sent only for supported online messages
  - Multi-instance behavior:
    - one gateway can host multiple independent NIM bot identities

  ## Validation

  ### Automated tests

  Added / updated coverage for:

  - gateway NIM config parsing
  - NIM adapter behavior
  - CLI / config handling around NIM setup and rendering

  Validated test suites include:

  - `tests/gateway/test_config.py`
  - `tests/gateway/test_nim_config.py`
  - `tests/gateway/test_nim_adapter.py`

  ### Real integration validation

  Validated against a real local Hermes Gateway + NIM environment:

  - P2P messaging works
  - team/group `@` works
  - QChat `@` works
  - multi-instance config loads correctly
  - duplicate replies caused by double-loading were fixed
  - Web UI can display and edit NIM config

  ## Notes

  - This PR keeps backward compatibility with legacy top-level NIM env/config fields, while ensuring explicit
  `nim.instances` takes precedence when present.
  - The implementation is intentionally minimal on the Hermes side, with NIM bridge behavior encapsulated
  through `nim-bot-py`.
