### PR TITLE
fix(update): recover unloaded launchd gateways

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1904,6 +1904,7 @@ def _wait_for_gateway_exit(timeout: float = 10.0, force_after: float | None = 5.
 def launchd_restart():
     label = get_launchd_label()
     target = f"{_launchd_domain()}/{label}"
+    refresh_launchd_plist_if_needed()
     drain_timeout = _get_restart_drain_timeout()
     from gateway.status import get_running_pid
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5758,6 +5758,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 try:
                     from hermes_cli.gateway import (
                         launchd_restart,
+                        launchd_start,
                         get_launchd_label,
                         get_launchd_plist_path,
                     )
@@ -5770,9 +5771,17 @@ def _cmd_update_impl(args, gateway_mode: bool):
                             text=True,
                             timeout=5,
                         )
-                        if check.returncode == 0:
+                        service_loaded = check.returncode == 0
+                        # In --gateway mode, the update was triggered by a live
+                        # messaging gateway. By the time update completes, that
+                        # service may already have stopped/unloaded itself, so
+                        # we must recover it even if `launchctl list` is empty.
+                        if service_loaded or gateway_mode:
                             try:
-                                launchd_restart()
+                                if service_loaded:
+                                    launchd_restart()
+                                else:
+                                    launchd_start()
                                 restarted_services.append(get_launchd_label())
                             except subprocess.CalledProcessError as e:
                                 stderr = (getattr(e, "stderr", "") or "").strip()

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -327,6 +327,27 @@ class TestLaunchdPlistRefresh:
         # Should NOT call bootout (nothing to bootout)
         assert not any("bootout" in s for s in cmd_strs)
 
+    def test_launchd_restart_calls_refresh(self, tmp_path, monkeypatch):
+        """launchd_restart refreshes a stale plist before kickstarting."""
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text("<plist>old</plist>")
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+
+        calls = []
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_restart()
+
+        cmd_strs = [" ".join(c) for c in calls]
+        assert any("bootout" in s for s in cmd_strs)
+        assert any("bootstrap" in s for s in cmd_strs)
+        assert any("kickstart -k" in s for s in cmd_strs)
+
 
 class TestCmdUpdateLaunchdRestart:
     """cmd_update correctly detects and handles launchd on macOS."""
@@ -391,6 +412,37 @@ class TestCmdUpdateLaunchdRestart:
 
         captured = capsys.readouterr().out
         assert "Restart manually: hermes gateway run" in captured
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_update_gateway_mode_recovers_unloaded_launchd_service(
+        self, mock_run, _mock_which, capsys, tmp_path, monkeypatch,
+    ):
+        """A gateway-triggered update should re-start launchd even if the job
+        unloaded itself before the restart phase runs."""
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text("<plist/>")
+
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_cli, "is_linux", lambda: False)
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+
+        mock_run.side_effect = _make_run_side_effect(
+            commit_count="3",
+            launchctl_loaded=False,
+        )
+
+        gateway_args = SimpleNamespace(gateway=True)
+
+        with patch.object(gateway_cli, "launchd_start") as mock_launchd_start, \
+             patch.object(gateway_cli, "launchd_restart") as mock_launchd_restart, \
+             patch.object(gateway_cli, "find_gateway_pids", return_value=[]):
+            cmd_update(gateway_args)
+
+        captured = capsys.readouterr().out
+        assert "Restarted" in captured
+        mock_launchd_start.assert_called_once_with()
+        mock_launchd_restart.assert_not_called()
 
     @patch("shutil.which", return_value=None)
     @patch("subprocess.run")


### PR DESCRIPTION
## Summary
- refresh the launchd plist before kickstarting a restart
- let `hermes update --gateway` recover a gateway whose launchd job unloaded itself during update
- add regression tests for both launchd restart refresh and unloaded-job recovery

## Testing
- pytest -o addopts='' tests/hermes_cli/test_update_gateway_restart.py -k "launchd_restart_calls_refresh or gateway_mode_recovers_unloaded_launchd_service or update_detects_launchd_and_skips_manual_restart_message or update_without_launchd_shows_manual_restart"