### PR TITLE
fix(cli): handle cross-drive path completion on Windows

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -862,12 +862,12 @@ class SlashCommandCompleter(Completer):
 
             # Build the completion text (what replaces the typed word)
             if word.startswith("~"):
-                display_path = "~/" + os.path.relpath(full_path, os.path.expanduser("~"))
+                display_path = "~/" + _safe_relpath(full_path, os.path.expanduser("~"))
             elif os.path.isabs(word):
                 display_path = full_path
             else:
                 # Keep relative
-                display_path = os.path.relpath(full_path)
+                display_path = _safe_relpath(full_path)
 
             if is_dir:
                 display_path += "/"
@@ -966,7 +966,7 @@ class SlashCommandCompleter(Completer):
                         continue
                     if count >= limit:
                         break
-                    display_path = os.path.relpath(full_path)
+                    display_path = _safe_relpath(full_path)
                     suffix = "/" if is_dir else ""
                     meta = "dir" if is_dir else _file_size_label(full_path)
                     completion = f"{prefix}{display_path}{suffix}"
@@ -1013,7 +1013,7 @@ class SlashCommandCompleter(Completer):
                     raw = proc.stdout.strip().split("\n")
                     # Store relative paths
                     for p in raw[:5000]:
-                        rel = os.path.relpath(p, cwd) if os.path.isabs(p) else p
+                        rel = _safe_relpath(p, cwd) if os.path.isabs(p) else p
                         files.append(rel)
                     break
             except (subprocess.TimeoutExpired, OSError):
@@ -1337,6 +1337,19 @@ class SlashCommandAutoSuggest(AutoSuggest):
         if self._history:
             return self._history.get_suggestion(buffer, document)
         return None
+
+
+def _safe_relpath(path: str, start: str | None = None) -> str:
+    """Return *os.path.relpath* or fall back to *path* on cross-drive errors.
+
+    On Windows, ``os.path.relpath`` raises ``ValueError`` when *path*
+    and the CWD (or *start*) sit on different drive letters.  In that
+    case the absolute path is already the most compact representation.
+    """
+    try:
+        return os.path.relpath(path) if start is None else os.path.relpath(path, start)
+    except ValueError:
+        return path
 
 
 def _file_size_label(path: str) -> str:

--- a/tests/hermes_cli/test_safe_relpath.py
+++ b/tests/hermes_cli/test_safe_relpath.py
@@ -1,0 +1,71 @@
+"""Tests for _safe_relpath and cross-drive path completion on Windows.
+
+Covers the fix for issue #13261: ``os.path.relpath`` raises ``ValueError``
+when the target path is on a different drive letter than the CWD (Windows
+only).  The ``_safe_relpath`` helper catches this and falls back to the
+absolute path.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.commands import _safe_relpath
+
+
+class TestSafeRelpath:
+    """Unit tests for the _safe_relpath helper."""
+
+    def test_normal_relative(self, tmp_path):
+        """When relpath works normally, return the relative path."""
+        child = tmp_path / "sub" / "file.txt"
+        child.parent.mkdir(parents=True, exist_ok=True)
+        child.touch()
+        old = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            result = _safe_relpath(str(child))
+            assert result == os.path.join("sub", "file.txt")
+        finally:
+            os.chdir(old)
+
+    def test_normal_relative_with_start(self, tmp_path):
+        """When relpath with an explicit start works, return the result."""
+        child = tmp_path / "a" / "b.txt"
+        child.parent.mkdir(parents=True, exist_ok=True)
+        child.touch()
+        result = _safe_relpath(str(child), str(tmp_path))
+        assert result == os.path.join("a", "b.txt")
+
+    def test_cross_drive_fallback(self):
+        """When relpath raises ValueError (cross-drive), return the path as-is."""
+        fake_path = "D:\\projects\\file.py"
+        with patch("os.path.relpath", side_effect=ValueError("path is on mount 'D:', start on mount 'C:'")):
+            result = _safe_relpath(fake_path)
+        assert result == fake_path
+
+    def test_cross_drive_fallback_with_start(self):
+        """Cross-drive fallback also works when *start* is explicit."""
+        fake_path = "E:\\data\\report.csv"
+        with patch("os.path.relpath", side_effect=ValueError("path is on mount 'E:', start on mount 'C:'")):
+            result = _safe_relpath(fake_path, "C:\\Users\\me")
+        assert result == fake_path
+
+    def test_same_path_returns_dot(self, tmp_path):
+        """relpath of a dir to itself is '.', and _safe_relpath preserves that."""
+        old = os.getcwd()
+        os.chdir(tmp_path)
+        try:
+            result = _safe_relpath(str(tmp_path))
+            assert result == "."
+        finally:
+            os.chdir(old)
+
+    def test_passes_start_to_relpath(self, tmp_path):
+        """Ensure the *start* parameter is forwarded to os.path.relpath."""
+        parent = tmp_path / "a"
+        child = tmp_path / "a" / "b"
+        parent.mkdir()
+        child.mkdir()
+        assert _safe_relpath(str(child), str(parent)) == "b"


### PR DESCRIPTION
## Summary

Fixes #13261 — `@file:` / `@folder:` path completion crashes with an unhandled `ValueError` when the target path is on a different drive letter than the CWD (e.g. target on `C:`, CWD on `E:`).

## Root Cause

`os.path.relpath(path)` raises `ValueError` on Windows when `path` and the CWD sit on different drive letters:

```
ValueError: path is on mount 'C:', start on mount 'E:'
```

The exception propagates through `_context_completions` → `get_completions` → prompt_toolkit event loop, producing an unhandled exception dialog and killing tab-completion.

Four call sites in `commands.py` are affected:
1. **Line 865** — `_path_completions`: tilde-relative display paths
2. **Line 870** — `_path_completions`: CWD-relative display paths
3. **Line 952** — `_context_completions`: `@file:`/`@folder:` context completions *(the reported crash site)*
4. **Line 1000** — `_get_project_files`: `git ls-files` output normalization

## Fix

Add a `_safe_relpath(path, start=None)` helper that wraps `os.path.relpath` in a `try/except ValueError` and falls back to the absolute path — the most compact representation when no relative path exists between different mount points.

Replace all four `os.path.relpath` call sites with `_safe_relpath`.

## Changes

| File | Change |
|------|--------|
| `hermes_cli/commands.py` | Add `_safe_relpath` helper; replace 4 `os.path.relpath` calls |
| `tests/hermes_cli/test_safe_relpath.py` | 6 regression tests (normal paths, cross-drive mock, explicit start) |

## Tests

- 6 new tests in `test_safe_relpath.py`
- All 26 existing `test_path_completion.py` tests still pass
- Cross-drive behavior simulated via `unittest.mock.patch` (reliable on all platforms)

```
tests/hermes_cli/test_safe_relpath.py   6 passed
tests/hermes_cli/test_path_completion.py  26 passed
```