### PR TITLE
fix(tools): reuse persistent loop in Home Assistant async bridge

### DIFF
--- a/tests/tools/test_homeassistant_tool.py
+++ b/tests/tools/test_homeassistant_tool.py
@@ -1,10 +1,12 @@
 """Tests for the Home Assistant tool module.
 
 Tests real logic: entity filtering, payload building, response parsing,
-handler validation, and availability gating.
+handler validation, availability gating, and async bridge lifecycle.
 """
 
+import asyncio
 import json
+import threading
 from unittest.mock import patch
 
 import pytest
@@ -323,6 +325,7 @@ class TestCallServiceStringData:
             "data": '{"hvac_mode": "heat"}',
         })
         call_args = mock_run.call_args[0][0]  # the coroutine arg
+        call_args.close()
         # _run_async was called, meaning we got past validation
 
     @patch("tools.homeassistant_tool._run_async", return_value={"success": True})
@@ -335,6 +338,7 @@ class TestCallServiceStringData:
             "data": {"brightness": 255},
         })
         mock_run.assert_called_once()
+        mock_run.call_args[0][0].close()
 
     def test_invalid_json_string_returns_error(self):
         """Malformed JSON string in data returns a clear error."""
@@ -357,6 +361,7 @@ class TestCallServiceStringData:
             "data": "   ",
         })
         mock_run.assert_called_once()
+        mock_run.call_args[0][0].close()
 
 
 # ---------------------------------------------------------------------------
@@ -516,3 +521,115 @@ class TestRegistration:
         invalidate_check_fn_cache()
         defs = registry.get_definitions({"ha_list_entities", "ha_get_state", "ha_call_service"})
         assert len(defs) == 3
+
+
+# ---------------------------------------------------------------------------
+# Async bridge lifecycle regression tests
+# ---------------------------------------------------------------------------
+
+
+async def _get_current_loop():
+    """Return the running event loop from inside a coroutine."""
+    return asyncio.get_event_loop()
+
+
+class TestRunAsyncLoopLifecycle:
+    """Verify homeassistant_tool._run_async keeps loops alive."""
+
+    def test_loop_not_closed_after_run_async(self):
+        from tools.homeassistant_tool import _run_async
+
+        loop = _run_async(_get_current_loop())
+
+        assert not loop.is_closed(), (
+            "homeassistant_tool._run_async() closed the event loop — "
+            "aiohttp clients can emit unclosed session/connector warnings"
+        )
+
+    def test_same_loop_reused_across_calls(self):
+        from tools.homeassistant_tool import _run_async
+
+        loop1 = _run_async(_get_current_loop())
+        loop2 = _run_async(_get_current_loop())
+
+        assert loop1 is loop2, (
+            "homeassistant_tool._run_async() created a new loop on the "
+            "second call instead of reusing a persistent loop"
+        )
+
+    def test_running_loop_calls_use_persistent_background_loop(self):
+        from tools.homeassistant_tool import _run_async
+
+        async def _run_twice_inside_running_loop():
+            loop1 = _run_async(_get_current_loop())
+            loop2 = _run_async(_get_current_loop())
+            return loop1, loop2
+
+        loop1, loop2 = asyncio.run(_run_twice_inside_running_loop())
+
+        assert loop1 is loop2, (
+            "Calls from inside a running event loop should reuse the same "
+            "persistent background loop"
+        )
+        assert not loop1.is_closed(), (
+            "Background loop used for running-loop calls was closed after "
+            "_run_async returned"
+        )
+
+
+class TestRunAsyncWorkerThread:
+    """Verify worker threads also keep a persistent loop."""
+
+    def test_worker_thread_loop_not_closed(self):
+        from concurrent.futures import ThreadPoolExecutor
+        from tools.homeassistant_tool import _run_async
+
+        def _run_on_worker():
+            loop = _run_async(_get_current_loop())
+            still_open = not loop.is_closed()
+            return loop, still_open
+
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            _loop, still_open = pool.submit(_run_on_worker).result()
+
+        assert still_open, (
+            "Worker thread event loop was closed after _run_async returned"
+        )
+
+    def test_worker_thread_reuses_loop_across_calls(self):
+        from concurrent.futures import ThreadPoolExecutor
+        from tools.homeassistant_tool import _run_async
+
+        def _run_twice_on_worker():
+            loop1 = _run_async(_get_current_loop())
+            loop2 = _run_async(_get_current_loop())
+            return loop1, loop2
+
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            loop1, loop2 = pool.submit(_run_twice_on_worker).result()
+
+        assert loop1 is loop2, (
+            "Worker thread created different loops for consecutive calls"
+        )
+        assert not loop1.is_closed()
+
+    def test_parallel_workers_get_separate_loops(self):
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+        from tools.homeassistant_tool import _run_async
+
+        barrier = threading.Barrier(3, timeout=5)
+
+        def _get_loop_id():
+            loop = _run_async(_get_current_loop())
+            barrier.wait()
+            return id(loop), not loop.is_closed(), threading.current_thread().ident
+
+        with ThreadPoolExecutor(max_workers=3) as pool:
+            futures = [pool.submit(_get_loop_id) for _ in range(3)]
+            results = [f.result() for f in as_completed(futures)]
+
+        loop_ids = {result[0] for result in results}
+        thread_ids = {result[2] for result in results}
+        assert all(result[1] for result in results)
+        assert len(thread_ids) == 3
+        assert len(loop_ids) == 3

--- a/tests/tools/test_homeassistant_tool.py
+++ b/tests/tools/test_homeassistant_tool.py
@@ -576,6 +576,19 @@ class TestRunAsyncLoopLifecycle:
             "_run_async returned"
         )
 
+    def test_running_loop_scheduler_failure_is_reported(self):
+        from tools.homeassistant_tool import _submit_to_async_context_loop
+
+        with patch(
+            "asyncio.run_coroutine_threadsafe",
+            side_effect=RuntimeError("scheduler down"),
+        ):
+            with pytest.raises(
+                RuntimeError,
+                match="Failed to schedule Home Assistant coroutine",
+            ):
+                _submit_to_async_context_loop(_get_current_loop())
+
 
 class TestRunAsyncWorkerThread:
     """Verify worker threads also keep a persistent loop."""

--- a/tests/tools/test_homeassistant_tool.py
+++ b/tests/tools/test_homeassistant_tool.py
@@ -1,10 +1,12 @@
 """Tests for the Home Assistant tool module.
 
 Tests real logic: entity filtering, payload building, response parsing,
-handler validation, and availability gating.
+handler validation, availability gating, and async bridge lifecycle.
 """
 
+import asyncio
 import json
+import threading
 from unittest.mock import patch
 
 import pytest
@@ -323,6 +325,7 @@ class TestCallServiceStringData:
             "data": '{"hvac_mode": "heat"}',
         })
         call_args = mock_run.call_args[0][0]  # the coroutine arg
+        call_args.close()
         # _run_async was called, meaning we got past validation
 
     @patch("tools.homeassistant_tool._run_async", return_value={"success": True})
@@ -335,6 +338,7 @@ class TestCallServiceStringData:
             "data": {"brightness": 255},
         })
         mock_run.assert_called_once()
+        mock_run.call_args[0][0].close()
 
     def test_invalid_json_string_returns_error(self):
         """Malformed JSON string in data returns a clear error."""
@@ -357,6 +361,7 @@ class TestCallServiceStringData:
             "data": "   ",
         })
         mock_run.assert_called_once()
+        mock_run.call_args[0][0].close()
 
 
 # ---------------------------------------------------------------------------
@@ -514,3 +519,115 @@ class TestRegistration:
         monkeypatch.setenv("HASS_TOKEN", "test-token")
         defs = registry.get_definitions({"ha_list_entities", "ha_get_state", "ha_call_service"})
         assert len(defs) == 3
+
+
+# ---------------------------------------------------------------------------
+# Async bridge lifecycle regression tests
+# ---------------------------------------------------------------------------
+
+
+async def _get_current_loop():
+    """Return the running event loop from inside a coroutine."""
+    return asyncio.get_event_loop()
+
+
+class TestRunAsyncLoopLifecycle:
+    """Verify homeassistant_tool._run_async keeps loops alive."""
+
+    def test_loop_not_closed_after_run_async(self):
+        from tools.homeassistant_tool import _run_async
+
+        loop = _run_async(_get_current_loop())
+
+        assert not loop.is_closed(), (
+            "homeassistant_tool._run_async() closed the event loop — "
+            "aiohttp clients can emit unclosed session/connector warnings"
+        )
+
+    def test_same_loop_reused_across_calls(self):
+        from tools.homeassistant_tool import _run_async
+
+        loop1 = _run_async(_get_current_loop())
+        loop2 = _run_async(_get_current_loop())
+
+        assert loop1 is loop2, (
+            "homeassistant_tool._run_async() created a new loop on the "
+            "second call instead of reusing a persistent loop"
+        )
+
+    def test_running_loop_calls_use_persistent_background_loop(self):
+        from tools.homeassistant_tool import _run_async
+
+        async def _run_twice_inside_running_loop():
+            loop1 = _run_async(_get_current_loop())
+            loop2 = _run_async(_get_current_loop())
+            return loop1, loop2
+
+        loop1, loop2 = asyncio.run(_run_twice_inside_running_loop())
+
+        assert loop1 is loop2, (
+            "Calls from inside a running event loop should reuse the same "
+            "persistent background loop"
+        )
+        assert not loop1.is_closed(), (
+            "Background loop used for running-loop calls was closed after "
+            "_run_async returned"
+        )
+
+
+class TestRunAsyncWorkerThread:
+    """Verify worker threads also keep a persistent loop."""
+
+    def test_worker_thread_loop_not_closed(self):
+        from concurrent.futures import ThreadPoolExecutor
+        from tools.homeassistant_tool import _run_async
+
+        def _run_on_worker():
+            loop = _run_async(_get_current_loop())
+            still_open = not loop.is_closed()
+            return loop, still_open
+
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            _loop, still_open = pool.submit(_run_on_worker).result()
+
+        assert still_open, (
+            "Worker thread event loop was closed after _run_async returned"
+        )
+
+    def test_worker_thread_reuses_loop_across_calls(self):
+        from concurrent.futures import ThreadPoolExecutor
+        from tools.homeassistant_tool import _run_async
+
+        def _run_twice_on_worker():
+            loop1 = _run_async(_get_current_loop())
+            loop2 = _run_async(_get_current_loop())
+            return loop1, loop2
+
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            loop1, loop2 = pool.submit(_run_twice_on_worker).result()
+
+        assert loop1 is loop2, (
+            "Worker thread created different loops for consecutive calls"
+        )
+        assert not loop1.is_closed()
+
+    def test_parallel_workers_get_separate_loops(self):
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+        from tools.homeassistant_tool import _run_async
+
+        barrier = threading.Barrier(3, timeout=5)
+
+        def _get_loop_id():
+            loop = _run_async(_get_current_loop())
+            barrier.wait()
+            return id(loop), not loop.is_closed(), threading.current_thread().ident
+
+        with ThreadPoolExecutor(max_workers=3) as pool:
+            futures = [pool.submit(_get_loop_id) for _ in range(3)]
+            results = [f.result() for f in as_completed(futures)]
+
+        loop_ids = {result[0] for result in results}
+        thread_ids = {result[2] for result in results}
+        assert all(result[1] for result in results)
+        assert len(thread_ids) == 3
+        assert len(loop_ids) == 3

--- a/tools/homeassistant_tool.py
+++ b/tools/homeassistant_tool.py
@@ -15,6 +15,7 @@ import json
 import logging
 import os
 import re
+import threading
 from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
@@ -26,6 +27,80 @@ logger = logging.getLogger(__name__)
 # Kept for backward compatibility (e.g. test monkeypatching); prefer _get_config().
 _HASS_URL: str = ""
 _HASS_TOKEN: str = ""
+
+# Persistent event loops for sync->async bridging. Using asyncio.run() per call
+# creates and then closes a new event loop every time, which can orphan cached
+# async client transports and surface as "Unclosed client session" warnings.
+_tool_loop = None
+_tool_loop_lock = threading.Lock()
+_worker_thread_local = threading.local()
+_async_context_loop = None
+_async_context_loop_thread = None
+_async_context_loop_lock = threading.Lock()
+
+
+def _run_background_loop(loop: asyncio.AbstractEventLoop, ready: threading.Event) -> None:
+    """Own a persistent event loop on a dedicated daemon thread."""
+    asyncio.set_event_loop(loop)
+    ready.set()
+    loop.run_forever()
+
+
+def _get_async_context_loop() -> asyncio.AbstractEventLoop:
+    """Return a persistent background loop for calls made inside a running loop."""
+    global _async_context_loop, _async_context_loop_thread
+    with _async_context_loop_lock:
+        if (
+            _async_context_loop is None
+            or _async_context_loop.is_closed()
+            or _async_context_loop_thread is None
+            or not _async_context_loop_thread.is_alive()
+        ):
+            loop = asyncio.new_event_loop()
+            ready = threading.Event()
+            thread = threading.Thread(
+                target=_run_background_loop,
+                args=(loop, ready),
+                name="homeassistant-tool-async-bridge",
+                daemon=True,
+            )
+            thread.start()
+            if not ready.wait(timeout=5):
+                loop.close()
+                raise RuntimeError("Timed out starting Home Assistant async bridge loop")
+            _async_context_loop = loop
+            _async_context_loop_thread = thread
+        return _async_context_loop
+
+
+def _submit_to_async_context_loop(coro):
+    """Run a coroutine on the persistent async-context bridge loop."""
+    bridge_loop = _get_async_context_loop()
+    future = asyncio.run_coroutine_threadsafe(coro, bridge_loop)
+    try:
+        return future.result(timeout=30)
+    except Exception:
+        future.cancel()
+        raise
+
+
+def _get_tool_loop():
+    """Return a long-lived event loop for main-thread tool calls."""
+    global _tool_loop
+    with _tool_loop_lock:
+        if _tool_loop is None or _tool_loop.is_closed():
+            _tool_loop = asyncio.new_event_loop()
+        return _tool_loop
+
+
+def _get_worker_loop():
+    """Return a persistent event loop for the current worker thread."""
+    loop = getattr(_worker_thread_local, "loop", None)
+    if loop is None or loop.is_closed():
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        _worker_thread_local.loop = loop
+    return loop
 
 
 def _get_config():
@@ -205,20 +280,27 @@ async def _async_call_service(
 # ---------------------------------------------------------------------------
 
 def _run_async(coro):
-    """Run an async coroutine from a sync handler."""
+    """Run an async coroutine from a sync handler.
+
+    When possible, reuse a persistent event loop instead of asyncio.run(),
+    which creates and closes a fresh loop on every call. Reusing loops keeps
+    async client cleanup bound to a live loop and avoids aiohttp unclosed
+    session/connector warnings.
+    """
     try:
         loop = asyncio.get_running_loop()
     except RuntimeError:
         loop = None
 
     if loop and loop.is_running():
-        # Already inside an event loop -- create a new thread
-        import concurrent.futures
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-            future = pool.submit(asyncio.run, coro)
-            return future.result(timeout=30)
-    else:
-        return asyncio.run(coro)
+        return _submit_to_async_context_loop(coro)
+
+    if threading.current_thread() is not threading.main_thread():
+        worker_loop = _get_worker_loop()
+        return worker_loop.run_until_complete(coro)
+
+    tool_loop = _get_tool_loop()
+    return tool_loop.run_until_complete(coro)
 
 
 def _handle_list_entities(args: dict, **kw) -> str:

--- a/tools/homeassistant_tool.py
+++ b/tools/homeassistant_tool.py
@@ -18,6 +18,8 @@ import re
 import threading
 from typing import Any, Dict, Optional
 
+from agent.async_utils import safe_schedule_threadsafe
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -76,7 +78,16 @@ def _get_async_context_loop() -> asyncio.AbstractEventLoop:
 def _submit_to_async_context_loop(coro):
     """Run a coroutine on the persistent async-context bridge loop."""
     bridge_loop = _get_async_context_loop()
-    future = asyncio.run_coroutine_threadsafe(coro, bridge_loop)
+    future = safe_schedule_threadsafe(
+        coro,
+        bridge_loop,
+        logger=logger,
+        log_message="Failed to schedule Home Assistant coroutine on async bridge loop",
+    )
+    if future is None:
+        raise RuntimeError(
+            "Failed to schedule Home Assistant coroutine on async bridge loop"
+        )
     try:
         return future.result(timeout=30)
     except Exception:


### PR DESCRIPTION
## What does this PR do?

This PR fixes the remaining async-context gap in `tools/homeassistant_tool.py`'s sync-to-async bridge.

The Home Assistant tool already reused persistent event loops for some sync call paths, but when `_run_async()` was invoked from inside an already-running event loop it still spawned a disposable thread and called `asyncio.run(coro)` per invocation. That per-call create-and-destroy loop behavior can leave `aiohttp` cleanup tied to dead loops, which risks `Unclosed client session` / `Unclosed connector` warnings in long-running Hermes processes.

This change makes that path reuse a dedicated persistent background loop thread instead, bringing the Home Assistant tool in line with Hermes' persistent-loop bridge pattern.

## Related Issue

Fixes #13586

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- update `tools/homeassistant_tool.py` so async-context calls no longer use per-call `asyncio.run()`
- add a dedicated persistent background loop thread for calls made while another event loop is already running
- submit async-context coroutines with `asyncio.run_coroutine_threadsafe(...)`
- keep the existing persistent main-thread and per-worker-thread loop behavior
- add regression coverage in `tests/tools/test_homeassistant_tool.py` for loop reuse and liveness from inside a running event loop

## How to Test

1. Reproduce the bug scenario by calling `tools/homeassistant_tool.py:_run_async()` from within an already-running event loop.
2. Verify that the call succeeds without falling back to per-call `asyncio.run()` loop creation/destruction behavior.
3. Run the targeted regression tests:
   - `python -m pytest tests/tools/test_homeassistant_tool.py -q -o 'addopts='`
   - `python -m pytest tests/gateway/test_homeassistant.py -q -o 'addopts='`
4. Optional broader check: run `pytest tests/ -q`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted local test results:

- `tests/tools/test_homeassistant_tool.py`: passed
- `tests/gateway/test_homeassistant.py`: passed

Note: I did not mark the full `pytest tests/ -q` checkbox as complete here because repository-wide baseline failures unrelated to this PR were observed separately.