### PR TITLE
fix(gateway): lead with session ID in Discord /resume session listings

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -2040,8 +2040,8 @@ class DiscordAdapter(BasePlatformAdapter):
         async def slash_title(interaction: discord.Interaction, name: str = ""):
             await self._run_simple_slash(interaction, f"/title {name}".strip())
 
-        @tree.command(name="resume", description="Resume a previously-named session")
-        @discord.app_commands.describe(name="Session name to resume. Leave empty to list sessions.")
+        @tree.command(name="resume", description="Resume a previous session by name or ID")
+        @discord.app_commands.describe(name="Session name or ID to resume. Leave empty to list sessions.")
         async def slash_resume(interaction: discord.Interaction, name: str = ""):
             await self._run_simple_slash(interaction, f"/resume {name}".strip())
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7070,19 +7070,22 @@ class GatewayRunner:
                 sessions = self._session_db.list_sessions_rich(
                     source=user_source, limit=10
                 )
-                titled = [s for s in sessions if s.get("title")]
-                if not titled:
+                if not sessions:
                     return (
-                        "No named sessions found.\n"
-                        "Use `/title My Session` to name your current session, "
-                        "then `/resume My Session` to return to it later."
+                        "No sessions found.\n"
+                        "Start a conversation and it will appear here."
                     )
-                lines = ["📋 **Named Sessions**\n"]
-                for s in titled[:10]:
-                    title = s["title"]
+                lines = ["📋 **Recent Sessions**\n"]
+                for s in sessions[:10]:
+                    sid = s["id"]
+                    title = s.get("title")
                     preview = s.get("preview", "")[:40]
-                    preview_part = f" — _{preview}_" if preview else ""
-                    lines.append(f"• **{title}**{preview_part}")
+                    if title:
+                        preview_part = f" — _{preview}_" if preview else ""
+                        lines.append(f"• **{sid}** — {title}{preview_part}")
+                    else:
+                        preview_part = preview or "(no messages)"
+                        lines.append(f"• **{sid}** — _{preview_part}_")
                 lines.append("\nUsage: `/resume <session name>`")
                 return "\n".join(lines)
             except Exception as e:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -97,8 +97,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("profile", "Show active profile name and home directory", "Info"),
     CommandDef("sethome", "Set this chat as the home channel", "Session",
                gateway_only=True, aliases=("set-home",)),
-    CommandDef("resume", "Resume a previously-named session", "Session",
-               args_hint="[name]"),
+    CommandDef("resume", "Resume a previous session by name or ID", "Session",
+                args_hint="[name|id]"),
 
     # Configuration
     CommandDef("config", "Show current configuration", "Configuration",


### PR DESCRIPTION
Fix Discord /resume session listings to:
- Lead with session ID for visibility when embed is truncated
- Include untitled sessions using preview as fallback
- Updated slash command description to reflect session ID support

**Files changed:**
- `gateway/run.py` — Session list now leads with `s["id"]`, includes untitled sessions, uses `preview` as fallback
- `gateway/platforms/discord.py` — Slash command description: "Resume a previous session by name or ID"
- `hermes_cli/commands.py` — `args_hint`: `[name|id]`

All 90 relevant tests pass.