### PR TITLE
tests: make real subagent interrupt test hermetic

### DIFF
--- a/tests/run_agent/test_real_interrupt_subagent.py
+++ b/tests/run_agent/test_real_interrupt_subagent.py
@@ -42,9 +42,21 @@ class TestRealSubagentInterrupt(unittest.TestCase):
     def setUp(self):
         set_interrupt(False)
         os.environ.setdefault("OPENAI_API_KEY", "test-key")
+        self._old_terminal_env = os.environ.get("TERMINAL_ENV")
+        self._old_terminal_modal_mode = os.environ.get("TERMINAL_MODAL_MODE")
+        os.environ["TERMINAL_ENV"] = "local"
+        os.environ.pop("TERMINAL_MODAL_MODE", None)
 
     def tearDown(self):
         set_interrupt(False)
+        if self._old_terminal_env is None:
+            os.environ.pop("TERMINAL_ENV", None)
+        else:
+            os.environ["TERMINAL_ENV"] = self._old_terminal_env
+        if self._old_terminal_modal_mode is None:
+            os.environ.pop("TERMINAL_MODAL_MODE", None)
+        else:
+            os.environ["TERMINAL_MODAL_MODE"] = self._old_terminal_modal_mode
 
     def test_interrupt_child_during_api_call(self):
         """Real AIAgent child interrupted while making API call."""
@@ -95,8 +107,12 @@ class TestRealSubagentInterrupt(unittest.TestCase):
                     mock_client.close = MagicMock()
                     MockOpenAI.return_value = mock_client
 
-                    # Patch the instance method so it skips prompt assembly
-                    with patch.object(AIAgent, '_build_system_prompt', return_value="You are a test agent"):
+                    # Patch instance methods unrelated to interrupt behavior so
+                    # the test stays hermetic and focused on delegate interrupt
+                    # propagation rather than prompt assembly / auxiliary model
+                    # preflight checks.
+                    with patch.object(AIAgent, '_build_system_prompt', return_value="You are a test agent"), \
+                         patch.object(AIAgent, '_check_compression_model_feasibility', return_value=None):
                         # Signal when child starts
                         original_run = AIAgent.run_conversation
 
@@ -106,7 +122,7 @@ class TestRealSubagentInterrupt(unittest.TestCase):
 
                         with patch.object(AIAgent, 'run_conversation', patched_run):
                             # Build a real child agent (AIAgent is NOT patched here,
-                            # only run_conversation and _build_system_prompt are)
+                            # only run_conversation and unrelated preflight helpers are)
                             child = AIAgent(
                                 base_url="http://localhost:1",
                                 api_key="test-key",


### PR DESCRIPTION
## Summary
- make `test_real_interrupt_subagent` hermetic against leaked terminal backend env
- isolate the test from unrelated preflight checks that can block child construction before `run_conversation()` starts

## Root cause
This test is intended to verify delegate interrupt propagation, but in suite runs it could be influenced by:
- leaked `TERMINAL_ENV` / `TERMINAL_MODAL_MODE`
- `_build_system_prompt`
- `_check_compression_model_feasibility()` and its auxiliary/provider preflight path

That allowed the child to get stuck during construction / pre-conversation setup instead of exercising the interrupt path the test claims to cover.

## Changes
- force `TERMINAL_ENV=local` in `setUp()` and restore env in `tearDown()`
- patch `_build_system_prompt`
- patch `_check_compression_model_feasibility()` so the test stays focused on interrupt propagation rather than auxiliary compression/provider preflight behavior

## Verification
- `pytest -n0 tests/tools/test_terminal_requirements.py::test_modal_backend_direct_mode_does_not_fall_back_to_managed tests/run_agent/test_real_interrupt_subagent.py::TestRealSubagentInterrupt::test_interrupt_child_during_api_call -vv -s`
- `pytest tests/run_agent/test_real_interrupt_subagent.py::TestRealSubagentInterrupt::test_interrupt_child_during_api_call -vv -s`
- `./scripts/run_tests.sh tests/run_agent/test_real_interrupt_subagent.py tests/tools/test_terminal_requirements.py --maxfail=1 -q`

## Notes
This fixes the test/harness hermeticity issue. There may still be a production-level follow-up worth discussing around whether `AIAgent.__init__` should do auxiliary compression feasibility checks eagerly for child agents.
