### PR TITLE
feat(browser): add headed mode config for local browser visibility

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -252,6 +252,10 @@ BROWSER_SESSION_TIMEOUT=300
 # Browser sessions are automatically closed after this period of no activity
 BROWSER_INACTIVITY_TIMEOUT=120
 
+# Run local browser in headed (visible window) mode (default: false)
+# Useful for debugging or when you want to watch the agent interact with pages
+# AGENT_BROWSER_HEADED=false
+
 # =============================================================================
 # SESSION LOGGING
 # =============================================================================

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -426,6 +426,7 @@ DEFAULT_CONFIG = {
         "command_timeout": 30,  # Timeout for browser commands in seconds (screenshot, navigate, etc.)
         "record_sessions": False,  # Auto-record browser sessions as WebM videos
         "allow_private_urls": False,  # Allow navigating to private/internal IPs (localhost, 192.168.x.x, etc.)
+        "headed": False,  # Run local browser in headed (visible window) mode instead of headless
         "cdp_url": "",  # Optional persistent CDP endpoint for attaching to an existing Chromium/Chrome
         "camofox": {
             # When true, Hermes sends a stable profile-scoped userId to Camofox
@@ -1302,6 +1303,13 @@ OPTIONAL_ENV_VARS = {
         "description": "Camofox browser server URL for local anti-detection browsing (e.g. http://localhost:9377)",
         "prompt": "Camofox server URL",
         "url": "https://github.com/jo-inc/camofox-browser",
+        "tools": ["browser_navigate", "browser_click"],
+        "password": False,
+        "category": "tool",
+    },
+    "AGENT_BROWSER_HEADED": {
+        "description": "Run local browser in headed (visible window) mode instead of headless (default: false)",
+        "prompt": "Run browser in headed mode (true/false)",
         "tools": ["browser_navigate", "browser_click"],
         "password": False,
         "category": "tool",

--- a/tests/tools/test_browser_hardening.py
+++ b/tests/tools/test_browser_hardening.py
@@ -18,6 +18,8 @@ def _reset_caches():
     bt._agent_browser_resolved = False
     bt._cached_command_timeout = None
     bt._command_timeout_resolved = False
+    bt._cached_headed = None
+    bt._headed_resolved = False
     # lru_cache for _discover_homebrew_node_dirs
     if hasattr(bt._discover_homebrew_node_dirs, "cache_clear"):
         bt._discover_homebrew_node_dirs.cache_clear()
@@ -114,6 +116,66 @@ class TestCommandTimeoutCache:
             _get_command_timeout()
             _get_command_timeout()
         mock_read.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Caching: _get_headed
+# ---------------------------------------------------------------------------
+
+class TestHeadedCache:
+
+    def test_default_is_false(self):
+        from tools.browser_tool import _get_headed
+        with patch("hermes_cli.config.read_raw_config", return_value={}):
+            assert _get_headed() is False
+
+    def test_reads_from_config_bool_true(self):
+        from tools.browser_tool import _get_headed
+        cfg = {"browser": {"headed": True}}
+        with patch("hermes_cli.config.read_raw_config", return_value=cfg):
+            assert _get_headed() is True
+
+    def test_reads_from_config_string_truthy(self):
+        from tools.browser_tool import _get_headed
+        cfg = {"browser": {"headed": "yes"}}
+        with patch("hermes_cli.config.read_raw_config", return_value=cfg):
+            assert _get_headed() is True
+
+    def test_env_var_overrides_config(self):
+        from tools.browser_tool import _get_headed
+        cfg = {"browser": {"headed": True}}
+        with patch("hermes_cli.config.read_raw_config", return_value=cfg), \
+             patch.dict(os.environ, {"AGENT_BROWSER_HEADED": "false"}):
+            assert _get_headed() is False
+
+    def test_env_var_truthy_values(self):
+        from tools.browser_tool import _get_headed
+        for val in ("true", "1", "yes"):
+            with patch("hermes_cli.config.read_raw_config", return_value={}), \
+                 patch.dict(os.environ, {"AGENT_BROWSER_HEADED": val}):
+                assert _get_headed() is True, f"Expected True for AGENT_BROWSER_HEADED={val}"
+
+    def test_env_var_falsy_values(self):
+        from tools.browser_tool import _get_headed
+        for val in ("false", "0", "no", "random"):
+            with patch("hermes_cli.config.read_raw_config", return_value={}), \
+                 patch.dict(os.environ, {"AGENT_BROWSER_HEADED": val}):
+                assert _get_headed() is False, f"Expected False for AGENT_BROWSER_HEADED={val}"
+
+    def test_cached_after_first_call(self):
+        from tools.browser_tool import _get_headed
+        mock_read = MagicMock(return_value={"browser": {"headed": True}})
+        with patch("hermes_cli.config.read_raw_config", mock_read):
+            _get_headed()
+            _get_headed()
+        mock_read.assert_called_once()
+
+    def test_cache_cleared_by_cleanup(self):
+        import tools.browser_tool as bt
+        bt._cached_headed = True
+        bt._headed_resolved = True
+        bt.cleanup_all_browsers()
+        assert bt._headed_resolved is False
 
 
 # ---------------------------------------------------------------------------

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -207,15 +207,15 @@ _headed_resolved = False
 def _get_headed() -> bool:
     """Return whether the local browser should run in headed (visible) mode.
 
-    Checks ``config["browser"]["headed"]`` first, then falls back to the
-    ``AGENT_BROWSER_HEADED`` environment variable.  Both accept truthy
-    values (``true``, ``1``, ``yes``).  Defaults to ``False`` (headless).
-    Only meaningful for local browser mode — cloud providers and Camofox
-    are unaffected.
+    Checks ``config["browser"]["headed"]`` first.  The ``AGENT_BROWSER_HEADED``
+    environment variable takes precedence over the config value when set.
+    Both accept truthy values (``true``, ``1``, ``yes``).  Defaults to
+    ``False`` (headless).  Only meaningful for local browser mode — cloud
+    providers and Camofox are unaffected.
     """
     global _cached_headed, _headed_resolved
     if _headed_resolved:
-        return _cached_headed or False
+        return _cached_headed
 
     _headed_resolved = True
     result = False

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -200,6 +200,46 @@ def _get_command_timeout() -> int:
     return result
 
 
+_cached_headed: Optional[bool] = None
+_headed_resolved = False
+
+
+def _get_headed() -> bool:
+    """Return whether the local browser should run in headed (visible) mode.
+
+    Checks ``config["browser"]["headed"]`` first, then falls back to the
+    ``AGENT_BROWSER_HEADED`` environment variable.  Both accept truthy
+    values (``true``, ``1``, ``yes``).  Defaults to ``False`` (headless).
+    Only meaningful for local browser mode — cloud providers and Camofox
+    are unaffected.
+    """
+    global _cached_headed, _headed_resolved
+    if _headed_resolved:
+        return _cached_headed or False
+
+    _headed_resolved = True
+    result = False
+    try:
+        from hermes_cli.config import read_raw_config
+        cfg = read_raw_config()
+        val = cfg.get("browser", {}).get("headed")
+        if val is not None:
+            if isinstance(val, bool):
+                result = val
+            else:
+                result = str(val).lower() in ("true", "1", "yes")
+    except Exception as e:
+        logger.debug("Could not read headed from config: %s", e)
+
+    # Env var overrides config if set
+    env_val = os.environ.get("AGENT_BROWSER_HEADED", "").strip()
+    if env_val:
+        result = env_val.lower() in ("true", "1", "yes")
+
+    _cached_headed = result
+    return result
+
+
 def _get_vision_model() -> Optional[str]:
     """Model for browser_vision (screenshot analysis — multimodal)."""
     return os.getenv("AUXILIARY_VISION_MODEL", "").strip() or None
@@ -1149,8 +1189,10 @@ def _run_browser_command(
         # --session creates a local browser instance and silently ignores --cdp.
         backend_args = ["--cdp", session_info["cdp_url"]]
     else:
-        # Local mode — launch a headless Chromium instance
+        # Local mode — launch a headless (or headed) Chromium instance
         backend_args = ["--session", session_info["session_name"]]
+        if _get_headed():
+            backend_args.append("--headed")
 
     # Keep concrete executable paths intact, even when they contain spaces.
     # Only the synthetic npx fallback needs to expand into multiple argv items.
@@ -2332,6 +2374,10 @@ def cleanup_all_browsers() -> None:
     _discover_homebrew_node_dirs.cache_clear()
     _cached_command_timeout = None
     _command_timeout_resolved = False
+
+    global _cached_headed, _headed_resolved
+    _cached_headed = None
+    _headed_resolved = False
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Add `browser.headed` config option and `AGENT_BROWSER_HEADED` env var to run the local Chromium browser in headed (visible window) mode instead of headless.

This is useful for debugging, watching the agent interact with pages in real time, or manually intervening during login flows / captchas.

Related to #11020 (addresses the config-gap — the per-turn cleanup fix is separate).

## Changes

### `tools/browser_tool.py`
- Add `_get_headed()` function with config + env var resolution (follows the same cached-pattern as `_get_command_timeout()`)
- Pass `--headed` flag to `agent-browser` when enabled (local mode only — cloud/Camofox unaffected)
- Reset headed cache in `cleanup_all_browsers()`

### `hermes_cli/config.py`
- Add `headed: false` to `DEFAULT_CONFIG["browser"]`
- Add `AGENT_BROWSER_HEADED` to `OPTIONAL_ENV_VARS`

### `.env.example`
- Document `AGENT_BROWSER_HEADED` option with comment

### `tests/tools/test_browser_hardening.py`
- Update `_reset_caches()` to also reset headed cache
- Add `TestHeadedCache` class with 8 tests covering:
  - Default value (false)
  - Config bool true
  - Config string truthy ("yes")
  - Env var overrides config
  - Env var truthy values ("true", "1", "yes")
  - Env var falsy values ("false", "0", "no", "random")
  - Cache hit after first call
  - Cache cleared by `cleanup_all_browsers()`

## Usage

**config.yaml:**
```yaml
browser:
  headed: true
```

**Environment variable:**
```bash
export AGENT_BROWSER_HEADED=true
```

The env var takes precedence over config when set.

## Test plan

- [x] 8/8 new unit tests pass
- [x] Manually tested on macOS — Chrome window appears when `headed: true`
- [x] Headless mode still works with default `headed: false`

## Review notes

Code reviewed by Codex and Claude Code (see session for details). Key feedback addressed:
- Fixed docstring: env var "takes precedence" not "falls back to"
- Removed unnecessary `or False` on cache return
- Added test coverage
- Updated `_reset_caches()` in test helper