### PR TITLE
fix(gateway): stream consumer first message drops thread context

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -4103,21 +4103,31 @@ class FeishuAdapter(BasePlatformAdapter):
             request = self._build_reply_message_request(effective_reply_to, body)
             return await asyncio.to_thread(self._client.im.v1.message.reply, request)
 
-        body = self._build_create_message_body(
-            receive_id=chat_id,
-            msg_type=msg_type,
-            content=payload,
-            uuid_value=str(uuid.uuid4()),
-        )
-        # Detect whether chat_id is a user open_id (DM) or a chat_id (group).
-        # Feishu API expects receive_id_type="open_id" for user DMs (ou_ prefix)
-        # and receive_id_type="chat_id" for group chats (oc_ prefix, which IS
-        # the chat_id format — see https://open.feishu.cn/document/).
-        if chat_id.startswith("ou_"):
-            receive_id_type = "open_id"
+        # For topic/thread messages that fell back from reply→create, use
+        # thread_id as receive_id so the message lands in the topic instead of
+        # the main chat.
+        _thread_id = (metadata or {}).get("thread_id")
+        if _thread_id:
+            body = self._build_create_message_body(
+                receive_id=_thread_id,
+                msg_type=msg_type,
+                content=payload,
+                uuid_value=str(uuid.uuid4()),
+            )
+            request = self._build_create_message_request("thread_id", body)
         else:
-            receive_id_type = "chat_id"
-        request = self._build_create_message_request(receive_id_type, body)
+            body = self._build_create_message_body(
+                receive_id=chat_id,
+                msg_type=msg_type,
+                content=payload,
+                uuid_value=str(uuid.uuid4()),
+            )
+            # Detect whether chat_id is a user open_id (DM) or a chat_id (group).
+            if chat_id.startswith("ou_"):
+                receive_id_type = "open_id"
+            else:
+                receive_id_type = "chat_id"
+            request = self._build_create_message_request(receive_id_type, body)
         return await asyncio.to_thread(self._client.im.v1.message.create, request)
 
     @staticmethod

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -3918,13 +3918,26 @@ class FeishuAdapter(BasePlatformAdapter):
             request = self._build_reply_message_request(reply_to, body)
             return await asyncio.to_thread(self._client.im.v1.message.reply, request)
 
-        body = self._build_create_message_body(
-            receive_id=chat_id,
-            msg_type=msg_type,
-            content=payload,
-            uuid_value=str(uuid.uuid4()),
-        )
-        request = self._build_create_message_request("chat_id", body)
+        # For topic/thread messages that fell back from reply→create, use
+        # thread_id as receive_id so the message lands in the topic instead of
+        # the main chat.
+        _thread_id = (metadata or {}).get("thread_id")
+        if _thread_id:
+            body = self._build_create_message_body(
+                receive_id=_thread_id,
+                msg_type=msg_type,
+                content=payload,
+                uuid_value=str(uuid.uuid4()),
+            )
+            request = self._build_create_message_request("thread_id", body)
+        else:
+            body = self._build_create_message_body(
+                receive_id=chat_id,
+                msg_type=msg_type,
+                content=payload,
+                uuid_value=str(uuid.uuid4()),
+            )
+            request = self._build_create_message_request("chat_id", body)
         return await asyncio.to_thread(self._client.im.v1.message.create, request)
 
     @staticmethod

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13142,6 +13142,7 @@ class GatewayRunner:
                         chat_id=source.chat_id,
                         config=_consumer_cfg,
                         metadata=_thread_metadata,
+                        initial_reply_to_id=event_message_id,
                     )
             except Exception as _sc_err:
                 logger.debug("Proxy: could not set up stream consumer: %s", _sc_err)
@@ -13963,6 +13964,7 @@ class GatewayRunner:
                                 if progress_queue is not None
                                 else None
                             ),
+                            initial_reply_to_id=event_message_id,
                         )
                         if _want_stream_deltas:
                             def _stream_delta_cb(text: str) -> None:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9149,6 +9149,7 @@ class GatewayRunner:
                         chat_id=source.chat_id,
                         config=_consumer_cfg,
                         metadata=_thread_metadata,
+                        initial_reply_to_id=event_message_id,
                     )
             except Exception as _sc_err:
                 logger.debug("Proxy: could not set up stream consumer: %s", _sc_err)
@@ -9772,6 +9773,7 @@ class GatewayRunner:
                             chat_id=source.chat_id,
                             config=_consumer_cfg,
                             metadata={"thread_id": _progress_thread_id} if _progress_thread_id else None,
+                            initial_reply_to_id=event_message_id,
                         )
                         if _want_stream_deltas:
                             def _stream_delta_cb(text: str) -> None:

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -83,11 +83,13 @@ class GatewayStreamConsumer:
         chat_id: str,
         config: Optional[StreamConsumerConfig] = None,
         metadata: Optional[dict] = None,
+        initial_reply_to_id: Optional[str] = None,
     ):
         self.adapter = adapter
         self.chat_id = chat_id
         self.cfg = config or StreamConsumerConfig()
         self.metadata = metadata
+        self._initial_reply_to_id = initial_reply_to_id
         self._queue: queue.Queue = queue.Queue()
         self._accumulated = ""
         self._message_id: Optional[str] = None
@@ -843,10 +845,12 @@ class GatewayStreamConsumer:
                     # The final response will be sent by the fallback path.
                     return False
             else:
-                # First message — send new
+                # First message — send new, threaded to the original user message
+                # so it lands in the correct topic/thread.
                 result = await self.adapter.send(
                     chat_id=self.chat_id,
                     content=text,
+                    reply_to=self._initial_reply_to_id,
                     metadata=self.metadata,
                 )
                 if result.success:

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -365,7 +365,10 @@ class GatewayStreamConsumer:
                             self._accumulated, _safe_limit
                         )
                         for chunk in chunks:
-                            await self._send_new_chunk(chunk, self._message_id)
+                            await self._send_new_chunk(
+                                chunk,
+                                self._message_id or self._initial_reply_to_id,
+                            )
                         self._accumulated = ""
                         self._last_sent_text = ""
                         self._last_edit_time = time.monotonic()

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -92,6 +92,7 @@ class GatewayStreamConsumer:
         config: Optional[StreamConsumerConfig] = None,
         metadata: Optional[dict] = None,
         on_new_message: Optional[callable] = None,
+        initial_reply_to_id: Optional[str] = None,
     ):
         self.adapter = adapter
         self.chat_id = chat_id
@@ -105,6 +106,7 @@ class GatewayStreamConsumer:
         # the content, not edit the old bubble above it.
         # Called with no arguments. Exceptions are swallowed.
         self._on_new_message = on_new_message
+        self._initial_reply_to_id = initial_reply_to_id
         self._queue: queue.Queue = queue.Queue()
         self._accumulated = ""
         self._message_id: Optional[str] = None
@@ -979,10 +981,12 @@ class GatewayStreamConsumer:
                     # The final response will be sent by the fallback path.
                     return False
             else:
-                # First message — send new
+                # First message — send new, threaded to the original user message
+                # so it lands in the correct topic/thread.
                 result = await self.adapter.send(
                     chat_id=self.chat_id,
                     content=text,
+                    reply_to=self._initial_reply_to_id,
                     metadata=self.metadata,
                 )
                 if result.success:

--- a/tests/gateway/test_stream_consumer_thread_routing.py
+++ b/tests/gateway/test_stream_consumer_thread_routing.py
@@ -108,6 +108,36 @@ class TestInitialReplyToId:
         assert call_kwargs["metadata"] == metadata
 
 
+class TestOverflowFirstMessage:
+    """Verify thread routing is preserved when the first message overflows."""
+
+    @pytest.mark.asyncio
+    async def test_overflow_first_send_uses_initial_reply_to_id(self):
+        """When first message exceeds platform limit and is split into chunks,
+        each chunk should be threaded to initial_reply_to_id, not None."""
+        adapter = _make_adapter(max_length=10)
+        adapter.truncate_message = MagicMock(
+            return_value=["chunk_1", "chunk_2"]
+        )
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_123",
+            metadata={"thread_id": "omt_topic123"},
+            initial_reply_to_id="om_user_msg_789",
+        )
+
+        # Inject oversized accumulated text to trigger overflow path
+        consumer._accumulated = "A" * 100
+        consumer._current_edit_interval = 999
+        await consumer._send_new_chunk("chunk_1", consumer._message_id or consumer._initial_reply_to_id)
+
+        adapter.send.assert_called_once()
+        call_kwargs = adapter.send.call_args[1]
+        assert call_kwargs["reply_to"] == "om_user_msg_789", (
+            "Overflow first chunk should use initial_reply_to_id"
+        )
+
+
 class TestFeishuFallbackThreadRouting:
     """Verify FeishuAdapter._send_raw_message routes to topic on fallback."""
 
@@ -153,11 +183,12 @@ class TestFeishuFallbackThreadRouting:
         # receive_id should be the thread_id, not the chat_id
         import json as _json
         body_dict = _json.loads(body) if isinstance(body, str) else body
-        # The body is a CreateMessageRequestBody — check its receive_id
-        if hasattr(body, 'receive_id'):
-            assert body.receive_id == "omt_topic_abc", (
-                f"Expected receive_id='omt_topic_abc', got '{body.receive_id}'"
-            )
+        assert hasattr(body, 'receive_id'), (
+            "CreateMessageRequestBody missing receive_id attribute"
+        )
+        assert body.receive_id == "omt_topic_abc", (
+            f"Expected receive_id='omt_topic_abc', got '{body.receive_id}'"
+        )
 
     @pytest.mark.asyncio
     async def test_create_uses_chat_id_when_no_thread(self):

--- a/tests/gateway/test_stream_consumer_thread_routing.py
+++ b/tests/gateway/test_stream_consumer_thread_routing.py
@@ -1,0 +1,190 @@
+"""Regression tests for stream consumer thread/topic routing fix.
+
+Verifies that GatewayStreamConsumer correctly passes reply_to on the first
+message send, ensuring messages land in the correct topic/thread instead of
+the main group chat.
+
+Covers: #6969, #9916, #7355
+"""
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.stream_consumer import (
+    GatewayStreamConsumer,
+    StreamConsumerConfig,
+)
+
+
+def _make_adapter(send_result=None, edit_result=None, max_length=4096):
+    adapter = MagicMock()
+    adapter.send = AsyncMock(
+        return_value=send_result or SimpleNamespace(success=True, message_id="msg_1")
+    )
+    adapter.edit_message = AsyncMock(
+        return_value=edit_result or SimpleNamespace(success=True)
+    )
+    adapter.MAX_MESSAGE_LENGTH = max_length
+    return adapter
+
+
+class TestInitialReplyToId:
+    """Verify initial_reply_to_id is passed as reply_to on first send."""
+
+    @pytest.mark.asyncio
+    async def test_first_send_uses_initial_reply_to_id(self):
+        """When initial_reply_to_id is set, first adapter.send() should
+        include reply_to=initial_reply_to_id."""
+        adapter = _make_adapter()
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_123",
+            metadata={"thread_id": "omt_topic123"},
+            initial_reply_to_id="om_user_msg_456",
+        )
+        await consumer._send_or_edit("Hello world")
+
+        adapter.send.assert_called_once()
+        call_kwargs = adapter.send.call_args[1]
+        assert call_kwargs["reply_to"] == "om_user_msg_456", (
+            "First send should pass initial_reply_to_id as reply_to"
+        )
+        assert call_kwargs["chat_id"] == "chat_123"
+
+    @pytest.mark.asyncio
+    async def test_first_send_without_initial_reply_to_id(self):
+        """When initial_reply_to_id is None, first send should have
+        reply_to=None (backward compatible)."""
+        adapter = _make_adapter()
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_123",
+        )
+        await consumer._send_or_edit("Hello world")
+
+        adapter.send.assert_called_once()
+        call_kwargs = adapter.send.call_args[1]
+        assert call_kwargs.get("reply_to") is None
+
+    @pytest.mark.asyncio
+    async def test_subsequent_edits_ignore_initial_reply_to_id(self):
+        """After first send, edits should use message_id, not initial_reply_to_id."""
+        adapter = _make_adapter()
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_123",
+            metadata={"thread_id": "omt_topic123"},
+            initial_reply_to_id="om_user_msg_456",
+        )
+
+        # First send
+        await consumer._send_or_edit("Hello world")
+        assert adapter.send.call_count == 1
+
+        # Second call should edit, not send
+        await consumer._send_or_edit("Hello world updated")
+        assert adapter.send.call_count == 1, "Should edit, not send again"
+        adapter.edit_message.assert_called_once()
+        edit_kwargs = adapter.edit_message.call_args[1]
+        assert edit_kwargs["message_id"] == "msg_1"
+        assert edit_kwargs["chat_id"] == "chat_123"
+
+    @pytest.mark.asyncio
+    async def test_metadata_passed_on_first_send(self):
+        """Metadata (containing thread_id) should be forwarded on first send."""
+        adapter = _make_adapter()
+        metadata = {"thread_id": "omt_topic789"}
+        consumer = GatewayStreamConsumer(
+            adapter,
+            "chat_123",
+            metadata=metadata,
+            initial_reply_to_id="om_msg_000",
+        )
+        await consumer._send_or_edit("Test")
+
+        call_kwargs = adapter.send.call_args[1]
+        assert call_kwargs["metadata"] == metadata
+
+
+class TestFeishuFallbackThreadRouting:
+    """Verify FeishuAdapter._send_raw_message routes to topic on fallback."""
+
+    @pytest.mark.asyncio
+    async def test_create_uses_thread_id_when_available(self):
+        """When reply_to=None and metadata has thread_id, message.create
+        should use receive_id_type='thread_id'."""
+        from gateway.platforms.feishu import FeishuAdapter
+
+        # We test the _send_raw_message method directly by mocking the client
+        adapter = MagicMock(spec=FeishuAdapter)
+
+        # Set up the real _send_raw_message logic manually
+        mock_client = MagicMock()
+        mock_create_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="new_msg_1"),
+        )
+        mock_client.im.v1.message.create = MagicMock(return_value=mock_create_response)
+
+        # Use the real implementation path
+        adapter._client = mock_client
+        adapter._build_create_message_body = FeishuAdapter._build_create_message_body
+        adapter._build_create_message_request = FeishuAdapter._build_create_message_request
+
+        # Call _send_raw_message with reply_to=None and thread_id in metadata
+        import json
+        result = await FeishuAdapter._send_raw_message(
+            adapter,
+            chat_id="oc_main_chat",
+            msg_type="text",
+            payload=json.dumps({"text": "hello"}),
+            reply_to=None,
+            metadata={"thread_id": "omt_topic_abc"},
+        )
+
+        # Verify message.create was called (not message.reply)
+        mock_client.im.v1.message.create.assert_called_once()
+
+        # The request should have receive_id_type="thread_id"
+        call_args = mock_client.im.v1.message.create.call_args[0][0]
+        body = call_args.body
+        # receive_id should be the thread_id, not the chat_id
+        import json as _json
+        body_dict = _json.loads(body) if isinstance(body, str) else body
+        # The body is a CreateMessageRequestBody — check its receive_id
+        if hasattr(body, 'receive_id'):
+            assert body.receive_id == "omt_topic_abc", (
+                f"Expected receive_id='omt_topic_abc', got '{body.receive_id}'"
+            )
+
+    @pytest.mark.asyncio
+    async def test_create_uses_chat_id_when_no_thread(self):
+        """When reply_to=None and metadata has no thread_id, message.create
+        should use receive_id_type='chat_id' (original behavior)."""
+        from gateway.platforms.feishu import FeishuAdapter
+
+        mock_client = MagicMock()
+        mock_create_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="new_msg_1"),
+        )
+        mock_client.im.v1.message.create = MagicMock(return_value=mock_create_response)
+
+        adapter = MagicMock(spec=FeishuAdapter)
+        adapter._client = mock_client
+        adapter._build_create_message_body = FeishuAdapter._build_create_message_body
+        adapter._build_create_message_request = FeishuAdapter._build_create_message_request
+
+        import json
+        result = await FeishuAdapter._send_raw_message(
+            adapter,
+            chat_id="oc_main_chat",
+            msg_type="text",
+            payload=json.dumps({"text": "hello"}),
+            reply_to=None,
+            metadata=None,
+        )
+
+        mock_client.im.v1.message.create.assert_called_once()


### PR DESCRIPTION
## Problem

When a user @mentions the bot inside a group **topic thread** (Feishu group topic / Slack thread / Telegram forum), the first streamed message chunk is sent via `message.create` with `receive_id=chat_id` (the main group) instead of being threaded into the topic. The response — including any visible thinking/reasoning — appears in the main group chat rather than the topic thread.

This is a **cross-platform architecture defect** in `GatewayStreamConsumer` that has been reported multiple times across different platforms:

- **#6969** — Feishu: progress messages create new topics instead of staying in original topic
- **#9916** — Feishu: bot replies leak out of P2P topic thread into main chat
- **#7355** — Telegram: final response chunks lose thread_id, breaking forum topic routing

## Root Cause

Two bugs:

### Bug 1: `GatewayStreamConsumer` sends first chunk without `reply_to`

`gateway/stream_consumer.py` — `_send_or_edit()` first-message path:

```python
# BEFORE — no reply_to passed
result = await self.adapter.send(
    chat_id=self.chat_id,
    content=text,
    metadata=self.metadata,
)
```

`self._message_id` is `None` on the first send, and no fallback `reply_to` is provided. The adapter receives `reply_to=None` → falls to `message.create` with `receive_id=chat_id` → message lands in main chat.

Meanwhile, the **non-streaming path** in `base.py` has always correctly passed `reply_to=event.message_id`. This is why short answers work fine — only streaming (long answers / tool-heavy responses) triggers the bug.

### Bug 2: `FeishuAdapter._send_raw_message` fallback loses thread context

When `message.reply` fails (e.g. message withdrawn, error codes in `_FEISHU_REPLY_FALLBACK_CODES`) and falls back to `message.create`, the fallback uses `receive_id=chat_id` even though `metadata.thread_id` is available — as independently identified in #9916.

## Fix (3 files)

| File | Change |
|------|--------|
| `gateway/stream_consumer.py` | `__init__` accepts optional `initial_reply_to_id`; `_send_or_edit` passes it as `reply_to` on first send |
| `gateway/platforms/feishu.py` | `_send_raw_message` fallback checks `metadata.thread_id`, uses `receive_id_type="thread_id"` instead of `"chat_id"` |
| `gateway/run.py` | Both `GatewayStreamConsumer` creation sites (proxy path L8000 + local path L8575) pass `initial_reply_to_id=event_message_id` |

## Affected Platforms

Any platform using topic/thread routing:
- **Feishu** — group topics (群主题), P2P topic threads
- **Telegram** — forum topics
- **Slack** — thread replies
- **Discord** — thread messages
- **Mattermost** — per-issue #12063

## Reproduction

1. Create a group chat topic in Feishu (or forum topic in Telegram)
2. @mention the bot inside the topic thread
3. Ask something that triggers a long response or tool use (streaming)
4. Observe: the streamed response appears in the main group chat, not in the topic thread
5. Short non-streaming answers work correctly

## Backward Compatibility

`initial_reply_to_id` defaults to `None` — no impact on existing code or platforms without thread routing.

## Closes

Closes #6969
Closes #9916
Closes #7355