### PR TITLE
feat: add Kimi K2.6 model support

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -134,6 +134,7 @@ DEFAULT_CONTEXT_LENGTHS = {
     "Qwen/Qwen3.5-397B-A17B": 131072,
     "Qwen/Qwen3.5-35B-A3B": 131072,
     "deepseek-ai/DeepSeek-V3.2": 65536,
+    "moonshotai/Kimi-K2.6": 262144,
     "moonshotai/Kimi-K2.5": 262144,
     "moonshotai/Kimi-K2-Thinking": 262144,
     "MiniMaxAI/MiniMax-M2.5": 1048576,

--- a/benchmarks/kimi-k26-andrew.json
+++ b/benchmarks/kimi-k26-andrew.json
@@ -1,0 +1,65 @@
+{
+  "name": "kimi-k26-andrew",
+  "description": "Small real-world benchmark set for Andrew-style evaluation of Kimi 2.6 and competing models.",
+  "version": 1,
+  "criteria": [
+    "clarity",
+    "usefulness",
+    "tightness",
+    "taste",
+    "instruction_following",
+    "structured_output_reliability"
+  ],
+  "cases": [
+    {
+      "id": "doc-hooks",
+      "category": "story",
+      "prompt": "Give me 3 documentary hooks for a story about Filipino spider fighting that starts as a colorful kids game and slowly escalates into a darker blood-sport pipeline. Keep each hook under 22 words.",
+      "expect": [
+        "3 hooks",
+        "clear escalation arc",
+        "concise and vivid"
+      ]
+    },
+    {
+      "id": "episode-structure",
+      "category": "story",
+      "prompt": "Outline a 6-beat episode structure for a documentary that begins in a playful world and ends with social consequences. Each beat must be one sentence.",
+      "expect": [
+        "6 beats",
+        "progressive escalation",
+        "strong ending payoff"
+      ]
+    },
+    {
+      "id": "research-distill",
+      "category": "research",
+      "prompt": "You are helping a documentary producer. Summarize the strongest 5 angles from a messy research dump about an underground subculture. Output bullets only, one line each, no fluff.",
+      "expect": [
+        "5 bullets",
+        "prioritized angles",
+        "minimal fluff"
+      ]
+    },
+    {
+      "id": "ops-decision",
+      "category": "ops",
+      "prompt": "I run multiple AI providers. Give me a 4-bullet framework for deciding when to use a direct provider API versus an aggregator like OpenRouter. Be specific, not generic.",
+      "expect": [
+        "4 bullets",
+        "concrete tradeoffs",
+        "operator useful"
+      ]
+    },
+    {
+      "id": "json-discipline",
+      "category": "structured-output",
+      "prompt": "Return valid JSON with keys: headline, risk_level, actions. headline must be a string, risk_level must be one of low/medium/high, actions must be an array of exactly 3 short strings. Scenario: a billing provider is already at 92% of monthly cap halfway through the month.",
+      "expect": [
+        "valid JSON",
+        "correct enum",
+        "exactly 3 actions"
+      ]
+    }
+  ]
+}

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2228,6 +2228,7 @@ def _model_flow_kimi(config, current_model=""):
         # Coding Plan models (kimi-for-coding first)
         model_list = [
             "kimi-for-coding",
+            "kimi-k2.6",
             "kimi-k2.5",
             "kimi-k2-thinking",
             "kimi-k2-thinking-turbo",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -46,6 +46,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("minimax/minimax-m2.5",            ""),
     ("z-ai/glm-5.1",                    ""),
     ("z-ai/glm-5-turbo",                ""),
+    ("moonshotai/kimi-k2.6",            ""),
     ("moonshotai/kimi-k2.5",            ""),
     ("x-ai/grok-4.20-beta",             ""),
     ("nvidia/nemotron-3-super-120b-a12b",      ""),
@@ -131,6 +132,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     ],
     "kimi-coding": [
         "kimi-for-coding",
+        "kimi-k2.6",
         "kimi-k2.5",
         "kimi-k2-thinking",
         "kimi-k2-thinking-turbo",
@@ -138,6 +140,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "kimi-k2-0905-preview",
     ],
     "moonshot": [
+        "kimi-k2.6",
         "kimi-k2.5",
         "kimi-k2-thinking",
         "kimi-k2-turbo-preview",

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -104,7 +104,7 @@ _DEFAULT_PROVIDER_MODELS = {
         "gemma-4-31b-it", "gemma-4-26b-it",
     ],
     "zai": ["glm-5", "glm-4.7", "glm-4.5", "glm-4.5-flash"],
-    "kimi-coding": ["kimi-k2.5", "kimi-k2-thinking", "kimi-k2-turbo-preview"],
+    "kimi-coding": ["kimi-k2.6", "kimi-k2.5", "kimi-k2-thinking", "kimi-k2-turbo-preview"],
     "minimax": ["MiniMax-M1", "MiniMax-M1-40k", "MiniMax-M1-80k", "MiniMax-M1-128k", "MiniMax-M1-256k", "MiniMax-M2.5", "MiniMax-M2.7"],
     "minimax-cn": ["MiniMax-M1", "MiniMax-M1-40k", "MiniMax-M1-80k", "MiniMax-M1-128k", "MiniMax-M1-256k", "MiniMax-M2.5", "MiniMax-M2.7"],
     "ai-gateway": ["anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5", "google/gemini-3-flash"],

--- a/tests/hermes_cli/test_setup_model_selection.py
+++ b/tests/hermes_cli/test_setup_model_selection.py
@@ -33,7 +33,7 @@ class TestSetupProviderModelSelection:
 
     @pytest.mark.parametrize("provider_id,expected_defaults", [
         ("zai", ["glm-5", "glm-4.7", "glm-4.5", "glm-4.5-flash"]),
-        ("kimi-coding", ["kimi-k2.5", "kimi-k2-thinking", "kimi-k2-turbo-preview"]),
+        ("kimi-coding", ["kimi-k2.6", "kimi-k2.5", "kimi-k2-thinking", "kimi-k2-turbo-preview"]),
         ("minimax", ["MiniMax-M1", "MiniMax-M1-40k", "MiniMax-M1-80k", "MiniMax-M1-128k", "MiniMax-M1-256k", "MiniMax-M2.5", "MiniMax-M2.7"]),
         ("minimax-cn", ["MiniMax-M1", "MiniMax-M1-40k", "MiniMax-M1-80k", "MiniMax-M1-128k", "MiniMax-M1-256k", "MiniMax-M2.5", "MiniMax-M2.7"]),
         ("opencode-zen", ["gpt-5.4", "gpt-5.3-codex", "claude-sonnet-4-6", "gemini-3-flash"]),


### PR DESCRIPTION
## Summary
- add Kimi K2.6 to Moonshot/OpenRouter model lists
- expose Kimi K2.6 in the Moonshot setup/model flow
- add metadata context length hint for Kimi K2.6
- add a small Andrew-focused benchmark pack for evaluating the model

## Validation
- Confirmed direct Moonshot API access with existing key
- pytest tests/hermes_cli/test_setup_model_selection.py -q ✅
- Additional unrelated baseline failures remain in test_model_provider_persistence.py / test_codex_models.py due existing import/version issues not caused by this patch

## Notes
- OpenRouter side-by-side could not be completed because no usable OPENROUTER_API_KEY was present in the env files inspected during this session.
