### PR TITLE
fix(telegram): log document/video send failures instead of printing to stdout (#13356)

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1942,7 +1942,20 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
-            print(f"[{self.name}] Failed to send document: {e}")
+            # Route to the standard logger so operators see the
+            # diagnostic (exception type + stack) in gateway logs.
+            # The previous ``print`` went to stdout and was invisible
+            # in systemd/Docker-captured log streams — operators
+            # reporting "Hermes says success, Telegram received
+            # nothing" had no way to see the underlying error.  See
+            # #13356.  Matches the established pattern in
+            # ``send_voice`` / ``send_image_file`` below/above.
+            logger.error(
+                "[%s] Failed to send Telegram document, falling back to base adapter: %s",
+                self.name,
+                e,
+                exc_info=True,
+            )
             return await super().send_document(chat_id, file_path, caption, file_name, reply_to)
 
     async def send_video(
@@ -1973,7 +1986,15 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
-            print(f"[{self.name}] Failed to send video: {e}")
+            # Route to the standard logger so operators see the
+            # diagnostic (exception type + stack) in gateway logs —
+            # same rationale as ``send_document`` above.  See #13356.
+            logger.error(
+                "[%s] Failed to send Telegram video, falling back to base adapter: %s",
+                self.name,
+                e,
+                exc_info=True,
+            )
             return await super().send_video(chat_id, video_path, caption, reply_to)
 
     async def send_image(

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -606,6 +606,110 @@ class TestSendDocument:
         assert result.success is True
         assert result.message_id == "fallback"
 
+    # --- Regression coverage for #13356 -----------------------------------
+    # Before the fix, ``send_document`` wrote the exception to stdout via
+    # ``print(...)`` instead of ``logger.error``.  On systemd/Docker gateway
+    # deployments the diagnostic was invisible, so operators seeing
+    # "Hermes says success, Telegram received nothing" had no way to
+    # see the underlying error.  These tests pin that every failure
+    # routes through the standard logger with a full stack trace (matches
+    # the pattern established by ``send_voice`` and ``send_image_file``).
+
+    @pytest.mark.asyncio
+    async def test_send_document_api_error_is_logged_with_exc_info(
+        self, connected_adapter, tmp_path, caplog
+    ):
+        """Native send_document failures must be logged via logger.error
+        with ``exc_info=True`` so operators can diagnose from gateway logs
+        (not stdout via ``print``).  See #13356."""
+        import logging
+        test_file = tmp_path / "file.pdf"
+        test_file.write_bytes(b"data")
+
+        connected_adapter._bot.send_document = AsyncMock(
+            side_effect=RuntimeError("Telegram upload rejected")
+        )
+        connected_adapter.send = AsyncMock(
+            return_value=SendResult(success=True, message_id="fallback")
+        )
+
+        with caplog.at_level(logging.ERROR, logger="gateway.platforms.telegram"):
+            await connected_adapter.send_document(
+                chat_id="12345", file_path=str(test_file),
+            )
+
+        matching = [
+            r for r in caplog.records
+            if r.name == "gateway.platforms.telegram" and r.levelno == logging.ERROR
+        ]
+        assert matching, (
+            "Expected an ERROR-level log from gateway.platforms.telegram on "
+            "send_document failure; caplog records: "
+            f"{[(r.name, r.levelname, r.getMessage()) for r in caplog.records]}"
+        )
+        log = matching[0]
+        # Full diagnostic must be attached (exc_info=True path).
+        assert log.exc_info is not None, (
+            "logger.error must be called with exc_info=True so the stack "
+            "trace lands in the gateway log — this is the whole point of "
+            "the #13356 fix."
+        )
+        # The underlying exception text must surface in the log message.
+        assert "Telegram upload rejected" in log.getMessage()
+        # And the log line must name the adapter so operators see which
+        # platform raised (matches ``send_voice`` / ``send_image_file``).
+        assert connected_adapter.name in log.getMessage()
+
+    @pytest.mark.asyncio
+    async def test_send_document_logs_do_not_hit_stdout(
+        self, connected_adapter, tmp_path, capsys
+    ):
+        """Structural pin: the old ``print(...)`` path is gone.  Any
+        stdout output during a send_document failure would be a
+        regression (invisible to systemd / Docker log capture)."""
+        test_file = tmp_path / "file.pdf"
+        test_file.write_bytes(b"data")
+
+        connected_adapter._bot.send_document = AsyncMock(
+            side_effect=RuntimeError("boom")
+        )
+        connected_adapter.send = AsyncMock(
+            return_value=SendResult(success=True, message_id="fallback")
+        )
+
+        await connected_adapter.send_document(
+            chat_id="12345", file_path=str(test_file),
+        )
+        captured = capsys.readouterr()
+        # Nothing on stdout — all diagnostic must flow via ``logger``.
+        assert f"[{connected_adapter.name}] Failed to send document" not in captured.out
+
+    @pytest.mark.asyncio
+    async def test_send_document_still_invokes_base_fallback_on_error(
+        self, connected_adapter, tmp_path
+    ):
+        """Preserved-behaviour canary: even after the logging fix, the
+        native-failure path still falls through to the base adapter's
+        text fallback — matches sibling ``send_voice`` / ``send_image_file``
+        semantics.  This PR only changes observability, not routing."""
+        test_file = tmp_path / "file.pdf"
+        test_file.write_bytes(b"data")
+
+        connected_adapter._bot.send_document = AsyncMock(
+            side_effect=RuntimeError("boom")
+        )
+        connected_adapter.send = AsyncMock(
+            return_value=SendResult(success=True, message_id="fallback-msg-id")
+        )
+
+        result = await connected_adapter.send_document(
+            chat_id="12345", file_path=str(test_file),
+        )
+        # Base fallback ran (routed through self.send)
+        connected_adapter.send.assert_awaited_once()
+        assert result.success is True
+        assert result.message_id == "fallback-msg-id"
+
     @pytest.mark.asyncio
     async def test_send_document_reply_to(self, connected_adapter, tmp_path):
         """reply_to parameter is forwarded as reply_to_message_id."""
@@ -771,3 +875,66 @@ class TestSendVideo:
 
         call_kwargs = connected_adapter._bot.send_video.call_args[1]
         assert call_kwargs["message_thread_id"] == 789
+
+    # --- Regression coverage for #13356 (send_video path) ----------------
+    # Identical observability fix as ``send_document`` — the ``print(...)``
+    # path was the twin of the one flagged in the issue.
+
+    @pytest.mark.asyncio
+    async def test_send_video_api_error_is_logged_with_exc_info(
+        self, connected_adapter, tmp_path, caplog
+    ):
+        """Native send_video failures must route through logger.error with
+        ``exc_info=True`` so gateway log capture sees them."""
+        import logging
+        test_file = tmp_path / "clip.mp4"
+        test_file.write_bytes(b"\x00\x00\x00\x1c" + b"ftyp" + b"\x00" * 100)
+
+        connected_adapter._bot.send_video = AsyncMock(
+            side_effect=RuntimeError("Telegram video rejected")
+        )
+        connected_adapter.send = AsyncMock(
+            return_value=SendResult(success=True, message_id="fallback")
+        )
+
+        with caplog.at_level(logging.ERROR, logger="gateway.platforms.telegram"):
+            await connected_adapter.send_video(
+                chat_id="12345", video_path=str(test_file),
+            )
+
+        matching = [
+            r for r in caplog.records
+            if r.name == "gateway.platforms.telegram" and r.levelno == logging.ERROR
+        ]
+        assert matching, (
+            "Expected an ERROR-level log on send_video failure; caplog records: "
+            f"{[(r.name, r.levelname, r.getMessage()) for r in caplog.records]}"
+        )
+        log = matching[0]
+        assert log.exc_info is not None, (
+            "logger.error must be called with exc_info=True — the stack "
+            "trace is the whole diagnostic."
+        )
+        assert "Telegram video rejected" in log.getMessage()
+        assert connected_adapter.name in log.getMessage()
+
+    @pytest.mark.asyncio
+    async def test_send_video_logs_do_not_hit_stdout(
+        self, connected_adapter, tmp_path, capsys
+    ):
+        """Structural pin: no ``print(...)`` leak on send_video errors."""
+        test_file = tmp_path / "clip.mp4"
+        test_file.write_bytes(b"\x00\x00\x00\x1c" + b"ftyp" + b"\x00" * 100)
+
+        connected_adapter._bot.send_video = AsyncMock(
+            side_effect=RuntimeError("boom")
+        )
+        connected_adapter.send = AsyncMock(
+            return_value=SendResult(success=True, message_id="fallback")
+        )
+
+        await connected_adapter.send_video(
+            chat_id="12345", video_path=str(test_file),
+        )
+        captured = capsys.readouterr()
+        assert f"[{connected_adapter.name}] Failed to send video" not in captured.out


### PR DESCRIPTION
Addresses the observability portion of #13356.

## TL;DR

`TelegramAdapter.send_document` and `send_video` wrote native-send exceptions to `stdout` via `print(...)` before falling back to the base adapter. On systemd / Docker / journald-captured gateway deployments `stdout` isn't captured in the gateway log stream — so operators reporting *"Hermes says success, Telegram received nothing"* had **no visible error to diagnose**.

Fix: replace `print` with `logger.error(..., exc_info=True)`, matching the established pattern in `send_voice` and `send_image_file` in the same file.

## Root cause

`gateway/platforms/telegram.py`:

```python
# send_document (line 1777)
except Exception as e:
    print(f"[{self.name}] Failed to send document: {e}")   # ← stdout, invisible
    return await super().send_document(...)                # ← fallback to text
```

```python
# send_video (line 1808) — same pattern
except Exception as e:
    print(f"[{self.name}] Failed to send video: {e}")
    return await super().send_video(...)
```

The two adjacent native-send methods in the same file already use the correct pattern:

```python
# send_voice (line 1701)
logger.error(
    "[%s] Failed to send Telegram voice/audio, falling back to base adapter: %s",
    self.name, e, exc_info=True,
)

# send_image_file (line 1738) — identical
logger.error(
    "[%s] Failed to send Telegram local image, falling back to base adapter: %s",
    self.name, e, exc_info=True,
)
```

Only `send_document` and `send_video` drifted to `print`.

## Fix

```python
# send_document
except Exception as e:
    logger.error(
        "[%s] Failed to send Telegram document, falling back to base adapter: %s",
        self.name, e, exc_info=True,
    )
    return await super().send_document(chat_id, file_path, caption, file_name, reply_to)
```

Identical change for `send_video`. 4 production-line delta total.

## Behaviour matrix

| Scenario | Before | After |
| --- | --- | --- |
| Native send fails → text fallback succeeds | `print` to stdout (invisible in journald), fallback returns success | `logger.error(exc_info=True)` to gateway log, fallback returns success |
| Native send fails → fallback also fails | `print` to stdout, exception propagates | `logger.error(exc_info=True)`, exception propagates |
| Native send succeeds | unchanged | unchanged |

## Narrow scope — explicitly not changed

* **Fallback routing.** Still falls through to `super().send_document(...)` / `super().send_video(...)`, matching `send_voice` / `send_image_file`. This PR only fixes observability.
* **Return value.** `SendResult` still reflects the text fallback's success, same as the sibling methods.
* **Other adapters.** Only Telegram had the `print` pattern; other platforms already use `logger`.
* **The deeper reporter question** — whether Telegram's native send returning a `Message` object (with `message_id`) for a subsequently-dropped file is *also* a bug — is out of scope here. With proper logging in place operators can now diagnose the actual upstream error and decide if that semantic needs changing.

## Regression coverage

`tests/gateway/test_telegram_documents.py` gets 5 new cases (3 for send_document, 2 for send_video), leveraging `caplog` + `capsys`:

**`TestSendDocument`:**
- `test_send_document_api_error_is_logged_with_exc_info` — asserts an ERROR record lands in `gateway.platforms.telegram` logger with (1) `exc_info` attached, (2) exception text present, (3) adapter name in message.
- `test_send_document_logs_do_not_hit_stdout` — structural pin: the old `"[Telegram] Failed to send document"` string must not appear on stdout. Prevents regression back to `print`.
- `test_send_document_still_invokes_base_fallback_on_error` — preserved-behaviour canary: this PR only changes observability, not routing.

**`TestSendVideo`:** matching pair (`..._is_logged_with_exc_info`, `..._logs_do_not_hit_stdout`).

**4 of 4 stdout-and-logger tests fail on clean `origin/main` (`6fb69229`)** with the exact symptom:

```
AssertionError: '[Telegram] Failed to send document' is contained here:
  [Telegram] Failed to send document: boom
AssertionError: Expected an ERROR-level log from gateway.platforms.telegram
  on send_document failure
```

## Validation

```bash
source venv/bin/activate
python -m pytest tests/gateway/test_telegram_documents.py -q
# 36 passed
```

Broader Telegram suite (4 test files) → **68 passed, 0 regressions**.

## Pre-empted review questions

**Q. Why not also remove the `super()` text fallback — isn't returning `success=True` misleading when the file didn't actually send?**
Maybe, but that's a deliberate scope-narrowing choice. The same "fall through to base on native failure" pattern exists in `send_voice` and `send_image_file` — changing it for Telegram specifically would break adapter symmetry and risk regressions in callers that rely on the fallback. Happy to follow up with a separate PR if the maintainer wants that behavior for Telegram.

**Q. Why test both `caplog` and `capsys`?**
`caplog` pins the positive invariant (error IS logged correctly). `capsys` pins the negative invariant (error is NOT leaked to stdout). Together they're a two-sided guard — a future refactor that adds `print` back *in addition to* `logger.error` would still be caught by `capsys`.

**Q. Is this a complete fix for #13356?**
For the observability portion, yes. For the reporter's deeper "success reported, file never arrives" concern, the fix here at minimum makes any raised exception diagnosable. If Telegram is returning `message_id` for a file that's subsequently server-side dropped, that's either a python-telegram-bot semantics issue or a `message_thread_id` / path-access issue that needs separate investigation — with proper logging in place operators can now surface the actual upstream error.

---

<sub>Co-authored via LLM assistance; I've reviewed every line and am responsible for correctness.</sub>

