### PR TITLE
fix: preserve conversation context when provider fallback activates

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7231,6 +7231,105 @@ class AIAgent:
         """
         return self.api_mode != "codex_responses"
 
+    def _build_api_messages_for_attempt(
+        self,
+        messages: List[Dict[str, Any]],
+        *,
+        current_turn_user_idx: int,
+        active_system_prompt: str,
+        ext_prefetch_cache: str = "",
+        plugin_user_context: str = "",
+    ) -> tuple[list, int, int]:
+        """Build provider-ready API messages for the current attempt.
+
+        This must run inside the retry loop, not once per outer turn. Provider
+        fallback can change api_mode, prompt-caching behavior, and strict-schema
+        sanitization requirements mid-turn. Reusing a payload built for the
+        previous provider leaks provider-specific transformations into the
+        fallback request and can make it appear as if the model lost context.
+        """
+        api_messages = []
+        for idx, msg in enumerate(messages):
+            api_msg = msg.copy()
+
+            if idx == current_turn_user_idx and msg.get("role") == "user":
+                _injections = []
+                if ext_prefetch_cache:
+                    _fenced = build_memory_context_block(ext_prefetch_cache)
+                    if _fenced:
+                        _injections.append(_fenced)
+                if plugin_user_context:
+                    _injections.append(plugin_user_context)
+                if _injections:
+                    _base = api_msg.get("content", "")
+                    if isinstance(_base, str):
+                        api_msg["content"] = _base + "\n\n" + "\n\n".join(_injections)
+
+            if msg.get("role") == "assistant":
+                reasoning_text = msg.get("reasoning")
+                if reasoning_text:
+                    api_msg["reasoning_content"] = reasoning_text
+
+            api_msg.pop("reasoning", None)
+            api_msg.pop("finish_reason", None)
+            api_msg.pop("_thinking_prefill", None)
+
+            if self._should_sanitize_tool_calls():
+                self._sanitize_tool_calls_for_strict_api(api_msg)
+
+            api_messages.append(api_msg)
+
+        effective_system = active_system_prompt or ""
+        if self.ephemeral_system_prompt:
+            effective_system = (effective_system + "\n\n" + self.ephemeral_system_prompt).strip()
+        if effective_system:
+            api_messages = [{"role": "system", "content": effective_system}] + api_messages
+
+        if self.prefill_messages:
+            sys_offset = 1 if effective_system else 0
+            for idx, pfm in enumerate(self.prefill_messages):
+                api_messages.insert(sys_offset + idx, pfm.copy())
+
+        if self._use_prompt_caching:
+            api_messages = apply_anthropic_cache_control(
+                api_messages,
+                cache_ttl=self._cache_ttl,
+                native_anthropic=getattr(self, "_use_native_cache_layout", self.api_mode == 'anthropic_messages'),
+            )
+
+        api_messages = self._sanitize_api_messages(api_messages)
+
+        for am in api_messages:
+            if isinstance(am.get("content"), str):
+                am["content"] = am["content"].strip()
+        for am in api_messages:
+            tcs = am.get("tool_calls")
+            if not tcs:
+                continue
+            new_tcs = []
+            for tc in tcs:
+                if isinstance(tc, dict) and "function" in tc:
+                    try:
+                        args_obj = json.loads(tc["function"]["arguments"])
+                        tc = {**tc, "function": {
+                            **tc["function"],
+                            "arguments": json.dumps(
+                                args_obj, separators=(",", ":"), sort_keys=True,
+                            ),
+                        }}
+                    except Exception:
+                        tc["function"]["arguments"] = _repair_tool_call_arguments(
+                            tc["function"]["arguments"],
+                            tc["function"].get("name", "?"),
+                        )
+                new_tcs.append(tc)
+            am["tool_calls"] = new_tcs
+
+        _sanitize_messages_surrogates(api_messages)
+        total_chars = sum(len(str(msg)) for msg in api_messages)
+        approx_tokens = estimate_messages_tokens_rough(api_messages)
+        return api_messages, total_chars, approx_tokens
+
     def flush_memories(self, messages: list = None, min_turns: int = None):
         """Give the model one turn to persist memories before context is lost.
 
@@ -8961,7 +9060,6 @@ class AIAgent:
                         if isinstance(existing, str):
                             _sm["content"] = existing + marker
                         else:
-                            # Multimodal content blocks — append text block
                             try:
                                 blocks = list(existing) if existing else []
                                 blocks.append({"type": "text", "text": marker})
@@ -8975,8 +9073,6 @@ class AIAgent:
                         )
                         break
                 if not _injected:
-                    # No tool message to inject into — put it back so
-                    # the post-tool-execution drain picks it up later.
                     _lock = getattr(self, "_pending_steer_lock", None)
                     if _lock is not None:
                         with _lock:
@@ -8988,144 +9084,6 @@ class AIAgent:
                         existing = getattr(self, "_pending_steer", None)
                         self._pending_steer = (existing + "\n" + _pre_api_steer) if existing else _pre_api_steer
 
-            # Prepare messages for API call
-            # If we have an ephemeral system prompt, prepend it to the messages
-            # Note: Reasoning is embedded in content via <think> tags for trajectory storage.
-            # However, providers like Moonshot AI require a separate 'reasoning_content' field
-            # on assistant messages with tool_calls. We handle both cases here.
-            api_messages = []
-            for idx, msg in enumerate(messages):
-                api_msg = msg.copy()
-
-                # Inject ephemeral context into the current turn's user message.
-                # Sources: memory manager prefetch + plugin pre_llm_call hooks
-                # with target="user_message" (the default).  Both are
-                # API-call-time only — the original message in `messages` is
-                # never mutated, so nothing leaks into session persistence.
-                if idx == current_turn_user_idx and msg.get("role") == "user":
-                    _injections = []
-                    if _ext_prefetch_cache:
-                        _fenced = build_memory_context_block(_ext_prefetch_cache)
-                        if _fenced:
-                            _injections.append(_fenced)
-                    if _plugin_user_context:
-                        _injections.append(_plugin_user_context)
-                    if _injections:
-                        _base = api_msg.get("content", "")
-                        if isinstance(_base, str):
-                            api_msg["content"] = _base + "\n\n" + "\n\n".join(_injections)
-
-                # For ALL assistant messages, pass reasoning back to the API
-                # This ensures multi-turn reasoning context is preserved
-                if msg.get("role") == "assistant":
-                    reasoning_text = msg.get("reasoning")
-                    if reasoning_text:
-                        # Add reasoning_content for API compatibility (Moonshot AI, Novita, OpenRouter)
-                        api_msg["reasoning_content"] = reasoning_text
-
-                # Remove 'reasoning' field - it's for trajectory storage only
-                # We've copied it to 'reasoning_content' for the API above
-                if "reasoning" in api_msg:
-                    api_msg.pop("reasoning")
-                # Remove finish_reason - not accepted by strict APIs (e.g. Mistral)
-                if "finish_reason" in api_msg:
-                    api_msg.pop("finish_reason")
-                # Strip internal thinking-prefill marker
-                api_msg.pop("_thinking_prefill", None)
-                # Strip Codex Responses API fields (call_id, response_item_id) for
-                # strict providers like Mistral, Fireworks, etc. that reject unknown fields.
-                # Uses new dicts so the internal messages list retains the fields
-                # for Codex Responses compatibility.
-                if self._should_sanitize_tool_calls():
-                    self._sanitize_tool_calls_for_strict_api(api_msg)
-                # Keep 'reasoning_details' - OpenRouter uses this for multi-turn reasoning context
-                # The signature field helps maintain reasoning continuity
-                api_messages.append(api_msg)
-
-            # Build the final system message: cached prompt + ephemeral system prompt.
-            # Ephemeral additions are API-call-time only (not persisted to session DB).
-            # External recall context is injected into the user message, not the system
-            # prompt, so the stable cache prefix remains unchanged.
-            effective_system = active_system_prompt or ""
-            if self.ephemeral_system_prompt:
-                effective_system = (effective_system + "\n\n" + self.ephemeral_system_prompt).strip()
-            # NOTE: Plugin context from pre_llm_call hooks is injected into the
-            # user message (see injection block above), NOT the system prompt.
-            # This is intentional — system prompt modifications break the prompt
-            # cache prefix.  The system prompt is reserved for Hermes internals.
-            if effective_system:
-                api_messages = [{"role": "system", "content": effective_system}] + api_messages
-
-            # Inject ephemeral prefill messages right after the system prompt
-            # but before conversation history. Same API-call-time-only pattern.
-            if self.prefill_messages:
-                sys_offset = 1 if effective_system else 0
-                for idx, pfm in enumerate(self.prefill_messages):
-                    api_messages.insert(sys_offset + idx, pfm.copy())
-
-            # Apply Anthropic prompt caching for Claude models on native
-            # Anthropic, OpenRouter, and third-party Anthropic-compatible
-            # gateways. Auto-detected: if ``_use_prompt_caching`` is set,
-            # inject cache_control breakpoints (system + last 3 messages)
-            # to reduce input token costs by ~75% on multi-turn
-            # conversations. Layout is chosen per endpoint by
-            # ``_anthropic_prompt_cache_policy``.
-            if self._use_prompt_caching:
-                api_messages = apply_anthropic_cache_control(
-                    api_messages,
-                    cache_ttl=self._cache_ttl,
-                    native_anthropic=self._use_native_cache_layout,
-                )
-
-            # Safety net: strip orphaned tool results / add stubs for missing
-            # results before sending to the API.  Runs unconditionally — not
-            # gated on context_compressor — so orphans from session loading or
-            # manual message manipulation are always caught.
-            api_messages = self._sanitize_api_messages(api_messages)
-
-            # Normalize message whitespace and tool-call JSON for consistent
-            # prefix matching.  Ensures bit-perfect prefixes across turns,
-            # which enables KV cache reuse on local inference servers
-            # (llama.cpp, vLLM, Ollama) and improves cache hit rates for
-            # cloud providers.  Operates on api_messages (the API copy) so
-            # the original conversation history in `messages` is untouched.
-            for am in api_messages:
-                if isinstance(am.get("content"), str):
-                    am["content"] = am["content"].strip()
-            for am in api_messages:
-                tcs = am.get("tool_calls")
-                if not tcs:
-                    continue
-                new_tcs = []
-                for tc in tcs:
-                    if isinstance(tc, dict) and "function" in tc:
-                        try:
-                            args_obj = json.loads(tc["function"]["arguments"])
-                            tc = {**tc, "function": {
-                                **tc["function"],
-                                "arguments": json.dumps(
-                                    args_obj, separators=(",", ":"),
-                                    sort_keys=True,
-                                ),
-                            }}
-                        except Exception:
-                            tc["function"]["arguments"] = _repair_tool_call_arguments(
-                                tc["function"]["arguments"],
-                                tc["function"].get("name", "?"),
-                            )
-                    new_tcs.append(tc)
-                am["tool_calls"] = new_tcs
-
-            # Proactively strip any surrogate characters before the API call.
-            # Models served via Ollama (Kimi K2.5, GLM-5, Qwen) can return
-            # lone surrogates (U+D800-U+DFFF) that crash json.dumps() inside
-            # the OpenAI SDK. Sanitizing here prevents the 3-retry cycle.
-            _sanitize_messages_surrogates(api_messages)
-
-            # Calculate approximate request size for logging
-            total_chars = sum(len(str(msg)) for msg in api_messages)
-            approx_tokens = estimate_messages_tokens_rough(api_messages)
-            
             # Thinking spinner for quiet mode (animated during API call)
             thinking_spinner = None
             
@@ -9170,8 +9128,18 @@ class AIAgent:
             finish_reason = "stop"
             response = None  # Guard against UnboundLocalError if all retries fail
             api_kwargs = None  # Guard against UnboundLocalError in except handler
+            api_messages = None
+            total_chars = 0
+            approx_tokens = 0
 
             while retry_count < max_retries:
+                api_messages, total_chars, approx_tokens = self._build_api_messages_for_attempt(
+                    messages,
+                    current_turn_user_idx=current_turn_user_idx,
+                    active_system_prompt=active_system_prompt,
+                    ext_prefetch_cache=_ext_prefetch_cache,
+                    plugin_user_context=_plugin_user_context,
+                )
                 # ── Nous Portal rate limit guard ──────────────────────
                 # If another session already recorded that Nous is rate-
                 # limited, skip the API call entirely.  Each attempt

--- a/tests/run_agent/test_fallback_context_preservation.py
+++ b/tests/run_agent/test_fallback_context_preservation.py
@@ -1,0 +1,161 @@
+import copy
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import run_agent
+
+
+def _make_tool_defs(*names: str) -> list:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": n,
+                "description": f"{n} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for n in names
+    ]
+
+
+def _build_agent(*, fallback_model, model="gpt-5-codex", provider="openai-codex", api_mode="codex_responses", base_url="https://chatgpt.com/backend-api/codex", api_key="codex-token"):
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("terminal")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = run_agent.AIAgent(
+            model=model,
+            provider=provider,
+            api_mode=api_mode,
+            base_url=base_url,
+            api_key=api_key,
+            fallback_model=fallback_model,
+            quiet_mode=True,
+            max_iterations=3,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.client = MagicMock()
+        agent._cleanup_task_resources = lambda task_id: None
+        agent._persist_session = lambda messages, history=None: None
+        agent._save_trajectory = lambda messages, user_message, completed: None
+        agent._save_session_log = lambda messages: None
+        return agent
+
+
+def _chat_response(text: str):
+    msg = SimpleNamespace(content=text, tool_calls=None)
+    choice = SimpleNamespace(message=msg, finish_reason="stop")
+    return SimpleNamespace(choices=[choice], model="fallback/model", usage=None)
+
+
+def test_run_conversation_rebuilds_api_messages_after_fallback_switch():
+    fallback_client = MagicMock()
+    fallback_client.api_key = "fallback-key"
+    fallback_client.base_url = "https://api.example.com/v1"
+
+    agent = _build_agent(
+        fallback_model={"provider": "custom", "model": "fallback-model", "base_url": "https://api.example.com/v1", "api_key": "fallback-key"}
+    )
+
+    requests = []
+
+    def _fake_api_call(api_kwargs):
+        requests.append(copy.deepcopy(api_kwargs))
+        if len(requests) == 1:
+            # Invalid Codex response -> triggers eager fallback path
+            return SimpleNamespace(output=[], output_text="", model="gpt-5-codex", status="failed", incomplete_details=None)
+        return _chat_response("fallback answer")
+
+    history = [
+        {"role": "user", "content": "run terminal"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_pair123|fc_pair123",
+                    "call_id": "call_pair123",
+                    "response_item_id": "fc_pair123",
+                    "type": "function",
+                    "function": {"name": "terminal", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_pair123|fc_pair123", "content": '{"ok":true}'},
+    ]
+
+    with patch(
+        "agent.auxiliary_client.resolve_provider_client",
+        return_value=(fallback_client, "fallback-model"),
+    ):
+        agent._interruptible_api_call = _fake_api_call
+        result = agent.run_conversation("continue", conversation_history=history)
+
+    assert result["final_response"] == "fallback answer"
+    assert len(requests) == 2
+
+    first_request = requests[0]
+    second_request = requests[1]
+
+    # First request is Codex Responses payload and should preserve Codex-specific IDs.
+    function_call = next(item for item in first_request["input"] if item.get("type") == "function_call")
+    assert function_call["call_id"] == "call_pair123"
+
+    # Second request is chat-completions payload rebuilt for the fallback provider.
+    assert "messages" in second_request
+    assistant_with_tool_call = next(
+        msg for msg in second_request["messages"]
+        if msg.get("role") == "assistant" and msg.get("tool_calls")
+    )
+    tool_call = assistant_with_tool_call["tool_calls"][0]
+    assert "call_id" not in tool_call
+    assert "response_item_id" not in tool_call
+
+
+def test_run_conversation_rebuilds_prompt_cached_messages_after_fallback_switch():
+    fallback_client = MagicMock()
+    fallback_client.api_key = "fallback-key"
+    fallback_client.base_url = "https://api.example.com/v1"
+
+    agent = _build_agent(
+        model="anthropic/claude-sonnet-4",
+        provider="openrouter",
+        api_mode="chat_completions",
+        base_url="https://openrouter.ai/api/v1",
+        api_key="openrouter-key",
+        fallback_model={"provider": "custom", "model": "fallback-model", "base_url": "https://api.example.com/v1", "api_key": "fallback-key"},
+    )
+
+    requests = []
+
+    def _fake_api_call(api_kwargs):
+        requests.append(copy.deepcopy(api_kwargs))
+        if len(requests) == 1:
+            return None  # invalid chat-completions response => eager fallback
+        return _chat_response("fallback answer")
+
+    with patch(
+        "agent.auxiliary_client.resolve_provider_client",
+        return_value=(fallback_client, "fallback-model"),
+    ):
+        agent._interruptible_api_call = _fake_api_call
+        result = agent.run_conversation("hello world")
+
+    assert result["final_response"] == "fallback answer"
+    assert len(requests) == 2
+
+    first_messages = requests[0]["messages"]
+    second_messages = requests[1]["messages"]
+
+    # Primary OpenRouter Claude request gets Anthropic cache-control wrappers.
+    first_user = next(msg for msg in first_messages if msg.get("role") == "user")
+    assert isinstance(first_user["content"], list)
+    assert first_user["content"][-1].get("cache_control") == {"type": "ephemeral"}
+
+    # Fallback request must be rebuilt from canonical messages, not reuse the
+    # prompt-cached payload from the failed provider.
+    second_user = next(msg for msg in second_messages if msg.get("role") == "user")
+    assert second_user["content"] == "hello world"

--- a/tests/run_agent/test_fallback_model.py
+++ b/tests/run_agent/test_fallback_model.py
@@ -45,8 +45,11 @@ def _make_agent(fallback_model=None):
         patch("run_agent.OpenAI"),
     ):
         agent = AIAgent(
-            api_key="test-key",
+            model="gpt-4.1",
+            provider="openrouter",
             base_url="https://openrouter.ai/api/v1",
+            api_mode="chat_completions",
+            api_key="test-key",
             quiet_mode=True,
             skip_context_files=True,
             skip_memory=True,


### PR DESCRIPTION
## Summary
- rebuild `api_messages` on every retry attempt instead of reusing a payload prepared for the previous provider
- prevent provider-specific transforms (for example Anthropic/OpenRouter prompt caching wrappers) from leaking into fallback requests
- add regression coverage for fallback from codex/chat paths and prompt-cached Claude requests
- make fallback tests self-contained so they do not depend on local provider config

## Root cause
When the primary model failed, Hermes switched `provider` / `model` / `api_mode` in-place, but continued using an `api_messages` payload that had already been prepared for the previous backend.

That meant fallback requests could inherit backend-specific payload mutations such as:
- Anthropic/OpenRouter `cache_control` wrappers
- provider-specific tool-call sanitization state
- message formatting intended for the old API mode

In practice this could look like context loss or broken continuity after fallback, because the new backend was not receiving a fresh request built from the canonical conversation state.

## Fix
- extracted per-attempt payload construction into `AIAgent._build_api_messages_for_attempt(...)`
- moved API message reconstruction inside the retry loop
- ensured each retry/fallback attempt recalculates request size from the rebuilt payload
- preserved newer upstream behavior while resolving the cherry-pick conflict (`/steer` pre-API drain, cache layout selection, tool-argument repair)

## Tests
Added regression coverage in:
- `tests/run_agent/test_fallback_context_preservation.py`

Validated with:
- `pytest tests/run_agent/test_fallback_context_preservation.py -q`
- `pytest tests/run_agent/test_fallback_model.py -q`
- `pytest tests/run_agent/test_run_agent_codex_responses.py -q`

## Why this matters
Fallback should always start from the canonical conversation history, not from a payload already transformed for a different provider. This keeps tool state, prompt context, and conversation continuity intact when Hermes has to fail over mid-turn.
