### PR TITLE
fix(tui): auto-expand Activity section on error

### DIFF
--- a/ui-tui/src/components/thinking.tsx
+++ b/ui-tui/src/components/thinking.tsx
@@ -596,6 +596,17 @@ export const ToolTrail = memo(function ToolTrail({
     }
   }, [detailsMode])
 
+  const latestErrorId = useMemo(
+    () => activity.reduce((max, i) => (i.tone === 'error' && i.id > max ? i.id : max), -1),
+    [activity]
+  )
+
+  useEffect(() => {
+    if (latestErrorId >= 0) {
+      setOpenMeta(true)
+    }
+  }, [latestErrorId])
+
   const cot = useMemo(() => thinkingPreview(reasoning, 'full', THINKING_COT_MAX), [reasoning])
 
   if (


### PR DESCRIPTION
## Problem

In `ui-tui`, when an `ActivityItem` has `tone: 'error'`, the `Activity` accordion inside `ToolTrail` (`src/components/thinking.tsx`) already tints its chevron red via `metaTone`, but the section stays collapsed. The error text is hidden behind a red arrow — you have to click to see what failed, which defeats the point of flagging it.

## Fix

Track the highest error id in the `activity` array and force `openMeta` to `true` whenever that id advances. One `useMemo` + one `useEffect`, scoped to the existing `ToolTrail` state machine. Eleven lines.

Behavior:
- New error arrives → section auto-expands, red content visible.
- User can still manually collapse after reading.
- Next error with a higher id re-opens it (ids are monotonic via `turnController.activityId`).
- No effect on `detailsMode === 'hidden'` (that path renders alerts separately and early-returns before `openMeta` is consulted) or `'expanded'` (already forces everything open).

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm test` — 102/102 pass
- [x] Lint — no new errors in touched file (pre-existing lint in unrelated files)
- [ ] Manual: trigger a tool error in `hermes --tui`, confirm the red Activity row is visible without a click