### PR TITLE
fix(auth): suppress codex CLI reseed on remove

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -68,6 +68,7 @@ DEFAULT_AGENT_KEY_MIN_TTL_SECONDS = 30 * 60  # 30 minutes
 ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 120       # refresh 2 min before expiry
 DEVICE_AUTH_POLL_INTERVAL_CAP_SECONDS = 1     # poll at most every 1s
 DEFAULT_CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
+CODEX_CLI_IMPORT_SOURCE = "codex_cli"
 DEFAULT_QWEN_BASE_URL = "https://portal.qwen.ai/v1"
 DEFAULT_GITHUB_MODELS_BASE_URL = "https://api.githubcopilot.com"
 DEFAULT_COPILOT_ACP_BASE_URL = "acp://copilot"
@@ -774,21 +775,31 @@ def write_credential_pool(provider_id: str, entries: List[Dict[str, Any]]) -> Pa
 
 def suppress_credential_source(provider_id: str, source: str) -> None:
     """Mark a credential source as suppressed so it won't be re-seeded."""
+    source = (source or "").strip()
+    sources = [source]
+    if provider_id == "openai-codex" and source in {"device_code", CODEX_CLI_IMPORT_SOURCE}:
+        sources = ["device_code", CODEX_CLI_IMPORT_SOURCE]
     with _auth_store_lock():
         auth_store = _load_auth_store()
         suppressed = auth_store.setdefault("suppressed_sources", {})
         provider_list = suppressed.setdefault(provider_id, [])
-        if source not in provider_list:
-            provider_list.append(source)
+        for item in sources:
+            if item and item not in provider_list:
+                provider_list.append(item)
         _save_auth_store(auth_store)
 
 
 def is_source_suppressed(provider_id: str, source: str) -> bool:
     """Check if a credential source has been suppressed by the user."""
     try:
+        source = (source or "").strip()
+        if provider_id == "openai-codex" and source in {"device_code", CODEX_CLI_IMPORT_SOURCE}:
+            source_aliases = {"device_code", CODEX_CLI_IMPORT_SOURCE}
+        else:
+            source_aliases = {source}
         auth_store = _load_auth_store()
         suppressed = auth_store.get("suppressed_sources", {})
-        return source in suppressed.get(provider_id, [])
+        return any(alias in suppressed.get(provider_id, []) for alias in source_aliases)
     except Exception:
         return False
 
@@ -798,15 +809,22 @@ def unsuppress_credential_source(provider_id: str, source: str) -> bool:
 
     Returns True if a marker was cleared, False if no marker existed.
     """
+    source = (source or "").strip()
+    if provider_id == "openai-codex" and source in {"device_code", CODEX_CLI_IMPORT_SOURCE}:
+        source_aliases = {"device_code", CODEX_CLI_IMPORT_SOURCE}
+    else:
+        source_aliases = {source}
     with _auth_store_lock():
         auth_store = _load_auth_store()
         suppressed = auth_store.get("suppressed_sources")
         if not isinstance(suppressed, dict):
             return False
         provider_list = suppressed.get(provider_id)
-        if not isinstance(provider_list, list) or source not in provider_list:
+        if not isinstance(provider_list, list) or not any(alias in provider_list for alias in source_aliases):
             return False
-        provider_list.remove(source)
+        for alias in source_aliases:
+            while alias in provider_list:
+                provider_list.remove(alias)
         if not provider_list:
             suppressed.pop(provider_id, None)
         if not suppressed:
@@ -1582,6 +1600,8 @@ def _import_codex_cli_tokens() -> Optional[Dict[str, str]]:
     Returns tokens dict if valid and not expired, None otherwise.
     Does NOT write to the shared file.
     """
+    if is_source_suppressed("openai-codex", CODEX_CLI_IMPORT_SOURCE):
+        return None
     codex_home = os.getenv("CODEX_HOME", "").strip()
     if not codex_home:
         codex_home = str(Path.home() / ".codex")
@@ -2979,6 +2999,8 @@ def login_command(args) -> None:
 
 def _login_openai_codex(args, pconfig: ProviderConfig) -> None:
     """OpenAI Codex login via device code flow. Tokens stored in ~/.hermes/auth.json."""
+    # Re-enable the Codex CLI import path for an explicit login flow.
+    unsuppress_credential_source("openai-codex", "device_code")
 
     # Check for existing Hermes-owned credentials
     try:

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -12,6 +12,8 @@ from hermes_cli.auth import (
     AuthError,
     DEFAULT_CODEX_BASE_URL,
     PROVIDER_REGISTRY,
+    suppress_credential_source,
+    unsuppress_credential_source,
     _read_codex_tokens,
     _save_codex_tokens,
     _import_codex_cli_tokens,
@@ -149,6 +151,29 @@ def test_import_codex_cli_tokens(tmp_path, monkeypatch):
     }))
     monkeypatch.setenv("CODEX_HOME", str(codex_home))
 
+    tokens = _import_codex_cli_tokens()
+    assert tokens is not None
+    assert tokens["access_token"] == "cli-at"
+    assert tokens["refresh_token"] == "cli-rt"
+
+
+def test_import_codex_cli_tokens_respects_suppression(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    codex_home = tmp_path / "codex-cli"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    codex_home.mkdir(parents=True, exist_ok=True)
+
+    (hermes_home / "auth.json").write_text(json.dumps({"version": 1, "providers": {}}))
+    (codex_home / "auth.json").write_text(json.dumps({
+        "tokens": {"access_token": "cli-at", "refresh_token": "cli-rt"},
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    suppress_credential_source("openai-codex", "device_code")
+    assert _import_codex_cli_tokens() is None
+
+    unsuppress_credential_source("openai-codex", "device_code")
     tokens = _import_codex_cli_tokens()
     assert tokens is not None
     assert tokens["access_token"] == "cli-at"

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -836,12 +836,15 @@ def test_unsuppress_credential_source_preserves_other_markers(tmp_path, monkeypa
 def test_auth_remove_codex_device_code_suppresses_reseed(tmp_path, monkeypatch):
     """Removing an auto-seeded openai-codex credential must mark the source as suppressed."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "codex-cli"))
     monkeypatch.setattr(
         "agent.credential_pool._seed_from_singletons",
         lambda provider, entries: (False, {"device_code"}),
     )
     hermes_home = tmp_path / "hermes"
+    codex_home = tmp_path / "codex-cli"
     hermes_home.mkdir(parents=True, exist_ok=True)
+    codex_home.mkdir(parents=True, exist_ok=True)
 
     auth_store = {
         "version": 1,
@@ -866,8 +869,15 @@ def test_auth_remove_codex_device_code_suppresses_reseed(tmp_path, monkeypatch):
         },
     }
     (hermes_home / "auth.json").write_text(json.dumps(auth_store))
+    (codex_home / "auth.json").write_text(json.dumps({
+        "tokens": {
+            "access_token": "cli-token",
+            "refresh_token": "cli-refresh",
+        }
+    }))
 
     from types import SimpleNamespace
+    from hermes_cli.auth import _import_codex_cli_tokens
     from hermes_cli.auth_commands import auth_remove_command
 
     auth_remove_command(SimpleNamespace(provider="openai-codex", target="1"))
@@ -876,6 +886,8 @@ def test_auth_remove_codex_device_code_suppresses_reseed(tmp_path, monkeypatch):
     suppressed = updated.get("suppressed_sources", {})
     assert "openai-codex" in suppressed
     assert "device_code" in suppressed["openai-codex"]
+    assert "codex_cli" in suppressed["openai-codex"]
+    assert _import_codex_cli_tokens() is None
     # Tokens in providers state should also be cleared
     assert "openai-codex" not in updated.get("providers", {})
 
@@ -924,6 +936,7 @@ def test_auth_remove_codex_manual_source_suppresses_reseed(tmp_path, monkeypatch
     # Critical: manual:device_code source must also trigger the suppression path
     assert "openai-codex" in suppressed
     assert "device_code" in suppressed["openai-codex"]
+    assert "codex_cli" in suppressed["openai-codex"]
     assert "openai-codex" not in updated.get("providers", {})
 
 


### PR DESCRIPTION
Fixes #12747.

Root cause:
`hermes auth remove openai-codex` suppressed the Hermes `device_code` source, but the same credentials could still be imported from the Codex CLI shared `~/.codex/auth.json` file on the next pool load.

Fix summary:
- Treat the Codex CLI import as an alias of the OpenAI Codex device-code source for suppression checks.
- Skip Codex CLI token import while the source is suppressed.
- Clear both suppression aliases when the user explicitly logs in again.
- Add regression coverage for direct import, auth remove, manual device-code removal, and re-linking.

Tests:
- `uv run --frozen --python 3.11 --extra dev pytest -o addopts= tests/hermes_cli/test_auth_commands.py tests/hermes_cli/test_auth_codex_provider.py -q`
- `git diff --check -- hermes_cli/auth.py tests/hermes_cli/test_auth_codex_provider.py tests/hermes_cli/test_auth_commands.py`