### PR TITLE
fix(slack): allow voice replies after voice input

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6177,12 +6177,15 @@ class GatewayRunner:
         if has_agent_tts:
             return False
 
-        # Dedup: base adapter auto-TTS already handles voice input
-        # (play_tts plays in VC when connected, so runner can skip).
-        # When streaming already delivered the text (already_sent=True),
-        # the base adapter will receive None and can't run auto-TTS,
-        # so the runner must take over.
-        if is_voice_input and not already_sent:
+        # Dedup: base adapter auto-TTS already handles voice input on
+        # platforms that do native voice playback/reply handling.
+        # Slack still needs the runner path for voice replies, so keep it
+        # out of this skip list.
+        if (
+            is_voice_input
+            and not already_sent
+            and event.source.platform in {Platform.TELEGRAM, Platform.DISCORD}
+        ):
             return False
 
         return True

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -240,15 +240,20 @@ class TestAutoVoiceReply:
         return _make_runner(tmp_path)
 
     def _call(self, runner, voice_mode, message_type, agent_messages=None,
-              response="Hello!", in_voice_channel=False):
+              response="Hello!", in_voice_channel=False, platform=None):
         """Call real _should_send_voice_reply on a GatewayRunner instance."""
+        from gateway.config import Platform
+
         chat_id = "123"
+        platform = platform or Platform.TELEGRAM
+        voice_key = f"{platform.value}:{chat_id}"
         if voice_mode != "off":
-            runner._voice_mode["telegram:" + chat_id] = voice_mode
+            runner._voice_mode[voice_key] = voice_mode
         else:
-            runner._voice_mode.pop("telegram:" + chat_id, None)
+            runner._voice_mode.pop(voice_key, None)
 
         event = _make_event(message_type=message_type)
+        event.source.platform = platform
 
         if in_voice_channel:
             mock_adapter = MagicMock()
@@ -280,13 +285,13 @@ class TestAutoVoiceReply:
     # | Web UI        | voice | off        | yes  | skip   | 1 audio      |
     # | Web UI        | voice | all        | yes  | skip*  | 1 audio      |
     # | Web UI        | text  | all        | skip | yes    | 1 audio      |
-    # | Slack         | voice | all        | yes  | skip*  | 1 audio      |
+    # | Slack         | voice | all        | yes  | yes    | 1 audio      |
     # | Slack         | text  | all        | skip | yes    | 1 audio      |
     #
-    # * skip_double: voice input → base already handles
+    # * skip_double: voice input → base already handles on Telegram/Discord
     # † Discord play_tts override skips when in VC
 
-    # -- Telegram/Slack/Web: voice input, base handles ---------------------
+    # -- Telegram/Discord: voice input, base handles -----------------------
 
     def test_voice_input_voice_only_skipped(self, runner):
         """voice_only + voice input: base auto-TTS handles it, runner skips."""
@@ -324,6 +329,18 @@ class TestAutoVoiceReply:
     def test_discord_vc_voice_only_base_handles(self, runner):
         """Discord VC + voice_only + voice: base adapter handles."""
         assert self._call(runner, "voice_only", MessageType.VOICE, in_voice_channel=True) is False
+
+    # -- Slack keeps the runner voice-reply path ---------------------------
+
+    def test_slack_voice_input_all_mode_runner_fires(self, runner):
+        """Slack voice input should still produce a voice reply."""
+        from gateway.config import Platform
+        assert self._call(runner, "all", MessageType.VOICE, platform=Platform.SLACK) is True
+
+    def test_slack_voice_input_voice_only_runner_fires(self, runner):
+        """Slack voice_only mode should still produce a voice reply."""
+        from gateway.config import Platform
+        assert self._call(runner, "voice_only", MessageType.VOICE, platform=Platform.SLACK) is True
 
     # -- Edge cases --------------------------------------------------------
 


### PR DESCRIPTION
Fixes #13126.

Root cause:
The runner skipped automatic voice replies for every voice input because Telegram and Discord adapters can already handle native voice playback. Slack does not have that same adapter-side voice reply path, so Slack voice inputs never produced the configured TTS voice response.

Fix summary:
- Keep the voice-input dedupe skip for Telegram and Discord only.
- Let Slack continue through the runner voice-reply path.
- Add Slack-specific regression cases for `all` and `voice_only` voice modes.

Tests:
- `uv run --frozen --python 3.11 --extra dev pytest -o addopts= tests/gateway/test_voice_command.py -k 'TestAutoVoiceReply or TestHandleVoiceCommand' -q`
- `git diff --check -- gateway/run.py tests/gateway/test_voice_command.py`