### PR TITLE
fix: treat Telegram image documents as images

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2665,10 +2665,60 @@ class TelegramAdapter(BasePlatformAdapter):
                     _, ext = os.path.splitext(original_filename)
                     ext = ext.lower()
 
-                # If no extension from filename, reverse-lookup from MIME type
-                if not ext and doc.mime_type:
-                    mime_to_ext = {v: k for k, v in SUPPORTED_DOCUMENT_TYPES.items()}
-                    ext = mime_to_ext.get(doc.mime_type, "")
+                image_mime_to_ext = {
+                    "image/png": ".png",
+                    "image/jpeg": ".jpg",
+                    "image/jpg": ".jpg",
+                    "image/webp": ".webp",
+                    "image/gif": ".gif",
+                }
+                image_ext_to_mime = {
+                    ".png": "image/png",
+                    ".jpg": "image/jpeg",
+                    ".jpeg": "image/jpeg",
+                    ".webp": "image/webp",
+                    ".gif": "image/gif",
+                }
+                image_exts = set(image_ext_to_mime.keys())
+                mime_type = str(doc.mime_type or "").lower()
+                image_ext = ""
+                if mime_type.startswith("image/"):
+                    image_ext = image_mime_to_ext.get(mime_type, "")
+                elif mime_type in ("", "application/octet-stream") and ext in image_exts:
+                    image_ext = ext
+
+                # Telegram screenshots are often sent as documents to preserve quality.
+                # Treat supported image documents as images so they flow through vision normally.
+                if image_ext:
+                    MAX_IMAGE_BYTES = 20 * 1024 * 1024
+                    if not doc.file_size or doc.file_size > MAX_IMAGE_BYTES:
+                        event.text = (
+                            "The image is too large or its size could not be verified. "
+                            "Maximum: 20 MB."
+                        )
+                        logger.info("[Telegram] Image document too large: %s bytes", doc.file_size)
+                        await self.handle_message(event)
+                        return
+
+                    file_obj = await doc.get_file()
+                    image_bytes = bytes(await file_obj.download_as_bytearray())
+                    try:
+                        cached_path = cache_image_from_bytes(image_bytes, ext=image_ext)
+                    except ValueError:
+                        supported_list = ", ".join(sorted(SUPPORTED_DOCUMENT_TYPES.keys()))
+                        event.text = (
+                            f"Unsupported document type '{ext or image_ext or 'unknown'}'. "
+                            f"Supported types: {supported_list}"
+                        )
+                        logger.info("[Telegram] Rejected invalid image document: %s", ext or image_ext or "unknown")
+                        await self.handle_message(event)
+                        return
+                    event.message_type = MessageType.PHOTO
+                    event.media_urls = [cached_path]
+                    event.media_types = [image_ext_to_mime[image_ext]]
+                    logger.info("[Telegram] Cached user image document at %s", cached_path)
+                    await self.handle_message(event)
+                    return
 
                 if not ext and doc.mime_type:
                     video_mime_to_ext = {v: k for k, v in SUPPORTED_VIDEO_TYPES.items()}
@@ -2684,6 +2734,11 @@ class TelegramAdapter(BasePlatformAdapter):
                     logger.info("[Telegram] Cached user video document at %s", cached_path)
                     await self.handle_message(event)
                     return
+
+                # If no extension from filename, reverse-lookup from MIME type
+                if not ext and doc.mime_type:
+                    mime_to_ext = {v: k for k, v in SUPPORTED_DOCUMENT_TYPES.items()}
+                    ext = mime_to_ext.get(doc.mime_type, "")
 
                 # Check if supported
                 if ext not in SUPPORTED_DOCUMENT_TYPES:

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -199,6 +199,111 @@ class TestDocumentDownloadBlock:
         assert event.media_types == ["application/pdf"]
 
     @pytest.mark.asyncio
+    async def test_png_document_is_treated_as_image(self, adapter):
+        png_bytes = b"\x89PNG\r\n\x1a\n fake png data"
+        file_obj = _make_file_obj(png_bytes)
+        file_obj.file_path = "documents/screenshot.png"
+        doc = _make_document(
+            file_name="screenshot.png",
+            mime_type="image/png",
+            file_size=len(png_bytes),
+            file_obj=file_obj,
+        )
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        with patch("gateway.platforms.telegram.cache_image_from_bytes", return_value="/tmp/screenshot.png") as mock_cache:
+            await adapter._handle_media_message(update, MagicMock())
+
+        event = adapter.handle_message.call_args[0][0]
+        mock_cache.assert_called_once_with(png_bytes, ext=".png")
+        assert event.message_type == MessageType.PHOTO
+        assert event.media_urls == ["/tmp/screenshot.png"]
+        assert event.media_types == ["image/png"]
+        assert "Unsupported document type" not in (event.text or "")
+
+    @pytest.mark.asyncio
+    async def test_image_mime_normalizes_non_image_filename_extension(self, adapter):
+        png_bytes = b"\x89PNG\r\n\x1a\n fake png data"
+        doc = _make_document(
+            file_name="notes.txt",
+            mime_type="image/png",
+            file_size=len(png_bytes),
+            file_obj=_make_file_obj(png_bytes),
+        )
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        with patch("gateway.platforms.telegram.cache_image_from_bytes", return_value="/tmp/normalized.png") as mock_cache:
+            await adapter._handle_media_message(update, MagicMock())
+
+        event = adapter.handle_message.call_args[0][0]
+        mock_cache.assert_called_once_with(png_bytes, ext=".png")
+        assert event.message_type == MessageType.PHOTO
+        assert event.media_urls == ["/tmp/normalized.png"]
+        assert event.media_types == ["image/png"]
+
+    @pytest.mark.asyncio
+    async def test_unsupported_image_document_returns_unsupported_type_message(self, adapter):
+        heic_bytes = b"not-a-supported-image"
+        doc = _make_document(
+            file_name="capture.heic",
+            mime_type="image/heic",
+            file_size=len(heic_bytes),
+            file_obj=_make_file_obj(heic_bytes),
+        )
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        with patch("gateway.platforms.telegram.cache_image_from_bytes") as mock_cache:
+            await adapter._handle_media_message(update, MagicMock())
+
+        event = adapter.handle_message.call_args[0][0]
+        mock_cache.assert_not_called()
+        assert event.message_type == MessageType.DOCUMENT
+        assert "Unsupported document type '.heic'" in (event.text or "")
+
+    @pytest.mark.asyncio
+    async def test_image_extension_with_non_image_mime_is_rejected_cleanly(self, adapter):
+        bad_bytes = b"%PDF-1.4 fake"
+        doc = _make_document(
+            file_name="sneaky.png",
+            mime_type="application/pdf",
+            file_size=len(bad_bytes),
+            file_obj=_make_file_obj(bad_bytes),
+        )
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        with patch("gateway.platforms.telegram.cache_image_from_bytes") as mock_cache:
+            await adapter._handle_media_message(update, MagicMock())
+
+        event = adapter.handle_message.call_args[0][0]
+        mock_cache.assert_not_called()
+        assert event.message_type == MessageType.DOCUMENT
+        assert "Unsupported document type '.png'" in (event.text or "")
+
+    @pytest.mark.asyncio
+    async def test_unsupported_image_mime_does_not_fallback_to_supported_extension(self, adapter):
+        heic_bytes = b"fake-heic"
+        doc = _make_document(
+            file_name="photo.jpg",
+            mime_type="image/heic",
+            file_size=len(heic_bytes),
+            file_obj=_make_file_obj(heic_bytes),
+        )
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        with patch("gateway.platforms.telegram.cache_image_from_bytes") as mock_cache:
+            await adapter._handle_media_message(update, MagicMock())
+
+        event = adapter.handle_message.call_args[0][0]
+        mock_cache.assert_not_called()
+        assert event.message_type == MessageType.DOCUMENT
+        assert "Unsupported document type '.jpg'" in (event.text or "")
+
+    @pytest.mark.asyncio
     async def test_supported_txt_injects_content(self, adapter):
         content = b"Hello from a text file"
         file_obj = _make_file_obj(content)


### PR DESCRIPTION
## Summary
- treat supported image documents sent through Telegram as image attachments instead of unsupported documents
- preserve existing video-document and standard document handling paths
- add regression coverage for image MIME/extension edge cases and invalid metadata

## Test Plan
- source venv/bin/activate && python -m pytest tests/gateway/test_telegram_documents.py -q
- source venv/bin/activate && python -m py_compile gateway/platforms/telegram.py tests/gateway/test_telegram_documents.py