### PR TITLE
fix(anthropic): preserve Bedrock inference profile IDs in normalize_model_name()

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -846,7 +846,7 @@ def normalize_model_name(model: str, preserve_dots: bool = False) -> str:
         model = model[len("anthropic/"):]
         lower = model.lower()
     _BEDROCK_PREFIXES = ("global.", "us.", "eu.", "ap.", "jp.")
-    if preserve_dots and any(lower.startswith(p) for p in _BEDROCK_PREFIXES):
+    if any(lower.startswith(p) for p in _BEDROCK_PREFIXES):
         return model
     if not preserve_dots:
         # OpenRouter uses dots for version separators (claude-opus-4.6),

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -838,10 +838,16 @@ def normalize_model_name(model: str, preserve_dots: bool = False) -> str:
     - Converts dots to hyphens in version numbers (OpenRouter uses dots,
       Anthropic uses hyphens: claude-opus-4.6 → claude-opus-4-6), unless
       preserve_dots is True (e.g. for Alibaba/DashScope: qwen3.5-plus).
+    - Preserves Bedrock inference profile IDs (global., us., eu., ap., jp.)
+      which use dots as namespace separators, not version separators.
     """
     lower = model.lower()
     if lower.startswith("anthropic/"):
         model = model[len("anthropic/"):]
+        lower = model.lower()
+    _BEDROCK_PREFIXES = ("global.", "us.", "eu.", "ap.", "jp.")
+    if any(lower.startswith(p) for p in _BEDROCK_PREFIXES):
+        return model
     if not preserve_dots:
         # OpenRouter uses dots for version separators (claude-opus-4.6),
         # Anthropic uses hyphens (claude-opus-4-6). Convert dots to hyphens.

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -846,7 +846,7 @@ def normalize_model_name(model: str, preserve_dots: bool = False) -> str:
         model = model[len("anthropic/"):]
         lower = model.lower()
     _BEDROCK_PREFIXES = ("global.", "us.", "eu.", "ap.", "jp.")
-    if any(lower.startswith(p) for p in _BEDROCK_PREFIXES):
+    if preserve_dots and any(lower.startswith(p) for p in _BEDROCK_PREFIXES):
         return model
     if not preserve_dots:
         # OpenRouter uses dots for version separators (claude-opus-4.6),

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -98,6 +98,7 @@ AUTHOR_MAP = {
     "liujinkun@bytedance.com": "liujinkun2025",
     "dmayhem93@gmail.com": "dmahan93",
     "cdanis@gmail.com": "cdanis",
+    "oluwadare1803@gmail.com": "Bennytimz",
     "samherring99@gmail.com": "samherring99",
     "desaiaum08@gmail.com": "Aum08Desai",
     "shannon.sands.1979@gmail.com": "shannonsands",

--- a/tests/agent/test_bedrock_integration.py
+++ b/tests/agent/test_bedrock_integration.py
@@ -376,17 +376,15 @@ class TestBedrockModelNameNormalization:
             "apac.anthropic.claude-haiku-4-5", preserve_dots=True
         ) == "apac.anthropic.claude-haiku-4-5"
 
-    def test_preserve_false_mangles_as_documented(self):
-        """Canary: with ``preserve_dots=False`` the function still
-        produces the broken all-hyphen form — this is the shape that
-        Bedrock rejected and that the fix avoids.  Keeping this test
-        locks in the existing behaviour of ``normalize_model_name`` so a
-        future refactor doesn't accidentally decouple the knob from its
-        effect."""
+    def test_bedrock_prefix_preserved_regardless_of_preserve_dots(self):
+        """Bedrock inference profile IDs are auto-detected by prefix and
+        always returned unmangled — ``preserve_dots`` is irrelevant for
+        these IDs because the dots are namespace separators, not version
+        separators."""
         from agent.anthropic_adapter import normalize_model_name
         assert normalize_model_name(
             "global.anthropic.claude-opus-4-7", preserve_dots=False
-        ) == "global-anthropic-claude-opus-4-7"
+        ) == "global.anthropic.claude-opus-4-7"
 
     def test_bare_foundation_model_id_preserved(self):
         """Non-inference-profile Bedrock IDs
@@ -422,12 +420,10 @@ class TestBedrockBuildAnthropicKwargsEndToEnd:
             f"{kwargs['model']!r}"
         )
 
-    def test_bedrock_model_mangled_without_preserve_dots(self):
-        """Inverse canary: without the flag, ``build_anthropic_kwargs``
-        still produces the broken form — so the fix in
-        ``_anthropic_preserve_dots`` is the load-bearing piece that
-        wires ``preserve_dots=True`` through to this builder for the
-        Bedrock case."""
+    def test_bedrock_model_preserved_without_preserve_dots(self):
+        """Bedrock inference profile IDs survive ``build_anthropic_kwargs``
+        even without ``preserve_dots=True`` — the prefix auto-detection in
+        ``normalize_model_name`` is the load-bearing piece."""
         from agent.anthropic_adapter import build_anthropic_kwargs
         kwargs = build_anthropic_kwargs(
             model="global.anthropic.claude-opus-4-7",
@@ -437,4 +433,4 @@ class TestBedrockBuildAnthropicKwargsEndToEnd:
             reasoning_config=None,
             preserve_dots=False,
         )
-        assert kwargs["model"] == "global-anthropic-claude-opus-4-7"
+        assert kwargs["model"] == "global.anthropic.claude-opus-4-7"


### PR DESCRIPTION
Fixes #12727.

`normalize_model_name()` unconditionally converts dots to hyphens for OpenRouter compatibility (`claude-opus-4.6` → `claude-opus-4-6`). However, Bedrock inference profile IDs use dots as **namespace separators** (`global.anthropic.claude-sonnet-4-6`, `us.anthropic.*`, `eu.anthropic.*`, `ap.anthropic.*`, `jp.anthropic.*`) — not version separators. Converting them produces an invalid ID and HTTP 400.

## Fix

Adds an early-return guard for the five Bedrock region prefixes (`global.`, `us.`, `eu.`, `ap.`, `jp.`). The `lower` recalculation after stripping the `anthropic/` prefix ensures the guard also fires correctly on `anthropic/global.*` inputs. All existing behaviour is preserved — dot-to-hyphen conversion and `preserve_dots=True` both work unchanged for non-Bedrock model names.

```python
lower = model.lower()
if lower.startswith("anthropic/"):
    model = model[len("anthropic/"):]
    lower = model.lower()          # recalculate after strip
_BEDROCK_PREFIXES = ("global.", "us.", "eu.", "ap.", "jp.")
if any(lower.startswith(p) for p in _BEDROCK_PREFIXES):
    return model                   # preserve namespace dots intact
if not preserve_dots:
    model = model.replace(".", "-")
return model
```

## Test plan

- [ ] Set `model.default: global.anthropic.claude-sonnet-4-6` and `model.provider: bedrock` — verify no HTTP 400
- [ ] Same with `us.anthropic.*`, `eu.anthropic.*`, `ap.anthropic.*`, `jp.anthropic.*` prefixes
- [ ] Verify `anthropic/global.anthropic.*` input also works (prefix stripped then Bedrock guard fires)
- [ ] Verify standard `claude-opus-4.6` → `claude-opus-4-6` conversion still works
- [ ] Verify `preserve_dots=True` still passes through dots for Alibaba/DashScope models

Behavioural assertions covering all 5 cases pass locally.