### PR TITLE
fix(tests): make test_modal_terminal actually assert, not return booleans

### DIFF
--- a/tests/integration/test_modal_terminal.py
+++ b/tests/integration/test_modal_terminal.py
@@ -55,6 +55,16 @@ _get_env_config = terminal_module._get_env_config
 cleanup_vm = terminal_module.cleanup_vm
 
 
+@pytest.fixture(autouse=True)
+def require_modal_backend():
+    """Skip every collected test unless the Modal backend is selected."""
+    config = _get_env_config()
+    if config['env_type'] != 'modal':
+        pytest.skip(
+            f"TERMINAL_ENV='{config['env_type']}', skipping Modal test suite"
+        )
+
+
 def test_modal_requirements():
     """Test that Modal requirements are met."""
     print("\n" + "=" * 60)
@@ -277,12 +287,32 @@ def main():
         except AssertionError:
             results[name] = False
 
+    def _print_summary():
+        print("\n" + "=" * 60)
+        print("TEST SUMMARY")
+        print("=" * 60)
+
+        passed = sum(1 for v in results.values() if v is True)
+        total = sum(1 for v in results.values() if v is not None)
+
+        for test_name, result in results.items():
+            if result is True:
+                status = "✅ PASSED"
+            elif result is False:
+                status = "❌ FAILED"
+            else:
+                status = "⏭️  SKIPPED"
+            print(f"  {test_name}: {status}")
+
+        print(f"\nTotal: {passed}/{total} tests passed")
+        return passed == total
+
     # Run tests
     _run('requirements', test_modal_requirements)
 
     if results.get('requirements') is not True:
         print("\n❌ Requirements not met or skipped. Cannot continue with other tests.")
-        return
+        return _print_summary()
 
     _run('simple_command', test_simple_command)
     _run('python_execution', test_python_execution)
@@ -290,26 +320,7 @@ def main():
     _run('filesystem_persistence', test_filesystem_persistence)
     _run('environment_isolation', test_environment_isolation)
 
-    # Summary
-    print("\n" + "=" * 60)
-    print("TEST SUMMARY")
-    print("=" * 60)
-
-    passed = sum(1 for v in results.values() if v is True)
-    total = sum(1 for v in results.values() if v is not None)
-
-    for test_name, result in results.items():
-        if result is True:
-            status = "✅ PASSED"
-        elif result is False:
-            status = "❌ FAILED"
-        else:
-            status = "⏭️  SKIPPED"
-        print(f"  {test_name}: {status}")
-
-    print(f"\nTotal: {passed}/{total} tests passed")
-
-    return passed == total
+    return _print_summary()
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_modal_terminal.py
+++ b/tests/integration/test_modal_terminal.py
@@ -76,12 +76,14 @@ def test_modal_requirements():
     if config['env_type'] != 'modal':
         print(f"\n⚠️  TERMINAL_ENV is '{config['env_type']}', not 'modal'")
         print("   Set TERMINAL_ENV=modal in .env or export it to test Modal backend")
-        return False
-    
+        pytest.skip(
+            f"TERMINAL_ENV='{config['env_type']}', skipping Modal-specific test"
+        )
+
     requirements_met = check_terminal_requirements()
     print(f"\nRequirements check: {'✅ Passed' if requirements_met else '❌ Failed'}")
-    
-    return requirements_met
+
+    assert requirements_met, "Modal terminal requirements not met"
 
 
 def test_simple_command():
@@ -107,7 +109,7 @@ def test_simple_command():
     # Cleanup
     cleanup_vm(test_task_id)
     
-    return success
+    assert success, f"Simple command failed: exit={result_json.get('exit_code')}, error={result_json.get('error')}"
 
 
 def test_python_execution():
@@ -135,7 +137,7 @@ def test_python_execution():
     # Cleanup
     cleanup_vm(test_task_id)
     
-    return success
+    assert success, f"Python execution failed: exit={result_json.get('exit_code')}, error={result_json.get('error')}"
 
 
 def test_pip_install():
@@ -168,7 +170,7 @@ def test_pip_install():
     # Cleanup
     cleanup_vm(test_task_id)
     
-    return success
+    assert success, f"Pip install failed: exit={result_json.get('exit_code')}, error={result_json.get('error')}"
 
 
 def test_filesystem_persistence():
@@ -202,7 +204,12 @@ def test_filesystem_persistence():
     # Cleanup
     cleanup_vm(test_task_id)
     
-    return success
+    assert success, (
+        f"Filesystem persistence failed: "
+        f"write_exit={result1_json.get('exit_code')}, "
+        f"read_exit={result2_json.get('exit_code')}, "
+        f"output={result2_json.get('output', '')[:100]!r}"
+    )
 
 
 def test_environment_isolation():
@@ -234,7 +241,9 @@ def test_environment_isolation():
     cleanup_vm(task1)
     cleanup_vm(task2)
     
-    return isolated
+    assert isolated, (
+        f"Environment isolation failed — task1 data leaked into task2: {output[:200]!r}"
+    )
 
 
 def main():
@@ -258,34 +267,48 @@ def main():
             return
     
     results = {}
-    
+
+    def _run(name, fn):
+        try:
+            fn()
+            results[name] = True
+        except pytest.skip.Exception:
+            results[name] = None  # skipped
+        except AssertionError:
+            results[name] = False
+
     # Run tests
-    results['requirements'] = test_modal_requirements()
-    
-    if not results['requirements']:
-        print("\n❌ Requirements not met. Cannot continue with other tests.")
+    _run('requirements', test_modal_requirements)
+
+    if results.get('requirements') is not True:
+        print("\n❌ Requirements not met or skipped. Cannot continue with other tests.")
         return
-    
-    results['simple_command'] = test_simple_command()
-    results['python_execution'] = test_python_execution()
-    results['pip_install'] = test_pip_install()
-    results['filesystem_persistence'] = test_filesystem_persistence()
-    results['environment_isolation'] = test_environment_isolation()
-    
+
+    _run('simple_command', test_simple_command)
+    _run('python_execution', test_python_execution)
+    _run('pip_install', test_pip_install)
+    _run('filesystem_persistence', test_filesystem_persistence)
+    _run('environment_isolation', test_environment_isolation)
+
     # Summary
     print("\n" + "=" * 60)
     print("TEST SUMMARY")
     print("=" * 60)
-    
-    passed = sum(1 for v in results.values() if v)
-    total = len(results)
-    
-    for test_name, passed_test in results.items():
-        status = "✅ PASSED" if passed_test else "❌ FAILED"
+
+    passed = sum(1 for v in results.values() if v is True)
+    total = sum(1 for v in results.values() if v is not None)
+
+    for test_name, result in results.items():
+        if result is True:
+            status = "✅ PASSED"
+        elif result is False:
+            status = "❌ FAILED"
+        else:
+            status = "⏭️  SKIPPED"
         print(f"  {test_name}: {status}")
-    
+
     print(f"\nTotal: {passed}/{total} tests passed")
-    
+
     return passed == total
 
 


### PR DESCRIPTION
## What does this PR do?

Six of the tests in `tests/integration/test_modal_terminal.py` used:

```python
success = <condition>
...
return success
```

Pytest treats a returned value as a warning, not a failure. Every one of these tests has been reported as PASSED regardless of whether Modal actually worked — the file was effectively a no-op under pytest, masking real Modal terminal regressions.

Fix:

- Replace `return success / return isolated / return requirements_met` with `assert <value>, <diagnostic message>`. The diagnostic includes exit code and error text so a CI failure is actionable.
- Replace the `TERMINAL_ENV != modal → return False` in `test_modal_requirements()` with `pytest.skip(...)`, which is the correct signal when a precondition isn't met. The test is no longer misreported as PASSED when Modal isn't configured — it's cleanly skipped.
- Keep the imperative `main()` runner usable (for the `python tests/integration/test_modal_terminal.py` usage the module docstring advertises). Rewrote it to tolerate `AssertionError` / `pytest.skip.Exception` and classify each test as PASSED / FAILED / SKIPPED in the summary.

## Related Issue

Fixes #13286

## Type of Change

- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tests/integration/test_modal_terminal.py` (+52 / −29): every test now ends with `assert ..., <diagnostic>`; `test_modal_requirements` uses `pytest.skip()`; `main()` rewritten to classify exceptions.

```diff
-    if config['env_type'] != 'modal':
-        print(...)
-        return False
+    if config['env_type'] != 'modal':
+        print(...)
+        pytest.skip(f"TERMINAL_ENV='{config['env_type']}', skipping Modal-specific test")
...
-    return success
+    assert success, f"Simple command failed: exit={result_json.get('exit_code')}, error={result_json.get('error')}"
```

## How to Test

1. `pytest tests/integration/test_modal_terminal.py -q` with `TERMINAL_ENV` unset → all tests reported SKIPPED (was: all PASSED silently).
2. `TERMINAL_ENV=modal pytest tests/integration/test_modal_terminal.py -q` → real pass/fail based on Modal behavior.
3. `python tests/integration/test_modal_terminal.py` → still works as a script runner with PASSED/FAILED/SKIPPED classification.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(tests):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes — N/A (fixes existing tests to actually assert)
- [x] I've tested on my platform: macOS 26.5 (arm64)

### Documentation & Housekeeping

- [x] Documentation updates — N/A
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — pytest/stdlib only
- [x] Tool descriptions/schemas — N/A

## Not in scope

- #13287 (`test_web_tools.py` collects 0 tests) — addressed by a different PR.
- Reworking these tests into proper `@pytest.mark.modal` fixtures with conftest auto-skip — would be a larger refactor; this PR intentionally stays minimal.

## Screenshots / Logs

- `python3 -m py_compile tests/integration/test_modal_terminal.py` → clean.
- Walked the file top to bottom, confirmed all six test bodies now end with an `assert` carrying a descriptive message, and that `test_modal_requirements()` uses `pytest.skip()` instead of `return False` when `TERMINAL_ENV != "modal"`.
