### PR TITLE
feat(skill): split meme generation helpers

### DIFF
--- a/optional-skills/creative/meme-generation/EXAMPLES.md
+++ b/optional-skills/creative/meme-generation/EXAMPLES.md
@@ -1,46 +1,5 @@
 # Meme Generation Examples
 
-## Example 1: Debugging at 2 AM
+This file is kept as a compatibility pointer.
 
-**Topic:** debugging production at 2 AM
-**Template:** this-is-fine
-
-```bash
-python generate_meme.py this-is-fine /tmp/meme.png "PRODUCTION IS DOWN" "This is fine"
-```
-
-## Example 2: Developer Priorities
-
-**Topic:** choosing between writing tests and shipping features
-**Template:** drake
-
-```bash
-python generate_meme.py drake /tmp/meme.png "Writing unit tests" "Shipping straight to prod"
-```
-
-## Example 3: Exam Stress
-
-**Topic:** final exam preparation
-**Template:** two-buttons
-
-```bash
-python generate_meme.py two-buttons /tmp/meme.png "Study everything" "Sleep" "Me at midnight"
-```
-
-## Example 4: Escalating Solutions
-
-**Topic:** fixing a CSS bug
-**Template:** expanding-brain
-
-```bash
-python generate_meme.py expanding-brain /tmp/meme.png "Reading the docs" "Stack Overflow" "!important on everything" "Deleting the stylesheet"
-```
-
-## Example 5: Hot Take
-
-**Topic:** tabs vs spaces
-**Template:** change-my-mind
-
-```bash
-python generate_meme.py change-my-mind /tmp/meme.png "Tabs are just thicc spaces"
-```
+See `references/meme-generation.md` for the canonical template-selection heuristics and usage examples.

--- a/optional-skills/creative/meme-generation/EXAMPLES.md
+++ b/optional-skills/creative/meme-generation/EXAMPLES.md
@@ -1,5 +1,0 @@
-# Meme Generation Examples
-
-This file is kept as a compatibility pointer.
-
-See `references/meme-generation.md` for the canonical template-selection heuristics and usage examples.

--- a/optional-skills/creative/meme-generation/SKILL.md
+++ b/optional-skills/creative/meme-generation/SKILL.md
@@ -37,7 +37,8 @@ Do not use this skill for generic photo editing, video memes, or free-form image
 ## References
 
 - Curated template list: `references/curated-templates.md`
-- Template selection heuristics, matching examples, and usage examples: `references/meme-generation.md`
+- Template selection heuristics and Imgflip source notes: `references/meme-generation.md`
+- Usage examples: `references/examples.md`
 - Script behavior and deterministic rendering: `scripts/generate_meme.py`
 
 ## Pitfalls

--- a/optional-skills/creative/meme-generation/SKILL.md
+++ b/optional-skills/creative/meme-generation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: meme-generation
-description: Generate real meme images by finding blank templates, including Imgflip sources, and overlaying text with Pillow. Produces actual .png meme files.
-version: 2.0.0
+description: Generate meme images by choosing a template, downloading a blank source from Imgflip when needed, and overlaying short captions with Pillow.
+version: 2.1.0
 author: adanaleycio
 license: MIT
 metadata:
@@ -13,122 +13,43 @@ metadata:
 
 # Meme Generation
 
-Generate actual meme images from a topic. Picks a template, writes captions, and renders a real .png file with text overlay.
+Generate real meme images from a topic by selecting an appropriate template, writing short captions, and rendering a .png file.
 
-## When to Use
+## When to use
 
-- User asks you to make or generate a meme
-- User wants a meme about a specific topic, situation, or frustration
-- User says "meme this" or similar
+Use this skill when the user wants to:
+- make a meme
+- caption a reaction image or blank meme template
+- search Imgflip for a template/source image
+- turn a topic into a meme with text overlay
 
-## Available Templates
-
-The skill supports **any of the ~100 popular Imgflip templates** by name or ID, plus 10 curated templates with hand-tuned text positioning.
-
-Use `scripts/imgflip_download.py` when you want a clean blank source image from Imgflip.
-Use `scripts/meme_caption.py` when you already have a local image and only want to add captions.
-
-For matching rules, template examples, and source notes, read `references/meme-generation.md`.
-
-### Curated Templates (custom text placement)
-
-| ID | Name | Fields | Best for |
-|----|------|--------|----------|
-| `this-is-fine` | This is Fine | top, bottom | chaos, denial |
-| `drake` | Drake Hotline Bling | reject, approve | rejecting/preferring |
-| `distracted-boyfriend` | Distracted Boyfriend | distraction, current, person | temptation, shifting priorities |
-| `two-buttons` | Two Buttons | left, right, person | impossible choice |
-| `expanding-brain` | Expanding Brain | 4 levels | escalating irony |
-| `change-my-mind` | Change My Mind | statement | hot takes |
-| `woman-yelling-at-cat` | Woman Yelling at Cat | woman, cat | arguments |
-| `one-does-not-simply` | One Does Not Simply | top, bottom | deceptively hard things |
-| `grus-plan` | Gru's Plan | step1-3, realization | plans that backfire |
-| `batman-slapping-robin` | Batman Slapping Robin | robin, batman | shutting down bad ideas |
-
-### Dynamic Templates (from imgflip API)
-
-Any template not in the curated list can be used by name or Imgflip ID. These get smart default text positioning (top/bottom for 2-field, evenly spaced for 3+). Search with:
-```bash
-python "$SKILL_DIR/scripts/imgflip_download.py" --search "disaster"
-```
+Do not use this skill for generic photo editing, video memes, or free-form image generation.
 
 ## Procedure
 
-### Mode 1: Classic Template (default)
+1. Identify the joke structure first: chaos, dilemma, comparison, escalation, hot take, irony, and similar patterns.
+2. Prefer a curated template when one clearly matches the structure.
+3. If no curated template fits, search the Imgflip template list and pick a blank source by name or ID.
+4. Keep captions short. Shorter text is usually better for readability and timing.
+5. Run `scripts/generate_meme.py` to render the image.
+6. Return the resulting file with a `MEDIA:` path.
 
-1. Read the user's topic and identify the core dynamic (chaos, dilemma, preference, irony, etc.)
-2. Pick the template that best matches. Use the "Best for" column, or search with `--search`.
-3. Write short captions for each field (8-12 words max per field, shorter is better).
-4. Find the skill's script directory:
-   ```
-   SKILL_DIR=$(dirname "$(find ~/.hermes/skills -path '*/meme-generation/SKILL.md' 2>/dev/null | head -1)")
-   ```
-5. Run the generator:
-   ```bash
-   python "$SKILL_DIR/scripts/generate_meme.py" <template_id> /tmp/meme.png "caption 1" "caption 2" ...
-   ```
-6. Return the image with `MEDIA:/tmp/meme.png`
+## References
 
-### Mode 2: Custom AI Image (when image_generate is available)
-
-Use this when no classic template fits, or when the user wants something original.
-
-1. Write the captions first.
-2. Use `image_generate` to create a scene that matches the meme concept. Do NOT include any text in the image prompt — text will be added by the script. Describe only the visual scene.
-3. Find the generated image path from the image_generate result URL. Download it to a local path if needed.
-4. Run the caption script to overlay text, choosing a mode:
-   - **Overlay** (text directly on image, white with black outline):
-     ```bash
-     python "$SKILL_DIR/scripts/meme_caption.py" /path/to/scene.png /tmp/meme.png "top text" "bottom text"
-     ```
-   - **Bars** (black bars above/below with white text — cleaner, always readable):
-     ```bash
-     python "$SKILL_DIR/scripts/meme_caption.py" --bars /path/to/scene.png /tmp/meme.png "top text" "bottom text"
-     ```
-   Use `--trim-padding` when the image has wide white borders that should be removed before captioning.
-5. **Verify with vision** (if `vision_analyze` is available): Check the result looks good:
-   ```
-   vision_analyze(image_url="/tmp/meme.png", question="Is the text legible and well-positioned? Does the meme work visually?")
-   ```
-   If the vision model flags issues (text hard to read, bad placement, etc.), try the other mode (switch between overlay and bars) or regenerate the scene.
-6. Return the image with `MEDIA:/tmp/meme.png`
-
-## Examples
-
-**"debugging production at 2 AM":**
-```bash
-python generate_meme.py this-is-fine /tmp/meme.png "SERVERS ARE ON FIRE" "This is fine"
-```
-
-**"choosing between sleep and one more episode":**
-```bash
-python generate_meme.py drake /tmp/meme.png "Getting 8 hours of sleep" "One more episode at 3 AM"
-```
-
-**"the stages of a Monday morning":**
-```bash
-python generate_meme.py expanding-brain /tmp/meme.png "Setting an alarm" "Setting 5 alarms" "Sleeping through all alarms" "Working from bed"
-```
-
-## Listing Templates
-
-To see all available templates:
-```bash
-python generate_meme.py --list
-```
+- Template selection heuristics, matching examples, and usage examples live in `references/meme-generation.md`.
+- Script behavior and deterministic rendering live in `scripts/generate_meme.py`.
 
 ## Pitfalls
 
-- Keep captions SHORT. Memes with long text look terrible.
-- Match the number of text arguments to the template's field count.
-- Pick the template that fits the joke structure, not just the topic.
+- Do not force a template just because it matches the topic words; match the joke structure instead.
+- Match the number of text fields to the template.
+- Keep the final text readable and concise.
 - Do not generate hateful, abusive, or personally targeted content.
-- The script caches template images in `scripts/.cache/` after first download.
 
 ## Verification
 
 The output is correct if:
-- A .png file was created at the output path
-- Text is legible (white with black outline) on the template
-- The joke lands — caption matches the template's intended structure
-- File can be delivered via MEDIA: path
+- a .png file was created at the output path
+- the text is legible on the template
+- the chosen template fits the joke
+- the file can be delivered via `MEDIA:`

--- a/optional-skills/creative/meme-generation/SKILL.md
+++ b/optional-skills/creative/meme-generation/SKILL.md
@@ -29,17 +29,24 @@ Do not use this skill for generic photo editing, video memes, or free-form image
 
 1. Identify the joke structure first: chaos, dilemma, comparison, escalation, hot take, irony, and similar patterns.
 2. Prefer a curated template when one clearly matches the structure.
-3. If no curated template fits, search the Imgflip template list and pick a blank source by name or ID.
-4. Keep captions short. Shorter text is usually better for readability and timing.
-5. Run `scripts/generate_meme.py` to render the image.
-6. Return the resulting file with a `MEDIA:` path.
+3. If the task needs a blank source, use `scripts/imgflip_download.py` to search Imgflip and save the template locally.
+4. If the task already has a local image, use `scripts/meme_caption.py` to add captions to that image.
+5. Use `scripts/generate_meme.py` when a single entry point is enough or when compatibility with the combined flow is desired.
+6. Keep captions short. Shorter text is usually better for readability and timing.
+7. Return the resulting file with a `MEDIA:` path.
+
+## Scripts
+
+- `scripts/imgflip_download.py`: search Imgflip and download a blank template to a local file.
+- `scripts/meme_caption.py`: add meme captions to an existing local image, with optional padding trim and bars mode.
+- `scripts/generate_meme.py`: main renderer and compatibility wrapper for template-based or local-image meme generation.
 
 ## References
 
 - Curated template list: `references/curated-templates.md`
 - Template selection heuristics and Imgflip source notes: `references/meme-generation.md`
 - Usage examples: `references/examples.md`
-- Script behavior and deterministic rendering: `scripts/generate_meme.py`
+- Script details and preferred entry points: `references/scripts.md`
 
 ## Pitfalls
 

--- a/optional-skills/creative/meme-generation/SKILL.md
+++ b/optional-skills/creative/meme-generation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: meme-generation
-description: Generate real meme images by picking a template and overlaying text with Pillow. Produces actual .png meme files.
+description: Generate real meme images by finding blank templates, including Imgflip sources, and overlaying text with Pillow. Produces actual .png meme files.
 version: 2.0.0
 author: adanaleycio
 license: MIT
@@ -23,7 +23,12 @@ Generate actual meme images from a topic. Picks a template, writes captions, and
 
 ## Available Templates
 
-The script supports **any of the ~100 popular imgflip templates** by name or ID, plus 10 curated templates with hand-tuned text positioning.
+The skill supports **any of the ~100 popular Imgflip templates** by name or ID, plus 10 curated templates with hand-tuned text positioning.
+
+Use `scripts/imgflip_download.py` when you want a clean blank source image from Imgflip.
+Use `scripts/meme_caption.py` when you already have a local image and only want to add captions.
+
+For matching rules, template examples, and source notes, read `references/meme-generation.md`.
 
 ### Curated Templates (custom text placement)
 
@@ -42,9 +47,9 @@ The script supports **any of the ~100 popular imgflip templates** by name or ID,
 
 ### Dynamic Templates (from imgflip API)
 
-Any template not in the curated list can be used by name or imgflip ID. These get smart default text positioning (top/bottom for 2-field, evenly spaced for 3+). Search with:
+Any template not in the curated list can be used by name or Imgflip ID. These get smart default text positioning (top/bottom for 2-field, evenly spaced for 3+). Search with:
 ```bash
-python "$SKILL_DIR/scripts/generate_meme.py" --search "disaster"
+python "$SKILL_DIR/scripts/imgflip_download.py" --search "disaster"
 ```
 
 ## Procedure
@@ -71,16 +76,16 @@ Use this when no classic template fits, or when the user wants something origina
 1. Write the captions first.
 2. Use `image_generate` to create a scene that matches the meme concept. Do NOT include any text in the image prompt — text will be added by the script. Describe only the visual scene.
 3. Find the generated image path from the image_generate result URL. Download it to a local path if needed.
-4. Run the script with `--image` to overlay text, choosing a mode:
+4. Run the caption script to overlay text, choosing a mode:
    - **Overlay** (text directly on image, white with black outline):
      ```bash
-     python "$SKILL_DIR/scripts/generate_meme.py" --image /path/to/scene.png /tmp/meme.png "top text" "bottom text"
+     python "$SKILL_DIR/scripts/meme_caption.py" /path/to/scene.png /tmp/meme.png "top text" "bottom text"
      ```
    - **Bars** (black bars above/below with white text — cleaner, always readable):
      ```bash
-     python "$SKILL_DIR/scripts/generate_meme.py" --image /path/to/scene.png --bars /tmp/meme.png "top text" "bottom text"
+     python "$SKILL_DIR/scripts/meme_caption.py" --bars /path/to/scene.png /tmp/meme.png "top text" "bottom text"
      ```
-   Use `--bars` when the image is busy/detailed and text would be hard to read on top of it.
+   Use `--trim-padding` when the image has wide white borders that should be removed before captioning.
 5. **Verify with vision** (if `vision_analyze` is available): Check the result looks good:
    ```
    vision_analyze(image_url="/tmp/meme.png", question="Is the text legible and well-positioned? Does the meme work visually?")

--- a/optional-skills/creative/meme-generation/SKILL.md
+++ b/optional-skills/creative/meme-generation/SKILL.md
@@ -36,8 +36,9 @@ Do not use this skill for generic photo editing, video memes, or free-form image
 
 ## References
 
-- Template selection heuristics, matching examples, and usage examples live in `references/meme-generation.md`.
-- Script behavior and deterministic rendering live in `scripts/generate_meme.py`.
+- Curated template list: `references/curated-templates.md`
+- Template selection heuristics, matching examples, and usage examples: `references/meme-generation.md`
+- Script behavior and deterministic rendering: `scripts/generate_meme.py`
 
 ## Pitfalls
 

--- a/optional-skills/creative/meme-generation/references/curated-templates.md
+++ b/optional-skills/creative/meme-generation/references/curated-templates.md
@@ -1,0 +1,24 @@
+# Curated Meme Templates
+
+These are the hand-tuned templates used by the meme-generation skill.
+
+## List
+
+| ID | Name | Fields | Best for |
+|----|------|--------|----------|
+| `this-is-fine` | This is Fine | top, bottom | chaos, denial, pretending things are okay |
+| `drake` | Drake Hotline Bling | reject, approve | rejecting one thing, preferring another |
+| `distracted-boyfriend` | Distracted Boyfriend | distraction, current, person | distraction, shifting priorities, temptation |
+| `two-buttons` | Two Buttons | left_button, right_button, person | impossible choice, dilemma between two options |
+| `expanding-brain` | Expanding Brain | level1, level2, level3, level4 | escalating irony, increasingly absurd ideas |
+| `change-my-mind` | Change My Mind | statement | strong or ironic opinion, controversial take |
+| `woman-yelling-at-cat` | Woman Yelling at Cat | woman, cat | argument, blame, misunderstanding |
+| `one-does-not-simply` | One Does Not Simply | top, bottom | something that sounds easy but is actually hard |
+| `grus-plan` | Gru's Plan | step1, step2, step3, realization | a plan that backfires, unexpected consequence |
+| `batman-slapping-robin` | Batman Slapping Robin | robin, batman | shutting down a bad idea, correcting someone |
+
+## Notes
+
+- Use these when a template needs custom text placement.
+- The script's curated layout data should stay aligned with this list.
+- For template matching heuristics and Imgflip source notes, see `meme-generation.md`.

--- a/optional-skills/creative/meme-generation/references/examples.md
+++ b/optional-skills/creative/meme-generation/references/examples.md
@@ -1,0 +1,46 @@
+# Meme Generation Examples
+
+## Example 1: Debugging at 2 AM
+
+**Topic:** debugging production at 2 AM
+**Template:** this-is-fine
+
+```bash
+python generate_meme.py this-is-fine /tmp/meme.png "PRODUCTION IS DOWN" "This is fine"
+```
+
+## Example 2: Developer Priorities
+
+**Topic:** choosing between writing tests and shipping features
+**Template:** drake
+
+```bash
+python generate_meme.py drake /tmp/meme.png "Writing unit tests" "Shipping straight to prod"
+```
+
+## Example 3: Exam Stress
+
+**Topic:** final exam preparation
+**Template:** two-buttons
+
+```bash
+python generate_meme.py two-buttons /tmp/meme.png "Study everything" "Sleep" "Me at midnight"
+```
+
+## Example 4: Escalating Solutions
+
+**Topic:** fixing a CSS bug
+**Template:** expanding-brain
+
+```bash
+python generate_meme.py expanding-brain /tmp/meme.png "Reading the docs" "Stack Overflow" "!important on everything" "Deleting the stylesheet"
+```
+
+## Example 5: Hot Take
+
+**Topic:** tabs vs spaces
+**Template:** change-my-mind
+
+```bash
+python generate_meme.py change-my-mind /tmp/meme.png "Tabs are just thicc spaces"
+```

--- a/optional-skills/creative/meme-generation/references/meme-generation.md
+++ b/optional-skills/creative/meme-generation/references/meme-generation.md
@@ -1,0 +1,31 @@
+# Meme Generation Source Notes
+
+Imgflip is the canonical source for blank meme templates in this skill.
+
+## Search and download workflow
+
+1. Query the Imgflip template catalog.
+2. Pick the best name or ID match.
+3. Download the raw template image URL from Imgflip.
+4. Use the downloaded file as the source image for captioning.
+
+## Matching rules
+
+The helper script ranks matches in this order:
+- exact normalized name or ID
+- prefix match
+- substring match
+- token overlap
+
+## Common examples
+
+- Absolute Cinema
+  - Imgflip URL: https://i.imgflip.com/8d317n.png
+- Woman Yelling at Cat
+  - Imgflip URL: https://i.imgflip.com/345v97.jpg
+
+## Notes
+
+- The Imgflip API returns the template URL directly in the `url` field.
+- Use the downloaded blank template, not a screenshot or a captioned copy.
+- Keep the source image local before adding captions.

--- a/optional-skills/creative/meme-generation/references/scripts.md
+++ b/optional-skills/creative/meme-generation/references/scripts.md
@@ -1,0 +1,38 @@
+# Meme Generation Scripts
+
+## `scripts/imgflip_download.py`
+
+Use this script to discover and download blank Imgflip templates.
+
+Responsibilities:
+- search Imgflip templates by name or ID
+- rank close matches by normalized name, prefix, substring, and token overlap
+- download the raw blank template image to a local file
+
+Use this when the task starts from a meme source/template request and a local blank image is needed before captioning.
+
+## `scripts/meme_caption.py`
+
+Use this script to caption an already-downloaded local image.
+
+Responsibilities:
+- add meme-style captions to a local image
+- optionally trim near-white padding before rendering
+- optionally render the text in bars above and below the image
+
+Use this when the source image already exists locally, including an Imgflip download or any other blank template.
+
+## `scripts/generate_meme.py`
+
+Use this script as the main renderer and compatibility wrapper.
+
+Responsibilities:
+- resolve curated templates by ID or name
+- resolve Imgflip templates as blank sources
+- render captions directly onto a template image
+- caption custom local images through `--image`
+- list curated templates and search Imgflip templates
+
+Prefer `imgflip_download.py` when the workflow should explicitly fetch a blank source first.
+Prefer `meme_caption.py` when the workflow should explicitly caption a local image.
+Use `generate_meme.py` when a single entry point is enough or when compatibility with the older combined flow is desired.

--- a/optional-skills/creative/meme-generation/scripts/imgflip_download.py
+++ b/optional-skills/creative/meme-generation/scripts/imgflip_download.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Find and download blank meme templates from Imgflip.
+
+This script focuses on source lookup:
+- search popular Imgflip templates by name or ID
+- download the blank template image to a local path
+
+Usage:
+    python imgflip_download.py --search "absolute cinema"
+    python imgflip_download.py --download "absolute cinema" /tmp/template.png
+    python imgflip_download.py --download 505705955 /tmp/template.png
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from io import BytesIO
+from pathlib import Path
+
+try:
+    import requests as _requests
+except ImportError:  # pragma: no cover - requests is part of the base repo deps
+    _requests = None
+
+from PIL import Image
+
+SCRIPT_DIR = Path(__file__).parent
+IMGFLIP_API = "https://api.imgflip.com/get_memes"
+IMGFLIP_CACHE_FILE = SCRIPT_DIR / ".cache" / "imgflip_memes.json"
+IMGFLIP_CACHE_MAX_AGE = 86400
+
+
+def _fetch_url(url: str, timeout: int = 15) -> bytes:
+    if _requests is not None:
+        resp = _requests.get(url, timeout=timeout)
+        resp.raise_for_status()
+        return resp.content
+    import urllib.request
+
+    return urllib.request.urlopen(url, timeout=timeout).read()
+
+
+def _normalize(text: str) -> str:
+    return re.sub(r"[^a-z0-9]+", " ", text.lower()).strip()
+
+
+def fetch_imgflip_templates() -> list[dict]:
+    """Fetch popular meme templates from Imgflip, cached for 24h."""
+    import time
+
+    IMGFLIP_CACHE_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+    if IMGFLIP_CACHE_FILE.exists():
+        age = time.time() - IMGFLIP_CACHE_FILE.stat().st_mtime
+        if age < IMGFLIP_CACHE_MAX_AGE:
+            with IMGFLIP_CACHE_FILE.open("r", encoding="utf-8") as f:
+                return json.load(f)
+
+    try:
+        data = json.loads(_fetch_url(IMGFLIP_API))
+        memes = data.get("data", {}).get("memes", [])
+        with IMGFLIP_CACHE_FILE.open("w", encoding="utf-8") as f:
+            json.dump(memes, f)
+        return memes
+    except Exception as exc:  # pragma: no cover - network failure fallback
+        if IMGFLIP_CACHE_FILE.exists():
+            with IMGFLIP_CACHE_FILE.open("r", encoding="utf-8") as f:
+                return json.load(f)
+        print(f"Warning: could not fetch Imgflip templates: {exc}", file=sys.stderr)
+        return []
+
+
+def _score_template(query: str, meme: dict) -> tuple[int, int, str]:
+    """Return a ranking tuple where lower is better."""
+    normalized_query = _normalize(query)
+    normalized_name = _normalize(meme.get("name", ""))
+    meme_id = str(meme.get("id", ""))
+
+    if normalized_query == normalized_name or query.strip() == meme_id:
+        return (0, 0, normalized_name)
+    if normalized_name.startswith(normalized_query) or meme_id.startswith(query.strip()):
+        return (1, len(normalized_name), normalized_name)
+    if normalized_query in normalized_name:
+        return (2, len(normalized_name), normalized_name)
+
+    query_tokens = set(normalized_query.split())
+    name_tokens = set(normalized_name.split())
+    overlap = len(query_tokens & name_tokens)
+    return (10 - overlap, len(normalized_name), normalized_name)
+
+
+def search_templates(query: str, limit: int = 10) -> list[dict]:
+    """Search Imgflip templates by name or ID."""
+    memes = fetch_imgflip_templates()
+    ranked = sorted(memes, key=lambda meme: _score_template(query, meme))
+    normalized_query = _normalize(query)
+
+    matches: list[dict] = []
+    for meme in ranked:
+        if not normalized_query:
+            break
+        name = meme.get("name", "")
+        meme_id = str(meme.get("id", ""))
+        normalized_name = _normalize(name)
+        if (
+            normalized_query == normalized_name
+            or query.strip() == meme_id
+            or normalized_name.startswith(normalized_query)
+            or normalized_query in normalized_name
+            or len(set(normalized_query.split()) & set(normalized_name.split())) > 0
+        ):
+            matches.append(meme)
+            if len(matches) >= limit:
+                break
+    return matches
+
+
+def resolve_template(query: str) -> dict | None:
+    """Resolve one Imgflip template from a search query or numeric ID."""
+    matches = search_templates(query, limit=1)
+    if not matches:
+        return None
+    meme = matches[0]
+    return {
+        "id": meme.get("id"),
+        "name": meme.get("name"),
+        "url": meme.get("url"),
+        "box_count": meme.get("box_count", 2),
+        "source": "imgflip",
+    }
+
+
+def download_template(query: str, output_path: str | Path) -> str:
+    """Download the best matching blank template and save it locally."""
+    template = resolve_template(query)
+    if template is None:
+        raise SystemExit(f"No Imgflip templates found for: {query}")
+
+    data = _fetch_url(template["url"])
+    image = Image.open(BytesIO(data)).convert("RGBA")
+    output = Path(output_path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    if output.suffix.lower() in {".jpg", ".jpeg"}:
+        image = image.convert("RGB")
+    image.save(output)
+    return str(output)
+
+
+def _format_match(meme: dict) -> str:
+    return f"{meme.get('id')}\t{meme.get('box_count', 2)}\t{meme.get('name')}\t{meme.get('url')}"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Search and download blank Imgflip meme templates.")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--search", metavar="QUERY", help="Search Imgflip templates by name or ID")
+    group.add_argument(
+        "--download",
+        nargs=2,
+        metavar=("QUERY", "OUTPUT"),
+        help="Download the best matching template to OUTPUT",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+
+    if args.search:
+        matches = search_templates(args.search)
+        if not matches:
+            print(f"No Imgflip templates found for: {args.search}")
+            return 1
+        for meme in matches:
+            print(_format_match(meme))
+        return 0
+
+    query, output = args.download
+    result = download_template(query, output)
+    print(result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/optional-skills/creative/meme-generation/scripts/meme_caption.py
+++ b/optional-skills/creative/meme-generation/scripts/meme_caption.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Caption a local image with meme-style text.
+
+This script is intentionally narrow:
+- it takes an already-downloaded image
+- it adds captions
+- it can trim white padding before rendering the caption
+
+Usage:
+    python meme_caption.py input.png output.png "TOP TEXT" "BOTTOM TEXT"
+    python meme_caption.py --trim-padding input.png output.png "TOP TEXT" "BOTTOM TEXT"
+    python meme_caption.py --bars input.png output.png "TOP TEXT" "BOTTOM TEXT"
+"""
+
+from __future__ import annotations
+
+import argparse
+import tempfile
+from pathlib import Path
+
+from PIL import Image
+
+import generate_meme
+
+DEFAULT_PADDING_THRESHOLD = 248
+DEFAULT_PADDING_MARGIN = 8
+
+
+def _trim_padding(image: Image.Image, threshold: int = DEFAULT_PADDING_THRESHOLD, margin: int = DEFAULT_PADDING_MARGIN) -> Image.Image:
+    """Trim near-white padding from the image while keeping a small margin."""
+    rgba = image.convert("RGBA")
+    pixels = rgba.load()
+    width, height = rgba.size
+
+    left = width
+    top = height
+    right = -1
+    bottom = -1
+
+    for y in range(height):
+        for x in range(width):
+            r, g, b, a = pixels[x, y]
+            if a == 0:
+                continue
+            if r >= threshold and g >= threshold and b >= threshold:
+                continue
+            left = min(left, x)
+            top = min(top, y)
+            right = max(right, x)
+            bottom = max(bottom, y)
+
+    if right < left or bottom < top:
+        return rgba
+
+    left = max(0, left - margin)
+    top = max(0, top - margin)
+    right = min(width - 1, right + margin)
+    bottom = min(height - 1, bottom + margin)
+    return rgba.crop((left, top, right + 1, bottom + 1))
+
+
+def caption_image(
+    input_path: str | Path,
+    output_path: str | Path,
+    top_text: str,
+    bottom_text: str = "",
+    *,
+    trim_padding: bool = False,
+    bars: bool = False,
+) -> str:
+    """Caption a local image and save the result."""
+    image_path = Path(input_path)
+    output = Path(output_path)
+    texts = [text for text in [top_text, bottom_text] if text]
+
+    if trim_padding:
+        with Image.open(image_path) as original:
+            trimmed = _trim_padding(original)
+            with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
+                temp_path = Path(tmp.name)
+            try:
+                trimmed.save(temp_path)
+                return generate_meme.generate_from_image(str(temp_path), texts, str(output), use_bars=bars)
+            finally:
+                temp_path.unlink(missing_ok=True)
+
+    return generate_meme.generate_from_image(str(image_path), texts, str(output), use_bars=bars)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Caption a local image with meme-style text.")
+    parser.add_argument("--trim-padding", action="store_true", help="Trim white padding before captioning")
+    parser.add_argument("--bars", action="store_true", help="Render text in black bars above and below the image")
+    parser.add_argument("input", help="Path to the input image")
+    parser.add_argument("output", help="Path to the output image")
+    parser.add_argument("top_text", help="Top caption")
+    parser.add_argument("bottom_text", nargs="?", default="", help="Bottom caption")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    result = caption_image(
+        args.input,
+        args.output,
+        args.top_text,
+        args.bottom_text,
+        trim_padding=args.trim_padding,
+        bars=args.bars,
+    )
+    print(result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/skills/test_meme_generation_helpers.py
+++ b/tests/skills/test_meme_generation_helpers.py
@@ -1,0 +1,105 @@
+"""Tests for optional-skills/creative/meme-generation helper scripts."""
+
+import struct
+import sys
+import zlib
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "optional-skills" / "creative" / "meme-generation" / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import imgflip_download
+import meme_caption
+
+
+def _png_bytes(width: int, height: int, pixel_fn) -> bytes:
+    """Create a small RGBA PNG without external dependencies."""
+    raw = bytearray()
+    for y in range(height):
+        raw.append(0)
+        for x in range(width):
+            r, g, b, a = pixel_fn(x, y)
+            raw.extend([r, g, b, a])
+    compressed = zlib.compress(bytes(raw), level=9)
+
+    def chunk(kind: bytes, data: bytes) -> bytes:
+        return (
+            struct.pack(">I", len(data))
+            + kind
+            + data
+            + struct.pack(">I", zlib.crc32(kind + data) & 0xFFFFFFFF)
+        )
+
+    return (
+        b"\x89PNG\r\n\x1a\n"
+        + chunk(b"IHDR", struct.pack(">IIBBBBB", width, height, 8, 6, 0, 0, 0))
+        + chunk(b"IDAT", compressed)
+        + chunk(b"IEND", b"")
+    )
+
+
+def _png_size(path: Path) -> tuple[int, int]:
+    data = path.read_bytes()
+    return struct.unpack(">II", data[16:24])
+
+
+class TestImgflipDownload:
+    def test_resolve_template_matches_imgflip_name(self, monkeypatch):
+        monkeypatch.setattr(
+            imgflip_download,
+            "fetch_imgflip_templates",
+            lambda: [
+                {"id": "505705955", "name": "Absolute Cinema", "url": "https://i.imgflip.com/8d317n.png", "box_count": 1},
+                {"id": "345v97", "name": "Woman Yelling at Cat", "url": "https://i.imgflip.com/345v97.jpg", "box_count": 2},
+            ],
+        )
+
+        template = imgflip_download.resolve_template("absolute cinema")
+        assert template["name"] == "Absolute Cinema"
+        assert template["url"] == "https://i.imgflip.com/8d317n.png"
+        assert template["source"] == "imgflip"
+
+    def test_download_template_writes_image_file(self, tmp_path, monkeypatch):
+        payload = _png_bytes(64, 64, lambda x, y: (0, 0, 255, 255))
+
+        monkeypatch.setattr(
+            imgflip_download,
+            "fetch_imgflip_templates",
+            lambda: [{"id": "abc", "name": "Test Meme", "url": "https://example.com/test.png", "box_count": 2}],
+        )
+        monkeypatch.setattr(imgflip_download, "_fetch_url", lambda url, timeout=15: payload)
+
+        out = tmp_path / "template.png"
+        result = imgflip_download.download_template("test meme", out)
+
+        assert Path(result) == out
+        assert out.exists()
+        assert _png_size(out) == (64, 64)
+
+
+class TestMemeCaption:
+    def test_caption_image_with_trim_padding(self, tmp_path, monkeypatch):
+        source = tmp_path / "source.png"
+        output = tmp_path / "captioned.png"
+
+        payload = _png_bytes(
+            400,
+            240,
+            lambda x, y: (255, 255, 255, 255) if not (70 <= x < 330 and 70 <= y < 170) else (240, 60, 60, 255),
+        )
+        source.write_bytes(payload)
+
+        monkeypatch.setattr(meme_caption.generate_meme, "find_font", lambda size: meme_caption.generate_meme.ImageFont.load_default())
+
+        result = meme_caption.caption_image(
+            source,
+            output,
+            top_text="TOP TEXT",
+            bottom_text="BOTTOM TEXT",
+            trim_padding=True,
+        )
+
+        assert Path(result) == output
+        assert output.exists()
+        assert _png_size(output)[0] < 400
+        assert _png_size(output)[1] <= 240


### PR DESCRIPTION
Summary
- Split meme template lookup into a dedicated Imgflip downloader script.
- Added a separate captioning script for local images, including optional trim-padding support.
- Updated the meme-generation skill docs to point at the new helpers and source notes.
- Added tests for the helper scripts.

Tested
- python -m pytest tests/skills/test_meme_generation_helpers.py -q
- python -m pytest tests/ -q (baseline suite still has unrelated environment/dependency failures)
