### PR TITLE
fix(session_search): enforce async summarization timeout

### DIFF
--- a/tests/tools/test_session_search_timeout.py
+++ b/tests/tools/test_session_search_timeout.py
@@ -1,0 +1,36 @@
+import asyncio
+import json
+
+from tools.session_search_tool import session_search
+
+
+class DummyDB:
+    def search_messages(self, query, role_filter=None, exclude_sources=None, limit=50, offset=0):
+        return [{"session_id": "s1", "source": "telegram", "session_started": 1710000000, "model": "gpt-5.4"}]
+
+    def get_session(self, session_id):
+        return {"session_id": session_id, "source": "telegram", "started_at": 1710000000}
+
+    def get_messages_as_conversation(self, session_id):
+        return [{"role": "user", "content": "drift fixes github repo"}]
+
+
+def test_session_search_returns_timeout_error_on_async_timeout(monkeypatch):
+    async def fake_wait_for(awaitable, timeout):
+        awaitable.close()
+        raise asyncio.TimeoutError()
+
+    def fake_run_async(coro):
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+
+    monkeypatch.setattr("tools.session_search_tool.asyncio.wait_for", fake_wait_for)
+    monkeypatch.setattr("model_tools._run_async", fake_run_async)
+
+    result = json.loads(session_search(query="drift OR fixes", limit=1, db=DummyDB(), current_session_id="current"))
+
+    assert result["success"] is False
+    assert "timed out" in result["error"].lower()

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -475,14 +475,15 @@ def session_search(
 
         try:
             # Use _run_async() which properly manages event loops across
-            # CLI, gateway, and worker-thread contexts.  The previous
-            # pattern (asyncio.run() in a ThreadPoolExecutor) created a
-            # disposable event loop that conflicted with cached
-            # AsyncOpenAI/httpx clients bound to a different loop,
-            # causing deadlocks in gateway mode (#2681).
+            # CLI, gateway, and worker-thread contexts. Wrap the coroutine
+            # itself in asyncio.wait_for() so the 60s cap applies on every
+            # execution path, including the main-thread persistent-loop path
+            # where _run_async() does not use Future.result(timeout=...).
+            # Without this, session_search can hang for minutes if auxiliary
+            # summarization stalls or retries repeatedly.
             from model_tools import _run_async
-            results = _run_async(_summarize_all())
-        except concurrent.futures.TimeoutError:
+            results = _run_async(asyncio.wait_for(_summarize_all(), timeout=60))
+        except (concurrent.futures.TimeoutError, TimeoutError, asyncio.TimeoutError):
             logging.warning(
                 "Session summarization timed out after 60 seconds",
                 exc_info=True,


### PR DESCRIPTION
## Summary

- wrap session_search summarization in `asyncio.wait_for` so the timeout applies across `_run_async` execution paths
- catch asyncio and built-in timeout variants alongside `concurrent.futures.TimeoutError`
- add regression coverage for the async timeout path

## Why

This prevents `session_search` from hanging indefinitely when auxiliary summarization stalls on persistent-loop or main-thread execution paths.

## Validation

- `./scripts/run_tests.sh -n 0 tests/tools/test_session_search_timeout.py tests/tools/test_session_search.py -q --tb=short`, `39 passed`
- `python -m compileall -q tools/session_search_tool.py tests/tools/test_session_search_timeout.py tests/tools/test_session_search.py`
- `git diff --check origin/main...HEAD`

## Notes

- Rebuilt on current `main` after #21012 so the old shared baseline commit is no longer part of this PR
