### PR TITLE
feat: Skills Hub full lifecycle management for web UI

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2082,6 +2082,37 @@ class SkillToggle(BaseModel):
     enabled: bool
 
 
+class SkillInstallBody(BaseModel):
+    identifier: str
+    category: str = ""
+    force: bool = False
+
+class SkillUpdateBody(BaseModel):
+    name: Optional[str] = None
+
+class SkillPublishBody(BaseModel):
+    skill_path: str
+    target: str = "github"
+    repo: str = ""
+
+class SkillCreateBody(BaseModel):
+    name: str
+    display_name: str = ""
+    description: str = ""
+    category: str = ""
+    tags: str = ""
+    icon: str = ""
+
+class SnapshotImportBody(BaseModel):
+    data: dict
+    force: bool = False
+
+class TapAddBody(BaseModel):
+    repo: str
+    path: str = "skills/"
+
+
+
 @app.get("/api/skills")
 async def get_skills():
     from tools.skills_tool import _find_all_skills
@@ -2105,6 +2136,526 @@ async def toggle_skill(body: SkillToggle):
         disabled.add(body.name)
     save_disabled_skills(config, disabled)
     return {"ok": True, "name": body.name, "enabled": body.enabled}
+
+
+
+# ---------------------------------------------------------------------------
+# Skills Hub — Search
+# ---------------------------------------------------------------------------
+
+@app.get("/api/skills/search")
+async def search_skills(q: str = "", source: str = "all", limit: int = 20):
+    """Search skills across registries."""
+    if not q.strip():
+        return []
+    try:
+        from tools.skills_hub import GitHubAuth, create_source_router, unified_search
+        auth = GitHubAuth()
+        sources = create_source_router(auth)
+        results = unified_search(q, sources, source_filter=source, limit=limit)
+        return [
+            {
+                "name": r.name,
+                "description": r.description,
+                "source": r.source,
+                "trust": r.trust_level,
+                "identifier": r.identifier,
+            }
+            for r in results
+        ]
+    except Exception as e:
+        return JSONResponse(status_code=500, content={"error": str(e)})
+
+
+# ---------------------------------------------------------------------------
+# Skills Hub — Browse
+# ---------------------------------------------------------------------------
+
+@app.get("/api/skills/browse")
+async def browse_skills(page: int = 1, page_size: int = 20, source: str = "all"):
+    """Browse available skills with pagination."""
+    try:
+        from hermes_cli.skills_hub import browse_skills as _browse
+        return _browse(page=page, page_size=page_size, source=source)
+    except Exception as e:
+        return JSONResponse(status_code=500, content={"error": str(e)})
+
+
+# ---------------------------------------------------------------------------
+# Skills Hub — Inspect
+# ---------------------------------------------------------------------------
+
+@app.get("/api/skills/inspect")
+async def inspect_skill(name: str = ""):
+    """Get detailed info about a skill (installed or remote)."""
+    if not name:
+        return JSONResponse(status_code=400, content={"error": "name parameter required"})
+    try:
+        from hermes_cli.skills_hub import inspect_skill as _inspect
+        result = _inspect(name)
+        if result is None:
+            return JSONResponse(status_code=404, content={"error": f"Skill \'{name}\' not found"})
+        return result
+    except Exception as e:
+        return JSONResponse(status_code=500, content={"error": str(e)})
+
+
+# ---------------------------------------------------------------------------
+# Skills Hub — Installed (detailed, with hub metadata)
+# ---------------------------------------------------------------------------
+
+@app.get("/api/skills/installed")
+async def get_installed_skills():
+    """List installed skills with full metadata (hub-installed + builtin + local)."""
+    try:
+        from tools.skills_tool import _find_all_skills
+        from tools.skills_hub import HubLockFile
+        from hermes_cli.skills_config import get_disabled_skills
+
+        config = load_config()
+        disabled = get_disabled_skills(config)
+        all_skills = _find_all_skills(skip_disabled=False)
+        lock = HubLockFile()
+        installed_map = {e["name"]: e for e in lock.list_installed()}
+
+        result = []
+        for s in all_skills:
+            entry = {
+                "name": s.get("name", ""),
+                "description": s.get("description", ""),
+                "category": s.get("category", ""),
+                "enabled": s["name"] not in disabled,
+                "type": "local",
+                "source": "",
+            }
+            if s["name"] in installed_map:
+                hub = installed_map[s["name"]]
+                entry["type"] = "hub"
+                entry["source"] = hub.get("source", "")
+                entry["identifier"] = hub.get("identifier", "")
+                entry["trust_level"] = hub.get("trust_level", "")
+                entry["install_path"] = hub.get("install_path", "")
+                entry["installed_at"] = hub.get("installed_at", "")
+                entry["content_hash"] = hub.get("content_hash", "")
+            result.append(entry)
+        return result
+    except Exception as e:
+        return JSONResponse(status_code=500, content={"error": str(e)})
+
+
+# ---------------------------------------------------------------------------
+# Skills Hub — Install
+# ---------------------------------------------------------------------------
+
+@app.post("/api/skills/install")
+async def install_skill(body: SkillInstallBody):
+    """Install a skill from a registry."""
+    try:
+        from hermes_cli.skills_hub import do_install
+        from tools.skills_hub import HubLockFile
+
+        if not body.force:
+            lock = HubLockFile()
+            existing = lock.get_installed(body.identifier)
+            if not existing and "/" not in body.identifier:
+                from tools.skills_tool import _find_all_skills
+                for s in _find_all_skills(skip_disabled=False):
+                    if s.get("name") == body.identifier:
+                        return JSONResponse(status_code=409, content={
+                            "error": f"\'{body.identifier}\' is already installed locally",
+                        })
+
+        class _SilentConsole:
+            def print(self, *a, **k): pass
+            def status(self, *a, **k):
+                class _Ctx:
+                    def __enter__(self): return self
+                    def __exit__(self, *a): pass
+                return _Ctx()
+
+        c = _SilentConsole()
+        do_install(body.identifier, category=body.category, force=body.force,
+                   console=c, skip_confirm=True)
+
+        lock = HubLockFile()
+        installed = lock.get_installed(body.identifier)
+        if not installed and "/" in body.identifier:
+            parts = body.identifier.split("/")
+            for entry in lock.list_installed():
+                if entry.get("identifier") == body.identifier or entry.get("name") == parts[-1]:
+                    installed = entry
+                    break
+
+        skill_name = installed.get("name", body.identifier) if installed else body.identifier
+        install_path = installed.get("install_path", "") if installed else ""
+
+        return {"ok": True, "name": skill_name, "install_path": install_path}
+    except SystemExit:
+        return JSONResponse(status_code=500, content={"error": "Installation failed"})
+    except Exception as e:
+        return JSONResponse(status_code=500, content={"error": str(e)})
+
+
+# ---------------------------------------------------------------------------
+# Skills Hub — Uninstall
+# ---------------------------------------------------------------------------
+
+@app.delete("/api/skills/uninstall/{name}")
+async def uninstall_skill(name: str):
+    """Uninstall a hub-installed skill."""
+    try:
+        from tools.skills_hub import uninstall_skill as _raw_uninstall
+
+        success, msg = _raw_uninstall(name)
+        if not success:
+            return JSONResponse(status_code=404, content={"error": msg})
+
+        try:
+            from agent.prompt_builder import clear_skills_system_prompt_cache
+            clear_skills_system_prompt_cache(clear_snapshot=True)
+        except Exception:
+            pass
+
+        return {"ok": True, "name": name, "message": msg}
+    except Exception as e:
+        return JSONResponse(status_code=500, content={"error": str(e)})
+
+
+# ---------------------------------------------------------------------------
+# Skills Hub — Check Updates
+# ---------------------------------------------------------------------------
+
+@app.get("/api/skills/check-updates")
+async def check_skill_updates(name: Optional[str] = None):
+    """Check for available updates to installed skills."""
+    try:
+        from tools.skills_hub import check_for_skill_updates
+        results = check_for_skill_updates(name=name)
+        for r in results:
+            r.pop("bundle", None)
+        return results
+    except Exception as e:
+        return JSONResponse(status_code=500, content={"error": str(e)})
+
+
+# ---------------------------------------------------------------------------
+# Skills Hub — Update
+# ---------------------------------------------------------------------------
+
+@app.put("/api/skills/update")
+async def update_skill(body: SkillUpdateBody):
+    """Update hub-installed skills."""
+    try:
+        from tools.skills_hub import HubLockFile, check_for_skill_updates
+        from hermes_cli.skills_hub import do_install
+
+        updates = [e for e in check_for_skill_updates(name=body.name)
+                    if e.get("status") == "update_available"]
+
+        if not updates:
+            return {"ok": True, "updated": 0, "message": "No updates available"}
+
+        class _SilentConsole:
+            def print(self, *a, **k): pass
+            def status(self, *a, **k):
+                class _Ctx:
+                    def __enter__(self): return self
+                    def __exit__(self, *a): pass
+                return _Ctx()
+
+        c = _SilentConsole()
+        updated_names = []
+        for entry in updates:
+            try:
+                lock = HubLockFile()
+                installed = lock.get_installed(entry["name"])
+                category = ""
+                if installed:
+                    ip = installed.get("install_path", "")
+                    if "/" in ip:
+                        category = str(Path(ip).parent)
+                do_install(entry["identifier"], category=category,
+                           force=True, console=c, skip_confirm=True)
+                updated_names.append(entry["name"])
+            except Exception:
+                pass
+
+        return {"ok": True, "updated": len(updated_names), "skills": updated_names}
+    except Exception as e:
+        return JSONResponse(status_code=500, content={"error": str(e)})
+
+
+# ---------------------------------------------------------------------------
+# Skills Hub — Audit
+# ---------------------------------------------------------------------------
+
+@app.get("/api/skills/audit")
+async def audit_skills(name: Optional[str] = None):
+    """Re-run security scan on installed hub skills."""
+    try:
+        from tools.skills_hub import HubLockFile, SKILLS_DIR
+        from tools.skills_guard import scan_skill
+
+        lock = HubLockFile()
+        installed = lock.list_installed()
+        if name:
+            installed = [e for e in installed if e["name"] == name]
+
+        results = []
+        for entry in installed:
+            skill_path = SKILLS_DIR / entry["install_path"]
+            if not skill_path.exists():
+                results.append({"name": entry["name"], "status": "path_missing"})
+                continue
+            scan_result = scan_skill(skill_path, source=entry.get("identifier", entry.get("source", "")))
+            results.append({
+                "name": entry["name"],
+                "source": entry.get("source", ""),
+                "verdict": scan_result.verdict,
+                "findings_count": len(scan_result.findings),
+                "findings": [
+                    {"severity": f.severity, "category": f.category, "description": f.description}
+                    for f in scan_result.findings
+                ],
+            })
+        return results
+    except Exception as e:
+        return JSONResponse(status_code=500, content={"error": str(e)})
+
+
+# ---------------------------------------------------------------------------
+# Skills Hub — Taps
+# ---------------------------------------------------------------------------
+
+@app.get("/api/skills/taps")
+async def list_taps():
+    """List configured taps (custom skill sources)."""
+    try:
+        from tools.skills_hub import TapsManager
+        return TapsManager().list_taps()
+    except Exception as e:
+        return JSONResponse(status_code=500, content={"error": str(e)})
+
+
+@app.post("/api/skills/taps")
+async def add_tap(body: TapAddBody):
+    """Add a new tap (custom skill source)."""
+    try:
+        from tools.skills_hub import TapsManager
+        mgr = TapsManager()
+        if mgr.add(body.repo, body.path):
+            return {"ok": True, "repo": body.repo}
+        return JSONResponse(status_code=409, content={"error": f"Tap \'{body.repo}\' already exists"})
+    except Exception as e:
+        return JSONResponse(status_code=500, content={"error": str(e)})
+
+
+@app.delete("/api/skills/taps/{repo:path}")
+async def remove_tap(repo: str):
+    """Remove a tap by repo name."""
+    try:
+        from tools.skills_hub import TapsManager
+        mgr = TapsManager()
+        if mgr.remove(repo):
+            return {"ok": True, "repo": repo}
+        return JSONResponse(status_code=404, content={"error": f"Tap \'{repo}\' not found"})
+    except Exception as e:
+        return JSONResponse(status_code=500, content={"error": str(e)})
+
+
+# ---------------------------------------------------------------------------
+# Skills Hub — Snapshot Export
+# ---------------------------------------------------------------------------
+
+@app.get("/api/skills/snapshot/export")
+async def export_snapshot():
+    """Export current skill configuration as a portable JSON snapshot."""
+    try:
+        from tools.skills_hub import HubLockFile, TapsManager
+        import datetime
+
+        lock = HubLockFile()
+        taps_mgr = TapsManager()
+        installed = lock.list_installed()
+        tap_list = taps_mgr.list_taps()
+
+        def _derive_category(install_path: str) -> str:
+            if not install_path or "/" not in install_path:
+                return ""
+            parts = Path(install_path).parts
+            return "/".join(p for p in parts[:-1] if p not in (".", "skills"))
+
+        return {
+            "hermes_version": __version__,
+            "exported_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "skills": [
+                {
+                    "name": e["name"],
+                    "source": e.get("source", ""),
+                    "identifier": e.get("identifier", ""),
+                    "category": _derive_category(e.get("install_path", "")),
+                }
+                for e in installed
+            ],
+            "taps": tap_list,
+        }
+    except Exception as e:
+        return JSONResponse(status_code=500, content={"error": str(e)})
+
+
+# ---------------------------------------------------------------------------
+# Skills Hub — Snapshot Import
+# ---------------------------------------------------------------------------
+
+@app.post("/api/skills/snapshot/import")
+async def import_snapshot(body: SnapshotImportBody):
+    """Re-install skills from a snapshot."""
+    try:
+        from tools.skills_hub import TapsManager
+        from hermes_cli.skills_hub import do_install
+
+        snapshot = body.data
+
+        taps = snapshot.get("taps", [])
+        if taps:
+            mgr = TapsManager()
+            for tap in taps:
+                repo = tap.get("repo", "")
+                if repo:
+                    mgr.add(repo, tap.get("path", "skills/"))
+
+        skills = snapshot.get("skills", [])
+        installed_count = 0
+        errors = []
+
+        class _SilentConsole:
+            def print(self, *a, **k): pass
+            def status(self, *a, **k):
+                class _Ctx:
+                    def __enter__(self): return self
+                    def __exit__(self, *a): pass
+                return _Ctx()
+
+        c = _SilentConsole()
+        for entry in skills:
+            identifier = entry.get("identifier", "")
+            if not identifier:
+                continue
+            try:
+                do_install(identifier, category=entry.get("category", ""),
+                           force=body.force, console=c, skip_confirm=True)
+                installed_count += 1
+            except Exception as ex:
+                errors.append({"name": entry.get("name", identifier), "error": str(ex)})
+
+        return {"ok": True, "installed": installed_count, "errors": errors}
+    except Exception as e:
+        return JSONResponse(status_code=500, content={"error": str(e)})
+
+
+# ---------------------------------------------------------------------------
+# Skills Hub — Publish
+# ---------------------------------------------------------------------------
+
+@app.post("/api/skills/publish")
+async def publish_skill(body: SkillPublishBody):
+    """Publish a local skill to a registry."""
+    try:
+        from tools.skills_hub import SKILLS_DIR, GitHubAuth
+        from tools.skills_guard import scan_skill
+
+        path = Path(body.skill_path)
+        if not path.is_absolute():
+            path = SKILLS_DIR / path
+        if not path.exists() or not (path / "SKILL.md").exists():
+            return JSONResponse(status_code=400, content={"error": f"No SKILL.md found at {path}"})
+
+        skill_md = (path / "SKILL.md").read_text(encoding="utf-8")
+        fm = {}
+        if skill_md.startswith("---"):
+            import re
+            match = re.search(r'\n---\s*\n', skill_md[3:])
+            if match:
+                try:
+                    fm = yaml.safe_load(skill_md[3:match.start() + 3]) or {}
+                except yaml.YAMLError:
+                    pass
+
+        description = fm.get("description", "")
+        if not description:
+            return JSONResponse(status_code=400, content={"error": "SKILL.md must have a \'description\' in frontmatter"})
+
+        scan_result = scan_skill(path, source="self")
+        if scan_result.verdict == "dangerous":
+            return JSONResponse(status_code=403, content={"error": "Cannot publish a skill with DANGEROUS verdict"})
+
+        if body.target == "github":
+            if not body.repo:
+                return JSONResponse(status_code=400, content={"error": "repo is required for GitHub publish"})
+            auth = GitHubAuth()
+            if not auth.is_authenticated():
+                return JSONResponse(status_code=401, content={"error": "GitHub authentication required"})
+
+            from hermes_cli.skills_hub import _github_publish
+            skill_name = fm.get("name", path.name)
+            success, msg = _github_publish(path, skill_name, body.repo, auth)
+            if success:
+                return {"ok": True, "name": skill_name, "message": msg}
+            return JSONResponse(status_code=500, content={"error": msg})
+        else:
+            return JSONResponse(status_code=400, content={"error": f"Unknown target: {body.target}. Use \'github\'"})
+    except Exception as e:
+        return JSONResponse(status_code=500, content={"error": str(e)})
+
+
+# ---------------------------------------------------------------------------
+# Skills Hub — Create Skill
+# ---------------------------------------------------------------------------
+
+@app.post("/api/skills/create")
+async def create_skill(body: SkillCreateBody):
+    """Create a new local skill from template."""
+    try:
+        from tools.skills_hub import SKILLS_DIR, _validate_skill_name, _validate_category_name
+
+        try:
+            name = _validate_skill_name(body.name)
+        except ValueError as e:
+            return JSONResponse(status_code=400, content={"error": str(e)})
+
+        skill_dir = SKILLS_DIR / name
+        if skill_dir.exists():
+            return JSONResponse(status_code=409, content={"error": f"Skill \'{name}\' already exists at {skill_dir}"})
+
+        category = body.category.strip()
+        if category:
+            try:
+                category = _validate_category_name(category)
+            except ValueError:
+                return JSONResponse(status_code=400, content={"error": f"Invalid category: {category}"})
+
+        display_name = body.display_name.strip() or name
+        description = body.description.strip() or f"Custom skill: {display_name}"
+        tags = [t.strip() for t in body.tags.split(",") if t.strip()] if body.tags.strip() else []
+
+        frontmatter = {"name": name, "description": description}
+        if category:
+            frontmatter["category"] = category
+        if tags:
+            frontmatter["tags"] = tags
+        if body.icon.strip():
+            frontmatter["icon"] = body.icon.strip()
+
+        fm_yaml = yaml.dump(frontmatter, default_flow_style=False, allow_unicode=True).strip()
+        skill_md = f"---\n{fm_yaml}\n---\n\n# {display_name}\n\n{description}\n\n## Usage\n\nDescribe how to use this skill here.\n"
+
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        (skill_dir / "SKILL.md").write_text(skill_md, encoding="utf-8")
+
+        return {"ok": True, "name": name, "path": str(skill_dir)}
+    except Exception as e:
+        return JSONResponse(status_code=500, content={"error": str(e)})
+
 
 
 @app.get("/api/tools/toolsets")

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -193,6 +193,111 @@ export const api = {
       `/api/actions/${encodeURIComponent(name)}/status?lines=${lines}`,
     ),
 
+  // Skills Hub — Search
+  searchSkills: (q: string, source = "all", limit = 20) =>
+    fetchJSON<SkillSearchResult[]>(
+      `/api/skills/search?q=${encodeURIComponent(q)}&source=${source}&limit=${limit}`,
+    ),
+
+  // Skills Hub — Browse
+  browseSkills: (page = 1, pageSize = 20, source = "all") =>
+    fetchJSON<SkillBrowseResult>(
+      `/api/skills/browse?page=${page}&page_size=${pageSize}&source=${source}`,
+    ),
+
+  // Skills Hub — Inspect
+  inspectSkill: (name: string) =>
+    fetchJSON<Record<string, unknown>>(`/api/skills/inspect?name=${encodeURIComponent(name)}`),
+
+  // Skills Hub — Installed (detailed, with hub metadata)
+  getInstalledSkills: () => fetchJSON<HubSkillInfo[]>("/api/skills/installed"),
+
+  // Skills Hub — Install
+  installSkill: (identifier: string, category = "", force = false) =>
+    fetchJSON<SkillInstallResult>("/api/skills/install", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ identifier, category, force }),
+    }),
+
+  // Skills Hub — Uninstall
+  uninstallSkill: (name: string) =>
+    fetchJSON<{ ok: boolean; name: string; message: string }>(
+      `/api/skills/uninstall/${encodeURIComponent(name)}`,
+      { method: "DELETE" },
+    ),
+
+  // Skills Hub — Check Updates
+  checkSkillUpdates: (name?: string) =>
+    fetchJSON<SkillUpdateCheck[]>(
+      `/api/skills/check-updates${name ? `?name=${encodeURIComponent(name)}` : ""}`,
+    ),
+
+  // Skills Hub — Update
+  updateSkill: (name?: string) =>
+    fetchJSON<{ ok: boolean; updated: number; skills: string[] }>("/api/skills/update", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name }),
+    }),
+
+  // Skills Hub — Audit
+  auditSkills: (name?: string) =>
+    fetchJSON<SkillAuditResult[]>(
+      `/api/skills/audit${name ? `?name=${encodeURIComponent(name)}` : ""}`,
+    ),
+
+  // Skills Hub — Taps
+  listTaps: () => fetchJSON<TapInfo[]>("/api/skills/taps"),
+  addTap: (repo: string, path = "skills/") =>
+    fetchJSON<{ ok: boolean; repo: string }>("/api/skills/taps", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ repo, path }),
+    }),
+  removeTap: (repo: string) =>
+    fetchJSON<{ ok: boolean; repo: string }>(
+      `/api/skills/taps/${encodeURIComponent(repo)}`,
+      { method: "DELETE" },
+    ),
+
+  // Skills Hub — Snapshot
+  exportSnapshot: () => fetchJSON<SkillSnapshot>("/api/skills/snapshot/export"),
+  importSnapshot: (data: SkillSnapshot, force = false) =>
+    fetchJSON<{ ok: boolean; installed: number; errors: { name: string; error: string }[] }>(
+      "/api/skills/snapshot/import",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ data, force }),
+      },
+    ),
+
+  // Skills Hub — Publish
+  publishSkill: (skillPath: string, target = "github", repo = "") =>
+    fetchJSON<{ ok: boolean; name: string; message: string }>("/api/skills/publish", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ skill_path: skillPath, target, repo }),
+    }),
+
+  // Skills Hub — Create
+  createSkill: (
+    name: string,
+    displayName = "",
+    description = "",
+    category = "",
+    tags = "",
+    icon = "",
+  ) =>
+    fetchJSON<{ ok: boolean; name: string; path: string }>("/api/skills/create", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name, display_name: displayName, description, category, tags, icon }),
+    }),
+
+
+
   // Dashboard plugins
   getPlugins: () =>
     fetchJSON<PluginManifestResponse[]>("/api/dashboard/plugins"),
@@ -387,6 +492,66 @@ export interface ToolsetInfo {
   configured: boolean;
   tools: string[];
 }
+
+export interface HubSkillInfo extends SkillInfo {
+  type: "builtin" | "local" | "hub";
+  source: string;
+  identifier?: string;
+  trust_level?: string;
+  install_path?: string;
+  installed_at?: string;
+  content_hash?: string;
+}
+
+export interface SkillSearchResult {
+  name: string;
+  description: string;
+  source: string;
+  trust: string;
+  identifier: string;
+}
+
+export interface SkillBrowseResult {
+  skills: SkillSearchResult[];
+  page: number;
+  page_size: number;
+  total: number;
+}
+
+export interface SkillInstallResult {
+  ok: boolean;
+  name: string;
+  install_path: string;
+}
+
+export interface SkillUpdateCheck {
+  name: string;
+  identifier: string;
+  current_hash: string;
+  latest_hash: string;
+  status: string;
+}
+
+export interface SkillAuditResult {
+  name: string;
+  source: string;
+  verdict: string;
+  findings_count: number;
+  findings: { severity: string; category: string; description: string }[];
+}
+
+export interface TapInfo {
+  repo: string;
+  path: string;
+}
+
+export interface SkillSnapshot {
+  hermes_version: string;
+  exported_at: string;
+  skills: { name: string; source: string; identifier: string; category: string }[];
+  taps: TapInfo[];
+}
+
 
 export interface SessionSearchResult {
   session_id: string;

--- a/web/src/pages/SkillsPage.tsx
+++ b/web/src/pages/SkillsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useState, useMemo, useCallback } from "react";
 import {
   Package,
   Search,
@@ -14,16 +14,37 @@ import {
   Blocks,
   Code,
   Zap,
+  Download,
+  Upload,
+  RefreshCw,
+  ShieldCheck,
+  Plus,
+  Globe2,
+  Trash2,
+  FileUp,
+  Rocket,
 } from "lucide-react";
 import { H2 } from "@nous-research/ui";
 import { api } from "@/lib/api";
-import type { SkillInfo, ToolsetInfo } from "@/lib/api";
+import type {
+  SkillInfo,
+  ToolsetInfo,
+  HubSkillInfo,
+  SkillSearchResult,
+  SkillUpdateCheck,
+  SkillAuditResult,
+  TapInfo,
+  SkillSnapshot,
+} from "@/lib/api";
 import { useToast } from "@/hooks/useToast";
 import { Toast } from "@/components/Toast";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { Label } from "@/components/ui/label";
 import { useI18n } from "@/i18n";
 
 /* ------------------------------------------------------------------ */
@@ -84,29 +105,71 @@ function toolsetIcon(
   return Wrench;
 }
 
+type SubView =
+  | "all"
+  | "browse"
+  | "search"
+  | "updates"
+  | "audit"
+  | "taps"
+  | "snapshot"
+  | "create"
+  | "toolsets";
+
 /* ------------------------------------------------------------------ */
 /*  Component                                                          */
 /* ------------------------------------------------------------------ */
 
 export default function SkillsPage() {
   const [skills, setSkills] = useState<SkillInfo[]>([]);
+  const [hubSkills, setHubSkills] = useState<HubSkillInfo[]>([]);
   const [toolsets, setToolsets] = useState<ToolsetInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState("");
   const [view, setView] = useState<"skills" | "toolsets">("skills");
+  const [subView, setSubView] = useState<SubView>("all");
   const [activeCategory, setActiveCategory] = useState<string | null>(null);
   const [togglingSkills, setTogglingSkills] = useState<Set<string>>(new Set());
   const { toast, showToast } = useToast();
   const { t } = useI18n();
 
+  // Sub-view state
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchResults, setSearchResults] = useState<SkillSearchResult[]>([]);
+  const [browseResults, setSearchBrowseResults] = useState<SkillSearchResult[]>([]);
+  const [updateChecks, setUpdateChecks] = useState<SkillUpdateCheck[]>([]);
+  const [auditResults, setAuditResults] = useState<SkillAuditResult[]>([]);
+  const [taps, setTapsList] = useState<TapInfo[]>([]);
+  const [snapshotData, setSnapshotData] = useState<SkillSnapshot | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  // Dialog state
+  const [installId, setInstallId] = useState("");
+  const [createName, setCreateName] = useState("");
+  const [createDisplay, setCreateDisplay] = useState("");
+  const [createDesc, setCreateDesc] = useState("");
+  const [createCategory, setCreateCategory] = useState("");
+  const [createTags, setCreateTags] = useState("");
+  const [tapRepo, setTapRepo] = useState("");
+  const [publishPath, setPublishPath] = useState("");
+  const [publishRepo, setPublishRepo] = useState("");
+
   useEffect(() => {
-    Promise.all([api.getSkills(), api.getToolsets()])
-      .then(([s, tsets]) => {
+    Promise.all([api.getSkills(), api.getToolsets(), api.getInstalledSkills()])
+      .then(([s, tsets, hub]) => {
         setSkills(s);
         setToolsets(tsets);
+        setHubSkills(hub);
       })
       .catch(() => showToast(t.common.loading, "error"))
       .finally(() => setLoading(false));
+  }, []);
+
+  const refreshHubSkills = useCallback(async () => {
+    try {
+      const hub = await api.getInstalledSkills();
+      setHubSkills(hub);
+    } catch { /* ignore */ }
   }, []);
 
   /* ---- Toggle skill ---- */
@@ -133,6 +196,201 @@ export default function SkillsPage() {
       });
     }
   };
+
+  /* ---- Hub actions ---- */
+  const handleSearch = useCallback(async () => {
+    if (!searchQuery.trim()) return;
+    setBusy(true);
+    try {
+      const results = await api.searchSkills(searchQuery);
+      setSearchResults(results);
+      setSubView("search");
+    } catch (e) {
+      showToast(`Search failed: ${(e as Error).message}`, "error");
+    } finally {
+      setBusy(false);
+    }
+  }, [searchQuery, showToast]);
+
+  const handleBrowse = useCallback(async () => {
+    setBusy(true);
+    try {
+      const results = await api.browseSkills(1, 50);
+      setSearchBrowseResults(results.skills || []);
+      setSubView("browse");
+    } catch (e) {
+      showToast(`Browse failed: ${(e as Error).message}`, "error");
+    } finally {
+      setBusy(false);
+    }
+  }, [showToast]);
+
+  const handleInstall = useCallback(async () => {
+    if (!installId.trim()) return;
+    setBusy(true);
+    try {
+      const result = await api.installSkill(installId);
+      showToast(`Installed: ${result.name}`, "success");
+      setInstallId("");
+      await refreshHubSkills();
+    } catch (e) {
+      showToast(`Install failed: ${(e as Error).message}`, "error");
+    } finally {
+      setBusy(false);
+    }
+  }, [installId, showToast, refreshHubSkills]);
+
+  const handleUninstall = useCallback(async (name: string) => {
+    setBusy(true);
+    try {
+      await api.uninstallSkill(name);
+      showToast(`Uninstalled: ${name}`, "success");
+      await refreshHubSkills();
+    } catch (e) {
+      showToast(`Uninstall failed: ${(e as Error).message}`, "error");
+    } finally {
+      setBusy(false);
+    }
+  }, [showToast, refreshHubSkills]);
+
+  const handleCheckUpdates = useCallback(async () => {
+    setBusy(true);
+    try {
+      const checks = await api.checkSkillUpdates();
+      setUpdateChecks(checks);
+      setSubView("updates");
+    } catch (e) {
+      showToast(`Check failed: ${(e as Error).message}`, "error");
+    } finally {
+      setBusy(false);
+    }
+  }, [showToast]);
+
+  const handleUpdateAll = useCallback(async () => {
+    setBusy(true);
+    try {
+      const result = await api.updateSkill();
+      showToast(`Updated ${result.updated} skills`, "success");
+    } catch (e) {
+      showToast(`Update failed: ${(e as Error).message}`, "error");
+    } finally {
+      setBusy(false);
+    }
+  }, [showToast]);
+
+  const handleAudit = useCallback(async () => {
+    setBusy(true);
+    try {
+      const results = await api.auditSkills();
+      setAuditResults(results);
+      setSubView("audit");
+    } catch (e) {
+      showToast(`Audit failed: ${(e as Error).message}`, "error");
+    } finally {
+      setBusy(false);
+    }
+  }, [showToast]);
+
+  const handleLoadTaps = useCallback(async () => {
+    setBusy(true);
+    try {
+      const list = await api.listTaps();
+      setTapsList(list);
+      setSubView("taps");
+    } catch (e) {
+      showToast(`Load taps failed: ${(e as Error).message}`, "error");
+    } finally {
+      setBusy(false);
+    }
+  }, [showToast]);
+
+  const handleAddTap = useCallback(async () => {
+    if (!tapRepo.trim()) return;
+    setBusy(true);
+    try {
+      await api.addTap(tapRepo);
+      showToast(`Tap added: ${tapRepo}`, "success");
+      setTapRepo("");
+      const list = await api.listTaps();
+      setTapsList(list);
+    } catch (e) {
+      showToast(`Add tap failed: ${(e as Error).message}`, "error");
+    } finally {
+      setBusy(false);
+    }
+  }, [tapRepo, showToast]);
+
+  const handleRemoveTap = useCallback(async (repo: string) => {
+    setBusy(true);
+    try {
+      await api.removeTap(repo);
+      showToast(`Tap removed: ${repo}`, "success");
+      setTapsList((prev) => prev.filter((t) => t.repo !== repo));
+    } catch (e) {
+      showToast(`Remove tap failed: ${(e as Error).message}`, "error");
+    } finally {
+      setBusy(false);
+    }
+  }, [showToast]);
+
+  const handleExportSnapshot = useCallback(async () => {
+    setBusy(true);
+    try {
+      const data = await api.exportSnapshot();
+      setSnapshotData(data);
+      setSubView("snapshot");
+    } catch (e) {
+      showToast(`Export failed: ${(e as Error).message}`, "error");
+    } finally {
+      setBusy(false);
+    }
+  }, [showToast]);
+
+  const handleImportSnapshot = useCallback(async () => {
+    if (!snapshotData) return;
+    setBusy(true);
+    try {
+      const result = await api.importSnapshot(snapshotData, true);
+      showToast(`Imported ${result.installed} skills`, "success");
+      await refreshHubSkills();
+    } catch (e) {
+      showToast(`Import failed: ${(e as Error).message}`, "error");
+    } finally {
+      setBusy(false);
+    }
+  }, [snapshotData, showToast, refreshHubSkills]);
+
+  const handleCreateSkill = useCallback(async () => {
+    if (!createName.trim()) return;
+    setBusy(true);
+    try {
+      const result = await api.createSkill(
+        createName, createDisplay, createDesc, createCategory, createTags,
+      );
+      showToast(`Created: ${result.name}`, "success");
+      setCreateName(""); setCreateDisplay(""); setCreateDesc("");
+      setCreateCategory(""); setCreateTags("");
+      await refreshHubSkills();
+    } catch (e) {
+      showToast(`Create failed: ${(e as Error).message}`, "error");
+    } finally {
+      setBusy(false);
+    }
+  }, [createName, createDisplay, createDesc, createCategory, createTags, showToast, refreshHubSkills]);
+
+  const handlePublish = useCallback(async () => {
+    if (!publishPath.trim() || !publishRepo.trim()) return;
+    setBusy(true);
+    try {
+      const result = await api.publishSkill(publishPath, "github", publishRepo);
+      showToast(`Published: ${result.name}`, "success");
+      setPublishPath(""); setPublishRepo("");
+    } catch (e) {
+      showToast(`Publish failed: ${(e as Error).message}`, "error");
+    } finally {
+      setBusy(false);
+    }
+  }, [publishPath, publishRepo, showToast]);
 
   /* ---- Derived data ---- */
   const lowerSearch = search.toLowerCase();
@@ -252,11 +510,12 @@ export default function SkillsPage() {
                 type="button"
                 onClick={() => {
                   setView("skills");
+                  setSubView("all");
                   setActiveCategory(null);
                   setSearch("");
                 }}
                 className={`group flex items-center gap-2 px-2.5 py-1.5 text-left text-xs transition-colors cursor-pointer ${
-                  view === "skills" && !isSearching
+                  view === "skills" && subView === "all" && !isSearching
                     ? "bg-primary/10 text-primary font-medium"
                     : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
                 }`}
@@ -265,13 +524,13 @@ export default function SkillsPage() {
                 <span className="flex-1 truncate">
                   {t.skills.all} ({skills.length})
                 </span>
-                {view === "skills" && !isSearching && (
+                {view === "skills" && subView === "all" && !isSearching && (
                   <ChevronRight className="h-3 w-3 text-primary/50 shrink-0" />
                 )}
               </button>
 
               {/* Skill categories (nested under All Skills) */}
-              {view === "skills" &&
+              {view === "skills" && subView === "all" &&
                 !isSearching &&
                 allCategories.map(({ key, name, count }) => {
                   const isActive = activeCategory === key;
@@ -297,6 +556,54 @@ export default function SkillsPage() {
                     </button>
                   );
                 })}
+
+              {/* Hub nav items */}
+              <Separator className="my-1 hidden sm:block" />
+
+              <SidebarItem
+                icon={<Search className="h-3.5 w-3.5 shrink-0" />}
+                label="Search Hub"
+                active={view === "skills" && subView === "search"}
+                onClick={() => { setView("skills"); setSubView("search"); setSearch(""); }}
+              />
+              <SidebarItem
+                icon={<Download className="h-3.5 w-3.5 shrink-0" />}
+                label="Browse"
+                active={view === "skills" && subView === "browse"}
+                onClick={() => { setView("skills"); setSubView("browse"); handleBrowse(); }}
+              />
+              <SidebarItem
+                icon={<RefreshCw className="h-3.5 w-3.5 shrink-0" />}
+                label="Updates"
+                active={view === "skills" && subView === "updates"}
+                onClick={() => { setView("skills"); setSubView("updates"); handleCheckUpdates(); }}
+              />
+              <SidebarItem
+                icon={<ShieldCheck className="h-3.5 w-3.5 shrink-0" />}
+                label="Audit"
+                active={view === "skills" && subView === "audit"}
+                onClick={() => { setView("skills"); setSubView("audit"); handleAudit(); }}
+              />
+              <SidebarItem
+                icon={<Globe2 className="h-3.5 w-3.5 shrink-0" />}
+                label="Skill Sources"
+                active={view === "skills" && subView === "taps"}
+                onClick={() => { setView("skills"); setSubView("taps"); handleLoadTaps(); }}
+              />
+              <SidebarItem
+                icon={<FileUp className="h-3.5 w-3.5 shrink-0" />}
+                label="Snapshot"
+                active={view === "skills" && subView === "snapshot"}
+                onClick={() => { setView("skills"); setSubView("snapshot"); handleExportSnapshot(); }}
+              />
+              <SidebarItem
+                icon={<Plus className="h-3.5 w-3.5 shrink-0" />}
+                label="Create"
+                active={view === "skills" && subView === "create"}
+                onClick={() => { setView("skills"); setSubView("create"); setSearch(""); }}
+              />
+
+              <Separator className="my-1 hidden sm:block" />
 
               <button
                 type="button"
@@ -325,7 +632,7 @@ export default function SkillsPage() {
         {/* ---- Content ---- */}
         <div className="flex-1 min-w-0">
           {isSearching ? (
-            /* Search results */
+            /* Local search results */
             <Card>
               <CardHeader className="py-3 px-4">
                 <div className="flex items-center justify-between">
@@ -334,12 +641,7 @@ export default function SkillsPage() {
                     {t.skills.title}
                   </CardTitle>
                   <Badge variant="secondary" className="text-[10px]">
-                    {t.skills.resultCount
-                      .replace("{count}", String(searchMatchedSkills.length))
-                      .replace(
-                        "{s}",
-                        searchMatchedSkills.length !== 1 ? "s" : "",
-                      )}
+                    {searchMatchedSkills.length} result{searchMatchedSkills.length !== 1 ? "s" : ""}
                   </Badge>
                 </div>
               </CardHeader>
@@ -363,51 +665,7 @@ export default function SkillsPage() {
                 )}
               </CardContent>
             </Card>
-          ) : view === "skills" ? (
-            /* Skills list */
-            <Card>
-              <CardHeader className="py-3 px-4">
-                <div className="flex items-center justify-between">
-                  <CardTitle className="text-sm flex items-center gap-2">
-                    <Package className="h-4 w-4" />
-                    {activeCategory
-                      ? prettyCategory(
-                          activeCategory === "__none__" ? null : activeCategory,
-                          t.common.general,
-                        )
-                      : t.skills.all}
-                  </CardTitle>
-                  <Badge variant="secondary" className="text-[10px]">
-                    {activeSkills.length}{" "}
-                    {t.skills.skillCount
-                      .replace("{count}", String(activeSkills.length))
-                      .replace("{s}", activeSkills.length !== 1 ? "s" : "")}
-                  </Badge>
-                </div>
-              </CardHeader>
-              <CardContent className="px-4 pb-4">
-                {activeSkills.length === 0 ? (
-                  <p className="text-sm text-muted-foreground text-center py-8">
-                    {skills.length === 0
-                      ? t.skills.noSkills
-                      : t.skills.noSkillsMatch}
-                  </p>
-                ) : (
-                  <div className="grid gap-1">
-                    {activeSkills.map((skill) => (
-                      <SkillRow
-                        key={skill.name}
-                        skill={skill}
-                        toggling={togglingSkills.has(skill.name)}
-                        onToggle={() => handleToggleSkill(skill)}
-                        noDescriptionLabel={t.skills.noDescription}
-                      />
-                    ))}
-                  </div>
-                )}
-              </CardContent>
-            </Card>
-          ) : (
+          ) : view === "toolsets" ? (
             /* Toolsets grid */
             <>
               {filteredToolsets.length === 0 ? (
@@ -423,7 +681,6 @@ export default function SkillsPage() {
                     const labelText =
                       ts.label.replace(/^[\p{Emoji}\s]+/u, "").trim() ||
                       ts.name;
-
                     return (
                       <Card key={ts.name} className="relative">
                         <CardContent className="py-4">
@@ -431,48 +688,23 @@ export default function SkillsPage() {
                             <TsIcon className="h-5 w-5 text-muted-foreground shrink-0 mt-0.5" />
                             <div className="flex-1 min-w-0">
                               <div className="flex items-center gap-2 mb-1">
-                                <span className="font-medium text-sm">
-                                  {labelText}
-                                </span>
-                                <Badge
-                                  variant={ts.enabled ? "success" : "outline"}
-                                  className="text-[10px]"
-                                >
-                                  {ts.enabled
-                                    ? t.common.active
-                                    : t.common.inactive}
+                                <span className="font-medium text-sm">{labelText}</span>
+                                <Badge variant={ts.enabled ? "success" : "outline"} className="text-[10px]">
+                                  {ts.enabled ? t.common.active : t.common.inactive}
                                 </Badge>
                               </div>
-                              <p className="text-xs text-muted-foreground mb-2">
-                                {ts.description}
-                              </p>
+                              <p className="text-xs text-muted-foreground mb-2">{ts.description}</p>
                               {ts.enabled && !ts.configured && (
-                                <p className="text-[10px] text-amber-300/80 mb-2">
-                                  {t.skills.setupNeeded}
-                                </p>
+                                <p className="text-[10px] text-amber-300/80 mb-2">{t.skills.setupNeeded}</p>
                               )}
                               {ts.tools.length > 0 && (
                                 <div className="flex flex-wrap gap-1">
                                   {ts.tools.map((tool) => (
-                                    <Badge
-                                      key={tool}
-                                      variant="secondary"
-                                      className="text-[10px] font-mono"
-                                    >
+                                    <Badge key={tool} variant="secondary" className="text-[10px] font-mono">
                                       {tool}
                                     </Badge>
                                   ))}
                                 </div>
-                              )}
-                              {ts.tools.length === 0 && (
-                                <span className="text-[10px] text-muted-foreground/60">
-                                  {ts.enabled
-                                    ? t.skills.toolsetLabel.replace(
-                                        "{name}",
-                                        ts.name,
-                                      )
-                                    : t.skills.disabledForCli}
-                                </span>
                               )}
                             </div>
                           </div>
@@ -483,10 +715,367 @@ export default function SkillsPage() {
                 </div>
               )}
             </>
+          ) : subView === "search" ? (
+            /* Hub search */
+            <Card>
+              <CardHeader className="py-3 px-4">
+                <CardTitle className="text-sm flex items-center gap-2">
+                  <Search className="h-4 w-4" /> Search Hub
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="px-4 pb-4 space-y-4">
+                <div className="flex gap-2">
+                  <Input
+                    placeholder="Search skills in registry..."
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    onKeyDown={(e) => e.key === "Enter" && handleSearch()}
+                    className="flex-1"
+                  />
+                  <Button onClick={handleSearch} disabled={busy || !searchQuery.trim()} size="sm">
+                    <Search className="h-4 w-4 mr-1" /> Search
+                  </Button>
+                </div>
+                {searchResults.length > 0 && (
+                  <div className="grid gap-2">
+                    {searchResults.map((r) => (
+                      <div key={r.identifier} className="flex items-center justify-between px-3 py-2 hover:bg-muted/40 transition-colors">
+                        <div>
+                          <span className="font-mono-ui text-sm">{r.name}</span>
+                          <p className="text-xs text-muted-foreground">{r.description || "No description"}</p>
+                          <div className="flex gap-1 mt-1">
+                            <Badge variant="secondary" className="text-[10px]">{r.source}</Badge>
+                            <Badge variant="outline" className="text-[10px]">{r.trust}</Badge>
+                          </div>
+                        </div>
+                        <Button size="sm" variant="outline" onClick={() => { setInstallId(r.identifier); }}>
+                          <Download className="h-3 w-3 mr-1" /> Install
+                        </Button>
+                      </div>
+                    ))}
+                  </div>
+                )}
+                {searchResults.length === 0 && searchQuery && !busy && (
+                  <p className="text-sm text-muted-foreground text-center py-4">No results. Try a different query.</p>
+                )}
+              </CardContent>
+            </Card>
+          ) : subView === "browse" ? (
+            <Card>
+              <CardHeader className="py-3 px-4">
+                <div className="flex items-center justify-between">
+                  <CardTitle className="text-sm flex items-center gap-2">
+                    <Download className="h-4 w-4" /> Browse Available Skills
+                  </CardTitle>
+                  <Button size="sm" variant="outline" onClick={handleBrowse} disabled={busy}>
+                    <RefreshCw className={`h-3 w-3 mr-1 ${busy ? "animate-spin" : ""}`} /> Refresh
+                  </Button>
+                </div>
+              </CardHeader>
+              <CardContent className="px-4 pb-4">
+                {browseResults.length === 0 && !busy && (
+                  <p className="text-sm text-muted-foreground text-center py-4">No skills available.</p>
+                )}
+                <div className="grid gap-2">
+                  {browseResults.map((r) => (
+                    <div key={r.identifier} className="flex items-center justify-between px-3 py-2 hover:bg-muted/40 transition-colors">
+                      <div>
+                        <span className="font-mono-ui text-sm">{r.name}</span>
+                        <p className="text-xs text-muted-foreground">{r.description || "No description"}</p>
+                      </div>
+                      <Button size="sm" variant="outline" onClick={() => setInstallId(r.identifier)}>
+                        <Download className="h-3 w-3 mr-1" /> Install
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          ) : subView === "updates" ? (
+            <Card>
+              <CardHeader className="py-3 px-4">
+                <div className="flex items-center justify-between">
+                  <CardTitle className="text-sm flex items-center gap-2">
+                    <RefreshCw className="h-4 w-4" /> Skill Updates
+                  </CardTitle>
+                  <Button size="sm" variant="outline" onClick={handleUpdateAll} disabled={busy}>
+                    <Upload className="h-3 w-3 mr-1" /> Update All
+                  </Button>
+                </div>
+              </CardHeader>
+              <CardContent className="px-4 pb-4">
+                {updateChecks.length === 0 && !busy && (
+                  <p className="text-sm text-muted-foreground text-center py-4">No hub-installed skills to check.</p>
+                )}
+                <div className="grid gap-2">
+                  {updateChecks.map((u) => (
+                    <div key={u.name} className="flex items-center justify-between px-3 py-2 hover:bg-muted/40 transition-colors">
+                      <div>
+                        <span className="font-mono-ui text-sm">{u.name}</span>
+                        <Badge variant={u.status === "update_available" ? "destructive" : "secondary"} className="text-[10px] ml-2">
+                          {u.status}
+                        </Badge>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          ) : subView === "audit" ? (
+            <Card>
+              <CardHeader className="py-3 px-4">
+                <CardTitle className="text-sm flex items-center gap-2">
+                  <ShieldCheck className="h-4 w-4" /> Security Audit
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="px-4 pb-4">
+                {auditResults.length === 0 && !busy && (
+                  <p className="text-sm text-muted-foreground text-center py-4">No hub-installed skills to audit.</p>
+                )}
+                <div className="grid gap-2">
+                  {auditResults.map((a) => (
+                    <div key={a.name} className="px-3 py-2 hover:bg-muted/40 transition-colors">
+                      <div className="flex items-center gap-2">
+                        <span className="font-mono-ui text-sm">{a.name}</span>
+                        <Badge
+                          variant={a.verdict === "safe" ? "success" : a.verdict === "caution" ? "secondary" : "destructive"}
+                          className="text-[10px]"
+                        >
+                          {a.verdict}
+                        </Badge>
+                        <span className="text-[10px] text-muted-foreground">{a.findings_count} findings</span>
+                      </div>
+                      {a.findings.length > 0 && (
+                        <div className="mt-1 ml-4 space-y-0.5">
+                          {a.findings.map((f, i) => (
+                            <p key={i} className="text-[11px] text-muted-foreground">
+                              <Badge variant="outline" className="text-[9px] mr-1">{f.severity}</Badge>
+                              {f.description}
+                            </p>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          ) : subView === "taps" ? (
+            <Card>
+              <CardHeader className="py-3 px-4">
+                <CardTitle className="text-sm flex items-center gap-2">
+                  <Globe2 className="h-4 w-4" /> Skill Sources (Taps)
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="px-4 pb-4 space-y-4">
+                <div className="flex gap-2">
+                  <Input
+                    placeholder="GitHub repo URL (e.g. user/skills-repo)"
+                    value={tapRepo}
+                    onChange={(e) => setTapRepo(e.target.value)}
+                    onKeyDown={(e) => e.key === "Enter" && handleAddTap()}
+                    className="flex-1"
+                  />
+                  <Button onClick={handleAddTap} disabled={busy || !tapRepo.trim()} size="sm">
+                    <Plus className="h-3 w-3 mr-1" /> Add
+                  </Button>
+                </div>
+                {taps.length === 0 && !busy && (
+                  <p className="text-sm text-muted-foreground text-center py-4">No custom skill sources configured.</p>
+                )}
+                <div className="grid gap-2">
+                  {taps.map((tap) => (
+                    <div key={tap.repo} className="flex items-center justify-between px-3 py-2 hover:bg-muted/40 transition-colors">
+                      <div>
+                        <span className="font-mono-ui text-sm">{tap.repo}</span>
+                        <span className="text-[10px] text-muted-foreground ml-2">/{tap.path}</span>
+                      </div>
+                      <Button size="sm" variant="ghost" onClick={() => handleRemoveTap(tap.repo)}>
+                        <Trash2 className="h-3 w-3" />
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          ) : subView === "snapshot" ? (
+            <Card>
+              <CardHeader className="py-3 px-4">
+                <CardTitle className="text-sm flex items-center gap-2">
+                  <FileUp className="h-4 w-4" /> Snapshot Export / Import
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="px-4 pb-4 space-y-4">
+                <div className="flex gap-2">
+                  <Button onClick={handleExportSnapshot} disabled={busy} size="sm">
+                    <Download className="h-3 w-3 mr-1" /> Export
+                  </Button>
+                  <Button onClick={handleImportSnapshot} disabled={busy || !snapshotData} size="sm" variant="outline">
+                    <Upload className="h-3 w-3 mr-1" /> Import
+                  </Button>
+                </div>
+                {snapshotData && (
+                  <div className="relative">
+                    <pre className="bg-muted/30 rounded p-3 text-[11px] font-mono overflow-auto max-h-64">
+                      {JSON.stringify(snapshotData, null, 2)}
+                    </pre>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          ) : subView === "create" ? (
+            <Card>
+              <CardHeader className="py-3 px-4">
+                <CardTitle className="text-sm flex items-center gap-2">
+                  <Plus className="h-4 w-4" /> Create Skill
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="px-4 pb-4 space-y-3">
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <Label className="text-xs mb-1">Skill Name *</Label>
+                    <Input placeholder="my-skill" value={createName} onChange={(e) => setCreateName(e.target.value)} />
+                  </div>
+                  <div>
+                    <Label className="text-xs mb-1">Display Name</Label>
+                    <Input placeholder="My Skill" value={createDisplay} onChange={(e) => setCreateDisplay(e.target.value)} />
+                  </div>
+                </div>
+                <div>
+                  <Label className="text-xs mb-1">Description</Label>
+                  <Input placeholder="What this skill does..." value={createDesc} onChange={(e) => setCreateDesc(e.target.value)} />
+                </div>
+                <div className="grid grid-cols-2 gap-3">
+                  <div>
+                    <Label className="text-xs mb-1">Category</Label>
+                    <Input placeholder="mlops" value={createCategory} onChange={(e) => setCreateCategory(e.target.value)} />
+                  </div>
+                  <div>
+                    <Label className="text-xs mb-1">Tags (comma-separated)</Label>
+                    <Input placeholder="python, ml" value={createTags} onChange={(e) => setCreateTags(e.target.value)} />
+                  </div>
+                </div>
+                <Separator />
+                <div className="flex items-center gap-3">
+                  <Button onClick={handleCreateSkill} disabled={busy || !createName.trim()} size="sm">
+                    <Plus className="h-3 w-3 mr-1" /> Create
+                  </Button>
+                  <Separator orientation="vertical" className="h-6" />
+                  <Input
+                    placeholder="Skill path to publish..."
+                    value={publishPath}
+                    onChange={(e) => setPublishPath(e.target.value)}
+                    className="flex-1"
+                  />
+                  <Input
+                    placeholder="GitHub repo"
+                    value={publishRepo}
+                    onChange={(e) => setPublishRepo(e.target.value)}
+                    className="w-48"
+                  />
+                  <Button onClick={handlePublish} disabled={busy || !publishPath.trim() || !publishRepo.trim()} size="sm" variant="outline">
+                    <Rocket className="h-3 w-3 mr-1" /> Publish
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          ) : (
+            /* Default: Skills list (with install bar) */
+            <Card>
+              <CardHeader className="py-3 px-4">
+                <div className="flex items-center justify-between">
+                  <CardTitle className="text-sm flex items-center gap-2">
+                    <Package className="h-4 w-4" />
+                    {activeCategory
+                      ? prettyCategory(
+                          activeCategory === "__none__" ? null : activeCategory,
+                          t.common.general,
+                        )
+                      : t.skills.all}
+                  </CardTitle>
+                  <div className="flex items-center gap-2">
+                    <Badge variant="secondary" className="text-[10px]">
+                      {activeSkills.length} skill{activeSkills.length !== 1 ? "s" : ""}
+                    </Badge>
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent className="px-4 pb-4">
+                {/* Quick install bar */}
+                <div className="flex gap-2 mb-3">
+                  <Input
+                    placeholder="Install skill (e.g. nous-research/skill-name)..."
+                    value={installId}
+                    onChange={(e) => setInstallId(e.target.value)}
+                    onKeyDown={(e) => e.key === "Enter" && handleInstall()}
+                    className="flex-1 h-8 text-xs"
+                  />
+                  <Button onClick={handleInstall} disabled={busy || !installId.trim()} size="sm">
+                    <Download className="h-3 w-3 mr-1" /> Install
+                  </Button>
+                </div>
+
+                {activeSkills.length === 0 ? (
+                  <p className="text-sm text-muted-foreground text-center py-8">
+                    {skills.length === 0 ? t.skills.noSkills : t.skills.noSkillsMatch}
+                  </p>
+                ) : (
+                  <div className="grid gap-1">
+                    {activeSkills.map((skill) => {
+                      const hub = hubSkills.find((h) => h.name === skill.name);
+                      return (
+                        <SkillRow
+                          key={skill.name}
+                          skill={skill}
+                          toggling={togglingSkills.has(skill.name)}
+                          onToggle={() => handleToggleSkill(skill)}
+                          noDescriptionLabel={t.skills.noDescription}
+                          hubType={hub?.type}
+                          isHubInstalled={hub?.type === "hub"}
+                          onUninstall={() => hub && handleUninstall(skill.name)}
+                        />
+                      );
+                    })}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
           )}
         </div>
       </div>
     </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Sub-components                                                     */
+/* ------------------------------------------------------------------ */
+
+function SidebarItem({
+  icon,
+  label,
+  active,
+  onClick,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`group flex items-center gap-2 px-2.5 py-1.5 text-left text-xs transition-colors cursor-pointer ${
+        active
+          ? "bg-primary/10 text-primary font-medium"
+          : "text-muted-foreground hover:text-foreground hover:bg-muted/50"
+      }`}
+    >
+      {icon}
+      <span className="flex-1 truncate">{label}</span>
+      {active && <ChevronRight className="h-3 w-3 text-primary/50 shrink-0" />}
+    </button>
   );
 }
 
@@ -495,6 +1084,9 @@ function SkillRow({
   toggling,
   onToggle,
   noDescriptionLabel,
+  hubType,
+  isHubInstalled,
+  onUninstall,
 }: SkillRowProps) {
   return (
     <div className="group flex items-start gap-3 px-3 py-2.5 transition-colors hover:bg-muted/40">
@@ -514,11 +1106,26 @@ function SkillRow({
           >
             {skill.name}
           </span>
+          {hubType && (
+            <Badge variant={hubType === "hub" ? "default" : "outline"} className="text-[9px]">
+              {hubType}
+            </Badge>
+          )}
         </div>
         <p className="text-xs text-muted-foreground leading-relaxed line-clamp-2">
           {skill.description || noDescriptionLabel}
         </p>
       </div>
+      {isHubInstalled && onUninstall && (
+        <Button
+          size="sm"
+          variant="ghost"
+          className="opacity-0 group-hover:opacity-100 transition-opacity shrink-0"
+          onClick={onUninstall}
+        >
+          <Trash2 className="h-3 w-3" />
+        </Button>
+      )}
     </div>
   );
 }
@@ -528,4 +1135,7 @@ interface SkillRowProps {
   toggling: boolean;
   onToggle: () => void;
   noDescriptionLabel: string;
+  hubType?: string;
+  isHubInstalled?: boolean;
+  onUninstall?: () => void;
 }


### PR DESCRIPTION
## Summary

This PR adds comprehensive Skills Hub lifecycle management to the Hermes Agent web UI, addressing Issue #13453.

### Backend Changes (`hermes_cli/web_server.py`)

Added **16 new FastAPI endpoints** that wrap existing `hermes_cli/skills_hub.py` and `tools/skills_hub.py` functions:

| Endpoint | Method | Description |
|---|---|---|
| `/api/skills/search` | GET | Search skills across registries |
| `/api/skills/browse` | GET | Browse available skills with pagination |
| `/api/skills/inspect` | GET | Get detailed skill info |
| `/api/skills/installed` | GET | List installed skills with hub metadata |
| `/api/skills/install` | POST | Install a skill from a registry |
| `/api/skills/uninstall/{name}` | DELETE | Uninstall a hub-installed skill |
| `/api/skills/check-updates` | GET | Check for available updates |
| `/api/skills/update` | PUT | Update hub-installed skills |
| `/api/skills/audit` | GET | Run security audit on hub skills |
| `/api/skills/taps` | GET/POST | List/add skill sources (taps) |
| `/api/skills/taps/{repo}` | DELETE | Remove a skill source |
| `/api/skills/snapshot/export` | GET | Export skill config as JSON snapshot |
| `/api/skills/snapshot/import` | POST | Import skills from a snapshot |
| `/api/skills/publish` | POST | Publish a local skill to GitHub |
| `/api/skills/create` | POST | Create a new local skill from template |

All endpoints use existing upstream functions — no new Python dependencies.

### Frontend Changes

**`web/src/lib/api.ts`** — Added 9 new TypeScript interfaces and 15 API client methods.

**`web/src/pages/SkillsPage.tsx`** — Enhanced with:
- 🔍 **Hub Search** — Search skills across registries
- 📦 **Browse** — Browse available skills with install action
- 🔄 **Updates** — Check for and apply skill updates
- 🛡️ **Audit** — View security scan results for hub-installed skills
- 🌐 **Skill Sources** — Manage taps (custom skill registries)
- 💾 **Snapshot** — Export/import skill configuration
- ➕ **Create** — Create new local skills from template
- 🚀 **Publish** — Publish local skills to GitHub

All new UI uses existing shadcn/ui components and follows the established design patterns.

Closes #13453
