### PR TITLE
fix(web): cross-platform sync-assets + surface build errors on failure

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4365,13 +4365,25 @@ def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
         return True
     import shutil
 
+    # Console-encoding-safe print: Windows consoles default to cp1252
+    # (or similar) and will raise UnicodeEncodeError on arrow / check
+    # glyphs unless PYTHONIOENCODING=utf-8 is set. Routing every print
+    # in this function through _say() with errors="replace" keeps the
+    # build path usable on a stock `py -m hermes_cli.main web` invocation.
+    def _say(text: str) -> None:
+        try:
+            print(text)
+        except UnicodeEncodeError:
+            encoding = getattr(sys.stdout, "encoding", None) or "ascii"
+            print(text.encode(encoding, errors="replace").decode(encoding, errors="replace"))
+
     npm = shutil.which("npm")
     if not npm:
         if fatal:
-            print("Web UI frontend not built and npm is not available.")
-            print("Install Node.js, then run:  cd web && npm install && npm run build")
+            _say("Web UI frontend not built and npm is not available.")
+            _say("Install Node.js, then run:  cd web && npm install && npm run build")
         return not fatal
-    print("→ Building web UI...")
+    _say("→ Building web UI...")
 
     def _relay(result: "subprocess.CompletedProcess") -> None:
         """Print captured npm output so users can see *why* a step failed."""
@@ -4380,31 +4392,31 @@ def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
                 continue
             text = blob.decode("utf-8", errors="replace").rstrip() if isinstance(blob, bytes) else blob.rstrip()
             if text:
-                print(text)
+                _say(text)
 
     r1 = subprocess.run(
         [npm, "install", "--silent"], cwd=web_dir, capture_output=True
     )
     if r1.returncode != 0:
-        print(
+        _say(
             f"  {'✗' if fatal else '⚠'} Web UI npm install failed"
             + ("" if fatal else " (hermes web will not be available)")
         )
         _relay(r1)
         if fatal:
-            print("  Run manually:  cd web && npm install && npm run build")
+            _say("  Run manually:  cd web && npm install && npm run build")
         return False
     r2 = subprocess.run([npm, "run", "build"], cwd=web_dir, capture_output=True)
     if r2.returncode != 0:
-        print(
+        _say(
             f"  {'✗' if fatal else '⚠'} Web UI build failed"
             + ("" if fatal else " (hermes web will not be available)")
         )
         _relay(r2)
         if fatal:
-            print("  Run manually:  cd web && npm install && npm run build")
+            _say("  Run manually:  cd web && npm install && npm run build")
         return False
-    print("  ✓ Web UI built")
+    _say("  ✓ Web UI built")
     return True
 
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4372,12 +4372,25 @@ def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
             print("Install Node.js, then run:  cd web && npm install && npm run build")
         return not fatal
     print("→ Building web UI...")
-    r1 = subprocess.run([npm, "install", "--silent"], cwd=web_dir, capture_output=True)
+
+    def _relay(result: "subprocess.CompletedProcess") -> None:
+        """Print captured npm output so users can see *why* a step failed."""
+        for blob in (result.stdout, result.stderr):
+            if not blob:
+                continue
+            text = blob.decode("utf-8", errors="replace").rstrip() if isinstance(blob, bytes) else blob.rstrip()
+            if text:
+                print(text)
+
+    r1 = subprocess.run(
+        [npm, "install", "--silent"], cwd=web_dir, capture_output=True
+    )
     if r1.returncode != 0:
         print(
             f"  {'✗' if fatal else '⚠'} Web UI npm install failed"
             + ("" if fatal else " (hermes web will not be available)")
         )
+        _relay(r1)
         if fatal:
             print("  Run manually:  cd web && npm install && npm run build")
         return False
@@ -4387,6 +4400,7 @@ def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
             f"  {'✗' if fatal else '⚠'} Web UI build failed"
             + ("" if fatal else " (hermes web will not be available)")
         )
+        _relay(r2)
         if fatal:
             print("  Run manually:  cd web && npm install && npm run build")
         return False

--- a/web/package.json
+++ b/web/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "sync-assets": "rm -rf public/fonts public/ds-assets && cp -r node_modules/@nous-research/ui/dist/fonts public/fonts && cp -r node_modules/@nous-research/ui/dist/assets public/ds-assets",
+    "sync-assets": "node scripts/sync-assets.mjs",
     "predev": "npm run sync-assets",
     "prebuild": "npm run sync-assets",
     "dev": "vite",

--- a/web/scripts/sync-assets.mjs
+++ b/web/scripts/sync-assets.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+// Cross-platform replacement for the previous shell pipeline:
+//
+//   rm -rf public/fonts public/ds-assets
+//   && cp -r node_modules/@nous-research/ui/dist/fonts public/fonts
+//   && cp -r node_modules/@nous-research/ui/dist/assets public/ds-assets
+//
+// `rm -rf` / `cp -r` don't exist on Windows cmd.exe, so `npm run build`
+// (invoked from Python via subprocess → cmd.exe) failed before Vite ran.
+// Using Node's stdlib fs keeps this dependency-free and platform-neutral.
+
+import { cpSync, rmSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const webRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const uiDist = resolve(webRoot, "node_modules", "@nous-research", "ui", "dist");
+
+const targets = [
+  { from: resolve(uiDist, "fonts"), to: resolve(webRoot, "public", "fonts") },
+  { from: resolve(uiDist, "assets"), to: resolve(webRoot, "public", "ds-assets") },
+];
+
+for (const { from, to } of targets) {
+  rmSync(to, { recursive: true, force: true });
+  cpSync(from, to, { recursive: true });
+}


### PR DESCRIPTION
## Summary

Three Windows-only bugs in the web-dashboard build path. Each is small, scoped, and verified end-to-end on Windows 11 — including (now) under a stock `cmd.exe` / PowerShell console with its default cp1252 encoding.

## The problems

### 1. `sync-assets` shells out to Unix-only commands

[`web/package.json`](../blob/main/web/package.json) hard-codes:

```
rm -rf public/fonts public/ds-assets && cp -r node_modules/.../fonts public/fonts && cp -r node_modules/.../assets public/ds-assets
```

Neither `rm -rf` nor `cp -r` exist on Windows `cmd.exe`. `hermes_cli/main.py::_build_web_ui` runs `npm install` / `npm run build` via `subprocess.run(...)`, which on Windows defaults to `cmd.exe` — so the `prebuild` hook crashes before Vite ever gets invoked and the dashboard never gets built.

### 2. Build failures are silent

[`hermes_cli/main.py::_build_web_ui`](../blob/main/hermes_cli/main.py) runs both subprocess calls with `capture_output=True` and never relays the captured buffers on failure. Users see:

```
✗ Web UI build failed
```

…and nothing else. No stdout. No stderr. No hint that the real problem was `'rm' is not recognized as an internal or external command`. This is exactly how (1) stayed invisible: the error was right there in the stderr buffer, and we threw it away.

### 3. Console glyphs crash on non-UTF8 Windows terminals

Even after fixing (1) and (2), `_build_web_ui` still crashed on a stock Windows PowerShell / `cmd.exe` session:

```
UnicodeEncodeError: 'charmap' codec can't encode character '\u2192' in position 0
```

Python's stdout on Windows defaults to cp1252 (or similar code page). The function prints `→`, `✗`, `⚠`, and `✓` as status markers — all of which blow up on cp1252 with a hard exception before npm is even consulted. Under `PYTHONIOENCODING=utf-8` this is hidden; under the actual defaults a user gets out of the box, the whole function is unreachable.

Caught by a Codex review pass on an earlier revision of this PR — not in the initial report.

## The fixes

### (1) Cross-platform `sync-assets`

Replace the shell pipeline with `web/scripts/sync-assets.mjs` — ~20 lines of Node using `fs.rmSync` + `fs.cpSync` (stdlib, Node ≥ 16.7). No new dependencies, identical behavior on POSIX and Windows. `package.json` just calls `node scripts/sync-assets.mjs`.

### (2) Relay captured subprocess output

Add a `_relay(result)` inner helper that decodes and prints stdout + stderr (utf-8, `errors='replace'`) whenever a step returns non-zero. Success path is unchanged — still silent when things work.

### (3) Safe `print` under cp1252

Add a `_say(text)` inner helper that catches `UnicodeEncodeError` and falls back to:

```python
text.encode(sys.stdout.encoding, errors='replace').decode(...)
```

Glyphs degrade to `?` on cp1252 / ASCII consoles; utf-8 consoles are unaffected. All prints in `_build_web_ui` route through `_say` now.

## Test plan

All run on Windows 11, Python 3.11, Node 24, npm 10:

- [x] `node --check web/scripts/sync-assets.mjs` — passes
- [x] `node web/scripts/sync-assets.mjs` — populates `public/fonts` + `public/ds-assets` correctly
- [x] `subprocess.run([npm, 'install', '--silent'], cwd=web, capture_output=True)` from the bundled Python — exit 0
- [x] `subprocess.run([npm, 'run', 'build'], cwd=web, capture_output=True)` from the bundled Python — exit 0, produces `hermes_cli/web_dist/` with `index.html`, `assets/`, `fonts/`, `ds-assets/`, `favicon.ico`
- [x] `PYTHONIOENCODING=cp1252 python -c "_build_web_ui(Path('web'), fatal=True)"` — completes successfully; glyphs print as `?`
- [x] Mocked `npm` failure under cp1252 — captured stderr relays safely, no UnicodeEncodeError
- [x] `python -m py_compile hermes_cli/main.py` — passes
- [x] `git diff --check upstream/main..HEAD` — clean

## Commits

- `9a276b6` — cross-platform `sync-assets` + surface build errors
- `2b0d1ff` — handle non-UTF8 Windows console encodings in `_build_web_ui`

Both reviewed by independent Codex passes; the cp1252 issue was caught by the second pass and fixed before this PR was reopened.

## Scope

Intentionally **not** bundled with #13198 (the `pid_is_alive` Windows fix) — those are runtime liveness-check crashes, this is a build-time shell + console-encoding issue. Keeping them separate for cleaner review.

---

_Reopened after an additional Codex review pass caught the cp1252 encoding bug (fix #3) — apologies for the close/reopen churn._