### PR TITLE
fix(tui): markdown — guard intraword underscores + clean protocol sentinels

### DIFF
--- a/ui-tui/src/__tests__/markdown.test.ts
+++ b/ui-tui/src/__tests__/markdown.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import { INLINE_RE, stripInlineMarkup } from '../components/markdown.js'
+
+const matches = (text: string) => [...text.matchAll(INLINE_RE)].map(m => m[0])
+
+describe('INLINE_RE emphasis', () => {
+  it('matches word-boundary italic/bold', () => {
+    expect(matches('say _hi_ there')).toEqual(['_hi_'])
+    expect(matches('very __bold__ move')).toEqual(['__bold__'])
+    expect(matches('(_paren_) and [_bracket_]')).toEqual(['_paren_', '_bracket_'])
+  })
+
+  it('keeps intraword underscores literal', () => {
+    const path = '/home/me/.hermes/cache/screenshots/browser_screenshot_ecc1c3feab.png'
+
+    expect(matches(path)).toEqual([])
+    expect(matches('snake_case_var and MY_CONST')).toEqual([])
+    expect(matches('foo__bar__baz')).toEqual([])
+  })
+
+  it('still matches asterisk emphasis intraword', () => {
+    expect(matches('a*b*c')).toEqual(['*b*'])
+    expect(matches('a**bold**c')).toEqual(['**bold**'])
+  })
+})
+
+describe('stripInlineMarkup', () => {
+  it('strips word-boundary emphasis only', () => {
+    expect(stripInlineMarkup('say _hi_ there')).toBe('say hi there')
+    expect(stripInlineMarkup('browser_screenshot_ecc.png')).toBe('browser_screenshot_ecc.png')
+    expect(stripInlineMarkup('__bold__ and foo__bar__')).toBe('bold and foo__bar__')
+  })
+})

--- a/ui-tui/src/__tests__/markdown.test.ts
+++ b/ui-tui/src/__tests__/markdown.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { INLINE_RE, stripInlineMarkup } from '../components/markdown.js'
+import { AUDIO_DIRECTIVE_RE, INLINE_RE, MEDIA_LINE_RE, stripInlineMarkup } from '../components/markdown.js'
 
 const matches = (text: string) => [...text.matchAll(INLINE_RE)].map(m => m[0])
 
@@ -30,5 +30,27 @@ describe('stripInlineMarkup', () => {
     expect(stripInlineMarkup('say _hi_ there')).toBe('say hi there')
     expect(stripInlineMarkup('browser_screenshot_ecc.png')).toBe('browser_screenshot_ecc.png')
     expect(stripInlineMarkup('__bold__ and foo__bar__')).toBe('bold and foo__bar__')
+  })
+})
+
+describe('protocol sentinels', () => {
+  it('captures MEDIA: paths with surrounding quotes or backticks', () => {
+    expect('MEDIA:/tmp/a.png'.match(MEDIA_LINE_RE)?.[1]).toBe('/tmp/a.png')
+    expect('  MEDIA: /home/me/.hermes/cache/screenshots/browser_screenshot_ecc.png  '.match(MEDIA_LINE_RE)?.[1]).toBe(
+      '/home/me/.hermes/cache/screenshots/browser_screenshot_ecc.png'
+    )
+    expect('`MEDIA:/tmp/a.png`'.match(MEDIA_LINE_RE)?.[1]).toBe('/tmp/a.png')
+    expect('"MEDIA:C:\\files\\a.png"'.match(MEDIA_LINE_RE)?.[1]).toBe('C:\\files\\a.png')
+  })
+
+  it('ignores MEDIA: tokens embedded in prose', () => {
+    expect('here is MEDIA:/tmp/a.png for you'.match(MEDIA_LINE_RE)).toBeNull()
+    expect('the media: section is empty'.match(MEDIA_LINE_RE)).toBeNull()
+  })
+
+  it('matches the [[audio_as_voice]] directive', () => {
+    expect(AUDIO_DIRECTIVE_RE.test('[[audio_as_voice]]')).toBe(true)
+    expect(AUDIO_DIRECTIVE_RE.test('  [[audio_as_voice]]  ')).toBe(true)
+    expect(AUDIO_DIRECTIVE_RE.test('audio_as_voice')).toBe(false)
   })
 })

--- a/ui-tui/src/components/markdown.tsx
+++ b/ui-tui/src/components/markdown.tsx
@@ -12,6 +12,9 @@ const DEF_RE = /^\s*:\s+(.+)$/
 const TABLE_DIVIDER_CELL_RE = /^:?-{3,}:?$/
 const MD_URL_RE = '((?:[^\\s()]|\\([^\\s()]*\\))+?)'
 
+export const MEDIA_LINE_RE = /^\s*[`"']?MEDIA:\s*(\S+?)[`"']?\s*$/
+export const AUDIO_DIRECTIVE_RE = /^\s*\[\[audio_as_voice\]\]\s*$/
+
 export const INLINE_RE = new RegExp(
   `(!\\[(.*?)\\]\\(${MD_URL_RE}\\)|\\[(.+?)\\]\\(${MD_URL_RE}\\)|<((?:https?:\\/\\/|mailto:)[^>\\s]+|[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,})>|~~(.+?)~~|\`([^\\\`]+)\`|\\*\\*(.+?)\\*\\*|(?<!\\w)__(.+?)__(?!\\w)|\\*(.+?)\\*|(?<!\\w)_(.+?)_(?!\\w)|==(.+?)==|\\[\\^([^\\]]+)\\]|\\^([^^\\s][^^]*?)\\^|~([^~\\s][^~]*?)~|(https?:\\/\\/[^\\s<]+))`,
   'g'
@@ -262,6 +265,35 @@ function MdImpl({ compact, t, text }: MdProps) {
 
       if (!line.trim()) {
         gap()
+        i++
+
+        continue
+      }
+
+      if (AUDIO_DIRECTIVE_RE.test(line)) {
+        i++
+
+        continue
+      }
+
+      const media = line.match(MEDIA_LINE_RE)
+
+      if (media) {
+        start('paragraph')
+
+        const path = media[1]!
+        const url = /^(?:\/|[a-z]:[\\/])/i.test(path) ? `file://${path}` : path
+
+        nodes.push(
+          <Text color={t.color.dim} key={key}>
+            {'▸ '}
+            <Link url={url}>
+              <Text color={t.color.amber} underline>
+                {path}
+              </Text>
+            </Link>
+          </Text>
+        )
         i++
 
         continue

--- a/ui-tui/src/components/markdown.tsx
+++ b/ui-tui/src/components/markdown.tsx
@@ -12,8 +12,8 @@ const DEF_RE = /^\s*:\s+(.+)$/
 const TABLE_DIVIDER_CELL_RE = /^:?-{3,}:?$/
 const MD_URL_RE = '((?:[^\\s()]|\\([^\\s()]*\\))+?)'
 
-const INLINE_RE = new RegExp(
-  `(!\\[(.*?)\\]\\(${MD_URL_RE}\\)|\\[(.+?)\\]\\(${MD_URL_RE}\\)|<((?:https?:\\/\\/|mailto:)[^>\\s]+|[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,})>|~~(.+?)~~|\`([^\\\`]+)\`|\\*\\*(.+?)\\*\\*|__(.+?)__|\\*(.+?)\\*|_(.+?)_|==(.+?)==|\\[\\^([^\\]]+)\\]|\\^([^^\\s][^^]*?)\\^|~([^~\\s][^~]*?)~|(https?:\\/\\/[^\\s<]+))`,
+export const INLINE_RE = new RegExp(
+  `(!\\[(.*?)\\]\\(${MD_URL_RE}\\)|\\[(.+?)\\]\\(${MD_URL_RE}\\)|<((?:https?:\\/\\/|mailto:)[^>\\s]+|[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,})>|~~(.+?)~~|\`([^\\\`]+)\`|\\*\\*(.+?)\\*\\*|(?<!\\w)__(.+?)__(?!\\w)|\\*(.+?)\\*|(?<!\\w)_(.+?)_(?!\\w)|==(.+?)==|\\[\\^([^\\]]+)\\]|\\^([^^\\s][^^]*?)\\^|~([^~\\s][^~]*?)~|(https?:\\/\\/[^\\s<]+))`,
   'g'
 )
 
@@ -90,7 +90,7 @@ const isTableDivider = (row: string) => {
   return cells.length > 1 && cells.every(cell => TABLE_DIVIDER_CELL_RE.test(cell))
 }
 
-const stripInlineMarkup = (value: string) =>
+export const stripInlineMarkup = (value: string) =>
   value
     .replace(/!\[(.*?)\]\(((?:[^\s()]|\([^\s()]*\))+?)\)/g, '[image: $1] $2')
     .replace(/\[(.+?)\]\(((?:[^\s()]|\([^\s()]*\))+?)\)/g, '$1')
@@ -98,9 +98,9 @@ const stripInlineMarkup = (value: string) =>
     .replace(/~~(.+?)~~/g, '$1')
     .replace(/`([^`]+)`/g, '$1')
     .replace(/\*\*(.+?)\*\*/g, '$1')
-    .replace(/__(.+?)__/g, '$1')
+    .replace(/(?<!\w)__(.+?)__(?!\w)/g, '$1')
     .replace(/\*(.+?)\*/g, '$1')
-    .replace(/_(.+?)_/g, '$1')
+    .replace(/(?<!\w)_(.+?)_(?!\w)/g, '$1')
     .replace(/==(.+?)==/g, '$1')
     .replace(/\[\^([^\]]+)\]/g, '[$1]')
     .replace(/\^([^^\s][^^]*?)\^/g, '^$1')


### PR DESCRIPTION
## Summary

Two related fixes for the TUI markdown renderer, both rooted in "what shouldn't be markdown".

### 1. Intraword underscores stay literal

`Md`'s `INLINE_RE` matched `_..._` and `__...__` with no word-boundary guard, so paths and `snake_case` identifiers rendered mid-italic/bold. Example: `browser_screenshot_ecc1c3feab.png` showed `_screenshot_` italicized mid-path.

Gated `_` / `__` emphasis with `(?<!\w)` / `(?!\w)` on both the render regex and the table-width `stripInlineMarkup`. `*` / `**` intentionally keep intraword behavior — that's CommonMark-legal and rarely wrong in practice.

### 2. Protocol sentinels get clean handling

The agent emits `MEDIA:<path>` to tell the gateway to deliver a file, and `[[audio_as_voice]]` to request voice-message delivery. The gateway strips both (`_clean_for_display` in `stream_consumer.py`), but the TUI was passing them through markdown — which is where the original bug showed up.

At the `Md` layer:
- `MEDIA:<path>` on its own line → `▸ <path>` (dim triangle, amber underlined, literal path) wrapped in `Link` for OSC 8 hyperlink support (absolute paths get `file://` so modern terminals make them clickable).
- `[[audio_as_voice]]` → dropped; it has no meaning in TUI.

Mid-prose `MEDIA:` tokens (rare) are intentionally left untouched and rely on the intraword-underscore guard to stay literal.

## Test plan

- [x] `npm test` in `ui-tui/` — 109/109 passing, 7 new cases in `markdown.test.ts`.
- [x] `tsc --noEmit` clean.
- [x] `eslint` clean on touched files.

## Before

```
browser_screenshot_ecc1c3feab.png   → browser<i>screenshot</i>ecc1c3feab.png
MEDIA:/tmp/x.png                    → rendered as prose
[[audio_as_voice]]                  → rendered as prose
```

## After

```
browser_screenshot_ecc1c3feab.png   → literal
MEDIA:/tmp/x.png                    → ▸ /tmp/x.png  (clickable, no markdown)
[[audio_as_voice]]                  → hidden
_italic_ / __bold__                 → still work
snake_case_var / foo__bar__baz      → literal
```

## Why not generic path-detection?

Punting on speculative "detect anything code-like and skip markdown" — heuristic explosion, false positives on prose (`use the /api/users endpoint` rendering monospaced), and the real offender was the CommonMark intraword rule plus two well-defined protocol sentinels. Targeted beats clever.
