### PR TITLE
fix(whatsapp): remove 120s timeout on bridge npm install

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1291,16 +1291,27 @@ def cmd_whatsapp(args):
         return
 
     if not (bridge_dir / "node_modules").exists():
-        print("\n→ Installing WhatsApp bridge dependencies...")
-        result = subprocess.run(
-            ["npm", "install"],
-            cwd=str(bridge_dir),
-            capture_output=True,
-            text=True,
-            timeout=120,
-        )
+        print("\n→ Installing WhatsApp bridge dependencies (this can take a few minutes)...")
+        npm = shutil.which("npm")
+        if not npm:
+            print("  ✗ npm not found on PATH — install Node.js first")
+            return
+        try:
+            result = subprocess.run(
+                [npm, "install", "--no-fund", "--no-audit", "--progress=false"],
+                cwd=str(bridge_dir),
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+        except KeyboardInterrupt:
+            print("\n  ✗ Install cancelled")
+            return
         if result.returncode != 0:
-            print(f"  ✗ npm install failed: {result.stderr}")
+            err = (result.stderr or "").strip()
+            preview = "\n".join(err.splitlines()[-30:]) if err else "(no output)"
+            print("  ✗ npm install failed:")
+            print(preview)
             return
         print("  ✓ Dependencies installed")
     else:


### PR DESCRIPTION
## Summary
`hermes whatsapp` setup no longer crashes with a raw `TimeoutExpired` traceback on slow connections.

Root cause: `cmd_whatsapp` ran `npm install` with a hardcoded `timeout=120`. The bridge depends on `@whiskeysockets/baileys` pulled from a GitHub commit tarball (not the registry), which routinely exceeds 120s. Reported by community user in Telegram.

## Changes
- `hermes_cli/main.py` `cmd_whatsapp()`: match the TUI's npm install pattern (lines 945–950) — no timeout, `--no-fund --no-audit --progress=false`, stderr captured and last 30 lines shown on failure
- Resolve `npm` via `shutil.which` so missing Node gives a clean error instead of `FileNotFoundError`
- Handle `KeyboardInterrupt` cleanly

## Validation
| | Before | After |
|---|---|---|
| Slow/sluggish connection | `subprocess.TimeoutExpired` traceback after 120s | Runs to completion |
| npm not installed | `FileNotFoundError` traceback | `✗ npm not found on PATH — install Node.js first` |
| Install failure | `✗ npm install failed: <full stderr>` | `✗ npm install failed:` + last 30 lines |
| Ctrl+C mid-install | `KeyboardInterrupt` traceback | `✗ Install cancelled` |

Reported via Telegram by community user.