### PR TITLE
feat(tui): add number-key shortcut for 'Other' row in ClarifyPrompt

### DIFF
--- a/ui-tui/src/components/prompts.tsx
+++ b/ui-tui/src/components/prompts.tsx
@@ -112,10 +112,16 @@ export function ClarifyPrompt({ cols = 80, onAnswer, onCancel, req, t }: Clarify
       sel === choices.length ? setTyping(true) : choices[sel] && onAnswer(choices[sel]!)
     }
 
-    const n = parseInt(ch)
+    const n = parseInt(ch, 10)
 
     if (n >= 1 && n <= choices.length) {
       onAnswer(choices[n - 1]!)
+
+      return
+    }
+
+    if (n === choices.length + 1) {
+      setTyping(true)
     }
   })
 
@@ -149,7 +155,7 @@ export function ClarifyPrompt({ cols = 80, onAnswer, onCancel, req, t }: Clarify
         </Text>
       ))}
 
-      <Text color={t.color.dim}>↑/↓ select · Enter confirm · 1-{choices.length} quick pick · Esc/Ctrl+C cancel</Text>
+      <Text color={t.color.dim}>↑/↓ select · Enter confirm · 1-{choices.length + 1} quick pick · Esc/Ctrl+C cancel</Text>
     </Box>
   )
 }


### PR DESCRIPTION
Complements CLI PR #13416 (salvage of #2429 by @francip) on the TUI side.

## Summary
The TUI Clarify prompt already renders a numbered 'Other (type your answer)' row but had no matching keyboard shortcut — users had to arrow+Enter to reach freetext mode. Pressing N+1 now jumps straight into freetext entry.

## Changes
- `ui-tui/src/components/prompts.tsx`: `ClarifyPrompt` handler listens for `len(choices)+1` and enters `typing` mode. Footer hint updated from `1-{N}` to `1-{N+1}`. Added explicit radix to `parseInt`.

## Validation
| | Before | After |
|---|---|---|
| Press 1-N | selects choice N | selects choice N |
| Press N+1 | ignored | opens 'Other' freetext entry |
| Arrow + Enter on Other | opens freetext | opens freetext |
| Footer hint | `1-{N} quick pick` | `1-{N+1} quick pick` |

Type-check clean. No new lint/test issues vs main (lint error on line 8 and 2 test-file failures pre-existed on origin/main, unrelated to this diff).

Note: the TUI already had numbered shortcuts for choice rows from an earlier change, so this doesn't need to port francip's full CLI change — just fills the missing 'Other' case. The `0`-for-10th-item overflow from the CLI PR was intentionally skipped (Clarify choices in practice are always <= 4).