### PR TITLE
fix(tools): return read_file dedup hint in error field, not content (#13079)

### DIFF
--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -169,10 +169,14 @@ class TestFileDedup(unittest.TestCase):
         r1 = json.loads(read_file_tool(self._tmpfile, task_id="dup"))
         self.assertNotIn("dedup", r1)
 
-        # Second read — should get dedup stub
+        # Second read — should get dedup stub. The skip hint is returned in
+        # ``error`` (not ``content``) so downstream tooling that treats
+        # ``content`` as literal file text cannot splice the hint into the
+        # file payload — see #13079.
         r2 = json.loads(read_file_tool(self._tmpfile, task_id="dup"))
         self.assertTrue(r2.get("dedup"), "Second read should return dedup stub")
-        self.assertIn("unchanged", r2.get("content", ""))
+        self.assertNotIn("content", r2, "Dedup stub must not leak into content field")
+        self.assertIn("unchanged", r2.get("error", "").lower())
 
     @patch("tools.file_tools._get_file_ops")
     def test_modified_file_not_deduped(self, mock_ops):

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -398,11 +398,18 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
             try:
                 current_mtime = os.path.getmtime(resolved_str)
                 if current_mtime == cached_mtime:
+                    # Return the hint in ``error`` (not ``content``) so it
+                    # never gets spliced into downstream tooling that treats
+                    # ``content`` as literal file text with line-number
+                    # prefixes (see ``subdir_hints`` in run_agent.py). Using
+                    # ``content`` caused the hint to accumulate inside the
+                    # file payload after repeated reads.
                     return json.dumps({
-                        "content": (
-                            "File unchanged since last read. The content from "
-                            "the earlier read_file result in this conversation is "
-                            "still current — refer to that instead of re-reading."
+                        "error": (
+                            "SKIP: File unchanged since last read. You already "
+                            "have this content from the earlier read_file call "
+                            "in this conversation — refer to that instead of "
+                            "re-reading."
                         ),
                         "path": path,
                         "dedup": True,


### PR DESCRIPTION
## Problem

When the same ``read_file`` call hit the in-memory dedup cache, the tool returned the skip hint in the ``content`` field. Downstream tooling — in particular ``_subdirectory_hints.check_tool_call`` in ``run_agent.py`` — treats ``content`` as literal file text with line-number prefixes, which allowed the hint to splice into the file payload and nest across repeated reads, eventually corrupting what the model sees.

Fixes #13079.

## Fix

Return the dedup hint in ``error`` instead. The ``dedup: True`` flag is preserved so callers that want to distinguish "skip" from a real error can still do so, but consumers that route ``content`` and ``error`` differently (including anything that line-number-prefixes file text) can no longer confuse the stub for file content.

## Test plan

- Updated ``test_second_read_returns_dedup_stub`` to assert the new contract (no ``content`` key, hint text lives in ``error``).
- ``pytest tests/tools/test_file_read_guards.py tests/tools/test_file_operations.py`` — 67 passed.
- Reran the Python reproducer from the issue: second read returns ``{dedup: true, error: "SKIP: File unchanged..."}`` with no ``content`` key; first reads and post-modification reads still return normal content.