### PR TITLE
feat(send_message): enable media file delivery for Feishu

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -500,11 +500,26 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             last_result = result
         return last_result
 
-    # --- Non-Telegram/Discord platforms ---
+    # --- Feishu: native adapter supports documents/images/voice/video ---
+    if platform == Platform.FEISHU:
+        last_result = None
+        for i, chunk in enumerate(chunks):
+            is_last = (i == len(chunks) - 1)
+            result = await _send_feishu(
+                pconfig, chat_id, chunk,
+                media_files=media_files if is_last else [],
+                thread_id=thread_id,
+            )
+            if isinstance(result, dict) and result.get("error"):
+                return result
+            last_result = result
+        return last_result
+
+    # --- Non-Telegram/Discord/Matrix/Weixin/Feishu platforms ---
     if media_files and not message.strip():
         return {
             "error": (
-                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, and weixin; "
+                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, and feishu; "
                 f"target {platform.value} had only media attachments"
             )
         }
@@ -512,7 +527,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files:
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
-            "native send_message media delivery is currently only supported for telegram, discord, matrix, and weixin"
+            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, and feishu"
         )
 
     last_result = None
@@ -535,8 +550,6 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             result = await _send_homeassistant(pconfig.token, pconfig.extra, chat_id, chunk)
         elif platform == Platform.DINGTALK:
             result = await _send_dingtalk(pconfig.extra, chat_id, chunk)
-        elif platform == Platform.FEISHU:
-            result = await _send_feishu(pconfig, chat_id, chunk, thread_id=thread_id)
         elif platform == Platform.WECOM:
             result = await _send_wecom(pconfig.extra, chat_id, chunk)
         elif platform == Platform.BLUEBUBBLES:


### PR DESCRIPTION
## What does this PR do?

Enables the `send_message` tool to deliver media files (documents, images, voice, video) to Feishu conversations. Previously, Feishu was excluded from native media delivery, causing attachments to be silently omitted or rejected with an error.

## Related Issue

N/A (no existing issue)

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/send_message_tool.py`: Route Feishu through `_send_feishu()` with `media_files` before the default text-only fallback path, matching the pattern used for Telegram, Discord, and Matrix.
- Removed the old Feishu branch from the default path that silently omitted media attachments.
- Updated error/warning messages to include `feishu` in the list of platforms supporting native media delivery.

## How to Test

1. Start Hermes gateway with a Feishu bot configured.
2. In a Feishu chat, trigger `send_message` with a file path (e.g. a PDF or image).
3. Verify the file is uploaded and delivered to the chat.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've tested on my platform: Ubuntu 22.04
- [x] I've considered cross-platform impact — N/ A (Feishu-specific)
