### PR TITLE
fix (cli): restart all loaded launchd gateways on macOS

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1660,6 +1660,85 @@ def _launchd_domain() -> str:
     return f"gui/{os.getuid()}"
 
 
+def _launchd_target(label: str) -> str:
+    return f"{_launchd_domain()}/{label}"
+
+
+def _list_hermes_launchd_services() -> list[tuple[str, Path]]:
+    """Return installed Hermes launchd service labels and plist paths.
+
+    The default profile is returned first so status/restart flows remain
+    deterministic and easier to read.
+    """
+    launch_agents = _launchd_user_home() / "Library" / "LaunchAgents"
+    if not launch_agents.exists():
+        return []
+
+    services: list[tuple[str, Path]] = []
+    for plist_path in sorted(
+        launch_agents.glob("ai.hermes.gateway*.plist"),
+        key=lambda path: (0 if path.stem == "ai.hermes.gateway" else 1, path.stem),
+    ):
+        label = plist_path.stem
+        if label == "ai.hermes.gateway" or label.startswith("ai.hermes.gateway-"):
+            services.append((label, plist_path))
+    return services
+
+
+def _launchd_service_loaded(label: str) -> bool:
+    try:
+        result = subprocess.run(
+            ["launchctl", "print", _launchd_target(label)],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+    return result.returncode == 0
+
+
+def _launchd_restart_service(label: str, plist_path: Path) -> None:
+    """Restart a specific Hermes launchd service label safely."""
+    target = _launchd_target(label)
+    try:
+        subprocess.run(
+            ["launchctl", "kickstart", "-k", target],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=90,
+        )
+        return
+    except subprocess.CalledProcessError as e:
+        if e.returncode not in (3, 113):
+            raise
+
+    subprocess.run(
+        ["launchctl", "bootstrap", _launchd_domain(), str(plist_path)],
+        check=True,
+        timeout=30,
+    )
+    subprocess.run(
+        ["launchctl", "kickstart", target],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+def restart_all_launchd_services() -> list[str]:
+    """Restart loaded Hermes launchd services across all profiles."""
+    restarted: list[str] = []
+    for label, plist_path in _list_hermes_launchd_services():
+        if not _launchd_service_loaded(label):
+            continue
+        _launchd_restart_service(label, plist_path)
+        restarted.append(label)
+    return restarted
+
+
 def generate_launchd_plist() -> str:
     python_path = get_python_path()
     working_dir = str(PROJECT_ROOT)
@@ -3671,34 +3750,42 @@ def gateway_command(args):
         service_configured = False
 
         if restart_all:
-            # --all: stop every gateway process across all profiles, then start fresh
-            service_stopped = False
+            # --all: restart every gateway process across all profiles.
             if supports_systemd_services() and (get_systemd_unit_path(system=False).exists() or get_systemd_unit_path(system=True).exists()):
+                service_stopped = False
                 try:
                     systemd_stop(system=system)
                     service_stopped = True
                 except subprocess.CalledProcessError:
                     pass
-            elif is_macos() and get_launchd_plist_path().exists():
-                try:
-                    launchd_stop()
-                    service_stopped = True
-                except subprocess.CalledProcessError:
-                    pass
-            killed = kill_gateway_processes(all_profiles=True)
-            total = killed + (1 if service_stopped else 0)
-            if total:
-                print(f"✓ Stopped {total} gateway process(es) across all profiles")
+                killed = kill_gateway_processes(all_profiles=True)
+                total = killed + (1 if service_stopped else 0)
+                if total:
+                    print(f"✓ Stopped {total} gateway process(es) across all profiles")
+                _wait_for_gateway_exit(timeout=10.0, force_after=5.0)
+
+                print("Starting gateway...")
+                systemd_start(system=system)
+                return
+
+            if is_macos() and get_launchd_plist_path().exists():
+                restarted_labels = restart_all_launchd_services()
+                if restarted_labels:
+                    print(f"✓ Restarted {len(restarted_labels)} gateway service(s) across all profiles")
+                else:
+                    print("✗ No loaded gateway services found across all profiles")
+                return
+
+            killed = 0
+            if stop_profile_gateway():
+                killed += 1
+            killed += kill_gateway_processes(all_profiles=True)
+            if killed:
+                print(f"✓ Stopped {killed} gateway process(es) across all profiles")
             _wait_for_gateway_exit(timeout=10.0, force_after=5.0)
 
-            # Start the current profile's service fresh
             print("Starting gateway...")
-            if supports_systemd_services() and (get_systemd_unit_path(system=False).exists() or get_systemd_unit_path(system=True).exists()):
-                systemd_start(system=system)
-            elif is_macos() and get_launchd_plist_path().exists():
-                launchd_start()
-            else:
-                run_gateway(verbose=0)
+            run_gateway(verbose=0)
             return
         
         if supports_systemd_services() and (get_systemd_unit_path(system=False).exists() or get_systemd_unit_path(system=True).exists()):

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5844,28 +5844,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
             # --- Launchd services (macOS) ---
             if is_macos():
                 try:
-                    from hermes_cli.gateway import (
-                        launchd_restart,
-                        get_launchd_label,
-                        get_launchd_plist_path,
-                    )
+                    from hermes_cli.gateway import restart_all_launchd_services
 
-                    plist_path = get_launchd_plist_path()
-                    if plist_path.exists():
-                        check = subprocess.run(
-                            ["launchctl", "list", get_launchd_label()],
-                            capture_output=True,
-                            text=True,
-                            timeout=5,
-                        )
-                        if check.returncode == 0:
-                            try:
-                                launchd_restart()
-                                restarted_services.append(get_launchd_label())
-                            except subprocess.CalledProcessError as e:
-                                stderr = (getattr(e, "stderr", "") or "").strip()
-                                print(f"  ⚠ Gateway restart failed: {stderr}")
-                except (FileNotFoundError, subprocess.TimeoutExpired, ImportError):
+                    restarted_services.extend(restart_all_launchd_services())
+                except (FileNotFoundError, subprocess.TimeoutExpired, ImportError, subprocess.CalledProcessError):
                     pass
 
             # --- Manual (non-service) gateways ---

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -374,6 +374,84 @@ class TestLaunchdServiceRecovery:
         assert len(wait_called) == 1
         assert wait_called[0] == {"timeout": 10.0, "force_after": 5.0}
 
+    def test_list_launchd_services_prefers_default_profile_first(self, tmp_path, monkeypatch):
+        launch_agents = tmp_path / "Library" / "LaunchAgents"
+        launch_agents.mkdir(parents=True)
+        default_plist = launch_agents / "ai.hermes.gateway.plist"
+        bolt_plist = launch_agents / "ai.hermes.gateway-bolt.plist"
+        ignored = launch_agents / "com.example.other.plist"
+        default_plist.write_text("default", encoding="utf-8")
+        bolt_plist.write_text("bolt", encoding="utf-8")
+        ignored.write_text("ignored", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_cli, "_launchd_user_home", lambda: tmp_path)
+
+        assert gateway_cli._list_hermes_launchd_services() == [
+            ("ai.hermes.gateway", default_plist),
+            ("ai.hermes.gateway-bolt", bolt_plist),
+        ]
+
+    def test_launchd_restart_service_bootstraps_unloaded_job(self, tmp_path, monkeypatch):
+        plist_path = tmp_path / "ai.hermes.gateway-bolt.plist"
+        plist_path.write_text("plist", encoding="utf-8")
+        label = "ai.hermes.gateway-bolt"
+        target = f"{gateway_cli._launchd_domain()}/{label}"
+        calls = []
+
+        def fake_run(cmd, check=False, **kwargs):
+            calls.append(cmd)
+            if cmd == ["launchctl", "kickstart", "-k", target]:
+                raise gateway_cli.subprocess.CalledProcessError(3, cmd, stderr="Could not find service")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli._launchd_restart_service(label, plist_path)
+
+        assert calls == [
+            ["launchctl", "kickstart", "-k", target],
+            ["launchctl", "bootstrap", gateway_cli._launchd_domain(), str(plist_path)],
+            ["launchctl", "kickstart", target],
+        ]
+
+    def test_restart_all_launchd_services_only_touches_loaded_labels(self, tmp_path, monkeypatch):
+        default_plist = tmp_path / "ai.hermes.gateway.plist"
+        bolt_plist = tmp_path / "ai.hermes.gateway-bolt.plist"
+        idle_plist = tmp_path / "ai.hermes.gateway-idle.plist"
+        for path in (default_plist, bolt_plist, idle_plist):
+            path.write_text("plist", encoding="utf-8")
+
+        monkeypatch.setattr(
+            gateway_cli,
+            "_list_hermes_launchd_services",
+            lambda: [
+                ("ai.hermes.gateway", default_plist),
+                ("ai.hermes.gateway-bolt", bolt_plist),
+                ("ai.hermes.gateway-idle", idle_plist),
+            ],
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "_launchd_service_loaded",
+            lambda label: label != "ai.hermes.gateway-idle",
+        )
+
+        restarted = []
+        monkeypatch.setattr(
+            gateway_cli,
+            "_launchd_restart_service",
+            lambda label, plist_path: restarted.append((label, plist_path)),
+        )
+
+        assert gateway_cli.restart_all_launchd_services() == [
+            "ai.hermes.gateway",
+            "ai.hermes.gateway-bolt",
+        ]
+        assert restarted == [
+            ("ai.hermes.gateway", default_plist),
+            ("ai.hermes.gateway-bolt", bolt_plist),
+        ]
+
     def test_launchd_status_reports_local_stale_plist_when_unloaded(self, tmp_path, monkeypatch, capsys):
         plist_path = tmp_path / "ai.hermes.gateway.plist"
         plist_path.write_text("<plist>old content</plist>", encoding="utf-8")
@@ -626,6 +704,40 @@ class TestGatewaySystemServiceRouting:
             raise AssertionError("Expected gateway_command to exit when service restart fails")
 
         assert run_calls == []
+
+    def test_gateway_restart_all_on_macos_uses_launchd_service_restart_helper(self, tmp_path, monkeypatch):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text("plist\n", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+
+        restarted = []
+        monkeypatch.setattr(
+            gateway_cli,
+            "restart_all_launchd_services",
+            lambda: restarted.extend(["ai.hermes.gateway", "ai.hermes.gateway-bolt"]) or ["ai.hermes.gateway", "ai.hermes.gateway-bolt"],
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "kill_gateway_processes",
+            lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("macOS service restart should not kill processes directly")),
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "launchd_stop",
+            lambda: (_ for _ in ()).throw(AssertionError("macOS --all should not stop only current profile")),
+        )
+        monkeypatch.setattr(
+            gateway_cli,
+            "launchd_start",
+            lambda: (_ for _ in ()).throw(AssertionError("macOS --all should not start only current profile")),
+        )
+
+        gateway_cli.gateway_command(SimpleNamespace(gateway_command="restart", system=False, **{"all": True}))
+
+        assert restarted == ["ai.hermes.gateway", "ai.hermes.gateway-bolt"]
 
 
 class TestDetectVenvDir:


### PR DESCRIPTION
## Summary
This fixes `hermes gateway restart --all` on macOS when multiple Hermes profiles each have their own launchd gateway service.

Previously, the macOS `--all` path only cleanly stop/started the current profile's launchd service and relied on process killing for the rest. In practice, that meant other profile gateways were not actually restarted as launchd services.

This patch adds launchd-specific multi-service helpers that:
- discover installed Hermes launchd services from `~/Library/LaunchAgents`
- detect which labels are currently loaded
- restart each loaded label directly, including bootstrap fallback for unloaded jobs

The same helper is also reused by the macOS update restart path.

## Touched files
- `hermes_cli/gateway.py`
- `hermes_cli/main.py`
- `tests/hermes_cli/test_gateway_service.py`

## Validation
- `pytest tests/hermes_cli/test_gateway_service.py -q`
- `100 passed in 1.91s`

## Scope
- fixes macOS / launchd behavior
- does not claim a Linux/systemd bug
- preserves existing non-macOS fallback behavior