### PR TITLE
fix: add UTF-8 encoding for Windows compatibility

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -581,7 +581,7 @@ def _load_context_cache() -> Dict[str, int]:
     if not path.exists():
         return {}
     try:
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             data = yaml.safe_load(f) or {}
         return data.get("context_lengths", {})
     except Exception as e:
@@ -603,7 +603,7 @@ def save_context_length(model: str, base_url: str, length: int) -> None:
     path = _get_context_cache_path()
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        with open(path, "w") as f:
+        with open(path, "w", encoding="utf-8") as f:
             yaml.dump({"context_lengths": cache}, f, default_flow_style=False)
         logger.info("Cached context length %s -> %s tokens", key, f"{length:,}")
     except Exception as e:

--- a/agent/nous_rate_guard.py
+++ b/agent/nous_rate_guard.py
@@ -143,7 +143,7 @@ def nous_rate_limit_remaining() -> Optional[float]:
     """
     path = _state_path()
     try:
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             state = json.load(f)
         reset_at = state.get("reset_at", 0)
         remaining = reset_at - time.time()

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -781,7 +781,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             import yaml
             _cfg_path = str(_hermes_home / "config.yaml")
             if os.path.exists(_cfg_path):
-                with open(_cfg_path) as _f:
+                with open(_cfg_path, encoding="utf-8") as _f:
                     _cfg = yaml.safe_load(_f) or {}
                 _model_cfg = _cfg.get("model", {})
                 if not job.get("model"):

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -520,7 +520,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 return
 
             import yaml as _yaml
-            with open(config_path, "r") as f:
+            with open(config_path, "r", encoding="utf-8") as f:
                 config = _yaml.safe_load(f) or {}
 
             # Navigate to platforms.telegram.extra.dm_topics
@@ -2861,7 +2861,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 return
 
             import yaml as _yaml
-            with open(config_path, "r") as f:
+            with open(config_path, "r", encoding="utf-8") as f:
                 config = _yaml.safe_load(f) or {}
 
             dm_topics = (


### PR DESCRIPTION
## Problem

On Windows, Python's default file encoding is cp1252 (not utf-8). When configuration files or state files contain non-ASCII characters (e.g., Chinese model names, special characters), file operations fail with UnicodeDecodeError.

## Solution

Explicitly add encoding='utf-8' to all file operations that handle config/state files to ensure cross-platform compatibility.

## Files Changed

- agent/model_metadata.py - 2 locations (context length cache read/write)
- agent/nous_rate_guard.py - 1 location (rate limit state read)
- cron/scheduler.py - 1 location (config.yaml read)
- gateway/platforms/telegram.py - 2 locations (DM topic thread config read/write)

## Testing

No functional changes - only adds explicit encoding parameter to existing open() calls.