### PR TITLE
fix(api_server): load reasoning config

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -527,11 +527,12 @@ class APIServerAdapter(BasePlatformAdapter):
         gateway platforms), falling back to the hermes-api-server default.
         """
         from run_agent import AIAgent
-        from gateway.run import _resolve_runtime_agent_kwargs, _resolve_gateway_model, _load_gateway_config
+        from gateway.run import GatewayRunner, _resolve_runtime_agent_kwargs, _resolve_gateway_model, _load_gateway_config
         from hermes_cli.tools_config import _get_platform_tools
 
         runtime_kwargs = _resolve_runtime_agent_kwargs()
         model = _resolve_gateway_model()
+        reasoning_config = GatewayRunner._load_reasoning_config()
 
         user_config = _load_gateway_config()
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))
@@ -540,7 +541,6 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # Load fallback provider chain so the API server platform has the
         # same fallback behaviour as Telegram/Discord/Slack (fixes #4954).
-        from gateway.run import GatewayRunner
         fallback_model = GatewayRunner._load_fallback_model()
 
         agent = AIAgent(
@@ -553,6 +553,7 @@ class APIServerAdapter(BasePlatformAdapter):
             enabled_toolsets=enabled_toolsets,
             session_id=session_id,
             platform="api_server",
+            reasoning_config=reasoning_config,
             stream_delta_callback=stream_delta_callback,
             tool_progress_callback=tool_progress_callback,
             tool_start_callback=tool_start_callback,


### PR DESCRIPTION
## What changed
- Load `reasoning_config` in `gateway/platforms/api_server.py` and pass it into `AIAgent`.
- Fix the `GatewayRunner` import order so the config load does not hit `UnboundLocalError`.

## Why
Hermes-web-ui initiated API-server sessions were not honoring `config.yaml`'s `reasoning_effort` setting.

## Validation
- `python3 -m py_compile gateway/platforms/api_server.py`
