### PR TITLE
fix(gateway): cap inbound media attachment bytes

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -316,12 +316,66 @@ async def _ssrf_redirect_guard(response):
 
 # Default location: {HERMES_HOME}/cache/images/ (legacy: image_cache/)
 IMAGE_CACHE_DIR = get_hermes_dir("cache/images", "image_cache")
+DEFAULT_INBOUND_MEDIA_MAX_BYTES = 128 * 1024 * 1024
 
 
 def get_image_cache_dir() -> Path:
     """Return the image cache directory, creating it if it doesn't exist."""
     IMAGE_CACHE_DIR.mkdir(parents=True, exist_ok=True)
     return IMAGE_CACHE_DIR
+
+
+def get_inbound_media_max_bytes() -> int:
+    """Return the max inbound image/audio/video bytes allowed in memory."""
+    raw = os.getenv("HERMES_MAX_INBOUND_MEDIA_BYTES", "").strip()
+    if raw:
+        try:
+            parsed = int(raw)
+            if parsed > 0:
+                return parsed
+        except ValueError:
+            logger.warning("Ignoring invalid HERMES_MAX_INBOUND_MEDIA_BYTES=%r", raw)
+    return DEFAULT_INBOUND_MEDIA_MAX_BYTES
+
+
+def validate_inbound_media_size(
+    size: int,
+    *,
+    media_type: str = "media",
+    max_bytes: Optional[int] = None,
+) -> None:
+    """Raise if an inbound media payload exceeds the configured memory cap."""
+    limit = max_bytes or get_inbound_media_max_bytes()
+    if size > limit:
+        raise ValueError(
+            f"Inbound {media_type} payload is too large "
+            f"({size} bytes > {limit} bytes)"
+        )
+
+
+async def _read_httpx_body_with_limit(response, *, media_type: str) -> bytes:
+    """Read an httpx response body without exceeding the inbound media cap."""
+    max_bytes = get_inbound_media_max_bytes()
+    content_length = response.headers.get("content-length")
+    if content_length:
+        try:
+            declared_size = int(content_length)
+        except ValueError:
+            logger.debug("Ignoring invalid Content-Length for inbound %s: %r", media_type, content_length)
+        else:
+            validate_inbound_media_size(
+                declared_size,
+                media_type=media_type,
+                max_bytes=max_bytes,
+            )
+
+    chunks: list[bytes] = []
+    total = 0
+    async for chunk in response.aiter_bytes():
+        total += len(chunk)
+        validate_inbound_media_size(total, media_type=media_type, max_bytes=max_bytes)
+        chunks.append(chunk)
+    return b"".join(chunks)
 
 
 def _looks_like_image(data: bytes) -> bool:
@@ -356,6 +410,7 @@ def cache_image_from_bytes(data: bytes, ext: str = ".jpg") -> str:
         ValueError: If *data* does not look like a valid image (e.g. an HTML
             error page returned by the upstream server).
     """
+    validate_inbound_media_size(len(data), media_type="image")
     if not _looks_like_image(data):
         snippet = data[:80].decode("utf-8", errors="replace")
         raise ValueError(
@@ -404,15 +459,20 @@ async def cache_image_from_url(url: str, ext: str = ".jpg", retries: int = 2) ->
     ) as client:
         for attempt in range(retries + 1):
             try:
-                response = await client.get(
+                async with client.stream(
+                    "GET",
                     url,
                     headers={
                         "User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)",
                         "Accept": "image/*,*/*;q=0.8",
                     },
-                )
-                response.raise_for_status()
-                return cache_image_from_bytes(response.content, ext)
+                ) as response:
+                    response.raise_for_status()
+                    content = await _read_httpx_body_with_limit(
+                        response,
+                        media_type="image",
+                    )
+                return cache_image_from_bytes(content, ext)
             except (httpx.TimeoutException, httpx.HTTPStatusError) as exc:
                 last_exc = exc
                 if isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code < 429:
@@ -481,6 +541,7 @@ def cache_audio_from_bytes(data: bytes, ext: str = ".ogg") -> str:
     Returns:
         Absolute path to the cached audio file as a string.
     """
+    validate_inbound_media_size(len(data), media_type="audio")
     cache_dir = get_audio_cache_dir()
     filename = f"audio_{uuid.uuid4().hex[:12]}{ext}"
     filepath = cache_dir / filename
@@ -523,15 +584,20 @@ async def cache_audio_from_url(url: str, ext: str = ".ogg", retries: int = 2) ->
     ) as client:
         for attempt in range(retries + 1):
             try:
-                response = await client.get(
+                async with client.stream(
+                    "GET",
                     url,
                     headers={
                         "User-Agent": "Mozilla/5.0 (compatible; HermesAgent/1.0)",
                         "Accept": "audio/*,*/*;q=0.8",
                     },
-                )
-                response.raise_for_status()
-                return cache_audio_from_bytes(response.content, ext)
+                ) as response:
+                    response.raise_for_status()
+                    content = await _read_httpx_body_with_limit(
+                        response,
+                        media_type="audio",
+                    )
+                return cache_audio_from_bytes(content, ext)
             except (httpx.TimeoutException, httpx.HTTPStatusError) as exc:
                 last_exc = exc
                 if isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code < 429:

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -56,6 +56,7 @@ from gateway.platforms.base import (
     cache_audio_from_bytes,
     cache_document_from_bytes,
     SUPPORTED_DOCUMENT_TYPES,
+    validate_inbound_media_size,
 )
 from tools.url_safety import is_safe_url
 
@@ -2847,7 +2848,12 @@ class DiscordAdapter(BasePlatformAdapter):
     # non-CDN URL into the ``att.url`` field. (issue #11345)
     # ------------------------------------------------------------------
 
-    async def _read_attachment_bytes(self, att) -> Optional[bytes]:
+    async def _read_attachment_bytes(
+        self,
+        att,
+        *,
+        media_type: str = "media",
+    ) -> Optional[bytes]:
         """Read an attachment via discord.py's authenticated bot session.
 
         Returns the raw bytes on success, or ``None`` if ``att`` doesn't
@@ -2855,11 +2861,15 @@ class DiscordAdapter(BasePlatformAdapter):
         should treat ``None`` as a signal to fall back to the URL-based
         downloaders.
         """
+        attachment_size = getattr(att, "size", None)
+        if attachment_size:
+            validate_inbound_media_size(int(attachment_size), media_type=media_type)
+
         reader = getattr(att, "read", None)
         if reader is None or not callable(reader):
             return None
         try:
-            return await reader()
+            raw_bytes = await reader()
         except Exception as e:
             logger.warning(
                 "[Discord] Authenticated attachment read failed for %s: %s",
@@ -2867,6 +2877,8 @@ class DiscordAdapter(BasePlatformAdapter):
                 e,
             )
             return None
+        validate_inbound_media_size(len(raw_bytes), media_type=media_type)
+        return raw_bytes
 
     async def _cache_discord_image(self, att, ext: str) -> str:
         """Cache a Discord image attachment to local disk.
@@ -2876,7 +2888,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
         Fallback: ``cache_image_from_url`` (plain httpx, SSRF-gated).
         """
-        raw_bytes = await self._read_attachment_bytes(att)
+        raw_bytes = await self._read_attachment_bytes(att, media_type="image")
         if raw_bytes is not None:
             try:
                 return cache_image_from_bytes(raw_bytes, ext=ext)
@@ -2895,7 +2907,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
         Fallback: ``cache_audio_from_url`` (plain httpx, SSRF-gated).
         """
-        raw_bytes = await self._read_attachment_bytes(att)
+        raw_bytes = await self._read_attachment_bytes(att, media_type="audio")
         if raw_bytes is not None:
             try:
                 return cache_audio_from_bytes(raw_bytes, ext=ext)
@@ -2917,7 +2929,7 @@ class DiscordAdapter(BasePlatformAdapter):
         for passing the returned bytes to ``cache_document_from_bytes``
         (and, where applicable, for injecting text content).
         """
-        raw_bytes = await self._read_attachment_bytes(att)
+        raw_bytes = await self._read_attachment_bytes(att, media_type="document")
         if raw_bytes is not None:
             return raw_bytes
 

--- a/tests/gateway/test_discord_document_handling.py
+++ b/tests/gateway/test_discord_document_handling.py
@@ -383,3 +383,23 @@ class TestIncomingDocumentHandling:
         assert event.message_type == MessageType.PHOTO
         assert event.media_urls == ["/tmp/cached_image.png"]
         assert event.media_types == ["image/png"]
+
+    @pytest.mark.asyncio
+    async def test_oversized_image_attachment_skips_authenticated_read(self, adapter, monkeypatch):
+        """Known oversized image attachments should not be read into memory."""
+        monkeypatch.setenv("HERMES_MAX_INBOUND_MEDIA_BYTES", "100")
+        att = make_attachment(
+            filename="huge.png",
+            content_type="image/png",
+            size=101,
+            url="https://cdn.discordapp.com/attachments/fake/huge.png",
+        )
+        att.read = AsyncMock(return_value=b"\x89PNG\r\n\x1a\n")
+
+        msg = make_message([att])
+        await adapter._handle_message(msg)
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.PHOTO
+        assert event.media_urls == [att.url]
+        att.read.assert_not_called()

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -3,11 +3,15 @@
 import os
 from unittest.mock import patch
 
+import pytest
+
 from gateway.platforms.base import (
     BasePlatformAdapter,
     GATEWAY_SECRET_CAPTURE_UNSUPPORTED_MESSAGE,
     MessageEvent,
     MessageType,
+    cache_audio_from_bytes,
+    cache_image_from_bytes,
     safe_url_for_log,
     utf16_len,
     _prefix_within_utf16_limit,
@@ -44,6 +48,21 @@ class TestSafeUrlForLog:
         assert safe_url_for_log(url, max_len=3) == "..."
         assert safe_url_for_log(url, max_len=2) == ".."
         assert safe_url_for_log(url, max_len=0) == ""
+
+
+class TestInboundMediaCaps:
+    def test_cache_image_from_bytes_rejects_oversized_payload(self, monkeypatch):
+        monkeypatch.setenv("HERMES_MAX_INBOUND_MEDIA_BYTES", "12")
+        png_bytes = b"\x89PNG\r\n\x1a\n" + (b"x" * 16)
+
+        with pytest.raises(ValueError, match="Inbound image payload is too large"):
+            cache_image_from_bytes(png_bytes, ext=".png")
+
+    def test_cache_audio_from_bytes_rejects_oversized_payload(self, monkeypatch):
+        monkeypatch.setenv("HERMES_MAX_INBOUND_MEDIA_BYTES", "4")
+
+        with pytest.raises(ValueError, match="Inbound audio payload is too large"):
+            cache_audio_from_bytes(b"x" * 8, ext=".ogg")
 
 
 # ---------------------------------------------------------------------------
@@ -581,4 +600,3 @@ class TestTruncateMessageUtf16:
             assert fence_count % 2 == 0, (
                 f"Chunk {i} has unbalanced fences ({fence_count})"
             )
-


### PR DESCRIPTION
Fixes #13145.

Root cause:
Inbound image/audio attachment caching accepted full byte payloads without a shared size limit. Discord could also call `att.read()` for known-large image/audio attachments before any cap, which risks loading very large uploads into process memory.

Fix summary:
- Add a shared inbound media byte cap, defaulting to 128 MiB and overrideable via `HERMES_MAX_INBOUND_MEDIA_BYTES`.
- Enforce the cap in `cache_image_from_bytes()` and `cache_audio_from_bytes()` before writing to cache.
- Switch image/audio URL cache downloads to streaming reads that check `Content-Length` early and abort on chunked overflow.
- Make Discord check attachment `size` before authenticated `att.read()`, and validate returned bytes when size is missing.
- Add regressions for oversized image/audio cache bytes and a Discord oversized image attachment that must not call `att.read()`.

Tests:
- `uv run --frozen --python 3.11 --extra dev pytest -o addopts= tests/gateway/test_platform_base.py tests/gateway/test_discord_document_handling.py -q` -> `90 passed`
- `git diff --check -- gateway/platforms/base.py gateway/platforms/discord.py tests/gateway/test_platform_base.py tests/gateway/test_discord_document_handling.py`