### PR TITLE
fix(honcho): normalize session override paths

### DIFF
--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -79,6 +79,14 @@ _RECALL_MODE_ALIASES = {"auto": "hybrid"}
 _VALID_RECALL_MODES = {"hybrid", "context", "tools"}
 
 
+def _normalize_session_path(path: str) -> str:
+    """Return a stable cwd key for Honcho session override lookup."""
+    try:
+        return str(Path(path).expanduser().resolve(strict=False))
+    except (OSError, RuntimeError):
+        return str(Path(path).expanduser().absolute())
+
+
 def _normalize_recall_mode(val: str) -> str:
     """Normalize legacy recall mode values (e.g. 'auto' → 'hybrid')."""
     val = _RECALL_MODE_ALIASES.get(val, val)
@@ -544,11 +552,19 @@ class HonchoClientConfig:
 
         if not cwd:
             cwd = os.getcwd()
+        cwd = str(cwd)
 
         # Manual override always wins
         manual = self.sessions.get(cwd)
         if manual:
             return manual
+        normalized_cwd = _normalize_session_path(cwd)
+        for configured_cwd, configured_session in self.sessions.items():
+            if (
+                configured_session
+                and _normalize_session_path(configured_cwd) == normalized_cwd
+            ):
+                return configured_session
 
         # /title mid-session remap
         if session_title:

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -282,6 +282,44 @@ class TestResolveSessionName:
         config = HonchoClientConfig(sessions={"/home/user/proj": "custom-session"})
         assert config.resolve_session_name("/home/user/proj") == "custom-session"
 
+    def test_manual_override_accepts_trailing_slash(self, tmp_path):
+        project = tmp_path / "project"
+        project.mkdir()
+        config = HonchoClientConfig(sessions={str(project): "custom-session"})
+
+        assert config.resolve_session_name(f"{project}{os.sep}") == "custom-session"
+
+    def test_manual_override_accepts_relative_cwd(self, tmp_path, monkeypatch):
+        project = tmp_path / "project"
+        project.mkdir()
+        monkeypatch.chdir(tmp_path)
+        config = HonchoClientConfig(sessions={str(project): "custom-session"})
+
+        assert config.resolve_session_name("project") == "custom-session"
+
+    def test_manual_override_accepts_symlinked_cwd(self, tmp_path):
+        project = tmp_path / "project"
+        project.mkdir()
+        link = tmp_path / "project-link"
+        try:
+            link.symlink_to(project, target_is_directory=True)
+        except (OSError, NotImplementedError) as exc:
+            pytest.skip(f"Symlink creation unavailable: {exc}")
+        config = HonchoClientConfig(sessions={str(project): "custom-session"})
+
+        assert config.resolve_session_name(str(link)) == "custom-session"
+
+    def test_manual_override_exact_key_still_wins(self, tmp_path):
+        project = tmp_path / "project"
+        project.mkdir()
+        exact_cwd = f"{project}{os.sep}"
+        config = HonchoClientConfig(sessions={
+            exact_cwd: "exact-session",
+            str(project): "normalized-session",
+        })
+
+        assert config.resolve_session_name(exact_cwd) == "exact-session"
+
     def test_derive_from_dirname(self):
         config = HonchoClientConfig()
         result = config.resolve_session_name("/home/user/my-project")


### PR DESCRIPTION
Fixes #13284.

Root cause:
Honcho session overrides checked the configured `sessions` map only with the raw `cwd` string. Equivalent directory spellings such as trailing slashes, relative paths, or symlinked paths missed the manual override and fell back to basename-derived sessions.

Fix summary:
- Preserve exact `sessions` key lookup first so intentionally exact entries still win.
- Add a normalized fallback lookup using `Path(...).expanduser().resolve(strict=False)` for both the requested cwd and configured session keys.
- Add regression coverage for trailing slash, relative cwd, symlink cwd, and exact-key precedence.

Tests:
- `uv run --frozen --python 3.11 --extra dev pytest -o addopts= tests/honcho_plugin/test_client.py -q`
- `git diff --check -- plugins/memory/honcho/client.py tests/honcho_plugin/test_client.py`