### PR TITLE
feat(cli): persist explicit api_mode for manual custom endpoints

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2471,12 +2471,17 @@ def _model_flow_custom(config):
 
     current_url = get_env_value("OPENAI_BASE_URL") or ""
     current_key = get_env_value("OPENAI_API_KEY") or ""
+    current_api_mode = ""
+    current_model_cfg = config.get("model") if isinstance(config, dict) else None
+    if isinstance(current_model_cfg, dict):
+        current_api_mode = str(current_model_cfg.get("api_mode") or "").strip()
 
     print("Custom OpenAI-compatible endpoint configuration:")
     if current_url:
         print(f"  Current URL: {current_url}")
     if current_key:
         print(f"  Current key: {current_key[:8]}...")
+    print(f"  Current API mode: {current_api_mode or '-'}")
     print()
 
     try:
@@ -2590,6 +2595,10 @@ def _model_flow_custom(config):
         # Prompt for a display name — shown in the provider menu on future runs
         default_name = _auto_provider_name(effective_url)
         display_name = input(f"Display name [{default_name}]: ").strip() or default_name
+        explicit_api_mode = _prompt_custom_api_mode(
+            effective_url,
+            current_api_mode=current_api_mode,
+        )
     except (KeyboardInterrupt, EOFError):
         print("\nCancelled.")
         return
@@ -2621,7 +2630,10 @@ def _model_flow_custom(config):
         model["base_url"] = effective_url
         if effective_key:
             model["api_key"] = effective_key
-        model.pop("api_mode", None)  # let runtime auto-detect from URL
+        if explicit_api_mode:
+            model["api_mode"] = explicit_api_mode
+        else:
+            model.pop("api_mode", None)  # let runtime auto-detect from URL
         save_config(cfg)
         deactivate_provider()
 
@@ -2632,6 +2644,7 @@ def _model_flow_custom(config):
         config["model"] = dict(model)
 
         print(f"Default model set to: {model_name} (via {effective_url})")
+        print(f"  API mode: {explicit_api_mode or 'auto'}")
     else:
         if base_url or api_key:
             deactivate_provider()
@@ -2644,8 +2657,12 @@ def _model_flow_custom(config):
         _caller_model["base_url"] = effective_url
         if effective_key:
             _caller_model["api_key"] = effective_key
-        _caller_model.pop("api_mode", None)
+        if explicit_api_mode:
+            _caller_model["api_mode"] = explicit_api_mode
+        else:
+            _caller_model.pop("api_mode", None)
         config["model"] = _caller_model
+        print(f"  API mode: {explicit_api_mode or 'auto'}")
         print("Endpoint saved. Use `/model` in chat or `hermes model` to set a model.")
 
     # Auto-save to custom_providers so it appears in the menu next time
@@ -2655,6 +2672,7 @@ def _model_flow_custom(config):
         model_name or "",
         context_length=context_length,
         name=display_name,
+        api_mode=explicit_api_mode,
     )
 
 
@@ -2679,13 +2697,81 @@ def _auto_provider_name(base_url: str) -> str:
     return name
 
 
+_EXPLICIT_CUSTOM_API_MODES = (
+    "chat_completions",
+    "codex_responses",
+    "anthropic_messages",
+)
+_CUSTOM_API_MODE_UNSET = object()
+
+
+def _normalize_custom_api_mode(value) -> Optional[str]:
+    """Normalize a persisted custom-endpoint api_mode.
+
+    Returns ``None`` for ``auto`` / unset values, or when the value is not one
+    of the explicit transports supported by the custom OpenAI-compatible flow.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower()
+    if not normalized or normalized == "auto":
+        return None
+    if normalized in _EXPLICIT_CUSTOM_API_MODES:
+        return normalized
+    return None
+
+
+def _default_custom_api_mode(base_url: str, current_api_mode: str = "") -> str:
+    """Return the default api_mode shown in the custom endpoint prompt."""
+    current = _normalize_custom_api_mode(current_api_mode)
+    if current:
+        return current
+
+    from hermes_cli.runtime_provider import _detect_api_mode_for_url
+
+    detected = _detect_api_mode_for_url(base_url or "")
+    if detected in _EXPLICIT_CUSTOM_API_MODES:
+        return detected
+    return "auto"
+
+
+def _prompt_custom_api_mode(base_url: str, current_api_mode: str = "") -> Optional[str]:
+    """Prompt for the wire protocol used by a custom OpenAI-compatible endpoint."""
+    default_mode = _default_custom_api_mode(base_url, current_api_mode=current_api_mode)
+
+    print("  API mode:")
+    print("    auto                 Detect from URL")
+    print("    chat_completions     OpenAI-compatible Chat Completions")
+    print("    codex_responses      OpenAI Responses / Codex Responses")
+    print("    anthropic_messages   Anthropic Messages API")
+
+    while True:
+        raw = input(f"API mode [{default_mode}]: ").strip().lower()
+        selected = raw or default_mode
+        normalized = _normalize_custom_api_mode(selected)
+        if selected == "auto" or normalized:
+            return normalized
+        print(
+            "Invalid API mode. Choose auto, chat_completions, "
+            "codex_responses, or anthropic_messages."
+        )
+
+
 def _save_custom_provider(
-    base_url, api_key="", model="", context_length=None, name=None
+    base_url,
+    api_key="",
+    model="",
+    context_length=None,
+    name=None,
+    api_mode=_CUSTOM_API_MODE_UNSET,
 ):
     """Save a custom endpoint to custom_providers in config.yaml.
 
     Deduplicates by base_url — if the URL already exists, updates the
-    model name and context_length but doesn't add a duplicate entry.
+    model name, context_length, and explicit api_mode but doesn't add a
+    duplicate entry.
     Uses *name* when provided, otherwise auto-generates from the URL.
     """
     from hermes_cli.config import load_config, save_config
@@ -2694,6 +2780,7 @@ def _save_custom_provider(
     providers = cfg.get("custom_providers") or []
     if not isinstance(providers, list):
         providers = []
+    normalized_api_mode = _normalize_custom_api_mode(api_mode)
 
     # Check if this URL is already saved — update model/context_length if so
     for entry in providers:
@@ -2711,6 +2798,14 @@ def _save_custom_provider(
                 models_cfg[model] = {"context_length": context_length}
                 entry["models"] = models_cfg
                 changed = True
+            if api_mode is not _CUSTOM_API_MODE_UNSET:
+                if normalized_api_mode:
+                    if entry.get("api_mode") != normalized_api_mode:
+                        entry["api_mode"] = normalized_api_mode
+                        changed = True
+                elif "api_mode" in entry:
+                    entry.pop("api_mode", None)
+                    changed = True
             if changed:
                 cfg["custom_providers"] = providers
                 save_config(cfg)
@@ -2723,6 +2818,8 @@ def _save_custom_provider(
     entry = {"name": name, "base_url": base_url}
     if api_key:
         entry["api_key"] = api_key
+    if normalized_api_mode:
+        entry["api_mode"] = normalized_api_mode
     if model:
         entry["model"] = model
     if model and context_length:

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -531,8 +531,8 @@ def test_model_flow_custom_saves_verified_v1_base_url(monkeypatch, capsys):
 
     # After the probe detects a single model ("llm"), the flow asks
     # "Use this model? [Y/n]:" — confirm with Enter, then context length,
-    # then display name.
-    answers = iter(["http://localhost:8000", "local-key", "", "", "", ""])
+    # display name, and API mode.
+    answers = iter(["http://localhost:8000", "local-key", "", "", "", "", ""])
     monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
     monkeypatch.setattr("getpass.getpass", lambda _prompt="": next(answers))
 
@@ -544,6 +544,140 @@ def test_model_flow_custom_saves_verified_v1_base_url(monkeypatch, capsys):
     # OPENAI_BASE_URL is no longer saved to .env — config.yaml is authoritative
     assert "OPENAI_BASE_URL" not in saved_env
     assert saved_env["MODEL"] == "llm"
+
+
+def test_model_flow_custom_persists_explicit_codex_responses_api_mode(tmp_path, monkeypatch):
+    import yaml
+
+    home = tmp_path / "hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text("model: old-model\ncustom_providers: []\n")
+    (home / ".env").write_text("")
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(
+        "hermes_cli.models.probe_api_models",
+        lambda api_key, base_url: {
+            "models": ["gpt-5.4"],
+            "probed_url": f"{base_url.rstrip('/')}/models",
+            "resolved_base_url": base_url.rstrip("/"),
+            "suggested_base_url": base_url.rstrip("/"),
+            "used_fallback": False,
+        },
+    )
+    monkeypatch.setattr("hermes_cli.auth.deactivate_provider", lambda: None)
+
+    answers = iter(
+        [
+            "https://cch.example.com/v1",
+            "",
+            "",
+            "Claude Code Hub",
+            "codex_responses",
+        ]
+    )
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
+    monkeypatch.setattr("getpass.getpass", lambda _prompt="": "sk-cch")
+
+    hermes_main._model_flow_custom({})
+
+    config = yaml.safe_load((home / "config.yaml").read_text()) or {}
+    model = config.get("model")
+    assert isinstance(model, dict)
+    assert model["provider"] == "custom"
+    assert model["base_url"] == "https://cch.example.com/v1"
+    assert model["default"] == "gpt-5.4"
+    assert model["api_mode"] == "codex_responses"
+
+    providers = config.get("custom_providers")
+    assert isinstance(providers, list)
+    assert providers == [
+        {
+            "name": "Claude Code Hub",
+            "base_url": "https://cch.example.com/v1",
+            "api_key": "sk-cch",
+            "api_mode": "codex_responses",
+            "model": "gpt-5.4",
+        }
+    ]
+
+
+def test_model_flow_custom_auto_api_mode_clears_stale_entry(tmp_path, monkeypatch):
+    import yaml
+
+    home = tmp_path / "hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "model": {
+                    "provider": "custom",
+                    "base_url": "https://cch.example.com/v1",
+                    "default": "gpt-5.4",
+                    "api_mode": "codex_responses",
+                },
+                "custom_providers": [
+                    {
+                        "name": "Claude Code Hub",
+                        "base_url": "https://cch.example.com/v1",
+                        "api_key": "sk-cch",
+                        "api_mode": "codex_responses",
+                        "model": "gpt-5.4",
+                    }
+                ],
+            }
+        )
+    )
+    (home / ".env").write_text("")
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(
+        "hermes_cli.models.probe_api_models",
+        lambda api_key, base_url: {
+            "models": ["gpt-5.4"],
+            "probed_url": f"{base_url.rstrip('/')}/models",
+            "resolved_base_url": base_url.rstrip("/"),
+            "suggested_base_url": base_url.rstrip("/"),
+            "used_fallback": False,
+        },
+    )
+    monkeypatch.setattr("hermes_cli.auth.deactivate_provider", lambda: None)
+
+    answers = iter(
+        [
+            "https://cch.example.com/v1",
+            "",
+            "",
+            "Claude Code Hub",
+            "auto",
+        ]
+    )
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
+    monkeypatch.setattr("getpass.getpass", lambda _prompt="": "sk-cch")
+
+    hermes_main._model_flow_custom({})
+
+    config = yaml.safe_load((home / "config.yaml").read_text()) or {}
+    model = config.get("model")
+    assert isinstance(model, dict)
+    assert "api_mode" not in model
+
+    providers = config.get("custom_providers")
+    assert isinstance(providers, list)
+    assert providers == [
+        {
+            "name": "Claude Code Hub",
+            "base_url": "https://cch.example.com/v1",
+            "api_key": "sk-cch",
+            "model": "gpt-5.4",
+        }
+    ]
 
 
 def test_cmd_model_forwards_nous_login_tls_options(monkeypatch):
@@ -639,3 +773,53 @@ def test_save_custom_provider_uses_provided_name(monkeypatch, tmp_path):
     entries = saved.get("custom_providers", [])
     assert len(entries) == 1
     assert entries[0]["name"] == "Ollama"
+
+
+def test_save_custom_provider_updates_existing_api_mode(monkeypatch, tmp_path):
+    """Saving the same endpoint should update or clear persisted api_mode."""
+    import yaml
+    from hermes_cli.main import _save_custom_provider
+
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(
+        yaml.safe_dump(
+            {
+                "custom_providers": [
+                    {
+                        "name": "Claude Code Hub",
+                        "base_url": "https://cch.example.com/v1",
+                        "api_key": "sk-old",
+                        "api_mode": "chat_completions",
+                        "model": "gpt-5.4",
+                    }
+                ]
+            }
+        )
+    )
+
+    def _load():
+        return yaml.safe_load(cfg_path.read_text()) or {}
+
+    def _save(cfg):
+        cfg_path.write_text(yaml.safe_dump(cfg))
+
+    monkeypatch.setattr("hermes_cli.config.load_config", _load)
+    monkeypatch.setattr("hermes_cli.config.save_config", _save)
+
+    _save_custom_provider(
+        "https://cch.example.com/v1",
+        api_key="sk-old",
+        model="gpt-5.4",
+        api_mode="codex_responses",
+    )
+    config = yaml.safe_load(cfg_path.read_text()) or {}
+    assert config["custom_providers"][0]["api_mode"] == "codex_responses"
+
+    _save_custom_provider(
+        "https://cch.example.com/v1",
+        api_key="sk-old",
+        model="gpt-5.4",
+        api_mode=None,
+    )
+    config = yaml.safe_load(cfg_path.read_text()) or {}
+    assert "api_mode" not in config["custom_providers"][0]


### PR DESCRIPTION
### Summary                          

Manual custom endpoint setup now supports explicit `api_mode` selection.

Hermes already supports explicit transport routing such as `codex_responses` at runtime, but the manual custom endpoint flow did not expose that setting. It always relied on URL-based detection and cleared any explicit `api_mode` during save.

That made some OpenAI-compatible relays and gateways hard to configure through the CLI. A common example is CCH-style proxies: the base URL does not look like the official OpenAI/Codex endpoint, so Hermes falls back to `chat_completions`, while some relays only support `codex_responses`.  Refer to Issue: https://github.com/NousResearch/hermes-agent/issues/13415

This change adds an explicit API mode prompt to the manual custom endpoint flow so users can choose the transport they need without depending entirely on URL heuristics.


### Changes

  - Added an explicit `API mode` prompt to the manual custom endpoint flow in `hermes_cli/main.py`
  - Supported the following choices:
    - `auto`
    - `chat_completions`
    - `codex_responses`
    - `anthropic_messages`
  - Persisted explicit selections to `model.api_mode`
  - Persisted the same selection to the saved `custom_providers` entry for the endpoint
  - Kept `auto` behavior as “unset”, so existing URL-based detection continues to work as before
  - Cleared stale saved `api_mode` values when the same endpoint is reconfigured back to `auto`
  - Kept existing saved-provider behavior unchanged: no new editing UI was added for named saved providers
  - Added regression coverage in `tests/cli/test_cli_provider_resolution.py` for:
    - explicit `codex_responses` persistence
    - clearing stale `api_mode` when switching back to `auto`
    - updating an existing saved custom endpoint entry

### Validation

Ran:
  - `scripts/run_tests.sh tests/cli/test_cli_provider_resolution.py tests/hermes_cli/test_custom_provider_model_switch.py tests/hermes_cli/test_runtime_provider_resolution.py tests/hermes_cli/test_update_config_clears_custom_fields.py -q`

Result:
  - `98 passed`
