### PR TITLE
fix(honcho): support base_url-only config in cmd_identity for local instances

### DIFF
--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -278,6 +278,21 @@ def _resolve_api_key(cfg: dict) -> str:
     return host_key or cfg.get("apiKey", "") or os.environ.get("HONCHO_API_KEY", "")
 
 
+def _resolve_base_url(cfg: dict) -> str:
+    """Resolve base_url with host -> root fallback (snake_case and camelCase)."""
+    host = (cfg.get("hosts") or {}).get(_host_key()) or {}
+    return (
+        host.get("baseUrl") or host.get("base_url")
+        or cfg.get("baseUrl") or cfg.get("base_url")
+        or ""
+    )
+
+
+def _is_configured(cfg: dict) -> bool:
+    """Return True if Honcho is configured with either an API key or a base_url."""
+    return bool(_resolve_api_key(cfg) or _resolve_base_url(cfg))
+
+
 def _prompt(label: str, default: str | None = None, secret: bool = False) -> str:
     suffix = f" [{default}]" if default else ""
     sys.stdout.write(f"  {label}{suffix}: ")
@@ -975,8 +990,8 @@ def cmd_tokens(args) -> None:
 def cmd_identity(args) -> None:
     """Seed AI peer identity or show both peer representations."""
     cfg = _read_config()
-    if not _resolve_api_key(cfg):
-        print("  No API key configured. Run 'hermes honcho setup' first.\n")
+    if not _is_configured(cfg):
+        print("  No API key or base_url configured. Run 'hermes honcho setup' first.\n")
         return
 
     file_path = getattr(args, "file", None)


### PR DESCRIPTION
## Problem

Local Honcho instances using `base_url` instead of an API key could not use `hermes honcho identity` — it required an API key and exited early with "No API key configured".

## Fix

Adds to `plugins/memory/honcho/cli.py`:
- `_resolve_base_url()` helper: reads `baseUrl`/`base_url` from host block and root level (camelCase + snake_case)
- `_is_configured()` helper: returns `True` if either `api_key` OR `base_url` is set
- `cmd_identity()`: uses `_is_configured()` instead of `_resolve_api_key()` only

## Note

Rebased from #2619 to target the current `plugins/memory/honcho/` layout after `honcho_integration/` was moved in the pluggable memory provider refactor (#4623).

Fixes #2613