### PR TITLE
fix(whatsapp): mitigate libsignal protobufjs CVE in bridge deps

### DIFF
--- a/scripts/whatsapp-bridge/package-lock.json
+++ b/scripts/whatsapp-bridge/package-lock.json
@@ -8,7 +8,7 @@
       "name": "hermes-whatsapp-bridge",
       "version": "1.0.0",
       "dependencies": {
-        "@whiskeysockets/baileys": "WhiskeySockets/Baileys#fix/abprops-abt-fetch",
+        "@whiskeysockets/baileys": "WhiskeySockets/Baileys#01047debd81beb20da7b7779b08edcb06aa03770",
         "express": "^4.21.0",
         "pino": "^9.0.0",
         "qrcode-terminal": "^0.12.0"
@@ -714,12 +714,6 @@
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
       "license": "MIT"
     },
-    "node_modules/@types/long": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
-      "license": "MIT"
-    },
     "node_modules/@types/node": {
       "version": "25.3.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.1.tgz",
@@ -1320,49 +1314,12 @@
     "node_modules/libsignal": {
       "name": "@whiskeysockets/libsignal-node",
       "version": "2.0.1",
-      "resolved": "git+ssh://git@github.com/whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67",
+      "resolved": "git+ssh://git@github.com/amodsachintha/libsignal-node.git#2d617e9faf868a978518247392170bc038aa9f0a",
+      "integrity": "sha512-l+PC+1YVd1UzJTIq/NSmkW71hqPHfQ6n+j2BQtwPP38HSrPaOAH9Mq12BHCP4JtGkGPfmPfhNPojzV6qfgO9yg==",
       "license": "GPL-3.0",
       "dependencies": {
         "curve25519-js": "^0.0.4",
-        "protobufjs": "6.8.8"
-      }
-    },
-    "node_modules/libsignal/node_modules/@types/node": {
-      "version": "10.17.60",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
-      "license": "MIT"
-    },
-    "node_modules/libsignal/node_modules/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/libsignal/node_modules/protobufjs": {
-      "version": "6.8.8",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
-      "integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.0",
-        "@types/node": "^10.1.0",
-        "long": "^4.0.0"
-      },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
+        "protobufjs": "^7.5.5"
       }
     },
     "node_modules/long": {
@@ -1648,9 +1605,9 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/scripts/whatsapp-bridge/package.json
+++ b/scripts/whatsapp-bridge/package.json
@@ -12,5 +12,8 @@
     "express": "^4.21.0",
     "qrcode-terminal": "^0.12.0",
     "pino": "^9.0.0"
+  },
+  "overrides": {
+    "libsignal": "git+https://github.com/amodsachintha/libsignal-node.git#2d617e9faf868a978518247392170bc038aa9f0a"
   }
 }


### PR DESCRIPTION
## Bug Description

Hermes' optional WhatsApp bridge currently pulls a vulnerable transitive dependency chain:

- `@whiskeysockets/baileys`
- `libsignal` (`@whiskeysockets/libsignal-node`)
- `protobufjs < 7.5.5`

That leaves `scripts/whatsapp-bridge` reporting critical vulnerabilities in `npm audit`, which also surfaces in `hermes doctor`.

## Root Cause

Baileys currently resolves `libsignal` to a commit whose `package.json` still pins:

- `protobufjs: 6.8.8`

Upstream already has a pending fix in WhiskeySockets/libsignal-node PR #15, but Hermes still resolves the older vulnerable commit today.

## Fix

- Add an npm `overrides` entry in `scripts/whatsapp-bridge/package.json`
- Override Baileys' `libsignal` dependency to the patched `libsignal-node` commit from upstream PR #15
- Refresh `scripts/whatsapp-bridge/package-lock.json`

This is a targeted mitigation for Hermes until the upstream dependency is merged and released.

## How to Verify

1. `cd scripts/whatsapp-bridge`
2. `npm install --package-lock-only --ignore-scripts`
3. `npm audit --json` → expect `0 vulnerabilities`
4. `node -e "import('./bridge.js').then(()=>console.log('ok'))"`

## Test Plan

- [ ] Added regression test for this bug
- [x] Existing tests still pass
- [x] Manual verification of the fix

Manual verification performed:

- `npm install --package-lock-only --ignore-scripts`
- `npm audit --json` → `0 vulnerabilities`
- `node -e "import('./bridge.js').then(()=>console.log('bridge-import-ok'))"`

## Risk Assessment

Medium — this changes a transitive WhatsApp bridge dependency source to a patched upstream PR commit. Scope is limited to the optional `scripts/whatsapp-bridge` package and does not affect non-WhatsApp users.
