### PR TITLE
Fix provider alias handling in list_provider_models (/model command)

### DIFF
--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -417,6 +417,9 @@ def list_provider_models(provider: str) -> List[str]:
 
     Returns an empty list if the provider is unknown or has no data.
     """
+    from hermes_cli.models import normalize_provider
+    provider = normalize_provider(provider) or provider
+    
     models = _get_provider_models(provider)
     if models is None:
         return []


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where the `/model` command fails for certain provider aliases
(e.g. "kimi") due to missing provider normalization.

Previously, `list_provider_models()` passed the raw provider string directly
to `_get_provider_models()`, which expects a normalized provider ID that
matches `PROVIDER_TO_MODELS_DEV`. When an alias was used, the lookup failed
and no models were returned.

This PR normalizes the provider using `normalize_provider()` before resolving
models, ensuring consistent behavior across the system.


## Related Issue

N/A


## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)


## Changes Made

- Added provider normalization in `list_provider_models()`
- Ensures compatibility with provider aliases (e.g. "kimi")
- Fixes model lookup failure caused by mismatched provider IDs


## How to Test

1. Run `hermes`
2. Execute `/model kimi`
3. Verify that available models are listed successfully

Before:
- `/model kimi` → Error / no provider found

After:
- `/model kimi` → 
- ✓ Model switched: mimo-v2-omni
    Provider: Xiaomi MiMo
    Context: 256,000 tokens
    Max output: 128,000 tokens
    Cost: $0.40/M in, $2.00/M out, cache read $0.08/M
    Capabilities: reasoning, tools, vision, PDF, audio, open weights
    (session only — add --global to persist)


## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, etc.)
- [x] I searched for existing PRs to ensure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu / WSL

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A
- [x] I've considered cross-platform impact — or N/A


## Screenshots / Logs

/model kimi  
→ Successfully lists available models