### PR TITLE
fix(tui): follow compression tips when resuming sessions

### DIFF
--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -295,6 +295,9 @@ def test_session_resume_returns_hydrated_messages(server, monkeypatch):
         def get_session_by_title(self, _title):
             return None
 
+        def get_compression_tip(self, session_id):
+            return session_id
+
         def reopen_session(self, _sid):
             return None
 
@@ -327,6 +330,64 @@ def test_session_resume_returns_hydrated_messages(server, monkeypatch):
         {"role": "user", "text": "hello"},
         {"role": "assistant", "text": "yo"},
         {"role": "tool", "name": "tool", "context": ""},
+    ]
+
+
+def test_session_resume_follows_compression_tip(server, monkeypatch):
+    seen = {"reopened": None, "loaded": None, "made": None, "resumed": None}
+
+    class _DB:
+        def get_session(self, sid):
+            if sid in {"root-session", "tip-session"}:
+                return {"id": sid}
+            return None
+
+        def get_session_by_title(self, _title):
+            return None
+
+        def get_compression_tip(self, session_id):
+            assert session_id == "root-session"
+            return "tip-session"
+
+        def reopen_session(self, sid):
+            seen["reopened"] = sid
+            return None
+
+        def get_messages_as_conversation(self, sid, include_ancestors=False):
+            seen["loaded"] = sid
+            return [
+                {"role": "user", "content": f"history-from-{sid}"},
+            ]
+
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+
+    def _make_agent(sid, key, session_id=None):
+        seen["made"] = session_id
+        return object()
+
+    def _init_session(sid, key, agent, history, cols=80):
+        seen["resumed"] = key
+
+    monkeypatch.setattr(server, "_make_agent", _make_agent)
+    monkeypatch.setattr(server, "_init_session", _init_session)
+    monkeypatch.setattr(server, "_session_info", lambda _agent: {"model": "test/model"})
+
+    resp = server.handle_request(
+        {
+            "id": "r2",
+            "method": "session.resume",
+            "params": {"session_id": "root-session", "cols": 100},
+        }
+    )
+
+    assert "error" not in resp
+    assert seen["reopened"] == "tip-session"
+    assert seen["loaded"] == "tip-session"
+    assert seen["made"] == "tip-session"
+    assert seen["resumed"] == "tip-session"
+    assert resp["result"]["resumed"] == "tip-session"
+    assert resp["result"]["messages"] == [
+        {"role": "user", "text": "history-from-tip-session"},
     ]
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2250,6 +2250,10 @@ def _(rid, params: dict) -> dict:
             target = found["id"]
         else:
             return _err(rid, 4007, "session not found")
+    try:
+        target = db.get_compression_tip(target) or target
+    except Exception:
+        pass
     sid = uuid.uuid4().hex[:8]
     _enable_gateway_prompts()
     try:


### PR DESCRIPTION
## Summary

- make TUI/gateway `session.resume` follow compression continuations through `db.get_compression_tip(...)`
- add regression coverage that resumes a compression root and verifies the live continuation tip is reopened and hydrated

## Why

A resumed compressed conversation could appear to lose post-compaction messages because `session.resume` reopened the old root session instead of the latest continuation tip. The data was still present in session lineage, but this path was not following it.

## Validation

- `./scripts/run_tests.sh -n 0 tests/tui_gateway/test_protocol.py tests/test_hermes_state.py -q --tb=short`, `266 passed`
- `python -m compileall -q tui_gateway/server.py tests/tui_gateway/test_protocol.py`
- `git diff --check origin/main...HEAD`

## Notes

- Rebuilt on current `main` after #21012 so the old shared baseline commit is no longer part of this PR
