### PR TITLE
fix: enable right click to paste

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/components/App.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/components/App.tsx
@@ -617,6 +617,14 @@ export function handleMouseEvent(app: App, m: ParsedMouse): void {
       // Non-left press breaks the multi-click chain.
       app.clickCount = 0
 
+      // Forward middle/right button presses to the DOM so components can
+      // react (e.g. right-click-to-paste on input fields). Middle/right
+      // don't participate in selection, multi-click, or hyperlink UX, so
+      // we just dispatch and exit without setting mouseCaptureTarget —
+      // the matching release (if any) falls through the release path and
+      // is ignored there because baseButton !== 0 && !sel.isDragging.
+      app.props.onMouseDownAt(col, row, baseButton)
+
       return
     }
 

--- a/ui-tui/packages/hermes-ink/src/ink/components/App.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/components/App.tsx
@@ -616,13 +616,6 @@ export function handleMouseEvent(app: App, m: ParsedMouse): void {
     if (baseButton !== 0) {
       // Non-left press breaks the multi-click chain.
       app.clickCount = 0
-
-      // Forward middle/right button presses to the DOM so components can
-      // react (e.g. right-click-to-paste on input fields). Middle/right
-      // don't participate in selection, multi-click, or hyperlink UX, so
-      // we just dispatch and exit without setting mouseCaptureTarget —
-      // the matching release (if any) falls through the release path and
-      // is ignored there because baseButton !== 0 && !sel.isDragging.
       app.props.onMouseDownAt(col, row, baseButton)
 
       return

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -671,6 +671,15 @@ export function TextInput({
         setCur(next)
         curRef.current = next
       }}
+      onMouseDown={(e: { button: number }) => {
+        // Right-click to paste: route through the same hotkey path as
+        // Alt+V so the composer's clipboard RPC (text or image) handles it.
+        if (!focus || e.button !== 2) {
+          return
+        }
+
+        emitPaste({ cursor: curRef.current, hotkey: true, text: '', value: vRef.current })
+      }}
       ref={boxRef}
     >
       <Text wrap="wrap">{rendered}</Text>


### PR DESCRIPTION
## What does this PR do?

Adds right-click-to-paste in the React/Ink TUI. Previously, SGR mouse tracking inside the alt screen swallowed right-clicks (`handleMouseEvent` early-returned on non-left presses), which meant the terminal's native right-click paste was intercepted by the app but never wired to anything — users had to reach for Alt+V or `/paste`.

The fix dispatches middle/right-button presses through the DOM event system just like left-clicks, and has `TextInput` listen for button 2 and route it into the existing clipboard-paste hotkey path (same as Alt+V / `/paste`). This reuses the gateway's `clipboard.paste` RPC for free, so right-click handles both text and image clipboard content identically to the existing hotkey.

Approach rationale:
- Modifying `@hermes/ink`'s `App.tsx` to forward non-left presses (instead of swallowing them) is the minimal change and doesn't touch selection, multi-click, or hyperlink logic. Non-left presses intentionally skip `mouseCaptureTarget` so they don't start a drag capture.
- Reusing `emitPaste({ hotkey: true })` in `TextInput` keeps all clipboard logic (image attach, text surface, OSC 52 fallback, Linux clipboard tool probing) in one place — the composer's `handleTextPaste` already branches on `hotkey: true` to call `onClipboardPaste`.

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `ui-tui/packages/hermes-ink/src/ink/components/App.tsx` — in `handleMouseEvent`, forward middle/right-button presses (`baseButton !== 0`) to `onMouseDownAt` instead of dropping them. Deliberately does not set `mouseCaptureTarget` so non-left releases stay a no-op in the existing release path.
- `ui-tui/src/components/textInput.tsx` — add `onMouseDown` on the outer `Box` that filters for SGR button 2 (right-click) and calls `emitPaste({ hotkey: true, text: '', ... })`, which funnels into the existing Alt+V path via `useComposerState.handleTextPaste`.
- `ui-tui/packages/hermes-ink/dist/ink-bundle.js` — rebuilt (`npm run build --prefix packages/hermes-ink`).

## How to Test

1. `cd hermes-agent/ui-tui && npm run dev`
2. Copy some text to your system clipboard (or a screenshot/image on macOS).
3. In the TUI composer, right-click anywhere in the input area — clipboard text gets inserted (small paste) or collapsed to a token (large paste); clipboard images get attached with `📎 Image #N attached from clipboard`.
4. Confirm behavior matches pressing Alt+V.
5. Verify left-click still repositions the cursor, double-click still word-selects, drag-select still works, and middle-click is a no-op.
6. Test on a terminal that forwards right-click (iTerm2, WezTerm, Alacritty, Windows Terminal, Kitty, Ghostty). On macOS Terminal.app or a terminal that doesn't forward right-click, users can fall back to Shift+right-click (native terminal paste) or Alt+V — unchanged behavior.

Automated:

```bash
cd hermes-agent/ui-tui
npm run type-check   # passes
npm run lint         # passes
npm test             # 92/92 passing
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A (TUI-only change; ran `npm test` in `ui-tui/`, 92/92 pass)
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — manual verification only; the mouse-dispatch path has no existing unit-test harness in `ui-tui/src/__tests__/`
- [x] I've tested on my platform: Ubuntu 24.04 (WSL2) — Windows Terminal + tmux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (behavior parallels existing Alt+V hotkey; `content/hotkeys.ts` already lists the clipboard paste affordance)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — relies on the existing `clipboard.paste` gateway RPC which already handles pbpaste / wl-paste / xclip / xsel / PowerShell; no new platform code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

<!-- Add a short screencast of right-clicking in the composer and seeing the clipboard land in the input (and/or "📎 Image #1 attached from clipboard") -->