### PR TITLE
fix(models): use x-api-key for Anthropic API probing

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1781,6 +1781,11 @@ def probe_api_models(
     headers: dict[str, str] = {"User-Agent": _HERMES_USER_AGENT}
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"
+    # Anthropic native API uses x-api-key, not Bearer auth
+    if normalized.startswith("https://api.anthropic.com"):
+        headers.pop("Authorization", None)
+        headers["x-api-key"] = api_key
+        headers["anthropic-version"] = "2023-06-01"
     if normalized.startswith(COPILOT_BASE_URL):
         headers.update(copilot_default_headers())
 


### PR DESCRIPTION
## Problem

🐛 <i>Describe the bug</i>


detect_provider_for_model() silently rerouted Anthropic requests to OpenRouter (fixed in #10300 / f2f9d0c8). Now that direct provider routing is respected,  unconditionally sends  to every endpoint. Anthropic's native API () rejects Bearer tokens and returns HTTP 401, which blocks native Anthropic usage entirely.

## Reproduction

1. Configure a direct Anthropic provider: , 
2. Run  (or any Claude model)
3.  hits  with 
4. Anthropic returns 401 → probe fails → model switch blocked

## Fix

Detect  in  and swap the auth headers before making the  request:



## Checklist

- [x] Minimal change (5 lines)
- [x] Follows existing code style (same pattern as  check just below)
- [x] No breaking changes

Closes the latent probing issue exposed by #10300.