### PR TITLE
feat(gateway): Tool calls produce emoji reactions for Signal

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2980,6 +2980,7 @@ class BasePlatformAdapter(ABC):
         guild_id: Optional[str] = None,
         parent_chat_id: Optional[str] = None,
         message_id: Optional[str] = None,
+        signal_react_to: Optional[Dict[str, Any]] = None,
     ) -> SessionSource:
         """Helper to build a SessionSource for this platform."""
         # Normalize empty topic to None
@@ -3000,6 +3001,7 @@ class BasePlatformAdapter(ABC):
             guild_id=str(guild_id) if guild_id else None,
             parent_chat_id=str(parent_chat_id) if parent_chat_id else None,
             message_id=str(message_id) if message_id else None,
+            signal_react_to=signal_react_to,
         )
     
     @abstractmethod

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -534,6 +534,17 @@ class SignalAdapter(BasePlatformAdapter):
                 except Exception:
                     logger.exception("Signal: failed to fetch attachment %s", att_id)
 
+        # Parse timestamp from envelope data (milliseconds since epoch)
+        ts_ms = envelope_data.get("timestamp", 0)
+        if ts_ms:
+            signal_react_to = dict(author=sender, timestamp=ts_ms, group_id= group_id if is_group else None)
+            try:
+                timestamp = datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
+            except (ValueError, OSError):
+                timestamp = datetime.now(tz=timezone.utc)
+        else:
+            timestamp = datetime.now(tz=timezone.utc)
+
         # Build session source
         source = self.build_source(
             chat_id=chat_id,
@@ -543,6 +554,8 @@ class SignalAdapter(BasePlatformAdapter):
             user_name=sender_name or sender,
             user_id_alt=sender_uuid if sender_uuid else None,
             chat_id_alt=group_id if is_group else None,
+            # Store signal-cli message targeting info for emoji reactions
+            signal_react_to=signal_react_to,
         )
 
         # Determine message type from media
@@ -1313,6 +1326,58 @@ class SignalAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send a video file as a Signal attachment."""
         return await self._send_attachment(chat_id, video_path, "Video", caption)
+
+    # ------------------------------------------------------------------
+    # Emoji Reactions
+    # ------------------------------------------------------------------
+
+    async def _send_reaction(
+        self,
+        chat_id: str,
+        emoji: str,
+        target_author: str = None,
+        target_timestamp: int = None,
+        *,
+        remove: bool = False,
+    ) -> SendResult:
+        """Send an emoji reaction to a message via signal-cli's sendReaction endpoint.
+
+        Args:
+            chat_id: Chat/channel to react in (phone number or group ID).
+            emoji: Unicode emoji to react with (e.g., "📖", "❤️").
+            target_author: Author of the message being reacted to (source phone/UUID).
+            target_timestamp: Timestamp of the message being reacted to (milliseconds since epoch).
+            remove: If True, removes the reaction instead of adding it.
+
+        Returns:
+            SendResult indicating success or failure.
+        """
+        if not self.client:
+            logger.warning("Signal: cannot send reaction — client not connected")
+            return SendResult(success=False, error="Not connected")
+
+        params: Dict[str, Any] = {
+            "account": self.account,
+            "emoji": emoji,
+        }
+
+        # For group chats, targetAuthor and targetTimestamp may be omitted
+        if chat_id.startswith("group:"):
+            params["groupId"] = chat_id[6:]
+        else:
+            resolved = await self._resolve_recipient(chat_id)
+            params["recipient"] = [resolved]
+
+        # Reaction targeting — identify which message to react to
+        if target_author:
+            params["targetAuthor"] = target_author
+        if target_timestamp:
+            params["targetTimestamp"] = int(target_timestamp)
+        if remove:
+            params["remove"] = True
+
+        result = await self._rpc("sendReaction", params)
+        return SendResult(success=result is not None)
 
     # ------------------------------------------------------------------
     # Typing Indicators

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11189,6 +11189,12 @@ class GatewayRunner:
         
         # Queue for progress messages (thread-safe)
         progress_queue = queue.Queue() if tool_progress_enabled else None
+
+        # Capture gateway loop BEFORE the agent runs in an executor thread,
+        # so progress_callback can use run_coroutine_threadsafe to schedule
+        # async work back on the main event loop.
+        self_loop = asyncio.get_running_loop()
+
         last_tool = [None]  # Mutable container for tracking in closure
         last_progress_msg = [None]  # Track last message for dedup
         repeat_count = [0]  # How many times the same message repeated
@@ -11248,6 +11254,40 @@ class GatewayRunner:
                     return
             except Exception:
                 pass
+
+            # Signal emoji reactions: instead of text messages, react with emoji to user's message
+            # This provides "/verbose new"-like feedback without creating separate bubbles.
+            if source.platform.value == "signal" and hasattr(source, 'signal_react_to') and source.signal_react_to:
+                from agent.display import get_tool_emoji
+                emoji = get_tool_emoji(tool_name, default="👀")
+                react_info = source.signal_react_to
+
+                # For group chats, signal-cli only needs groupId (no targetAuthor/targetTimestamp)
+                if source.chat_id.startswith("group:") and isinstance(react_info.get("group_id"), str):
+                    asyncio.run_coroutine_threadsafe(
+                        self.adapters[source.platform]._send_reaction(
+                            chat_id=source.chat_id,
+                            emoji=emoji,
+                            target_author=None,
+                            target_timestamp=None,
+                        ),
+                        self_loop,
+                    )
+                else:
+                    # DM: need targetAuthor and targetTimestamp (ms) for signal-cli sendReaction
+                    target_ts = react_info.get("timestamp")
+                    target_author = react_info.get("author")
+                    if target_ts is not None and target_author:
+                        asyncio.run_coroutine_threadsafe(
+                            self.adapters[source.platform]._send_reaction(
+                                chat_id=source.chat_id,
+                                emoji=emoji,
+                                target_author=target_author,
+                                target_timestamp=int(target_ts),
+                            ),
+                            self_loop,
+                        )
+                # Signal emoji reactions happen alongside normal progress messages below
 
             # "new" mode: only report when tool changes
             if progress_mode == "new" and tool_name == last_tool[0]:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -92,6 +92,9 @@ class SessionSource:
     parent_chat_id: Optional[str] = None  # Parent channel when chat_id refers to a thread
     message_id: Optional[str] = None  # ID of the triggering message (for pin/reply/react)
     
+    # Signal-specific metadata for emoji reactions on incoming messages.
+    signal_react_to: Optional[Dict[str, Any]] = None
+
     @property
     def description(self) -> str:
         """Human-readable description of the source."""


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

Tool calls now result in the gateway sending relevant emoji reactions to the user's original message.
This is a soft way of showing progress without cluttering the DM/group chat.

- Normal /verbose behavior preserved
- SignalAdapter._send_reaction(): send emoji reactions via signal-cli JSON-RPC endpoint
- SessionSource.signal_react_to: track signal-cli message targeting info from envelopes
- build_source(signal_react_to=...): pass through platform reaction metadata
- Gateway progress_callback: fire _send_reaction() on tool.started for /verbose new"-like UX
- Groups react via groupId only; DMs use targetAuthor + targetTimestamp

## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- gateway/platforms/base.py: new field on BasePlatformAdapter
- gateway/session.py: new field on SessionSource
- gateway/platforms/signal.py: add _send_reaction() and glue code
- gateway/run.py: added handling in GatewayRunner (there's probably a better place for this)

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Use gateway with Signal
2. Issue a query that makes a tool call
3. Observe emoji response

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian Trixie

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or **N/A**
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or **N/A**
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or **N/A**
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or **N/A**
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or **N/A**

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

<img width="276" height="64" alt="image" src="https://github.com/user-attachments/assets/6d4136a8-9185-428c-96c6-9abbef9548de" />
