### PR TITLE
fix: read /status token usage from SQLite session stats

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4911,6 +4911,21 @@ class GatewayRunner:
 
         return "\n".join(lines)
 
+    def _status_total_tokens(self, session_entry: "SessionEntry") -> int:
+        """Return total tokens for /status, preferring SQLite session stats."""
+        if self._session_db:
+            try:
+                row = self._session_db.get_session(session_entry.session_id)
+            except Exception:
+                row = None
+            if row:
+                input_tokens = int(row.get("input_tokens") or 0)
+                output_tokens = int(row.get("output_tokens") or 0)
+                cache_read_tokens = int(row.get("cache_read_tokens") or 0)
+                cache_write_tokens = int(row.get("cache_write_tokens") or 0)
+                return input_tokens + output_tokens + cache_read_tokens + cache_write_tokens
+        return int(getattr(session_entry, "total_tokens", 0) or 0)
+
     async def _handle_status_command(self, event: MessageEvent) -> str:
         """Handle /status command."""
         source = event.source
@@ -4929,6 +4944,8 @@ class GatewayRunner:
             except Exception:
                 title = None
 
+        total_tokens = self._status_total_tokens(session_entry)
+
         lines = [
             "📊 **Hermes Gateway Status**",
             "",
@@ -4939,7 +4956,7 @@ class GatewayRunner:
         lines.extend([
             f"**Created:** {session_entry.created_at.strftime('%Y-%m-%d %H:%M')}",
             f"**Last Activity:** {session_entry.updated_at.strftime('%Y-%m-%d %H:%M')}",
-            f"**Tokens:** {session_entry.total_tokens:,}",
+            f"**Tokens:** {total_tokens:,}",
             f"**Agent Running:** {'Yes ⚡' if is_running else 'No'}",
             "",
             f"**Connected Platforms:** {', '.join(connected_platforms)}",

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -54,6 +54,7 @@ def _make_runner(session_entry: SessionEntry):
     runner._pending_messages = {}
     runner._pending_approvals = {}
     runner._session_db = MagicMock()
+    runner._session_db.get_session.return_value = None
     runner._session_db.get_session_title.return_value = None
     runner._reasoning_config = None
     runner._provider_routing = {}
@@ -111,6 +112,31 @@ async def test_status_command_includes_session_title_when_present():
 
     assert "**Session ID:** `sess-1`" in result
     assert "**Title:** My titled session" in result
+
+
+@pytest.mark.asyncio
+async def test_status_command_prefers_sqlite_token_counts_over_session_store_entry():
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        total_tokens=0,
+    )
+    runner = _make_runner(session_entry)
+    runner._session_db.get_session.return_value = {
+        "id": "sess-1",
+        "input_tokens": 120,
+        "output_tokens": 45,
+        "cache_read_tokens": 30,
+        "cache_write_tokens": 5,
+    }
+
+    result = await runner._handle_message(_make_event("/status"))
+
+    assert "**Tokens:** 200" in result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- make gateway `/status` read token totals from the SQLite session record first
- keep the legacy in-memory session entry as a fallback when no DB row exists
- add a regression test covering the SQLite-backed token display path

## Root cause
Gateway token accounting is now persisted directly into `state.db`, but `/status` still displayed `session_store` JSON metadata. That JSON path no longer updates token totals, so `/status` could show `0` even when the session had real usage recorded in SQLite.

## Testing
- `source venv/bin/activate && pytest tests/gateway/test_status_command.py -q`
- `source venv/bin/activate && pytest tests/gateway/test_status_command.py tests/gateway/test_unknown_command.py -q`
