### PR TITLE
feat(session_search): add optional Chinese tokenization

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -476,6 +476,13 @@ DEFAULT_CONFIG = {
 
     },
 
+    "search": {
+        # Opt-in Chinese word segmentation for session_search. When enabled,
+        # SessionDB stores jieba-tokenized text in the FTS5 index and tokenizes
+        # CJK queries before MATCH.
+        "chinese_tokenization": False,
+    },
+
     # AWS Bedrock provider configuration.
     # Only used when model.provider is "bedrock".
     "bedrock": {
@@ -2144,7 +2151,7 @@ def check_config_version() -> Tuple[int, int]:
 _KNOWN_ROOT_KEYS = {
     "_config_version", "model", "providers", "fallback_model",
     "fallback_providers", "credential_pool_strategies", "toolsets",
-    "agent", "terminal", "display", "compression", "delegation",
+    "agent", "terminal", "display", "compression", "search", "delegation",
     "auxiliary", "custom_providers", "context", "memory", "gateway",
     "sessions",
 }

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1513,6 +1513,7 @@ def _apply_default_agent_settings(config: dict):
 
     config.setdefault("compression", {})["enabled"] = True
     config["compression"]["threshold"] = 0.50
+    config.setdefault("search", {})["chinese_tokenization"] = False
 
     config.setdefault("session_reset", {}).update({
         "mode": "both",
@@ -1525,6 +1526,7 @@ def _apply_default_agent_settings(config: dict):
     print_info("  Max iterations: 90")
     print_info("  Tool progress: all")
     print_info("  Compression threshold: 0.50")
+    print_info("  Chinese session search tokenization: off")
     print_info("  Session reset: inactivity (1440 min) + daily (4:00)")
     print_info("  Run `hermes setup agent` later to customize.")
 
@@ -1598,6 +1600,21 @@ def setup_agent_settings(config: dict):
     print_success(
         f"Context compression threshold set to {config['compression'].get('threshold', 0.50)}"
     )
+
+    # ── Session Search Language Support ──
+    print_header("Session Search")
+    print_info("Hermes indexes past conversations with SQLite FTS5.")
+    print_info("Enable Chinese tokenization if you search Chinese chat history often.")
+    current_chinese_search = config.get("search", {}).get("chinese_tokenization", False)
+    enable_chinese_search = prompt_yes_no(
+        "Enable Chinese word segmentation for session search?",
+        bool(current_chinese_search),
+    )
+    config.setdefault("search", {})["chinese_tokenization"] = enable_chinese_search
+    if enable_chinese_search:
+        print_success("Chinese session search tokenization enabled")
+    else:
+        print_info("Chinese session search tokenization disabled")
 
     # ── Session Reset Policy ──
     print_header("Session Reset Policy")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -315,6 +315,7 @@ _CATEGORY_MERGE: Dict[str, str] = {
     "skills": "agent",
     "cron": "agent",
     "network": "agent",
+    "search": "agent",
     "checkpoints": "agent",
     "approvals": "security",
     "human_delay": "display",

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -14,6 +14,7 @@ Key design decisions:
 - Session source tagging ('cli', 'telegram', 'discord', etc.) for filtering
 """
 
+import importlib
 import json
 import logging
 import random
@@ -31,7 +32,7 @@ T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 
-SCHEMA_VERSION = 8
+SCHEMA_VERSION = 9
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (
@@ -99,23 +100,15 @@ CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, timestam
 
 FTS_SQL = """
 CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
-    content,
-    content=messages,
-    content_rowid=id
+    content
 );
+"""
 
-CREATE TRIGGER IF NOT EXISTS messages_fts_insert AFTER INSERT ON messages BEGIN
-    INSERT INTO messages_fts(rowid, content) VALUES (new.id, new.content);
-END;
-
-CREATE TRIGGER IF NOT EXISTS messages_fts_delete AFTER DELETE ON messages BEGIN
-    INSERT INTO messages_fts(messages_fts, rowid, content) VALUES('delete', old.id, old.content);
-END;
-
-CREATE TRIGGER IF NOT EXISTS messages_fts_update AFTER UPDATE ON messages BEGIN
-    INSERT INTO messages_fts(messages_fts, rowid, content) VALUES('delete', old.id, old.content);
-    INSERT INTO messages_fts(rowid, content) VALUES (new.id, new.content);
-END;
+DROP_FTS_SQL = """
+DROP TRIGGER IF EXISTS messages_fts_insert;
+DROP TRIGGER IF EXISTS messages_fts_delete;
+DROP TRIGGER IF EXISTS messages_fts_update;
+DROP TABLE IF EXISTS messages_fts;
 """
 
 
@@ -141,13 +134,22 @@ class SessionDB:
     _WRITE_RETRY_MAX_S = 0.150   # 150ms
     # Attempt a PASSIVE WAL checkpoint every N successful writes.
     _CHECKPOINT_EVERY_N_WRITES = 50
+    _FTS_TOKENIZER_METADATA_KEY = "messages_fts_tokenizer"
+    _jieba = None
+    _jieba_import_attempted = False
+    _jieba_warning_logged = False
 
-    def __init__(self, db_path: Path = None):
+    def __init__(self, db_path: Path = None, chinese_search: bool = None):
         self.db_path = db_path or DEFAULT_DB_PATH
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
 
         self._lock = threading.Lock()
         self._write_count = 0
+        self._chinese_search_enabled = (
+            self._load_chinese_search_enabled()
+            if chinese_search is None else bool(chinese_search)
+        )
+        self._jieba_for_search = self._load_jieba() if self._chinese_search_enabled else None
         self._conn = sqlite3.connect(
             str(self.db_path),
             check_same_thread=False,
@@ -165,6 +167,124 @@ class SessionDB:
         self._conn.execute("PRAGMA foreign_keys=ON")
 
         self._init_schema()
+
+    @staticmethod
+    def _load_chinese_search_enabled() -> bool:
+        """Read the profile-scoped session search tokenizer setting."""
+        config_path = get_hermes_home() / "config.yaml"
+        if not config_path.exists():
+            return False
+        try:
+            import yaml
+
+            with config_path.open("r", encoding="utf-8") as f:
+                config = yaml.safe_load(f) or {}
+        except Exception:
+            return False
+
+        search_config = config.get("search", {})
+        if not isinstance(search_config, dict):
+            return False
+        return bool(
+            search_config.get("chinese_tokenization")
+            or search_config.get("enable_chinese_search")
+        )
+
+    @classmethod
+    def _load_jieba(cls):
+        """Load jieba lazily so the feature remains opt-in at runtime."""
+        if not cls._jieba_import_attempted:
+            cls._jieba_import_attempted = True
+            try:
+                cls._jieba = importlib.import_module("jieba")
+                try:
+                    cls._jieba.setLogLevel(logging.WARNING)
+                except Exception:
+                    pass
+            except Exception:
+                cls._jieba = None
+        if cls._jieba is None and not cls._jieba_warning_logged:
+            cls._jieba_warning_logged = True
+            logger.warning(
+                "search.chinese_tokenization is enabled, but jieba is not installed; "
+                "falling back to SQLite unicode61 search."
+            )
+        return cls._jieba
+
+    def _fts_tokenizer_name(self) -> str:
+        if self._chinese_search_enabled and self._jieba_for_search:
+            return "jieba"
+        return "unicode61"
+
+    def _tokenize_chinese_for_search(self, text: str) -> str:
+        """Return jieba search-mode tokens with punctuation removed."""
+        if not text or not self._jieba_for_search or not self._contains_cjk(text):
+            return text or ""
+        tokens = []
+        for token in self._jieba_for_search.cut_for_search(text):
+            token = token.strip()
+            if token and re.search(r"\w", token, re.UNICODE):
+                tokens.append(token)
+        return " ".join(tokens)
+
+    def _index_content_for_search(self, content: str) -> str:
+        """Build the text stored in the decoupled FTS table."""
+        content = content or ""
+        if self._fts_tokenizer_name() != "jieba" or not self._contains_cjk(content):
+            return content
+        segmented = self._tokenize_chinese_for_search(content)
+        if not segmented or segmented == content:
+            return content
+        # Keep the original text for mixed English/code recall and add jieba
+        # tokens so unicode61 can match Chinese words efficiently.
+        return f"{content}\n{segmented}"
+
+    def _query_for_search(self, query: str) -> str:
+        if self._fts_tokenizer_name() == "jieba" and self._contains_cjk(query):
+            segmented = self._tokenize_chinese_for_search(query)
+            if segmented:
+                return self._sanitize_fts5_query(segmented)
+        return self._sanitize_fts5_query(query)
+
+    def _insert_fts_row(
+        self, conn: sqlite3.Connection, msg_id: int, content: str
+    ) -> None:
+        indexed_content = self._index_content_for_search(content or "")
+        if indexed_content:
+            conn.execute(
+                "INSERT INTO messages_fts(rowid, content) VALUES (?, ?)",
+                (msg_id, indexed_content),
+            )
+
+    def _build_plain_snippet(self, content: str, query: str, radius: int = 40) -> str:
+        """Return a compact snippet from the original message content."""
+        content = content or ""
+        if not content:
+            return ""
+
+        candidates = [query.strip().strip('"')]
+        if self._fts_tokenizer_name() == "jieba" and self._contains_cjk(query):
+            candidates = self._tokenize_chinese_for_search(query).split() + candidates
+
+        lower_content = content.lower()
+        first = -1
+        found_len = 0
+        for term in candidates:
+            if not term:
+                continue
+            idx = lower_content.find(term.lower())
+            if idx >= 0 and (first < 0 or idx < first):
+                first = idx
+                found_len = len(term)
+
+        if first < 0:
+            return content[: radius * 3]
+
+        start = max(0, first - radius)
+        end = min(len(content), first + found_len + radius)
+        prefix = "..." if start > 0 else ""
+        suffix = "..." if end < len(content) else ""
+        return f"{prefix}{content[start:end]}{suffix}"
 
     # ── Core write helper ──
 
@@ -356,6 +476,12 @@ class SessionDB:
                 except sqlite3.OperationalError:
                     pass  # Column already exists
                 cursor.execute("UPDATE schema_version SET version = 8")
+            if current_version < 9:
+                # v9: make messages_fts independent from messages so we can
+                # index pre-tokenized text while keeping canonical message
+                # content unchanged.
+                cursor.executescript(DROP_FTS_SQL)
+                cursor.execute("UPDATE schema_version SET version = 9")
 
         # Unique title index — always ensure it exists (safe to run after migrations
         # since the title column is guaranteed to exist at this point)
@@ -367,13 +493,57 @@ class SessionDB:
         except sqlite3.OperationalError:
             pass  # Index already exists
 
-        # FTS5 setup (separate because CREATE VIRTUAL TABLE can't be in executescript with IF NOT EXISTS reliably)
-        try:
-            cursor.execute("SELECT * FROM messages_fts LIMIT 0")
-        except sqlite3.OperationalError:
-            cursor.executescript(FTS_SQL)
+        self._ensure_fts_index(cursor)
 
         self._conn.commit()
+
+    def _ensure_fts_index(self, cursor: sqlite3.Cursor) -> None:
+        """Create or rebuild the decoupled FTS index when its mode changes."""
+        cursor.execute(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'messages_fts'"
+        )
+        row = cursor.fetchone()
+        fts_sql = (
+            row["sql"]
+            if row and isinstance(row, sqlite3.Row)
+            else (row[0] if row else "")
+        )
+        has_fts = bool(row)
+        external_content = "content=messages" in (fts_sql or "").lower()
+
+        cursor.execute(
+            "SELECT value FROM state_meta WHERE key = ?",
+            (self._FTS_TOKENIZER_METADATA_KEY,),
+        )
+        metadata_row = cursor.fetchone()
+        current_tokenizer = (
+            metadata_row["value"]
+            if metadata_row and isinstance(metadata_row, sqlite3.Row)
+            else (metadata_row[0] if metadata_row else None)
+        )
+        desired_tokenizer = self._fts_tokenizer_name()
+
+        if not has_fts or external_content or current_tokenizer != desired_tokenizer:
+            cursor.executescript(DROP_FTS_SQL)
+            cursor.executescript(FTS_SQL)
+            self._rebuild_fts_index(cursor)
+            cursor.execute(
+                """INSERT INTO state_meta(key, value) VALUES (?, ?)
+                   ON CONFLICT(key) DO UPDATE SET value = excluded.value""",
+                (self._FTS_TOKENIZER_METADATA_KEY, desired_tokenizer),
+            )
+
+    def _rebuild_fts_index(self, cursor: sqlite3.Cursor) -> None:
+        cursor.execute("SELECT id, content FROM messages")
+        for row in cursor.fetchall():
+            msg_id = row["id"] if isinstance(row, sqlite3.Row) else row[0]
+            content = row["content"] if isinstance(row, sqlite3.Row) else row[1]
+            indexed_content = self._index_content_for_search(content or "")
+            if indexed_content:
+                cursor.execute(
+                    "INSERT INTO messages_fts(rowid, content) VALUES (?, ?)",
+                    (msg_id, indexed_content),
+                )
 
     # =========================================================================
     # Session lifecycle
@@ -1002,6 +1172,7 @@ class SessionDB:
                 ),
             )
             msg_id = cursor.lastrowid
+            self._insert_fts_row(conn, msg_id, content)
 
             # Update counters
             if num_tool_calls > 0:
@@ -1185,13 +1356,14 @@ class SessionDB:
         if not query or not query.strip():
             return []
 
-        query = self._sanitize_fts5_query(query)
-        if not query:
+        raw_query = query.strip()
+        fts_query = self._query_for_search(raw_query)
+        if not fts_query:
             return []
 
         # Build WHERE clauses dynamically
         where_clauses = ["messages_fts MATCH ?"]
-        params: list = [query]
+        params: list = [fts_query]
 
         if source_filter is not None:
             source_placeholders = ",".join("?" for _ in source_filter)
@@ -1237,18 +1409,28 @@ class SessionDB:
             except sqlite3.OperationalError:
                 # FTS5 query syntax error despite sanitization — return empty
                 # unless query contains CJK (fall back to LIKE below)
-                if not self._contains_cjk(query):
+                if not self._contains_cjk(raw_query):
                     return []
                 matches = []
             else:
                 matches = [dict(row) for row in cursor.fetchall()]
 
-        # LIKE fallback for CJK queries: FTS5 default tokenizer splits CJK
-        # characters individually, causing multi-character queries to fail.
-        if not matches and self._contains_cjk(query):
-            raw_query = query.strip('"').strip()
+        if (
+            matches
+            and self._fts_tokenizer_name() == "jieba"
+            and self._contains_cjk(raw_query)
+        ):
+            for match in matches:
+                match["snippet"] = self._build_plain_snippet(
+                    match.get("content") or "", raw_query
+                )
+
+        # LIKE fallback for CJK queries: preserves substring behavior for
+        # languages or query shapes the configured tokenizer still misses.
+        if not matches and self._contains_cjk(raw_query):
+            like_query = raw_query.strip('"').strip()
             like_where = ["m.content LIKE ?"]
-            like_params: list = [f"%{raw_query}%"]
+            like_params: list = [f"%{like_query}%"]
             if source_filter is not None:
                 like_where.append(f"s.source IN ({','.join('?' for _ in source_filter)})")
                 like_params.extend(source_filter)
@@ -1273,10 +1455,14 @@ class SessionDB:
             """
             like_params.extend([limit, offset])
             # instr() parameter goes first in the bound list
-            like_params = [raw_query] + like_params
+            like_params = [like_query] + like_params
             with self._lock:
                 like_cursor = self._conn.execute(like_sql, like_params)
                 matches = [dict(row) for row in like_cursor.fetchall()]
+            for match in matches:
+                match["snippet"] = self._build_plain_snippet(
+                    match.get("content") or "", like_query
+                )
 
         # Add surrounding context (1 message before + after each match).
         # Done outside the lock so we don't hold it across N sequential queries.
@@ -1404,6 +1590,11 @@ class SessionDB:
         """Delete all messages for a session and reset its counters."""
         def _do(conn):
             conn.execute(
+                "DELETE FROM messages_fts WHERE rowid IN "
+                "(SELECT id FROM messages WHERE session_id = ?)",
+                (session_id,),
+            )
+            conn.execute(
                 "DELETE FROM messages WHERE session_id = ?", (session_id,)
             )
             conn.execute(
@@ -1429,6 +1620,11 @@ class SessionDB:
             conn.execute(
                 "UPDATE sessions SET parent_session_id = NULL "
                 "WHERE parent_session_id = ?",
+                (session_id,),
+            )
+            conn.execute(
+                "DELETE FROM messages_fts WHERE rowid IN "
+                "(SELECT id FROM messages WHERE session_id = ?)",
                 (session_id,),
             )
             conn.execute("DELETE FROM messages WHERE session_id = ?", (session_id,))
@@ -1471,6 +1667,11 @@ class SessionDB:
             )
 
             for sid in session_ids:
+                conn.execute(
+                    "DELETE FROM messages_fts WHERE rowid IN "
+                    "(SELECT id FROM messages WHERE session_id = ?)",
+                    (sid,),
+                )
                 conn.execute("DELETE FROM messages WHERE session_id = ?", (sid,))
                 conn.execute("DELETE FROM sessions WHERE id = ?", (sid,))
             return len(session_ids)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
   "requests>=2.33.0,<3",  # CVE-2026-25645
   "jinja2>=3.1.5,<4",
   "pydantic>=2.12.5,<3",
+  "jieba>=0.42.1,<1",
   # Interactive CLI (prompt_toolkit is used directly by cli.py)
   "prompt_toolkit>=3.0.52,<4",
   # Tools

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -640,3 +640,8 @@ class TestUserMessagePreviewConfig:
         preview = DEFAULT_CONFIG["display"]["user_message_preview"]
         assert preview["first_lines"] == 2
         assert preview["last_lines"] == 2
+
+
+class TestSearchConfig:
+    def test_default_config_disables_chinese_tokenization(self):
+        assert DEFAULT_CONFIG["search"]["chinese_tokenization"] is False

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -717,6 +717,68 @@ class TestCJKSearchFallback:
         assert len(results) == 1
 
 
+class TestChineseTokenizedSearch:
+    def test_fts_table_is_decoupled_from_messages(self, tmp_path):
+        db = SessionDB(db_path=tmp_path / "state.db", chinese_search=True)
+        try:
+            cursor = db._conn.execute(
+                "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'messages_fts'"
+            )
+            sql = cursor.fetchone()[0].lower()
+        finally:
+            db.close()
+
+        assert "content=messages" not in sql
+        assert "content_rowid" not in sql
+
+    def test_jieba_tokenized_index_finds_spaced_chinese_query(self, tmp_path):
+        pytest.importorskip("jieba")
+        db = SessionDB(db_path=tmp_path / "state.db", chinese_search=True)
+        try:
+            content = "\u6211\u6700\u8fd1\u5728\u7814\u7a76\u673a\u5668\u5b66\u4e60\u7b97\u6cd5"
+            db.create_session(session_id="s1", source="cli")
+            msg_id = db.append_message("s1", role="user", content=content)
+
+            results = db.search_messages("\u673a\u5668 \u5b66\u4e60")
+            cursor = db._conn.execute(
+                "SELECT content FROM messages_fts WHERE rowid = ?", (msg_id,)
+            )
+            indexed_content = cursor.fetchone()[0]
+        finally:
+            db.close()
+
+        assert len(results) == 1
+        assert results[0]["session_id"] == "s1"
+        assert "\u673a\u5668" in indexed_content
+        assert "\u5b66\u4e60" in indexed_content
+        assert "\u673a\u5668\u5b66\u4e60" in results[0]["snippet"]
+
+    def test_existing_index_rebuilds_when_chinese_tokenization_enabled(self, tmp_path):
+        pytest.importorskip("jieba")
+        db_path = tmp_path / "state.db"
+        db = SessionDB(db_path=db_path, chinese_search=False)
+        db.create_session(session_id="s1", source="cli")
+        db.append_message(
+            "s1",
+            role="user",
+            content="\u6b63\u5728\u8c03\u8bd5\u81ea\u7136\u8bed\u8a00\u5904\u7406\u7ba1\u9053",
+        )
+        db.close()
+
+        db = SessionDB(db_path=db_path, chinese_search=True)
+        try:
+            results = db.search_messages("\u81ea\u7136 \u8bed\u8a00")
+            cursor = db._conn.execute(
+                "SELECT value FROM state_meta WHERE key = 'messages_fts_tokenizer'"
+            )
+            tokenizer = cursor.fetchone()[0]
+        finally:
+            db.close()
+
+        assert len(results) == 1
+        assert tokenizer == "jieba"
+
+
 # =========================================================================
 # Session search and listing
 # =========================================================================
@@ -1169,11 +1231,12 @@ class TestSchemaInit:
         assert "sessions" in tables
         assert "messages" in tables
         assert "schema_version" in tables
+        assert "state_meta" in tables
 
     def test_schema_version(self, db):
         cursor = db._conn.execute("SELECT version FROM schema_version")
         version = cursor.fetchone()[0]
-        assert version == 8
+        assert version == 9
 
     def test_title_column_exists(self, db):
         """Verify the title column was created in the sessions table."""
@@ -1234,7 +1297,7 @@ class TestSchemaInit:
 
         # Verify migration
         cursor = migrated_db._conn.execute("SELECT version FROM schema_version")
-        assert cursor.fetchone()[0] == 8
+        assert cursor.fetchone()[0] == 9
 
         # Verify title column exists and is NULL for existing sessions
         session = migrated_db.get_session("existing")
@@ -1253,6 +1316,92 @@ class TestSchemaInit:
         assert session["title"] == "Migrated Title"
 
         migrated_db.close()
+
+    def test_migration_rebuilds_external_content_fts(self, tmp_path):
+        """v6 databases used an external-content FTS table with triggers."""
+        import sqlite3
+
+        db_path = tmp_path / "migrate_fts.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.executescript("""
+            CREATE TABLE schema_version (version INTEGER NOT NULL);
+            INSERT INTO schema_version (version) VALUES (6);
+
+            CREATE TABLE state_meta (key TEXT PRIMARY KEY, value TEXT);
+
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                source TEXT NOT NULL,
+                user_id TEXT,
+                model TEXT,
+                model_config TEXT,
+                system_prompt TEXT,
+                parent_session_id TEXT,
+                started_at REAL NOT NULL,
+                ended_at REAL,
+                end_reason TEXT,
+                message_count INTEGER DEFAULT 0,
+                tool_call_count INTEGER DEFAULT 0,
+                input_tokens INTEGER DEFAULT 0,
+                output_tokens INTEGER DEFAULT 0,
+                cache_read_tokens INTEGER DEFAULT 0,
+                cache_write_tokens INTEGER DEFAULT 0,
+                reasoning_tokens INTEGER DEFAULT 0,
+                billing_provider TEXT,
+                billing_base_url TEXT,
+                billing_mode TEXT,
+                estimated_cost_usd REAL,
+                actual_cost_usd REAL,
+                cost_status TEXT,
+                cost_source TEXT,
+                pricing_version TEXT,
+                title TEXT
+            );
+
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                role TEXT NOT NULL,
+                content TEXT,
+                tool_call_id TEXT,
+                tool_calls TEXT,
+                tool_name TEXT,
+                timestamp REAL NOT NULL,
+                token_count INTEGER,
+                finish_reason TEXT,
+                reasoning TEXT,
+                reasoning_details TEXT,
+                codex_reasoning_items TEXT
+            );
+
+            CREATE VIRTUAL TABLE messages_fts USING fts5(
+                content,
+                content=messages,
+                content_rowid=id
+            );
+
+            INSERT INTO sessions (id, source, started_at, message_count)
+            VALUES ('s1', 'cli', 1000.0, 1);
+            INSERT INTO messages (session_id, role, content, timestamp)
+            VALUES ('s1', 'user', 'Docker deployment notes', 1001.0);
+            INSERT INTO messages_fts(rowid, content)
+            VALUES (1, 'Docker deployment notes');
+        """)
+        conn.close()
+
+        migrated_db = SessionDB(db_path=db_path)
+        try:
+            cursor = migrated_db._conn.execute(
+                "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'messages_fts'"
+            )
+            sql = cursor.fetchone()[0].lower()
+            results = migrated_db.search_messages("Docker")
+        finally:
+            migrated_db.close()
+
+        assert "content=messages" not in sql
+        assert len(results) == 1
+        assert results[0]["session_id"] == "s1"
 
 
 class TestTitleUniqueness:


### PR DESCRIPTION
## What does this PR do?

This PR adds opt-in Chinese tokenization for `session_search` so Chinese chat history can be indexed and queried through FTS5 more effectively.

Hermes currently uses SQLite FTS5 with the default tokenizer, which works well for whitespace-separated languages but does not segment Chinese words. When `search.chinese_tokenization` is enabled, Hermes now stores a jieba-tokenized copy of each message in the FTS index and tokenizes Chinese queries before running `MATCH`, while preserving the original message content in the `messages` table.

The existing CJK `LIKE` fallback remains in place as a safety net for query shapes or languages that the tokenizer does not cover.

## Related Issue

N/A. This came from local usage while searching Chinese conversation history.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [x] Tests (adding or improving test coverage)
- [x] Refactor (keeps canonical message storage separate from search-index text)

## Changes Made

- Added `search.chinese_tokenization` to the default config.
- Added an install/setup prompt for enabling Chinese session-search tokenization.
- Added `jieba` as a dependency for Chinese word segmentation.
- Decoupled `messages_fts` from the `messages` table so indexed text can differ from canonical message content.
- Added schema migration logic that rebuilds old external-content FTS tables into the new decoupled index.
- Tokenize message content with `jieba.cut_for_search()` before inserting into `messages_fts` when Chinese tokenization is enabled.
- Tokenize CJK search queries before FTS5 `MATCH` when Chinese tokenization is enabled.
- Kept the existing CJK `LIKE` fallback for missed matches.
- Added tests for Chinese tokenized search, index rebuilds, schema migration, config defaults, and config version updates.

## How to Test

1. Enable Chinese tokenization in config:

   ```yaml
   search:
     chinese_tokenization: true
   ```

2. Start Hermes and create/search Chinese conversation history with `session_search`.
3. Run the targeted test suites:

   ```powershell
   python -m pytest -o "addopts=" -n 4 tests/test_hermes_state.py
   python -m pytest -o "addopts=" -n 4 tests/test_hermes_state.py tests/hermes_cli/test_config.py tests/tools/test_browser_camofox_state.py tests/test_project_metadata.py tests/test_packaging_metadata.py
   ```

Local result after merging latest `main`: `227 passed`.

Note: I could not run `scripts/run_tests.sh` in this Windows environment because bash startup was denied, so I used the documented Windows fallback with `python -m pytest -n 4`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows / PowerShell / Python 3.12 virtualenv

### Documentation & Housekeeping

- [x] I've updated relevant documentation, docstrings, or comments where needed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A, default config and setup prompt were updated instead
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A, this changes storage/search internals rather than tool schema

## Screenshots / Logs

N/A.