### PR TITLE
fix(hermes_state): gracefully degrade when SQLite build lacks FTS5

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -340,11 +340,41 @@ class SessionDB:
         except sqlite3.OperationalError:
             pass  # Index already exists
 
-        # FTS5 setup (separate because CREATE VIRTUAL TABLE can't be in executescript with IF NOT EXISTS reliably)
+        # FTS5 setup (separate because CREATE VIRTUAL TABLE can't be in executescript with IF NOT EXISTS reliably).
+        #
+        # Some Python SQLite builds (notably Python 3.11 on macOS via certain Homebrew
+        # formulae and pyenv builds) compile sqlite3 without the FTS5 module. When FTS5
+        # is missing, CREATE VIRTUAL TABLE ... USING fts5(...) raises `no such module:
+        # fts5`. Historically this killed every SQLite-backed feature (`hermes sessions
+        # list`, `hermes insights`, external readers like Scarf) because init threw and
+        # the database connection never opened.
+        #
+        # Degrade gracefully instead: keep the rest of the schema, mark FTS5 as
+        # unavailable, and let search callers fall back to substring/LIKE matching.
+        # Non-search features (sessions list, session history, insights primary path)
+        # keep working. (#13029)
+        self._fts5_available: bool = False
         try:
             cursor.execute("SELECT * FROM messages_fts LIMIT 0")
+            self._fts5_available = True
         except sqlite3.OperationalError:
-            cursor.executescript(FTS_SQL)
+            try:
+                cursor.executescript(FTS_SQL)
+                self._fts5_available = True
+            except sqlite3.OperationalError as err:
+                message = str(err).lower()
+                if "no such module" in message and "fts5" in message:
+                    logger.warning(
+                        "SQLite build lacks the FTS5 module — full-text search is disabled "
+                        "for this session store. Session history, CLI list, and insights "
+                        "will continue to work; only `hermes sessions search` will degrade "
+                        "to substring match. Fix by installing a Python whose sqlite3 has "
+                        "FTS5 (e.g. Python 3.12/3.13/3.14 via Homebrew, pyenv with "
+                        "--enable-loadable-sqlite-extensions, or rebuilding SQLite with "
+                        "FTS5 enabled)."
+                    )
+                else:
+                    raise
 
         self._conn.commit()
 
@@ -1196,21 +1226,30 @@ class SessionDB:
             LIMIT ? OFFSET ?
         """
 
-        with self._lock:
-            try:
-                cursor = self._conn.execute(sql, params)
-            except sqlite3.OperationalError:
-                # FTS5 query syntax error despite sanitization — return empty
-                # unless query contains CJK (fall back to LIKE below)
-                if not self._contains_cjk(query):
-                    return []
-                matches = []
-            else:
-                matches = [dict(row) for row in cursor.fetchall()]
+        # When FTS5 is unavailable on this SQLite build, skip the MATCH query
+        # entirely and jump to the LIKE fallback below. (#13029)
+        fts5_unavailable = not getattr(self, "_fts5_available", True)
 
-        # LIKE fallback for CJK queries: FTS5 default tokenizer splits CJK
-        # characters individually, causing multi-character queries to fail.
-        if not matches and self._contains_cjk(query):
+        if fts5_unavailable:
+            matches = []
+        else:
+            with self._lock:
+                try:
+                    cursor = self._conn.execute(sql, params)
+                except sqlite3.OperationalError:
+                    # FTS5 query syntax error despite sanitization — return empty
+                    # unless query contains CJK (fall back to LIKE below)
+                    if not self._contains_cjk(query):
+                        return []
+                    matches = []
+                else:
+                    matches = [dict(row) for row in cursor.fetchall()]
+
+        # LIKE fallback for CJK queries AND for SQLite builds without FTS5.
+        # FTS5 default tokenizer splits CJK characters individually, causing
+        # multi-character queries to fail; when the whole FTS5 module is
+        # missing the fallback is the only path.
+        if not matches and (self._contains_cjk(query) or fts5_unavailable):
             raw_query = query.strip('"').strip()
             like_where = ["m.content LIKE ?"]
             like_params: list = [f"%{raw_query}%"]

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -314,6 +314,28 @@ class TestFTS5Search:
         assert db.search_messages("") == []
         assert db.search_messages("   ") == []
 
+    def test_search_falls_back_to_like_when_fts5_unavailable(self, db):
+        """#13029: when SQLite was built without the FTS5 module, SessionDB
+        init should set ``_fts5_available = False`` and search_messages should
+        route through the LIKE fallback instead of trying MATCH.
+
+        We simulate "no FTS5" by flipping the flag after init. The MATCH code
+        path is never reached; results come from the substring fallback that
+        already exists for CJK queries.
+        """
+        db.create_session(session_id="s1", source="cli")
+        db.append_message("s1", role="user", content="How do I deploy with Docker?")
+        db.append_message("s1", role="assistant", content="Use docker compose up.")
+
+        db._fts5_available = False
+        results = db.search_messages("docker")
+
+        assert len(results) == 2, (
+            "LIKE fallback must find both messages when FTS5 is unavailable"
+        )
+        snippets = [r.get("snippet", "").lower() for r in results]
+        assert any("docker" in s for s in snippets)
+
     def test_search_with_source_filter(self, db):
         db.create_session(session_id="s1", source="cli")
         db.append_message("s1", role="user", content="CLI question about Python")


### PR DESCRIPTION
## Problem

Some SQLite builds (Python 3.11 on macOS via certain Homebrew and pyenv formulae) compile \`sqlite3\` without the FTS5 module. When FTS5 is missing, \`CREATE VIRTUAL TABLE ... USING fts5(...)\` throws \`sqlite3.OperationalError: no such module: fts5\`.

Before this patch, that error killed \`SessionDB\` init completely — every SQLite-backed feature (\`hermes sessions list\`, \`hermes insights\`, external tools like Scarf reading \`state.db\`) failed silently while the JSONL fallback kept the primary WhatsApp/CLI chat flow working. Reported by @chillprakash in #13029 with clear repro on macOS ARM64 + Python 3.11.13.

## Fix

**Init path (\`hermes_state.py:343-378\`)**: catch the \`OperationalError\` when the message matches \`no such module / fts5\`, log a one-time warning with a remediation hint (switch to Python 3.12/3.13/3.14 with FTS5 built in, or rebuild SQLite with FTS5 enabled), and set \`self._fts5_available = False\`. Other \`OperationalError\`s are still re-raised so legitimate schema bugs aren't swallowed.

**Search path (\`search_messages\`)**: when \`_fts5_available\` is \`False\`, skip the \`MATCH\` branch entirely and route into the existing LIKE fallback that already handles CJK queries. No new fallback code — just extending the existing condition.

## Pre-implement audit

- **A (existing helper):** the LIKE fallback for CJK was already there; I reuse it rather than inventing a new one. ✓
- **B (shared callers):** \`SessionDB\` is the single owner; init contract becomes strictly more permissive (never throws FTS5-missing), no downstream contract change. ✓
- **C (broader rival):** \`gh pr list --search \"13029\"\` returned no rivals. ✓

## Testing

- New \`TestFTS5Search::test_search_falls_back_to_like_when_fts5_unavailable\` — creates 2 messages, flips \`_fts5_available = False\`, asserts \`search_messages(\"docker\")\` returns both messages via LIKE.
- Full \`tests/test_hermes_state.py\` suite passes (160/160).

Fixes #13029