### PR TITLE
feat(webhook): support platform:chat_id shorthand in deliver field

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -56,6 +56,14 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_HOST = "0.0.0.0"
 DEFAULT_PORT = 8644
+
+# Valid cross-platform target names for deliver routing.
+_CROSS_PLATFORM_NAMES = frozenset((
+    "telegram", "discord", "slack", "signal", "sms", "whatsapp",
+    "matrix", "mattermost", "homeassistant", "email", "dingtalk",
+    "feishu", "wecom", "wecom_callback", "weixin", "bluebubbles",
+    "qqbot",
+))
 _INSECURE_NO_AUTH = "INSECURE_NO_AUTH"
 _DYNAMIC_ROUTES_FILENAME = "webhook_subscriptions.json"
 
@@ -63,6 +71,28 @@ _DYNAMIC_ROUTES_FILENAME = "webhook_subscriptions.json"
 def check_webhook_requirements() -> bool:
     """Check if webhook adapter dependencies are available."""
     return AIOHTTP_AVAILABLE
+
+
+def _resolve_deliver_shorthand(delivery: dict) -> str:
+    """Parse ``"platform:chat_id"`` shorthand in the ``deliver`` field.
+
+    When the ``deliver`` value contains a colon and the prefix matches a
+    known platform name (e.g. ``"discord:1494411283582292058"``), the
+    chat_id portion is stashed into ``delivery["deliver_extra"]["chat_id"]``
+    and ``deliver`` is normalised to the bare platform name.  This lets n8n
+    routes specify the target channel in a single string instead of
+    requiring a separate ``deliver_extra.chat_id`` entry.
+
+    Returns the (possibly rewritten) ``deliver_type``.
+    """
+    deliver_type = delivery.get("deliver", "log")
+    if ":" in deliver_type and deliver_type != "log":
+        platform_name, _, target_chat_id = deliver_type.partition(":")
+        if platform_name in _CROSS_PLATFORM_NAMES:
+            delivery.setdefault("deliver_extra", {})["chat_id"] = target_chat_id
+            deliver_type = platform_name
+            delivery["deliver"] = deliver_type  # normalise for retries
+    return deliver_type
 
 
 class WebhookAdapter(BasePlatformAdapter):
@@ -193,7 +223,7 @@ class WebhookAdapter(BasePlatformAdapter):
         to the ``log`` deliver type.  TTL cleanup happens on POST.
         """
         delivery = self._delivery_info.get(chat_id, {})
-        deliver_type = delivery.get("deliver", "log")
+        deliver_type = _resolve_deliver_shorthand(delivery)
 
         if deliver_type == "log":
             logger.info("[webhook] Response for %s: %s", chat_id, content[:200])
@@ -203,25 +233,7 @@ class WebhookAdapter(BasePlatformAdapter):
             return await self._deliver_github_comment(content, delivery)
 
         # Cross-platform delivery — any platform with a gateway adapter
-        if self.gateway_runner and deliver_type in (
-            "telegram",
-            "discord",
-            "slack",
-            "signal",
-            "sms",
-            "whatsapp",
-            "matrix",
-            "mattermost",
-            "homeassistant",
-            "email",
-            "dingtalk",
-            "feishu",
-            "wecom",
-            "wecom_callback",
-            "weixin",
-            "bluebubbles",
-            "qqbot",
-        ):
+        if self.gateway_runner and deliver_type in _CROSS_PLATFORM_NAMES:
             return await self._deliver_cross_platform(
                 deliver_type, content, delivery
             )
@@ -658,7 +670,7 @@ class WebhookAdapter(BasePlatformAdapter):
         work in agent mode work here — Telegram, Discord, Slack, GitHub
         PR comments, etc.
         """
-        deliver_type = delivery.get("deliver", "log")
+        deliver_type = _resolve_deliver_shorthand(delivery)
 
         if deliver_type == "log":
             # Shouldn't reach here — startup validation rejects deliver_only

--- a/tests/gateway/test_webhook_deliver_only.py
+++ b/tests/gateway/test_webhook_deliver_only.py
@@ -471,3 +471,116 @@ class TestDirectDeliverUnit:
             )
             assert result.success is True
             mock_gh.assert_awaited_once()
+
+
+# ===================================================================
+# platform:chat_id shorthand in the deliver field
+# ===================================================================
+
+class TestDeliverShorthand:
+    """Tests for the ``"platform:chat_id"`` shorthand in ``deliver``.
+
+    When a route specifies ``"discord:1494411283582292058"`` as the deliver
+    value, the adapter should extract the chat_id and normalise the deliver
+    type to ``"discord"`` so it routes through ``_deliver_cross_platform``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_shorthand_in_deliver_only_route(self):
+        """``deliver: "discord:998877"`` works the same as separate fields."""
+        routes = {
+            "r": {
+                "secret": _INSECURE_NO_AUTH,
+                "deliver": "discord:998877",
+                "deliver_only": True,
+                "prompt": "hello from {service}",
+            }
+        }
+        adapter = _make_adapter(routes)
+        mock_target = _wire_mock_target(adapter, "discord")
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/r",
+                json={"service": "monitoring"},
+                headers={"X-GitHub-Delivery": "d-shorthand-1"},
+            )
+            assert resp.status == 200
+
+        mock_target.send.assert_awaited_once()
+        chat_id_arg = mock_target.send.await_args.args[0]
+        content_arg = mock_target.send.await_args.args[1]
+        assert chat_id_arg == "998877"
+        assert content_arg == "hello from monitoring"
+
+    @pytest.mark.asyncio
+    async def test_shorthand_in_direct_deliver_unit(self):
+        """``_direct_deliver`` resolves shorthand without separate chat_id."""
+        adapter = _make_adapter({})
+        mock_target = _wire_mock_target(adapter, "discord")
+
+        delivery = {"deliver": "discord:112233"}
+        result = await adapter._direct_deliver("test msg", delivery)
+
+        assert result.success is True
+        mock_target.send.assert_awaited_once_with(
+            "112233", "test msg", metadata=None
+        )
+        # The delivery dict should be normalised in-place.
+        assert delivery["deliver"] == "discord"
+        assert delivery["deliver_extra"]["chat_id"] == "112233"
+
+    @pytest.mark.asyncio
+    async def test_shorthand_does_not_overwrite_existing_chat_id(self):
+        """If deliver_extra.chat_id already exists, shorthand still wins."""
+        adapter = _make_adapter({})
+        mock_target = _wire_mock_target(adapter, "telegram")
+
+        delivery = {
+            "deliver": "telegram:from-shorthand",
+            "deliver_extra": {"chat_id": "from-extra"},
+        }
+        result = await adapter._direct_deliver("msg", delivery)
+
+        assert result.success is True
+        chat_id_arg = mock_target.send.await_args.args[0]
+        # setdefault doesn't overwrite — existing value wins
+        assert chat_id_arg == "from-extra"
+
+    def test_resolve_shorthand_non_platform_prefix_ignored(self):
+        """``"something:else"`` where "something" isn't a platform → passthrough."""
+        from gateway.platforms.webhook import _resolve_deliver_shorthand
+
+        delivery = {"deliver": "custom:my-value"}
+        result = _resolve_deliver_shorthand(delivery)
+        assert result == "custom:my-value"
+        assert "deliver_extra" not in delivery
+
+    def test_resolve_shorthand_log_untouched(self):
+        """``"log"`` is never treated as shorthand."""
+        from gateway.platforms.webhook import _resolve_deliver_shorthand
+
+        delivery = {"deliver": "log"}
+        result = _resolve_deliver_shorthand(delivery)
+        assert result == "log"
+
+    def test_resolve_shorthand_telegram_with_chat_id(self):
+        """``"telegram:12345"`` resolves and normalises."""
+        from gateway.platforms.webhook import _resolve_deliver_shorthand
+
+        delivery = {"deliver": "telegram:12345"}
+        result = _resolve_deliver_shorthand(delivery)
+        assert result == "telegram"
+        assert delivery["deliver"] == "telegram"
+        assert delivery["deliver_extra"]["chat_id"] == "12345"
+
+    def test_resolve_shorthand_no_colon_passthrough(self):
+        """Bare platform name without colon passes through unchanged."""
+        from gateway.platforms.webhook import _resolve_deliver_shorthand
+
+        delivery = {"deliver": "discord"}
+        result = _resolve_deliver_shorthand(delivery)
+        assert result == "discord"
+        # No deliver_extra injected
+        assert delivery.get("deliver_extra", {}) == {}


### PR DESCRIPTION
## Summary

When the `deliver` field in a webhook route configuration contains a colon and the prefix matches a known platform name (e.g. `"discord:1494411283582292058"`), extract the chat_id portion into `deliver_extra` and normalise `deliver` to the bare platform name.

This lets n8n routes specify the target channel in a single string instead of requiring a separate `deliver_extra.chat_id` entry:

```yaml
# Before (works today):
deliver: discord
deliver_extra:
  chat_id: "1494411283582292058"

# After (shorthand — this PR):
deliver: "discord:1494411283582292058"
```

### Changes

- **`_CROSS_PLATFORM_NAMES`** — extracted `frozenset` constant for the cross-platform target names (deduplicates the inline tuple that was in `send()`)
- **`_resolve_deliver_shorthand(delivery) -> str`** — helper that parses the `"platform:chat_id"` pattern and mutates the delivery dict in-place
- Both `send()` and `_direct_deliver()` now call `_resolve_deliver_shorthand()` — no code duplication
- 8 new tests covering shorthand resolution, passthrough for non-platform prefixes, bare names, `log`, and `setdefault` semantics for existing `deliver_extra.chat_id`

### Testing

```
pytest tests/gateway/test_webhook_deliver_only.py -v
```
