### PR TITLE
fix(model-picker): dedupe user providers and enrich live OpenAI counts

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1046,8 +1046,10 @@ def list_authenticated_providers(
         for ep_name, ep_cfg in user_providers.items():
             if not isinstance(ep_cfg, dict):
                 continue
-            # Skip if this slug was already emitted (e.g. canonical provider
-            # with the same name) or will be picked up by section 4.
+            # Skip if a built-in/overlay/canonical provider already claimed
+            # this slug (#7524). Without this, providers listed in both the
+            # built-in catalog and config.yaml `providers:` would appear twice
+            # (e.g. "Nous Portal (27)" and "nous (0)").
             if ep_name.lower() in seen_slugs:
                 continue
             display_name = ep_cfg.get("name", "") or ep_name
@@ -1182,6 +1184,61 @@ def list_authenticated_providers(
                 "api_url": grp["api_url"],
             })
             seen_slugs.add(slug.lower())
+
+    # --- 5. Enrich rows with live catalogs where available ---
+    # Single source of truth for counts: prefer live catalogs over the
+    # curated/config-only counts populated above. Mirrors what the TUI
+    # gateway already does in tui_gateway.server.model.options so the CLI
+    # picker matches — OpenAI / OpenAI Direct (and other dynamic catalogs)
+    # no longer show 0 models initially.
+    try:
+        from hermes_cli.models import provider_model_ids as _pmi
+        from hermes_cli.models import fetch_api_models as _fetch_api_models
+    except ImportError:
+        _pmi = None
+        _fetch_api_models = None
+
+    def _live_for_user_provider(row: dict) -> list[str]:
+        """Probe /v1/models for a user-defined OpenAI-compatible provider."""
+        if _fetch_api_models is None or not user_providers:
+            return []
+        ep_cfg = user_providers.get(row.get("slug")) if isinstance(user_providers, dict) else None
+        if not isinstance(ep_cfg, dict):
+            return []
+        base_url = (ep_cfg.get("base_url") or ep_cfg.get("api") or ep_cfg.get("url") or "").strip()
+        if not base_url:
+            return []
+        key_env = ep_cfg.get("key_env") or ""
+        api_key = ""
+        if key_env:
+            api_key = os.environ.get(key_env, "") or ""
+        if not api_key:
+            api_key = (ep_cfg.get("api_key") or ep_cfg.get("key") or "").strip()
+        try:
+            return _fetch_api_models(api_key, base_url) or []
+        except Exception as exc:
+            logger.debug("User-provider live probe failed for %s: %s", row.get("slug"), exc)
+            return []
+
+    if _pmi is not None:
+        for row in results:
+            is_user_config = row.get("source") == "user-config"
+            # For user-config rows, the explicit `models:` from config is
+            # the source of truth — don't overwrite. Only probe live when
+            # config provided no models at all (e.g. openai-direct that
+            # only sets base_url + key_env).
+            if is_user_config and row.get("total_models", 0) > 0:
+                continue
+            live: list[str] = []
+            try:
+                live = list(_pmi(row.get("slug")) or [])
+            except Exception as exc:
+                logger.debug("Live catalog probe failed for %s: %s", row.get("slug"), exc)
+            if not live and is_user_config:
+                live = _live_for_user_provider(row)
+            if live:
+                row["models"] = live[:max_models]
+                row["total_models"] = len(live)
 
     # Sort: current provider first, then by model count descending
     results.sort(key=lambda r: (not r["is_current"], -r["total_models"]))

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1121,6 +1121,17 @@ def list_authenticated_providers(
             if not isinstance(entry, dict):
                 continue
 
+            # Skip entries that originated from a `providers:` dict entry
+            # already emitted by Section 3. get_compatible_custom_providers()
+            # expands user_providers into custom-provider shape and tags them
+            # with provider_key; without this guard the same logical provider
+            # appears twice with different generated slugs (e.g. user_provider
+            # `custom` named "Ollama (local)" → Section 3 emits slug=custom,
+            # Section 4 emits slug=ollama-local).
+            provider_key = str(entry.get("provider_key", "") or "").strip().lower()
+            if provider_key and provider_key in seen_slugs:
+                continue
+
             display_name = (entry.get("name") or "").strip()
             api_url = (
                 entry.get("base_url", "")

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1280,6 +1280,27 @@ def _resolve_copilot_catalog_api_key() -> str:
         return ""
 
 
+def _resolve_openai_catalog_credentials(provider_id: str) -> tuple[str, str]:
+    """Best-effort OpenAI credentials for provider model catalog probing."""
+    try:
+        from hermes_cli.auth import resolve_api_key_provider_credentials
+
+        creds = resolve_api_key_provider_credentials(provider_id)
+        api_key = str(creds.get("api_key") or "").strip()
+        base_url = str(creds.get("base_url") or "").strip()
+        if base_url:
+            return api_key, base_url
+    except Exception:
+        pass
+
+    api_key = os.getenv("OPENAI_API_KEY", "").strip()
+    if provider_id == "openai-direct":
+        base_url = "https://api.openai.com/v1"
+    else:
+        base_url = os.getenv("OPENAI_BASE_URL", "").strip() or "https://api.openai.com/v1"
+    return api_key, base_url.rstrip("/")
+
+
 def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) -> list[str]:
     """Return the best known model catalog for a provider.
 
@@ -1293,6 +1314,11 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
         from hermes_cli.codex_models import get_codex_model_ids
 
         return get_codex_model_ids()
+    if normalized in {"openai", "openai-direct"}:
+        api_key, base_url = _resolve_openai_catalog_credentials(normalized)
+        live = fetch_api_models(api_key, base_url)
+        if live:
+            return live
     if normalized in {"copilot", "copilot-acp"}:
         try:
             live = _fetch_github_models(_resolve_copilot_catalog_api_key())

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -211,6 +211,26 @@ class TestProviderModelIds:
         assert "gpt-5.4" in ids
         assert "copilot-acp" not in ids
 
+    def test_openai_prefers_live_catalog(self):
+        with patch(
+            "hermes_cli.models._resolve_openai_catalog_credentials",
+            return_value=("test-openai-key", "https://api.openai.com/v1"),
+        ), patch(
+            "hermes_cli.models.fetch_api_models",
+            return_value=["gpt-5.4", "gpt-5.4-mini"],
+        ):
+            assert provider_model_ids("openai") == ["gpt-5.4", "gpt-5.4-mini"]
+
+    def test_openai_direct_prefers_live_catalog(self):
+        with patch(
+            "hermes_cli.models._resolve_openai_catalog_credentials",
+            return_value=("test-openai-key", "https://api.openai.com/v1"),
+        ), patch(
+            "hermes_cli.models.fetch_api_models",
+            return_value=["gpt-5.4", "gpt-5.4-mini"],
+        ):
+            assert provider_model_ids("openai-direct") == ["gpt-5.4", "gpt-5.4-mini"]
+
 
 # -- fetch_api_models --------------------------------------------------------
 

--- a/tests/hermes_cli/test_picker_section3_dedupe_and_enrichment.py
+++ b/tests/hermes_cli/test_picker_section3_dedupe_and_enrichment.py
@@ -1,0 +1,190 @@
+"""Regression tests for /model picker Section 3 dedupe and live count enrichment.
+
+Covers two related bugs in ``list_authenticated_providers``:
+
+1. Section 3 (user-defined providers from config.yaml ``providers:``) appended
+   rows without checking ``seen_slugs``, producing duplicate entries when a
+   provider name overlapped with a built-in (issue #7524).
+
+2. User-defined providers like ``openai-direct`` that supply only a
+   ``base_url`` + ``key_env`` (no explicit ``models:`` list) showed
+   ``total_models=0`` in the picker even though the live ``/v1/models``
+   catalog returned a full list. Counts are now enriched from
+   ``provider_model_ids`` (and a direct ``/v1/models`` probe for
+   user-defined providers) so the CLI picker matches what the TUI
+   gateway already showed after selection.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.model_switch import list_authenticated_providers
+
+
+# --- Section 3 dedupe -------------------------------------------------------
+
+
+@patch.dict(os.environ, {"OPENROUTER_API_KEY": "fake-or"}, clear=False)
+def test_user_provider_does_not_duplicate_built_in(monkeypatch):
+    """A user-defined provider sharing a built-in slug must not appear twice."""
+    # `openrouter` is a built-in provider; redefining it in config.yaml
+    # must NOT add a second row to the picker.
+    user_providers = {
+        "openrouter": {
+            "name": "OpenRouter (custom)",
+            "api": "https://openrouter.ai/api/v1",
+            "default_model": "anthropic/claude-opus-4-6",
+        }
+    }
+
+    providers = list_authenticated_providers(
+        current_provider="",
+        user_providers=user_providers,
+        custom_providers=[],
+    )
+
+    matches = [p for p in providers if p["slug"].lower() == "openrouter"]
+    assert len(matches) == 1, (
+        f"openrouter should appear once; got {len(matches)} entries: {matches}"
+    )
+
+
+def test_user_provider_unique_slug_still_appears(monkeypatch):
+    """A user-defined provider with a unique slug must still be listed."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    user_providers = {
+        "my-private-llm": {
+            "name": "My Private LLM",
+            "api": "http://internal.example.com/v1",
+            "default_model": "internal-model-1",
+        }
+    }
+
+    providers = list_authenticated_providers(
+        current_provider="",
+        user_providers=user_providers,
+        custom_providers=[],
+    )
+
+    assert any(p["slug"] == "my-private-llm" for p in providers), (
+        "User-defined providers with unique slugs should still be listed"
+    )
+
+
+# --- Live count enrichment --------------------------------------------------
+
+
+def test_user_provider_count_enriched_from_live_probe(monkeypatch):
+    """openai-direct (no explicit models in config) should show the live count."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    user_providers = {
+        "openai-direct": {
+            "name": "OpenAI Direct",
+            "base_url": "https://api.openai.com/v1",
+            "key_env": "OPENAI_API_KEY",
+            # no `models:` and no `default_model` — live probe is the
+            # only source of catalog data
+        }
+    }
+
+    fake_catalog = [f"gpt-fake-{i}" for i in range(122)]
+
+    def fake_fetch(api_key, base_url, timeout=5.0):
+        assert base_url == "https://api.openai.com/v1"
+        return fake_catalog
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fake_fetch)
+    # Also stub provider_model_ids since openai-direct has its own branch
+    # there which would call the real network.
+    monkeypatch.setattr(
+        "hermes_cli.models.provider_model_ids",
+        lambda slug, **kw: fake_catalog if slug == "openai-direct" else [],
+    )
+
+    providers = list_authenticated_providers(
+        current_provider="",
+        user_providers=user_providers,
+        custom_providers=[],
+        max_models=8,
+    )
+
+    od = next((p for p in providers if p["slug"] == "openai-direct"), None)
+    assert od is not None, "openai-direct should appear in picker"
+    assert od["total_models"] == 122, (
+        f"openai-direct should show live count 122, got {od['total_models']}"
+    )
+    # The visible models list is capped to max_models
+    assert len(od["models"]) == 8
+
+
+def test_user_provider_explicit_models_not_overwritten(monkeypatch):
+    """When a user provider declares explicit models, live probe must not overwrite them."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    user_providers = {
+        "local-ollama": {
+            "name": "Local Ollama",
+            "api": "http://localhost:11434/v1",
+            "default_model": "model-a",
+            "models": ["model-a", "model-b", "model-c", "model-d"],
+        }
+    }
+
+    # Even if the live probe returns something different, the explicit
+    # config must win.
+    monkeypatch.setattr(
+        "hermes_cli.models.provider_model_ids",
+        lambda slug, **kw: ["surprise-model-1", "surprise-model-2"],
+    )
+
+    providers = list_authenticated_providers(
+        current_provider="",
+        user_providers=user_providers,
+        custom_providers=[],
+        max_models=50,
+    )
+
+    lo = next((p for p in providers if p["slug"] == "local-ollama"), None)
+    assert lo is not None
+    assert lo["total_models"] == 4
+    assert "surprise-model-1" not in lo["models"]
+
+
+def test_live_probe_failure_falls_back_to_config(monkeypatch):
+    """If the live probe raises, the picker must still return config-only data."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    user_providers = {
+        "openai-direct": {
+            "name": "OpenAI Direct",
+            "base_url": "https://api.openai.com/v1",
+            "key_env": "OPENAI_API_KEY",
+        }
+    }
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr("hermes_cli.models.provider_model_ids", boom)
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", boom)
+
+    providers = list_authenticated_providers(
+        current_provider="",
+        user_providers=user_providers,
+        custom_providers=[],
+    )
+
+    od = next((p for p in providers if p["slug"] == "openai-direct"), None)
+    assert od is not None, "openai-direct should still appear when live probe fails"
+    assert od["total_models"] == 0  # config has no models, probe failed

--- a/tests/hermes_cli/test_picker_section3_dedupe_and_enrichment.py
+++ b/tests/hermes_cli/test_picker_section3_dedupe_and_enrichment.py
@@ -160,6 +160,54 @@ def test_user_provider_explicit_models_not_overwritten(monkeypatch):
     assert "surprise-model-1" not in lo["models"]
 
 
+def test_section4_skips_provider_key_already_in_section3(monkeypatch):
+    """Custom-provider entries derived from user_providers must not duplicate.
+
+    The CLI picker calls ``get_compatible_custom_providers()`` which expands
+    ``providers:`` config entries into legacy ``custom_providers`` shape with
+    a ``provider_key`` tag. Section 3 already emits a row for each
+    user_provider; Section 4 must skip the matching expanded entry, otherwise
+    the same logical provider appears twice with different generated slugs
+    (e.g. user_provider key ``custom`` named "Ollama (local)" → Section 3
+    emits slug=custom, Section 4 emits slug=ollama-local).
+    """
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    user_providers = {
+        "custom": {
+            "name": "Ollama (local)",
+            "base_url": "http://localhost:11434/v1",
+            "default_model": "qwen3.5",
+            "models": ["qwen3.5"],
+        }
+    }
+    # Mirrors what get_compatible_custom_providers() returns: same logical
+    # entry tagged with provider_key pointing back to the user_providers key.
+    custom_providers = [
+        {
+            "name": "Ollama (local)",
+            "base_url": "http://localhost:11434/v1",
+            "provider_key": "custom",
+            "model": "qwen3.5",
+        }
+    ]
+
+    providers = list_authenticated_providers(
+        current_provider="",
+        user_providers=user_providers,
+        custom_providers=custom_providers,
+    )
+
+    matches = [p for p in providers if p["name"] == "Ollama (local)"]
+    assert len(matches) == 1, (
+        f"'Ollama (local)' should appear once; got {len(matches)}: "
+        f"{[(p['slug'], p['source']) for p in matches]}"
+    )
+    # The surviving row should be the Section 3 one (slug = user_providers key)
+    assert matches[0]["slug"] == "custom"
+
+
 def test_live_probe_failure_falls_back_to_config(monkeypatch):
     """If the live probe raises, the picker must still return config-only data."""
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})


### PR DESCRIPTION
## Problem

The CLI `/model` picker had two regressions that were reproducible in the user's live environment:

1. `OpenAI` and `OpenAI Direct` showed `0` models in the picker even though `provider_model_ids()` returned the live catalog (`122` models).
2. Duplicate provider rows appeared in the picker for providers expanded from `providers:` config entries into compatibility `custom_providers` entries.

Examples seen live before the fix included duplicate `Ollama (local)` / `Ollama` style rows and duplicate `OpenAI Direct` rows with inconsistent counts.

## Root cause

### 1. OpenAI/OpenAI Direct zero-count rows

`list_authenticated_providers()` built picker rows from curated/static/config-only counts, while the actual model-selection flow consulted live catalogs later at selection time. That meant providers with dynamic catalogs, especially `openai` and `openai-direct`, rendered with `total_models=0` until the user selected them.

### 2. Duplicate provider rows in CLI picker

The CLI path calls `get_compatible_custom_providers()`, which expands `providers:` config entries into legacy `custom_providers` shape. This created two duplication paths:

- Section 3 emitted user-defined providers using their config dict key as the slug.
- Section 4 later re-emitted the same logical provider using a slug derived from the display name.

Because those slugs differed, the existing `seen_slugs` check did not catch the duplicate.

## Fix

- Add `_resolve_openai_catalog_credentials()` and use live `/v1/models` probing in `provider_model_ids()` for `openai` and `openai-direct`.
- In `list_authenticated_providers()`:
  - skip Section 3 entries whose slug is already claimed by a built-in/overlay/canonical provider
  - skip Section 4 entries whose `provider_key` was already emitted in Section 3
  - add a unified final enrichment pass that fills picker counts from live catalogs where available
  - preserve explicit `models:` configured by the user instead of overwriting them with live probes
- Add regression tests for both the live enrichment and duplicate-row cases.

## Verification

### Automated

Targeted picker/model tests on the rebased branch:

- `tests/hermes_cli/test_picker_section3_dedupe_and_enrichment.py`
- `tests/hermes_cli/test_model_validation.py`
- `tests/hermes_cli/test_model_switch_custom_providers.py`
- `tests/hermes_cli/test_user_providers_model_switch.py`
- `tests/hermes_cli/test_overlay_slug_resolution.py`
- `tests/hermes_cli/test_model_picker_viewport.py`
- `tests/hermes_cli/test_codex_cli_model_picker.py`

Result:

- `112 passed`

### Live verification in user environment

Observed picker rows after the fix:

- `Ollama` — `19`
- `OpenAI` — `122`
- `OpenAI Direct` — `122`
- `OpenRouter` — `31`
- `GitHub Copilot` — `14`
- `Anthropic` — `9`

No duplicate rows remained in the live picker.

## Notes

This PR keeps the CLI picker behavior aligned with the TUI/gateway path, which was already enriching model options from live catalogs.