### PR TITLE
fix(cron): inherit runtime provider on gateway create

### DIFF
--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -3,6 +3,7 @@
 import json
 import pytest
 from pathlib import Path
+from unittest.mock import MagicMock
 
 from tools.cronjob_tools import (
     _scan_cron_prompt,
@@ -121,6 +122,48 @@ class TestUnifiedCronjobTool:
         assert listing["count"] == 1
         assert listing["jobs"][0]["name"] == "Server Check"
         assert listing["jobs"][0]["state"] == "scheduled"
+
+    def test_create_inherits_runtime_provider_for_gateway_session(self, monkeypatch):
+        runtime = {
+            "provider": "openrouter",
+            "base_url": "https://openrouter.example.com/v1",
+            "api_key": "runtime-key",
+            "api_mode": "chat_completions",
+        }
+        resolve_runtime_provider = MagicMock(return_value=runtime)
+
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "weixin")
+        monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "wxid_home")
+        monkeypatch.setenv("HERMES_SESSION_CHAT_NAME", "Home")
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            resolve_runtime_provider,
+        )
+
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Check server status",
+                schedule="every 1h",
+                name="Gateway check",
+            )
+        )
+
+        assert created["success"] is True
+        resolve_runtime_provider.assert_called_once_with(
+            requested=None,
+            explicit_base_url=None,
+        )
+
+        from cron.jobs import get_job
+
+        job = get_job(created["job_id"])
+        assert job is not None
+        assert job["provider"] == "openrouter"
+        assert job["provider"] != "openai"
+        assert job["base_url"] == "https://openrouter.example.com/v1"
+        assert job["origin"]["platform"] == "weixin"
+        assert job["origin"]["chat_id"] == "wxid_home"
 
     def test_pause_and_resume(self):
         created = json.loads(cronjob(action="create", prompt="Check", schedule="every 1h"))

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -150,6 +150,41 @@ def _normalize_optional_job_value(value: Optional[Any], *, strip_trailing_slash:
     return text or None
 
 
+def _resolve_create_runtime_defaults(
+    provider: Optional[str] = None,
+    base_url: Optional[str] = None,
+) -> tuple[Optional[str], Optional[str]]:
+    """Fill in missing runtime fields from the active provider config.
+
+    Gateway/Weixin cron creation can arrive without an explicit model object.
+    In that case we still want to persist the same runtime provider settings
+    the gateway is actively using, rather than falling back to a stale or
+    invalid default.
+    """
+    normalized_provider = _normalize_optional_job_value(provider)
+    normalized_base_url = _normalize_optional_job_value(base_url, strip_trailing_slash=True)
+
+    if normalized_provider and normalized_base_url:
+        return normalized_provider, normalized_base_url
+
+    try:
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        runtime = resolve_runtime_provider(
+            requested=normalized_provider,
+            explicit_base_url=normalized_base_url,
+        )
+    except Exception:
+        runtime = {}
+
+    if not normalized_provider:
+        normalized_provider = _normalize_optional_job_value(runtime.get("provider"))
+    if not normalized_base_url:
+        normalized_base_url = _normalize_optional_job_value(runtime.get("base_url"), strip_trailing_slash=True)
+
+    return normalized_provider, normalized_base_url
+
+
 def _validate_cron_script_path(script: Optional[str]) -> Optional[str]:
     """Validate a cron job script path at the API boundary.
 
@@ -259,6 +294,7 @@ def cronjob(
                 if script_error:
                     return tool_error(script_error, success=False)
 
+            resolved_provider, resolved_base_url = _resolve_create_runtime_defaults(provider, base_url)
             job = create_job(
                 prompt=prompt or "",
                 schedule=schedule,
@@ -268,8 +304,8 @@ def cronjob(
                 origin=_origin_from_env(),
                 skills=canonical_skills,
                 model=_normalize_optional_job_value(model),
-                provider=_normalize_optional_job_value(provider),
-                base_url=_normalize_optional_job_value(base_url, strip_trailing_slash=True),
+                provider=resolved_provider,
+                base_url=resolved_base_url,
                 script=_normalize_optional_job_value(script),
             )
             return json.dumps(


### PR DESCRIPTION
Fixes #13288.

Root cause:
Gateway/Weixin-created cron jobs could be created without explicit runtime provider fields, leaving the persisted job to fall back to the invalid legacy `openai` provider at execution time. Equivalent CLI-created jobs had a working active runtime provider available.

Fix summary:
- Fill missing cron create `provider` and `base_url` from `resolve_runtime_provider()` before persisting the job.
- Preserve explicit cron `provider` / `base_url` values when supplied.
- Keep failures non-fatal: if runtime resolution is unavailable, creation falls back to the previous optional values.
- Add a Weixin/gateway-session regression proving the stored job inherits the active runtime provider/base URL instead of `openai`.

Tests:
- `uv run --frozen --python 3.11 --extra dev pytest -o addopts= tests/tools/test_cronjob_tools.py -q` -> `26 passed`
- `git diff --check -- tools/cronjob_tools.py tests/tools/test_cronjob_tools.py`