### PR TITLE
fix(cli): recognise every PROVIDER_REGISTRY provider in setup wizard (#13024)

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -2808,13 +2808,20 @@ def run_setup_wizard(args):
         print_info(f"Available sections: {', '.join(k for k, _, _ in SETUP_SECTIONS)}")
         return
 
-    # Check if this is an existing installation with a provider configured
-    from hermes_cli.auth import get_active_provider
+    # Check if this is an existing installation with a provider configured.
+    # Walk PROVIDER_REGISTRY so every API-key provider (Anthropic, Z.AI,
+    # MiniMax, Kimi, Copilot, …) is recognised — previously only
+    # OPENROUTER_API_KEY / OPENAI_BASE_URL / OAuth were checked, which
+    # misclassified many perfectly-configured installs as first-time.
+    from hermes_cli.auth import get_active_provider, PROVIDER_REGISTRY
 
     active_provider = get_active_provider()
+    provider_env_vars: set[str] = {"OPENROUTER_API_KEY", "OPENAI_API_KEY", "OPENAI_BASE_URL"}
+    for pconfig in PROVIDER_REGISTRY.values():
+        if pconfig.auth_type == "api_key":
+            provider_env_vars.update(pconfig.api_key_env_vars)
     is_existing = (
-        bool(get_env_value("OPENROUTER_API_KEY"))
-        or bool(get_env_value("OPENAI_BASE_URL"))
+        any(get_env_value(v) for v in provider_env_vars)
         or active_provider is not None
     )
 

--- a/tests/hermes_cli/test_setup_noninteractive.py
+++ b/tests/hermes_cli/test_setup_noninteractive.py
@@ -229,6 +229,39 @@ class TestNonInteractiveSetup:
             "Exit",
         ]
 
+    def test_api_key_provider_install_detected_as_existing(self, tmp_path):
+        """Regression for #13024: installs whose only provider key is an
+        API-key provider registered via PROVIDER_REGISTRY (Anthropic, Z.AI,
+        MiniMax, Kimi, …) must be treated as existing installations, not
+        as first-time setups."""
+        from hermes_cli import setup as setup_mod
+
+        args = _make_setup_args()
+        captured = {}
+
+        def fake_prompt_choice(question, choices, default=0):
+            captured["question"] = question
+            captured["choices"] = list(choices)
+            return len(choices) - 1  # "Exit"
+
+        with (
+            patch.object(setup_mod, "ensure_hermes_home"),
+            patch.object(setup_mod, "load_config", return_value={}),
+            patch.object(setup_mod, "get_hermes_home", return_value=tmp_path),
+            patch.object(setup_mod, "is_interactive_stdin", return_value=True),
+            patch.object(
+                setup_mod,
+                "get_env_value",
+                side_effect=lambda key: "sk-ant" if key == "ANTHROPIC_API_KEY" else "",
+            ),
+            patch("hermes_cli.auth.get_active_provider", return_value=None),
+            patch.object(setup_mod, "prompt_choice", side_effect=fake_prompt_choice),
+        ):
+            setup_mod.run_setup_wizard(args)
+
+        # Returning-user menu is shown (not the first-time quick-setup prompt).
+        assert captured["question"] == "What would you like to do?"
+
     def test_main_accepts_tts_setup_section(self, monkeypatch):
         """`hermes setup tts` should parse and dispatch like other setup sections."""
         from hermes_cli import main as main_mod


### PR DESCRIPTION
## Problem

``run_setup_wizard`` only treated an install as "existing" when one of these was present:

- ``OPENROUTER_API_KEY``
- ``OPENAI_BASE_URL``
- An OAuth provider from ``get_active_provider()``

This excluded every API-key provider registered via ``PROVIDER_REGISTRY`` (Anthropic, Z.AI, MiniMax, Kimi, Copilot, …), even though ``hermes_cli.main._has_any_provider_configured()`` and the rest of the CLI already recognise them. Users with only ``ANTHROPIC_API_KEY`` (or similar) saw the first-time quick-setup flow on every invocation.

Fixes #13024.

## Fix

Walk ``PROVIDER_REGISTRY`` and union the ``api_key_env_vars`` of every ``api_key``-typed entry into the existence check, querying each via the same ``get_env_value`` helper the rest of setup uses. Keeps the lightweight env-vars-only approach of the previous check so existing tests that mock ``setup_mod.get_env_value`` continue to work.

## Test plan

- Added ``test_api_key_provider_install_detected_as_existing`` regression in ``tests/hermes_cli/test_setup_noninteractive.py``.
- ``pytest tests/hermes_cli/test_setup.py tests/hermes_cli/test_setup_openclaw_migration.py tests/hermes_cli/test_setup_noninteractive.py`` — 52 passed.
- Reran the shell/Python repro from the issue against the fixed branch: install with only ``ANTHROPIC_API_KEY`` now hits the returning-user menu (``_run_quick_setup`` branch), not the first-time flow.