### PR TITLE
fix(auxiliary): classify z.ai 429 "subscription plan" as payment; log 400 diag

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1216,9 +1216,69 @@ def _is_payment_error(exc: Exception) -> bool:
     if status in (402, 429, None):
         if any(kw in err_lower for kw in ("credits", "insufficient funds",
                                            "can only afford", "billing",
-                                           "payment required")):
+                                           "payment required",
+                                           # z.ai returns 429 code 1311 when
+                                           # the plan lacks access to the
+                                           # requested model (e.g. GLM-5V-Turbo
+                                           # on the coding plan).  Permanent,
+                                           # not transient — treat as billing
+                                           # so the payment-fallback chain
+                                           # picks a different backend instead
+                                           # of a useless cooldown.
+                                           "subscription plan",
+                                           "does not yet include",
+                                           "plan does not include")):
             return True
     return False
+
+
+def _message_content_shape(messages: list) -> str:
+    """Summarise message shape for 400-diagnostics without logging image bytes."""
+    if not messages:
+        return "empty"
+    parts = []
+    for m in messages:
+        role = m.get("role", "?") if isinstance(m, dict) else "?"
+        content = m.get("content") if isinstance(m, dict) else None
+        if isinstance(content, list):
+            block_types = [
+                b.get("type", "?") if isinstance(b, dict) else "?"
+                for b in content
+            ]
+            parts.append(f"{role}:[{','.join(block_types)}]")
+        elif isinstance(content, str):
+            parts.append(f"{role}:str({len(content)})")
+        else:
+            parts.append(f"{role}:{type(content).__name__}")
+    return " ".join(parts)
+
+
+def _log_400_diag(
+    exc: Exception,
+    task: Optional[str],
+    provider: Optional[str],
+    model: Optional[str],
+    kwargs: dict,
+) -> None:
+    """On HTTP 400, log request shape so the next regression is diagnosable.
+
+    Logs key names only — never message content (image data URLs would bloat
+    the log).  Quiet on non-400 errors.
+    """
+    status = getattr(exc, "status_code", None)
+    if status != 400:
+        return
+    try:
+        key_list = sorted(kwargs.keys())
+        shape = _message_content_shape(kwargs.get("messages") or [])
+        logger.warning(
+            "400 from %s task=%s provider=%s model=%s kwargs=%s msgs=%s err=%s",
+            getattr(exc, "__class__", type(exc)).__name__,
+            task or "call", provider, model, key_list, shape,
+            str(exc)[:300],
+        )
+    except Exception:
+        pass
 
 
 def _is_connection_error(exc: Exception) -> bool:
@@ -2631,6 +2691,7 @@ def call_llm(
         return _validate_llm_response(
             client.chat.completions.create(**kwargs), task)
     except Exception as first_err:
+        _log_400_diag(first_err, task, resolved_provider, final_model, kwargs)
         err_str = str(first_err)
         if "max_tokens" in err_str or "unsupported_parameter" in err_str:
             kwargs.pop("max_tokens", None)
@@ -2829,6 +2890,7 @@ async def async_call_llm(
         return _validate_llm_response(
             await client.chat.completions.create(**kwargs), task)
     except Exception as first_err:
+        _log_400_diag(first_err, task, resolved_provider, final_model, kwargs)
         err_str = str(first_err)
         if "max_tokens" in err_str or "unsupported_parameter" in err_str:
             kwargs.pop("max_tokens", None)

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -516,6 +516,67 @@ class TestIsPaymentError:
         exc = Exception("connection reset")
         assert _is_payment_error(exc) is False
 
+    def test_zai_1311_subscription_plan_is_payment(self):
+        """z.ai returns HTTP 429 code 1311 when the plan lacks the model
+        (e.g. GLM-5V-Turbo on the coding plan).  Permanent — must route to
+        payment fallback, not transient rate-limit handling."""
+        exc = Exception(
+            "{'error': {'code': '1311', 'message': "
+            "'Your current subscription plan does not yet include access to GLM-5V-Turbo'}}"
+        )
+        exc.status_code = 429
+        assert _is_payment_error(exc) is True
+
+    def test_zai_1305_overloaded_is_not_payment(self):
+        """Transient overload must NOT be classified as payment — it will
+        recover, and misclassifying it skips retry/cooldown paths."""
+        exc = Exception(
+            "{'error': {'code': '1305', 'message': "
+            "'The service may be temporarily overloaded, please try again later'}}"
+        )
+        exc.status_code = 429
+        assert _is_payment_error(exc) is False
+
+
+class TestLog400Diag:
+    """_log_400_diag emits actionable diagnostics on HTTP 400 without ever
+    logging message content (image data URLs would bloat the log)."""
+
+    def test_ignored_on_non_400(self, caplog):
+        from agent.auxiliary_client import _log_400_diag
+        exc = Exception("bad request")
+        exc.status_code = 500
+        with caplog.at_level("WARNING"):
+            _log_400_diag(exc, "vision", "zai", "glm-5v-turbo", {"model": "x"})
+        assert not any("400 from" in r.message for r in caplog.records)
+
+    def test_logs_kwargs_keys_and_msg_shape_on_400(self, caplog):
+        from agent.auxiliary_client import _log_400_diag
+        exc = Exception("invalid parameter")
+        exc.status_code = 400
+        kwargs = {
+            "model": "glm-5v-turbo",
+            "messages": [{"role": "user", "content": [
+                {"type": "text", "text": "hi"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+            ]}],
+            "max_tokens": 2000,
+            "temperature": 0.1,
+            "timeout": 120,
+        }
+        with caplog.at_level("WARNING"):
+            _log_400_diag(exc, "vision", "zai", "glm-5v-turbo", kwargs)
+        msg = " ".join(r.message for r in caplog.records)
+        assert "400 from" in msg
+        assert "task=vision" in msg
+        assert "provider=zai" in msg
+        assert "model=glm-5v-turbo" in msg
+        assert "max_tokens" in msg and "messages" in msg
+        assert "user:[text,image_url]" in msg
+        # Must NOT log the data URL
+        assert "data:image" not in msg
+        assert "AAAA" not in msg
+
 
 class TestGetProviderChain:
     """_get_provider_chain() resolves functions at call time (testable)."""


### PR DESCRIPTION
## Summary

Two surgical fixes in `agent/auxiliary_client.py`, deliberately scoped narrow and orthogonal to any rate-limit-strategy redesign (e.g. #7479's concurrency semaphore).

### 1. `_is_payment_error` classifies z.ai `code 1311` as payment

z.ai returns HTTP **429** for two very different conditions:

| code | meaning | current handling | correct handling |
|---|---|---|---|
| `1305` | "temporarily overloaded" — **transient** | retry / cooldown ✅ | retry / cooldown |
| `1311` | "subscription plan does not yet include \<model\>" — **permanent** | treated as rate-limit → loops forever ❌ | payment fallback ✅ |

Observed in recent prod logs against the z.ai coding plan + `glm-5v-turbo`:

```
Error code: 429 - {'error': {'code': '1311',
  'message': 'Your current subscription plan does not yet include access to GLM-5V-Turbo'}}
```

The existing `_is_payment_error` was added specifically to route non-payment-literal 429s (credits, billing, "can only afford") into the payment fallback chain. This PR extends the same pattern to cover the subscription-plan wording z.ai uses — same intent, widened vocabulary.

### 2. `_log_400_diag` — one-line diagnostic on HTTP 400

Recent logs contain **10+ `code 1210 Invalid API parameter` errors** from the vision tool with no way to tell which parameter the provider rejected. `_log_400_diag` emits a `WARNING` log line on any HTTP 400 with:

- Task name (`vision`, `compression`, `session_search`, etc.)
- Resolved provider + model
- Sorted list of kwargs keys
- Per-message role + content block types (e.g. `user:[text,image_url]`)
- First 300 chars of the provider error

Critically **never** the message content itself — image data URLs would bloat the log. The next `1210` regression becomes diagnosable at a glance.

## Why not part of a larger rate-limit PR

Both fixes exist in isolation as clean bug fixes:

- The `1311` classification is needed whether the repo adopts a cooldown ladder, a concurrency semaphore (#7479), or neither — the error is a hard "try a different backend" signal regardless.
- The 400 diagnostic is pure logging, helps any future debugging.

Split off from a larger cooldown-ladder PR (closed) after triage signal on #3910 / #12148 indicated the repo is moving toward proactive concurrency limiting rather than reactive cooldowns.

## Test plan

- [x] 2 new tests on the classification boundary: `test_zai_1311_subscription_plan_is_payment`, `test_zai_1305_overloaded_is_not_payment` — verify the transient/permanent distinction holds.
- [x] 2 new tests on `_log_400_diag`: silent on non-400 status, logs the expected fields on 400, asserts image data URL + base64 payload are **not** present in the log output.
- [x] Full `tests/agent/test_auxiliary_client.py` + `test_auxiliary_config_bridge.py`: 97/99 pass (2 pre-existing `pytest.mark.asyncio` plugin failures on clean `main`, unchanged by this PR).

## Scope discipline

- `agent/auxiliary_client.py`: +64 lines (3 helpers, 2 call-site one-liners).
- `tests/agent/test_auxiliary_client.py`: +61 lines.
- No other files touched. No behavior change outside the 400 and 429-1311 paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)