### PR TITLE
fix(cli): clear stale no_mcp and normalize numeric toolset names on save (#13028)

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -622,10 +622,13 @@ def _save_platform_tools(config: dict, platform: str, enabled_toolset_keys: Set[
     # would silently override the user's unchecked selections on the next read.
     platform_default_keys = {p["default_toolset"] for p in PLATFORMS.values()}
 
-    # Get existing toolsets for this platform
-    existing_toolsets = config.get("platform_toolsets", {}).get(platform, [])
-    if not isinstance(existing_toolsets, list):
-        existing_toolsets = []
+    # Get existing toolsets for this platform. YAML may parse bare numeric
+    # names (e.g. ``12306:``) as int, so normalise to str up front to mirror
+    # the read path in ``_get_platform_tools`` and keep ``sorted()`` monomorphic.
+    existing_toolsets_raw = config.get("platform_toolsets", {}).get(platform, [])
+    if not isinstance(existing_toolsets_raw, list):
+        existing_toolsets_raw = []
+    existing_toolsets = [str(ts) for ts in existing_toolsets_raw]
 
     # Preserve any entries that are NOT configurable toolsets and NOT platform
     # defaults (i.e. only MCP server names should be preserved)
@@ -634,8 +637,15 @@ def _save_platform_tools(config: dict, platform: str, enabled_toolset_keys: Set[
         if entry not in configurable_keys and entry not in platform_default_keys
     }
 
-    # Merge preserved entries with new enabled toolsets
-    config["platform_toolsets"][platform] = sorted(enabled_toolset_keys | preserved_entries)
+    # If the caller is re-enabling any MCP server, drop the stale ``no_mcp``
+    # disable-all sentinel so the selection actually takes effect.
+    mcp_server_names = set((config.get("mcp_servers") or {}).keys())
+    if "no_mcp" in preserved_entries and enabled_toolset_keys & mcp_server_names:
+        preserved_entries.discard("no_mcp")
+
+    # Merge preserved entries with new enabled toolsets (all strings now).
+    merged = {str(ts) for ts in enabled_toolset_keys} | preserved_entries
+    config["platform_toolsets"][platform] = sorted(merged)
 
     # Track which plugin toolsets are "known" for this platform so we can
     # distinguish "new plugin, default enabled" from "user disabled it".

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -308,6 +308,38 @@ def test_save_platform_tools_still_preserves_mcp_with_platform_default_present()
     assert "terminal" not in saved
 
 
+def test_save_platform_tools_clears_stale_no_mcp_when_enabling_mcp_server():
+    """Regression for #13028: re-enabling any MCP server for a platform must
+    drop the ``no_mcp`` disable-all sentinel, otherwise the newly selected
+    server is silently suppressed on the next read."""
+    config = {
+        "platform_toolsets": {"cli": ["web", "no_mcp"]},
+        "mcp_servers": {"exa": {"url": "https://mcp.exa.ai/mcp"}},
+    }
+
+    with patch("hermes_cli.tools_config.save_config"):
+        _save_platform_tools(config, "cli", {"web", "exa"})
+
+    saved = config["platform_toolsets"]["cli"]
+    assert "no_mcp" not in saved, "stale no_mcp sentinel leaked through save"
+    assert "exa" in saved
+    assert "web" in saved
+
+
+def test_save_platform_tools_normalises_numeric_existing_entries():
+    """Regression for #13028: YAML may parse bare numeric toolset names
+    (e.g. ``12306:``) as ``int``. Without normalisation the merged
+    ``sorted()`` call crashes with a str-vs-int comparison error."""
+    config = {"platform_toolsets": {"cli": ["web", 12306]}}
+
+    with patch("hermes_cli.tools_config.save_config"):
+        _save_platform_tools(config, "cli", {"web"})
+
+    saved = config["platform_toolsets"]["cli"]
+    assert "12306" in saved
+    assert "web" in saved
+
+
 def test_visible_providers_include_nous_subscription_when_logged_in(monkeypatch):
     monkeypatch.setattr("hermes_cli.tools_config.managed_nous_tools_enabled", lambda: True)
     config = {"model": {"provider": "nous"}}


### PR DESCRIPTION
## Problem

`_save_platform_tools()` has two separate save-path defects (both reproducible by running the Python snippets in the issue body):

1. When a platform previously had the `no_mcp` disable-all sentinel and the user re-enables an MCP server, the sentinel survives the preserve-filter and silently re-suppresses the newly selected server on the next read. Observed: `_get_platform_tools` returned `['web']` immediately after saving `{'web', 'exa'}`.
2. YAML may parse bare numeric toolset names (e.g. `12306:`) as `int`. The read path in `_get_platform_tools` already normalizes to `str` (lines 522-524), but the save path sorted mixed `str`/`int` entries and crashed with `TypeError: '<' not supported between instances of 'str' and 'int'`.

Fixes #13028.

## Fix

- Normalize `existing_toolsets` to strings up front so `sorted()` on the merged set stays monomorphic — mirrors what `_get_platform_tools` already does on the read side.
- When `enabled_toolset_keys` contains any MCP server name (resolved from `config['mcp_servers']`), drop the `no_mcp` sentinel from `preserved_entries`. Plain saves that don't touch MCP still keep the sentinel.

## Test plan

- Added two regression tests in `tests/hermes_cli/test_tools_config.py`:
  - `test_save_platform_tools_clears_stale_no_mcp_when_enabling_mcp_server`
  - `test_save_platform_tools_normalises_numeric_existing_entries`
- `pytest tests/hermes_cli/test_tools_config.py` — 34 passed
- Reran both Python reproducers from the issue against the fixed branch — first case: `['exa', 'web']` saved, `['exa', 'web']` enabled after reload; second case: no `TypeError`, `12306` round-trips as string