### PR TITLE
fix(opencode): route kimi through chat completions

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -146,6 +146,18 @@ def _parse_api_mode(raw: Any) -> Optional[str]:
     return None
 
 
+def _opencode_runtime_api_mode(provider: str, model_cfg: Dict[str, Any]) -> str:
+    """Derive the OpenCode transport from the configured default model.
+
+    OpenCode stores an ``api_mode`` alongside the selected model, but that
+    value can become stale when the default model changes.  The model family
+    is the runtime source of truth.
+    """
+    from hermes_cli.models import opencode_model_api_mode
+
+    return opencode_model_api_mode(provider, model_cfg.get("default", ""))
+
+
 def _resolve_runtime_from_pool_entry(
     *,
     provider: str,
@@ -196,11 +208,10 @@ def _resolve_runtime_from_pool_entry(
             if cfg_base_url:
                 base_url = cfg_base_url
         configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
-        if configured_mode and _provider_supports_explicit_api_mode(provider, configured_provider):
+        if provider in ("opencode-zen", "opencode-go"):
+            api_mode = _opencode_runtime_api_mode(provider, model_cfg)
+        elif configured_mode and _provider_supports_explicit_api_mode(provider, configured_provider):
             api_mode = configured_mode
-        elif provider in ("opencode-zen", "opencode-go"):
-            from hermes_cli.models import opencode_model_api_mode
-            api_mode = opencode_model_api_mode(provider, model_cfg.get("default", ""))
         else:
             # Auto-detect Anthropic-compatible endpoints (/anthropic suffix,
             # api.openai.com → codex_responses, api.x.ai → codex_responses).
@@ -974,11 +985,10 @@ def resolve_runtime_provider(
             configured_provider = str(model_cfg.get("provider") or "").strip().lower()
             # Only honor persisted api_mode when it belongs to the same provider family.
             configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
-            if configured_mode and _provider_supports_explicit_api_mode(provider, configured_provider):
+            if provider in ("opencode-zen", "opencode-go"):
+                api_mode = _opencode_runtime_api_mode(provider, model_cfg)
+            elif configured_mode and _provider_supports_explicit_api_mode(provider, configured_provider):
                 api_mode = configured_mode
-            elif provider in ("opencode-zen", "opencode-go"):
-                from hermes_cli.models import opencode_model_api_mode
-                api_mode = opencode_model_api_mode(provider, model_cfg.get("default", ""))
             else:
                 # Auto-detect Anthropic-compatible endpoints by URL convention
                 # (e.g. https://api.minimax.io/anthropic, https://dashscope.../anthropic)

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -368,6 +368,7 @@ class TestCopilotNormalization:
         assert opencode_model_api_mode("opencode-zen", "opencode-zen/claude-sonnet-4-6") == "anthropic_messages"
         assert opencode_model_api_mode("opencode-zen", "gemini-3-flash") == "chat_completions"
         assert opencode_model_api_mode("opencode-zen", "minimax-m2.5") == "chat_completions"
+        assert opencode_model_api_mode("opencode-zen", "kimi-k2.5-free") == "chat_completions"
 
     def test_opencode_go_api_modes_match_docs(self):
         assert opencode_model_api_mode("opencode-go", "glm-5.1") == "chat_completions"

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1075,6 +1075,27 @@ def test_opencode_zen_claude_defaults_to_messages(monkeypatch):
     assert resolved["base_url"] == "https://opencode.ai/zen"
 
 
+def test_opencode_zen_kimi_free_ignores_stale_anthropic_api_mode(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "opencode-zen")
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "opencode-zen",
+            "default": "kimi-k2.5-free",
+            "api_mode": "anthropic_messages",
+        },
+    )
+    monkeypatch.setenv("OPENCODE_ZEN_API_KEY", "test-opencode-zen-key")
+    monkeypatch.delenv("OPENCODE_ZEN_BASE_URL", raising=False)
+
+    resolved = rp.resolve_runtime_provider(requested="opencode-zen")
+
+    assert resolved["provider"] == "opencode-zen"
+    assert resolved["api_mode"] == "chat_completions"
+    assert resolved["base_url"] == "https://opencode.ai/zen/v1"
+
+
 def test_opencode_go_minimax_defaults_to_messages(monkeypatch):
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "opencode-go")
     monkeypatch.setattr(rp, "_get_model_config", lambda: {"default": "minimax-m2.5"})
@@ -1102,7 +1123,7 @@ def test_opencode_go_glm_defaults_to_chat_completions(monkeypatch):
     assert resolved["base_url"] == "https://opencode.ai/zen/go/v1"
 
 
-def test_opencode_go_configured_api_mode_still_overrides_default(monkeypatch):
+def test_opencode_go_stale_api_mode_does_not_override_model_family(monkeypatch):
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "opencode-go")
     monkeypatch.setattr(
         rp,
@@ -1119,7 +1140,7 @@ def test_opencode_go_configured_api_mode_still_overrides_default(monkeypatch):
     resolved = rp.resolve_runtime_provider(requested="opencode-go")
 
     assert resolved["provider"] == "opencode-go"
-    assert resolved["api_mode"] == "chat_completions"
+    assert resolved["api_mode"] == "anthropic_messages"
 
 
 def test_named_custom_provider_anthropic_api_mode(monkeypatch):


### PR DESCRIPTION
Fixes #13194.

Root cause:
OpenCode provider runtime resolution trusted a persisted `api_mode` value before deriving the transport from the current OpenCode model family. After switching to `kimi-k2.5-free`, a stale Anthropic `api_mode` could keep routing the request to `/messages` instead of `/chat/completions`.

Fix summary:
- Derive runtime `api_mode` for `opencode-zen` and `opencode-go` from the configured default model family.
- Add explicit coverage for `opencode-zen` `kimi-k2.5-free` resolving to `chat_completions` with the `/v1` base URL.
- Keep existing OpenCode Anthropic-message routing for Claude/Go MiniMax families.

Tests:
- `uv run --frozen --python 3.11 --extra dev pytest -o addopts= tests/hermes_cli/test_runtime_provider_resolution.py tests/hermes_cli/test_model_validation.py -q` -> `133 passed`
- `git diff --check -- hermes_cli/runtime_provider.py tests/hermes_cli/test_runtime_provider_resolution.py tests/hermes_cli/test_model_validation.py`