### PR TITLE
feat(cli): env var overrides for model config in Docker Compose

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2785,6 +2785,63 @@ def _expand_env_vars(obj):
     return obj
 
 
+def _apply_env_overrides(obj):
+    """Apply HERMES_* environment variable overrides to model config.
+
+    Priority: HERMES_* env vars > expanded config values.
+    Checks:
+    - HERMES_MODEL: sets config["model"]["default"]
+    - HERMES_INFERENCE_PROVIDER: sets config["model"]["provider"]
+    - HERMES_BASE_URL: sets config["model"]["base_url"]
+
+    Only applies if env var is set and non-empty. Does not clear existing
+    config values when env var is unset. Does not mutate the input dict.
+    """
+    if not isinstance(obj, dict):
+        return obj
+
+    # Check if any env overrides exist before doing conversions
+    has_overrides = (
+        bool(os.environ.get("HERMES_MODEL", "").strip())
+        or bool(os.environ.get("HERMES_INFERENCE_PROVIDER", "").strip())
+        or bool(os.environ.get("HERMES_BASE_URL", "").strip())
+    )
+
+    if not has_overrides:
+        # No overrides to apply; return unchanged
+        return obj
+
+    # Make shallow copies to avoid mutating input
+    obj = dict(obj)
+    model_cfg = obj.get("model")
+
+    if not isinstance(model_cfg, dict):
+        # Convert plain-string model to dict form (only if we have overrides)
+        if isinstance(model_cfg, str) and model_cfg:
+            model_cfg = {"default": model_cfg}
+        else:
+            model_cfg = {}
+    else:
+        # Work with a shallow copy of the existing dict
+        model_cfg = dict(model_cfg)
+
+    # Apply env var overrides
+    model_name = os.environ.get("HERMES_MODEL", "").strip()
+    if model_name:
+        model_cfg["default"] = model_name
+
+    provider = os.environ.get("HERMES_INFERENCE_PROVIDER", "").strip()
+    if provider:
+        model_cfg["provider"] = provider
+
+    base_url = os.environ.get("HERMES_BASE_URL", "").strip()
+    if base_url:
+        model_cfg["base_url"] = base_url
+
+    obj["model"] = model_cfg
+    return obj
+
+
 def _items_by_unique_name(items):
     """Return a name-indexed dict only when all items have unique string names."""
     if not isinstance(items, list):
@@ -2954,6 +3011,7 @@ def load_config() -> Dict[str, Any]:
 
     normalized = _normalize_root_model_keys(_normalize_max_turns_config(config))
     expanded = _expand_env_vars(normalized)
+    expanded = _apply_env_overrides(expanded)
     _LAST_EXPANDED_CONFIG_BY_PATH[str(config_path)] = copy.deepcopy(expanded)
     return expanded
 

--- a/tests/hermes_cli/test_config_env_overrides.py
+++ b/tests/hermes_cli/test_config_env_overrides.py
@@ -1,0 +1,168 @@
+"""Tests for HERMES_* env var overrides in config (Docker Compose support)."""
+
+import os
+import pytest
+from hermes_cli.config import load_config
+
+
+class TestEnvOverridesInLoadConfig:
+    """Test that HERMES_MODEL, HERMES_INFERENCE_PROVIDER, and HERMES_BASE_URL
+    override config.yaml values when set."""
+
+    def test_hermes_model_alone_no_config_file(self, tmp_path, monkeypatch):
+        """HERMES_MODEL sets model when no config.yaml exists."""
+        config_file = tmp_path / "config.yaml"
+        monkeypatch.setenv("HERMES_MODEL", "openrouter/anthropic/claude-opus-4")
+        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: config_file)
+
+        config = load_config()
+
+        assert config["model"]["default"] == "openrouter/anthropic/claude-opus-4"
+
+    def test_hermes_model_overrides_config_file(self, tmp_path, monkeypatch):
+        """HERMES_MODEL overrides model.default from config.yaml."""
+        config_yaml = "model:\n  default: openai/gpt-4\n"
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(config_yaml)
+
+        monkeypatch.setenv("HERMES_MODEL", "anthropic/claude-sonnet-4")
+        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: config_file)
+
+        config = load_config()
+
+        assert config["model"]["default"] == "anthropic/claude-sonnet-4"
+
+    def test_hermes_provider_overrides_config_file(self, tmp_path, monkeypatch):
+        """HERMES_INFERENCE_PROVIDER overrides model.provider from config.yaml."""
+        config_yaml = "model:\n  provider: openai\n"
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(config_yaml)
+
+        monkeypatch.setenv("HERMES_INFERENCE_PROVIDER", "anthropic")
+        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: config_file)
+
+        config = load_config()
+
+        assert config["model"]["provider"] == "anthropic"
+
+    def test_hermes_base_url_overrides_config_file(self, tmp_path, monkeypatch):
+        """HERMES_BASE_URL overrides model.base_url from config.yaml."""
+        config_yaml = "model:\n  base_url: https://openrouter.ai/api/v1\n"
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(config_yaml)
+
+        monkeypatch.setenv("HERMES_BASE_URL", "http://localhost:8000/v1")
+        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: config_file)
+
+        config = load_config()
+
+        assert config["model"]["base_url"] == "http://localhost:8000/v1"
+
+    def test_all_three_env_overrides_together(self, tmp_path, monkeypatch):
+        """HERMES_MODEL, HERMES_INFERENCE_PROVIDER, HERMES_BASE_URL all work together."""
+        config_yaml = "model:\n  default: openai/gpt-4\n  provider: openai\n"
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(config_yaml)
+
+        monkeypatch.setenv("HERMES_MODEL", "openrouter/meta-llama/llama-3.1-405b")
+        monkeypatch.setenv("HERMES_INFERENCE_PROVIDER", "openrouter")
+        monkeypatch.setenv("HERMES_BASE_URL", "https://openrouter.ai/api/v1")
+        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: config_file)
+
+        config = load_config()
+
+        assert config["model"]["default"] == "openrouter/meta-llama/llama-3.1-405b"
+        assert config["model"]["provider"] == "openrouter"
+        assert config["model"]["base_url"] == "https://openrouter.ai/api/v1"
+
+    def test_empty_env_vars_do_not_override(self, tmp_path, monkeypatch):
+        """Empty env vars don't override config.yaml values."""
+        config_yaml = (
+            "model:\n"
+            "  default: openai/gpt-4\n"
+            "  provider: openai\n"
+            "  base_url: https://api.openai.com/v1\n"
+        )
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(config_yaml)
+
+        monkeypatch.setenv("HERMES_MODEL", "")
+        monkeypatch.setenv("HERMES_INFERENCE_PROVIDER", "")
+        monkeypatch.setenv("HERMES_BASE_URL", "")
+        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: config_file)
+
+        config = load_config()
+
+        assert config["model"]["default"] == "openai/gpt-4"
+        assert config["model"]["provider"] == "openai"
+        assert config["model"]["base_url"] == "https://api.openai.com/v1"
+
+    def test_partial_env_overrides_preserve_other_fields(self, tmp_path, monkeypatch):
+        """Setting one env var doesn't clear other config fields."""
+        config_yaml = (
+            "model:\n"
+            "  default: openai/gpt-4\n"
+            "  provider: openai\n"
+            "  context_length: 128000\n"
+        )
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(config_yaml)
+
+        monkeypatch.setenv("HERMES_MODEL", "anthropic/claude-opus-4.6")
+        monkeypatch.delenv("HERMES_INFERENCE_PROVIDER", raising=False)
+        monkeypatch.delenv("HERMES_BASE_URL", raising=False)
+        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: config_file)
+
+        config = load_config()
+
+        assert config["model"]["default"] == "anthropic/claude-opus-4.6"
+        assert config["model"]["provider"] == "openai"  # unchanged
+        assert config["model"]["context_length"] == 128000  # unchanged
+
+    def test_hermes_model_with_env_var_templates_in_config(self, tmp_path, monkeypatch):
+        """HERMES_MODEL overrides even when config.yaml uses ${VAR} templates."""
+        config_yaml = "model:\n  default: ${CONFIG_MODEL}\n"
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(config_yaml)
+
+        monkeypatch.setenv("CONFIG_MODEL", "openai/gpt-4")
+        monkeypatch.setenv("HERMES_MODEL", "anthropic/claude-opus-4.6")
+        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: config_file)
+
+        config = load_config()
+
+        # HERMES_MODEL should override the expanded ${CONFIG_MODEL}
+        assert config["model"]["default"] == "anthropic/claude-opus-4.6"
+
+    def test_plain_string_model_converted_to_dict(self, tmp_path, monkeypatch):
+        """If config has a plain-string model value, env overrides work on dict form."""
+        config_yaml = "model: openai/gpt-4\n"
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text(config_yaml)
+
+        monkeypatch.setenv("HERMES_INFERENCE_PROVIDER", "openrouter")
+        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: config_file)
+
+        config = load_config()
+
+        assert config["model"]["default"] == "openai/gpt-4"  # preserved from plain string
+        assert config["model"]["provider"] == "openrouter"  # added by env override
+
+    def test_docker_compose_style_setup(self, tmp_path, monkeypatch):
+        """Simulate Docker Compose: no config.yaml, env vars set for model, provider, base_url."""
+        config_file = tmp_path / "config.yaml"
+        # No config file — Docker entrypoint will create the default one
+
+        monkeypatch.setenv("HERMES_MODEL", "openrouter/openai/gpt-4o")
+        monkeypatch.setenv("HERMES_INFERENCE_PROVIDER", "openrouter")
+        monkeypatch.setenv("HERMES_BASE_URL", "https://openrouter.ai/api/v1")
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-xxx")
+        monkeypatch.setattr("hermes_cli.config.get_config_path", lambda: config_file)
+
+        config = load_config()
+
+        # Model should be fully configured from env vars
+        assert config["model"]["default"] == "openrouter/openai/gpt-4o"
+        assert config["model"]["provider"] == "openrouter"
+        assert config["model"]["base_url"] == "https://openrouter.ai/api/v1"
+        # API key comes from .env or directly from environ, already handled

--- a/website/docs/user-guide/docker.md
+++ b/website/docs/user-guide/docker.md
@@ -169,6 +169,65 @@ networks:
 
 Start with `docker compose up -d` and view logs with `docker compose logs -f`.
 
+## Configuring the model and provider
+
+Instead of running the interactive `hermes model` command in the container, you can set the model, inference provider, and API endpoint via environment variables. This is especially useful in Docker Compose where interactive setup is inconvenient.
+
+| Environment variable | Config key | Default | Example |
+|---|---|---|---|
+| `HERMES_MODEL` | `model.default` | *(from config.yaml)* | `openrouter/anthropic/claude-opus-4` |
+| `HERMES_INFERENCE_PROVIDER` | `model.provider` | `auto` | `openrouter`, `anthropic`, `openai`, `ollama` |
+| `HERMES_BASE_URL` | `model.base_url` | *(depends on provider)* | `http://localhost:8000/v1` |
+
+These env vars override the corresponding values in `~/.hermes/config.yaml`. If not set, Hermes falls back to the config file (or defaults).
+
+**Docker Compose example with model configuration:**
+
+```yaml
+services:
+  hermes:
+    image: nousresearch/hermes-agent:latest
+    container_name: hermes
+    restart: unless-stopped
+    command: gateway run
+    ports:
+      - "8642:8642"
+    volumes:
+      - ~/.hermes:/opt/data
+    environment:
+      # Inference provider configuration
+      - HERMES_MODEL=openrouter/openai/gpt-4o
+      - HERMES_INFERENCE_PROVIDER=openrouter
+      - HERMES_BASE_URL=https://openrouter.ai/api/v1
+      # API credentials (from host .env or secrets manager)
+      - OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
+    networks:
+      - hermes-net
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+          cpus: "2.0"
+```
+
+Run this with: `OPENROUTER_API_KEY=sk-or-xxx docker compose up -d`
+
+Alternatively, for local models (vLLM, Ollama, LM Studio):
+
+```yaml
+services:
+  hermes:
+    image: nousresearch/hermes-agent:latest
+    environment:
+      - HERMES_MODEL=meta-llama/llama-2-70b-chat
+      - HERMES_INFERENCE_PROVIDER=custom
+      - HERMES_BASE_URL=http://vllm:8000/v1  # point to your local server
+```
+
+:::note
+For more complex setups (multiple providers, fallback models, custom settings), use a mounted `config.yaml` file with `${VAR}` template expansion. See [Configuration](./configuration.md) for details.
+:::
+
 ## Resource limits
 
 The Hermes container needs moderate resources. Recommended minimums:


### PR DESCRIPTION
## Summary

Add support for setting Hermes model configuration via environment variables in Docker Compose. Solves  by allowing users to configure the agent without interactive setup or manual config.yaml editing.

## Changes

- **hermes_cli/config.py**: Add `_apply_env_overrides()` function that checks `HERMES_MODEL`, `HERMES_INFERENCE_PROVIDER`, `HERMES_BASE_URL` env vars and applies them as top-priority config overrides
- **tests/hermes_cli/test_config_env_overrides.py**: 10 comprehensive tests covering solo overrides, combined use, empty vars, partial overrides, and Docker Compose scenarios
- **website/docs/user-guide/docker.md**: New section with env var table and Docker Compose examples for both OpenRouter and local servers

## How to test

```bash
# Run all config tests (26 passing, no regressions)
pytest tests/hermes_cli/test_config.py::TestLoadConfigDefaults tests/hermes_cli/test_config.py::TestSaveAndLoadRoundtrip tests/hermes_cli/test_config_env_expansion.py::TestExpandEnvVars tests/hermes_cli/test_config_env_expansion.py::TestLoadConfigExpansion tests/hermes_cli/test_config_env_overrides.py -v

# Run new tests only
pytest tests/hermes_cli/test_config_env_overrides.py -v

# Smoke test
HERMES_MODEL=anthropic/claude-opus-4.6 HERMES_INFERENCE_PROVIDER=anthropic python -c "from hermes_cli.config import load_config; c = load_config(); print(c['model'])"
```