### PR TITLE
fix(hindsight): preserve non-ASCII text in retained conversation turns

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -888,7 +888,7 @@ class HindsightMemoryProvider(MemoryProvider):
         if session_id:
             self._session_id = str(session_id).strip()
 
-        turn = json.dumps(self._build_turn_messages(user_content, assistant_content))
+        turn = json.dumps(self._build_turn_messages(user_content, assistant_content), ensure_ascii=False)
         self._session_turns.append(turn)
         self._turn_counter += 1
         self._turn_index = self._turn_counter

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -531,6 +531,22 @@ class TestSyncTurn:
         if provider._sync_thread:
             provider._sync_thread.join(timeout=5.0)
 
+    def test_sync_turn_preserves_unicode(self, provider_with_config):
+        """Non-ASCII text (CJK, ZWJ emoji) must survive JSON round-trip intact."""
+        p = provider_with_config()
+        p._client = _make_mock_client()
+        p.sync_turn("안녕 こんにちは 你好", "👨‍👩‍👧‍👦 family")
+        p._sync_thread.join(timeout=5.0)
+        p._client.aretain_batch.assert_called_once()
+        item = p._client.aretain_batch.call_args.kwargs["items"][0]
+        # ensure_ascii=False means non-ASCII chars appear as-is in the raw JSON,
+        # not as \uXXXX escape sequences.
+        raw_json = item["content"]
+        assert "안녕" in raw_json
+        assert "こんにちは" in raw_json
+        assert "你好" in raw_json
+        assert "👨‍👩‍👧‍👦" in raw_json
+
 
 # ---------------------------------------------------------------------------
 # System prompt tests


### PR DESCRIPTION
## fix(hindsight): preserve non-ASCII text in retained conversation turns

### Problem

`sync_turn` serializes conversation turns with `json.dumps(messages)`, which defaults to `ensure_ascii=True`. This escapes all non-ASCII characters (Korean, Japanese, Chinese, emoji) into `\uXXXX` sequences before sending to Hindsight via `aretain_batch`.

The escaped content is stored as-is in Hindsight's `documents.original_text` column and `chunks.chunk_text` column, confirmed via direct DB queries:

```sql
-- documents.original_text
[[{"role": "user", "content": "[\ub098] <@1487373250630651975> ...

-- chunks.chunk_text
[[{"role": "user", "content": "[\ub098] ...
```

This affects the Hindsight pipeline in two ways:

**1. LLM token waste during fact extraction** — The escaped `original_text` is passed to the LLM for fact extraction. Tokenizers break `\uXXXX` escapes into far more tokens than the original characters:

| Text | `ensure_ascii=True` | `ensure_ascii=False` | Token increase |
|------|---------------------|---------------------|----------------|
| `안녕 こんにちは 你好` | 31 tokens | 8 tokens | +287% |
| `👨‍👩‍👧‍👦 family` | 43 tokens | 14 tokens | +207% |
| `나 Hermes Agent 로그 보는 방법` | 29 tokens | 8 tokens | +262% |

(Token counts via `tiktoken` with `gpt-4o` encoding.)

**2. Chunk readability** — When `include_chunks=True` is used in recall, the returned `chunk_text` contains escaped Unicode, degrading readability for both LLMs and humans.

### What is NOT affected

DB investigation shows that Hindsight's retrieval pipeline works correctly regardless of `ensure_ascii`:

- **`memory_units.text`** — LLM extracts facts in the original language even from escaped input, so extracted facts contain proper Korean/CJK characters.
- **`memory_units.search_vector`** (BM25) — Built from `memory_units.text`, not from `original_text` or `chunk_text`. BM25 keyword search works correctly.
- **`memory_units.embedding`** — Also built from `memory_units.text`. Semantic search works correctly.

Note on embeddings: `bge-m3` treats `"나"` and `"\\ub098"` as very different strings (`cosine = 0.47`). If embeddings were generated from the escaped `original_text`, semantic search would break. However, Hindsight generates embeddings from `memory_units.text` (the LLM-extracted facts, which are correct Korean), so recall is unaffected.

### Fix

Add `ensure_ascii=False` to the `json.dumps` call in `sync_turn` so non-ASCII text is preserved as-is in the serialized JSON sent to Hindsight.

**Before:**
```json
[{"role": "user", "content": "\uc548\ub155 \u3053\u3093\u306b\u3061\u306f \u4f60\u597d"}]
```

**After:**
```json
[{"role": "user", "content": "안녕 こんにちは 你好"}]
```

### Test

Added `test_sync_turn_preserves_unicode` that verifies the **serialized** JSON content (not just the round-tripped Python object) contains the original CJK characters and ZWJ composite emoji. This test fails without the fix and passes with it.

Note: A test that only checks `json.loads` round-trip would pass regardless of `ensure_ascii`, since `json.loads` silently decodes `\uXXXX` back to the original characters. The test must inspect the raw serialized string to catch this bug.

### How to test

```bash
pytest tests/plugins/memory/test_hindsight_provider.py -v
```