### PR TITLE
fix: honor approvals.timeout across CLI and ACP

### DIFF
--- a/acp_adapter/permissions.py
+++ b/acp_adapter/permissions.py
@@ -27,7 +27,7 @@ def make_approval_callback(
     request_permission_fn: Callable,
     loop: asyncio.AbstractEventLoop,
     session_id: str,
-    timeout: float = 60.0,
+    timeout: float | None = None,
 ) -> Callable[[str, str], str]:
     """
     Return a hermes-compatible ``approval_callback(command, description) -> str``
@@ -38,7 +38,16 @@ def make_approval_callback(
         loop: The event loop on which the ACP connection lives.
         session_id: Current ACP session id.
         timeout: Seconds to wait for a response before auto-denying.
+            If None, use Hermes approvals.timeout config. If <= 0, wait indefinitely.
     """
+
+    if timeout is None:
+        try:
+            from tools.approval import _get_approval_timeout
+
+            timeout = float(_get_approval_timeout())
+        except Exception:
+            timeout = 60.0
 
     def _callback(command: str, description: str) -> str:
         options = [
@@ -58,7 +67,10 @@ def make_approval_callback(
 
         try:
             future = asyncio.run_coroutine_threadsafe(coro, loop)
-            response = future.result(timeout=timeout)
+            if timeout is not None and timeout <= 0:
+                response = future.result()
+            else:
+                response = future.result(timeout=timeout)
         except (FutureTimeout, Exception) as exc:
             logger.warning("Permission request timed out or failed: %s", exc)
             return "deny"

--- a/cli.py
+++ b/cli.py
@@ -9071,7 +9071,7 @@ class HermesCLI:
         import time as _time
 
         with self._approval_lock:
-            timeout = 60
+            timeout = int((CLI_CONFIG.get("approvals", {}) or {}).get("timeout", 60) or 60)
             response_queue = queue.Queue()
 
             self._approval_state = {

--- a/tests/acp/test_permissions.py
+++ b/tests/acp/test_permissions.py
@@ -87,3 +87,32 @@ class TestApprovalMapping:
             result = cb("echo hi", "demo")
 
         assert result == "deny"
+
+    def test_approval_uses_hermes_config_timeout_when_not_provided(self):
+        """ACP approvals should inherit Hermes approvals.timeout when timeout=None."""
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        mock_rp = MagicMock(name="request_permission")
+        future = MagicMock(spec=Future)
+        future.result.return_value = _make_response(AllowedOutcome(option_id="allow_once", outcome="selected"))
+
+        with patch("acp_adapter.permissions.asyncio.run_coroutine_threadsafe", return_value=future), \
+             patch("tools.approval._get_approval_timeout", return_value=86400):
+            cb = make_approval_callback(mock_rp, loop, session_id="s1")
+            result = cb("rm -rf /", "dangerous")
+
+        future.result.assert_called_once_with(timeout=86400.0)
+        assert result == "once"
+
+    def test_non_positive_timeout_waits_indefinitely(self):
+        """A non-positive timeout should call Future.result() with no timeout."""
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        mock_rp = MagicMock(name="request_permission")
+        future = MagicMock(spec=Future)
+        future.result.return_value = _make_response(AllowedOutcome(option_id="allow_once", outcome="selected"))
+
+        with patch("acp_adapter.permissions.asyncio.run_coroutine_threadsafe", return_value=future):
+            cb = make_approval_callback(mock_rp, loop, session_id="s1", timeout=0)
+            result = cb("rm -rf /", "dangerous")
+
+        future.result.assert_called_once_with()
+        assert result == "once"

--- a/tests/cli/test_cli_approval_ui.py
+++ b/tests/cli/test_cli_approval_ui.py
@@ -117,6 +117,28 @@ class TestCliApprovalUi:
         thread.join(timeout=2)
         assert result["value"] == "deny"
 
+
+    def test_approval_callback_uses_configured_timeout(self):
+        cli = _make_cli_stub()
+        command = "rm -f /tmp/test-file"
+        captured = {}
+
+        def _fake_get(self, timeout=None):
+            captured["poll_timeout"] = timeout
+            captured["remaining_before_expire"] = cli._approval_deadline - time.monotonic()
+            cli._approval_deadline = time.monotonic() - 1
+            raise queue.Empty
+
+        with patch.object(cli_module, "CLI_CONFIG", {"approvals": {"timeout": 86400}}), \
+             patch.object(queue.Queue, "get", _fake_get), \
+             patch.object(cli_module, "_cprint"):
+            result = cli._approval_callback(command, "delete temp file")
+
+        assert result == "deny"
+        assert captured["poll_timeout"] == 1
+        assert captured["remaining_before_expire"] > 86000
+        assert cli._approval_deadline == 0
+
     def test_handle_approval_selection_view_expands_in_place(self):
         cli = _make_cli_stub()
         cli._approval_state = {


### PR DESCRIPTION
## Summary
- make ACP approvals inherit `approvals.timeout` from config when no explicit timeout is provided
- allow non-positive ACP timeout values to wait indefinitely
- make the main terminal CLI approval UI also honor `approvals.timeout` instead of a hardcoded 60s limit
- add regression tests for both ACP and terminal CLI approval flows

## Problem
Hermes had two separate 60-second approval timeouts:
- the ACP approval bridge defaulted to 60 seconds
- the main terminal CLI approval UI also hardcoded 60 seconds

This meant `approvals.timeout` in `config.yaml` was not fully honored, and users could still hit 1-minute expiry in regular terminal sessions even after fixing the ACP path.

## Test Plan
- run `./venv/bin/python -m pytest tests/acp/test_permissions.py tests/cli/test_cli_approval_ui.py -q -o 'addopts='`
- run `./venv/bin/python -m py_compile cli.py acp_adapter/permissions.py tests/cli/test_cli_approval_ui.py tests/acp/test_permissions.py`
- manually verify that dangerous-command approval prompts no longer expire after 60 seconds when `approvals.timeout` is set higher

Fixes #3765.
