### PR TITLE
fix: preserve queued follow-ups across restart drain

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -599,6 +599,13 @@ def load_gateway_config() -> GatewayConfig:
                     os.environ["DISCORD_AUTO_THREAD"] = str(discord_cfg["auto_thread"]).lower()
                 if "reactions" in discord_cfg and not os.getenv("DISCORD_REACTIONS"):
                     os.environ["DISCORD_REACTIONS"] = str(discord_cfg["reactions"]).lower()
+                allowed_users = discord_cfg.get("allowed_users")
+                if allowed_users is None:
+                    allowed_users = discord_cfg.get("allow_from")
+                if allowed_users is not None and not os.getenv("DISCORD_ALLOWED_USERS"):
+                    if isinstance(allowed_users, list):
+                        allowed_users = ",".join(str(v) for v in allowed_users)
+                    os.environ["DISCORD_ALLOWED_USERS"] = str(allowed_users)
                 # ignored_channels: channels where bot never responds (even when mentioned)
                 ic = discord_cfg.get("ignored_channels")
                 if ic is not None and not os.getenv("DISCORD_IGNORED_CHANNELS"):

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1290,6 +1290,84 @@ class DiscordAdapter(BasePlatformAdapter):
             return True
         return user_id in self._allowed_user_ids
 
+    def _message_mentions_self(self, message: DiscordMessage) -> bool:
+        """Return True when the current bot is explicitly mentioned."""
+        return bool(self._client and self._client.user and self._client.user in getattr(message, "mentions", []))
+
+    def _is_reply_to_self(self, message: DiscordMessage) -> bool:
+        """Return True when the message is an explicit reply to this bot's message."""
+        if not self._client or not self._client.user:
+            return False
+        ref = getattr(message, "reference", None)
+        if not ref:
+            return False
+        resolved = getattr(ref, "resolved", None)
+        if resolved is not None:
+            author = getattr(resolved, "author", None)
+            return bool(author and getattr(author, "id", None) == getattr(self._client.user, "id", None))
+        return False
+
+    def _looks_like_ack_only_bot_message(self, text: str) -> bool:
+        """Heuristic to suppress bot-to-bot acknowledgement loops.
+
+        Keep this intentionally narrow: short, low-information acknowledgements
+        that frequently create Discord ping-pong loops between agents.
+        """
+        text = (text or "").strip()
+        if not text:
+            return False
+        if len(text) > 160:
+            return False
+        lowered = text.lower()
+        if any(marker in lowered for marker in ("?", "```", "http://", "https://", "/", "todo", "fix", "patch", "implement", "test", "error", "traceback")):
+            return False
+
+        normalized = lowered
+        normalized = re.sub(r"<@!?\d+>", " ", normalized)
+        normalized = re.sub(r"\[[^\]]+\]", " ", normalized)
+        normalized = re.sub(r"\([^)]*\)", " ", normalized)
+        normalized = re.sub(r"[^\w\s가-힣]", " ", normalized)
+        normalized = re.sub(r"\s+", " ", normalized).strip()
+        if not normalized:
+            return False
+
+        ack_patterns = [
+            r"^확인했습니다$",
+            r"^네 확인했습니다$",
+            r"^알겠습니다$",
+            r"^좋습니다$",
+            r"^대기하겠습니다$",
+            r"^상태 알림으로 보고 여기서 멈춥니다$",
+            r"^상태 알림으로 보고 추가 응답 생략$",
+            r"^추가 액션 없이 유지하겠습니다$",
+            r"^작업 요청으로 취급하지 않고 추가 액션 없이 유지하겠습니다$",
+            r"^이 스레드는 대기 상태로 두겠습니다$",
+            r"^이 스레드는 대기 상태 유지로 두겠습니다$",
+            r"^필요한 요청이 들어오기 전까지 이 스레드는 대기로 두겠습니다$",
+            r"^ack(?:nowledged)?$",
+            r"^noted$",
+            r"^understood$",
+            r"^standing by$",
+            r"^will wait$",
+            r"^no additional action$",
+            r"^treat(?:ing)? .*status.*notification.*$",
+            r"^this message is .*system.*alert.*$",
+        ]
+        return any(re.fullmatch(pattern, normalized) for pattern in ack_patterns)
+
+    def _suppress_bot_loop_message(self, reason: str, message: DiscordMessage) -> None:
+        """Emit a structured log for bot-loop suppression decisions."""
+        logger.info(
+            "[%s] suppressed_bot_ack_loop reason=%s author_id=%s channel_id=%s thread_id=%s message_id=%s content=%r",
+            self.name,
+            reason,
+            getattr(getattr(message, "author", None), "id", None),
+            getattr(getattr(message, "channel", None), "id", None),
+            getattr(getattr(message, "channel", None), "parent_id", None) or getattr(getattr(message, "channel", None), "id", None),
+            getattr(message, "id", None),
+            (getattr(message, "content", "") or "")[:200],
+        )
+
     async def send_image_file(
         self,
         chat_id: str,
@@ -2469,15 +2547,28 @@ class DiscordAdapter(BasePlatformAdapter):
             is_voice_linked_channel = current_channel_id in voice_linked_ids
             is_free_channel = bool(channel_ids & free_channels) or is_voice_linked_channel
 
+            self_mentioned = self._message_mentions_self(message)
+            reply_to_self = self._is_reply_to_self(message)
+            author_is_bot = bool(getattr(message.author, "bot", False) or getattr(message, "webhook_id", None))
+            is_slash_like = bool((getattr(message, "content", "") or "").startswith("/"))
+
             # Skip the mention check if the message is in a thread where
             # the bot has previously participated (auto-created or replied in).
             in_bot_thread = is_thread and thread_id in self._threads
 
+            if author_is_bot and self._looks_like_ack_only_bot_message(message.content):
+                self._suppress_bot_loop_message("ack_only", message)
+                return
+
+            if author_is_bot and in_bot_thread and not self_mentioned and not reply_to_self and not is_slash_like:
+                self._suppress_bot_loop_message("thread_followup_requires_explicit_target", message)
+                return
+
             if require_mention and not is_free_channel and not in_bot_thread:
-                if self._client.user not in message.mentions:
+                if not self_mentioned and not reply_to_self:
                     return
 
-            if self._client.user and self._client.user in message.mentions:
+            if self_mentioned:
                 message.content = message.content.replace(f"<@{self._client.user.id}>", "").strip()
                 message.content = message.content.replace(f"<@!{self._client.user.id}>", "").strip()
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1460,6 +1460,59 @@ class GatewayRunner:
             return
         merge_pending_message_event(adapter._pending_messages, session_key, event)
 
+    def _preserve_pending_followup_during_drain(
+        self,
+        *,
+        adapter: Any,
+        session_key: str,
+        event: MessageEvent,
+        pending_event: MessageEvent | None,
+        pending_text: str | None,
+    ) -> tuple[MessageEvent | None, str | None]:
+        """Keep queued follow-ups across restart drains instead of dropping them.
+
+        During a restart drain, `_handle_message_with_agent()` may dequeue a
+        pending follow-up from the adapter right before shutdown. If we simply
+        discard it, `stop()` persists zero pending events and the next gateway
+        instance has nothing to restore.
+
+        Re-queue the follow-up into the adapter when queue-during-drain mode is
+        enabled so `stop()` can serialize it into `.restart_pending_events.json`.
+        """
+        if not self._draining or not (pending_event or pending_text):
+            return pending_event, pending_text
+
+        if self._restart_requested and self._queue_during_drain_enabled() and adapter and session_key:
+            queued_event = pending_event
+            if queued_event is None and pending_text:
+                queued_event = MessageEvent(
+                    text=pending_text,
+                    message_type=MessageType.TEXT,
+                    source=event.source,
+                    message_id=event.message_id,
+                    channel_prompt=event.channel_prompt,
+                )
+            if queued_event is not None:
+                merge_pending_message_event(
+                    adapter._pending_messages,
+                    session_key,
+                    queued_event,
+                    merge_text=True,
+                )
+                logger.info(
+                    "Preserving pending follow-up for session %s across gateway %s",
+                    session_key[:20] if session_key else "?",
+                    self._status_action_label(),
+                )
+            return None, None
+
+        logger.info(
+            "Discarding pending follow-up for session %s during gateway %s",
+            session_key[:20] if session_key else "?",
+            self._status_action_label(),
+        )
+        return None, None
+
     async def _handle_active_session_busy_message(self, event: MessageEvent, session_key: str) -> bool:
         # --- Draining case (gateway restarting/stopping) ---
         if self._draining:
@@ -9482,13 +9535,13 @@ class GatewayRunner:
                         pass
 
             if self._draining and (pending_event or pending):
-                logger.info(
-                    "Discarding pending follow-up for session %s during gateway %s",
-                    session_key[:20] if session_key else "?",
-                    self._status_action_label(),
+                pending_event, pending = self._preserve_pending_followup_during_drain(
+                    adapter=adapter,
+                    session_key=session_key,
+                    event=event,
+                    pending_event=pending_event,
+                    pending_text=pending,
                 )
-                pending_event = None
-                pending = None
 
             if pending_event or pending:
                 logger.debug("Processing pending message: '%s...'", pending[:40])

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -77,7 +77,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 # Resolve Hermes home directory (respects HERMES_HOME override)
 from hermes_constants import get_hermes_home
-from utils import atomic_yaml_write, is_truthy_value
+from utils import atomic_json_write, atomic_yaml_write, is_truthy_value
 _hermes_home = get_hermes_home()
 
 # Load environment variables from ~/.hermes/.env first.
@@ -1061,6 +1061,110 @@ class GatewayRunner:
     def _queue_during_drain_enabled(self) -> bool:
         return self._restart_requested and self._busy_input_mode == "queue"
 
+    def _restart_pending_events_path(self) -> Path:
+        return _hermes_home / ".restart_pending_events.json"
+
+    def _serialize_pending_event(self, event: MessageEvent) -> dict[str, Any]:
+        return {
+            "text": event.text,
+            "message_type": event.message_type.value,
+            "message_id": event.message_id,
+            "channel_prompt": event.channel_prompt,
+            "media_urls": list(event.media_urls or []),
+            "media_types": list(event.media_types or []),
+            "reply_to_message_id": event.reply_to_message_id,
+            "reply_to_text": event.reply_to_text,
+            "internal": bool(event.internal),
+            "source": event.source.to_dict() if event.source else None,
+        }
+
+    def _deserialize_pending_event(self, payload: dict[str, Any]) -> MessageEvent | None:
+        source_payload = payload.get("source")
+        if not source_payload:
+            return None
+        try:
+            source = SessionSource.from_dict(source_payload)
+            message_type = MessageType(payload.get("message_type", MessageType.TEXT.value))
+        except Exception:
+            return None
+        return MessageEvent(
+            text=str(payload.get("text") or ""),
+            message_type=message_type,
+            source=source,
+            message_id=payload.get("message_id"),
+            media_urls=list(payload.get("media_urls") or []),
+            media_types=list(payload.get("media_types") or []),
+            reply_to_message_id=payload.get("reply_to_message_id"),
+            reply_to_text=payload.get("reply_to_text"),
+            channel_prompt=payload.get("channel_prompt"),
+            internal=bool(payload.get("internal", False)),
+        )
+
+    def _persist_restart_pending_events(self) -> int:
+        checkpoint_path = self._restart_pending_events_path()
+        serialized: list[dict[str, Any]] = []
+        for adapter in self.adapters.values():
+            pending = getattr(adapter, "_pending_messages", None)
+            if not isinstance(pending, dict):
+                continue
+            for session_key, event in pending.items():
+                if not isinstance(event, MessageEvent):
+                    continue
+                if not getattr(event, "text", None) and not getattr(event, "media_urls", None):
+                    continue
+                serialized.append(
+                    {
+                        "session_key": session_key,
+                        "event": self._serialize_pending_event(event),
+                    }
+                )
+
+        if not serialized:
+            try:
+                checkpoint_path.unlink()
+            except FileNotFoundError:
+                pass
+            except Exception:
+                logger.debug("Failed removing stale restart pending checkpoint", exc_info=True)
+            return 0
+
+        atomic_json_write(checkpoint_path, serialized)
+        return len(serialized)
+
+    def _restore_restart_pending_events(self) -> int:
+        checkpoint_path = self._restart_pending_events_path()
+        if not checkpoint_path.exists():
+            return 0
+        try:
+            payload = json.loads(checkpoint_path.read_text(encoding="utf-8"))
+        except Exception as e:
+            logger.warning("Failed to read restart pending checkpoint: %s", e)
+            try:
+                checkpoint_path.unlink()
+            except Exception:
+                pass
+            return 0
+
+        restored = 0
+        for item in payload if isinstance(payload, list) else []:
+            if not isinstance(item, dict):
+                continue
+            session_key = str(item.get("session_key") or "").strip()
+            event = self._deserialize_pending_event(item.get("event") or {})
+            if not session_key or event is None or not event.source:
+                continue
+            adapter = self.adapters.get(event.source.platform)
+            if not adapter or not hasattr(adapter, "_pending_messages"):
+                continue
+            merge_pending_message_event(adapter._pending_messages, session_key, event, merge_text=True)
+            restored += 1
+
+        try:
+            checkpoint_path.unlink()
+        except Exception:
+            pass
+        return restored
+
     def _update_runtime_status(self, gateway_state: Optional[str] = None, exit_reason: Optional[str] = None) -> None:
         try:
             from gateway.status import write_runtime_status
@@ -1805,13 +1909,20 @@ class GatewayRunner:
         # This prevents unwanted auto-resets after `hermes update`,
         # `hermes gateway restart`, or `/restart`.
         _clean_marker = _hermes_home / ".clean_shutdown"
-        if _clean_marker.exists():
+        _previous_clean_shutdown = _clean_marker.exists()
+        if _previous_clean_shutdown:
             logger.info("Previous gateway exited cleanly — skipping session suspension")
             try:
                 _clean_marker.unlink()
             except Exception:
                 pass
         else:
+            try:
+                self._restart_pending_events_path().unlink()
+            except FileNotFoundError:
+                pass
+            except Exception:
+                logger.debug("Failed removing stale restart pending checkpoint", exc_info=True)
             try:
                 suspended = self.session_store.suspend_recently_active()
                 if suspended:
@@ -1967,6 +2078,16 @@ class GatewayRunner:
         })
         
         if connected_count > 0:
+            if _previous_clean_shutdown:
+                try:
+                    restored_pending = self._restore_restart_pending_events()
+                    if restored_pending:
+                        logger.info(
+                            "Restored %d queued pending event(s) from previous restart",
+                            restored_pending,
+                        )
+                except Exception as e:
+                    logger.warning("Pending restart-event restore failed: %s", e)
             logger.info("Gateway running with %s platform(s)", connected_count)
         
         # Build initial channel directory for send_message name resolution
@@ -2334,6 +2455,17 @@ class GatewayRunner:
                 _task.cancel()
             self._background_tasks.clear()
 
+            if self._restart_requested:
+                try:
+                    persisted_pending = self._persist_restart_pending_events()
+                    if persisted_pending:
+                        logger.info(
+                            "Persisted %d queued pending event(s) for restart resume",
+                            persisted_pending,
+                        )
+                except Exception as e:
+                    logger.warning("Failed to persist restart pending events: %s", e)
+
             self.adapters.clear()
             self._running_agents.clear()
             self._pending_messages.clear()
@@ -2365,13 +2497,16 @@ class GatewayRunner:
 
             # Write a clean-shutdown marker so the next startup knows this
             # wasn't a crash.  suspend_recently_active() only needs to run
-            # after unexpected exits.  However, if the drain timed out and
-            # agents were force-interrupted, their sessions may be in an
-            # incomplete state (trailing tool response, no final assistant
-            # message).  Skip the marker in that case so the next startup
-            # suspends those sessions — giving users a clean slate instead
-            # of resuming a half-finished tool loop.
-            if not timed_out:
+            # after unexpected exits.
+            #
+            # If a user-requested restart times out while draining, preserve the
+            # session mapping anyway so the next inbound message can resume from
+            # the existing transcript.  The auto-continue path handles trailing
+            # tool results by prepending an interruption note on the next turn.
+            # Unexpected shutdowns still skip the marker so crash recovery can
+            # suspend potentially-corrupt in-flight sessions.
+            preserve_resume_context = not timed_out or self._restart_requested
+            if preserve_resume_context:
                 try:
                     (_hermes_home / ".clean_shutdown").touch()
                 except Exception:

--- a/tests/gateway/test_clean_shutdown_marker.py
+++ b/tests/gateway/test_clean_shutdown_marker.py
@@ -224,3 +224,43 @@ class TestCleanShutdownMarker:
             asyncio.get_event_loop().run_until_complete(runner.stop(restart=True))
 
         assert marker.exists(), ".clean_shutdown marker should exist after restart-stop too"
+
+    def test_restart_timeout_still_writes_marker_for_resume(self, tmp_path, monkeypatch):
+        """User-requested restarts should preserve resume context even if drain times out."""
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+        marker = tmp_path / ".clean_shutdown"
+
+        from gateway.run import GatewayRunner
+        runner = object.__new__(GatewayRunner)
+        runner._restart_requested = True
+        runner._restart_detached = False
+        runner._restart_via_service = False
+        runner._restart_task_started = False
+        runner._running = True
+        runner._draining = False
+        runner._stop_task = None
+        runner._running_agents = {"agent:main:discord:thread:500:500": MagicMock()}
+        runner._pending_messages = {}
+        runner._pending_approvals = {}
+        runner._background_tasks = set()
+        runner._shutdown_event = MagicMock()
+        runner._restart_drain_timeout = 0.1
+        runner._exit_code = None
+        runner._exit_reason = None
+        runner.adapters = {}
+        runner.config = GatewayConfig()
+
+        active_agents = {"agent:main:discord:thread:500:500": MagicMock()}
+        with patch("gateway.run.GatewayRunner._drain_active_agents", new_callable=AsyncMock, return_value=(active_agents, True)), \
+             patch("gateway.run.GatewayRunner._finalize_shutdown_agents"), \
+             patch("gateway.run.GatewayRunner._update_runtime_status"), \
+             patch("gateway.status.remove_pid_file"), \
+             patch("tools.process_registry.process_registry") as mock_proc_reg, \
+             patch("tools.terminal_tool.cleanup_all_environments"), \
+             patch("tools.browser_tool.cleanup_all_browsers"):
+            mock_proc_reg.kill_all = MagicMock()
+
+            import asyncio
+            asyncio.get_event_loop().run_until_complete(runner.stop(restart=True))
+
+        assert marker.exists(), ".clean_shutdown marker should exist after timed-out restart to preserve resume context"

--- a/tests/gateway/test_discord_channel_controls.py
+++ b/tests/gateway/test_discord_channel_controls.py
@@ -74,9 +74,11 @@ class FakeThread:
 
 
 @pytest.fixture
-def adapter(monkeypatch):
+def adapter(monkeypatch, tmp_path):
     monkeypatch.setattr(discord_platform.discord, "DMChannel", FakeDMChannel, raising=False)
     monkeypatch.setattr(discord_platform.discord, "Thread", FakeThread, raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("DISCORD_ALLOWED_CHANNELS", raising=False)
 
     config = PlatformConfig(enabled=True, token="fake-token")
     adapter = DiscordAdapter(config)
@@ -86,17 +88,18 @@ def adapter(monkeypatch):
     return adapter
 
 
-def make_message(*, channel, content: str, mentions=None):
-    author = SimpleNamespace(id=42, display_name="TestUser", name="TestUser")
+def make_message(*, channel, content: str, mentions=None, author_bot: bool = False, reference=None, webhook_id=None):
+    author = SimpleNamespace(id=42, display_name="TestUser", name="TestUser", bot=author_bot)
     return SimpleNamespace(
         id=123,
         content=content,
         mentions=list(mentions or []),
         attachments=[],
-        reference=None,
+        reference=reference,
         created_at=datetime.now(timezone.utc),
         channel=channel,
         author=author,
+        webhook_id=webhook_id,
     )
 
 
@@ -281,6 +284,87 @@ async def test_no_thread_with_auto_thread_disabled_is_noop(adapter, monkeypatch)
     adapter.handle_message.assert_awaited_once()
 
 
+@pytest.mark.asyncio
+async def test_bot_ack_only_message_is_suppressed(adapter, monkeypatch, caplog):
+    """Short bot/app acknowledgements should be dropped to prevent ping-pong loops."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "mentions")
+    bot_user = adapter._client.user
+    message = make_message(
+        channel=FakeTextChannel(channel_id=500),
+        content=f"<@{bot_user.id}> 확인했습니다.",
+        mentions=[bot_user],
+        author_bot=True,
+    )
+
+    with caplog.at_level("INFO"):
+        await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+    assert "suppressed_bot_ack_loop reason=ack_only" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_bot_thread_followup_requires_explicit_target(adapter, monkeypatch, caplog):
+    """Bot authors no longer get free unmentioned follow-ups just because the bot joined the thread."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
+    parent = FakeTextChannel(channel_id=500, name="briefing")
+    thread = FakeThread(channel_id=501, name="thread", parent=parent)
+    adapter._threads.mark(str(thread.id))
+    message = make_message(
+        channel=thread,
+        content="구현 초안 올렸습니다. 검토 부탁드립니다.",
+        author_bot=True,
+    )
+
+    with caplog.at_level("INFO"):
+        await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+    assert "suppressed_bot_ack_loop reason=thread_followup_requires_explicit_target" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_human_thread_followup_still_allowed(adapter, monkeypatch):
+    """Human follow-ups in an active thread should still work without repeated mentions."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    parent = FakeTextChannel(channel_id=500, name="briefing")
+    thread = FakeThread(channel_id=501, name="thread", parent=parent)
+    adapter._threads.mark(str(thread.id))
+    message = make_message(
+        channel=thread,
+        content="추가 로그 붙였습니다.",
+        author_bot=False,
+    )
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_bot_reply_to_self_still_allowed(adapter, monkeypatch):
+    """Explicit replies to this bot remain valid even inside active threads."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "all")
+    parent = FakeTextChannel(channel_id=500, name="briefing")
+    thread = FakeThread(channel_id=501, name="thread", parent=parent)
+    adapter._threads.mark(str(thread.id))
+    resolved = SimpleNamespace(author=adapter._client.user, content="이 경로로 답장해 주세요")
+    reference = SimpleNamespace(message_id=321, resolved=resolved)
+    message = make_message(
+        channel=thread,
+        content="구체 패치 순서 정리했습니다.",
+        author_bot=True,
+        reference=reference,
+    )
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+
+
 # ── config.py bridging ───────────────────────────────────────────────
 
 
@@ -324,6 +408,46 @@ def test_config_bridges_no_thread_channels(monkeypatch, tmp_path):
     assert os.getenv("DISCORD_NO_THREAD_CHANNELS") == "333"
 
 
+def test_config_bridges_allowed_users(monkeypatch, tmp_path):
+    """gateway/config.py bridges discord.allowed_users to DISCORD_ALLOWED_USERS."""
+    import yaml
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump({
+        "discord": {
+            "allowed_users": ["111", "222"],
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("DISCORD_ALLOWED_USERS", "")
+
+    from gateway.config import load_gateway_config
+    load_gateway_config()
+
+    import os
+    assert os.getenv("DISCORD_ALLOWED_USERS") == "111,222"
+
+
+
+def test_config_bridges_allow_from_to_allowed_users(monkeypatch, tmp_path):
+    """gateway/config.py also accepts discord.allow_from for Discord allowlists."""
+    import yaml
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump({
+        "discord": {
+            "allow_from": ["333"],
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("DISCORD_ALLOWED_USERS", "")
+
+    from gateway.config import load_gateway_config
+    load_gateway_config()
+
+    import os
+    assert os.getenv("DISCORD_ALLOWED_USERS") == "333"
+
+
+
 def test_config_env_var_takes_precedence(monkeypatch, tmp_path):
     """Env vars should take precedence over config.yaml values."""
     import yaml
@@ -331,14 +455,17 @@ def test_config_env_var_takes_precedence(monkeypatch, tmp_path):
     config_file.write_text(yaml.dump({
         "discord": {
             "ignored_channels": ["111"],
+            "allowed_users": ["222"],
         },
     }))
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     monkeypatch.setenv("DISCORD_IGNORED_CHANNELS", "999")
+    monkeypatch.setenv("DISCORD_ALLOWED_USERS", "888")
 
     from gateway.config import load_gateway_config
     load_gateway_config()
 
     import os
-    # Env var should NOT be overwritten
+    # Env vars should NOT be overwritten
     assert os.getenv("DISCORD_IGNORED_CHANNELS") == "999"
+    assert os.getenv("DISCORD_ALLOWED_USERS") == "888"

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -315,3 +315,72 @@ def test_restore_restart_pending_events_rehydrates_adapter_queue(tmp_path, monke
     assert restored_event.message_id == "msg-restart"
     assert restored_event.channel_prompt == "channel prompt"
     assert not checkpoint.exists()
+
+
+def test_preserve_pending_followup_during_restart_drain_requeues_event():
+    runner, adapter = make_restart_runner()
+    runner._draining = True
+    runner._restart_requested = True
+    runner._busy_input_mode = "queue"
+
+    event = MessageEvent(
+        text="original request",
+        message_type=MessageType.TEXT,
+        source=make_restart_source(),
+        message_id="m-drain",
+        channel_prompt="prompt",
+    )
+    follow_up = MessageEvent(
+        text="follow-up survives restart",
+        message_type=MessageType.TEXT,
+        source=event.source,
+        message_id="m-follow",
+        channel_prompt="prompt",
+    )
+    session_key = build_session_key(event.source)
+
+    pending_event, pending_text = runner._preserve_pending_followup_during_drain(
+        adapter=adapter,
+        session_key=session_key,
+        event=event,
+        pending_event=follow_up,
+        pending_text=follow_up.text,
+    )
+
+    assert pending_event is None
+    assert pending_text is None
+    assert session_key in adapter._pending_messages
+    assert adapter._pending_messages[session_key].text == "follow-up survives restart"
+
+
+def test_preserve_pending_followup_during_restart_drain_still_discards_without_queue_mode():
+    runner, adapter = make_restart_runner()
+    runner._draining = True
+    runner._restart_requested = True
+    runner._busy_input_mode = "interrupt"
+
+    event = MessageEvent(
+        text="original request",
+        message_type=MessageType.TEXT,
+        source=make_restart_source(),
+        message_id="m-drain",
+    )
+    follow_up = MessageEvent(
+        text="drop me",
+        message_type=MessageType.TEXT,
+        source=event.source,
+        message_id="m-follow",
+    )
+    session_key = build_session_key(event.source)
+
+    pending_event, pending_text = runner._preserve_pending_followup_during_drain(
+        adapter=adapter,
+        session_key=session_key,
+        event=event,
+        pending_event=follow_up,
+        pending_text=follow_up.text,
+    )
+
+    assert pending_event is None
+    assert pending_text is None
+    assert session_key not in adapter._pending_messages

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -242,3 +242,76 @@ async def test_shutdown_notification_send_failure_does_not_block():
 
     # Should not raise
     await runner._notify_active_sessions_of_shutdown()
+
+
+def test_persist_restart_pending_events_writes_serialized_checkpoint(tmp_path, monkeypatch):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    runner, adapter = make_restart_runner()
+
+    source = make_restart_source(chat_id="777", chat_type="thread")
+    event = MessageEvent(
+        text="resume me after restart",
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id="msg-restart",
+        channel_prompt="channel prompt",
+    )
+    session_key = build_session_key(source)
+    adapter._pending_messages[session_key] = event
+
+    written = runner._persist_restart_pending_events()
+
+    assert written == 1
+    checkpoint = tmp_path / ".restart_pending_events.json"
+    assert checkpoint.exists()
+    payload = checkpoint.read_text(encoding="utf-8")
+    assert "resume me after restart" in payload
+    assert "msg-restart" in payload
+
+
+def test_restore_restart_pending_events_rehydrates_adapter_queue(tmp_path, monkeypatch):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    runner, adapter = make_restart_runner()
+    checkpoint = tmp_path / ".restart_pending_events.json"
+    checkpoint.write_text(
+        """
+[
+  {
+    "session_key": "agent:main:telegram:thread:777:u1:777",
+    "event": {
+      "text": "resume me after restart",
+      "message_type": "text",
+      "message_id": "msg-restart",
+      "channel_prompt": "channel prompt",
+      "media_urls": [],
+      "media_types": [],
+      "reply_to_message_id": null,
+      "reply_to_text": null,
+      "internal": false,
+      "source": {
+        "platform": "telegram",
+        "chat_id": "777",
+        "chat_name": null,
+        "chat_type": "thread",
+        "user_id": "u1",
+        "user_name": null,
+        "thread_id": null,
+        "chat_topic": null
+      }
+    }
+  }
+]
+        """.strip(),
+        encoding="utf-8",
+    )
+
+    restored = runner._restore_restart_pending_events()
+
+    assert restored == 1
+    session_key = "agent:main:telegram:thread:777:u1:777"
+    assert session_key in adapter._pending_messages
+    restored_event = adapter._pending_messages[session_key]
+    assert restored_event.text == "resume me after restart"
+    assert restored_event.message_id == "msg-restart"
+    assert restored_event.channel_prompt == "channel prompt"
+    assert not checkpoint.exists()


### PR DESCRIPTION
## Summary
- preserve dequeued pending follow-ups during restart drain instead of dropping them
- ensure queued follow-ups remain eligible for `.restart_pending_events.json` persistence before shutdown
- add regression coverage for queue-mode preserve vs non-queue discard behavior

## Background
During live verification, we found that a queued follow-up could be dequeued and discarded while the gateway was draining for restart. That left nothing to persist, so the next gateway instance had no pending event to restore.

## Changes
- `gateway/run.py`
  - add `_preserve_pending_followup_during_drain()`
  - re-queue pending follow-ups during `restart + queue mode`
  - keep the existing discard behavior for non-queue mode
- `tests/gateway/test_restart_drain.py`
  - add coverage for preserve/re-queue in queue mode
  - add coverage for discard in non-queue mode

## Verification
- [x] `python -m pytest -q tests/gateway/test_restart_drain.py`
- [x] `python -m pytest -q tests/gateway/test_restart_drain.py tests/gateway/test_clean_shutdown_marker.py`
