### PR TITLE
fix(agent): use Anthropic-format stub when streaming fails for anthropic_messages

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6754,18 +6754,38 @@ class AIAgent:
                         len(_partial_text or ""),
                         result["error"],
                     )
-                _stub_msg = SimpleNamespace(
-                    role="assistant", content=_partial_text, tool_calls=None,
-                    reasoning_content=None,
-                )
-                return SimpleNamespace(
-                    id="partial-stream-stub",
-                    model=getattr(self, "model", "unknown"),
-                    choices=[SimpleNamespace(
-                        index=0, message=_stub_msg, finish_reason="stop",
-                    )],
-                    usage=None,
-                )
+                if self.api_mode == "anthropic_messages":
+                    # Anthropic validation expects response.content to be a
+                    # list of content blocks, not the OpenAI choices format.
+                    _content_blocks = []
+                    if _partial_text:
+                        _content_blocks.append(
+                            SimpleNamespace(type="text", text=_partial_text)
+                        )
+                    return SimpleNamespace(
+                        id="partial-stream-stub",
+                        type="message",
+                        role="assistant",
+                        model=getattr(self, "model", "unknown"),
+                        content=_content_blocks,
+                        stop_reason="end_turn",
+                        usage=SimpleNamespace(
+                            input_tokens=0, output_tokens=0,
+                        ),
+                    )
+                else:
+                    _stub_msg = SimpleNamespace(
+                        role="assistant", content=_partial_text, tool_calls=None,
+                        reasoning_content=None,
+                    )
+                    return SimpleNamespace(
+                        id="partial-stream-stub",
+                        model=getattr(self, "model", "unknown"),
+                        choices=[SimpleNamespace(
+                            index=0, message=_stub_msg, finish_reason="stop",
+                        )],
+                        usage=None,
+                    )
             raise result["error"]
         return result["response"]
 


### PR DESCRIPTION
## What

When a stream fails partway through in `_interruptible_streaming_api_call`, the method returns a partial-stream stub to prevent duplicate messages. This stub always used the OpenAI `choices` format regardless of `api_mode`.

When `api_mode == "anthropic_messages"`, the validation in `run_conversation()` (line ~9967) checks `response.content` expecting a list of Anthropic content blocks. The `choices`-format stub has no `content` attribute as a list, so `getattr(response, "content", None)` returns `None`, failing the `isinstance(content_blocks, list)` check. This triggers "Empty/malformed response — switching to fallback" and unnecessary retries.

## Fix

Return an Anthropic-compatible stub when `api_mode == "anthropic_messages"`:
- `response.content` → list of `{type: "text", text: ...}` blocks  
- `response.stop_reason` → `"end_turn"`
- `response.usage` → `{input_tokens: 0, output_tokens: 0}`

The existing `choices` format is preserved for `chat_completions` and other modes.

## How to reproduce

1. Use an Anthropic provider through a proxy that occasionally drops connections mid-stream
2. Observe "Empty/malformed response" errors followed by unnecessary fallback switches
3. The root cause is the stub format mismatch, not an actual empty response

## How to test

- The fix is a conditional branch in the existing stub-creation code path
- `python3 -c "import py_compile; py_compile.compile('run_agent.py', doraise=True)"` passes
- The Anthropic stub shape matches what `normalize_anthropic_response` in `agent/anthropic_adapter.py` expects (iterates `response.content` blocks with `.type` and `.text`)

## Platform

Tested on macOS with Python 3.12, Anthropic SDK v0.95.0