### PR TITLE
[RFC] feat(agent): allow per-AIAgent tool injection via extra_tools=

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -37,7 +37,7 @@ import time
 import threading
 from types import SimpleNamespace
 import uuid
-from typing import List, Dict, Any, Optional
+from typing import Any, Callable, Dict, List, Optional
 from openai import OpenAI
 import fire
 from datetime import datetime
@@ -719,6 +719,7 @@ class AIAgent:
         tool_delay: float = 1.0,
         enabled_toolsets: List[str] = None,
         disabled_toolsets: List[str] = None,
+        extra_tools: Optional[List[Dict[str, Any]]] = None,
         save_trajectories: bool = False,
         verbose_logging: bool = False,
         quiet_mode: bool = False,
@@ -776,6 +777,20 @@ class AIAgent:
             tool_delay (float): Delay between tool calls in seconds (default: 1.0)
             enabled_toolsets (List[str]): Only enable tools from these toolsets (optional)
             disabled_toolsets (List[str]): Disable tools from these toolsets (optional)
+            extra_tools (List[Dict]): Per-agent tool specs bound to this AIAgent
+                instance only (not registered globally).  Each spec is
+                ``{"schema": <openai-format function schema>, "handler":
+                <callable(args: dict) -> str>}``.  Schemas merge into
+                ``self.tools`` so the model sees them; handlers live in
+                ``self._extra_tool_handlers`` and are dispatched before the
+                global registry fallback but after hard-coded built-ins
+                (todo/memory/clarify/delegate_task/session_search), so
+                extra_tools can augment an agent without shadowing them.
+                Generalizes the existing memory-provider tool-injection
+                pattern into a first-class parameter.  Useful for
+                domain-specific tools (Feishu doc reader, RL training,
+                Home Assistant) and for handlers that need to close over
+                runtime state (API client, per-event whitelist).
             save_trajectories (bool): Whether to save conversation trajectories to JSONL files (default: False)
             verbose_logging (bool): Enable verbose logging for debugging (default: False)
             quiet_mode (bool): Suppress progress output for clean CLI experience (default: False)
@@ -1304,7 +1319,38 @@ class AIAgent:
                     print(f"   ❌ Disabled toolsets: {', '.join(disabled_toolsets)}")
         elif not self.quiet_mode:
             print("🛠️  No tools loaded (all tools filtered out or unavailable)")
-        
+
+        # Per-agent extra tools: merge schemas into ``self.tools`` so the
+        # model sees them, and index handlers on the instance for dispatch.
+        # Follows the same shape as the memory-provider injection below
+        # (lines ~1408-1422) but parameterised.
+        self._extra_tool_handlers: Dict[str, Callable] = {}
+        if extra_tools:
+            _existing = {
+                t.get("function", {}).get("name")
+                for t in (self.tools or [])
+                if isinstance(t, dict)
+            }
+            for spec in extra_tools:
+                schema = spec["schema"]
+                name = schema["name"]
+                if name in _existing:
+                    # Do not shadow an already-registered tool of the same
+                    # name — global registry and built-ins take precedence.
+                    logger.warning(
+                        "extra_tools: skipping %r — already provided by registry/built-ins",
+                        name,
+                    )
+                    continue
+                self._extra_tool_handlers[name] = spec["handler"]
+                self.tools = (self.tools or []) + [
+                    {"type": "function", "function": schema}
+                ]
+                self.valid_tool_names.add(name)
+                _existing.add(name)
+            if self._extra_tool_handlers and not self.quiet_mode:
+                print(f"   ➕ extra_tools: {', '.join(sorted(self._extra_tool_handlers))}")
+
         # Check tool requirements
         if self.tools and not self.quiet_mode:
             requirements = check_toolset_requirements()
@@ -7616,6 +7662,13 @@ class AIAgent:
                 max_iterations=function_args.get("max_iterations"),
                 parent_agent=self,
             )
+        elif function_name in self._extra_tool_handlers:
+            # Per-agent extra tool dispatch.  Positioned after the hard-
+            # coded built-ins above so extra_tools cannot shadow critical
+            # agent-level surfaces (todo/memory/clarify/delegate_task/
+            # session_search); positioned before the registry fallback
+            # below so extra_tools don't need to be globally registered.
+            return self._extra_tool_handlers[function_name](function_args)
         else:
             return handle_function_call(
                 function_name, function_args, effective_task_id,

--- a/tests/run_agent/test_extra_tools.py
+++ b/tests/run_agent/test_extra_tools.py
@@ -1,0 +1,271 @@
+"""Tests for the ``extra_tools=`` parameter on ``AIAgent.__init__``.
+
+``extra_tools`` generalizes the existing memory-provider tool-injection
+pattern into a first-class parameter — per-agent tool schemas are merged
+into ``self.tools`` and their handlers are dispatched ahead of the global
+registry.  These tests lock in the contract:
+
+  * schemas merge into ``self.tools`` (model sees them)
+  * handlers land in ``self._extra_tool_handlers`` (agent can dispatch)
+  * ``_invoke_tool`` routes to extra handlers before falling through to
+    the registry
+  * built-in agent-level names (todo/memory/etc.) cannot be shadowed
+  * empty / None input is a no-op
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+
+
+def _make_tool_defs(*names: str) -> list:
+    """Build minimal OpenAI-format tool definitions."""
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": n,
+                "description": f"{n} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for n in names
+    ]
+
+
+def _build_agent(extra_tools=None, base_tool_names=()):
+    """Construct an AIAgent with mocked externals and a chosen registry view."""
+    with (
+        patch(
+            "run_agent.get_tool_definitions",
+            return_value=_make_tool_defs(*base_tool_names),
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            extra_tools=extra_tools,
+        )
+        agent.client = MagicMock()
+        return agent
+
+
+# ---------------------------------------------------------------------------
+# Construction-time contract
+# ---------------------------------------------------------------------------
+
+
+class TestExtraToolsConstruction:
+    """Schemas merge into the tool list visible to the model."""
+
+    def test_none_is_noop(self):
+        agent = _build_agent(extra_tools=None, base_tool_names=("web_search",))
+        assert agent._extra_tool_handlers == {}
+        assert {t["function"]["name"] for t in agent.tools} == {"web_search"}
+
+    def test_empty_list_is_noop(self):
+        agent = _build_agent(extra_tools=[], base_tool_names=("web_search",))
+        assert agent._extra_tool_handlers == {}
+        assert {t["function"]["name"] for t in agent.tools} == {"web_search"}
+
+    def test_single_tool_merges_into_self_tools(self):
+        schema = {
+            "name": "feishu_doc_read",
+            "description": "Read Feishu doc text",
+            "parameters": {"type": "object", "properties": {"doc_token": {"type": "string"}}},
+        }
+        handler = MagicMock(return_value='{"content": "ok"}')
+        agent = _build_agent(
+            extra_tools=[{"schema": schema, "handler": handler}],
+            base_tool_names=("web_search",),
+        )
+
+        # Schema visible to the model as a tool in self.tools.
+        names = {t["function"]["name"] for t in agent.tools}
+        assert names == {"web_search", "feishu_doc_read"}
+
+        # Handler indexed on the instance.
+        assert "feishu_doc_read" in agent._extra_tool_handlers
+        assert agent._extra_tool_handlers["feishu_doc_read"] is handler
+
+        # Name validation set updated so tool-call filtering accepts it.
+        assert "feishu_doc_read" in agent.valid_tool_names
+
+    def test_multiple_tools_all_merge(self):
+        specs = [
+            {"schema": {"name": f"domain_{i}", "description": "", "parameters": {}}, "handler": MagicMock()}
+            for i in range(3)
+        ]
+        agent = _build_agent(extra_tools=specs, base_tool_names=())
+        assert set(agent._extra_tool_handlers) == {"domain_0", "domain_1", "domain_2"}
+        assert {t["function"]["name"] for t in agent.tools} == {"domain_0", "domain_1", "domain_2"}
+
+    def test_schema_wrapped_in_type_function_envelope(self):
+        """Merged schemas must match the OpenAI-format envelope used by the model API."""
+        schema = {"name": "domain_x", "description": "", "parameters": {}}
+        agent = _build_agent(
+            extra_tools=[{"schema": schema, "handler": MagicMock()}],
+            base_tool_names=(),
+        )
+        wrapped = next(t for t in agent.tools if t["function"]["name"] == "domain_x")
+        assert wrapped == {"type": "function", "function": schema}
+
+
+# ---------------------------------------------------------------------------
+# Shadow prevention
+# ---------------------------------------------------------------------------
+
+
+class TestExtraToolsShadowPrevention:
+    """extra_tools must not override tools already provided by the registry."""
+
+    def test_name_collision_with_registry_is_ignored(self, caplog):
+        """If extra_tools supplies a name already in self.tools, drop it."""
+        handler = MagicMock()
+        agent = _build_agent(
+            extra_tools=[
+                {
+                    "schema": {"name": "web_search", "description": "", "parameters": {}},
+                    "handler": handler,
+                }
+            ],
+            base_tool_names=("web_search",),  # already in registry
+        )
+        # Registry version wins — handler never stored.
+        assert "web_search" not in agent._extra_tool_handlers
+        # self.tools still has exactly one web_search entry.
+        web_search_count = sum(
+            1 for t in agent.tools if t["function"]["name"] == "web_search"
+        )
+        assert web_search_count == 1
+
+    def test_built_in_agent_tool_name_cannot_be_shadowed(self):
+        """The hard-coded ``todo`` dispatch in _invoke_tool runs before extra."""
+        handler = MagicMock()
+        # Even if registry doesn't have "todo", the _invoke_tool dispatch
+        # for "todo" is hard-coded and checked before extra_tools, so a
+        # collision is harmless at dispatch time regardless of whether
+        # we store the handler.  Verify the schema-merge side stays sane.
+        agent = _build_agent(
+            extra_tools=[
+                {
+                    "schema": {"name": "todo", "description": "", "parameters": {}},
+                    "handler": handler,
+                }
+            ],
+            base_tool_names=(),  # registry has no 'todo' in this mock
+        )
+        # Handler IS stored (registry didn't claim it), but _invoke_tool
+        # dispatch order ensures the built-in path wins.  The dispatch
+        # ordering is exercised in TestExtraToolsDispatch below.
+        # Here we only verify schema merged without duplication.
+        todo_count = sum(1 for t in agent.tools if t["function"]["name"] == "todo")
+        assert todo_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Dispatch contract
+# ---------------------------------------------------------------------------
+
+
+class TestExtraToolsDispatch:
+    """``_invoke_tool`` routes to extra handlers before the registry."""
+
+    def test_extra_tool_handler_invoked(self):
+        handler = MagicMock(return_value='{"success": true}')
+        agent = _build_agent(
+            extra_tools=[
+                {
+                    "schema": {"name": "domain_x", "description": "", "parameters": {}},
+                    "handler": handler,
+                }
+            ],
+            base_tool_names=(),
+        )
+
+        result = agent._invoke_tool("domain_x", {"foo": "bar"}, effective_task_id="t1")
+        handler.assert_called_once_with({"foo": "bar"})
+        assert result == '{"success": true}'
+
+    def test_unknown_name_falls_through_to_registry(self):
+        """Names not in extra_tools must still hit ``handle_function_call``."""
+        handler = MagicMock()
+        agent = _build_agent(
+            extra_tools=[
+                {
+                    "schema": {"name": "domain_x", "description": "", "parameters": {}},
+                    "handler": handler,
+                }
+            ],
+            base_tool_names=(),
+        )
+
+        with patch("run_agent.handle_function_call", return_value='{"from": "registry"}') as mock_reg:
+            result = agent._invoke_tool("some_registry_tool", {}, effective_task_id="t1")
+        handler.assert_not_called()
+        mock_reg.assert_called_once()
+        assert result == '{"from": "registry"}'
+
+    def test_built_in_todo_not_shadowed_by_extra(self):
+        """Even if extra_tools supplies a ``todo`` handler, the built-in wins.
+
+        ``_invoke_tool`` dispatch order puts the hard-coded ``todo`` branch
+        above the extra-tools branch, so the extra handler must not fire
+        for that name.
+        """
+        extra_handler = MagicMock(return_value='{"from": "extra"}')
+        agent = _build_agent(
+            extra_tools=[
+                {
+                    "schema": {"name": "todo", "description": "", "parameters": {}},
+                    "handler": extra_handler,
+                }
+            ],
+            base_tool_names=(),
+        )
+        # ``todo_tool`` is lazy-imported inside _invoke_tool, so patch the
+        # source module (not ``run_agent``).
+        with patch("tools.todo_tool.todo_tool", return_value='{"from": "built-in"}'):
+            result = agent._invoke_tool(
+                "todo", {"todos": []}, effective_task_id="t1",
+            )
+        extra_handler.assert_not_called()
+        assert result == '{"from": "built-in"}'
+
+
+# ---------------------------------------------------------------------------
+# End-to-end-ish contract: extra_tools advertised exactly like registry tools
+# ---------------------------------------------------------------------------
+
+
+class TestExtraToolsExposureSymmetric:
+    """A model integrating with the agent should not be able to tell
+    extra_tools apart from registry tools at the wire-protocol level."""
+
+    def test_extra_tool_schema_survives_self_tools_shape(self):
+        """extra_tools should land under the same ``{'type': 'function', ...}``
+        envelope as registry-loaded tools."""
+        schema = {
+            "name": "image_generate",
+            "description": "Generate an image",
+            "parameters": {
+                "type": "object",
+                "properties": {"prompt": {"type": "string"}},
+                "required": ["prompt"],
+            },
+        }
+        agent = _build_agent(
+            extra_tools=[{"schema": schema, "handler": MagicMock()}],
+            base_tool_names=("web_search",),
+        )
+        registry_item = next(t for t in agent.tools if t["function"]["name"] == "web_search")
+        extra_item = next(t for t in agent.tools if t["function"]["name"] == "image_generate")
+        assert registry_item.keys() == extra_item.keys()
+        assert registry_item["type"] == extra_item["type"] == "function"


### PR DESCRIPTION
## Motivation

Today every tool an agent can reach must be registered in the global
`tools.registry` at import time. That fits cross-cutting capabilities
(`memory`, `session_search`, `todo`, `send_message`, …) but is a poor
fit for two other kinds of tool:

1. **Domain-specific** — only meaningful inside one platform or scenario
   (e.g. a Feishu doc reader, RL training, a Home Assistant entity
   getter). Today such tools are visible to any agent that opts into
   their toolset, even on unrelated channels.
2. **Instance-bound** — the handler needs to close over a runtime value
   owned by the caller (API client, per-event whitelist, auth context).
   Today those handlers resort to thread-locals or module singletons,
   with the familiar correctness concerns around `asyncio.to_thread`
   and multi-account fan-out.

## The pattern already exists — just not generalized

Hermes already implements per-agent tool injection for exactly one
consumer: the memory provider.

`run_agent.py` lines ~1408-1422:

```python
if self._memory_manager and self.tools is not None:
    _existing = {t.get("function", {}).get("name") for t in self.tools}
    for _schema in self._memory_manager.get_all_tool_schemas():
        _tname = _schema.get("name", "")
        if _tname in _existing:
            continue
        self.tools.append({"type": "function", "function": _schema})
        self.valid_tool_names.add(_tname)
```

And in `_invoke_tool` (~line 7998):

```python
elif self._memory_manager and self._memory_manager.has_tool(function_name):
    return self._memory_manager.handle_tool_call(function_name, function_args)
```

That is conceptually `extra_tools` — schemas merged into `self.tools`
plus a dispatch branch that checks per-agent handler storage before
falling through to the global registry. It's just hard-wired for
memory.

## Proposal

Promote the pattern to a generic `AIAgent.__init__` parameter:

```python
AIAgent(
    ...,
    extra_tools=[{"schema": <openai-fn-schema>, "handler": <callable>}, ...],
)
```

**Behavior** (see the commit for the ~25-line implementation):

- Schemas merge into `self.tools` under the same `{"type": "function", ...}`
  envelope as registry tools, so the model sees them uniformly.
- Handlers are indexed in a per-instance `self._extra_tool_handlers`
  dict and dispatched by `_invoke_tool` **after** the hard-coded
  agent-level built-ins (`todo` / `memory` / `clarify` /
  `delegate_task` / `session_search`) and **before** the registry
  fallback. Order means extra_tools can augment an agent but cannot
  shadow critical built-ins.
- Name collisions with entries already in `self.tools` (registry or
  earlier extra_tools) are logged and skipped.

## Concrete use case

[PR #13045](https://github.com/NousResearch/hermes-agent/pull/13045)
reworks the Feishu document-comment integration. Two findings there
would have been unnecessary with `extra_tools`:

- `feishu_doc_read` and the drive-comment tools had to live in the
  global registry, even though they are only meaningful inside the
  comment handler. They were deleted and replaced with an ad-hoc
  two-pass `<NEED_DOC_READ>` sentinel protocol on top of plaintext
  responses. That protocol has been harder to secure (three injection
  variants found so far) than a proper function-call tool would be.
- The lark client had to be injected via `threading.local` because
  there was no other way to pass an instance-bound dependency to a
  registry-level handler. This raised correctness concerns around
  `asyncio.to_thread` and multi-account paths.

Other likely consumers:

- `rl_*` — only meaningful when an RL training run is active.
- `homeassistant/*` — only meaningful when `HASS_TOKEN` is configured
  and a Home Assistant server is reachable.
- Future external plugins via `hermes_cli/plugins`: today
  `PluginContext.register_tool` calls `registry.register`, making the
  plugin's tools visible to every agent with no hook for per-agent
  scoping.

## Discussion points

1. Is the general direction acceptable? If not, what's the preferred
   alternative for "tool real enough to show the model but should not
   live in the global registry"?
2. Bikeshed: parameter name — `extra_tools`, `agent_tools`,
   `instance_tools`, `scoped_tools`? Happy to follow whatever
   convention fits hermes's style.
3. Dispatch order: current placement is *after* hard-coded built-ins,
   *before* registry fallback. I chose "cannot shadow built-ins" as
   the default safety posture; open to reversing it if the convention
   is "caller knows best".

## Test plan
- [x] 11 new unit tests in `tests/run_agent/test_extra_tools.py`
      covering construction (None / empty / single / multiple),
      shadow prevention (registry collision, built-in collision),
      dispatch (handler invoked for its name, unknown names fall
      through to registry, built-in dispatch order wins over
      extra_tools), and schema-envelope symmetry with registry tools.
- [x] Existing `tests/run_agent/test_run_agent.py` (275 tests) passes
      unchanged.