### PR TITLE
fix(tools): reap orphaned cloud browser daemons with hermes session p…

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -582,6 +582,8 @@ def _reap_orphaned_browser_sessions():
     socket_dirs = glob.glob(pattern)
     # Also pick up CDP sessions
     socket_dirs += glob.glob(os.path.join(tmpdir, "agent-browser-cdp_*"))
+    # Also pick up cloud-provider sessions (browser-use/browserbase/firecrawl)
+    socket_dirs += glob.glob(os.path.join(tmpdir, "agent-browser-hermes_*"))
 
     if not socket_dirs:
         return


### PR DESCRIPTION
## What does this PR do?

This PR fixes orphan browser daemon cleanup for cloud sessions.

Problem:
Cloud browser providers create session directories with the `hermes_` prefix (for example, `agent-browser-hermes_`...). The orphan reaper only scanned `h_` and `cdp_` prefixes, so `hermes_` orphan sessions were skipped after unclean exits.

Impact:
Skipped cleanup can leave many stale agent-browser node daemons running over time, which may contribute to socket and stability issues in later browser runs.

Why this approach:
This is a minimal, low-risk bug fix. It extends the existing glob-based discovery by adding `hermes_` to the scan list, while keeping all current ownership and pid safety checks unchanged.

## Related Issue

Fixes https://github.com/NousResearch/hermes-agent/issues/13081

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated orphan session discovery in browser_tool.py to include cloud-prefixed session directories:
- existing: agent-browser-h_*
- existing: agent-browser-cdp_*
- added: **agent-browser-hermes_***
- Kept all existing owner_pid and daemon pid liveness checks unchanged.
- No behavior changes outside orphan discovery scope.

## How to Test

1. Configure browser cloud provider to browser-use (or another cloud backend that creates `hermes_` session names).
2. Trigger browser navigation, then force an unclean process exit. Repeat a few times to create potential orphan sessions.
3. Restart Hermes and trigger browser usage again. Verify `hermes_` orphan directories are now discovered by the reaper and stale daemons are cleaned up.
4. Run targeted test command:
`run_tests.sh test_browser_cdp_tool.py`
5. Confirm result:
19 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (fix(scope):, feat(scope):, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run pytest tests/ -q and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

Notes:
I ran focused tests via the project test wrapper:
run_tests.sh test_browser_cdp_tool.py
Result: 19 passed.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
- [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused test run output:

- `run_tests.sh test_browser_cdp_tool.py`
- 19 passed in about 10 seconds