### PR TITLE
Add complete Docker image and publish workflow

### DIFF
--- a/.github/workflows/docker-publish-complete.yml
+++ b/.github/workflows/docker-publish-complete.yml
@@ -1,0 +1,129 @@
+name: Docker Build and Publish (Complete)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**/*.py'
+      - 'skills/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - 'Dockerfile'
+      - 'Dockerfile.complete'
+      - 'docker/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'web/package.json'
+      - 'web/package-lock.json'
+      - '.github/workflows/docker-publish-complete.yml'
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docker-complete-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push:
+    # Only run on the upstream repository, not on forks
+    if: github.repository == 'NousResearch/hermes-agent'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          submodules: recursive
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
+
+      # Build amd64 only so we can `load` the image for smoke testing.
+      # `load: true` cannot export a multi-arch manifest to the local daemon.
+      # The multi-arch build follows on push to main / release.
+      - name: Build image (amd64, smoke test)
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
+        with:
+          context: .
+          file: Dockerfile.complete
+          load: true
+          platforms: linux/amd64
+          tags: nousresearch/hermes-agent:complete-test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Test image starts
+        run: |
+          mkdir -p /tmp/hermes-complete-test
+          sudo chown -R 10000:10000 /tmp/hermes-complete-test
+          docker run --rm \
+            -v /tmp/hermes-complete-test:/opt/data \
+            --entrypoint /opt/hermes/docker/entrypoint.sh \
+            nousresearch/hermes-agent:complete-test --help
+
+      - name: Smoke test complete image tools
+        run: |
+          mkdir -p /tmp/hermes-complete-test
+          sudo chown -R 10000:10000 /tmp/hermes-complete-test
+          docker run --rm \
+            -v /tmp/hermes-complete-test:/opt/data \
+            --entrypoint /bin/bash \
+            nousresearch/hermes-agent:complete-test \
+            -lc '
+              source /opt/hermes/.venv/bin/activate
+              hermes --help >/dev/null
+              command -v claude
+              command -v gemini
+              command -v codex
+              command -v opencode
+              python - <<'"'"'PY'"'"'
+              import importlib
+
+              for module in (
+                  "pygount",
+                  "jupyterlab",
+                  "youtube_transcript_api",
+                  "PIL",
+                  "docx",
+              ):
+                  importlib.import_module(module)
+              PY
+              python -m markitdown --help >/dev/null
+            '
+
+      - name: Log in to Docker Hub
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'release'
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Push multi-arch image (main branch)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
+        with:
+          context: .
+          file: Dockerfile.complete
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: nousresearch/hermes-agent:complete-latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Push multi-arch image (release)
+        if: github.event_name == 'release'
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
+        with:
+          context: .
+          file: Dockerfile.complete
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: nousresearch/hermes-agent:complete-${{ github.event.release.tag_name }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile.complete
+++ b/Dockerfile.complete
@@ -1,0 +1,67 @@
+FROM ghcr.io/astral-sh/uv:0.11.6-python3.13-trixie@sha256:b3c543b6c4f23a5f2df22866bd7857e5d304b67a564f4feab6ac22044dde719b AS uv_source
+FROM tianon/gosu:1.19-trixie@sha256:3b176695959c71e123eb390d427efc665eeb561b1540e82679c15e992006b8b9 AS gosu_source
+FROM debian:13.4
+
+# Disable Python stdout buffering to ensure logs are printed immediately
+ENV PYTHONUNBUFFERED=1
+
+# Store Playwright browsers outside the volume mount so the build-time
+# install survives the /opt/data volume overlay at runtime.
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/hermes/.playwright
+
+# Install system dependencies in one layer, clear APT cache
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential nodejs npm python3 ripgrep ffmpeg gcc python3-dev libffi-dev procps git && \
+    rm -rf /var/lib/apt/lists/*
+
+# Non-root user for runtime; UID can be overridden via HERMES_UID at runtime
+RUN useradd -u 10000 -m -d /opt/data hermes
+
+COPY --chmod=0755 --from=gosu_source /gosu /usr/local/bin/
+COPY --chmod=0755 --from=uv_source /usr/local/bin/uv /usr/local/bin/uvx /usr/local/bin/
+
+WORKDIR /opt/hermes
+
+# ---------- Layer-cached dependency install ----------
+# Copy only package manifests first so npm install + Playwright are cached
+# unless the lockfiles themselves change.
+COPY package.json package-lock.json ./
+COPY web/package.json web/package-lock.json web/
+
+RUN npm install --prefer-offline --no-audit && \
+    npm install -g --no-fund --no-audit \
+        @anthropic-ai/claude-code \
+        @google/gemini-cli \
+        @openai/codex \
+        opencode-ai@latest && \
+    npx playwright install --with-deps chromium --only-shell && \
+    (cd web && npm install --prefer-offline --no-audit) && \
+    npm cache clean --force
+
+# ---------- Source code ----------
+# .dockerignore excludes node_modules, so the installs above survive.
+COPY --chown=hermes:hermes . .
+
+# Build web dashboard (Vite outputs to hermes_cli/web_dist/)
+RUN cd web && npm run build
+
+# ---------- Python virtualenv ----------
+RUN chown hermes:hermes /opt/hermes
+USER hermes
+RUN uv venv && \
+    uv pip install --no-cache-dir -e ".[all]" && \
+    uv pip install --no-cache-dir \
+        pygount \
+        jupyterlab \
+        youtube-transcript-api \
+        "markitdown[pptx]" \
+        Pillow \
+        python-docx \
+        pyfiglet
+
+# ---------- Runtime ----------
+ENV HERMES_WEB_DIST=/opt/hermes/hermes_cli/web_dist
+ENV HERMES_HOME=/opt/data
+VOLUME [ "/opt/data" ]
+ENTRYPOINT [ "/opt/hermes/docker/entrypoint.sh" ]

--- a/website/docs/user-guide/docker.md
+++ b/website/docs/user-guide/docker.md
@@ -210,6 +210,34 @@ The entrypoint script (`docker/entrypoint.sh`) bootstraps the data volume on fir
 - Syncs bundled skills using a manifest-based approach (preserves user edits)
 - Then runs `hermes` with whatever arguments you pass
 
+## Image variants
+
+Hermes publishes two Docker image variants:
+
+| Image | Purpose |
+|------|----------|
+| `nousresearch/hermes-agent:latest` | Lean/default image. This is the current official image and stays focused on the core Hermes runtime. |
+| `nousresearch/hermes-agent:complete-latest` | Lean image plus extra global npm CLIs and lightweight bundled-skill Python packages. |
+
+The `complete` image adds these extra packages on top of `latest`:
+
+| Type | Packages |
+|------|----------|
+| npm | `claude`, `gemini`, `codex`, `opencode` |
+| Python | `pygount`, `jupyterlab`, `youtube-transcript-api`, `markitdown[pptx]`, `Pillow`, `python-docx`, `pyfiglet` |
+
+The `complete` image is intentionally narrow. It does **not** add:
+
+- extra system packages beyond the current image
+- Docker / GitHub / vendor binary additions
+- heavy ML, OCR, or LaTeX stacks
+- `pptxgenjs` in this pass, because the bundled PowerPoint skill documents it as a Node module workflow rather than a clear CLI requirement
+
+Release tags follow the same split:
+
+- `nousresearch/hermes-agent:latest` and `nousresearch/hermes-agent:<tag>` for the lean image
+- `nousresearch/hermes-agent:complete-latest` and `nousresearch/hermes-agent:complete-<tag>` for the constrained complete image
+
 ## Upgrading
 
 Pull the latest image and recreate the container. Your data directory is untouched.


### PR DESCRIPTION
## Summary

This adds an opt-in `complete` Docker image variant for Hermes users who want a fuller container environment without changing the current lean/default image.

The existing `Dockerfile` and Docker publish workflow stay as-is. This PR introduces a parallel `complete` path with its own image tags and workflow.

## What changed

### New `Dockerfile.complete`
- starts from the current Dockerfile layout and behavior
- keeps the same base image, entrypoint model, web build, Playwright setup, and Hermes install flow
- adds these global npm CLIs:
  - `@anthropic-ai/claude-code`
  - `@google/gemini-cli`
  - `@openai/codex`
  - `opencode-ai@latest`
- adds these lightweight Python packages used by bundled skills:
  - `pygount`
  - `jupyterlab`
  - `youtube-transcript-api`
  - `markitdown[pptx]`
  - `Pillow`
  - `python-docx`
  - `pyfiglet`

### New publish workflow
Adds `.github/workflows/docker-publish-complete.yml` which mirrors the existing Docker publish workflow, but builds from `Dockerfile.complete` and publishes separate tags:
- `nousresearch/hermes-agent:complete-latest` from `main`
- `nousresearch/hermes-agent:complete-<release-tag>` from releases

The workflow also includes smoke checks for:
- container startup
- `hermes --help`
- `claude`, `gemini`, `codex`, and `opencode` on `PATH`
- Python imports for `pygount`, `jupyterlab`, `youtube_transcript_api`, `PIL`, and `docx`
- `python -m markitdown --help`

### Docker docs update
Updates the Docker guide to explain:
- `latest` remains the lean/default image
- `complete-latest` is the fuller opt-in variant
- which npm CLIs and Python packages are added in `complete`
- what is intentionally excluded from this pass

## Why this shape

The goal is to improve the Docker experience for Hermes users who need more built-in tooling, without turning the default image into a large general-purpose environment.

This keeps the current default image stable and introduces a separate published variant for the fuller setup.

## Explicit exclusions

This PR does not add:
- extra system packages beyond the current base image
- vendor CLIs such as Docker, GitHub CLI, or Cosign
- heavy ML / OCR / LaTeX / Java stacks
- heavyweight optional-skill-specific tooling
- `pptxgenjs` in this pass

## Validation

I did not run a local Docker build or workflow validation in this workspace.

Closes #13141
