### PR TITLE
fix(tui): use atomic config writes in tui gateway

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -6,6 +6,8 @@ import types
 from pathlib import Path
 from unittest.mock import patch
 
+import yaml
+
 from tui_gateway import server
 
 
@@ -228,6 +230,30 @@ def test_config_set_model_global_persists(monkeypatch):
     assert saved["model"]["default"] == "anthropic/claude-sonnet-4.6"
     assert saved["model"]["provider"] == "anthropic"
     assert saved["model"]["base_url"] == "https://api.anthropic.com"
+
+
+def test_save_cfg_uses_atomic_write_and_preserves_existing_config_on_failure(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.safe_dump({"existing": True}), encoding="utf-8")
+
+    server._hermes_home = tmp_path
+    server._cfg_cache = None
+    server._cfg_mtime = None
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("disk full")
+
+    monkeypatch.setattr("utils.atomic_yaml_write", _boom)
+
+    with patch.object(server, "_cfg_lock"):
+        try:
+            server._save_cfg({"new": True})
+        except RuntimeError as exc:
+            assert str(exc) == "disk full"
+        else:
+            raise AssertionError("expected _save_cfg to raise")
+
+    assert yaml.safe_load(config_path.read_text(encoding="utf-8")) == {"existing": True}
 
 
 def test_config_set_personality_rejects_unknown_name(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -295,10 +295,9 @@ def _load_cfg() -> dict:
 
 def _save_cfg(cfg: dict):
     global _cfg_cache, _cfg_mtime
-    import yaml
+    from utils import atomic_yaml_write
     path = _hermes_home / "config.yaml"
-    with open(path, "w") as f:
-        yaml.safe_dump(cfg, f)
+    atomic_yaml_write(path, cfg)
     with _cfg_lock:
         _cfg_cache = copy.deepcopy(cfg)
         try:


### PR DESCRIPTION
## Summary

Use crash-safe atomic writes for TUI gateway config persistence.

`tui_gateway.server._save_cfg()` previously wrote `config.yaml` with a direct
`open(..., "w")` + `yaml.safe_dump(...)` flow. That could truncate the user's
config before the new contents were fully written, leaving a partial or empty
file if the process was interrupted or the write failed mid-save.

This change switches the TUI path to the existing repo-standard
`utils.atomic_yaml_write(...)` helper.

## Why

The classic CLI and other config/state write paths already use atomic writes.
The TUI path was an inconsistent holdout and could cause real config loss during:

- process interruption
- disk-full / I/O failure
- crash during save

## Changes

- replace direct YAML write in `tui_gateway/server.py` with `atomic_yaml_write`
- add a regression test proving that a failed write does not clobber the
  existing `config.yaml`

## Testing

Ran:

```bash
tests/test_tui_gateway_server.py

46 passed
