### PR TITLE
fix(cli): preserve api_mode for named custom providers in runtime resolution (#13051)

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -311,16 +311,23 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
             if not resolved_api_key:
                 resolved_api_key = str(entry.get("api_key", "") or "").strip()
 
+            # Preserve an explicit api_mode so non-default protocols (e.g.
+            # ``codex_responses``) survive the named-provider resolution path.
+            parsed_api_mode = _parse_api_mode(entry.get("api_mode"))
+
             if requested_norm in {ep_name, name_norm, f"custom:{name_norm}"}:
                 # Found match by provider key
                 base_url = entry.get("api") or entry.get("url") or entry.get("base_url") or ""
                 if base_url:
-                    return {
+                    result = {
                         "name": entry.get("name", ep_name),
                         "base_url": base_url.strip(),
                         "api_key": resolved_api_key,
                         "model": entry.get("default_model", ""),
                     }
+                    if parsed_api_mode:
+                        result["api_mode"] = parsed_api_mode
+                    return result
             # Also check the 'name' field if present
             display_name = entry.get("name", "")
             if display_name:
@@ -329,12 +336,15 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                     # Found match by display name
                     base_url = entry.get("api") or entry.get("url") or entry.get("base_url") or ""
                     if base_url:
-                        return {
+                        result = {
                             "name": display_name,
                             "base_url": base_url.strip(),
                             "api_key": resolved_api_key,
                             "model": entry.get("default_model", ""),
                         }
+                        if parsed_api_mode:
+                            result["api_mode"] = parsed_api_mode
+                        return result
 
     # Fall back to custom_providers: list (legacy format)
     custom_providers = config.get("custom_providers")

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -866,6 +866,46 @@ def test_named_custom_provider_api_mode(monkeypatch):
     assert resolved["base_url"] == "http://localhost:8000/v1"
 
 
+def test_named_custom_provider_explicit_api_mode_from_providers_dict(monkeypatch):
+    """Regression for #13051: explicit ``api_mode`` in a ``providers:`` dict
+    entry must survive named-provider resolution instead of falling back to
+    URL-based auto-detection."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setenv("MY_CODEX_KEY", "sk-codex")
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "providers": {
+                "mycodex": {
+                    # Unknown host — _detect_api_mode_for_url returns None, so
+                    # the explicit api_mode must be the only source of truth.
+                    "base_url": "https://codex.example.invalid/v1",
+                    "default_model": "mymodel",
+                    "key_env": "MY_CODEX_KEY",
+                    "name": "My Codex",
+                    "api_mode": "codex_responses",
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_provider",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError("resolve_provider should not be called for named custom providers")
+        ),
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="mycodex")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["api_mode"] == "codex_responses"
+    assert resolved["base_url"] == "https://codex.example.invalid/v1"
+    assert resolved["api_key"] == "sk-codex"
+
+
 def test_named_custom_provider_without_api_mode_defaults(monkeypatch):
     """custom_providers entries without api_mode should default to chat_completions."""
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "my-server")


### PR DESCRIPTION
## Problem

Named custom providers defined under `providers:` drop the explicit `api_mode` during runtime resolution, so an endpoint configured with a non-default protocol (for example `codex_responses`) resolves correctly through the legacy `model.provider: custom` path but falls back to `chat_completions` when selected by its provider key. Cause: `_get_named_custom_provider()` did not copy `entry.get('api_mode')` into the dict it returned for the `providers:` branches (legacy `custom_providers:` list path at lines 377-379 already did this).

Fixes #13051.

## Fix

Parse `entry.get('api_mode')` via `_parse_api_mode` once per `providers:` entry, and include it in both the provider-key-match and display-name-match return branches. `_resolve_named_custom_runtime` already calls `custom_provider.get('api_mode')` first, so no downstream change is needed — the named path now mirrors the legacy path.

## Test plan

- Added `test_named_custom_provider_explicit_api_mode_from_providers_dict` — uses an unknown host (`codex.example.invalid`) so `_detect_api_mode_for_url` returns `None`, proving the explicit `api_mode` is the only source of truth on the fixed path.
- `pytest tests/hermes_cli/test_runtime_provider_resolution.py` — 68 passed
- Reran the issue's `resolve_runtime_provider(requested='<named>')` call on the fixed branch: `api_mode` now resolves to `codex_responses`, matching the legacy `requested='custom'` call.