### PR TITLE
fix(gateway): disambiguate channel_prompts across parents (#13256)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2185,10 +2185,16 @@ def resolve_channel_prompt(
     channel_id: str,
     parent_id: str | None = None,
 ) -> str | None:
-    """Resolve ``channel_prompts`` from ``config.extra``, most-specific first:
-    ``{parent_id}:{channel_id}`` (scopes a prompt to one parent — Telegram
-    forum thread_ids collide across supergroups, #13256), then ``channel_id``,
-    then ``parent_id``. Blank/whitespace-only values are skipped.
+    """Resolve ``channel_prompts`` from ``config.extra``, in this order:
+
+    1. ``{parent_id}:{channel_id}`` (composite — disambiguates parents
+       sharing a child id; e.g. Telegram forum thread_ids collide
+       across supergroups, #13256)
+    2. ``channel_id`` (existing thread/channel-level fallback)
+    3. ``parent_id`` (existing group-level fallback)
+
+    Blank/whitespace-only values are skipped at every level. Returns
+    ``None`` if no key matches.
     """
     prompts = config_extra.get("channel_prompts") or {}
     if not isinstance(prompts, dict):

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2185,20 +2185,17 @@ def resolve_channel_prompt(
     channel_id: str,
     parent_id: str | None = None,
 ) -> str | None:
-    """Resolve a per-channel ephemeral prompt from platform config.
-
-    Looks up ``channel_prompts`` in the adapter's ``config.extra`` dict.
-    Prefers an exact match on *channel_id*; falls back to *parent_id*
-    (useful for forum threads / child channels inheriting a parent prompt).
-
-    Returns the prompt string, or None if no match is found.  Blank/whitespace-
-    only prompts are treated as absent.
+    """Resolve ``channel_prompts`` from ``config.extra``, most-specific first:
+    ``{parent_id}:{channel_id}`` (scopes a prompt to one parent — Telegram
+    forum thread_ids collide across supergroups, #13256), then ``channel_id``,
+    then ``parent_id``. Blank/whitespace-only values are skipped.
     """
     prompts = config_extra.get("channel_prompts") or {}
     if not isinstance(prompts, dict):
         return None
 
-    for key in (channel_id, parent_id):
+    composite = f"{parent_id}:{channel_id}" if parent_id and channel_id else None
+    for key in (composite, channel_id, parent_id):
         if not key:
             continue
         prompt = prompts.get(key)

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -859,20 +859,17 @@ def resolve_channel_prompt(
     channel_id: str,
     parent_id: str | None = None,
 ) -> str | None:
-    """Resolve a per-channel ephemeral prompt from platform config.
-
-    Looks up ``channel_prompts`` in the adapter's ``config.extra`` dict.
-    Prefers an exact match on *channel_id*; falls back to *parent_id*
-    (useful for forum threads / child channels inheriting a parent prompt).
-
-    Returns the prompt string, or None if no match is found.  Blank/whitespace-
-    only prompts are treated as absent.
+    """Resolve ``channel_prompts`` from ``config.extra``, most-specific first:
+    ``{parent_id}:{channel_id}`` (scopes a prompt to one parent — Telegram
+    forum thread_ids collide across supergroups, #13256), then ``channel_id``,
+    then ``parent_id``. Blank/whitespace-only values are skipped.
     """
     prompts = config_extra.get("channel_prompts") or {}
     if not isinstance(prompts, dict):
         return None
 
-    for key in (channel_id, parent_id):
+    composite = f"{parent_id}:{channel_id}" if parent_id and channel_id else None
+    for key in (composite, channel_id, parent_id):
         if not key:
             continue
         prompt = prompts.get(key)

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -13,6 +13,7 @@ from gateway.platforms.base import (
     cache_audio_from_bytes,
     cache_image_from_bytes,
     cache_video_from_bytes,
+    resolve_channel_prompt,
     safe_url_for_log,
     utf16_len,
     validate_inbound_media_size,
@@ -1726,6 +1727,68 @@ class TestTruncateMessageUtf16:
             assert fence_count % 2 == 0, (
                 f"Chunk {i} has unbalanced fences ({fence_count})"
             )
+
+
+class TestResolveChannelPromptComposite:
+    def test_composite_key_match(self):
+        extra = {"channel_prompts": {"-1001:5": "Invoices in Group A"}}
+        assert resolve_channel_prompt(extra, "5", "-1001") == "Invoices in Group A"
+
+    def test_composite_key_disambiguates_colliding_threads(self):
+        # #13256 repro: same thread_id exists in both supergroups.
+        extra = {
+            "channel_prompts": {
+                "-1001:5": "Group A invoices",
+                "-1002:5": "Group B backend",
+            }
+        }
+        assert resolve_channel_prompt(extra, "5", "-1001") == "Group A invoices"
+        assert resolve_channel_prompt(extra, "5", "-1002") == "Group B backend"
+
+    def test_composite_preferred_over_channel_only(self):
+        extra = {
+            "channel_prompts": {
+                "-1001:5": "Scoped prompt",
+                "5": "Generic thread-5 prompt",
+            }
+        }
+        assert resolve_channel_prompt(extra, "5", "-1001") == "Scoped prompt"
+
+    def test_composite_preferred_over_parent_only(self):
+        extra = {
+            "channel_prompts": {
+                "-1001:5": "Scoped prompt",
+                "-1001": "Group-level prompt",
+            }
+        }
+        assert resolve_channel_prompt(extra, "5", "-1001") == "Scoped prompt"
+
+    def test_falls_back_to_channel_when_no_composite(self):
+        # Backward compat: pre-#13256 configs with only thread-level keys
+        # still resolve.
+        extra = {"channel_prompts": {"5": "Thread prompt"}}
+        assert resolve_channel_prompt(extra, "5", "-1001") == "Thread prompt"
+
+    def test_falls_back_to_parent_when_no_composite_or_channel(self):
+        extra = {"channel_prompts": {"-1001": "Group prompt"}}
+        assert resolve_channel_prompt(extra, "5", "-1001") == "Group prompt"
+
+    def test_composite_not_constructed_without_parent(self):
+        # Pins that a stray ``:5`` key in config cannot match when no parent
+        # is provided — the composite candidate must be None, not ":5".
+        extra = {"channel_prompts": {":5": "Malformed", "5": "Channel prompt"}}
+        assert resolve_channel_prompt(extra, "5") == "Channel prompt"
+
+    def test_blank_composite_value_falls_through(self):
+        # Blank prompt at the composite key must not short-circuit lookup —
+        # resolver continues to the next-most-specific candidate.
+        extra = {
+            "channel_prompts": {
+                "-1001:5": "   ",
+                "5": "Thread prompt",
+            }
+        }
+        assert resolve_channel_prompt(extra, "5", "-1001") == "Thread prompt"
 
 
 class TestProxyKwargsForAiohttp:

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -1791,6 +1791,32 @@ class TestResolveChannelPromptComposite:
         assert resolve_channel_prompt(extra, "5", "-1001") == "Thread prompt"
 
 
+class TestTelegramCallerContractCompositeKey:
+    """Mirror the Telegram adapter's ``resolve_channel_prompt`` arguments."""
+
+    def _telegram_call(self, extra: dict, chat_id: str, thread_id: str | None) -> str | None:
+        return resolve_channel_prompt(
+            extra,
+            thread_id or chat_id,
+            chat_id if thread_id else None,
+        )
+
+    def test_resolves_composite_key(self):
+        extra = {
+            "channel_prompts": {
+                "-1003742888118:5": "AI Villa ops",
+                "-1003953149701:5": "Design ai-villa",
+            }
+        }
+        assert self._telegram_call(extra, "-1003742888118", "5") == "AI Villa ops"
+        assert self._telegram_call(extra, "-1003953149701", "5") == "Design ai-villa"
+
+    def test_falls_through_to_chat_key_when_no_thread(self):
+        # DM or non-forum group: thread_id is None; only the chat-level key applies.
+        extra = {"channel_prompts": {"-1003742888118": "Group prompt"}}
+        assert self._telegram_call(extra, "-1003742888118", None) == "Group prompt"
+
+
 class TestProxyKwargsForAiohttp:
     """Verify proxy_kwargs_for_aiohttp routes all schemes through ProxyConnector."""
 

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -8,6 +8,7 @@ from gateway.platforms.base import (
     GATEWAY_SECRET_CAPTURE_UNSUPPORTED_MESSAGE,
     MessageEvent,
     MessageType,
+    resolve_channel_prompt,
     safe_url_for_log,
     utf16_len,
     _prefix_within_utf16_limit,
@@ -581,4 +582,66 @@ class TestTruncateMessageUtf16:
             assert fence_count % 2 == 0, (
                 f"Chunk {i} has unbalanced fences ({fence_count})"
             )
+
+
+class TestResolveChannelPromptComposite:
+    def test_composite_key_match(self):
+        extra = {"channel_prompts": {"-1001:5": "Invoices in Group A"}}
+        assert resolve_channel_prompt(extra, "5", "-1001") == "Invoices in Group A"
+
+    def test_composite_key_disambiguates_colliding_threads(self):
+        # #13256 repro: same thread_id exists in both supergroups.
+        extra = {
+            "channel_prompts": {
+                "-1001:5": "Group A invoices",
+                "-1002:5": "Group B backend",
+            }
+        }
+        assert resolve_channel_prompt(extra, "5", "-1001") == "Group A invoices"
+        assert resolve_channel_prompt(extra, "5", "-1002") == "Group B backend"
+
+    def test_composite_preferred_over_channel_only(self):
+        extra = {
+            "channel_prompts": {
+                "-1001:5": "Scoped prompt",
+                "5": "Generic thread-5 prompt",
+            }
+        }
+        assert resolve_channel_prompt(extra, "5", "-1001") == "Scoped prompt"
+
+    def test_composite_preferred_over_parent_only(self):
+        extra = {
+            "channel_prompts": {
+                "-1001:5": "Scoped prompt",
+                "-1001": "Group-level prompt",
+            }
+        }
+        assert resolve_channel_prompt(extra, "5", "-1001") == "Scoped prompt"
+
+    def test_falls_back_to_channel_when_no_composite(self):
+        # Backward compat: pre-#13256 configs with only thread-level keys
+        # still resolve.
+        extra = {"channel_prompts": {"5": "Thread prompt"}}
+        assert resolve_channel_prompt(extra, "5", "-1001") == "Thread prompt"
+
+    def test_falls_back_to_parent_when_no_composite_or_channel(self):
+        extra = {"channel_prompts": {"-1001": "Group prompt"}}
+        assert resolve_channel_prompt(extra, "5", "-1001") == "Group prompt"
+
+    def test_composite_not_constructed_without_parent(self):
+        # Pins that a stray ``:5`` key in config cannot match when no parent
+        # is provided — the composite candidate must be None, not ":5".
+        extra = {"channel_prompts": {":5": "Malformed", "5": "Channel prompt"}}
+        assert resolve_channel_prompt(extra, "5") == "Channel prompt"
+
+    def test_blank_composite_value_falls_through(self):
+        # Blank prompt at the composite key must not short-circuit lookup —
+        # resolver continues to the next-most-specific candidate.
+        extra = {
+            "channel_prompts": {
+                "-1001:5": "   ",
+                "5": "Thread prompt",
+            }
+        }
+        assert resolve_channel_prompt(extra, "5", "-1001") == "Thread prompt"
 

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -1243,6 +1243,19 @@ Keys are chat IDs (groups/supergroups) or forum topic IDs. For forum groups, top
 - Message in topic `99` (no explicit entry) → falls back to group `-1001234567890`'s prompt
 - Message in a group with no entry → no channel prompt applied
 
+Topic thread IDs are small integers scoped to each supergroup (the General topic is always `1`), so a bare `"42"` key will match topic 42 in *every* supergroup the bot is in. To scope a prompt to one supergroup's topic, use a `{chat_id}:{thread_id}` key:
+
+```yaml
+telegram:
+  channel_prompts:
+    "-1001234567890:42": |
+      Invoices topic in Group A.
+    "-1009876543210:42": |
+      Backend topic in Group B.
+```
+
+Composite keys win over bare `thread_id` or `chat_id` keys, so you can mix scoped and generic entries in the same config.
+
 Numeric YAML keys are automatically normalized to strings.
 
 ## Troubleshooting

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -581,6 +581,19 @@ Keys are chat IDs (groups/supergroups) or forum topic IDs. For forum groups, top
 - Message in topic `99` (no explicit entry) → falls back to group `-1001234567890`'s prompt
 - Message in a group with no entry → no channel prompt applied
 
+Topic thread IDs are small integers scoped to each supergroup (the General topic is always `1`), so a bare `"42"` key will match topic 42 in *every* supergroup the bot is in. To scope a prompt to one supergroup's topic, use a `{chat_id}:{thread_id}` key:
+
+```yaml
+telegram:
+  channel_prompts:
+    "-1001234567890:42": |
+      Invoices topic in Group A.
+    "-1009876543210:42": |
+      Backend topic in Group B.
+```
+
+Composite keys win over bare `thread_id` or `chat_id` keys, so you can mix scoped and generic entries in the same config.
+
 Numeric YAML keys are automatically normalized to strings.
 
 ## Troubleshooting


### PR DESCRIPTION
Closes #13256.

## Problem

`channel_prompts` keys are looked up as flat strings. Telegram forum `thread_id`s are small ints scoped to a single supergroup (the General topic is always `1`), so a bare `"1"` key matches the General topic of every supergroup the bot is in. A typical 5-supergroup setup has pervasive collisions at `thread_id=1`, plus incidental collisions at small ids like 5, 6.

## Fix

Extend `resolve_channel_prompt` in `gateway/platforms/base.py` to accept composite `{parent_id}:{channel_id}` keys, tried before the existing `channel_id` and `parent_id` lookups:

```yaml
telegram:
  channel_prompts:
    "-1001234567890:42": Invoices topic in Group A.
    "-1009876543210:42": Backend topic in Group B.
    "-1001234567890":    Group A fallback.
    "42":                Generic topic-42 fallback.
```

The composite is only constructed when both `parent_id` and `channel_id` are truthy, so adapters that don't pass a parent (Slack, Mattermost, Discord non-thread) are unaffected. Existing flat configs keep working — the new key is strictly additive.

## Precedent

The strongest precedent is `gateway/channel_directory.py`, where `_session_entry_id` returns `f"{chat_id}:{thread_id}"` and stores it as a routing/session-identity key — same purpose as the new composite key. `gateway/platforms/slack.py` (`f"{channel_id}:{thread_ts}"` as a thread-context cache key) and `gateway/delivery.py` (`platform:chat_id:thread_id` serialization separator) use the same `:` delimiter but for different purposes — related conventions, not equivalent routing-key precedents.

## Test plan

- [x] `uv run pytest tests/gateway/test_platform_base.py::TestResolveChannelPromptComposite tests/gateway/test_platform_base.py::TestTelegramCallerContractCompositeKey` — 10 tests cover composite match, collision disambiguation (the #13256 repro), precedence over both flat-key forms, backward-compat fall-through, composite-not-constructed-without-parent, blank-value fall-through, plus telegram-adapter caller-arg-shape pinning (composite hit and chat-key fallback when thread_id is None).
- [x] `uv run pytest tests/gateway/test_discord_channel_prompts.py` — 10 existing tests still pass; verifies backward compat across the Discord adapter path.
- [x] Docs updated in `website/docs/user-guide/messaging/telegram.md` to describe the composite key syntax in the existing Per-Channel Prompts section.