### PR TITLE
fix(classifier): recognize Anthropic 'out of extra usage' as billing error

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -97,6 +97,7 @@ _BILLING_PATTERNS = [
     "exceeded your current quota",
     "account is deactivated",
     "plan does not include",
+    "out of extra usage",          # Anthropic 2026-04-04 third-party enforcement
 ]
 
 # Patterns that indicate rate limiting (transient, will resolve)

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -850,6 +850,22 @@ class TestAdversarialEdgeCases:
         result = classify_api_error(e, provider="openrouter")
         assert result.reason == FailoverReason.model_not_found
 
+    def test_anthropic_out_of_extra_usage_is_billing(self):
+        """Anthropic's 2026-04-04 third-party enforcement returns HTTP 400
+        with body 'You're out of extra usage...' — must classify as billing
+        so the fallback chain engages with credential rotation.
+        """
+        msg = "You're out of extra usage. Add more at claude.ai/settings/usage and keep going."
+        e = MockAPIError(
+            msg,
+            status_code=400,
+            body={"error": {"message": msg}},
+        )
+        result = classify_api_error(e, provider="anthropic", model="claude-opus-4-7")
+        assert result.reason == FailoverReason.billing
+        assert result.should_fallback is True
+        assert result.should_rotate_credential is True
+
     # ── Regression: dict-typed message field (Issue #11233) ──
 
     def test_pydantic_dict_message_no_crash(self):


### PR DESCRIPTION
## Summary
- Adds `"out of extra usage"` to `_BILLING_PATTERNS` in `agent/error_classifier.py`
- Adds a regression test for the Anthropic 2026-04-04 third-party billing signal

## Why
Anthropic's 2026-04-04 third-party-tool enforcement surfaces as HTTP 400 with body:

> "You're out of extra usage. Add more at claude.ai/settings/usage and keep going."

That string wasn't matched by `_BILLING_PATTERNS`, so `classify_api_error` returned `format_error` (`retryable=False`, `should_rotate_credential=False`) instead of `billing` (`retryable=False`, `should_rotate_credential=True`, `should_fallback=True`).

Observed downstream: cron sessions hitting the cap could still fall back (because `format_error` also sets `should_fallback=True`), but without credential-rotation semantics or a clean "billing" signal for metrics/telemetry.

## Test plan
- [x] New unit test `test_anthropic_out_of_extra_usage_is_billing` — expects `reason=billing`, `should_fallback=True`, `should_rotate_credential=True`
- [x] Full `tests/agent/test_error_classifier.py` suite passes (104/104)