### PR TITLE
fix: allow session_search to find content from compression-ended parent sessions

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -255,6 +255,7 @@ AUTHOR_MAP = {
     "ygd58@users.noreply.github.com": "ygd58",
     "vominh1919@users.noreply.github.com": "vominh1919",
     "iamagenius00@users.noreply.github.com": "iamagenius00",
+    "vivien000812@gmail.com": "iamagenius00",
     "9219265+cresslank@users.noreply.github.com": "cresslank",
     "trevmanthony@gmail.com": "trevthefoolish",
     "ziliangpeng@users.noreply.github.com": "ziliangpeng",

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -320,8 +320,8 @@ class TestSessionSearch:
         assert result["sessions_searched"] == 1
         assert current_sid not in [r.get("session_id") for r in result.get("results", [])]
 
-    def test_current_child_session_excludes_parent_lineage(self):
-        """Compression/delegation parents should be excluded for the active child session."""
+    def test_current_child_session_excludes_delegation_parent_lineage(self):
+        """Delegation parents (non-compression) should be excluded for the active child session."""
         from unittest.mock import MagicMock
         from tools.session_search_tool import session_search
 
@@ -335,6 +335,7 @@ class TestSessionSearch:
             if session_id == "child_sid":
                 return {"parent_session_id": "parent_sid"}
             if session_id == "parent_sid":
+                # No end_reason — this is a delegation parent, not compression
                 return {"parent_session_id": None}
             return None
 
@@ -348,6 +349,47 @@ class TestSessionSearch:
         assert result["count"] == 0
         assert result["results"] == []
         assert result["sessions_searched"] == 0
+
+    def test_compression_parent_not_excluded_from_search(self):
+        """Compression-ended parents should be searchable — the agent no longer
+        has their content after context compaction."""
+        from unittest.mock import MagicMock, AsyncMock, patch as _patch
+        from tools.session_search_tool import session_search
+
+        mock_db = MagicMock()
+        # FTS5 returns a match from the compression-ended parent session
+        mock_db.search_messages.return_value = [
+            {"session_id": "parent_sid", "content": "important detail from earlier",
+             "source": "cli", "session_started": 1709500000, "model": "test"},
+        ]
+
+        def _get_session(session_id):
+            if session_id == "child_sid":
+                return {"parent_session_id": "parent_sid"}
+            if session_id == "parent_sid":
+                # This parent was ended due to compression — its content
+                # was summarized and is no longer in the agent's context
+                return {"parent_session_id": None, "end_reason": "compression"}
+            return None
+
+        mock_db.get_session.side_effect = _get_session
+        mock_db.get_messages_as_conversation.return_value = [
+            {"role": "user", "content": "tell me about X"},
+            {"role": "assistant", "content": "important detail from earlier"},
+        ]
+
+        with _patch("tools.session_search_tool.async_call_llm",
+                     new_callable=AsyncMock,
+                     side_effect=RuntimeError("no provider")):
+            result = json.loads(session_search(
+                query="important detail", db=mock_db,
+                current_session_id="child_sid",
+            ))
+
+        assert result["success"] is True
+        # The compression parent should NOT be excluded — it should appear
+        assert result["sessions_searched"] == 1
+        assert result["count"] == 1
 
     def test_limit_none_coerced_to_default(self):
         """Model sends limit=null → should fall back to 3, not TypeError."""

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -399,23 +399,50 @@ def session_search(
                     break
             return sid
 
+        def _is_compression_session(session_id: str) -> bool:
+            """Check if a session was ended due to context compression."""
+            try:
+                session = db.get_session(session_id)
+                if session and session.get("end_reason") == "compression":
+                    return True
+            except Exception:
+                pass
+            return False
+
         current_lineage_root = (
             _resolve_to_parent(current_session_id) if current_session_id else None
         )
 
         # Group by resolved (parent) session_id, dedup, skip the current
-        # session lineage. Compression and delegation create child sessions
-        # that still belong to the same active conversation.
+        # session lineage — but NOT compression parents whose content is no
+        # longer in the agent's context window.
+        #
+        # Context compaction splits the active session: the parent is closed
+        # with end_reason="compression" and a new child becomes the active
+        # session.  The parent's messages were summarized and the originals
+        # are no longer visible to the agent.  Excluding those parents from
+        # search results creates a "memory black hole" — the agent can't
+        # recall details that were compacted away.
+        #
+        # We still exclude:
+        #  - The current active session (agent has that context)
+        #  - Delegation children that resolve to the current lineage root,
+        #    UNLESS they are compression-ended sessions whose content the
+        #    agent no longer has.
         seen_sessions = {}
         for result in raw_results:
             raw_sid = result["session_id"]
             resolved_sid = _resolve_to_parent(raw_sid)
-            # Skip the current session lineage — the agent already has that
-            # context, even if older turns live in parent fragments.
-            if current_lineage_root and resolved_sid == current_lineage_root:
-                continue
+            # Always skip the current active session itself
             if current_session_id and raw_sid == current_session_id:
                 continue
+            # For sessions in the current lineage, only skip if they are
+            # NOT compression-ended (i.e. their content is still available
+            # to the agent).  Compression parents have been summarized and
+            # their original messages are gone from context.
+            if current_lineage_root and resolved_sid == current_lineage_root:
+                if not _is_compression_session(raw_sid):
+                    continue
             if resolved_sid not in seen_sessions:
                 result = dict(result)
                 result["session_id"] = resolved_sid


### PR DESCRIPTION
## What

`session_search` excludes the entire current session lineage from results, including compression-ended parent sessions whose content the agent **no longer has**.

After context compaction, the original messages from earlier in the conversation are summarized into a compact handoff. The agent loses access to specific details — but `session_search` still treats those parent sessions as "current context" and skips them. This creates a **memory black hole**: the agent cannot recall compacted details even though they exist in the database.

## Why

Context compaction splits the active session:
1. The parent session is closed with `end_reason="compression"`
2. A new child session becomes the active session
3. The parent's messages are replaced by a summary in the agent's context

The current lineage exclusion logic assumes all sessions in the lineage are still visible to the agent. After compaction, this assumption is wrong.

Reported independently in #5447, #6256, #6507, #8803.

## What's included

**`tools/session_search_tool.py`**
- Added `_is_compression_session()` helper that checks `end_reason == "compression"`
- Narrowed the lineage exclusion: sessions ended by compression are no longer skipped, since their content is gone from the agent's context window
- Delegation children (non-compression) are still properly excluded

**`tests/tools/test_session_search.py`**
- Renamed existing test to clarify it covers delegation parents only
- Added `test_compression_parent_not_excluded_from_search` — verifies that compression-ended parents appear in search results
- All 36 tests pass

## How it works

Before:
```python
if current_lineage_root and resolved_sid == current_lineage_root:
    continue  # skips ALL sessions in current lineage
```

After:
```python
if current_lineage_root and resolved_sid == current_lineage_root:
    if not _is_compression_session(raw_sid):
        continue  # only skip if content is still in agent's context
```

## Testing

```
$ python -m pytest tests/tools/test_session_search.py -v
36 passed in 1.54s
```
