### PR TITLE
feat(providers): native EUrouter provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 **The self-improving AI agent built by [Nous Research](https://nousresearch.com).** It's the only agent with a built-in learning loop — it creates skills from experience, improves them during use, nudges itself to persist knowledge, searches its own past conversations, and builds a deepening model of who you are across sessions. Run it on a $5 VPS, a GPU cluster, or serverless infrastructure that costs nearly nothing when idle. It's not tied to your laptop — talk to it from Telegram while it works on a cloud VM.
 
-Use any model you want — [Nous Portal](https://portal.nousresearch.com), [OpenRouter](https://openrouter.ai) (200+ models), [NVIDIA NIM](https://build.nvidia.com) (Nemotron), [Xiaomi MiMo](https://platform.xiaomimimo.com), [z.ai/GLM](https://z.ai), [Kimi/Moonshot](https://platform.moonshot.ai), [MiniMax](https://www.minimax.io), [Hugging Face](https://huggingface.co), OpenAI, or your own endpoint. Switch with `hermes model` — no code changes, no lock-in.
+Use any model you want — [Nous Portal](https://portal.nousresearch.com), [OpenRouter](https://openrouter.ai) (200+ models), [EUrouter](https://api.eurouter.ai) (EU-resident, GDPR-focused), [NVIDIA NIM](https://build.nvidia.com) (Nemotron), [Xiaomi MiMo](https://platform.xiaomimimo.com), [z.ai/GLM](https://z.ai), [Kimi/Moonshot](https://platform.moonshot.ai), [MiniMax](https://www.minimax.io), [Hugging Face](https://huggingface.co), OpenAI, or your own endpoint. Switch with `hermes model` — no code changes, no lock-in.
 
 <table>
 <tr><td><b>A real terminal interface</b></td><td>Full TUI with multiline editing, slash-command autocomplete, conversation history, interrupt-and-redirect, and streaming tool output.</td></tr>

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -58,6 +58,8 @@ _PROVIDER_ALIASES = {
     "google": "gemini",
     "google-gemini": "gemini",
     "google-ai-studio": "gemini",
+    "eu-router": "eurouter",
+    "eur": "eurouter",
     "x-ai": "xai",
     "x.ai": "xai",
     "grok": "xai",
@@ -186,6 +188,7 @@ _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = {
     "minimax-cn": "MiniMax-M2.7",
     "anthropic": "claude-haiku-4-5-20251001",
     "ai-gateway": "google/gemini-3-flash",
+    "eurouter": "minimax-m2.5",
     "opencode-zen": "gemini-3-flash",
     "opencode-go": "glm-5",
     "kilocode": "google/gemini-3-flash-preview",
@@ -2192,7 +2195,8 @@ def cleanup_stale_async_clients() -> None:
 
 def _is_openrouter_client(client: Any) -> bool:
     for obj in (client, getattr(client, "_client", None), getattr(client, "client", None)):
-        if obj and "openrouter" in str(getattr(obj, "base_url", "") or "").lower():
+        base_url = str(getattr(obj, "base_url", "") or "").lower()
+        if obj and ("openrouter" in base_url or "eurouter" in base_url):
             return True
     return False
 

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 # Only these are stripped — Ollama-style "model:tag" colons (e.g. "qwen3.5:27b")
 # are preserved so the full model name reaches cache lookups and server queries.
 _PROVIDER_PREFIXES: frozenset[str] = frozenset({
-    "openrouter", "nous", "openai-codex", "copilot", "copilot-acp",
+    "openrouter", "eurouter", "nous", "openai-codex", "copilot", "copilot-acp",
     "gemini", "ollama-cloud", "zai", "kimi-coding", "kimi-coding-cn", "minimax", "minimax-cn", "anthropic", "deepseek",
     "opencode-zen", "opencode-go", "ai-gateway", "kilocode", "alibaba",
     "qwen-oauth",
@@ -38,6 +38,7 @@ _PROVIDER_PREFIXES: frozenset[str] = frozenset({
     "mimo", "xiaomi-mimo",
     "arcee-ai", "arceeai",
     "xai", "x-ai", "x.ai", "grok",
+    "eu-router", "eur",
     "nvidia", "nim", "nvidia-nim", "nemotron",
     "qwen-portal",
 })
@@ -233,6 +234,7 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "dashscope-intl.aliyuncs.com": "alibaba",
     "portal.qwen.ai": "qwen-oauth",
     "openrouter.ai": "openrouter",
+    "api.eurouter.ai": "eurouter",
     "generativelanguage.googleapis.com": "gemini",
     "inference-api.nousresearch.com": "nous",
     "api.deepseek.com": "deepseek",

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -13,6 +13,7 @@ model:
   # Inference provider selection:
   #   "auto"         - Auto-detect from credentials (default)
   #   "openrouter"   - OpenRouter (requires: OPENROUTER_API_KEY or OPENAI_API_KEY)
+  #   "eurouter"    - EUrouter EU-resident gateway (requires: EUROUTER_API_KEY)
   #   "nous"         - Nous Portal OAuth (requires: hermes login)
   #   "nous-api"     - Nous Portal API key (requires: NOUS_API_KEY)
   #   "anthropic"    - Direct Anthropic API (requires: ANTHROPIC_API_KEY)
@@ -348,6 +349,7 @@ compression:
 # Provider options:
 #   "auto"       - Best available: OpenRouter → Nous Portal → main endpoint (default)
 #   "openrouter" - Force OpenRouter (requires OPENROUTER_API_KEY)
+#   "eurouter"   - Force EUrouter (requires EUROUTER_API_KEY)
 #   "nous"       - Force Nous Portal (requires: hermes login)
 #   "gemini"      - Force Google AI Studio direct (requires: GOOGLE_API_KEY or GEMINI_API_KEY)
 #   "ollama-cloud" - Ollama Cloud (requires: OLLAMA_API_KEY)
@@ -777,7 +779,7 @@ delegation:
   # model: "google/gemini-3-flash-preview"    # Override model for subagents (empty = inherit parent)
   # provider: "openrouter"                    # Override provider for subagents (empty = inherit parent)
   #                                           # Resolves full credentials (base_url, api_key) automatically.
-  #                                           # Supported: openrouter, nous, zai, kimi-coding, minimax
+  #                                           # Supported: openrouter, eurouter, nous, zai, kimi-coding, minimax
 
 # =============================================================================
 # Honcho Integration (Cross-Session User Modeling)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -226,6 +226,14 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         api_key_env_vars=("DEEPSEEK_API_KEY",),
         base_url_env_var="DEEPSEEK_BASE_URL",
     ),
+    "eurouter": ProviderConfig(
+        id="eurouter",
+        name="EUrouter",
+        auth_type="api_key",
+        inference_base_url="https://api.eurouter.ai/api/v1",
+        api_key_env_vars=("EUROUTER_API_KEY",),
+        base_url_env_var="EUROUTER_BASE_URL",
+    ),
     "xai": ProviderConfig(
         id="xai",
         name="xAI",
@@ -980,6 +988,7 @@ def resolve_provider(
     _PROVIDER_ALIASES = {
         "glm": "zai", "z-ai": "zai", "z.ai": "zai", "zhipu": "zai",
         "google": "gemini", "google-gemini": "gemini", "google-ai-studio": "gemini",
+        "eu-router": "eurouter", "eur": "eurouter",
         "x-ai": "xai", "x.ai": "xai", "grok": "xai",
         "kimi": "kimi-coding", "kimi-for-coding": "kimi-coding", "moonshot": "kimi-coding",
         "kimi-cn": "kimi-coding-cn", "moonshot-cn": "kimi-coding-cn",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -878,6 +878,22 @@ OPTIONAL_ENV_VARS = {
         "category": "provider",
         "advanced": True,
     },
+    "EUROUTER_API_KEY": {
+        "description": "EUrouter API key for the EU-resident OpenAI-compatible gateway",
+        "prompt": "EUrouter API key",
+        "url": "https://api.eurouter.ai/",
+        "password": True,
+        "category": "provider",
+        "advanced": True,
+    },
+    "EUROUTER_BASE_URL": {
+        "description": "EUrouter base URL override",
+        "prompt": "EUrouter base URL (leave empty for default)",
+        "url": None,
+        "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
     "GOOGLE_API_KEY": {
         "description": "Google AI Studio API key (also recognized as GEMINI_API_KEY)",
         "prompt": "Google AI Studio API key",

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -34,6 +34,7 @@ from hermes_constants import OPENROUTER_MODELS_URL
 
 _PROVIDER_ENV_HINTS = (
     "OPENROUTER_API_KEY",
+    "EUROUTER_API_KEY",
     "OPENAI_API_KEY",
     "ANTHROPIC_API_KEY",
     "ANTHROPIC_TOKEN",
@@ -319,7 +320,7 @@ def run_doctor(args):
                     )
 
             # Warn if model is set to a provider-prefixed name on a provider that doesn't use them
-            if default_model and "/" in default_model and canonical_provider and canonical_provider not in ("openrouter", "custom", "auto", "ai-gateway", "kilocode", "opencode-zen", "huggingface", "nous"):
+            if default_model and "/" in default_model and canonical_provider and canonical_provider not in ("openrouter", "eurouter", "custom", "auto", "ai-gateway", "kilocode", "opencode-zen", "huggingface", "nous"):
                 check_warn(
                     f"model.default '{default_model}' uses a vendor/model slug but provider is '{provider_raw}'",
                     "(vendor-prefixed slugs belong to aggregators like openrouter)",
@@ -909,6 +910,7 @@ def run_doctor(args):
     # Tuple: (name, env_vars, default_url, base_env, supports_models_endpoint)
     # If supports_models_endpoint is False, we skip the health check and just show "configured"
     _apikey_providers = [
+        ("EUrouter",        ("EUROUTER_API_KEY",),                           "https://api.eurouter.ai/api/v1/models", "EUROUTER_BASE_URL", True),
         ("Z.AI / GLM",      ("GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY"), "https://api.z.ai/api/paas/v4/models", "GLM_BASE_URL", True),
         ("Kimi / Moonshot",  ("KIMI_API_KEY",),                              "https://api.moonshot.ai/v1/models",   "KIMI_BASE_URL", True),
         ("Kimi / Moonshot (China)", ("KIMI_CN_API_KEY",),                    "https://api.moonshot.cn/v1/models",   None, True),

--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -263,6 +263,7 @@ def run_dump(args):
     lines.append("api_keys:")
     api_keys = [
         ("OPENROUTER_API_KEY", "openrouter"),
+        ("EUROUTER_API_KEY", "eurouter"),
         ("OPENAI_API_KEY", "openai"),
         ("ANTHROPIC_API_KEY", "anthropic"),
         ("ANTHROPIC_TOKEN", "anthropic_token"),

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1541,6 +1541,7 @@ def select_provider_and_model(args=None):
     elif selected_provider in (
         "gemini",
         "deepseek",
+        "eurouter",
         "xai",
         "zai",
         "kimi-coding-cn",
@@ -6427,6 +6428,7 @@ For more help on a command:
         choices=[
             "auto",
             "openrouter",
+            "eurouter",
             "nous",
             "openai-codex",
             "copilot-acp",

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -61,6 +61,7 @@ _VENDOR_PREFIXES: dict[str, str] = {
 # Providers whose APIs consume vendor/model slugs.
 _AGGREGATOR_PROVIDERS: frozenset[str] = frozenset({
     "openrouter",
+    "eurouter",
     "nous",
     "ai-gateway",
     "kilocode",
@@ -423,4 +424,3 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
 # ---------------------------------------------------------------------------
 # Batch / convenience helpers
 # ---------------------------------------------------------------------------
-

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -112,6 +112,8 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "openai/gpt-5.4-nano",
         "openrouter/elephant-alpha",
     ],
+    # Mirror the familiar OpenRouter starter set for the EUrouter gateway.
+    "eurouter": [mid for mid, _ in OPENROUTER_MODELS[:15]],
     "openai-codex": _codex_curated_models(),
     "copilot-acp": [
         "copilot-acp",
@@ -550,6 +552,7 @@ class ProviderEntry(NamedTuple):
 CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("nous",           "Nous Portal",              "Nous Portal (Nous Research subscription)"),
     ProviderEntry("openrouter",     "OpenRouter",               "OpenRouter (100+ models, pay-per-use)"),
+    ProviderEntry("eurouter",       "EUrouter",                 "EUrouter (EU-resident OpenAI-compatible gateway, GDPR-focused)"),
     ProviderEntry("anthropic",      "Anthropic",                "Anthropic (Claude models — API key or Claude Code)"),
     ProviderEntry("openai-codex",   "OpenAI Codex",             "OpenAI Codex"),
     ProviderEntry("xiaomi",         "Xiaomi MiMo",              "Xiaomi MiMo (MiMo-V2 models — pro, omni, flash)"),
@@ -583,6 +586,8 @@ _PROVIDER_LABELS["custom"] = "Custom endpoint"  # special case: not a named prov
 
 
 _PROVIDER_ALIASES = {
+    "eu-router": "eurouter",
+    "eur": "eurouter",
     "glm": "zai",
     "z-ai": "zai",
     "z.ai": "zai",
@@ -890,12 +895,25 @@ def _resolve_nous_pricing_credentials() -> tuple[str, str]:
 
 
 def get_pricing_for_provider(provider: str, *, force_refresh: bool = False) -> dict[str, dict[str, str]]:
-    """Return live pricing for providers that support it (openrouter, nous)."""
+    """Return live pricing for providers that support a compatible /v1/models API."""
     normalized = normalize_provider(provider)
     if normalized == "openrouter":
         return fetch_models_with_pricing(
             api_key=_resolve_openrouter_api_key(),
             base_url="https://openrouter.ai/api",
+            force_refresh=force_refresh,
+        )
+    if normalized == "eurouter":
+        api_key = os.getenv("EUROUTER_API_KEY", "").strip()
+        base_url = os.getenv("EUROUTER_BASE_URL", "").strip() or "https://api.eurouter.ai/api/v1"
+        stripped = base_url.rstrip("/")
+        if stripped.endswith("/api/v1"):
+            stripped = stripped[:-3]
+        elif stripped.endswith("/v1"):
+            stripped = stripped[:-3]
+        return fetch_models_with_pricing(
+            api_key=api_key,
+            base_url=stripped,
             force_refresh=force_refresh,
         )
     if normalized == "nous":
@@ -1078,7 +1096,7 @@ def detect_provider_for_model(
             return (resolved_provider, default_models[0])
 
     # Aggregators list other providers' models — never auto-switch TO them
-    _AGGREGATORS = {"nous", "openrouter", "ai-gateway", "copilot", "kilocode"}
+    _AGGREGATORS = {"nous", "openrouter", "eurouter", "ai-gateway", "copilot", "kilocode"}
 
     # If the model belongs to the current provider's catalog, don't suggest switching
     current_models = _PROVIDER_MODELS.get(current_provider, [])

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -48,6 +48,13 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         extra_env_vars=("OPENAI_API_KEY",),
         base_url_env_var="OPENROUTER_BASE_URL",
     ),
+    "eurouter": HermesOverlay(
+        transport="openai_chat",
+        is_aggregator=True,
+        extra_env_vars=("EUROUTER_API_KEY",),
+        base_url_override="https://api.eurouter.ai/api/v1",
+        base_url_env_var="EUROUTER_BASE_URL",
+    ),
     "nous": HermesOverlay(
         transport="openai_chat",
         auth_type="oauth_device_code",
@@ -184,6 +191,8 @@ class ProviderDef:
 ALIASES: Dict[str, str] = {
     # openrouter
     "openai": "openrouter",     # bare "openai" → route through aggregator
+    "eu-router": "eurouter",
+    "eur": "eurouter",
 
     # zai
     "glm": "zai",
@@ -290,6 +299,7 @@ ALIASES: Dict[str, str] = {
 
 _LABEL_OVERRIDES: Dict[str, str] = {
     "nous": "Nous Portal",
+    "eurouter": "EUrouter",
     "openai-codex": "OpenAI Codex",
     "copilot-acp": "GitHub Copilot ACP",
     "xiaomi": "Xiaomi MiMo",

--- a/run_agent.py
+++ b/run_agent.py
@@ -1229,7 +1229,7 @@ class AIAgent:
             # stream tool call arguments token-by-token, keeping the
             # connection alive.
             _effective_base = str(client_kwargs.get("base_url", "")).lower()
-            if "openrouter" in _effective_base and "claude" in (self.model or "").lower():
+            if self._is_openrouter_compatible_url(_effective_base) and "claude" in (self.model or "").lower():
                 headers = client_kwargs.get("default_headers") or {}
                 existing_beta = headers.get("x-anthropic-beta", "")
                 _FINE_GRAINED = "fine-grained-tool-streaming-2025-05-14"
@@ -2324,6 +2324,11 @@ class AIAgent:
         """Return True when the base URL targets OpenRouter."""
         return "openrouter" in self._base_url_lower
 
+    def _is_openrouter_compatible_url(self, base_url: Optional[str] = None) -> bool:
+        """Return True for OpenRouter-style chat-completions gateways."""
+        target = (base_url if base_url is not None else (self.base_url or "")).lower()
+        return "openrouter" in target or "eurouter" in target
+
     def _anthropic_prompt_cache_policy(
         self,
         *,
@@ -2357,7 +2362,7 @@ class AIAgent:
 
         base_lower = eff_base_url.lower()
         is_claude = "claude" in eff_model.lower()
-        is_openrouter = "openrouter" in base_lower
+        is_openrouter = self._is_openrouter_compatible_url(eff_base_url)
         is_anthropic_wire = eff_api_mode == "anthropic_messages"
         is_native_anthropic = (
             is_anthropic_wire
@@ -6357,7 +6362,7 @@ class AIAgent:
             return False
 
         # Skip for aggregator providers — they manage their own retry infra
-        if self._is_openrouter_url():
+        if self._is_openrouter_compatible_url():
             return False
         provider_lower = (self.provider or "").strip().lower()
         if provider_lower in ("nous", "nous-research"):
@@ -6893,7 +6898,7 @@ class AIAgent:
             # (the documented max output for qwen3-coder models) so the
             # model has adequate output budget for tool calls.
             api_kwargs.update(self._max_tokens_param(65536))
-        elif (self._is_openrouter_url() or "nousresearch" in self._base_url_lower) and "claude" in (self.model or "").lower():
+        elif (self._is_openrouter_compatible_url() or "nousresearch" in self._base_url_lower) and "claude" in (self.model or "").lower():
             # OpenRouter and Nous Portal translate requests to Anthropic's
             # Messages API, which requires max_tokens as a mandatory field.
             # When we omit it, the proxy picks a default that can be too
@@ -6993,6 +6998,13 @@ class AIAgent:
             return True
         if "ai-gateway.vercel.sh" in self._base_url_lower:
             return True
+        if "eurouter" in self._base_url_lower:
+            # EUrouter is OpenAI-compatible, but its current /chat/completions
+            # routes reject Hermes' default OpenRouter-style reasoning payload
+            # for many vendor-prefixed models (for example openai/*, qwen/*,
+            # anthropic/*). Until we have per-model capability detection for
+            # EUrouter, do not enable reasoning automatically.
+            return False
         if "models.github.ai" in self._base_url_lower or "api.githubcopilot.com" in self._base_url_lower:
             try:
                 from hermes_cli.models import github_model_reasoning_efforts
@@ -7000,7 +7012,7 @@ class AIAgent:
                 return bool(github_model_reasoning_efforts(self.model))
             except Exception:
                 return False
-        if "openrouter" not in self._base_url_lower:
+        if not self._is_openrouter_compatible_url():
             return False
         if "api.mistral.ai" in self._base_url_lower:
             return False

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -31,6 +31,7 @@ class TestProviderRegistry:
         ("copilot-acp", "GitHub Copilot ACP", "external_process"),
         ("copilot", "GitHub Copilot", "api_key"),
         ("huggingface", "Hugging Face", "api_key"),
+        ("eurouter", "EUrouter", "api_key"),
         ("zai", "Z.AI / GLM", "api_key"),
         ("xai", "xAI", "api_key"),
         ("nvidia", "NVIDIA NIM", "api_key"),
@@ -51,6 +52,12 @@ class TestProviderRegistry:
         pconfig = PROVIDER_REGISTRY["zai"]
         assert pconfig.api_key_env_vars == ("GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY")
         assert pconfig.base_url_env_var == "GLM_BASE_URL"
+
+    def test_eurouter_env_vars(self):
+        pconfig = PROVIDER_REGISTRY["eurouter"]
+        assert pconfig.api_key_env_vars == ("EUROUTER_API_KEY",)
+        assert pconfig.base_url_env_var == "EUROUTER_BASE_URL"
+        assert pconfig.inference_base_url == "https://api.eurouter.ai/api/v1"
 
     def test_xai_env_vars(self):
         pconfig = PROVIDER_REGISTRY["xai"]
@@ -125,6 +132,7 @@ class TestProviderRegistry:
 PROVIDER_ENV_VARS = (
     "OPENROUTER_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN",
     "CLAUDE_CODE_OAUTH_TOKEN",
+    "EUROUTER_API_KEY", "EUROUTER_BASE_URL",
     "GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY",
     "KIMI_API_KEY", "KIMI_BASE_URL", "MINIMAX_API_KEY", "MINIMAX_CN_API_KEY",
     "AI_GATEWAY_API_KEY", "AI_GATEWAY_BASE_URL",
@@ -146,6 +154,9 @@ def _clear_provider_env(monkeypatch):
 class TestResolveProvider:
     """Test resolve_provider() with new providers."""
 
+    def test_explicit_eurouter(self):
+        assert resolve_provider("eurouter") == "eurouter"
+
     def test_explicit_zai(self):
         assert resolve_provider("zai") == "zai"
 
@@ -163,6 +174,12 @@ class TestResolveProvider:
 
     def test_alias_glm(self):
         assert resolve_provider("glm") == "zai"
+
+    def test_alias_eu_router(self):
+        assert resolve_provider("eu-router") == "eurouter"
+
+    def test_alias_eur(self):
+        assert resolve_provider("eur") == "eurouter"
 
     def test_alias_z_ai(self):
         assert resolve_provider("z-ai") == "zai"
@@ -239,6 +256,10 @@ class TestResolveProvider:
     def test_auto_detects_z_ai_key(self, monkeypatch):
         monkeypatch.setenv("Z_AI_API_KEY", "test-z-ai-key")
         assert resolve_provider("auto") == "zai"
+
+    def test_auto_detects_eurouter_key(self, monkeypatch):
+        monkeypatch.setenv("EUROUTER_API_KEY", "eur-test-key")
+        assert resolve_provider("auto") == "eurouter"
 
     def test_auto_detects_kimi_key(self, monkeypatch):
         monkeypatch.setenv("KIMI_API_KEY", "test-kimi-key")

--- a/tests/hermes_cli/test_model_normalize.py
+++ b/tests/hermes_cli/test_model_normalize.py
@@ -155,6 +155,10 @@ class TestAggregatorProviders:
         result = normalize_model_for_provider("claude-sonnet-4.6", "openrouter")
         assert result == "anthropic/claude-sonnet-4.6"
 
+    def test_eurouter_prepends_vendor(self):
+        result = normalize_model_for_provider("claude-sonnet-4.6", "eurouter")
+        assert result == "anthropic/claude-sonnet-4.6"
+
     def test_nous_prepends_vendor(self):
         result = normalize_model_for_provider("gpt-5.4", "nous")
         assert result == "openai/gpt-5.4"
@@ -162,6 +166,9 @@ class TestAggregatorProviders:
     def test_vendor_already_present(self):
         result = normalize_model_for_provider("anthropic/claude-sonnet-4.6", "openrouter")
         assert result == "anthropic/claude-sonnet-4.6"
+
+    def test_eurouter_is_marked_as_aggregator(self):
+        assert "eurouter" in _AGGREGATOR_PROVIDERS
 
 
 class TestIssue6211NativeProviderPrefixNormalization:

--- a/tests/run_agent/test_anthropic_prompt_cache_policy.py
+++ b/tests/run_agent/test_anthropic_prompt_cache_policy.py
@@ -74,6 +74,17 @@ class TestOpenRouter:
         )
         assert agent._anthropic_prompt_cache_policy() == (False, False)
 
+    def test_claude_on_eurouter_caches_with_envelope_layout(self):
+        agent = _make_agent(
+            provider="eurouter",
+            base_url="https://api.eurouter.ai/api/v1",
+            api_mode="chat_completions",
+            model="anthropic/claude-sonnet-4.6",
+        )
+        should, native = agent._anthropic_prompt_cache_policy()
+        assert should is True
+        assert native is False
+
 
 class TestThirdPartyAnthropicGateway:
     """Third-party gateways speaking the Anthropic protocol (MiniMax, Zhipu GLM, LiteLLM)."""

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -540,6 +540,23 @@ class TestInit:
             )
             assert a._use_prompt_caching is True
 
+    def test_prompt_caching_claude_eurouter(self):
+        """Claude model via EUrouter should enable prompt caching."""
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            a = AIAgent(
+                api_key="test-k...7890",
+                model="anthropic/claude-sonnet-4-20250514",
+                base_url="https://api.eurouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            assert a._use_prompt_caching is True
+
     def test_prompt_caching_non_claude(self):
         """Non-Claude model should disable prompt caching."""
         with (
@@ -986,6 +1003,14 @@ class TestBuildApiKwargs:
         messages = [{"role": "user", "content": "hi"}]
         kwargs = agent._build_api_kwargs(messages)
         assert kwargs["extra_body"]["reasoning"]["effort"] == "medium"
+
+    def test_reasoning_not_sent_for_eurouter_model(self, agent):
+        agent.base_url = "https://api.eurouter.ai/api/v1"
+        agent._base_url_lower = "https://api.eurouter.ai/api/v1"
+        agent.model = "qwen/qwen3.5-plus-02-15"
+        messages = [{"role": "user", "content": "hi"}]
+        kwargs = agent._build_api_kwargs(messages)
+        assert "reasoning" not in kwargs.get("extra_body", {})
 
     def test_reasoning_sent_for_nous_route(self, agent):
         agent.base_url = "https://inference-api.nousresearch.com/v1"

--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -79,6 +79,7 @@ class TestProviderEnvBlocklist:
         registry_vars = {
             "ANTHROPIC_TOKEN": "ant-tok",
             "CLAUDE_CODE_OAUTH_TOKEN": "cc-tok",
+            "EUROUTER_API_KEY": "eur-key",
             "ZAI_API_KEY": "zai-key",
             "Z_AI_API_KEY": "z-ai-key",
             "GLM_API_KEY": "glm-key",

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -72,6 +72,7 @@ Good defaults:
 | You already have Claude or Codex auth | Anthropic or OpenAI Codex |
 | You want local/private inference | Ollama or any custom OpenAI-compatible endpoint |
 | You want multi-provider routing | OpenRouter |
+| You want EU-resident multi-provider routing | EUrouter |
 | You have a custom GPU server | vLLM, SGLang, LiteLLM, or any OpenAI-compatible endpoint |
 
 For most first-time users: choose a provider, accept the defaults unless you know why you're changing them. The full provider catalog with env vars and setup steps lives on the [Providers](../integrations/providers.md) page.

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -20,6 +20,7 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **GitHub Copilot ACP** | `hermes model` (spawns local `copilot --acp --stdio`) |
 | **Anthropic** | `hermes model` (Claude Pro/Max via Claude Code auth, Anthropic API key, or manual setup-token) |
 | **OpenRouter** | `OPENROUTER_API_KEY` in `~/.hermes/.env` |
+| **EUrouter** | `EUROUTER_API_KEY` in `~/.hermes/.env` (provider: `eurouter`; aliases: `eu-router`, `eur`) |
 | **AI Gateway** | `AI_GATEWAY_API_KEY` in `~/.hermes/.env` (provider: `ai-gateway`) |
 | **z.ai / GLM** | `GLM_API_KEY` in `~/.hermes/.env` (provider: `zai`) |
 | **Kimi / Moonshot** | `KIMI_API_KEY` in `~/.hermes/.env` (provider: `kimi-coding`) |
@@ -237,6 +238,30 @@ model:
 | `COPILOT_GITHUB_TOKEN` | GitHub token for Copilot API (first priority) |
 | `HERMES_COPILOT_ACP_COMMAND` | Override the Copilot CLI binary path (default: `copilot`) |
 | `HERMES_COPILOT_ACP_ARGS` | Override ACP args (default: `--acp --stdio`) |
+
+### EUrouter
+
+EUrouter is an EU-resident OpenAI-compatible gateway that accepts the same `vendor/model` slugs you already use with OpenRouter. If you already know the model ID you want, switching is just a provider and API-key change.
+
+```bash
+# EUrouter gateway
+hermes chat --provider eurouter --model anthropic/claude-sonnet-4.6
+# Requires: EUROUTER_API_KEY in ~/.hermes/.env
+
+# Optional base URL override
+EUROUTER_BASE_URL=https://api.eurouter.ai/api/v1 hermes chat --provider eurouter --model openai/gpt-5.4
+```
+
+Or set it permanently in `config.yaml`:
+```yaml
+model:
+  provider: "eurouter"
+  default: "anthropic/claude-sonnet-4.6"
+```
+
+:::tip One-line OpenRouter switch
+If you already use OpenRouter-format model IDs like `anthropic/claude-sonnet-4.6` or `openai/gpt-5.4`, you can usually switch to EUrouter by changing only `provider` and the API key. The model slug stays the same.
+:::
 
 ### First-Class Chinese AI Providers
 

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -82,7 +82,7 @@ Common options:
 | `-q`, `--query "..."` | One-shot, non-interactive prompt. |
 | `-m`, `--model <model>` | Override the model for this run. |
 | `-t`, `--toolsets <csv>` | Enable a comma-separated set of toolsets. |
-| `--provider <provider>` | Force a provider: `auto`, `openrouter`, `nous`, `openai-codex`, `copilot-acp`, `copilot`, `anthropic`, `gemini`, `google-gemini-cli`, `huggingface`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `kilocode`, `xiaomi`, `arcee`, `alibaba`, `deepseek`, `nvidia`, `ollama-cloud`, `xai` (alias `grok`), `qwen-oauth`, `bedrock`, `opencode-zen`, `opencode-go`, `ai-gateway`. |
+| `--provider <provider>` | Force a provider: `auto`, `openrouter`, `eurouter`, `nous`, `openai-codex`, `copilot-acp`, `copilot`, `anthropic`, `gemini`, `google-gemini-cli`, `huggingface`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `kilocode`, `xiaomi`, `arcee`, `alibaba`, `deepseek`, `nvidia`, `ollama-cloud`, `xai` (alias `grok`), `qwen-oauth`, `bedrock`, `opencode-zen`, `opencode-go`, `ai-gateway`. |
 | `-s`, `--skills <name>` | Preload one or more skills for the session (can be repeated or comma-separated). |
 | `-v`, `--verbose` | Verbose output. |
 | `-Q`, `--quiet` | Programmatic mode: suppress banner/spinner/tool previews. |

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -14,6 +14,8 @@ All variables go in `~/.hermes/.env`. You can also set them with `hermes config 
 |----------|-------------|
 | `OPENROUTER_API_KEY` | OpenRouter API key (recommended for flexibility) |
 | `OPENROUTER_BASE_URL` | Override the OpenRouter-compatible base URL |
+| `EUROUTER_API_KEY` | EUrouter API key for the EU-resident OpenAI-compatible gateway ([api.eurouter.ai](https://api.eurouter.ai)) |
+| `EUROUTER_BASE_URL` | Override the EUrouter base URL (default: `https://api.eurouter.ai/api/v1`) |
 | `NOUS_BASE_URL` | Override Nous Portal base URL (rarely needed; development/testing only) |
 | `NOUS_INFERENCE_BASE_URL` | Override Nous inference endpoint directly |
 | `AI_GATEWAY_API_KEY` | Vercel AI Gateway API key ([ai-gateway.vercel.sh](https://ai-gateway.vercel.sh)) |
@@ -86,7 +88,7 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 
 | Variable | Description |
 |----------|-------------|
-| `HERMES_INFERENCE_PROVIDER` | Override provider selection: `auto`, `openrouter`, `nous`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `huggingface`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `kilocode`, `xiaomi`, `arcee`, `alibaba`, `deepseek`, `nvidia`, `ollama-cloud`, `xai` (alias `grok`), `google-gemini-cli`, `qwen-oauth`, `bedrock`, `opencode-zen`, `opencode-go`, `ai-gateway` (default: `auto`) |
+| `HERMES_INFERENCE_PROVIDER` | Override provider selection: `auto`, `openrouter`, `eurouter`, `nous`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `huggingface`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `kilocode`, `xiaomi`, `arcee`, `alibaba`, `deepseek`, `nvidia`, `ollama-cloud`, `xai` (alias `grok`), `google-gemini-cli`, `qwen-oauth`, `bedrock`, `opencode-zen`, `opencode-go`, `ai-gateway` (default: `auto`) |
 | `HERMES_PORTAL_BASE_URL` | Override Nous Portal URL (for development/testing) |
 | `NOUS_INFERENCE_BASE_URL` | Override Nous inference API URL |
 | `HERMES_NOUS_MIN_KEY_TTL_SECONDS` | Min agent key TTL before re-mint (default: 1800 = 30min) |

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -628,7 +628,7 @@ Every model slot in Hermes — auxiliary tasks, compression, fallback — uses t
 
 When `base_url` is set, Hermes ignores the provider and calls that endpoint directly (using `api_key` or `OPENAI_API_KEY` for auth). When only `provider` is set, Hermes uses that provider's built-in auth and base URL.
 
-Available providers for auxiliary tasks: `auto`, `main`, plus any provider in the [provider registry](/docs/reference/environment-variables) — `openrouter`, `nous`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `gemini`, `google-gemini-cli`, `qwen-oauth`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `deepseek`, `nvidia`, `xai`, `ollama-cloud`, `alibaba`, `bedrock`, `huggingface`, `arcee`, `xiaomi`, `kilocode`, `opencode-zen`, `opencode-go`, `ai-gateway` — or any named custom provider from your `custom_providers` list (e.g. `provider: "beans"`).
+Available providers for auxiliary tasks: `auto`, `main`, plus any provider in the [provider registry](/docs/reference/environment-variables) — `openrouter`, `eurouter`, `nous`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `gemini`, `google-gemini-cli`, `qwen-oauth`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `deepseek`, `nvidia`, `xai`, `ollama-cloud`, `alibaba`, `bedrock`, `huggingface`, `arcee`, `xiaomi`, `kilocode`, `opencode-zen`, `opencode-go`, `ai-gateway` — or any named custom provider from your `custom_providers` list (e.g. `provider: "beans"`).
 
 :::warning `"main"` is for auxiliary tasks only
 The `"main"` provider option means "use whatever provider my main agent uses" — it's only valid inside `auxiliary:`, `compression:`, and `fallback_model:` configs. It is **not** a valid value for your top-level `model.provider` setting. If you use a custom OpenAI-compatible endpoint, set `provider: custom` in your `model:` section. See [AI Providers](/docs/integrations/providers) for all main model provider options.
@@ -762,6 +762,7 @@ These options apply to **auxiliary task configs** (`auxiliary:`, `compression:`,
 |----------|-------------|-------------|
 | `"auto"` | Best available (default). Vision tries OpenRouter → Nous → Codex. | — |
 | `"openrouter"` | Force OpenRouter — routes to any model (Gemini, GPT-4o, Claude, etc.) | `OPENROUTER_API_KEY` |
+| `"eurouter"` | Force EUrouter — OpenRouter-compatible EU-resident gateway | `EUROUTER_API_KEY` |
 | `"nous"` | Force Nous Portal | `hermes auth` |
 | `"codex"` | Force Codex OAuth (ChatGPT account). Supports vision (gpt-5.3-codex). | `hermes model` → Codex |
 | `"main"` | Use your active custom/main endpoint. This can come from `OPENAI_BASE_URL` + `OPENAI_API_KEY` or from a custom endpoint saved via `hermes model` / `config.yaml`. Works with OpenAI, local models, or any OpenAI-compatible API. **Auxiliary tasks only — not valid for `model.provider`.** | Custom endpoint credentials + base URL |

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -37,6 +37,7 @@ Both `provider` and `model` are **required**. If either is missing, the fallback
 |----------|-------|-------------|
 | AI Gateway | `ai-gateway` | `AI_GATEWAY_API_KEY` |
 | OpenRouter | `openrouter` | `OPENROUTER_API_KEY` |
+| EUrouter | `eurouter` | `EUROUTER_API_KEY` (optional: `EUROUTER_BASE_URL`) |
 | Nous Portal | `nous` | `hermes auth` (OAuth) |
 | OpenAI Codex | `openai-codex` | `hermes model` (ChatGPT OAuth) |
 | GitHub Copilot | `copilot` | `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN` |


### PR DESCRIPTION
Title: feat(providers): native EUrouter provider

## Summary

Ships EUrouter (`https://api.eurouter.ai/api/v1`) as a first-class OpenAI-compatible provider, at parity with xai / huggingface / deepseek / zai for auth, model selection, doctor/setup, docs, and runtime routing.

Follow-up parity work closes the gaps beyond basic provider registration: OpenRouter-compatible model handling in auxiliary/runtime paths, live `/models` pricing/catalog fetches, env/config discovery, and EUrouter-specific reasoning gating so vendor-prefixed model IDs do not 400 on unsupported `reasoning` payloads.

## Changes

Core provider registration:
* `hermes_cli/auth.py`: `PROVIDER_REGISTRY["eurouter"]` with `EUROUTER_API_KEY` and `EUROUTER_BASE_URL`
* `hermes_cli/providers.py`: `HERMES_OVERLAYS["eurouter"]` + aliases (`eu-router`, `eur`) + label override
* `hermes_cli/models.py`: `CANONICAL_PROVIDERS` entry, `_PROVIDER_MODELS["eurouter"]`, alias map, live pricing/catalog fetch via `https://api.eurouter.ai/api/v1/models`
* `agent/model_metadata.py`: eurouter URL mapping + provider prefixes
* `tests/hermes_cli/test_api_key_providers.py`: registry/env/alias coverage
* Docs: providers page, quickstart, fallback table, env-vars reference, README

Parity gaps closed:
* `hermes_cli/main.py`: add `eurouter` to `_model_flow_api_key_provider` dispatch tuple and `hermes chat --provider` argparse choices
* `hermes_cli/config.py`: register `EUROUTER_API_KEY` / `EUROUTER_BASE_URL` in `OPTIONAL_ENV_VARS`
* `hermes_cli/doctor.py`: EUrouter row in `_apikey_providers` probing `https://api.eurouter.ai/api/v1/models`
* `hermes_cli/dump.py`: credential-masking entry
* `hermes_cli/model_normalize.py`: mark `eurouter` as an aggregator-style provider for vendor/model normalization
* `agent/auxiliary_client.py`: preserve OpenRouter-style vendor/model slugs on EUrouter routes and add EUrouter auxiliary defaults
* `run_agent.py`:
  * treat EUrouter as OpenRouter-compatible where needed for prompt-caching / Claude proxy behavior
  * do **not** auto-send `extra_body.reasoning` on EUrouter routes, since many EUrouter models reject that payload
* `tests/tools/test_local_env_blocklist.py`: `EUROUTER_API_KEY` leak/blocklist coverage
* `tests/hermes_cli/test_model_normalize.py`: eurouter normalization coverage
* `tests/run_agent/test_anthropic_prompt_cache_policy.py`: Claude-over-EUrouter prompt-cache coverage
* `tests/run_agent/test_run_agent.py`: EUrouter prompt-caching and reasoning-gating coverage
* `cli-config.yaml.example`: document `eurouter` provider option

## Validation

Check | Before | After
`hermes chat --provider eurouter ...` | argparse `invalid choice` / no native provider path | parses and routes through EUrouter
`hermes model` → EUrouter picker | silent fall-through from api-key-provider flow | `_model_flow_api_key_provider` runs
`hermes doctor` with `EUROUTER_API_KEY` | no EUrouter row / no endpoint probe | `✓ EUrouter`, `/api/v1/models` probed
Vendor-prefixed EUrouter model IDs | `400` on unsupported `extra_body.reasoning` for models like `openai/gpt-4.1-mini` and `qwen/qwen3-coder-30b-a3b` | succeeds without auto-sending reasoning
EUrouter pricing/catalog fetch | no native support | live `/api/v1/models` pricing/catalog path wired

Targeted tests:
* `scripts/run_tests.sh tests/hermes_cli/test_api_key_providers.py tests/tools/test_local_env_blocklist.py tests/hermes_cli/test_model_normalize.py tests/run_agent/test_anthropic_prompt_cache_policy.py tests/run_agent/test_run_agent.py -q`
* Result: `497 passed, 8 warnings in 12.77s`

Reasoning-gating follow-up:
* `scripts/run_tests.sh tests/run_agent/test_anthropic_prompt_cache_policy.py tests/run_agent/test_run_agent.py -q`
* Result: `287 passed in 9.19s`

Live E2E verified against `https://api.eurouter.ai/api/v1` with a real key:
* `python -m hermes_cli.main doctor`
* `python -m hermes_cli.main chat --provider eurouter --model openai/gpt-4.1-mini -Q -q ...`
* `python -m hermes_cli.main chat --provider eurouter --model qwen/qwen3-coder-30b-a3b -Q -q ...`
* `python -m hermes_cli.main chat --provider eurouter --model anthropic/claude-sonnet-4-6 -Q -q ...`
* Raw model IDs also verified: `gpt-4.1-mini`, `qwen3-coder-30b-a3b`, `claude-sonnet-4-6`

## Suggested Commit Split

1. `feat(providers): add native EUrouter provider`
2. `fix(providers): complete EUrouter parity`

