### PR TITLE
fix(api-server): continue compressed chat sessions from stable ids

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -867,6 +867,11 @@ class APIServerAdapter(BasePlatformAdapter):
         # only allowed when the API key is configured and the request is
         # authenticated.  Without this gate, any unauthenticated client could
         # read arbitrary session history by guessing/enumerating session IDs.
+        #
+        # If the requested session has been compressed, SessionDB records the
+        # active continuation as a child session.  Clients can keep sending the
+        # original stable ID; internally we read/write against the compression
+        # tip so new messages do not land back in an ended parent session.
         provided_session_id = request.headers.get("X-Hermes-Session-Id", "").strip()
         if provided_session_id:
             if not self._api_key:
@@ -889,10 +894,23 @@ class APIServerAdapter(BasePlatformAdapter):
                     status=400,
                 )
             session_id = provided_session_id
+            response_session_id = provided_session_id
             try:
                 db = self._ensure_session_db()
                 if db is not None:
-                    history = db.get_messages_as_conversation(session_id)
+                    effective_session_id = provided_session_id
+                    get_compression_tip = getattr(db, "get_compression_tip", None)
+                    if callable(get_compression_tip):
+                        candidate = get_compression_tip(provided_session_id)
+                        if isinstance(candidate, str) and candidate.strip():
+                            effective_session_id = candidate
+                    if effective_session_id != provided_session_id:
+                        logger.info(
+                            "session compression tip resolved: %s -> %s",
+                            provided_session_id, effective_session_id,
+                        )
+                    history = db.get_messages_as_conversation(effective_session_id)
+                    session_id = effective_session_id
             except Exception as e:
                 logger.warning("Failed to load session history for %s: %s", session_id, e)
                 history = []
@@ -907,6 +925,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     first_user = cm.get("content", "")
                     break
             session_id = _derive_chat_session_id(system_prompt, first_user)
+            response_session_id = session_id
             # history already set from request body above
 
         completion_id = f"chatcmpl-{uuid.uuid4().hex[:29]}"
@@ -974,7 +993,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
             return await self._write_sse_chat_completion(
                 request, completion_id, model_name, created, _stream_q,
-                agent_task, agent_ref, session_id=session_id,
+                agent_task, agent_ref, session_id=response_session_id,
             )
 
         # Non-streaming: run the agent (with optional Idempotency-Key)
@@ -1033,7 +1052,7 @@ class APIServerAdapter(BasePlatformAdapter):
             },
         }
 
-        return web.json_response(response_data, headers={"X-Hermes-Session-Id": session_id})
+        return web.json_response(response_data, headers={"X-Hermes-Session-Id": response_session_id})
 
     async def _write_sse_chat_completion(
         self, request: "web.Request", completion_id: str, model: str,

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2161,6 +2161,56 @@ class TestSessionIdHeader:
             assert call_kwargs["user_message"] == "new question"
 
     @pytest.mark.asyncio
+    async def test_provided_session_id_uses_compression_tip_for_history_and_writes(self, auth_adapter):
+        """Stable client ids resolve to the active compressed session tip."""
+        mock_result = {"final_response": "OK", "messages": [], "api_calls": 1}
+        db_history = [
+            {"role": "user", "content": "compressed summary"},
+            {"role": "assistant", "content": "compressed reply"},
+        ]
+        mock_db = MagicMock()
+        mock_db.get_compression_tip.return_value = "tip-session"
+        mock_db.get_messages_as_conversation.return_value = db_history
+        auth_adapter._session_db = mock_db
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"X-Hermes-Session-Id": "root-session", "Authorization": "Bearer sk-secret"},
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "new question"}]},
+                )
+
+            assert resp.status == 200
+            assert resp.headers.get("X-Hermes-Session-Id") == "root-session"
+            mock_db.get_compression_tip.assert_called_once_with("root-session")
+            mock_db.get_messages_as_conversation.assert_called_once_with("tip-session")
+            call_kwargs = mock_run.call_args.kwargs
+            assert call_kwargs["session_id"] == "tip-session"
+            assert call_kwargs["conversation_history"] == db_history
+            assert call_kwargs["user_message"] == "new question"
+
+    @pytest.mark.asyncio
+    async def test_provided_session_id_requires_api_key_configuration(self, adapter):
+        """Session continuation is rejected on unauthenticated API-server deployments."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"X-Hermes-Session-Id": "some-session"},
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "Hi"}]},
+                )
+
+            assert resp.status == 403
+            assert not mock_run.called
+            body = await resp.json()
+            assert body["error"]["type"] == "invalid_request_error"
+            assert "requires API key authentication" in body["error"]["message"]
+
+    @pytest.mark.asyncio
     async def test_db_failure_falls_back_to_empty_history(self, auth_adapter):
         """If SessionDB raises, history falls back to empty and request still succeeds."""
         mock_result = {"final_response": "OK", "messages": [], "api_calls": 1}


### PR DESCRIPTION
## What
- Resolve `X-Hermes-Session-Id` through `SessionDB.get_compression_tip()` before loading Chat Completions history.
- Bind the API-server agent to the resolved compression tip so new messages write to the active continuation session.
- Keep echoing the original client-provided `X-Hermes-Session-Id` so API clients can use a stable session id across compression.
- Add regression coverage for compressed-session read/write routing and for the existing API-key gate.

## Why this helps Hermes users
Long-running API-server conversations can be compressed by Hermes into child continuation sessions. OpenAI-compatible clients only know the stable session id they originally sent, so subsequent turns can otherwise read/write against an ended parent session after compression. This keeps the public API stable while preserving Hermes' internal compressed-session continuity.

## Compatibility
- Existing clients that do not send `X-Hermes-Session-Id` are unchanged.
- Clients that do send it still receive the same stable id in response headers.
- Session continuation remains available only when API-server authentication is configured and the request is authenticated.
- The change reuses the existing upstream `SessionDB.get_compression_tip()` helper; it does not add a new state-layer lineage resolver.

## Verification
- `scripts/run_tests.sh tests/gateway/test_api_server.py::TestSessionIdHeader` (`6 passed`)
- `scripts/run_tests.sh tests/gateway/test_api_server.py` (`119 passed` before final rebase, `TestSessionIdHeader` rerun after rebase)
- Downstream smoke against a live Hermes/Oye deployment: synthetic compressed root/tip session kept the root id stable, left root messages unchanged, wrote the new turn to the tip, and returned `OYE_COMPRESSION_OK`.