### PR TITLE
fix(gateway): keep retryable platform reconnects queued

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2401,10 +2401,9 @@ class GatewayRunner:
         """Background task that periodically retries connecting failed platforms.
 
         Uses exponential backoff: 30s → 60s → 120s → 240s → 300s (cap).
-        Stops retrying a platform after 20 failed attempts or if the error
-        is non-retryable (e.g. bad auth token).
+        Retryable failures remain in the reconnect queue until they recover
+        or become non-retryable (e.g. bad auth token).
         """
-        _MAX_ATTEMPTS = 20
         _BACKOFF_CAP = 300  # 5 minutes max between retries
 
         await asyncio.sleep(10)  # initial delay — let startup finish
@@ -2425,19 +2424,20 @@ class GatewayRunner:
                 if now < info["next_retry"]:
                     continue  # not time yet
 
-                if info["attempts"] >= _MAX_ATTEMPTS:
-                    logger.warning(
-                        "Giving up reconnecting %s after %d attempts",
-                        platform.value, info["attempts"],
-                    )
-                    del self._failed_platforms[platform]
-                    continue
-
                 platform_config = info["config"]
                 attempt = info["attempts"] + 1
+                retry_delay = max(0, int(info["next_retry"] - now))
+                if attempt % 10 == 0:
+                    logger.warning(
+                        "Still retrying %s after %d failed attempt(s)",
+                        platform.value,
+                        info["attempts"],
+                    )
                 logger.info(
-                    "Reconnecting %s (attempt %d/%d)...",
-                    platform.value, attempt, _MAX_ATTEMPTS,
+                    "Reconnecting %s (attempt %d, retry delay %ds)...",
+                    platform.value,
+                    attempt,
+                    retry_delay,
                 )
 
                 try:

--- a/tests/gateway/test_platform_reconnect.py
+++ b/tests/gateway/test_platform_reconnect.py
@@ -208,20 +208,23 @@ class TestPlatformReconnectWatcher:
         assert runner._failed_platforms[Platform.TELEGRAM]["attempts"] == 2
 
     @pytest.mark.asyncio
-    async def test_reconnect_gives_up_after_max_attempts(self):
-        """After max attempts, platform should be removed from retry queue."""
+    async def test_reconnect_retryable_past_previous_max_attempts(self):
+        """Retryable failures should remain queued even after many attempts."""
         runner = _make_runner()
 
         platform_config = PlatformConfig(enabled=True, token="test")
         runner._failed_platforms[Platform.TELEGRAM] = {
             "config": platform_config,
-            "attempts": 20,  # At max
+            "attempts": 20,
             "next_retry": time.monotonic() - 1,
         }
 
+        fail_adapter = StubAdapter(
+            succeed=False, fatal_error="DNS failure", fatal_retryable=True
+        )
         real_sleep = asyncio.sleep
 
-        with patch.object(runner, "_create_adapter") as mock_create:
+        with patch.object(runner, "_create_adapter", return_value=fail_adapter) as mock_create:
             async def run_one_iteration():
                 runner._running = True
                 call_count = 0
@@ -238,8 +241,9 @@ class TestPlatformReconnectWatcher:
 
             await run_one_iteration()
 
-        assert Platform.TELEGRAM not in runner._failed_platforms
-        mock_create.assert_not_called()  # Should give up without trying
+        assert Platform.TELEGRAM in runner._failed_platforms
+        assert runner._failed_platforms[Platform.TELEGRAM]["attempts"] == 21
+        mock_create.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_reconnect_skips_when_not_time_yet(self):


### PR DESCRIPTION
The reconnect watcher previously gave up after 20 failed attempts, even when the adapter marked the failure as retryable. That caused transient infrastructure issues like DNS failures to become permanent until the gateway was restarted.

Keep retryable failures in the reconnect queue and continue applying backoff until the platform recovers or returns a non-retryable error. Add a regression test covering retryable failures past the previous 20-attempt limit.

## What does this PR do?

Fixes a gateway reconnect bug where retryable platform failures were eventually dropped after repeated attempts instead of staying in the reconnect queue. This allows transient outages such as prolonged network loss or DNS failures to recover automatically once connectivity returns.

## Related Issue

Fixes #12607

Related: #11241, which keeps retryable fatal failures in-process. This PR fixes the remaining reconnect path where retryable failures were still dropped after 20 attempts.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `gateway/run.py` so retryable reconnect failures remain queued instead of being dropped after the previous 20-attempt limit.
- Preserved reconnect backoff behavior until the platform recovers or reports a non-retryable error.
- Tightened reconnect logging so periodic warnings start at the 10th attempt while normal retry logs include the retry delay.
- Added a regression test in `tests/gateway/test_platform_reconnect.py` covering retryable failures beyond the old limit.

## How to Test

1. Run `scripts/run_tests.sh tests/gateway/test_platform_reconnect.py`.
2. Confirm the reconnect watcher tests pass, including the retryable failure case beyond 20 attempts.
3. Optionally reproduce manually by forcing repeated retryable reconnect failures, then restoring connectivity and confirming the gateway resumes reconnecting without a restart.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian 13 (x86_64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted regression test run:

`14 passed in 0.74s`

Note: upstream `main` is currently red in GitHub Actions, including at least one unrelated failing test (`tests/test_mcp_serve.py::TestEventBridgePollE2E::test_poll_detects_new_message_after_db_write`) reproduced on clean `upstream/main` outside this PR.
