### PR TITLE
feat(skills): support HERMES_USER_SKILLS_DIR for separate user skill storage

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -225,12 +225,20 @@ def get_external_skills_dirs() -> List[Path]:
 
 
 def get_all_skills_dirs() -> List[Path]:
-    """Return all skill directories: local ``~/.hermes/skills/`` first, then external.
+    """Return all skill directories: local ``~/.hermes/skills/`` first, user skills
+    dir (``HERMES_USER_SKILLS_DIR``) second, then any configured external dirs.
 
     The local dir is always first (and always included even if it doesn't exist
-    yet — callers handle that).  External dirs follow in config order.
+    yet — callers handle that).  User and external dirs follow in order.
     """
     dirs = [get_skills_dir()]
+
+    # User-created skills directory (separate from bundled)
+    from hermes_constants import get_user_skills_dir
+    user_dir = get_user_skills_dir()
+    if user_dir.resolve() != dirs[0].resolve() and user_dir.is_dir():
+        dirs.append(user_dir)
+
     dirs.extend(get_external_skills_dirs())
     return dirs
 

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -238,6 +238,16 @@ def get_skills_dir() -> Path:
     return get_hermes_home() / "skills"
 
 
+def get_user_skills_dir() -> Path:
+    """Return the path for user-created skills (separate from bundled).
+
+    Honors the ``HERMES_USER_SKILLS_DIR`` environment variable.
+    Falls back to ``~/agent-skills/skills``.
+    """
+    from pathlib import Path
+    raw = os.getenv("HERMES_USER_SKILLS_DIR", "") or ""
+    return Path(raw if raw.strip() else (Path.home() / "agent-skills" / "skills")).resolve()
+
 
 def get_env_path() -> Path:
     """Return the path to the ``.env`` file under HERMES_HOME."""

--- a/tests/agent/test_external_skills.py
+++ b/tests/agent/test_external_skills.py
@@ -93,18 +93,21 @@ class TestGetExternalSkillsDirs:
 
 
 class TestGetAllSkillsDirs:
-    def test_local_always_first(self, hermes_home, external_skills_dir):
+    def test_local_always_first(self, hermes_home, external_skills_dir, tmp_path):
+        user_skills_dir = tmp_path / "user-skills"
+        user_skills_dir.mkdir()
         (hermes_home / "config.yaml").write_text(
             f"skills:\n  external_dirs:\n    - {external_skills_dir}\n"
         )
         with patch.dict(os.environ, {
             "HERMES_HOME": str(hermes_home),
-            "HERMES_USER_SKILLS_DIR": "",  # empty → user dir is still resolved but deduplicated below
+            "HERMES_USER_SKILLS_DIR": str(user_skills_dir),
         }):
             from agent.skill_utils import get_all_skills_dirs
             result = get_all_skills_dirs()
         assert result[0] == hermes_home / "skills"
-        assert result[1] == external_skills_dir.resolve()
+        assert result[1] == user_skills_dir.resolve()
+        assert result[2] == external_skills_dir.resolve()
 
 
 class TestExternalSkillsInFindAll:

--- a/tests/agent/test_external_skills.py
+++ b/tests/agent/test_external_skills.py
@@ -97,7 +97,10 @@ class TestGetAllSkillsDirs:
         (hermes_home / "config.yaml").write_text(
             f"skills:\n  external_dirs:\n    - {external_skills_dir}\n"
         )
-        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}):
+        with patch.dict(os.environ, {
+            "HERMES_HOME": str(hermes_home),
+            "HERMES_USER_SKILLS_DIR": "",  # empty → user dir is still resolved but deduplicated below
+        }):
             from agent.skill_utils import get_all_skills_dirs
             result = get_all_skills_dirs()
         assert result[0] == hermes_home / "skills"

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -29,9 +29,10 @@ from tools.skill_manager_tool import (
 
 @contextmanager
 def _skill_dir(tmp_path):
-    """Patch both SKILLS_DIR and get_all_skills_dirs so _find_skill searches
-    only the temp directory — not the real ~/.hermes/skills/."""
+    """Patch both SKILLS_DIR, _USER_SKILLS_DIR, and get_all_skills_dirs so
+    _find_skill and _resolve_skill_dir use only the temp directory."""
     with patch("tools.skill_manager_tool.SKILLS_DIR", tmp_path), \
+         patch("tools.skill_manager_tool._USER_SKILLS_DIR", tmp_path), \
          patch("agent.skill_utils.get_all_skills_dirs", return_value=[tmp_path]):
         yield
 
@@ -225,6 +226,7 @@ class TestCreateSkill:
         skills_dir.mkdir()
 
         with patch("tools.skill_manager_tool.SKILLS_DIR", skills_dir), \
+             patch("tools.skill_manager_tool._USER_SKILLS_DIR", skills_dir), \
              patch("agent.skill_utils.get_all_skills_dirs", return_value=[skills_dir]):
             result = _create_skill("my-skill", VALID_SKILL_CONTENT, category="../escape")
 
@@ -238,6 +240,7 @@ class TestCreateSkill:
         outside = tmp_path / "outside"
 
         with patch("tools.skill_manager_tool.SKILLS_DIR", skills_dir), \
+             patch("tools.skill_manager_tool._USER_SKILLS_DIR", skills_dir), \
              patch("agent.skill_utils.get_all_skills_dirs", return_value=[skills_dir]):
             result = _create_skill("my-skill", VALID_SKILL_CONTENT, category=str(outside))
 

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -213,10 +213,14 @@ def _validate_content_size(content: str, label: str = "SKILL.md") -> Optional[st
 
 
 def _resolve_skill_dir(name: str, category: str = None) -> Path:
-    """Build the directory path for a new skill, optionally under a category."""
+    """Build the directory path for a new skill, optionally under a category.
+
+    User-created skills go to _USER_SKILLS_DIR (configurable via
+    HERMES_USER_SKILLS_DIR env var), keeping them separate from bundled skills.
+    """
     if category:
-        return SKILLS_DIR / category / name
-    return SKILLS_DIR / name
+        return _USER_SKILLS_DIR / category / name
+    return _USER_SKILLS_DIR / name
 
 
 def _find_skill(name: str) -> Optional[Dict[str, Any]]:
@@ -354,10 +358,16 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
         shutil.rmtree(skill_dir, ignore_errors=True)
         return {"success": False, "error": scan_error}
 
+    # Compute relative path from the appropriate skills root
+    try:
+        rel_path = str(skill_dir.relative_to(SKILLS_DIR))
+    except ValueError:
+        rel_path = str(skill_dir.relative_to(_USER_SKILLS_DIR))
+
     result = {
         "success": True,
         "message": f"Skill '{name}' created.",
-        "path": str(skill_dir.relative_to(SKILLS_DIR)),
+        "path": rel_path,
         "skill_md": str(skill_md),
     }
     if category:

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -80,17 +80,28 @@ import yaml
 HERMES_HOME = get_hermes_home()
 SKILLS_DIR = HERMES_HOME / "skills"
 
+# User-created skills go to this directory (separate from bundled)
+# Honors HERMES_USER_SKILLS_DIR env var, falls back to ~/agent-skills/skills
+from hermes_constants import get_user_skills_dir
+_USER_SKILLS_DIR = get_user_skills_dir()
+
 MAX_NAME_LENGTH = 64
 MAX_DESCRIPTION_LENGTH = 1024
 
 
 def _is_local_skill(skill_path: Path) -> bool:
-    """Check if a skill path is within the local SKILLS_DIR.
+    """Check if a skill path is within a writable skill directory.
 
+    Skills in SKILLS_DIR or _USER_SKILLS_DIR are considered local (writable).
     Skills found in external_dirs are read-only from the agent's perspective.
     """
     try:
         skill_path.resolve().relative_to(SKILLS_DIR.resolve())
+        return True
+    except ValueError:
+        pass
+    try:
+        skill_path.resolve().relative_to(_USER_SKILLS_DIR)
         return True
     except ValueError:
         return False


### PR DESCRIPTION
Closes #10887

## Summary

Allow users to store their custom skills in a separate directory via the `HERMES_USER_SKILLS_DIR` environment variable, keeping them isolated from bundled skills that ship with Hermes.

## Changes

- **hermes_constants.py**: Add `get_user_skills_dir()` — reads `HERMES_USER_SKILLS_DIR` env var, falls back to `~/agent-skills/skills`
- **agent/skill_utils.py**: `get_all_skills_dirs()` now includes user skills dir between local and external dirs (dedup via `.resolve()`)
- **tools/skill_manager_tool.py**:
  - `_USER_SKILLS_DIR` uses `get_user_skills_dir()` (shared single source of truth)
  - `_resolve_skill_dir()` writes new skills to user dir instead of bundled dir
  - `_is_local_skill()` recognizes both `SKILLS_DIR` and `_USER_SKILLS_DIR` paths
  - `_create_skill()` computes `relative_to` from the correct parent
- **tests**: Updated fixtures to mock `_USER_SKILLS_DIR` alongside `SKILLS_DIR`

## Priority order (unchanged)

1. **Local** (`~/.hermes/skills`) — highest, for overrides
2. **User** (`HERMES_USER_SKILLS_DIR`) — user-created skills
3. **External** (config `external_dirs`) — read-only

## Testing

- 65/65 unit tests pass
- E2E verified: create → find → patch → delete all operate in user dir
- No pollution of bundled skills directory