### PR TITLE
fix(gateway): exclude _run_restart from _background_tasks to prevent zombie on /restart

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1877,9 +1877,13 @@ class GatewayRunner:
             await asyncio.sleep(0.05)
             await self.stop(restart=True, detached_restart=detached, service_restart=via_service)
 
-        task = asyncio.create_task(_run_restart())
-        self._background_tasks.add(task)
-        task.add_done_callback(self._background_tasks.discard)
+        # _run_restart is a short-lived self-terminating task (calls stop()
+        # then returns).  Don't add it to _background_tasks — _stop_impl
+        # cancels all entries in that set, which would cancel _run_restart
+        # while it's awaiting _stop_task, propagating CancelledError into
+        # _stop_impl and preventing _shutdown_event.set() / _exit_code = 75.
+        # See #12875.
+        asyncio.create_task(_run_restart())
         return True
 
     async def start(self) -> bool:

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -125,11 +125,20 @@ async def test_request_restart_is_idempotent():
     runner, _adapter = make_restart_runner()
     runner.stop = AsyncMock()
 
-    assert runner.request_restart(detached=True, via_service=False) is True
-    first_task = next(iter(runner._background_tasks))
-    assert runner.request_restart(detached=True, via_service=False) is False
+    # Patch create_task to capture the restart task (it's no longer in
+    # _background_tasks — see #12875).
+    _captured = []
+    _orig_create_task = asyncio.create_task
+    def _capture(coro, **kw):
+        t = _orig_create_task(coro, **kw)
+        _captured.append(t)
+        return t
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(asyncio, "create_task", _capture)
+        assert runner.request_restart(detached=True, via_service=False) is True
+        assert runner.request_restart(detached=True, via_service=False) is False
 
-    await first_task
+    await _captured[0]
 
     runner.stop.assert_awaited_once_with(
         restart=True, detached_restart=True, service_restart=False


### PR DESCRIPTION
## What

Removes the `_run_restart` task from `_background_tasks` in `request_restart()`.  It was the only entry in that set that is both (a) awaiting `_stop_task` and (b) liable to be cancelled by `_stop_impl`'s cleanup loop.

## Why

`_stop_impl` (line 2570-2574) cancels every task in `_background_tasks` except `_stop_task`.  When `_run_restart` is in that set and is cancelled mid-await, the `CancelledError` propagates into `_stop_task`, interrupting `_stop_impl` before it reaches:

- `self._shutdown_event.set()` (line 2583) — gateway hangs as a zombie
- `self._exit_code = 75` (line 2649) — gateway exits with code 0, systemd `Restart=on-failure` does not restart

This is a 2-line deletion with a comment explaining why the task is excluded.

## How to test

1. Run the gateway under systemd with `Restart=on-failure`
2. Trigger `/restart` from Discord or Telegram
3. Verify the gateway exits with code 75 and systemd restarts it (not code 0 or zombie)

Unit tests: `pytest tests/gateway/test_restart_drain.py -q` — all 13 pass.

## Platforms tested

- Linux (aarch64, Ubuntu 22.04) — systemd

## Related

- Fixes #12875
- Related symptom: #11258