### PR TITLE
chore: map Es1la contributor email for AUTHOR_MAP

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -176,6 +176,7 @@ AUTHOR_MAP = {
     "simon@simonmarcus.org": "simon-marcus",
     "xowiekk@gmail.com": "Xowiek",
     "1243352777@qq.com": "zons-zhaozhy",
+    "e.silacandmr@gmail.com": "Es1la",
     # ── bulk addition: 75 emails resolved via API, PR salvage bodies, noreply
     #    crossref, and GH contributor list matching (April 2026 audit) ──
     "1115117931@qq.com": "aaronagent",


### PR DESCRIPTION
Adds e.silacandmr@gmail.com → Es1la mapping so CI's contributor attribution check passes for PR #13270 (merged).

Routine AUTHOR_MAP entry — one-line release.py addition.