### PR TITLE
fix(discord): defer interaction in model picker to prevent 10062 Unknown interaction error

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3637,6 +3637,9 @@ if DISCORD_AVAILABLE:
             self.resolved = True
             model_id = interaction.data["values"][0]
 
+            # Defer immediately to avoid Discord's ~3s interaction timeout (error 10062)
+            await interaction.response.defer()
+
             try:
                 result_text = await self.on_model_selected(
                     str(interaction.channel_id),
@@ -3647,7 +3650,7 @@ if DISCORD_AVAILABLE:
                 result_text = f"Error switching model: {exc}"
 
             self.clear_items()
-            await interaction.response.edit_message(
+            await interaction.edit_original_response(
                 embed=discord.Embed(
                     title="⚙ Model Switched",
                     description=result_text,


### PR DESCRIPTION
## Problem

When a user selects a model in the Discord `/model` picker, the
`ModelPickerView._on_model_selected` callback awaits the full model-switch
logic before responding to the interaction. This can take several seconds.

Discord requires component interactions to be acknowledged within **~3
seconds**. If no acknowledgement is sent in time, any subsequent call to
`interaction.response.edit_message()` raises:

```
discord.errors.NotFound: 404 Not Found (error code: 10062): Unknown interaction
```

This caused the `/model` picker to silently fail or show an error every
time the model-switch logic took longer than Discord's deadline.

## Root Cause

```python
# Before — response sent AFTER slow work, interaction already expired
result_text = await self.on_model_selected(...)   # slow
await interaction.response.edit_message(...)       # 10062 here
```

## Fix

Acknowledge the interaction immediately with `defer()`, then perform the
model-switch work, and finally update the original response. This is the
standard discord.py pattern for callbacks that do any async work.

```python
# After — acknowledge first, then do the work
await interaction.response.defer()                 # instant ACK
result_text = await self.on_model_selected(...)    # slow, but safe
await interaction.edit_original_response(...)      # no timeout risk
```

## Changes

- `gateway/platforms/discord.py`: add `await interaction.response.defer()`
  at the top of `_on_model_selected`, and replace
  `interaction.response.edit_message()` with
  `interaction.edit_original_response()`.

## Testing

Reproduced the 10062 error locally by triggering `/model` with a slow
provider (GitHub Copilot). After this fix, the picker completes without
error regardless of model-switch latency.

## Related

- Discord developer docs: [Responding to interactions](https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-response-object)
- Similar pattern used throughout discord.py ecosystem for deferred responses