### PR TITLE
fix: add lock to IterationBudget.used to prevent race condition

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -203,7 +203,8 @@ class IterationBudget:
 
     @property
     def used(self) -> int:
-        return self._used
+        with self._lock:
+            return self._used
 
     @property
     def remaining(self) -> int:


### PR DESCRIPTION
The `IterationBudget.used` property reads `self._used` without acquiring `self._lock`, while `consume()` and `refund()` both use the lock. This is a data race.

**Fix**: Added `with self._lock:` around the read in the `used` property, consistent with `remaining` property.