### PR TITLE
fix(anthropic): prevent cache_control overload with LiteLLM-style proxies

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1270,6 +1270,47 @@ def convert_messages_to_anthropic(
     return system, result
 
 
+def _cap_cache_control_markers(kwargs: dict, max_markers: int = 4) -> None:
+    """Cap total cache_control markers in the final kwargs at Anthropic's limit.
+
+    The system_and_3 caching strategy assumes 4 distinct messages each get
+    ONE marker. But when multiple consecutive tool-role messages merge into
+    a single Anthropic user message (each carrying its own cache_control on
+    the resulting tool_result block), the total marker count can exceed 4 —
+    producing HTTP 400 "A maximum of 4 blocks with cache_control may be
+    provided".
+
+    Scan system + messages in order (oldest first), keep the rightmost
+    max_markers, strip the rest. Rightmost wins because the end of the
+    conversation is where cache-prefix boundaries are most valuable.
+    Tool definitions are untouched (they live in kwargs['tools'] and are
+    caller-managed).
+    """
+    locations = []  # dicts carrying cache_control, oldest first
+
+    system = kwargs.get("system")
+    if isinstance(system, list):
+        for block in system:
+            if isinstance(block, dict) and block.get("cache_control"):
+                locations.append(block)
+
+    for msg in kwargs.get("messages", []) or []:
+        if isinstance(msg, dict):
+            if isinstance(msg.get("cache_control"), dict):
+                locations.append(msg)
+            content = msg.get("content")
+            if isinstance(content, list):
+                for block in content:
+                    if isinstance(block, dict) and block.get("cache_control"):
+                        locations.append(block)
+
+    excess = len(locations) - max_markers
+    if excess <= 0:
+        return
+    for container in locations[:excess]:
+        container.pop("cache_control", None)
+
+
 def build_anthropic_kwargs(
     model: str,
     messages: List[Dict],
@@ -1454,6 +1495,18 @@ def build_anthropic_kwargs(
             betas.extend(_OAUTH_ONLY_BETAS)
         betas.append(_FAST_MODE_BETA)
         kwargs["extra_headers"] = {"anthropic-beta": ",".join(betas)}
+
+    # Safety net: cap cache_control markers at Anthropic's 4-breakpoint limit.
+    # Prevents HTTP 400 when tool-result merging clusters multiple markers
+    # onto a single Anthropic message.
+    # For third-party Anthropic-compatible proxies (LiteLLM-style, e.g.
+    # llm.echo.tech) strip ALL markers — the proxy auto-injects its own
+    # cache hints upstream, and anything we send stacks on top and
+    # deterministically exceeds 4.
+    if _is_third_party_anthropic_endpoint(base_url):
+        _cap_cache_control_markers(kwargs, max_markers=0)
+    else:
+        _cap_cache_control_markers(kwargs, max_markers=4)
 
     return kwargs
 

--- a/agent/prompt_caching.py
+++ b/agent/prompt_caching.py
@@ -38,6 +38,18 @@ def _apply_cache_marker(msg: dict, cache_marker: dict, native_anthropic: bool = 
             last["cache_control"] = cache_marker
 
 
+def _strip_all_cache_control(msg: dict) -> None:
+    """Remove any cache_control markers that may have leaked in from previous
+    turns or upstream history. Prevents accumulation across turns which would
+    otherwise exceed Anthropic/Bedrock's 4-breakpoint limit."""
+    msg.pop("cache_control", None)
+    content = msg.get("content")
+    if isinstance(content, list):
+        for block in content:
+            if isinstance(block, dict):
+                block.pop("cache_control", None)
+
+
 def apply_anthropic_cache_control(
     api_messages: List[Dict[str, Any]],
     cache_ttl: str = "5m",
@@ -53,6 +65,12 @@ def apply_anthropic_cache_control(
     messages = copy.deepcopy(api_messages)
     if not messages:
         return messages
+
+    # Scrub any pre-existing cache_control markers so we don't accumulate
+    # breakpoints across turns (would exceed the 4-breakpoint limit and
+    # trigger HTTP 400 on Anthropic/Bedrock).
+    for m in messages:
+        _strip_all_cache_control(m)
 
     marker = {"type": "ephemeral"}
     if cache_ttl == "1h":


### PR DESCRIPTION
## TL;DR

When Hermes uses `provider: anthropic` + a non-`api.anthropic.com` `base_url` (e.g., `llm.echo.tech` or any self-hosted LiteLLM), every tool-heavy turn deterministically fails with:

```
HTTP 400 "A maximum of 4 blocks with cache_control may be provided. Found 5"
```

Root cause: the proxy injects its own `cache_control` markers server-side before forwarding to Anthropic/Bedrock. Whatever we send from the client stacks on top of what the proxy adds, blowing past the 4-breakpoint limit.

This PR adds two layered defenses:

1. `_strip_all_cache_control` in `prompt_caching.py` — scrubs accumulated markers from session history before reapplying fresh ones each turn (prevents intra-client accumulation across turns).
2. `_cap_cache_control_markers` in `anthropic_adapter.py`, invoked at the end of `build_anthropic_kwargs` — caps total markers in the outgoing request; **strips all of them** when `_is_third_party_anthropic_endpoint(base_url)` is true.

## Reproduction

1. Configure Hermes:
   ```yaml
   model:
     default: "claude-sonnet-4-6"
     provider: "anthropic"
     base_url: "https://llm.echo.tech"    # or any LiteLLM proxy
   ```
2. Run any multi-turn task that fires ≥4 consecutive tool calls (e.g., a skill that uses `terminal` repeatedly).
3. Observe the HTTP 400 above on turn 5–7 depending on how aggressively the proxy injects.

## Debug trail (for reviewers who want the receipts)

Narrowing the root cause took three iterations. Each is concrete — the comparison between **client-side marker count** and the server's **"Found N"** number is what pinpointed the proxy as the added party:

| phase | fix attempted | dump markers | server says | verdict |
|------|--------------|-------------|------------|---------|
| 1 | Scrub accumulated markers (`_strip_all_cache_control` on load) | 5 → 4 | Found 5 | still over — client isn't the only source |
| 2 | Cap at end of `build_anthropic_kwargs` (max_markers=4) | 4 | Found 5 | **proxy is adding 1** |
| 3 | Cap to 3 as stress test | 3 | Found 5 | **proxy is adding 2 on some turns** |
| 4 | Cap to 0 for third-party proxies only | 0 | (no error) | ✅ — pass through no markers, proxy manages its own |

Cost: we lose client-side prompt-prefix caching hints on LiteLLM-style endpoints. That's acceptable — LiteLLM proxies typically implement their own server-side prompt caching anyway, and correctness beats an optimization that deterministically 400s.

Native Anthropic and OpenRouter paths keep the existing 4-marker strategy unchanged.

## Related

A cleaner long-term fix may be to teach `_anthropic_prompt_cache_policy` to return `(False, False)` for third-party LiteLLM-style endpoints — i.e., don't emit markers at all rather than cap them after the fact. Happy to follow up with that approach if the maintainers prefer. This PR keeps the change minimal and scoped to the one call site that actually ships requests.

## Test plan

- [x] Existing Hermes deploy on `llm.echo.tech`: 8-tool-call skill invocation, completed in 24s with zero HTTP 400. Before this patch, the same skill failed on turn 5.
- [x] `python3 -m py_compile agent/anthropic_adapter.py agent/prompt_caching.py` — clean
- [ ] Unit test to be added if maintainers request — the behavior is a post-transform on `kwargs` and is trivially testable.
