### PR TITLE
feat(api-server): stream chat reasoning chunks

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -706,6 +706,7 @@ class APIServerAdapter(BasePlatformAdapter):
         ephemeral_system_prompt: Optional[str] = None,
         session_id: Optional[str] = None,
         stream_delta_callback=None,
+        reasoning_callback=None,
         tool_progress_callback=None,
         tool_start_callback=None,
         tool_complete_callback=None,
@@ -746,6 +747,7 @@ class APIServerAdapter(BasePlatformAdapter):
             session_id=session_id,
             platform="api_server",
             stream_delta_callback=stream_delta_callback,
+            reasoning_callback=reasoning_callback,
             tool_progress_callback=tool_progress_callback,
             tool_start_callback=tool_start_callback,
             tool_complete_callback=tool_complete_callback,
@@ -928,6 +930,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 if delta is not None:
                     _stream_q.put(delta)
 
+            def _on_reasoning(delta):
+                if delta:
+                    _stream_q.put(("__reasoning__", delta))
+
             def _on_tool_progress(event_type, name, preview, args, **kwargs):
                 """Send tool progress as a separate SSE event.
 
@@ -968,6 +974,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
                 stream_delta_callback=_on_delta,
+                reasoning_callback=_on_reasoning,
                 tool_progress_callback=_on_tool_progress,
                 agent_ref=agent_ref,
             ))
@@ -1080,6 +1087,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 """Write a single queue item to the SSE stream.
 
                 Plain strings are sent as normal ``delta.content`` chunks.
+                Tagged tuples ``("__reasoning__", text)`` are sent as normal
+                OpenAI-compatible chunks with ``delta.reasoning_content`` so
+                clients can display model reasoning separately from the final
+                assistant text.
                 Tagged tuples ``("__tool_progress__", payload)`` are sent
                 as a custom ``event: hermes.tool.progress`` SSE event so
                 frontends can display them without storing the markers in
@@ -1090,6 +1101,13 @@ class APIServerAdapter(BasePlatformAdapter):
                     await response.write(
                         f"event: hermes.tool.progress\ndata: {event_data}\n\n".encode()
                     )
+                elif isinstance(item, tuple) and len(item) == 2 and item[0] == "__reasoning__":
+                    reasoning_chunk = {
+                        "id": completion_id, "object": "chat.completion.chunk",
+                        "created": created, "model": model,
+                        "choices": [{"index": 0, "delta": {"reasoning_content": item[1]}, "finish_reason": None}],
+                    }
+                    await response.write(f"data: {json.dumps(reasoning_chunk)}\n\n".encode())
                 else:
                     content_chunk = {
                         "id": completion_id, "object": "chat.completion.chunk",
@@ -2165,6 +2183,7 @@ class APIServerAdapter(BasePlatformAdapter):
         ephemeral_system_prompt: Optional[str] = None,
         session_id: Optional[str] = None,
         stream_delta_callback=None,
+        reasoning_callback=None,
         tool_progress_callback=None,
         tool_start_callback=None,
         tool_complete_callback=None,
@@ -2188,6 +2207,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=ephemeral_system_prompt,
                 session_id=session_id,
                 stream_delta_callback=stream_delta_callback,
+                reasoning_callback=reasoning_callback,
                 tool_progress_callback=tool_progress_callback,
                 tool_start_callback=tool_start_callback,
                 tool_complete_callback=tool_complete_callback,

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -646,6 +646,56 @@ class TestChatCompletionsEndpoint:
                 assert " about it..." in body
 
     @pytest.mark.asyncio
+    async def test_stream_includes_reasoning_content(self, adapter):
+        """reasoning_callback fires → reasoning appears outside delta.content."""
+        import asyncio
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                reasoning_cb = kwargs.get("reasoning_callback")
+                cb = kwargs.get("stream_delta_callback")
+                if reasoning_cb:
+                    reasoning_cb("I should inspect the request first.")
+                if cb:
+                    await asyncio.sleep(0.05)
+                    cb("The answer is 42.")
+                return (
+                    {"final_response": "The answer is 42.", "messages": [], "api_calls": 1},
+                    {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "answer"}],
+                        "stream": True,
+                    },
+                )
+                assert resp.status == 200
+                body = await resp.text()
+                assert "[DONE]" in body
+                assert "The answer is 42." in body
+                assert "I should inspect the request first." in body
+
+                saw_reasoning = False
+                for line in body.splitlines():
+                    if not line.startswith("data: ") or line.strip() == "data: [DONE]":
+                        continue
+                    chunk = json.loads(line[len("data: "):])
+                    if chunk.get("object") != "chat.completion.chunk":
+                        continue
+                    for choice in chunk.get("choices", []):
+                        delta = choice.get("delta", {})
+                        assert "I should inspect the request first." not in delta.get("content", "")
+                        if delta.get("reasoning_content") == "I should inspect the request first.":
+                            saw_reasoning = True
+
+                assert saw_reasoning
+
+    @pytest.mark.asyncio
     async def test_stream_includes_tool_progress(self, adapter):
         """tool_progress_callback fires → progress appears as custom SSE event, not in delta.content."""
         import asyncio


### PR DESCRIPTION
## Summary
- Forward `AIAgent` reasoning callbacks through `/v1/chat/completions` streaming.
- Emit reasoning as OpenAI-style `delta.reasoning_content` chunks, separate from `delta.content`.
- Keep the existing `hermes.tool.progress` SSE event behavior unchanged.
- Add focused Chat Completions SSE regression coverage.

## Why
API-server clients can already receive assistant text and tool progress while a run is active, but reasoning-capable models have no compatible path to stream reasoning tokens through Chat Completions. This exposes that signal to OpenAI-compatible clients without mixing reasoning into the persisted assistant message content.

Supersedes #4265 with a fresh branch on current `main` and a narrower scope.

## Verification
- `scripts/run_tests.sh tests/gateway/test_api_server.py` (`118 passed`)