### PR TITLE
fix(batch): dedupe final checkpoint completions

### DIFF
--- a/batch_runner.py
+++ b/batch_runner.py
@@ -57,6 +57,17 @@ ALL_POSSIBLE_TOOLS = set(TOOL_TO_TOOLSET_MAP.keys())
 DEFAULT_TOOL_STATS = {'count': 0, 'success': 0, 'failure': 0}
 
 
+def _merge_completed_prompts(
+    completed_prompts: List[Any],
+    batch_results: List[Dict[str, Any]],
+) -> List[Any]:
+    """Return the unique completed prompt ids from checkpoint and batch results."""
+    merged = set(completed_prompts or [])
+    for batch_result in batch_results:
+        merged.update(batch_result.get("completed_prompts", []) or [])
+    return sorted(merged)
+
+
 def _normalize_tool_stats(tool_stats: Dict[str, Dict[str, int]]) -> Dict[str, Dict[str, int]]:
     """
     Normalize tool_stats to include all possible tools with consistent schema.
@@ -951,13 +962,10 @@ class BatchRunner:
                     root_logger.setLevel(original_level)
         
         # Aggregate all batch statistics and update checkpoint
-        all_completed_prompts = list(completed_prompts_set)
+        all_completed_prompts = _merge_completed_prompts(list(completed_prompts_set), results)
         total_reasoning_stats = {"total_assistant_turns": 0, "turns_with_reasoning": 0, "turns_without_reasoning": 0}
         
         for batch_result in results:
-            # Add newly completed prompts
-            all_completed_prompts.extend(batch_result.get("completed_prompts", []))
-            
             # Aggregate tool stats
             for tool_name, stats in batch_result.get("tool_stats", {}).items():
                 if tool_name not in total_tool_stats:
@@ -1288,4 +1296,3 @@ def main(
 
 if __name__ == "__main__":
     fire.Fire(main)
-

--- a/tests/test_batch_runner_checkpoint.py
+++ b/tests/test_batch_runner_checkpoint.py
@@ -12,7 +12,7 @@ import pytest
 import sys
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from batch_runner import BatchRunner, _process_batch_worker
+from batch_runner import BatchRunner, _merge_completed_prompts, _process_batch_worker
 
 
 @pytest.fixture
@@ -157,6 +157,20 @@ class TestResumePreservesProgress:
 
         assert checkpoint_data["completed_prompts"] == []
         assert checkpoint_data["run_name"] == "test_run"
+
+
+class TestCompletedPromptAggregation:
+    """Final checkpoint aggregation should not duplicate incremental progress."""
+
+    def test_final_checkpoint_dedupes_incremental_and_batch_results(self):
+        existing = [0, 1, 2]
+        batch_results = [
+            {"completed_prompts": [1, 2, 3]},
+            {"completed_prompts": [3, 4]},
+            {"completed_prompts": []},
+        ]
+
+        assert _merge_completed_prompts(existing, batch_results) == [0, 1, 2, 3, 4]
 
 
 class TestBatchWorkerResumeBehavior:


### PR DESCRIPTION
## Summary
- Fixes #13285
- Deduplicates completed prompt IDs when writing the final batch checkpoint
- Keeps incremental checkpoint recovery behavior intact while preventing final aggregation from re-adding the same prompt IDs

## Root Cause
The parent process updated `completed_prompts_set` during incremental checkpoint writes, then initialized final aggregation from that same set and extended it again with each batch result. That made final `completed_prompts` contain duplicates.

## Tests
- `uv run --python 3.11 --extra dev pytest tests/test_batch_runner_checkpoint.py -q` (`14 passed`)
- `git diff --check -- batch_runner.py tests/test_batch_runner_checkpoint.py`
