### PR TITLE
fix(cli): also suppress OSError EINVAL from kqueue stdin register (#6393)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10431,16 +10431,25 @@ class HermesCLI:
         
         # Install a custom asyncio exception handler that suppresses the
         # "Event loop is closed" RuntimeError from httpx transport cleanup
-        # and the "0 is not registered" KeyError from broken stdin (#6393).
+        # and selector-registration failures from broken/unusable stdin (#6393).
         # The RuntimeError fix is defense-in-depth — the primary fix is
-        # neuter_async_httpx_del which disables __del__ entirely.  The
-        # KeyError fix handles macOS + uv-managed Python environments where
-        # fd 0 is not reliably available to the asyncio selector.
+        # neuter_async_httpx_del which disables __del__ entirely.  The stdin
+        # fixes handle environments where fd 0 is not reliably registerable
+        # with the asyncio kqueue selector, which shows up as:
+        #   - KeyError "0 is not registered" — uv-managed cPython quirk
+        #   - OSError EBADF                   — fd 0 closed
+        #   - OSError EINVAL                  — TTY-like device not supported
+        #                                       by kqueue EVFILT_READ (seen
+        #                                       with some non-Apple terminal
+        #                                       emulators on macOS 26)
+        import errno as _errno
         def _suppress_closed_loop_errors(loop, context):
             exc = context.get("exception")
             if isinstance(exc, RuntimeError) and "Event loop is closed" in str(exc):
                 return  # silently suppress
             if isinstance(exc, KeyError) and "is not registered" in str(exc):
+                return  # suppress selector registration failures (#6393)
+            if isinstance(exc, OSError) and getattr(exc, "errno", None) in (_errno.EBADF, _errno.EINVAL):
                 return  # suppress selector registration failures (#6393)
             # Fall back to default handler for everything else
             loop.default_exception_handler(context)
@@ -10477,11 +10486,29 @@ class HermesCLI:
         except (KeyError, OSError) as _stdin_err:
             # Catch selector registration failures from broken stdin (#6393).
             # This is the fallback for cases that slip past the fstat() guard.
-            if "is not registered" in str(_stdin_err) or "Bad file descriptor" in str(_stdin_err):
+            # Multiple flavors depending on Python and stdin state:
+            #   - KeyError "0 is not registered" — asyncio selector path
+            #   - OSError EBADF                   — fd 0 closed
+            #   - OSError EINVAL                  — TTY-like fd rejected by
+            #                                       kqueue EVFILT_READ on macOS
+            #                                       (e.g. certain non-Apple
+            #                                       terminal emulators)
+            _stdin_errno = getattr(_stdin_err, "errno", None)
+            _stdin_unusable = (
+                isinstance(_stdin_err, KeyError)
+                or _stdin_errno in (_errno.EBADF, _errno.EINVAL)
+                or "is not registered" in str(_stdin_err)
+                or "Bad file descriptor" in str(_stdin_err)
+            )
+            if _stdin_unusable:
                 print(
                     f"\nError: stdin is not usable ({_stdin_err}).\n"
-                    "This can happen with certain Python installations (e.g. uv-managed cPython on macOS).\n"
-                    "Try reinstalling Python via pyenv or Homebrew, then re-run: hermes setup"
+                    "This can happen when the terminal emulator's PTY is not\n"
+                    "compatible with macOS kqueue (some non-Apple terminals on\n"
+                    "macOS 26), or with certain Python installations (e.g.\n"
+                    "uv-managed cPython on macOS).\n"
+                    "Workarounds: launch from Terminal.app or iTerm2, or\n"
+                    "reinstall Python via pyenv/Homebrew and re-run: hermes setup"
                 )
             else:
                 raise


### PR DESCRIPTION
## Summary

Closes the EINVAL variant of the prompt_toolkit stdin-register crash filed as #6393. The existing guard already caught `KeyError: "0 is not registered"` and `OSError: Bad file descriptor`, but it was a substring match — so `OSError: [Errno 22] Invalid argument` slipped through and the user still got a raw traceback.

## What changed

`cli.py`, in `HermesCLI.run()`:

1. **Asyncio loop exception handler** (`_suppress_closed_loop_errors`) — now also suppresses `OSError` whose `errno` is `EBADF` or `EINVAL`.
2. **Outer `except (KeyError, OSError)` around `app.run()`** — detects unusable stdin by errno (`EBADF` / `EINVAL`) in addition to the existing substring checks.
3. **User-facing message** — broadened to mention terminal-emulator PTY compatibility and suggest Terminal.app / iTerm2 as a workaround, since this manifests in several non-Apple terminal emulators on macOS 26, not just with uv-managed cPython.

## Why

Reported by a user hitting the exact traceback in #6393 on macOS 26.4.1:

```
File ".../prompt_toolkit/input/vt100.py", line 165, in _attached_input
    loop.add_reader(fd, callback_wrapper)
  ...
  File ".../selectors.py", line 523, in register
    self._selector.control([kev], 0, 0)
OSError: [Errno 22] Invalid argument
```

Verified against that user's environment:

- `os.fstat(0)` succeeds (so the existing `fstat()` guard passes)
- `os.isatty(0)` returns True
- kqueue's `control([kev], 0, 0)` with `EVFILT_READ` on fd 0 returns `EINVAL` — the fd is a char device but not one kqueue will watch for read.

The error string is `"[Errno 22] Invalid argument"`, which doesn't contain `"is not registered"` or `"Bad file descriptor"`, so the existing handler re-raised.

## Why errno instead of broader string match

`errno` comparisons are robust across Python versions and localized `strerror` output. I kept the existing string checks as a belt-and-suspenders for cases where errno is missing (e.g. the KeyError path, or a re-wrapped exception).

## How to test

Can't easily script the EINVAL case since it depends on the terminal emulator's PTY behavior, but the code path is easy to verify by injecting a synthetic exception:

```python
import asyncio, errno
# ... in place of app.run():
raise OSError(errno.EINVAL, "Invalid argument")
```

With this change, that now prints the friendly diagnostic instead of re-raising.

Also verified `python3 -m py_compile cli.py` passes, and that hermes still launches cleanly in a working Terminal.app window.

## Tested on

- macOS 26.4.1 (Darwin 25.4.0) / cPython 3.11.15 (uv-managed)

## Related

- Closes #6393 (for real this time — the previous guard didn't cover EINVAL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)