### PR TITLE
feat(opencode-go): add Kimi K2.6 and Qwen3.5/3.6 Plus to curated catalog

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -292,6 +292,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "big-pickle",
     ],
     "opencode-go": [
+        "kimi-k2.6",
         "kimi-k2.5",
         "glm-5.1",
         "glm-5",
@@ -299,6 +300,8 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "mimo-v2-omni",
         "minimax-m2.7",
         "minimax-m2.5",
+        "qwen3.6-plus",
+        "qwen3.5-plus",
     ],
     "kilocode": [
         "anthropic/claude-opus-4.6",

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -102,7 +102,7 @@ _DEFAULT_PROVIDER_MODELS = {
     "ai-gateway": ["anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5", "google/gemini-3-flash"],
     "kilocode": ["anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5.4", "google/gemini-3-pro-preview", "google/gemini-3-flash-preview"],
     "opencode-zen": ["gpt-5.4", "gpt-5.3-codex", "claude-sonnet-4-6", "gemini-3-flash", "glm-5", "kimi-k2.5", "minimax-m2.7"],
-    "opencode-go": ["glm-5.1", "glm-5", "kimi-k2.5", "mimo-v2-pro", "mimo-v2-omni", "minimax-m2.5", "minimax-m2.7"],
+    "opencode-go": ["kimi-k2.6", "kimi-k2.5", "glm-5.1", "glm-5", "mimo-v2-pro", "mimo-v2-omni", "minimax-m2.5", "minimax-m2.7", "qwen3.6-plus", "qwen3.5-plus"],
     "huggingface": [
         "Qwen/Qwen3.5-397B-A17B", "Qwen/Qwen3-235B-A22B-Thinking-2507",
         "Qwen/Qwen3-Coder-480B-A35B-Instruct", "deepseek-ai/DeepSeek-R1-0528",

--- a/tests/hermes_cli/test_opencode_go_in_model_list.py
+++ b/tests/hermes_cli/test_opencode_go_in_model_list.py
@@ -15,7 +15,7 @@ def test_opencode_go_appears_when_api_key_set():
     opencode_go = next((p for p in providers if p["slug"] == "opencode-go"), None)
     
     assert opencode_go is not None, "opencode-go should appear when OPENCODE_GO_API_KEY is set"
-    assert opencode_go["models"] == ["kimi-k2.5", "glm-5.1", "glm-5", "mimo-v2-pro", "mimo-v2-omni", "minimax-m2.7", "minimax-m2.5"]
+    assert opencode_go["models"] == ["kimi-k2.6", "kimi-k2.5", "glm-5.1", "glm-5", "mimo-v2-pro", "mimo-v2-omni", "minimax-m2.7", "minimax-m2.5"]
     # opencode-go can appear as "built-in" (from PROVIDER_TO_MODELS_DEV when
     # models.dev is reachable) or "hermes" (from HERMES_OVERLAYS fallback when
     # the API is unavailable, e.g. in CI).


### PR DESCRIPTION
## Summary
`hermes model` now shows every model OpenCode Go actually offers. Previously the curated fallback was missing kimi-k2.6, qwen3.6-plus, and qwen3.5-plus, so when the live /models probe flaked users had to type those slugs via 'Enter custom model name'.

## Changes
- `hermes_cli/models.py`: opencode-go curated list → adds kimi-k2.6 (first), qwen3.6-plus, qwen3.5-plus
- `hermes_cli/setup.py`: setup-wizard defaults aligned with the same list
- `tests/hermes_cli/test_opencode_go_in_model_list.py`: assertion updated to match new top-8 slice

## Validation
```
scripts/run_tests.sh tests/hermes_cli/test_opencode_go_in_model_list.py \
  tests/hermes_cli/test_model_validation.py \
  tests/hermes_cli/test_model_provider_persistence.py \
  tests/hermes_cli/test_model_normalize.py
# 132 passed in 1.20s
```

No `opencode_model_api_mode()` change needed — kimi-k2.6 and qwen*-plus route through the existing `chat_completions` default for opencode-go (only minimax-* uses anthropic_messages). Source: https://opencode.ai/docs/go