### PR TITLE
fix(runtime): check providers: dict even for resolved provider aliases

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -284,19 +284,26 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
     # Raw names should only map to custom providers when they are not already
     # valid built-in providers or aliases. Explicit menu keys like
     # ``custom:local`` always target the saved custom provider.
+    # However, we still check the user's providers: dict even for resolved
+    # aliases (e.g. "lmstudio" → "custom") because users may have defined
+    # a custom provider under that alias name. See GitHub issue re: lmstudio
+    # provider alias shadowing user-defined providers: dict entries.
     if requested_norm == "auto":
         return None
+    built_in_match = False
     if not requested_norm.startswith("custom:"):
         try:
             auth_mod.resolve_provider(requested_norm)
         except AuthError:
             pass
         else:
-            return None
+            built_in_match = True
 
     config = load_config()
     
     # First check providers: dict (new-style user-defined providers)
+    # We check this regardless of built_in_match, because users can define
+    # custom providers under names that happen to be aliases (e.g. "lmstudio").
     providers = config.get("providers")
     if isinstance(providers, dict):
         for ep_name, entry in providers.items():


### PR DESCRIPTION
## Problem

When `resolve_provider()` successfully maps an alias like `lmstudio` to `custom`, the code was returning `None` immediately, skipping the user's `providers:` dict entirely. This meant custom provider definitions under alias names (e.g. `providers.lmstudio`) were silently ignored, causing fallback to openrouter.

## Fix

Continue to check `providers:` dict regardless of built-in alias resolution, allowing user-defined custom providers to shadow aliases.

## Changes

- `hermes_cli/runtime_provider.py`: `_get_named_custom_provider()` now stores the built-in match result in a flag instead of returning early, allowing the providers: dict check to proceed for all non-`auto`/non-`custom` requests.