### PR TITLE
fix(weixin): avoid cross-loop live adapter reuse in direct send

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1983,29 +1983,16 @@ async def send_weixin_direct(
     live_adapter = _LIVE_ADAPTERS.get(resolved_token)
     send_session = getattr(live_adapter, '_send_session', None)
     if live_adapter is not None and send_session is not None and not send_session.closed:
-        last_result: Optional[SendResult] = None
-        cleaned = live_adapter.format_message(message)
-        if cleaned:
-            last_result = await live_adapter.send(chat_id, cleaned)
-            if not last_result.success:
-                return {"error": f"Weixin send failed: {last_result.error}"}
-
-        for media_path, _is_voice in media_files or []:
-            ext = Path(media_path).suffix.lower()
-            if ext in {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"}:
-                last_result = await live_adapter.send_image_file(chat_id, media_path)
-            else:
-                last_result = await live_adapter.send_document(chat_id, media_path)
-            if not last_result.success:
-                return {"error": f"Weixin media send failed: {last_result.error}"}
-
-        return {
-            "success": True,
-            "platform": "weixin",
-            "chat_id": chat_id,
-            "message_id": last_result.message_id if last_result else None,
-            "context_token_used": bool(context_token),
-        }
+        # The live adapter's aiohttp sessions are bound to the gateway event loop.
+        # Reusing them directly from cron/send_message helper paths can run under a
+        # different event loop (or even a different thread), which trips aiohttp
+        # timeout/task checks with errors like:
+        #   "Timeout context manager should be used inside a task"
+        #
+        # For one-shot delivery helpers, prefer an isolated session instead of
+        # cross-loop adapter reuse. This keeps cron/send_message delivery safe even
+        # while the gateway is running.
+        live_adapter = None
 
     async with aiohttp.ClientSession(trust_env=True, connector=_make_ssl_connector()) as session:
         adapter = WeixinAdapter(

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -11,7 +11,7 @@ from gateway.config import PlatformConfig
 from gateway.config import GatewayConfig, HomeChannel, Platform, _apply_env_overrides
 from gateway.platforms.base import SendResult
 from gateway.platforms import weixin
-from gateway.platforms.weixin import ContextTokenStore, WeixinAdapter
+from gateway.platforms.weixin import ContextTokenStore, WeixinAdapter, send_weixin_direct
 from tools.send_message_tool import _parse_target_ref, _send_to_platform
 
 
@@ -307,6 +307,40 @@ class TestWeixinSendMessageIntegration:
             "hello",
             media_files=[("/tmp/demo.png", False)],
         )
+
+    def test_send_weixin_direct_avoids_cross_loop_live_adapter_reuse(self):
+        class _DummyClientSession:
+            def __init__(self, *args, **kwargs):
+                self.closed = False
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                self.closed = True
+                return False
+
+        live_adapter = AsyncMock()
+        live_adapter._send_session = type("_LiveSession", (), {"closed": False})()
+        live_adapter.send.side_effect = AssertionError("should not reuse live adapter across loops")
+
+        with patch.dict(weixin._LIVE_ADAPTERS, {"test-token": live_adapter}, clear=True), \
+             patch.object(weixin.ContextTokenStore, "restore", return_value=None), \
+             patch.object(weixin.ContextTokenStore, "get", return_value=None), \
+             patch("gateway.platforms.weixin.aiohttp.ClientSession", _DummyClientSession), \
+             patch.object(WeixinAdapter, "send", new=AsyncMock(return_value=SendResult(success=True, message_id="msg-direct"))):
+            result = asyncio.run(
+                send_weixin_direct(
+                    extra={"account_id": "test-account"},
+                    token="test-token",
+                    chat_id="wxid_test123",
+                    message="hello from cron",
+                )
+            )
+
+        assert result["success"] is True
+        assert result["message_id"] == "msg-direct"
+        live_adapter.send.assert_not_awaited()
 
 
 class TestWeixinChunkDelivery:


### PR DESCRIPTION
## Summary
- stop `send_weixin_direct()` from reusing a live Weixin adapter across event loops
- force one-shot Weixin sends to use an isolated `aiohttp.ClientSession`
- add a regression test covering cross-loop direct-send safety

## Why
Cron delivery and other one-shot messaging paths can call `send_weixin_direct()` outside the gateway's main event loop. Reusing a live Weixin adapter from those paths can cross event-loop boundaries and trigger aiohttp task/timeout errors instead of delivering the message.

## Root cause
`send_weixin_direct()` preferred `_LIVE_ADAPTERS[resolved_token]` whenever a live adapter and `_send_session` existed. That live adapter's aiohttp session is created inside the gateway event loop, but one-shot delivery helpers may execute from another loop or thread. Reusing the live adapter directly in that context can raise errors such as:

- `Timeout context manager should be used inside a task`

## Behavior before
- cron / one-shot Weixin delivery could try to reuse a live adapter bound to another event loop
- delivery could fail with aiohttp timeout/task-context errors

## Behavior after
- `send_weixin_direct()` no longer reuses a live adapter across loops
- one-shot delivery uses an isolated session instead
- live gateway operation remains unchanged for normal in-loop sends

## How to test
- `source venv/bin/activate && python -m pytest tests/gateway/test_weixin.py -q`
- with the gateway running and a Weixin target configured, trigger cron or one-shot delivery and confirm it no longer fails with `Timeout context manager should be used inside a task`

## Platforms tested
- Linux (local Hermes development environment on omarchy)

## Notes
- This PR is intentionally scoped to event-loop safety for one-shot Weixin delivery helpers.
- It takes the low-risk approach of avoiding cross-loop live-adapter reuse instead of adding more complex loop-handoff logic.
