### PR TITLE
Fix Slack mention gating and workspace routing

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -546,6 +546,10 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["require_mention"] = platform_cfg["require_mention"]
                 if "free_response_channels" in platform_cfg:
                     bridged["free_response_channels"] = platform_cfg["free_response_channels"]
+                if "allowed_channels" in platform_cfg:
+                    bridged["allowed_channels"] = platform_cfg["allowed_channels"]
+                if "dm_policy" in platform_cfg:
+                    bridged["dm_policy"] = platform_cfg["dm_policy"]
                 if "mention_patterns" in platform_cfg:
                     bridged["mention_patterns"] = platform_cfg["mention_patterns"]
                 if plat == Platform.DISCORD and "channel_skill_bindings" in platform_cfg:
@@ -574,6 +578,13 @@ def load_gateway_config() -> GatewayConfig:
                     if isinstance(frc, list):
                         frc = ",".join(str(v) for v in frc)
                     os.environ["SLACK_FREE_RESPONSE_CHANNELS"] = str(frc)
+                ac = slack_cfg.get("allowed_channels")
+                if ac is not None and not os.getenv("SLACK_ALLOWED_CHANNELS"):
+                    if isinstance(ac, list):
+                        ac = ",".join(str(v) for v in ac)
+                    os.environ["SLACK_ALLOWED_CHANNELS"] = str(ac)
+                if "dm_policy" in slack_cfg and not os.getenv("SLACK_DM_POLICY"):
+                    os.environ["SLACK_DM_POLICY"] = str(slack_cfg["dm_policy"]).lower()
 
             # Discord settings → env vars (env vars take precedence)
             discord_cfg = yaml_cfg.get("discord", {})

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -175,7 +175,7 @@ def _normalise(setting: str, value: Any) -> Any:
         if value is True:
             return "all"
         return str(value).lower()
-    if setting in ("show_reasoning", "streaming"):
+    if setting in ("show_reasoning", "interim_assistant_messages", "streaming"):
         if isinstance(value, str):
             return value.lower() in ("true", "1", "yes", "on")
         return bool(value)

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -191,6 +191,17 @@ class SlackAdapter(BasePlatformAdapter):
             async def handle_app_mention(event, say):
                 pass
 
+            # Slack echoes reaction lifecycle events, including the bot's own
+            # reactions. We don't use them, but Bolt warns if they're
+            # unhandled, so register explicit no-op listeners.
+            @self._app.event("reaction_added")
+            async def handle_reaction_added(event, say):
+                pass
+
+            @self._app.event("reaction_removed")
+            async def handle_reaction_removed(event, say):
+                pass
+
             @self._app.event("assistant_thread_started")
             async def handle_assistant_thread_started(event, say):
                 await self._handle_assistant_thread_lifecycle_event(event)
@@ -562,6 +573,32 @@ class SlackAdapter(BasePlatformAdapter):
         except Exception as e:
             logger.debug("[Slack] reactions.remove failed (%s): %s", emoji, e)
             return False
+
+    def _normalize_reaction_name(self, value: Any) -> str:
+        """Normalize optional Slack reaction config to an emoji name or empty."""
+        if value is None:
+            return ""
+        if isinstance(value, bool):
+            return "" if value is False else ""
+        normalized = str(value).strip().strip(":").lower()
+        if normalized in {"", "off", "none", "false", "disabled", "disable", "no", "0"}:
+            return ""
+        return normalized
+
+    def _slack_processing_reaction(self) -> str:
+        """Return the emoji name used while a Slack message is being processed."""
+        reaction = self.config.extra.get("processing_reaction")
+        return self._normalize_reaction_name(reaction)
+
+    def _slack_success_reaction(self) -> str:
+        """Return the emoji name used after a successful Slack response."""
+        reaction = self.config.extra.get("success_reaction")
+        return self._normalize_reaction_name(reaction)
+
+    def _slack_failure_reaction(self) -> str:
+        """Return the emoji name used after a failed Slack response."""
+        reaction = self.config.extra.get("failure_reaction")
+        return self._normalize_reaction_name(reaction)
 
     # ----- User identity resolution -----
 
@@ -993,6 +1030,15 @@ class SlackAdapter(BasePlatformAdapter):
             channel_type = "im"
         is_dm = channel_type in ("im", "mpim")  # Both 1:1 and group DMs
 
+        if is_dm and self._slack_dm_policy() == "disabled":
+            logger.debug("[Slack] Ignoring DM due to dm_policy=disabled")
+            return
+        if not is_dm:
+            allowed_channels = self._slack_allowed_channels()
+            if allowed_channels and channel_id not in allowed_channels:
+                logger.debug("[Slack] Ignoring message from non-whitelisted channel %s", channel_id)
+                return
+
         # Build thread_ts for session keying.
         # In channels: fall back to ts so each top-level @mention starts a
         #   new thread/session (the bot always replies in a thread).
@@ -1183,14 +1229,26 @@ class SlackAdapter(BasePlatformAdapter):
         # casual message would be noisy.
         _should_react = is_dm or is_mentioned
 
-        if _should_react:
-            await self._add_reaction(channel_id, ts, "eyes")
+        processing_reaction = self._slack_processing_reaction() if _should_react else ""
+        success_reaction = self._slack_success_reaction() if _should_react else ""
+        failure_reaction = self._slack_failure_reaction() if _should_react else ""
 
-        await self.handle_message(msg_event)
+        if processing_reaction:
+            await self._add_reaction(channel_id, ts, processing_reaction)
 
-        if _should_react:
-            await self._remove_reaction(channel_id, ts, "eyes")
-            await self._add_reaction(channel_id, ts, "white_check_mark")
+        try:
+            await self.handle_message(msg_event)
+        except Exception:
+            if processing_reaction and processing_reaction != failure_reaction:
+                await self._remove_reaction(channel_id, ts, processing_reaction)
+            if failure_reaction:
+                await self._add_reaction(channel_id, ts, failure_reaction)
+            raise
+
+        if processing_reaction and processing_reaction != success_reaction:
+            await self._remove_reaction(channel_id, ts, processing_reaction)
+        if success_reaction and success_reaction != processing_reaction:
+            await self._add_reaction(channel_id, ts, success_reaction)
 
     # ----- Approval button support (Block Kit) -----
 
@@ -1668,3 +1726,29 @@ class SlackAdapter(BasePlatformAdapter):
         if isinstance(raw, str) and raw.strip():
             return {part.strip() for part in raw.split(",") if part.strip()}
         return set()
+
+    def _slack_allowed_channels(self) -> set:
+        """Return the Slack channel whitelist. Empty means allow all channels."""
+        raw = self.config.extra.get("allowed_channels")
+        if raw is None:
+            raw = os.getenv("SLACK_ALLOWED_CHANNELS", "")
+        if isinstance(raw, list):
+            return {str(part).strip() for part in raw if str(part).strip()}
+        if isinstance(raw, str) and raw.strip():
+            return {part.strip() for part in raw.split(",") if part.strip()}
+        return set()
+
+    def _slack_dm_policy(self) -> str:
+        """Return Slack DM policy. Supported values: open, disabled."""
+        raw = self.config.extra.get("dm_policy")
+        if raw is None:
+            raw = os.getenv("SLACK_DM_POLICY", "")
+        if isinstance(raw, str):
+            normalized = raw.strip().lower()
+            if normalized in {"disabled", "off", "deny", "closed"}:
+                return "disabled"
+            if normalized in {"open", "enabled", "on", "allow"}:
+                return "open"
+        if isinstance(raw, bool):
+            return "open" if raw else "disabled"
+        return "open"

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -96,14 +96,6 @@ class SlackAdapter(BasePlatformAdapter):
         # Track pending approval message_ts → resolved flag to prevent
         # double-clicks on approval buttons.
         self._approval_resolved: Dict[str, bool] = {}
-        # Track timestamps of messages sent by the bot so we can respond
-        # to thread replies even without an explicit @mention.
-        self._bot_message_ts: set = set()
-        self._BOT_TS_MAX = 5000  # cap to avoid unbounded growth
-        # Track threads where the bot has been @mentioned — once mentioned,
-        # respond to ALL subsequent messages in that thread automatically.
-        self._mentioned_threads: set = set()
-        self._MENTIONED_THREADS_MAX = 5000
         # Assistant thread metadata keyed by (channel_id, thread_ts). Slack's
         # AI Assistant lifecycle events can arrive before/alongside message
         # events, and they carry the user/thread identity needed for stable
@@ -181,8 +173,8 @@ class SlackAdapter(BasePlatformAdapter):
 
             # Register message event handler
             @self._app.event("message")
-            async def handle_message_event(event, say):
-                await self._handle_slack_message(event)
+            async def handle_message_event(event, say, body):
+                await self._handle_slack_message(event, body=body)
 
             # Acknowledge app_mention events to prevent Bolt 404 errors.
             # The "message" handler above already processes @mentions in
@@ -203,12 +195,12 @@ class SlackAdapter(BasePlatformAdapter):
                 pass
 
             @self._app.event("assistant_thread_started")
-            async def handle_assistant_thread_started(event, say):
-                await self._handle_assistant_thread_lifecycle_event(event)
+            async def handle_assistant_thread_started(event, say, body):
+                await self._handle_assistant_thread_lifecycle_event(event, body=body)
 
             @self._app.event("assistant_thread_context_changed")
-            async def handle_assistant_thread_context_changed(event, say):
-                await self._handle_assistant_thread_lifecycle_event(event)
+            async def handle_assistant_thread_context_changed(event, say, body):
+                await self._handle_assistant_thread_lifecycle_event(event, body=body)
 
             # Register slash command handler
             @self._app.command("/hermes")
@@ -299,18 +291,7 @@ class SlackAdapter(BasePlatformAdapter):
 
                 last_result = await self._get_client(chat_id).chat_postMessage(**kwargs)
 
-            # Track the sent message ts so we can auto-respond to thread
-            # replies without requiring @mention.
             sent_ts = last_result.get("ts") if last_result else None
-            if sent_ts:
-                self._bot_message_ts.add(sent_ts)
-                # Also register the thread root so replies-to-my-replies work
-                if thread_ts:
-                    self._bot_message_ts.add(thread_ts)
-                if len(self._bot_message_ts) > self._BOT_TS_MAX:
-                    excess = len(self._bot_message_ts) - self._BOT_TS_MAX // 2
-                    for old_ts in list(self._bot_message_ts)[:excess]:
-                        self._bot_message_ts.discard(old_ts)
 
             return SendResult(
                 success=True,
@@ -847,7 +828,19 @@ class SlackAdapter(BasePlatformAdapter):
             return None
         return (str(channel_id), str(thread_ts))
 
-    def _extract_assistant_thread_metadata(self, event: dict) -> Dict[str, str]:
+    def _extract_team_id(self, event: dict, body: Optional[dict] = None) -> str:
+        """Resolve the Slack workspace/team id from event or outer envelope."""
+        authorizations = body.get("authorizations") if isinstance(body, dict) else None
+        first_auth = authorizations[0] if isinstance(authorizations, list) and authorizations else {}
+        return str(
+            event.get("team")
+            or event.get("team_id")
+            or (body.get("team_id") if isinstance(body, dict) else "")
+            or (first_auth.get("team_id") if isinstance(first_auth, dict) else "")
+            or ""
+        )
+
+    def _extract_assistant_thread_metadata(self, event: dict, body: Optional[dict] = None) -> Dict[str, str]:
         """Extract Slack Assistant thread identity data from an event payload."""
         assistant_thread = event.get("assistant_thread") or {}
         context = assistant_thread.get("context") or event.get("context") or {}
@@ -870,12 +863,7 @@ class SlackAdapter(BasePlatformAdapter):
             or context.get("user_id")
             or ""
         )
-        team_id = (
-            event.get("team")
-            or event.get("team_id")
-            or assistant_thread.get("team_id")
-            or ""
-        )
+        team_id = self._extract_team_id(event, body) or assistant_thread.get("team_id") or ""
         context_channel_id = context.get("channel_id") or ""
 
         return {
@@ -914,9 +902,10 @@ class SlackAdapter(BasePlatformAdapter):
         event: dict,
         channel_id: str = "",
         thread_ts: str = "",
+        body: Optional[dict] = None,
     ) -> Dict[str, str]:
         """Load cached assistant-thread metadata that matches the current event."""
-        metadata = self._extract_assistant_thread_metadata(event)
+        metadata = self._extract_assistant_thread_metadata(event, body)
         if channel_id and not metadata.get("channel_id"):
             metadata["channel_id"] = channel_id
         if thread_ts and not metadata.get("thread_ts"):
@@ -964,13 +953,17 @@ class SlackAdapter(BasePlatformAdapter):
                 exc_info=True,
             )
 
-    async def _handle_assistant_thread_lifecycle_event(self, event: dict) -> None:
+    async def _handle_assistant_thread_lifecycle_event(
+        self,
+        event: dict,
+        body: Optional[dict] = None,
+    ) -> None:
         """Handle Slack Assistant lifecycle events that carry user/thread identity."""
-        metadata = self._extract_assistant_thread_metadata(event)
+        metadata = self._extract_assistant_thread_metadata(event, body)
         self._cache_assistant_thread_metadata(metadata)
         self._seed_assistant_thread_session(metadata)
 
-    async def _handle_slack_message(self, event: dict) -> None:
+    async def _handle_slack_message(self, event: dict, body: Optional[dict] = None) -> None:
         """Handle an incoming Slack message event."""
         # Dedup: Slack Socket Mode can redeliver events after reconnects (#4777)
         event_ts = event.get("ts", "")
@@ -1010,15 +1003,12 @@ class SlackAdapter(BasePlatformAdapter):
             event,
             channel_id=channel_id,
             thread_ts=event.get("thread_ts", ""),
+            body=body,
         )
         user_id = event.get("user") or assistant_meta.get("user_id", "")
         if not channel_id:
             channel_id = assistant_meta.get("channel_id", "")
-        team_id = (
-            event.get("team")
-            or event.get("team_id")
-            or assistant_meta.get("team_id", "")
-        )
+        team_id = self._extract_team_id(event, body) or assistant_meta.get("team_id", "")
 
         # Track which workspace owns this channel
         if team_id and channel_id:
@@ -1052,10 +1042,7 @@ class SlackAdapter(BasePlatformAdapter):
         # In channels, respond if:
         #   0. Channel is in free_response_channels, OR require_mention is
         #      disabled — always process regardless of mention.
-        #   1. The bot is @mentioned in this message, OR
-        #   2. The message is a reply in a thread the bot started/participated in, OR
-        #   3. The message is in a thread where the bot was previously @mentioned, OR
-        #   4. There's an existing session for this thread (survives restarts)
+        #   1. The bot is @mentioned in this message.
         bot_uid = self._team_bot_user_ids.get(team_id, self._bot_user_id)
         is_mentioned = bot_uid and f"<@{bot_uid}>" in text
         event_thread_ts = event.get("thread_ts")
@@ -1067,34 +1054,11 @@ class SlackAdapter(BasePlatformAdapter):
             elif not self._slack_require_mention():
                 pass  # Mention requirement disabled globally for Slack
             elif not is_mentioned:
-                reply_to_bot_thread = (
-                    is_thread_reply and event_thread_ts in self._bot_message_ts
-                )
-                in_mentioned_thread = (
-                    event_thread_ts is not None
-                    and event_thread_ts in self._mentioned_threads
-                )
-                has_session = (
-                    is_thread_reply
-                    and self._has_active_session_for_thread(
-                        channel_id=channel_id,
-                        thread_ts=event_thread_ts,
-                        user_id=user_id,
-                    )
-                )
-                if not reply_to_bot_thread and not in_mentioned_thread and not has_session:
-                    return
+                return
 
         if is_mentioned:
             # Strip the bot mention from the text
             text = text.replace(f"<@{bot_uid}>", "").strip()
-            # Register this thread so all future messages auto-trigger the bot
-            if event_thread_ts:
-                self._mentioned_threads.add(event_thread_ts)
-                if len(self._mentioned_threads) > self._MENTIONED_THREADS_MAX:
-                    to_remove = list(self._mentioned_threads)[:self._MENTIONED_THREADS_MAX // 2]
-                    for t in to_remove:
-                        self._mentioned_threads.discard(t)
 
         # When entering a thread for the first time (no existing session),
         # fetch thread context so the agent understands the conversation.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2280,6 +2280,17 @@ class GatewayRunner:
         if not user_id:
             return False
 
+        # Slack authorization is split by surface:
+        # - DMs honor SLACK_ALLOWED_USERS / pairing / allow-all
+        # - Public channels rely on channel gating + @mention rules instead
+        #   of a per-user allowlist so any member can @mention the bot in an
+        #   approved channel.
+        if (
+            source.platform == Platform.SLACK
+            and getattr(source, "chat_type", None) != "dm"
+        ):
+            return True
+
         platform_env_map = {
             Platform.TELEGRAM: "TELEGRAM_ALLOWED_USERS",
             Platform.DISCORD: "DISCORD_ALLOWED_USERS",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7458,7 +7458,12 @@ class GatewayRunner:
         interim_assistant_messages_enabled = (
             source.platform != Platform.WEBHOOK
             and is_truthy_value(
-                display_config.get("interim_assistant_messages"),
+                resolve_display_setting(
+                    user_config,
+                    platform_key,
+                    "interim_assistant_messages",
+                    True,
+                ),
                 default=True,
             )
         )

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -156,6 +156,17 @@ class TestYAMLNormalisation:
         config = {"display": {"platforms": {"telegram": {"show_reasoning": "true"}}}}
         assert resolve_display_setting(config, "telegram", "show_reasoning") is True
 
+    def test_interim_assistant_messages_string_false(self):
+        """String 'false' is normalised to bool False."""
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "platforms": {"slack": {"interim_assistant_messages": "false"}},
+            }
+        }
+        assert resolve_display_setting(config, "slack", "interim_assistant_messages") is False
+
     def test_tool_preview_length_string(self):
         """String numbers are normalised to int."""
         from gateway.display_config import resolve_display_setting
@@ -218,41 +229,6 @@ class TestPlatformDefaults:
         from gateway.display_config import resolve_display_setting
 
         assert resolve_display_setting({}, "telegram", "streaming") is None
-
-
-# ---------------------------------------------------------------------------
-# get_effective_display / get_platform_defaults
-# ---------------------------------------------------------------------------
-
-class TestHelpers:
-    """Helper functions return correct composite results."""
-
-    def test_get_effective_display_merges_correctly(self):
-        from gateway.display_config import get_effective_display
-
-        config = {
-            "display": {
-                "tool_progress": "new",
-                "show_reasoning": True,
-                "platforms": {
-                    "telegram": {"tool_progress": "verbose"},
-                },
-            }
-        }
-        eff = get_effective_display(config, "telegram")
-        assert eff["tool_progress"] == "verbose"  # platform override
-        assert eff["show_reasoning"] is True       # global
-        assert "tool_preview_length" in eff        # default filled in
-
-    def test_get_platform_defaults_returns_dict(self):
-        from gateway.display_config import get_platform_defaults
-
-        defaults = get_platform_defaults("telegram")
-        assert "tool_progress" in defaults
-        assert "show_reasoning" in defaults
-        # Returns a new dict (not the shared tier dict)
-        defaults["tool_progress"] = "changed"
-        assert get_platform_defaults("telegram")["tool_progress"] != "changed"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -573,6 +573,27 @@ class TestMessageRouting:
         assert "<@U_BOT>" not in msg_event.text
 
     @pytest.mark.asyncio
+    async def test_channel_message_uses_body_team_id_when_event_omits_it(self, adapter):
+        """Socket Mode envelopes can carry team_id only on the outer body."""
+        event = {
+            "text": "<@U_BOT> hello",
+            "user": "U_USER",
+            "channel": "C123",
+            "channel_type": "channel",
+            "ts": "1234567890.000001",
+        }
+        body = {
+            "authorizations": [
+                {"team_id": "T_TEAM"}
+            ]
+        }
+
+        await adapter._handle_slack_message(event, body=body)
+
+        assert adapter._channel_team["C123"] == "T_TEAM"
+        adapter.handle_message.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_bot_messages_ignored(self, adapter):
         """Messages from bots should be ignored."""
         event = {
@@ -1192,10 +1213,10 @@ class TestThreadReplyHandling:
         adapter_with_session_store.handle_message.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_thread_reply_without_mention_with_session_processed(
+    async def test_thread_reply_without_mention_with_session_ignored(
         self, adapter_with_session_store, mock_session_store
     ):
-        """Thread replies without mention should be processed if there's an active session."""
+        """Thread replies without mention should still be ignored in channels."""
         # Simulate an active session for this thread
         session_key = "agent:main:slack:group:C123:123.000:U_USER"
         mock_session_store._entries = {session_key: MagicMock()}
@@ -1210,11 +1231,7 @@ class TestThreadReplyHandling:
             "team": "T_TEAM",
         }
         await adapter_with_session_store._handle_slack_message(event)
-        adapter_with_session_store.handle_message.assert_called_once()
-
-        # Verify the text is passed through unchanged (no mention stripping needed)
-        msg_event = adapter_with_session_store.handle_message.call_args[0][0]
-        assert msg_event.text == "Follow-up question"
+        adapter_with_session_store.handle_message.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_thread_reply_with_mention_strips_bot_id(

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -86,6 +86,16 @@ def _redirect_cache(tmp_path, monkeypatch):
     monkeypatch.setattr(
         "gateway.platforms.base.DOCUMENT_CACHE_DIR", tmp_path / "doc_cache"
     )
+    for key in (
+        "SLACK_ALLOWED_CHANNELS",
+        "SLACK_DM_POLICY",
+        "SLACK_FREE_RESPONSE_CHANNELS",
+        "SLACK_REQUIRE_MENTION",
+        "SLACK_DM_CHANNELS",
+        "SLACK_MENTION_PATTERNS",
+        "SLACK_ALLOW_BOTS",
+    ):
+        monkeypatch.delenv(key, raising=False)
 
 
 # ---------------------------------------------------------------------------
@@ -493,6 +503,20 @@ class TestMessageRouting:
         adapter.handle_message.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_dm_ignored_when_dm_policy_disabled(self, adapter):
+        """DMs should be ignored when Slack dm_policy disables them."""
+        adapter.config.extra["dm_policy"] = "disabled"
+        event = {
+            "text": "hello",
+            "user": "U_USER",
+            "channel": "D123",
+            "channel_type": "im",
+            "ts": "1234567890.000001",
+        }
+        await adapter._handle_slack_message(event)
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_channel_message_requires_mention(self, adapter):
         """Channel messages without a bot mention should be ignored."""
         event = {
@@ -504,6 +528,34 @@ class TestMessageRouting:
         }
         await adapter._handle_slack_message(event)
         adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_channel_message_ignored_when_not_in_allowed_channels(self, adapter):
+        """Channel allowlist should block messages even when they mention the bot."""
+        adapter.config.extra["allowed_channels"] = ["C_ALLOWED"]
+        event = {
+            "text": "<@U_BOT> hello",
+            "user": "U_USER",
+            "channel": "C_BLOCKED",
+            "channel_type": "channel",
+            "ts": "1234567890.000001",
+        }
+        await adapter._handle_slack_message(event)
+        adapter.handle_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_channel_message_processed_when_in_allowed_channels(self, adapter):
+        """Channel allowlist should still permit configured channels."""
+        adapter.config.extra["allowed_channels"] = ["C123"]
+        event = {
+            "text": "<@U_BOT> what's the weather?",
+            "user": "U_USER",
+            "channel": "C123",
+            "channel_type": "channel",
+            "ts": "1234567890.000001",
+        }
+        await adapter._handle_slack_message(event)
+        adapter.handle_message.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_channel_mention_strips_bot_id(self, adapter):
@@ -1005,8 +1057,8 @@ class TestReactions:
         assert result is True
 
     @pytest.mark.asyncio
-    async def test_reactions_in_message_flow(self, adapter):
-        """Reactions should be added on receipt and swapped on completion."""
+    async def test_reactions_disabled_by_default(self, adapter):
+        """Slack message reactions are opt-in to avoid duplicate visible ACKs."""
         adapter._app.client.reactions_add = AsyncMock()
         adapter._app.client.reactions_remove = AsyncMock()
         adapter._app.client.users_info = AsyncMock(return_value={
@@ -1022,7 +1074,29 @@ class TestReactions:
         }
         await adapter._handle_slack_message(event)
 
-        # Should have added 👀, then removed 👀, then added ✅
+        adapter._app.client.reactions_add.assert_not_called()
+        adapter._app.client.reactions_remove.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_reactions_in_message_flow_when_enabled(self, adapter):
+        """Opt-in reactions should be added on receipt and swapped on completion."""
+        adapter.config.extra["processing_reaction"] = "eyes"
+        adapter.config.extra["success_reaction"] = "white_check_mark"
+        adapter._app.client.reactions_add = AsyncMock()
+        adapter._app.client.reactions_remove = AsyncMock()
+        adapter._app.client.users_info = AsyncMock(return_value={
+            "user": {"profile": {"display_name": "Tyler"}}
+        })
+
+        event = {
+            "text": "hello",
+            "user": "U_USER",
+            "channel": "C123",
+            "channel_type": "im",
+            "ts": "1234567890.000001",
+        }
+        await adapter._handle_slack_message(event)
+
         add_calls = adapter._app.client.reactions_add.call_args_list
         remove_calls = adapter._app.client.reactions_remove.call_args_list
         assert len(add_calls) == 2
@@ -1030,6 +1104,40 @@ class TestReactions:
         assert add_calls[1].kwargs["name"] == "white_check_mark"
         assert len(remove_calls) == 1
         assert remove_calls[0].kwargs["name"] == "eyes"
+
+    @pytest.mark.asyncio
+    async def test_reactions_can_keep_processing_emoji_on_success(self, adapter):
+        """When success_reaction matches processing_reaction, keep only one emoji."""
+        adapter.config.extra["processing_reaction"] = "eyes"
+        adapter.config.extra["success_reaction"] = "eyes"
+        adapter._app.client.reactions_add = AsyncMock()
+        adapter._app.client.reactions_remove = AsyncMock()
+        adapter._app.client.users_info = AsyncMock(return_value={
+            "user": {"profile": {"display_name": "Tyler"}}
+        })
+
+        event = {
+            "text": "hello",
+            "user": "U_USER",
+            "channel": "C123",
+            "channel_type": "im",
+            "ts": "1234567890.000001",
+        }
+        await adapter._handle_slack_message(event)
+
+        add_calls = adapter._app.client.reactions_add.call_args_list
+        remove_calls = adapter._app.client.reactions_remove.call_args_list
+        assert len(add_calls) == 1
+        assert add_calls[0].kwargs["name"] == "eyes"
+        assert len(remove_calls) == 0
+
+    def test_reaction_normalization_treats_falsey_aliases_as_disabled(self, adapter):
+        """False/off-style values should disable reactions instead of becoming literal names."""
+        assert adapter._normalize_reaction_name(None) == ""
+        assert adapter._normalize_reaction_name(False) == ""
+        assert adapter._normalize_reaction_name("off") == ""
+        assert adapter._normalize_reaction_name(":disabled:") == ""
+        assert adapter._normalize_reaction_name(" :eyes: ") == "eyes"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_slack_mention.py
+++ b/tests/gateway/test_slack_mention.py
@@ -194,10 +194,7 @@ def _would_process(adapter, *, is_dm=False, channel_id=CHANNEL_ID,
         elif not adapter._slack_require_mention():
             return True
         elif not is_mentioned:
-            if thread_reply and active_session:
-                return True
-            else:
-                return False
+            return False
     return True
 
 
@@ -237,12 +234,12 @@ def test_mentioned_message_always_processed():
     assert _would_process(adapter, mentioned=True, text="what's up") is True
 
 
-def test_thread_reply_with_active_session_processed():
+def test_thread_reply_with_active_session_still_requires_mention():
     adapter = _make_adapter(require_mention=True)
     assert _would_process(
         adapter, text="followup",
         thread_reply=True, active_session=True,
-    ) is True
+    ) is False
 
 
 def test_thread_reply_without_active_session_ignored():

--- a/tests/gateway/test_unauthorized_dm_behavior.py
+++ b/tests/gateway/test_unauthorized_dm_behavior.py
@@ -51,6 +51,22 @@ def _make_event(platform: Platform, user_id: str, chat_id: str) -> MessageEvent:
     )
 
 
+def _make_source(
+    platform: Platform,
+    user_id: str,
+    chat_id: str,
+    *,
+    chat_type: str = "dm",
+) -> SessionSource:
+    return SessionSource(
+        platform=platform,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name="tester",
+        chat_type=chat_type,
+    )
+
+
 def _make_runner(platform: Platform, config: GatewayConfig):
     from gateway.run import GatewayRunner
 
@@ -128,6 +144,41 @@ def test_star_wildcard_works_for_any_platform(monkeypatch):
         chat_type="dm",
     )
     assert runner._is_user_authorized(source) is True
+
+
+def test_slack_dm_allowlist_still_applies(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("SLACK_ALLOWED_USERS", "U_ALLOWED")
+
+    runner, _adapter = _make_runner(
+        Platform.SLACK,
+        GatewayConfig(platforms={Platform.SLACK: PlatformConfig(enabled=True, token="xoxb-fake")}),
+    )
+
+    allowed_dm = _make_source(Platform.SLACK, "U_ALLOWED", "D123", chat_type="dm")
+    blocked_dm = _make_source(Platform.SLACK, "U_BLOCKED", "D456", chat_type="dm")
+
+    assert runner._is_user_authorized(allowed_dm) is True
+    assert runner._is_user_authorized(blocked_dm) is False
+
+
+def test_slack_channel_mentions_bypass_user_allowlist(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("SLACK_ALLOWED_USERS", "U_DM_ONLY")
+
+    runner, _adapter = _make_runner(
+        Platform.SLACK,
+        GatewayConfig(platforms={Platform.SLACK: PlatformConfig(enabled=True, token="xoxb-fake")}),
+    )
+
+    public_source = _make_source(
+        Platform.SLACK,
+        "U_SOMEONE_ELSE",
+        "C123",
+        chat_type="channel",
+    )
+
+    assert runner._is_user_authorized(public_source) is True
 
 
 @pytest.mark.asyncio

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1162,6 +1162,23 @@ discord:
 - `free_response_channels` — comma-separated list of channel IDs where the bot responds to every message without requiring a mention.
 - `auto_thread` — when `true` (default), mentions in channels automatically create a thread for the conversation, keeping channels clean (similar to Slack threading).
 
+## Slack
+
+Configure Slack-specific behavior for the messaging gateway:
+
+```yaml
+slack:
+  require_mention: true          # Require @mention in channels by default
+  free_response_channels: []     # Channel IDs that do not require @mention
+  allowed_channels: []           # Optional channel whitelist
+  dm_policy: "open"              # open | disabled
+```
+
+- `require_mention` — when `true` (default), Hermes only responds in Slack channels when mentioned, unless the channel is listed in `free_response_channels`.
+- `free_response_channels` — channel IDs where Hermes responds to every message without needing `@mention`.
+- `allowed_channels` — optional whitelist. When set, Hermes ignores channel messages outside the listed channel IDs.
+- `dm_policy` — controls Slack DM handling. Use `disabled` if you want Hermes to ignore direct messages.
+
 ## Security
 
 Pre-execution security scanning and secret redaction:

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -209,12 +209,12 @@ Understanding how Hermes behaves in different contexts:
 
 | Context | Behavior |
 |---------|----------|
-| **DMs** | Bot responds to every message — no @mention needed |
-| **Channels** | Bot **only responds when @mentioned** (e.g., `@Hermes Agent what time is it?`). In channels, Hermes replies in a thread attached to that message. |
+| **DMs** | Bot responds to every message by default. You can disable DMs with `slack.dm_policy: disabled`. |
+| **Channels** | Bot responds when @mentioned by default (e.g., `@Hermes Agent what time is it?`). You can relax this with `free_response_channels` or `require_mention: false`, and you can restrict replies with `allowed_channels`. |
 | **Threads** | If you @mention Hermes inside an existing thread, it replies in that same thread. Once the bot has an active session in a thread, **subsequent replies in that thread do not require @mention** — the bot follows the conversation naturally. |
 
 :::tip
-In channels, always @mention the bot to start a conversation. Once the bot is active in a thread, you can reply in that thread without mentioning it. Outside of threads, messages without @mention are ignored to prevent noise in busy channels.
+Default Slack behavior is: DMs are open, channels require `@mention`, and active threads continue without repeated mentions. If the bot responds without an `@mention`, the usual causes are `free_response_channels`, `require_mention: false`, or an existing Slack thread/session the bot is already participating in.
 :::
 
 ---
@@ -268,9 +268,20 @@ Set to `false` if you want a collaborative mode where the entire channel shares 
 ```yaml
 slack:
   # Require @mention in channels (this is the default behavior;
-  # the Slack adapter enforces @mention gating in channels regardless,
-  # but you can set this explicitly for consistency with other platforms)
+  # set false to allow channel messages without mention)
   require_mention: true
+
+  # Channel IDs where Hermes responds without an @mention
+  free_response_channels:
+    - C01234567890
+
+  # If set, Hermes only responds in these channel IDs
+  allowed_channels:
+    - C01234567890
+    - C02345678901
+
+  # DM policy: "open" (default) or "disabled"
+  dm_policy: "open"
 
   # Custom mention patterns that trigger the bot
   # (in addition to the default @mention detection)
@@ -282,9 +293,28 @@ slack:
   reply_prefix: ""
 ```
 
-:::info
-Unlike Discord and Telegram, Slack does not have a `free_response_channels` equivalent. The Slack adapter requires `@mention` to start a conversation in channels. However, once the bot has an active session in a thread, subsequent thread replies do not require a mention. In DMs, the bot always responds without needing a mention.
-:::
+| Key | Default | Description |
+|-----|---------|-------------|
+| `slack.require_mention` | `true` | When `true`, channel messages need `@mention` unless another trigger rule applies. |
+| `slack.free_response_channels` | empty | Channel IDs where Hermes responds to every message without an `@mention`. |
+| `slack.allowed_channels` | empty | Channel whitelist. When set, Hermes ignores messages outside these channels. |
+| `slack.dm_policy` | `"open"` | Controls DM handling. Use `"disabled"` to ignore Slack DMs entirely. |
+| `slack.mention_patterns` | empty | Extra text patterns that should trigger Hermes in addition to native Slack mentions. |
+
+### Reactions
+
+Hermes can add Slack reactions as lightweight status indicators while it is processing a message.
+
+```yaml
+platforms:
+  slack:
+    extra:
+      processing_reaction: "eyes"
+      success_reaction: "white_check_mark"
+      failure_reaction: "x"
+```
+
+These reactions are opt-in. If unset, Hermes will not add any reactions.
 
 ### Unauthorized User Handling
 
@@ -324,6 +354,11 @@ stt_enabled: true
 # Slack-specific settings
 slack:
   require_mention: true
+  free_response_channels:
+    - C01234567890
+  allowed_channels:
+    - C01234567890
+  dm_policy: "open"
   unauthorized_dm_behavior: "pair"
 
 # Platform config
@@ -333,6 +368,8 @@ platforms:
     extra:
       reply_in_thread: true
       reply_broadcast: false
+      processing_reaction: "eyes"
+      success_reaction: "white_check_mark"
 ```
 
 ---


### PR DESCRIPTION
## Summary
- require explicit @mentions for Slack messages in public channels instead of auto-continuing thread/session replies
- apply `SLACK_ALLOWED_USERS` only to Slack DMs so allowed channels can respond to any user who mentions the bot
- resolve Slack workspace/team IDs from the Socket Mode envelope body so replies use the correct workspace client and avoid `channel_not_found`

## Testing
- /Users/onekey/.hermes/hermes-agent/venv/bin/python -m pytest /Users/onekey/.hermes/hermes-agent/tests/gateway/test_slack.py /Users/onekey/.hermes/hermes-agent/tests/gateway/test_slack_mention.py /Users/onekey/.hermes/hermes-agent/tests/gateway/test_unauthorized_dm_behavior.py -q