### PR TITLE
fix(approval): redact secrets in user-facing approval prompts

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -426,9 +426,17 @@ def prompt_dangerous_approval(command: str, description: str,
     if timeout_seconds is None:
         timeout_seconds = _get_approval_timeout()
 
+    # Redact secrets before any user-visible rendering. The original
+    # `command` is still what executes after approval; only the displayed
+    # copy is scrubbed. Reuses the same redaction module used for memory
+    # and log sanitization so tokens mask consistently across surfaces.
+    from agent.redact import redact_sensitive_text
+    display_command = redact_sensitive_text(command)
+    display_description = redact_sensitive_text(description)
+
     if approval_callback is not None:
         try:
-            return approval_callback(command, description,
+            return approval_callback(display_command, display_description,
                                      allow_permanent=allow_permanent)
         except Exception as e:
             logger.error("Approval callback failed: %s", e, exc_info=True)
@@ -438,8 +446,8 @@ def prompt_dangerous_approval(command: str, description: str,
     try:
         while True:
             print()
-            print(f"  ⚠️  DANGEROUS COMMAND: {description}")
-            print(f"      {command}")
+            print(f"  ⚠️  DANGEROUS COMMAND: {display_description}")
+            print(f"      {display_command}")
             print()
             if allow_permanent:
                 print("      [o]nce  |  [s]ession  |  [a]lways  |  [d]eny")
@@ -844,11 +852,17 @@ def check_all_command_guards(command: str, env_type: str,
             # --- Blocking gateway approval (queue-based) ---
             # Each call gets its own _ApprovalEntry so parallel subagents
             # and execute_code threads can block concurrently.
+            #
+            # Redact secrets in the notified payload: gateway renders this
+            # dict directly to Discord/Slack/etc. and those messages are
+            # screenshottable. The raw `command` still executes after
+            # approval via the closure below, so redaction is display-only.
+            from agent.redact import redact_sensitive_text
             approval_data = {
-                "command": command,
+                "command": redact_sensitive_text(command),
                 "pattern_key": primary_key,
                 "pattern_keys": all_keys,
-                "description": combined_desc,
+                "description": redact_sensitive_text(combined_desc),
             }
             entry = _ApprovalEntry(approval_data)
             with _lock:


### PR DESCRIPTION
## What does this PR do?

The dangerous-command approval prompt renders the flagged command text so the user can decide whether to approve. This happens in two places:

1. **CLI terminal** (`prompt_dangerous_approval`): prints command + description to stdout for the interactive `[o]nce / [s]ession / [a]lways / [d]eny` choice
2. **Gateway** (`approval_data` dict → `notify_cb`): sends command + description to Discord/Slack/etc. so the user can approve via slash command

If the agent constructs a command containing credentials — `curl -H "Authorization: Bearer sk-..."`, `psql postgres://user:password@host`, `gh auth login --with-token ghp_...` — those secrets end up on-screen and in messaging platforms. Discord messages in particular are screenshottable and forwardable.

This PR applies the existing `agent.redact.redact_sensitive_text()` (introduced in 9ca954a2 for memory/log sanitization) to both approval display paths. The raw `command` in the enclosing closure is untouched and is still what executes after approval — redaction is display-only, so users still see enough context to make an approval decision (command structure, flag names, target URLs) while the token value itself is masked.

**Why reuse `redact_sensitive_text` instead of a new pattern list:** 9ca954a2 already established `agent/redact.py` as the canonical secret-masking path. Reusing it keeps token coverage consistent across memory, logs, and approval surfaces, and means future additions to the pattern list automatically apply here too.

## Related Issue

Related to #8738 (broader redaction hardening — gateway-mode force-on + config.yaml write protection). This PR is a narrower, complementary change: applying existing redaction to the approval-prompt surface specifically.

## Type of Change

- [x] 🔒 Security fix
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/approval.py`:
  - `prompt_dangerous_approval()`: redacts `command` + `description` via `redact_sensitive_text()` before handing them to `approval_callback` or the stdout fallback
  - Gateway `approval_data` dict construction: redacts `command` + `combined_desc` before `notify_cb(...)` delivers them to the messaging platform

No new patterns, no module additions, no behavioral change to the approval-decision logic itself.

## How to Test

**Reproduce the issue without the patch:**

1. Configure a local llama.cpp endpoint or any model provider; enable gateway + Discord (or run CLI with tirith/pattern-matcher enabled)
2. Have the agent construct a command with a fake credential, e.g.:
   ```
   curl -H "Authorization: Bearer sk-proj-REDACTED1234567890" https://api.openai.com/v1/models
   ```
3. Observe that the approval prompt (stdout or Discord notification) renders the full `Bearer sk-proj-...` token verbatim.

**Verify the fix:**

1. Check out this branch
2. Repeat steps 1-2 above
3. Approval prompt now renders `Authorization: Bearer ***` (token masked); the decision context (URL, method, scheme) is preserved
4. Approve the command and confirm it still executes successfully — the original token is passed to the underlying shell, only the display is scrubbed

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(approval): ...`)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (single commit, single file, no unrelated changes)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04 / Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (display-only behavior change, covered by inline code comments)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (no platform-specific code; reuses existing cross-platform `redact_sensitive_text`)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no tool schema changes)

## Screenshots / Logs

**Before** (approval prompt with secret in plaintext):
```
⚠️  DANGEROUS COMMAND: pipe remote content to shell; potential credential exposure
    curl -H "Authorization: Bearer sk-proj-abc123xyz4567890abcdef" https://api.openai.com/v1/models | jq .data

    [o]nce  |  [s]ession  |  [a]lways  |  [d]eny
```

**After** (same command, redacted):
```
⚠️  DANGEROUS COMMAND: pipe remote content to shell; potential credential exposure
    curl -H "Authorization: Bearer ***" https://api.openai.com/v1/models | jq .data

    [o]nce  |  [s]ession  |  [a]lways  |  [d]eny
```

## Follow-up (separate PR, out of scope)

Noticed `agent/redact.py`'s DSN pattern covers `postgres://`, `mysql://`, `mongodb://`, `redis://`, `amqp://` but not `http://` / `https://` URL-embedded basic auth (`http://user:password@host`). Probably worth a small follow-up to extend coverage, but intentionally left out of this PR to keep scope tight.