### PR TITLE
fix(checkpoint): self-heal stale index.lock from crashed git process

### DIFF
--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -13,6 +13,8 @@ from tools.checkpoint_manager import (
     _run_git,
     _git_env,
     _dir_file_count,
+    _clear_stale_lock,
+    _STALE_LOCK_SECONDS,
     format_checkpoint_list,
     DEFAULT_EXCLUDES,
     CHECKPOINT_BASE,
@@ -597,6 +599,7 @@ class TestSecurity:
 # every time the agent took a background snapshot.
 
 import os as _os
+import time as _time
 
 
 class TestGpgAndGlobalConfigIsolation:
@@ -696,3 +699,55 @@ class TestGpgAndGlobalConfigIsolation:
         mgr = CheckpointManager(enabled=True)
         assert mgr.ensure_checkpoint(str(work_dir), reason="prefix-shadow") is True
         assert len(mgr.list_checkpoints(str(work_dir))) == 1
+
+
+class TestStaleLockCleanup:
+    """Stale index.lock cleanup prevents wedged checkpoints after a crashed
+    git process leaves a zombie lock file (observed in production: 56+ errors
+    over 6 days on one shadow repo)."""
+
+    def _backdate(self, path, seconds_ago):
+        ts = _time.time() - seconds_ago
+        _os.utime(path, (ts, ts))
+
+    def test_removes_old_stale_lock(self, tmp_path):
+        shadow = tmp_path / "shadow"
+        shadow.mkdir()
+        lock = shadow / "index.lock"
+        lock.touch()
+        self._backdate(lock, _STALE_LOCK_SECONDS + 30)
+        _clear_stale_lock(shadow)
+        assert not lock.exists()
+
+    def test_preserves_fresh_lock(self, tmp_path):
+        """A lock younger than the threshold may belong to a live git op —
+        leave it alone."""
+        shadow = tmp_path / "shadow"
+        shadow.mkdir()
+        lock = shadow / "index.lock"
+        lock.touch()
+        _clear_stale_lock(shadow)
+        assert lock.exists()
+
+    def test_noop_when_no_lock(self, tmp_path):
+        shadow = tmp_path / "shadow"
+        shadow.mkdir()
+        _clear_stale_lock(shadow)  # must not raise
+
+    def test_run_git_unwedges_after_stale_lock(
+        self, work_dir, checkpoint_base, monkeypatch
+    ):
+        """End-to-end: a stale lock predating a real git call is cleaned up
+        automatically, and the call succeeds."""
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base)
+        shadow = _shadow_repo_path(str(work_dir))
+        _init_shadow_repo(shadow, str(work_dir))
+
+        stale = shadow / "index.lock"
+        stale.touch()
+        self._backdate(stale, _STALE_LOCK_SECONDS + 30)
+
+        ok, _, _ = _run_git(["add", "-A"], shadow, str(work_dir))
+        assert ok, "git add -A should succeed after stale-lock cleanup"
+        assert not stale.exists()
+

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -24,6 +24,7 @@ import os
 import re
 import shutil
 import subprocess
+import time
 from pathlib import Path
 from hermes_constants import get_hermes_home
 from typing import Dict, List, Optional, Set
@@ -159,6 +160,38 @@ def _git_env(shadow_repo: Path, working_dir: str) -> dict:
     return env
 
 
+_STALE_LOCK_SECONDS = 60.0
+
+
+def _clear_stale_lock(shadow_repo: Path) -> None:
+    """Remove a stale ``index.lock`` left behind by a crashed/killed git process.
+
+    Checkpoint ops against a shadow repo are strictly serial (one gateway
+    agent per session), so any ``index.lock`` older than ``_STALE_LOCK_SECONDS``
+    at entry to a new git call is unambiguously orphaned.  Without this,
+    a single crashed ``git add`` wedges checkpointing for that repo until
+    manual cleanup (seen in logs: 56+ errors over 6 days on one shadow).
+    """
+    lock_path = shadow_repo / "index.lock"
+    try:
+        age = time.time() - lock_path.stat().st_mtime
+    except FileNotFoundError:
+        return
+    except OSError:
+        return
+    if age < _STALE_LOCK_SECONDS:
+        return
+    try:
+        lock_path.unlink()
+        logger.warning(
+            "Removed stale index.lock (age=%.0fs) at %s", age, lock_path,
+        )
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        logger.warning("Failed to remove stale index.lock at %s: %s", lock_path, exc)
+
+
 def _run_git(
     args: List[str],
     shadow_repo: Path,
@@ -181,6 +214,8 @@ def _run_git(
         msg = f"working directory is not a directory: {normalized_working_dir}"
         logger.error("Git command skipped: %s (%s)", " ".join(["git"] + list(args)), msg)
         return False, "", msg
+
+    _clear_stale_lock(shadow_repo)
 
     env = _git_env(shadow_repo, str(normalized_working_dir))
     cmd = ["git"] + list(args)


### PR DESCRIPTION
## Summary

`tools/checkpoint_manager._run_git` now removes any `index.lock` older than 60s in the shadow repo before invoking git. Checkpoint ops per shadow are strictly serial (one gateway agent per session), so a lock file that old is unambiguously orphaned from a crashed or killed prior git subprocess.

## The bug

A single crashed `git add` leaves `index.lock` behind. Every subsequent checkpoint for that shadow then fails with:

```
fatal: Unable to create '/home/<user>/.hermes/checkpoints/<hash>/index.lock': File exists.
Another git process seems to be running in this repository, e.g.
an editor opened by 'git commit'. Please make sure all processes
are terminated then try again.
```

Observed in prod logs: **56 identical errors over 6 days on a single shadow repo** until manual cleanup. No recovery path — the agent just keeps retrying and failing forever.

## Why 60s

Real git ops on a shadow repo finish in milliseconds. 60s is ~1000x the realistic upper bound for an in-flight op, so any lock older than that is a zombie. Conservative enough to never race against a legitimate concurrent op, tight enough to recover within one retry cycle.

## Scope

- `_clear_stale_lock(shadow_repo)` — new helper, called from `_run_git` entry.
- Logs a `WARNING` with the lock age when it removes one, so the underlying crash pattern stays visible.
- No behavior change when no lock exists or the lock is fresh.

## Test plan

4 new tests in `tests/tools/test_checkpoint_manager.py::TestStaleLockCleanup`:

- [x] Removes a stale lock (backdated 90s)
- [x] Preserves a fresh lock (might be live op)
- [x] No-op when no lock exists
- [x] End-to-end: `git add -A` succeeds after stale-lock cleanup

Full `tests/tools/test_checkpoint_manager.py` + `tests/test_batch_runner_checkpoint.py`: **69/69** pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)