### PR TITLE
fix(docker): add SETUID/SETGID caps so gosu drop in entrypoint succeeds

### DIFF
--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -382,3 +382,31 @@ def test_normalize_env_dict_rejects_complex_values():
         "BAD_DICT": {"nested": True},
     })
     assert result == {"GOOD": "string"}
+
+
+def test_security_args_include_setuid_setgid_for_gosu_drop():
+    """_SECURITY_ARGS must include SETUID and SETGID so the image entrypoint
+    can drop from root to the non-root `hermes` user via gosu.
+
+    Without these caps gosu exits with
+    ``error: failed switching to 'hermes': operation not permitted``
+    and the container exits immediately (exit 1) before running any work.
+
+    `no-new-privileges` is kept, so gosu still cannot escalate back to root
+    after the drop — the drop is a one-way transition performed before the
+    `no_new_privs` bit is enforced on the exec boundary.
+    """
+    args = docker_env._SECURITY_ARGS
+
+    # Flatten to set of added caps for clarity.
+    added = {
+        args[i + 1]
+        for i, flag in enumerate(args[:-1])
+        if flag == "--cap-add"
+    }
+    assert "SETUID" in added, "SETUID cap missing — gosu drop in entrypoint will fail"
+    assert "SETGID" in added, "SETGID cap missing — gosu drop in entrypoint will fail"
+
+    # Sanity: the hardening posture is still in place.
+    assert "--cap-drop" in args and "ALL" in args
+    assert "--security-opt" in args and "no-new-privileges" in args

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -148,6 +148,10 @@ def find_docker() -> Optional[str]:
 # We drop all capabilities then add back the minimum needed:
 #   DAC_OVERRIDE - root can write to bind-mounted dirs owned by host user
 #   CHOWN/FOWNER - package managers (pip, npm, apt) need to set file ownership
+#   SETUID/SETGID - the image entrypoint drops from root to the 'hermes'
+#       user via `gosu`, which requires these caps. Combined with
+#       `no-new-privileges`, gosu still cannot escalate back to root after
+#       the drop, so the security posture is preserved.
 # Block privilege escalation and limit PIDs.
 # /tmp is size-limited and nosuid but allows exec (needed by pip/npm builds).
 _SECURITY_ARGS = [
@@ -155,6 +159,8 @@ _SECURITY_ARGS = [
     "--cap-add", "DAC_OVERRIDE",
     "--cap-add", "CHOWN",
     "--cap-add", "FOWNER",
+    "--cap-add", "SETUID",
+    "--cap-add", "SETGID",
     "--security-opt", "no-new-privileges",
     "--pids-limit", "256",
     "--tmpfs", "/tmp:rw,nosuid,size=512m",


### PR DESCRIPTION
## What does this PR do?

Fixes a regression in the Docker terminal backend where every sandbox container exits immediately on startup with:

```
Dropping root privileges
error: failed switching to 'hermes': operation not permitted
```

### Root cause

`tools/environments/docker.py` hardens each container with `--cap-drop ALL` and re-adds only `DAC_OVERRIDE`, `CHOWN`, `FOWNER`. Since commit `fee0e0d3` (*"fix(docker): run as non-root user, use virtualenv"*), the image entrypoint (`docker/entrypoint.sh`) drops from root to the `hermes` user via `gosu`, which requires `CAP_SETUID` and `CAP_SETGID`. With those caps absent, gosu fails and the container exits with code 1 before any work runs — breaking every terminal/file tool invocation in `terminal.backend: docker` mode.

### Fix

Add `SETUID` and `SETGID` to the `--cap-add` list in `_SECURITY_ARGS`. The `no-new-privileges` security-opt is kept, so gosu still cannot escalate back to root after the one-way drop — overall hardening posture is preserved.

## Related Issue

No dedicated issue filed. Related:

- PR #2420 surfaces `terminal.docker_extra_args` as a generic workaround lever and uses `--cap-add SETUID` as its example — implying the author hit this but chose not to file the root-cause issue.
- Issue #9730 reports a different symptom on the same docker backend (`--init` permission on restricted hosts) — their container dies earlier so they don't reach this failure.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] 🔒 Security fix

## Changes Made

- `tools/environments/docker.py` — add `--cap-add SETUID` and `--cap-add SETGID` to `_SECURITY_ARGS`; extend the surrounding comment to explain why the caps are needed and why the posture is preserved.
- `tests/tools/test_docker_environment.py` — new `test_security_args_include_setuid_setgid_for_gosu_drop` asserting both caps are present and `--cap-drop ALL` + `no-new-privileges` are still in place.

## How to Test

**Reproduction (before the fix):**

```bash
docker run --rm \
    --cap-drop ALL \
    --cap-add DAC_OVERRIDE --cap-add CHOWN --cap-add FOWNER \
    --security-opt no-new-privileges \
    --entrypoint /usr/local/bin/gosu \
    hermes-claude:latest hermes id
# error: failed switching to 'hermes': operation not permitted
```

**After the fix (same command with SETUID + SETGID added):**

```bash
# uid=10000(hermes) gid=10000(hermes) groups=10000(hermes)
```

**Unit test:**

```bash
pytest tests/tools/test_docker_environment.py -q
# 19 passed
```

**End-to-end:** rebuilt `hermes-claude:latest`, restarted 6 gateway services, launched sandbox containers → entrypoint succeeds, gosu drops cleanly, tool execution works.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(docker):`)
- [x] I searched for existing PRs (#2420 is adjacent but doesn't fix this directly)
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/tools/test_docker_environment.py -q` and all tests pass
- [x] I've added tests for this change
- [x] Tested on: Ubuntu 24.04 (Azure VM, Linux 6.17), Docker 28.x with containerd snapshotter

### Documentation & Housekeeping

- [x] Updated the `_SECURITY_ARGS` docstring comment to cover the new caps — other docs N/A
- [x] No config keys changed
- [x] Cross-platform: capability flags behave identically on Docker Desktop (macOS/Windows) and Docker Engine (Linux); `no-new-privileges` semantics are kernel-level and unchanged.