### PR TITLE
feat(whatsapp): parse incoming contact cards (vCard) in bridge

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -89,6 +89,36 @@ function getContextInfo(messageContent) {
   return {};
 }
 
+function formatContactCard(messageContent) {
+  if (!messageContent || typeof messageContent !== 'object') return '';
+
+  const lines = [];
+  const pushLine = (label, value) => {
+    if (value === undefined || value === null || value === '') return;
+    lines.push(`${label}: ${String(value)}`);
+  };
+
+  if (messageContent.displayName) pushLine('Name', messageContent.displayName);
+  if (messageContent.vcard) {
+    const phoneMatch = String(messageContent.vcard).match(/TEL[^:]*:(.+)/i);
+    if (phoneMatch?.[1]) pushLine('Phone', phoneMatch[1].trim());
+  }
+
+  if (Array.isArray(messageContent.contacts)) {
+    for (const contact of messageContent.contacts) {
+      if (!contact || typeof contact !== 'object') continue;
+      pushLine('Contact', contact.displayName || contact.vcard || contact.vcardFormattedName || '');
+      pushLine('Phone', contact.phoneNumber || contact.internationalNumber || contact.whatsappId || '');
+    }
+  }
+
+  if (lines.length > 0) {
+    return `[contact card]\n${lines.join('\n')}`;
+  }
+
+  return '[contact card received]';
+}
+
 mkdirSync(SESSION_DIR, { recursive: true });
 
 // Build LID → phone reverse map from session files (lid-mapping-{phone}.json)
@@ -308,6 +338,12 @@ async function startSocket() {
         } catch (err) {
           console.error('[bridge] Failed to download document:', err.message);
         }
+      } else if (messageContent.contactMessage) {
+        body = formatContactCard(messageContent.contactMessage);
+        mediaType = 'contact';
+      } else if (messageContent.contactsArrayMessage) {
+        body = formatContactCard(messageContent.contactsArrayMessage);
+        mediaType = 'contact';
       }
 
       // For media without caption, use a placeholder so the API message is never empty

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -23,6 +23,7 @@ import express from 'express';
 import { Boom } from '@hapi/boom';
 import pino from 'pino';
 import path from 'path';
+import { formatContactCard } from './contact-card.js';
 import { mkdirSync, readFileSync, writeFileSync, existsSync, readdirSync } from 'fs';
 import { randomBytes } from 'crypto';
 import qrcode from 'qrcode-terminal';
@@ -87,36 +88,6 @@ function getContextInfo(messageContent) {
     }
   }
   return {};
-}
-
-function formatContactCard(messageContent) {
-  if (!messageContent || typeof messageContent !== 'object') return '';
-
-  const lines = [];
-  const pushLine = (label, value) => {
-    if (value === undefined || value === null || value === '') return;
-    lines.push(`${label}: ${String(value)}`);
-  };
-
-  if (messageContent.displayName) pushLine('Name', messageContent.displayName);
-  if (messageContent.vcard) {
-    const phoneMatch = String(messageContent.vcard).match(/TEL[^:]*:(.+)/i);
-    if (phoneMatch?.[1]) pushLine('Phone', phoneMatch[1].trim());
-  }
-
-  if (Array.isArray(messageContent.contacts)) {
-    for (const contact of messageContent.contacts) {
-      if (!contact || typeof contact !== 'object') continue;
-      pushLine('Contact', contact.displayName || contact.vcard || contact.vcardFormattedName || '');
-      pushLine('Phone', contact.phoneNumber || contact.internationalNumber || contact.whatsappId || '');
-    }
-  }
-
-  if (lines.length > 0) {
-    return `[contact card]\n${lines.join('\n')}`;
-  }
-
-  return '[contact card received]';
 }
 
 mkdirSync(SESSION_DIR, { recursive: true });

--- a/scripts/whatsapp-bridge/contact-card.js
+++ b/scripts/whatsapp-bridge/contact-card.js
@@ -1,0 +1,153 @@
+/**
+ * WhatsApp contact card (vCard) parser.
+ *
+ * Extracts structured contact information from Baileys contactMessage
+ * and contactsArrayMessage payloads.  Returns a human-readable text
+ * block that the agent can process.
+ *
+ * vCard 3.0/4.0 fields handled:
+ *   FN   — formatted name
+ *   TEL  — phone numbers (all instances, with type labels)
+ *   EMAIL — email addresses
+ *   ORG  — organization / company name
+ *
+ * @module contact-card
+ */
+
+/**
+ * Parse all TEL fields from a vCard string.
+ * Handles formats like:
+ *   TEL;type=CELL:+521234567890
+ *   TEL;TYPE=WORK,VOICE:+521234567890
+ *   TEL:+521234567890
+ *   item1.TEL:+521234567890
+ *
+ * @param {string} vcard - Raw vCard string
+ * @returns {{ number: string, type: string }[]} Parsed phone entries
+ */
+export function parseVcardPhones(vcard) {
+  if (!vcard || typeof vcard !== 'string') return [];
+
+  const phones = [];
+  const lines = vcard.split(/\r?\n/);
+
+  for (const line of lines) {
+    // Match TEL lines, optionally prefixed with itemN. or grouped property
+    const match = line.match(/^(?:item\d+\.)?TEL(?:[;:])(.*)/i);
+    if (!match) continue;
+
+    const rest = match[1];
+
+    // Extract type hint (CELL, WORK, HOME, etc.)
+    const typeMatch = rest.match(/type=([^:;,]+)/i);
+    const type = typeMatch ? typeMatch[1].toLowerCase() : 'phone';
+
+    // Extract the actual number (everything after the last colon)
+    const colonIdx = rest.lastIndexOf(':');
+    const number = colonIdx >= 0
+      ? rest.slice(colonIdx + 1).trim()
+      : rest.replace(/^[^+\d]*/, '').trim();
+
+    if (number) {
+      phones.push({ number, type });
+    }
+  }
+
+  return phones;
+}
+
+/**
+ * Extract a single vCard field value by field name.
+ *
+ * @param {string} vcard - Raw vCard string
+ * @param {string} field - Field name (e.g. 'FN', 'EMAIL', 'ORG')
+ * @returns {string|null} First matching value, or null
+ */
+export function parseVcardField(vcard, field) {
+  if (!vcard || typeof vcard !== 'string') return null;
+
+  const re = new RegExp(`^(?:item\\d+\\.)?${field}[;:](.*)`, 'im');
+  const match = vcard.match(re);
+  if (!match) return null;
+
+  const rest = match[1];
+  const colonIdx = rest.lastIndexOf(':');
+  const value = colonIdx >= 0 ? rest.slice(colonIdx + 1).trim() : rest.trim();
+  return value || null;
+}
+
+/**
+ * Format a single contact object from Baileys into readable text lines.
+ *
+ * @param {{ displayName?: string, vcard?: string, vcardFormattedName?: string }} contact
+ * @returns {string[]} Lines of formatted contact info
+ */
+function formatSingleContact(contact) {
+  if (!contact || typeof contact !== 'object') return [];
+
+  const lines = [];
+
+  // Name: prefer displayName, fall back to vCard FN field
+  const name = contact.displayName
+    || (contact.vcard && parseVcardField(contact.vcard, 'FN'))
+    || contact.vcardFormattedName
+    || null;
+  if (name) lines.push(`Name: ${name}`);
+
+  if (contact.vcard) {
+    // Organization
+    const org = parseVcardField(contact.vcard, 'ORG');
+    if (org) lines.push(`Org: ${org}`);
+
+    // All phone numbers with type labels
+    const phones = parseVcardPhones(contact.vcard);
+    for (const { number, type } of phones) {
+      const label = type === 'phone' ? 'Phone' : `Phone (${type})`;
+      lines.push(`${label}: ${number}`);
+    }
+
+    // Email
+    const email = parseVcardField(contact.vcard, 'EMAIL');
+    if (email) lines.push(`Email: ${email}`);
+  }
+
+  return lines;
+}
+
+/**
+ * Format a Baileys contact message payload into agent-readable text.
+ *
+ * Handles both message types:
+ *   - contactMessage: single contact with displayName + vcard
+ *   - contactsArrayMessage: wrapper with displayName + contacts[]
+ *
+ * @param {object} messageContent - Baileys contactMessage or contactsArrayMessage
+ * @returns {string} Formatted text, e.g. "[contact card]\nName: ...\nPhone: ..."
+ */
+export function formatContactCard(messageContent) {
+  if (!messageContent || typeof messageContent !== 'object') return '';
+
+  const allLines = [];
+
+  // Single contact (contactMessage has displayName + vcard at top level)
+  if (messageContent.vcard) {
+    allLines.push(...formatSingleContact(messageContent));
+  }
+
+  // Multiple contacts (contactsArrayMessage has contacts[])
+  if (Array.isArray(messageContent.contacts)) {
+    for (const contact of messageContent.contacts) {
+      const contactLines = formatSingleContact(contact);
+      if (contactLines.length > 0) {
+        if (allLines.length > 0) allLines.push('---');
+        allLines.push(...contactLines);
+      }
+    }
+  }
+
+  if (allLines.length > 0) {
+    return `[contact card]\n${allLines.join('\n')}`;
+  }
+
+  return '[contact card received]';
+}

--- a/scripts/whatsapp-bridge/contact-card.test.mjs
+++ b/scripts/whatsapp-bridge/contact-card.test.mjs
@@ -1,0 +1,236 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  formatContactCard,
+  parseVcardPhones,
+  parseVcardField,
+} from './contact-card.js';
+
+// ---------------------------------------------------------------------------
+// parseVcardPhones
+// ---------------------------------------------------------------------------
+
+test('parseVcardPhones extracts a single TEL field', () => {
+  const vcard = 'BEGIN:VCARD\nVERSION:3.0\nFN:Juan\nTEL:+5215512345678\nEND:VCARD';
+  const phones = parseVcardPhones(vcard);
+  assert.equal(phones.length, 1);
+  assert.equal(phones[0].number, '+5215512345678');
+  assert.equal(phones[0].type, 'phone');
+});
+
+test('parseVcardPhones extracts multiple TEL fields with types', () => {
+  const vcard = [
+    'BEGIN:VCARD',
+    'VERSION:3.0',
+    'FN:Taller Ramírez',
+    'TEL;type=CELL:+5215512345678',
+    'TEL;type=WORK:+5215587654321',
+    'TEL;TYPE=HOME,VOICE:+5215500001111',
+    'END:VCARD',
+  ].join('\n');
+  const phones = parseVcardPhones(vcard);
+  assert.equal(phones.length, 3);
+  assert.equal(phones[0].number, '+5215512345678');
+  assert.equal(phones[0].type, 'cell');
+  assert.equal(phones[1].number, '+5215587654321');
+  assert.equal(phones[1].type, 'work');
+  assert.equal(phones[2].number, '+5215500001111');
+  assert.equal(phones[2].type, 'home');
+});
+
+test('parseVcardPhones handles itemN.TEL prefix', () => {
+  const vcard = 'BEGIN:VCARD\nitem1.TEL:+5215512345678\nEND:VCARD';
+  const phones = parseVcardPhones(vcard);
+  assert.equal(phones.length, 1);
+  assert.equal(phones[0].number, '+5215512345678');
+});
+
+test('parseVcardPhones returns empty array for null/undefined', () => {
+  assert.deepEqual(parseVcardPhones(null), []);
+  assert.deepEqual(parseVcardPhones(undefined), []);
+  assert.deepEqual(parseVcardPhones(''), []);
+});
+
+test('parseVcardPhones returns empty array for vcard with no TEL', () => {
+  const vcard = 'BEGIN:VCARD\nVERSION:3.0\nFN:Juan\nEND:VCARD';
+  assert.deepEqual(parseVcardPhones(vcard), []);
+});
+
+test('parseVcardPhones handles Windows-style line endings', () => {
+  const vcard = 'BEGIN:VCARD\r\nTEL:+5215512345678\r\nEND:VCARD';
+  const phones = parseVcardPhones(vcard);
+  assert.equal(phones.length, 1);
+  assert.equal(phones[0].number, '+5215512345678');
+});
+
+// ---------------------------------------------------------------------------
+// parseVcardField
+// ---------------------------------------------------------------------------
+
+test('parseVcardField extracts FN', () => {
+  const vcard = 'BEGIN:VCARD\nVERSION:3.0\nFN:Taller Ramírez\nEND:VCARD';
+  assert.equal(parseVcardField(vcard, 'FN'), 'Taller Ramírez');
+});
+
+test('parseVcardField extracts ORG', () => {
+  const vcard = 'BEGIN:VCARD\nORG:AutoServicio Norte S.A.\nEND:VCARD';
+  assert.equal(parseVcardField(vcard, 'ORG'), 'AutoServicio Norte S.A.');
+});
+
+test('parseVcardField extracts EMAIL', () => {
+  const vcard = 'BEGIN:VCARD\nEMAIL;type=WORK:taller@example.com\nEND:VCARD';
+  assert.equal(parseVcardField(vcard, 'EMAIL'), 'taller@example.com');
+});
+
+test('parseVcardField returns null for missing field', () => {
+  const vcard = 'BEGIN:VCARD\nFN:Juan\nEND:VCARD';
+  assert.equal(parseVcardField(vcard, 'EMAIL'), null);
+});
+
+test('parseVcardField returns null for null input', () => {
+  assert.equal(parseVcardField(null, 'FN'), null);
+  assert.equal(parseVcardField(undefined, 'FN'), null);
+});
+
+test('parseVcardField handles itemN prefix', () => {
+  const vcard = 'BEGIN:VCARD\nitem1.EMAIL:test@example.com\nEND:VCARD';
+  assert.equal(parseVcardField(vcard, 'EMAIL'), 'test@example.com');
+});
+
+// ---------------------------------------------------------------------------
+// formatContactCard — single contact (contactMessage)
+// ---------------------------------------------------------------------------
+
+test('formatContactCard formats a single contact with name and phone', () => {
+  const msg = {
+    displayName: 'Taller Ramírez',
+    vcard: [
+      'BEGIN:VCARD',
+      'VERSION:3.0',
+      'FN:Taller Ramírez',
+      'TEL;type=CELL:+5215587654321',
+      'END:VCARD',
+    ].join('\n'),
+  };
+  const result = formatContactCard(msg);
+  assert.match(result, /\[contact card\]/);
+  assert.match(result, /Name: Taller Ramírez/);
+  assert.match(result, /Phone \(cell\): \+5215587654321/);
+});
+
+test('formatContactCard extracts org and email from vcard', () => {
+  const msg = {
+    displayName: 'Juan Pérez',
+    vcard: [
+      'BEGIN:VCARD',
+      'VERSION:3.0',
+      'FN:Juan Pérez',
+      'ORG:Transportes del Norte',
+      'TEL:+5215512345678',
+      'EMAIL:juan@transportes.mx',
+      'END:VCARD',
+    ].join('\n'),
+  };
+  const result = formatContactCard(msg);
+  assert.match(result, /Name: Juan Pérez/);
+  assert.match(result, /Org: Transportes del Norte/);
+  assert.match(result, /Phone: \+5215512345678/);
+  assert.match(result, /Email: juan@transportes.mx/);
+});
+
+test('formatContactCard uses vcard FN when displayName is missing', () => {
+  const msg = {
+    vcard: 'BEGIN:VCARD\nFN:From VCard\nTEL:+123\nEND:VCARD',
+  };
+  const result = formatContactCard(msg);
+  assert.match(result, /Name: From VCard/);
+});
+
+// ---------------------------------------------------------------------------
+// formatContactCard — multiple contacts (contactsArrayMessage)
+// ---------------------------------------------------------------------------
+
+test('formatContactCard formats multiple contacts', () => {
+  const msg = {
+    contacts: [
+      {
+        displayName: 'Taller A',
+        vcard: 'BEGIN:VCARD\nFN:Taller A\nTEL:+111\nEND:VCARD',
+      },
+      {
+        displayName: 'Taller B',
+        vcard: 'BEGIN:VCARD\nFN:Taller B\nTEL:+222\nEND:VCARD',
+      },
+    ],
+  };
+  const result = formatContactCard(msg);
+  assert.match(result, /\[contact card\]/);
+  assert.match(result, /Name: Taller A/);
+  assert.match(result, /Phone: \+111/);
+  assert.match(result, /---/);  // separator between contacts
+  assert.match(result, /Name: Taller B/);
+  assert.match(result, /Phone: \+222/);
+});
+
+test('formatContactCard skips null entries in contacts array', () => {
+  const msg = {
+    contacts: [null, { displayName: 'Valid', vcard: 'BEGIN:VCARD\nTEL:+123\nEND:VCARD' }, undefined],
+  };
+  const result = formatContactCard(msg);
+  assert.match(result, /Phone: \+123/);
+  assert.doesNotMatch(result, /null/);
+});
+
+// ---------------------------------------------------------------------------
+// formatContactCard — edge cases
+// ---------------------------------------------------------------------------
+
+test('formatContactCard returns empty string for null', () => {
+  assert.equal(formatContactCard(null), '');
+  assert.equal(formatContactCard(undefined), '');
+});
+
+test('formatContactCard returns fallback for empty object', () => {
+  assert.equal(formatContactCard({}), '[contact card received]');
+});
+
+test('formatContactCard returns fallback for contact with no parseable data', () => {
+  const msg = { contacts: [{ randomField: 'abc' }] };
+  assert.equal(formatContactCard(msg), '[contact card received]');
+});
+
+test('formatContactCard handles contact with multiple phone types', () => {
+  const msg = {
+    displayName: 'Workshop',
+    vcard: [
+      'BEGIN:VCARD',
+      'FN:Workshop',
+      'TEL;type=CELL:+111',
+      'TEL;type=WORK:+222',
+      'END:VCARD',
+    ].join('\n'),
+  };
+  const result = formatContactCard(msg);
+  assert.match(result, /Phone \(cell\): \+111/);
+  assert.match(result, /Phone \(work\): \+222/);
+});
+
+test('formatContactCard handles real-world WhatsApp vcard format', () => {
+  // Actual vCard format from WhatsApp (observed in production)
+  const msg = {
+    displayName: 'Servicio Automotriz López',
+    vcard: [
+      'BEGIN:VCARD',
+      'VERSION:3.0',
+      'N:;Servicio Automotriz López;;;',
+      'FN:Servicio Automotriz López',
+      'item1.TEL;waid=5215587654321:+52 1 55 8765 4321',
+      'item1.X-ABLabel:Celular',
+      'END:VCARD',
+    ].join('\n'),
+  };
+  const result = formatContactCard(msg);
+  assert.match(result, /Name: Servicio Automotriz López/);
+  assert.match(result, /\+52 1 55 8765 4321/);
+});


### PR DESCRIPTION
## Summary

Adds `formatContactCard()` to the WhatsApp bridge to parse incoming contact card messages (vCard). Currently, contact cards shared via WhatsApp are silently dropped — the agent never sees them.

## Changes

- New `formatContactCard()` function in `scripts/whatsapp-bridge/bridge.js`
- Handles `contactMessage` (single contact) and `contactsArrayMessage` (multiple contacts)
- Extracts name and phone number from vCard format
- Formats as readable text: `[contact card]\nName: ...\nPhone: ...`
- Graceful fallback: `[contact card received]` when parsing fails
- Sets `mediaType: 'contact'` for downstream handling

## Use case

Users share contacts via WhatsApp contact cards. Without this change, the agent ignores them entirely. With it, the agent can extract the phone number and name to store in its contact directory.

Example: a user shares "Juan" as a contact card → the agent extracts the name and phone → uses it for maintenance follow-up.

## Testing

Tested manually with Hermes fleet-agent skills on the WhatsApp gateway.