### PR TITLE
refactor(steer): simplify injection marker to 'User guidance:' prefix

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3670,7 +3670,7 @@ class AIAgent:
                 existing = getattr(self, "_pending_steer", None)
                 self._pending_steer = (existing + "\n" + steer_text) if existing else steer_text
             return
-        marker = f"\n\n[USER STEER (injected mid-run, not tool output): {steer_text}]"
+        marker = f"\n\nUser guidance: {steer_text}"
         existing_content = messages[target_idx].get("content", "")
         if not isinstance(existing_content, str):
             # Anthropic multimodal content blocks — preserve them and append
@@ -8956,7 +8956,7 @@ class AIAgent:
                 for _si in range(len(messages) - 1, -1, -1):
                     _sm = messages[_si]
                     if isinstance(_sm, dict) and _sm.get("role") == "tool":
-                        marker = f"\n\n[USER STEER (injected mid-run, not tool output): {_pre_api_steer}]"
+                        marker = f"\n\nUser guidance: {_pre_api_steer}"
                         existing = _sm.get("content", "")
                         if isinstance(existing, str):
                             _sm["content"] = existing + marker

--- a/tests/run_agent/test_steer.py
+++ b/tests/run_agent/test_steer.py
@@ -85,7 +85,7 @@ class TestSteerInjection:
         # The LAST tool result is modified; earlier ones are untouched.
         assert messages[2]["content"] == "ls output A"
         assert "ls output B" in messages[3]["content"]
-        assert "[USER STEER" in messages[3]["content"]
+        assert "User guidance:" in messages[3]["content"]
         assert "please also check auth.log" in messages[3]["content"]
         # And pending_steer is consumed.
         assert agent._pending_steer is None
@@ -107,18 +107,19 @@ class TestSteerInjection:
         # Steer should remain pending (nothing to drain into)
         assert agent._pending_steer == "steer"
 
-    def test_marker_is_unambiguous_about_origin(self):
-        """The injection marker must make clear the text is from the user
-        and not tool output — this is the cache-safe way to signal
-        provenance without violating message-role alternation.
+    def test_marker_labels_text_as_user_guidance(self):
+        """The injection marker must label the appended text as user
+        guidance so the model attributes it to the user rather than
+        confusing it with tool output.  This is the cache-safe way to
+        signal provenance without violating message-role alternation.
         """
         agent = _bare_agent()
         agent.steer("stop after next step")
         messages = [{"role": "tool", "content": "x", "tool_call_id": "1"}]
         agent._apply_pending_steer_to_tool_results(messages, num_tool_msgs=1)
         content = messages[-1]["content"]
-        assert "USER STEER" in content
-        assert "not tool output" in content.lower() or "injected mid-run" in content.lower()
+        assert "User guidance:" in content
+        assert "stop after next step" in content
 
     def test_multimodal_content_list_preserved(self):
         """Anthropic-style list content should be preserved, with the steer
@@ -226,9 +227,9 @@ class TestPreApiCallSteerDrain:
         # Inject into last tool msg (mirrors the new code in run_conversation)
         for _si in range(len(messages) - 1, -1, -1):
             if messages[_si].get("role") == "tool":
-                messages[_si]["content"] += f"\n\n[USER STEER (injected mid-run, not tool output): {_pre_api_steer}]"
+                messages[_si]["content"] += f"\n\nUser guidance: {_pre_api_steer}"
                 break
-        assert "[USER STEER" in messages[-1]["content"]
+        assert "User guidance:" in messages[-1]["content"]
         assert "focus on error handling" in messages[-1]["content"]
         assert agent._pending_steer is None
 
@@ -270,7 +271,7 @@ class TestPreApiCallSteerDrain:
         assert _pre_api_steer is not None
         for _si in range(len(messages) - 1, -1, -1):
             if messages[_si].get("role") == "tool":
-                messages[_si]["content"] += f"\n\n[USER STEER (injected mid-run, not tool output): {_pre_api_steer}]"
+                messages[_si]["content"] += f"\n\nUser guidance: {_pre_api_steer}"
                 break
         assert "change approach" in messages[2]["content"]
 


### PR DESCRIPTION
## Summary
Mid-run `/steer` text is now appended to the last tool result as `\n\nUser guidance: <text>` instead of `\n\n[USER STEER (injected mid-run, not tool output): <text>]`.

The old bracketed tag read like structured metadata that some tools (terminal, execute_code) could confuse with their own output framing. A plain labelled suffix works uniformly across JSON tool results, plain-text tool results, MCP results, and plugin results — all of which we now support.

## Changes
- `run_agent.py` — update the marker string at both drain sites (`_apply_pending_steer_to_tool_results` and the pre-API-call drain added in #13205).
- `tests/run_agent/test_steer.py` — rename `test_marker_is_unambiguous_about_origin` to `test_marker_labels_text_as_user_guidance` and update 3 other assertions that checked the literal old string.

Behavior unchanged — same placement (last tool-role message), same multimodal handling, same two drain sites.

## Codex cross-check
Reviewed `codex-rs/core/src/codex.rs` + `hook_runtime.rs` + `state/turn.rs`. Codex records mid-turn user input as a real `role:user` message via `record_user_prompt_and_emit_turn_item()`, gated by `can_drain_pending_input` at the top of their sampling loop. That's cleaner for the Responses API (flatter event model) but isn't portable to Chat Completions providers where alternation after `assistant(tool_calls=[...])` is strict. Embedding the guidance in the last tool result remains the correct placement for us.

## Validation
| | Before | After |
|---|---|---|
| Marker string | `[USER STEER (injected mid-run, not tool output): ...]` | `User guidance: ...` |
| `tests/run_agent/test_steer.py` | 21 pass | 21 pass |