### PR TITLE
fix(gateway): show sender id in non-thread group prompts

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -254,13 +254,14 @@ def build_session_context_prompt(
             "**Session type:** Multi-user thread — messages are prefixed "
             "with [sender name]. Multiple users may participate."
         )
-    elif context.source.user_name:
-        lines.append(f"**User:** {context.source.user_name}")
-    elif context.source.user_id:
-        uid = context.source.user_id
-        if redact_pii:
-            uid = _hash_sender_id(uid)
-        lines.append(f"**User ID:** {uid}")
+    else:
+        if context.source.user_name:
+            lines.append(f"**User:** {context.source.user_name}")
+        if context.source.user_id:
+            uid = context.source.user_id
+            if redact_pii:
+                uid = _hash_sender_id(uid)
+            lines.append(f"**User ID:** {uid}")
     
     # Platform-specific behavioral notes
     if context.source.platform == Platform.SLACK:

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -356,6 +356,27 @@ class TestBuildSessionContextPrompt:
         assert "**User:** Alice" in prompt
         assert "Multi-user thread" not in prompt
 
+    def test_non_thread_group_shows_user_id_when_available(self):
+        """Identity-sensitive lanes need the stable sender ID, not just display name."""
+        config = GatewayConfig(
+            platforms={
+                Platform.FEISHU: PlatformConfig(enabled=True, token="fake"),
+            },
+        )
+        source = SessionSource(
+            platform=Platform.FEISHU,
+            chat_id="oc_group",
+            chat_name="Test Group",
+            chat_type="group",
+            user_id="ou_sender_123",
+            user_name="Jc",
+        )
+        ctx = build_session_context(source, config)
+        prompt = build_session_context_prompt(ctx)
+
+        assert "**User:** Jc" in prompt
+        assert "**User ID:** ou_sender_123" in prompt
+
     def test_dm_thread_shows_user_not_multi(self):
         """DM threads are single-user and should show User, not multi-user note."""
         config = GatewayConfig(


### PR DESCRIPTION
## Summary
- show both display name and stable sender ID for non-thread group sessions
- add a regression test covering Feishu-style group senders

## Testing
- pytest -o addopts='' tests/gateway/test_session.py
