### PR TITLE
Improve external context engine plugin support

### DIFF
--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -26,7 +26,7 @@ Lifecycle:
 """
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 
 class ContextEngine(ABC):

--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -91,7 +91,7 @@ class ContextEngine(ABC):
         Args:
             focus_topic: Optional topic string from manual ``/compress <focus>``.
                 Engines that support guided compression should prioritise
-                preserving information related to this topic.  Engines that
+                preserving information related to this topic. Engines that
                 don't support it may simply ignore this argument.
         """
 

--- a/cli.py
+++ b/cli.py
@@ -4655,31 +4655,48 @@ class HermesCLI:
         flush_tool_summary()
         print()
     
-    def _notify_session_boundary(self, event_type: str) -> None:
+    def _notify_session_boundary(self, event_type: str, **extra_context) -> None:
         """Fire a session-boundary plugin hook (on_session_finalize or on_session_reset).
 
-        Non-blocking — errors are caught and logged.  Safe to call from any
-        lifecycle point (shutdown, /new, /reset).
+        Non-blocking — errors are caught and logged. Safe to call from any
+        lifecycle point (shutdown, /new, /reset). Extra keyword context is
+        passed through verbatim so external plugins can observe richer session
+        boundary metadata without affecting the default built-in behavior.
         """
         try:
             from hermes_cli.plugins import invoke_hook as _invoke_hook
-            _invoke_hook(
-                event_type,
-                session_id=self.agent.session_id if self.agent else None,
-                platform=getattr(self, "platform", None) or "cli",
-            )
+            payload = {
+                "session_id": self.agent.session_id if self.agent else None,
+                "platform": getattr(self, "platform", None) or "cli",
+            }
+            payload.update(extra_context)
+            _invoke_hook(event_type, **payload)
         except Exception:
             pass
 
     def new_session(self, silent=False):
         """Start a fresh session with a new session ID and cleared agent state."""
+        _old_history = list(self.conversation_history)
+        _boundary_old_session_id = (
+            getattr(self.agent, "session_id", None) if self.agent else None
+        ) or self.session_id
         if self.agent and self.conversation_history:
             # Trigger memory extraction on the old session before session_id rotates.
             self.agent.commit_memory_session(self.conversation_history)
-            self._notify_session_boundary("on_session_finalize")
+            self._notify_session_boundary(
+                "on_session_finalize",
+                old_session_id=_boundary_old_session_id,
+                previous_messages=_old_history,
+                previous_message_count=len(_old_history),
+            )
         elif self.agent:
             # First session or empty history — still finalize the old session
-            self._notify_session_boundary("on_session_finalize")
+            self._notify_session_boundary(
+                "on_session_finalize",
+                old_session_id=_boundary_old_session_id,
+                previous_messages=[],
+                previous_message_count=0,
+            )
 
         old_session_id = self.session_id
         if self._session_db and old_session_id:
@@ -4729,7 +4746,12 @@ class HermesCLI:
                     )
                 except Exception:
                     pass
-            self._notify_session_boundary("on_session_reset")
+            self._notify_session_boundary(
+                "on_session_reset",
+                old_session_id=_boundary_old_session_id,
+                new_session_id=self.session_id,
+                carry_over_context=True,
+            )
 
         if not silent:
             print("(^_^)v New session started!")

--- a/cli.py
+++ b/cli.py
@@ -4688,6 +4688,7 @@ class HermesCLI:
             except Exception:
                 pass
 
+        _old_history = list(self.conversation_history)
         self.session_start = datetime.now()
         timestamp_str = self.session_start.strftime("%Y%m%d_%H%M%S")
         short_uuid = uuid.uuid4().hex[:6]
@@ -4699,7 +4700,11 @@ class HermesCLI:
         if self.agent:
             self.agent.session_id = self.session_id
             self.agent.session_start = self.session_start
-            self.agent.reset_session_state()
+            self.agent.reset_session_state(
+                previous_messages=_old_history,
+                old_session_id=old_session_id,
+                carry_over_context=True,
+            )
             if hasattr(self.agent, "_last_flushed_db_idx"):
                 self.agent._last_flushed_db_idx = 0
             if hasattr(self.agent, "_todo_store"):
@@ -4783,6 +4788,8 @@ class HermesCLI:
             pass
 
         # Switch to the target session
+        _old_history = list(self.conversation_history)
+        _old_agent_session_id = getattr(self.agent, "session_id", None) if self.agent else None
         self.session_id = target_id
         self._resumed = True
         self._pending_title = None
@@ -4801,7 +4808,11 @@ class HermesCLI:
         # Sync the agent if already initialised
         if self.agent:
             self.agent.session_id = target_id
-            self.agent.reset_session_state()
+            self.agent.reset_session_state(
+                previous_messages=_old_history,
+                old_session_id=_old_agent_session_id,
+                carry_over_context=False,
+            )
             if hasattr(self.agent, "_last_flushed_db_idx"):
                 self.agent._last_flushed_db_idx = len(self.conversation_history)
             if hasattr(self.agent, "_todo_store"):
@@ -4906,6 +4917,8 @@ class HermesCLI:
             pass
 
         # Switch to the new session
+        _old_history = list(self.conversation_history)
+        _old_agent_session_id = getattr(self.agent, "session_id", None) if self.agent else None
         self.session_id = new_session_id
         self.session_start = now
         self._pending_title = None
@@ -4915,7 +4928,11 @@ class HermesCLI:
         if self.agent:
             self.agent.session_id = new_session_id
             self.agent.session_start = now
-            self.agent.reset_session_state()
+            self.agent.reset_session_state(
+                previous_messages=_old_history,
+                old_session_id=_old_agent_session_id,
+                carry_over_context=False,
+            )
             if hasattr(self.agent, "_last_flushed_db_idx"):
                 self.agent._last_flushed_db_idx = len(self.conversation_history)
             if hasattr(self.agent, "_todo_store"):

--- a/cli.py
+++ b/cli.py
@@ -4682,7 +4682,11 @@ class HermesCLI:
         ) or self.session_id
         if self.agent and self.conversation_history:
             # Trigger memory extraction on the old session before session_id rotates.
-            self.agent.commit_memory_session(self.conversation_history)
+            if hasattr(self.agent, "commit_memory_session"):
+                try:
+                    self.agent.commit_memory_session(self.conversation_history)
+                except (Exception, KeyboardInterrupt):
+                    pass
             self._notify_session_boundary(
                 "on_session_finalize",
                 old_session_id=_boundary_old_session_id,

--- a/cli.py
+++ b/cli.py
@@ -2110,6 +2110,7 @@ class HermesCLI:
         # Background task tracking: {task_id: threading.Thread}
         self._background_tasks: Dict[str, threading.Thread] = {}
         self._background_task_counter = 0
+        self._last_session_boundary_thread: Optional[threading.Thread] = None
 
     def _invalidate(self, min_interval: float = 0.25) -> None:
         """Throttled UI repaint — prevents terminal blinking on slow/SSH connections."""
@@ -4674,6 +4675,32 @@ class HermesCLI:
         except Exception:
             pass
 
+    def _launch_session_boundary_memory_flush(self, history_snapshot: list) -> None:
+        """Kick old-session memory extraction off-thread so /new can feel immediate."""
+        self._last_session_boundary_thread = None
+        agent = getattr(self, "agent", None)
+        if not agent or not history_snapshot:
+            return
+
+        def _run_boundary_flush():
+            try:
+                agent.flush_memories(history_snapshot)
+            except (Exception, KeyboardInterrupt):
+                pass
+            if hasattr(agent, "commit_memory_session"):
+                try:
+                    agent.commit_memory_session(history_snapshot)
+                except (Exception, KeyboardInterrupt):
+                    pass
+
+        thread = threading.Thread(
+            target=_run_boundary_flush,
+            daemon=True,
+            name=f"session-boundary-flush-{(getattr(agent, 'session_id', '') or 'unknown')[:24]}",
+        )
+        self._last_session_boundary_thread = thread
+        thread.start()
+
     def new_session(self, silent=False):
         """Start a fresh session with a new session ID and cleared agent state."""
         _old_history = list(self.conversation_history)
@@ -4681,12 +4708,7 @@ class HermesCLI:
             getattr(self.agent, "session_id", None) if self.agent else None
         ) or self.session_id
         if self.agent and self.conversation_history:
-            # Trigger memory extraction on the old session before session_id rotates.
-            if hasattr(self.agent, "commit_memory_session"):
-                try:
-                    self.agent.commit_memory_session(self.conversation_history)
-                except (Exception, KeyboardInterrupt):
-                    pass
+            self._launch_session_boundary_memory_flush(_old_history)
             self._notify_session_boundary(
                 "on_session_finalize",
                 old_session_id=_boundary_old_session_id,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5088,8 +5088,15 @@ class GatewayRunner:
         try:
             from hermes_cli.plugins import invoke_hook as _invoke_hook
             _old_sid = old_entry.session_id if old_entry else None
-            _invoke_hook("on_session_finalize", session_id=_old_sid,
-                         platform=source.platform.value if source.platform else "")
+            _old_history = self.session_store.load_transcript(_old_sid) if _old_sid else []
+            _invoke_hook(
+                "on_session_finalize",
+                session_id=_old_sid,
+                old_session_id=_old_sid,
+                previous_messages=_old_history,
+                previous_message_count=len(_old_history),
+                platform=source.platform.value if source.platform else "",
+            )
         except Exception:
             pass
 
@@ -5124,8 +5131,15 @@ class GatewayRunner:
         try:
             from hermes_cli.plugins import invoke_hook as _invoke_hook
             _new_sid = new_entry.session_id if new_entry else None
-            _invoke_hook("on_session_reset", session_id=_new_sid,
-                         platform=source.platform.value if source.platform else "")
+            _old_sid = old_entry.session_id if old_entry else None
+            _invoke_hook(
+                "on_session_reset",
+                session_id=_new_sid,
+                old_session_id=_old_sid,
+                new_session_id=_new_sid,
+                carry_over_context=True,
+                platform=source.platform.value if source.platform else "",
+            )
         except Exception:
             pass
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8278,6 +8278,7 @@ class GatewayRunner:
             user_id=str(context.source.user_id) if context.source.user_id else "",
             user_name=str(context.source.user_name) if context.source.user_name else "",
             session_key=context.session_key,
+            session_id=context.session_id,
         )
 
     def _clear_session_env(self, tokens: list) -> None:
@@ -8500,12 +8501,37 @@ class GatewayRunner:
             user_name=str(evt.get("user_name") or "").strip() or None,
         )
 
+    def _is_stale_process_notification(self, payload: dict) -> bool:
+        """Return True when a background-process event belongs to a superseded logical session."""
+        session_key = str(payload.get("session_key") or "").strip()
+        event_session_id = str(payload.get("conversation_session_id") or "").strip()
+        if not session_key or not event_session_id:
+            return False
+
+        try:
+            self.session_store._ensure_loaded()
+            entry = self.session_store._entries.get(session_key)
+        except Exception:
+            entry = None
+        current_session_id = str(getattr(entry, "session_id", "") or "").strip()
+        if current_session_id and current_session_id != event_session_id:
+            logger.info(
+                "Dropping stale process notification for %s: event session=%s current session=%s",
+                session_key[:40],
+                event_session_id,
+                current_session_id,
+            )
+            return True
+        return False
+
     async def _inject_watch_notification(self, synth_text: str, evt: dict) -> None:
         """Inject a watch-pattern notification as a synthetic message event.
 
         Routing must come from the queued watch event itself, not from whatever
         foreground message happened to be active when the queue was drained.
         """
+        if self._is_stale_process_notification(evt):
+            return
         source = self._build_process_event_source(evt)
         if not source:
             logger.warning(
@@ -8603,6 +8629,13 @@ class GatewayRunner:
                         f"Command: {session.command}\n"
                         f"Output:\n{_out}]"
                     )
+                    if self._is_stale_process_notification(watcher):
+                        logger.info(
+                            "Process %s finished after session boundary changed for %s — dropping stale agent notification",
+                            session_id,
+                            session_key[:40],
+                        )
+                        break
                     source = self._build_process_event_source({
                         "session_id": session_id,
                         "session_key": session_key,
@@ -8611,6 +8644,7 @@ class GatewayRunner:
                         "thread_id": thread_id,
                         "user_id": user_id,
                         "user_name": user_name,
+                        "conversation_session_id": watcher.get("conversation_session_id", ""),
                     })
                     if not source:
                         logger.warning(

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -55,6 +55,7 @@ _SESSION_THREAD_ID: ContextVar = ContextVar("HERMES_SESSION_THREAD_ID", default=
 _SESSION_USER_ID: ContextVar = ContextVar("HERMES_SESSION_USER_ID", default=_UNSET)
 _SESSION_USER_NAME: ContextVar = ContextVar("HERMES_SESSION_USER_NAME", default=_UNSET)
 _SESSION_KEY: ContextVar = ContextVar("HERMES_SESSION_KEY", default=_UNSET)
+_SESSION_ID: ContextVar = ContextVar("HERMES_SESSION_ID", default=_UNSET)
 
 # Cron auto-delivery vars — set per-job in run_job() so concurrent jobs
 # don't clobber each other's delivery targets.
@@ -70,6 +71,7 @@ _VAR_MAP = {
     "HERMES_SESSION_USER_ID": _SESSION_USER_ID,
     "HERMES_SESSION_USER_NAME": _SESSION_USER_NAME,
     "HERMES_SESSION_KEY": _SESSION_KEY,
+    "HERMES_SESSION_ID": _SESSION_ID,
     "HERMES_CRON_AUTO_DELIVER_PLATFORM": _CRON_AUTO_DELIVER_PLATFORM,
     "HERMES_CRON_AUTO_DELIVER_CHAT_ID": _CRON_AUTO_DELIVER_CHAT_ID,
     "HERMES_CRON_AUTO_DELIVER_THREAD_ID": _CRON_AUTO_DELIVER_THREAD_ID,
@@ -84,6 +86,7 @@ def set_session_vars(
     user_id: str = "",
     user_name: str = "",
     session_key: str = "",
+    session_id: str = "",
 ) -> list:
     """Set all session context variables and return reset tokens.
 
@@ -101,6 +104,7 @@ def set_session_vars(
         _SESSION_USER_ID.set(user_id),
         _SESSION_USER_NAME.set(user_name),
         _SESSION_KEY.set(session_key),
+        _SESSION_ID.set(session_id),
     ]
     return tokens
 
@@ -124,6 +128,7 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_USER_ID,
         _SESSION_USER_NAME,
         _SESSION_KEY,
+        _SESSION_ID,
     ):
         var.set("")
 

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -751,11 +751,29 @@ def _discover_memory_providers() -> list[tuple[str, str]]:
 
 def _discover_context_engines() -> list[tuple[str, str]]:
     """Return [(name, description), ...] for available context engines."""
+    engines: list[tuple[str, str]] = []
+    seen: set[str] = set()
+
     try:
         from plugins.context_engine import discover_context_engines
-        return [(name, desc) for name, desc, _avail in discover_context_engines()]
+        for name, desc, _avail in discover_context_engines():
+            if name not in seen:
+                engines.append((name, desc))
+                seen.add(name)
     except Exception:
-        return []
+        pass
+
+    try:
+        from hermes_cli.plugins import discover_plugins, get_plugin_context_engine
+
+        discover_plugins()
+        plugin_engine = get_plugin_context_engine()
+        if plugin_engine and plugin_engine.name not in seen:
+            engines.append((plugin_engine.name, "installed plugin"))
+    except Exception:
+        pass
+
+    return engines
 
 
 def _get_current_memory_provider() -> str:

--- a/run_agent.py
+++ b/run_agent.py
@@ -2078,6 +2078,7 @@ class AIAgent:
         previous_messages: list | None = None,
         carry_over_context: bool = False,
         reset_engine: bool = False,
+        boundary_reason: str | None = None,
     ) -> None:
         """Apply the host-side lifecycle contract for context-engine session boundaries."""
         engine = getattr(self, "context_compressor", None)
@@ -2091,6 +2092,8 @@ class AIAgent:
             "model": getattr(self, "model", ""),
             "context_length": getattr(engine, "context_length", 0),
         }
+        if boundary_reason:
+            lifecycle_kwargs["boundary_reason"] = boundary_reason
 
         if old_session_id and previous_messages is not None:
             rollover = getattr(engine, "rollover_session", None)
@@ -8251,6 +8254,7 @@ class AIAgent:
                     previous_messages=messages,
                     carry_over_context=True,
                     reset_engine=False,
+                    boundary_reason="compression",
                 )
                 # Auto-number the title for the continuation session
                 if old_title:

--- a/run_agent.py
+++ b/run_agent.py
@@ -2070,6 +2070,71 @@ class AIAgent:
                 "is_anthropic_oauth": self._is_anthropic_oauth,
             })
 
+    def _transition_context_engine_session(
+        self,
+        *,
+        old_session_id: str | None = None,
+        new_session_id: str | None = None,
+        previous_messages: list | None = None,
+        carry_over_context: bool = False,
+        reset_engine: bool = False,
+    ) -> None:
+        """Apply the host-side lifecycle contract for context-engine session boundaries."""
+        engine = getattr(self, "context_compressor", None)
+        if not engine:
+            return
+
+        target_session_id = new_session_id or getattr(self, "session_id", None) or ""
+        lifecycle_kwargs = {
+            "hermes_home": str(get_hermes_home()),
+            "platform": getattr(self, "platform", None) or "cli",
+            "model": getattr(self, "model", ""),
+            "context_length": getattr(engine, "context_length", 0),
+        }
+
+        if old_session_id and previous_messages is not None:
+            rollover = getattr(engine, "rollover_session", None)
+            if callable(rollover):
+                try:
+                    rollover(
+                        old_session_id,
+                        target_session_id,
+                        previous_messages=previous_messages,
+                        carry_over_context=carry_over_context,
+                        **lifecycle_kwargs,
+                    )
+                    return
+                except TypeError:
+                    try:
+                        rollover(old_session_id, target_session_id, previous_messages=previous_messages)
+                        return
+                    except Exception:
+                        pass
+                except Exception:
+                    pass
+
+            try:
+                engine.on_session_end(old_session_id, previous_messages)
+            except Exception:
+                pass
+
+        if reset_engine:
+            try:
+                engine.on_session_reset()
+            except Exception:
+                pass
+
+        try:
+            engine.on_session_start(target_session_id, **lifecycle_kwargs)
+        except Exception:
+            pass
+
+        if carry_over_context and old_session_id and hasattr(engine, "carry_over_new_session_context"):
+            try:
+                engine.carry_over_new_session_context(old_session_id, target_session_id)
+            except Exception:
+                pass
+
     def reset_session_state(
         self,
         previous_messages: list | None = None,
@@ -2093,12 +2158,6 @@ class AIAgent:
         This keeps the counter reset logic DRY and maintainable in one place
         rather than scattering it across multiple methods.
         """
-        if hasattr(self, "context_compressor") and self.context_compressor and previous_messages is not None:
-            try:
-                self.context_compressor.on_session_end(old_session_id or self.session_id or "", previous_messages)
-            except Exception:
-                pass
-
         # Token usage counters
         self.session_total_tokens = 0
         self.session_input_tokens = 0
@@ -2118,22 +2177,13 @@ class AIAgent:
 
         # Context engine reset (works for both built-in compressor and plugins)
         if hasattr(self, "context_compressor") and self.context_compressor:
-            self.context_compressor.on_session_reset()
-            try:
-                self.context_compressor.on_session_start(
-                    self.session_id,
-                    hermes_home=str(get_hermes_home()),
-                    platform=self.platform or "cli",
-                    model=self.model,
-                    context_length=getattr(self.context_compressor, "context_length", 0),
-                )
-            except Exception:
-                pass
-            if carry_over_context and old_session_id and hasattr(self.context_compressor, "carry_over_new_session_context"):
-                try:
-                    self.context_compressor.carry_over_new_session_context(old_session_id, self.session_id)
-                except Exception:
-                    pass
+            self._transition_context_engine_session(
+                old_session_id=old_session_id,
+                new_session_id=getattr(self, "session_id", None),
+                previous_messages=previous_messages,
+                carry_over_context=carry_over_context,
+                reset_engine=True,
+            )
     
     def switch_model(self, new_model, new_provider, api_key='', base_url='', api_mode=''):
         """Switch the model/provider in-place for a live agent.
@@ -8194,6 +8244,13 @@ class AIAgent:
                     source=self.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
                     model=self.model,
                     parent_session_id=old_session_id,
+                )
+                self._transition_context_engine_session(
+                    old_session_id=old_session_id,
+                    new_session_id=self.session_id,
+                    previous_messages=messages,
+                    carry_over_context=True,
+                    reset_engine=False,
                 )
                 # Auto-number the title for the continuation session
                 if old_title:

--- a/run_agent.py
+++ b/run_agent.py
@@ -25,6 +25,7 @@ import base64
 import concurrent.futures
 import copy
 import hashlib
+import inspect
 import json
 import logging
 logger = logging.getLogger(__name__)
@@ -1868,7 +1869,8 @@ class AIAgent:
             # Try general plugin system as fallback
             if _selected_engine is None:
                 try:
-                    from hermes_cli.plugins import get_plugin_context_engine
+                    from hermes_cli.plugins import discover_plugins, get_plugin_context_engine
+                    discover_plugins()
                     _candidate = get_plugin_context_engine()
                     if _candidate and _candidate.name == _engine_name:
                         _selected_engine = _candidate
@@ -1918,6 +1920,28 @@ class AIAgent:
                 provider=self.provider,
                 api_mode=self.api_mode,
             )
+
+        # Ensure the active context engine knows the live model/runtime details.
+        if hasattr(self, "context_compressor") and self.context_compressor:
+            try:
+                from agent.model_metadata import get_model_context_length
+
+                _engine_context_length = get_model_context_length(
+                    self.model,
+                    base_url=self.base_url,
+                    api_key=getattr(self, "api_key", ""),
+                    provider=self.provider,
+                    config_context_length=_config_context_length,
+                )
+                self.context_compressor.update_model(
+                    model=self.model,
+                    context_length=_engine_context_length,
+                    base_url=self.base_url,
+                    api_key=getattr(self, "api_key", ""),
+                    provider=self.provider,
+                )
+            except Exception as _ce_model_err:
+                logger.debug("Context engine update_model during init: %s", _ce_model_err)
         self.compression_enabled = compression_enabled
 
         # Reject models whose context window is below the minimum required
@@ -2046,7 +2070,12 @@ class AIAgent:
                 "is_anthropic_oauth": self._is_anthropic_oauth,
             })
 
-    def reset_session_state(self):
+    def reset_session_state(
+        self,
+        previous_messages: list | None = None,
+        old_session_id: str | None = None,
+        carry_over_context: bool = False,
+    ):
         """Reset all session-scoped token counters to 0 for a fresh session.
         
         This method encapsulates the reset logic for all session-level metrics
@@ -2064,6 +2093,12 @@ class AIAgent:
         This keeps the counter reset logic DRY and maintainable in one place
         rather than scattering it across multiple methods.
         """
+        if hasattr(self, "context_compressor") and self.context_compressor and previous_messages is not None:
+            try:
+                self.context_compressor.on_session_end(old_session_id or self.session_id or "", previous_messages)
+            except Exception:
+                pass
+
         # Token usage counters
         self.session_total_tokens = 0
         self.session_input_tokens = 0
@@ -2084,6 +2119,21 @@ class AIAgent:
         # Context engine reset (works for both built-in compressor and plugins)
         if hasattr(self, "context_compressor") and self.context_compressor:
             self.context_compressor.on_session_reset()
+            try:
+                self.context_compressor.on_session_start(
+                    self.session_id,
+                    hermes_home=str(get_hermes_home()),
+                    platform=self.platform or "cli",
+                    model=self.model,
+                    context_length=getattr(self.context_compressor, "context_length", 0),
+                )
+            except Exception:
+                pass
+            if carry_over_context and old_session_id and hasattr(self.context_compressor, "carry_over_new_session_context"):
+                try:
+                    self.context_compressor.carry_over_new_session_context(old_session_id, self.session_id)
+                except Exception:
+                    pass
     
     def switch_model(self, new_model, new_provider, api_key='', base_url='', api_mode=''):
         """Switch the model/provider in-place for a live agent.
@@ -8086,12 +8136,30 @@ class AIAgent:
             except Exception:
                 pass
 
-        try:
-            compressed = self.context_compressor.compress(messages, current_tokens=approx_tokens, focus_topic=focus_topic)
-        except TypeError:
-            # Plugin context engine with strict signature that doesn't accept
-            # focus_topic — fall back to calling without it.
-            compressed = self.context_compressor.compress(messages, current_tokens=approx_tokens)
+        _compress_kwargs = {"current_tokens": approx_tokens}
+        if focus_topic is not None:
+            _supports_focus_topic = False
+            try:
+                _sig = inspect.signature(self.context_compressor.compress)
+                _supports_focus_topic = (
+                    "focus_topic" in _sig.parameters
+                    or any(
+                        param.kind == inspect.Parameter.VAR_KEYWORD
+                        for param in _sig.parameters.values()
+                    )
+                )
+            except (TypeError, ValueError):
+                _supports_focus_topic = False
+
+            if _supports_focus_topic:
+                _compress_kwargs["focus_topic"] = focus_topic
+            else:
+                logger.debug(
+                    "Context engine '%s' does not accept focus_topic; compressing without it",
+                    getattr(self.context_compressor, "name", type(self.context_compressor).__name__),
+                )
+
+        compressed = self.context_compressor.compress(messages, **_compress_kwargs)
 
         summary_error = getattr(self.context_compressor, "_last_summary_error", None)
         if summary_error:

--- a/tests/cli/test_cli_new_session.py
+++ b/tests/cli/test_cli_new_session.py
@@ -51,7 +51,7 @@ class _FakeAgent:
         self.session_cost_source = "openrouter"
         self.context_compressor = _FakeCompressor()
 
-    def reset_session_state(self):
+    def reset_session_state(self, previous_messages=None, old_session_id=None, carry_over_context=False):
         """Mirror the real AIAgent.reset_session_state()."""
         self.session_total_tokens = 0
         self.session_input_tokens = 0

--- a/tests/cli/test_cli_new_session.py
+++ b/tests/cli/test_cli_new_session.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib
 import os
 import sys
+import threading
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
@@ -140,6 +141,10 @@ def test_new_command_creates_real_fresh_session_and_resets_agent_state(tmp_path)
 
     cli.process_command("/new")
 
+    _boundary_thread = getattr(cli, "_last_session_boundary_thread", None)
+    if _boundary_thread is not None:
+        _boundary_thread.join(timeout=1)
+
     assert cli.session_id != old_session_id
 
     old_session = cli._session_db.get_session(old_session_id)
@@ -157,6 +162,37 @@ def test_new_command_creates_real_fresh_session_and_resets_agent_state(tmp_path)
     assert cli.session_start > old_session_start
     assert cli.agent.session_start == cli.session_start
     cli.agent._invalidate_system_prompt.assert_called_once()
+
+
+def test_new_session_dispatches_memory_flush_on_background_thread(tmp_path):
+    cli = _prepare_cli_with_active_session(tmp_path)
+
+    import cli as _cli_mod
+
+    started = {}
+
+    class _DummyThread:
+        def __init__(self, *, target=None, args=(), kwargs=None, daemon=None, name=None):
+            started["target"] = target
+            started["args"] = args
+            started["kwargs"] = kwargs or {}
+            started["daemon"] = daemon
+            started["name"] = name
+            started["started"] = False
+
+        def start(self):
+            started["started"] = True
+
+        def join(self, timeout=None):
+            return None
+
+    with patch.object(_cli_mod.threading, "Thread", _DummyThread):
+        cli.process_command("/new")
+
+    assert started["started"] is True
+    assert callable(started["target"])
+    cli.agent.flush_memories.assert_not_called()
+    cli.agent.commit_memory_session.assert_not_called()
 
 
 def test_reset_command_is_alias_for_new_session(tmp_path):

--- a/tests/cli/test_cli_new_session.py
+++ b/tests/cli/test_cli_new_session.py
@@ -34,6 +34,7 @@ class _FakeAgent:
         self._todo_store.write(
             [{"id": "t1", "content": "unfinished task", "status": "in_progress"}]
         )
+        self.flush_memories = MagicMock()
         self.commit_memory_session = MagicMock()
         self._invalidate_system_prompt = MagicMock()
 

--- a/tests/cli/test_session_boundary_hooks.py
+++ b/tests/cli/test_session_boundary_hooks.py
@@ -19,17 +19,34 @@ def test_session_finalize_on_reset(mock_invoke_hook):
     cli = HermesCLI()
     cli.agent = MagicMock()
     cli.agent.session_id = "test-session-id"
+    cli.conversation_history = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "hello"},
+    ]
 
     # Simulate /new command which triggers on_session_finalize for the old session
     cli.new_session(silent=True)
 
     # Check if on_session_finalize was called for the old session
     mock_invoke_hook.assert_any_call(
-        "on_session_finalize", session_id="test-session-id", platform="cli"
+        "on_session_finalize",
+        session_id="test-session-id",
+        old_session_id="test-session-id",
+        previous_messages=[
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hello"},
+        ],
+        previous_message_count=2,
+        platform="cli",
     )
     # Check if on_session_reset was called for the new session
     mock_invoke_hook.assert_any_call(
-        "on_session_reset", session_id=cli.session_id, platform="cli"
+        "on_session_reset",
+        session_id=cli.session_id,
+        old_session_id="test-session-id",
+        new_session_id=cli.session_id,
+        carry_over_context=True,
+        platform="cli",
     )
 
 

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -32,6 +32,9 @@ class _FakeRegistry:
             return self._sessions.pop(0)
         return None
 
+    def is_completion_consumed(self, _session_id):
+        return False
+
 
 def _build_runner(monkeypatch, tmp_path, mode: str) -> GatewayRunner:
     """Create a GatewayRunner with a fake config for the given mode."""
@@ -337,6 +340,66 @@ async def test_inject_watch_notification_ignores_foreground_event_source(monkeyp
     # Must route to thread 42 (process origin), NOT some other thread
     assert synth_event.source.thread_id == "42"
     assert synth_event.source.user_id == "proc_owner"
+
+
+@pytest.mark.asyncio
+async def test_inject_watch_notification_drops_stale_boundary_after_reset(monkeypatch, tmp_path):
+    from gateway.session import SessionSource
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = runner.adapters[Platform.TELEGRAM]
+
+    runner.session_store._entries["agent:main:telegram:group:-100:42"] = SimpleNamespace(
+        session_id="sess-new",
+        origin=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-100",
+            chat_type="group",
+            thread_id="42",
+            user_id="proc_owner",
+            user_name="alice",
+        )
+    )
+
+    evt = {
+        "session_id": "proc_stale_watch",
+        "session_key": "agent:main:telegram:group:-100:42",
+        "conversation_session_id": "sess-old",
+    }
+
+    await runner._inject_watch_notification("[SYSTEM: stale watch match]", evt)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_process_watcher_drops_completion_for_reset_session_boundary(monkeypatch, tmp_path):
+    import tools.process_registry as pr_module
+
+    sessions = [SimpleNamespace(output_buffer="done\n", exited=True, exit_code=0, command="echo hi")]
+    monkeypatch.setattr(pr_module, "process_registry", _FakeRegistry(sessions))
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = runner.adapters[Platform.TELEGRAM]
+    runner.session_store._entries["agent:main:telegram:group:-100:42"] = SimpleNamespace(
+        session_id="sess-new",
+    )
+
+    watcher = _watcher_dict(session_id="proc_done")
+    watcher.update({
+        "session_key": "agent:main:telegram:group:-100:42",
+        "notify_on_complete": True,
+        "conversation_session_id": "sess-old",
+    })
+
+    await runner._run_process_watcher(watcher)
+
+    adapter.handle_message.assert_not_awaited()
 
 
 def test_build_process_event_source_returns_none_for_empty_evt(monkeypatch, tmp_path):

--- a/tests/gateway/test_session_boundary_hooks.py
+++ b/tests/gateway/test_session_boundary_hooks.py
@@ -60,6 +60,7 @@ def _make_runner():
     runner.session_store = MagicMock()
     runner.session_store.get_or_create_session.return_value = new_session_entry
     runner.session_store.reset_session.return_value = new_session_entry
+    runner.session_store.load_transcript.return_value = []
     runner.session_store._entries = {session_key: session_entry}
     runner.session_store._generate_session_key.return_value = session_key
     runner._running_agents = {}
@@ -78,11 +79,23 @@ def _make_runner():
 async def test_reset_fires_finalize_hook(mock_invoke_hook):
     """/new must fire on_session_finalize with the OLD session id."""
     runner = _make_runner()
+    runner.session_store.load_transcript.return_value = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "hello"},
+    ]
 
     await runner._handle_reset_command(_make_event("/new"))
 
     mock_invoke_hook.assert_any_call(
-        "on_session_finalize", session_id="sess-old", platform="telegram"
+        "on_session_finalize",
+        session_id="sess-old",
+        old_session_id="sess-old",
+        previous_messages=[
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hello"},
+        ],
+        previous_message_count=2,
+        platform="telegram",
     )
 
 
@@ -95,7 +108,12 @@ async def test_reset_fires_reset_hook(mock_invoke_hook):
     await runner._handle_reset_command(_make_event("/new"))
 
     mock_invoke_hook.assert_any_call(
-        "on_session_reset", session_id="sess-new", platform="telegram"
+        "on_session_reset",
+        session_id="sess-new",
+        old_session_id="sess-old",
+        new_session_id="sess-new",
+        carry_over_context=True,
+        platform="telegram",
     )
 
 

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -578,12 +578,28 @@ class TestProviderDiscovery:
             assert result == []
 
     def test_discover_context_engines_empty(self):
-        """Discovery returns empty list when import fails."""
+        """Discovery returns empty list when both discovery paths are unavailable."""
         with patch("plugins.context_engine.discover_context_engines",
-                    side_effect=ImportError("no module")):
+                    side_effect=ImportError("no module")), \
+             patch("hermes_cli.plugins.discover_plugins", side_effect=ImportError("no plugins")):
             from hermes_cli.plugins_cmd import _discover_context_engines
             result = _discover_context_engines()
             assert result == []
+
+    def test_discover_context_engines_includes_external_plugin_engine(self):
+        """External context-engine plugins should appear in the provider picker."""
+
+        class StubPluginEngine:
+            name = "lcm"
+
+        with patch("plugins.context_engine.discover_context_engines", return_value=[]), \
+             patch("hermes_cli.plugins.discover_plugins") as mock_discover_plugins, \
+             patch("hermes_cli.plugins.get_plugin_context_engine", return_value=StubPluginEngine()):
+            from hermes_cli.plugins_cmd import _discover_context_engines
+            result = _discover_context_engines()
+
+        mock_discover_plugins.assert_called_once()
+        assert result == [("lcm", "installed plugin")]
 
 
 # ── Auto-activation fix ──────────────────────────────────────────────────

--- a/tests/run_agent/test_context_engine_plugin_init.py
+++ b/tests/run_agent/test_context_engine_plugin_init.py
@@ -56,6 +56,25 @@ class LegacyEngine:
         return list(messages)
 
 
+class RolloverEngine:
+    name = "rollover"
+    threshold_tokens = 999999
+    compression_count = 0
+    last_prompt_tokens = 0
+    last_completion_tokens = 0
+    last_total_tokens = 0
+    context_length = 4096
+
+    def __init__(self):
+        self.rollover_calls = []
+
+    def compress(self, messages, current_tokens=None, focus_topic=None):
+        return list(messages)
+
+    def rollover_session(self, old_session_id, new_session_id, **kwargs):
+        self.rollover_calls.append((old_session_id, new_session_id, kwargs))
+
+
 class TestContextEnginePluginInit:
     def test_default_compressor_ignores_external_plugin_engine(self):
         config = {
@@ -181,3 +200,60 @@ class TestContextEnginePluginInit:
 
         assert compressed == messages
         assert engine.seen_current_tokens == 1234
+
+    def test_compress_context_rolls_over_plugin_engine_session(self):
+        config = {
+            "model": {"context_length": 131072},
+            "compression": {"enabled": True},
+        }
+
+        with (
+            patch("hermes_cli.config.load_config", return_value=config),
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        agent.flush_memories = MagicMock()
+        agent.commit_memory_session = MagicMock()
+        agent._memory_manager = None
+        agent._cached_system_prompt = "system"
+        agent._todo_store = MagicMock()
+        agent._todo_store.format_for_injection.return_value = ""
+        agent._invalidate_system_prompt = MagicMock()
+        agent._build_system_prompt = MagicMock(return_value="new system prompt")
+        agent.logs_dir = MagicMock()
+        agent.session_log_file = MagicMock()
+        agent.platform = "cli"
+        agent.session_id = "sess-old"
+        agent._context_pressure_warned_at = 0.0
+        agent._last_flushed_db_idx = 4
+
+        agent._session_db = MagicMock()
+        agent._session_db.get_session_title.return_value = None
+
+        engine = RolloverEngine()
+        agent.context_compressor = engine
+
+        messages = [
+            {"role": "user", "content": "u1"},
+            {"role": "assistant", "content": "a1"},
+            {"role": "user", "content": "u2"},
+            {"role": "assistant", "content": "a2"},
+        ]
+
+        with patch("tools.file_tools.reset_file_dedup"):
+            agent._compress_context(messages, "system prompt", approx_tokens=1234)
+
+        assert agent.session_id != "sess-old"
+        assert engine.rollover_calls, "Expected compression split to invoke context-engine rollover_session()"
+        old_sid, new_sid, kwargs = engine.rollover_calls[0]
+        assert old_sid == "sess-old"
+        assert new_sid == agent.session_id
+        assert kwargs["previous_messages"] == messages

--- a/tests/run_agent/test_context_engine_plugin_init.py
+++ b/tests/run_agent/test_context_engine_plugin_init.py
@@ -57,6 +57,59 @@ class LegacyEngine:
 
 
 class TestContextEnginePluginInit:
+    def test_default_compressor_ignores_external_plugin_engine(self):
+        config = {
+            "context": {"engine": "compressor"},
+            "model": {"context_length": 131072},
+            "compression": {"enabled": True},
+        }
+
+        with (
+            patch("hermes_cli.config.load_config", return_value=config),
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch("hermes_cli.plugins.discover_plugins") as mock_discover_plugins,
+            patch("hermes_cli.plugins.get_plugin_context_engine"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        mock_discover_plugins.assert_not_called()
+        assert agent.context_compressor.name == "compressor"
+        assert "lcm_grep" not in agent.valid_tool_names
+
+    def test_missing_external_engine_falls_back_to_builtin_compressor(self):
+        config = {
+            "context": {"engine": "lcm"},
+            "model": {"context_length": 131072},
+            "compression": {"enabled": True},
+        }
+
+        with (
+            patch("hermes_cli.config.load_config", return_value=config),
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch("plugins.context_engine.load_context_engine", return_value=None),
+            patch("hermes_cli.plugins.discover_plugins") as mock_discover_plugins,
+            patch("hermes_cli.plugins.get_plugin_context_engine", return_value=None),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        mock_discover_plugins.assert_called_once()
+        assert agent.context_compressor.name == "compressor"
+        assert agent._context_engine_tool_names == set()
+
     def test_aiagent_initializes_external_context_engine_plugin(self):
         config = {
             "context": {"engine": "lcm"},

--- a/tests/run_agent/test_context_engine_plugin_init.py
+++ b/tests/run_agent/test_context_engine_plugin_init.py
@@ -93,6 +93,8 @@ class TestContextEnginePluginInit:
         ):
             agent = AIAgent(
                 api_key="test-key-1234567890",
+                base_url="https://llm.example.com/v1",
+                provider="custom",
                 quiet_mode=True,
                 skip_context_files=True,
                 skip_memory=True,
@@ -120,6 +122,8 @@ class TestContextEnginePluginInit:
         ):
             agent = AIAgent(
                 api_key="test-key-1234567890",
+                base_url="https://llm.example.com/v1",
+                provider="custom",
                 quiet_mode=True,
                 skip_context_files=True,
                 skip_memory=True,
@@ -148,6 +152,8 @@ class TestContextEnginePluginInit:
         ):
             agent = AIAgent(
                 api_key="test-key-1234567890",
+                base_url="https://llm.example.com/v1",
+                provider="custom",
                 quiet_mode=True,
                 skip_context_files=True,
                 skip_memory=True,
@@ -175,6 +181,8 @@ class TestContextEnginePluginInit:
         ):
             agent = AIAgent(
                 api_key="test-key-1234567890",
+                base_url="https://llm.example.com/v1",
+                provider="custom",
                 quiet_mode=True,
                 skip_context_files=True,
                 skip_memory=True,
@@ -215,6 +223,8 @@ class TestContextEnginePluginInit:
         ):
             agent = AIAgent(
                 api_key="test-key-1234567890",
+                base_url="https://llm.example.com/v1",
+                provider="custom",
                 quiet_mode=True,
                 skip_context_files=True,
                 skip_memory=True,

--- a/tests/run_agent/test_context_engine_plugin_init.py
+++ b/tests/run_agent/test_context_engine_plugin_init.py
@@ -1,0 +1,130 @@
+"""Tests for external context-engine plugin initialization in AIAgent."""
+
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+class ExternalStubEngine:
+    name = "lcm"
+    threshold_tokens = 0
+    context_length = 0
+    compression_count = 0
+    last_prompt_tokens = 0
+    last_completion_tokens = 0
+    last_total_tokens = 0
+
+    def __init__(self):
+        self.update_model_calls = []
+
+    def update_model(self, **kwargs):
+        self.update_model_calls.append(kwargs)
+        self.context_length = kwargs["context_length"]
+        self.threshold_tokens = int(kwargs["context_length"] * 0.75)
+
+    def get_tool_schemas(self):
+        return [
+            {
+                "name": "lcm_grep",
+                "description": "Search the external context engine",
+                "parameters": {"type": "object", "properties": {}},
+            }
+        ]
+
+    def on_session_start(self, session_id, **kwargs):
+        self.started = (session_id, kwargs)
+
+    def on_session_reset(self):
+        pass
+
+    def compress(self, messages, current_tokens=None):
+        return list(messages)
+
+
+class LegacyEngine:
+    name = "legacy"
+    threshold_tokens = 999999
+    compression_count = 0
+    last_prompt_tokens = 0
+    last_completion_tokens = 0
+
+    def __init__(self):
+        self.seen_current_tokens = None
+
+    def compress(self, messages, current_tokens=None):
+        self.seen_current_tokens = current_tokens
+        return list(messages)
+
+
+class TestContextEnginePluginInit:
+    def test_aiagent_initializes_external_context_engine_plugin(self):
+        config = {
+            "context": {"engine": "lcm"},
+            "model": {"context_length": 131072},
+            "compression": {"enabled": True},
+        }
+        engine = ExternalStubEngine()
+
+        with (
+            patch("hermes_cli.config.load_config", return_value=config),
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch("plugins.context_engine.load_context_engine", return_value=None),
+            patch("hermes_cli.plugins.discover_plugins") as mock_discover_plugins,
+            patch("hermes_cli.plugins.get_plugin_context_engine", return_value=engine),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        mock_discover_plugins.assert_called_once()
+        assert agent.context_compressor is engine
+        assert engine.update_model_calls
+        assert engine.context_length == 131072
+        assert engine.threshold_tokens == int(131072 * 0.75)
+        assert "lcm_grep" in agent.valid_tool_names
+        assert "lcm_grep" in agent._context_engine_tool_names
+
+    def test_compress_context_supports_legacy_engine_without_focus_topic(self):
+        config = {
+            "model": {"context_length": 131072},
+            "compression": {"enabled": True},
+        }
+
+        with (
+            patch("hermes_cli.config.load_config", return_value=config),
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            agent = AIAgent(
+                api_key="test-key-1234567890",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        agent.flush_memories = MagicMock()
+        engine = LegacyEngine()
+        agent.context_compressor = engine
+
+        messages = [
+            {"role": "user", "content": "u1"},
+            {"role": "assistant", "content": "a1"},
+            {"role": "user", "content": "u2"},
+            {"role": "assistant", "content": "a2"},
+        ]
+
+        compressed, _ = agent._compress_context(
+            messages,
+            "",
+            approx_tokens=1234,
+            focus_topic="database schema",
+        )
+
+        assert compressed == messages
+        assert engine.seen_current_tokens == 1234

--- a/tests/run_agent/test_context_engine_plugin_init.py
+++ b/tests/run_agent/test_context_engine_plugin_init.py
@@ -267,3 +267,5 @@ class TestContextEnginePluginInit:
         assert old_sid == "sess-old"
         assert new_sid == agent.session_id
         assert kwargs["previous_messages"] == messages
+        assert kwargs["carry_over_context"] is True
+        assert kwargs["boundary_reason"] == "compression"

--- a/tests/run_agent/test_session_reset_fix.py
+++ b/tests/run_agent/test_session_reset_fix.py
@@ -119,3 +119,46 @@ class TestResetSessionState:
         agent.reset_session_state()
 
         assert agent._user_turn_count == 0
+
+    def test_plugin_context_engine_restarts_with_new_session_id(self):
+        """Plugin engines should be re-bound to the agent's current session after /new."""
+        agent = _make_minimal_agent()
+        agent.session_id = "new-session-id"
+        agent.platform = "cli"
+        agent.model = "test-model"
+
+        class FakePluginEngine:
+            def __init__(self):
+                self.context_length = 1234
+                self.reset_called = False
+                self.started_with = None
+                self.ended_with = None
+                self.carried_over = None
+
+            def on_session_end(self, session_id, messages):
+                self.ended_with = (session_id, list(messages))
+
+            def on_session_reset(self):
+                self.reset_called = True
+
+            def on_session_start(self, session_id, **kwargs):
+                self.started_with = (session_id, kwargs)
+
+            def carry_over_new_session_context(self, old_session_id, new_session_id):
+                self.carried_over = (old_session_id, new_session_id)
+
+        engine = FakePluginEngine()
+        agent.context_compressor = engine
+
+        agent.reset_session_state(
+            previous_messages=[{"role": "user", "content": "old stuff"}],
+            old_session_id="old-session-id",
+            carry_over_context=True,
+        )
+
+        assert engine.ended_with == ("old-session-id", [{"role": "user", "content": "old stuff"}])
+        assert engine.reset_called is True
+        assert engine.started_with is not None
+        assert engine.started_with[0] == "new-session-id"
+        assert engine.started_with[1]["context_length"] == 1234
+        assert engine.carried_over == ("old-session-id", "new-session-id")

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -109,6 +109,7 @@ class ProcessSession:
     watcher_user_id: str = ""
     watcher_user_name: str = ""
     watcher_thread_id: str = ""
+    conversation_session_id: str = ""          # Logical Hermes session_id when spawned
     watcher_interval: int = 0                   # 0 = no watcher configured
     notify_on_complete: bool = False             # Queue agent notification on exit
     # Watch patterns — trigger agent notification when output matches any pattern
@@ -278,6 +279,7 @@ class ProcessRegistry:
                     "user_id": session.watcher_user_id,
                     "user_name": session.watcher_user_name,
                     "thread_id": session.watcher_thread_id,
+                    "conversation_session_id": session.conversation_session_id,
                     "message": (
                         f"Watch patterns disabled for process {session.id} — "
                         f"{WATCH_STRIKE_LIMIT} consecutive rate-limit windows triggered "
@@ -310,6 +312,7 @@ class ProcessRegistry:
             "user_id": session.watcher_user_id,
             "user_name": session.watcher_user_name,
             "thread_id": session.watcher_thread_id,
+            "conversation_session_id": session.conversation_session_id,
         })
 
     def _global_watch_admit(self, now: float) -> bool:
@@ -1171,6 +1174,7 @@ class ProcessRegistry:
                             "watcher_user_id": s.watcher_user_id,
                             "watcher_user_name": s.watcher_user_name,
                             "watcher_thread_id": s.watcher_thread_id,
+                            "conversation_session_id": s.conversation_session_id,
                             "watcher_interval": s.watcher_interval,
                             "notify_on_complete": s.notify_on_complete,
                             "watch_patterns": s.watch_patterns,
@@ -1234,6 +1238,7 @@ class ProcessRegistry:
                     watcher_user_id=entry.get("watcher_user_id", ""),
                     watcher_user_name=entry.get("watcher_user_name", ""),
                     watcher_thread_id=entry.get("watcher_thread_id", ""),
+                    conversation_session_id=entry.get("conversation_session_id", ""),
                     watcher_interval=entry.get("watcher_interval", 0),
                     notify_on_complete=entry.get("notify_on_complete", False),
                     watch_patterns=entry.get("watch_patterns", []),
@@ -1254,6 +1259,7 @@ class ProcessRegistry:
                         "user_id": session.watcher_user_id,
                         "user_name": session.watcher_user_name,
                         "thread_id": session.watcher_thread_id,
+                        "conversation_session_id": session.conversation_session_id,
                         "notify_on_complete": session.notify_on_complete,
                     })
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1722,11 +1722,13 @@ def terminal_tool(
                         _gw_thread_id = _gse("HERMES_SESSION_THREAD_ID", "")
                         _gw_user_id = _gse("HERMES_SESSION_USER_ID", "")
                         _gw_user_name = _gse("HERMES_SESSION_USER_NAME", "")
+                        _gw_session_id = _gse("HERMES_SESSION_ID", "")
                         proc_session.watcher_platform = _gw_platform
                         proc_session.watcher_chat_id = _gw_chat_id
                         proc_session.watcher_user_id = _gw_user_id
                         proc_session.watcher_user_name = _gw_user_name
                         proc_session.watcher_thread_id = _gw_thread_id
+                        proc_session.conversation_session_id = _gw_session_id
 
                 # Mutual exclusion: if both notify_on_complete and watch_patterns
                 # are set, drop watch_patterns. The combination produces duplicate
@@ -1763,6 +1765,7 @@ def terminal_tool(
                             "user_id": proc_session.watcher_user_id,
                             "user_name": proc_session.watcher_user_name,
                             "thread_id": proc_session.watcher_thread_id,
+                            "conversation_session_id": proc_session.conversation_session_id,
                             "notify_on_complete": True,
                         })
 


### PR DESCRIPTION
Supersedes closed PR #8416. The original PR became unreopenable after the source fork disappeared; this recreates the same branch on the restored fork.

## Summary
- improves Hermes as a host for external context-engine plugins
- does not vendor any plugin code into Hermes core
- keeps the built-in compressor as the default unless `context.engine` explicitly selects something else

## What changed
- load plugin-registered context engines only when `context.engine` explicitly asks for one
- make the fallback path actually discover installed plugins before checking the active plugin engine
- pass live model/context information into the selected engine during init
- restart context-engine lifecycle cleanly across `/new`, `/resume`, and `/branch`
- keep `/compress <focus>` backward-compatible with engines that do not accept a `focus_topic` argument
- surface an installed plugin-registered context engine in `hermes plugins` so it can be selected from the provider UI

## Non-goals
- no bundled `hermes-lcm`
- no vendored engine code under `plugins/context_engine/`
- no change to the default behavior for users who stay on the built-in compressor

## Validation
Passed:
- `python -m pytest tests/run_agent/test_context_engine_plugin_init.py tests/run_agent/test_session_reset_fix.py tests/cli/test_cli_new_session.py tests/hermes_cli/test_plugins_cmd.py tests/agent/test_context_engine.py -q`
  - result: `93 passed`

That slice includes explicit coverage for:
- default compressor stays active when no external engine is selected
- missing external engine falls back cleanly to the built-in compressor
- external plugin engine init/discovery paths
- session reset / resume / branch lifecycle handling
