### PR TITLE
fix(model): preserve user provider transport in runtime resolution

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -148,6 +148,29 @@ def _parse_api_mode(raw: Any) -> Optional[str]:
     return None
 
 
+def _config_entry_api_mode(entry: Dict[str, Any]) -> Optional[str]:
+    """Resolve api_mode from a provider config entry.
+
+    ``providers:`` entries may carry either an explicit ``api_mode`` or a
+    higher-level ``transport`` field. Runtime resolution should preserve both
+    shapes so mid-session /model switches keep the configured wire protocol.
+    """
+    api_mode = _parse_api_mode(entry.get("api_mode"))
+    if api_mode:
+        return api_mode
+
+    transport = str(entry.get("transport", "") or "").strip().lower()
+    if not transport:
+        return None
+
+    try:
+        from hermes_cli.providers import TRANSPORT_TO_API_MODE
+    except Exception:
+        return None
+
+    return TRANSPORT_TO_API_MODE.get(transport)
+
+
 def _resolve_runtime_from_pool_entry(
     *,
     provider: str,
@@ -317,12 +340,16 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                 # Found match by provider key
                 base_url = entry.get("api") or entry.get("url") or entry.get("base_url") or ""
                 if base_url:
-                    return {
+                    result = {
                         "name": entry.get("name", ep_name),
                         "base_url": base_url.strip(),
                         "api_key": resolved_api_key,
-                        "model": entry.get("default_model", ""),
+                        "model": entry.get("default_model", "") or entry.get("model", ""),
                     }
+                    api_mode = _config_entry_api_mode(entry)
+                    if api_mode:
+                        result["api_mode"] = api_mode
+                    return result
             # Also check the 'name' field if present
             display_name = entry.get("name", "")
             if display_name:
@@ -331,12 +358,16 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                     # Found match by display name
                     base_url = entry.get("api") or entry.get("url") or entry.get("base_url") or ""
                     if base_url:
-                        return {
+                        result = {
                             "name": display_name,
                             "base_url": base_url.strip(),
                             "api_key": resolved_api_key,
-                            "model": entry.get("default_model", ""),
+                            "model": entry.get("default_model", "") or entry.get("model", ""),
                         }
+                        api_mode = _config_entry_api_mode(entry)
+                        if api_mode:
+                            result["api_mode"] = api_mode
+                        return result
 
     # Fall back to custom_providers: list (legacy format)
     custom_providers = config.get("custom_providers")

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1141,6 +1141,33 @@ def test_named_custom_provider_anthropic_api_mode(monkeypatch):
     assert resolved["base_url"] == "https://proxy.example.com/anthropic"
 
 
+def test_named_user_provider_transport_maps_to_runtime_api_mode(monkeypatch):
+    """providers: dict entries should preserve transport-derived api_mode."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "team-proxy")
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "providers": {
+                "team-proxy": {
+                    "base_url": "https://proxy.example.test/v1",
+                    "name": "Team Proxy",
+                    "model": "claude-sonnet-4-6",
+                    "transport": "anthropic_messages",
+                }
+            }
+        },
+    )
+    monkeypatch.setattr(rp, "_try_resolve_from_custom_pool", lambda *a, **k: None)
+
+    resolved = rp.resolve_runtime_provider(requested="team-proxy")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["base_url"] == "https://proxy.example.test/v1"
+    assert resolved["api_mode"] == "anthropic_messages"
+    assert resolved["model"] == "claude-sonnet-4-6"
+
+
 # ------------------------------------------------------------------
 # fix #2562 — resolve_provider("custom") must not remap to "openrouter"
 # ------------------------------------------------------------------

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -514,3 +514,52 @@ def test_switch_model_resolves_user_provider_credentials(monkeypatch, tmp_path):
     
     assert result.success is True
     assert result.error_message == ""
+
+
+def test_switch_model_preserves_user_provider_transport_api_mode(monkeypatch, tmp_path):
+    """/model should honor ``providers:`` transport metadata for custom endpoints.
+
+    Regression: providers defined in the canonical ``providers:`` dict can set
+    ``transport: anthropic_messages`` even when their base URL does not use the
+    conventional ``/anthropic`` suffix. The shared /model switch path resolved
+    those endpoints through runtime_provider but dropped the configured
+    transport, silently falling back to ``chat_completions``.
+    """
+    import yaml
+
+    config = {
+        "providers": {
+            "team-proxy": {
+                "base_url": "https://proxy.example.test/v1",
+                "name": "Team Proxy",
+                "model": "claude-sonnet-4-6",
+                "transport": "anthropic_messages",
+            }
+        }
+    }
+
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump(config))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    monkeypatch.setattr(
+        "hermes_cli.models.validate_requested_model",
+        lambda *a, **k: {"accepted": True, "persist": True, "recognized": True, "message": None},
+    )
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_info", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_capabilities", lambda *a, **k: None)
+
+    result = switch_model(
+        raw_input="claude-sonnet-4-6",
+        current_provider="openrouter",
+        current_model="anthropic/claude-sonnet-4.6",
+        current_base_url="https://openrouter.ai/api/v1",
+        current_api_key="or-key",
+        explicit_provider="team-proxy",
+        user_providers=config["providers"],
+    )
+
+    assert result.success is True
+    assert result.target_provider == "team-proxy"
+    assert result.base_url == "https://proxy.example.test/v1"
+    assert result.api_mode == "anthropic_messages"


### PR DESCRIPTION
## What

Fix `/model` switching for user-defined endpoints in `providers:` so runtime resolution preserves the endpoint's configured wire protocol.

This keeps `api_mode` when explicitly set and also derives it from `transport` when only `transport` is configured.

## Why

`providers:` is the canonical user-defined provider format, but the named custom-provider resolution path was only returning base URL, API key, and model. That dropped transport metadata during `/model --provider <user-provider>` flows.

User-facing effect: endpoints configured with `transport: anthropic_messages` could be silently routed as `chat_completions` unless their URL happened to match the `/anthropic` heuristic.

## How to test

Run the focused regressions:

```bash
source venv/bin/activate
scripts/run_tests.sh tests/hermes_cli/test_user_providers_model_switch.py::test_switch_model_preserves_user_provider_transport_api_mode -q
scripts/run_tests.sh tests/hermes_cli/test_runtime_provider_resolution.py::test_named_user_provider_transport_maps_to_runtime_api_mode -q

Expected result: both tests pass.

