### PR TITLE
fix(gateway): exclude CLI invocations from _looks_like_gateway_process (Closes #13242)

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -112,18 +112,37 @@ def _read_process_cmdline(pid: int) -> Optional[str]:
 
 
 def _looks_like_gateway_process(pid: int) -> bool:
-    """Return True when the live PID still looks like the Hermes gateway."""
+    """Return True when the live PID still looks like the Hermes gateway.
+
+    Excludes CLI invocations like ``hermes gateway run`` or ``hermes gateway
+    status`` that match the broad ``"hermes gateway"`` pattern but are not
+    actually the gateway daemon — a common false-positive when starting the
+    gateway from an interactive CLI session (issue #13242).
+    """
     cmdline = _read_process_cmdline(pid)
     if not cmdline:
         return False
 
-    patterns = (
+    gateway_patterns = (
         "hermes_cli.main gateway",
         "hermes_cli/main.py gateway",
-        "hermes gateway",
         "gateway/run.py",
     )
-    return any(pattern in cmdline for pattern in patterns)
+    if any(pattern in cmdline for pattern in gateway_patterns):
+        return True
+
+    # Only accept 'hermes gateway' if it is NOT followed by a CLI subcommand
+    # like 'run', 'stop', 'status', 'restart', 'install', etc. A real gateway
+    # process has 'gateway' as the final subcommand (no further args) or is
+    # invoked via the module runner.
+    if "hermes gateway" in cmdline:
+        cli_subcommands = ("run", "stop", "status", "restart", "install",
+                           "uninstall", "start", "setup", "doctor")
+        # If a CLI subcommand appears after 'hermes gateway', this is a
+        # CLI process, not the gateway daemon.
+        return not any(f"gateway {cmd}" in cmdline for cmd in cli_subcommands)
+
+    return False
 
 
 def _record_looks_like_gateway(record: dict[str, Any]) -> bool:


### PR DESCRIPTION
## Summary

Fixes the false-positive "gateway already running" detection when starting the gateway from an interactive CLI session (`hermes gateway run` / `hermes gateway run --replace`).

Closes #13242.

## Root Cause

`_looks_like_gateway_process()` in `gateway/status.py` used a broad `"hermes gateway"` substring match that also matched CLI invocations like:

- `hermes gateway run`
- `hermes gateway status`
- `hermes gateway restart`
- etc.

When the gateway scans `/proc/<pid>/cmdline` to verify a PID-file entry, it would incorrectly classify the calling CLI process as a running gateway daemon, triggering the duplicate-instance guard and aborting startup.

## Fix

Split the broad `"hermes gateway"` pattern into two checks:

1. **Precise gateway patterns** — `hermes_cli.main gateway`, `hermes_cli/main.py gateway`, `gateway/run.py` — these always identify a real gateway process.
2. **CLI-subcommand exclusion** — if `"hermes gateway"` is matched but followed by a known CLI subcommand (`run`, `stop`, `status`, `restart`, `install`, `uninstall`, `start`, `setup`, `doctor`), the process is classified as a CLI invocation and **rejected**.

This preserves backward compatibility for processes that legitimately match `"hermes gateway"` without subcommands while eliminating the self-detection false positive.

## Changed Files

- `gateway/status.py` — `_looks_like_gateway_process()` (lines 114-146)

## Testing

Manual test scenarios:
- `hermes gateway run` — should NOT detect self as running
- `hermes gateway status` — should NOT detect CLI as running gateway
- Actual gateway process (`python -m hermes_cli.main gateway run`) — SHOULD still be detected
- Stale PID file pointing to CLI process — should be cleaned up correctly