### PR TITLE
fix(deps): add tzdata for Windows zoneinfo support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
   "edge-tts>=7.2.7,<8",
   # Skills Hub (GitHub App JWT auth — optional, only needed for bot identity)
   "PyJWT[crypto]>=2.12.0,<3",  # CVE-2026-32597
+  "tzdata>=2025.2; sys_platform == 'win32'",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## What does this PR do?

`hermes_time` uses Python's `zoneinfo` module (stdlib since 3.9) to handle IANA timezone lookups. On Linux and macOS, the OS ships the timezone database. On Windows, it does not — `zoneinfo` silently falls back or raises `ZoneInfoNotFoundError` unless the `tzdata` PyPI package is installed.

Without this fix, any user who sets `HERMES_TIMEZONE` on Windows gets broken behavior:
- `hermes_time.now()` returns wrong timezone or crashes
- Cron jobs are scheduled with incorrect timestamps
- `get_due_jobs()` may skip jobs or run them at wrong times

This PR adds `tzdata` as a Windows-only conditional dependency, following the exact same pattern already used in `pyproject.toml` for `pywinpty`:

```toml
"pywinpty>=2.0.0,<3; sys_platform == 'win32'",  # existing
"tzdata>=2025.2; sys_platform == 'win32'",       # this PR
```

No impact on Linux or macOS installs — the conditional ensures `tzdata` is only pulled in on Windows.

## Type of Change
- 🐛 Bug fix

## Changes Made
- `pyproject.toml` — added `"tzdata>=2025.2; sys_platform == 'win32'"` to core dependencies, after `PyJWT`

## How to Test
1. On a Windows environment, install Hermes Agent
2. Set `HERMES_TIMEZONE=America/New_York` in `config.yaml`
3. Run `hermes chat -q "what time is it?"` — should return correct local time
4. Create a cron job and verify `next_run_at` uses the correct timezone offset

## Checklist
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs — no existing `tzdata` PR found
- [x] My PR contains only changes related to this fix
- [x] Tested on: Ubuntu 24.04 (WSL2)
- [x] Cross-platform impact considered — Linux/macOS unaffected (conditional marker)