### PR TITLE
fix(memory): defer state mutation in add_provider until schema load succeeds

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -116,12 +116,25 @@ class MemoryManager:
                     provider.name, existing,
                 )
                 return
-            self._has_external = True
 
+        # Load schemas before mutating state so a failure leaves the manager clean.
+        try:
+            schemas = list(provider.get_tool_schemas())
+        except Exception as e:
+            logger.error(
+                "Memory provider '%s' get_tool_schemas() raised during registration, "
+                "provider NOT added: %s",
+                provider.name, e,
+            )
+            return
+
+        # Commit state only after schema loading succeeds.
+        if not is_builtin:
+            self._has_external = True
         self._providers.append(provider)
 
         # Index tool names → provider for routing
-        for schema in provider.get_tool_schemas():
+        for schema in schemas:
             tool_name = schema.get("name", "")
             if tool_name and tool_name not in self._tool_to_provider:
                 self._tool_to_provider[tool_name] = provider
@@ -137,7 +150,7 @@ class MemoryManager:
         logger.info(
             "Memory provider '%s' registered (%d tools)",
             provider.name,
-            len(provider.get_tool_schemas()),
+            len(schemas),
         )
 
     @property


### PR DESCRIPTION
## Problem\n\nMemoryManager.add_provider() mutates internal state (_has_external = True and appends provider to _providers) BEFORE provider.get_tool_schemas() succeeds. If get_tool_schemas() raises, the manager is left in a poisoned half-registered state.\n\n## Fix\n\n- Call get_tool_schemas() first in a try/except\n- Only mutate _has_external and _providers after successful schema load\n- Reuse the loaded schemas list instead of calling get_tool_schemas() redundantly\n\nFixes #9948