### PR TITLE
feat(cli): warn users to restart gateway after config changes

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3537,6 +3537,7 @@ def edit_config():
     
     print(f"Opening {config_path} in {editor}...")
     subprocess.run([editor, str(config_path)])
+    print(color("Note: If the Hermes Gateway is currently running, you must restart it for config changes to take effect.", Colors.YELLOW))
 
 
 def set_config_value(key: str, value: str):
@@ -3624,6 +3625,7 @@ def set_config_value(key: str, value: str):
         save_env_value(_config_to_env_sync[key], str(value))
 
     print(f"✓ Set {key} = {value} in {config_path}")
+    print(color("Note: If the Hermes Gateway is currently running, you must restart it for config changes to take effect.", Colors.YELLOW))
 
 
 # =============================================================================


### PR DESCRIPTION
## What does this PR do?

Adds a printed warning to the CLI whenever a configuration is modified, notifying the user that they must restart the Hermes Gateway for the changes to take effect. This prevents the confusion of the gateway silently continuing with old settings.

## Related Issue

Fixes #13146 

## Type of Change

- [  ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ x ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added a printed warning message using "hermes_cli.colors" to the "set_config_value" (and "edit_config") function in "hermes_cli/config.py".

- 

## How to Test

1. Run `hermes config set agent.max_turns 100` in the terminal.
2. Verify that the success message is immediately followed by a yellow warning: "Note: If the Hermes Gateway is currently running, you must restart it for config changes to take effect."

## Checklist

### Code

- [ x ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ x ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ x ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ x ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ x ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<img width="744" height="49" alt="Screenshot 2026-04-21 at 01 43 29" src="https://github.com/user-attachments/assets/b998c518-c385-4bd5-9bd4-03580f27ea9b" />
