### PR TITLE
fix(tui): theme-driven update-behind banner + auto-detect light terminals (#11300)

### DIFF
--- a/ui-tui/src/__tests__/theme.test.ts
+++ b/ui-tui/src/__tests__/theme.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { DARK_THEME, DEFAULT_THEME, fromSkin, LIGHT_THEME } from '../theme.js'
+import { DARK_THEME, DEFAULT_THEME, detectLightMode, fromSkin, LIGHT_THEME } from '../theme.js'
 
 describe('DEFAULT_THEME', () => {
   it('has brand defaults', () => {
@@ -30,8 +30,34 @@ describe('LIGHT_THEME', () => {
 })
 
 describe('DEFAULT_THEME aliasing', () => {
-  it('defaults to DARK_THEME when HERMES_TUI_LIGHT is unset', () => {
+  it('defaults to DARK_THEME when nothing signals light', () => {
     expect(DEFAULT_THEME).toBe(DARK_THEME)
+  })
+})
+
+describe('detectLightMode', () => {
+  it('returns false on empty env', () => {
+    expect(detectLightMode({})).toBe(false)
+  })
+
+  it('honors HERMES_TUI_LIGHT on/off', () => {
+    expect(detectLightMode({ HERMES_TUI_LIGHT: '1' })).toBe(true)
+    expect(detectLightMode({ HERMES_TUI_LIGHT: 'true' })).toBe(true)
+    expect(detectLightMode({ HERMES_TUI_LIGHT: 'on' })).toBe(true)
+    expect(detectLightMode({ HERMES_TUI_LIGHT: '0' })).toBe(false)
+    expect(detectLightMode({ HERMES_TUI_LIGHT: 'off' })).toBe(false)
+  })
+
+  it('sniffs COLORFGBG bg slots 7 and 15 as light (#11300)', () => {
+    expect(detectLightMode({ COLORFGBG: '0;15' })).toBe(true)
+    expect(detectLightMode({ COLORFGBG: '0;default;15' })).toBe(true)
+    expect(detectLightMode({ COLORFGBG: '0;7' })).toBe(true)
+    expect(detectLightMode({ COLORFGBG: '15;0' })).toBe(false)
+    expect(detectLightMode({ COLORFGBG: '7;default;0' })).toBe(false)
+  })
+
+  it('lets HERMES_TUI_LIGHT=0 override a light COLORFGBG', () => {
+    expect(detectLightMode({ COLORFGBG: '0;15', HERMES_TUI_LIGHT: '0' })).toBe(false)
   })
 })
 

--- a/ui-tui/src/components/branding.tsx
+++ b/ui-tui/src/components/branding.tsx
@@ -161,16 +161,16 @@ export function SessionPanel({ info, sid, t }: SessionPanelProps) {
         </Text>
 
         {typeof info.update_behind === 'number' && info.update_behind > 0 && (
-          <Text bold color="yellow">
+          <Text bold color={t.color.warn}>
             ! {info.update_behind} {info.update_behind === 1 ? 'commit' : 'commits'} behind
-            <Text bold={false} color="yellow" dimColor>
+            <Text bold={false} color={t.color.warn} dimColor>
               {' '}
               - run{' '}
             </Text>
-            <Text bold color="yellow">
+            <Text bold color={t.color.warn}>
               {info.update_command || 'hermes update'}
             </Text>
-            <Text bold={false} color="yellow" dimColor>
+            <Text bold={false} color={t.color.warn} dimColor>
               {' '}
               to update
             </Text>

--- a/ui-tui/src/theme.ts
+++ b/ui-tui/src/theme.ts
@@ -171,9 +171,26 @@ export const LIGHT_THEME: Theme = {
   bannerHero: ''
 }
 
-const LIGHT_MODE = /^(?:1|true|yes|on)$/i.test((process.env.HERMES_TUI_LIGHT ?? '').trim())
+// Pick light vs dark. Explicit `HERMES_TUI_LIGHT` wins; otherwise sniff
+// `COLORFGBG` (set by XFCE Terminal, rxvt, Terminal.app, etc.) — last field is the
+// background ANSI index; 7/15 are the "white" slots most light themes emit (#11300).
+export function detectLightMode(env: NodeJS.ProcessEnv = process.env): boolean {
+  const explicit = (env.HERMES_TUI_LIGHT ?? '').trim().toLowerCase()
 
-export const DEFAULT_THEME: Theme = LIGHT_MODE ? LIGHT_THEME : DARK_THEME
+  if (/^(?:1|true|yes|on)$/.test(explicit)) {
+    return true
+  }
+
+  if (/^(?:0|false|no|off)$/.test(explicit)) {
+    return false
+  }
+
+  const bg = Number((env.COLORFGBG ?? '').trim().split(';').at(-1))
+
+  return bg === 7 || bg === 15
+}
+
+export const DEFAULT_THEME: Theme = detectLightMode() ? LIGHT_THEME : DARK_THEME
 
 // ── Skin → Theme ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
Fixes #11300. Alt to #12487 — routes through the existing theme instead of swapping one hardcoded color for another.

## Summary

- `branding.tsx`: 4× `color="yellow"` → `color={t.color.warn}`. Now respects theme (amber `#ffa726` on dark, burnt-orange `#E65100` on light). PR #12487 swapped in `#b8860b` — better than bright yellow but still bypasses the theme and ignores the LIGHT_THEME that already landed in `20eab355`.
- `theme.ts`: `HERMES_TUI_LIGHT` regex → `detectLightMode(env)` that also sniffs `COLORFGBG`. Bg slot 7 or 15 → LIGHT_THEME. Explicit `HERMES_TUI_LIGHT` (on *or* off) still wins. XFCE Terminal / rxvt / Terminal.app / iTerm2 users get light mode with no config.
- `theme.test.ts`: +10 assertions covering empty env, explicit on/off, COLORFGBG positions (`0;15`, `0;default;15`, `0;7`, `15;0`, `7;default;0`), and off-overrides-light.

## Test plan

- [x] `npm run type-check` — clean
- [x] `npx vitest run src/__tests__/theme.test.ts` — 15/15
- [x] `npm run lint` on touched files — clean (pre-existing errors unrelated)
- [ ] Manual: `COLORFGBG=0;15 hermes --tui` on a real light terminal shows dark-orange "commits behind" text

## Notes for reviewers

If #12487 is preferred for the color-swap narrowness, this PR supersedes it: same readability win, plus the theme path and autodetect. If both land, the `color={t.color.warn}` change is a clean rebase on top.