### PR TITLE
fix(honcho): resolve global config path at runtime

### DIFF
--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -31,6 +31,11 @@ GLOBAL_CONFIG_PATH = Path.home() / ".honcho" / "config.json"
 HOST = "hermes"
 
 
+def _global_config_path() -> Path:
+    """Return the current global Honcho config path."""
+    return Path.home() / ".honcho" / "config.json"
+
+
 def resolve_active_host() -> str:
     """Derive the Honcho host key from the active Hermes profile.
 
@@ -72,7 +77,7 @@ def resolve_config_path() -> Path:
     if default_path != local_path and default_path.exists():
         return default_path
 
-    return GLOBAL_CONFIG_PATH
+    return _global_config_path()
 
 
 _RECALL_MODE_ALIASES = {"auto": "hybrid"}

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -360,7 +360,7 @@ class TestResolveConfigPath:
         with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}), \
              patch.object(Path, "home", return_value=fake_home):
             result = resolve_config_path()
-        assert result == GLOBAL_CONFIG_PATH
+        assert result == fake_home / ".honcho" / "config.json"
 
     def test_falls_back_to_global_without_hermes_home_env(self, tmp_path):
         fake_home = tmp_path / "fakehome"
@@ -370,7 +370,21 @@ class TestResolveConfigPath:
              patch.object(Path, "home", return_value=fake_home):
             os.environ.pop("HERMES_HOME", None)
             result = resolve_config_path()
-        assert result == GLOBAL_CONFIG_PATH
+        assert result == fake_home / ".honcho" / "config.json"
+
+    def test_uses_current_home_for_global_fallback_after_import(self, tmp_path):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        fake_home = tmp_path / "new-home"
+        fake_home.mkdir()
+        expected_global = fake_home / ".honcho" / "config.json"
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}), \
+             patch.object(Path, "home", return_value=fake_home):
+            result = resolve_config_path()
+
+        assert result == expected_global
+        assert result != GLOBAL_CONFIG_PATH
 
     def test_from_global_config_uses_local_path(self, tmp_path):
         hermes_home = tmp_path / "hermes"


### PR DESCRIPTION
## Summary
- Fixes #13283
- Resolves the global Honcho config path at call time instead of freezing `Path.home()` at import time
- Preserves `GLOBAL_CONFIG_PATH` as a compatibility snapshot for existing imports

## Root Cause
`GLOBAL_CONFIG_PATH` was computed during module import, so tests or runtime environments that changed `HOME` later still fell back to the old home directory.

## Tests
- `uv run --frozen --python 3.11 --extra dev pytest -o addopts='' tests/honcho_plugin/test_client.py -q` (`70 passed, 3 skipped`)
- `git diff --check -- plugins/memory/honcho/client.py tests/honcho_plugin/test_client.py`
