### PR TITLE
ci(supply-chain): use merge-base diff (A...B) so upstream drift doesn't false-positive

### DIFF
--- a/.github/workflows/supply-chain-audit.yml
+++ b/.github/workflows/supply-chain-audit.yml
@@ -47,14 +47,22 @@ jobs:
           HEAD="${{ github.event.pull_request.head.sha }}"
 
           # Added lines only, excluding lockfiles.
-          DIFF=$(git diff "$BASE".."$HEAD" -- . ':!uv.lock' ':!*.lock' ':!package-lock.json' ':!yarn.lock' || true)
+          # Use three-dot (merge-base) form so the diff reflects only what
+          # this PR introduced, not commits upstream landed between the PR
+          # branch-off and the workflow run.  GitHub re-resolves
+          # `pull_request.base.sha` to the current upstream HEAD at trigger
+          # time; two-dot `BASE..HEAD` would then include every commit
+          # upstream merged after the contributor's last push, causing the
+          # install-hook regex below to false-positive on `setup.py` (or
+          # any other matched file) that upstream — not this PR — touched.
+          DIFF=$(git diff "$BASE"..."$HEAD" -- . ':!uv.lock' ':!*.lock' ':!package-lock.json' ':!yarn.lock' || true)
 
           FINDINGS=""
 
           # --- .pth files (auto-execute on Python startup) ---
           # The exact mechanism used in the litellm supply chain attack:
           # https://github.com/BerriAI/litellm/issues/24512
-          PTH_FILES=$(git diff --name-only "$BASE".."$HEAD" | grep '\.pth$' || true)
+          PTH_FILES=$(git diff --name-only "$BASE"..."$HEAD" | grep '\.pth$' || true)
           if [ -n "$PTH_FILES" ]; then
             FINDINGS="${FINDINGS}
           ### 🚨 CRITICAL: .pth file added or modified
@@ -97,7 +105,7 @@ jobs:
 
           # --- Install-hook files (setup.py/sitecustomize/usercustomize/__init__.pth) ---
           # These execute during pip install or interpreter startup.
-          SETUP_HITS=$(git diff --name-only "$BASE".."$HEAD" | grep -E '(^|/)(setup\.py|setup\.cfg|sitecustomize\.py|usercustomize\.py|__init__\.pth)$' || true)
+          SETUP_HITS=$(git diff --name-only "$BASE"..."$HEAD" | grep -E '(^|/)(setup\.py|setup\.cfg|sitecustomize\.py|usercustomize\.py|__init__\.pth)$' || true)
           if [ -n "$SETUP_HITS" ]; then
             FINDINGS="${FINDINGS}
           ### 🚨 CRITICAL: Install-hook file added or modified


### PR DESCRIPTION
## What does this PR do?

The supply-chain scan has been failing on every fork PR since `19db7fa3` (Apr 19) — not because of real attack patterns, but because the diff computation includes **all of main's upstream drift** since the PR branch was forked.

`BASE..HEAD` (two-dot) shows the full diff between the two trees in both directions. When main moves forward between when the PR was opened and when CI runs, files changed upstream appear in the scan as though the PR had touched them. Concrete measurement on one of my open fork PRs: two-dot returns 551 files; three-dot returns 2 — the PR's actual changes. The install-hook regex then matches `hermes_cli/setup.py` (modified upstream) and the workflow fails.

Why this only just surfaced: before `19db7fa3` the fail condition was `critical == 'true'`. WARNING-tier checks bumped `found=true` but not `critical=true`, so main-drift false positives surfaced only as a PR comment. `19db7fa3` simplified the fail to `found == 'true'`, unmasking the pre-existing `BASE..HEAD` bug.

The fix: three-character edit — change `"$BASE".."$HEAD"` to `"$BASE"..."$HEAD"` in 3 places. `A...B` = `diff(merge-base(A, B), B)`, which matches what GitHub's "Files changed" tab shows.

## Related Issue

Fixes #13411 / surfaces from the failing supply-chain scan on every open fork PR.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `.github/workflows/supply-chain-audit.yml` — change `git diff "$BASE".."$HEAD"` to `"$BASE"..."$HEAD"` in the `DIFF=`, `PTH_FILES=`, and `SETUP_HITS=` lines. The other two scan checks (`B64_EXEC_HITS`, `PROC_HITS`) build on the already-corrected `$DIFF` variable so they inherit the fix without their own edit. Detection regexes unchanged. Warning-vs-critical split unchanged. Fork-PR comment fallback unchanged. BASE/HEAD env derivation unchanged.

## How to Test

1. Re-run `supply-chain-audit.yml` on any currently-red fork PR — scan now reports zero matches (e.g. #13406, #13387, #12908, #12889 all match nothing under `A...B`).
2. Replay the four scan regexes against `"$BASE"..."$HEAD"` on a branch with synthetic `.pth` addition — matches as expected (no detection regression).
3. Behaviour matrix (before → after):
   - PR adds real `.pth` file: fail → fail (correct)
   - PR adds `setup.py`: fail → fail (correct)
   - PR adds `base64.b64decode() + exec()`: fail → fail (correct)
   - PR is 2-file fix, main drifted, upstream touched `hermes_cli/setup.py`: **FAIL (false positive) → pass**
   - Arbitrary unrelated change: pass → pass

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused tests for the touched code and all pass — N/A, workflow shell; correctness verifiable from `git diff` documented semantics
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — N/A; no existing harness for the workflow itself
- [x] I've tested on my platform: macOS 15.x (replayed against open fork PRs)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, behavior of the workflow narrows false-positives only
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — runs on `ubuntu-latest`
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

- Same issue was briefly raised on other GitHub Actions that compute PR diffs across the ecosystem; the standard fix is three-dot. Git docs: `git diff A..B` vs `git diff A...B` — https://git-scm.com/docs/gitrevisions#_dotted_range_notations
- Pre-empted review questions: `A...B` does not skip attack-shaped commits introduced on the PR branch; it only excludes main's own commits, which are main's responsibility. Behaviour is identical to `A..B` when the PR branch is up-to-date with main (merge-base equals base).

> Audited siblings: confirmed the other two scan checks (`B64_EXEC_HITS`, `PROC_HITS`) consume `$DIFF` and inherit the three-dot fix without separate edits. No widening needed.
