### PR TITLE
fix(memory): auto-install hindsight-all for local_embedded mode

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -500,6 +500,48 @@ class HindsightMemoryProvider(MemoryProvider):
         # "local" is a legacy alias for "local_embedded"
         if self._mode == "local":
             self._mode = "local_embedded"
+
+        # For local_embedded mode, ensure the hindsight package (from hindsight-all)
+        # is installed. The setup wizard may silently fail to install it, and
+        # plugin.yaml only declares hindsight-client, so startup validation passes
+        # even when hindsight-all is missing — leading to a crash at runtime.
+        if self._mode == "local_embedded":
+            try:
+                import hindsight as _hindsight_check  # noqa: F401
+            except ImportError:
+                logger.warning("hindsight package not found (required for local_embedded mode), attempting to install hindsight-all...")
+                import shutil, subprocess, sys
+                uv_path = shutil.which("uv")
+                if uv_path:
+                    try:
+                        subprocess.run(
+                            [uv_path, "pip", "install", "--python", sys.executable,
+                             "--quiet", "hindsight-all"],
+                            check=True, timeout=180, capture_output=True,
+                        )
+                        logger.info("hindsight-all installed successfully")
+                    except subprocess.CalledProcessError as e:
+                        stderr_output = e.stderr.decode(errors="replace") if e.stderr else ""
+                        logger.error("Failed to install hindsight-all: %s. stderr: %s. "
+                                     "Run manually: uv pip install hindsight-all", e, stderr_output)
+                        raise RuntimeError(
+                            "hindsight-all is required for local_embedded mode but could not be installed. "
+                            "Run: uv pip install hindsight-all"
+                        ) from e
+                    except Exception as e:
+                        logger.error("Failed to install hindsight-all: %s. "
+                                     "Run manually: uv pip install hindsight-all", e)
+                        raise RuntimeError(
+                            "hindsight-all is required for local_embedded mode but could not be installed. "
+                            "Run: uv pip install hindsight-all"
+                        ) from e
+                else:
+                    logger.error("uv not found. Run: pip install hindsight-all")
+                    raise RuntimeError(
+                        "hindsight-all is required for local_embedded mode. "
+                        "Install uv or run: pip install hindsight-all"
+                    )
+
         self._api_key = self._config.get("apiKey") or self._config.get("api_key") or os.environ.get("HINDSIGHT_API_KEY", "")
         default_url = _DEFAULT_LOCAL_URL if self._mode in ("local_embedded", "local_external") else _DEFAULT_API_URL
         self._api_url = self._config.get("api_url") or os.environ.get("HINDSIGHT_API_URL", default_url)

--- a/plugins/memory/hindsight/plugin.yaml
+++ b/plugins/memory/hindsight/plugin.yaml
@@ -3,6 +3,8 @@ version: 1.0.0
 description: "Hindsight — long-term memory with knowledge graph, entity resolution, and multi-strategy retrieval."
 pip_dependencies:
   - "hindsight-client>=0.4.22"
+  # hindsight-all is also required for local_embedded mode, but is auto-installed
+  # by the plugin's initialize() method to avoid pulling heavy deps for cloud-only users.
 requires_env: []
 hooks:
   - on_session_end


### PR DESCRIPTION
## What does this PR do?

Fixes a crash when users select `local_embedded` mode via `hermes memory setup`. The setup wizard tries to install `hindsight-all` but the install can silently fail because `capture_output=True` swallows errors. Since `plugin.yaml` only declares `hindsight-client>=0.4.22` as a dependency, hermes startup validation passes even when `hindsight-all` is missing. At runtime, `from hindsight import HindsightEmbedded` crashes with `ModuleNotFoundError: No module named 'hindsight'`.

This patch adds a guard in `HindsightMemoryProvider.initialize()` that:
1. Detects when mode is `local_embedded`
2. Attempts to `import hindsight` — if it fails, auto-installs `hindsight-all` via `uv pip install`
3. Raises a clear `RuntimeError` with manual install instructions if installation fails
4. Does **not** surface errors as swallowed silent failures — errors are logged and propagated

This mirrors the existing auto-upgrade logic for `hindsight-client` already present in `initialize()` for cloud mode.

## Related Issue

Fixes crash described in hindsight local_embedded setup flow.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/hindsight/__init__.py`: Added auto-install guard for `hindsight-all` in `initialize()` when mode is `local_embedded`
- `plugins/memory/hindsight/plugin.yaml`: Added comment documenting the `hindsight-all` dependency for local_embedded mode

## How to Test

1. Configure hindsight with `local_embedded` mode but ensure `hindsight-all` is NOT installed
2. Start a new hermes session with hindsight memory enabled
3. Verify that the plugin auto-installs `hindsight-all` and logs the installation
4. Verify that if installation fails, a clear `RuntimeError` is raised with manual instructions
5. Test cloud mode still works without `hindsight-all` installed (no regression)

## Checklist

- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix
- [x] I have considered cross-platform impact (uses shutil.which("uv") which works on all platforms)
- [x] Updated relevant docstrings/comments — plugin.yaml comment added