### PR TITLE
fix(feishu): include parent media context for replies

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1143,6 +1143,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._sent_message_id_order: List[str] = []  # LRU order for _sent_message_ids_to_chat
         self._chat_info_cache: Dict[str, Dict[str, Any]] = {}
         self._message_text_cache: Dict[str, Optional[str]] = {}
+        self._message_context_cache: Dict[str, tuple[Optional[str], List[str], List[str]]] = {}
         self._app_lock_identity: Optional[str] = None
         self._text_batch_state = FeishuBatchState()
         self._pending_text_batches = self._text_batch_state.events
@@ -2483,7 +2484,12 @@ class FeishuAdapter(BasePlatformAdapter):
             or getattr(message, "upper_message_id", None)
             or None
         )
-        reply_to_text = await self._fetch_message_text(reply_to_message_id) if reply_to_message_id else None
+        reply_media_urls: List[str] = []
+        reply_media_types: List[str] = []
+        if reply_to_message_id:
+            reply_to_text, reply_media_urls, reply_media_types = await self._fetch_message_context(reply_to_message_id)
+        else:
+            reply_to_text = None
 
         logger.info(
             "[Feishu] Inbound %s message received: id=%s type=%s chat_id=%s text=%r media=%d",
@@ -2513,8 +2519,8 @@ class FeishuAdapter(BasePlatformAdapter):
             source=source,
             raw_message=data,
             message_id=message_id,
-            media_urls=media_urls,
-            media_types=media_types,
+            media_urls=[*reply_media_urls, *media_urls],
+            media_types=[*reply_media_types, *media_types],
             reply_to_message_id=reply_to_message_id,
             reply_to_text=reply_to_text,
             timestamp=datetime.now(),
@@ -3291,10 +3297,16 @@ class FeishuAdapter(BasePlatformAdapter):
         return None
 
     async def _fetch_message_text(self, message_id: str) -> Optional[str]:
+        text, _, _ = await self._fetch_message_context(message_id)
+        return text
+
+    async def _fetch_message_context(self, message_id: str) -> tuple[Optional[str], List[str], List[str]]:
         if not self._client or not message_id:
-            return None
+            return None, [], []
+        if message_id in self._message_context_cache:
+            return self._message_context_cache[message_id]
         if message_id in self._message_text_cache:
-            return self._message_text_cache[message_id]
+            return self._message_text_cache[message_id], [], []
         try:
             request = self._build_get_message_request(message_id)
             response = await asyncio.to_thread(self._client.im.v1.message.get, request)
@@ -3302,24 +3314,39 @@ class FeishuAdapter(BasePlatformAdapter):
                 code = getattr(response, "code", "unknown")
                 msg = getattr(response, "msg", "message lookup failed")
                 logger.warning("[Feishu] Failed to fetch parent message %s: [%s] %s", message_id, code, msg)
-                return None
+                return None, [], []
             items = getattr(getattr(response, "data", None), "items", None) or []
             parent = items[0] if items else None
             body = getattr(parent, "body", None)
             msg_type = getattr(parent, "msg_type", "") or ""
             raw_content = getattr(body, "content", "") or ""
-            text = self._extract_text_from_raw_content(msg_type=msg_type, raw_content=raw_content)
+            normalized = normalize_feishu_message(message_type=msg_type, raw_content=raw_content)
+            media_urls, media_types = await self._download_feishu_message_resources(
+                message_id=message_id,
+                normalized=normalized,
+            )
+            text = self._text_from_normalized_message(normalized)
+            context = (text, media_urls, media_types)
+            self._message_context_cache[message_id] = context
             self._message_text_cache[message_id] = text
-            return text
+            if media_urls:
+                logger.info("[Feishu] Fetched parent message %s with %d media resource(s)", message_id, len(media_urls))
+            return context
         except Exception:
             logger.warning("[Feishu] Failed to fetch parent message %s", message_id, exc_info=True)
-            return None
+            return None, [], []
 
     def _extract_text_from_raw_content(self, *, msg_type: str, raw_content: str) -> Optional[str]:
         normalized = normalize_feishu_message(message_type=msg_type, raw_content=raw_content)
+        return self._text_from_normalized_message(normalized)
+
+    @staticmethod
+    def _text_from_normalized_message(normalized: FeishuNormalizedMessage) -> Optional[str]:
         if normalized.text_content:
             return normalized.text_content
         placeholder = normalized.metadata.get("placeholder_text") if isinstance(normalized.metadata, dict) else None
+        if placeholder is None:
+            return None
         return str(placeholder).strip() or None
 
     @staticmethod

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1269,6 +1269,45 @@ class TestAdapterBehavior(unittest.TestCase):
         )
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_fetch_message_context_downloads_parent_image(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=SimpleNamespace(
+                        get=Mock(
+                            return_value=SimpleNamespace(
+                                success=lambda: True,
+                                data=SimpleNamespace(
+                                    items=[
+                                        SimpleNamespace(
+                                            msg_type="image",
+                                            body=SimpleNamespace(content='{"image_key":"img_parent"}'),
+                                        )
+                                    ]
+                                ),
+                            )
+                        )
+                    )
+                )
+            )
+        )
+        adapter._download_feishu_image = AsyncMock(return_value=("/tmp/parent-image.jpg", "image/jpeg"))
+
+        text, media_urls, media_types = asyncio.run(adapter._fetch_message_context("om_parent"))
+
+        self.assertIsNone(text)
+        self.assertEqual(media_urls, ["/tmp/parent-image.jpg"])
+        self.assertEqual(media_types, ["image/jpeg"])
+        adapter._download_feishu_image.assert_awaited_once_with(
+            message_id="om_parent",
+            image_key="img_parent",
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_extract_audio_message_downloads_and_caches(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter
@@ -1769,7 +1808,7 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(event.source.chat_type, "group")
 
     @patch.dict(os.environ, {}, clear=True)
-    def test_process_inbound_message_fetches_reply_to_text(self):
+    def test_process_inbound_message_fetches_reply_context(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter
 
@@ -1781,7 +1820,9 @@ class TestAdapterBehavior(unittest.TestCase):
         adapter._resolve_sender_profile = AsyncMock(
             return_value={"user_id": "ou_user", "user_name": "张三", "user_id_alt": None}
         )
-        adapter._fetch_message_text = AsyncMock(return_value="父消息内容")
+        adapter._fetch_message_context = AsyncMock(
+            return_value=("父消息内容", ["/tmp/replied-image.png"], ["image/png"])
+        )
         message = SimpleNamespace(
             chat_id="oc_chat",
             thread_id=None,
@@ -1805,6 +1846,8 @@ class TestAdapterBehavior(unittest.TestCase):
         event = adapter._dispatch_inbound_event.await_args.args[0]
         self.assertEqual(event.reply_to_message_id, "om_parent")
         self.assertEqual(event.reply_to_text, "父消息内容")
+        self.assertEqual(event.media_urls, ["/tmp/replied-image.png"])
+        self.assertEqual(event.media_types, ["image/png"])
 
     @patch.dict(os.environ, {}, clear=True)
     def test_send_replies_in_thread_when_thread_metadata_present(self):


### PR DESCRIPTION
## Summary
- Fetch full parent message context for Feishu replies, including downloadable image/file media resources
- Merge parent media into the inbound MessageEvent so reply-to-image prompts preserve visual context
- Keep the existing text-only helper compatible via the new context fetcher

## Tests
- /Users/tangyuanjc/.hermes/hermes-agent/venv/bin/python -m pytest tests/gateway/test_feishu.py

Result: 126 passed, 70 warnings (dependency deprecation warnings from lark_oapi/websockets).