### PR TITLE
fix(tui): pass provider credentials explicitly to AIAgent

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -961,12 +961,18 @@ def _reset_session_agent(sid: str, session: dict) -> dict:
 
 def _make_agent(sid: str, key: str, session_id: str | None = None):
     from run_agent import AIAgent
+    from hermes_cli.runtime_provider import resolve_runtime_provider
     cfg = _load_cfg()
     system_prompt = cfg.get("agent", {}).get("system_prompt", "") or ""
     if not system_prompt:
         system_prompt = _resolve_personality_prompt(cfg)
+    runtime = resolve_runtime_provider(requested=None)
     return AIAgent(
         model=_resolve_model(),
+        api_key=runtime.get("api_key"),
+        base_url=runtime.get("base_url"),
+        provider=runtime.get("provider"),
+        api_mode=runtime.get("api_mode"),
         quiet_mode=True,
         verbose_logging=_load_tool_progress_mode() == "verbose",
         reasoning_config=_load_reasoning_config(),


### PR DESCRIPTION
## Problem

When using `hermes --tui`, all API calls to Anthropic fail with `404 page not found`.

The root cause is in `tui_gateway/server.py` — `_make_agent()` was creating `AIAgent` without passing `provider`, `base_url`, `api_key`, or `api_mode`. This forced AIAgent to auto-detect the provider, but because `base_url` was empty at init time, the detection condition:

```python
elif self.provider == "anthropic" or (provider_name is None and "api.anthropic.com" in self._base_url_lower):
    self.api_mode = "anthropic_messages"
```

...never matched. So `api_mode` fell through to the default `"chat_completions"`.

The OpenAI SDK then retrieved `base_url = "https://api.anthropic.com"` (without `/v1/`) from the provider router and constructed:

```
POST https://api.anthropic.com/chat/completions  ← 404
```

Instead of the correct Anthropic Messages API endpoint:

```
POST https://api.anthropic.com/v1/messages
```

## Fix

Call `resolve_runtime_provider()` inside `_make_agent()` and pass `api_key`, `base_url`, `provider`, and `api_mode` explicitly to `AIAgent` — exactly as `cli.py` already does.

## Verification

Confirmed by inspecting `~/.hermes/sessions/request_dump_*.json` which showed the wrong URL, and verified the fix resolves the issue locally with `hermes --tui`.

`hermes chat` was unaffected because `cli.py` already resolves and passes credentials explicitly.