### PR TITLE
fix(tools): keep default-off toolsets disabled on fresh config

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -546,6 +546,10 @@ def _get_platform_tools(
             ts_tools = set(resolve_toolset(ts_key))
             if ts_tools and ts_tools.issubset(all_tool_names):
                 enabled_toolsets.add(ts_key)
+        default_off = set(_DEFAULT_OFF_TOOLSETS)
+        if platform in default_off:
+            default_off.remove(platform)
+        enabled_toolsets -= default_off
 
     # Plugin toolsets: enabled by default unless explicitly disabled.
     # A plugin toolset is "known" for a platform once `hermes tools`

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -55,6 +55,7 @@ AUTHOR_MAP = {
     "185121704+stablegenius49@users.noreply.github.com": "stablegenius49",
     "101283333+batuhankocyigit@users.noreply.github.com": "batuhankocyigit",
     "valdi.jorge@gmail.com": "jvcl",
+    "oussama.redcode@gmail.com": "mavrickdeveloper",
     "126368201+vilkasdev@users.noreply.github.com": "vilkasdev",
     "137614867+cutepawss@users.noreply.github.com": "cutepawss",
     "96793918+memosr@users.noreply.github.com": "memosr",

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -3,6 +3,8 @@
 from unittest.mock import patch
 
 from hermes_cli.tools_config import (
+    _DEFAULT_OFF_TOOLSETS,
+    _apply_toolset_change,
     _configure_provider,
     _get_platform_tools,
     _platform_toolset_summary,
@@ -21,6 +23,7 @@ def test_get_platform_tools_uses_default_when_platform_not_configured():
     enabled = _get_platform_tools(config, "cli")
 
     assert enabled
+    assert enabled.isdisjoint(_DEFAULT_OFF_TOOLSETS)
 
 
 def test_configurable_toolsets_include_messaging():
@@ -32,12 +35,44 @@ def test_get_platform_tools_default_telegram_includes_messaging():
     assert "messaging" in enabled
 
 
+def test_get_platform_tools_homeassistant_platform_keeps_homeassistant_toolset():
+    enabled = _get_platform_tools({}, "homeassistant")
+
+    assert "homeassistant" in enabled
+
+
 def test_get_platform_tools_preserves_explicit_empty_selection():
     config = {"platform_toolsets": {"cli": []}}
 
     enabled = _get_platform_tools(config, "cli")
 
     assert enabled == set()
+
+
+def test_apply_toolset_change_from_default_does_not_enable_default_off_toolsets():
+    """Disabling one default toolset on a fresh config must not persist
+    default-off toolsets as explicitly enabled.
+    """
+    config = {}
+
+    with patch("hermes_cli.tools_config.save_config"):
+        _apply_toolset_change(config, "cli", ["memory"], "disable")
+
+    saved = set(config["platform_toolsets"]["cli"])
+    assert "memory" not in saved
+    assert "terminal" in saved
+    assert saved.isdisjoint(_DEFAULT_OFF_TOOLSETS)
+
+
+def test_apply_toolset_change_can_enable_default_off_toolset_from_default():
+    config = {}
+
+    with patch("hermes_cli.tools_config.save_config"):
+        _apply_toolset_change(config, "cli", ["homeassistant"], "enable")
+
+    saved = set(config["platform_toolsets"]["cli"])
+    assert "homeassistant" in saved
+    assert "terminal" in saved
 
 
 def test_get_platform_tools_handles_null_platform_toolsets():


### PR DESCRIPTION
Salvage of #12726 by @mavrickdeveloper onto current main.

Fresh-config edge case on #2761: `hermes tools disable memory --platform cli` was persisting default-off toolsets (`homeassistant`, `moa`, `rl`) as explicitly enabled because the composite `hermes-cli` preset includes them and the resolver fallback reverse-mapped them in.

## Changes
- `hermes_cli/tools_config.py`: resolver fallback subtracts `_DEFAULT_OFF_TOOLSETS`, preserves the platform's own default-off entry (so `homeassistant` platform still gets `homeassistant`).
- `tests/hermes_cli/test_tools_config.py`: regression coverage for the fresh-config paths.

Fix placed in `_get_platform_tools` (not `_apply_toolset_change`) per @dlkakbs's analysis in the issue thread — filtering in `_apply_toolset_change` would silently break `hermes tools enable moa` on a fresh config.

## Validation
|  | Before | After |
|---|---|---|
| Fresh `disable memory --platform cli` | persisted `homeassistant`/`moa`/`rl` | only removes `memory` |
| Fresh `enable homeassistant --platform cli` | works | works |
| Fresh `enable moa --platform cli` | works | works |
| `homeassistant` platform defaults | include `homeassistant` | include `homeassistant` |

Targeted tests: 42/42 pass (`tests/hermes_cli/test_tools_config.py` + `tests/gateway/test_reasoning_command.py`).

Closes #2761. Supersedes #12726.