### PR TITLE
fix(docker): fix HERMES_UID permission handling and add docker-compose.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,5 @@ mini-swe-agent/
 .nix-stamps/
 result
 website/static/api/skills-index.json
+
+.hermes

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,15 @@ COPY --chown=hermes:hermes . .
 # Build web dashboard (Vite outputs to hermes_cli/web_dist/)
 RUN cd web && npm run build
 
+# ---------- Permissions ----------
+# Make install dir world-readable so any HERMES_UID can read it at runtime.
+# The venv needs to be traversable too.
+USER root
+RUN chmod -R a+rX /opt/hermes
+# Start as root so the entrypoint can usermod/groupmod + gosu.
+# If HERMES_UID is unset, the entrypoint drops to the default hermes user (10000).
+
 # ---------- Python virtualenv ----------
-RUN chown hermes:hermes /opt/hermes
-USER hermes
 RUN uv venv && \
     uv pip install --no-cache-dir -e ".[all]"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+services:
+  gateway:
+    build: .
+    image: hermes-agent
+    container_name: hermes
+    restart: unless-stopped
+    network_mode: host
+    volumes:
+      - ~/.hermes:/opt/data
+    environment:
+      - HERMES_UID=${HERMES_UID:-1001}
+      - HERMES_GID=${HERMES_GID:-1001}
+      # Uncomment to expose API server beyond localhost (requires API_SERVER_KEY):
+      # - API_SERVER_HOST=0.0.0.0
+      # - API_SERVER_KEY=${API_SERVER_KEY}
+    command: ["gateway", "run"]
+
+  dashboard:
+    image: hermes-agent
+    container_name: hermes-dashboard
+    restart: unless-stopped
+    network_mode: host
+    depends_on:
+      - gateway
+    volumes:
+      - ~/.hermes:/opt/data
+    environment:
+      - HERMES_UID=${HERMES_UID:-1001}
+      - HERMES_GID=${HERMES_GID:-1001}
+    command: ["dashboard", "--host", "0.0.0.0", "--insecure"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -22,9 +22,18 @@ if [ "$(id -u)" = "0" ]; then
         groupmod -o -g "$HERMES_GID" hermes 2>/dev/null || true
     fi
 
+    # Fix ownership of the data volume. When HERMES_UID remaps the hermes user,
+    # files created by previous runs (under the old UID) become inaccessible.
+    # Always chown -R when UID was remapped; otherwise only if top-level is wrong.
     actual_hermes_uid=$(id -u hermes)
-    if [ "$(stat -c %u "$HERMES_HOME" 2>/dev/null)" != "$actual_hermes_uid" ]; then
-        echo "$HERMES_HOME is not owned by $actual_hermes_uid, fixing"
+    needs_chown=false
+    if [ -n "$HERMES_UID" ] && [ "$HERMES_UID" != "10000" ]; then
+        needs_chown=true
+    elif [ "$(stat -c %u "$HERMES_HOME" 2>/dev/null)" != "$actual_hermes_uid" ]; then
+        needs_chown=true
+    fi
+    if [ "$needs_chown" = true ]; then
+        echo "Fixing ownership of $HERMES_HOME to hermes ($actual_hermes_uid)"
         # In rootless Podman the container's "root" is mapped to an unprivileged
         # host UID — chown will fail.  That's fine: the volume is already owned
         # by the mapped user on the host side.


### PR DESCRIPTION
## What does this PR do?
- Remove 'USER hermes' from Dockerfile so entrypoint runs as root and can usermod/groupmod before gosu drop. Add chmod -R a+rX /opt/hermes so any remapped UID can read the install directory.
- Fix entrypoint chown logic: always chown -R when HERMES_UID is remapped from default 10000, not just when top-level dir ownership mismatches.
- Add docker-compose.yml with gateway + dashboard services.
- Add .hermes to .gitignore.

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->
- Fixes volume path permission denied when trying to run hermes-agent in docker with `HERMES_UID` and `HERMES_GID` specified;
- Add docker-compose.yml file;
- Add `.hermes` in .gitignore;

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->
- Dockerfile: Make install dir world-readable so any HERMES_UID can read it at runtime.
- docker/entrypoint.sh: Fix ownership of the data volume.
- docker-compose.yml: Add docker compose file.
- .gitignore: Add `.hermes` so developers/users can create symlink to `~/.hermes`.

## How to Test

1. docker build -t hermes-agent .
2. docker compose up -t
3. docker ps | grep hermes


