### PR TITLE
fix(providers): deduplicate custom providers — register both plain and prefixed slugs in seen_slugs

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -933,6 +933,8 @@ def list_authenticated_providers(
                 "source": "user-config",
                 "api_url": api_url,
             })
+            seen_slugs.add(ep_name)
+            seen_slugs.add(custom_provider_slug(display_name))
 
     # --- 4. Saved custom providers from config ---
     if custom_providers and isinstance(custom_providers, list):


### PR DESCRIPTION
Fixes #12293.

In `list_providers()`, Section 3 (user-defined endpoints) appends each provider to `results` but never registers its slug in `seen_slugs`. Section 4 (saved custom providers) generates the `custom:`-prefixed slug via `custom_provider_slug()` and checks `seen_slugs` for deduplication — but since the plain `ep_name` was never registered, the check never fires and the same provider is emitted twice in `/model`.

## Root cause

`hermes_cli/model_switch.py`, Section 3:
```python
results.append({
    "slug": ep_name,
    ...
})
# ep_name never added to seen_slugs — Section 4 can't dedup against it
```

Section 4 generates `custom:<name>` via `custom_provider_slug()`, checks `seen_slugs`, finds nothing, and emits a duplicate.

## Fix

After the `results.append()` in Section 3, register both slug forms:
```python
seen_slugs.add(ep_name)
seen_slugs.add(custom_provider_slug(display_name))
```

This ensures Section 4's dedup check correctly suppresses the duplicate entry regardless of which slug format it generates. `custom_provider_slug` is already imported at module level (line 28) — no new imports required.

## Test plan

- [ ] Define a custom provider in `~/.hermes/config.yaml` that also appears in the built-in registry cache
- [ ] Run `/model` — verify the provider appears exactly once
- [ ] Verify providers that exist only in Section 3 or only in Section 4 still appear normally