### PR TITLE
Add Windows WSL auto-start helper scripts

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3598,6 +3598,7 @@ def gateway_command(args):
             print("  tmux new -s hermes 'hermes gateway run'         # persistent via tmux")
             print("  nohup hermes gateway run > ~/.hermes/logs/gateway.log 2>&1 &  # background")
             print()
+            print("For Windows logon auto-start, use scripts/setup_hermes_autostart.ps1.")
             print("To enable systemd: add systemd=true to /etc/wsl.conf and run 'wsl --shutdown' from PowerShell.")
             sys.exit(1)
         elif is_container():

--- a/package-lock.json
+++ b/package-lock.json
@@ -954,9 +954,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
-      "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/scripts/hermes_autostart.sh
+++ b/scripts/hermes_autostart.sh
@@ -26,19 +26,19 @@ start_gateway_background() {
   local logfile="$LOG_DIR/gateway.log"
   if [[ -x "$PROJECT_DIR/venv/bin/python" ]]; then
     "$PROJECT_DIR/venv/bin/python" -m hermes_cli.main gateway run --replace >>"$logfile" 2>&1 &
-    printf '%s' "$!"
+    GATEWAY_PID=$!
     return 0
   fi
 
   if command -v hermes >/dev/null 2>&1; then
     hermes gateway run --replace >>"$logfile" 2>&1 &
-    printf '%s' "$!"
+    GATEWAY_PID=$!
     return 0
   fi
 
   if command -v python3 >/dev/null 2>&1; then
     python3 -m hermes_cli.main gateway run --replace >>"$logfile" 2>&1 &
-    printf '%s' "$!"
+    GATEWAY_PID=$!
     return 0
   fi
 
@@ -49,19 +49,19 @@ start_dashboard_background() {
   local logfile="$LOG_DIR/dashboard.log"
   if [[ -x "$PROJECT_DIR/venv/bin/python" ]]; then
     "$PROJECT_DIR/venv/bin/python" -m hermes_cli.main dashboard --no-open >>"$logfile" 2>&1 &
-    printf '%s' "$!"
+    DASHBOARD_PID=$!
     return 0
   fi
 
   if command -v hermes >/dev/null 2>&1; then
     hermes dashboard --no-open >>"$logfile" 2>&1 &
-    printf '%s' "$!"
+    DASHBOARD_PID=$!
     return 0
   fi
 
   if command -v python3 >/dev/null 2>&1; then
     python3 -m hermes_cli.main dashboard --no-open >>"$logfile" 2>&1 &
-    printf '%s' "$!"
+    DASHBOARD_PID=$!
     return 0
   fi
 
@@ -70,7 +70,6 @@ start_dashboard_background() {
 
 watch_gateway() {
   local delay="$RESTART_DELAY"
-  local pid
 
   if is_gateway_running; then
     log "Gateway is already running; leaving it alone."
@@ -78,14 +77,14 @@ watch_gateway() {
   fi
 
   while true; do
-    if ! pid="$(start_gateway_background)"; then
+    if ! start_gateway_background; then
       log "No gateway launch command was found."
       return 1
     fi
 
-    log "Gateway PID: ${pid}"
+    log "Gateway PID: ${GATEWAY_PID}"
 
-    if wait "$pid"; then
+    if wait "$GATEWAY_PID"; then
       log "Gateway exited cleanly."
     else
       log "Gateway exited with status $?"
@@ -114,7 +113,6 @@ watch_gateway() {
 
 watch_dashboard() {
   local delay="${HERMES_AUTOSTART_DASHBOARD_RESTART_DELAY:-10}"
-  local pid
 
   if [[ "$DASHBOARD_ENABLED" != "1" ]]; then
     log "Web UI mode disabled; dashboard watcher will not start."
@@ -122,14 +120,14 @@ watch_dashboard() {
   fi
 
   while true; do
-    if ! pid="$(start_dashboard_background)"; then
+    if ! start_dashboard_background; then
       log "Dashboard launch command not found; skipping web UI mode."
       return 0
     fi
 
-    log "Dashboard PID: ${pid}"
+    log "Dashboard PID: ${DASHBOARD_PID}"
 
-    if wait "$pid"; then
+    if wait "$DASHBOARD_PID"; then
       log "Dashboard exited cleanly."
       return 0
     fi

--- a/scripts/hermes_autostart.sh
+++ b/scripts/hermes_autostart.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="${HERMES_AUTOSTART_REPO_DIR:-$(cd -- "${SCRIPT_DIR}/.." && pwd)}"
+LOG_DIR="${HERMES_AUTOSTART_LOG_DIR:-${HOME}/.hermes/logs}"
+MODE="${HERMES_AUTOSTART_MODE:-gateway}"
+STARTUP_DELAY="${HERMES_AUTOSTART_STARTUP_DELAY:-15}"
+RESTART_DELAY="${HERMES_AUTOSTART_RESTART_DELAY:-5}"
+MAX_RESTART_DELAY="${HERMES_AUTOSTART_MAX_RESTART_DELAY:-60}"
+WATCHDOG_ENABLED="${HERMES_AUTOSTART_WATCHDOG:-1}"
+DASHBOARD_ENABLED="${HERMES_AUTOSTART_WEBUI:-0}"
+
+mkdir -p "$LOG_DIR"
+exec >>"$LOG_DIR/autostart.log" 2>&1
+
+log() {
+  printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*"
+}
+
+is_gateway_running() {
+  pgrep -f 'hermes_cli\.main.*gateway run|hermes gateway run' >/dev/null 2>&1
+}
+
+start_gateway_background() {
+  local logfile="$LOG_DIR/gateway.log"
+  if [[ -x "$PROJECT_DIR/venv/bin/python" ]]; then
+    "$PROJECT_DIR/venv/bin/python" -m hermes_cli.main gateway run --replace >>"$logfile" 2>&1 &
+    printf '%s' "$!"
+    return 0
+  fi
+
+  if command -v hermes >/dev/null 2>&1; then
+    hermes gateway run --replace >>"$logfile" 2>&1 &
+    printf '%s' "$!"
+    return 0
+  fi
+
+  if command -v python3 >/dev/null 2>&1; then
+    python3 -m hermes_cli.main gateway run --replace >>"$logfile" 2>&1 &
+    printf '%s' "$!"
+    return 0
+  fi
+
+  return 1
+}
+
+start_dashboard_background() {
+  local logfile="$LOG_DIR/dashboard.log"
+  if [[ -x "$PROJECT_DIR/venv/bin/python" ]]; then
+    "$PROJECT_DIR/venv/bin/python" -m hermes_cli.main dashboard --no-open >>"$logfile" 2>&1 &
+    printf '%s' "$!"
+    return 0
+  fi
+
+  if command -v hermes >/dev/null 2>&1; then
+    hermes dashboard --no-open >>"$logfile" 2>&1 &
+    printf '%s' "$!"
+    return 0
+  fi
+
+  if command -v python3 >/dev/null 2>&1; then
+    python3 -m hermes_cli.main dashboard --no-open >>"$logfile" 2>&1 &
+    printf '%s' "$!"
+    return 0
+  fi
+
+  return 1
+}
+
+watch_gateway() {
+  local delay="$RESTART_DELAY"
+  local pid
+
+  if is_gateway_running; then
+    log "Gateway is already running; leaving it alone."
+    return 0
+  fi
+
+  while true; do
+    if ! pid="$(start_gateway_background)"; then
+      log "No gateway launch command was found."
+      return 1
+    fi
+
+    log "Gateway PID: ${pid}"
+
+    if wait "$pid"; then
+      log "Gateway exited cleanly."
+    else
+      log "Gateway exited with status $?"
+    fi
+
+    if [[ "$WATCHDOG_ENABLED" != "1" ]]; then
+      log "Watchdog disabled; not restarting gateway."
+      return 0
+    fi
+
+    if is_gateway_running; then
+      log "Another gateway instance is already running; stopping watchdog."
+      return 0
+    fi
+
+    log "Restarting gateway in ${delay}s..."
+    sleep "$delay"
+    if (( delay < MAX_RESTART_DELAY )); then
+      delay=$(( delay * 2 ))
+      if (( delay > MAX_RESTART_DELAY )); then
+        delay="$MAX_RESTART_DELAY"
+      fi
+    fi
+  done
+}
+
+watch_dashboard() {
+  local delay="${HERMES_AUTOSTART_DASHBOARD_RESTART_DELAY:-10}"
+  local pid
+
+  if [[ "$DASHBOARD_ENABLED" != "1" ]]; then
+    log "Web UI mode disabled; dashboard watcher will not start."
+    return 0
+  fi
+
+  while true; do
+    if ! pid="$(start_dashboard_background)"; then
+      log "Dashboard launch command not found; skipping web UI mode."
+      return 0
+    fi
+
+    log "Dashboard PID: ${pid}"
+
+    if wait "$pid"; then
+      log "Dashboard exited cleanly."
+      return 0
+    fi
+
+    log "Dashboard exited with status $?; restarting in ${delay}s..."
+    sleep "$delay"
+  done
+}
+
+main() {
+  local normalized_mode
+  normalized_mode="$(printf '%s' "$MODE" | tr '[:upper:]' '[:lower:]')"
+
+  case "$normalized_mode" in
+    gateway|headless)
+      DASHBOARD_ENABLED=0
+      ;;
+    webui|dashboard|both)
+      DASHBOARD_ENABLED=1
+      ;;
+    *)
+      log "Unknown HERMES_AUTOSTART_MODE='$MODE' (expected gateway, headless, dashboard, webui, or both)."
+      return 1
+      ;;
+  esac
+
+  log "Starting Hermes autostart watcher (mode=${normalized_mode})"
+  log "Project directory: ${PROJECT_DIR}"
+  log "Log directory: ${LOG_DIR}"
+  sleep "$STARTUP_DELAY"
+
+  if [[ "$DASHBOARD_ENABLED" != "1" ]]; then
+    watch_gateway
+    return 0
+  fi
+
+  watch_gateway &
+  local gateway_watcher_pid=$!
+  log "Gateway watcher PID: ${gateway_watcher_pid}"
+
+  watch_dashboard &
+  local dashboard_watcher_pid=$!
+  log "Dashboard watcher PID: ${dashboard_watcher_pid}"
+
+  wait "$gateway_watcher_pid"
+  wait "$dashboard_watcher_pid" || true
+}
+
+trap 'log "Autostart watcher interrupted; exiting."' INT TERM
+main "$@"

--- a/scripts/setup_hermes_autostart.ps1
+++ b/scripts/setup_hermes_autostart.ps1
@@ -1,0 +1,110 @@
+param(
+    [string]$Distro = "",
+    [string]$RepoPath = "",
+    [ValidateSet("gateway", "headless", "dashboard", "webui", "both")]
+    [string]$Mode = "gateway",
+    [string]$TaskName = "HermesAgentAutoStart"
+)
+
+$ErrorActionPreference = "Stop"
+
+function Get-WslDistros {
+    $raw = & wsl.exe -l -q 2>$null
+    if (-not $raw) {
+        throw "No WSL distros were found. Install WSL2 and a Linux distribution first."
+    }
+    $distros = @()
+    foreach ($line in $raw) {
+        $name = ($line | ForEach-Object { $_.Trim() })
+        if ($name) { $distros += $name }
+    }
+    if (-not $distros) {
+        throw "Could not enumerate WSL distros."
+    }
+    return $distros
+}
+
+function Get-DefaultDistro {
+    param([string[]]$Distros)
+    foreach ($preferred in @("Ubuntu", "Ubuntu-24.04", "Ubuntu-22.04", "Debian", "openSUSE-Leap", "Arch")) {
+        if ($Distros -contains $preferred) {
+            return $preferred
+        }
+    }
+    return $Distros[0]
+}
+
+function Get-WslHome {
+    param([string]$Distribution)
+    $home = & wsl.exe -d $Distribution -- bash -lc 'printf %s "$HOME"' 2>$null
+    if (-not $home) {
+        throw "Unable to determine the WSL home directory for distribution '$Distribution'."
+    }
+    return ($home | Out-String).Trim()
+}
+
+function New-HermesTaskAction {
+    param(
+        [string]$Distribution,
+        [string]$ScriptPath,
+        [string]$AutostartMode
+    )
+
+    $bashCommand = "HERMES_AUTOSTART_MODE='$AutostartMode' '$ScriptPath'"
+    $argument = "-d $Distribution -- bash -lc `"$bashCommand`""
+    return New-ScheduledTaskAction -Execute "wsl.exe" -Argument $argument
+}
+
+$distros = Get-WslDistros
+if (-not $Distro) {
+    $Distro = Get-DefaultDistro -Distros $distros
+}
+
+if ($distros -notcontains $Distro) {
+    throw "WSL distro '$Distro' was not found. Available distros: $($distros -join ', ')"
+}
+
+$wslHome = Get-WslHome -Distribution $Distro
+if (-not $RepoPath) {
+    $RepoPath = "$wslHome/hermes-agent"
+}
+
+$wslScriptPath = "$RepoPath/scripts/hermes_autostart.sh"
+$scriptCheck = & wsl.exe -d $Distro -- bash -lc "test -x '$wslScriptPath'" 2>$null
+if ($LASTEXITCODE -ne 0) {
+    throw @"
+Could not find an executable Hermes autostart script at:
+  $wslScriptPath
+
+If Hermes lives somewhere other than $wslHome/hermes-agent, re-run this script with:
+  .\setup_hermes_autostart.ps1 -RepoPath /path/to/hermes-agent
+
+The path you pass must be a WSL path, not a Windows path.
+"@
+}
+
+$action = New-HermesTaskAction -Distribution $Distro -ScriptPath $wslScriptPath -AutostartMode $Mode
+$trigger = New-ScheduledTaskTrigger -AtLogOn
+$userId = if ($env:USERDOMAIN) { "$env:USERDOMAIN\$env:USERNAME" } else { $env:USERNAME }
+$principal = New-ScheduledTaskPrincipal -UserId $userId -LogonType Interactive -RunLevel LeastPrivilege
+$settings = New-ScheduledTaskSettingsSet -StartWhenAvailable -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -MultipleInstances IgnoreNew
+
+Register-ScheduledTask `
+    -TaskName $TaskName `
+    -Action $action `
+    -Trigger $trigger `
+    -Principal $principal `
+    -Settings $settings `
+    -Description "Auto-start Hermes Agent in WSL at logon" `
+    -Force | Out-Null
+
+Write-Host "✓ Scheduled task '$TaskName' created." -ForegroundColor Green
+Write-Host "  Distro : $Distro" -ForegroundColor Cyan
+Write-Host "  Repo   : $RepoPath" -ForegroundColor Cyan
+Write-Host "  Mode   : $Mode" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "To test it now, run:" -ForegroundColor Yellow
+Write-Host "  Start-ScheduledTask -TaskName '$TaskName'" -ForegroundColor Yellow
+Write-Host ""
+Write-Host "To remove it later, run:" -ForegroundColor Yellow
+Write-Host "  Unregister-ScheduledTask -TaskName '$TaskName' -Confirm:$false" -ForegroundColor Yellow

--- a/ui-tui/package-lock.json
+++ b/ui-tui/package-lock.json
@@ -89,7 +89,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -317,6 +316,31 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1365,6 +1389,29 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
       "version": "1.0.0-rc.15",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
@@ -1462,7 +1509,6 @@
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -1473,7 +1519,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1484,7 +1529,6 @@
       "integrity": "sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.58.1",
@@ -1514,7 +1558,6 @@
       "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.1",
         "@typescript-eslint/types": "8.58.1",
@@ -1832,7 +1875,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2168,7 +2210,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2854,7 +2895,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3750,7 +3790,6 @@
       "resolved": "https://registry.npmjs.org/ink-text-input/-/ink-text-input-6.0.0.tgz",
       "integrity": "sha512-Fw64n7Yha5deb1rHY137zHTAbSTNelUKuB5Kkk2HACXEtwIHBCf9OH2tP/LQ9fRYTl1F0dZgbW0zPnZk6FA9Lw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chalk": "^5.3.0",
         "type-fest": "^4.18.2"
@@ -5107,7 +5146,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5207,7 +5245,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5980,7 +6017,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -6107,7 +6143,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6217,7 +6252,6 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -6626,7 +6660,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -70,7 +70,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1104,7 +1103,6 @@
       "resolved": "https://registry.npmjs.org/@observablehq/plot/-/plot-0.6.17.tgz",
       "integrity": "sha512-/qaXP/7mc4MUS0s4cPPFASDRjtsWp85/TbfsciqDgU1HwYixbSbbytNuInD8AcTYC3xaxACgVX06agdfQy9W+g==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "d3": "^7.9.0",
         "interval-tree-1d": "^1.0.0",
@@ -1757,7 +1755,6 @@
       "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.6.0.tgz",
       "integrity": "sha512-90abYK2q5/qDM+GACs9zRvc5KhEEpEWqWlHSd64zTPNxg+9wCJvTfyD9x2so7hlQhjRYO1Fa6flR3BC/kpTFkA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@types/webxr": "*",
@@ -2492,7 +2489,6 @@
       "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2502,7 +2498,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2513,7 +2508,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2578,7 +2572,6 @@
       "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.0",
         "@typescript-eslint/types": "8.57.0",
@@ -2874,7 +2867,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3027,7 +3019,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3535,7 +3526,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3849,7 +3839,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4228,8 +4217,7 @@
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.15.0.tgz",
       "integrity": "sha512-dMW4CWBTUK1AEEDeZc1g4xpPGIrSf9fJF960qbTZmN/QwZIWY5wgliS6JWl9/25fpTGJrMRtSjGtOmPnfjZB+A==",
-      "license": "Standard 'no charge' license: https://gsap.com/standard-license.",
-      "peer": true
+      "license": "Standard 'no charge' license: https://gsap.com/standard-license."
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -4544,7 +4532,6 @@
       "resolved": "https://registry.npmjs.org/leva/-/leva-0.10.1.tgz",
       "integrity": "sha512-BcjnfUX8jpmwZUz2L7AfBtF9vn4ggTH33hmeufDULbP3YgNZ/C+ss/oO3stbrqRQyaOmRwy70y7BGTGO81S3rA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@radix-ui/react-portal": "^1.1.4",
         "@radix-ui/react-tooltip": "^1.1.8",
@@ -4966,7 +4953,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^20.0.0 || >=22.0.0"
       }
@@ -5094,7 +5080,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5166,7 +5151,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5186,7 +5170,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5549,8 +5532,7 @@
       "version": "0.180.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.180.0.tgz",
       "integrity": "sha512-o+qycAMZrh+TsE01GqWUxUIKR1AL0S8pq7zDkYOQw8GqfX8b8VoCKYUoHbhiX5j+7hr8XsuHDVU6+gkQJQKg9w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
@@ -5615,7 +5597,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5701,7 +5682,6 @@
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -5717,7 +5697,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -5839,7 +5818,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -176,7 +176,18 @@ Subcommands:
 | `setup` | Interactive messaging-platform setup. |
 
 :::tip WSL users
-Use `hermes gateway run` instead of `hermes gateway start` — WSL's systemd support is unreliable. Wrap it in tmux for persistence: `tmux new -s hermes 'hermes gateway run'`. See [WSL FAQ](/docs/reference/faq#wsl-gateway-keeps-disconnecting-or-hermes-gateway-start-fails) for details.
+Use `hermes gateway run` instead of `hermes gateway start` — WSL's systemd support is unreliable.
+
+For a persistent session, `tmux new -s hermes 'hermes gateway run'` still works.
+
+For automatic start on Windows logon, use the official helper script:
+
+```powershell
+irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/setup_hermes_autostart.ps1 -OutFile $env:TEMP\setup_hermes_autostart.ps1
+& $env:TEMP\setup_hermes_autostart.ps1 -Distro Ubuntu
+```
+
+See [WSL FAQ](/docs/reference/faq#wsl-gateway-keeps-disconnecting-or-hermes-gateway-start-fails) for details.
 :::
 
 ## `hermes setup`

--- a/website/docs/reference/faq.md
+++ b/website/docs/reference/faq.md
@@ -432,9 +432,25 @@ If you want to try systemd anyway, make sure it's enabled:
 5. Verify: `systemctl is-system-running` should say "running" or "degraded"
 
 :::tip Auto-start on Windows boot
-For reliable auto-start, use Windows Task Scheduler to launch WSL + the gateway on login:
-1. Create a task that runs `wsl -d Ubuntu -- bash -lc 'hermes gateway run'`
-2. Set it to trigger on user logon
+For a more reliable Windows startup flow, use the official helper script from the repo:
+
+```powershell
+irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/setup_hermes_autostart.ps1 -OutFile $env:TEMP\setup_hermes_autostart.ps1
+& $env:TEMP\setup_hermes_autostart.ps1 -Distro Ubuntu
+```
+
+That creates a Scheduled Task which launches WSL at logon and runs `scripts/hermes_autostart.sh`, which starts and monitors the gateway.
+
+Useful flags:
+- `-Mode gateway` keeps it headless (default)
+- `-Mode webui` also starts the browser dashboard
+- `-RepoPath /path/to/hermes-agent` if your clone is not in `~/hermes-agent`
+
+If you want the shortest possible manual setup, you can still create a task that runs:
+
+```powershell
+wsl -d Ubuntu -- bash -lc 'hermes gateway run'
+```
 :::
 
 #### macOS: Node.js / ffmpeg / other tools not found by gateway


### PR DESCRIPTION
## What this changes

Adds an official Windows 11 + WSL2 auto-start path for Hermes:

- PowerShell installer that creates a Windows Scheduled Task at logon
- Bash autostart helper inside WSL that starts and watches `hermes gateway run`
- Documentation updates for WSL auto-start and gateway startup guidance
- Small gateway warning text update for the WSL/no-systemd case
- Lockfile refreshes included per request

## Why

WSL systemd/startup behavior is not reliable enough for a first-class auto-start story. This PR gives Windows users a supported way to bring Hermes up automatically after login while keeping the runtime inside WSL.

## Validation

What I verified locally:

- Bash syntax check for `scripts/hermes_autostart.sh`
- WSL smoke-run of the helper using a fake `hermes` shim in `PATH` to validate launcher behavior, PID handling, log writing, and clean shutdown
- Manual review of the helper scripts and docs

I did not run the full Windows PowerShell flow in this environment.

## Manual usage

From Windows PowerShell:

```powershell
irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/setup_hermes_autostart.ps1 -OutFile $env:TEMP\setup_hermes_autostart.ps1
& $env:TEMP\setup_hermes_autostart.ps1 -Distro Ubuntu
```

Then optionally start the scheduled task once:

```powershell
Start-ScheduledTask -TaskName 'HermesAgentAutoStart'
```

To remove it later:

```powershell
Unregister-ScheduledTask -TaskName 'HermesAgentAutoStart' -Confirm:$false
```

## Platforms targeted

- Windows 11 + WSL2
- Bash helper script syntax on Linux/WSL

## Notes

- Native Windows is still not a supported runtime for Hermes; this is a Windows logon wrapper that launches Hermes inside WSL.
- If Hermes is installed in a non-default WSL path, the PowerShell helper supports `-RepoPath /path/to/hermes-agent`.