### PR TITLE
fix: recover inline Hermes tool calls

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4286,6 +4286,38 @@ class AIAgent:
         """Split a stored tool id into (call_id, response_item_id)."""
         return _codex_split_responses_tool_id(raw_id)
 
+    def _recover_hermes_tool_calls_from_content(self, assistant_message) -> None:
+        """Parse raw Hermes-style tool-call tags from assistant content.
+
+        Some providers return tool calls inline as ``<tool_call>...</tool_call>``
+        text instead of populating structured ``tool_calls``.  When tools are
+        enabled, recover those calls so the main agent loop executes them rather
+        than treating the markup as a plain assistant reply.
+        """
+        if getattr(assistant_message, "tool_calls", None) or not self.tools:
+            return
+
+        content = getattr(assistant_message, "content", None)
+        if not isinstance(content, str) or "<tool_call>" not in content:
+            return
+
+        try:
+            from environments.tool_call_parsers import get_parser
+
+            parsed_content, parsed_calls = get_parser("hermes").parse(content)
+        except Exception:
+            return
+
+        if not parsed_calls:
+            return
+
+        assistant_message.tool_calls = parsed_calls
+        assistant_message.content = parsed_content
+        logger.info(
+            "Recovered %d Hermes-format tool call(s) from raw assistant content",
+            len(parsed_calls),
+        )
+
     def _derive_responses_function_call_id(
         self,
         call_id: str,
@@ -10834,6 +10866,8 @@ class AIAgent:
                         assistant_message.content = "\n".join(parts)
                     else:
                         assistant_message.content = str(raw)
+
+                self._recover_hermes_tool_calls_from_content(assistant_message)
 
                 try:
                     from hermes_cli.plugins import invoke_hook as _invoke_hook

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1212,6 +1212,41 @@ class TestBuildAssistantMessage:
         assert result["content"] == ""
 
 
+class TestRecoverHermesToolCalls:
+    def test_recovers_raw_tool_call_tags_from_content(self, agent):
+        msg = _mock_assistant_msg(
+            content=(
+                "Let me check that.\n"
+                '<tool_call>{"name": "web_search", "arguments": {"q": "MiniMax tool call bug"}}</tool_call>'
+            ),
+            tool_calls=None,
+        )
+
+        agent._recover_hermes_tool_calls_from_content(msg)
+
+        assert msg.content == "Let me check that."
+        assert msg.tool_calls is not None
+        assert len(msg.tool_calls) == 1
+        assert msg.tool_calls[0].function.name == "web_search"
+        assert json.loads(msg.tool_calls[0].function.arguments) == {
+            "q": "MiniMax tool call bug"
+        }
+
+    def test_does_not_recover_raw_tool_calls_when_tools_disabled(self, agent):
+        agent.tools = []
+        msg = _mock_assistant_msg(
+            content='<tool_call>{"name": "web_search", "arguments": {"q": "test"}}</tool_call>',
+            tool_calls=None,
+        )
+
+        agent._recover_hermes_tool_calls_from_content(msg)
+
+        assert msg.content == (
+            '<tool_call>{"name": "web_search", "arguments": {"q": "test"}}</tool_call>'
+        )
+        assert msg.tool_calls is None
+
+
 class TestFormatToolsForSystemMessage:
     def test_no_tools_returns_empty_array(self, agent):
         agent.tools = []


### PR DESCRIPTION
## Summary
- recover Hermes-format `<tool_call>...</tool_call>` blocks from raw assistant content when providers fail to populate structured `tool_calls`
- run the fallback only when tools are enabled, so text-only/tool-disabled sessions keep their content unchanged
- add regression coverage for both recovery and no-tools behavior

## Why
MiniMax/Anthropic-compatible responses can sometimes return valid Hermes tool-call markup inline in `content` instead of structured tool metadata. In the main agent loop that markup was treated as plain assistant text, so Telegram users could see the raw tool call and the tool never executed.

Fixes #12090.

## Testing
- `pytest -o addopts= tests/run_agent/test_run_agent.py -k "RecoverHermesToolCalls or TestBuildAssistantMessage"`
