### PR TITLE
fix(docker): pass RPC dir through exec env

### DIFF
--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -17,6 +17,7 @@ import pytest
 
 import json
 import os
+import re
 
 os.environ["TERMINAL_ENV"] = "local"
 
@@ -132,8 +133,8 @@ class TestExecuteCodeRemoteTempDir(unittest.TestCase):
             def get_temp_dir(self):
                 return "/data/data/com.termux/files/usr/tmp"
 
-            def execute(self, command, cwd=None, timeout=None):
-                self.commands.append((command, cwd, timeout))
+            def execute(self, command, cwd=None, timeout=None, extra_env=None):
+                self.commands.append((command, cwd, timeout, extra_env))
                 if "command -v python3" in command:
                     return {"output": "OK\n"}
                 if "python3 script.py" in command:
@@ -151,12 +152,47 @@ class TestExecuteCodeRemoteTempDir(unittest.TestCase):
 
         self.assertEqual(result["status"], "success")
         mkdir_cmd = env.commands[1][0]
-        run_cmd = next(cmd for cmd, _, _ in env.commands if "python3 script.py" in cmd)
+        run_cmd = next(cmd for cmd, _, _, _ in env.commands if "python3 script.py" in cmd)
         cleanup_cmd = env.commands[-1][0]
         self.assertIn("mkdir -p /data/data/com.termux/files/usr/tmp/hermes_exec_", mkdir_cmd)
         self.assertIn("HERMES_RPC_DIR=/data/data/com.termux/files/usr/tmp/hermes_exec_", run_cmd)
         self.assertIn("rm -rf /data/data/com.termux/files/usr/tmp/hermes_exec_", cleanup_cmd)
         self.assertNotIn("mkdir -p /tmp/hermes_exec_", mkdir_cmd)
+
+    def test_execute_remote_passes_rpc_dir_through_docker_env(self):
+        class FakeDockerEnv:
+            def __init__(self):
+                self.calls = []
+
+            def get_temp_dir(self):
+                return "/tmp"
+
+            def execute(self, command, cwd=None, timeout=None, extra_env=None):
+                self.calls.append((command, cwd, timeout, extra_env))
+                if "command -v python3" in command:
+                    return {"output": "OK\n"}
+                if "python3 script.py" in command:
+                    return {"output": "hello\n", "returncode": 0}
+                return {"output": ""}
+
+        env = FakeDockerEnv()
+        fake_thread = MagicMock()
+
+        with patch("tools.code_execution_tool._load_config", return_value={"timeout": 30, "max_tool_calls": 5}), \
+             patch("tools.code_execution_tool._get_or_create_env", return_value=(env, "docker")), \
+             patch("tools.code_execution_tool._ship_file_to_remote"), \
+             patch("tools.code_execution_tool.threading.Thread", return_value=fake_thread):
+            result = json.loads(_execute_remote("print('hello')", "task-2", ["terminal"]))
+
+        self.assertEqual(result["status"], "success")
+        run_cmd, _, _, extra_env = next(call for call in env.calls if "python3 script.py" in call[0])
+        match = re.search(r"HERMES_RPC_DIR=([^ ]+)", run_cmd)
+        self.assertIsNotNone(match)
+        rpc_dir = match.group(1)
+        self.assertTrue(rpc_dir.startswith("/tmp/hermes_exec_"))
+        self.assertTrue(rpc_dir.endswith("/rpc"))
+        self.assertIsInstance(extra_env, dict)
+        self.assertEqual(extra_env, {"HERMES_RPC_DIR": rpc_dir})
 
 
 @unittest.skipIf(sys.platform == "win32", "UDS not available on Windows")

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -285,6 +285,30 @@ def test_init_env_args_prefers_shell_env_over_hermes_dotenv(monkeypatch):
     assert "value_from_dotenv" not in args_str
 
 
+def test_run_bash_passes_extra_env_to_docker_exec(monkeypatch):
+    """Per-call env overrides should be passed through docker exec -e."""
+    env = _make_execute_only_env()
+    popen_calls = []
+
+    def _fake_popen(cmd, stdin_data=None):
+        popen_calls.append((cmd, stdin_data))
+        return _FakePopen(cmd)
+
+    monkeypatch.setattr(docker_env, "_popen_bash", _fake_popen)
+
+    env._run_bash(
+        "python3 script.py",
+        extra_env={"HERMES_RPC_DIR": "/tmp/hermes_exec_abcd/rpc"},
+    )
+
+    assert popen_calls
+    cmd, stdin_data = popen_calls[0]
+    assert stdin_data is None
+    assert cmd[:2] == ["/usr/bin/docker", "exec"]
+    assert "HERMES_RPC_DIR=/tmp/hermes_exec_abcd/rpc" in cmd
+    assert cmd.index("-e") < cmd.index("test-container")
+
+
 # ── docker_env tests ──────────────────────────────────────────────
 
 

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -783,6 +783,9 @@ def _execute_remote(
         rpc_thread.start()
 
         # Build environment variable prefix for the script
+        remote_env = {
+            "HERMES_RPC_DIR": f"{sandbox_dir}/rpc",
+        }
         env_prefix = (
             f"HERMES_RPC_DIR={shlex.quote(f'{sandbox_dir}/rpc')} "
             f"PYTHONDONTWRITEBYTECODE=1"
@@ -797,6 +800,7 @@ def _execute_remote(
         script_result = env.execute(
             f"cd {quoted_sandbox_dir} && {env_prefix} python3 script.py",
             timeout=timeout,
+            extra_env=remote_env,
         )
 
         stdout_text = script_result.get("output", "")

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -310,6 +310,7 @@ class BaseEnvironment(ABC):
         login: bool = False,
         timeout: int = 120,
         stdin_data: str | None = None,
+        extra_env: dict[str, str] | None = None,
     ) -> ProcessHandle:
         """Spawn a bash process to run *cmd_string*.
 
@@ -700,6 +701,7 @@ class BaseEnvironment(ABC):
         *,
         timeout: int | None = None,
         stdin_data: str | None = None,
+        extra_env: dict[str, str] | None = None,
     ) -> dict:
         """Execute a command, return {"output": str, "returncode": int}."""
         self._before_execute()
@@ -733,9 +735,15 @@ class BaseEnvironment(ABC):
         # Use login shell if snapshot failed (so user's profile still loads)
         login = not self._snapshot_ready
 
-        proc = self._run_bash(
-            wrapped, login=login, timeout=effective_timeout, stdin_data=effective_stdin
-        )
+        run_kwargs = {
+            "login": login,
+            "timeout": effective_timeout,
+            "stdin_data": effective_stdin,
+        }
+        if extra_env:
+            run_kwargs["extra_env"] = extra_env
+
+        proc = self._run_bash(wrapped, **run_kwargs)
         result = self._wait_for_process(proc, timeout=effective_timeout)
         self._update_cwd(result)
 
@@ -760,4 +768,3 @@ class BaseEnvironment(ABC):
         from tools.terminal_tool import _transform_sudo_command
 
         return _transform_sudo_command(command)
-

--- a/tools/environments/daytona.py
+++ b/tools/environments/daytona.py
@@ -207,7 +207,8 @@ class DaytonaEnvironment(BaseEnvironment):
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
-                  stdin_data: str | None = None):
+                  stdin_data: str | None = None,
+                  extra_env: dict[str, str] | None = None):
         """Return a _ThreadedProcessHandle wrapping a blocking Daytona SDK call."""
         sandbox = self._sandbox
         lock = self._lock

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -487,17 +487,22 @@ class DockerEnvironment(BaseEnvironment):
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
-                  stdin_data: str | None = None) -> subprocess.Popen:
+                  stdin_data: str | None = None,
+                  extra_env: dict[str, str] | None = None) -> subprocess.Popen:
         """Spawn a bash process inside the Docker container."""
         assert self._container_id, "Container not started"
         cmd = [self._docker_exe, "exec"]
         if stdin_data is not None:
             cmd.append("-i")
 
-        # Only inject -e env args during init_session (login=True).
-        # Subsequent commands get env vars from the snapshot.
+        # Inject snapshot env args during init_session (login=True), and
+        # apply any per-call env overrides for the command being executed.
         if login:
             cmd.extend(self._init_env_args)
+
+        if extra_env:
+            for key in sorted(extra_env):
+                cmd.extend(["-e", f"{key}={extra_env[key]}"])
 
         cmd.extend([self._container_id])
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -253,10 +253,11 @@ class LocalEnvironment(BaseEnvironment):
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
-                  stdin_data: str | None = None) -> subprocess.Popen:
+                  stdin_data: str | None = None,
+                  extra_env: dict[str, str] | None = None) -> subprocess.Popen:
         bash = _find_bash()
         args = [bash, "-l", "-c", cmd_string] if login else [bash, "-c", cmd_string]
-        run_env = _make_run_env(self.env)
+        run_env = _make_run_env({**self.env, **(extra_env or {})})
 
         proc = subprocess.Popen(
             args,

--- a/tools/environments/modal.py
+++ b/tools/environments/modal.py
@@ -389,7 +389,8 @@ class ModalEnvironment(BaseEnvironment):
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
-                  stdin_data: str | None = None):
+                  stdin_data: str | None = None,
+                  extra_env: dict[str, str] | None = None):
         """Return a _ThreadedProcessHandle wrapping an async Modal sandbox exec."""
         sandbox = self._sandbox
         worker = self._worker

--- a/tools/environments/singularity.py
+++ b/tools/environments/singularity.py
@@ -229,7 +229,8 @@ class SingularityEnvironment(BaseEnvironment):
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
-                  stdin_data: str | None = None) -> subprocess.Popen:
+                  stdin_data: str | None = None,
+                  extra_env: dict[str, str] | None = None) -> subprocess.Popen:
         """Spawn a bash process inside the Singularity instance."""
         if not self._instance_started:
             raise RuntimeError("Singularity instance not started")

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -259,7 +259,8 @@ class SSHEnvironment(BaseEnvironment):
 
     def _run_bash(self, cmd_string: str, *, login: bool = False,
                   timeout: int = 120,
-                  stdin_data: str | None = None) -> subprocess.Popen:
+                  stdin_data: str | None = None,
+                  extra_env: dict[str, str] | None = None) -> subprocess.Popen:
         """Spawn an SSH process that runs bash on the remote host."""
         cmd = self._build_ssh_command()
         if login:


### PR DESCRIPTION
Fixes #13142.

Root cause:
`execute_code` set `HERMES_RPC_DIR` only through the remote shell prefix. On Docker, the file-based hermes_tools RPC bridge also needs the RPC directory in the container execution environment; without it, tool calls from inside `execute_code` could silently resolve to the wrong default and report `tool_calls_made: 0`.

Fix summary:
- Thread optional per-call `extra_env` through the execution environment interface.
- Pass `HERMES_RPC_DIR` as `extra_env` when running the remote execute_code script, while keeping the existing shell prefix for compatibility.
- Apply `extra_env` to Docker via `docker exec -e KEY=value` and to the local backend via the subprocess environment.
- Update other environment backends to accept the optional argument without changing their existing shell-prefix behavior.
- Add regressions proving `execute_code` passes the RPC dir through `extra_env` and Docker turns it into `docker exec -e HERMES_RPC_DIR=...`.

Tests:
- `uv run --frozen --python 3.11 --extra dev pytest -o addopts= tests/tools/test_code_execution.py tests/tools/test_docker_environment.py -q` -> `83 passed, 1 warning`
- `git diff --check -- tools/code_execution_tool.py tools/environments/base.py tools/environments/docker.py tools/environments/local.py tools/environments/ssh.py tools/environments/modal.py tools/environments/daytona.py tools/environments/singularity.py tests/tools/test_code_execution.py tests/tools/test_docker_environment.py`

Note:
- The warning is the existing fake-Popen drain-thread warning in `tests/tools/test_docker_environment.py`; the targeted suite passed.