### PR TITLE
fix(tools): reap orphaned cloud browser daemons with hermes session prefix

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -582,6 +582,8 @@ def _reap_orphaned_browser_sessions():
     socket_dirs = glob.glob(pattern)
     # Also pick up CDP sessions
     socket_dirs += glob.glob(os.path.join(tmpdir, "agent-browser-cdp_*"))
+    # Also pick up cloud-provider sessions (browser-use/browserbase/firecrawl)
+    socket_dirs += glob.glob(os.path.join(tmpdir, "agent-browser-hermes_*"))
 
     if not socket_dirs:
         return


### PR DESCRIPTION
## Summary
Salvage of #13084 by @AllardQuek — cherry-picked onto current main.

Cloud browser providers (Browserbase, Browser Use, Firecrawl) create session dirs with `hermes_` prefix, but the orphan reaper only scanned `h_*` and `cdp_*`. Stale cloud daemons were never cleaned up.

## Changes
- `tools/browser_tool.py`: add `agent-browser-hermes_*` glob to `_reap_orphaned_browser_sessions()`

## Validation
19/19 browser CDP tests pass.

Closes #13081