### PR TITLE
fix(telegram): add allow-bots gate

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -584,6 +584,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["group_policy"] = platform_cfg["group_policy"]
                 if "group_allow_from" in platform_cfg:
                     bridged["group_allow_from"] = platform_cfg["group_allow_from"]
+                if plat == Platform.TELEGRAM and "allow_bots" in platform_cfg:
+                    bridged["allow_bots"] = platform_cfg["allow_bots"]
                 if plat == Platform.DISCORD and "channel_skill_bindings" in platform_cfg:
                     bridged["channel_skill_bindings"] = platform_cfg["channel_skill_bindings"]
                 if "channel_prompts" in platform_cfg:
@@ -669,6 +671,8 @@ def load_gateway_config() -> GatewayConfig:
             if isinstance(telegram_cfg, dict):
                 if "require_mention" in telegram_cfg and not os.getenv("TELEGRAM_REQUIRE_MENTION"):
                     os.environ["TELEGRAM_REQUIRE_MENTION"] = str(telegram_cfg["require_mention"]).lower()
+                if "allow_bots" in telegram_cfg and not os.getenv("TELEGRAM_ALLOW_BOTS"):
+                    os.environ["TELEGRAM_ALLOW_BOTS"] = str(telegram_cfg["allow_bots"]).lower()
                 if "mention_patterns" in telegram_cfg and not os.getenv("TELEGRAM_MENTION_PATTERNS"):
                     import json as _json
                     os.environ["TELEGRAM_MENTION_PATTERNS"] = _json.dumps(telegram_cfg["mention_patterns"])
@@ -861,6 +865,12 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         if Platform.TELEGRAM not in config.platforms:
             config.platforms[Platform.TELEGRAM] = PlatformConfig()
         config.platforms[Platform.TELEGRAM].reply_to_mode = telegram_reply_mode
+
+    telegram_allow_bots = os.getenv("TELEGRAM_ALLOW_BOTS", "").lower().strip()
+    if telegram_allow_bots in ("none", "mentions", "all"):
+        if Platform.TELEGRAM not in config.platforms:
+            config.platforms[Platform.TELEGRAM] = PlatformConfig()
+        config.platforms[Platform.TELEGRAM].extra["allow_bots"] = telegram_allow_bots
     
     telegram_fallback_ips = os.getenv("TELEGRAM_FALLBACK_IPS", "")
     if telegram_fallback_ips:

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2277,6 +2277,16 @@ class TelegramAdapter(BasePlatformAdapter):
         reply_user = getattr(message.reply_to_message, "from_user", None)
         return bool(reply_user and getattr(reply_user, "id", None) == getattr(self._bot, "id", None))
 
+    def _is_bot_message(self, message: Message) -> bool:
+        author = getattr(message, "from_user", None)
+        return bool(author and getattr(author, "is_bot", False))
+
+    def _is_own_bot_message(self, message: Message) -> bool:
+        if not self._bot:
+            return False
+        author = getattr(message, "from_user", None)
+        return bool(author and getattr(author, "id", None) == getattr(self._bot, "id", None))
+
     def _message_mentions_bot(self, message: Message) -> bool:
         if not self._bot:
             return False
@@ -2322,6 +2332,12 @@ class TelegramAdapter(BasePlatformAdapter):
                     return True
         return False
 
+    def _telegram_allow_bots(self) -> str:
+        configured = self.config.extra.get("allow_bots")
+        if not configured:
+            configured = os.getenv("TELEGRAM_ALLOW_BOTS", "none")
+        return str(configured).lower().strip()
+
     def _clean_bot_trigger_text(self, text: Optional[str]) -> Optional[str]:
         if not text or not self._bot or not getattr(self._bot, "username", None):
             return text
@@ -2340,6 +2356,17 @@ class TelegramAdapter(BasePlatformAdapter):
         - the bot is @mentioned
         - the text/caption matches a configured regex wake-word pattern
         """
+        if self._is_own_bot_message(message):
+            return False
+
+        if self._is_bot_message(message):
+            allow_bots = self._telegram_allow_bots()
+            if allow_bots == "none":
+                return False
+            if allow_bots == "mentions":
+                if not (self._is_reply_to_bot(message) or self._message_mentions_bot(message)):
+                    return False
+
         if not self._is_group_chat(message):
             return True
         thread_id = getattr(message, "message_thread_id", None)

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -5,7 +5,13 @@ from unittest.mock import AsyncMock
 from gateway.config import Platform, PlatformConfig, load_gateway_config
 
 
-def _make_adapter(require_mention=None, free_response_chats=None, mention_patterns=None, ignored_threads=None):
+def _make_adapter(
+    require_mention=None,
+    free_response_chats=None,
+    mention_patterns=None,
+    ignored_threads=None,
+    allow_bots=None,
+):
     from gateway.platforms.telegram import TelegramAdapter
 
     extra = {}
@@ -17,6 +23,8 @@ def _make_adapter(require_mention=None, free_response_chats=None, mention_patter
         extra["mention_patterns"] = mention_patterns
     if ignored_threads is not None:
         extra["ignored_threads"] = ignored_threads
+    if allow_bots is not None:
+        extra["allow_bots"] = allow_bots
 
     adapter = object.__new__(TelegramAdapter)
     adapter.platform = Platform.TELEGRAM
@@ -59,6 +67,31 @@ def _mention_entity(text, mention="@hermes_bot"):
     return SimpleNamespace(type="mention", offset=offset, length=len(mention))
 
 
+def _bot_message(
+    text="hello",
+    *,
+    chat_id=-100,
+    thread_id=None,
+    bot_id=555,
+    bot_username="other_bot",
+    reply_to_bot=False,
+    entities=None,
+):
+    reply_to_message = None
+    if reply_to_bot:
+        reply_to_message = SimpleNamespace(from_user=SimpleNamespace(id=999))
+    return SimpleNamespace(
+        text=text,
+        caption=None,
+        entities=entities or [],
+        caption_entities=[],
+        message_thread_id=thread_id,
+        chat=SimpleNamespace(id=chat_id, type="group"),
+        reply_to_message=reply_to_message,
+        from_user=SimpleNamespace(id=bot_id, is_bot=True, username=bot_username),
+    )
+
+
 def test_group_messages_can_be_opened_via_config():
     adapter = _make_adapter(require_mention=False)
 
@@ -72,6 +105,46 @@ def test_group_messages_can_require_direct_trigger_via_config():
     assert adapter._should_process_message(_group_message("hi @hermes_bot", entities=[_mention_entity("hi @hermes_bot")])) is True
     assert adapter._should_process_message(_group_message("replying", reply_to_bot=True)) is True
     assert adapter._should_process_message(_group_message("/status"), is_command=True) is True
+
+
+def test_bot_messages_default_to_none():
+    adapter = _make_adapter(require_mention=False)
+
+    assert adapter._should_process_message(_bot_message("bot says hi")) is False
+
+
+def test_bot_messages_all_follow_existing_group_gates():
+    adapter = _make_adapter(require_mention=True, allow_bots="all")
+
+    assert adapter._should_process_message(_bot_message("bot says hi")) is False
+    assert adapter._should_process_message(
+        _bot_message("hi @hermes_bot", entities=[_mention_entity("hi @hermes_bot")])
+    ) is True
+    assert adapter._should_process_message(_bot_message("replying", reply_to_bot=True)) is True
+
+
+def test_bot_messages_all_accept_in_free_response_chats():
+    adapter = _make_adapter(require_mention=True, free_response_chats=["-200"], allow_bots="all")
+
+    assert adapter._should_process_message(_bot_message("bot says hi", chat_id=-200)) is True
+
+
+def test_bot_messages_mentions_only_accept_when_explicitly_triggered():
+    adapter = _make_adapter(require_mention=True, allow_bots="mentions")
+
+    assert adapter._should_process_message(_bot_message("bot says hi")) is False
+    assert adapter._should_process_message(
+        _bot_message("hi @hermes_bot", entities=[_mention_entity("hi @hermes_bot")])
+    ) is True
+    assert adapter._should_process_message(_bot_message("replying", reply_to_bot=True)) is True
+
+
+def test_own_bot_messages_are_always_ignored():
+    adapter = _make_adapter(require_mention=False, allow_bots="all")
+
+    assert adapter._should_process_message(
+        _bot_message("our bot says hi", bot_id=999, bot_username="hermes_bot")
+    ) is False
 
 
 def test_free_response_chats_bypass_mention_requirement():
@@ -110,6 +183,7 @@ def test_config_bridges_telegram_group_settings(monkeypatch, tmp_path):
     (hermes_home / "config.yaml").write_text(
         "telegram:\n"
         "  require_mention: true\n"
+        "  allow_bots: mentions\n"
         "  mention_patterns:\n"
         "    - \"^\\\\s*chompy\\\\b\"\n"
         "  free_response_chats:\n"
@@ -119,6 +193,7 @@ def test_config_bridges_telegram_group_settings(monkeypatch, tmp_path):
 
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
     monkeypatch.delenv("TELEGRAM_REQUIRE_MENTION", raising=False)
+    monkeypatch.delenv("TELEGRAM_ALLOW_BOTS", raising=False)
     monkeypatch.delenv("TELEGRAM_MENTION_PATTERNS", raising=False)
     monkeypatch.delenv("TELEGRAM_FREE_RESPONSE_CHATS", raising=False)
 
@@ -126,6 +201,7 @@ def test_config_bridges_telegram_group_settings(monkeypatch, tmp_path):
 
     assert config is not None
     assert __import__("os").environ["TELEGRAM_REQUIRE_MENTION"] == "true"
+    assert __import__("os").environ["TELEGRAM_ALLOW_BOTS"] == "mentions"
     assert json.loads(__import__("os").environ["TELEGRAM_MENTION_PATTERNS"]) == [r"^\s*chompy\b"]
     assert __import__("os").environ["TELEGRAM_FREE_RESPONSE_CHATS"] == "-123"
 


### PR DESCRIPTION
Fixes #13083.

Root cause:
Telegram had group mention controls, but no equivalent to the Discord/Slack bot-message modes. Messages from other bots could be processed without an explicit Telegram-specific policy, while messages from Hermes itself needed to remain hard-blocked.

Fix summary:
- Add `telegram.allow_bots` / `TELEGRAM_ALLOW_BOTS` with `none`, `mentions`, and `all` modes.
- Always ignore messages authored by the Telegram bot itself.
- Require explicit mention/reply for bot messages in `mentions` mode, and keep existing group gates in `all` mode.
- Add regression coverage for default blocking, all/mentions modes, own-bot suppression, and config/env bridging.

Tests:
- `uv run --frozen --python 3.11 --extra dev pytest -o addopts= tests/gateway/test_telegram_group_gating.py -q`
- `git diff --check -- gateway/config.py gateway/platforms/telegram.py tests/gateway/test_telegram_group_gating.py`