### PR TITLE
feat(gateway): Initialize plugin system on startup

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2148,6 +2148,14 @@ class GatewayRunner:
         self._running = True
         self._update_runtime_status("running")
         
+        # Initialize plugin system (discover and load all enabled plugins)
+        try:
+            from hermes_cli.plugins import discover_plugins
+            discover_plugins()
+            logger.info("Plugin system initialized")
+        except Exception as e:
+            logger.warning("Plugin system initialization failed: %s", e)
+        
         # Emit gateway:startup hook
         hook_count = len(self.hooks.loaded_hooks)
         if hook_count:


### PR DESCRIPTION
## Summary

This PR adds automatic plugin system initialization during gateway startup, ensuring that all enabled plugins are discovered and loaded when the gateway starts.

## Changes

- Added `discover_plugins()` call in `gateway/run.py` during the startup sequence
- Wrapped in try-except to prevent plugin failures from crashing the gateway
- Added appropriate logging for success/failure

## Motivation

Currently, plugins are not automatically loaded when the gateway starts. This requires users to manually patch the gateway code to enable plugin functionality, which gets overwritten on every `hermes update`.

This change makes plugin loading automatic and official, eliminating the need for local patches.

## Testing

- Gateway starts successfully with plugins enabled
- Plugins are discovered and loaded automatically
- Gateway continues to work if plugin system fails (graceful degradation)

## Related

Resolves the need for manual patches to enable plugin functionality.