### PR TITLE
fix(model_switch): deduplicate custom providers — register prefixed slug in seen_slugs

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1095,6 +1095,7 @@ def list_authenticated_providers(
                 "api_url": api_url,
             })
             seen_slugs.add(ep_name.lower())
+            seen_slugs.add(custom_provider_slug(display_name).lower())
             _pair = (
                 str(display_name).strip().lower(),
                 str(api_url).strip().rstrip("/").lower(),


### PR DESCRIPTION
## Summary
Registers `custom_provider_slug(display_name).lower()` in `seen_slugs` after Section 3 emits a user-defined provider, so Section 4's dedup check correctly suppresses the duplicate entry.

Closes #12293. Salvaged from PR #13114 (@bennytimz).

## Changes
- `hermes_cli/model_switch.py`: +1 line after Section 3's `seen_slugs.add(ep_name.lower())`

## Validation
| | Before | After |
|---|---|---|
| Custom provider in both sections | Two rows in `/model` picker | One row |
| Section-4-only provider | One row | One row (no regression) |

63 existing tests pass.