### PR TITLE
fix(telegram): slash commands respect require_mention in groups (salvage of #6036)

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2333,10 +2333,16 @@ class TelegramAdapter(BasePlatformAdapter):
         DMs remain unrestricted. Group/supergroup messages are accepted when:
         - the chat is explicitly allowlisted in ``free_response_chats``
         - ``require_mention`` is disabled
-        - the message is a command
         - the message replies to the bot
         - the bot is @mentioned
         - the text/caption matches a configured regex wake-word pattern
+
+        When ``require_mention`` is enabled, slash commands are not given
+        special treatment — they must pass the same mention/reply checks
+        as any other group message.  Users can still trigger commands via
+        the Telegram bot menu (``/command@botname``) or by explicitly
+        mentioning the bot (``@botname /command``), both of which are
+        recognised as mentions by :meth:`_message_mentions_bot`.
         """
         if not self._is_group_chat(message):
             return True
@@ -2350,8 +2356,6 @@ class TelegramAdapter(BasePlatformAdapter):
         if str(getattr(getattr(message, "chat", None), "id", "")) in self._telegram_free_response_chats():
             return True
         if not self._telegram_require_mention():
-            return True
-        if is_command:
             return True
         if self._is_reply_to_bot(message):
             return True

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -326,6 +326,7 @@ AUTHOR_MAP = {
     "aniruddhaadak80@users.noreply.github.com": "aniruddhaadak80",
     "zheng.jerilyn@gmail.com": "jerilynzheng",
     "asslaenn5@gmail.com": "Aslaaen",
+    "shalompmc0505@naver.com": "pinion05",
 }
 
 

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -71,7 +71,13 @@ def test_group_messages_can_require_direct_trigger_via_config():
     assert adapter._should_process_message(_group_message("hello everyone")) is False
     assert adapter._should_process_message(_group_message("hi @hermes_bot", entities=[_mention_entity("hi @hermes_bot")])) is True
     assert adapter._should_process_message(_group_message("replying", reply_to_bot=True)) is True
-    assert adapter._should_process_message(_group_message("/status"), is_command=True) is True
+    # Commands must also respect require_mention when it is enabled
+    assert adapter._should_process_message(_group_message("/status"), is_command=True) is False
+    # But commands with @mention still pass
+    assert adapter._should_process_message(_group_message("/status@hermes_bot")) is True
+    # And commands still pass unconditionally when require_mention is disabled
+    adapter_no_mention = _make_adapter(require_mention=False)
+    assert adapter_no_mention._should_process_message(_group_message("/status"), is_command=True) is True
 
 
 def test_free_response_chats_bypass_mention_requirement():

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -73,8 +73,12 @@ def test_group_messages_can_require_direct_trigger_via_config():
     assert adapter._should_process_message(_group_message("replying", reply_to_bot=True)) is True
     # Commands must also respect require_mention when it is enabled
     assert adapter._should_process_message(_group_message("/status"), is_command=True) is False
-    # But commands with @mention still pass
-    assert adapter._should_process_message(_group_message("/status@hermes_bot")) is True
+    # But commands with @mention still pass (Telegram emits a MENTION entity
+    # for /cmd@botname — the bot menu and python-telegram-bot's CommandHandler
+    # rely on this same mechanism)
+    assert adapter._should_process_message(
+        _group_message("/status@hermes_bot", entities=[_mention_entity("/status@hermes_bot")])
+    ) is True
     # And commands still pass unconditionally when require_mention is disabled
     adapter_no_mention = _make_adapter(require_mention=False)
     assert adapter_no_mention._should_process_message(_group_message("/status"), is_command=True) is True


### PR DESCRIPTION
## Summary
Slash commands in Telegram groups now respect `require_mention` instead of bypassing it. Fixes the multi-bot duplicate-response bug from #6033 — both bots responding to every `/command` when both had `require_mention: true`.

Salvaged from @pinion05's PR #6036.

## Changes
- `gateway/platforms/telegram.py`: drop the `if is_command: return True` shortcut in `_should_process_message()`; docstring updated to explain how commands still route through `/cmd@botname`, `@botname /cmd`, or reply-to-bot.
- `tests/gateway/test_telegram_group_gating.py`: update the `/cmd@botname` assertion to include a MENTION entity (required after Teknium's April 19 entity-only refactor in e330112a).
- `scripts/release.py`: add pinion05 AUTHOR_MAP entry.

## Validation

| Scenario | `require_mention` | Expected | Result |
|---|---|---|---|
| bare `/status` | true | filtered | ✓ |
| `/status@hermes_bot` + mention entity | true | passes | ✓ |
| `/status@other_bot` (not us) | true | filtered | ✓ |
| `/status` reply-to-bot | true | passes | ✓ |
| bare `/status` | false | passes | ✓ |

Targeted tests: `tests/gateway/test_telegram_group_gating.py` + 3 adjacent telegram files → 125/125 passing.

## Behavior change
Single-bot groups with `require_mention: true` who type bare `/cmd` will no longer get a response. The bot menu uses `/cmd@botname` automatically, so the common path is unaffected. Users with `require_mention: false` (default) see no change.

Closes #6036, closes #6033.
