### PR TITLE
fix(whatsapp): remove shadowing shutil import in cmd_whatsapp

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1330,8 +1330,6 @@ def cmd_whatsapp(args):
         except (EOFError, KeyboardInterrupt):
             response = "n"
         if response.lower() in ("y", "yes"):
-            import shutil
-
             shutil.rmtree(session_dir, ignore_errors=True)
             session_dir.mkdir(parents=True, exist_ok=True)
             print("  ✓ Session cleared")


### PR DESCRIPTION
## Summary
`hermes whatsapp` (and `hermes doctor`'s WhatsApp check path) crashed with `UnboundLocalError: cannot access local variable 'shutil'` on the bridge-dependency install step, after PR #13339 removed the npm timeout.

## Root cause
`cmd_whatsapp` had a redundant `import shutil` inside the re-pair branch (line 1333). Python scoping rule: any `import X` inside a function makes X a local throughout the entire function body, so the earlier `shutil.which("npm")` at line 1295 blew up before control ever reached the local import. `shutil` is already imported at module level (line 48), so the inner import was dead code.

## Changes
- `hermes_cli/main.py`: delete `import shutil` inside `cmd_whatsapp` (-2 lines).

## Validation
- `py_compile` clean.
- Minimal repro: a function that does `shutil.which(...)` early and `import shutil` later raises `UnboundLocalError` on the early call; removing the inner import makes both call sites work. Verified.

Reported on Discord by @Frieza.