### PR TITLE
feat(gateway): add telegram reply branching support

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2168,6 +2168,7 @@ class BasePlatformAdapter(ABC):
         user_id_alt: Optional[str] = None,
         chat_id_alt: Optional[str] = None,
         is_bot: bool = False,
+        reply_branch_id: Optional[str] = None,
     ) -> SessionSource:
         """Helper to build a SessionSource for this platform."""
         # Normalize empty topic to None
@@ -2185,6 +2186,7 @@ class BasePlatformAdapter(ABC):
             user_id_alt=user_id_alt,
             chat_id_alt=chat_id_alt,
             is_bot=is_bot,
+            reply_branch_id=reply_branch_id,
         )
     
     @abstractmethod

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -249,6 +249,22 @@ class TelegramAdapter(BasePlatformAdapter):
         self._model_picker_state: Dict[str, dict] = {}
         # Approval button state: message_id → session_key
         self._approval_state: Dict[int, str] = {}
+        # Reply branch map: chat_id -> {message_id: branch_id}.
+        # Tracks which branch root a previously-seen message_id belongs to so
+        # follow-up replies can be routed back onto the same session lane.
+        self._reply_branch_map: Dict[str, Dict[str, str]] = {}
+
+    def _remember_reply_branch(self, chat_id: str, message_id: str, branch_id: str) -> None:
+        """Record that ``message_id`` (in ``chat_id``) is part of branch ``branch_id``."""
+        if not chat_id or not message_id or not branch_id:
+            return
+        self._reply_branch_map.setdefault(str(chat_id), {})[str(message_id)] = str(branch_id)
+
+    def _resolve_reply_branch(self, chat_id: str, message_id: str) -> Optional[str]:
+        """Look up the branch id previously associated with ``message_id`` in ``chat_id``."""
+        if not chat_id or not message_id:
+            return None
+        return self._reply_branch_map.get(str(chat_id), {}).get(str(message_id))
 
     @staticmethod
     def _is_callback_user_authorized(user_id: str) -> bool:
@@ -969,6 +985,8 @@ class TelegramAdapter(BasePlatformAdapter):
             
             message_ids = []
             thread_id = self._metadata_thread_id(metadata)
+            force_reply_chain = bool(metadata.get("force_reply_chain")) if metadata else False
+            outgoing_branch_id = metadata.get("reply_branch_id") if metadata else None
             
             try:
                 from telegram.error import NetworkError as _NetErr
@@ -986,7 +1004,10 @@ class TelegramAdapter(BasePlatformAdapter):
                 _TimedOut = None  # type: ignore[assignment,misc]
 
             for i, chunk in enumerate(chunks):
-                should_thread = self._should_thread_reply(reply_to, i)
+                if force_reply_chain and reply_to:
+                    should_thread = True
+                else:
+                    should_thread = self._should_thread_reply(reply_to, i)
                 reply_to_id = int(reply_to) if should_thread else None
                 effective_thread_id = self._message_thread_id_for_send(thread_id)
 
@@ -1076,7 +1097,11 @@ class TelegramAdapter(BasePlatformAdapter):
                                 continue
                         raise
                 message_ids.append(str(msg.message_id))
-            
+                if outgoing_branch_id:
+                    self._remember_reply_branch(
+                        str(chat_id), str(msg.message_id), str(outgoing_branch_id)
+                    )
+
             return SendResult(
                 success=True,
                 message_id=message_ids[0] if message_ids else None,
@@ -2959,6 +2984,15 @@ class TelegramAdapter(BasePlatformAdapter):
                             break
                     break
 
+        # Extract reply context if this message is a reply
+        reply_to_id = None
+        reply_to_text = None
+        reply_branch_id = None
+        if message.reply_to_message:
+            reply_to_id = str(message.reply_to_message.message_id)
+            reply_to_text = message.reply_to_message.text or message.reply_to_message.caption or None
+            reply_branch_id = self._resolve_reply_branch(str(chat.id), reply_to_id)
+
         # Build source
         source = self.build_source(
             chat_id=str(chat.id),
@@ -2968,14 +3002,8 @@ class TelegramAdapter(BasePlatformAdapter):
             user_name=user.full_name if user else (chat.full_name if hasattr(chat, "full_name") and chat_type == "dm" else None),
             thread_id=thread_id_str,
             chat_topic=chat_topic,
+            reply_branch_id=reply_branch_id,
         )
-        
-        # Extract reply context if this message is a reply
-        reply_to_id = None
-        reply_to_text = None
-        if message.reply_to_message:
-            reply_to_id = str(message.reply_to_message.message_id)
-            reply_to_text = message.reply_to_message.text or message.reply_to_message.caption or None
 
         # Per-channel/topic ephemeral prompt
         from gateway.platforms.base import resolve_channel_prompt

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -83,6 +83,7 @@ class SessionSource:
     user_id_alt: Optional[str] = None  # Signal UUID (alternative to phone number)
     chat_id_alt: Optional[str] = None  # Signal group internal ID
     is_bot: bool = False  # True when the message author is a bot/webhook (Discord)
+    reply_branch_id: Optional[str] = None  # Telegram-style reply chain root, isolates sessions per branch
     
     @property
     def description(self) -> str:
@@ -120,6 +121,8 @@ class SessionSource:
             d["user_id_alt"] = self.user_id_alt
         if self.chat_id_alt:
             d["chat_id_alt"] = self.chat_id_alt
+        if self.reply_branch_id:
+            d["reply_branch_id"] = self.reply_branch_id
         return d
     
     @classmethod
@@ -135,6 +138,7 @@ class SessionSource:
             chat_topic=data.get("chat_topic"),
             user_id_alt=data.get("user_id_alt"),
             chat_id_alt=data.get("chat_id_alt"),
+            reply_branch_id=data.get("reply_branch_id"),
         )
     
 
@@ -498,6 +502,8 @@ def build_session_key(
     platform = source.platform.value
     if source.chat_type == "dm":
         if source.chat_id:
+            if source.reply_branch_id:
+                return f"agent:main:{platform}:dm:{source.chat_id}:{source.reply_branch_id}"
             if source.thread_id:
                 return f"agent:main:{platform}:dm:{source.chat_id}:{source.thread_id}"
             return f"agent:main:{platform}:dm:{source.chat_id}"

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -83,11 +83,16 @@ class GatewayStreamConsumer:
         chat_id: str,
         config: Optional[StreamConsumerConfig] = None,
         metadata: Optional[dict] = None,
+        reply_to: Optional[str] = None,
     ):
         self.adapter = adapter
         self.chat_id = chat_id
         self.cfg = config or StreamConsumerConfig()
         self.metadata = metadata
+        # External reply target (incoming user message) that every outgoing
+        # chunk should thread to, so all chunks stay on the same reply lane
+        # instead of only chunk 1 replying and 2..N forming their own chain.
+        self._reply_to: Optional[str] = reply_to
         self._queue: queue.Queue = queue.Queue()
         self._accumulated = ""
         self._message_id: Optional[str] = None
@@ -504,10 +509,11 @@ class GatewayStreamConsumer:
             return reply_to_id
         try:
             meta = dict(self.metadata) if self.metadata else {}
+            effective_reply_to = self._reply_to or reply_to_id
             result = await self.adapter.send(
                 chat_id=self.chat_id,
                 content=text,
-                reply_to=reply_to_id,
+                reply_to=effective_reply_to,
                 metadata=meta,
             )
             if result.success and result.message_id:

--- a/tests/gateway/test_telegram_reply_branching.py
+++ b/tests/gateway/test_telegram_reply_branching.py
@@ -1,0 +1,129 @@
+"""Tests for Telegram native reply branching."""
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import MessageType
+from gateway.session import SessionSource, build_session_key
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+
+def _ensure_telegram_mock():
+    import sys
+
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ChatType.GROUP = "group"
+    mod.constants.ChatType.SUPERGROUP = "supergroup"
+    mod.constants.ChatType.CHANNEL = "channel"
+    mod.constants.ChatType.PRIVATE = "private"
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+
+
+_ensure_telegram_mock()
+
+from gateway.platforms.telegram import TelegramAdapter  # noqa: E402
+
+
+def test_build_session_key_includes_dm_reply_branch():
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type="dm",
+        reply_branch_id="branch-1",
+    )
+
+    assert build_session_key(source) == "agent:main:telegram:dm:123:branch-1"
+
+
+def test_build_message_event_uses_stable_reply_branch_root():
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    adapter._bot = SimpleNamespace(id=42)
+    adapter._remember_reply_branch("123", "777", "555")
+
+    reply_target = SimpleNamespace(
+        message_id=777,
+        text="chunk 2",
+        caption=None,
+        from_user=SimpleNamespace(id=42),
+    )
+    message = SimpleNamespace(
+        chat=SimpleNamespace(id=123, type="private", title=None),
+        from_user=SimpleNamespace(id=7, full_name="Alice"),
+        message_thread_id=None,
+        reply_to_message=reply_target,
+        text="follow up",
+        caption=None,
+        message_id=888,
+        date=datetime.now(),
+    )
+
+    event = adapter._build_message_event(message, MessageType.TEXT)
+
+    assert event.reply_to_message_id == "777"
+    assert event.source.reply_branch_id == "555"
+
+
+@pytest.mark.asyncio
+async def test_send_forced_reply_chain_threads_every_chunk():
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    adapter._bot = MagicMock()
+    adapter._bot.send_message = AsyncMock(
+        side_effect=[
+            SimpleNamespace(message_id=101),
+            SimpleNamespace(message_id=102),
+            SimpleNamespace(message_id=103),
+        ]
+    )
+    adapter.truncate_message = lambda content, max_len, **kw: ["chunk1", "chunk2", "chunk3"]
+
+    await adapter.send(
+        "12345",
+        "test content",
+        reply_to="999",
+        metadata={"reply_branch_id": "555", "force_reply_chain": True},
+    )
+
+    calls = adapter._bot.send_message.call_args_list
+    assert len(calls) == 3
+    assert [call.kwargs.get("reply_to_message_id") for call in calls] == [999, 999, 999]
+    assert adapter._resolve_reply_branch("12345", "101") == "555"
+    assert adapter._resolve_reply_branch("12345", "102") == "555"
+    assert adapter._resolve_reply_branch("12345", "103") == "555"
+
+
+@pytest.mark.asyncio
+async def test_stream_consumer_keeps_all_chunks_in_same_reply_chain():
+    adapter = MagicMock()
+    adapter.MAX_MESSAGE_LENGTH = 610
+    adapter.truncate_message = lambda content, max_len, **kw: ["chunk 1", "chunk 2"]
+    adapter.send = AsyncMock(
+        side_effect=[
+            SimpleNamespace(success=True, message_id="msg_1"),
+            SimpleNamespace(success=True, message_id="msg_2"),
+        ]
+    )
+
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat_123",
+        StreamConsumerConfig(edit_interval=0.01, buffer_threshold=1),
+        reply_to="incoming_42",
+    )
+    consumer.on_delta("x" * 1000)
+    consumer.finish()
+
+    await consumer.run()
+
+    calls = adapter.send.call_args_list
+    assert len(calls) == 2
+    assert [call.kwargs.get("reply_to") for call in calls] == ["incoming_42", "incoming_42"]


### PR DESCRIPTION
## Summary
- add reply_branch_id to session sources and DM session keys
- track Telegram reply branches so follow-up replies stay on the same lane
- keep streamed chunks threaded to the original incoming reply target
- add reply branching regression tests

## Test Plan
- source venv/bin/activate && python -m pytest -o 'addopts=' -n 4 --ignore=tests/integration --ignore=tests/e2e -m 'not integration' tests/hermes_cli/test_runtime_provider_resolution.py tests/gateway/test_telegram_reply_mode.py tests/gateway/test_telegram_reply_branching.py -q

## Notes
- runtime_provider / ollama alias changes were pre-existing local work and are not included in this PR