### PR TITLE
feat: Add config option to disable Discord slash commands

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -527,6 +527,7 @@ class DiscordAdapter(BasePlatformAdapter):
         # Reply threading mode: "off" (no replies), "first" (reply on first
         # chunk only, default), "all" (reply-reference on every chunk).
         self._reply_to_mode: str = getattr(config, 'reply_to_mode', 'first') or 'first'
+        self._slash_commands: bool = self.config.extra.get("slash_commands", True) or True
 
     async def connect(self) -> bool:
         """Connect to Discord and start receiving events."""
@@ -745,7 +746,8 @@ class DiscordAdapter(BasePlatformAdapter):
                     )
 
             # Register slash commands
-            self._register_slash_commands()
+            if self._slash_commands:
+                self._register_slash_commands()
 
             # Start the bot in background
             self._bot_task = asyncio.create_task(self._client.start(self.config.token))


### PR DESCRIPTION
## Summary

Adds a new `discord.slash_commands` config option (default: `true`) to disable Discord slash command registration when running Hermes alongside other bots that use the same command names.

## Problem

When running Hermes alongside other Discord bots on the same server, Hermes's registered slash commands (e.g. `/stop`, `/reset`, `/status`) override identical slash commands used by other bots. Discord's slash command autocomplete intercepts input before other bots can parse it as a text message.

Text-based parsing of `/command` continues to work perfectly without slash commands registered.

## Solution

Add `discord.slash_commands: false` to config.yaml:

```yaml
discord:
  slash_commands: false
```

When `false`, `_register_slash_commands()` is skipped. The text-based `/command` parsing continues to work normally.

## Changes

- `gateway/platforms/discord.py`: Added `self._slash_commands` initialization from `config.extra.get("slash_commands", True)`
- Modified `connect()` to conditionally call `_register_slash_commands()` only when `_slash_commands` is `True`

Fixes #4881