### PR TITLE
feat: add operational model router v1

### DIFF
--- a/.github/workflows/router-ci.yml
+++ b/.github/workflows/router-ci.yml
@@ -1,0 +1,57 @@
+name: Router CI
+
+on:
+  push:
+    paths:
+      - "model_router/**"
+      - ".github/workflows/router-ci.yml"
+  pull_request:
+    paths:
+      - "model_router/**"
+      - ".github/workflows/router-ci.yml"
+  workflow_dispatch:
+
+jobs:
+  validate-and-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: model_router
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: model_router/pyproject.toml
+
+      - name: Install project
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+
+      - name: Validate router config
+        run: |
+          validate-router-config router_config.yaml
+
+      - name: Run end-to-end demo workflow
+        run: |
+          python scripts/demo_workflow.py > /tmp/model-router-demo.json
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          data = json.loads(Path('/tmp/model-router-demo.json').read_text(encoding='utf-8'))
+          assert data['summary']['total_decisions'] == 3
+          assert data['summary']['total_feedback_events'] == 3
+          assert data['patched_config_valid'] is True
+          assert Path(data['log_path']).exists()
+          print('demo workflow OK')
+          PY
+
+      - name: Run test suite
+        run: |
+          pytest -q

--- a/model_router/.gitignore
+++ b/model_router/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.pyc
+.pytest_cache/
+.venv/
+logs/
+sample_data/*.jsonl
+dist/
+build/
+*.egg-info/

--- a/model_router/Makefile
+++ b/model_router/Makefile
@@ -1,0 +1,59 @@
+PYTHON ?= python3
+LOG_PATH ?= logs/router-decisions.jsonl
+CONFIG ?= router_config.yaml
+
+.PHONY: install install-dev test validate-config check route analyze analyze-json suggest suggest-segments propose-patch propose-patch-full demo review
+
+install:
+	$(PYTHON) -m pip install -e .
+
+install-dev:
+	$(PYTHON) -m pip install -e .[dev]
+
+test:
+	pytest -q
+
+validate-config:
+	validate-router-config $(CONFIG)
+
+check: validate-config test
+
+route:
+	route-model --task-type coding --mode execute --priority high --has-code --json
+
+analyze:
+	analyze-router-telemetry $(LOG_PATH)
+
+analyze-json:
+	analyze-router-telemetry $(LOG_PATH) --json
+
+suggest:
+	suggest-router-changes $(LOG_PATH)
+
+suggest-segments:
+	suggest-router-segments $(LOG_PATH)
+
+propose-patch:
+	propose-router-patch $(LOG_PATH) --config $(CONFIG)
+
+propose-patch-full:
+	propose-router-patch $(LOG_PATH) --config $(CONFIG) --full-config
+
+demo:
+	$(PYTHON) scripts/demo_workflow.py
+
+review:
+	@echo "== validate config =="
+	@validate-router-config $(CONFIG)
+	@echo
+	@echo "== telemetry summary =="
+	@analyze-router-telemetry $(LOG_PATH)
+	@echo
+	@echo "== general suggestions =="
+	@suggest-router-changes $(LOG_PATH)
+	@echo
+	@echo "== segment suggestions =="
+	@suggest-router-segments $(LOG_PATH)
+	@echo
+	@echo "== proposed patch =="
+	@propose-router-patch $(LOG_PATH) --config $(CONFIG)

--- a/model_router/README.md
+++ b/model_router/README.md
@@ -1,0 +1,256 @@
+# Model Router
+
+ראוטר אופרטיבי לבחירת מודל לפי סוג משימה, עדיפות, פרטיות, מצב מכסה ומהירות — עם telemetry, feedback loop, ניתוח ביצועים, segmented suggestions והצעת patch ל-policy.
+
+## Quick Start
+
+```bash
+cd model_router
+python3 -m pip install -e .
+validate-router-config router_config.yaml
+python3 scripts/demo_workflow.py
+```
+
+אם יש סביבת test מלאה:
+
+```bash
+python3 -m pip install -e .[dev]
+pytest -q
+```
+
+## מה כבר עובד בפועל
+
+זה כבר לא scaffold בלבד. כרגע יש כאן מערכת עובדת עם החלקים הבאים:
+
+- `model_router.py` — מנוע הראוטר
+- `route_cli.py` — CLI לבחירת מודל
+- `telemetry.py` — append-only JSONL logging ל-decisions
+- `log_router_feedback.py` — append-only JSONL logging ל-feedback
+- `analyze_telemetry.py` — summary + join לפי `request_id`
+- `suggest_router_changes.py` — המלצות כלליות
+- `suggest_router_changes_v2.py` — segmented suggestions
+- `propose_config_patch.py` — הצעת patch ל-`router_config.yaml`
+- `validate_router_config.py` — ולידציה לקונפיג
+
+## מבנה הפרויקט
+
+```txt
+model_router/
+  README.md
+  pyproject.toml
+  router_config.yaml
+  model_router.py
+  route_cli.py
+  telemetry.py
+  log_router_feedback.py
+  analyze_telemetry.py
+  suggest_router_changes.py
+  suggest_router_changes_v2.py
+  propose_config_patch.py
+  validate_router_config.py
+  Makefile
+  justfile
+  scripts/
+    demo_workflow.py
+  sample_data/
+  tests/
+```
+
+## CLI commands זמינים
+
+אחרי `pip install -e .` יהיו זמינים:
+
+- `validate-router-config`
+- `route-model`
+- `log-router-feedback`
+- `analyze-router-telemetry`
+- `suggest-router-changes`
+- `suggest-router-segments`
+- `propose-router-patch`
+
+בנוסף יש demo script מקומי:
+
+- `python3 scripts/demo_workflow.py`
+
+## דוגמאות שימוש
+
+### 1. בחירת מודל
+```bash
+route-model --task-type coding --mode execute --priority high --has-code --json
+```
+
+### 2. כתיבת decision log
+```bash
+route-model \
+  --task-type coding \
+  --mode execute \
+  --priority high \
+  --has-code \
+  --log-path logs/router-decisions.jsonl \
+  --request-id req-1 \
+  --json
+```
+
+### 3. כתיבת feedback
+```bash
+log-router-feedback \
+  --log-path logs/router-decisions.jsonl \
+  --request-id req-1 \
+  --outcome success \
+  --actual-model-used gpt-5.4 \
+  --user-rating 5 \
+  --notes "worked well"
+```
+
+### 4. ניתוח telemetry
+```bash
+analyze-router-telemetry logs/router-decisions.jsonl
+```
+
+### 5. הצעות כלליות
+```bash
+suggest-router-changes logs/router-decisions.jsonl
+```
+
+### 6. segmented suggestions
+```bash
+suggest-router-segments logs/router-decisions.jsonl
+```
+
+### 7. הצעת patch ל-config
+```bash
+propose-router-patch logs/router-decisions.jsonl --config router_config.yaml
+```
+
+### 8. הרצת demo end-to-end
+```bash
+python3 scripts/demo_workflow.py
+```
+
+הסקריפט:
+- יוצר `sample_data/demo_router_log.jsonl`
+- מדמה 3 החלטות + 3 אירועי feedback
+- מריץ summary + suggestions + segmented suggestions
+- בונה patch proposal
+- מוודא שה-config המוצע עדיין valid
+- מכוסה גם בטסט ייעודי: `tests/test_demo_workflow.py`
+
+## `router_config.yaml`
+
+הקובץ מגדיר כרגע:
+
+- `router.default_model`
+- `base_by_task`
+- `fallbacks`
+- `mode_overrides`
+- `reviewers`
+- `policy_overrides`
+
+דוגמה:
+
+```yaml
+policy_overrides:
+  - name: "auto-chat-medium-critical"
+    when:
+      task_type: "chat"
+      priority: "medium"
+      quota: "critical"
+    force: "claude-sonnet-4.6"
+    reason: "telemetry: avoid weak routing for chat+medium+critical"
+```
+
+## סדר הקדימויות בראוטר
+
+הזרימה כרגע היא:
+
+1. normalize
+2. base selection
+3. mode override
+4. hard safety overrides
+5. soft routing overrides
+6. policy overrides
+7. hard safety overrides שוב
+8. constraints
+9. reviewer
+
+המשמעות:
+- policy יכול לדרוס quota/speed heuristics
+- אבל לא יכול לדרוס privacy safety
+
+## Makefile / justfile
+
+### Makefile
+```bash
+make install-dev
+make validate-config
+make test
+make check
+make analyze
+make suggest
+make suggest-segments
+make propose-patch
+make demo
+make review
+```
+
+### justfile
+```bash
+just install-dev
+just validate-config
+just test
+just check
+just analyze
+just suggest
+just suggest-segments
+just propose-patch
+just demo
+just review
+```
+
+## CI
+
+יש workflow ב:
+
+```txt
+.github/workflows/router-ci.yml
+```
+
+הוא רץ על שינויים ב-`model_router/**` ומבצע:
+
+1. install (`.[dev]`)
+2. `validate-router-config router_config.yaml`
+3. demo workflow end-to-end
+4. `pytest -q`
+
+## סטטוס נוכחי
+
+עובד בפועל:
+- routing
+- policy overrides
+- decision logging
+- feedback logging
+- telemetry analysis
+- general suggestions
+- segmented suggestions
+- config patch proposal
+- config validation
+- demo workflow end-to-end
+- demo workflow test coverage
+
+עדיין חסר או תלוי סביבה:
+- הרצת `pytest` מלאה בסביבה עם `pip/pytest`
+- CI ירוק בפועל על runner אמיתי
+- polish קטן נוסף אם תרצה, אבל לא חסר רכיב v1 קריטי
+
+## workflow מומלץ
+
+```bash
+route-model ... --log-path logs/router-decisions.jsonl --request-id req-123
+log-router-feedback --log-path logs/router-decisions.jsonl --request-id req-123 --outcome success --actual-model-used gpt-5.4
+analyze-router-telemetry logs/router-decisions.jsonl
+suggest-router-changes logs/router-decisions.jsonl
+suggest-router-segments logs/router-decisions.jsonl
+propose-router-patch logs/router-decisions.jsonl --config router_config.yaml
+```
+
+זה כבר v1 פנימי די רציני, לא רק skeleton.

--- a/model_router/analyze_telemetry.py
+++ b/model_router/analyze_telemetry.py
@@ -1,0 +1,279 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+
+def load_events(path: str | Path) -> list[dict[str, Any]]:
+    log_path = Path(path)
+    if not log_path.exists():
+        raise SystemExit(f"Log file not found: {log_path}")
+
+    events = []
+    for line in log_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        events.append(json.loads(line))
+    return events
+
+
+def safe_get(d: dict[str, Any], *keys, default=None):
+    cur = d
+    for key in keys:
+        if not isinstance(cur, dict) or key not in cur:
+            return default
+        cur = cur[key]
+    return cur
+
+
+def split_events(events: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    decisions = []
+    feedbacks = []
+    for event in events:
+        event_type = event.get("event_type", "decision")
+        if event_type == "feedback":
+            feedbacks.append(event)
+        else:
+            decisions.append(event)
+    return decisions, feedbacks
+
+
+def latest_feedback_by_request_id(feedbacks: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for fb in feedbacks:
+        request_id = fb.get("request_id")
+        if request_id:
+            grouped[request_id].append(fb)
+
+    latest = {}
+    for request_id, items in grouped.items():
+        items_sorted = sorted(items, key=lambda row: row.get("timestamp", ""))
+        latest[request_id] = items_sorted[-1]
+    return latest
+
+
+def join_decisions_with_feedback(
+    decisions: list[dict[str, Any]], latest_feedback: dict[str, dict[str, Any]]
+) -> list[dict[str, Any]]:
+    joined = []
+    for decision_event in decisions:
+        request_id = decision_event.get("request_id")
+        feedback = latest_feedback.get(request_id)
+        joined.append(
+            {
+                "request_id": request_id,
+                "timestamp": decision_event.get("timestamp"),
+                "task_type": safe_get(decision_event, "input", "task_type"),
+                "priority": safe_get(decision_event, "input", "priority"),
+                "quota": safe_get(decision_event, "input", "quota"),
+                "primary_model": safe_get(decision_event, "decision", "primary_model"),
+                "reviewer": safe_get(decision_event, "decision", "reviewer"),
+                "feedback_present": feedback is not None,
+                "outcome": feedback.get("outcome") if feedback else None,
+                "actual_model_used": feedback.get("actual_model_used") if feedback else None,
+                "fallback_used": feedback.get("fallback_used") if feedback else False,
+                "user_rating": feedback.get("user_rating") if feedback else None,
+            }
+        )
+    return joined
+
+
+def aggregate_joined(joined: list[dict[str, Any]], key_name: str) -> dict[str, Any]:
+    buckets: dict[str, dict[str, Any]] = {}
+
+    for row in joined:
+        key = row.get(key_name) or "unknown"
+        bucket = buckets.setdefault(
+            key,
+            {
+                "total": 0,
+                "with_feedback": 0,
+                "success": 0,
+                "bad_fit": 0,
+                "failed": 0,
+                "fallback_used": 0,
+                "abandoned": 0,
+                "ratings": [],
+                "mismatch_actual_model": 0,
+            },
+        )
+
+        bucket["total"] += 1
+        if row["feedback_present"]:
+            bucket["with_feedback"] += 1
+
+        outcome = row.get("outcome")
+        if outcome in ("success", "bad_fit", "failed", "fallback_used", "abandoned"):
+            bucket[outcome] += 1
+        elif row.get("fallback_used"):
+            bucket["fallback_used"] += 1
+
+        rating = row.get("user_rating")
+        if isinstance(rating, int):
+            bucket["ratings"].append(rating)
+
+        actual_model = row.get("actual_model_used")
+        primary_model = row.get("primary_model")
+        if actual_model and primary_model and actual_model != primary_model:
+            bucket["mismatch_actual_model"] += 1
+
+    result = {}
+    for key, bucket in buckets.items():
+        ratings = bucket.pop("ratings")
+        total = bucket["total"]
+        with_feedback = bucket["with_feedback"]
+        result[key] = {
+            **bucket,
+            "feedback_coverage_rate": round(with_feedback / total, 4) if total else 0.0,
+            "success_rate": round(bucket["success"] / with_feedback, 4) if with_feedback else None,
+            "fallback_rate": round(bucket["fallback_used"] / with_feedback, 4) if with_feedback else None,
+            "average_rating": round(sum(ratings) / len(ratings), 3) if ratings else None,
+        }
+    return result
+
+
+def summarize(events: list[dict[str, Any]]) -> dict[str, Any]:
+    decisions, feedbacks = split_events(events)
+    latest_feedback = latest_feedback_by_request_id(feedbacks)
+    joined = join_decisions_with_feedback(decisions, latest_feedback)
+
+    request_ids = set()
+    timestamps = []
+    primary_models = Counter()
+    task_types = Counter()
+    priorities = Counter()
+    reviewers = Counter()
+    override_signals = Counter()
+    outcomes = Counter()
+    actual_models = Counter()
+    ratings = []
+    feedback_request_ids = set()
+
+    for event in decisions:
+        request_id = event.get("request_id")
+        if request_id:
+            request_ids.add(request_id)
+        ts = event.get("timestamp")
+        if ts:
+            timestamps.append(ts)
+        primary = safe_get(event, "decision", "primary_model")
+        if primary:
+            primary_models[primary] += 1
+        task_type = safe_get(event, "input", "task_type")
+        if task_type:
+            task_types[task_type] += 1
+        priority = safe_get(event, "input", "priority")
+        if priority:
+            priorities[priority] += 1
+        reviewer = safe_get(event, "decision", "reviewer")
+        if reviewer:
+            reviewers[reviewer] += 1
+        trace = safe_get(event, "decision", "trace", default=[]) or []
+        for item in trace:
+            if "normalize: has_code/has_logs -> coding" in item:
+                override_signals["normalized_to_coding"] += 1
+            if "override: quota=" in item:
+                override_signals["quota_override"] += 1
+            if "override: privacy=" in item or "privacy=sensitive + batch" in item:
+                override_signals["privacy_override"] += 1
+            if "override: fast + trivial + low" in item:
+                override_signals["fast_trivial_override"] += 1
+            if "constraint: high priority forbids cheap primary" in item:
+                override_signals["high_priority_constraint"] += 1
+
+    for fb in feedbacks:
+        request_id = fb.get("request_id")
+        if request_id:
+            feedback_request_ids.add(request_id)
+            request_ids.add(request_id)
+        outcome = fb.get("outcome")
+        if outcome:
+            outcomes[outcome] += 1
+        actual_model = fb.get("actual_model_used")
+        if actual_model:
+            actual_models[actual_model] += 1
+        rating = fb.get("user_rating")
+        if isinstance(rating, int):
+            ratings.append(rating)
+
+    return {
+        "total_decisions": len(decisions),
+        "total_feedback_events": len(feedbacks),
+        "unique_request_ids": len(request_ids),
+        "time_range": {
+            "first": min(timestamps) if timestamps else None,
+            "last": max(timestamps) if timestamps else None,
+        },
+        "primary_models": dict(primary_models),
+        "task_types": dict(task_types),
+        "priorities": dict(priorities),
+        "reviewers": dict(reviewers),
+        "override_signals": dict(override_signals),
+        "feedback": {
+            "unique_requests_with_feedback": len(feedback_request_ids),
+            "outcomes": dict(outcomes),
+            "actual_models_used": dict(actual_models),
+            "average_rating": (sum(ratings) / len(ratings)) if ratings else None,
+        },
+        "joined": {
+            "total_joined_rows": len(joined),
+            "by_primary_model": aggregate_joined(joined, "primary_model"),
+            "by_task_type": aggregate_joined(joined, "task_type"),
+        },
+    }
+
+
+def format_report(summary: dict[str, Any]) -> str:
+    lines = []
+    lines.append("== Router Telemetry Summary ==")
+    lines.append(f"Total decisions: {summary['total_decisions']}")
+    lines.append(f"Total feedback events: {summary['total_feedback_events']}")
+    lines.append(f"Unique request IDs: {summary['unique_request_ids']}")
+    lines.append(f"Time range: {summary['time_range']['first']} -> {summary['time_range']['last']}")
+
+    def add_ranked_section(title: str, data: dict[str, Any]):
+        lines.append("")
+        lines.append(f"{title}:")
+        if not data:
+            lines.append("  (none)")
+            return
+        for key, value in sorted(data.items(), key=lambda kv: (-kv[1], kv[0])):
+            lines.append(f"  - {key}: {value}")
+
+    add_ranked_section("Primary models", summary["primary_models"])
+    add_ranked_section("Task types", summary["task_types"])
+    add_ranked_section("Priorities", summary["priorities"])
+    add_ranked_section("Reviewers", summary["reviewers"])
+    add_ranked_section("Override signals", summary["override_signals"])
+    add_ranked_section("Feedback outcomes", summary["feedback"]["outcomes"])
+    add_ranked_section("Actual models used", summary["feedback"]["actual_models_used"])
+    lines.append("")
+    lines.append(f"Average rating: {summary['feedback']['average_rating']}")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Analyze router telemetry JSONL")
+    parser.add_argument("log_path", help="Path to telemetry JSONL log")
+    parser.add_argument("--json", action="store_true", help="Print raw JSON summary")
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    events = load_events(args.log_path)
+    summary = summarize(events)
+    if args.json:
+        print(json.dumps(summary, ensure_ascii=False, indent=2))
+    else:
+        print(format_report(summary))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/model_router/justfile
+++ b/model_router/justfile
@@ -1,0 +1,63 @@
+set shell := ["bash", "-cu"]
+
+config := "router_config.yaml"
+log_path := "logs/router-decisions.jsonl"
+
+default:
+    just --list
+
+install:
+    python3 -m pip install -e .
+
+install-dev:
+    python3 -m pip install -e .[dev]
+
+test:
+    pytest -q
+
+validate-config:
+    validate-router-config {{config}}
+
+check:
+    validate-router-config {{config}}
+    pytest -q
+
+route:
+    route-model --task-type coding --mode execute --priority high --has-code --json
+
+analyze:
+    analyze-router-telemetry {{log_path}}
+
+analyze-json:
+    analyze-router-telemetry {{log_path}} --json
+
+suggest:
+    suggest-router-changes {{log_path}}
+
+suggest-segments:
+    suggest-router-segments {{log_path}}
+
+propose-patch:
+    propose-router-patch {{log_path}} --config {{config}}
+
+propose-patch-full:
+    propose-router-patch {{log_path}} --config {{config}} --full-config
+
+demo:
+    python3 scripts/demo_workflow.py
+
+review:
+    echo "== validate config =="
+    validate-router-config {{config}}
+    echo
+    echo "== telemetry summary =="
+    analyze-router-telemetry {{log_path}}
+    echo
+    echo "== general suggestions =="
+    suggest-router-changes {{log_path}}
+    echo
+    echo "== segment suggestions =="
+    suggest-router-segments {{log_path}}
+    echo
+    echo "== proposed patch =="
+    propose-router-patch {{log_path}} --config {{config}}

--- a/model_router/log_router_feedback.py
+++ b/model_router/log_router_feedback.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from telemetry import append_jsonl, utc_now_iso
+
+
+VALID_OUTCOMES = {"success", "bad_fit", "fallback_used", "failed", "abandoned"}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Append router feedback event to telemetry log")
+    parser.add_argument("--log-path", required=True, help="Path to telemetry JSONL log")
+    parser.add_argument("--request-id", required=True, help="Request ID to attach feedback to")
+    parser.add_argument("--outcome", required=True, choices=sorted(VALID_OUTCOMES))
+    parser.add_argument("--actual-model-used", help="Model actually used in the end")
+    parser.add_argument("--fallback-used", action="store_true", help="Mark that fallback was used")
+    parser.add_argument("--user-rating", type=int, choices=[1, 2, 3, 4, 5], help="Optional 1-5 rating")
+    parser.add_argument("--notes", help="Optional freeform notes")
+    return parser
+
+
+def build_feedback_event(args: argparse.Namespace) -> dict:
+    return {
+        "timestamp": utc_now_iso(),
+        "event_type": "feedback",
+        "request_id": args.request_id,
+        "outcome": args.outcome,
+        "fallback_used": bool(args.fallback_used),
+        "actual_model_used": args.actual_model_used,
+        "user_rating": args.user_rating,
+        "notes": args.notes,
+    }
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    event = build_feedback_event(args)
+    append_jsonl(Path(args.log_path), event)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/model_router/model_router.py
+++ b/model_router/model_router.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+
+class TaskType(str, Enum):
+    CHAT = "chat"
+    CODING = "coding"
+    WRITING = "writing"
+    RESEARCH = "research"
+    BATCH = "batch"
+    TRIVIAL = "trivial"
+
+
+class Mode(str, Enum):
+    DRAFT = "draft"
+    EXECUTE = "execute"
+    REVIEW = "review"
+
+
+class Priority(str, Enum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+class Privacy(str, Enum):
+    NORMAL = "normal"
+    SENSITIVE = "sensitive"
+    LOCAL_ONLY = "local_only"
+
+
+class Quota(str, Enum):
+    NORMAL = "normal"
+    LOW = "low"
+    CRITICAL = "critical"
+
+
+class Speed(str, Enum):
+    NORMAL = "normal"
+    FAST = "fast"
+
+
+class Model(str, Enum):
+    CLAUDE = "claude-sonnet-4.6"
+    GPT = "gpt-5.4"
+    DEEPSEEK = "deepseek"
+    OLLAMA = "ollama"
+    FLASH = "flash_or_o4_mini"
+
+
+@dataclass
+class RouterInput:
+    task_type: TaskType
+    mode: Mode = Mode.DRAFT
+    priority: Priority = Priority.MEDIUM
+    privacy: Privacy = Privacy.NORMAL
+    quota: Quota = Quota.NORMAL
+    speed: Speed = Speed.NORMAL
+    has_code: bool = False
+    has_logs: bool = False
+
+
+@dataclass
+class RouterDecision:
+    primary_model: Model
+    fallback_models: list[Model]
+    reviewer: Optional[Model]
+    reason: str
+    trace: list[str] = field(default_factory=list)
+
+
+@dataclass
+class RouterConfig:
+    default_model: Model
+    base_by_task: dict[TaskType, Model]
+    fallbacks: dict[Model, list[Model]]
+    mode_overrides: dict[Mode, dict[TaskType, Model]]
+    reviewers: dict[Priority, dict[TaskType, Model]]
+    policy_overrides: list[dict[str, Any]]
+    router_version: str = "0.3"
+    config_path: str = ""
+
+
+def _to_model(value: str) -> Model:
+    return Model(value)
+
+
+def _to_task_type(value: str) -> TaskType:
+    return TaskType(value)
+
+
+def _to_mode(value: str) -> Mode:
+    return Mode(value)
+
+
+def _to_priority(value: str) -> Priority:
+    return Priority(value)
+
+
+def load_config(path: str | Path) -> RouterConfig:
+    raw = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+    router = raw["router"]
+
+    base_by_task = {
+        _to_task_type(key): _to_model(value)
+        for key, value in raw["base_by_task"].items()
+    }
+    fallbacks = {
+        _to_model(key): [_to_model(item) for item in value]
+        for key, value in raw["fallbacks"].items()
+    }
+    mode_overrides = {
+        _to_mode(mode): {_to_task_type(key): _to_model(value) for key, value in mapping.items()}
+        for mode, mapping in raw.get("mode_overrides", {}).items()
+    }
+    reviewers = {
+        _to_priority(priority): {_to_task_type(key): _to_model(value) for key, value in mapping.items()}
+        for priority, mapping in raw.get("reviewers", {}).items()
+    }
+
+    return RouterConfig(
+        default_model=_to_model(router["default_model"]),
+        base_by_task=base_by_task,
+        fallbacks=fallbacks,
+        mode_overrides=mode_overrides,
+        reviewers=reviewers,
+        policy_overrides=raw.get("policy_overrides", []) or [],
+        router_version=router.get("version", "0.3"),
+        config_path=str(Path(path)),
+    )
+
+
+def load_default_config() -> RouterConfig:
+    return load_config(Path(__file__).resolve().parent / "router_config.yaml")
+
+
+def normalize(ctx: RouterInput, trace: list[str]) -> RouterInput:
+    if ctx.has_code or ctx.has_logs:
+        ctx.task_type = TaskType.CODING
+        trace.append("normalize: has_code/has_logs -> coding")
+    else:
+        trace.append(f"normalize: keep task_type={ctx.task_type.value}")
+    return ctx
+
+
+def select_base_model(ctx: RouterInput, config: RouterConfig, trace: list[str]) -> Model:
+    model = config.base_by_task.get(ctx.task_type, config.default_model)
+    trace.append(f"base: task_type={ctx.task_type.value} -> {model.value}")
+    return model
+
+
+def apply_mode_override(model: Model, ctx: RouterInput, config: RouterConfig, trace: list[str]) -> Model:
+    mode_map = config.mode_overrides.get(ctx.mode, {})
+    if ctx.task_type in mode_map:
+        overridden = mode_map[ctx.task_type]
+        trace.append(f"mode_override: {ctx.mode.value}+{ctx.task_type.value} -> {overridden.value}")
+        return overridden
+
+    trace.append(f"mode_override: none -> {model.value}")
+    return model
+
+
+def _ctx_value_for_match(ctx: RouterInput, field_name: str) -> str | bool | None:
+    value = getattr(ctx, field_name, None)
+    if value is None:
+        return None
+    if hasattr(value, "value"):
+        return value.value
+    return value
+
+
+def _override_matches(ctx: RouterInput, override: dict[str, Any]) -> bool:
+    when = override.get("when", {}) or {}
+    if not when:
+        return False
+
+    for field_name, expected in when.items():
+        actual = _ctx_value_for_match(ctx, field_name)
+        if actual != expected:
+            return False
+
+    return True
+
+
+def apply_policy_overrides(model: Model, ctx: RouterInput, config: RouterConfig, trace: list[str]) -> Model:
+    for override in config.policy_overrides:
+        if not _override_matches(ctx, override):
+            continue
+
+        forced = override.get("force")
+        if forced:
+            forced_model = Model(forced)
+            name = override.get("name", "unnamed")
+            reason = override.get("reason", "")
+            trace.append(
+                f"policy_override: {name} -> {forced_model.value}" + (f" ({reason})" if reason else "")
+            )
+            return forced_model
+
+    trace.append(f"policy_override: none -> {model.value}")
+    return model
+
+
+def apply_hard_safety_overrides(model: Model, ctx: RouterInput, trace: list[str]) -> Model:
+    if ctx.privacy == Privacy.LOCAL_ONLY:
+        trace.append(f"override: privacy=local_only -> {Model.OLLAMA.value}")
+        return Model.OLLAMA
+
+    if ctx.privacy == Privacy.SENSITIVE and ctx.task_type == TaskType.BATCH:
+        trace.append(f"override: privacy=sensitive + batch -> {Model.OLLAMA.value}")
+        return Model.OLLAMA
+
+    trace.append(f"override_safety: none -> {model.value}")
+    return model
+
+
+def apply_soft_routing_overrides(model: Model, ctx: RouterInput, trace: list[str]) -> Model:
+    if ctx.quota == Quota.LOW and ctx.priority == Priority.LOW and model in (Model.CLAUDE, Model.GPT):
+        trace.append(f"override: quota=low + priority=low -> {Model.DEEPSEEK.value}")
+        return Model.DEEPSEEK
+
+    if ctx.quota == Quota.CRITICAL and ctx.priority == Priority.LOW:
+        trace.append(f"override: quota=critical + priority=low -> {Model.DEEPSEEK.value}")
+        return Model.DEEPSEEK
+
+    if ctx.speed == Speed.FAST and ctx.task_type == TaskType.TRIVIAL and ctx.priority == Priority.LOW:
+        trace.append(f"override: fast + trivial + low -> {Model.FLASH.value}")
+        return Model.FLASH
+
+    trace.append(f"override_soft: none -> {model.value}")
+    return model
+
+
+def enforce_constraints(model: Model, ctx: RouterInput, trace: list[str]) -> Model:
+    if ctx.priority == Priority.HIGH and model in (Model.FLASH, Model.DEEPSEEK):
+        if ctx.task_type == TaskType.CODING:
+            upgraded = Model.GPT
+        elif ctx.task_type == TaskType.BATCH and ctx.privacy in (Privacy.SENSITIVE, Privacy.LOCAL_ONLY):
+            upgraded = Model.OLLAMA
+        else:
+            upgraded = Model.CLAUDE
+        trace.append(f"constraint: high priority forbids cheap primary -> {upgraded.value}")
+        return upgraded
+
+    trace.append(f"constraint: none -> {model.value}")
+    return model
+
+
+def select_reviewer(ctx: RouterInput, config: RouterConfig, trace: list[str]) -> Optional[Model]:
+    priority_map = config.reviewers.get(ctx.priority, {})
+    reviewer = priority_map.get(ctx.task_type)
+    if reviewer:
+        trace.append(f"reviewer: {ctx.priority.value}+{ctx.task_type.value} -> {reviewer.value}")
+        return reviewer
+
+    trace.append("reviewer: none")
+    return None
+
+
+def build_reason(ctx: RouterInput, model: Model, trace: list[str]) -> str:
+    return (
+        f"task_type={ctx.task_type.value}, mode={ctx.mode.value}, priority={ctx.priority.value}, "
+        f"privacy={ctx.privacy.value}, quota={ctx.quota.value} | selected={model.value} | "
+        f"trace={' ; '.join(trace)}"
+    )
+
+
+def route_model(ctx: RouterInput, config: RouterConfig) -> RouterDecision:
+    trace: list[str] = []
+
+    ctx = normalize(ctx, trace)
+    model = select_base_model(ctx, config, trace)
+    model = apply_mode_override(model, ctx, config, trace)
+    model = apply_hard_safety_overrides(model, ctx, trace)
+    model = apply_soft_routing_overrides(model, ctx, trace)
+    model = apply_policy_overrides(model, ctx, config, trace)
+    model = apply_hard_safety_overrides(model, ctx, trace)
+    model = enforce_constraints(model, ctx, trace)
+
+    reviewer = select_reviewer(ctx, config, trace)
+    fallbacks = config.fallbacks[model]
+    reason = build_reason(ctx, model, trace)
+
+    return RouterDecision(
+        primary_model=model,
+        fallback_models=fallbacks,
+        reviewer=reviewer,
+        reason=reason,
+        trace=trace,
+    )

--- a/model_router/propose_config_patch.py
+++ b/model_router/propose_config_patch.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from analyze_telemetry import load_events, split_events, latest_feedback_by_request_id, join_decisions_with_feedback
+from suggest_router_changes_v2 import segmented_suggestions
+
+
+def load_yaml(path: str | Path) -> dict[str, Any]:
+    return yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+
+
+def dump_yaml(data: dict[str, Any]) -> str:
+    return yaml.safe_dump(data, allow_unicode=True, sort_keys=False)
+
+
+def make_override_name(segment: dict[str, Any]) -> str:
+    parts = []
+    for key in ("task_type", "priority", "quota", "privacy", "mode", "primary_model"):
+        value = segment.get(key)
+        if value:
+            parts.append(f"{key}-{value}")
+    return "auto-" + "-".join(parts[:4])
+
+
+def choose_replacement_model(segment: dict[str, Any]) -> str | None:
+    primary = segment.get("primary_model")
+    task_type = segment.get("task_type")
+
+    if task_type in {"chat", "writing", "research"}:
+        return "claude-sonnet-4.6"
+    if task_type == "coding":
+        return "gpt-5.4"
+    if task_type == "batch" and segment.get("privacy") in {"sensitive", "local_only"}:
+        return "ollama"
+    if primary == "deepseek":
+        if task_type == "coding":
+            return "gpt-5.4"
+        return "claude-sonnet-4.6"
+    return None
+
+
+def suggestion_to_override(suggestion: dict[str, Any]) -> dict[str, Any] | None:
+    segment = suggestion.get("segment", {})
+    if not segment:
+        return None
+
+    target_model = choose_replacement_model(segment)
+    if not target_model:
+        return None
+
+    when = {}
+    for key in ("task_type", "priority", "quota", "privacy", "mode"):
+        value = segment.get(key)
+        if value:
+            when[key] = value
+
+    if len(when) < 2:
+        return None
+
+    if "task_type" not in when and "quota" not in when:
+        return None
+
+    return {
+        "name": make_override_name(segment),
+        "when": when,
+        "force": target_model,
+        "reason": suggestion["message"],
+    }
+
+
+def _override_signature(override: dict[str, Any]) -> str:
+    return json.dumps(override.get("when", {}), sort_keys=True, ensure_ascii=False) + "::" + str(override.get("force"))
+
+
+def build_patch_proposal(config: dict[str, Any], suggestions: list[dict[str, Any]]) -> dict[str, Any]:
+    proposed = copy.deepcopy(config)
+    overrides = proposed.setdefault("policy_overrides", [])
+
+    generated = []
+    seen = {_override_signature(item) for item in overrides if isinstance(item, dict)}
+
+    for suggestion in suggestions:
+        if suggestion.get("severity") not in {"high", "medium"}:
+            continue
+
+        override = suggestion_to_override(suggestion)
+        if not override:
+            continue
+
+        signature = _override_signature(override)
+        if signature in seen:
+            continue
+
+        seen.add(signature)
+        overrides.append(override)
+        generated.append(override)
+
+    return {
+        "generated_count": len(generated),
+        "generated_overrides": generated,
+        "proposed_config": proposed,
+    }
+
+
+def format_report(result: dict[str, Any]) -> str:
+    lines = ["== Proposed Router Config Patch =="]
+    lines.append(f"Generated overrides: {result['generated_count']}")
+
+    if not result["generated_overrides"]:
+        lines.append("")
+        lines.append("לא נוצרו overrides חדשים.")
+        return "\n".join(lines)
+
+    lines.append("")
+    lines.append("Proposed overrides:")
+    for item in result["generated_overrides"]:
+        lines.append(f"- name: {item['name']}")
+        lines.append(f"  when: {item['when']}")
+        lines.append(f"  force: {item['force']}")
+        lines.append(f"  reason: {item['reason']}")
+        lines.append("")
+
+    lines.append("YAML snippet:")
+    lines.append(
+        yaml.safe_dump(
+            {"policy_overrides": result["generated_overrides"]},
+            allow_unicode=True,
+            sort_keys=False,
+        ).rstrip()
+    )
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Propose router_config.yaml patch from telemetry")
+    parser.add_argument("log_path", help="Path to telemetry JSONL log")
+    parser.add_argument("--config", required=True, help="Path to router_config.yaml")
+    parser.add_argument("--json", action="store_true", help="Print JSON result")
+    parser.add_argument("--full-config", action="store_true", help="Print full proposed config YAML")
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    config = load_yaml(args.config)
+    events = load_events(Path(args.log_path))
+    decisions, feedbacks = split_events(events)
+    latest_feedback = latest_feedback_by_request_id(feedbacks)
+    joined = join_decisions_with_feedback(decisions, latest_feedback)
+
+    suggestions = segmented_suggestions(joined, min_feedback_samples=3)
+    result = build_patch_proposal(config, suggestions)
+
+    if args.json:
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        return 0
+
+    if args.full_config:
+        print(dump_yaml(result["proposed_config"]))
+        return 0
+
+    print(format_report(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/model_router/pyproject.toml
+++ b/model_router/pyproject.toml
@@ -1,0 +1,34 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "model-router"
+version = "0.1.0"
+description = "Operational model routing with telemetry, feedback analysis, suggestions, and policy patch proposals"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+  "pyyaml>=6.0",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=8.0",
+]
+
+[project.scripts]
+validate-router-config = "validate_router_config:main"
+route-model = "route_cli:main"
+log-router-feedback = "log_router_feedback:main"
+analyze-router-telemetry = "analyze_telemetry:main"
+suggest-router-changes = "suggest_router_changes:main"
+suggest-router-segments = "suggest_router_changes_v2:main"
+propose-router-patch = "propose_config_patch:main"
+
+[tool.setuptools]
+py-modules = ["validate_router_config", "model_router", "route_cli", "telemetry", "log_router_feedback", "analyze_telemetry", "suggest_router_changes", "suggest_router_changes_v2", "propose_config_patch"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"

--- a/model_router/route_cli.py
+++ b/model_router/route_cli.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from model_router import (
+    Mode,
+    Privacy,
+    Priority,
+    Quota,
+    RouterInput,
+    Speed,
+    TaskType,
+    load_default_config,
+    route_model,
+)
+from telemetry import append_jsonl, build_event
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Operational model router CLI")
+    parser.add_argument("--task-type", required=True, choices=[item.value for item in TaskType])
+    parser.add_argument("--mode", default=Mode.DRAFT.value, choices=[item.value for item in Mode])
+    parser.add_argument("--priority", default=Priority.MEDIUM.value, choices=[item.value for item in Priority])
+    parser.add_argument("--privacy", default=Privacy.NORMAL.value, choices=[item.value for item in Privacy])
+    parser.add_argument("--quota", default=Quota.NORMAL.value, choices=[item.value for item in Quota])
+    parser.add_argument("--speed", default=Speed.NORMAL.value, choices=[item.value for item in Speed])
+    parser.add_argument("--has-code", action="store_true")
+    parser.add_argument("--has-logs", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--show-trace", action="store_true")
+    parser.add_argument("--primary-only", action="store_true")
+    parser.add_argument("--log-path", help="Append telemetry event to JSONL file")
+    parser.add_argument("--request-id", help="Optional request id for telemetry correlation")
+    parser.add_argument("--no-log", action="store_true", help="Disable logging even if log-path was provided")
+    return parser
+
+
+def format_text(decision, show_trace: bool) -> str:
+    lines = [
+        f"primary_model: {decision.primary_model.value}",
+        f"fallback_models: {[item.value for item in decision.fallback_models]}",
+        f"reviewer: {decision.reviewer.value if decision.reviewer else None}",
+        f"reason: {decision.reason}",
+    ]
+    if show_trace:
+        lines.append("trace:")
+        lines.extend([f"  - {item}" for item in decision.trace])
+    return "\n".join(lines)
+
+
+def maybe_log_decision(args, config, router_input, decision) -> None:
+    if args.no_log or not args.log_path:
+        return
+    event = build_event(
+        router_version=config.router_version,
+        config_path=config.config_path,
+        request_input=router_input,
+        decision=decision,
+        request_id=args.request_id,
+    )
+    append_jsonl(Path(args.log_path), event)
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    config = load_default_config()
+
+    router_input = RouterInput(
+        task_type=TaskType(args.task_type),
+        mode=Mode(args.mode),
+        priority=Priority(args.priority),
+        privacy=Privacy(args.privacy),
+        quota=Quota(args.quota),
+        speed=Speed(args.speed),
+        has_code=args.has_code,
+        has_logs=args.has_logs,
+    )
+    decision = route_model(router_input, config)
+    maybe_log_decision(args, config, router_input, decision)
+
+    if args.primary_only:
+        print(decision.primary_model.value)
+        return 0
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "primary_model": decision.primary_model.value,
+                    "fallback_models": [item.value for item in decision.fallback_models],
+                    "reviewer": decision.reviewer.value if decision.reviewer else None,
+                    "reason": decision.reason,
+                    "trace": decision.trace,
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+        )
+        return 0
+
+    print(format_text(decision, args.show_trace))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/model_router/router_config.yaml
+++ b/model_router/router_config.yaml
@@ -1,0 +1,40 @@
+router:
+  version: "0.3"
+  default_model: "claude-sonnet-4.6"
+
+base_by_task:
+  chat: "claude-sonnet-4.6"
+  coding: "gpt-5.4"
+  writing: "claude-sonnet-4.6"
+  research: "claude-sonnet-4.6"
+  batch: "ollama"
+  trivial: "flash_or_o4_mini"
+
+fallbacks:
+  claude-sonnet-4.6: ["gpt-5.4", "deepseek", "ollama"]
+  gpt-5.4: ["claude-sonnet-4.6", "deepseek", "ollama"]
+  deepseek: ["claude-sonnet-4.6", "gpt-5.4", "ollama"]
+  ollama: ["deepseek", "gpt-5.4", "claude-sonnet-4.6"]
+  flash_or_o4_mini: ["deepseek", "claude-sonnet-4.6"]
+
+mode_overrides:
+  execute:
+    coding: "gpt-5.4"
+  review:
+    coding: "claude-sonnet-4.6"
+    writing: "claude-sonnet-4.6"
+
+reviewers:
+  high:
+    coding: "claude-sonnet-4.6"
+    writing: "claude-sonnet-4.6"
+    research: "claude-sonnet-4.6"
+
+policy_overrides:
+  - name: "auto-chat-medium-critical"
+    when:
+      task_type: "chat"
+      priority: "medium"
+      quota: "critical"
+    force: "claude-sonnet-4.6"
+    reason: "telemetry: avoid weak routing for chat+medium+critical"

--- a/model_router/scripts/demo_workflow.py
+++ b/model_router/scripts/demo_workflow.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import json
+import sys
+from argparse import Namespace
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from analyze_telemetry import (
+    join_decisions_with_feedback,
+    latest_feedback_by_request_id,
+    split_events,
+    summarize,
+)
+from log_router_feedback import build_feedback_event
+from propose_config_patch import build_patch_proposal, load_yaml
+from route_cli import build_parser as build_route_parser, maybe_log_decision
+from model_router import (
+    Mode,
+    Privacy,
+    Priority,
+    Quota,
+    RouterInput,
+    Speed,
+    TaskType,
+    load_default_config,
+    route_model,
+)
+from suggest_router_changes import suggest_from_summary
+from suggest_router_changes_v2 import segmented_suggestions
+from telemetry import append_jsonl
+from validate_router_config import validate_router_config
+
+
+def run_route(log_path: Path, request_id: str, *, task_type: str, mode: str = "draft", priority: str = "medium", privacy: str = "normal", quota: str = "normal", speed: str = "normal", has_code: bool = False, has_logs: bool = False) -> dict:
+    config = load_default_config()
+    router_input = RouterInput(
+        task_type=TaskType(task_type),
+        mode=Mode(mode),
+        priority=Priority(priority),
+        privacy=Privacy(privacy),
+        quota=Quota(quota),
+        speed=Speed(speed),
+        has_code=has_code,
+        has_logs=has_logs,
+    )
+    decision = route_model(router_input, config)
+
+    args = build_route_parser().parse_args([
+        "--task-type", task_type,
+        "--mode", mode,
+        "--priority", priority,
+        "--privacy", privacy,
+        "--quota", quota,
+        "--speed", speed,
+        "--log-path", str(log_path),
+        "--request-id", request_id,
+        *( ["--has-code"] if has_code else [] ),
+        *( ["--has-logs"] if has_logs else [] ),
+    ])
+    maybe_log_decision(args, config, router_input, decision)
+
+    return {
+        "request_id": request_id,
+        "primary_model": decision.primary_model.value,
+        "reviewer": decision.reviewer.value if decision.reviewer else None,
+        "trace": decision.trace,
+    }
+
+
+def add_feedback(log_path: Path, request_id: str, *, outcome: str, actual_model_used: str | None = None, fallback_used: bool = False, user_rating: int | None = None, notes: str | None = None) -> None:
+    args = Namespace(
+        request_id=request_id,
+        outcome=outcome,
+        actual_model_used=actual_model_used,
+        fallback_used=fallback_used,
+        user_rating=user_rating,
+        notes=notes,
+    )
+    append_jsonl(log_path, build_feedback_event(args))
+
+
+def build_demo_output(log_path: Path) -> dict:
+    root = Path(__file__).resolve().parent.parent
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    if log_path.exists():
+        log_path.unlink()
+
+    routes = [
+        run_route(log_path, "req-demo-1", task_type="coding", mode="execute", priority="high", has_code=True),
+        run_route(log_path, "req-demo-2", task_type="chat", priority="low", quota="critical"),
+        run_route(log_path, "req-demo-3", task_type="batch", privacy="local_only"),
+    ]
+
+    add_feedback(log_path, "req-demo-1", outcome="success", actual_model_used="gpt-5.4", user_rating=5, notes="coding flow worked well")
+    add_feedback(log_path, "req-demo-2", outcome="bad_fit", actual_model_used="claude-sonnet-4.6", fallback_used=True, user_rating=2, notes="deepseek היה חלש לשיחה הזאת")
+    add_feedback(log_path, "req-demo-3", outcome="success", actual_model_used="ollama", user_rating=4, notes="privacy rule נשמר")
+
+    events = [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    summary = summarize(events)
+    suggestions = suggest_from_summary(summary, min_feedback_samples=1, low_usage_threshold=0)
+
+    decisions_raw, feedbacks_raw = split_events(events)
+    latest_feedback = latest_feedback_by_request_id(feedbacks_raw)
+    joined_rows = join_decisions_with_feedback(decisions_raw, latest_feedback)
+    segment_suggestions = segmented_suggestions(joined_rows, min_feedback_samples=1)
+
+    config = load_yaml(root / "router_config.yaml")
+    patch_result = build_patch_proposal(config, segment_suggestions)
+    validation = validate_router_config(patch_result["proposed_config"])
+
+    return {
+        "log_path": str(log_path),
+        "routes": routes,
+        "summary": {
+            "total_decisions": summary["total_decisions"],
+            "total_feedback_events": summary["total_feedback_events"],
+            "primary_models": summary["primary_models"],
+            "feedback_outcomes": summary["feedback"]["outcomes"],
+        },
+        "global_suggestions": suggestions,
+        "segment_suggestions": segment_suggestions,
+        "patch_generated_count": patch_result["generated_count"],
+        "patch_generated_overrides": patch_result["generated_overrides"],
+        "patched_config_valid": validation["valid"],
+        "patched_config_errors": validation["errors"],
+        "patched_config_warnings": validation["warnings"],
+    }
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parent.parent
+    output = build_demo_output(root / "sample_data" / "demo_router_log.jsonl")
+    print(json.dumps(output, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/model_router/suggest_router_changes.py
+++ b/model_router/suggest_router_changes.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from analyze_telemetry import load_events, summarize
+
+
+def suggest_from_summary(
+    summary: dict[str, Any],
+    *,
+    min_feedback_samples: int = 5,
+    high_fallback_rate: float = 0.35,
+    low_success_rate: float = 0.60,
+    low_rating: float = 3.2,
+    high_mismatch_rate: float = 0.25,
+    low_usage_threshold: int = 2,
+) -> list[dict[str, Any]]:
+    suggestions: list[dict[str, Any]] = []
+
+    by_model = summary.get("joined", {}).get("by_primary_model", {})
+    by_task = summary.get("joined", {}).get("by_task_type", {})
+    primary_models = summary.get("primary_models", {})
+
+    for model, stats in by_model.items():
+        total = stats.get("total", 0)
+        with_feedback = stats.get("with_feedback", 0)
+        success_rate = stats.get("success_rate")
+        fallback_rate = stats.get("fallback_rate")
+        avg_rating = stats.get("average_rating")
+        mismatch_count = stats.get("mismatch_actual_model", 0)
+        mismatch_rate = (mismatch_count / with_feedback) if with_feedback else None
+
+        if with_feedback >= min_feedback_samples:
+            if fallback_rate is not None and fallback_rate > high_fallback_rate:
+                suggestions.append(
+                    {
+                        "type": "high_fallback_rate",
+                        "scope": "primary_model",
+                        "target": model,
+                        "severity": "high" if fallback_rate > 0.5 else "medium",
+                        "message": f"המודל {model} מציג fallback_rate גבוה ({fallback_rate:.2%}). כדאי לצמצם ניתוב אליו למשימות גבוליות או להקשיח תנאי כניסה.",
+                    }
+                )
+
+            if success_rate is not None and success_rate < low_success_rate:
+                suggestions.append(
+                    {
+                        "type": "low_success_rate",
+                        "scope": "primary_model",
+                        "target": model,
+                        "severity": "high" if success_rate < 0.4 else "medium",
+                        "message": f"המודל {model} מציג success_rate נמוך ({success_rate:.2%}). כדאי לבדוק באילו סוגי משימות הוא נכשל ולהפחית שימוש ראשי.",
+                    }
+                )
+
+            if avg_rating is not None and avg_rating < low_rating:
+                suggestions.append(
+                    {
+                        "type": "low_rating",
+                        "scope": "primary_model",
+                        "target": model,
+                        "severity": "medium",
+                        "message": f"המודל {model} מקבל דירוג ממוצע נמוך ({avg_rating:.2f}). שווה לבדוק אם הוא נבחר למשימות לא מתאימות.",
+                    }
+                )
+
+            if mismatch_rate is not None and mismatch_rate > high_mismatch_rate:
+                suggestions.append(
+                    {
+                        "type": "high_mismatch_rate",
+                        "scope": "primary_model",
+                        "target": model,
+                        "severity": "medium",
+                        "message": f"המודל {model} מוחלף בפועל לעיתים קרובות ({mismatch_rate:.2%} mismatch). כנראה הבחירה הראשונית לא אופטימלית.",
+                    }
+                )
+
+    for task_type, stats in by_task.items():
+        with_feedback = stats.get("with_feedback", 0)
+        success_rate = stats.get("success_rate")
+        fallback_rate = stats.get("fallback_rate")
+        avg_rating = stats.get("average_rating")
+
+        if with_feedback >= min_feedback_samples:
+            if success_rate is not None and success_rate < low_success_rate:
+                suggestions.append(
+                    {
+                        "type": "weak_task_routing",
+                        "scope": "task_type",
+                        "target": task_type,
+                        "severity": "high" if success_rate < 0.4 else "medium",
+                        "message": f"בקטגוריית {task_type} יש success_rate נמוך ({success_rate:.2%}). כדאי לבדוק אם המודל הראשי לקטגוריה הזו נכון.",
+                    }
+                )
+
+            if fallback_rate is not None and fallback_rate > high_fallback_rate:
+                suggestions.append(
+                    {
+                        "type": "task_type_high_fallback",
+                        "scope": "task_type",
+                        "target": task_type,
+                        "severity": "medium",
+                        "message": f"בקטגוריית {task_type} יש fallback_rate גבוה ({fallback_rate:.2%}). ייתכן שהראוטר בוחר מודל ראשוני חלש מדי.",
+                    }
+                )
+
+            if avg_rating is not None and avg_rating < low_rating:
+                suggestions.append(
+                    {
+                        "type": "task_type_low_rating",
+                        "scope": "task_type",
+                        "target": task_type,
+                        "severity": "medium",
+                        "message": f"בקטגוריית {task_type} הדירוג הממוצע נמוך ({avg_rating:.2f}). שווה לבדוק התאמת מודל או policy.",
+                    }
+                )
+
+    for model, count in primary_models.items():
+        if count <= low_usage_threshold:
+            suggestions.append(
+                {
+                    "type": "low_usage_model",
+                    "scope": "primary_model",
+                    "target": model,
+                    "severity": "low",
+                    "message": f"המודל {model} כמעט לא נבחר ({count} פעמים). ייתכן שהחוק שמוביל אליו מיותר או לא נגיש בפועל.",
+                }
+            )
+
+    if not suggestions:
+        suggestions.append(
+            {
+                "type": "no_action",
+                "scope": "global",
+                "target": "router",
+                "severity": "info",
+                "message": "לא נמצאו כרגע דפוסים חזקים שמצדיקים שינוי policy. כדאי לאסוף עוד נתונים.",
+            }
+        )
+
+    severity_order = {"high": 0, "medium": 1, "low": 2, "info": 3}
+    suggestions.sort(key=lambda item: (severity_order.get(item["severity"], 99), item["type"], item["target"]))
+    return suggestions
+
+
+def format_suggestions(suggestions: list[dict[str, Any]]) -> str:
+    lines = ["== Router Change Suggestions =="]
+    for item in suggestions:
+        lines.append("")
+        lines.append(f"- [{item['severity']}] {item['type']} / {item['scope']} / {item['target']}")
+        lines.append(f"  {item['message']}")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Suggest router policy changes from telemetry")
+    parser.add_argument("log_path", help="Path to telemetry JSONL log")
+    parser.add_argument("--json", action="store_true", help="Output suggestions as JSON")
+    parser.add_argument("--min-feedback-samples", type=int, default=5)
+    parser.add_argument("--high-fallback-rate", type=float, default=0.35)
+    parser.add_argument("--low-success-rate", type=float, default=0.60)
+    parser.add_argument("--low-rating", type=float, default=3.2)
+    parser.add_argument("--high-mismatch-rate", type=float, default=0.25)
+    parser.add_argument("--low-usage-threshold", type=int, default=2)
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    events = load_events(Path(args.log_path))
+    summary = summarize(events)
+    suggestions = suggest_from_summary(
+        summary,
+        min_feedback_samples=args.min_feedback_samples,
+        high_fallback_rate=args.high_fallback_rate,
+        low_success_rate=args.low_success_rate,
+        low_rating=args.low_rating,
+        high_mismatch_rate=args.high_mismatch_rate,
+        low_usage_threshold=args.low_usage_threshold,
+    )
+
+    if args.json:
+        print(json.dumps(suggestions, ensure_ascii=False, indent=2))
+    else:
+        print(format_suggestions(suggestions))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/model_router/suggest_router_changes_v2.py
+++ b/model_router/suggest_router_changes_v2.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any
+
+from analyze_telemetry import (
+    join_decisions_with_feedback,
+    latest_feedback_by_request_id,
+    load_events,
+    split_events,
+)
+
+
+def segment_key(row: dict[str, Any], fields: list[str]) -> str:
+    parts = []
+    for field in fields:
+        parts.append(f"{field}={row.get(field) or 'unknown'}")
+    return " | ".join(parts)
+
+
+def aggregate_segments(joined: list[dict[str, Any]], fields: list[str]) -> dict[str, dict[str, Any]]:
+    buckets: dict[str, dict[str, Any]] = {}
+
+    for row in joined:
+        key = segment_key(row, fields)
+        bucket = buckets.setdefault(
+            key,
+            {
+                "fields": {field: row.get(field) for field in fields},
+                "total": 0,
+                "with_feedback": 0,
+                "success": 0,
+                "bad_fit": 0,
+                "failed": 0,
+                "fallback_used": 0,
+                "abandoned": 0,
+                "ratings": [],
+                "mismatch_actual_model": 0,
+            },
+        )
+
+        bucket["total"] += 1
+        if row["feedback_present"]:
+            bucket["with_feedback"] += 1
+
+        outcome = row.get("outcome")
+        if outcome in ("success", "bad_fit", "failed", "fallback_used", "abandoned"):
+            bucket[outcome] += 1
+        elif row.get("fallback_used"):
+            bucket["fallback_used"] += 1
+
+        rating = row.get("user_rating")
+        if isinstance(rating, int):
+            bucket["ratings"].append(rating)
+
+        actual_model = row.get("actual_model_used")
+        primary_model = row.get("primary_model")
+        if actual_model and primary_model and actual_model != primary_model:
+            bucket["mismatch_actual_model"] += 1
+
+    result = {}
+    for key, bucket in buckets.items():
+        ratings = bucket.pop("ratings")
+        total = bucket["total"]
+        with_feedback = bucket["with_feedback"]
+        result[key] = {
+            **bucket,
+            "feedback_coverage_rate": round(with_feedback / total, 4) if total else 0.0,
+            "success_rate": round(bucket["success"] / with_feedback, 4) if with_feedback else None,
+            "fallback_rate": round(bucket["fallback_used"] / with_feedback, 4) if with_feedback else None,
+            "mismatch_rate": round(bucket["mismatch_actual_model"] / with_feedback, 4) if with_feedback else None,
+            "average_rating": round(sum(ratings) / len(ratings), 3) if ratings else None,
+        }
+    return result
+
+
+def segmented_suggestions(
+    joined: list[dict[str, Any]],
+    *,
+    min_feedback_samples: int = 4,
+    high_fallback_rate: float = 0.35,
+    low_success_rate: float = 0.60,
+    low_rating: float = 3.2,
+    high_mismatch_rate: float = 0.25,
+) -> list[dict[str, Any]]:
+    suggestions = []
+
+    segment_defs = [
+        ["primary_model", "task_type"],
+        ["primary_model", "priority"],
+        ["task_type", "priority"],
+        ["task_type", "quota"],
+    ]
+
+    for fields in segment_defs:
+        if joined and any(field not in joined[0] for field in fields):
+            continue
+
+        segments = aggregate_segments(joined, fields)
+
+        for seg_key, stats in segments.items():
+            with_feedback = stats["with_feedback"]
+            if with_feedback < min_feedback_samples:
+                continue
+
+            success_rate = stats["success_rate"]
+            fallback_rate = stats["fallback_rate"]
+            avg_rating = stats["average_rating"]
+            mismatch_rate = stats["mismatch_rate"]
+
+            if fallback_rate is not None and fallback_rate > high_fallback_rate:
+                suggestions.append(
+                    {
+                        "type": "segment_high_fallback",
+                        "segment": stats["fields"],
+                        "severity": "high" if fallback_rate > 0.5 else "medium",
+                        "message": f"בסגמנט {seg_key} יש fallback_rate גבוה ({fallback_rate:.2%}). כדאי להקשיח routing או לבחור מודל ראשי אחר עבור המקרה הזה.",
+                    }
+                )
+
+            if success_rate is not None and success_rate < low_success_rate:
+                suggestions.append(
+                    {
+                        "type": "segment_low_success",
+                        "segment": stats["fields"],
+                        "severity": "high" if success_rate < 0.4 else "medium",
+                        "message": f"בסגמנט {seg_key} יש success_rate נמוך ({success_rate:.2%}). זה נראה כמו כלל ניתוב בעייתי.",
+                    }
+                )
+
+            if avg_rating is not None and avg_rating < low_rating:
+                suggestions.append(
+                    {
+                        "type": "segment_low_rating",
+                        "segment": stats["fields"],
+                        "severity": "medium",
+                        "message": f"בסגמנט {seg_key} יש דירוג ממוצע נמוך ({avg_rating:.2f}). שווה לבדוק איכות התאמה.",
+                    }
+                )
+
+            if mismatch_rate is not None and mismatch_rate > high_mismatch_rate:
+                suggestions.append(
+                    {
+                        "type": "segment_high_mismatch",
+                        "segment": stats["fields"],
+                        "severity": "medium",
+                        "message": f"בסגמנט {seg_key} יש mismatch_rate גבוה ({mismatch_rate:.2%}). כנראה המודל הראשוני לא נכון לעיתים קרובות.",
+                    }
+                )
+
+    severity_order = {"high": 0, "medium": 1, "low": 2, "info": 3}
+    suggestions.sort(key=lambda item: (severity_order.get(item["severity"], 99), item["type"], json.dumps(item["segment"], sort_keys=True)))
+
+    if not suggestions:
+        return [
+            {
+                "type": "no_segment_action",
+                "segment": {},
+                "severity": "info",
+                "message": "לא נמצאו כרגע חריגות חזקות ברמת סגמנט. צריך עוד feedback או שהתצורה הנוכחית סבירה.",
+            }
+        ]
+
+    return suggestions
+
+
+def format_suggestions(items: list[dict[str, Any]]) -> str:
+    lines = ["== Segmented Router Suggestions =="]
+    for item in items:
+        lines.append("")
+        lines.append(f"- [{item['severity']}] {item['type']}")
+        lines.append(f"  segment: {item['segment']}")
+        lines.append(f"  {item['message']}")
+    return "\n".join(lines)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Suggest segmented router policy changes from telemetry")
+    parser.add_argument("log_path", help="Path to telemetry JSONL log")
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--min-feedback-samples", type=int, default=4)
+    parser.add_argument("--high-fallback-rate", type=float, default=0.35)
+    parser.add_argument("--low-success-rate", type=float, default=0.60)
+    parser.add_argument("--low-rating", type=float, default=3.2)
+    parser.add_argument("--high-mismatch-rate", type=float, default=0.25)
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    events = load_events(args.log_path)
+    decisions, feedbacks = split_events(events)
+    latest_feedback = latest_feedback_by_request_id(feedbacks)
+    joined = join_decisions_with_feedback(decisions, latest_feedback)
+
+    suggestions = segmented_suggestions(
+        joined,
+        min_feedback_samples=args.min_feedback_samples,
+        high_fallback_rate=args.high_fallback_rate,
+        low_success_rate=args.low_success_rate,
+        low_rating=args.low_rating,
+        high_mismatch_rate=args.high_mismatch_rate,
+    )
+
+    if args.json:
+        print(json.dumps(suggestions, ensure_ascii=False, indent=2))
+    else:
+        print(format_suggestions(suggestions))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/model_router/telemetry.py
+++ b/model_router/telemetry.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import asdict, is_dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def ensure_parent_dir(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def to_jsonable(value: Any) -> Any:
+    if is_dataclass(value):
+        return {k: to_jsonable(v) for k, v in asdict(value).items()}
+    if isinstance(value, dict):
+        return {str(k): to_jsonable(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [to_jsonable(v) for v in value]
+    if hasattr(value, "value"):
+        return value.value
+    return value
+
+
+def build_event(
+    *,
+    router_version: str,
+    config_path: str,
+    request_input: Any,
+    decision: Any,
+    request_id: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "timestamp": utc_now_iso(),
+        "event_type": "decision",
+        "request_id": request_id or str(uuid.uuid4()),
+        "router_version": router_version,
+        "config_path": config_path,
+        "input": to_jsonable(request_input),
+        "decision": to_jsonable(decision),
+    }
+
+
+def append_jsonl(path: str | Path, event: dict[str, Any]) -> None:
+    log_path = Path(path)
+    ensure_parent_dir(log_path)
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(event, ensure_ascii=False) + "\n")

--- a/model_router/tests/test_analyze_telemetry.py
+++ b/model_router/tests/test_analyze_telemetry.py
@@ -1,0 +1,98 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from analyze_telemetry import summarize
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_summarize_counts_decisions_feedback_and_joined_stats():
+    events = [
+        {
+            "timestamp": "2026-04-20T10:00:00+00:00",
+            "event_type": "decision",
+            "request_id": "r1",
+            "input": {"task_type": "coding", "priority": "high", "quota": "normal"},
+            "decision": {
+                "primary_model": "gpt-5.4",
+                "reviewer": "claude-sonnet-4.6",
+                "trace": ["normalize: has_code/has_logs -> coding"],
+            },
+        },
+        {
+            "timestamp": "2026-04-20T10:01:00+00:00",
+            "event_type": "feedback",
+            "request_id": "r1",
+            "outcome": "success",
+            "fallback_used": False,
+            "actual_model_used": "gpt-5.4",
+            "user_rating": 5,
+        },
+        {
+            "timestamp": "2026-04-20T10:02:00+00:00",
+            "event_type": "decision",
+            "request_id": "r2",
+            "input": {"task_type": "chat", "priority": "low", "quota": "critical"},
+            "decision": {
+                "primary_model": "deepseek",
+                "reviewer": None,
+                "trace": ["override: quota=critical + priority=low -> deepseek"],
+            },
+        },
+        {
+            "timestamp": "2026-04-20T10:03:00+00:00",
+            "event_type": "feedback",
+            "request_id": "r2",
+            "outcome": "fallback_used",
+            "fallback_used": True,
+            "actual_model_used": "claude-sonnet-4.6",
+            "user_rating": 3,
+        },
+    ]
+
+    summary = summarize(events)
+
+    assert summary["total_decisions"] == 2
+    assert summary["total_feedback_events"] == 2
+    assert summary["primary_models"]["gpt-5.4"] == 1
+    assert summary["primary_models"]["deepseek"] == 1
+    assert summary["feedback"]["outcomes"]["success"] == 1
+    assert summary["feedback"]["outcomes"]["fallback_used"] == 1
+
+    gpt_stats = summary["joined"]["by_primary_model"]["gpt-5.4"]
+    assert gpt_stats["success_rate"] == 1.0
+    assert gpt_stats["fallback_rate"] == 0.0
+    assert gpt_stats["average_rating"] == 5.0
+
+    deepseek_stats = summary["joined"]["by_primary_model"]["deepseek"]
+    assert deepseek_stats["fallback_rate"] == 1.0
+    assert deepseek_stats["mismatch_actual_model"] == 1
+
+
+def test_analyze_cli_outputs_json(tmp_path: Path):
+    log_path = tmp_path / "router.jsonl"
+    rows = [
+        {
+            "timestamp": "2026-04-20T10:00:00+00:00",
+            "event_type": "decision",
+            "request_id": "1",
+            "input": {"task_type": "coding", "priority": "high", "quota": "normal"},
+            "decision": {"primary_model": "gpt-5.4", "reviewer": None, "trace": []},
+        }
+    ]
+    log_path.write_text("\n".join(json.dumps(r) for r in rows), encoding="utf-8")
+
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "analyze_telemetry.py"), str(log_path), "--json"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload["total_decisions"] == 1
+    assert payload["primary_models"]["gpt-5.4"] == 1

--- a/model_router/tests/test_demo_workflow.py
+++ b/model_router/tests/test_demo_workflow.py
@@ -1,0 +1,44 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from scripts.demo_workflow import build_demo_output
+
+
+def test_build_demo_output_creates_valid_end_to_end_result(tmp_path: Path):
+    log_path = tmp_path / "demo-router.jsonl"
+
+    result = build_demo_output(log_path)
+
+    assert log_path.exists()
+    assert result["summary"]["total_decisions"] == 3
+    assert result["summary"]["total_feedback_events"] == 3
+    assert result["patched_config_valid"] is True
+    assert result["patched_config_errors"] == []
+    assert result["patch_generated_count"] >= 1
+    assert len(result["routes"]) == 3
+    assert any(item["primary_model"] == "ollama" for item in result["routes"])
+
+    lines = log_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 6
+    payloads = [json.loads(line) for line in lines]
+    assert sum(1 for row in payloads if row.get("event_type") == "feedback") == 3
+
+
+def test_demo_script_outputs_json(tmp_path: Path):
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "demo_workflow.py")],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload["summary"]["total_decisions"] == 3
+    assert payload["patched_config_valid"] is True

--- a/model_router/tests/test_log_router_feedback.py
+++ b/model_router/tests/test_log_router_feedback.py
@@ -1,0 +1,71 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_feedback_cli_appends_event(tmp_path: Path):
+    log_path = tmp_path / "router.jsonl"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "log_router_feedback.py"),
+            "--log-path",
+            str(log_path),
+            "--request-id",
+            "req_123",
+            "--outcome",
+            "success",
+            "--actual-model-used",
+            "gpt-5.4",
+            "--user-rating",
+            "5",
+            "--notes",
+            "worked well",
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    assert result.returncode == 0
+    lines = log_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+
+    event = json.loads(lines[0])
+    assert event["event_type"] == "feedback"
+    assert event["request_id"] == "req_123"
+    assert event["outcome"] == "success"
+    assert event["actual_model_used"] == "gpt-5.4"
+    assert event["user_rating"] == 5
+    assert event["notes"] == "worked well"
+
+
+def test_feedback_cli_marks_fallback(tmp_path: Path):
+    log_path = tmp_path / "router.jsonl"
+
+    subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "log_router_feedback.py"),
+            "--log-path",
+            str(log_path),
+            "--request-id",
+            "req_456",
+            "--outcome",
+            "fallback_used",
+            "--fallback-used",
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    event = json.loads(log_path.read_text(encoding="utf-8").splitlines()[0])
+    assert event["fallback_used"] is True

--- a/model_router/tests/test_model_router.py
+++ b/model_router/tests/test_model_router.py
@@ -1,0 +1,100 @@
+from pathlib import Path
+
+from model_router import (
+    Mode,
+    Model,
+    Privacy,
+    Priority,
+    Quota,
+    RouterInput,
+    TaskType,
+    load_config,
+    route_model,
+)
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def get_config():
+    return load_config(ROOT / "router_config.yaml")
+
+
+def test_coding_execute_high_priority_selects_gpt_and_claude_reviewer():
+    decision = route_model(
+        RouterInput(
+            task_type=TaskType.CODING,
+            mode=Mode.EXECUTE,
+            priority=Priority.HIGH,
+            privacy=Privacy.NORMAL,
+            quota=Quota.NORMAL,
+            has_code=True,
+            has_logs=True,
+        ),
+        get_config(),
+    )
+
+    assert decision.primary_model == Model.GPT
+    assert decision.reviewer == Model.CLAUDE
+    assert decision.fallback_models == [Model.CLAUDE, Model.DEEPSEEK, Model.OLLAMA]
+
+
+def test_chat_medium_critical_uses_policy_override_to_claude():
+    decision = route_model(
+        RouterInput(
+            task_type=TaskType.CHAT,
+            mode=Mode.DRAFT,
+            priority=Priority.MEDIUM,
+            privacy=Privacy.NORMAL,
+            quota=Quota.CRITICAL,
+        ),
+        get_config(),
+    )
+
+    assert decision.primary_model == Model.CLAUDE
+    assert any("policy_override: auto-chat-medium-critical" in item for item in decision.trace)
+
+
+def test_batch_local_only_forces_ollama():
+    decision = route_model(
+        RouterInput(
+            task_type=TaskType.BATCH,
+            mode=Mode.EXECUTE,
+            priority=Priority.MEDIUM,
+            privacy=Privacy.LOCAL_ONLY,
+            quota=Quota.NORMAL,
+        ),
+        get_config(),
+    )
+
+    assert decision.primary_model == Model.OLLAMA
+
+
+def test_review_mode_for_coding_prefers_claude():
+    decision = route_model(
+        RouterInput(
+            task_type=TaskType.CODING,
+            mode=Mode.REVIEW,
+            priority=Priority.MEDIUM,
+            privacy=Privacy.NORMAL,
+            quota=Quota.NORMAL,
+        ),
+        get_config(),
+    )
+
+    assert decision.primary_model == Model.CLAUDE
+
+
+def test_high_priority_disallows_cheap_primary():
+    decision = route_model(
+        RouterInput(
+            task_type=TaskType.CHAT,
+            mode=Mode.DRAFT,
+            priority=Priority.HIGH,
+            privacy=Privacy.NORMAL,
+            quota=Quota.CRITICAL,
+        ),
+        get_config(),
+    )
+
+    assert decision.primary_model == Model.CLAUDE

--- a/model_router/tests/test_policy_flow_e2e.py
+++ b/model_router/tests/test_policy_flow_e2e.py
@@ -1,0 +1,112 @@
+import copy
+from pathlib import Path
+
+import yaml
+
+from model_router import (
+    Mode,
+    Privacy,
+    Priority,
+    Quota,
+    RouterInput,
+    TaskType,
+    load_config,
+    route_model,
+    Model,
+)
+from propose_config_patch import build_patch_proposal
+from validate_router_config import validate_router_config
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def load_base_config_dict():
+    return yaml.safe_load((ROOT / "router_config.yaml").read_text(encoding="utf-8"))
+
+
+def test_generated_patch_produces_valid_config_and_changes_routing(tmp_path: Path):
+    config = load_base_config_dict()
+    config["policy_overrides"] = []
+
+    suggestions = [
+        {
+            "type": "segment_low_success",
+            "severity": "high",
+            "segment": {
+                "task_type": "chat",
+                "priority": "low",
+                "quota": "critical",
+                "primary_model": "deepseek",
+            },
+            "message": "בעיה בסגמנט הזה",
+        }
+    ]
+
+    result = build_patch_proposal(config, suggestions)
+    assert result["generated_count"] == 1
+
+    validation = validate_router_config(result["proposed_config"])
+    assert validation["valid"] is True
+
+    patched_path = tmp_path / "router_config.yaml"
+    patched_path.write_text(yaml.safe_dump(result["proposed_config"], allow_unicode=True, sort_keys=False), encoding="utf-8")
+    patched_config = load_config(patched_path)
+
+    decision = route_model(
+        RouterInput(
+            task_type=TaskType.CHAT,
+            mode=Mode.DRAFT,
+            priority=Priority.LOW,
+            privacy=Privacy.NORMAL,
+            quota=Quota.CRITICAL,
+        ),
+        patched_config,
+    )
+
+    assert decision.primary_model == Model.CLAUDE
+    assert any("policy_override" in item for item in decision.trace)
+
+
+def test_build_patch_proposal_does_not_duplicate_existing_override():
+    config = load_base_config_dict()
+    existing_count = len(config.get("policy_overrides", []))
+
+    suggestions = [
+        {
+            "type": "segment_low_success",
+            "severity": "high",
+            "segment": {
+                "task_type": "chat",
+                "priority": "medium",
+                "quota": "critical",
+                "primary_model": "deepseek",
+            },
+            "message": "כבר יש כלל כזה",
+        }
+    ]
+
+    result = build_patch_proposal(copy.deepcopy(config), suggestions)
+    assert result["generated_count"] == 0
+    assert len(result["proposed_config"]["policy_overrides"]) == existing_count
+
+
+def test_build_patch_proposal_skips_overly_broad_override():
+    config = load_base_config_dict()
+    config["policy_overrides"] = []
+
+    suggestions = [
+        {
+            "type": "segment_low_success",
+            "severity": "high",
+            "segment": {
+                "priority": "low",
+                "primary_model": "deepseek",
+            },
+            "message": "רחב מדי",
+        }
+    ]
+
+    result = build_patch_proposal(copy.deepcopy(config), suggestions)
+    assert result["generated_count"] == 0
+    assert result["generated_overrides"] == []

--- a/model_router/tests/test_propose_config_patch.py
+++ b/model_router/tests/test_propose_config_patch.py
@@ -1,0 +1,52 @@
+from propose_config_patch import build_patch_proposal, suggestion_to_override
+
+
+def test_suggestion_to_override_builds_force_rule():
+    suggestion = {
+        "type": "segment_low_success",
+        "severity": "high",
+        "segment": {
+            "task_type": "chat",
+            "priority": "medium",
+            "quota": "critical",
+            "primary_model": "deepseek",
+        },
+        "message": "בעיה בסגמנט הזה",
+    }
+
+    override = suggestion_to_override(suggestion)
+
+    assert override is not None
+    assert override["when"] == {
+        "task_type": "chat",
+        "priority": "medium",
+        "quota": "critical",
+    }
+    assert override["force"] == "claude-sonnet-4.6"
+
+
+def test_build_patch_proposal_adds_generated_overrides():
+    config = {
+        "router": {"version": "0.3", "default_model": "claude-sonnet-4.6"},
+        "policy_overrides": [],
+    }
+
+    suggestions = [
+        {
+            "type": "segment_low_success",
+            "severity": "high",
+            "segment": {
+                "task_type": "chat",
+                "priority": "medium",
+                "quota": "critical",
+                "primary_model": "deepseek",
+            },
+            "message": "בעיה בסגמנט הזה",
+        }
+    ]
+
+    result = build_patch_proposal(config, suggestions)
+
+    assert result["generated_count"] == 1
+    assert len(result["generated_overrides"]) == 1
+    assert result["proposed_config"]["policy_overrides"][0]["force"] == "claude-sonnet-4.6"

--- a/model_router/tests/test_route_cli.py
+++ b/model_router/tests/test_route_cli.py
@@ -1,0 +1,64 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def run_cli(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(ROOT / "route_cli.py"), *args],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def test_cli_primary_only_for_coding():
+    result = run_cli(
+        "--task-type", "coding",
+        "--mode", "execute",
+        "--priority", "high",
+        "--has-code",
+        "--primary-only",
+    )
+
+    assert result.stdout.strip() == "gpt-5.4"
+
+
+def test_cli_json_output_for_policy_override_chat_medium_critical():
+    result = run_cli(
+        "--task-type", "chat",
+        "--mode", "draft",
+        "--priority", "medium",
+        "--quota", "critical",
+        "--json",
+    )
+
+    payload = json.loads(result.stdout)
+    assert payload["primary_model"] == "claude-sonnet-4.6"
+    assert any("policy_override" in item for item in payload["trace"])
+
+
+def test_cli_writes_telemetry_log(tmp_path: Path):
+    log_path = tmp_path / "router.jsonl"
+
+    result = run_cli(
+        "--task-type", "coding",
+        "--mode", "execute",
+        "--priority", "high",
+        "--has-code",
+        "--log-path", str(log_path),
+        "--request-id", "req-test-1",
+        "--primary-only",
+    )
+
+    assert result.stdout.strip() == "gpt-5.4"
+    lines = log_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    payload = json.loads(lines[0])
+    assert payload["request_id"] == "req-test-1"
+    assert payload["decision"]["primary_model"] == "gpt-5.4"

--- a/model_router/tests/test_scaffold.py
+++ b/model_router/tests/test_scaffold.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+import yaml
+
+from validate_router_config import validate_router_config
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_readme_exists():
+    assert (ROOT / "README.md").exists()
+
+
+def test_router_config_is_valid_yaml_and_passes_validation():
+    config_path = ROOT / "router_config.yaml"
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    result = validate_router_config(config)
+    assert result["valid"] is True
+    assert result["errors"] == []
+
+
+def test_makefile_exists():
+    assert (ROOT / "Makefile").exists()

--- a/model_router/tests/test_suggest_router_changes.py
+++ b/model_router/tests/test_suggest_router_changes.py
@@ -1,0 +1,112 @@
+from suggest_router_changes import suggest_from_summary
+
+
+def test_suggests_high_fallback_low_success_and_task_issue():
+    summary = {
+        "primary_models": {
+            "deepseek": 10,
+            "gpt-5.4": 12,
+        },
+        "joined": {
+            "by_primary_model": {
+                "deepseek": {
+                    "total": 10,
+                    "with_feedback": 8,
+                    "success": 2,
+                    "bad_fit": 2,
+                    "failed": 1,
+                    "fallback_used": 4,
+                    "abandoned": 0,
+                    "feedback_coverage_rate": 0.8,
+                    "success_rate": 0.25,
+                    "fallback_rate": 0.50,
+                    "average_rating": 2.8,
+                    "mismatch_actual_model": 3,
+                },
+                "gpt-5.4": {
+                    "total": 12,
+                    "with_feedback": 10,
+                    "success": 8,
+                    "bad_fit": 1,
+                    "failed": 0,
+                    "fallback_used": 1,
+                    "abandoned": 0,
+                    "feedback_coverage_rate": 0.83,
+                    "success_rate": 0.80,
+                    "fallback_rate": 0.10,
+                    "average_rating": 4.5,
+                    "mismatch_actual_model": 0,
+                },
+            },
+            "by_task_type": {
+                "coding": {
+                    "total": 14,
+                    "with_feedback": 10,
+                    "success": 9,
+                    "bad_fit": 0,
+                    "failed": 0,
+                    "fallback_used": 1,
+                    "abandoned": 0,
+                    "feedback_coverage_rate": 0.71,
+                    "success_rate": 0.90,
+                    "fallback_rate": 0.10,
+                    "average_rating": 4.7,
+                    "mismatch_actual_model": 0,
+                },
+                "chat": {
+                    "total": 8,
+                    "with_feedback": 7,
+                    "success": 2,
+                    "bad_fit": 2,
+                    "failed": 1,
+                    "fallback_used": 3,
+                    "abandoned": 0,
+                    "feedback_coverage_rate": 0.87,
+                    "success_rate": 0.29,
+                    "fallback_rate": 0.43,
+                    "average_rating": 2.9,
+                    "mismatch_actual_model": 2,
+                },
+            },
+        },
+    }
+
+    suggestions = suggest_from_summary(summary, min_feedback_samples=5)
+    messages = [s["message"] for s in suggestions]
+
+    assert any("deepseek" in msg and "fallback_rate גבוה" in msg for msg in messages)
+    assert any("deepseek" in msg and "success_rate נמוך" in msg for msg in messages)
+    assert any("deepseek" in msg and "דירוג ממוצע נמוך" in msg for msg in messages)
+    assert any("קטגוריית chat" in msg and "success_rate נמוך" in msg for msg in messages)
+
+
+def test_returns_no_action_when_no_patterns_found():
+    summary = {
+        "primary_models": {
+            "claude-sonnet-4.6": 5,
+            "gpt-5.4": 6,
+        },
+        "joined": {
+            "by_primary_model": {
+                "claude-sonnet-4.6": {
+                    "total": 5,
+                    "with_feedback": 5,
+                    "success": 5,
+                    "bad_fit": 0,
+                    "failed": 0,
+                    "fallback_used": 0,
+                    "abandoned": 0,
+                    "feedback_coverage_rate": 1.0,
+                    "success_rate": 1.0,
+                    "fallback_rate": 0.0,
+                    "average_rating": 4.8,
+                    "mismatch_actual_model": 0,
+                },
+            },
+            "by_task_type": {},
+        },
+    }
+
+    suggestions = suggest_from_summary(summary, min_feedback_samples=3, low_usage_threshold=0)
+    assert len(suggestions) == 1
+    assert suggestions[0]["type"] == "no_action"

--- a/model_router/tests/test_suggest_router_changes_v2.py
+++ b/model_router/tests/test_suggest_router_changes_v2.py
@@ -1,0 +1,105 @@
+from suggest_router_changes_v2 import segmented_suggestions
+
+
+def test_segmented_suggestions_flags_bad_primary_model_for_task_type():
+    joined = [
+        {
+            "request_id": "1",
+            "task_type": "chat",
+            "priority": "medium",
+            "quota": "critical",
+            "privacy": "normal",
+            "mode": "draft",
+            "primary_model": "deepseek",
+            "feedback_present": True,
+            "outcome": "fallback_used",
+            "actual_model_used": "claude-sonnet-4.6",
+            "fallback_used": True,
+            "user_rating": 3,
+        },
+        {
+            "request_id": "2",
+            "task_type": "chat",
+            "priority": "medium",
+            "quota": "critical",
+            "privacy": "normal",
+            "mode": "draft",
+            "primary_model": "deepseek",
+            "feedback_present": True,
+            "outcome": "bad_fit",
+            "actual_model_used": "claude-sonnet-4.6",
+            "fallback_used": True,
+            "user_rating": 2,
+        },
+        {
+            "request_id": "3",
+            "task_type": "chat",
+            "priority": "medium",
+            "quota": "critical",
+            "privacy": "normal",
+            "mode": "draft",
+            "primary_model": "deepseek",
+            "feedback_present": True,
+            "outcome": "failed",
+            "actual_model_used": "claude-sonnet-4.6",
+            "fallback_used": True,
+            "user_rating": 2,
+        },
+        {
+            "request_id": "4",
+            "task_type": "chat",
+            "priority": "medium",
+            "quota": "critical",
+            "privacy": "normal",
+            "mode": "draft",
+            "primary_model": "deepseek",
+            "feedback_present": True,
+            "outcome": "success",
+            "actual_model_used": "deepseek",
+            "fallback_used": False,
+            "user_rating": 4,
+        },
+    ]
+
+    suggestions = segmented_suggestions(joined, min_feedback_samples=4)
+    messages = [s["message"] for s in suggestions]
+
+    assert any("primary_model=deepseek | task_type=chat" in msg for msg in messages)
+    assert any("task_type=chat | priority=medium" in msg for msg in messages)
+
+
+def test_segmented_suggestions_returns_no_action_when_clean():
+    joined = [
+        {
+            "request_id": "1",
+            "task_type": "coding",
+            "priority": "high",
+            "quota": "normal",
+            "privacy": "normal",
+            "mode": "execute",
+            "primary_model": "gpt-5.4",
+            "feedback_present": True,
+            "outcome": "success",
+            "actual_model_used": "gpt-5.4",
+            "fallback_used": False,
+            "user_rating": 5,
+        },
+        {
+            "request_id": "2",
+            "task_type": "coding",
+            "priority": "high",
+            "quota": "normal",
+            "privacy": "normal",
+            "mode": "execute",
+            "primary_model": "gpt-5.4",
+            "feedback_present": True,
+            "outcome": "success",
+            "actual_model_used": "gpt-5.4",
+            "fallback_used": False,
+            "user_rating": 5,
+        },
+    ]
+
+    suggestions = segmented_suggestions(joined, min_feedback_samples=2)
+    assert len(suggestions) == 1
+    assert suggestions[0]["type"] == "no_segment_action"

--- a/model_router/tests/test_telemetry.py
+++ b/model_router/tests/test_telemetry.py
@@ -1,0 +1,49 @@
+import json
+from pathlib import Path
+
+from telemetry import append_jsonl, build_event
+from model_router import (
+    Mode,
+    Model,
+    Privacy,
+    Priority,
+    Quota,
+    RouterDecision,
+    RouterInput,
+    TaskType,
+)
+
+
+def test_build_event_generates_request_id_when_missing():
+    event = build_event(
+        router_version="0.3",
+        config_path="/tmp/router_config.yaml",
+        request_input=RouterInput(
+            task_type=TaskType.CHAT,
+            mode=Mode.DRAFT,
+            priority=Priority.MEDIUM,
+            privacy=Privacy.NORMAL,
+            quota=Quota.NORMAL,
+        ),
+        decision=RouterDecision(
+            primary_model=Model.CLAUDE,
+            fallback_models=[Model.GPT, Model.DEEPSEEK],
+            reviewer=None,
+            reason="demo",
+            trace=["x"],
+        ),
+    )
+
+    assert event["event_type"] == "decision"
+    assert event["request_id"]
+    assert event["input"]["task_type"] == "chat"
+    assert event["decision"]["primary_model"] == "claude-sonnet-4.6"
+
+
+def test_append_jsonl_writes_one_line(tmp_path: Path):
+    path = tmp_path / "router.jsonl"
+    append_jsonl(path, {"request_id": "abc", "event_type": "decision"})
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0])["request_id"] == "abc"

--- a/model_router/tests/test_validate_router_config.py
+++ b/model_router/tests/test_validate_router_config.py
@@ -1,0 +1,133 @@
+import copy
+from pathlib import Path
+
+import yaml
+
+from validate_router_config import validate_router_config
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def load_base_config_dict():
+    return yaml.safe_load((ROOT / "router_config.yaml").read_text(encoding="utf-8"))
+
+
+def test_validate_router_config_accepts_current_config():
+    config = load_base_config_dict()
+    result = validate_router_config(config)
+
+    assert result["valid"] is True
+    assert result["errors"] == []
+
+
+
+def test_validate_router_config_rejects_invalid_policy_values():
+    config = load_base_config_dict()
+    config["policy_overrides"] = [
+        {
+            "name": "bad-values",
+            "when": {
+                "task_type": "sales",
+                "has_code": "yes",
+                "privacy": "private",
+            },
+            "force": "claude-sonnet-4.6",
+        }
+    ]
+
+    result = validate_router_config(config)
+
+    assert result["valid"] is False
+    assert any("task_type" in item and "ערך לא חוקי" in item for item in result["errors"])
+    assert any("has_code" in item and "boolean" in item for item in result["errors"])
+    assert any("privacy" in item and "ערך לא חוקי" in item for item in result["errors"])
+
+
+
+def test_validate_router_config_warns_on_broad_policy_override():
+    config = load_base_config_dict()
+    config["policy_overrides"] = [
+        {
+            "name": "too-broad",
+            "when": {"priority": "low"},
+            "force": "deepseek",
+        }
+    ]
+
+    result = validate_router_config(config)
+
+    assert result["valid"] is True
+    assert any("רחב מאוד" in item for item in result["warnings"])
+    assert any("לא כולל task_type או quota" in item for item in result["warnings"])
+
+
+
+def test_validate_router_config_warns_when_local_only_force_is_not_ollama():
+    config = load_base_config_dict()
+    config["policy_overrides"] = [
+        {
+            "name": "bad-local-only-force",
+            "when": {
+                "task_type": "chat",
+                "privacy": "local_only",
+            },
+            "force": "claude-sonnet-4.6",
+        }
+    ]
+
+    result = validate_router_config(config)
+
+    assert result["valid"] is True
+    assert any("privacy=local_only" in item and "ollama" in item for item in result["warnings"])
+
+
+
+def test_validate_router_config_warns_on_duplicate_and_shadowed_policy_rules():
+    config = load_base_config_dict()
+    config["policy_overrides"] = [
+        {
+            "name": "chat-critical",
+            "when": {
+                "task_type": "chat",
+                "quota": "critical",
+            },
+            "force": "claude-sonnet-4.6",
+        },
+        {
+            "name": "chat-critical",
+            "when": {
+                "task_type": "chat",
+                "quota": "critical",
+            },
+            "force": "claude-sonnet-4.6",
+        },
+        {
+            "name": "chat-critical-low",
+            "when": {
+                "task_type": "chat",
+                "quota": "critical",
+                "priority": "low",
+            },
+            "force": "gpt-5.4",
+        },
+    ]
+
+    result = validate_router_config(config)
+
+    assert result["valid"] is True
+    assert any("name כפול" in item for item in result["warnings"])
+    assert any("when זהה" in item for item in result["warnings"])
+    assert any("לא יופעל" in item or "כלל מאוחר מיותר" in item for item in result["warnings"])
+
+
+
+def test_validate_router_config_warns_on_duplicate_fallback_entries():
+    config = load_base_config_dict()
+    config["fallbacks"] = copy.deepcopy(config["fallbacks"])
+    config["fallbacks"]["claude-sonnet-4.6"] = ["gpt-5.4", "gpt-5.4", "deepseek"]
+
+    result = validate_router_config(config)
+
+    assert result["valid"] is True
+    assert any("כפילות" in item and "gpt-5.4" in item for item in result["warnings"])

--- a/model_router/validate_router_config.py
+++ b/model_router/validate_router_config.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+VALID_MODELS = {
+    "claude-sonnet-4.6",
+    "gpt-5.4",
+    "deepseek",
+    "ollama",
+    "flash_or_o4_mini",
+}
+
+VALID_TASK_TYPES = {"chat", "coding", "writing", "research", "batch", "trivial"}
+VALID_MODES = {"draft", "execute", "review"}
+VALID_PRIORITIES = {"low", "medium", "high"}
+VALID_PRIVACY = {"normal", "sensitive", "local_only"}
+VALID_QUOTA = {"normal", "low", "critical"}
+VALID_SPEED = {"normal", "fast"}
+VALID_POLICY_FIELDS = {"task_type", "mode", "priority", "privacy", "quota", "speed", "has_code", "has_logs"}
+VALID_BOOLEAN_POLICY_FIELDS = {"has_code", "has_logs"}
+VALID_POLICY_VALUES = {
+    "task_type": VALID_TASK_TYPES,
+    "mode": VALID_MODES,
+    "priority": VALID_PRIORITIES,
+    "privacy": VALID_PRIVACY,
+    "quota": VALID_QUOTA,
+    "speed": VALID_SPEED,
+}
+
+
+def _err(errors: list[str], msg: str) -> None:
+    errors.append(msg)
+
+
+def _warn(warnings: list[str], msg: str) -> None:
+    warnings.append(msg)
+
+
+def _normalize_when_signature(when: dict) -> tuple[tuple[str, object], ...]:
+    return tuple(sorted(when.items(), key=lambda item: item[0]))
+
+
+def _is_subset_when(left: dict, right: dict) -> bool:
+    return all(right.get(key) == value for key, value in left.items())
+
+
+def _validate_policy_value(errors: list[str], path: str, field: str, value: object) -> None:
+    if field in VALID_BOOLEAN_POLICY_FIELDS:
+        if not isinstance(value, bool):
+            _err(errors, f"{path}.{field} חייב להיות boolean")
+        return
+
+    valid_values = VALID_POLICY_VALUES.get(field)
+    if valid_values is None:
+        return
+
+    if value not in valid_values:
+        allowed = ", ".join(sorted(valid_values))
+        _err(errors, f"{path}.{field} כולל ערך לא חוקי: {value} (מותר: {allowed})")
+
+
+def validate_router_config(config: dict) -> dict:
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    if not isinstance(config, dict):
+        return {"valid": False, "errors": ["קובץ config ראשי לא תקין"], "warnings": []}
+
+    for key in ("router", "base_by_task", "fallbacks"):
+        if key not in config:
+            _err(errors, f"שדה חובה חסר: {key}")
+
+    if errors:
+        return {"valid": False, "errors": errors, "warnings": warnings}
+
+    router = config["router"]
+    if not isinstance(router, dict):
+        _err(errors, "router חייב להיות mapping")
+        router = {}
+
+    version = router.get("version")
+    if version is not None and not isinstance(version, str):
+        _err(errors, "router.version חייב להיות string")
+
+    default_model = router.get("default_model")
+    if default_model not in VALID_MODELS:
+        _err(errors, f"router.default_model לא חוקי: {default_model}")
+
+    base_by_task = config.get("base_by_task", {})
+    if not isinstance(base_by_task, dict):
+        _err(errors, "base_by_task חייב להיות mapping")
+        base_by_task = {}
+    else:
+        for task_type, model in base_by_task.items():
+            if task_type not in VALID_TASK_TYPES:
+                _err(errors, f"base_by_task כולל task_type לא חוקי: {task_type}")
+            if model not in VALID_MODELS:
+                _err(errors, f"base_by_task.{task_type} כולל מודל לא חוקי: {model}")
+
+        missing_tasks = sorted(VALID_TASK_TYPES - set(base_by_task.keys()))
+        if missing_tasks:
+            _warn(warnings, f"base_by_task לא מכסה את כל סוגי המשימות: {', '.join(missing_tasks)}")
+
+    fallbacks = config.get("fallbacks", {})
+    if not isinstance(fallbacks, dict):
+        _err(errors, "fallbacks חייב להיות mapping")
+        fallbacks = {}
+    else:
+        for model, values in fallbacks.items():
+            if model not in VALID_MODELS:
+                _err(errors, f"fallbacks key לא חוקי: {model}")
+            if not isinstance(values, list):
+                _err(errors, f"fallbacks.{model} חייב להיות list")
+                continue
+            seen_items = set()
+            for item in values:
+                if item not in VALID_MODELS:
+                    _err(errors, f"fallbacks.{model} כולל מודל fallback לא חוקי: {item}")
+                if item == model:
+                    _warn(warnings, f"fallbacks.{model} כולל את עצמו")
+                if item in seen_items:
+                    _warn(warnings, f"fallbacks.{model} כולל כפילות של {item}")
+                seen_items.add(item)
+
+        referenced_models = {default_model} | {model for model in base_by_task.values() if model in VALID_MODELS}
+        for model in sorted(referenced_models):
+            if model and model not in fallbacks:
+                _warn(warnings, f"fallbacks חסר עבור מודל בשימוש: {model}")
+
+    mode_overrides = config.get("mode_overrides", {})
+    if mode_overrides and not isinstance(mode_overrides, dict):
+        _err(errors, "mode_overrides חייב להיות mapping")
+    elif isinstance(mode_overrides, dict):
+        for mode, mapping in mode_overrides.items():
+            if mode not in VALID_MODES:
+                _err(errors, f"mode_overrides כולל mode לא חוקי: {mode}")
+            if not isinstance(mapping, dict):
+                _err(errors, f"mode_overrides.{mode} חייב להיות mapping")
+                continue
+            for task_type, model in mapping.items():
+                if task_type not in VALID_TASK_TYPES:
+                    _err(errors, f"mode_overrides.{mode} כולל task_type לא חוקי: {task_type}")
+                if model not in VALID_MODELS:
+                    _err(errors, f"mode_overrides.{mode}.{task_type} כולל מודל לא חוקי: {model}")
+
+    reviewers = config.get("reviewers", {})
+    if reviewers and not isinstance(reviewers, dict):
+        _err(errors, "reviewers חייב להיות mapping")
+    elif isinstance(reviewers, dict):
+        for priority, mapping in reviewers.items():
+            if priority not in VALID_PRIORITIES:
+                _err(errors, f"reviewers כולל priority לא חוקי: {priority}")
+            if not isinstance(mapping, dict):
+                _err(errors, f"reviewers.{priority} חייב להיות mapping")
+                continue
+            for task_type, model in mapping.items():
+                if task_type not in VALID_TASK_TYPES:
+                    _err(errors, f"reviewers.{priority} כולל task_type לא חוקי: {task_type}")
+                if model not in VALID_MODELS:
+                    _err(errors, f"reviewers.{priority}.{task_type} כולל מודל לא חוקי: {model}")
+
+    policy_overrides = config.get("policy_overrides", [])
+    valid_policy_entries: list[dict[str, object]] = []
+    if policy_overrides and not isinstance(policy_overrides, list):
+        _err(errors, "policy_overrides חייב להיות list")
+    elif isinstance(policy_overrides, list):
+        seen_names: dict[str, int] = {}
+        seen_signatures: dict[tuple[tuple[str, object], ...], int] = {}
+
+        for i, override in enumerate(policy_overrides):
+            path = f"policy_overrides[{i}]"
+            if not isinstance(override, dict):
+                _err(errors, f"{path} חייב להיות mapping")
+                continue
+
+            name = override.get("name")
+            if not isinstance(name, str) or not name:
+                _err(errors, f"{path}.name חסר או לא תקין")
+            else:
+                previous_index = seen_names.get(name)
+                if previous_index is not None:
+                    _warn(warnings, f"{path}.name כפול ל-{name} (כבר קיים ב-policy_overrides[{previous_index}])")
+                else:
+                    seen_names[name] = i
+
+            reason = override.get("reason")
+            if reason is not None and not isinstance(reason, str):
+                _err(errors, f"{path}.reason חייב להיות string אם הוא קיים")
+
+            when = override.get("when")
+            if not isinstance(when, dict) or not when:
+                _err(errors, f"{path}.when חייב להיות mapping לא ריק")
+                when = None
+            else:
+                for field, value in when.items():
+                    if field not in VALID_POLICY_FIELDS:
+                        _err(errors, f"{path}.when כולל שדה לא נתמך: {field}")
+                        continue
+                    _validate_policy_value(errors, f"{path}.when", field, value)
+
+                if len(when) < 2:
+                    _warn(warnings, f"{path} רחב מאוד — מומלץ לפחות שני תנאים ב-when")
+                if "task_type" not in when and "quota" not in when:
+                    _warn(warnings, f"{path} לא כולל task_type או quota — עלול להיות כלל רחב מדי")
+
+            force = override.get("force")
+            if force not in VALID_MODELS:
+                _err(errors, f"{path}.force לא חוקי: {force}")
+
+            if isinstance(when, dict) and force in VALID_MODELS:
+                if when.get("privacy") == "local_only" and force != "ollama":
+                    _warn(warnings, f"{path} מנסה לכפות {force} על privacy=local_only — בפועל hard safety יחזיר ollama")
+
+                signature = _normalize_when_signature(when)
+                previous_index = seen_signatures.get(signature)
+                if previous_index is not None:
+                    _warn(warnings, f"{path}.when זהה ל-policy_overrides[{previous_index}].when")
+                else:
+                    seen_signatures[signature] = i
+
+                valid_policy_entries.append({
+                    "index": i,
+                    "path": path,
+                    "name": name or f"override-{i}",
+                    "when": when,
+                    "force": force,
+                })
+
+        for entry_index, entry in enumerate(valid_policy_entries):
+            for prior in valid_policy_entries[:entry_index]:
+                if _is_subset_when(prior["when"], entry["when"]):
+                    if prior["force"] == entry["force"]:
+                        _warn(
+                            warnings,
+                            f"{entry['path']} נבלע ע\"י {prior['path']} עם אותו force={entry['force']} — כלל מאוחר מיותר",
+                        )
+                    else:
+                        _warn(
+                            warnings,
+                            f"{entry['path']} לא יופעל כי {prior['path']} נתפס קודם עבור אותם תנאים או כלל רחב יותר",
+                        )
+                    break
+
+    return {"valid": not errors, "errors": errors, "warnings": warnings}
+
+
+if __name__ == "__main__":
+    import argparse
+    import json
+    from pathlib import Path
+
+    import yaml
+
+    parser = argparse.ArgumentParser(description="Validate router_config.yaml")
+    parser.add_argument("config_path")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    config = yaml.safe_load(Path(args.config_path).read_text(encoding="utf-8"))
+    result = validate_router_config(config)
+
+    if args.json:
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+    else:
+        print(f"== Router Config Validation ==\nValid: {'yes' if result['valid'] else 'no'}\n")
+        print("Errors:")
+        if result["errors"]:
+            for item in result["errors"]:
+                print(f"  - {item}")
+        else:
+            print("  (none)")
+        print("\nWarnings:")
+        if result["warnings"]:
+            for item in result["warnings"]:
+                print(f"  - {item}")
+        else:
+            print("  (none)")
+
+    raise SystemExit(0 if result["valid"] else 1)
+
+
+
+def main():
+    import subprocess
+    import sys
+
+    raise SystemExit(subprocess.call([sys.executable, __file__, *sys.argv[1:]]))


### PR DESCRIPTION
## Summary
- add a new `model_router/` internal project for YAML-driven model routing
- implement the full v1 loop: routing -> telemetry -> feedback -> analysis -> suggestions -> patch proposal -> validation
- add CLI entrypoints, hardened config validation, local workflows, end-to-end demo flow, and CI coverage

## What changed
- core router engine with hard safety vs soft routing precedence
- `router_config.yaml` and validator for supported models, policy fields, overlap warnings, and risky override warnings
- decision telemetry + feedback logging via append-only JSONL
- telemetry analysis, global suggestions, segmented suggestions, and focused policy patch proposal flow
- demo workflow script plus dedicated demo test
- README, Makefile, justfile, and GitHub Actions workflow

## Validation
- `python3 -m py_compile model_router/model_router.py model_router/route_cli.py model_router/telemetry.py model_router/log_router_feedback.py model_router/analyze_telemetry.py model_router/suggest_router_changes.py model_router/suggest_router_changes_v2.py model_router/propose_config_patch.py model_router/validate_router_config.py model_router/scripts/demo_workflow.py model_router/tests/test_demo_workflow.py`
- `cd model_router && python3 validate_router_config.py router_config.yaml --json`
- `cd model_router && python3 scripts/demo_workflow.py`

## Notes
- full `pytest -q` could not be run in this local environment because `pip` / `pytest` are unavailable here
- CI is configured to install `.[dev]`, run config validation, run the demo workflow smoke check, and then run `pytest -q`
