### PR TITLE
fix(trajectory): add file locking to save_trajectory() to prevent concurrent JSONL corruption

### DIFF
--- a/agent/trajectory.py
+++ b/agent/trajectory.py
@@ -7,6 +7,7 @@ the file-write logic live here.
 
 import json
 import logging
+import sys
 from datetime import datetime
 from typing import Any, Dict, List
 
@@ -50,7 +51,13 @@ def save_trajectory(trajectory: List[Dict[str, Any]], model: str,
 
     try:
         with open(filename, "a", encoding="utf-8") as f:
+            if sys.platform != "win32":
+                import fcntl
+                fcntl.flock(f, fcntl.LOCK_EX)
             f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+            f.flush()
+            if sys.platform != "win32":
+                fcntl.flock(f, fcntl.LOCK_UN)
         logger.info("Trajectory saved to %s", filename)
     except Exception as e:
         logger.warning("Failed to save trajectory: %s", e)

--- a/agent/trajectory.py
+++ b/agent/trajectory.py
@@ -11,6 +11,9 @@ import sys
 from datetime import datetime
 from typing import Any, Dict, List
 
+if sys.platform != "win32":
+    import fcntl
+
 logger = logging.getLogger(__name__)
 
 
@@ -52,7 +55,6 @@ def save_trajectory(trajectory: List[Dict[str, Any]], model: str,
     try:
         with open(filename, "a", encoding="utf-8") as f:
             if sys.platform != "win32":
-                import fcntl
                 fcntl.flock(f, fcntl.LOCK_EX)
             f.write(json.dumps(entry, ensure_ascii=False) + "\n")
             f.flush()

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -98,6 +98,7 @@ AUTHOR_MAP = {
     "liujinkun@bytedance.com": "liujinkun2025",
     "dmayhem93@gmail.com": "dmahan93",
     "cdanis@gmail.com": "cdanis",
+    "oluwadare1803@gmail.com": "Bennytimz",
     "samherring99@gmail.com": "samherring99",
     "desaiaum08@gmail.com": "Aum08Desai",
     "shannon.sands.1979@gmail.com": "shannonsands",

--- a/tests/test_trajectory_compressor_async.py
+++ b/tests/test_trajectory_compressor_async.py
@@ -91,7 +91,7 @@ class TestSourceLineVerification:
     def _read_file() -> str:
         import os
         base = os.path.dirname(os.path.dirname(__file__))
-        with open(os.path.join(base, "trajectory_compressor.py")) as f:
+        with open(os.path.join(base, "trajectory_compressor.py"), encoding="utf-8") as f:
             return f.read()
 
     def test_no_eager_async_openai_in_init(self):


### PR DESCRIPTION
Fixes #12684.

`save_trajectory()` opens the JSONL file with a plain `open(filename, "a")` and no locking. Under concurrent load on Linux ext4/NFS, writes from multiple processes interleave and split JSON objects across lines — corrupting the trajectory file. On macOS/APFS small writes are atomically hidden but the race is still present.

## Fix

Wrap the write in an `fcntl.LOCK_EX` exclusive lock on Unix/macOS. The lock is acquired before the write and released after `flush()`. On Windows (which lacks `fcntl`), the guard is skipped — the write proceeds as before since Windows file I/O has implicit locking semantics for append mode.

The `fcntl` import is intentionally lazy (inside the `with` block) so the module loads cleanly on Windows without `ImportError`.

```python
with open(filename, "a", encoding="utf-8") as f:
    if sys.platform != "win32":
        import fcntl
        fcntl.flock(f, fcntl.LOCK_EX)
    f.write(json.dumps(entry, ensure_ascii=False) + "\n")
    f.flush()
    if sys.platform != "win32":
        fcntl.flock(f, fcntl.LOCK_UN)
```

## Test plan

- [ ] Run `save_trajectory()` from two or more processes simultaneously targeting the same file — verify all lines parse as valid JSON
- [ ] Verify behaviour is unchanged on a single-process run
- [ ] Verify the module imports without error on Windows (no `fcntl` present)