### PR TITLE
fix(docker): entrypoint pass-through for non-hermes commands (e.g. sleep infinity)

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -68,4 +68,19 @@ if [ -d "$INSTALL_DIR/skills" ]; then
     python3 "$INSTALL_DIR/tools/skills_sync.py"
 fi
 
+# Final exec: two supported invocation patterns.
+#
+#   docker run <image>                 -> exec `hermes` with no args (legacy default)
+#   docker run <image> chat -q "..."   -> exec `hermes chat -q "..."` (legacy wrap)
+#   docker run <image> sleep infinity  -> exec `sleep infinity` directly
+#   docker run <image> bash            -> exec `bash` directly
+#
+# If the first positional arg resolves to an executable on PATH, we assume the
+# caller wants to run it directly (needed by the launcher which runs long-lived
+# `sleep infinity` sandbox containers — see tools/environments/docker.py).
+# Otherwise we treat the args as a hermes subcommand and wrap with `hermes`,
+# preserving the documented `docker run <image> <subcommand>` behavior.
+if [ $# -gt 0 ] && command -v "$1" >/dev/null 2>&1; then
+    exec "$@"
+fi
 exec hermes "$@"


### PR DESCRIPTION
## What does this PR do?

Fixes a second regression in the Docker terminal backend: every sandbox container exits immediately with exit code 2 after startup:

```
hermes: error: argument command: invalid choice: 'sleep'
    (choose from chat, model, gateway, setup, whatsapp, login, logout,
    auth, status, cron, webhook, doctor, ...)
```

### Root cause

Commit `8254b820` (*"fix(docker): --init for zombie reaping + sleep infinity for idle-based lifetime"*) made the launcher run sandbox containers with `sleep infinity` as the command, so lifetime is managed by an external idle reaper instead of a fixed timeout:

```python
# tools/environments/docker.py
"sleep", "infinity",  # no fixed lifetime — idle reaper handles cleanup
```

But `docker/entrypoint.sh` unconditionally wraps its args with `hermes`:

```bash
exec hermes "$@"
```

So the final command becomes `hermes sleep infinity` — argparse rejects `sleep` as a subcommand, the container exits with code 2, and every terminal/file tool invocation fails end-to-end.

### Fix

Make the entrypoint's final exec dispatch by checking whether the first positional arg resolves to an executable on PATH:

- If yes (`sleep`, `bash`, `sh`, etc.) — exec it directly. The launcher's `sleep infinity` works.
- If no (a hermes subcommand like `chat`, `gateway`, `doctor`) — preserve the legacy `hermes <subcommand>` wrapping.

Both documented invocation styles keep working:

| Invocation | Behavior |
|---|---|
| `docker run <image>` | `hermes` (interactive, unchanged) |
| `docker run <image> chat -q "hi"` | `hermes chat -q "hi"` (unchanged) |
| `docker run <image> sleep infinity` | `sleep infinity` (was broken, now works) |
| `docker run <image> bash` | `bash` (was broken, now works) |

## Related Issue

No dedicated issue filed. Issue #9730 reports another symptom of the same `8254b820` commit (`--init` permission on hosts with restrictive AppArmor/seccomp) — different failure mode, same root commit.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `docker/entrypoint.sh` — replace `exec hermes "$@"` with a small dispatch that preserves the legacy wrap behavior but allows raw pass-through when `$1` is a PATH executable. Added a block comment documenting all four supported invocation patterns.

## How to Test

**Reproduction (before the fix):**

```bash
docker run --rm hermes-claude:latest sleep infinity
# hermes: error: argument command: invalid choice: 'sleep'
# (container exits 2 immediately)
```

**After the fix:**

```bash
docker run --rm hermes-claude:latest sleep 1
# (sleeps 1s, exits 0)

docker run --rm hermes-claude:latest bash -c 'echo hi'
# hi

docker run --rm hermes-claude:latest chat --help
# hermes chat --help output (legacy wrap still works)
```

**Dispatch unit test (standalone bash):**

```bash
fn() { if [ $# -gt 0 ] && command -v "$1" >/dev/null 2>&1; then echo "RAW: $*"; else echo "WRAP: hermes $*"; fi; }
fn sleep 1            # RAW: sleep 1
fn bash -c "echo hi"  # RAW: bash -c echo hi
fn chat -q hello      # WRAP: hermes chat -q hello
fn                    # WRAP: hermes
```

**End-to-end:** rebuilt `hermes-claude:latest`, restarted 6 gateway services, launched sandbox containers → containers stay up on `sleep infinity`, tools execute via `docker exec hermes ...` successfully.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(docker):`)
- [x] I searched for existing PRs (none found for this specific dispatch issue)
- [x] My PR contains **only** changes related to this fix
- [x] `pytest tests/ -q` is unaffected (no Python changes)
- [ ] Shell script — no unit-test framework for entrypoints in the repo; dispatch logic verified manually with the standalone bash test above and end-to-end against a rebuilt image.
- [x] Tested on: Ubuntu 24.04 (Azure VM, Linux 6.17), Docker 28.x with containerd snapshotter

### Documentation & Housekeeping

- [x] Entrypoint comment documents all four supported invocation patterns
- [x] No config keys changed
- [x] Cross-platform: `command -v` is POSIX; behavior identical on Docker Desktop (macOS/Windows) and Docker Engine (Linux).

## Notes for reviewers

Companion PR #13346 fixes a prerequisite regression (missing `SETUID`/`SETGID` caps) in the same Docker backend. Either can land independently, but until both are merged a fresh install with `terminal.backend: docker` cannot launch any sandbox container.