### PR TITLE
fix: Windows stale-cwd causes exit 126 on all subsequent commands

### DIFF
--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -38,6 +38,38 @@ if _DEBUG_INTERRUPT:
     # agent.log regardless of quiet-mode.  Scoped to the opt-in case only.
     logger.setLevel(logging.INFO)
 
+_IS_WINDOWS = os.name == "nt"
+
+
+def _posix_drive_to_win(path: str) -> str:
+    """Convert Git Bash /c/Users/... to C:/Users/... so Python can stat it.
+
+    Returns the path unchanged when it doesn't match the /<letter>/... shape.
+    """
+    if len(path) >= 3 and path[0] == "/" and path[2] == "/" and path[1].isalpha():
+        return f"{path[1].upper()}:/{path[3:]}"
+    return path
+
+
+def _is_cwd_stale(cwd: str) -> bool:
+    """Best-effort check: is *cwd* a path whose directory no longer exists?
+
+    Conservative on Windows: only reports stale when we can resolve the path
+    to a Windows form Python can stat. POSIX-only paths like /tmp/... on
+    Windows (whose Git Bash mapping we don't resolve here) return False —
+    the shell-side fallback in _wrap_command catches those.
+    """
+    if not cwd:
+        return True
+    if _IS_WINDOWS:
+        if len(cwd) >= 2 and cwd[1] == ":":
+            return not os.path.isdir(cwd)
+        if len(cwd) >= 3 and cwd[0] == "/" and cwd[2] == "/" and cwd[1].isalpha():
+            return not os.path.isdir(_posix_drive_to_win(cwd))
+        return False
+    return not os.path.isdir(cwd)
+
+
 # Thread-local activity callback.  The agent sets this before a tool call so
 # long-running _wait_for_process loops can report liveness to the gateway.
 _activity_callback_local = threading.local()
@@ -289,6 +321,9 @@ class BaseEnvironment(ABC):
 
     def __init__(self, cwd: str, timeout: int, env: dict = None):
         self.cwd = cwd
+        # Captured at construction — used as fallback when self.cwd gets wedged
+        # on a deleted/unreachable dir (see _wrap_command + execute stale-check).
+        self._startup_cwd = cwd
         self.timeout = timeout
         self.env = env or {}
 
@@ -383,7 +418,20 @@ class BaseEnvironment(ABC):
         quoted_cwd = (
             shlex.quote(cwd) if cwd != "~" and not cwd.startswith("~/") else cwd
         )
-        parts.append(f"cd {quoted_cwd} || exit 126")
+        # Shell-side fallback: if the requested cwd is unreachable (stale path
+        # Python couldn't detect, e.g. /tmp/... on Windows, or a race where the
+        # dir disappeared between the Python check and the bash spawn), try the
+        # startup cwd and emit a stderr breadcrumb. Only exit 126 if both fail.
+        fallback = self._startup_cwd or "~"
+        quoted_fallback = (
+            shlex.quote(fallback) if fallback != "~" and not fallback.startswith("~/") else fallback
+        )
+        parts.append(
+            f"cd {quoted_cwd} 2>/dev/null || "
+            f"{{ cd {quoted_fallback} 2>/dev/null && "
+            f"echo '[hermes] cwd '{quoted_cwd}' unreachable; using '{quoted_fallback} >&2; }} "
+            f"|| exit 126"
+        )
 
         # Run the actual command
         parts.append(f"eval '{escaped}'")
@@ -714,6 +762,18 @@ class BaseEnvironment(ABC):
         exec_command = _rewrite_compound_background(exec_command)
         effective_timeout = timeout or self.timeout
         effective_cwd = cwd or self.cwd
+
+        # Self-heal stale cwd: if a prior command cd'd into a dir that's since
+        # been deleted (temp dir, checkpoint, cleaned build artifact), every
+        # subsequent command would exit 126 from the shell-side cd guard.
+        # Reset to startup_cwd when we can confirm the path is gone.
+        if _is_cwd_stale(effective_cwd):
+            logger.warning(
+                "Stale cwd %r detected; resetting to startup cwd %r",
+                effective_cwd, self._startup_cwd,
+            )
+            effective_cwd = self._startup_cwd
+            self.cwd = effective_cwd
 
         # Merge sudo stdin with caller stdin
         if sudo_stdin is not None and stdin_data is not None:


### PR DESCRIPTION
## Summary

Fix the "every terminal command returns exit 126" wedge that users on Windows hit after a prior command cd's into a directory that later gets deleted (temp build dir, checkpoint, intermediate tempdir). The root cause is the shell wrapper's `cd '<self.cwd>' || exit 126` guard combined with `pwd -P > <cwd_file>` running *after* the user command — so a failing cd short-circuits the write, and `self.cwd` stays permanently wedged on the bad path until Hermes restarts.

## Root cause

`BaseEnvironment._wrap_command` builds a per-execute bash script of the shape:

```bash
source <snapshot> 2>/dev/null || true
cd '<self.cwd>' || exit 126        # ← sentinel fires here when cwd is gone
eval '<user command>'
__hermes_ec=$?
...
pwd -P > <cwd_file> 2>/dev/null || true   # ← never reached on stale-cwd branch
exit $__hermes_ec
```

When `self.cwd` points at a deleted directory, `cd` fails, the script exits 126 *before* `pwd -P > <cwd_file>`, so `self._update_cwd()` reads the old (stale) path back next turn — and every subsequent `execute()` repeats the 126 exit until the whole Python process restarts.

On Windows this scenario is especially common because:
- `os.getcwd()` (used at construction time) returns `C:\Users\...` while `pwd -P` returns `/c/Users/...` — two representations that only the first command's bash successfully normalises; if that fails for any reason, drift can leave `self.cwd` in a form Git Bash can't resolve.
- Many authoring workflows `cd` into ephemeral build/checkpoint temp dirs that are later cleaned.

## Fix

Two complementary layers, both in `tools/environments/base.py`:

**Layer 1 — Python-side self-heal in `BaseEnvironment.execute()`.**
A new module-level `_is_cwd_stale(cwd)` helper calls `os.path.isdir` (or, on Windows, translates Git Bash's `/c/Users/...` to `C:/Users/...` via `_posix_drive_to_win` before calling `isdir`). When the check reports stale, `effective_cwd` is reset to `self._startup_cwd` (captured at `__init__`) and a `logger.warning` is emitted. Conservative on Windows: POSIX-only paths like `/tmp/...` (whose MSYS mapping isn't reconstructed in Python) are *not* declared stale — the shell-side fallback handles them.

**Layer 2 — Shell-side fallback in `_wrap_command`.**
The single `cd '<cwd>' || exit 126` is replaced with

```bash
cd '<cwd>' 2>/dev/null || { cd '<startup_cwd>' 2>/dev/null && echo '[hermes] ...' >&2; } || exit 126
```

If the Python check missed (race with external cleanup, or a path Python couldn't resolve), bash falls back to startup cwd and emits a stderr breadcrumb so the caller can see what happened. The final `exit 126` still fires only when *both* cwds fail — preserving the original signal when the environment is genuinely broken.

`self._startup_cwd` is captured once in `BaseEnvironment.__init__` alongside `self.cwd`.

## Non-breaking on Linux/Mac

- `_is_cwd_stale` on non-Windows falls straight through to `os.path.isdir` — same semantics as a plain fs check.
- `_posix_drive_to_win` is a no-op for paths that don't match `/<letter>/...`.
- The shell wrapper's new form is a *superset* of the prior `cd || exit 126`: same sentinel on double failure, no new failure modes.
- `_startup_cwd` is purely internal; no public API change.

## Test results

All passing on Windows 11 / Python 3.12 / Git for Windows bash:

| Test | Result |
|---|---|
| `_posix_drive_to_win`: `/c/Users/...` → `C:/Users/...`, `/tmp/x` unchanged (4 cases) | 4/4 PASS |
| `_is_cwd_stale`: empty=stale, live=ok, nonexistent Win=stale, `/c/<bogus>`=stale, `/tmp/<bogus>`=not-declared | 5/5 PASS |
| Integration: fresh env, `echo hello` → rc=0 | PASS |
| Integration: `cd <tempdir>`, delete tempdir externally, `echo recovered` → rc=0, `self.cwd` reset to startup | PASS |
| Integration: force `self.cwd = /tmp/<not-here>` (Python can't verify on Windows), `echo shell_fallback_worked` → rc=0 (shell fallback fires) | PASS |
| Integration: second command after self-heal remains stable | PASS |

Total: 10/10 unit + 4/4 integration = 14 assertions, all pass. On a wedged environment without the patch, every command returns 126 including the trivial `echo hello`.

## Related / side finding

While writing the regression test I noticed `_wait_for_process` uses `select.select([pipe_fd], ...)` which raises `OSError` on Windows (select there only supports sockets) — this is orthogonal to the exit-126 bug but does mean local terminal commands return `output=""` even when `rc=0` on Windows. That's a separate issue I can file a follow-up for if useful; it didn't affect the 126 diagnosis because users see the return code, not the captured output.