### PR TITLE
fix(feishu): suppress group progress noise and skip placeholder media

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1358,6 +1358,12 @@ class BasePlatformAdapter(ABC):
             if len(path) >= 2 and path[0] == path[-1] and path[0] in "`\"'":
                 path = path[1:-1].strip()
             path = path.lstrip("`\"'").rstrip("`\"',.;:)}]")
+            lowered_path = path.lower()
+            if (
+                lowered_path in {"<path>", "<file>", "<filepath>", "<screenshot_path>", "<image_path>", "{path}", "{file}"}
+                or (lowered_path.startswith("<") and lowered_path.endswith(">"))
+            ):
+                continue
             if path:
                 media.append((os.path.expanduser(path), has_voice_tag))
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -28,7 +28,7 @@ from collections import OrderedDict
 from contextvars import copy_context
 from pathlib import Path
 from datetime import datetime
-from typing import Dict, Optional, Any, List
+from typing import Dict, Optional, Any, List, Tuple
 
 # --- Agent cache tuning ---------------------------------------------------
 # Bounds the per-session AIAgent cache to prevent unbounded growth in
@@ -88,6 +88,61 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from hermes_constants import get_hermes_home
 from utils import atomic_yaml_write, is_truthy_value
 _hermes_home = get_hermes_home()
+
+_MEDIA_TAG_RE = re.compile(r"MEDIA:\s*(\S+)")
+_PLACEHOLDER_MEDIA_PATHS = {
+    "<path>",
+    "<file>",
+    "<filepath>",
+    "<screenshot_path>",
+    "<image_path>",
+    "{path}",
+    "{file}",
+}
+
+
+def _normalize_media_tag_path(raw_path: str) -> Optional[str]:
+    """Return a deliverable local media path, ignoring docs placeholders."""
+    path = (raw_path or "").strip().strip("`\"'")
+    path = path.rstrip('",.;:)}]')
+    if not path:
+        return None
+    lowered = path.lower()
+    if lowered in _PLACEHOLDER_MEDIA_PATHS:
+        return None
+    if lowered.startswith("<") and lowered.endswith(">"):
+        return None
+    if not (path.startswith("/") or path.startswith("~/")):
+        return None
+    return path
+
+
+def _iter_media_paths_from_content(content: str):
+    for match in _MEDIA_TAG_RE.finditer(content or ""):
+        path = _normalize_media_tag_path(match.group(1))
+        if path:
+            yield path
+
+
+def _extract_media_tags_from_tool_messages(
+    messages: List[Dict[str, Any]],
+    history_media_paths: set,
+) -> Tuple[List[str], bool]:
+    """Extract new deliverable MEDIA tags from tool/function messages."""
+    media_tags: List[str] = []
+    has_voice_directive = False
+    for msg in messages:
+        if msg.get("role") not in ("tool", "function"):
+            continue
+        content = msg.get("content", "") or ""
+        if "MEDIA:" not in content:
+            continue
+        for path in _iter_media_paths_from_content(content):
+            if path not in history_media_paths:
+                media_tags.append(f"MEDIA:{path}")
+        if "[[audio_as_voice]]" in content:
+            has_voice_directive = True
+    return media_tags, has_voice_directive
 
 # Load environment variables from ~/.hermes/.env first.
 # User-managed env files should override stale shell exports on restart.
@@ -9160,7 +9215,14 @@ class GatewayRunner:
         # Disable tool progress for webhooks - they don't support message editing,
         # so each progress line would be sent as a separate message.
         from gateway.config import Platform
-        tool_progress_enabled = progress_mode != "off" and source.platform != Platform.WEBHOOK
+        feishu_group_visual_noise = (
+            source.platform == Platform.FEISHU and source.chat_type != "dm"
+        )
+        tool_progress_enabled = (
+            progress_mode != "off"
+            and source.platform != Platform.WEBHOOK
+            and not feishu_group_visual_noise
+        )
         # Natural assistant status messages are intentionally independent from
         # tool progress and token streaming. Users can keep tool_progress quiet
         # in chat platforms while opting into concise mid-turn updates.
@@ -9433,7 +9495,7 @@ class GatewayRunner:
         _status_thread_metadata = {"thread_id": _progress_thread_id} if _progress_thread_id else None
 
         def _status_callback_sync(event_type: str, message: str) -> None:
-            if not _status_adapter or not _run_still_current():
+            if not _status_adapter or feishu_group_visual_noise or not _run_still_current():
                 return
             try:
                 asyncio.run_coroutine_threadsafe(
@@ -9791,10 +9853,8 @@ class GatewayRunner:
                 if _hm.get("role") in ("tool", "function"):
                     _hc = _hm.get("content", "")
                     if "MEDIA:" in _hc:
-                        for _match in re.finditer(r'MEDIA:(\S+)', _hc):
-                            _p = _match.group(1).strip().rstrip('",}')
-                            if _p:
-                                _history_media_paths.add(_p)
+                        for _p in _iter_media_paths_from_content(_hc):
+                            _history_media_paths.add(_p)
             
             # Register per-session gateway approval callback so dangerous
             # command approval blocks the agent thread (mirrors CLI input()).
@@ -9983,18 +10043,10 @@ class GatewayRunner:
             # before run_conversation) instead of index slicing. This is safe even
             # when context compression shrinks the message list. (Fixes #160)
             if "MEDIA:" not in final_response:
-                media_tags = []
-                has_voice_directive = False
-                for msg in result.get("messages", []):
-                    if msg.get("role") in ("tool", "function"):
-                        content = msg.get("content", "")
-                        if "MEDIA:" in content:
-                            for match in re.finditer(r'MEDIA:(\S+)', content):
-                                path = match.group(1).strip().rstrip('",}')
-                                if path and path not in _history_media_paths:
-                                    media_tags.append(f"MEDIA:{path}")
-                            if "[[audio_as_voice]]" in content:
-                                has_voice_directive = True
+                media_tags, has_voice_directive = _extract_media_tags_from_tool_messages(
+                    result.get("messages", []),
+                    _history_media_paths,
+                )
                 
                 if media_tags:
                     seen = set()

--- a/tests/gateway/test_media_extraction.py
+++ b/tests/gateway/test_media_extraction.py
@@ -179,6 +179,25 @@ class TestMediaExtraction:
         unique = [t for t in tags if t not in seen and not seen.add(t)]
         assert len(unique) == 2  # After dedup: same.ogg and different.ogg
 
+    def test_gateway_extractor_ignores_placeholder_media_path(self):
+        from gateway.run import _extract_media_tags_from_tool_messages
+
+        messages = [
+            {
+                "role": "tool",
+                "content": (
+                    '{"success": false, "note": "Screenshot captured. '
+                    'You can still share it via MEDIA:<path>."}'
+                ),
+            },
+            {"role": "tool", "content": "MEDIA:/tmp/real-chart.png"},
+        ]
+
+        tags, voice = _extract_media_tags_from_tool_messages(messages, set())
+
+        assert tags == ["MEDIA:/tmp/real-chart.png"]
+        assert voice is False
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -241,6 +241,64 @@ async def test_run_agent_progress_does_not_use_event_message_id_for_telegram_dm(
 
 
 @pytest.mark.asyncio
+async def test_run_agent_suppresses_feishu_group_tool_progress(monkeypatch, tmp_path):
+    """Feishu group chats should not receive internal tool-progress messages."""
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    class FeishuGroupAgent:
+        def __init__(self, **kwargs):
+            self.tool_progress_callback = kwargs.get("tool_progress_callback")
+            self.status_callback = kwargs.get("status_callback")
+            self.tools = []
+
+        def run_conversation(self, message, conversation_history=None, task_id=None):
+            if self.tool_progress_callback:
+                self.tool_progress_callback("tool.started", "terminal", "pwd", {})
+            if self.status_callback:
+                self.status_callback("status", "processing")
+            return {
+                "final_response": "done",
+                "messages": [],
+                "api_calls": 1,
+            }
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FeishuGroupAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = ProgressCaptureAdapter(platform=Platform.FEISHU)
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    source = SessionSource(
+        platform=Platform.FEISHU,
+        chat_id="oc_group",
+        chat_type="group",
+        thread_id=None,
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-feishu-group",
+        session_key="agent:main:feishu:group:oc_group",
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.sent == []
+    assert adapter.edits == []
+    assert adapter.typing == []
+
+
+@pytest.mark.asyncio
 async def test_run_agent_progress_uses_event_message_id_for_slack_dm(monkeypatch, tmp_path):
     """Slack DM progress should keep event ts fallback threading."""
     monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")

--- a/tests/gateway/test_send_image_file.py
+++ b/tests/gateway/test_send_image_file.py
@@ -57,6 +57,12 @@ class TestExtractMediaImages:
         assert "/audio.ogg" in paths
         assert "/screenshot.png" in paths
 
+    def test_placeholder_media_path_not_extracted(self):
+        content = "Screenshot captured. You can still share it via MEDIA:<path>."
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == []
+        assert "MEDIA:<path>" in cleaned
+
 
 # ---------------------------------------------------------------------------
 # Telegram send_image_file tests

--- a/tests/tools/test_browser_console.py
+++ b/tests/tools/test_browser_console.py
@@ -251,6 +251,26 @@ class TestBrowserVisionConfig:
         assert mock_llm.call_args.kwargs["temperature"] == 0.1
         assert mock_llm.call_args.kwargs["timeout"] == 120.0
 
+    def test_failed_analysis_note_does_not_emit_placeholder_media_tag(self, tmp_path):
+        """Failed browser_vision should not advertise literal MEDIA:<path>."""
+        from tools.browser_tool import browser_vision
+
+        shots_dir, screenshot = self._setup_screenshot(tmp_path)
+
+        with (
+            patch("hermes_constants.get_hermes_dir", return_value=shots_dir),
+            patch("tools.browser_tool._cleanup_old_screenshots"),
+            patch("tools.browser_tool._run_browser_command", return_value={"success": True, "data": {"path": str(screenshot)}}),
+            patch("tools.browser_tool._get_vision_model", return_value="test-model"),
+            patch("hermes_cli.config.load_config", return_value={"auxiliary": {"vision": {}}}),
+            patch("tools.browser_tool.call_llm", side_effect=TimeoutError("Request timed out.")),
+        ):
+            result = json.loads(browser_vision("what is on the page?", task_id="test"))
+
+        assert result["success"] is False
+        assert result["screenshot_path"] == str(screenshot)
+        assert "MEDIA:<path>" not in result.get("note", "")
+
 
 # ── auto-recording config ────────────────────────────────────────────
 

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2178,7 +2178,7 @@ def browser_vision(question: str, annotate: bool = False, task_id: Optional[str]
         error_info = {"success": False, "error": f"Error during vision analysis: {str(e)}"}
         if screenshot_path.exists():
             error_info["screenshot_path"] = str(screenshot_path)
-            error_info["note"] = "Screenshot was captured but vision analysis failed. You can still share it via MEDIA:<path>."
+            error_info["note"] = "Screenshot was captured but vision analysis failed. Use screenshot_path to attach it if needed."
         return json.dumps(error_info, ensure_ascii=False)
 
 


### PR DESCRIPTION
## Summary
- suppress tool/status progress chatter in Feishu group chats while keeping DM behavior unchanged
- ignore placeholder `MEDIA:<path>` style documentation tags during adapter and gateway media extraction
- stop `browser_vision` failure notes from advertising a fake deliverable media tag

## Testing
- `.venv/bin/python -m pytest tests/gateway/test_media_extraction.py tests/gateway/test_send_image_file.py tests/tools/test_browser_console.py tests/gateway/test_run_progress_topics.py -q -n0`
