### PR TITLE
feat(models): add kimi-k2.6 to opencode-zen/go, alibaba, HuggingFace

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -167,6 +167,7 @@ DEFAULT_CONTEXT_LENGTHS = {
     "Qwen/Qwen3.5-397B-A17B": 131072,
     "Qwen/Qwen3.5-35B-A3B": 131072,
     "deepseek-ai/DeepSeek-V3.2": 65536,
+    "moonshotai/Kimi-K2.6": 262144,
     "moonshotai/Kimi-K2.5": 262144,
     "moonshotai/Kimi-K2-Thinking": 262144,
     "MiniMaxAI/MiniMax-M2.5": 204800,

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -230,6 +230,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "trinity-mini",
     ],
     "opencode-zen": [
+        "kimi-k2.6",
         "kimi-k2.5",
         "gpt-5.4-pro",
         "gpt-5.4",
@@ -267,6 +268,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "big-pickle",
     ],
     "opencode-go": [
+        "kimi-k2.6",
         "kimi-k2.5",
         "glm-5.1",
         "glm-5",
@@ -302,6 +304,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     # to https://dashscope-intl.aliyuncs.com/compatible-mode/v1 (OpenAI-compat)
     # or https://dashscope-intl.aliyuncs.com/apps/anthropic (Anthropic-compat).
     "alibaba": [
+        "kimi-k2.6",
         "kimi-k2.5",
         "qwen3.5-plus",
         "qwen3-coder-plus",
@@ -313,6 +316,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     ],
     # Curated HF model list — only agentic models that map to OpenRouter defaults.
     "huggingface": [
+        "moonshotai/Kimi-K2.6",
         "moonshotai/Kimi-K2.5",
         "Qwen/Qwen3.5-397B-A17B",
         "Qwen/Qwen3.5-35B-A3B",

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -100,12 +100,13 @@ _DEFAULT_PROVIDER_MODELS = {
     "minimax-cn": ["MiniMax-M2.7", "MiniMax-M2.5", "MiniMax-M2.1", "MiniMax-M2"],
     "ai-gateway": ["anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5", "google/gemini-3-flash"],
     "kilocode": ["anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5.4", "google/gemini-3-pro-preview", "google/gemini-3-flash-preview"],
-    "opencode-zen": ["gpt-5.4", "gpt-5.3-codex", "claude-sonnet-4-6", "gemini-3-flash", "glm-5", "kimi-k2.5", "minimax-m2.7"],
-    "opencode-go": ["glm-5.1", "glm-5", "kimi-k2.5", "mimo-v2-pro", "mimo-v2-omni", "minimax-m2.5", "minimax-m2.7"],
+    "opencode-zen": ["gpt-5.4", "gpt-5.3-codex", "claude-sonnet-4-6", "gemini-3-flash", "glm-5", "kimi-k2.6", "kimi-k2.5", "minimax-m2.7"],
+    "opencode-go": ["glm-5.1", "glm-5", "kimi-k2.6", "kimi-k2.5", "mimo-v2-pro", "mimo-v2-omni", "minimax-m2.5", "minimax-m2.7"],
     "huggingface": [
         "Qwen/Qwen3.5-397B-A17B", "Qwen/Qwen3-235B-A22B-Thinking-2507",
         "Qwen/Qwen3-Coder-480B-A35B-Instruct", "deepseek-ai/DeepSeek-R1-0528",
-        "deepseek-ai/DeepSeek-V3.2", "moonshotai/Kimi-K2.5",
+        "deepseek-ai/DeepSeek-V3.2", "moonshotai/Kimi-K2.6",
+        "moonshotai/Kimi-K2.5",
     ],
 }
 

--- a/tests/hermes_cli/test_opencode_go_in_model_list.py
+++ b/tests/hermes_cli/test_opencode_go_in_model_list.py
@@ -15,7 +15,7 @@ def test_opencode_go_appears_when_api_key_set():
     opencode_go = next((p for p in providers if p["slug"] == "opencode-go"), None)
     
     assert opencode_go is not None, "opencode-go should appear when OPENCODE_GO_API_KEY is set"
-    assert opencode_go["models"] == ["kimi-k2.5", "glm-5.1", "glm-5", "mimo-v2-pro", "mimo-v2-omni", "minimax-m2.7", "minimax-m2.5"]
+    assert opencode_go["models"] == ["kimi-k2.6", "kimi-k2.5", "glm-5.1", "glm-5", "mimo-v2-pro", "mimo-v2-omni", "minimax-m2.7", "minimax-m2.5"]
     # opencode-go can appear as "built-in" (from PROVIDER_TO_MODELS_DEV when
     # models.dev is reachable) or "hermes" (from HERMES_OVERLAYS fallback when
     # the API is unavailable, e.g. in CI).


### PR DESCRIPTION
## What does this PR do?

Moonshot's `kimi-k2.6` landed on main via #13148 and #13152 for the main aggregator/native catalogs (OpenRouter, Nous, NVIDIA NIM, kimi-coding, kimi-coding-cn, moonshot). This PR fills in the remaining static model lists so the model is also selectable from:

- `opencode-zen`
- `opencode-go`
- `alibaba` (DashScope)
- `huggingface` Inference Providers

And pins the HuggingFace variant's context length at 256K in `agent/model_metadata.py` for parity with `Kimi-K2.5`.

From a user's point of view: if you're on any of these providers and run `hermes model`, `kimi-k2.6` is now in the list.

Temperature handling is already covered by #13157's `OMIT_TEMPERATURE` sentinel + `_is_kimi_model()` prefix check, which matches every `kimi-*` ID automatically — no per-model changes needed here.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/models.py` — add `kimi-k2.6` to `opencode-zen`, `opencode-go`, `alibaba`, and `huggingface` provider lists.
- `hermes_cli/setup.py` — add `kimi-k2.6` to the default-models fallback for `opencode-zen`, `opencode-go`, and `huggingface`.
- `agent/model_metadata.py` — pin `moonshotai/Kimi-K2.6` context length at 256K.
- `tests/hermes_cli/test_opencode_go_in_model_list.py` — include `kimi-k2.6` in the exact-list assertion.

## How to Test

```bash
pytest tests/hermes_cli/test_opencode_go_in_model_list.py tests/agent/test_auxiliary_client.py -q
```

Then with a real key (e.g. Alibaba DashScope or OpenCode):

```bash
hermes model          # kimi-k2.6 now appears in the list
```

## Checklist

- [x] Conventional Commits
- [x] No unrelated changes
- [x] Tested on macOS 15 (Darwin 25.4.0)