### PR TITLE
fix(file_tools): resolve relative paths against TERMINAL_CWD for worktree isolation

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -312,6 +312,7 @@ AUTHOR_MAP = {
     "261797239+lumenradley@users.noreply.github.com": "lumenradley",
     "166376523+sjz-ks@users.noreply.github.com": "sjz-ks",
     "haileymarshall005@gmail.com": "haileymarshall",
+    "aniruddhaadak80@users.noreply.github.com": "aniruddhaadak80",
 }
 
 

--- a/tests/tools/test_resolve_path.py
+++ b/tests/tools/test_resolve_path.py
@@ -1,0 +1,52 @@
+"""Tests for _resolve_path() — TERMINAL_CWD-aware path resolution in file_tools."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+
+class TestResolvePath:
+    """Verify _resolve_path respects TERMINAL_CWD for worktree isolation."""
+
+    def test_relative_path_uses_terminal_cwd(self, monkeypatch, tmp_path):
+        """Relative paths resolve against TERMINAL_CWD, not process CWD."""
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+        from tools.file_tools import _resolve_path
+
+        result = _resolve_path("foo/bar.py")
+        assert result == (tmp_path / "foo" / "bar.py")
+
+    def test_absolute_path_ignores_terminal_cwd(self, monkeypatch, tmp_path):
+        """Absolute paths are unaffected by TERMINAL_CWD."""
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+        from tools.file_tools import _resolve_path
+
+        result = _resolve_path("/etc/hosts")
+        assert result == Path("/etc/hosts")
+
+    def test_falls_back_to_cwd_without_terminal_cwd(self, monkeypatch):
+        """Without TERMINAL_CWD, falls back to os.getcwd()."""
+        monkeypatch.delenv("TERMINAL_CWD", raising=False)
+        from tools.file_tools import _resolve_path
+
+        result = _resolve_path("some_file.txt")
+        assert result == Path(os.getcwd()) / "some_file.txt"
+
+    def test_tilde_expansion(self, monkeypatch, tmp_path):
+        """~ is expanded before TERMINAL_CWD join (already absolute)."""
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+        from tools.file_tools import _resolve_path
+
+        result = _resolve_path("~/notes.txt")
+        # After expanduser, ~/notes.txt becomes absolute → TERMINAL_CWD ignored
+        assert result == Path.home() / "notes.txt"
+
+    def test_result_is_resolved(self, monkeypatch, tmp_path):
+        """Output path has no '..' components."""
+        monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+        from tools.file_tools import _resolve_path
+
+        result = _resolve_path("a/../b/file.txt")
+        assert ".." not in str(result)
+        assert result == (tmp_path / "b" / "file.txt")

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -71,6 +71,17 @@ _BLOCKED_DEVICE_PATHS = frozenset({
 })
 
 
+def _resolve_path(filepath: str) -> Path:
+    """Resolve a path relative to TERMINAL_CWD (the worktree base directory)
+    instead of the main repository root.
+    """
+    p = Path(filepath).expanduser()
+    if not p.is_absolute():
+        base = os.environ.get("TERMINAL_CWD", os.getcwd())
+        p = Path(base) / p
+    return p.resolve()
+
+
 def _is_blocked_device(filepath: str) -> bool:
     """Return True if the path would hang the process (infinite output or blocking input).
 
@@ -102,7 +113,7 @@ _SENSITIVE_EXACT_PATHS = {"/var/run/docker.sock", "/run/docker.sock"}
 def _check_sensitive_path(filepath: str) -> str | None:
     """Return an error message if the path targets a sensitive system location."""
     try:
-        resolved = os.path.realpath(os.path.expanduser(filepath))
+        resolved = str(_resolve_path(filepath))
     except (OSError, ValueError):
         resolved = filepath
     normalized = os.path.normpath(os.path.expanduser(filepath))
@@ -347,7 +358,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                 ),
             })
 
-        _resolved = Path(path).expanduser().resolve()
+        _resolved = _resolve_path(path)
 
         # ── Binary file guard ─────────────────────────────────────────
         # Block binary files by extension (no I/O).
@@ -555,7 +566,7 @@ def _update_read_timestamp(filepath: str, task_id: str) -> None:
     refreshes the stored timestamp to match the file's new state.
     """
     try:
-        resolved = str(Path(filepath).expanduser().resolve())
+        resolved = str(_resolve_path(filepath))
         current_mtime = os.path.getmtime(resolved)
     except (OSError, ValueError):
         return
@@ -574,7 +585,7 @@ def _check_file_staleness(filepath: str, task_id: str) -> str | None:
     or was never read.  Does not block — the write still proceeds.
     """
     try:
-        resolved = str(Path(filepath).expanduser().resolve())
+        resolved = str(_resolve_path(filepath))
     except (OSError, ValueError):
         return None
     with _read_tracker_lock:


### PR DESCRIPTION
## Summary
Resolves relative paths in file_tools.py against `TERMINAL_CWD` instead of process CWD, so pre-check guards (binary detection, dedup, staleness, sensitive path) resolve the same file the actual I/O targets.

Fixes #12689. Salvaged from PR #12695 (@aniruddhaadak80, first submitter). Supersedes PR #13080 (@bennytimz, same fix submitted later).

## Changes
- `tools/file_tools.py`: new `_resolve_path()` helper, applied to 4 call sites
- `tests/tools/test_resolve_path.py`: 5 tests covering relative, absolute, tilde, fallback, and traversal normalization
- `scripts/release.py`: AUTHOR_MAP entry for contributor

## Validation
| | Before | After |
|---|---|---|
| Relative path in `-w` mode | Resolves against process CWD (main repo) | Resolves against TERMINAL_CWD (worktree) |
| Absolute path | Unchanged | Unchanged |
| No TERMINAL_CWD set | os.getcwd() | os.getcwd() (no behavior change) |

Tests: 21/21 file_tools + 5/5 new resolve_path tests passing.