### PR TITLE
fix(tools): fix discord tool schema type mismatch for Gemini

### DIFF
--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -422,14 +422,14 @@ def _create_thread(
         path = f"/channels/{channel_id}/messages/{message_id}/threads"
         body: Dict[str, Any] = {
             "name": name,
-            "auto_archive_duration": auto_archive_duration,
+            "auto_archive_duration": int(auto_archive_duration),
         }
     else:
         # Create a standalone thread
         path = f"/channels/{channel_id}/threads"
         body = {
             "name": name,
-            "auto_archive_duration": auto_archive_duration,
+            "auto_archive_duration": int(auto_archive_duration),
             "type": 11,  # PUBLIC_THREAD
         }
     thread = _discord_request("POST", path, token, body=body)
@@ -669,9 +669,9 @@ def _build_schema(
             "description": "Snowflake ID for forward pagination (fetch_messages).",
         },
         "auto_archive_duration": {
-            "type": "integer",
-            "enum": [60, 1440, 4320, 10080],
-            "description": "Thread archive duration in minutes (create_thread, default 1440).",
+            "type": "string",
+            "description": "Duration before the channel is automatically archived (minutes).",
+            "enum": ["60", "1440", "4320", "10080"],
         },
     }
 


### PR DESCRIPTION
## What does this PR do?

Resolves an issue where the `discord_server` tool causes Google Gemini API requests to fail with `HTTP 400 INVALID_ARGUMENT`. 

**Problem:** 
The Google Gemini API strictly requires all `enum` parameter values in tool function declarations to be strings (or it rejects the schema). The `auto_archive_duration` parameter in the `discord_server` schema was using an integer enum (`[60, 1440, ...]`). Because Gemini validates the entire toolset upon initialization, this single typo would cause the entire tool payload to be rejected, instantly breaking agent sessions and any scheduled Cron jobs that rely on these global toolsets.

**Solution:** 
Changed the `auto_archive_duration` schema type to `"string"` and converted its enums to string representations (`["60", "1440", ...]`). To preserve compatibility with Discord's REST API (which expects an integer payload), a simple `int()` cast was added inside the tool's runtime implementation.

## Related Issue

<!-- Leave blank or add Fixes #XXX if you already submitted an issue -->

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/discord_tool.py`:
  - Updated `auto_archive_duration` parameter schema type to `"string"`.
  - Updated enum list to strictly use strings: `["60", "1440", "4320", "10080"]`.
  - Added an `int()` cast to `auto_archive_duration` when constructing the JSON body in `_create_thread`.

## How to Test

1. Configure an agent session using a Gemini model (`google/gemma-4-31b` via AI Studio).
2. Start the Hermes Agent or run a Cron Job that injects the full global toolset (including `discord_server`).
3. **Before**, the connection immediately crashes on startup with `400 Bad Request` regarding schema validation.
4. **After**, the toolset is successfully parsed, and Discord features work as intended.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows/Production Environment

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs
_Tested on production with `google/gemma-4-31b` where all previously failing Cron jobs utilizing the same toolset were successfully restored._
