### PR TITLE
fix(cron): inherit config runtime provider for jobs

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -777,6 +777,9 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
 
         # Load config.yaml for model, reasoning, prefill, toolsets, provider routing
         _cfg = {}
+        _model_cfg = {}
+        _configured_provider = ""
+        _configured_base_url = ""
         try:
             import yaml
             _cfg_path = str(_hermes_home / "config.yaml")
@@ -789,6 +792,9 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                         model = _model_cfg
                     elif isinstance(_model_cfg, dict):
                         model = _model_cfg.get("default", model)
+                if isinstance(_model_cfg, dict):
+                    _configured_provider = str(_model_cfg.get("provider") or "").strip()
+                    _configured_base_url = str(_model_cfg.get("base_url") or "").strip()
         except Exception as e:
             logger.warning("Job '%s': failed to load config.yaml, using defaults: %s", job_id, e)
 
@@ -835,11 +841,21 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             format_runtime_provider_error,
         )
         try:
-            runtime_kwargs = {
-                "requested": job.get("provider") or os.getenv("HERMES_INFERENCE_PROVIDER"),
-            }
-            if job.get("base_url"):
-                runtime_kwargs["explicit_base_url"] = job.get("base_url")
+            requested_provider = (
+                str(job.get("provider") or "").strip()
+                or _configured_provider
+                or os.getenv("HERMES_INFERENCE_PROVIDER")
+                or ""
+            )
+            runtime_kwargs = {}
+            if requested_provider:
+                runtime_kwargs["requested"] = requested_provider
+
+            explicit_base_url = str(job.get("base_url") or "").strip()
+            if not explicit_base_url and requested_provider.lower() == "custom":
+                explicit_base_url = _configured_base_url
+            if explicit_base_url:
+                runtime_kwargs["explicit_base_url"] = explicit_base_url
             runtime = resolve_runtime_provider(**runtime_kwargs)
         except Exception as exc:
             message = format_runtime_provider_error(exc)

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -864,6 +864,56 @@ class TestRunJobConfigLogging:
         assert any("failed to parse prefill messages" in r.message for r in caplog.records), \
             f"Expected 'failed to parse prefill messages' warning in logs, got: {[r.message for r in caplog.records]}"
 
+    def test_job_without_provider_inherits_config_runtime_over_env_override(self, tmp_path, monkeypatch):
+        config_yaml = tmp_path / "config.yaml"
+        config_yaml.write_text(
+            "model:\n"
+            "  default: gpt-5.4\n"
+            "  provider: custom\n"
+            "  base_url: https://api.655147.xyz/v1\n"
+        )
+        monkeypatch.setenv("HERMES_INFERENCE_PROVIDER", "openrouter")
+
+        job = {
+            "id": "briefing-job",
+            "name": "briefing",
+            "prompt": "hello",
+            "model": None,
+            "provider": None,
+            "base_url": None,
+        }
+
+        fake_db = MagicMock()
+        fake_runtime = {
+            "provider": "custom",
+            "api_mode": "chat_completions",
+            "base_url": "https://api.655147.xyz/v1",
+            "api_key": "***",
+        }
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("dotenv.load_dotenv"), \
+             patch("hermes_state.SessionDB", return_value=fake_db), \
+             patch("hermes_cli.runtime_provider.resolve_runtime_provider", return_value=fake_runtime) as runtime_mock, \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+            mock_agent_cls.return_value = mock_agent
+
+            success, output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert final_response == "ok"
+        assert "ok" in output
+        runtime_mock.assert_called_once_with(
+            requested="custom",
+            explicit_base_url="https://api.655147.xyz/v1",
+        )
+        assert mock_agent_cls.call_args.kwargs["model"] == "gpt-5.4"
+        fake_db.close.assert_called_once()
+
 
 class TestRunJobSkillBacked:
     def test_run_job_preserves_skill_env_passthrough_into_worker_thread(self, tmp_path):


### PR DESCRIPTION
## Summary
- let cron jobs inherit the runtime provider configured in config.yaml when the job omits provider
- preserve config model.base_url for custom providers unless the job overrides it
- add a regression test covering config runtime inheritance over env overrides

## Testing
- pytest -o addopts='' tests/cron/test_scheduler.py -k "config_runtime_over_env_override or bad_config_yaml_is_logged or bad_prefill_messages_is_logged"