### PR TITLE
fix(streaming): synthesize usage estimate when provider omits usage chunk (closes #12023)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5703,6 +5703,27 @@ class AIAgent:
                 effective_finish_reason = "length"
 
             full_reasoning = "".join(reasoning_parts) or None
+
+            # When the upstream provider does not emit a usage chunk (observed
+            # with MiniMax M2 streaming), synthesize an approximate usage
+            # object from the accumulated text so context-management and
+            # cost-tracking downstream still make forward progress.  The
+            # resulting CompletionUsage is marked estimated=True so metrics
+            # reporters can distinguish.
+            if usage_obj is None:
+                _est_prompt = estimate_messages_tokens_rough(
+                    api_kwargs.get("messages", [])
+                )
+                _est_completion = estimate_tokens_rough(full_content or "")
+                if full_reasoning:
+                    _est_completion += estimate_tokens_rough(full_reasoning)
+                usage_obj = SimpleNamespace(
+                    prompt_tokens=_est_prompt,
+                    completion_tokens=_est_completion,
+                    total_tokens=_est_prompt + _est_completion,
+                    estimated=True,
+                )
+
             mock_message = SimpleNamespace(
                 role=role,
                 content=full_content,

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -272,6 +272,96 @@ class TestStreamingAccumulator:
         assert response.choices[0].message.content == "Let me check"
         assert len(response.choices[0].message.tool_calls) == 1
 
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_missing_usage_falls_back_to_estimate(self, mock_close, mock_create):
+        """Stream without a usage chunk (e.g. MiniMax M2) produces an
+        estimated usage object instead of `usage=None`, so downstream
+        context-management and cost-tracking still make forward progress.
+
+        Regression guard for issue #12023.
+        """
+        from run_agent import AIAgent
+
+        # No usage chunk in the stream — mirrors observed MiniMax behavior.
+        chunks = [
+            _make_stream_chunk(content="Hello"),
+            _make_stream_chunk(content=" world"),
+            _make_stream_chunk(content="!", finish_reason="stop", model="test-model"),
+        ]
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = iter(chunks)
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        messages = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Say hi"},
+        ]
+        response = agent._interruptible_streaming_api_call({"messages": messages})
+
+        assert response.usage is not None, (
+            "Missing-usage stream should not return usage=None"
+        )
+        assert getattr(response.usage, "estimated", False) is True, (
+            "Synthesized usage should be marked estimated=True"
+        )
+        assert response.usage.prompt_tokens > 0
+        assert response.usage.completion_tokens > 0
+        assert (
+            response.usage.total_tokens
+            == response.usage.prompt_tokens + response.usage.completion_tokens
+        )
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_present_usage_is_preferred_over_estimate(
+        self, mock_close, mock_create
+    ):
+        """When the provider DOES emit usage, that value wins and is not
+        clobbered by an estimate."""
+        from run_agent import AIAgent
+
+        chunks = [
+            _make_stream_chunk(content="Hello"),
+            _make_stream_chunk(content=" world", finish_reason="stop"),
+            _make_empty_chunk(
+                usage=SimpleNamespace(prompt_tokens=42, completion_tokens=7)
+            ),
+        ]
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = iter(chunks)
+        mock_create.return_value = mock_client
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
+
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.usage.prompt_tokens == 42
+        assert response.usage.completion_tokens == 7
+        assert getattr(response.usage, "estimated", False) is False
+
 
 # ── Test: Streaming Callbacks ────────────────────────────────────────────
 


### PR DESCRIPTION
## What does this PR do?

OpenAI chat-completions streaming requires a terminal chunk with `usage` populated, requested via `stream_options={include_usage: True}`. **MiniMax M2** (and any other provider that doesn't honor that flag) never emits that chunk, so `usage_obj` stays `None` and the mock response at `run_agent.py` ~line 5721 is built with `usage=None`.

Every downstream consumer guards with `if hasattr(response, 'usage') and response.usage:`, so a chain of behavior silently no-ops:

- `context_compressor.update_from_response()` never runs → context growth is invisible → preflight trim fires later than it should
- `normalize_usage()` / `estimate_usage_cost()` never run → cost metrics stay at zero
- Cached context-length probes never persist → repeated probing on future runs

This was flagged in the original issue and the problem persists on current `main`.

**Fix:** At mock-response construction time, when `usage_obj` is still `None` after the stream ends, synthesize one from the accumulated stream content using the existing helpers `estimate_messages_tokens_rough(...)` and `estimate_tokens_rough(...)`. Same rough ~4 chars/token heuristic the repo already uses everywhere for preflight accounting. Marked with `estimated=True` so metrics reporters can distinguish synthesized from reported usage. **No behavior change** when the provider does emit the usage chunk — the synthesis branch is skipped.

## Related Issue

Fixes #12023

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `run_agent.py` (+): synthesize `SimpleNamespace` usage when `usage_obj is None` after streaming completes, using already-imported `estimate_tokens_rough` / `estimate_messages_tokens_rough` (line 92).
- `tests/run_agent/test_streaming.py` (+): two regression tests (missing-usage fallback; present-usage preferred).

```diff
 full_reasoning = "".join(reasoning_parts) or None
+
+# Synthesize a rough usage estimate when the provider omits the
+# terminal usage chunk (observed with MiniMax M2 streaming).
+if usage_obj is None:
+    _est_prompt = estimate_messages_tokens_rough(api_kwargs.get("messages", []))
+    _est_completion = estimate_tokens_rough(full_content or "")
+    if full_reasoning:
+        _est_completion += estimate_tokens_rough(full_reasoning)
+    usage_obj = SimpleNamespace(
+        prompt_tokens=_est_prompt,
+        completion_tokens=_est_completion,
+        total_tokens=_est_prompt + _est_completion,
+        estimated=True,
+    )
```

Two files changed, +111 / −0.

## How to Test

1. Run Hermes against MiniMax M2 with streaming enabled.
2. Inspect the mock response: `usage` is populated with `estimated=True`, total = prompt + completion.
3. Run tests:

   ```
   pytest tests/run_agent/test_streaming.py -q
   ```

   Both `test_missing_usage_falls_back_to_estimate` and `test_present_usage_is_preferred_over_estimate` pass.
4. Confirm context-compressor and cost-tracking paths now fire for MiniMax-like providers.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(streaming):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (2 regression tests)
- [x] I've tested on my platform: macOS 26.5 (arm64)

### Documentation & Housekeeping

- [x] Documentation updates — N/A (internal streaming normalization)
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — pure Python
- [x] Tool descriptions/schemas — N/A

## Not in scope

- `tool_execution_token_tracker` — its call site already handles `usage=None` gracefully; the estimate will start flowing into it automatically.
- Anthropic native streaming — `_call_anthropic` returns a real Anthropic `Message` object, which always carries usage.

## Screenshots / Logs

- `python3 -m py_compile run_agent.py tests/run_agent/test_streaming.py` → clean.
- Tests added in `tests/run_agent/test_streaming.py`:
  - `test_missing_usage_falls_back_to_estimate` — simulates MiniMax pattern; asserts a usable estimate synthesized, marked `estimated=True`, `total == prompt + completion`.
  - `test_present_usage_is_preferred_over_estimate` — asserts real usage wins and `estimated` stays false.
