### PR TITLE
fix(agent): make Copilot ACP compatible with async auxiliary calls and streaming

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -644,6 +644,33 @@ class AsyncAnthropicAuxiliaryClient:
         self.base_url = sync_wrapper.base_url
 
 
+class _AsyncCopilotACPCompletionsAdapter:
+    """Async wrapper for the synchronous Copilot ACP adapter."""
+
+    def __init__(self, sync_adapter: Any):
+        self._sync = sync_adapter
+
+    async def create(self, **kwargs) -> Any:
+        import asyncio
+        return await asyncio.to_thread(self._sync.create, **kwargs)
+
+
+class _AsyncCopilotACPChatShim:
+    def __init__(self, adapter: _AsyncCopilotACPCompletionsAdapter):
+        self.completions = adapter
+
+
+class AsyncCopilotACPClient:
+    """Async-compatible wrapper for Copilot ACP used by async auxiliary tasks."""
+
+    def __init__(self, sync_wrapper: "CopilotACPClient"):
+        sync_adapter = sync_wrapper.chat.completions
+        async_adapter = _AsyncCopilotACPCompletionsAdapter(sync_adapter)
+        self.chat = _AsyncCopilotACPChatShim(async_adapter)
+        self.api_key = sync_wrapper.api_key
+        self.base_url = sync_wrapper.base_url
+
+
 def _read_nous_auth() -> Optional[dict]:
     """Read and validate ~/.hermes/auth.json for an active Nous provider.
 
@@ -1351,7 +1378,7 @@ def _to_async_client(sync_client, model: str):
     try:
         from agent.copilot_acp_client import CopilotACPClient
         if isinstance(sync_client, CopilotACPClient):
-            return sync_client, model
+            return AsyncCopilotACPClient(sync_client), model
     except ImportError:
         pass
 

--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -253,6 +253,23 @@ class _ACPChatNamespace:
         self.completions = _ACPChatCompletions(client)
 
 
+class _ACPStreamResponse:
+    """Minimal iterable stream wrapper for Copilot ACP.
+
+    Hermes's main agent loop expects ``client.chat.completions.create(..., stream=True)``
+    to return an iterable of OpenAI-style chunks. Copilot ACP is fundamentally
+    synchronous, so we synthesize a tiny stream from the final response instead
+    of returning the raw ``SimpleNamespace`` completion object.
+    """
+
+    def __init__(self, chunks: list[SimpleNamespace]):
+        self._chunks = chunks
+        self.response = SimpleNamespace(headers={})
+
+    def __iter__(self):
+        return iter(self._chunks)
+
+
 class CopilotACPClient:
     """Minimal OpenAI-client-compatible facade for Copilot ACP."""
 
@@ -305,7 +322,7 @@ class CopilotACPClient:
         timeout: float | None = None,
         tools: list[dict[str, Any]] | None = None,
         tool_choice: Any = None,
-        **_: Any,
+        **kwargs: Any,
     ) -> Any:
         prompt_text = _format_messages_as_prompt(
             messages or [],
@@ -351,6 +368,28 @@ class CopilotACPClient:
         )
         finish_reason = "tool_calls" if tool_calls else "stop"
         choice = SimpleNamespace(message=assistant_message, finish_reason=finish_reason)
+        if kwargs.get("stream"):
+            streamed_tool_calls = [
+                SimpleNamespace(
+                    index=i,
+                    id=tc.id,
+                    type=getattr(tc, "type", "function"),
+                    function=tc.function,
+                )
+                for i, tc in enumerate(tool_calls or [])
+            ] or None
+            delta = SimpleNamespace(
+                content=cleaned_text or None,
+                tool_calls=streamed_tool_calls,
+                reasoning=reasoning_text or None,
+                reasoning_content=reasoning_text or None,
+            )
+            chunk = SimpleNamespace(
+                choices=[SimpleNamespace(delta=delta, index=0, finish_reason=None)],
+                model=model or "copilot-acp",
+            )
+            final_chunk = SimpleNamespace(choices=[], usage=usage, model=model or "copilot-acp")
+            return _ACPStreamResponse([chunk, final_chunk])
         return SimpleNamespace(
             choices=[choice],
             usage=usage,

--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -384,8 +384,12 @@ class CopilotACPClient:
                 reasoning=reasoning_text or None,
                 reasoning_content=reasoning_text or None,
             )
+            # Propagate finish_reason on the delta-bearing chunk. The streaming
+            # accumulator in run_agent.py only inspects finish_reason on chunks
+            # that have choices; the empty-choices final chunk is for usage only.
+            # Without this, tool_calls silently degrade to finish_reason="stop".
             chunk = SimpleNamespace(
-                choices=[SimpleNamespace(delta=delta, index=0, finish_reason=None)],
+                choices=[SimpleNamespace(delta=delta, index=0, finish_reason=finish_reason)],
                 model=model or "copilot-acp",
             )
             final_chunk = SimpleNamespace(choices=[], usage=usage, model=model or "copilot-acp")

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch, MagicMock, AsyncMock
 
 import pytest
@@ -776,6 +777,65 @@ class TestKimiForCodingTemperature:
         kwargs = client.chat.completions.create.call_args.kwargs
         assert kwargs["model"] == "kimi-for-coding"
         assert kwargs["temperature"] == 0.6
+
+    @pytest.mark.asyncio
+    async def test_copilot_acp_client_is_async_compatible(self):
+        """Copilot ACP must be wrapped before async_call_llm awaits it."""
+        from agent.auxiliary_client import _to_async_client
+        from agent.copilot_acp_client import CopilotACPClient
+
+        sync_client = CopilotACPClient(
+            api_key="copilot-acp",
+            base_url="acp://copilot",
+            command="copilot",
+            args=["--acp", "--stdio"],
+        )
+
+        sync_response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok", tool_calls=[]))],
+            usage=SimpleNamespace(prompt_tokens=0, completion_tokens=0, total_tokens=0),
+            model="gpt-5.4-mini",
+        )
+
+        def fake_create(**kwargs):
+            return sync_response
+
+        sync_client.chat.completions.create = fake_create
+
+        async_client, model = _to_async_client(sync_client, "gpt-5.4-mini")
+        result = await async_client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": "hello"}],
+        )
+
+        assert model == "gpt-5.4-mini"
+        assert result is sync_response
+        assert result.choices[0].message.content == "ok"
+
+    def test_copilot_acp_client_stream_mode_returns_iterable_chunks(self):
+        """Copilot ACP streaming must yield OpenAI-style chunks, not a bare response."""
+        from agent.copilot_acp_client import CopilotACPClient
+
+        client = CopilotACPClient(
+            api_key="copilot-acp",
+            base_url="acp://copilot",
+            command="copilot",
+            args=["--acp", "--stdio"],
+        )
+        client._run_prompt = lambda *args, **kwargs: ("hello", "thinking")
+
+        stream = client.chat.completions.create(
+            model="gpt-5.4-mini",
+            messages=[{"role": "user", "content": "hi"}],
+            stream=True,
+        )
+
+        chunks = list(stream)
+        assert len(chunks) == 2
+        assert chunks[0].choices[0].delta.content == "hello"
+        assert chunks[0].choices[0].delta.reasoning_content == "thinking"
+        assert chunks[1].choices == []
+        assert hasattr(chunks[1], "usage")
 
     @pytest.mark.parametrize(
         "model,expected",

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -837,6 +837,33 @@ class TestKimiForCodingTemperature:
         assert chunks[1].choices == []
         assert hasattr(chunks[1], "usage")
 
+    def test_copilot_acp_stream_propagates_tool_call_finish_reason(self):
+        """Streaming tool calls must surface finish_reason='tool_calls' on the delta chunk."""
+        from agent.copilot_acp_client import CopilotACPClient
+
+        client = CopilotACPClient(
+            api_key="copilot-acp",
+            base_url="acp://copilot",
+            command="copilot",
+            args=["--acp", "--stdio"],
+        )
+        # Synthesize a response containing an OpenAI-style tool call block.
+        tool_call_json = (
+            '<tool_call>{"function": {"name": "read_file", "arguments": "{\\"path\\": \\"/tmp/x\\"}"}}</tool_call>'
+        )
+        client._run_prompt = lambda *args, **kwargs: (tool_call_json, "")
+
+        stream = client.chat.completions.create(
+            model="gpt-5.4-mini",
+            messages=[{"role": "user", "content": "hi"}],
+            stream=True,
+        )
+
+        chunks = list(stream)
+        assert chunks[0].choices[0].finish_reason == "tool_calls"
+        assert chunks[0].choices[0].delta.tool_calls
+        assert chunks[0].choices[0].delta.tool_calls[0].function.name == "read_file"
+
     @pytest.mark.parametrize(
         "model,expected",
         [


### PR DESCRIPTION
## Summary
Copilot ACP was still behaving like a synchronous, non-streaming client in paths that now expect both async compatibility and OpenAI-style streaming. This PR adds the missing async wrapper and stream adapter so auxiliary async calls can await Copilot ACP, `stream=True` returns iterable chunks, and downstream tool execution keeps `finish_reason="tool_calls"` instead of silently degrading.

## Changes
- `agent/auxiliary_client.py`: add `AsyncCopilotACPClient` so async auxiliary tasks can safely await Copilot ACP completions via `asyncio.to_thread`
- `agent/copilot_acp_client.py`: synthesize an iterable stream response when `stream=True` instead of returning a bare completion object
- `agent/copilot_acp_client.py`: propagate `finish_reason="tool_calls"` on the delta-bearing chunk so streaming tool calls are preserved downstream
- `tests/agent/test_auxiliary_client.py`: add regression coverage for async wrapping, iterable stream chunks, and tool-call finish-reason propagation

## Validation
| | Before | After |
|---|---|---|
| Async auxiliary path | Copilot ACP stayed sync-only, so async auxiliary callers could not safely `await` it | Copilot ACP is wrapped for async auxiliary use |
| Streaming callers | `stream=True` returned a bare response object | `stream=True` returns iterable OpenAI-style chunks |
| Streaming tool calls | Tool calls could degrade to `finish_reason="stop"` because the stream accumulator never saw `tool_calls` on a chunk with choices | Tool-call streams preserve `finish_reason="tool_calls"` on the delta chunk |

`python -m pytest tests/agent/test_auxiliary_client.py -q` → `74 passed`
