### PR TITLE
fix: add missing reset_cache() function in hermes_time

### DIFF
--- a/hermes_time.py
+++ b/hermes_time.py
@@ -88,6 +88,14 @@ def get_timezone() -> Optional[ZoneInfo]:
     return _cached_tz
 
 
+def reset_cache() -> None:
+    """Clear the cached timezone so the next call re-resolves it."""
+    global _cached_tz, _cached_tz_name, _cache_resolved
+    _cached_tz = None
+    _cached_tz_name = None
+    _cache_resolved = False
+
+
 def now() -> datetime:
     """
     Return the current time as a timezone-aware datetime.


### PR DESCRIPTION
## Summary
- `hermes_time.reset_cache()` is referenced in module comments and docstrings but was never defined
- Calling it would raise `AttributeError` at runtime
- The test suite already works around this by directly manipulating module globals (`_cached_tz`, `_cached_tz_name`, `_cache_resolved`)

## Fix
Adds the missing `reset_cache()` function that clears the cached timezone state, allowing callers to re-resolve the timezone after configuration changes (e.g. changing `HERMES_TIMEZONE` env var or updating `config.yaml`).

## Test plan
- [x] Existing tests in `tests/test_timezone.py` validate cache behavior via direct global manipulation — the new function provides the canonical API for the same operation
- [ ] Manual test: set `HERMES_TIMEZONE`, call `hermes_time.now()`, change timezone, call `reset_cache()`, verify `now()` reflects the new timezone

🤖 Generated with [Claude Code](https://claude.com/claude-code)