### PR TITLE
feat: add cross-process API rate limiter for multi-profile coordination

### DIFF
--- a/rate_limiter.py
+++ b/rate_limiter.py
@@ -1,0 +1,101 @@
+"""Shared cross-process API rate limiter.
+
+All Hermes profiles share a single rate-limit state file.  Before any
+gateway makes an API request it calls ``acquire_api_slot()`` which:
+
+1. Takes an exclusive flock on ``~/.hermes/api_rate.lock``
+2. Reads the last-request timestamp from ``~/.hermes/api_rate``
+3. If enough time has elapsed → writes the new timestamp, releases the
+   lock, returns immediately.
+4. If not enough time → releases the lock, sleeps the remaining
+   interval, then retries.
+
+The state file is a single line of text: the epoch timestamp (float)
+of the last approved request.  No daemon process is needed — every
+caller coordinates through the lock file.
+"""
+
+import fcntl
+import os
+import time
+from pathlib import Path
+from typing import Optional
+
+from hermes_constants import get_hermes_home
+
+# Default minimum interval between API requests (seconds).
+# Can be overridden with HERMES_API_RATE_INTERVAL env var.
+DEFAULT_INTERVAL = 1.0
+
+# How long to wait for the flock itself (seconds).
+LOCK_TIMEOUT = 10.0
+
+# Max retries before giving up.
+MAX_RETRIES = 60
+
+
+def _state_path() -> Path:
+    return get_hermes_home() / "api_rate"
+
+
+def _lock_path() -> Path:
+    return get_hermes_home() / "api_rate.lock"
+
+
+def acquire_api_slot(interval: Optional[float] = None) -> None:
+    """Block until an API request slot is available.
+
+    Call this right before every external API request (LLM inference,
+    token refresh, agent key minting, etc.) to enforce a global
+    minimum interval across all Hermes profiles.
+    """
+    interval = interval or float(os.getenv("HERMES_API_RATE_INTERVAL", DEFAULT_INTERVAL))
+    state_path = _state_path()
+    lock_path = _lock_path()
+
+    # Ensure parent dir exists
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+
+    for _ in range(MAX_RETRIES):
+        # Open / create the lock file
+        lock_fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o600)
+        try:
+            # Acquire exclusive lock (blocking with timeout)
+            deadline = time.monotonic() + LOCK_TIMEOUT
+            while True:
+                try:
+                    fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    break
+                except (BlockingIOError, OSError):
+                    if time.monotonic() >= deadline:
+                        raise TimeoutError("rate_limit: timed out waiting for flock")
+                    time.sleep(0.01)
+
+            # Read last request time
+            last_time = 0.0
+            try:
+                with open(state_path, "r") as f:
+                    last_time = float(f.read().strip() or "0")
+            except (FileNotFoundError, ValueError):
+                pass
+
+            now = time.time()
+            elapsed = now - last_time
+
+            if elapsed >= interval:
+                # Slot available — record this request and return
+                with open(state_path, "w") as f:
+                    f.write(f"{now:.6f}")
+                    f.flush()
+                    os.fsync(f.fileno())
+                return  # GO
+            else:
+                # Need to wait — release lock first, sleep, retry
+                wait_time = interval - elapsed
+        finally:
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            os.close(lock_fd)
+
+        time.sleep(max(0.001, wait_time))
+
+    # If we exhausted retries, just proceed (don't block forever)

--- a/run_agent.py
+++ b/run_agent.py
@@ -111,6 +111,7 @@ from agent.trajectory import (
     save_trajectory as _save_trajectory_to_file,
 )
 from utils import atomic_json_write, env_var_enabled
+from rate_limiter import acquire_api_slot
 
 
 
@@ -5838,6 +5839,7 @@ class AIAgent:
 
         def _call():
             try:
+                acquire_api_slot()
                 if self.api_mode == "codex_responses":
                     request_client_holder["client"] = self._create_request_openai_client(reason="codex_stream_request")
                     result["response"] = self._run_codex_stream(
@@ -6211,6 +6213,7 @@ class AIAgent:
             # attempt's start, not a previous attempt's last chunk.
             last_chunk_time["t"] = time.time()
             self._touch_activity("waiting for provider response (streaming)")
+            acquire_api_slot()
             stream = request_client_holder["client"].chat.completions.create(**stream_kwargs)
 
             # Capture rate limit headers from the initial HTTP response.
@@ -8033,6 +8036,7 @@ class AIAgent:
                     **self._max_tokens_param(5120),
                 }
                 from agent.auxiliary_client import _get_task_timeout
+                acquire_api_slot()
                 response = self._ensure_primary_openai_client(reason="flush_memories").chat.completions.create(
                     **api_kwargs, timeout=_get_task_timeout("flush_memories")
                 )
@@ -9115,6 +9119,7 @@ class AIAgent:
                     _msg, _ = _nar(summary_response, strip_tool_prefix=self._is_anthropic_oauth)
                     final_response = (_msg.content or "").strip()
                 else:
+                    acquire_api_slot()
                     summary_response = self._ensure_primary_openai_client(reason="iteration_limit_summary").chat.completions.create(**summary_kwargs)
 
                     if summary_response.choices and summary_response.choices[0].message.content:
@@ -9158,6 +9163,7 @@ class AIAgent:
                     if summary_extra_body:
                         summary_kwargs["extra_body"] = summary_extra_body
 
+                    acquire_api_slot()
                     summary_response = self._ensure_primary_openai_client(reason="iteration_limit_summary_retry").chat.completions.create(**summary_kwargs)
 
                     if summary_response.choices and summary_response.choices[0].message.content:


### PR DESCRIPTION
## Summary

Add a lightweight file-lock-based rate limiter to coordinate API requests across multiple Hermes profiles running on the same machine.

## Problem

When multiple Hermes profiles (agents) share the same provider account, concurrent API requests can:
- Trigger provider rate limits (429 errors)
- Cause race conditions on shared auth state
- Waste retry budget on requests that would succeed if slightly delayed

## Solution

### New file: `rate_limiter.py`
- `acquire_api_slot()` — blocks until a request slot is available
- Uses `fcntl.flock` (exclusive lock) on `~/.hermes/api_rate.lock`
- Stores last-request timestamp in `~/.hermes/api_rate`
- Default 1s minimum interval, configurable via `HERMES_API_RATE_INTERVAL` env var
- No daemon process — all callers coordinate through the lock file
- Auto-creates state files on first use

### Modified: `run_agent.py`
Added `acquire_api_slot()` calls before all API requests:
- Main chat completion calls (streaming)
- `flush_memories` (auxiliary LLM call)
- `iteration_limit_summary` and retry
- Codex stream requests

## Usage

For multi-profile setups, share the rate limiter state via symlink:
```bash
ln -sf ~/.hermes/api_rate ~/.hermes/profiles/agent-code/api_rate
ln -sf ~/.hermes/api_rate.lock ~/.hermes/profiles/agent-code/api_rate.lock
```

Interval override:
```bash
export HERMES_API_RATE_INTERVAL=2.0  # 2 seconds between requests
```