### PR TITLE
fix(permissions): handle None response from ACP request_permission

### DIFF
--- a/acp_adapter/permissions.py
+++ b/acp_adapter/permissions.py
@@ -63,6 +63,9 @@ def make_approval_callback(
             logger.warning("Permission request timed out or failed: %s", exc)
             return "deny"
 
+        if response is None:
+            return "deny"
+
         outcome = response.outcome
         if isinstance(outcome, AllowedOutcome):
             option_id = outcome.option_id

--- a/tests/acp/test_permissions.py
+++ b/tests/acp/test_permissions.py
@@ -73,3 +73,17 @@ class TestApprovalMapping:
             result = cb("rm -rf /", "dangerous")
 
         assert result == "deny"
+
+    def test_approval_none_response_returns_deny(self):
+        """When request_permission resolves to None, the callback should return 'deny'."""
+        loop = MagicMock(spec=asyncio.AbstractEventLoop)
+        mock_rp = MagicMock(name="request_permission")
+
+        future = MagicMock(spec=Future)
+        future.result.return_value = None
+
+        with patch("acp_adapter.permissions.asyncio.run_coroutine_threadsafe", return_value=future):
+            cb = make_approval_callback(mock_rp, loop, session_id="s1", timeout=1.0)
+            result = cb("echo hi", "demo")
+
+        assert result == "deny"


### PR DESCRIPTION
## What does this PR do?
This PR hardens the ACP ? Hermes permission-approval bridge by safely handling an unexpected None result from equest_permission, preventing attribute errors and defaulting to a safe deny.

## Related Issue
Fixes #13449

## Type of Change
- [x] ?? Bug fix (non-breaking change that fixes an issue)
- [ ] ? New feature (non-breaking change that adds functionality)
- [ ] ?? Security fix
- [ ] ?? Documentation update
- [x] ? Tests (adding or improving test coverage)
- [ ] ?? Refactor (no behavior change)
- [ ] ?? New skill (bundled or hub)

## Changes Made
- Return "deny" when equest_permission resolves to None in the approval callback.
- Add a unit test covering the None response case to ensure the callback denies safely.

## How to Test
1. Connect via an ACP client that sends an empty response to permission requests.
2. Verify the permission is denied rather than throwing an exception.

## Checklist
### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run pytest tests/ -q and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform

### Documentation & Housekeeping
- [x] I've updated relevant documentation (README, docs/, docstrings) � or N/A
- [x] I've updated cli-config.yaml.example if I added/changed config keys � or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows � or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide � or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior � or N/A
