### PR TITLE
fix(setup): recognize gateway-managed tools

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -2428,6 +2428,12 @@ def _gateway_platform_short_label(label: str) -> str:
     return base or label
 
 
+def _tool_uses_gateway(config: dict, section_key: str) -> bool:
+    """Return True when a tool section is explicitly routed via Nous gateway."""
+    section = config.get(section_key) if isinstance(config, dict) else None
+    return isinstance(section, dict) and bool(section.get("use_gateway"))
+
+
 def _get_section_config_summary(config: dict, section_key: str) -> Optional[str]:
     """Return a short summary if a setup section is already configured, else None.
 
@@ -2465,12 +2471,24 @@ def _get_section_config_summary(config: dict, section_key: str) -> Optional[str]
 
     elif section_key == "tools":
         tools = []
-        if get_env_value("ELEVENLABS_API_KEY"):
+        if _tool_uses_gateway(config, "tts"):
+            tools.append("TTS/Nous Gateway")
+        elif get_env_value("ELEVENLABS_API_KEY"):
             tools.append("TTS/ElevenLabs")
-        if get_env_value("BROWSERBASE_API_KEY"):
+
+        if _tool_uses_gateway(config, "browser"):
+            tools.append("Browser/Nous Gateway")
+        elif get_env_value("BROWSERBASE_API_KEY"):
             tools.append("Browser")
-        if get_env_value("FIRECRAWL_API_KEY"):
+
+        if _tool_uses_gateway(config, "web"):
+            tools.append("Web/Nous Gateway")
+        elif get_env_value("FIRECRAWL_API_KEY"):
             tools.append("Firecrawl")
+
+        if _tool_uses_gateway(config, "image_gen"):
+            tools.append("Image/Nous Gateway")
+
         if tools:
             return ", ".join(tools)
         return None

--- a/tests/hermes_cli/test_setup.py
+++ b/tests/hermes_cli/test_setup.py
@@ -223,6 +223,43 @@ def test_setup_gateway_in_container_shows_docker_guidance(monkeypatch, capsys):
     assert "restart" in out.lower()
 
 
+def test_tools_summary_includes_gateway_managed_tools(monkeypatch):
+    """Setup should not report gateway-managed tools as unconfigured."""
+    monkeypatch.setattr(setup_mod, "get_env_value", lambda key: "")
+
+    summary = setup_mod._get_section_config_summary(
+        {
+            "tts": {"use_gateway": True},
+            "web": {"use_gateway": True},
+            "browser": {"use_gateway": True},
+            "image_gen": {"use_gateway": True},
+        },
+        "tools",
+    )
+
+    assert summary == (
+        "TTS/Nous Gateway, Browser/Nous Gateway, "
+        "Web/Nous Gateway, Image/Nous Gateway"
+    )
+
+
+def test_tools_summary_prefers_gateway_over_direct_keys(monkeypatch):
+    """use_gateway should be visible even when direct provider keys exist."""
+    env = {
+        "ELEVENLABS_API_KEY": "eleven-key",
+        "BROWSERBASE_API_KEY": "browser-key",
+        "FIRECRAWL_API_KEY": "firecrawl-key",
+    }
+    monkeypatch.setattr(setup_mod, "get_env_value", lambda key: env.get(key, ""))
+
+    summary = setup_mod._get_section_config_summary(
+        {"web": {"use_gateway": True}},
+        "tools",
+    )
+
+    assert summary == "TTS/ElevenLabs, Browser, Web/Nous Gateway"
+
+
 def test_setup_syncs_custom_provider_removal_from_disk(tmp_path, monkeypatch):
     """Removing the last custom provider in model setup should persist."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))


### PR DESCRIPTION
## Summary
- Fixes #13301
- Treats `tts.use_gateway`, `browser.use_gateway`, `web.use_gateway`, and `image_gen.use_gateway` as configured tools in setup summaries
- Keeps direct-key summaries intact, while preferring the gateway label for sections explicitly routed through the Nous Tool Gateway

## Root Cause
`hermes setup` only looked for direct provider API keys such as `FIRECRAWL_API_KEY` and `BROWSERBASE_API_KEY` when deciding whether the tools section was configured. Gateway-managed tools persist intent in config via `use_gateway: true`, so they were incorrectly reported as unconfigured.

## Tests
- `uv run --frozen --python 3.11 --extra dev pytest -o addopts='' tests/hermes_cli/test_setup.py -q` (`20 passed`)
- `git diff --check -- hermes_cli/setup.py tests/hermes_cli/test_setup.py`
