### PR TITLE
fix(mcp): avoid replaying historical events on startup

### DIFF
--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -198,6 +198,8 @@ class EventBridge:
         self._running = False
         self._thread: Optional[threading.Thread] = None
         self._last_poll_timestamps: Dict[str, float] = {}  # session_key -> unix timestamp
+        self._bridge_started_at = time.time()
+        self._initial_scan_complete = False
         # In-memory approval tracking (populated from events)
         self._pending_approvals: Dict[str, dict] = {}
         # mtime cache — skip expensive work when files haven't changed
@@ -337,7 +339,8 @@ class EventBridge:
         except OSError:
             sj_mtime = 0.0
 
-        if sj_mtime != self._sessions_json_mtime:
+        sessions_changed = sj_mtime != self._sessions_json_mtime
+        if sessions_changed:
             self._sessions_json_mtime = sj_mtime
             self._cached_sessions_index = _load_sessions_index()
 
@@ -353,7 +356,8 @@ class EventBridge:
         except OSError:
             db_mtime = 0.0
 
-        if db_mtime == self._state_db_mtime and sj_mtime == self._sessions_json_mtime:
+        db_changed = db_mtime != self._state_db_mtime
+        if not db_changed and not sessions_changed:
             return  # Nothing changed since last poll — skip entirely
 
         self._state_db_mtime = db_mtime
@@ -364,7 +368,11 @@ class EventBridge:
             if not session_id:
                 continue
 
-            last_seen = self._last_poll_timestamps.get(session_key, 0.0)
+            has_seen_session = session_key in self._last_poll_timestamps
+            if has_seen_session:
+                last_seen = self._last_poll_timestamps[session_key]
+            else:
+                last_seen = 0.0 if not self._initial_scan_complete else self._bridge_started_at
 
             try:
                 messages = db.get_messages(session_id)
@@ -372,6 +380,7 @@ class EventBridge:
                 continue
 
             if not messages:
+                self._last_poll_timestamps.setdefault(session_key, last_seen)
                 continue
 
             # Normalize timestamps to float for comparison
@@ -389,6 +398,16 @@ class EventBridge:
                         except Exception:
                             return 0.0
                 return 0.0
+
+            all_ts = [_ts_float(m.get("timestamp", 0)) for m in messages]
+            latest = max(all_ts) if all_ts else last_seen
+
+            # The first successful scan establishes a baseline. Without this,
+            # starting the MCP server replays every saved conversation message
+            # as a new live event.
+            if not has_seen_session and not self._initial_scan_complete:
+                self._last_poll_timestamps[session_key] = latest
+                continue
 
             # Find messages newer than our last seen timestamp
             new_messages = []
@@ -416,12 +435,10 @@ class EventBridge:
                     },
                 ))
 
-            # Update last seen to the most recent message timestamp
-            all_ts = [_ts_float(m.get("timestamp", 0)) for m in messages]
-            if all_ts:
-                latest = max(all_ts)
-                if latest > last_seen:
-                    self._last_poll_timestamps[session_key] = latest
+            # Update last seen to the most recent message timestamp.
+            self._last_poll_timestamps[session_key] = max(latest, last_seen)
+
+        self._initial_scan_complete = True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -931,8 +931,8 @@ class TestEdgeCases:
 class TestEventBridgePollE2E:
     """End-to-end tests for the EventBridge polling loop with real files."""
 
-    def test_poll_detects_new_messages(self, tmp_path, monkeypatch):
-        """Write to SQLite + sessions.json, verify EventBridge picks it up."""
+    def test_initial_poll_baselines_existing_messages(self, tmp_path, monkeypatch):
+        """Existing transcript rows must not be replayed as live events."""
         import mcp_serve
         sessions_dir = tmp_path / "sessions"
         sessions_dir.mkdir()
@@ -982,12 +982,12 @@ class TestEventBridgePollE2E:
         # Run one poll cycle manually
         bridge._poll_once(TestDB())
 
-        # Should have found the messages
+        # Startup should establish the last-seen timestamp without replaying
+        # old conversation history as new MCP events.
         result = bridge.poll_events(after_cursor=0)
-        assert len(result["events"]) == 2
-        assert result["events"][0]["role"] == "user"
-        assert result["events"][0]["content"] == "First message"
-        assert result["events"][1]["role"] == "assistant"
+        assert result["events"] == []
+        assert result["next_cursor"] == 0
+        assert bridge._last_poll_timestamps["agent:main:telegram:dm:poll_test"] > 0
 
     def test_poll_skips_when_unchanged(self, tmp_path, monkeypatch):
         """Second poll with no file changes should be a no-op."""
@@ -1079,10 +1079,11 @@ class TestEventBridgePollE2E:
         db = TestDB()
         bridge = mcp_serve.EventBridge()
 
-        # First poll
+        # First poll establishes the baseline and should not replay history.
         bridge._poll_once(db)
         r1 = bridge.poll_events(after_cursor=0)
-        assert len(r1["events"]) == 1
+        assert r1["events"] == []
+        assert r1["next_cursor"] == 0
 
         # Add a new message to the DB
         conn = sqlite3.connect(str(db_path))


### PR DESCRIPTION
## What does this PR do?

This fixes the MCP event bridge so starting `hermes mcp serve` does not replay existing conversation history as new live events.

Previously, `EventBridge` initialized each session with a `last_seen` timestamp of `0`, so the first poll treated every saved `user` and `assistant` message in `state.db` as a fresh `events_poll` event. That made MCP clients see stale transcript rows as live messages immediately after connecting.

The fix makes the first successful scan establish a per-session timestamp baseline, then only emits messages written after that baseline. It also preserves the existing mtime optimization while correctly treating `sessions.json` changes as poll work.

## Related Issue

N/A - found during code audit. I searched open issues/PRs for the MCP event surface (`EventBridge`, `mcp_serve`, `events_poll`, stale/historical/live MCP events) and did not find matching open work.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `mcp_serve.py`
  - Added startup baseline tracking for `EventBridge` so historical transcript rows are not emitted as live MCP events.
  - Keeps emitting new messages added after the initial baseline.
  - Fixed the poll skip check to use explicit `sessions_changed` and `db_changed` flags.

- `tests/test_mcp_serve.py`
  - Added regression coverage that verifies existing messages are not replayed on initial poll.
  - Updated the new-message-after-DB-write test to assert that only the post-baseline message is emitted.

## How to Test

1. Run the focused MCP server test file:

   ```bash
   source .venv/bin/activate
   scripts/run_tests.sh tests/test_mcp_serve.py -q
   ```

2. Confirm the MCP tests pass:

   ```text
   79 passed
   ```

3. Optional manual behavior check:
   - Start `hermes mcp serve` with existing conversation history.
   - Call `events_poll`.
   - Confirm old transcript messages are not returned as live events.
   - Add or send a new message and confirm it is returned by the next poll.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, Python 3.14 local virtualenv

Full-suite note: I attempted the repo wrapper with `scripts/run_tests.sh -q`. The full run failed on unrelated local environment/test failures, including missing `acp` and `fastapi`, plus unrelated gateway/web/tools test failures. The affected MCP test file passes cleanly through the required wrapper.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

Focused test run:

```text
$ source .venv/bin/activate && scripts/run_tests.sh tests/test_mcp_serve.py -q
running pytest with 4 workers, hermetic env, in /Users/afurm/Development/hermes-agent
(TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0; all credential env vars unset)

79 passed, 79 warnings in 2.21s
```

Whitespace check:

```text
$ git diff --check
# no output
```
