### PR TITLE
fix(batch_runner): don't re-append per-batch completed_prompts to the final checkpoint

### DIFF
--- a/batch_runner.py
+++ b/batch_runner.py
@@ -950,14 +950,15 @@ class BatchRunner:
                 finally:
                     root_logger.setLevel(original_level)
         
-        # Aggregate all batch statistics and update checkpoint
-        all_completed_prompts = list(completed_prompts_set)
+        # Aggregate all batch statistics and update checkpoint.
+        # NB: completed_prompts_set is already maintained as a dedup’d
+        # set of every completed prompt ID; we must NOT extend this list
+        # again from each batch result below, or the final checkpoint
+        # will contain duplicates (every ID the incremental path already
+        # recorded would get re-appended).  See #13285.
         total_reasoning_stats = {"total_assistant_turns": 0, "turns_with_reasoning": 0, "turns_without_reasoning": 0}
-        
+
         for batch_result in results:
-            # Add newly completed prompts
-            all_completed_prompts.extend(batch_result.get("completed_prompts", []))
-            
             # Aggregate tool stats
             for tool_name, stats in batch_result.get("tool_stats", {}).items():
                 if tool_name not in total_tool_stats:
@@ -975,9 +976,11 @@ class BatchRunner:
             for key in total_reasoning_stats:
                 total_reasoning_stats[key] += batch_result.get("reasoning_stats", {}).get(key, 0)
         
-        # Save final checkpoint (best-effort; incremental writes already happened)
+        # Save final checkpoint (best-effort; incremental writes already happened).
+        # Use the already-deduplicated set, sorted for deterministic output,
+        # matching the format written by the incremental checkpoint path above.
         try:
-            checkpoint_data["completed_prompts"] = all_completed_prompts
+            checkpoint_data["completed_prompts"] = sorted(completed_prompts_set)
             self._save_checkpoint(checkpoint_data, lock=checkpoint_lock)
         except Exception as ckpt_err:
             print(f"âš ï¸  Warning: Failed to save final checkpoint: {ckpt_err}")


### PR DESCRIPTION
## What does this PR do?

`batch_runner.py`'s incremental checkpoint path maintains `completed_prompts_set` as a deduplicated set of every completed prompt ID (lines 925-939, written to disk as `sorted(completed_prompts_set)` at line 941). The final-aggregation path, however, did:

```python
all_completed_prompts = list(completed_prompts_set)
for batch_result in results:
    all_completed_prompts.extend(batch_result.get('completed_prompts', []))
```

…which re-appends every prompt that's **already** in the set — so the final checkpoint contains each completed ID twice. Checkpoint consumers expect `completed_prompts` to be the set of completed items; duplicates inflate counts and complicate resume/progress logic.

Fix: drop the extend loop, write `sorted(completed_prompts_set)` directly. Matches the shape already used by the incremental write at line 941 and keeps output deterministic for easier diff/review of checkpoint files.

## Related Issue

Fixes #13285

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `batch_runner.py` (+11, −8): remove `all_completed_prompts` accumulator; write `sorted(completed_prompts_set)` directly into the final checkpoint.

```diff
-        all_completed_prompts = list(completed_prompts_set)
+        # NB: completed_prompts_set is already maintained as a dedup'd
+        # set of every completed prompt ID; we must NOT extend this list
+        # again from each batch result below, or the final checkpoint
+        # will contain duplicates.  See #13285.
         total_reasoning_stats = {...}

         for batch_result in results:
-            all_completed_prompts.extend(batch_result.get("completed_prompts", []))
             ...

         try:
-            checkpoint_data["completed_prompts"] = all_completed_prompts
+            checkpoint_data["completed_prompts"] = sorted(completed_prompts_set)
             self._save_checkpoint(checkpoint_data, lock=checkpoint_lock)
```

## How to Test

Reporter's minimal repro:

```python
completed_prompts_set = {'p0'}
results = [{'completed_prompts': ['p0']}]
# Before: list(completed_prompts_set) + extend -> ['p0', 'p0']
# After:  sorted(completed_prompts_set)         -> ['p0']
```

1. Run a batch with at least one completed prompt.
2. Inspect the final checkpoint file — `completed_prompts` should contain each ID exactly once.
3. `python3 -m py_compile batch_runner.py`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(batch_runner):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes — N/A (single-line dedup; covered by trace + grep verification)
- [x] I've tested on my platform: macOS 26.5 (arm64)

### Documentation & Housekeeping

- [x] Documentation updates — N/A (no user-visible API change)
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — pure Python, set/sort only
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

Verification:
- `python3 -m py_compile batch_runner.py` → clean.
- Confirmed `all_completed_prompts` is no longer referenced anywhere else in the file (grep returns nothing).
- Incremental checkpoint behavior at lines 925-941 is unchanged.
