### PR TITLE
fix(models): add live Bedrock discovery to provider_model_ids

### DIFF
--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -291,14 +291,52 @@ def has_aws_credentials(env: Optional[Dict[str, str]] = None) -> bool:
 def resolve_bedrock_region(env: Optional[Dict[str, str]] = None) -> str:
     """Resolve the AWS region for Bedrock API calls.
 
-    Priority: AWS_REGION → AWS_DEFAULT_REGION → us-east-1 (fallback).
+    Priority:
+      1. AWS_REGION env var
+      2. AWS_DEFAULT_REGION env var
+      3. boto3/botocore configured region (from ~/.aws/config or SSO profile)
+      4. us-east-1 (hard fallback)
+
+    The boto3 fallback is critical for EU/AP users who configure their region
+    in ~/.aws/config via a named profile rather than env vars — without it,
+    live model discovery would always return us.* profile IDs regardless of
+    the user's actual region.
     """
     env = env if env is not None else os.environ
-    return (
+    explicit = (
         env.get("AWS_REGION", "").strip()
         or env.get("AWS_DEFAULT_REGION", "").strip()
-        or "us-east-1"
     )
+    if explicit:
+        return explicit
+    try:
+        import botocore.session
+        region = botocore.session.get_session().get_config_variable("region")
+        if region:
+            return region
+    except Exception:
+        pass
+    return "us-east-1"
+
+
+def bedrock_model_ids_or_none() -> Optional[List[str]]:
+    """Live-discover Bedrock model IDs for the active region.
+
+    Returns a list of model ID strings if discovery succeeds and yields
+    at least one model, or ``None`` on failure / empty result.  Callers
+    should fall back to the static curated list when ``None`` is returned.
+
+    This helper consolidates the discover → extract-ids → fallback
+    pattern that was previously duplicated across ``provider_model_ids``,
+    ``list_authenticated_providers`` section 2, and section 3.
+    """
+    try:
+        discovered = discover_bedrock_models(resolve_bedrock_region())
+        if discovered:
+            return [m["id"] for m in discovered]
+    except Exception:
+        pass
+    return None
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1175,6 +1175,15 @@ def list_authenticated_providers(
 
         if hermes_slug in {"copilot", "copilot-acp"}:
             model_ids = provider_model_ids(hermes_slug)
+        # For aws_sdk providers (bedrock), use live discovery so the list
+        # reflects the active region (eu.*, ap.*) not the static us.* list.
+        elif overlay.auth_type == "aws_sdk":
+            try:
+                from agent.bedrock_adapter import bedrock_model_ids_or_none
+                _ids = bedrock_model_ids_or_none()
+                model_ids = _ids if _ids is not None else (curated.get(hermes_slug, []) or curated.get(pid, []))
+            except Exception:
+                model_ids = curated.get(hermes_slug, []) or curated.get(pid, [])
         else:
             # Use curated list — look up by Hermes slug, fall back to overlay key
             model_ids = curated.get(hermes_slug, []) or curated.get(pid, [])
@@ -1237,10 +1246,30 @@ def list_authenticated_providers(
             except Exception:
                 pass
 
+        # Special case: aws_sdk auth (bedrock) — no API key env vars,
+        # credentials come from the boto3 credential chain (env vars,
+        # ~/.aws/credentials, instance roles, etc.)
+        if not _cp_has_creds and _cp_config and getattr(_cp_config, "auth_type", "") == "aws_sdk":
+            try:
+                from agent.bedrock_adapter import has_aws_credentials
+                _cp_has_creds = has_aws_credentials()
+            except Exception:
+                pass
+
         if not _cp_has_creds:
             continue
 
-        _cp_model_ids = curated.get(_cp.slug, [])
+        # For bedrock, use live discovery so the list reflects the active
+        # region (eu.*, us.*, ap.*) instead of the hardcoded us.* static list.
+        if _cp_config and getattr(_cp_config, "auth_type", "") == "aws_sdk":
+            try:
+                from agent.bedrock_adapter import bedrock_model_ids_or_none
+                _ids = bedrock_model_ids_or_none()
+                _cp_model_ids = _ids if _ids is not None else curated.get(_cp.slug, [])
+            except Exception:
+                _cp_model_ids = curated.get(_cp.slug, [])
+        else:
+            _cp_model_ids = curated.get(_cp.slug, [])
         _cp_total = len(_cp_model_ids)
         _cp_top = _cp_model_ids[:max_models]
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1861,6 +1861,18 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
             live = fetch_api_models(api_key, base_url)
             if live:
                 return live
+    # Bedrock uses live discovery keyed by the resolved AWS region so that
+    # EU/AP users see eu.*/ap.* model IDs instead of the static us.* list.
+    # Note: early return intentionally skips _MODELS_DEV_PREFERRED merge
+    # below — bedrock is not expected to appear in that table.
+    if normalized == "bedrock":
+        try:
+            from agent.bedrock_adapter import bedrock_model_ids_or_none
+            ids = bedrock_model_ids_or_none()
+            if ids is not None:
+                return ids
+        except Exception:
+            pass
     curated_static = list(_PROVIDER_MODELS.get(normalized, []))
     if normalized in _MODELS_DEV_PREFERRED:
         return _merge_with_models_dev(normalized, curated_static)

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -173,6 +173,10 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         transport="openai_chat",  # default; overridden by api_mode in config
         base_url_env_var="AZURE_FOUNDRY_BASE_URL",
     ),
+    "bedrock": HermesOverlay(
+        transport="bedrock_converse",
+        auth_type="aws_sdk",
+    ),
 }
 
 

--- a/tests/agent/test_bedrock_adapter.py
+++ b/tests/agent/test_bedrock_adapter.py
@@ -117,7 +117,25 @@ class TestResolveBedrocRegion:
 
     def test_defaults_to_us_east_1(self):
         from agent.bedrock_adapter import resolve_bedrock_region
-        assert resolve_bedrock_region({}) == "us-east-1"
+        from unittest.mock import patch, MagicMock
+        mock_session = MagicMock()
+        mock_session.get_config_variable.return_value = None
+        with patch("botocore.session.get_session", return_value=mock_session):
+            assert resolve_bedrock_region({}) == "us-east-1"
+
+    def test_falls_back_to_botocore_profile_region(self):
+        from agent.bedrock_adapter import resolve_bedrock_region
+        from unittest.mock import patch, MagicMock
+        mock_session = MagicMock()
+        mock_session.get_config_variable.return_value = "eu-central-1"
+        with patch("botocore.session.get_session", return_value=mock_session):
+            assert resolve_bedrock_region({}) == "eu-central-1"
+
+    def test_botocore_failure_falls_back_to_us_east_1(self):
+        from agent.bedrock_adapter import resolve_bedrock_region
+        from unittest.mock import patch
+        with patch("botocore.session.get_session", side_effect=Exception("no botocore")):
+            assert resolve_bedrock_region({}) == "us-east-1"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_bedrock_model_picker.py
+++ b/tests/hermes_cli/test_bedrock_model_picker.py
@@ -1,0 +1,324 @@
+"""Tests for AWS Bedrock integration in the model picker and provider catalog.
+
+Covers the three paths changed by fix/bedrock-provider-model-ids-live-discovery:
+
+  1. provider_model_ids("bedrock") — uses live discover_bedrock_models() instead
+     of the static _PROVIDER_MODELS table, with curated fallback.
+
+  2. list_authenticated_providers() Section 2 (HERMES_OVERLAYS) — bedrock
+     appears when AWS credentials are present; model list comes from live
+     discovery keyed by the resolved region, NOT the static us.* table.
+
+  3. Region resolution — resolve_bedrock_region() reads from botocore profile
+     when no AWS_REGION / AWS_DEFAULT_REGION env vars are set, so EU/AP users
+     in eu-central-1 get eu.* profile IDs, not us.* ones.
+
+All Bedrock API calls are mocked — no real AWS credentials needed.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers / fixtures
+# ---------------------------------------------------------------------------
+
+_EU_MODELS = [
+    {"id": "eu.anthropic.claude-sonnet-4-6-20250514-v1:0", "name": "Claude Sonnet 4.6 (EU)", "provider": "inference-profile"},
+    {"id": "eu.anthropic.claude-haiku-4-5-20251015-v1:0",  "name": "Claude Haiku 4.5 (EU)",  "provider": "inference-profile"},
+    {"id": "eu.amazon.nova-pro-v1:0",                       "name": "Nova Pro (EU)",           "provider": "inference-profile"},
+]
+
+_US_MODELS = [
+    {"id": "us.anthropic.claude-sonnet-4-6-20250514-v1:0", "name": "Claude Sonnet 4.6 (US)", "provider": "inference-profile"},
+    {"id": "us.amazon.nova-pro-v1:0",                       "name": "Nova Pro (US)",           "provider": "inference-profile"},
+]
+
+
+def _mock_discover(region: str):
+    """Return EU models for eu-* regions, US models otherwise."""
+    return _EU_MODELS if region.startswith("eu-") else _US_MODELS
+
+
+# ---------------------------------------------------------------------------
+# 1. provider_model_ids("bedrock")
+# ---------------------------------------------------------------------------
+
+class TestProviderModelIdsBedrock:
+    """provider_model_ids("bedrock") should use live Bedrock discovery."""
+
+    def test_returns_live_discovered_model_ids(self, monkeypatch):
+        """Live discovery result is returned as a flat list of model ID strings."""
+        from hermes_cli.models import provider_model_ids
+
+        monkeypatch.setenv("AWS_REGION", "eu-central-1")
+
+        with patch("agent.bedrock_adapter.discover_bedrock_models", side_effect=_mock_discover), \
+             patch("agent.bedrock_adapter.resolve_bedrock_region", return_value="eu-central-1"):
+            result = provider_model_ids("bedrock")
+
+        assert "eu.anthropic.claude-sonnet-4-6-20250514-v1:0" in result
+        assert "eu.anthropic.claude-haiku-4-5-20251015-v1:0" in result
+        assert len(result) == len(_EU_MODELS)
+
+    def test_region_determines_model_ids(self, monkeypatch):
+        """Different regions produce different model ID prefixes (eu.* vs us.*)."""
+        from hermes_cli.models import provider_model_ids
+
+        with patch("agent.bedrock_adapter.discover_bedrock_models", side_effect=_mock_discover):
+            with patch("agent.bedrock_adapter.resolve_bedrock_region", return_value="eu-central-1"):
+                eu_result = provider_model_ids("bedrock")
+            with patch("agent.bedrock_adapter.resolve_bedrock_region", return_value="us-east-1"):
+                us_result = provider_model_ids("bedrock")
+
+        assert all(m.startswith("eu.") for m in eu_result)
+        assert all(m.startswith("us.") for m in us_result)
+        assert eu_result != us_result
+
+    def test_falls_back_to_static_list_when_discovery_empty(self, monkeypatch):
+        """When discover_bedrock_models() returns [], fall back to curated static list."""
+        from hermes_cli.models import _PROVIDER_MODELS, provider_model_ids
+
+        with patch("agent.bedrock_adapter.discover_bedrock_models", return_value=[]), \
+             patch("agent.bedrock_adapter.resolve_bedrock_region", return_value="eu-central-1"):
+            result = provider_model_ids("bedrock")
+
+        # Should fall back to static table (may be empty or populated depending on
+        # the current static list, but must not crash and must be a list).
+        assert isinstance(result, list)
+
+    def test_falls_back_to_static_list_on_exception(self, monkeypatch):
+        """When discover_bedrock_models() raises, fall back gracefully."""
+        from hermes_cli.models import provider_model_ids
+
+        with patch("agent.bedrock_adapter.discover_bedrock_models",
+                   side_effect=Exception("boto3 not installed")), \
+             patch("agent.bedrock_adapter.resolve_bedrock_region", return_value="eu-central-1"):
+            result = provider_model_ids("bedrock")
+
+        assert isinstance(result, list)  # no crash
+
+    def test_accepts_bedrock_aliases(self, monkeypatch):
+        """Provider aliases (aws, aws-bedrock, amazon) should also trigger live discovery."""
+        from hermes_cli.models import provider_model_ids
+
+        _expected_ids = [m["id"] for m in _US_MODELS]
+
+        with patch("agent.bedrock_adapter.discover_bedrock_models", side_effect=_mock_discover), \
+             patch("agent.bedrock_adapter.resolve_bedrock_region", return_value="us-east-1"):
+            for alias in ("aws", "aws-bedrock", "amazon-bedrock"):
+                result = provider_model_ids(alias)
+                assert result == _expected_ids, \
+                    f"alias {alias!r} should return live-discovered US model IDs, got {result!r}"
+
+
+# ---------------------------------------------------------------------------
+# 2. list_authenticated_providers() — bedrock via HERMES_OVERLAYS (Section 2)
+# ---------------------------------------------------------------------------
+
+class TestListAuthenticatedProvidersBedrock:
+    """Bedrock should appear in the /model picker when AWS creds are present."""
+
+    def test_bedrock_appears_with_aws_profile(self, monkeypatch):
+        """Bedrock shows up when AWS_PROFILE is set."""
+        from hermes_cli.model_switch import list_authenticated_providers
+
+        monkeypatch.setenv("AWS_PROFILE", "my-sso-profile")
+        monkeypatch.setenv("AWS_REGION", "eu-central-1")
+
+        with patch("agent.bedrock_adapter.has_aws_credentials", return_value=True), \
+             patch("agent.bedrock_adapter.discover_bedrock_models", side_effect=_mock_discover), \
+             patch("agent.bedrock_adapter.resolve_bedrock_region", return_value="eu-central-1"):
+            providers = list_authenticated_providers(current_provider="bedrock")
+
+        bedrock = next((p for p in providers if p["slug"] == "bedrock"), None)
+        assert bedrock is not None, "bedrock should appear when AWS credentials are present"
+
+    def test_bedrock_uses_live_discovery_not_static_list(self, monkeypatch):
+        """Model IDs come from discover_bedrock_models(), not the static _PROVIDER_MODELS table."""
+        from hermes_cli.model_switch import list_authenticated_providers
+
+        monkeypatch.setenv("AWS_PROFILE", "my-sso-profile")
+
+        with patch("agent.bedrock_adapter.has_aws_credentials", return_value=True), \
+             patch("agent.bedrock_adapter.discover_bedrock_models", side_effect=_mock_discover), \
+             patch("agent.bedrock_adapter.resolve_bedrock_region", return_value="eu-central-1"):
+            providers = list_authenticated_providers(current_provider="bedrock")
+
+        bedrock = next((p for p in providers if p["slug"] == "bedrock"), None)
+        assert bedrock is not None
+
+        # All returned model IDs should have eu.* prefix — live discovery result
+        for model_id in bedrock["models"]:
+            assert model_id.startswith("eu."), \
+                f"Expected eu.* model ID from live discovery, got {model_id!r}"
+
+    def test_bedrock_total_models_matches_discovery(self, monkeypatch):
+        """total_models reflects the actual discovered count."""
+        from hermes_cli.model_switch import list_authenticated_providers
+
+        monkeypatch.setenv("AWS_PROFILE", "my-sso-profile")
+
+        with patch("agent.bedrock_adapter.has_aws_credentials", return_value=True), \
+             patch("agent.bedrock_adapter.discover_bedrock_models", return_value=_EU_MODELS), \
+             patch("agent.bedrock_adapter.resolve_bedrock_region", return_value="eu-central-1"):
+            providers = list_authenticated_providers(current_provider="openai")
+
+        bedrock = next((p for p in providers if p["slug"] == "bedrock"), None)
+        assert bedrock is not None
+        assert bedrock["total_models"] == len(_EU_MODELS)
+
+    def test_bedrock_is_current_when_selected(self, monkeypatch):
+        """is_current=True when current_provider matches bedrock."""
+        from hermes_cli.model_switch import list_authenticated_providers
+
+        monkeypatch.setenv("AWS_PROFILE", "my-sso-profile")
+
+        with patch("agent.bedrock_adapter.has_aws_credentials", return_value=True), \
+             patch("agent.bedrock_adapter.discover_bedrock_models", return_value=_EU_MODELS), \
+             patch("agent.bedrock_adapter.resolve_bedrock_region", return_value="eu-central-1"):
+            providers = list_authenticated_providers(current_provider="bedrock")
+
+        bedrock = next((p for p in providers if p["slug"] == "bedrock"), None)
+        assert bedrock is not None
+        assert bedrock["is_current"] is True
+
+    def test_bedrock_not_shown_without_credentials(self, monkeypatch):
+        """Bedrock must not appear when no AWS credentials are present."""
+        from hermes_cli.model_switch import list_authenticated_providers
+
+        monkeypatch.delenv("AWS_PROFILE", raising=False)
+        monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+        monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+        monkeypatch.delenv("AWS_BEARER_TOKEN_BEDROCK", raising=False)
+        monkeypatch.delenv("AWS_WEB_IDENTITY_TOKEN_FILE", raising=False)
+        monkeypatch.delenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", raising=False)
+
+        with patch("agent.bedrock_adapter.has_aws_credentials", return_value=False):
+            providers = list_authenticated_providers(current_provider="openai")
+
+        bedrock = next((p for p in providers if p["slug"] == "bedrock"), None)
+        assert bedrock is None, "bedrock should NOT appear when AWS credentials are absent"
+
+    def test_bedrock_falls_back_to_curated_when_discovery_fails(self, monkeypatch):
+        """When discover_bedrock_models() raises, fall back to curated list without crashing."""
+        from hermes_cli.model_switch import list_authenticated_providers
+
+        monkeypatch.setenv("AWS_PROFILE", "my-sso-profile")
+
+        with patch("agent.bedrock_adapter.has_aws_credentials", return_value=True), \
+             patch("agent.bedrock_adapter.discover_bedrock_models",
+                   side_effect=Exception("API call failed")), \
+             patch("agent.bedrock_adapter.resolve_bedrock_region", return_value="eu-central-1"):
+            providers = list_authenticated_providers(current_provider="bedrock")
+
+        # Should not raise — bedrock entry may or may not appear depending on
+        # whether the curated fallback has entries, but the call must succeed.
+        assert isinstance(providers, list)
+
+    def test_bedrock_no_duplicate_entries(self, monkeypatch):
+        """Bedrock must appear at most once — not in both Section 1 and Section 2."""
+        from hermes_cli.model_switch import list_authenticated_providers
+
+        monkeypatch.setenv("AWS_PROFILE", "my-sso-profile")
+
+        with patch("agent.bedrock_adapter.has_aws_credentials", return_value=True), \
+             patch("agent.bedrock_adapter.discover_bedrock_models", return_value=_EU_MODELS), \
+             patch("agent.bedrock_adapter.resolve_bedrock_region", return_value="eu-central-1"):
+            providers = list_authenticated_providers(current_provider="bedrock")
+
+        bedrock_entries = [p for p in providers if p["slug"] == "bedrock"]
+        assert len(bedrock_entries) <= 1, \
+            f"bedrock should appear at most once, got {len(bedrock_entries)} entries"
+
+
+# ---------------------------------------------------------------------------
+# 3. Region routing: EU/AP users see regional model IDs
+# ---------------------------------------------------------------------------
+
+class TestBedrockRegionRouting:
+    """End-to-end: region from botocore profile is used for discovery, so EU/AP
+    users get eu.*/ap.* model IDs rather than the hardcoded us-east-1 list."""
+
+    def test_eu_region_from_botocore_profile_yields_eu_models(self):
+        """When botocore resolves eu-central-1, picker shows eu.* model IDs."""
+        from hermes_cli.model_switch import list_authenticated_providers
+
+        mock_session = MagicMock()
+        mock_session.get_config_variable.return_value = "eu-central-1"
+
+        with patch("agent.bedrock_adapter.has_aws_credentials", return_value=True), \
+             patch("agent.bedrock_adapter.discover_bedrock_models", side_effect=_mock_discover), \
+             patch("botocore.session.get_session", return_value=mock_session):
+            providers = list_authenticated_providers(current_provider="bedrock")
+
+        bedrock = next((p for p in providers if p["slug"] == "bedrock"), None)
+        assert bedrock is not None
+        for model_id in bedrock["models"]:
+            assert model_id.startswith("eu."), \
+                f"Expected eu.* model ID from eu-central-1 profile, got {model_id!r}"
+
+    def test_us_region_from_env_var_yields_us_models(self, monkeypatch):
+        """Explicit AWS_REGION=us-east-1 returns us.* model IDs."""
+        from hermes_cli.model_switch import list_authenticated_providers
+
+        monkeypatch.setenv("AWS_REGION", "us-east-1")
+
+        with patch("agent.bedrock_adapter.has_aws_credentials", return_value=True), \
+             patch("agent.bedrock_adapter.discover_bedrock_models", side_effect=_mock_discover):
+            providers = list_authenticated_providers(current_provider="bedrock")
+
+        bedrock = next((p for p in providers if p["slug"] == "bedrock"), None)
+        assert bedrock is not None
+        for model_id in bedrock["models"]:
+            assert model_id.startswith("us."), \
+                f"Expected us.* model ID from us-east-1, got {model_id!r}"
+
+    def test_env_var_takes_priority_over_botocore_profile(self, monkeypatch):
+        """AWS_REGION env var wins over botocore profile region."""
+        from agent.bedrock_adapter import resolve_bedrock_region
+
+        monkeypatch.setenv("AWS_REGION", "us-west-2")
+
+        mock_session = MagicMock()
+        mock_session.get_config_variable.return_value = "eu-central-1"
+
+        with patch("botocore.session.get_session", return_value=mock_session):
+            region = resolve_bedrock_region()
+
+        assert region == "us-west-2", "env var should override botocore profile"
+
+
+# ---------------------------------------------------------------------------
+# 4. providers.py overlay registration
+# ---------------------------------------------------------------------------
+
+class TestBedrockOverlayRegistration:
+    """bedrock entry in HERMES_OVERLAYS is correctly configured."""
+
+    def test_bedrock_overlay_exists(self):
+        from hermes_cli.providers import HERMES_OVERLAYS
+        assert "bedrock" in HERMES_OVERLAYS
+
+    def test_bedrock_overlay_transport(self):
+        from hermes_cli.providers import HERMES_OVERLAYS
+        assert HERMES_OVERLAYS["bedrock"].transport == "bedrock_converse"
+
+    def test_bedrock_overlay_auth_type(self):
+        from hermes_cli.providers import HERMES_OVERLAYS
+        assert HERMES_OVERLAYS["bedrock"].auth_type == "aws_sdk"
+
+    def test_bedrock_label(self):
+        from hermes_cli.providers import get_label
+        label = get_label("bedrock")
+        assert label  # non-empty
+        assert "bedrock" in label.lower() or "aws" in label.lower()
+
+    def test_bedrock_aliases_resolve(self):
+        from hermes_cli.providers import normalize_provider
+        for alias in ("aws", "aws-bedrock", "amazon-bedrock", "amazon"):
+            assert normalize_provider(alias) == "bedrock", \
+                f"alias {alias!r} should normalize to 'bedrock'"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2255,6 +2255,7 @@ def _(rid, params: dict) -> dict:
                     getattr(agent, "model", "") or _resolve_model(),
                     base_url=getattr(agent, "base_url", "") or "",
                     api_key=getattr(agent, "api_key", "") or "",
+                    provider=getattr(agent, "provider", "") or "",
                 )
                 ctx = preprocess_context_references(
                     prompt,


### PR DESCRIPTION
## What does this PR do?

Users configured for non-US AWS regions (e.g. `eu-central-1`, `ap-northeast-1`) see wrong or no models in `/model` and autocomplete when using the Bedrock provider. Three root causes:

1. **`provider_model_ids("bedrock")`** fell through to a static `_PROVIDER_MODELS` table containing only hardcoded `us.*` model IDs — every other provider (openrouter, anthropic, ollama-cloud, etc.) already performed live API discovery; bedrock did not.
2. **`list_authenticated_providers()` (the `/model` picker)** had the same gap: bedrock was not registered as a `HERMES_OVERLAYS` entry, and even after registration its model list came from the static table rather than live discovery.
3. **`resolve_bedrock_region()`** hardcoded `us-east-1` as the fallback when neither `AWS_REGION` nor `AWS_DEFAULT_REGION` was set. Users who configure their region via `~/.aws/config` (named SSO profiles, assume-role, etc.) silently got the US region and therefore `us.*` profile IDs regardless of their actual region.

## Related Issue

N/A — discovered while testing Bedrock from an EU region.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`agent/bedrock_adapter.py`**: `resolve_bedrock_region()` now reads the configured region from `botocore.session` before falling back to `us-east-1` — covers users with a region set in `~/.aws/config` but no env vars.
- **`hermes_cli/providers.py`**: Registers `"bedrock"` in `HERMES_OVERLAYS` with `transport="bedrock_converse"` and `auth_type="aws_sdk"`, making it a first-class overlay provider.
- **`hermes_cli/models.py`**: `provider_model_ids("bedrock")` calls `discover_bedrock_models(resolve_bedrock_region())` before falling back to the static table. Mirrors the pattern already used by `validate_model_for_provider()`.
- **`hermes_cli/model_switch.py`**: `list_authenticated_providers()` Section 2 detects AWS credentials via `has_aws_credentials()` for `auth_type="aws_sdk"` overlays, then calls `discover_bedrock_models()` for the model list. Section 3 (canonical providers) gets the same treatment. Non-bedrock overlays preserve the existing `_MODELS_DEV_PREFERRED` merge behaviour.
- **`tui_gateway/server.py`**: Passes `provider=` to `get_model_context_length()` so context window lookups work correctly for the Bedrock provider.

## How to Test

1. Set `AWS_PROFILE` to an SSO profile configured for a non-US region (e.g. `eu-central-1`) — do **not** set `AWS_REGION` or `AWS_DEFAULT_REGION` env vars.
2. Run `hermes` and type `/model`.
3. **Before**: the picker shows ~10 hardcoded `us.*` inference profile IDs (or nothing for bedrock).
4. **After**: the picker shows all live `eu.*` inference profiles discovered from the actual region.

Alternatively, run the unit tests (no real AWS credentials required — all Bedrock API calls are mocked):
```bash
scripts/run_tests.sh tests/hermes_cli/test_bedrock_model_picker.py tests/agent/test_bedrock_adapter.py -v
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — change is in model discovery logic, not visual.