### PR TITLE
docs: add hermes_mem schema draft and design docs

### DIFF
--- a/docs/hermes-mem-spec.md
+++ b/docs/hermes-mem-spec.md
@@ -1,0 +1,406 @@
+# hermes-mem-spec
+
+Design spec for a native Hermes persistent-memory subsystem inspired by claude-mem, but built around Hermes's existing architecture, local-first priorities, and auditability requirements.
+
+---
+
+## Overview
+
+Hermes already has several memory-adjacent systems:
+
+- built-in durable memory via `memory` and `USER PROFILE`
+- cross-session transcript recall via `session_search`
+- pluggable memory backends via `MemoryProvider` and `MemoryManager`
+- context compression via `agent/context_compressor.py`
+- persistent session storage in SQLite via `hermes_state.py`
+
+What Hermes does not yet have natively is an operational memory layer that continuously turns session activity into reusable, inspectable observations with stable IDs, cheap progressive recall, and a local viewer for audit/debugging.
+
+This spec proposes that layer under the working name `hermes-mem`.
+
+---
+
+## Goal
+
+Add a native, local-first memory subsystem that:
+
+- captures useful observations from agent work across sessions
+- compresses noisy interaction history into reusable memory units
+- supports progressive recall with low token cost
+- provides stable observation IDs and citations
+- exposes a simple local inspection UI
+- fits the current Hermes runner without forcing an external SaaS dependency
+
+---
+
+## Why This Fits Hermes
+
+The right move for Hermes is not to clone claude-mem literally.
+
+The right move is to use the primitives Hermes already has and close the missing loop:
+
+1. capture
+2. compress
+3. index
+4. recall
+5. audit
+
+Hermes already has the right extension seam:
+
+- `agent/memory_provider.py` defines the lifecycle hooks needed for a real memory engine
+- `agent/memory_manager.py` already routes providers and fences memory context
+- `run_agent.py` already initializes a configured memory provider and injects provider tool schemas
+
+That means `hermes-mem` should land first as a native provider plugin, not as an invasive rewrite of the core loop.
+
+---
+
+## Current State vs Target State
+
+### Current Hermes memory capabilities
+
+Hermes today can already do all of the following:
+
+- persist compact durable facts about the user and environment
+- search and summarize previous sessions with `session_search`
+- activate external memory providers such as `supermemory`
+- compress long conversations when context gets tight
+- observe delegation results through `on_delegation`
+
+### Gaps
+
+Hermes does not yet have a first-class native concept of:
+
+- observation IDs as durable memory units
+- chronological memory timelines around a result
+- structured session-derived observations separate from raw transcripts
+- recall in layers: compact index → nearby context → full detail
+- a local web viewer showing what was stored and what was reinjected
+- a local-first memory backend purpose-built for Hermes rather than delegated to a third party
+
+---
+
+## Proposed Architecture
+
+### 1. New provider: `plugins/memory/hermes_mem`
+
+Recommended first implementation path:
+
+- add a new native provider named `hermes_mem`
+- keep it selectable via `memory.provider`
+- let it use the existing `MemoryProvider` lifecycle
+- avoid spreading bespoke hooks all over the codebase until the design proves itself
+- start from the committed storage draft in `plugins/memory/hermes_mem/schema.sql`
+
+This preserves the current model:
+
+- built-in memory remains separate and always available
+- `hermes_mem` handles operational memory and recall
+- external providers remain optional alternatives, not blockers
+
+### 2. Data layers
+
+#### Layer A: raw sessions
+
+Keep using existing session persistence from `hermes_state.py`.
+
+This remains the canonical source for full transcripts.
+
+#### Layer B: observations
+
+Add a new local store for structured observations extracted from turns, delegations, compression events, and session-end synthesis.
+
+An observation is the core atomic unit of reusable operational memory.
+
+#### Layer C: summaries
+
+Persist composite summaries by:
+
+- session
+- topic
+- project/workspace
+- time window
+
+This allows cheap recall without reprocessing entire transcripts.
+
+---
+
+## Observation Model
+
+Use `observation` as the primary durable unit.
+
+Suggested minimum schema:
+
+```python
+@dataclass
+class Observation:
+    id: int
+    session_id: str
+    project: str | None
+    kind: str
+    title: str
+    summary: str
+    detail: str
+    source_type: str
+    source_ref: str | None
+    created_at: str
+    importance: float
+    tags: list[str]
+```
+
+Recommended `kind` values:
+
+- `fact`
+- `decision`
+- `bugfix`
+- `investigation`
+- `tool_result`
+- `file_change`
+- `user_preference`
+- `delegation_result`
+- `session_summary`
+
+Design rule:
+
+- raw tool output is not the memory unit
+- the useful conclusion is the memory unit
+
+---
+
+## Capture Pipeline
+
+### Turn-level capture
+
+Use `sync_turn()` to extract compact candidate observations from:
+
+- the user's request
+- the assistant's final response
+- selected tool-call outcomes
+
+This is for lightweight, low-latency memory creation.
+
+### Session-end synthesis
+
+Use `on_session_end()` to generate:
+
+- denser observations that require broader session context
+- one session summary record
+- optional topic or project summaries if enough signal exists
+
+### Compression hook integration
+
+Use `on_pre_compress()` to preserve learnings from messages about to be summarized or discarded.
+
+### Delegation capture
+
+Use `on_delegation()` to record task/result pairs from subagents as high-value observations.
+
+That is especially important because delegated work often contains the best problem-solving signal.
+
+---
+
+## Progressive Recall Model
+
+Hermes should adopt a 3-layer recall flow.
+
+### Layer 1: compact search index
+
+Tool: `memory_search`
+
+Purpose:
+
+- return cheap results with IDs and short summaries
+- let the agent filter before fetching full detail
+
+Suggested output fields:
+
+- `id`
+- `kind`
+- `title`
+- `summary`
+- `score`
+- `created_at`
+
+### Layer 2: timeline context
+
+Tool: `memory_timeline`
+
+Purpose:
+
+- show what happened around a memory
+- expose nearby events before the model spends tokens on full payloads
+
+Useful for:
+
+- debugging sequences
+- architecture decisions
+- multi-step bugfixes
+- understanding what came before/after a result
+
+### Layer 3: full detail fetch
+
+Tool: `memory_get`
+
+Purpose:
+
+- fetch full details only for selected IDs
+- avoid flooding the prompt with large payloads upfront
+
+This follows the same broad idea that makes claude-mem attractive, but adapted to Hermes's provider/tool model.
+
+---
+
+## Automatic Context Injection
+
+`prefetch()` should inject only a small, fenced context block.
+
+Recommended policy:
+
+- include the most relevant 2–5 observations
+- include stable user/project facts when clearly relevant
+- include observation IDs for citation/debugging
+- prefer summaries over detail bodies
+- keep the injected block compact and deterministic
+
+Important:
+
+- full observation payloads should remain opt-in via tools
+- reinjection should never behave like dumping raw history into the prompt
+
+---
+
+## Storage Strategy
+
+### MVP storage
+
+Required:
+
+- SQLite
+- FTS5 full-text index
+
+Optional later:
+
+- embeddings
+- hybrid semantic retrieval
+- local vector index or pluggable embedding backends
+
+Rationale:
+
+- SQLite/FTS5 matches Hermes's current storage posture
+- it keeps the MVP local-first and operationally simple
+- it reduces external dependencies and makes debugging easier
+
+---
+
+## Viewer / Audit UI
+
+A local inspection surface is part of the product, not a nice-to-have.
+
+### MVP viewer goals
+
+- recent observation feed
+- search UI
+- filter by `kind`, session, project, and date
+- observation detail page
+- session summary view
+- visible record of what was reinjected on the last turn
+
+### MVP HTTP surface
+
+Suggested endpoints:
+
+- `GET /health`
+- `GET /observations`
+- `GET /observations/{id}`
+- `GET /search?q=...`
+- `GET /sessions/{id}/summary`
+- `GET /recall/latest`
+
+The first version does not need rich styling. It needs trust and debuggability.
+
+---
+
+## Relationship To Existing Hermes Features
+
+### Built-in memory
+
+Keep built-in `memory` and `USER PROFILE` focused on compact durable facts.
+
+Do not overload them with operational event history.
+
+### `session_search`
+
+Keep `session_search` as transcript-centric cross-session recall.
+
+`hermes_mem` is complementary:
+
+- `session_search` answers: "what happened in that conversation?"
+- `hermes_mem` answers: "what reusable observations matter now?"
+
+Longer-term, `hermes_mem` may internally reuse session data and summarization logic from `session_search`, but the mental model should remain separate.
+
+### External memory providers
+
+`hermes_mem` should not delete the provider abstraction.
+
+Instead it should become the native local-first option in that ecosystem.
+
+---
+
+## Recommended MVP Scope
+
+### In scope
+
+- new provider `plugins/memory/hermes_mem`
+- local SQLite/FTS5 observation store
+- observation extraction from turns, session end, delegation, and pre-compression
+- tools:
+  - `memory_search`
+  - `memory_timeline`
+  - `memory_get`
+- compact automatic prefetch injection
+- local read-only viewer
+- stable observation IDs and citations
+
+### Out of scope for v1
+
+- mandatory embeddings
+- cloud sync
+- heavy UI polish
+- collaborative multi-user knowledge management
+- aggressive auto-learning of every tool result
+- editing/forget UI beyond basic debug workflows
+
+---
+
+## Design Constraints
+
+1. Local-first by default.
+2. Avoid mandatory external SaaS dependencies.
+3. Preserve current provider architecture.
+4. Prefer compact recall over verbose reinjection.
+5. Make every stored unit auditable.
+6. Separate durable user/profile memory from operational project memory.
+
+---
+
+## Open Questions
+
+1. Should `hermes_mem` eventually become the default memory provider?
+2. Should observation extraction happen on every turn, session end, or both with different density levels?
+3. Should the viewer be shipped inside the provider or as a separate memory-inspection tool?
+4. Should `session_search` be reused internally for session synthesis, or kept as a parallel system?
+5. When should embeddings become worth the complexity increase?
+
+---
+
+## Recommended Implementation Order
+
+1. create the provider skeleton in `plugins/memory/hermes_mem/`
+2. build `store.py` and SQLite schema
+3. implement `sync_turn`, `prefetch`, `on_session_end`, `on_delegation`, and `on_pre_compress`
+4. add `memory_search`, `memory_timeline`, and `memory_get`
+5. add tests for storage, extraction, and provider lifecycle
+6. add a minimal local viewer
+
+This path delivers the core value quickly without overengineering the first version.

--- a/docs/plans/2026-04-17-hermes-mem-implementation-plan.md
+++ b/docs/plans/2026-04-17-hermes-mem-implementation-plan.md
@@ -1,0 +1,250 @@
+# Hermes Mem Implementation Plan
+
+Date: 2026-04-17
+
+## Goal
+
+Add a native, local-first operational memory subsystem to Hermes that continuously captures useful observations from agent work, stores them with stable IDs, supports progressive recall, and exposes a local viewer for audit/debugging.
+
+This plan is inspired by the product shape of claude-mem, but it is deliberately designed around Hermes's current internals rather than as a direct clone.
+
+## Why This Should Exist
+
+Hermes already has:
+
+- durable compact memory through the built-in `memory` tool and `USER PROFILE`
+- cross-session recall through `session_search`
+- a provider abstraction for external memory backends
+- context compression and persistent session storage
+
+But Hermes does not yet have a native operational memory layer that turns activity into reusable observations with:
+
+- stable observation IDs
+- layered recall
+- timeline navigation
+- local auditability
+- explicit separation between transcript history and reusable memory units
+
+## Design Direction
+
+Implement a new memory provider:
+
+- `plugins/memory/hermes_mem`
+
+Use the existing provider lifecycle:
+
+- `initialize`
+- `prefetch`
+- `queue_prefetch`
+- `sync_turn`
+- `on_session_end`
+- `on_pre_compress`
+- `on_delegation`
+
+Use local storage first:
+
+- SQLite
+- FTS5
+
+Add progressive recall tools:
+
+- `memory_search`
+- `memory_timeline`
+- `memory_get`
+
+Add a local viewer:
+
+- read-only first
+- audit/debug focused rather than polished
+
+## Core Concepts
+
+### Observation
+
+The primary durable unit should be an `observation`, not a raw transcript chunk.
+
+Every observation should have at least:
+
+- `id`
+- `session_id`
+- `project`
+- `kind`
+- `title`
+- `summary`
+- `detail`
+- `source_type`
+- `source_ref`
+- `created_at`
+- `importance`
+- `tags`
+
+Recommended observation kinds:
+
+- `fact`
+- `decision`
+- `bugfix`
+- `investigation`
+- `tool_result`
+- `file_change`
+- `user_preference`
+- `delegation_result`
+- `session_summary`
+
+### Progressive recall
+
+The retrieval flow should work in 3 layers:
+
+1. `memory_search`
+   - compact index of candidate memories
+2. `memory_timeline`
+   - chronological context around a selected memory or query
+3. `memory_get`
+   - full detail fetch only for selected IDs
+
+This keeps token usage low and makes memory auditable.
+
+## Proposed Work Breakdown
+
+### Phase 1: provider scaffold
+
+Create:
+
+- `plugins/memory/hermes_mem/__init__.py`
+- `plugins/memory/hermes_mem/plugin.yaml`
+- `plugins/memory/hermes_mem/README.md`
+
+The provider should be loadable through the existing plugin system and selectable by `memory.provider`.
+
+### Phase 2: storage layer
+
+Create:
+
+- `plugins/memory/hermes_mem/store.py`
+- `plugins/memory/hermes_mem/schema.sql`  ← initial draft already committed
+
+Add tests:
+
+- `tests/plugins/memory/test_hermes_mem_store.py`
+
+Initial tables should cover:
+
+- `observations`
+- `observation_fts`
+- `session_summaries`
+- `recall_log`
+
+### Phase 3: observation extraction
+
+Create:
+
+- `plugins/memory/hermes_mem/extraction.py`
+
+Add tests:
+
+- `tests/plugins/memory/test_hermes_mem_extraction.py`
+
+Sources to extract from:
+
+- completed turns via `sync_turn`
+- session end via `on_session_end`
+- delegation results via `on_delegation`
+- pre-compression state via `on_pre_compress`
+
+### Phase 4: retrieval tools
+
+Add provider tools:
+
+- `memory_search(query, kind=None, session_id=None, limit=10)`
+- `memory_timeline(observation_id=None, query=None, window=5)`
+- `memory_get(ids=[...])`
+
+Add tests:
+
+- `tests/plugins/memory/test_hermes_mem_search.py`
+- `tests/plugins/memory/test_hermes_mem_timeline.py`
+- `tests/plugins/memory/test_hermes_mem_get.py`
+
+### Phase 5: automatic prefetch
+
+Use `prefetch()` for compact reinjection of relevant observations.
+
+Rules:
+
+- inject no more than a short fenced context block
+- prefer summaries, not full payloads
+- include IDs for later citation/debugging
+- keep the default result stable and cheap
+
+### Phase 6: local viewer
+
+Create:
+
+- `plugins/memory/hermes_mem/viewer.py`
+
+Add tests:
+
+- `tests/plugins/memory/test_hermes_mem_viewer.py`
+
+Suggested minimal endpoints:
+
+- `GET /health`
+- `GET /observations`
+- `GET /observations/{id}`
+- `GET /search?q=...`
+- `GET /sessions/{id}/summary`
+- `GET /recall/latest`
+
+## Non-Goals For MVP
+
+Do not include in v1:
+
+- mandatory vector embeddings
+- SaaS dependency for storage or retrieval
+- polished dashboard UI
+- broad collaborative knowledge-sharing workflows
+- indiscriminate storage of raw tool outputs
+
+## Important Design Rules
+
+1. Keep built-in durable memory separate from operational memory.
+2. Do not treat raw tool output as the memory unit.
+3. Make every observation addressable by stable ID.
+4. Keep the MVP local-first.
+5. Optimize recall for token efficiency.
+6. Make reinjected memory easy to inspect and debug.
+
+## Relationship To Existing Features
+
+### Built-in memory
+
+Keep using the existing built-in memory for concise durable facts.
+
+### `session_search`
+
+Keep `session_search` transcript-centric.
+
+`hermes_mem` should focus on reusable observations rather than conversation recap.
+
+### Existing providers
+
+Do not remove support for external providers.
+
+`hermes_mem` should become the native local-first option in the same provider ecosystem.
+
+## Open Questions
+
+1. Should `hermes_mem` become the default provider later?
+2. Should embeddings be optional in v1 behind a config gate, or deferred entirely?
+3. Should the viewer ship inside the provider or as a separate memory-inspection module?
+4. Should session-derived summaries reuse any `session_search` internals?
+
+## Recommended First Implementation Order
+
+1. provider scaffold
+2. storage + schema
+3. turn/session extraction
+4. progressive recall tools
+5. tests
+6. viewer
+
+That order delivers the core memory product without requiring a full UX layer first.

--- a/plugins/memory/hermes_mem/README.md
+++ b/plugins/memory/hermes_mem/README.md
@@ -1,0 +1,38 @@
+# Hermes Mem (design stub)
+
+This directory holds the initial design assets for the planned native `hermes_mem` memory provider.
+
+Current contents:
+
+- `schema.sql` — initial SQLite/FTS5 schema for the MVP operational-memory store
+
+Status:
+
+- design/documentation only
+- provider implementation not added yet
+- no `__init__.py` on purpose, so discovery does not treat this as a loadable memory provider yet
+
+## What the initial schema covers
+
+The first schema is designed around four core storage concerns:
+
+1. `observations`
+   - reusable memory units with stable IDs
+   - session/project/profile/workspace scoping
+   - kind, summary, detail, importance, confidence, and source metadata
+
+2. `observation_tags` and `observation_links`
+   - lightweight tagging
+   - explicit graph relationships between observations
+
+3. `session_summaries`
+   - one summary row per session for cheap recall and viewer support
+
+4. `recall_log`
+   - audit trail of what was selected and reinjected during recall
+
+## Design intent
+
+This schema is for a local-first Hermes memory system that stores reusable operational observations rather than raw transcripts.
+
+The transcript source of truth remains Hermes's existing session database. `hermes_mem` is intended to sit above that layer as a compact, searchable memory index.

--- a/plugins/memory/hermes_mem/schema.sql
+++ b/plugins/memory/hermes_mem/schema.sql
@@ -1,0 +1,209 @@
+-- Hermes Mem initial SQLite schema
+--
+-- Purpose:
+--   Store operational memory observations extracted from Hermes sessions,
+--   plus session-level summaries and a small audit trail of recalled context.
+--
+-- Notes:
+--   - This is a design-first schema for the initial hermes_mem MVP.
+--   - It intentionally uses SQLite + FTS5 only; embeddings are deferred.
+--   - The raw session transcript remains in Hermes's existing SessionDB.
+--   - hermes_mem stores reusable observations, not the full conversation log.
+
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS observations (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id       TEXT NOT NULL,
+    parent_id        INTEGER REFERENCES observations(id) ON DELETE SET NULL,
+    project          TEXT,
+    workspace        TEXT,
+    profile          TEXT,
+    kind             TEXT NOT NULL,
+    title            TEXT NOT NULL,
+    summary          TEXT NOT NULL,
+    detail           TEXT DEFAULT '',
+    source_type      TEXT NOT NULL,
+    source_ref       TEXT,
+    importance       REAL NOT NULL DEFAULT 0.5,
+    confidence       REAL NOT NULL DEFAULT 0.5,
+    token_cost_hint  INTEGER DEFAULT 0,
+    turn_number      INTEGER,
+    delegated        INTEGER NOT NULL DEFAULT 0,
+    pinned           INTEGER NOT NULL DEFAULT 0,
+    created_at       TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at       TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    deleted_at       TEXT,
+    CHECK (kind IN (
+        'fact',
+        'decision',
+        'bugfix',
+        'investigation',
+        'tool_result',
+        'file_change',
+        'user_preference',
+        'delegation_result',
+        'session_summary'
+    )),
+    CHECK (source_type IN (
+        'turn',
+        'tool',
+        'delegation',
+        'compression',
+        'session_end',
+        'manual'
+    )),
+    CHECK (importance >= 0.0 AND importance <= 1.0),
+    CHECK (confidence >= 0.0 AND confidence <= 1.0),
+    CHECK (delegated IN (0, 1)),
+    CHECK (pinned IN (0, 1))
+);
+
+CREATE INDEX IF NOT EXISTS idx_observations_session_created
+    ON observations(session_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_observations_kind_created
+    ON observations(kind, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_observations_project_created
+    ON observations(project, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_observations_profile_created
+    ON observations(profile, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_observations_workspace_created
+    ON observations(workspace, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_observations_importance
+    ON observations(importance DESC, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_observations_active
+    ON observations(deleted_at, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS observation_tags (
+    observation_id   INTEGER NOT NULL REFERENCES observations(id) ON DELETE CASCADE,
+    tag              TEXT NOT NULL,
+    created_at       TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (observation_id, tag)
+);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS observations_fts USING fts5(
+    title,
+    summary,
+    detail,
+    tags,
+    content='observations',
+    content_rowid='id',
+    tokenize='porter unicode61'
+);
+
+CREATE TRIGGER IF NOT EXISTS observations_ai AFTER INSERT ON observations BEGIN
+    INSERT INTO observations_fts(rowid, title, summary, detail, tags)
+    VALUES (new.id, new.title, new.summary, new.detail, COALESCE((SELECT GROUP_CONCAT(tag, ' ')
+      FROM observation_tags WHERE observation_id = new.id), ''));
+END;
+
+CREATE TRIGGER IF NOT EXISTS observations_ad AFTER DELETE ON observations BEGIN
+    INSERT INTO observations_fts(observations_fts, rowid, title, summary, detail, tags)
+    VALUES ('delete', old.id, old.title, old.summary, old.detail, COALESCE((SELECT GROUP_CONCAT(tag, ' ')
+      FROM observation_tags WHERE observation_id = old.id), ''));
+END;
+
+CREATE TRIGGER IF NOT EXISTS observations_au AFTER UPDATE ON observations BEGIN
+    INSERT INTO observations_fts(observations_fts, rowid, title, summary, detail, tags)
+    VALUES ('delete', old.id, old.title, old.summary, old.detail, COALESCE((SELECT GROUP_CONCAT(tag, ' ')
+      FROM observation_tags WHERE observation_id = old.id), ''));
+    INSERT INTO observations_fts(rowid, title, summary, detail, tags)
+    VALUES (new.id, new.title, new.summary, new.detail, COALESCE((SELECT GROUP_CONCAT(tag, ' ')
+      FROM observation_tags WHERE observation_id = new.id), ''));
+END;
+
+CREATE INDEX IF NOT EXISTS idx_observation_tags_tag
+    ON observation_tags(tag);
+
+CREATE TRIGGER IF NOT EXISTS observation_tags_ai AFTER INSERT ON observation_tags BEGIN
+    INSERT INTO observations_fts(observations_fts, rowid, title, summary, detail, tags)
+    VALUES ('delete', new.observation_id,
+        COALESCE((SELECT title FROM observations WHERE id = new.observation_id), ''),
+        COALESCE((SELECT summary FROM observations WHERE id = new.observation_id), ''),
+        COALESCE((SELECT detail FROM observations WHERE id = new.observation_id), ''),
+        COALESCE((SELECT GROUP_CONCAT(tag, ' ') FROM observation_tags WHERE observation_id = new.observation_id), '')
+    );
+    INSERT INTO observations_fts(rowid, title, summary, detail, tags)
+    SELECT o.id, o.title, o.summary, o.detail,
+           COALESCE((SELECT GROUP_CONCAT(tag, ' ') FROM observation_tags WHERE observation_id = o.id), '')
+      FROM observations o
+     WHERE o.id = new.observation_id;
+END;
+
+CREATE TRIGGER IF NOT EXISTS observation_tags_ad AFTER DELETE ON observation_tags BEGIN
+    INSERT INTO observations_fts(observations_fts, rowid, title, summary, detail, tags)
+    VALUES ('delete', old.observation_id,
+        COALESCE((SELECT title FROM observations WHERE id = old.observation_id), ''),
+        COALESCE((SELECT summary FROM observations WHERE id = old.observation_id), ''),
+        COALESCE((SELECT detail FROM observations WHERE id = old.observation_id), ''),
+        COALESCE((SELECT GROUP_CONCAT(tag, ' ') FROM observation_tags WHERE observation_id = old.observation_id), '')
+    );
+    INSERT INTO observations_fts(rowid, title, summary, detail, tags)
+    SELECT o.id, o.title, o.summary, o.detail,
+           COALESCE((SELECT GROUP_CONCAT(tag, ' ') FROM observation_tags WHERE observation_id = o.id), '')
+      FROM observations o
+     WHERE o.id = old.observation_id;
+END;
+
+CREATE TABLE IF NOT EXISTS observation_links (
+    from_observation_id  INTEGER NOT NULL REFERENCES observations(id) ON DELETE CASCADE,
+    to_observation_id    INTEGER NOT NULL REFERENCES observations(id) ON DELETE CASCADE,
+    link_type            TEXT NOT NULL,
+    created_at           TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (from_observation_id, to_observation_id, link_type),
+    CHECK (link_type IN ('related', 'caused_by', 'supersedes', 'supports', 'contradicts', 'follows'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_observation_links_to
+    ON observation_links(to_observation_id, link_type);
+
+CREATE TABLE IF NOT EXISTS session_summaries (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id          TEXT NOT NULL UNIQUE,
+    project             TEXT,
+    workspace           TEXT,
+    profile             TEXT,
+    title               TEXT,
+    summary             TEXT NOT NULL,
+    open_questions      TEXT DEFAULT '',
+    outcomes            TEXT DEFAULT '',
+    observation_count   INTEGER NOT NULL DEFAULT 0,
+    started_at          TEXT,
+    ended_at            TEXT,
+    created_at          TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at          TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_session_summaries_project
+    ON session_summaries(project, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS recall_log (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id          TEXT NOT NULL,
+    turn_number         INTEGER,
+    query               TEXT NOT NULL,
+    recall_mode         TEXT NOT NULL,
+    selected_ids_json   TEXT NOT NULL DEFAULT '[]',
+    injected_text       TEXT NOT NULL DEFAULT '',
+    token_estimate      INTEGER NOT NULL DEFAULT 0,
+    created_at          TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CHECK (recall_mode IN ('prefetch', 'search', 'timeline', 'get'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_recall_log_session_turn
+    ON recall_log(session_id, turn_number DESC, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    version             INTEGER PRIMARY KEY,
+    name                TEXT NOT NULL,
+    applied_at          TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT OR IGNORE INTO schema_migrations(version, name)
+VALUES (1, 'initial hermes_mem schema');


### PR DESCRIPTION
## Summary
- add the initial `hermes_mem` design spec under `docs/hermes-mem-spec.md`
- add an implementation plan under `docs/plans/2026-04-17-hermes-mem-implementation-plan.md`
- add a first-pass plugin README under `plugins/memory/hermes_mem/README.md`
- add a draft SQLite/FTS5 schema under `plugins/memory/hermes_mem/schema.sql`

## Scope
This PR is intentionally documentation/design-only.
It does **not** activate the provider or change runtime behavior.

The goal is to preserve and review the proposed architecture separately from implementation work.

## Why separate PR
The related runtime fallback/context fix was split into a different PR so:
- production bugfixes stay isolated
- design review for `hermes_mem` can happen independently
- implementation can follow later from an approved schema/spec baseline

## Contents
### Design docs
- problem framing and goals for `hermes_mem`
- proposed data model and retrieval strategy
- implementation sequencing notes

### Schema draft
- initial SQLite tables
- FTS-oriented structure for retrieval/search workflows
- draft plugin storage layout under `plugins/memory/hermes_mem/`

## Notes
This is a draft intended for architecture review and iteration before provider activation.
