### PR TITLE
fix: preserve Bedrock inference profile ID namespace separators

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -838,10 +838,17 @@ def normalize_model_name(model: str, preserve_dots: bool = False) -> str:
     - Converts dots to hyphens in version numbers (OpenRouter uses dots,
       Anthropic uses hyphens: claude-opus-4.6 → claude-opus-4-6), unless
       preserve_dots is True (e.g. for Alibaba/DashScope: qwen3.5-plus).
+    - Preserves Bedrock inference profile IDs (global., us., eu., ap., jp.)
+      which use dots as namespace separators, not version separators.
     """
     lower = model.lower()
     if lower.startswith("anthropic/"):
         model = model[len("anthropic/"):]
+    # Bedrock inference profile IDs use dots as namespace separators
+    # (global., us., eu., ap., jp.) and must be preserved.
+    _BEDROCK_REGION_PREFIXES = ("global.", "us.", "eu.", "ap.", "jp.")
+    if any(lower.startswith(p) for p in _BEDROCK_REGION_PREFIXES):
+        return model
     if not preserve_dots:
         # OpenRouter uses dots for version separators (claude-opus-4.6),
         # Anthropic uses hyphens (claude-opus-4-6). Convert dots to hyphens.

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -481,6 +481,17 @@ class TestNormalizeModelName:
         assert normalize_model_name("anthropic/qwen3.5-plus", preserve_dots=True) == "qwen3.5-plus"
         assert normalize_model_name("qwen3.5-flash", preserve_dots=True) == "qwen3.5-flash"
 
+    def test_bedrock_inference_profile_ids_preserved(self):
+        """Bedrock inference profile IDs use dots as namespace separators (global., us., eu., ap., jp.).
+        These must be preserved, not converted to hyphens. Fixes #12727."""
+        assert normalize_model_name("global.anthropic.claude-sonnet-4-6") == "global.anthropic.claude-sonnet-4-6"
+        assert normalize_model_name("us.anthropic.claude-3-5-sonnet-20240620-v1:0") == "us.anthropic.claude-3-5-sonnet-20240620-v1:0"
+        assert normalize_model_name("eu.anthropic.claude-sonnet-4-5") == "eu.anthropic.claude-sonnet-4-5"
+        assert normalize_model_name("ap.anthropic.claude-opus-4") == "ap.anthropic.claude-opus-4"
+        assert normalize_model_name("jp.anthropic.claude-haiku-4-5") == "jp.anthropic.claude-haiku-4-5"
+        # Ensure non-Bedrock model names still convert dots to hyphens
+        assert normalize_model_name("claude-opus-4.6") == "claude-opus-4-6"
+
 
 # ---------------------------------------------------------------------------
 # Tool conversion


### PR DESCRIPTION
## What broke
When using Bedrock with an inference profile ID like `global.anthropic.claude-sonnet-4-6`, the `normalize_model_name()` function in `agent/anthropic_adapter.py` converted all dots to hyphens, producing the invalid ID `global-anthropic-claude-sonnet-4-6`. This caused HTTP 400: The provided model identifier is invalid.

## Root cause
`normalize_model_name()` unconditionally replaced `.` → `-` for Anthropic API compatibility (OpenRouter uses dots in versions, Anthropic uses hyphens). But Bedrock inference profile IDs use dots as namespace separators (`global.`, `us.`, `eu.`, `ap.`, `jp.`) and must be preserved.

## Why this fix is minimal
The fix is scoped to exactly one function (`normalize_model_name`) with a single conditional check added before the dot-to-hyphen conversion. The check detects Bedrock region prefixes and returns early, preserving the original model name. No broader changes to auth, client construction, or other provider handling.

## What I tested
- All Bedrock region prefixes preserved correctly:
  - `global.anthropic.claude-sonnet-4-6` → preserved
  - `us.anthropic.claude-3-5-sonnet-20240620-v1:0` → preserved
  - `eu.anthropic.claude-sonnet-4-5` → preserved
  - `ap.anthropic.claude-opus-4` → preserved
  - `jp.anthropic.claude-haiku-4-5` → preserved
- Existing behavior unchanged:
  - `claude-opus-4.6` → `claude-opus-4-6` (still converts)
  - `anthropic/claude-sonnet-4.5` → `claude-sonnet-4-5` (strips prefix, converts)
  - `qwen3.5-plus` with `preserve_dots=True` → preserved

Added regression test: `test_bedrock_inference_profile_ids_preserved` in `tests/agent/test_anthropic_adapter.py`.

## What I intentionally did not change
- No changes to `_anthropic_preserve_dots()` method or provider detection
- No changes to Bedrock client construction or auth handling
- No speculative refactoring of model name handling

Fixes #12727