### PR TITLE
feat: add moonshotai/Kimi-K2.6 to HuggingFace provider models

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -321,6 +321,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "zai-org/GLM-5",
         "XiaomiMiMo/MiMo-V2-Flash",
         "moonshotai/Kimi-K2-Thinking",
+        "moonshotai/Kimi-K2.6",
     ],
     # AWS Bedrock — static fallback list used when dynamic discovery is
     # unavailable (no boto3, no credentials, or API error).  The agent


### PR DESCRIPTION
Add Kimi-K2.6 to the HuggingFace provider static model list.