### PR TITLE
fix: strip whitespace from HERMES_HOME in get_subprocess_home()

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -129,7 +129,7 @@ def get_subprocess_home() -> str | None:
     Activation is directory-based: if the ``home/`` subdirectory doesn't
     exist, returns ``None`` and behavior is unchanged.
     """
-    hermes_home = os.getenv("HERMES_HOME")
+    hermes_home = os.getenv("HERMES_HOME", "").strip()
     if not hermes_home:
         return None
     profile_home = os.path.join(hermes_home, "home")


### PR DESCRIPTION
## Summary
- `get_hermes_home()` (line 17) strips whitespace from `HERMES_HOME` via `.strip()`, but `get_subprocess_home()` (line 132) reads the raw env var without stripping
- When `HERMES_HOME` contains leading/trailing whitespace (e.g. from `.env` files, systemd unit files, or Docker env), subprocess tool configs (git, ssh, npm, gh) would be written to a path with spaces while the application uses the stripped path
- This causes subprocess tools to fail to find their configs or create phantom directories

## Before
```python
# get_hermes_home() — strips whitespace
val = os.environ.get("HERMES_HOME", "").strip()

# get_subprocess_home() — no stripping
hermes_home = os.getenv("HERMES_HOME")
```

## After
```python
# Both consistently strip whitespace
hermes_home = os.getenv("HERMES_HOME", "").strip()
```

## Test plan
- [x] Verified the change matches the pattern used by `get_hermes_home()`
- [ ] Set `HERMES_HOME="  /opt/data  "` and verify subprocess HOME resolves to `/opt/data/home` (not `/opt/data  /home`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)