### PR TITLE
fix(gateway): strip ANSI from background watcher messages

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8421,7 +8421,13 @@ class GatewayRunner:
                     or (notify_mode == "error" and session.exit_code not in (0, None))
                 )
                 if should_notify:
-                    new_output = session.output_buffer[-1000:] if session.output_buffer else ""
+                    from tools.ansi_strip import strip_ansi
+
+                    new_output = (
+                        strip_ansi(session.output_buffer[-1000:])
+                        if session.output_buffer
+                        else ""
+                    )
                     message_text = (
                         f"[Background process {session_id} finished with exit code {session.exit_code}~ "
                         f"Here's the final output:\n{new_output}]"
@@ -8442,7 +8448,13 @@ class GatewayRunner:
             elif has_new_output and notify_mode == "all" and not agent_notify:
                 # New output available -- deliver status update (only in "all" mode)
                 # Skip periodic updates for agent_notify watchers (they only care about completion)
-                new_output = session.output_buffer[-500:] if session.output_buffer else ""
+                from tools.ansi_strip import strip_ansi
+
+                new_output = (
+                    strip_ansi(session.output_buffer[-500:])
+                    if session.output_buffer
+                    else ""
+                )
                 message_text = (
                     f"[Background process {session_id} is still running~ "
                     f"New output:\n{new_output}]"

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -246,6 +246,63 @@ async def test_no_thread_id_sends_no_metadata(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_finished_notification_strips_ansi_output(monkeypatch, tmp_path):
+    import tools.process_registry as pr_module
+
+    sessions = [
+        SimpleNamespace(
+            output_buffer="\x1b[31merror line\x1b[0m\n",
+            exited=True,
+            exit_code=1,
+        )
+    ]
+    monkeypatch.setattr(pr_module, "process_registry", _FakeRegistry(sessions))
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = runner.adapters[Platform.TELEGRAM]
+
+    await runner._run_process_watcher(_watcher_dict())
+
+    sent_message = adapter.send.await_args.args[1]
+    assert "\x1b[" not in sent_message
+    assert "error line" in sent_message
+
+
+@pytest.mark.asyncio
+async def test_running_notification_strips_ansi_output(monkeypatch, tmp_path):
+    import tools.process_registry as pr_module
+
+    sessions = [
+        SimpleNamespace(
+            output_buffer="\x1b[32mbuilding...\x1b[0m\n",
+            exited=False,
+            exit_code=None,
+        ),
+        None,
+    ]
+    monkeypatch.setattr(pr_module, "process_registry", _FakeRegistry(sessions))
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = runner.adapters[Platform.TELEGRAM]
+
+    await runner._run_process_watcher(_watcher_dict())
+
+    sent_message = adapter.send.await_args.args[1]
+    assert "\x1b[" not in sent_message
+    assert "building..." in sent_message
+
+
+@pytest.mark.asyncio
 async def test_inject_watch_notification_routes_from_session_store_origin(monkeypatch, tmp_path):
     from gateway.session import SessionSource
 


### PR DESCRIPTION
## Summary
- strip ANSI escape sequences from background watcher completion notifications
- strip ANSI escape sequences from running-output watcher updates as well
- add regression coverage for both message paths

## Why
The gateway already has a shared `tools.ansi_strip.strip_ansi()` helper, but these two watcher-to-chat notification paths were still sending raw control sequences back to users. That pollutes chat text with terminal color/control bytes.

## Validation
- `python3 -m pytest tests/gateway/test_background_process_notifications.py -q`