### PR TITLE
fix: send presence_penalty for local endpoints to prevent tool-call r…

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -200,6 +200,8 @@ if _config_path.exists():
         if _agent_cfg and isinstance(_agent_cfg, dict):
             if "max_turns" in _agent_cfg:
                 os.environ["HERMES_MAX_ITERATIONS"] = str(_agent_cfg["max_turns"])
+            if "presence_penalty" in _agent_cfg and "HERMES_PRESENCE_PENALTY" not in os.environ:
+                os.environ["HERMES_PRESENCE_PENALTY"] = str(_agent_cfg["presence_penalty"])
             # Bridge agent.gateway_timeout → HERMES_AGENT_TIMEOUT env var.
             # Env var from .env takes precedence (already in os.environ).
             if "gateway_timeout" in _agent_cfg and "HERMES_AGENT_TIMEOUT" not in os.environ:

--- a/run_agent.py
+++ b/run_agent.py
@@ -7552,6 +7552,20 @@ class AIAgent:
                 "sessionId": self.session_id or "hermes",
                 "promptId": str(uuid.uuid4()),
             }
+        # Presence penalty — prevents small/local models (Qwen3.x, Gemma, etc.)
+        # from entering repetition loops where the same tool is called with
+        # identical args across turns.  The OpenAI Python SDK sends
+        # presence_penalty=0 by default, overriding any server-side setting.
+        # Config: agent.presence_penalty in config.yaml, or env
+        # HERMES_PRESENCE_PENALTY.  When set, always sent.  When unset,
+        # defaults to 1.5 for local endpoints (localhost/127.0.0.1) which
+        # overwhelmingly run open-weight models susceptible to this issue.
+        _pp = os.environ.get("HERMES_PRESENCE_PENALTY")
+        if _pp is not None:
+            api_kwargs["presence_penalty"] = float(_pp)
+        elif "localhost" in (self.base_url or "") or "127.0.0.1" in (self.base_url or ""):
+            api_kwargs["presence_penalty"] = 1.5
+
         if self.tools:
             api_kwargs["tools"] = self.tools
 


### PR DESCRIPTION

Small/local models (Qwen3.x, Gemma, etc.) are susceptible to entering degenerate loops where the same tool is called with identical arguments across turns. The circuit breaker (#10447) handles the error case, but when tools succeed yet return unhelpful results the model retries indefinitely — burning through all 90 iterations with zero useful output.

Root cause: the OpenAI Python SDK sends presence_penalty=0 by default, overriding any server-side setting (e.g. llama-server's --presence-penalty). This effectively disables the repetition discouragement that local inference servers configure for these models.

Fix: auto-inject presence_penalty=1.5 for requests to localhost/127.0.0.1 endpoints. This matches Qwen's own recommended sampling config for non-thinking mode and makes repeated token sequences (like identical tool-call JSON) progressively less likely each turn.

The value is configurable via:
  - config.yaml: agent.presence_penalty: 1.5
  - env: HERMES_PRESENCE_PENALTY=1.5

When neither is set, the 1.5 default only activates for local endpoints. Cloud API users are unaffected.

Before: 43 API calls, 280s, 180k chars of repeated tool results, generic answer
After:  6 API calls, 32s, 17k chars of varied tool results, specific answer

Refs: #5254, #10447
