### PR TITLE
fix(telegram): avoid unexpected thread session splits

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -686,6 +686,16 @@ def load_gateway_config() -> GatewayConfig:
                     os.environ["TELEGRAM_REACTIONS"] = str(telegram_cfg["reactions"]).lower()
                 if "proxy_url" in telegram_cfg and not os.getenv("TELEGRAM_PROXY"):
                     os.environ["TELEGRAM_PROXY"] = str(telegram_cfg["proxy_url"]).strip()
+                if "preserve_group_thread_ids" in telegram_cfg:
+                    plat_data = platforms_data.setdefault(Platform.TELEGRAM.value, {})
+                    if not isinstance(plat_data, dict):
+                        plat_data = {}
+                        platforms_data[Platform.TELEGRAM.value] = plat_data
+                    extra = plat_data.setdefault("extra", {})
+                    if not isinstance(extra, dict):
+                        extra = {}
+                        plat_data["extra"] = extra
+                    extra["preserve_group_thread_ids"] = telegram_cfg["preserve_group_thread_ids"]
                 if "disable_link_previews" in telegram_cfg:
                     plat_data = platforms_data.setdefault(Platform.TELEGRAM.value, {})
                     if not isinstance(plat_data, dict):

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -327,6 +327,10 @@ class TelegramAdapter(BasePlatformAdapter):
             return default
         return bool(value)
 
+    def _telegram_group_thread_ids_enabled(self) -> bool:
+        """Return whether raw Telegram group thread IDs should affect routing."""
+        return self._coerce_bool_extra("preserve_group_thread_ids", False)
+
     def _link_preview_kwargs(self) -> Dict[str, Any]:
         if not getattr(self, "_disable_link_previews", False):
             return {}
@@ -2965,13 +2969,12 @@ class TelegramAdapter(BasePlatformAdapter):
         elif chat.type == ChatType.CHANNEL:
             chat_type = "channel"
 
-        # Resolve DM topic name and skill binding
+        # Resolve DM/topic metadata.
         thread_id_raw = message.message_thread_id
         thread_id_str = str(thread_id_raw) if thread_id_raw is not None else None
-        if chat_type == "group" and thread_id_str is None and getattr(chat, "is_forum", False):
-            thread_id_str = self._GENERAL_TOPIC_THREAD_ID
         chat_topic = None
         topic_skill = None
+        explicit_group_topic = False
 
         if chat_type == "dm" and thread_id_str:
             topic_info = self._get_dm_topic_info(str(chat.id), thread_id_str)
@@ -2988,7 +2991,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         chat_topic = created_name
 
         elif chat_type == "group" and thread_id_str:
-            # Group/supergroup forum topic skill binding via config.extra['group_topics']
+            # Group/supergroup forum topic skill binding via config.extra['group_topics'].
             group_topics_config: list = self.config.extra.get("group_topics", [])
             for chat_entry in group_topics_config:
                 if str(chat_entry.get("chat_id", "")) == str(chat.id):
@@ -2997,8 +3000,16 @@ class TelegramAdapter(BasePlatformAdapter):
                         if tid is not None and str(tid) == thread_id_str:
                             chat_topic = topic.get("name")
                             topic_skill = topic.get("skill")
+                            explicit_group_topic = True
                             break
                     break
+
+        if chat_type == "group":
+            preserve_group_thread_ids = self._telegram_group_thread_ids_enabled()
+            if thread_id_str == self._GENERAL_TOPIC_THREAD_ID:
+                thread_id_str = None
+            elif not preserve_group_thread_ids and not explicit_group_topic:
+                thread_id_str = None
 
         # Build source
         source = self.build_source(

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -259,6 +259,22 @@ class TestLoadGatewayConfig:
             "456": "Therapist mode",
         }
 
+    def test_bridges_telegram_group_thread_id_setting_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "telegram:\n"
+            "  preserve_group_thread_ids: true\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.TELEGRAM].extra["preserve_group_thread_ids"] is True
+
     def test_bridges_telegram_channel_prompts_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()

--- a/tests/gateway/test_dm_topics.py
+++ b/tests/gateway/test_dm_topics.py
@@ -561,6 +561,7 @@ def test_group_topic_skill_binding():
 
     assert event.auto_skill == "software-development"
     assert event.source.chat_topic == "Engineering"
+    assert event.source.thread_id == "5"
 
 
 def test_group_topic_skill_binding_second_topic():
@@ -606,6 +607,7 @@ def test_group_topic_no_skill_binding():
 
     assert event.auto_skill is None
     assert event.source.chat_topic == "General"
+    assert event.source.thread_id is None
 
 
 def test_group_topic_unmapped_thread_id():
@@ -628,6 +630,7 @@ def test_group_topic_unmapped_thread_id():
 
     assert event.auto_skill is None
     assert event.source.chat_topic is None
+    assert event.source.thread_id is None
 
 
 def test_group_topic_unmapped_chat_id():
@@ -650,6 +653,7 @@ def test_group_topic_unmapped_chat_id():
 
     assert event.auto_skill is None
     assert event.source.chat_topic is None
+    assert event.source.thread_id is None
 
 
 def test_group_topic_no_config():
@@ -665,6 +669,7 @@ def test_group_topic_no_config():
 
     assert event.auto_skill is None
     assert event.source.chat_topic is None
+    assert event.source.thread_id is None
 
 
 def test_group_topic_chat_id_int_string_coercion():
@@ -687,6 +692,76 @@ def test_group_topic_chat_id_int_string_coercion():
 
     assert event.auto_skill == "hermes-agent-dev"
     assert event.source.chat_topic == "Dev"
+    assert event.source.thread_id == "7"
+
+
+def test_group_thread_id_defaults_to_parent_session():
+    """Raw Telegram group thread IDs should not fragment sessions by default."""
+    from gateway.platforms.base import MessageType
+    from gateway.session import build_session_key
+
+    adapter = _make_adapter()
+
+    msg = _make_mock_message(
+        chat_id=-1001234567890,
+        chat_type=_ChatType.SUPERGROUP,
+        thread_id=17,
+        text="hello from a regular group",
+    )
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    parent_source = adapter.build_source(
+        chat_id="-1001234567890",
+        chat_type="group",
+        user_id="42",
+        user_name="Test User",
+    )
+
+    assert event.source.thread_id is None
+    assert build_session_key(
+        event.source,
+        group_sessions_per_user=True,
+        thread_sessions_per_user=False,
+    ) == build_session_key(
+        parent_source,
+        group_sessions_per_user=True,
+        thread_sessions_per_user=False,
+    )
+
+
+def test_group_thread_id_can_be_preserved_when_opted_in():
+    """Opt-in config should preserve raw Telegram group thread IDs."""
+    from gateway.platforms.base import MessageType
+    from gateway.session import build_session_key
+
+    adapter = _make_adapter()
+    adapter.config.extra["preserve_group_thread_ids"] = True
+
+    msg = _make_mock_message(
+        chat_id=-1001234567890,
+        chat_type=_ChatType.SUPERGROUP,
+        thread_id=17,
+        text="hello from a forum topic",
+    )
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    parent_source = adapter.build_source(
+        chat_id="-1001234567890",
+        chat_type="group",
+        user_id="42",
+        user_name="Test User",
+    )
+
+    assert event.source.thread_id == "17"
+    assert build_session_key(
+        event.source,
+        group_sessions_per_user=True,
+        thread_sessions_per_user=False,
+    ) != build_session_key(
+        parent_source,
+        group_sessions_per_user=True,
+        thread_sessions_per_user=False,
+    )
 
 
 # ── _build_message_event: from_user=None fallback in DMs ──


### PR DESCRIPTION
Fixes #13195.

Root cause:
Telegram group and supergroup messages can include raw `message_thread_id` values even when the operator did not explicitly configure forum-topic routing. Hermes copied every inbound thread ID into `source.thread_id`, and `build_session_key()` then treated it as a hard session boundary, fragmenting one visible group conversation into multiple sessions.

Fix summary:
- Collapse raw Telegram group thread IDs out of session routing by default.
- Continue preserving explicitly configured group topics so topic skill bindings still work.
- Add an opt-in `telegram.preserve_group_thread_ids` setting for operators who want raw per-thread sessions.
- Collapse Telegram general topic `1` back to the parent group session.
- Add regression coverage for default parent-session behavior, opt-in preservation, explicit topic preservation, and config bridging.

Tests:
- `uv run --frozen --python 3.11 --extra dev pytest -o addopts= tests/gateway/test_dm_topics.py tests/gateway/test_config.py -q` -> `61 passed`
- `git diff --check -- gateway/platforms/telegram.py gateway/config.py tests/gateway/test_dm_topics.py tests/gateway/test_config.py`