### PR TITLE
fix(cron): honor shebang for pre-run scripts instead of forcing Python

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -536,9 +536,16 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
 
     script_timeout = _get_script_timeout()
 
+    if os.access(str(path), os.X_OK):
+        cmd = [str(path)]
+    elif path.suffix.lower() in {".sh", ".bash"}:
+        cmd = ["/bin/bash", str(path)]
+    else:
+        cmd = [sys.executable, str(path)]
+
     try:
         result = subprocess.run(
-            [sys.executable, str(path)],
+            cmd,
             capture_output=True,
             text=True,
             timeout=script_timeout,

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -174,6 +174,34 @@ class TestRunJobScript:
         parsed = json.loads(output)
         assert parsed["new_prs"][0]["number"] == 42
 
+    def test_executable_shell_script_honors_shebang(self, cron_env):
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "hello.sh"
+        script.write_text(textwrap.dedent("""\
+            #!/usr/bin/env bash
+            echo "hello from shell"
+        """))
+        script.chmod(script.stat().st_mode | stat.S_IXUSR)
+
+        success, output = _run_job_script(str(script))
+        assert success is True
+        assert output == "hello from shell"
+
+    def test_non_executable_shell_script_falls_back_to_bash(self, cron_env):
+        from cron.scheduler import _run_job_script
+
+        script = cron_env / "scripts" / "fallback.sh"
+        script.write_text(textwrap.dedent("""\
+            #!/usr/bin/env bash
+            echo "shell fallback works"
+        """))
+        script.chmod(0o644)
+
+        success, output = _run_job_script(str(script))
+        assert success is True
+        assert output == "shell fallback works"
+
 
 class TestBuildJobPromptWithScript:
     """Test that script output is injected into the prompt."""

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -51,6 +51,24 @@ class TestGatewayPidState:
         assert status.get_running_pid() is None
         assert not pid_path.exists()
 
+    def test_get_running_pid_rejects_stale_gateway_pid_and_removes_file(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        pid_path = tmp_path / "gateway.pid"
+        pid_path.write_text(json.dumps({
+            "pid": 99999,
+            "kind": "hermes-gateway",
+            "argv": ["python", "-m", "hermes_cli.main", "gateway", "run", "--replace"],
+            "start_time": 123,
+        }))
+
+        def fake_kill(pid, sig):
+            raise ProcessLookupError
+
+        monkeypatch.setattr(status.os, "kill", fake_kill)
+
+        assert status.get_running_pid() is None
+        assert not pid_path.exists()
+
     def test_get_running_pid_accepts_gateway_metadata_when_cmdline_unavailable(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         pid_path = tmp_path / "gateway.pid"


### PR DESCRIPTION
### Problem

`cron.scheduler._run_job_script` hardcodes the interpreter as `sys.executable`:

```python
result = subprocess.run([sys.executable, str(path)], ...)
```

This means a bash cron-context script with `#!/usr/bin/env bash` is parsed by Python and dies on the first shell builtin. Observed in the wild — a 4-job proactive-stack (github-notifications, rss-digest, morning-briefing, evening-digest) all failed for hours with:

```
File ".../github-notifications-poll.sh", line 10
    mkdir -p "$STATE_DIR"
             ^^^^^^^^^^^^
SyntaxError: invalid syntax
```

The docstring on `script` says "Python script," but cron jobs are created through `cronjob(..., script="my-collector.sh")` in the tool layer with no such constraint — users legitimately expect shell scripts to work.

### Fix

Pick the interpreter based on the script:

- Executable file (`+x`) → run by shebang (`[str(path)]`)
- `.sh` / `.bash` without `+x` → `/bin/bash script`
- Everything else → `sys.executable script` (unchanged behavior for `.py`)

Path-traversal sandbox is unchanged — scripts still must resolve inside `HERMES_HOME/scripts/`.

### Verification

- `pytest tests/cron/test_cron_script.py` → 37/37 pass
- Re-ran all 4 of my bash cron scripts via `_run_job_script()` — all now return real data instead of SyntaxError.

### Alternative considered

Rename docstring and require users to write Python. Rejected: breaks existing deployments, and invoking bash/curl/jq from Python for every poll script is strictly worse DX.