### PR TITLE
fix: detect qwen3.6 256k context on local endpoints

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -134,6 +134,7 @@ DEFAULT_CONTEXT_LENGTHS = {
     # Official docs: https://help.aliyun.com/zh/model-studio/developer-reference/
     "qwen3-coder-plus": 1000000,  # 1M context
     "qwen3-coder": 262144,        # 256K context
+    "qwen3.6": 262144,            # 256K context (Qwen3.6 series)
     "qwen": 131072,
     # MiniMax — official docs: 204,800 context for all models
     # https://platform.minimax.io/docs/api-reference/text-anthropic-api
@@ -1002,13 +1003,17 @@ def get_model_context_length(
                 if local_ctx and local_ctx > 0:
                     save_context_length(model, base_url, local_ctx)
                     return local_ctx
-            logger.info(
-                "Could not detect context length for model %r at %s — "
-                "defaulting to %s tokens (probe-down). Set model.context_length "
-                "in config.yaml to override.",
-                model, base_url, f"{DEFAULT_FALLBACK_CONTEXT:,}",
-            )
-            return DEFAULT_FALLBACK_CONTEXT
+                # Some local OpenAI-compatible endpoints do not expose context
+                # metadata in /v1/models. Fall through to curated family defaults
+                # before using the generic probe-tier fallback.
+            else:
+                logger.info(
+                    "Could not detect context length for model %r at %s — "
+                    "defaulting to %s tokens (probe-down). Set model.context_length "
+                    "in config.yaml to override.",
+                    model, base_url, f"{DEFAULT_FALLBACK_CONTEXT:,}",
+                )
+                return DEFAULT_FALLBACK_CONTEXT
 
     # 4. Anthropic /v1/models API (only for regular API keys, not OAuth)
     if provider == "anthropic" or (

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -98,6 +98,7 @@ AUTHOR_MAP = {
     "liujinkun@bytedance.com": "liujinkun2025",
     "dmayhem93@gmail.com": "dmahan93",
     "cdanis@gmail.com": "cdanis",
+    "JoshCSan@gmail.com": "MrNiceRicee",
     "samherring99@gmail.com": "samherring99",
     "desaiaum08@gmail.com": "Aum08Desai",
     "shannon.sands.1979@gmail.com": "shannonsands",

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -240,6 +240,12 @@ class TestGetModelContextLength:
         assert get_model_context_length("qwen3-coder") == 262144
 
     @patch("agent.model_metadata.fetch_model_metadata")
+    def test_qwen3_6_context_length(self, mock_fetch):
+        """qwen3.6 models have a 256K context window, not the generic 128K Qwen default."""
+        mock_fetch.return_value = {}
+        assert get_model_context_length("Qwen3.6-35B-A3B-8bit") == 262144
+
+    @patch("agent.model_metadata.fetch_model_metadata")
     def test_qwen_generic_context_length(self, mock_fetch):
         """Generic qwen models still get the 128K default."""
         mock_fetch.return_value = {}

--- a/tests/agent/test_model_metadata_local_ctx.py
+++ b/tests/agent/test_model_metadata_local_ctx.py
@@ -480,7 +480,7 @@ class TestGetModelContextLengthLocalFallback:
         mock_save.assert_called_once_with("omnicoder-9b", "http://localhost:11434/v1", 131072)
 
     def test_local_endpoint_server_returns_none_falls_back_to_2m(self):
-        """When local server returns None, still falls back to 2M probe tier."""
+        """When local server returns None for unknown models, still falls back to 128K probe tier."""
         from agent.model_metadata import get_model_context_length, CONTEXT_PROBE_TIERS
 
         with patch("agent.model_metadata.get_cached_context_length", return_value=None), \
@@ -491,6 +491,19 @@ class TestGetModelContextLengthLocalFallback:
             result = get_model_context_length("omnicoder-9b", "http://localhost:11434/v1")
 
         assert result == CONTEXT_PROBE_TIERS[0]
+
+    def test_local_endpoint_qwen3_6_without_metadata_uses_family_default(self):
+        """Local endpoints without context metadata should still resolve Qwen3.6 to 256K."""
+        from agent.model_metadata import get_model_context_length
+
+        with patch("agent.model_metadata.get_cached_context_length", return_value=None), \
+             patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
+             patch("agent.model_metadata.fetch_model_metadata", return_value={}), \
+             patch("agent.model_metadata.is_local_endpoint", return_value=True), \
+             patch("agent.model_metadata._query_local_context_length", return_value=None):
+            result = get_model_context_length("Qwen3.6-35B-A3B-8bit", "http://127.0.0.1:7070/v1")
+
+        assert result == 262144
 
     def test_non_local_endpoint_does_not_query_local_server(self):
         """For non-local endpoints, _query_local_context_length is not called."""


### PR DESCRIPTION
## Summary
- add an explicit `qwen3.6 -> 262144` fallback in `DEFAULT_CONTEXT_LENGTHS`
- allow local OpenAI-compatible endpoints to fall through to curated family defaults when `/v1/models` does not report context metadata
- keep the current conservative behavior for non-local custom endpoints
- add tests for both the `qwen3.6` mapping and the local-endpoint fallback path

## Why
Some local OpenAI-compatible inference servers expose `/v1/models` but omit the `context_length` field entirely — this is provider-agnostic, not tied to any single runtime.

In the current resolution order, Hermes queries the local endpoint, gets no context metadata back, and immediately falls through to the blind 128K probe tier before ever considering known model-family defaults.

That means models like `Qwen3.6-35B-A3B-*`, which have a native 262,144-token context window, are incorrectly treated as 128K on local endpoints unless the user adds a manual config override.

This change fixes that local-only gap while preserving the existing behavior for non-local custom endpoints.

## Test plan
Ran:

```bash
source venv/bin/activate && pytest -q \
  tests/agent/test_model_metadata.py \
  tests/agent/test_model_metadata_local_ctx.py \
  tests/run_agent/test_invalid_context_length_warning.py
```
