### PR TITLE
Fix AttributeError in bundle_content_hash when content is already bytes

### DIFF
--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -2630,7 +2630,10 @@ def bundle_content_hash(bundle: SkillBundle) -> str:
     """Compute a deterministic hash for an in-memory skill bundle."""
     h = hashlib.sha256()
     for rel_path in sorted(bundle.files):
-        h.update(bundle.files[rel_path].encode("utf-8"))
+        content = bundle.files[rel_path]
+        if isinstance(content, str):
+            content = content.encode("utf-8")
+        h.update(content)
     return f"sha256:{h.hexdigest()[:16]}"
 
 


### PR DESCRIPTION
## Bug Fix

The undle_content_hashunction in 	ools/skills_hub.pyailed with:



This occurred because the function assumed undle.files[rel_path]
was always a string, but it can be bytes in some cases (e.g., when reading
from certain skill bundle sources).

## Fix

Added a type check to handle both strings and bytes properly:
- If content is a string, encode it to bytes
- If content is already bytes, use it directly

## Testing

This fix allows 
hermes skills update
to work correctly without crashing.

Fixes the error reported when checking for skill updates.