### PR TITLE
fix(mcp): treat explicit empty include list as "block all" (#12865)

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -681,12 +681,14 @@ def cmd_mcp_configure(args):
 
     tool_names = [t[0] for t in all_tools]
 
-    if include and isinstance(include, list):
+    # An explicit empty list (``include: []``) means "block every tool" —
+    # do not treat it the same as an absent filter (which registers all).
+    if isinstance(include, list):
         include_set = set(include)
         pre_selected = {
             i for i, tn in enumerate(tool_names) if tn in include_set
         }
-    elif exclude and isinstance(exclude, list):
+    elif isinstance(exclude, list):
         exclude_set = set(exclude)
         pre_selected = {
             i for i, tn in enumerate(tool_names) if tn not in exclude_set

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -2710,6 +2710,22 @@ class TestMCPSelectiveToolLoading:
         assert registered == ["mcp_ink_no_caps_create_service"]
         assert set(mock_registry.get_all_tool_names()) == {"mcp_ink_no_caps_create_service"}
 
+    def test_empty_include_list_blocks_every_tool(self):
+        """Regression for #12865: ``tools.include: []`` saved by
+        ``hermes mcp configure`` when the operator deselects every tool
+        must disable all tools, not silently fall back to 'no filter'."""
+        config = {
+            "url": "https://mcp.example.com",
+            "tools": {"include": []},
+        }
+        registered, _ = self._run_discover(
+            "ink_empty",
+            ["create_service", "delete_service", "list_services"],
+            config,
+            session=SimpleNamespace(),
+        )
+        assert registered == []
+
     def test_no_filter_registers_all_server_tools_when_no_utilities_supported(self):
         registered, _ = self._run_discover(
             "ink_no_filter",

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2067,16 +2067,23 @@ def _build_utility_schemas(server_name: str) -> List[dict]:
     ]
 
 
-def _normalize_name_filter(value: Any, label: str) -> set[str]:
-    """Normalize include/exclude config to a set of tool names."""
+def _normalize_name_filter(value: Any, label: str) -> Optional[frozenset[str]]:
+    """Normalize include/exclude config to a frozenset of tool names.
+
+    Returns ``None`` when the config key is absent/null or malformed (i.e.
+    "no filter" — honour the backward-compatible default). Returns a
+    (possibly empty) ``frozenset`` when the key is explicitly present, so
+    callers can distinguish ``include: []`` ("block everything") from
+    ``include: null`` / missing key ("no filter, register all").
+    """
     if value is None:
-        return set()
+        return None
     if isinstance(value, str):
-        return {value}
+        return frozenset([value])
     if isinstance(value, (list, tuple, set)):
-        return {str(item) for item in value}
+        return frozenset(str(item) for item in value)
     logger.warning("MCP config %s must be a string or list of strings; ignoring %r", label, value)
-    return set()
+    return None
 
 
 def _parse_boolish(value: Any, default: bool = True) -> bool:
@@ -2173,9 +2180,14 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
     exclude_set = _normalize_name_filter(tools_filter.get("exclude"), f"mcp_servers.{name}.tools.exclude")
 
     def _should_register(tool_name: str) -> bool:
-        if include_set:
+        # Distinguish an *absent* filter (None — register all) from an
+        # explicitly-present but empty filter. Previously the truthiness
+        # check treated ``include: []`` — saved by ``hermes mcp configure``
+        # when the operator deselects every tool — as "no filter", which
+        # silently re-registered every tool on the next load.
+        if include_set is not None:
             return tool_name in include_set
-        if exclude_set:
+        if exclude_set is not None:
             return tool_name not in exclude_set
         return True
 


### PR DESCRIPTION
## Problem

``hermes mcp configure`` lets the operator deselect every tool for an MCP server and saves ``tools.include: []`` under that server's config. The runtime then silently re-registered every tool on the next load because the filter logic used truthiness to decide whether an ``include`` filter was present:

- ``_normalize_name_filter`` collapsed both "key absent / null" and "explicit empty list" into an empty ``set()``.
- ``_should_register`` checked ``if include_set:`` — empty set is falsy, so the filter was skipped.
- The UI pre-selection in ``hermes_cli/mcp_config.py`` had the same ``if include and isinstance(include, list)`` bug, so next time the operator opened the picker every tool was pre-selected despite the saved ``include: []``.

Fixes #12865.

## Fix

- ``_normalize_name_filter`` now returns ``Optional[frozenset[str]]``: ``None`` when the key is absent / null / malformed, a possibly-empty frozenset when it's explicitly present.
- ``_should_register`` switches from truthiness to ``is not None``, so an empty include filter correctly matches zero tools.
- The UI pre-selection logic in ``mcp_config.py`` switches to ``isinstance(include, list)`` only, matching runtime semantics.

## Test plan

- Added ``test_empty_include_list_blocks_every_tool`` regression in ``tests/tools/test_mcp_tool.py``.
- ``pytest tests/tools/test_mcp_tool.py tests/hermes_cli/test_mcp_config.py tests/hermes_cli/test_mcp_tools_config.py`` — 213 passed.
- Reran the minimal Python reproducer from the issue on the fixed branch: ``include=[]`` now yields ``_should_register('a') is False``, whereas ``include=None`` still returns ``True``.