### PR TITLE
fix(qqbot): add backoff upper-bound for QQCloseError reconnect path

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -535,6 +535,9 @@ class QQAdapter(BasePlatformAdapter):
                     quick_disconnect_count = 0
                 else:
                     backoff_idx += 1
+                    if backoff_idx >= MAX_RECONNECT_ATTEMPTS:
+                        logger.error("[%s] Max reconnect attempts reached (QQCloseError)", self._log_tag)
+                        return
 
             except Exception as exc:
                 if not self._running:


### PR DESCRIPTION
## Summary

The QQCloseError (non-4008) reconnect path in `_listen_loop` is missing the `MAX_RECONNECT_ATTEMPTS` upper-bound check that exists in both the Exception handler and the 4008 rate-limit handler. This causes the bot to hang silently for hours after a permanent network failure instead of giving up cleanly.

## Bug: Silent Hang After Network Failure

**Observed behavior (from real logs, 2026-04-20):**

```
08:12:53  WebSocket error: WebSocket closed
08:12:53  Reconnecting in 2s (attempt 1)...
08:12:55  Reconnect failed: Cannot connect to host api.sgroup.qq.com:443 [Network is unreachable]
08:12:55 ~ 08:51:59  ← ZERO logs — completely silent for ~39 minutes
08:51:59           ← WSL Ubuntu rebooted (old gateway process killed)
12:01:33           ← New gateway started, reconnected successfully
```

After the initial reconnect failure at 08:12:55, the bot produced **no logs for nearly 4 hours** until the WSL restart killed the process. The bot was alive (gateway was processing other events) but completely unresponsive on QQ — users would perceive it as dead.

## Root Cause

In `_listen_loop`, after `_reconnect()` returns `False`:

```python
# Line 536-537 (QQCloseError non-4008 path):
else:
    backoff_idx += 1  # ← no upper-bound check
# → continue → while self._running loop → sleep(backoff) → _reconnect() again
```

With no upper-bound check, `backoff_idx` grows indefinitely (though capped at 4 by `RECONNECT_BACKOFF` table lookup, giving a constant 60s retry interval). Critically, **there is no log written between retry attempts** — no "Reconnecting in Xs (attempt N)..." and no "Reconnect failed" — so the bot silently hangs until externally killed.

## Fix

Add the same `MAX_RECONNECT_ATTEMPTS` guard that already exists in the `except Exception` path (line 546) and the 4008 path (line 486):

```python
# Before (line 536-537):
else:
    backoff_idx += 1

# After:
else:
    backoff_idx += 1
    if backoff_idx >= MAX_RECONNECT_ATTEMPTS:
        logger.error("[%s] Max reconnect attempts reached (QQCloseError)", self._log_tag)
        return
```

This ensures that after 100 consecutive reconnect failures, the bot logs a clear error message and exits the listen loop cleanly, rather than hanging silently forever.

## Trigger Condition

This bug triggers whenever `_reconnect()` permanently fails for any non-4008 close code (e.g., network unreachable, DNS failure, SSL error). In the observed case, WSL lost network connectivity for ~4 hours.