### PR TITLE
fix(skills-hub): handle bytes content in bundle_content_hash

### DIFF
--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -2630,7 +2630,8 @@ def bundle_content_hash(bundle: SkillBundle) -> str:
     """Compute a deterministic hash for an in-memory skill bundle."""
     h = hashlib.sha256()
     for rel_path in sorted(bundle.files):
-        h.update(bundle.files[rel_path].encode("utf-8"))
+        content = bundle.files[rel_path]
+        h.update(content if isinstance(content, bytes) else content.encode("utf-8"))
     return f"sha256:{h.hexdigest()[:16]}"
 
 


### PR DESCRIPTION
## Bug

`hermes skills check` and `hermes skills update` crash with:

```
AttributeError: 'bytes' object has no attribute 'encode'. Did you mean: 'decode'?
```

at `tools/skills_hub.py:2633` in `bundle_content_hash()`.

## Root Cause

`SkillBundle.files` is typed `Dict[str, Union[str, bytes]]` (line 81), but `bundle_content_hash()` unconditionally calls `.encode('utf-8')` on every value. When a bundle contains binary files (images, compiled assets, etc.), the value is already `bytes` and `.encode()` raises `AttributeError`.

## Fix

Add an `isinstance` check: pass `bytes` directly to `h.update()`, only encode `str` values. One-line change, no behavior change for string content.

## Verification

Before fix:
```
$ hermes skills check
Traceback (most recent call last):
  ...
  File "tools/skills_hub.py", line 2633, in bundle_content_hash
    h.update(bundle.files[rel_path].encode("utf-8"))
AttributeError: 'bytes' object has no attribute 'encode'
```

After fix:
```
$ hermes skills check
Skill Updates
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┓
┃ Name                       ┃ Source    ┃ Status           ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━┩
│ blender-mcp                │ official  │ up_to_date       │
│ ...                        │ ...       │ ...              │
└────────────────────────────┴───────────┴──────────────────┘
```

All 90 hub-installed skills checked successfully.