### PR TITLE
fix: improve Gemini OAuth model switching

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -133,15 +133,22 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "grok-code-fast-1",
     ],
     "gemini": [
+        "gemini-2.5-flash",
+        "gemini-2.5-flash-lite",
+        "gemini-2.5-pro",
         "gemini-3.1-pro-preview",
         "gemini-3-pro-preview",
         "gemini-3-flash-preview",
         "gemini-3.1-flash-lite-preview",
     ],
     "google-gemini-cli": [
-        "gemini-3.1-pro-preview",
+        "gemini-2.5-flash",
+        "gemini-2.5-flash-lite",
+        "gemini-2.5-pro",
         "gemini-3-pro-preview",
         "gemini-3-flash-preview",
+        "gemini-3.1-flash-lite-preview",
+        "gemini-3.1-pro-preview",
     ],
     "zai": [
         "glm-5.1",
@@ -1041,6 +1048,38 @@ def curated_models_for_provider(
     return [(m, "") for m in models]
 
 
+def _provider_has_any_credentials(provider_id: str) -> bool:
+    """Return whether a provider has usable credentials in env/auth store/pool."""
+    try:
+        from hermes_cli.auth import PROVIDER_REGISTRY
+        pconfig = PROVIDER_REGISTRY.get(provider_id)
+        if pconfig:
+            import os
+            for env_var in pconfig.api_key_env_vars:
+                if os.getenv(env_var, "").strip():
+                    return True
+    except Exception:
+        pass
+
+    try:
+        from agent.credential_pool import load_pool
+        pool = load_pool(provider_id)
+        if pool.has_credentials():
+            return True
+    except Exception:
+        pass
+
+    try:
+        from hermes_cli.auth import _load_auth_store
+        store = _load_auth_store()
+        if provider_id in store.get("providers", {}) or provider_id in store.get("credential_pool", {}):
+            return True
+    except Exception:
+        pass
+
+    return False
+
+
 def detect_provider_for_model(
     model_name: str,
     current_provider: str,
@@ -1086,52 +1125,30 @@ def detect_provider_for_model(
     if any(name_lower == m.lower() for m in current_models):
         return None
 
-    # --- Step 1: check static provider catalogs for a direct match ---
-    direct_match: Optional[str] = None
+    # --- Step 1: check static provider catalogs for direct matches ---
+    direct_matches: list[str] = []
     for pid, models in _PROVIDER_MODELS.items():
         if pid == current_provider or pid in _AGGREGATORS:
             continue
         if any(name_lower == m.lower() for m in models):
-            direct_match = pid
-            break
+            direct_matches.append(pid)
 
-    if direct_match:
-        # Check if we have credentials for this provider — env vars,
-        # credential pool, or auth store entries.
-        has_creds = False
-        try:
-            from hermes_cli.auth import PROVIDER_REGISTRY
-            pconfig = PROVIDER_REGISTRY.get(direct_match)
-            if pconfig:
-                import os
-                for env_var in pconfig.api_key_env_vars:
-                    if os.getenv(env_var, "").strip():
-                        has_creds = True
-                        break
-        except Exception:
-            pass
-        # Also check credential pool and auth store — covers OAuth,
-        # Claude Code tokens, and other non-env-var credentials (#10300).
-        if not has_creds:
-            try:
-                from agent.credential_pool import load_pool
-                pool = load_pool(direct_match)
-                if pool.has_credentials():
-                    has_creds = True
-            except Exception:
-                pass
-        if not has_creds:
-            try:
-                from hermes_cli.auth import _load_auth_store
-                store = _load_auth_store()
-                if direct_match in store.get("providers", {}) or direct_match in store.get("credential_pool", {}):
-                    has_creds = True
-            except Exception:
-                pass
+    if direct_matches:
+        # Prefer providers that actually have credentials configured.
+        direct_with_creds = [pid for pid in direct_matches if _provider_has_any_credentials(pid)]
+        preferred_matches = direct_with_creds or direct_matches
 
-        # Always return the direct provider match.  If credentials are
-        # missing, the client init will give a clear error rather than
-        # silently routing through the wrong provider (#10300).
+        # If both Google AI Studio and Google Gemini OAuth match, prefer the
+        # provider with credentials. Otherwise fall back to a stable ordering
+        # that keeps the dedicated OAuth/Code Assist provider available.
+        if "google-gemini-cli" in preferred_matches and "gemini" in preferred_matches:
+            direct_match = "google-gemini-cli" if direct_with_creds else "gemini"
+        else:
+            direct_match = preferred_matches[0]
+
+        # Always return the direct provider match. If credentials are missing,
+        # the client init will give a clear error rather than silently routing
+        # through the wrong provider (#10300).
         return (direct_match, name)
 
     # --- Step 2: check OpenRouter catalog ---
@@ -2113,9 +2130,9 @@ def validate_requested_model(
                 ),
             }
 
-    # MiniMax providers don't expose a /models endpoint — validate against
-    # the static catalog instead, similar to openai-codex.
-    if normalized in ("minimax", "minimax-cn"):
+    # MiniMax and Google Gemini OAuth don't expose a normal /models endpoint
+    # on their runtime base URLs — validate against the curated catalog instead.
+    if normalized in ("minimax", "minimax-cn", "google-gemini-cli"):
         try:
             catalog_models = provider_model_ids(normalized)
         except Exception:
@@ -2123,7 +2140,8 @@ def validate_requested_model(
         if catalog_models:
             # Case-insensitive lookup (catalog uses mixed case like MiniMax-M2.7)
             catalog_lower = {m.lower(): m for m in catalog_models}
-            if requested_for_lookup.lower() in catalog_lower:
+            lookup_key = requested_for_lookup.lower()
+            if lookup_key in catalog_lower:
                 return {
                     "accepted": True,
                     "persist": True,
@@ -2132,7 +2150,7 @@ def validate_requested_model(
                 }
             # Auto-correct close matches (case-insensitive)
             catalog_lower_list = list(catalog_lower.keys())
-            auto = get_close_matches(requested_for_lookup.lower(), catalog_lower_list, n=1, cutoff=0.9)
+            auto = get_close_matches(lookup_key, catalog_lower_list, n=1, cutoff=0.9)
             if auto:
                 corrected = catalog_lower[auto[0]]
                 return {
@@ -2142,10 +2160,22 @@ def validate_requested_model(
                     "corrected_model": corrected,
                     "message": f"Auto-corrected `{requested}` → `{corrected}`",
                 }
-            suggestions = get_close_matches(requested_for_lookup.lower(), catalog_lower_list, n=3, cutoff=0.5)
+            suggestions = get_close_matches(lookup_key, catalog_lower_list, n=3, cutoff=0.5)
             suggestion_text = ""
             if suggestions:
                 suggestion_text = "\n  Similar models: " + ", ".join(f"`{catalog_lower[s]}`" for s in suggestions)
+            if normalized == "google-gemini-cli":
+                return {
+                    "accepted": True,
+                    "persist": True,
+                    "recognized": False,
+                    "message": (
+                        f"Note: `{requested}` was not found in the Google Gemini (OAuth) curated catalog."
+                        f"{suggestion_text}"
+                        "\n  Google Gemini (OAuth) does not expose a /models endpoint on the Code Assist runtime, so Hermes cannot verify the model name live."
+                        "\n  The model may still work if your account has access to it."
+                    ),
+                }
             return {
                 "accepted": True,
                 "persist": True,

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -291,6 +291,7 @@ ALIASES: Dict[str, str] = {
 _LABEL_OVERRIDES: Dict[str, str] = {
     "nous": "Nous Portal",
     "openai-codex": "OpenAI Codex",
+    "google-gemini-cli": "Google Gemini (OAuth)",
     "copilot-acp": "GitHub Copilot ACP",
     "xiaomi": "Xiaomi MiMo",
     "local": "Local endpoint",

--- a/tests/hermes_cli/test_gemini_provider.py
+++ b/tests/hermes_cli/test_gemini_provider.py
@@ -138,6 +138,13 @@ class TestGeminiModelCatalog:
         assert "gemini-3-flash-preview" in models
         assert "gemini-3.1-flash-lite-preview" in models
 
+    def test_google_gemini_cli_catalog_has_free_oauth_workhorses(self):
+        models = _PROVIDER_MODELS["google-gemini-cli"]
+        assert "gemini-2.5-flash" in models
+        assert "gemini-2.5-flash-lite" in models
+        assert "gemini-3-flash-preview" in models
+        assert "gemini-3.1-flash-lite-preview" in models
+
     def test_provider_label(self):
         assert "gemini" in _PROVIDER_LABELS
         assert _PROVIDER_LABELS["gemini"] == "Google AI Studio"

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -507,6 +507,37 @@ class TestValidateApiFallback:
 
 # -- validate — Codex auto-correction ------------------------------------------
 
+class TestValidateGoogleGeminiCliFallback:
+    """google-gemini-cli uses a curated catalog, not a live /models probe."""
+
+    def test_known_google_gemini_cli_model_accepted_when_api_probe_unreachable(self):
+        with patch("hermes_cli.models.fetch_api_models", return_value=None):
+            result = validate_requested_model("gemini-3-flash-preview", "google-gemini-cli")
+
+        assert result["accepted"] is True
+        assert result["persist"] is True
+        assert result["recognized"] is True
+        assert result["message"] is None
+
+    def test_known_google_gemini_cli_flash_model_accepted_when_api_probe_unreachable(self):
+        with patch("hermes_cli.models.fetch_api_models", return_value=None):
+            result = validate_requested_model("gemini-2.5-flash", "google-gemini-cli")
+
+        assert result["accepted"] is True
+        assert result["persist"] is True
+        assert result["recognized"] is True
+        assert result["message"] is None
+
+    def test_unknown_google_gemini_cli_model_warns_but_is_allowed(self):
+        with patch("hermes_cli.models.fetch_api_models", return_value=None):
+            result = validate_requested_model("gemini-next-future", "google-gemini-cli")
+
+        assert result["accepted"] is True
+        assert result["persist"] is True
+        assert result["recognized"] is False
+        assert "does not expose a /models endpoint" in result["message"]
+
+
 class TestValidateCodexAutoCorrection:
     """Auto-correction for typos on openai-codex provider."""
 

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -7,6 +7,7 @@ from hermes_cli.models import (
     filter_nous_free_models, _NOUS_ALLOWED_FREE_MODELS,
     is_nous_free_tier, partition_nous_models_by_tier,
     check_nous_free_tier, _FREE_TIER_CACHE_TTL,
+    _PROVIDER_MODELS,
 )
 import hermes_cli.models as _models_mod
 
@@ -166,6 +167,35 @@ class TestDetectProviderForModel:
             result = detect_provider_for_model("claude-opus-4-6", "openai-codex")
         assert result is not None
         assert result[0] not in ("nous",)  # nous has claude models but shouldn't be suggested
+
+
+    def test_google_oauth_gemini_model_prefers_oauth_provider_when_oauth_creds_exist(self):
+        """Shared Gemini model names should prefer google-gemini-cli when OAuth creds exist."""
+        original_gemini = list(_PROVIDER_MODELS.get("gemini", []))
+        original_google = list(_PROVIDER_MODELS.get("google-gemini-cli", []))
+        _PROVIDER_MODELS["gemini"] = ["gemini-2.5-flash"]
+        _PROVIDER_MODELS["google-gemini-cli"] = ["gemini-2.5-flash"]
+        try:
+            with patch("hermes_cli.models._provider_has_any_credentials", side_effect=lambda pid: pid == "google-gemini-cli"):
+                result = detect_provider_for_model("gemini-2.5-flash", "openai-codex")
+            assert result == ("google-gemini-cli", "gemini-2.5-flash")
+        finally:
+            _PROVIDER_MODELS["gemini"] = original_gemini
+            _PROVIDER_MODELS["google-gemini-cli"] = original_google
+
+    def test_google_api_key_gemini_model_prefers_ai_studio_when_api_key_creds_exist(self):
+        """Shared Gemini model names should still prefer AI Studio when that provider has creds."""
+        original_gemini = list(_PROVIDER_MODELS.get("gemini", []))
+        original_google = list(_PROVIDER_MODELS.get("google-gemini-cli", []))
+        _PROVIDER_MODELS["gemini"] = ["gemini-2.5-flash"]
+        _PROVIDER_MODELS["google-gemini-cli"] = ["gemini-2.5-flash"]
+        try:
+            with patch("hermes_cli.models._provider_has_any_credentials", side_effect=lambda pid: pid == "gemini"):
+                result = detect_provider_for_model("gemini-2.5-flash", "openai-codex")
+            assert result == ("gemini", "gemini-2.5-flash")
+        finally:
+            _PROVIDER_MODELS["gemini"] = original_gemini
+            _PROVIDER_MODELS["google-gemini-cli"] = original_google
 
 
 class TestFilterNousFreeModels:

--- a/tests/hermes_cli/test_overlay_slug_resolution.py
+++ b/tests/hermes_cli/test_overlay_slug_resolution.py
@@ -9,7 +9,7 @@ Covers: #5223, #6492
 
 import json
 import os
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -68,6 +68,20 @@ def test_kimi_for_coding_overlay_uses_hermes_slug():
     # Must NOT appear under the models.dev key
     kimi_mdev = next((p for p in providers if p["slug"] == "kimi-for-coding"), None)
     assert kimi_mdev is None, "kimi-for-coding slug should not appear (resolved to kimi-coding)"
+
+
+@patch.dict(os.environ, {}, clear=False)
+def test_google_gemini_oauth_uses_human_label():
+    """google-gemini-cli should display a friendly label in the /model picker."""
+    with patch("agent.credential_pool.load_pool") as mock_load_pool:
+        mock_pool = MagicMock()
+        mock_pool.has_credentials.return_value = True
+        mock_load_pool.return_value = mock_pool
+        providers = list_authenticated_providers(current_provider="openai-codex")
+
+    gemini = next((p for p in providers if p["slug"] == "google-gemini-cli"), None)
+    assert gemini is not None, "google-gemini-cli should appear when OAuth creds exist"
+    assert gemini["name"] == "Google Gemini (OAuth)"
 
 
 @patch.dict(os.environ, {"KILOCODE_API_KEY": "fake-key"}, clear=False)


### PR DESCRIPTION
## Summary
- treat Google Gemini OAuth as a curated-catalog provider instead of probing a live /models endpoint
- add missing Gemini 2.5/3.x flash models to the Gemini and Google Gemini OAuth catalogs
- prefer the provider with real credentials when bare Gemini model names could map to either AI Studio or Google Gemini OAuth
- show a friendlier `Google Gemini (OAuth)` label in the /model picker

## Testing
- source venv/bin/activate && pytest tests/hermes_cli/test_models.py tests/hermes_cli/test_model_validation.py tests/hermes_cli/test_gemini_provider.py tests/hermes_cli/test_overlay_slug_resolution.py -q
- source venv/bin/activate && python3 - <<'PY'
from hermes_cli.model_switch import switch_model, list_authenticated_providers
providers = list_authenticated_providers(current_provider='openai-codex', max_models=10)
print(next(p for p in providers if p['slug'] == 'google-gemini-cli'))
for raw in ['gemini-2.5-flash', 'gemini-3-flash-preview', 'gemini-3.1-flash-lite-preview']:
    r = switch_model(raw_input=raw, current_provider='openai-codex', current_model='gpt-5.4', current_base_url='', current_api_key='')
    print(raw, r.success, r.target_provider, r.new_model, r.error_message)
PY