### PR TITLE
feat(feishu): support custom domain and encrypted webhook payloads

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -56,6 +56,7 @@ except ImportError:
 
 try:
     import lark_oapi as lark
+    from lark_oapi import AESCipher
     from lark_oapi.api.application.v6 import GetApplicationRequest
     from lark_oapi.api.im.v1 import (
         CreateFileRequest,
@@ -1184,7 +1185,7 @@ class FeishuAdapter(BasePlatformAdapter):
         return FeishuAdapterSettings(
             app_id=str(extra.get("app_id") or os.getenv("FEISHU_APP_ID", "")).strip(),
             app_secret=str(extra.get("app_secret") or os.getenv("FEISHU_APP_SECRET", "")).strip(),
-            domain_name=str(extra.get("domain") or os.getenv("FEISHU_DOMAIN", "feishu")).strip().lower(),
+            domain_name=str(extra.get("domain") or os.getenv("FEISHU_DOMAIN", "feishu")).strip(),
             connection_mode=str(
                 extra.get("connection_mode") or os.getenv("FEISHU_CONNECTION_MODE", "websocket")
             ).strip().lower(),
@@ -2714,6 +2715,23 @@ class FeishuAdapter(BasePlatformAdapter):
             self._record_webhook_anomaly(remote_ip, "400")
             return web.json_response({"code": 400, "msg": "invalid json"}, status=400)
 
+        # Decrypt encrypted payload if needed (before any other checks)
+        if payload.get("encrypt"):
+            if not self._encrypt_key:
+                logger.error("[Feishu] Received encrypted payload but FEISHU_ENCRYPT_KEY not set")
+                self._record_webhook_anomaly(remote_ip, "400-encrypted-no-key")
+                return web.json_response({"code": 400, "msg": "encrypt key not configured"}, status=400)
+
+            try:
+                cipher = AESCipher(self._encrypt_key)
+                decrypted_str = cipher.decrypt_str(payload["encrypt"])
+                payload = json.loads(decrypted_str)
+                logger.debug("[Feishu] Successfully decrypted webhook payload")
+            except Exception as e:
+                logger.error("[Feishu] Failed to decrypt webhook payload: %s", e)
+                self._record_webhook_anomaly(remote_ip, "400-decrypt-failed")
+                return web.json_response({"code": 400, "msg": "decryption failed"}, status=400)
+
         # URL verification challenge — respond before other checks so that Feishu's
         # subscription setup works even before encrypt_key is wired.
         if payload.get("type") == "url_verification":
@@ -2727,17 +2745,6 @@ class FeishuAdapter(BasePlatformAdapter):
                 logger.warning("[Feishu] Webhook rejected: invalid verification token from %s", remote_ip)
                 self._record_webhook_anomaly(remote_ip, "401-token")
                 return web.Response(status=401, text="Invalid verification token")
-
-        # Timing-safe signature verification (only enforced when encrypt_key is set).
-        if self._encrypt_key and not self._is_webhook_signature_valid(request.headers, body_bytes):
-            logger.warning("[Feishu] Webhook rejected: invalid signature from %s", remote_ip)
-            self._record_webhook_anomaly(remote_ip, "401-sig")
-            return web.Response(status=401, text="Invalid signature")
-
-        if payload.get("encrypt"):
-            logger.error("[Feishu] Encrypted webhook payloads are not supported by Hermes webhook mode")
-            self._record_webhook_anomaly(remote_ip, "400-encrypted")
-            return web.json_response({"code": 400, "msg": "encrypted webhook payloads are not supported"}, status=400)
 
         self._clear_webhook_anomaly(remote_ip)
 
@@ -3728,10 +3735,15 @@ class FeishuAdapter(BasePlatformAdapter):
                 )
                 await asyncio.sleep(wait_seconds)
 
+    def _resolve_domain(self) -> Any:
+        if self._domain_name.startswith("http"):
+            return self._domain_name
+        return LARK_DOMAIN if self._domain_name == "lark" else FEISHU_DOMAIN
+
     async def _connect_websocket(self) -> None:
         if not FEISHU_WEBSOCKET_AVAILABLE:
             raise RuntimeError("websockets not installed; websocket mode unavailable")
-        domain = FEISHU_DOMAIN if self._domain_name != "lark" else LARK_DOMAIN
+        domain = self._resolve_domain()
         self._client = self._build_lark_client(domain)
         self._event_handler = self._build_event_handler()
         if self._event_handler is None:
@@ -3757,7 +3769,7 @@ class FeishuAdapter(BasePlatformAdapter):
     async def _connect_webhook(self) -> None:
         if not FEISHU_WEBHOOK_AVAILABLE:
             raise RuntimeError("aiohttp not installed; webhook mode unavailable")
-        domain = FEISHU_DOMAIN if self._domain_name != "lark" else LARK_DOMAIN
+        domain = self._resolve_domain()
         self._client = self._build_lark_client(domain)
         self._event_handler = self._build_event_handler()
         if self._event_handler is None:

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -4893,9 +4893,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 await asyncio.sleep(wait_seconds)
 
     def _resolve_domain(self) -> Any:
-        if self._domain_name.startswith("http"):
-            return self._domain_name
-        return LARK_DOMAIN if self._domain_name == "lark" else FEISHU_DOMAIN
+        return _resolve_feishu_domain(self._domain_name)
 
     async def _connect_websocket(self) -> None:
         if not FEISHU_WEBSOCKET_AVAILABLE:
@@ -5234,11 +5232,29 @@ class FeishuAdapter(BasePlatformAdapter):
 
 
 def _accounts_base_url(domain: str) -> str:
+    if domain.startswith("http"):
+        # Custom deployments host accounts/oauth on the same origin.
+        return domain.rstrip("/")
     return _ONBOARD_ACCOUNTS_URLS.get(domain, _ONBOARD_ACCOUNTS_URLS["feishu"])
 
 
 def _onboard_open_base_url(domain: str) -> str:
+    if domain.startswith("http"):
+        return domain.rstrip("/")
     return _ONBOARD_OPEN_URLS.get(domain, _ONBOARD_OPEN_URLS["feishu"])
+
+
+def _resolve_feishu_domain(domain_name: str) -> Any:
+    """Map a configured domain name to the SDK domain value.
+
+    ``domain_name`` may be:
+      - ``"feishu"`` (default) → SDK ``FEISHU_DOMAIN``
+      - ``"lark"``              → SDK ``LARK_DOMAIN``
+      - any ``http(s)://...``   → returned verbatim, for private deployments
+    """
+    if domain_name.startswith("http"):
+        return domain_name
+    return LARK_DOMAIN if domain_name == "lark" else FEISHU_DOMAIN
 
 
 def _post_registration(base_url: str, body: Dict[str, str]) -> dict:
@@ -5411,8 +5427,12 @@ def probe_bot(app_id: str, app_secret: str, domain: str) -> Optional[dict]:
 
 
 def _build_onboard_client(app_id: str, app_secret: str, domain: str) -> Any:
-    """Build a lark Client for the given credentials and domain."""
-    sdk_domain = LARK_DOMAIN if domain == "lark" else FEISHU_DOMAIN
+    """Build a lark Client for the given credentials and domain.
+
+    ``domain`` accepts ``"feishu"``, ``"lark"``, or a full ``http(s)://`` URL
+    pointing at a private Feishu deployment.
+    """
+    sdk_domain = _resolve_feishu_domain(domain)
     return (
         lark.Client.builder()
         .app_id(app_id)
@@ -5599,9 +5619,9 @@ async def _standalone_send(
     media_files = media_files or []
     try:
         adapter = FeishuAdapter(pconfig)
-        domain_name = getattr(adapter, "_domain_name", "feishu")
-        domain = FEISHU_DOMAIN if domain_name != "lark" else LARK_DOMAIN
-        adapter._client = adapter._build_lark_client(domain)
+        # Resolve the SDK domain through the adapter so private deployments
+        # (FEISHU_DOMAIN set to a full URL) route to the correct host.
+        adapter._client = adapter._build_lark_client(adapter._resolve_domain())
         metadata = {"thread_id": thread_id} if thread_id else None
 
         last_result = None
@@ -5701,8 +5721,28 @@ def interactive_setup() -> None:
         if not app_secret:
             print_warning("Skipped — Feishu / Lark won't work without an App Secret.")
             return
-        domain_idx = prompt_choice("Domain", ["feishu (China)", "lark (International)"], 0)
-        domain = "lark" if domain_idx == 1 else "feishu"
+        domain_choices = [
+            "feishu (China)",
+            "lark (International)",
+            "Custom (private deployment URL)",
+        ]
+        domain_idx = prompt_choice("Domain", domain_choices, 0)
+        if domain_idx == 1:
+            domain = "lark"
+        elif domain_idx == 2:
+            while True:
+                custom = prompt(
+                    "Private Feishu base URL (e.g. https://open.example.com)",
+                    password=False,
+                ).strip().rstrip("/")
+                if custom.startswith(("http://", "https://")):
+                    domain = custom
+                    break
+                print_warning(
+                    "Enter a full URL starting with http:// or https://"
+                )
+        else:
+            domain = "feishu"
 
         bot_name = None
         try:

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -87,6 +87,7 @@ except ImportError:
 
 try:
     import lark_oapi as lark
+    from lark_oapi import AESCipher
     from lark_oapi.api.application.v6 import GetApplicationRequest
     from lark_oapi.api.im.v1 import (
         CreateFileRequest,
@@ -1554,7 +1555,7 @@ class FeishuAdapter(BasePlatformAdapter):
         return FeishuAdapterSettings(
             app_id=str(extra.get("app_id") or os.getenv("FEISHU_APP_ID", "")).strip(),
             app_secret=str(extra.get("app_secret") or os.getenv("FEISHU_APP_SECRET", "")).strip(),
-            domain_name=str(extra.get("domain") or os.getenv("FEISHU_DOMAIN", "feishu")).strip().lower(),
+            domain_name=str(extra.get("domain") or os.getenv("FEISHU_DOMAIN", "feishu")).strip(),
             connection_mode=str(
                 extra.get("connection_mode") or os.getenv("FEISHU_CONNECTION_MODE", "websocket")
             ).strip().lower(),
@@ -3557,6 +3558,35 @@ class FeishuAdapter(BasePlatformAdapter):
             self._record_webhook_anomaly(remote_ip, "400")
             return web.json_response({"code": 400, "msg": "invalid json"}, status=400)
 
+        # Timing-safe signature verification (only enforced when encrypt_key is set,
+        # performed on the raw body before any decryption).
+        if self._encrypt_key and not self._is_webhook_signature_valid(request.headers, body_bytes):
+            logger.warning("[Feishu] Webhook rejected: invalid signature from %s", remote_ip)
+            self._record_webhook_anomaly(remote_ip, "401-sig")
+            return web.Response(status=401, text="Invalid signature")
+
+        # Decrypt encrypted payload if needed (before token/challenge checks).
+        if payload.get("encrypt"):
+            if not self._encrypt_key:
+                logger.error("[Feishu] Received encrypted payload but FEISHU_ENCRYPT_KEY not set")
+                self._record_webhook_anomaly(remote_ip, "400-encrypted-no-key")
+                return web.json_response({"code": 400, "msg": "encrypt key not configured"}, status=400)
+
+            try:
+                cipher = AESCipher(self._encrypt_key)
+                decrypted_str = cipher.decrypt_str(payload["encrypt"])
+                payload = json.loads(decrypted_str)
+                logger.debug("[Feishu] Successfully decrypted webhook payload")
+            except Exception as e:
+                logger.error("[Feishu] Failed to decrypt webhook payload: %s", e)
+                self._record_webhook_anomaly(remote_ip, "400-decrypt-failed")
+                return web.json_response({"code": 400, "msg": "decryption failed"}, status=400)
+
+        # URL verification challenge — Feishu includes the verification token in
+        # challenge requests. Validate the token (below) before reflecting the
+        # challenge so an unauthenticated remote request cannot prove endpoint
+        # control by getting attacker-supplied challenge data echoed back.
+
         # Verification token check — second layer of defence beyond signature (matches openclaw).
         if self._verification_token:
             header = payload.get("header") or {}
@@ -3570,24 +3600,8 @@ class FeishuAdapter(BasePlatformAdapter):
                 self._record_webhook_anomaly(remote_ip, "401-token")
                 return web.Response(status=401, text="Invalid verification token")
 
-        # URL verification challenge — Feishu includes the verification token in
-        # challenge requests. Validate the token (above) before reflecting the
-        # challenge so an unauthenticated remote request cannot prove endpoint
-        # control by getting attacker-supplied challenge data echoed back.
         if payload.get("type") == "url_verification":
             return web.json_response({"challenge": payload.get("challenge", "")})
-
-        # Timing-safe signature verification (only enforced when encrypt_key is set).
-        if self._encrypt_key and not self._is_webhook_signature_valid(request.headers, body_bytes):
-            logger.warning("[Feishu] Webhook rejected: invalid signature from %s", remote_ip)
-            self._record_webhook_anomaly(remote_ip, "401-sig")
-            return web.Response(status=401, text="Invalid signature")
-
-        if payload.get("encrypt"):
-            logger.error("[Feishu] Encrypted webhook payloads are not supported by Hermes webhook mode")
-            self._record_webhook_anomaly(remote_ip, "400-encrypted")
-            return web.json_response({"code": 400, "msg": "encrypted webhook payloads are not supported"}, status=400)
-
         self._clear_webhook_anomaly(remote_ip)
 
         event_type = str((payload.get("header") or {}).get("event_type") or "")
@@ -4878,10 +4892,15 @@ class FeishuAdapter(BasePlatformAdapter):
                 )
                 await asyncio.sleep(wait_seconds)
 
+    def _resolve_domain(self) -> Any:
+        if self._domain_name.startswith("http"):
+            return self._domain_name
+        return LARK_DOMAIN if self._domain_name == "lark" else FEISHU_DOMAIN
+
     async def _connect_websocket(self) -> None:
         if not FEISHU_WEBSOCKET_AVAILABLE:
             raise RuntimeError("websockets not installed; websocket mode unavailable")
-        domain = FEISHU_DOMAIN if self._domain_name != "lark" else LARK_DOMAIN
+        domain = self._resolve_domain()
         self._client = self._build_lark_client(domain)
         self._event_handler = self._build_event_handler()
         if self._event_handler is None:
@@ -4913,7 +4932,7 @@ class FeishuAdapter(BasePlatformAdapter):
     async def _connect_webhook(self) -> None:
         if not FEISHU_WEBHOOK_AVAILABLE:
             raise RuntimeError("aiohttp not installed; webhook mode unavailable")
-        domain = FEISHU_DOMAIN if self._domain_name != "lark" else LARK_DOMAIN
+        domain = self._resolve_domain()
         self._client = self._build_lark_client(domain)
         self._event_handler = self._build_event_handler()
         if self._event_handler is None:

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -118,6 +118,7 @@ try:
     FEISHU_AVAILABLE = True
 except ImportError:
     FEISHU_AVAILABLE = False
+    AESCipher = None  # type: ignore[assignment]
     lark = None  # type: ignore[assignment]
     CallBackCard = None  # type: ignore[assignment]
     P2CardActionTriggerResponse = None  # type: ignore[assignment]
@@ -1396,6 +1397,7 @@ def check_feishu_requirements() -> bool:
         from lark_oapi.core import AccessTokenType, HttpMethod
         from lark_oapi.core.const import FEISHU_DOMAIN, LARK_DOMAIN
         from lark_oapi.core.model import BaseRequest
+        from lark_oapi import AESCipher
         from lark_oapi.event.callback.model.p2_card_action_trigger import (
             CallBackCard, P2CardActionTriggerResponse,
         )
@@ -1423,6 +1425,7 @@ def check_feishu_requirements() -> bool:
             "FEISHU_DOMAIN": FEISHU_DOMAIN,
             "LARK_DOMAIN": LARK_DOMAIN,
             "BaseRequest": BaseRequest,
+            "AESCipher": AESCipher,
             "CallBackCard": CallBackCard,
             "P2CardActionTriggerResponse": P2CardActionTriggerResponse,
             "EventDispatcherHandler": EventDispatcherHandler,
@@ -3558,19 +3561,39 @@ class FeishuAdapter(BasePlatformAdapter):
             self._record_webhook_anomaly(remote_ip, "400")
             return web.json_response({"code": 400, "msg": "invalid json"}, status=400)
 
-        # Timing-safe signature verification (only enforced when encrypt_key is set,
-        # performed on the raw body before any decryption).
-        if self._encrypt_key and not self._is_webhook_signature_valid(request.headers, body_bytes):
-            logger.warning("[Feishu] Webhook rejected: invalid signature from %s", remote_ip)
-            self._record_webhook_anomaly(remote_ip, "401-sig")
-            return web.Response(status=401, text="Invalid signature")
+        signature_verified = False
+        unsigned_encrypted_payload = False
 
-        # Decrypt encrypted payload if needed (before token/challenge checks).
+        # Normal encrypted events authenticate the raw envelope before decryption.
+        # Feishu URL-verification envelopes are the documented exception: they may
+        # arrive without signature headers and can only be identified after decrypting.
         if payload.get("encrypt"):
             if not self._encrypt_key:
                 logger.error("[Feishu] Received encrypted payload but FEISHU_ENCRYPT_KEY not set")
                 self._record_webhook_anomaly(remote_ip, "400-encrypted-no-key")
                 return web.json_response({"code": 400, "msg": "encrypt key not configured"}, status=400)
+
+            signature_headers_present = any(
+                str(headers.get(name, "") or "")
+                for name in (
+                    "x-lark-request-timestamp",
+                    "x-lark-request-nonce",
+                    "x-lark-signature",
+                )
+            )
+            if signature_headers_present:
+                if not self._is_webhook_signature_valid(headers, body_bytes):
+                    logger.warning("[Feishu] Webhook rejected: invalid signature from %s", remote_ip)
+                    self._record_webhook_anomaly(remote_ip, "401-sig")
+                    return web.Response(status=401, text="Invalid signature")
+                signature_verified = True
+            else:
+                unsigned_encrypted_payload = True
+
+            if AESCipher is None:
+                logger.error("[Feishu] Cannot decrypt webhook payload: lark_oapi is not installed")
+                self._record_webhook_anomaly(remote_ip, "500-no-lark-oapi")
+                return web.json_response({"code": 500, "msg": "missing Feishu dependency"}, status=500)
 
             try:
                 cipher = AESCipher(self._encrypt_key)
@@ -3600,8 +3623,33 @@ class FeishuAdapter(BasePlatformAdapter):
                 self._record_webhook_anomaly(remote_ip, "401-token")
                 return web.Response(status=401, text="Invalid verification token")
 
-        if payload.get("type") == "url_verification":
-            return web.json_response({"challenge": payload.get("challenge", "")})
+        is_v1_url_verification = payload.get("type") == "url_verification"
+        is_v2_url_verification = (
+            str((payload.get("header") or {}).get("event_type") or "")
+            == "url_verification"
+        )
+        if is_v1_url_verification or is_v2_url_verification:
+            challenge = (
+                payload.get("challenge", "")
+                if is_v1_url_verification
+                else (payload.get("event") or {}).get("challenge", "")
+            )
+            return web.json_response({"challenge": challenge})
+
+        if unsigned_encrypted_payload:
+            logger.warning("[Feishu] Webhook rejected: missing signature from %s", remote_ip)
+            self._record_webhook_anomaly(remote_ip, "401-sig")
+            return web.Response(status=401, text="Invalid signature")
+
+        if (
+            self._encrypt_key
+            and not signature_verified
+            and not self._is_webhook_signature_valid(headers, body_bytes)
+        ):
+            logger.warning("[Feishu] Webhook rejected: invalid signature from %s", remote_ip)
+            self._record_webhook_anomaly(remote_ip, "401-sig")
+            return web.Response(status=401, text="Invalid signature")
+
         self._clear_webhook_anomaly(remote_ip)
 
         event_type = str((payload.get("header") or {}).get("event_type") or "")

--- a/plugins/platforms/feishu/plugin.yaml
+++ b/plugins/platforms/feishu/plugin.yaml
@@ -23,8 +23,8 @@ requires_env:
     password: true
 optional_env:
   - name: FEISHU_DOMAIN
-    description: "Domain: 'feishu' (China) or 'lark' (International)"
-    prompt: "Domain (feishu/lark)"
+    description: "Domain: 'feishu' (China), 'lark' (International), or a full private deployment URL"
+    prompt: "Domain (feishu/lark/https://...)"
     password: false
   - name: FEISHU_ALLOWED_USERS
     description: "Comma-separated Feishu user IDs allowed to talk to the bot"

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1533,6 +1533,16 @@ class TestWebhookSecurity(unittest.TestCase):
         }, clear=True):
             return FeishuAdapter(PlatformConfig())
 
+    @staticmethod
+    def _send_webhook(adapter, body: bytes, headers=None):
+        request = SimpleNamespace(
+            remote="127.0.0.1",
+            content_length=len(body),
+            headers=headers or {"Content-Type": "application/json"},
+            content=_FakeRequestContent(body),
+        )
+        return asyncio.run(adapter._handle_webhook_request(request))
+
     def test_signature_valid_passes(self):
         import hashlib
 
@@ -1621,6 +1631,113 @@ class TestWebhookSecurity(unittest.TestCase):
 
         self.assertEqual(response.status, 400)
         self.assertIn(b"decryption failed", response.body)
+
+    def test_bad_signature_is_rejected_before_decryption(self):
+        adapter = self._make_adapter("test_secret")
+        body = json.dumps({"encrypt": "ciphertext"}).encode()
+        headers = {
+            "x-lark-request-timestamp": "1700000000",
+            "x-lark-request-nonce": "bad-signature",
+            "x-lark-signature": "invalid",
+        }
+
+        with patch("plugins.platforms.feishu.adapter.AESCipher") as cipher:
+            response = self._send_webhook(adapter, body, headers)
+
+        self.assertEqual(response.status, 401)
+        cipher.assert_not_called()
+
+    def test_unsigned_encrypted_v1_url_verification_is_decrypted(self):
+        adapter = self._make_adapter("test_secret")
+        body = json.dumps({"encrypt": "ciphertext"}).encode()
+        cipher = Mock()
+        cipher.decrypt_str.return_value = json.dumps({
+            "type": "url_verification",
+            "challenge": "schema_v1_challenge",
+        })
+
+        with patch("plugins.platforms.feishu.adapter.AESCipher", return_value=cipher):
+            response = self._send_webhook(adapter, body)
+
+        self.assertEqual(response.status, 200)
+        self.assertIn(b"schema_v1_challenge", response.body)
+
+    def test_unsigned_encrypted_v2_url_verification_is_decrypted(self):
+        adapter = self._make_adapter("test_secret")
+        body = json.dumps({"encrypt": "ciphertext"}).encode()
+        cipher = Mock()
+        cipher.decrypt_str.return_value = json.dumps({
+            "schema": "2.0",
+            "header": {"event_type": "url_verification"},
+            "event": {"challenge": "encrypted_schema_v2_challenge"},
+        })
+
+        with patch("plugins.platforms.feishu.adapter.AESCipher", return_value=cipher):
+            response = self._send_webhook(adapter, body)
+
+        self.assertEqual(response.status, 200)
+        self.assertIn(b"encrypted_schema_v2_challenge", response.body)
+
+    def test_unsigned_encrypted_normal_event_is_rejected(self):
+        adapter = self._make_adapter("test_secret")
+        body = json.dumps({"encrypt": "ciphertext"}).encode()
+        cipher = Mock()
+        cipher.decrypt_str.return_value = json.dumps({
+            "header": {"event_type": "im.message.receive_v1"},
+            "event": {},
+        })
+
+        with patch(
+            "plugins.platforms.feishu.adapter.AESCipher", return_value=cipher
+        ), patch.object(adapter, "_on_message_event") as dispatch:
+            response = self._send_webhook(adapter, body)
+
+        self.assertEqual(response.status, 401)
+        dispatch.assert_not_called()
+
+    def test_unsigned_unencrypted_normal_event_is_rejected_when_key_is_set(self):
+        adapter = self._make_adapter("test_secret")
+        body = json.dumps({
+            "header": {"event_type": "im.message.receive_v1"},
+            "event": {},
+        }).encode()
+
+        with patch.object(adapter, "_on_message_event") as dispatch:
+            response = self._send_webhook(adapter, body)
+
+        self.assertEqual(response.status, 401)
+        dispatch.assert_not_called()
+
+    def test_schema_v2_url_verification_returns_nested_challenge(self):
+        adapter = self._make_adapter()
+        body = json.dumps({
+            "schema": "2.0",
+            "header": {"event_type": "url_verification"},
+            "event": {"challenge": "schema_v2_challenge"},
+        }).encode()
+
+        response = self._send_webhook(adapter, body)
+
+        self.assertEqual(response.status, 200)
+        self.assertIn(b"schema_v2_challenge", response.body)
+
+    def test_lazy_requirement_check_rebinds_aes_cipher(self):
+        import plugins.platforms.feishu.adapter as feishu
+
+        rebound = {}
+
+        def fake_ensure_and_bind(_feature, importer, target, **_kwargs):
+            bindings = importer()
+            rebound.update(bindings)
+            target.update(bindings)
+            return True
+
+        with patch.object(feishu, "FEISHU_AVAILABLE", False), patch.object(
+            feishu, "AESCipher", None
+        ), patch("tools.lazy_deps.ensure_and_bind", side_effect=fake_ensure_and_bind):
+            self.assertTrue(feishu.check_feishu_requirements())
+
+        self.assertIs(rebound["AESCipher"], feishu.AESCipher)
 
 
     def test_rate_limit_resets_after_window_expires(self):

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1517,11 +1517,20 @@ class TestPendingInboundQueue(unittest.TestCase):
 class TestWebhookSecurity(unittest.TestCase):
     """Tests for webhook signature verification, rate limiting, and body size limits."""
 
+    def setUp(self):
+        self._hermes_home = tempfile.TemporaryDirectory()
+        self.addCleanup(self._hermes_home.cleanup)
+
     def _make_adapter(self, encrypt_key: str = "") -> "FeishuAdapter":
         from gateway.config import PlatformConfig
         from plugins.platforms.feishu.adapter import FeishuAdapter
 
-        with patch.dict(os.environ, {"FEISHU_APP_ID": "cli", "FEISHU_APP_SECRET": "sec", "FEISHU_ENCRYPT_KEY": encrypt_key}, clear=True):
+        with patch.dict(os.environ, {
+            "HERMES_HOME": self._hermes_home.name,
+            "FEISHU_APP_ID": "cli",
+            "FEISHU_APP_SECRET": "sec",
+            "FEISHU_ENCRYPT_KEY": encrypt_key,
+        }, clear=True):
             return FeishuAdapter(PlatformConfig())
 
     def test_signature_valid_passes(self):
@@ -1536,6 +1545,82 @@ class TestWebhookSecurity(unittest.TestCase):
         sig = hashlib.sha256(content.encode("utf-8")).hexdigest()
         headers = {"x-lark-request-timestamp": timestamp, "x-lark-request-nonce": nonce, "x-lark-signature": sig}
         self.assertTrue(adapter._is_webhook_signature_valid(headers, body))
+
+    def test_signed_encrypted_webhook_is_decrypted_and_dispatched(self):
+        import hashlib
+
+        adapter = self._make_adapter("test_secret")
+        encrypted = (
+            "AAECAwQFBgcICQoLDA0OD0+Gb/yr067+r5mghNBcHHlX3lVwaTGGWW6oYloTartRjkvPVXeY/"
+            "p2DFkUzR4uOv8JAv2gzln5OaPZzEdik+iz4w4zj+YeGptP3dByWbkcu5dc+2pojAriILtOYe"
+            "GKkU4xmY17oHPwwEsmWDsa7f9mQC/gPy5rJglr6dKQPK6D7"
+        )
+        body = json.dumps({"encrypt": encrypted}, separators=(",", ":")).encode()
+        timestamp = "1700000000"
+        nonce = "encrypted-event"
+        signature = hashlib.sha256(
+            timestamp.encode() + nonce.encode() + b"test_secret" + body
+        ).hexdigest()
+        request = SimpleNamespace(
+            remote="127.0.0.1",
+            content_length=None,
+            headers={
+                "x-lark-request-timestamp": timestamp,
+                "x-lark-request-nonce": nonce,
+                "x-lark-signature": signature,
+            },
+            content=_FakeRequestContent(body),
+        )
+
+        with patch.object(adapter, "_on_message_event") as dispatch:
+            response = asyncio.run(adapter._handle_webhook_request(request))
+
+        self.assertEqual(response.status, 200)
+        dispatch.assert_called_once()
+        event = dispatch.call_args.args[0]
+        self.assertEqual(event.header.event_type, "im.message.receive_v1")
+        self.assertEqual(event.event.message.message_id, "om_encrypted")
+
+    def test_encrypted_webhook_without_key_is_rejected(self):
+        adapter = self._make_adapter()
+        body = json.dumps({"encrypt": "not-used-without-a-key"}).encode()
+        request = SimpleNamespace(
+            remote="127.0.0.1",
+            content_length=None,
+            headers={},
+            content=_FakeRequestContent(body),
+        )
+
+        response = asyncio.run(adapter._handle_webhook_request(request))
+
+        self.assertEqual(response.status, 400)
+        self.assertIn(b"encrypt key not configured", response.body)
+
+    def test_signed_webhook_with_bad_ciphertext_is_rejected(self):
+        import hashlib
+
+        adapter = self._make_adapter("test_secret")
+        body = json.dumps({"encrypt": "not-valid-ciphertext"}, separators=(",", ":")).encode()
+        timestamp = "1700000000"
+        nonce = "bad-ciphertext"
+        signature = hashlib.sha256(
+            timestamp.encode() + nonce.encode() + b"test_secret" + body
+        ).hexdigest()
+        request = SimpleNamespace(
+            remote="127.0.0.1",
+            content_length=None,
+            headers={
+                "x-lark-request-timestamp": timestamp,
+                "x-lark-request-nonce": nonce,
+                "x-lark-signature": signature,
+            },
+            content=_FakeRequestContent(body),
+        )
+
+        response = asyncio.run(adapter._handle_webhook_request(request))
+
+        self.assertEqual(response.status, 400)
+        self.assertIn(b"decryption failed", response.body)
 
 
     def test_rate_limit_resets_after_window_expires(self):

--- a/tests/gateway/test_feishu_onboard.py
+++ b/tests/gateway/test_feishu_onboard.py
@@ -162,6 +162,44 @@ class TestProbeBot:
         assert result["bot_name"] == "TestBot"
         assert result["bot_open_id"] == "ou_bot123"
 
+    @patch("plugins.platforms.feishu.adapter.FEISHU_AVAILABLE", False)
+    @patch("plugins.platforms.feishu.adapter.urlopen")
+    def test_http_fallback_uses_custom_domain_url(self, mock_urlopen_fn):
+        """When ``domain`` is a full https:// URL, the HTTP probe targets that host."""
+        from plugins.platforms.feishu.adapter import probe_bot
+
+        token_resp = _mock_urlopen({"code": 0, "tenant_access_token": "t-123"})
+        bot_resp = _mock_urlopen({"code": 0, "bot": {"bot_name": "PrivateBot", "open_id": "ou_priv"}})
+        mock_urlopen_fn.side_effect = [token_resp, bot_resp]
+
+        result = probe_bot("cli_app", "secret", "https://open.example.com")
+        assert result is not None
+        assert result["bot_name"] == "PrivateBot"
+
+        # Both calls must hit open.example.com, not open.feishu.cn
+        called_urls = [call.args[0].full_url for call in mock_urlopen_fn.call_args_list]
+        assert all(u.startswith("https://open.example.com/") for u in called_urls), called_urls
+
+
+class TestResolveFeishuDomain:
+    """Tests for the shared domain resolver used by both runtime and onboarding."""
+
+    def test_returns_url_verbatim(self):
+        from plugins.platforms.feishu.adapter import _resolve_feishu_domain
+        assert _resolve_feishu_domain("https://open.xfchat.iflytek.com") == "https://open.xfchat.iflytek.com"
+
+    def test_http_url_passes_through(self):
+        from plugins.platforms.feishu.adapter import _resolve_feishu_domain
+        assert _resolve_feishu_domain("http://internal.example.com") == "http://internal.example.com"
+
+    def test_onboard_open_base_url_strips_trailing_slash(self):
+        from plugins.platforms.feishu.adapter import _onboard_open_base_url
+        assert _onboard_open_base_url("https://open.example.com/") == "https://open.example.com"
+
+    def test_onboard_open_base_url_named_domains(self):
+        from plugins.platforms.feishu.adapter import _onboard_open_base_url
+        assert _onboard_open_base_url("feishu") == "https://open.feishu.cn"
+        assert _onboard_open_base_url("lark") == "https://open.larksuite.com"
 
 class TestQrRegister:
     """Tests for the public qr_register entry point."""

--- a/tests/gateway/test_setup_feishu.py
+++ b/tests/gateway/test_setup_feishu.py
@@ -114,6 +114,51 @@ class TestSetupFeishuConnectionMode:
         )
         assert env["FEISHU_CONNECTION_MODE"] == "websocket"
 
+    @patch("plugins.platforms.feishu.adapter.probe_bot", return_value=None)
+    def test_manual_path_custom_domain(self, _mock_probe):
+        """Selecting the custom-domain option saves the typed URL into FEISHU_DOMAIN."""
+        env, _ = _run_setup_feishu(
+            qr_result=None,
+            prompt_choice_responses=[1, 2, 0, 0, 0],  # method=manual, domain=custom, connection=ws, dm=pairing, group=open
+            prompt_responses=[
+                "cli_manual",
+                "secret_manual",
+                "https://open.xfchat.iflytek.com",  # custom URL prompt
+                "",                                   # home_channel
+            ],
+        )
+        assert env["FEISHU_DOMAIN"] == "https://open.xfchat.iflytek.com"
+        assert env["FEISHU_CONNECTION_MODE"] == "websocket"
+
+    @patch("plugins.platforms.feishu.adapter.probe_bot", return_value=None)
+    def test_manual_path_custom_domain_strips_trailing_slash(self, _mock_probe):
+        env, _ = _run_setup_feishu(
+            qr_result=None,
+            prompt_choice_responses=[1, 2, 0, 0, 0],
+            prompt_responses=[
+                "cli_manual",
+                "secret_manual",
+                "https://open.example.com/",
+                "",
+            ],
+        )
+        assert env["FEISHU_DOMAIN"] == "https://open.example.com"
+
+    @patch("plugins.platforms.feishu.adapter.probe_bot", return_value=None)
+    def test_manual_path_custom_domain_rejects_non_url(self, _mock_probe):
+        """A non-URL entry is rejected and the user is reprompted."""
+        env, _ = _run_setup_feishu(
+            qr_result=None,
+            prompt_choice_responses=[1, 2, 0, 0, 0],
+            prompt_responses=[
+                "cli_manual",
+                "secret_manual",
+                "not-a-url",                       # rejected
+                "https://open.example.com",        # accepted on retry
+                "",
+            ],
+        )
+        assert env["FEISHU_DOMAIN"] == "https://open.example.com"
 
 # ---------------------------------------------------------------------------
 # DM security policy

--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -158,6 +158,7 @@ FEISHU_HOME_CHANNEL=oc_xxx
 
 - `feishu` for Feishu China
 - `lark` for Lark international
+- A full `https://` base URL, such as `https://open.example.com`, for a private deployment
 
 ## Step 4: Start the Gateway
 
@@ -191,7 +192,7 @@ If you leave the allowlist empty, anyone who can reach the bot may be able to us
 
 ### Webhook Encryption Key
 
-When running in webhook mode, set an encryption key to enable signature verification of inbound webhook payloads:
+When running in webhook mode, set an encryption key to enable signature verification and decryption of inbound webhook payloads:
 
 ```bash
 FEISHU_ENCRYPT_KEY=your-encrypt-key
@@ -203,7 +204,7 @@ This key is found in the **Event Subscriptions** section of your Feishu app conf
 SHA256(timestamp + nonce + encrypt_key + body)
 ```
 
-The computed hash is compared against the `x-lark-signature` header using timing-safe comparison. Requests with invalid or missing signatures are rejected with HTTP 401.
+The computed hash is compared against the `x-lark-signature` header using timing-safe comparison before the payload is decrypted. Requests with invalid or missing signatures are rejected with HTTP 401. Encrypted event and URL-verification payloads are decrypted with the official Feishu SDK before token validation and dispatch.
 
 :::tip
 In WebSocket mode, signature verification is handled by the SDK itself, so `FEISHU_ENCRYPT_KEY` is optional. In webhook mode, it is strongly recommended for production.
@@ -542,7 +543,7 @@ Inbound messages are deduplicated using message IDs with a 24-hour TTL. The dedu
 |----------|----------|---------|-------------|
 | `FEISHU_APP_ID` | ✅ | — | Feishu/Lark App ID |
 | `FEISHU_APP_SECRET` | ✅ | — | Feishu/Lark App Secret |
-| `FEISHU_DOMAIN` | — | `feishu` | `feishu` (China) or `lark` (international) |
+| `FEISHU_DOMAIN` | — | `feishu` | `feishu` (China), `lark` (international), or a full private deployment URL |
 | `FEISHU_CONNECTION_MODE` | — | `websocket` | `websocket` or `webhook` |
 | `FEISHU_ALLOWED_USERS` | — | _(empty)_ | Comma-separated open_id list for user allowlist |
 | `FEISHU_ALLOW_BOTS` | — | `none` | Accept messages from other bots: `none`, `mentions`, or `all` |

--- a/website/docs/user-guide/messaging/feishu.md
+++ b/website/docs/user-guide/messaging/feishu.md
@@ -204,7 +204,7 @@ This key is found in the **Event Subscriptions** section of your Feishu app conf
 SHA256(timestamp + nonce + encrypt_key + body)
 ```
 
-The computed hash is compared against the `x-lark-signature` header using timing-safe comparison before the payload is decrypted. Requests with invalid or missing signatures are rejected with HTTP 401. Encrypted event and URL-verification payloads are decrypted with the official Feishu SDK before token validation and dispatch.
+The computed hash is compared against the `x-lark-signature` header using timing-safe comparison before the payload is decrypted. Requests with invalid or missing signatures are rejected with HTTP 401. Encrypted event and URL-verification payloads are decrypted with the official Feishu SDK before token validation and dispatch. URL verification supports both Schema 1.0 (`type` / `challenge`) and Schema 2.0 (`header.event_type` / `event.challenge`) payloads.
 
 :::tip
 In WebSocket mode, signature verification is handled by the SDK itself, so `FEISHU_ENCRYPT_KEY` is optional. In webhook mode, it is strongly recommended for production.


### PR DESCRIPTION
- Allow FEISHU_DOMAIN to accept full URLs for private Feishu deployments
- Add AES decryption support for encrypted webhook payloads using lark_oapi.AESCipher
- Preserve domain case sensitivity to support custom URLs
- Add _resolve_domain() method to handle both standard domains (feishu/lark) and custom URLs

This enables Hermes to work with private/self-hosted Feishu instances that use custom domains and encrypted webhook payloads.

Tested with iFlytek's private Feishu deployment (open.xfchat.iflytek.com).

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #13254

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

