### PR TITLE
fix(telegram): actionable error for DM topics when Topics mode not enabled

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -496,6 +496,13 @@ class TelegramAdapter(BasePlatformAdapter):
                     "[%s] DM topic '%s' already exists in chat %s (will be mapped from incoming messages)",
                     self.name, name, chat_id,
                 )
+            elif "not a forum" in error_text or "forums_disabled" in error_text:
+                logger.warning(
+                    "[%s] Cannot create DM topic '%s' in chat %s: Topics mode is not enabled. "
+                    "The user must open the DM with this bot in Telegram, tap the bot name "
+                    "at the top, and enable 'Topics' in chat settings before topics can be created.",
+                    self.name, name, chat_id,
+                )
             else:
                 logger.warning(
                     "[%s] Failed to create DM topic '%s' in chat %s: %s",

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -325,6 +325,16 @@ Each topic gets its own conversation session, history, and context — completel
 
 ### Configuration
 
+:::caution Prerequisites
+Before adding topics to your config, the user must **enable Topics mode** in the DM chat with the bot:
+
+1. Open your private chat with the Hermes bot in Telegram
+2. Tap the bot's name at the top to open chat info
+3. Enable **Topics** (the toggle to turn the chat into a forum)
+
+Without this, Hermes will log `The chat is not a forum` on startup and skip topic creation. This is a Telegram client-side setting — the bot cannot enable it programmatically.
+:::
+
 Add topics under `platforms.telegram.extra.dm_topics` in `~/.hermes/config.yaml`:
 
 ```yaml


### PR DESCRIPTION
## Summary
Gives users an actionable error message when DM topic creation fails because Topics mode isn't enabled in the private chat, and documents the prerequisite in the docs.

Reported by @trapsticles — configured `dm_topics` per docs, got `The chat is not a forum` with no guidance on what to do.

## Changes
- `gateway/platforms/telegram.py`: detect `not a forum` / `forums_disabled` error in `_create_dm_topic()`, log a message explaining the user must enable Topics in the DM chat settings from the Telegram app
- `website/docs/user-guide/messaging/telegram.md`: add a Prerequisites callout before the config section explaining the client-side requirement

## Validation
- `tests/gateway/test_telegram_thread_fallback.py`: 10/10 passed
- All telegram gateway tests: 315 passed (3 pre-existing failures in approval button tests, unrelated)