### PR TITLE
refactor(ai-gateway): single source of truth for model catalog

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -72,7 +72,7 @@ _openrouter_catalog_cache: list[tuple[str, str]] | None = None
 # OSS / open-weight models prioritized first, then closed-source by family.
 # Slugs match Vercel's actual /v1/models catalog (e.g. alibaba/ for Qwen,
 # zai/ and xai/ without hyphens).
-AI_GATEWAY_MODELS: list[tuple[str, str]] = [
+VERCEL_AI_GATEWAY_MODELS: list[tuple[str, str]] = [
     ("moonshotai/kimi-k2.6",                 "recommended"),
     ("alibaba/qwen3.6-plus",                 ""),
     ("zai/glm-5.1",                          ""),
@@ -300,20 +300,6 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "minimax-m2.7",
         "minimax-m2.5",
     ],
-    "ai-gateway": [
-        "anthropic/claude-opus-4.6",
-        "anthropic/claude-sonnet-4.6",
-        "anthropic/claude-sonnet-4.5",
-        "anthropic/claude-haiku-4.5",
-        "openai/gpt-5",
-        "openai/gpt-4.1",
-        "openai/gpt-4.1-mini",
-        "google/gemini-3-pro-preview",
-        "google/gemini-3-flash",
-        "google/gemini-2.5-pro",
-        "google/gemini-2.5-flash",
-        "deepseek/deepseek-v3.2",
-    ],
     "kilocode": [
         "anthropic/claude-opus-4.6",
         "anthropic/claude-sonnet-4.6",
@@ -365,6 +351,12 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "us.meta.llama4-scout-17b-instruct-v1:0",
     ],
 }
+
+# Vercel AI Gateway: derive the bare-model-id catalog from the curated
+# ``VERCEL_AI_GATEWAY_MODELS`` snapshot so both the picker (tuples with descriptions)
+# and the static fallback catalog (bare ids) stay in sync from a single
+# source of truth.
+_PROVIDER_MODELS["ai-gateway"] = [mid for mid, _ in VERCEL_AI_GATEWAY_MODELS]
 
 # ---------------------------------------------------------------------------
 # Nous Portal free-model filtering
@@ -777,7 +769,7 @@ def fetch_ai_gateway_models(
 
     from hermes_constants import AI_GATEWAY_BASE_URL
 
-    fallback = list(AI_GATEWAY_MODELS)
+    fallback = list(VERCEL_AI_GATEWAY_MODELS)
     preferred_ids = [mid for mid, _ in fallback]
 
     try:

--- a/tests/hermes_cli/test_ai_gateway_models.py
+++ b/tests/hermes_cli/test_ai_gateway_models.py
@@ -10,7 +10,7 @@ from unittest.mock import patch, MagicMock
 
 from hermes_cli import models as models_module
 from hermes_cli.models import (
-    AI_GATEWAY_MODELS,
+    VERCEL_AI_GATEWAY_MODELS,
     _ai_gateway_model_is_free,
     fetch_ai_gateway_models,
     fetch_ai_gateway_pricing,
@@ -89,7 +89,7 @@ def test_ai_gateway_free_detector():
 
 def test_fetch_ai_gateway_models_filters_against_live_catalog():
     _reset_caches()
-    preferred = [mid for mid, _ in AI_GATEWAY_MODELS]
+    preferred = [mid for mid, _ in VERCEL_AI_GATEWAY_MODELS]
     live_ids = preferred[:3]  # only first three exist live
     payload = {
         "data": [
@@ -106,8 +106,8 @@ def test_fetch_ai_gateway_models_filters_against_live_catalog():
 
 def test_fetch_ai_gateway_models_tags_free_models():
     _reset_caches()
-    first_id = AI_GATEWAY_MODELS[0][0]
-    second_id = AI_GATEWAY_MODELS[1][0]
+    first_id = VERCEL_AI_GATEWAY_MODELS[0][0]
+    second_id = VERCEL_AI_GATEWAY_MODELS[1][0]
     payload = {
         "data": [
             {"id": first_id, "pricing": {"input": "0.001", "output": "0.002"}},
@@ -124,7 +124,7 @@ def test_fetch_ai_gateway_models_tags_free_models():
 
 def test_free_moonshot_model_auto_promoted_to_top_even_if_not_curated():
     _reset_caches()
-    first_curated = AI_GATEWAY_MODELS[0][0]
+    first_curated = VERCEL_AI_GATEWAY_MODELS[0][0]
     unlisted_free_moonshot = "moonshotai/kimi-coder-free-preview"
     payload = {
         "data": [
@@ -141,7 +141,7 @@ def test_free_moonshot_model_auto_promoted_to_top_even_if_not_curated():
 
 def test_paid_moonshot_does_not_get_auto_promoted():
     _reset_caches()
-    first_curated = AI_GATEWAY_MODELS[0][0]
+    first_curated = VERCEL_AI_GATEWAY_MODELS[0][0]
     payload = {
         "data": [
             {"id": first_curated, "pricing": {"input": "0.001", "output": "0.002"}},
@@ -158,4 +158,4 @@ def test_fetch_ai_gateway_models_falls_back_on_error():
     _reset_caches()
     with patch("urllib.request.urlopen", side_effect=OSError("network")):
         result = fetch_ai_gateway_models(force_refresh=True)
-    assert result == list(AI_GATEWAY_MODELS)
+    assert result == list(VERCEL_AI_GATEWAY_MODELS)


### PR DESCRIPTION
## Summary
Follow-up to #13223. Delete the stale literal `_PROVIDER_MODELS["ai-gateway"]` and derive it from the curated `VERCEL_AI_GATEWAY_MODELS` snapshot instead, so the picker tuples and the bare-id fallback catalog stay in sync. Also renames the snapshot from `AI_GATEWAY_MODELS` → `VERCEL_AI_GATEWAY_MODELS` to avoid collisions with future Cloudflare/Google/etc. AI-gateway backends.

## Changes
- `hermes_cli/models.py`: rename `AI_GATEWAY_MODELS` → `VERCEL_AI_GATEWAY_MODELS`; remove 12-entry stale literal (gpt-5, gemini-2.5-pro, claude-sonnet-4.5…); populate `_PROVIDER_MODELS["ai-gateway"]` from the curated snapshot right after the dict definition.
- `tests/hermes_cli/test_ai_gateway_models.py`: update to the new symbol name.

## Effect
| | Before | After |
|---|---|---|
| Default for `ai-gateway` | `anthropic/claude-opus-4.6` | `moonshotai/kimi-k2.6` (curated recommendation) |
| Catalog entries | 12 (stale) | 15 (current, OSS-first) |
| Sources of truth | 2 | 1 |
| Symbol name | `AI_GATEWAY_MODELS` | `VERCEL_AI_GATEWAY_MODELS` (collision-free) |

## Validation
- `tests/hermes_cli/test_ai_gateway_models.py` + `tests/run_agent/test_provider_attribution_headers.py` — 12/12 pass
- `tests/hermes_cli/test_api_key_providers.py tests/hermes_cli/test_runtime_provider_resolution.py tests/run_agent/test_provider_parity.py` — 271/272 pass (the 1 failure is `test_model_metadata_has_context_lengths` for HF's `moonshotai/Kimi-K2.6`, pre-existing on `main`)
- Smoke: `detect_provider_for_model('ai-gateway', 'openrouter')` → `('ai-gateway', 'moonshotai/kimi-k2.6')`; `curated_models_for_provider('ai-gateway')` (no creds / no network) → 15-entry fallback with recommendation at top