### PR TITLE
feat(whatsapp): send read receipts for incoming messages

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -910,6 +910,18 @@ class WhatsAppAdapter(BasePlatformAdapter):
                             event = await self._build_message_event(msg_data)
                             if event:
                                 await self.handle_message(event)
+                                # Mark message as read (send read receipt / blue ticks)
+                                try:
+                                    async with self._http_session.post(
+                                        f"http://127.0.0.1:{self._bridge_port}/read",
+                                        json={"chatId": msg_data.get("chatId"), "messageId": msg_data.get("messageId")},
+                                        timeout=aiohttp.ClientTimeout(total=5)
+                                    ) as resp:
+                                        if resp.status != 200:
+                                            err_body = await resp.text()
+                                            print(f"[{self.name}] Failed to mark as read (HTTP {resp.status}): {err_body}", flush=True)
+                                except Exception as read_err:
+                                    print(f"[{self.name}] Read receipt failed: {read_err}", flush=True)
             except asyncio.CancelledError:
                 break
             except Exception as e:

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -547,6 +547,30 @@ app.get('/chat/:id', async (req, res) => {
   });
 });
 
+// Mark messages as read (send read receipts)
+app.post('/read', async (req, res) => {
+  if (!sock || connectionState !== 'connected') {
+    return res.status(503).json({ error: 'Not connected' });
+  }
+
+  const { chatId, messageId } = req.body;
+  if (!chatId || !messageId) {
+    return res.status(400).json({ error: 'chatId and messageId are required' });
+  }
+
+  try {
+    await sock.readMessages([{
+      remoteJid: chatId,
+      id: messageId,
+      fromMe: false,
+    }]);
+    res.json({ success: true });
+  } catch (err) {
+    console.error('[bridge] Failed to mark message as read:', err.message);
+    res.status(500).json({ error: err.message });
+  }
+});
+
 // Health check
 app.get('/health', (req, res) => {
   res.json({


### PR DESCRIPTION
## Summary

Automatically mark incoming WhatsApp messages as read after processing, so the sender sees blue ticks (read receipts).

## Changes

### `scripts/whatsapp-bridge/bridge.js`
- Added `POST /read` endpoint that calls Baileys `sock.readMessages()` to send read receipts

### `gateway/platforms/whatsapp.py`
- After each incoming message is processed in `_poll_messages()`, calls the `/read` bridge endpoint with `chatId` and `messageId`
- Graceful error handling — read receipt failures never break the poll loop

## Why

Without this, WhatsApp senders never see blue ticks when the bot reads their messages, making conversations feel one-sided.