### PR TITLE
fix(mcp): preserve URL path when constructing OAuthClientProvider

### DIFF
--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -563,7 +563,7 @@ def build_oauth_auth(
     _maybe_preregister_client(storage, cfg, client_metadata)
 
     return OAuthClientProvider(
-        server_url=_parse_base_url(server_url),
+        server_url=server_url,
         client_metadata=client_metadata,
         storage=storage,
         redirect_handler=_redirect_handler,

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -387,7 +387,7 @@ class MCPOAuthManager:
 
         return _HERMES_PROVIDER_CLS(
             server_name=server_name,
-            server_url=_parse_base_url(entry.server_url),
+            server_url=entry.server_url,
             client_metadata=client_metadata,
             storage=storage,
             redirect_handler=_redirect_handler,


### PR DESCRIPTION
## Summary

MCP servers mounted at a non-root path advertise their RFC 9728 protected-resource identifier as the **full URL, path included**. `tools/mcp_oauth.py::_parse_base_url()` strips the path before handing the server URL to `OAuthClientProvider`, so SDK discovery compares e.g. advertised `https://mcp.granola.ai/mcp` against what we passed (`https://mcp.granola.ai`) and fails with:

```
Protected resource https://mcp.granola.ai/mcp does not match expected https://mcp.granola.ai
```

The SDK already handles `.well-known` discovery correctly regardless of URL path, so `_parse_base_url()` is stripping information the caller already authored. This PR passes `server_url` through unchanged at both OAuth provider construction sites:

- `tools/mcp_oauth.py:566` (legacy `build_oauth_auth()` helper)
- `tools/mcp_oauth_manager.py:390` (current `MCPOAuthManager._build_provider()` runtime path)

No-op for MCP servers mounted at the origin (`https://example.com/`).

## Reproduction

Minimal `~/.hermes/config.yaml`:

```yaml
mcp_servers:
  granola:
    url: "https://mcp.granola.ai/mcp"
    auth: oauth
```

Before patch:
```
$ hermes mcp test granola
  Testing 'granola'...
  Transport: HTTP → https://mcp.granola.ai/mcp
  Auth: OAuth 2.1 PKCE
  ✗ Connection failed (8277ms): Protected resource https://mcp.granola.ai/mcp does not match expected https://mcp.granola.ai
```

After patch:
```
$ hermes mcp test granola
  MCP OAuth: authorization required.
  Open this URL in your browser:
    https://mcp-auth.granola.ai/oauth2/authorize?...&resource=https%3A%2F%2Fmcp.granola.ai%2Fmcp&...
  (Browser opened automatically.)
  Testing 'granola'...
  Transport: HTTP → https://mcp.granola.ai/mcp
  Auth: OAuth 2.1 PKCE
  ✓ Connected (29762ms)
  ✓ Tools discovered: 5
    query_granola_meetings
    list_meetings
    list_meeting_folders
    get_meetings
    get_meeting_transcript
```

Full OAuth 2.1 PKCE + DCR flow completes end-to-end and all 5 tools are discovered.

## References

- [RFC 9728 §3.3](https://datatracker.ietf.org/doc/html/rfc9728#section-3.3) — protected resource identifier uses the canonical URL the server returns
- Granola MCP docs: https://docs.granola.so/ (listed as "generally available to test" with browser OAuth + DCR)

## Test plan

- [x] `hermes mcp test granola` succeeds where it previously failed
- [x] Full OAuth flow (browser → redirect → token exchange) completes; tokens persisted to `~/.hermes/mcp-tokens/granola.json`
- [x] All 5 Granola MCP tools discovered and listed
- [ ] Regression check against an existing root-mounted MCP server (no-op by construction — `_parse_base_url` and pass-through return the same string for root-mounted URLs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)