### PR TITLE
fix(plugins): await async plugin command handlers in process_command

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5490,6 +5490,16 @@ class HermesCLI:
                     user_args = cmd_original[len(base_cmd):].strip()
                     try:
                         result = plugin_handler(user_args)
+                        import inspect as _inspect
+                        if _inspect.iscoroutine(result):
+                            import asyncio as _asyncio
+                            try:
+                                _loop = _asyncio.get_running_loop()
+                                import concurrent.futures as _cf
+                                _fut = _asyncio.run_coroutine_threadsafe(result, _loop)
+                                result = _fut.result(timeout=30)
+                            except RuntimeError:
+                                result = _asyncio.run(result)
                         if result:
                             _cprint(str(result))
                     except Exception as e:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -64,6 +64,7 @@ AUTHOR_MAP = {
     "259807879+Bartok9@users.noreply.github.com": "Bartok9",
     # contributors (manual mapping from git names)
     "dmayhem93@gmail.com": "dmahan93",
+    "oluwadare1803@gmail.com": "Bennytimz",
     "samherring99@gmail.com": "samherring99",
     "desaiaum08@gmail.com": "Aum08Desai",
     "shannon.sands.1979@gmail.com": "shannonsands",


### PR DESCRIPTION
Fixes #12449.

When a plugin registers an `async def` command handler, `process_command()` calls `plugin_handler(user_args)` but never awaits the result. This causes two problems: the raw coroutine object is printed instead of the actual output, and Python fires `RuntimeWarning: coroutine was never awaited`.

## Root cause

`cli.py`, plugin dispatch block:
```python
result = plugin_handler(user_args)   # returns coroutine if async def
if result:
    _cprint(str(result))             # prints <coroutine object ...>
```

No `inspect.iscoroutine()` check — the coroutine is never awaited and is garbage-collected, triggering the RuntimeWarning.

## Fix

After calling the handler, check `inspect.iscoroutine(result)` and run the coroutine safely depending on context:

- **Gateway mode** (event loop already running): use `asyncio.run_coroutine_threadsafe(result, loop)` to schedule on the existing loop and block for the result.
- **CLI mode** (no running loop): use `asyncio.run(result)`.

The already-created coroutine object is reused in both paths — the handler is never called twice, avoiding double side-effects.

```python
result = plugin_handler(user_args)
import inspect as _inspect
if _inspect.iscoroutine(result):
    import asyncio as _asyncio
    try:
        _loop = _asyncio.get_running_loop()
        import concurrent.futures as _cf
        _fut = _asyncio.run_coroutine_threadsafe(result, _loop)
        result = _fut.result(timeout=30)
    except RuntimeError:
        result = _asyncio.run(result)
```

## Test plan

- [ ] Register an `async def` plugin command handler and invoke it via `/my-command` in CLI mode — verify output is correct, no RuntimeWarning
- [ ] Same test in gateway mode (Telegram/Discord) — verify no `RuntimeError: This event loop is already running`
- [ ] Verify sync plugin handlers are unaffected (iscoroutine returns False, existing path runs unchanged)