### PR TITLE
fix: browser_cdp toolset check hijacks browser tool availability

### DIFF
--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -402,7 +402,7 @@ def _browser_cdp_check() -> bool:
 
 registry.register(
     name="browser_cdp",
-    toolset="browser",
+    toolset="browser-cdp",
     schema=BROWSER_CDP_SCHEMA,
     handler=lambda args, **kw: browser_cdp(
         method=args.get("method", ""),


### PR DESCRIPTION
## Problem

`hermes doctor` reports the entire **browser** toolset as unavailable even when `agent-browser` is correctly installed:

```
External Tools:
  ✓ agent-browser (Node.js) (browser automation)

Tool Availability:
  ⚠ browser (system dependency not met)    ← contradicts the above
```

## Root Cause

`tools/registry.py` imports tool modules in **alphabetical file order** and only stores the **first** check_fn for each toolset (line 226-227):

```python
if check_fn and toolset not in self._toolset_checks:
    self._toolset_checks[toolset] = check_fn
```

Both `browser_cdp_tool.py` and `browser_tool.py` register under `toolset="browser"`. Since `browser_cdp_tool.py` comes first alphabetically, its check_fn (`_browser_cdp_check`) becomes the toolset-level check. This function requires a reachable CDP endpoint (`BROWSER_CDP_URL` / `browser.cdp_url`), which most users don't have configured.

Result: all 11 browser tools (`browser_navigate`, `browser_click`, etc.) are marked unavailable because of a check meant only for `browser_cdp`.

## Fix

Move `browser_cdp` to `toolset="browser-cdp"` (1 line change). Each toolset is now evaluated independently:

- **browser** — available when `agent-browser` is installed (the common case)
- **browser-cdp** — available only when a CDP endpoint is configured (the advanced case)

## Verification

Before fix:
```
Browser available: []
Browser unavailable: [{name: browser, tools: [browser_cdp, browser_navigate, ...]}]
```

After fix:
```
Browser available: [browser]
Browser unavailable: [{name: browser-cdp, tools: [browser_cdp]}]
```