### PR TITLE
fix: avoid cross-loop reuse in weixin direct send

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1982,7 +1982,15 @@ async def send_weixin_direct(
 
     live_adapter = _LIVE_ADAPTERS.get(resolved_token)
     send_session = getattr(live_adapter, '_send_session', None)
-    if live_adapter is not None and send_session is not None and not send_session.closed:
+    current_loop = asyncio.get_running_loop()
+    live_session_loop = getattr(send_session, '_loop', None)
+    can_reuse_live_adapter = (
+        live_adapter is not None
+        and send_session is not None
+        and not send_session.closed
+        and live_session_loop is current_loop
+    )
+    if can_reuse_live_adapter:
         last_result: Optional[SendResult] = None
         cleaned = live_adapter.format_message(message)
         if cleaned:
@@ -2006,6 +2014,14 @@ async def send_weixin_direct(
             "message_id": last_result.message_id if last_result else None,
             "context_token_used": bool(context_token),
         }
+
+    if live_adapter is not None and send_session is not None and not send_session.closed and live_session_loop is not current_loop:
+        logger.debug(
+            "[weixin-direct] live adapter loop mismatch for %s: adapter loop=%r current loop=%r; using isolated session",
+            _safe_id(chat_id),
+            live_session_loop,
+            current_loop,
+        )
 
     async with aiohttp.ClientSession(trust_env=True, connector=_make_ssl_connector()) as session:
         adapter = WeixinAdapter(

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -359,6 +359,94 @@ class TestWeixinChunkDelivery:
         assert first_try["client_id"] == retry["client_id"]
 
 
+class TestWeixinDirectSend:
+    def test_send_weixin_direct_reuses_live_adapter_only_on_same_event_loop(self):
+        adapter = _make_adapter()
+        loop = asyncio.new_event_loop()
+        adapter._send_session = type("Session", (), {"closed": False, "_loop": loop})()
+        adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="live-msg"))
+        adapter.send_image_file = AsyncMock()
+        adapter.send_document = AsyncMock()
+
+        async def _run():
+            with patch.dict(weixin._LIVE_ADAPTERS, {"test-token": adapter}, clear=True), \
+                 patch.object(weixin, "ContextTokenStore") as store_cls, \
+                 patch.object(weixin, "get_hermes_home", return_value="/tmp"), \
+                 patch.object(weixin.aiohttp, "ClientSession") as client_session_cls:
+                store = store_cls.return_value
+                store.restore.return_value = None
+                store.get.return_value = None
+
+                result = await weixin.send_weixin_direct(
+                    extra={"account_id": "test-account", "base_url": "https://wx.example.com"},
+                    token="test-token",
+                    chat_id="wxid_test123",
+                    message="hello from same loop",
+                )
+
+            assert result["success"] is True
+            assert result["message_id"] == "live-msg"
+            adapter.send.assert_awaited_once_with("wxid_test123", "hello from same loop")
+            client_session_cls.assert_not_called()
+
+        try:
+            loop.run_until_complete(_run())
+        finally:
+            loop.close()
+
+    def test_send_weixin_direct_avoids_live_adapter_across_event_loops(self):
+        adapter = _make_adapter()
+        foreign_loop = asyncio.new_event_loop()
+        adapter._send_session = type("Session", (), {"closed": False, "_loop": foreign_loop})()
+        adapter.send = AsyncMock(side_effect=AssertionError("should not reuse foreign-loop live adapter"))
+
+        isolated_session = type("Session", (), {"closed": False})()
+
+        class _ClientSessionCtx:
+            def __init__(self, session):
+                self._session = session
+
+            async def __aenter__(self):
+                return self._session
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        async def _run():
+            with patch.dict(weixin._LIVE_ADAPTERS, {"test-token": adapter}, clear=True), \
+                 patch.object(weixin, "ContextTokenStore") as store_cls, \
+                 patch.object(weixin, "get_hermes_home", return_value="/tmp"), \
+                 patch.object(weixin.aiohttp, "ClientSession", return_value=_ClientSessionCtx(isolated_session)) as client_session_cls, \
+                 patch.object(weixin, "WeixinAdapter") as adapter_cls:
+                store = store_cls.return_value
+                store.restore.return_value = None
+                store.get.return_value = None
+
+                fresh_adapter = adapter_cls.return_value
+                fresh_adapter.format_message.return_value = "fresh message"
+                fresh_adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="fresh-msg"))
+                fresh_adapter.send_image_file = AsyncMock()
+                fresh_adapter.send_document = AsyncMock()
+
+                result = await weixin.send_weixin_direct(
+                    extra={"account_id": "test-account", "base_url": "https://wx.example.com"},
+                    token="test-token",
+                    chat_id="wxid_test123",
+                    message="hello from foreign loop",
+                )
+
+            assert result["success"] is True
+            assert result["message_id"] == "fresh-msg"
+            fresh_adapter.send.assert_awaited_once_with("wxid_test123", "fresh message")
+            client_session_cls.assert_called_once()
+            adapter.send.assert_not_awaited()
+
+        try:
+            asyncio.run(_run())
+        finally:
+            foreign_loop.close()
+
+
 class TestWeixinOutboundMedia:
     def test_send_image_file_accepts_keyword_image_path(self):
         adapter = _make_adapter()


### PR DESCRIPTION
## Summary
- only reuse the live Weixin adapter session when it belongs to the current event loop
- fall back to an isolated aiohttp session when direct sends run on a different loop
- add regression tests covering same-loop reuse and cross-loop fallback

## Problem
Weixin direct sends could reuse a live adapter session created on the gateway loop from a different event loop used by the send_message tool path. That produced runtime failures like:

```text
Timeout context manager should be used inside a task
```

## Testing
- `python -m pytest tests/gateway/test_weixin.py -q -o 'addopts='`
- `python -m pytest tests/tools/test_send_message_tool.py -q -o 'addopts='`

## Verification
- manually restarted the gateway
- sent a real Weixin validation message successfully after the fix