### PR TITLE
fix: restrict provider URL detection to exact hostname matches

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 from typing import Any, Dict, Optional
+from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +36,14 @@ def _normalize_custom_provider_name(value: str) -> str:
     return value.strip().lower().replace(" ", "-")
 
 
+def _base_url_hostname(base_url: str) -> str:
+    raw = (base_url or "").strip()
+    if not raw:
+        return ""
+    parsed = urlparse(raw if "://" in raw else f"//{raw}")
+    return (parsed.hostname or "").lower().rstrip(".")
+
+
 def _detect_api_mode_for_url(base_url: str) -> Optional[str]:
     """Auto-detect api_mode from the resolved base URL.
 
@@ -47,9 +56,10 @@ def _detect_api_mode_for_url(base_url: str) -> Optional[str]:
       ``chat_completions``.
     """
     normalized = (base_url or "").strip().lower().rstrip("/")
-    if "api.x.ai" in normalized:
+    hostname = _base_url_hostname(base_url)
+    if hostname == "api.x.ai":
         return "codex_responses"
-    if "api.openai.com" in normalized and "openrouter" not in normalized:
+    if hostname == "api.openai.com":
         return "codex_responses"
     if normalized.endswith("/anthropic"):
         return "anthropic_messages"

--- a/run_agent.py
+++ b/run_agent.py
@@ -38,6 +38,7 @@ import threading
 from types import SimpleNamespace
 import uuid
 from typing import List, Dict, Any, Optional
+from urllib.parse import urlparse
 from openai import OpenAI
 import fire
 from datetime import datetime
@@ -125,6 +126,14 @@ from agent.trajectory import (
     save_trajectory as _save_trajectory_to_file,
 )
 from utils import atomic_json_write, env_var_enabled
+
+
+def _base_url_hostname(base_url: str) -> str:
+    raw = (base_url or "").strip()
+    if not raw:
+        return ""
+    parsed = urlparse(raw if "://" in raw else f"//{raw}")
+    return (parsed.hostname or "").lower().rstrip(".")
 
 
 
@@ -703,6 +712,7 @@ class AIAgent:
     def base_url(self, value: str) -> None:
         self._base_url = value
         self._base_url_lower = value.lower() if value else ""
+        self._base_url_hostname = _base_url_hostname(value)
 
     def __init__(
         self,
@@ -847,7 +857,7 @@ class AIAgent:
         elif (provider_name is None) and "chatgpt.com/backend-api/codex" in self._base_url_lower:
             self.api_mode = "codex_responses"
             self.provider = "openai-codex"
-        elif (provider_name is None) and "api.x.ai" in self._base_url_lower:
+        elif (provider_name is None) and self._base_url_hostname == "api.x.ai":
             self.api_mode = "codex_responses"
             self.provider = "xai"
         elif self.provider == "anthropic" or (provider_name is None and "api.anthropic.com" in self._base_url_lower):
@@ -2259,8 +2269,13 @@ class AIAgent:
 
     def _is_direct_openai_url(self, base_url: str = None) -> bool:
         """Return True when a base URL targets OpenAI's native API."""
-        url = (base_url or self._base_url_lower).lower()
-        return "api.openai.com" in url and "openrouter" not in url
+        if base_url is not None:
+            hostname = _base_url_hostname(base_url)
+        else:
+            hostname = getattr(self, "_base_url_hostname", "") or _base_url_hostname(
+                getattr(self, "_base_url_lower", "")
+            )
+        return hostname == "api.openai.com"
 
     def _resolved_api_call_timeout(self) -> float:
         """Resolve the effective per-call request timeout in seconds.
@@ -6745,7 +6760,7 @@ class AIAgent:
             if not is_github_responses:
                 kwargs["prompt_cache_key"] = self.session_id
 
-            is_xai_responses = self.provider == "xai" or "api.x.ai" in (self.base_url or "").lower()
+            is_xai_responses = self.provider == "xai" or self._base_url_hostname == "api.x.ai"
 
             if reasoning_enabled and is_xai_responses:
                 # xAI reasons automatically — no effort param, just include encrypted content

--- a/tests/agent/test_direct_provider_url_detection.py
+++ b/tests/agent/test_direct_provider_url_detection.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from run_agent import AIAgent
+
+
+def _agent_with_base_url(base_url: str) -> AIAgent:
+    agent = object.__new__(AIAgent)
+    agent.base_url = base_url
+    return agent
+
+
+def test_direct_openai_url_requires_openai_host():
+    agent = _agent_with_base_url("https://api.openai.com.example/v1")
+
+    assert agent._is_direct_openai_url() is False
+
+
+def test_direct_openai_url_ignores_path_segment_match():
+    agent = _agent_with_base_url("https://proxy.example.test/api.openai.com/v1")
+
+    assert agent._is_direct_openai_url() is False
+
+
+def test_direct_openai_url_accepts_native_host():
+    agent = _agent_with_base_url("https://api.openai.com/v1")
+
+    assert agent._is_direct_openai_url() is True

--- a/tests/hermes_cli/test_detect_api_mode_for_url.py
+++ b/tests/hermes_cli/test_detect_api_mode_for_url.py
@@ -28,6 +28,15 @@ class TestCodexResponsesDetection:
         # api.openai.com check must exclude openrouter (which routes to openai-hosted models).
         assert _detect_api_mode_for_url("https://openrouter.ai/api/v1") is None
 
+    def test_openai_host_suffix_does_not_match(self):
+        assert _detect_api_mode_for_url("https://api.openai.com.example/v1") is None
+
+    def test_openai_path_segment_does_not_match(self):
+        assert _detect_api_mode_for_url("https://proxy.example.test/api.openai.com/v1") is None
+
+    def test_xai_host_suffix_does_not_match(self):
+        assert _detect_api_mode_for_url("https://api.x.ai.example/v1") is None
+
 
 class TestAnthropicMessagesDetection:
     """Third-party gateways that speak the Anthropic protocol under /anthropic."""


### PR DESCRIPTION
## Summary

Fix provider URL auto-detection so direct OpenAI and xAI routing is based on the parsed URL hostname instead of substring matches.

Previously, custom endpoints such as:

- `https://api.openai.com.example/v1`
- `https://proxy.example.test/api.openai.com/v1`
- `https://api.x.ai.example/v1`

could be misclassified as native OpenAI/xAI endpoints because detection searched the whole URL string. That could incorrectly force `codex_responses` routing for OpenAI-compatible custom providers that only include those strings in their host suffix or path.

This change parses the base URL hostname and only treats exact `api.openai.com` and `api.x.ai` hosts as native direct endpoints.

## Changes

- Add host parsing helper for provider URL detection.
- Update `hermes_cli.runtime_provider._detect_api_mode_for_url()` to use exact hostname checks.
- Cache the parsed base URL hostname on `AIAgent.base_url`.
- Update `AIAgent` direct OpenAI and xAI checks to use exact hostname matching.
- Add regression tests for host suffix and path-segment false positives.

## Tests

- `uv run --frozen --extra dev python -m pytest -q -n 4 tests/hermes_cli/test_detect_api_mode_for_url.py tests/agent/test_direct_provider_url_detection.py`
- `.venv\Scripts\python.exe -m py_compile hermes_cli\runtime_provider.py run_agent.py tests\hermes_cli\test_detect_api_mode_for_url.py tests\agent\test_direct_provider_url_detection.py`
- `git diff --check -- hermes_cli\runtime_provider.py run_agent.py tests\hermes_cli\test_detect_api_mode_for_url.py tests\agent\test_direct_provider_url_detection.py`
