### PR TITLE
feat(api_server): accept input_audio chat parts

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -21,6 +21,8 @@ Requires:
 """
 
 import asyncio
+import base64
+import binascii
 import hashlib
 import hmac
 import json
@@ -29,6 +31,7 @@ import os
 import socket as _socket
 import re
 import sqlite3
+import tempfile
 import time
 import uuid
 from typing import Any, Dict, List, Optional
@@ -124,13 +127,87 @@ def _normalize_chat_content(
 _TEXT_PART_TYPES = frozenset({"text", "input_text", "output_text"})
 _IMAGE_PART_TYPES = frozenset({"image_url", "input_image"})
 _FILE_PART_TYPES = frozenset({"file", "input_file"})
+_AUDIO_PART_TYPES = frozenset({"input_audio"})
 
 
-def _normalize_multimodal_content(content: Any) -> Any:
+def _normalize_input_audio_format(format_value: Any) -> str:
+    """Return a safe audio extension name without a leading dot."""
+    if format_value is None:
+        audio_format = "wav"
+    elif isinstance(format_value, str):
+        audio_format = format_value.strip().lower()
+    else:
+        raise ValueError("invalid_content_part:Audio format must be a non-empty string when provided.")
+
+    if audio_format.startswith("."):
+        audio_format = audio_format[1:]
+
+    if (
+        not audio_format
+        or "/" in audio_format
+        or "\\" in audio_format
+        or "." in audio_format
+        or not re.fullmatch(r"[a-z0-9]+", audio_format)
+    ):
+        raise ValueError("invalid_content_part:Audio format must be a safe file extension.")
+
+    from tools.transcription_tools import SUPPORTED_FORMATS
+
+    extension = f".{audio_format}"
+    if extension not in SUPPORTED_FORMATS:
+        supported = ", ".join(sorted(fmt.lstrip(".") for fmt in SUPPORTED_FORMATS))
+        raise ValueError(
+            f"unsupported_content_type:Unsupported audio format {audio_format!r}. "
+            f"Supported formats: {supported}."
+        )
+
+    return audio_format
+
+
+def _decode_input_audio_payload(part: Dict[str, Any]) -> tuple[bytes, str]:
+    """Validate and decode an OpenAI ``input_audio`` content part."""
+    audio = part.get("input_audio")
+    if not isinstance(audio, dict):
+        raise ValueError("invalid_content_part:Audio parts must include an input_audio object.")
+
+    data = audio.get("data")
+    if not isinstance(data, str) or not data.strip():
+        raise ValueError("invalid_content_part:Audio parts must include non-empty base64 data.")
+
+    audio_format = _normalize_input_audio_format(audio.get("format", "wav"))
+
+    try:
+        raw = base64.b64decode(data.strip(), validate=True)
+    except (binascii.Error, ValueError):
+        raise ValueError("invalid_content_part:Audio data must be valid base64.") from None
+
+    from tools.transcription_tools import MAX_FILE_SIZE
+
+    if len(raw) > MAX_FILE_SIZE:
+        raise ValueError(
+            "unsupported_content_type:Audio input is too large for transcription."
+        )
+
+    return raw, audio_format
+
+
+def _normalize_input_audio_part(part: Dict[str, Any]) -> Dict[str, Any]:
+    """Validate an audio part and emit the canonical API-server shape."""
+    _, audio_format = _decode_input_audio_payload(part)
+    audio = part["input_audio"]
+    return {
+        "type": "input_audio",
+        "input_audio": {"data": audio["data"].strip(), "format": audio_format},
+    }
+
+
+def _normalize_multimodal_content(content: Any, *, allow_audio: bool = False) -> Any:
     """Validate and normalize multimodal content for the API server.
 
     Returns a plain string when the content is text-only, or a list of
     ``{"type": "text"|"image_url", ...}`` parts when images are present.
+    When ``allow_audio`` is true, validated ``input_audio`` parts can also be
+    retained for the Chat Completions handler to transcribe before agent entry.
     The output shape is the native OpenAI Chat Completions vision format,
     which the agent pipeline accepts verbatim (OpenAI-wire providers) or
     converts (``_preprocess_anthropic_content`` for Anthropic).
@@ -139,7 +216,7 @@ def _normalize_multimodal_content(content: Any) -> Any:
       * ``unsupported_content_type`` — file/input_file/file_id parts, or
         non-image ``data:`` URLs.
       * ``invalid_image_url`` — missing URL or unsupported scheme.
-      * ``invalid_content_part`` — malformed text/image objects.
+      * ``invalid_content_part`` — malformed text/image/audio objects.
 
     Callers translate the ValueError into a 400 response.
     """
@@ -219,6 +296,15 @@ def _normalize_multimodal_content(content: Any) -> Any:
             normalized_parts.append(image_part)
             continue
 
+        if part_type in _AUDIO_PART_TYPES:
+            if allow_audio:
+                normalized_parts.append(_normalize_input_audio_part(part))
+                continue
+            raise ValueError(
+                "unsupported_content_type:Audio inputs are supported only for the "
+                "final user message on the Chat Completions endpoint."
+            )
+
         if part_type in _FILE_PART_TYPES:
             raise ValueError(
                 "unsupported_content_type:Inline image inputs are supported, "
@@ -227,9 +313,14 @@ def _normalize_multimodal_content(content: Any) -> Any:
 
         # Unknown part type — reject explicitly so clients get a clear error
         # instead of a silently dropped turn.
+        allowed = (
+            "Only text, image_url/input_image, and input_audio parts are supported."
+            if allow_audio
+            else "Only text and image_url/input_image parts are supported."
+        )
         raise ValueError(
             f"unsupported_content_type:Unsupported content part type {raw_type!r}. "
-            "Only text and image_url/input_image parts are supported."
+            f"{allowed}"
         )
 
     if not normalized_parts:
@@ -245,7 +336,7 @@ def _normalize_multimodal_content(content: Any) -> Any:
 
 
 def _content_has_visible_payload(content: Any) -> bool:
-    """True when content has any text or image attachment.  Used to reject empty turns."""
+    """True when content has any text, image, or audio payload. Used to reject empty turns."""
     if isinstance(content, str):
         return bool(content.strip())
     if isinstance(content, list):
@@ -255,6 +346,8 @@ def _content_has_visible_payload(content: Any) -> bool:
                 if ptype in _TEXT_PART_TYPES and str(part.get("text") or "").strip():
                     return True
                 if ptype in _IMAGE_PART_TYPES:
+                    return True
+                if ptype in _AUDIO_PART_TYPES:
                     return True
     return False
 
@@ -717,6 +810,68 @@ class APIServerAdapter(BasePlatformAdapter):
         return agent
 
     # ------------------------------------------------------------------
+    # Audio input processing
+    # ------------------------------------------------------------------
+
+    async def _process_input_audio_parts(self, content: Any) -> Any:
+        """Transcribe validated input_audio parts before AIAgent sees content."""
+        if not isinstance(content, list):
+            return content
+
+        output_parts: List[Dict[str, Any]] = []
+
+        for part in content:
+            if not isinstance(part, dict):
+                continue
+            ptype = str(part.get("type") or "").strip().lower()
+            if ptype in _TEXT_PART_TYPES or ptype in _IMAGE_PART_TYPES:
+                output_parts.append(part)
+                continue
+            if ptype in _AUDIO_PART_TYPES:
+                try:
+                    text = await self._transcribe_input_audio_part(part)
+                except ValueError:
+                    raise
+                except Exception as exc:
+                    logger.warning("Audio processing failed: %s", exc)
+                    text = "[The user sent a voice message but it could not be processed.]"
+                output_parts.append({"type": "text", "text": text})
+
+        if not output_parts:
+            return ""
+        if all(p.get("type") == "text" for p in output_parts):
+            return "\n\n".join(str(p.get("text", "")) for p in output_parts if p.get("text"))
+        return output_parts
+
+    async def _transcribe_input_audio_part(self, part: Dict[str, Any]) -> str:
+        """Transcribe one input_audio part through the existing STT pipeline."""
+        from tools.transcription_tools import transcribe_audio
+
+        raw, audio_format = _decode_input_audio_payload(part)
+        tmp_path = ""
+        try:
+            with tempfile.NamedTemporaryFile(suffix=f".{audio_format}", delete=False) as tmp:
+                tmp.write(raw)
+                tmp_path = tmp.name
+            loop = asyncio.get_running_loop()
+            result = await loop.run_in_executor(None, transcribe_audio, tmp_path)
+        finally:
+            if tmp_path:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+
+        if result.get("success"):
+            transcript = str(result.get("transcript") or "").strip()
+            if transcript:
+                return f'[The user sent a voice message. Transcript: "{transcript}"]'
+            return "[The user sent a voice message, but it transcribed to empty text.]"
+
+        error = str(result.get("error") or "unknown error")
+        return f"[The user sent a voice message but transcription failed: {error}]"
+
+    # ------------------------------------------------------------------
     # HTTP Handlers
     # ------------------------------------------------------------------
 
@@ -789,7 +944,17 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # Extract system message (becomes ephemeral system prompt layered ON TOP of core)
         system_prompt = None
-        conversation_messages: List[Dict[str, str]] = []
+        conversation_messages: List[Dict[str, Any]] = []
+        conversation_message_params: List[str] = []
+        last_conversation_idx = next(
+            (
+                idx
+                for idx in range(len(messages) - 1, -1, -1)
+                if isinstance(messages[idx], dict)
+                and messages[idx].get("role") in ("user", "assistant")
+            ),
+            None,
+        )
 
         for idx, msg in enumerate(messages):
             role = msg.get("role", "")
@@ -804,17 +969,30 @@ class APIServerAdapter(BasePlatformAdapter):
                     system_prompt = system_prompt + "\n" + content
             elif role in ("user", "assistant"):
                 try:
-                    content = _normalize_multimodal_content(raw_content)
+                    content = _normalize_multimodal_content(
+                        raw_content,
+                        allow_audio=(role == "user" and idx == last_conversation_idx),
+                    )
                 except ValueError as exc:
                     return _multimodal_validation_error(exc, param=f"messages[{idx}].content")
                 conversation_messages.append({"role": role, "content": content})
+                conversation_message_params.append(f"messages[{idx}].content")
 
         # Extract the last user message as the primary input
         user_message: Any = ""
         history = []
+        user_message_param = "messages.content"
         if conversation_messages:
             user_message = conversation_messages[-1].get("content", "")
             history = conversation_messages[:-1]
+            user_message_param = conversation_message_params[-1]
+
+        if conversation_messages and conversation_messages[-1].get("role") == "user":
+            try:
+                user_message = await self._process_input_audio_parts(user_message)
+            except ValueError as exc:
+                return _multimodal_validation_error(exc, param=user_message_param)
+            conversation_messages[-1]["content"] = user_message
 
         if not _content_has_visible_payload(user_message):
             return web.json_response(

--- a/tests/gateway/test_api_server_multimodal.py
+++ b/tests/gateway/test_api_server_multimodal.py
@@ -1,4 +1,4 @@
-"""End-to-end tests for inline image inputs on /v1/chat/completions and /v1/responses.
+"""End-to-end tests for inline multimodal inputs on API server endpoints.
 
 Covers the multimodal normalization path added to the API server.  Unlike the
 adapter-level tests that patch ``_run_agent``, these tests patch
@@ -7,6 +7,8 @@ path (including the ``run_agent`` prologue that used to crash on list content)
 executes against a real aiohttp app.
 """
 
+import base64
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -26,6 +28,16 @@ from gateway.platforms.api_server import (
 # ---------------------------------------------------------------------------
 # Pure-function tests for _normalize_multimodal_content
 # ---------------------------------------------------------------------------
+
+
+def _audio_part(data: bytes = b"hello", audio_format: str = "wav") -> dict:
+    return {
+        "type": "input_audio",
+        "input_audio": {
+            "data": base64.b64encode(data).decode("ascii"),
+            "format": audio_format,
+        },
+    }
 
 
 class TestNormalizeMultimodalContent:
@@ -102,6 +114,53 @@ class TestNormalizeMultimodalContent:
             _normalize_multimodal_content([{"type": "audio", "audio": {}}])
         assert str(exc.value).startswith("unsupported_content_type:")
 
+    def test_input_audio_rejected_by_default(self):
+        with pytest.raises(ValueError) as exc:
+            _normalize_multimodal_content([_audio_part()])
+        assert str(exc.value).startswith("unsupported_content_type:")
+
+    def test_input_audio_allowed_and_canonicalized(self):
+        out = _normalize_multimodal_content(
+            [_audio_part(data=b"voice", audio_format=".WAV")],
+            allow_audio=True,
+        )
+        assert out == [
+            {
+                "type": "input_audio",
+                "input_audio": {
+                    "data": base64.b64encode(b"voice").decode("ascii"),
+                    "format": "wav",
+                },
+            }
+        ]
+
+    @pytest.mark.parametrize(
+        "part",
+        [
+            {"type": "input_audio"},
+            {"type": "input_audio", "input_audio": "not-an-object"},
+            {"type": "input_audio", "input_audio": {"format": "wav"}},
+            {"type": "input_audio", "input_audio": {"data": "", "format": "wav"}},
+            {"type": "input_audio", "input_audio": {"data": "not base64!", "format": "wav"}},
+            {
+                "type": "input_audio",
+                "input_audio": {
+                    "data": base64.b64encode(b"voice").decode("ascii"),
+                    "format": "../wav",
+                },
+            },
+        ],
+    )
+    def test_malformed_input_audio_rejected_when_allowed(self, part):
+        with pytest.raises(ValueError) as exc:
+            _normalize_multimodal_content([part], allow_audio=True)
+        assert str(exc.value).startswith("invalid_content_part:")
+
+    def test_unsupported_input_audio_format_rejected_when_allowed(self):
+        with pytest.raises(ValueError) as exc:
+            _normalize_multimodal_content([_audio_part(audio_format="exe")], allow_audio=True)
+        assert str(exc.value).startswith("unsupported_content_type:")
+
 
 class TestContentHasVisiblePayload:
     def test_non_empty_string(self):
@@ -112,6 +171,9 @@ class TestContentHasVisiblePayload:
 
     def test_list_with_image_only(self):
         assert _content_has_visible_payload([{"type": "image_url", "image_url": {"url": "x"}}])
+
+    def test_list_with_audio_only(self):
+        assert _content_has_visible_payload([_audio_part()])
 
     def test_list_with_only_empty_text(self):
         assert not _content_has_visible_payload([{"type": "text", "text": ""}])
@@ -136,6 +198,17 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     return app
 
 
+def _capture_run_agent(mock_run: MagicMock, final_response: str = "ok") -> None:
+    async def _stub(**kwargs):
+        mock_run.captured = kwargs
+        return (
+            {"final_response": final_response, "messages": [], "api_calls": 1},
+            {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+        )
+
+    mock_run.side_effect = _stub
+
+
 @pytest.fixture
 def adapter():
     return _make_adapter()
@@ -157,13 +230,7 @@ class TestChatCompletionsMultimodalHTTP:
                 "_run_agent",
                 new=MagicMock(),
             ) as mock_run:
-                async def _stub(**kwargs):
-                    mock_run.captured = kwargs
-                    return (
-                        {"final_response": "A cat.", "messages": [], "api_calls": 1},
-                        {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
-                    )
-                mock_run.side_effect = _stub
+                _capture_run_agent(mock_run, final_response="A cat.")
 
                 resp = await cli.post(
                     "/v1/chat/completions",
@@ -182,13 +249,7 @@ class TestChatCompletionsMultimodalHTTP:
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
             with patch.object(adapter, "_run_agent", new=MagicMock()) as mock_run:
-                async def _stub(**kwargs):
-                    mock_run.captured = kwargs
-                    return (
-                        {"final_response": "ok", "messages": [], "api_calls": 1},
-                        {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
-                    )
-                mock_run.side_effect = _stub
+                _capture_run_agent(mock_run)
 
                 resp = await cli.post(
                     "/v1/chat/completions",
@@ -202,6 +263,163 @@ class TestChatCompletionsMultimodalHTTP:
 
             assert resp.status == 200, await resp.text()
             assert mock_run.captured["user_message"] == "hello"
+
+    @pytest.mark.asyncio
+    async def test_audio_only_transcribed_before_run_agent(self, adapter):
+        """Audio-only turns become visible transcript text instead of empty requests."""
+        temp_path = {}
+
+        def _fake_transcribe(path):
+            temp_path["path"] = path
+            assert Path(path).exists()
+            return {"success": True, "transcript": "hello from audio"}
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch("tools.transcription_tools.transcribe_audio", side_effect=_fake_transcribe),
+                patch.object(adapter, "_run_agent", new=MagicMock()) as mock_run,
+            ):
+                _capture_run_agent(mock_run)
+
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [{"role": "user", "content": [_audio_part()]}],
+                    },
+                )
+
+            assert resp.status == 200, await resp.text()
+            assert "Transcript: \"hello from audio\"" in mock_run.captured["user_message"]
+            assert temp_path["path"]
+            assert not Path(temp_path["path"]).exists()
+
+    @pytest.mark.asyncio
+    async def test_mixed_text_image_audio_preserves_image_and_adds_transcript(self, adapter):
+        image_part = {
+            "type": "image_url",
+            "image_url": {"url": "https://example.com/cat.png", "detail": "high"},
+        }
+        content = [
+            {"type": "text", "text": "Please inspect this."},
+            image_part,
+            _audio_part(),
+        ]
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch(
+                    "tools.transcription_tools.transcribe_audio",
+                    return_value={"success": True, "transcript": "also check the tail"},
+                ),
+                patch.object(adapter, "_run_agent", new=MagicMock()) as mock_run,
+            ):
+                _capture_run_agent(mock_run)
+
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": content}]},
+                )
+
+            assert resp.status == 200, await resp.text()
+            assert mock_run.captured["user_message"] == [
+                {"type": "text", "text": "Please inspect this."},
+                image_part,
+                {"type": "text", "text": '[The user sent a voice message. Transcript: "also check the tail"]'},
+            ]
+
+    @pytest.mark.parametrize(
+        ("transcribe_result", "expected_text"),
+        [
+            ({"success": False, "error": "no speech detected"}, "transcription failed: no speech detected"),
+            ({"success": True, "transcript": ""}, "transcribed to empty text"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_audio_transcription_non_text_outcomes_reach_run_agent_as_note(
+        self, adapter, transcribe_result, expected_text
+    ):
+        temp_path = {}
+
+        def _fake_transcribe(path):
+            temp_path["path"] = path
+            assert Path(path).exists()
+            return transcribe_result
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch("tools.transcription_tools.transcribe_audio", side_effect=_fake_transcribe),
+                patch.object(adapter, "_run_agent", new=MagicMock()) as mock_run,
+            ):
+                _capture_run_agent(mock_run)
+
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [{"role": "user", "content": [_audio_part()]}],
+                    },
+                )
+
+            assert resp.status == 200, await resp.text()
+            assert expected_text in mock_run.captured["user_message"]
+            assert temp_path["path"]
+            assert not Path(temp_path["path"]).exists()
+
+    @pytest.mark.asyncio
+    async def test_invalid_audio_base64_returns_400(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "hermes-agent",
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "input_audio", "input_audio": {"data": "nope!", "format": "wav"}},
+                            ],
+                        },
+                    ],
+                },
+            )
+            assert resp.status == 400
+            body = await resp.json()
+        assert body["error"]["code"] == "invalid_content_part"
+        assert body["error"]["param"] == "messages[0].content"
+
+    @pytest.mark.parametrize(
+        ("messages", "expected_param"),
+        [
+            ([{"role": "assistant", "content": [_audio_part()]}], "messages[0].content"),
+            (
+                [
+                    {"role": "user", "content": [_audio_part()]},
+                    {"role": "user", "content": "next turn"},
+                ],
+                "messages[0].content",
+            ),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_audio_outside_final_user_message_returns_400(self, adapter, messages, expected_param):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "hermes-agent",
+                    "messages": messages,
+                },
+            )
+            assert resp.status == 400
+            body = await resp.json()
+        assert body["error"]["code"] == "unsupported_content_type"
+        assert body["error"]["param"] == expected_param
 
     @pytest.mark.asyncio
     async def test_file_part_returns_400(self, adapter):
@@ -253,13 +471,7 @@ class TestResponsesMultimodalHTTP:
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
             with patch.object(adapter, "_run_agent", new=MagicMock()) as mock_run:
-                async def _stub(**kwargs):
-                    mock_run.captured = kwargs
-                    return (
-                        {"final_response": "ok", "messages": [], "api_calls": 1},
-                        {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
-                    )
-                mock_run.side_effect = _stub
+                _capture_run_agent(mock_run)
 
                 resp = await cli.post(
                     "/v1/responses",
@@ -299,6 +511,26 @@ class TestResponsesMultimodalHTTP:
                         {
                             "role": "user",
                             "content": [{"type": "input_file", "file_id": "f_1"}],
+                        }
+                    ],
+                },
+            )
+            assert resp.status == 400
+            body = await resp.json()
+        assert body["error"]["code"] == "unsupported_content_type"
+
+    @pytest.mark.asyncio
+    async def test_input_audio_returns_400(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/responses",
+                json={
+                    "model": "hermes-agent",
+                    "input": [
+                        {
+                            "role": "user",
+                            "content": [_audio_part()],
                         }
                     ],
                 },

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -83,7 +83,7 @@ Standard OpenAI Chat Completions format. Stateless — the full conversation is 
 }
 ```
 
-**Inline image input:** user messages may send `content` as an array of `text` and `image_url` parts. Both remote `http(s)` URLs and `data:image/...` URLs are supported:
+**Inline image and audio input:** user messages may send `content` as an array of `text`, `image_url`, and `input_audio` parts. Images support remote `http(s)` URLs and `data:image/...` URLs. Audio is decoded, transcribed through the configured Hermes STT provider, and passed to the agent as transcript text:
 
 ```json
 {
@@ -93,12 +93,21 @@ Standard OpenAI Chat Completions format. Stateless — the full conversation is 
       "role": "user",
       "content": [
         {"type": "text", "text": "What is in this image?"},
-        {"type": "image_url", "image_url": {"url": "https://example.com/cat.png", "detail": "high"}}
+        {"type": "image_url", "image_url": {"url": "https://example.com/cat.png", "detail": "high"}},
+        {
+          "type": "input_audio",
+          "input_audio": {
+            "data": "UklGRiQAAABXQVZFZm10IBAAAAABAAEA...",
+            "format": "wav"
+          }
+        }
       ]
     }
   ]
 }
 ```
+
+Chat Completions audio accepts `mp3`, `mp4`, `mpeg`, `mpga`, `m4a`, `wav`, `webm`, `ogg`, `aac`, and `flac` formats. Audio parts are supported only on the latest user message in the request. The API server keeps its existing 1 MB request-body limit, so larger audio is outside inline API-server payload support.
 
 Uploaded files (`file` / `input_file` / `file_id`) and non-image `data:` URLs return `400 unsupported_content_type`.
 
@@ -155,7 +164,7 @@ OpenAI Responses API format. Supports server-side conversation state via `previo
 }
 ```
 
-Uploaded files (`input_file` / `file_id`) and non-image `data:` URLs return `400 unsupported_content_type`.
+Uploaded files (`input_file` / `file_id`), audio parts, and non-image `data:` URLs return `400 unsupported_content_type`.
 
 #### Multi-turn with previous_response_id
 


### PR DESCRIPTION
## Summary
- Accept OpenAI-compatible `input_audio` content parts on the final user message for `/v1/chat/completions`.
- Validate base64 payloads and supported Hermes STT audio formats, then transcribe through the existing STT pipeline before agent entry.
- Preserve mixed text/image/audio requests by replacing audio parts with transcript text while leaving text and image parts intact.
- Keep `/v1/responses`, assistant messages, and non-final user-message audio explicitly rejected with OpenAI-shaped errors.
- Document the API Server audio-input contract and supported formats.

## Why
The API Server already accepts inline image content parts. This adds the audio side of the same OpenAI-compatible content-part surface without introducing a new provider or credential contract, because it reuses Hermes’ existing voice/STT implementation.

## Verification
- `scripts/run_tests.sh tests/gateway/test_api_server_multimodal.py tests/gateway/test_api_server.py`
- Result: `155 passed, 91 warnings`

## Notes
- Inline audio still uses the API Server request body limit, so larger audio remains outside this payload path.
- The PR is draft while CI and maintainer review shake out any contract preferences.