### PR TITLE
Add optional skill: Robin (knowledge management)

### DIFF
--- a/optional-skills/productivity/robin/SKILL.md
+++ b/optional-skills/productivity/robin/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: robin
+description: Save and review notes, links, media references, and other knowledge in a local commonplace book.
+version: 0.3.3
+author: Nitin Gupta
+license: MIT
+platforms: [macos, linux]
+metadata:
+  hermes:
+    tags: [productivity, knowledge-management, notes, commonplace, spaced-repetition]
+    requires_toolsets: [terminal]
+    category: productivity
+---
+
+# Robin
+
+Robin is a local commonplace-book skill for saving, organizing, searching, and reviewing knowledge over time. Use it when the user wants to remember a note, quote, article, link, image, video reference, or other durable item.
+
+Robin stores data in a user-controlled state directory. It does not require external services, API keys, or package installation.
+
+## When to Use
+
+Use Robin when the user wants to:
+
+- save something for later recall
+- organize knowledge by topic and tags
+- search or review prior saved entries
+- move or delete existing entries
+- check the health of the local Robin library
+
+Do not use Robin for short-lived reminders, calendar events, secrets, credentials, or files the user does not want persisted.
+
+## Setup
+
+Choose a Robin state directory, usually:
+
+```bash
+~/.hermes/data/robin
+```
+
+Initialize the directory before first use:
+
+```bash
+mkdir -p ~/.hermes/data/robin/topics ~/.hermes/data/robin/media
+printf '{}\n' > ~/.hermes/data/robin/robin-config.json
+python3 scripts/doctor.py --state-dir ~/.hermes/data/robin --json
+```
+
+Robin accepts either `--state-dir` or `ROBIN_STATE_DIR`. Prefer passing `--state-dir` explicitly in agent-run commands.
+
+## Common Commands
+
+Save a text entry:
+
+```bash
+python3 scripts/add_entry.py --state-dir ~/.hermes/data/robin --topic "AI" --content "Useful note" --description "Short label" --tags ai,notes
+```
+
+Save a source-backed entry:
+
+```bash
+python3 scripts/add_entry.py --state-dir ~/.hermes/data/robin --topic "Reading" --content "Key takeaway" --description "Article title" --source "https://example.com"
+```
+
+Search:
+
+```bash
+python3 scripts/search.py --state-dir ~/.hermes/data/robin --query "takeaway"
+python3 scripts/search.py --state-dir ~/.hermes/data/robin --topic "Reading" --json
+python3 scripts/search.py --state-dir ~/.hermes/data/robin --tags ai,notes
+```
+
+Review due items:
+
+```bash
+python3 scripts/review.py --state-dir ~/.hermes/data/robin --limit 5
+```
+
+Move or delete entries:
+
+```bash
+python3 scripts/entries.py --state-dir ~/.hermes/data/robin --id <entry-id> --move-to "New Topic"
+python3 scripts/entries.py --state-dir ~/.hermes/data/robin --id <entry-id> --delete
+```
+
+Check health:
+
+```bash
+python3 scripts/doctor.py --state-dir ~/.hermes/data/robin
+python3 scripts/selftest.py
+```
+
+## Operating Rules
+
+- Always include a topic and concise description when saving.
+- Use tags only when they will help future search or review.
+- Respect duplicate warnings. Use `--allow-duplicate` only when the user explicitly wants another copy.
+- For images, pass a local image path and let Robin copy it into the state directory.
+- For videos, save the URL/reference only; Robin does not copy video files.
+- When deleting, confirm the entry ID and user intent first.
+
+## Verification
+
+After setup or changes, run:
+
+```bash
+python3 scripts/doctor.py --state-dir ~/.hermes/data/robin --json
+```
+
+For a non-destructive integration check, run:
+
+```bash
+python3 scripts/selftest.py
+```
+
+See `references/guide.md` for the full CLI reference, JSON contracts, and advanced workflows.

--- a/optional-skills/productivity/robin/SKILL.md
+++ b/optional-skills/productivity/robin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: robin
-description: Save and review notes, links, media references, and other knowledge in a local commonplace book.
-version: 0.3.3
+description: Save, search, and review notes in a local commonplace book.
+version: 0.3.4
 author: Nitin Gupta
 license: MIT
 platforms: [macos, linux]
@@ -12,33 +12,29 @@ metadata:
     category: productivity
 ---
 
-# Robin
+# Robin Skill
 
-Robin is a local commonplace-book skill for saving, organizing, searching, and reviewing knowledge over time. Use it when the user wants to remember a note, quote, article, link, image, video reference, or other durable item.
-
-Robin stores data in a user-controlled state directory. It does not require external services, API keys, or package installation.
+Robin is a local commonplace book for saving, organizing, searching, and reviewing durable knowledge — notes, quotes, articles, links, images, and video references. It stores everything in a user-controlled state directory and needs no external services, API keys, or package installation. It is not a reminder, calendar, or secrets store.
 
 ## When to Use
 
-Use Robin when the user wants to:
-
-- save something for later recall
-- organize knowledge by topic and tags
-- search or review prior saved entries
-- move or delete existing entries
-- check the health of the local Robin library
+- The user wants to save something for later recall.
+- The user wants to organize knowledge by topic and tags.
+- The user wants to search or review previously saved entries.
+- The user wants to move or delete an existing entry.
+- The user wants to check the health of the local Robin library.
 
 Do not use Robin for short-lived reminders, calendar events, secrets, credentials, or files the user does not want persisted.
 
-## Setup
+## Prerequisites
 
-Choose a Robin state directory, usually:
+- Python 3.11+ and a POSIX shell (macOS or Linux) via the `terminal` toolset.
+- A Robin state directory, by default `~/.hermes/data/robin`. Robin reads it from `--state-dir` or the `ROBIN_STATE_DIR` environment variable; prefer passing `--state-dir` explicitly in agent-run commands.
+- All commands are run from this skill's directory so the bundled runtime under `scripts/robin/` is importable.
 
-```bash
-~/.hermes/data/robin
-```
+## How to Run
 
-Initialize the directory before first use:
+Initialize the state directory once before first use:
 
 ```bash
 mkdir -p ~/.hermes/data/robin/topics ~/.hermes/data/robin/media
@@ -46,71 +42,90 @@ printf '{}\n' > ~/.hermes/data/robin/robin-config.json
 python3 scripts/doctor.py --state-dir ~/.hermes/data/robin --json
 ```
 
-Robin accepts either `--state-dir` or `ROBIN_STATE_DIR`. Prefer passing `--state-dir` explicitly in agent-run commands.
+`robin-config.json` may stay `{}`; `topics_dir`/`media_dir` default to `topics`/`media` inside the state directory and must remain relative descendants of it.
 
-## Common Commands
+## Quick Reference
 
-Save a text entry:
+Save a text entry (`--topic` and `--description` are always required):
 
 ```bash
 python3 scripts/add_entry.py --state-dir ~/.hermes/data/robin --topic "AI" --content "Useful note" --description "Short label" --tags ai,notes
-```
-
-Save a source-backed entry:
-
-```bash
 python3 scripts/add_entry.py --state-dir ~/.hermes/data/robin --topic "Reading" --content "Key takeaway" --description "Article title" --source "https://example.com"
 ```
 
-Search:
+Save an image entry (media entries also require `--creator`, `--published-at`, `--summary`):
 
 ```bash
-python3 scripts/search.py --state-dir ~/.hermes/data/robin --query "takeaway"
+python3 scripts/add_entry.py --state-dir ~/.hermes/data/robin --entry-type image --topic "Design" --media-path ~/Downloads/shot.png --description "Reference screenshot" --creator "Jane Doe" --published-at 2026-01-15 --summary "Landing page layout"
+```
+
+Save a video reference (URL only — Robin never copies video files):
+
+```bash
+python3 scripts/add_entry.py --state-dir ~/.hermes/data/robin --entry-type video --topic "Talks" --media-url "https://example.com/watch" --description "Great talk" --creator "Jane Doe" --published-at 2026-01-15 --summary "Talk on X"
+```
+
+Search (the query is a **positional** argument, not a flag):
+
+```bash
+python3 scripts/search.py --state-dir ~/.hermes/data/robin "takeaway"
 python3 scripts/search.py --state-dir ~/.hermes/data/robin --topic "Reading" --json
 python3 scripts/search.py --state-dir ~/.hermes/data/robin --tags ai,notes
 ```
 
-Review due items:
+Review (surfaces one candidate; there is no `--limit`):
 
 ```bash
-python3 scripts/review.py --state-dir ~/.hermes/data/robin --limit 5
+python3 scripts/review.py --state-dir ~/.hermes/data/robin
+python3 scripts/review.py --state-dir ~/.hermes/data/robin --active-review --json
+python3 scripts/review.py --state-dir ~/.hermes/data/robin --status --json
+python3 scripts/review.py --state-dir ~/.hermes/data/robin --rate <entry-id> 5
 ```
 
-Move or delete entries:
+Move or delete entries (`--move ID --topic TOPIC`, or `--delete ID`):
 
 ```bash
-python3 scripts/entries.py --state-dir ~/.hermes/data/robin --id <entry-id> --move-to "New Topic"
-python3 scripts/entries.py --state-dir ~/.hermes/data/robin --id <entry-id> --delete
+python3 scripts/entries.py --state-dir ~/.hermes/data/robin --move <entry-id> --topic "New Topic"
+python3 scripts/entries.py --state-dir ~/.hermes/data/robin --delete <entry-id>
 ```
 
-Check health:
+List topics, rebuild the review index, or check health:
 
 ```bash
+python3 scripts/topics.py --state-dir ~/.hermes/data/robin --json
+python3 scripts/reindex.py --state-dir ~/.hermes/data/robin --json
 python3 scripts/doctor.py --state-dir ~/.hermes/data/robin
-python3 scripts/selftest.py
 ```
 
-## Operating Rules
+Add `--json` to any command for machine-readable output. See `references/guide.md` for the full CLI reference and JSON contracts.
 
-- Always include a topic and concise description when saving.
-- Use tags only when they will help future search or review.
-- Respect duplicate warnings. Use `--allow-duplicate` only when the user explicitly wants another copy.
-- For images, pass a local image path and let Robin copy it into the state directory.
-- For videos, save the URL/reference only; Robin does not copy video files.
-- When deleting, confirm the entry ID and user intent first.
+## Procedure
+
+1. Confirm (or initialize) the state directory and run `doctor.py` if unsure of its health.
+2. When saving, choose a topic and write a concise 2-3 sentence `--description`; add tags only when they aid future search or review.
+3. For images, pass a local `--media-path` and let Robin copy it into the state directory. For videos, pass a `--media-url` reference only.
+4. Respect duplicate warnings — pass `--allow-duplicate` only when the user explicitly wants another copy.
+5. To recall, use `search.py` with a positional query, `--topic`, or `--tags`; use `review.py` to surface an item and `--rate <id> <1-5>` to record a rating.
+6. Before deleting, confirm the entry ID and the user's intent.
+
+## Pitfalls
+
+- The search query is positional; `--query` is not a valid flag.
+- `review.py` surfaces a single best candidate and has no `--limit` option.
+- Entry moves/deletes use `--move ID --topic TOPIC` and `--delete ID`; there is no `--id`/`--move-to`.
+- `topics_dir`/`media_dir` in `robin-config.json` must be relative paths inside the state directory; absolute or `..` values are rejected.
+- Media entries (`image`/`video`) require `--creator`, `--published-at`, and `--summary`; video entries take `--media-url`, not a local file.
 
 ## Verification
 
-After setup or changes, run:
+After setup or changes, confirm the library is healthy:
 
 ```bash
 python3 scripts/doctor.py --state-dir ~/.hermes/data/robin --json
 ```
 
-For a non-destructive integration check, run:
+For a non-destructive, end-to-end integration check against a temporary state directory:
 
 ```bash
 python3 scripts/selftest.py
 ```
-
-See `references/guide.md` for the full CLI reference, JSON contracts, and advanced workflows.

--- a/optional-skills/productivity/robin/references/guide.md
+++ b/optional-skills/productivity/robin/references/guide.md
@@ -365,13 +365,15 @@ Body:
 Review behavior:
 
 1. Robin waits until there are at least `min_items_before_review` items.
-2. It prefers unrated items first.
-3. Then lower-rated items.
-4. Then items with the fewest total prior surfaces.
-5. It skips items surfaced within `review_cooldown_days`.
-6. Scheduled recall is the default: `python3 scripts/review.py --state-dir <state-dir>` increments `times_surfaced`, sets `last_surfaced`, and keeps `_awaiting_rating` as `false`.
-7. Active review is explicit: `python3 scripts/review.py --state-dir <state-dir> --active-review` increments `times_surfaced`, sets `last_surfaced`, and marks `_awaiting_rating` as `true`.
-8. A subsequent `--rate` call for that actively surfaced item overwrites the previous rating and sets `_awaiting_rating` back to `false` without incrementing `times_surfaced` again.
+2. It skips items surfaced within `review_cooldown_days`.
+3. It prefers items with the fewest total prior surfaces.
+4. It prefers never-surfaced items before previously surfaced items, then prefers the oldest prior surface.
+5. If another topic is eligible, it avoids surfacing the same topic that was surfaced most recently.
+6. Ratings are only a late tie-breaker; they do not lead scheduled recall ordering.
+7. Robin lightly randomizes within the best eligible pool so overloaded topics do not dominate recall.
+8. Scheduled recall is the default: `python3 scripts/review.py --state-dir <state-dir>` increments `times_surfaced`, sets `last_surfaced`, and keeps `_awaiting_rating` as `false`.
+9. Active review is explicit: `python3 scripts/review.py --state-dir <state-dir> --active-review` increments `times_surfaced`, sets `last_surfaced`, and marks `_awaiting_rating` as `true`.
+10. A subsequent `--rate` call for that actively surfaced item overwrites the previous rating and sets `_awaiting_rating` back to `false` without incrementing `times_surfaced` again.
 
 If `--rate` is called directly on an item that was not surfaced first, Robin still sets `last_surfaced`, increments `times_surfaced`, and keeps `_awaiting_rating` as `false`.
 

--- a/optional-skills/productivity/robin/references/guide.md
+++ b/optional-skills/productivity/robin/references/guide.md
@@ -1,0 +1,424 @@
+# Robin Guide
+
+This guide is for advanced users who want manual control over Robin: state-directory setup, config files, CLI usage, file layout, and troubleshooting.
+
+Important: Robin requires Python 3.11 or newer.
+
+## Storage Model
+
+Robin keeps both saved content and review state inside the state directory.
+
+Recommended layout:
+
+```text
+agent-workspace/
+  data/
+    robin/
+      robin-config.json
+      robin-review-index.json
+      media/
+        poetry/
+          20260409-a1f3c9.png
+      topics/
+        wisdom.md
+        poetry.md
+        quotes.md
+```
+
+- The Robin state directory stores config, review metadata, topic files, and copied images.
+- Robin does not guess where its state lives.
+
+Typical host examples:
+
+- Hermes: `~/.hermes/data/robin/`
+- OpenClaw: `~/.openclaw/workspace/data/robin/`
+
+## Runtime Contract
+
+Every Robin command needs a state directory.
+
+Robin accepts both:
+
+- `--state-dir /path/to/data/robin`
+- `ROBIN_STATE_DIR=/path/to/data/robin`
+
+Precedence:
+
+1. `--state-dir`
+2. `ROBIN_STATE_DIR`
+3. otherwise Robin exits with an error
+
+Expected files inside the state directory:
+
+- `robin-config.json`
+- optionally `robin-review-index.json`
+
+If neither `--state-dir` nor `ROBIN_STATE_DIR` is present, Robin exits with:
+
+```text
+Robin state directory is not configured. Pass --state-dir or set ROBIN_STATE_DIR.
+```
+
+## Manual Setup
+
+Create a state directory:
+
+```bash
+mkdir -p /path/to/agent-workspace/data/robin
+mkdir -p /path/to/agent-workspace/data/robin/topics
+mkdir -p /path/to/agent-workspace/data/robin/media
+```
+
+Create `/path/to/agent-workspace/data/robin/robin-config.json`. The file is required, but it may be an empty JSON object (`{}`):
+
+```json
+{
+  "topics_dir": "topics",
+  "media_dir": "media",
+  "min_items_before_review": 30,
+  "review_cooldown_days": 60
+}
+```
+
+Robin does not need a separate content-root path. Topic files and copied media live inside the state directory under `topics/` and `media/`.
+
+All fields inside `robin-config.json` are optional. Robin defaults to:
+
+- `topics_dir`: `topics`
+- `media_dir`: `media`
+- `min_items_before_review`: `30`
+- `review_cooldown_days`: `60`
+
+Optional: create `/path/to/agent-workspace/data/robin/robin-review-index.json`:
+
+```json
+{
+  "items": {}
+}
+```
+
+If the review index file is missing, Robin starts with an empty index and writes the file when review state is saved.
+
+Then either export the state dir:
+
+```bash
+export ROBIN_STATE_DIR=/path/to/agent-workspace/data/robin
+```
+
+Or pass it explicitly on each command:
+
+```bash
+python3 scripts/topics.py --state-dir /path/to/agent-workspace/data/robin
+```
+
+This is also the simplest setup verification step. A healthy empty setup returns `No topics yet. Start filing things with Robin!`
+
+For a fuller integration check that does not touch the user's real library, run:
+
+```bash
+python3 scripts/selftest.py
+```
+
+For a non-destructive setup check against a real state directory, run:
+
+```bash
+python3 scripts/selftest.py --state-dir /path/to/agent-workspace/data/robin
+```
+
+## Topic Files
+
+Robin stores content in topic-organized Markdown files under `topics/`.
+
+Topic filenames use lowercase slugs with non-alphanumeric characters normalized to dashes.
+
+Examples:
+
+- `Song Lyrics` -> `song-lyrics.md`
+- `AI/ML` -> `ai-ml.md`
+
+Entries are separated by `***`. Each entry has frontmatter, then a blank line, then optional body text.
+
+Text entries may omit `entry_type`; omitted `entry_type` is parsed as `text`.
+
+Text example:
+
+```text
+id: 20260408-a1f3c9
+date_added: 2026-04-08
+description: A short excerpt from a Paul Graham essay about optimizing for what matters. Useful as a general reminder when making tradeoff decisions.
+source: https://example.com/article
+tags: [ai, reasoning]
+
+Notable excerpt or the thing you sent.
+```
+
+Image example:
+
+```text
+id: 20260408-b7k2d1
+date_added: 2026-04-08
+entry_type: image
+media_kind: image
+media_source: media/poetry/20260408-b7k2d1.png
+description: A photographed poem excerpt worth revisiting for tone and imagery.
+creator: Mary Oliver
+published_at: 1986
+summary: An excerpt about attention and observation in everyday life.
+tags: [poetry]
+
+Opening lines from the photographed page.
+```
+
+Field meanings:
+
+- `id`: stable entry identifier
+- `date_added`: entry date
+- `entry_type`: `text`, `image`, or `video`
+- `media_kind`: same as `entry_type` for media entries; omitted for text entries, including text entries with image attachments
+- `media_source`: copied relative path for local images or external URL for videos; may be present on text entries when `--media-path` is used
+- `source`: original source URL when available
+- `description`: required context for every entry
+- `creator`, `published_at`, `summary`: required for media entries
+- `tags`: optional tag list
+
+## Topic and Content Policy
+
+- Start filing by running `python3 scripts/topics.py --state-dir <state-dir> --json`.
+- Choose a topic by name when there is a clear match.
+- If topic names alone are ambiguous, inspect relevant topic files or use host search for more context.
+- Prefer reusing an existing topic over creating a near-duplicate.
+- Prefer durable, reusable topics such as `quotes`, `wisdom`, `poetry`, or `talks`.
+- Create a new topic only when no existing topic clearly fits.
+- Ask the user when two existing topics are both plausible.
+- `add_entry.py` blocks deterministic duplicates by default when an existing entry has the same source URL, same media reference, or same normalized body text.
+- Use `--allow-duplicate` only when the duplicate is intentional.
+- For near-duplicates with meaningful differences, save only when the difference is worth preserving and explain the difference in `description`.
+- Robin has no hard body-size limit, but agents should summarize very long articles or transcripts unless the user explicitly asks to store the full text.
+
+Field semantics:
+
+- `description`: required context for every entry; why the item matters and how to recognize it later.
+- `summary`: required only for media entries; what the media itself contains.
+- `note`: optional curation commentary, reminders, or connections to other entries.
+- `tags`: pass on the CLI as one comma-separated string, for example `--tags "writing,clarity"`. Robin stores them as a frontmatter list.
+
+## Media Rules
+
+Robin accepts media with these rules:
+
+- local image files: accepted and copied into `media/<topic-slug>/`; Robin creates the topic subdirectory automatically
+- text entries require at least one payload: `content`, `note`, `source`, or local image attachment with `--media-path`
+- text entries may attach a local image with `--media-path`; Robin keeps `entry_type` as `text`, sets `media_source`, and does not require media metadata
+- remote image URLs: not supported directly by Robin's CLI
+- video URLs: accepted and stored by reference
+- uploaded or local video files: rejected; if the user cannot provide a shareable `http(s)` URL, save a normal `text` entry with the local path/context and tell the user Robin did not store the video file itself
+
+Robin will not store a media entry unless the caller provides:
+
+- `description`
+- `creator`
+- `published_at`
+- `summary`
+
+If a media item is rejected, Robin stores nothing and returns an error.
+
+Robin also rejects any entry whose serialized body would contain a standalone `***` line, because `***` is Robin's internal entry separator.
+
+## Search: Host Index vs Robin Search
+
+If your agent supports file indexing, it should index Robin topic files like any other Markdown content.
+
+Use host/global search for:
+
+- broad semantic recall across all user content
+- exploratory queries where Robin may be only one source
+
+Use `robin-search` for:
+
+- Robin-specific lookup
+- topic filtering
+- tag filtering
+- deterministic lookup of Robin entries
+- structured JSON output with stable ids, metadata, and ratings
+- fallback when host indexing is unavailable or stale
+
+`robin-search` can combine filters. If both `--topic` and `--tags` are provided, Robin first narrows to the topic and then applies the tag filter within that topic.
+
+## CLI Reference
+
+Default repo-local commands for agents:
+
+- `python3 scripts/add_entry.py`
+- `python3 scripts/doctor.py`
+- `python3 scripts/entries.py`
+- `python3 scripts/review.py`
+- `python3 scripts/reindex.py`
+- `python3 scripts/search.py`
+- `python3 scripts/selftest.py`
+- `python3 scripts/topics.py`
+
+Optional installed entry points for advanced users:
+
+- `robin-add`
+- `robin-doctor`
+- `robin-entries`
+- `robin-review`
+- `robin-reindex`
+- `robin-search`
+- `robin-topics`
+
+All Robin commands support `--state-dir`.
+
+Use `--json` whenever command output needs to be parsed programmatically. Without `--json`, Robin prints human-readable text for interactive use; that text is not a stable machine contract.
+
+CLI flags by command:
+
+- `add_entry.py`: `--state-dir`, `--topic`, `--entry-type text|image|video`, `--content`, `--description`, `--source`, `--media-path`, `--media-url`, `--creator`, `--published-at`, `--summary`, `--note`, `--tags`, `--allow-duplicate`, `--json`
+- `doctor.py`: `--state-dir`, `--json`
+- `entries.py`: `--state-dir`, `--delete ID`, `--move ID --topic TOPIC`, `--json`
+- `review.py`: `--state-dir`, `--status`, `--active-review`, `--rate ID RATING`, `--json`
+- `search.py`: `--state-dir`, optional positional `query` string, `--topic`, `--tags`, `--json`
+- `selftest.py`: optional `--state-dir` for non-destructive setup checks, `--keep-temp`
+- `topics.py`: `--state-dir`, `--json`
+- `reindex.py`: `--state-dir`, `--json`
+
+Recommended path for agents:
+
+- run the repo-local `python3 scripts/*.py` commands directly
+
+Optional path for advanced users:
+
+- `pip install -e .`
+- then use the installed `robin-add`, `robin-doctor`, `robin-entries`, `robin-review`, `robin-reindex`, `robin-search`, and `robin-topics` entry points
+
+The repo-local `python3 scripts/*.py` commands work without `pip install -e .` or manual path setup.
+
+Examples:
+
+```bash
+python3 scripts/search.py --state-dir /path/to/data/robin "clear thinking" --json
+python3 scripts/review.py --state-dir /path/to/data/robin --json
+python3 scripts/review.py --state-dir /path/to/data/robin --active-review --json
+python3 scripts/review.py --state-dir /path/to/data/robin --status --json
+python3 scripts/review.py --state-dir /path/to/data/robin --rate 20260408-a1f3c9 5
+python3 scripts/review.py --state-dir /path/to/data/robin --rate 20260408-a1f3c9 5 --json
+python3 scripts/doctor.py --state-dir /path/to/data/robin
+python3 scripts/doctor.py --state-dir /path/to/data/robin --json
+python3 scripts/entries.py --state-dir /path/to/data/robin --move 20260408-a1f3c9 --topic "AI Reasoning" --json
+python3 scripts/entries.py --state-dir /path/to/data/robin --delete 20260408-a1f3c9 --json
+python3 scripts/search.py --state-dir /path/to/data/robin --topic "AI Reasoning" --json
+python3 scripts/search.py --state-dir /path/to/data/robin --tags "writing,clarity" --json
+python3 scripts/search.py --state-dir /path/to/data/robin --topic "AI Reasoning" --tags "clarity" --json
+python3 scripts/topics.py --state-dir /path/to/data/robin --json
+python3 scripts/selftest.py
+python3 scripts/selftest.py --state-dir /path/to/data/robin
+python3 scripts/add_entry.py --state-dir /path/to/data/robin --topic "reasoning" --content "The most important thing is to decide what you are optimizing for." --description "A short Paul Graham line about choosing the objective before optimizing. Useful when reviewing tradeoff-heavy decisions." --json
+python3 scripts/add_entry.py --state-dir /path/to/data/robin --topic "writing" --content "Write as if speaking to a smart friend." --description "A reminder to keep prose conversational and clear." --source "https://example.com/article" --note "Pair this with other writing advice." --json
+python3 scripts/add_entry.py --state-dir /path/to/data/robin --topic "reasoning" --content "The map is not the territory." --description "A reminder that abstractions are not reality itself." --tags "thinking,quotes" --json
+python3 scripts/add_entry.py --state-dir /path/to/data/robin --topic "wisdom" --content "Filed this screenshot to wisdom." --description "A text note with a local screenshot attached for later context." --media-path ~/Downloads/screenshot.png --json
+python3 scripts/add_entry.py --state-dir /path/to/data/robin --entry-type image --topic "poetry" --media-path ~/Downloads/poem.png --description "A photographed poem excerpt worth revisiting." --creator "Mary Oliver" --published-at "1986" --summary "An excerpt about attention and observation." --json
+python3 scripts/add_entry.py --state-dir /path/to/data/robin --entry-type video --topic "talks" --media-url "https://www.youtube.com/watch?v=abc123" --description "A talk to revisit for its framing and examples." --creator "Speaker Name" --published-at "2025-01-01" --summary "A concise summary of the talk." --json
+python3 scripts/reindex.py --state-dir /path/to/data/robin
+python3 scripts/reindex.py --state-dir /path/to/data/robin --json
+```
+
+The examples above use the repo-local `python3 scripts/*.py` path. If you installed the package with `pip install -e .`, the `robin-*` entry points are equivalent aliases.
+
+All CLI helpers support `--json`.
+
+Use `python3 scripts/doctor.py --state-dir <state-dir> --json` to check config, topic parsing, local media references, and review-index drift without changing the library. Doctor is read-only; use `python3 scripts/reindex.py --state-dir <state-dir> --json` when it reports review-index drift.
+
+Use `python3 scripts/entries.py --state-dir <state-dir> --move <id> --topic <topic>` to move an entry, or `python3 scripts/entries.py --state-dir <state-dir> --delete <id>` to delete one. Delete removes the entry and its review-index item but keeps copied media files. `search.py` and `topics.py` remain read-only.
+
+Use `python3 scripts/reindex.py --state-dir <state-dir>` after manual edits to topic files, when rebuilding review state from existing markdown, or when importing legacy entries and wanting the review index rebuilt from disk.
+
+## Review System
+
+Robin maintains a review index keyed by entry `id`. It stores:
+
+- `rating`
+- `last_surfaced`
+- `times_surfaced`
+
+Scheduled recall means Robin resurfaces an item for learning. It is not an active review session. Cron or scheduled recall messages should use the same recall template for every entry type and should not ask the user to reply with a bare `1`-`5` rating.
+
+If the host scheduler supports skill metadata, scheduled recall jobs should load the `robin` skill. If it does not, the cron prompt must explicitly follow this review behavior.
+
+Default recall text output:
+
+```text
+📚 Robin Recall
+
+Topic: <topic>
+Type: <entry_type>
+Source: <source if present, else media_source if present, else "Not provided">
+Creator: <creator if present, else "Not provided">
+Saved on: <date_added> (<N> days ago)
+
+Description:
+<description if present, else "Not provided">
+
+Body:
+<body if present, else "Not provided">
+```
+
+Review behavior:
+
+1. Robin waits until there are at least `min_items_before_review` items.
+2. It prefers unrated items first.
+3. Then lower-rated items.
+4. Then items with the fewest total prior surfaces.
+5. It skips items surfaced within `review_cooldown_days`.
+6. Scheduled recall is the default: `python3 scripts/review.py --state-dir <state-dir>` increments `times_surfaced`, sets `last_surfaced`, and keeps `_awaiting_rating` as `false`.
+7. Active review is explicit: `python3 scripts/review.py --state-dir <state-dir> --active-review` increments `times_surfaced`, sets `last_surfaced`, and marks `_awaiting_rating` as `true`.
+8. A subsequent `--rate` call for that actively surfaced item overwrites the previous rating and sets `_awaiting_rating` back to `false` without incrementing `times_surfaced` again.
+
+If `--rate` is called directly on an item that was not surfaced first, Robin still sets `last_surfaced`, increments `times_surfaced`, and keeps `_awaiting_rating` as `false`.
+
+Preferred rating flow:
+
+- Use `python3 scripts/review.py --state-dir <state-dir> --active-review --json` to surface an item in a live active-review session.
+- After the user rates that surfaced item, call `python3 scripts/review.py --state-dir <state-dir> --rate <id> <rating> --json`.
+- Use direct `--rate` without a prior surface only for manual corrections or when the user explicitly names an existing entry id.
+- Do not request ratings in scheduled recall messages. Only rate during active review sessions or when the user explicitly names a Robin item id.
+
+Setup guidance for hosts: ask the user how often recall should happen and when it should run. If the host supports scheduling, a daily or weekly recall trigger is the normal default. Otherwise, keep active review available as an on-demand command.
+
+Example index shape:
+
+```json
+{
+  "items": {
+    "20260408-a1f3c9": {
+      "id": "20260408-a1f3c9",
+      "topic": "quotes",
+      "date": "2026-04-08",
+      "rating": null,
+      "last_surfaced": null,
+      "times_surfaced": 0,
+      "_awaiting_rating": false
+    }
+  }
+}
+```
+
+`_awaiting_rating` is an internal review-state flag. It is `true` only after Robin surfaces an item with `--active-review` and becomes `false` again after that surface is rated. Scheduled recall leaves it `false`.
+
+## Troubleshooting
+
+- Config not found:
+  Create `robin-config.json` in the state directory and pass `--state-dir` or set `ROBIN_STATE_DIR`.
+- Config has invalid JSON:
+  Recreate `robin-config.json` as `{}` or with the supported config fields.
+- Review index not found:
+  Robin can start without it. If you want to create it manually, use `{"items": {}}`, or run `python3 scripts/reindex.py --state-dir <state-dir> --json` to rebuild from topic files.
+- Review index has invalid JSON:
+  Back up or recreate `robin-review-index.json` as `{"items": {}}`, then run `python3 scripts/reindex.py --state-dir <state-dir> --json` to rebuild from topic files.
+- Library health is uncertain:
+  Run `python3 scripts/doctor.py --state-dir <state-dir> --json` for a read-only diagnostic report.
+- Media entry rejected:
+  Ensure the caller provided `description`, `creator`, `published_at`, and `summary`.
+- Local video rejected:
+  Provide an `http(s)` video URL instead, or save a normal text entry with the local path/context and note that Robin did not store the video file.
+- Image copy failed:
+  Confirm the local image path exists and the `media/` directory under the state dir is writable.

--- a/optional-skills/productivity/robin/scripts/__init__.py
+++ b/optional-skills/productivity/robin/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""CLI wrappers for Robin."""

--- a/optional-skills/productivity/robin/scripts/add_entry.py
+++ b/optional-skills/productivity/robin/scripts/add_entry.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""
+add_entry.py — Robin add entry script
+
+Usage:
+  python3 add_entry.py --state-dir /path/to/data/robin --topic "AI Reasoning" --content "..." --description "..." [--source URL] [--note "..."] [--tags tag1,tag2]
+
+Or set:
+  ROBIN_STATE_DIR=/path/to/data/robin
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from robin.cli import add_main
+
+
+def main():
+    add_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/productivity/robin/scripts/doctor.py
+++ b/optional-skills/productivity/robin/scripts/doctor.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""
+doctor.py - Check a Robin library for common health issues
+
+Usage:
+  python3 doctor.py --state-dir /path/to/data/robin
+  python3 doctor.py --state-dir /path/to/data/robin --json
+
+Or set:
+  ROBIN_STATE_DIR=/path/to/data/robin
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from robin.cli import doctor_main
+
+
+def main():
+    doctor_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/productivity/robin/scripts/entries.py
+++ b/optional-skills/productivity/robin/scripts/entries.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""
+entries.py - Move or delete Robin entries
+
+Usage:
+  python3 entries.py --state-dir /path/to/data/robin --delete ENTRY_ID
+  python3 entries.py --state-dir /path/to/data/robin --move ENTRY_ID --topic "New Topic"
+
+Or set:
+  ROBIN_STATE_DIR=/path/to/data/robin
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from robin.cli import entries_main
+
+
+def main():
+    entries_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/productivity/robin/scripts/reindex.py
+++ b/optional-skills/productivity/robin/scripts/reindex.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""
+reindex.py — Rebuild Robin's review index from topic files
+
+Usage:
+  python3 reindex.py --state-dir /path/to/data/robin
+
+Or set:
+  ROBIN_STATE_DIR=/path/to/data/robin
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from robin.cli import reindex_main
+
+
+def main():
+    reindex_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/productivity/robin/scripts/review.py
+++ b/optional-skills/productivity/robin/scripts/review.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""
+review.py — Robin review script
+
+Usage:
+  python3 review.py --state-dir /path/to/data/robin                    # Scheduled recall; no pending rating
+  python3 review.py --state-dir /path/to/data/robin --active-review    # Active review; await a rating
+  python3 review.py --state-dir /path/to/data/robin --rate ID 5        # Rate an item (overwrites previous)
+  python3 review.py --state-dir /path/to/data/robin --status           # Show review stats without surfacing
+
+Or set:
+  ROBIN_STATE_DIR=/path/to/data/robin
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from robin.cli import review_main
+
+
+def main():
+    review_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/productivity/robin/scripts/robin/__init__.py
+++ b/optional-skills/productivity/robin/scripts/robin/__init__.py
@@ -1,0 +1,1 @@
+"""Robin shared library for markdown-backed commonplace management."""

--- a/optional-skills/productivity/robin/scripts/robin/cli.py
+++ b/optional-skills/productivity/robin/scripts/robin/cli.py
@@ -1,0 +1,631 @@
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import date
+from typing import NoReturn
+
+from robin.config import load_config, load_index, save_index, topics_path
+from robin.doctor import run_doctor
+from robin.entry_ops import (
+    EntryOperationError,
+    append_entry_to_file,
+    delete_entry,
+    find_duplicate_candidates,
+    duplicate_payload,
+    move_entry,
+    remove_new_media_if_present,
+)
+from robin.index import ensure_entry_in_index, rebuild_index
+from robin.media import copy_image_to_media, is_video_url
+from robin.parser import RobinEntryParseError, SEPARATOR, load_all_entries, load_topic_entries, topic_slug, topic_to_filename
+from robin.review_logic import mark_surfaced, pick_best_candidate, rate_item
+from robin.search_logic import filter_by_tags, search_entries
+from robin.serializer import build_media_entry, build_text_entry, generate_entry_id, serialize_entry
+
+
+def _error(message: str, *, as_json: bool) -> NoReturn:
+    if as_json:
+        print(json.dumps({"error": message}, indent=2))
+    else:
+        print(f"ERROR: {message}")
+    raise SystemExit(1)
+
+
+def _duplicate_error(matches: list, *, as_json: bool, media_source_to_cleanup: str = "", explicit_state_dir: str | None = None) -> NoReturn:
+    remove_new_media_if_present(explicit_state_dir, media_source_to_cleanup)
+    payload = duplicate_payload(matches)
+    message = "Duplicate Robin entry found. Rerun with --allow-duplicate if this is intentional."
+    if as_json:
+        print(json.dumps({"error": message, "duplicates": payload}, indent=2))
+    else:
+        print(f"ERROR: {message}")
+        for entry in payload:
+            location = f"{entry['topic']} / {entry['id']}"
+            detail = entry.get("source") or entry.get("media_source") or entry.get("description") or "No detail"
+            print(f"  - {location}: {detail}")
+    raise SystemExit(1)
+
+
+def _emit_json(payload: dict) -> None:
+    print(json.dumps(payload, indent=2))
+
+
+def _recall_value(value: str) -> str:
+    return value.strip() if value.strip() else "Not provided"
+
+
+def _saved_on_value(value: str) -> str:
+    raw = _recall_value(value)
+    if raw == "Not provided":
+        return raw
+
+    try:
+        saved_on = date.fromisoformat(raw)
+    except ValueError:
+        return raw
+
+    delta_days = (date.today() - saved_on).days
+    if delta_days >= 0:
+        return f"{raw} ({delta_days} days ago)"
+    return f"{raw} (in {abs(delta_days)} days)"
+
+
+def _print_recall(entry) -> None:
+    source = entry.source.strip() or entry.media_source.strip()
+    print("📚 Robin Recall")
+    print()
+    print(f"Topic: {_recall_value(entry.topic)}")
+    print(f"Type: {_recall_value(entry.entry_type)}")
+    print(f"Source: {_recall_value(source)}")
+    print(f"Creator: {_recall_value(entry.creator)}")
+    print(f"Saved on: {_saved_on_value(entry.date_added)}")
+    print()
+    print("Description:")
+    print(_recall_value(entry.description))
+    print()
+    print("Body:")
+    print(_recall_value(entry.body))
+
+
+def _add_to_topic(config: dict, explicit_state_dir: str | None, topic: str, entry_text: str) -> str:
+    base = topics_path(config, explicit_state_dir)
+    base.mkdir(parents=True, exist_ok=True)
+    filepath = base / topic_to_filename(topic)
+    append_entry_to_file(filepath, entry_text)
+    return filepath.name
+
+
+def _validate_serialized_entry(entry_text: str, *, as_json: bool) -> None:
+    # The topic file writer appends a trailing newline after serialization, so
+    # validate against entry_text + "\n" to catch a body that ends with a
+    # standalone "***" line as well as separator occurrences in the middle.
+    if SEPARATOR in entry_text + "\n":
+        _error(
+            "Entry content cannot contain a standalone '***' line because Robin uses it as an internal separator.",
+            as_json=as_json,
+        )
+
+
+def _add_state_dir_arg(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--state-dir",
+        help="Directory containing robin-config.json and robin-review-index.json",
+    )
+
+
+def add_main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Add an entry to Robin's commonplace book")
+    _add_state_dir_arg(parser)
+    parser.add_argument("--topic", required=True, help="Topic name")
+    parser.add_argument("--entry-type", choices=["text", "image", "video"], default="text", help="Entry type")
+    parser.add_argument("--content", default="", help="Content to file")
+    parser.add_argument("--description", required=True, help="2-3 sentence context to store with the entry")
+    parser.add_argument("--source", help="Source URL")
+    parser.add_argument("--media-path", help="Local image file path for image entries or text entry attachments")
+    parser.add_argument("--media-url", help="Remote video URL for video entries")
+    parser.add_argument("--creator", help="Required for media entries")
+    parser.add_argument("--published-at", help="Required for media entries")
+    parser.add_argument("--summary", help="Required for media entries")
+    parser.add_argument("--note", help="Robin note")
+    parser.add_argument("--tags", default="", help="Comma-separated tags")
+    parser.add_argument("--allow-duplicate", action="store_true", help="Save even if Robin finds a likely duplicate")
+    parser.add_argument("--json", action="store_true", help="Output machine-readable JSON")
+    args = parser.parse_args(argv)
+
+    config = load_config(args.state_dir)
+    index = load_index(args.state_dir)
+
+    topic = args.topic.strip()
+    date_added = str(date.today())
+    tags = [tag.strip() for tag in args.tags.split(",") if tag.strip()]
+    entry_type = args.entry_type
+
+    if entry_type == "text":
+        has_text_payload = any(
+            [
+                args.content.strip(),
+                (args.note or "").strip(),
+                (args.source or "").strip(),
+                (args.media_path or "").strip(),
+            ]
+        )
+        if not has_text_payload:
+            _error("Text entries require --content, --note, --source, or --media-path.", as_json=args.json)
+        if args.media_url:
+            _error("Text entries do not accept --media-url. Attach local images with --media-path.", as_json=args.json)
+        entry_id = generate_entry_id(date_added) if args.media_path else None
+        media_source = ""
+        if args.media_path and entry_id:
+            try:
+                media_source = copy_image_to_media(config, args.state_dir, topic, entry_id, args.media_path)
+            except ValueError as exc:
+                _error(str(exc), as_json=args.json)
+            except OSError as exc:
+                _error(f"Failed to copy image into vault: {exc}", as_json=args.json)
+        entry = build_text_entry(
+            topic=topic,
+            content=args.content.strip(),
+            description=args.description.strip(),
+            source=args.source.strip() if args.source else None,
+            media_source=media_source,
+            note=args.note.strip() if args.note else None,
+            tags=tags,
+            date_added=date_added,
+            entry_id=entry_id,
+        )
+    else:
+        missing = [
+            flag
+            for flag, value in (
+                ("--creator", args.creator),
+                ("--published-at", args.published_at),
+                ("--summary", args.summary),
+            )
+            if not (value or "").strip()
+        ]
+        if missing:
+            _error(f"Media entries require {', '.join(missing)}.", as_json=args.json)
+
+        entry_id = generate_entry_id(date_added)
+        if entry_type == "image":
+            if not args.media_path:
+                _error("Image entries require --media-path.", as_json=args.json)
+            if args.media_url:
+                _error("Image entries do not accept --media-url.", as_json=args.json)
+            try:
+                media_source = copy_image_to_media(config, args.state_dir, topic, entry_id, args.media_path)
+            except ValueError as exc:
+                _error(str(exc), as_json=args.json)
+            except OSError as exc:
+                _error(f"Failed to copy image into vault: {exc}", as_json=args.json)
+        else:
+            if args.media_path:
+                _error("Uploaded or local video files are not supported. Pass a video URL with --media-url.", as_json=args.json)
+            if not args.media_url:
+                _error("Video entries require --media-url.", as_json=args.json)
+            if not is_video_url(args.media_url):
+                _error("Video entries require a valid http(s) URL.", as_json=args.json)
+            media_source = args.media_url.strip()
+
+        entry = build_media_entry(
+            topic=topic,
+            media_kind=entry_type,
+            media_source=media_source,
+            description=args.description.strip(),
+            creator=args.creator.strip(),
+            published_at=args.published_at.strip(),
+            summary=args.summary.strip(),
+            content=args.content.strip(),
+            source=args.source.strip() if args.source else None,
+            note=args.note.strip() if args.note else None,
+            tags=tags,
+            date_added=date_added,
+            entry_id=entry_id,
+        )
+
+    serialized_entry = serialize_entry(entry)
+    _validate_serialized_entry(serialized_entry, as_json=args.json)
+    if not args.allow_duplicate:
+        try:
+            matches = find_duplicate_candidates(config, args.state_dir, entry)
+        except RobinEntryParseError as exc:
+            remove_new_media_if_present(args.state_dir, entry.media_source)
+            _error(str(exc), as_json=args.json)
+        if matches:
+            _duplicate_error(
+                matches,
+                as_json=args.json,
+                media_source_to_cleanup=entry.media_source,
+                explicit_state_dir=args.state_dir,
+            )
+    try:
+        filename = _add_to_topic(config, args.state_dir, topic, serialized_entry)
+    except OSError as exc:
+        _error(f"Failed to write topic file: {exc}", as_json=args.json)
+    ensure_entry_in_index(entry, index)
+    try:
+        save_index(index, args.state_dir)
+    except OSError as exc:
+        _error(f"Failed to write review index: {exc}", as_json=args.json)
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "id": entry.entry_id,
+                    "topic": entry.topic,
+                    "filename": filename,
+                    "entry_type": entry.entry_type,
+                    "media_source": entry.media_source,
+                    "description": entry.description,
+                },
+                indent=2,
+            )
+        )
+        return
+
+    print(f"✓ Filed {entry.entry_id} under [{topic}]({filename})")
+
+
+def review_main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Robin review system")
+    _add_state_dir_arg(parser)
+    parser.add_argument("--status", action="store_true", help="Show review status")
+    parser.add_argument("--rate", nargs=2, metavar=("ID", "RATING"), help="Rate an item by stable entry id")
+    parser.add_argument("--active-review", action="store_true", help="Mark surfaced item as awaiting a rating")
+    parser.add_argument("--json", action="store_true", help="Output machine-readable JSON")
+    args = parser.parse_args(argv)
+
+    config = load_config(args.state_dir)
+    index = load_index(args.state_dir)
+
+    if args.rate:
+        entry_id, rating = args.rate
+        try:
+            rating_value = int(rating)
+        except ValueError:
+            _error("Rating must be a number between 1 and 5.", as_json=args.json)
+        try:
+            item = rate_item(index, entry_id, rating_value)
+        except KeyError:
+            _error(f"Item '{entry_id}' not found in index", as_json=args.json)
+        except ValueError as exc:
+            _error(str(exc), as_json=args.json)
+        try:
+            save_index(index, args.state_dir)
+        except OSError as exc:
+            _error(f"Failed to write review index: {exc}", as_json=args.json)
+        if args.json:
+            _emit_json(item)
+            return
+        print(f"✓ Rated {entry_id}: {item['rating']}/5")
+        return
+
+    if args.status:
+        index_items = index.get("items", {})
+        total = len(index_items)
+        min_items = config.get("min_items_before_review", 30)
+        rated = sum(1 for item in index_items.values() if item.get("rating") is not None)
+        if args.json:
+            print(json.dumps({
+                "total_items": total,
+                "rated": rated,
+                "unrated": total - rated,
+                "min_items_before_review": min_items,
+                "ready": total >= min_items,
+            }, indent=2))
+            return
+        print("Review status:")
+        print(f"  Total items:   {total}")
+        print(f"  Rated:         {rated}")
+        print(f"  Unrated:       {total - rated}")
+        print(f"  Min to review: {min_items}")
+        print(f"  Ready:         {'YES' if total >= min_items else 'NO'}")
+        return
+
+    total = len(index.get("items", {}))
+    min_items = config.get("min_items_before_review", 30)
+    if total < min_items:
+        if args.json:
+            _emit_json(
+                {
+                    "status": "skip",
+                    "reason": "not_enough_items",
+                    "total_items": total,
+                    "min_items_before_review": min_items,
+                }
+            )
+            return
+        print(f"SKIP: {total} items (need {min_items})")
+        return
+
+    try:
+        entries = load_all_entries(config, args.state_dir)
+    except RobinEntryParseError as exc:
+        _error(str(exc), as_json=args.json)
+    try:
+        candidate = pick_best_candidate(index, entries, config)
+    except ValueError as exc:
+        _error(f"Review index contains an invalid timestamp: {exc}", as_json=args.json)
+    if candidate is None:
+        if args.json:
+            _emit_json({"status": "skip", "reason": "no_eligible_items"})
+            return
+        print("SKIP: No eligible items (all recently surfaced or not indexed)")
+        return
+
+    item, entry = candidate
+    try:
+        item = mark_surfaced(index, entry.entry_id, awaiting_rating=args.active_review)
+    except KeyError:
+        _error(f"Item '{entry.entry_id}' not found in index", as_json=args.json)
+    try:
+        save_index(index, args.state_dir)
+    except OSError as exc:
+        _error(f"Failed to write review index: {exc}", as_json=args.json)
+    if args.json:
+        _emit_json({
+            "status": "ok",
+            "id": entry.entry_id,
+            "topic": entry.topic,
+            "date_added": entry.date_added,
+            "entry_type": entry.entry_type,
+            "media_kind": entry.media_kind,
+            "media_source": entry.media_source,
+            "source": entry.source,
+            "description": entry.description,
+            "creator": entry.creator,
+            "published_at": entry.published_at,
+            "summary": entry.summary,
+            "tags": entry.tags,
+            "body": entry.body,
+            "rating": item.get("rating"),
+            "times_surfaced": item.get("times_surfaced", 0),
+        })
+        return
+
+    _print_recall(entry)
+
+
+def search_main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Search Robin's commonplace book")
+    _add_state_dir_arg(parser)
+    parser.add_argument("query", nargs="?", help="Search query")
+    parser.add_argument("--topic", help="Filter by topic name")
+    parser.add_argument("--tags", help="Comma-separated tag filter")
+    parser.add_argument("--json", action="store_true", help="Output machine-readable JSON")
+    args = parser.parse_args(argv)
+
+    config = load_config(args.state_dir)
+    index = load_index(args.state_dir)
+
+    if args.topic:
+        topic_path = topics_path(config, args.state_dir) / topic_to_filename(args.topic)
+        if topic_path.exists():
+            try:
+                entries = load_topic_entries(topic_path)
+            except RobinEntryParseError as exc:
+                _error(str(exc), as_json=args.json)
+        else:
+            entries = []
+        heading = f"Topic '{args.topic}': {len(entries)} entries"
+    else:
+        try:
+            entries = load_all_entries(config, args.state_dir)
+        except RobinEntryParseError as exc:
+            _error(str(exc), as_json=args.json)
+        heading = f"Total: {len(entries)} entries"
+
+    if args.tags:
+        tags = [tag.strip() for tag in args.tags.split(",") if tag.strip()]
+        if not tags:
+            _error("Provide at least one non-empty tag.", as_json=args.json)
+        entries = filter_by_tags(entries, tags)
+        heading = f"Tags [{', '.join(tags)}]: {len(entries)} results"
+    elif args.query:
+        entries = search_entries(entries, args.query)
+        heading = f"Query '{args.query}': {len(entries)} results"
+
+    index_items = index.get("items", {})
+    if args.json:
+        print(json.dumps({
+            "count": len(entries),
+            "entries": [
+                {
+                    "id": entry.entry_id,
+                    "topic": entry.topic,
+                    "date_added": entry.date_added,
+                    "entry_type": entry.entry_type,
+                    "media_kind": entry.media_kind,
+                    "media_source": entry.media_source,
+                    "source": entry.source,
+                    "description": entry.description,
+                    "creator": entry.creator,
+                    "published_at": entry.published_at,
+                    "summary": entry.summary,
+                    "tags": entry.tags,
+                    "rating": index_items.get(entry.entry_id, {}).get("rating"),
+                    "body": entry.body,
+                }
+                for entry in entries
+            ],
+        }, indent=2))
+        return
+
+    print(heading)
+    print()
+    for entry in entries:
+        rating = index_items.get(entry.entry_id, {}).get("rating")
+        print(f"[{entry.topic}.md] {entry.entry_id} / {entry.date_added}  ★{rating or '—'}")
+        if entry.entry_type != "text":
+            print(f"  Type: {entry.entry_type}")
+        if entry.media_source:
+            print(f"  Media: {entry.media_source}")
+        if entry.source:
+            print(f"  Source: {entry.source}")
+        if entry.creator:
+            print(f"  Creator: {entry.creator}")
+        if entry.published_at:
+            print(f"  Published: {entry.published_at}")
+        if entry.summary:
+            print(f"  Summary: {entry.summary}")
+        if entry.description:
+            print(f"  Description: {entry.description}")
+        if entry.tags:
+            print(f"  Tags: {', '.join(entry.tags)}")
+        body = entry.body.replace("\n", " ").strip()
+        print(f"  {body[:200]}{'...' if len(body) > 200 else ''}")
+        print()
+
+
+def topics_main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="List all Robin topics")
+    _add_state_dir_arg(parser)
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args(argv)
+
+    config = load_config(args.state_dir)
+    index = load_index(args.state_dir)
+    try:
+        entries = load_all_entries(config, args.state_dir)
+    except RobinEntryParseError as exc:
+        _error(str(exc), as_json=args.json)
+
+    topics: dict[str, dict] = {}
+    index_items = index.get("items", {})
+    for entry in entries:
+        topic_stats = topics.setdefault(
+            entry.topic,
+            {"topic": entry.topic, "filename": f"{entry.topic}.md", "entries": 0, "rated": 0, "unrated": 0},
+        )
+        topic_stats["entries"] += 1
+        if index_items.get(entry.entry_id, {}).get("rating") is None:
+            topic_stats["unrated"] += 1
+        else:
+            topic_stats["rated"] += 1
+
+    ordered_topics = [topics[key] for key in sorted(topics)]
+    if args.json:
+        print(json.dumps(ordered_topics, indent=2))
+        return
+
+    if not ordered_topics:
+        print("No topics yet. Start filing things with Robin!")
+        return
+
+    total_entries = sum(topic["entries"] for topic in ordered_topics)
+    print(f"{len(ordered_topics)} topics, {total_entries} total entries\n")
+    visual_cap = 10
+    for topic in ordered_topics:
+        rated_visual = min(topic["rated"], visual_cap)
+        unrated_visual = min(max(visual_cap - rated_visual, 0), topic["unrated"])
+        stars = "★" * rated_visual + "☆" * unrated_visual
+        overflow = topic["entries"] - (rated_visual + unrated_visual)
+        if overflow > 0:
+            stars = f"{stars}+{overflow}"
+        print(f"  {topic['topic']}")
+        print(f"    {topic['entries']} entries  {stars}  {topic['rated']} rated / {topic['unrated']} unrated")
+        print()
+
+
+def entries_main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Move or delete Robin entries")
+    _add_state_dir_arg(parser)
+    parser.add_argument("--delete", metavar="ID", help="Delete an entry by stable entry id")
+    parser.add_argument("--move", metavar="ID", help="Move an entry by stable entry id")
+    parser.add_argument("--topic", help="Destination topic for --move")
+    parser.add_argument("--json", action="store_true", help="Output machine-readable JSON")
+    args = parser.parse_args(argv)
+
+    if bool(args.delete) == bool(args.move):
+        _error("Pass exactly one of --delete ID or --move ID.", as_json=args.json)
+    if args.delete and args.topic:
+        _error("--topic is only valid with --move.", as_json=args.json)
+    if args.move and not (args.topic or "").strip():
+        _error("--move requires --topic.", as_json=args.json)
+
+    config = load_config(args.state_dir)
+    index = load_index(args.state_dir)
+
+    try:
+        if args.delete:
+            payload = delete_entry(config, args.state_dir, index, args.delete)
+        else:
+            payload = move_entry(config, args.state_dir, index, args.move, args.topic or "")
+        save_index(index, args.state_dir)
+    except RobinEntryParseError as exc:
+        _error(str(exc), as_json=args.json)
+    except EntryOperationError as exc:
+        _error(str(exc), as_json=args.json)
+    except OSError as exc:
+        _error(f"Failed to update entry files: {exc}", as_json=args.json)
+
+    if args.json:
+        _emit_json(payload)
+        return
+    if payload["status"] == "deleted":
+        print(f"✓ Deleted {payload['id']} from {payload['filename']}")
+    else:
+        print(f"✓ Moved {payload['id']} from {payload['from_topic']} to {payload['to_topic']}")
+
+
+def _print_doctor_report(payload: dict) -> None:
+    print(f"Robin doctor: {'OK' if payload['ok'] else 'ISSUES FOUND'}")
+    print(f"Errors: {payload['errors']}  Warnings: {payload['warnings']}")
+    if not payload["diagnostics"]:
+        print("No issues found.")
+        return
+
+    print()
+    for item in payload["diagnostics"]:
+        location = f" ({item['path']})" if item.get("path") else ""
+        print(f"[{item['level'].upper()}] {item['code']}: {item['message']}{location}")
+
+
+def doctor_main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Check a Robin library for common health issues")
+    _add_state_dir_arg(parser)
+    parser.add_argument("--json", action="store_true", help="Output machine-readable JSON")
+    args = parser.parse_args(argv)
+
+    payload = run_doctor(args.state_dir)
+    if args.json:
+        _emit_json(payload)
+    else:
+        _print_doctor_report(payload)
+    raise SystemExit(0 if payload["ok"] else 1)
+
+
+def reindex_main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Rebuild Robin's review index")
+    _add_state_dir_arg(parser)
+    parser.add_argument("--json", action="store_true", help="Output machine-readable JSON")
+    args = parser.parse_args(argv)
+
+    config = load_config(args.state_dir)
+    old_index = load_index(args.state_dir)
+    if not args.json:
+        print("Scanning topic files...")
+    try:
+        entries = load_all_entries(config, args.state_dir)
+    except RobinEntryParseError as exc:
+        _error(str(exc), as_json=args.json)
+    new_index = rebuild_index(entries, old_index)
+    try:
+        save_index(new_index, args.state_dir)
+    except OSError as exc:
+        _error(f"Failed to write review index: {exc}", as_json=args.json)
+
+    rated = sum(1 for item in new_index["items"].values() if item.get("rating") is not None)
+    if args.json:
+        print(json.dumps({
+            "entries_found": len(entries),
+            "items_indexed": len(new_index["items"]),
+            "rated": rated,
+            "unrated": len(new_index["items"]) - rated,
+        }, indent=2))
+        return
+
+    print(f"Found {len(entries)} entries")
+    print(f"✓ Index rebuilt: {len(new_index['items'])} items, {rated} rated, {len(new_index['items']) - rated} unrated")

--- a/optional-skills/productivity/robin/scripts/robin/config.py
+++ b/optional-skills/productivity/robin/scripts/robin/config.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from robin.files import atomic_write_text
+
+LEGACY_SPLIT_LAYOUT_KEY = "vault" + "_path"
+
+
+def state_dir(explicit_state_dir: str | None = None) -> Path:
+    value = explicit_state_dir or os.environ.get("ROBIN_STATE_DIR")
+    if not value:
+        raise SystemExit(
+            "Robin state directory is not configured. Pass --state-dir or set ROBIN_STATE_DIR."
+        )
+    return Path(value).expanduser().resolve()
+
+
+def config_path(explicit_state_dir: str | None = None) -> Path:
+    return state_dir(explicit_state_dir) / "robin-config.json"
+
+
+def index_path(explicit_state_dir: str | None = None) -> Path:
+    return state_dir(explicit_state_dir) / "robin-review-index.json"
+
+
+def topics_path(config: dict, explicit_state_dir: str | None = None) -> Path:
+    return state_dir(explicit_state_dir) / config.get("topics_dir", "topics")
+
+
+def media_path(config: dict, explicit_state_dir: str | None = None) -> Path:
+    return state_dir(explicit_state_dir) / config.get("media_dir", "media")
+
+
+def load_config(explicit_state_dir: str | None = None) -> dict:
+    path = config_path(explicit_state_dir)
+    try:
+        with path.open(encoding="utf-8") as f:
+            config = json.load(f)
+    except FileNotFoundError as exc:
+        raise SystemExit(
+            f"Config not found at {path}. Create robin-config.json in the state directory first."
+        ) from exc
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Config at {path} is invalid JSON: {exc}") from exc
+
+    if LEGACY_SPLIT_LAYOUT_KEY in config:
+        raise SystemExit(
+            f"Config at {path} uses the old split-layout field for a separate content root. "
+            "Robin now stores topics and media inside the state directory. "
+            "Remove the legacy content-root field and keep only topics_dir/media_dir/review settings."
+        )
+
+    return config
+
+
+def empty_index() -> dict:
+    return {"items": {}}
+
+
+def load_index(explicit_state_dir: str | None = None) -> dict:
+    path = index_path(explicit_state_dir)
+    if path.exists():
+        try:
+            with path.open(encoding="utf-8") as f:
+                data = json.load(f)
+        except json.JSONDecodeError as exc:
+            raise SystemExit(f"Review index at {path} is invalid JSON: {exc}") from exc
+    else:
+        data = empty_index()
+
+    data.setdefault("items", {})
+    return data
+
+
+def save_index(index: dict, explicit_state_dir: str | None = None) -> None:
+    path = index_path(explicit_state_dir)
+    atomic_write_text(path, json.dumps(index, indent=2, sort_keys=True) + "\n")

--- a/optional-skills/productivity/robin/scripts/robin/config.py
+++ b/optional-skills/productivity/robin/scripts/robin/config.py
@@ -26,12 +26,27 @@ def index_path(explicit_state_dir: str | None = None) -> Path:
     return state_dir(explicit_state_dir) / "robin-review-index.json"
 
 
+def _confined_subpath(root: Path, value: str, field: str) -> Path:
+    """Resolve a configured subdirectory, refusing to leave the state directory.
+
+    Absolute values (``Path(root) / "/etc"`` discards the base) and ``..`` escapes
+    would otherwise let topic/media operations touch paths outside the state root.
+    """
+    root = root.resolve()
+    candidate = (root / value).resolve()
+    if candidate != root and root not in candidate.parents:
+        raise SystemExit(
+            f"Config {field}={value!r} must be a relative path inside the state directory."
+        )
+    return candidate
+
+
 def topics_path(config: dict, explicit_state_dir: str | None = None) -> Path:
-    return state_dir(explicit_state_dir) / config.get("topics_dir", "topics")
+    return _confined_subpath(state_dir(explicit_state_dir), config.get("topics_dir", "topics"), "topics_dir")
 
 
 def media_path(config: dict, explicit_state_dir: str | None = None) -> Path:
-    return state_dir(explicit_state_dir) / config.get("media_dir", "media")
+    return _confined_subpath(state_dir(explicit_state_dir), config.get("media_dir", "media"), "media_dir")
 
 
 def load_config(explicit_state_dir: str | None = None) -> dict:

--- a/optional-skills/productivity/robin/scripts/robin/doctor.py
+++ b/optional-skills/productivity/robin/scripts/robin/doctor.py
@@ -1,0 +1,338 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from robin.config import LEGACY_SPLIT_LAYOUT_KEY, config_path, index_path, media_path, state_dir, topics_path
+from robin.index import is_legacy_key
+from robin.media import is_remote_reference
+from robin.parser import RobinEntryParseError, load_topic_entries
+from robin.review_logic import parse_timestamp
+
+MAX_TOPIC_ENTRIES = 100
+MAX_TOPIC_BYTES = 1024 * 1024
+
+
+@dataclass(slots=True)
+class Diagnostic:
+    level: str
+    code: str
+    message: str
+    path: str | None = None
+    entry_id: str | None = None
+    topic: str | None = None
+    media_source: str | None = None
+
+    def to_dict(self) -> dict:
+        return {key: value for key, value in asdict(self).items() if value is not None}
+
+
+def _diag(
+    level: str,
+    code: str,
+    message: str,
+    *,
+    path: Path | str | None = None,
+    entry_id: str | None = None,
+    topic: str | None = None,
+    media_source: str | None = None,
+) -> Diagnostic:
+    return Diagnostic(
+        level=level,
+        code=code,
+        message=message,
+        path=str(path) if path is not None else None,
+        entry_id=entry_id,
+        topic=topic,
+        media_source=media_source,
+    )
+
+
+def _is_relative_to(path: Path, base: Path) -> bool:
+    try:
+        path.relative_to(base)
+    except ValueError:
+        return False
+    return True
+
+
+def _load_config(explicit_state_dir: str | None, diagnostics: list[Diagnostic]) -> tuple[Path | None, dict | None]:
+    try:
+        base = state_dir(explicit_state_dir)
+    except SystemExit as exc:
+        diagnostics.append(_diag("error", "missing_state_dir", str(exc)))
+        return None, None
+
+    if not base.exists():
+        diagnostics.append(_diag("error", "missing_state_dir", f"State directory does not exist: {base}", path=base))
+        return base, None
+    if not base.is_dir():
+        diagnostics.append(_diag("error", "invalid_state_dir", f"State path is not a directory: {base}", path=base))
+        return base, None
+
+    path = config_path(explicit_state_dir)
+    try:
+        with path.open(encoding="utf-8") as f:
+            config = json.load(f)
+    except FileNotFoundError:
+        diagnostics.append(_diag("error", "missing_config", f"Config not found at {path}", path=path))
+        return base, None
+    except json.JSONDecodeError as exc:
+        diagnostics.append(_diag("error", "invalid_config_json", f"Config at {path} is invalid JSON: {exc}", path=path))
+        return base, None
+
+    if not isinstance(config, dict):
+        diagnostics.append(_diag("error", "invalid_config", f"Config at {path} must be a JSON object.", path=path))
+        return base, None
+
+    if LEGACY_SPLIT_LAYOUT_KEY in config:
+        diagnostics.append(
+            _diag(
+                "error",
+                "legacy_split_layout",
+                "Config uses the old split-layout field for a separate content root.",
+                path=path,
+            )
+        )
+    return base, config
+
+
+def _load_entries(config: dict, explicit_state_dir: str | None, diagnostics: list[Diagnostic]) -> tuple[list, set[str]]:
+    base = topics_path(config, explicit_state_dir)
+    if not base.exists():
+        diagnostics.append(_diag("error", "missing_topics_dir", f"Topics directory does not exist: {base}", path=base))
+        return [], set()
+    if not base.is_dir():
+        diagnostics.append(_diag("error", "invalid_topics_dir", f"Topics path is not a directory: {base}", path=base))
+        return [], set()
+
+    entries = []
+    ids_seen: dict[str, Path] = {}
+    duplicate_ids: set[str] = set()
+    for filepath in sorted(base.glob("*.md")):
+        size = filepath.stat().st_size
+        if size > MAX_TOPIC_BYTES:
+            diagnostics.append(
+                _diag(
+                    "warning",
+                    "large_topic_file",
+                    f"Topic file is {size} bytes; consider splitting very large topic files.",
+                    path=filepath,
+                    topic=filepath.stem,
+                )
+            )
+        try:
+            topic_entries = load_topic_entries(filepath)
+        except RobinEntryParseError as exc:
+            diagnostics.append(_diag("error", "invalid_topic_entry", str(exc), path=filepath))
+            continue
+        if len(topic_entries) > MAX_TOPIC_ENTRIES:
+            diagnostics.append(
+                _diag(
+                    "warning",
+                    "large_topic_entry_count",
+                    f"Topic file contains {len(topic_entries)} entries; consider splitting very large topic files.",
+                    path=filepath,
+                    topic=filepath.stem,
+                )
+            )
+        entries.extend(topic_entries)
+        for entry in topic_entries:
+            previous_path = ids_seen.get(entry.entry_id)
+            if previous_path is not None:
+                duplicate_ids.add(entry.entry_id)
+                diagnostics.append(
+                    _diag(
+                        "error",
+                        "duplicate_entry_id",
+                        f"Entry id {entry.entry_id} appears in both {previous_path} and {filepath}.",
+                        path=filepath,
+                        entry_id=entry.entry_id,
+                        topic=entry.topic,
+                    )
+                )
+            else:
+                ids_seen[entry.entry_id] = filepath
+    return entries, set(ids_seen) | duplicate_ids
+
+
+def _check_media(
+    config: dict,
+    explicit_state_dir: str | None,
+    entries: list,
+    diagnostics: list[Diagnostic],
+) -> None:
+    base = state_dir(explicit_state_dir)
+    media_dir = media_path(config, explicit_state_dir)
+    referenced_files: set[Path] = set()
+
+    for entry in entries:
+        media_source = entry.media_source.strip()
+        if not media_source or is_remote_reference(media_source):
+            continue
+
+        media_file = (base / media_source).resolve()
+        if not _is_relative_to(media_file, base):
+            diagnostics.append(
+                _diag(
+                    "error",
+                    "media_outside_state_dir",
+                    f"Local media reference points outside the Robin state directory: {media_source}",
+                    path=media_file,
+                    entry_id=entry.entry_id,
+                    topic=entry.topic,
+                    media_source=media_source,
+                )
+            )
+            continue
+
+        referenced_files.add(media_file)
+        if not media_file.exists():
+            diagnostics.append(
+                _diag(
+                    "error",
+                    "missing_media",
+                    f"Local media file is missing: {media_source}",
+                    path=media_file,
+                    entry_id=entry.entry_id,
+                    topic=entry.topic,
+                    media_source=media_source,
+                )
+            )
+        elif not media_file.is_file():
+            diagnostics.append(
+                _diag(
+                    "error",
+                    "invalid_media",
+                    f"Local media reference is not a file: {media_source}",
+                    path=media_file,
+                    entry_id=entry.entry_id,
+                    topic=entry.topic,
+                    media_source=media_source,
+                )
+            )
+
+    if not media_dir.exists():
+        diagnostics.append(_diag("warning", "missing_media_dir", f"Media directory does not exist: {media_dir}", path=media_dir))
+        return
+    if not media_dir.is_dir():
+        diagnostics.append(_diag("error", "invalid_media_dir", f"Media path is not a directory: {media_dir}", path=media_dir))
+        return
+
+    for filepath in sorted(path for path in media_dir.rglob("*") if path.is_file()):
+        if filepath.resolve() not in referenced_files:
+            diagnostics.append(_diag("warning", "orphan_media", f"Media file is not referenced by any entry: {filepath}", path=filepath))
+
+
+def _check_index(
+    explicit_state_dir: str | None,
+    entry_ids: set[str],
+    diagnostics: list[Diagnostic],
+) -> None:
+    path = index_path(explicit_state_dir)
+    if not path.exists():
+        if entry_ids:
+            diagnostics.append(
+                _diag(
+                    "warning",
+                    "missing_index",
+                    "Review index is missing; run robin-reindex to rebuild review state from topic files.",
+                    path=path,
+                )
+            )
+        return
+
+    try:
+        with path.open(encoding="utf-8") as f:
+            index = json.load(f)
+    except json.JSONDecodeError as exc:
+        diagnostics.append(_diag("error", "invalid_index_json", f"Review index at {path} is invalid JSON: {exc}", path=path))
+        return
+
+    if not isinstance(index, dict) or not isinstance(index.get("items"), dict):
+        diagnostics.append(_diag("error", "invalid_index", f"Review index at {path} must contain an items object.", path=path))
+        return
+
+    index_items = index["items"]
+    for entry_id, item in index_items.items():
+        if not isinstance(item, dict):
+            diagnostics.append(
+                _diag("error", "invalid_index_item", f"Review index item {entry_id} must be an object.", path=path, entry_id=entry_id)
+            )
+            continue
+        if entry_id not in entry_ids:
+            if is_legacy_key(entry_id):
+                message = f"Legacy-format review item {entry_id}; run robin-reindex to migrate review history."
+            else:
+                message = f"Review index item {entry_id} has no matching topic entry."
+            diagnostics.append(
+                _diag(
+                    "warning",
+                    "orphan_index_item",
+                    message,
+                    path=path,
+                    entry_id=entry_id,
+                )
+            )
+        rating = item.get("rating")
+        if rating is not None and (not isinstance(rating, int) or rating < 1 or rating > 5):
+            diagnostics.append(
+                _diag("error", "invalid_rating", f"Review index item {entry_id} has an invalid rating.", path=path, entry_id=entry_id)
+            )
+        times_surfaced = item.get("times_surfaced", 0)
+        if not isinstance(times_surfaced, int) or times_surfaced < 0:
+            diagnostics.append(
+                _diag(
+                    "error",
+                    "invalid_times_surfaced",
+                    f"Review index item {entry_id} has an invalid times_surfaced value.",
+                    path=path,
+                    entry_id=entry_id,
+                )
+            )
+        last_surfaced = item.get("last_surfaced")
+        if last_surfaced:
+            try:
+                parse_timestamp(str(last_surfaced))
+            except ValueError:
+                diagnostics.append(
+                    _diag(
+                        "error",
+                        "invalid_last_surfaced",
+                        f"Review index item {entry_id} has an invalid last_surfaced timestamp.",
+                        path=path,
+                        entry_id=entry_id,
+                    )
+                )
+
+    for entry_id in sorted(entry_ids - set(index_items)):
+        diagnostics.append(
+            _diag(
+                "warning",
+                "missing_index_item",
+                f"Entry {entry_id} is missing from the review index; run robin-reindex to rebuild it.",
+                path=path,
+                entry_id=entry_id,
+            )
+        )
+
+
+def run_doctor(explicit_state_dir: str | None = None) -> dict:
+    diagnostics: list[Diagnostic] = []
+    _, config = _load_config(explicit_state_dir, diagnostics)
+    entries = []
+    entry_ids: set[str] = set()
+
+    if config is not None:
+        entries, entry_ids = _load_entries(config, explicit_state_dir, diagnostics)
+        _check_media(config, explicit_state_dir, entries, diagnostics)
+        _check_index(explicit_state_dir, entry_ids, diagnostics)
+
+    errors = sum(1 for item in diagnostics if item.level == "error")
+    warnings = sum(1 for item in diagnostics if item.level == "warning")
+    return {
+        "ok": errors == 0,
+        "errors": errors,
+        "warnings": warnings,
+        "diagnostics": [item.to_dict() for item in diagnostics],
+    }

--- a/optional-skills/productivity/robin/scripts/robin/entry_ops.py
+++ b/optional-skills/productivity/robin/scripts/robin/entry_ops.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+from robin.config import state_dir, topics_path
+from robin.files import atomic_write_text
+from robin.index import ensure_entry_in_index
+from robin.media import is_remote_reference
+from robin.models import Entry
+from robin.parser import RobinEntryParseError, SEPARATOR, parse_entry, topic_slug, topic_to_filename
+from robin.serializer import serialize_entry
+
+
+@dataclass(slots=True)
+class EntryMatch:
+    entry: Entry
+    filepath: Path
+    chunk_index: int
+    raw_chunk: str
+
+
+class EntryOperationError(ValueError):
+    pass
+
+
+def normalize_body(value: str) -> str:
+    return re.sub(r"\s+", " ", value).strip().lower()
+
+
+def duplicate_candidates(entries: list[Entry], entry: Entry) -> list[Entry]:
+    source = entry.source.strip().lower()
+    media_source = entry.media_source.strip().lower()
+    body = normalize_body(entry.body)
+
+    for candidate in entries:
+        if candidate.entry_id == entry.entry_id:
+            continue
+        if source and candidate.source.strip().lower() == source:
+            return [candidate]
+        if media_source and candidate.media_source.strip().lower() == media_source:
+            return [candidate]
+        if body and normalize_body(candidate.body) == body:
+            return [candidate]
+
+    return []
+
+
+def find_duplicate_candidates(config: dict, explicit_state_dir: str | None, entry: Entry) -> list[Entry]:
+    for filepath in _topic_files(config, explicit_state_dir):
+        for match in _load_topic_chunks(filepath):
+            duplicate = duplicate_candidates([match.entry], entry)
+            if duplicate:
+                return duplicate
+    return []
+
+
+def duplicate_payload(matches: list[Entry]) -> list[dict]:
+    return [
+        {
+            "id": entry.entry_id,
+            "topic": entry.topic,
+            "date_added": entry.date_added,
+            "source": entry.source,
+            "media_source": entry.media_source,
+            "description": entry.description,
+        }
+        for entry in matches
+    ]
+
+
+def _topic_files(config: dict, explicit_state_dir: str | None) -> list[Path]:
+    base = topics_path(config, explicit_state_dir)
+    if not base.exists():
+        return []
+    return sorted(base.glob("*.md"))
+
+
+def _load_topic_chunks(filepath: Path) -> list[EntryMatch]:
+    content = filepath.read_text(encoding="utf-8")
+    if not content.strip():
+        return []
+
+    matches: list[EntryMatch] = []
+    for chunk_index, chunk in enumerate(content.split(SEPARATOR), start=1):
+        if not chunk.strip():
+            continue
+        raw_chunk = chunk.lstrip()
+        try:
+            entry = parse_entry(raw_chunk, filepath.stem)
+        except ValueError as exc:
+            raise RobinEntryParseError(filepath, chunk_index, str(exc)) from exc
+        matches.append(EntryMatch(entry=entry, filepath=filepath, chunk_index=chunk_index, raw_chunk=raw_chunk))
+    return matches
+
+
+def _find_entry_matches(config: dict, explicit_state_dir: str | None, entry_id: str) -> list[EntryMatch]:
+    matches: list[EntryMatch] = []
+    for filepath in _topic_files(config, explicit_state_dir):
+        for chunk in _load_topic_chunks(filepath):
+            if chunk.entry.entry_id == entry_id:
+                matches.append(chunk)
+                if len(matches) >= 2:
+                    return matches
+    return matches
+
+
+def append_entry_to_file(filepath: Path, serialized: str) -> None:
+    if filepath.exists():
+        content = filepath.read_text(encoding="utf-8")
+        if content.endswith("\n"):
+            content = content[:-1]
+        out = content + SEPARATOR + serialized if content.strip() else serialized
+    else:
+        out = serialized
+    atomic_write_text(filepath, out + "\n")
+
+
+def _write_chunks(filepath: Path, chunks: list[str]) -> None:
+    if chunks:
+        atomic_write_text(filepath, SEPARATOR.join(chunks) + "\n")
+    elif filepath.exists():
+        filepath.unlink()
+
+
+def _remove_match(match: EntryMatch) -> None:
+    chunks = _load_topic_chunks(match.filepath)
+    remaining = [chunk.raw_chunk for chunk in chunks if chunk.entry.entry_id != match.entry.entry_id]
+    _write_chunks(match.filepath, remaining)
+
+
+def _require_single_match(config: dict, explicit_state_dir: str | None, entry_id: str) -> EntryMatch:
+    matches = _find_entry_matches(config, explicit_state_dir, entry_id)
+    if not matches:
+        raise EntryOperationError(f"Entry '{entry_id}' not found.")
+    if len(matches) > 1:
+        raise EntryOperationError(f"Entry '{entry_id}' appears more than once. Run robin-doctor before mutating entries.")
+    return matches[0]
+
+
+def validate_destination_topic(topic: str) -> str:
+    slug = topic_slug(topic)
+    if not topic.strip() or slug == "untitled":
+        raise EntryOperationError("Move requires a non-empty topic that normalizes to a valid filename.")
+    return slug
+
+
+def delete_entry(config: dict, explicit_state_dir: str | None, index: dict, entry_id: str) -> dict:
+    match = _require_single_match(config, explicit_state_dir, entry_id)
+    _remove_match(match)
+    index.setdefault("items", {}).pop(entry_id, None)
+    return {
+        "status": "deleted",
+        "id": match.entry.entry_id,
+        "topic": match.entry.topic,
+        "filename": match.filepath.name,
+    }
+
+
+def move_entry(config: dict, explicit_state_dir: str | None, index: dict, entry_id: str, topic: str) -> dict:
+    dest_topic = validate_destination_topic(topic)
+    match = _require_single_match(config, explicit_state_dir, entry_id)
+    from_filename = match.filepath.name
+    to_filename = topic_to_filename(topic)
+
+    if match.entry.topic != dest_topic:
+        moved = replace(match.entry, topic=dest_topic)
+        dest_path = topics_path(config, explicit_state_dir) / to_filename
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            serialized = serialize_entry(moved)
+        except ValueError as exc:
+            raise EntryOperationError(str(exc)) from exc
+        _remove_match(match)
+        append_entry_to_file(dest_path, serialized)
+    else:
+        moved = match.entry
+
+    ensure_entry_in_index(moved, index)
+    index["items"][entry_id]["topic"] = moved.topic
+    index["items"][entry_id]["date"] = moved.date_added
+    return {
+        "status": "moved",
+        "id": moved.entry_id,
+        "from_topic": match.entry.topic,
+        "to_topic": moved.topic,
+        "from_filename": from_filename,
+        "to_filename": to_filename,
+    }
+
+
+def remove_new_media_if_present(explicit_state_dir: str | None, media_source: str) -> None:
+    media_source = media_source.strip()
+    if not media_source or is_remote_reference(media_source):
+        return
+    base = state_dir(explicit_state_dir)
+    media_path = (base / media_source).resolve()
+    try:
+        media_path.relative_to(base)
+    except ValueError:
+        return
+    try:
+        if media_path.is_file():
+            media_path.unlink()
+    except OSError:
+        return

--- a/optional-skills/productivity/robin/scripts/robin/files.py
+++ b/optional-skills/productivity/robin/scripts/robin/files.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def atomic_write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(f"{path.name}.tmp")
+    with tmp_path.open("w", encoding="utf-8") as f:
+        f.write(content)
+    os.replace(tmp_path, path)

--- a/optional-skills/productivity/robin/scripts/robin/index.py
+++ b/optional-skills/productivity/robin/scripts/robin/index.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from robin.models import Entry
+
+
+def _legacy_key(topic: str, date_added: str, seq: int) -> str:
+    return f"{topic}:{date_added}:{seq:03d}"
+
+
+def is_legacy_key(key: str) -> bool:
+    parts = key.rsplit(":", 2)
+    if len(parts) != 3:
+        return False
+    _, date_part, seq_part = parts
+    return len(date_part) == 10 and date_part.count("-") == 2 and seq_part.isdigit() and len(seq_part) == 3
+
+
+def rebuild_index(entries: Iterable[Entry], old_index: dict) -> dict:
+    old_items = old_index.get("items", {})
+
+    legacy_items: dict[str, dict] = {}
+    id_items: dict[str, dict] = {}
+    for key, value in old_items.items():
+        if is_legacy_key(key):
+            legacy_items[key] = value
+        else:
+            id_items[key] = value
+
+    items: dict[str, dict] = {}
+    seq_counters: dict[tuple[str, str], int] = {}
+
+    for entry in entries:
+        group = (entry.topic, entry.date_added)
+        seq_counters[group] = seq_counters.get(group, 0) + 1
+        seq = seq_counters[group]
+
+        previous = id_items.get(entry.entry_id)
+        if previous is None:
+            previous = legacy_items.get(_legacy_key(entry.topic, entry.date_added, seq))
+
+        items[entry.entry_id] = {
+            "id": entry.entry_id,
+            "topic": entry.topic,
+            "date": entry.date_added,
+            "rating": previous.get("rating") if previous else None,
+            "last_surfaced": previous.get("last_surfaced") if previous else None,
+            "times_surfaced": previous.get("times_surfaced", 0) if previous else 0,
+            "_awaiting_rating": previous.get("_awaiting_rating", False) if previous else False,
+        }
+
+    return {"items": items}
+
+
+def ensure_entry_in_index(entry: Entry, index: dict) -> None:
+    index.setdefault("items", {})
+    index["items"].setdefault(
+        entry.entry_id,
+        {
+            "id": entry.entry_id,
+            "topic": entry.topic,
+            "date": entry.date_added,
+            "rating": None,
+            "last_surfaced": None,
+            "times_surfaced": 0,
+            "_awaiting_rating": False,
+        },
+    )

--- a/optional-skills/productivity/robin/scripts/robin/media.py
+++ b/optional-skills/productivity/robin/scripts/robin/media.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import mimetypes
+import shutil
+from pathlib import Path
+from urllib.parse import urlparse
+
+from robin.config import media_path, state_dir
+from robin.parser import topic_slug
+
+IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".tiff", ".svg"}
+
+
+def is_remote_reference(value: str) -> bool:
+    parsed = urlparse(value)
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
+
+
+def is_video_url(value: str) -> bool:
+    return is_remote_reference(value)
+
+
+def validate_image_path(value: str) -> Path:
+    path = Path(value).expanduser()
+    if not path.exists():
+        raise ValueError(f"Image file not found: {value}")
+    if not path.is_file():
+        raise ValueError(f"Image path is not a file: {value}")
+    suffix = path.suffix.lower()
+    mime, _ = mimetypes.guess_type(path.name)
+    if suffix not in IMAGE_EXTENSIONS and not (mime and mime.startswith("image/")):
+        raise ValueError(f"Unsupported image type: {value}")
+    return path
+
+
+def copy_image_to_media(
+    config: dict,
+    explicit_state_dir: str | None,
+    topic: str,
+    entry_id: str,
+    image_path: str,
+) -> str:
+    source = validate_image_path(image_path)
+    destination_dir = media_path(config, explicit_state_dir) / topic_slug(topic)
+    destination_dir.mkdir(parents=True, exist_ok=True)
+    destination = destination_dir / f"{entry_id}{source.suffix.lower()}"
+    shutil.copy2(source, destination)
+    return str(destination.relative_to(state_dir(explicit_state_dir)))
+
+
+def copy_image_to_vault(
+    config: dict,
+    explicit_state_dir: str | None,
+    topic: str,
+    entry_id: str,
+    image_path: str,
+) -> str:
+    return copy_image_to_media(config, explicit_state_dir, topic, entry_id, image_path)

--- a/optional-skills/productivity/robin/scripts/robin/models.py
+++ b/optional-skills/productivity/robin/scripts/robin/models.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(slots=True)
+class Entry:
+    entry_id: str
+    topic: str
+    date_added: str
+    entry_type: str = "text"
+    media_kind: str = ""
+    media_source: str = ""
+    source: str = ""
+    description: str = ""
+    creator: str = ""
+    published_at: str = ""
+    summary: str = ""
+    tags: list[str] = field(default_factory=list)
+    body: str = ""

--- a/optional-skills/productivity/robin/scripts/robin/parser.py
+++ b/optional-skills/productivity/robin/scripts/robin/parser.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import Path
+
+from robin.config import topics_path
+from robin.models import Entry
+
+SEPARATOR = "\n***\n"
+
+
+class RobinEntryParseError(ValueError):
+    def __init__(self, filepath: Path, chunk_index: int, message: str):
+        self.filepath = filepath
+        self.chunk_index = chunk_index
+        super().__init__(f"Failed to parse entry {chunk_index} in {filepath}: {message}")
+
+
+def topic_to_filename(topic: str) -> str:
+    normalized = re.sub(r"[^a-z0-9]+", "-", topic.strip().lower())
+    slug = normalized.strip("-") or "untitled"
+    return f"{slug}.md"
+
+
+def topic_slug(topic: str) -> str:
+    return topic_to_filename(topic).removesuffix(".md")
+
+
+def parse_tags(raw_value: str) -> list[str]:
+    value = raw_value.strip()
+    if value.startswith("[") and value.endswith("]"):
+        value = value[1:-1]
+    if not value:
+        return []
+    return [tag.strip() for tag in value.split(",") if tag.strip()]
+
+
+def parse_frontmatter_and_body(text: str) -> tuple[dict, str]:
+    lines = text.splitlines()
+    frontmatter: dict[str, str | list[str]] = {}
+    body_start = None
+
+    for i, line in enumerate(lines):
+        if not line.strip():
+            body_start = i + 1
+            break
+        if ":" not in line:
+            raise ValueError(f"Invalid frontmatter line {i + 1}: {line!r}")
+        key, value = line.split(":", 1)
+        normalized_key = key.strip().lower()
+        normalized_value = value.strip()
+        if normalized_key == "tags":
+            frontmatter["tags"] = parse_tags(normalized_value)
+        else:
+            frontmatter[normalized_key] = normalized_value
+
+    if body_start is None:
+        raise ValueError("Entry frontmatter must be followed by a blank line.")
+
+    body = "\n".join(lines[body_start:]).strip()
+    return frontmatter, body
+
+
+def parse_entry(text: str, topic: str) -> Entry:
+    frontmatter, body = parse_frontmatter_and_body(text)
+    entry_id = str(frontmatter.get("id", "")).strip()
+    if ":" in entry_id:
+        raise ValueError("Entry id cannot contain colon characters.")
+    date_added = str(frontmatter.get("date_added", "")).strip()
+    if not date_added:
+        raise ValueError("Entry is missing required date_added field.")
+    entry_type = str(frontmatter.get("entry_type", "text")).strip() or "text"
+    media_kind = str(frontmatter.get("media_kind", "")).strip()
+    media_source = str(frontmatter.get("media_source", "")).strip()
+    source = str(frontmatter.get("source", "")).strip()
+    description = str(frontmatter.get("description", "")).strip()
+    creator = str(frontmatter.get("creator", "")).strip()
+    published_at = str(frontmatter.get("published_at", "")).strip()
+    summary = str(frontmatter.get("summary", "")).strip()
+    tags = list(frontmatter.get("tags", []))
+    if not entry_id:
+        fingerprint = hashlib.sha256(
+            f"{topic}\n{date_added}\n{entry_type}\n{media_kind}\n{media_source}\n{source}\n{description}\n{creator}\n{published_at}\n{summary}\n{','.join(tags)}\n{body}".encode("utf-8")
+        ).hexdigest()[:10]
+        entry_id = f"legacy-{fingerprint}"
+
+    return Entry(
+        entry_id=entry_id,
+        topic=topic,
+        date_added=date_added,
+        entry_type=entry_type,
+        media_kind=media_kind,
+        media_source=media_source,
+        source=source,
+        description=description,
+        creator=creator,
+        published_at=published_at,
+        summary=summary,
+        tags=tags,
+        body=body,
+    )
+
+
+def load_topic_entries(filepath: Path) -> list[Entry]:
+    content = filepath.read_text(encoding="utf-8")
+    if not content.strip():
+        return []
+
+    entries: list[Entry] = []
+    for chunk_index, chunk in enumerate(content.split(SEPARATOR), start=1):
+        if not chunk.strip():
+            continue
+        try:
+            entries.append(parse_entry(chunk.lstrip(), filepath.stem))
+        except ValueError as exc:
+            raise RobinEntryParseError(filepath, chunk_index, str(exc)) from exc
+    return entries
+
+
+def load_all_entries(config: dict, explicit_state_dir: str | None = None) -> list[Entry]:
+    base = topics_path(config, explicit_state_dir)
+    if not base.exists():
+        return []
+
+    entries: list[Entry] = []
+    for filepath in sorted(base.glob("*.md")):
+        entries.extend(load_topic_entries(filepath))
+    return entries

--- a/optional-skills/productivity/robin/scripts/robin/review_logic.py
+++ b/optional-skills/productivity/robin/scripts/robin/review_logic.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import random
 from datetime import datetime, timedelta, timezone
 
 from robin.models import Entry
@@ -17,12 +18,38 @@ def parse_timestamp(value: str) -> datetime:
     return timestamp
 
 
+def _most_recent_surfaced_topic(index: dict) -> str | None:
+    latest_topic: str | None = None
+    latest_timestamp: datetime | None = None
+    for item in index.get("items", {}).values():
+        last_surfaced = item.get("last_surfaced")
+        if not last_surfaced:
+            continue
+        parsed = parse_timestamp(last_surfaced)
+        if latest_timestamp is None or parsed > latest_timestamp:
+            latest_timestamp = parsed
+            latest_topic = item.get("topic")
+    return latest_topic
+
+
+def _candidate_sort_key(item: dict, entry: Entry) -> tuple[int, int, datetime, tuple[int, int], str]:
+    last_surfaced = item.get("last_surfaced")
+    rating = item.get("rating")
+    return (
+        item.get("times_surfaced", 0),
+        0 if last_surfaced is None else 1,
+        parse_timestamp(last_surfaced) if last_surfaced else datetime.min.replace(tzinfo=timezone.utc),
+        (0, rating) if rating is not None else (1, 6),
+        entry.entry_id,
+    )
+
+
 def pick_best_candidate(index: dict, entries: list[Entry], config: dict) -> tuple[dict, Entry] | None:
     entries_by_id = {entry.entry_id: entry for entry in entries}
     cooldown_days = config.get("review_cooldown_days", 60)
     cutoff = datetime.now(timezone.utc) - timedelta(days=cooldown_days)
 
-    candidates: list[tuple[tuple[int, int, int, str], dict, Entry]] = []
+    candidates: list[tuple[dict, Entry]] = []
     for entry_id, item in index.get("items", {}).items():
         entry = entries_by_id.get(entry_id)
         if entry is None:
@@ -32,21 +59,21 @@ def pick_best_candidate(index: dict, entries: list[Entry], config: dict) -> tupl
         if last_surfaced and parse_timestamp(last_surfaced) > cutoff:
             continue
 
-        rating = item.get("rating")
-        times_surfaced = item.get("times_surfaced", 0)
-        score = (
-            0 if rating is None else 1,
-            rating if rating is not None else 0,
-            times_surfaced,
-            entry.entry_id,
-        )
-        candidates.append((score, item, entry))
+        candidates.append((item, entry))
 
     if not candidates:
         return None
 
-    _, item, entry = min(candidates, key=lambda candidate: candidate[0])
-    return item, entry
+    most_recent_topic = _most_recent_surfaced_topic(index)
+    if most_recent_topic is not None:
+        alternate_topic_candidates = [candidate for candidate in candidates if candidate[1].topic != most_recent_topic]
+        if alternate_topic_candidates:
+            candidates = alternate_topic_candidates
+
+    candidates.sort(key=lambda candidate: _candidate_sort_key(candidate[0], candidate[1]))
+    minimum_times_surfaced = candidates[0][0].get("times_surfaced", 0)
+    top_pool = [candidate for candidate in candidates if candidate[0].get("times_surfaced", 0) == minimum_times_surfaced][:10]
+    return random.choice(top_pool)
 
 
 def mark_surfaced(index: dict, entry_id: str, *, awaiting_rating: bool = False) -> dict:

--- a/optional-skills/productivity/robin/scripts/robin/review_logic.py
+++ b/optional-skills/productivity/robin/scripts/robin/review_logic.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from robin.models import Entry
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def parse_timestamp(value: str) -> datetime:
+    normalized = value.replace("Z", "+00:00")
+    timestamp = datetime.fromisoformat(normalized)
+    if timestamp.tzinfo is None:
+        return timestamp.replace(tzinfo=timezone.utc)
+    return timestamp
+
+
+def pick_best_candidate(index: dict, entries: list[Entry], config: dict) -> tuple[dict, Entry] | None:
+    entries_by_id = {entry.entry_id: entry for entry in entries}
+    cooldown_days = config.get("review_cooldown_days", 60)
+    cutoff = datetime.now(timezone.utc) - timedelta(days=cooldown_days)
+
+    candidates: list[tuple[tuple[int, int, int, str], dict, Entry]] = []
+    for entry_id, item in index.get("items", {}).items():
+        entry = entries_by_id.get(entry_id)
+        if entry is None:
+            continue
+
+        last_surfaced = item.get("last_surfaced")
+        if last_surfaced and parse_timestamp(last_surfaced) > cutoff:
+            continue
+
+        rating = item.get("rating")
+        times_surfaced = item.get("times_surfaced", 0)
+        score = (
+            0 if rating is None else 1,
+            rating if rating is not None else 0,
+            times_surfaced,
+            entry.entry_id,
+        )
+        candidates.append((score, item, entry))
+
+    if not candidates:
+        return None
+
+    _, item, entry = min(candidates, key=lambda candidate: candidate[0])
+    return item, entry
+
+
+def mark_surfaced(index: dict, entry_id: str, *, awaiting_rating: bool = False) -> dict:
+    if entry_id not in index.get("items", {}):
+        raise KeyError(entry_id)
+
+    item = index["items"][entry_id]
+    item["last_surfaced"] = now_iso()
+    item["times_surfaced"] = item.get("times_surfaced", 0) + 1
+    item["_awaiting_rating"] = awaiting_rating
+    return item
+
+
+def rate_item(index: dict, entry_id: str, rating: int) -> dict:
+    if entry_id not in index.get("items", {}):
+        raise KeyError(entry_id)
+    if rating < 1 or rating > 5:
+        raise ValueError("Rating must be between 1 and 5.")
+
+    item = index["items"][entry_id]
+    item["rating"] = rating
+    if not item.get("_awaiting_rating"):
+        item["last_surfaced"] = now_iso()
+        item["times_surfaced"] = item.get("times_surfaced", 0) + 1
+    item["_awaiting_rating"] = False
+    return item

--- a/optional-skills/productivity/robin/scripts/robin/search_logic.py
+++ b/optional-skills/productivity/robin/scripts/robin/search_logic.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from robin.models import Entry
+
+
+def search_entries(entries: list[Entry], query: str) -> list[Entry]:
+    query_lower = query.lower()
+    return [
+        entry
+        for entry in entries
+        if query_lower in entry.body.lower()
+        or query_lower in entry.source.lower()
+        or query_lower in entry.description.lower()
+        or query_lower in entry.summary.lower()
+        or query_lower in entry.creator.lower()
+        or query_lower in entry.published_at.lower()
+        or query_lower in entry.media_source.lower()
+        or any(query_lower in tag.lower() for tag in entry.tags)
+    ]
+
+
+def filter_by_tags(entries: list[Entry], tags: list[str]) -> list[Entry]:
+    normalized = {tag.lower() for tag in tags if tag.strip()}
+    return [
+        entry
+        for entry in entries
+        if normalized.issubset({tag.lower() for tag in entry.tags})
+    ]

--- a/optional-skills/productivity/robin/scripts/robin/serializer.py
+++ b/optional-skills/productivity/robin/scripts/robin/serializer.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from datetime import date
+from uuid import uuid4
+
+from robin.models import Entry
+from robin.parser import topic_slug
+
+
+def generate_entry_id(date_added: str | None = None) -> str:
+    stamp = (date_added or str(date.today())).replace("-", "")
+    return f"{stamp}-{uuid4().hex[:6]}"
+
+
+def build_text_entry(
+    topic: str,
+    content: str,
+    description: str,
+    source: str | None,
+    note: str | None,
+    tags: list[str],
+    date_added: str,
+    media_source: str | None = None,
+    entry_id: str | None = None,
+) -> Entry:
+    body_parts: list[str] = []
+    body_parts.append(content.strip())
+    if note:
+        body_parts.append("")
+        body_parts.append(f"**Robin note:** {note.strip()}")
+
+    return Entry(
+        entry_id=entry_id or generate_entry_id(date_added),
+        topic=topic_slug(topic),
+        date_added=date_added,
+        entry_type="text",
+        media_source=(media_source or "").strip(),
+        source=(source or "").strip(),
+        description=description.strip(),
+        tags=tags,
+        body="\n".join(body_parts).strip(),
+    )
+
+
+def build_media_entry(
+    topic: str,
+    media_kind: str,
+    media_source: str,
+    description: str,
+    creator: str,
+    published_at: str,
+    summary: str,
+    content: str,
+    source: str | None,
+    note: str | None,
+    tags: list[str],
+    date_added: str,
+    entry_id: str | None = None,
+) -> Entry:
+    body_parts: list[str] = []
+    if content.strip():
+        body_parts.append(content.strip())
+    if note:
+        if body_parts:
+            body_parts.append("")
+        body_parts.append(f"**Robin note:** {note.strip()}")
+
+    return Entry(
+        entry_id=entry_id or generate_entry_id(date_added),
+        topic=topic_slug(topic),
+        date_added=date_added,
+        entry_type=media_kind,
+        media_kind=media_kind,
+        media_source=media_source.strip(),
+        source=(source or "").strip(),
+        description=description.strip(),
+        creator=creator.strip(),
+        published_at=published_at.strip(),
+        summary=summary.strip(),
+        tags=tags,
+        body="\n".join(body_parts).strip(),
+    )
+
+
+def serialize_entry(entry: Entry) -> str:
+    if not entry.description.strip():
+        raise ValueError("Entry description is required.")
+    lines = [f"id: {entry.entry_id}", f"date_added: {entry.date_added}"]
+    optional_fields = [
+        ("entry_type", entry.entry_type if entry.entry_type != "text" else ""),
+        ("media_kind", entry.media_kind),
+        ("media_source", entry.media_source),
+        ("source", entry.source),
+        ("description", entry.description),
+        ("creator", entry.creator),
+        ("published_at", entry.published_at),
+        ("summary", entry.summary),
+    ]
+    for key, value in optional_fields:
+        if value:
+            lines.append(f"{key}: {value}")
+    if entry.tags:
+        lines.append(f"tags: [{', '.join(entry.tags)}]")
+    # The blank line is required even when the body is empty; it terminates frontmatter.
+    lines.extend(["", entry.body.strip()])
+    return "\n".join(lines)

--- a/optional-skills/productivity/robin/scripts/search.py
+++ b/optional-skills/productivity/robin/scripts/search.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""
+search.py — Search Robin's commonplace book
+
+Usage:
+  python3 search.py --state-dir /path/to/data/robin <query>           # Search entry bodies and sources
+  python3 search.py --state-dir /path/to/data/robin --topic <name>    # List all entries in a topic
+  python3 search.py --state-dir /path/to/data/robin --tags tag1,tag2  # Find entries with these tags
+
+Or set:
+  ROBIN_STATE_DIR=/path/to/data/robin
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from robin.cli import search_main
+
+
+def main():
+    search_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/productivity/robin/scripts/selftest.py
+++ b/optional-skills/productivity/robin/scripts/selftest.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3
+"""
+Robin integration selftest.
+
+Default mode uses a temporary state directory and exercises Robin's command
+surface without touching the user's real library. Passing --state-dir performs
+non-destructive setup checks only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+
+
+class SelftestFailure(Exception):
+    pass
+
+
+class Reporter:
+    def __init__(self) -> None:
+        self.results: list[tuple[bool, str, str | None]] = []
+
+    def check(self, label: str, func) -> Any:
+        try:
+            result = func()
+        except Exception as exc:
+            self.results.append((False, label, str(exc)))
+            return None
+        self.results.append((True, label, None))
+        return result
+
+    def print_report(self, state_dir: Path) -> None:
+        print(f"Robin integration check: {state_dir}")
+        for passed, label, error in self.results:
+            status = "PASS" if passed else "FAIL"
+            print(f"  [{status}] {label}")
+            if error:
+                print(f"         {error}")
+        passed = sum(1 for item in self.results if item[0])
+        total = len(self.results)
+        print(f"  {passed}/{total} passed")
+
+    @property
+    def ok(self) -> bool:
+        return all(passed for passed, _, _ in self.results)
+
+
+def _script(name: str) -> str:
+    return str(SCRIPTS / name)
+
+
+def _run_json(args: list[str], *, expect_success: bool = True) -> dict | list:
+    proc = subprocess.run(
+        [sys.executable, *args],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if expect_success and proc.returncode != 0:
+        raise SelftestFailure(f"Command failed: {' '.join(args)}\n{proc.stderr}{proc.stdout}")
+    if not expect_success and proc.returncode == 0:
+        raise SelftestFailure(f"Command unexpectedly succeeded: {' '.join(args)}\n{proc.stdout}")
+    output = proc.stdout.strip() or proc.stderr.strip()
+    try:
+        return json.loads(output)
+    except json.JSONDecodeError as exc:
+        raise SelftestFailure(
+            f"Command did not return valid JSON: {' '.join(args)}\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+        ) from exc
+
+
+def _require_keys(payload: dict, keys: set[str]) -> None:
+    missing = sorted(keys - set(payload))
+    if missing:
+        raise SelftestFailure(f"Missing keys: {', '.join(missing)}")
+
+
+def _fail_selftest(message: str) -> None:
+    raise SelftestFailure(message)
+
+
+def _write_config(state_dir: Path) -> None:
+    (state_dir / "topics").mkdir(parents=True, exist_ok=True)
+    (state_dir / "media").mkdir(parents=True, exist_ok=True)
+    config = {
+        "topics_dir": "topics",
+        "media_dir": "media",
+        "min_items_before_review": 1,
+        "review_cooldown_days": 0,
+    }
+    (state_dir / "robin-config.json").write_text(json.dumps(config, indent=2), encoding="utf-8")
+
+
+def _check_setup(state_dir: Path) -> None:
+    config_path = state_dir / "robin-config.json"
+    if not config_path.exists():
+        raise SelftestFailure(f"Missing {config_path}")
+    try:
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SelftestFailure(f"{config_path} is invalid JSON: {exc}") from exc
+    if not isinstance(config, dict):
+        raise SelftestFailure(f"{config_path} must contain a JSON object")
+    for dirname in (config.get("topics_dir", "topics"), config.get("media_dir", "media")):
+        path = state_dir / str(dirname)
+        if not path.is_dir():
+            raise SelftestFailure(f"Missing directory: {path}")
+
+
+def _check_topics_json(state_dir: Path) -> list[dict]:
+    payload = _run_json([_script("topics.py"), "--state-dir", str(state_dir), "--json"])
+    if not isinstance(payload, list):
+        raise SelftestFailure("topics.py --json did not return a list")
+    for item in payload:
+        if not isinstance(item, dict):
+            raise SelftestFailure("topics.py --json returned a non-object topic item")
+        _require_keys(item, {"topic", "filename", "entries", "rated", "unrated"})
+    return payload
+
+
+def _add_text_entry(state_dir: Path, *, allow_duplicate: bool = False) -> dict:
+    payload = _run_json(
+        [
+            _script("add_entry.py"),
+            "--state-dir",
+            str(state_dir),
+            "--topic",
+            "Robin Selftest",
+            "--content",
+            "Robin selftest distinctive phrase alpha bravo.",
+            "--description",
+            "A temporary selftest entry used to verify Robin's write path.",
+            "--tags",
+            "selftest,robin",
+            *(["--allow-duplicate"] if allow_duplicate else []),
+            "--json",
+        ]
+    )
+    if not isinstance(payload, dict):
+        raise SelftestFailure("add_entry.py --json did not return an object")
+    _require_keys(payload, {"id", "topic", "filename", "entry_type", "media_source", "description"})
+    if payload["topic"] != "robin-selftest" or payload["entry_type"] != "text":
+        raise SelftestFailure(f"Unexpected add payload: {payload}")
+    return payload
+
+
+def _check_topic_added(state_dir: Path) -> None:
+    topics = _check_topics_json(state_dir)
+    match = next((item for item in topics if item.get("topic") == "robin-selftest"), None)
+    if not match or match.get("entries") != 1:
+        raise SelftestFailure(f"Expected robin-selftest topic with one entry, got {topics}")
+
+
+def _check_search_finds_entry(state_dir: Path, entry_id: str) -> None:
+    payload = _run_json(
+        [
+            _script("search.py"),
+            "--state-dir",
+            str(state_dir),
+            "alpha bravo",
+            "--json",
+        ]
+    )
+    if not isinstance(payload, dict):
+        raise SelftestFailure("search.py --json did not return an object")
+    _require_keys(payload, {"count", "entries"})
+    entries = payload.get("entries")
+    if not isinstance(entries, list) or not any(entry.get("id") == entry_id for entry in entries):
+        raise SelftestFailure(f"Search did not return the added entry: {payload}")
+
+
+def _check_review_and_rate(state_dir: Path) -> None:
+    payload = _run_json([_script("review.py"), "--state-dir", str(state_dir), "--active-review", "--json"])
+    if not isinstance(payload, dict):
+        raise SelftestFailure("review.py --json did not return an object")
+    _require_keys(
+        payload,
+        {
+            "status",
+            "id",
+            "topic",
+            "date_added",
+            "entry_type",
+            "media_kind",
+            "media_source",
+            "source",
+            "description",
+            "creator",
+            "published_at",
+            "summary",
+            "tags",
+            "body",
+            "rating",
+            "times_surfaced",
+        },
+    )
+    if payload["status"] != "ok":
+        raise SelftestFailure(f"Expected review status ok, got {payload}")
+
+    rated = _run_json(
+        [
+            _script("review.py"),
+            "--state-dir",
+            str(state_dir),
+            "--rate",
+            payload["id"],
+            "4",
+            "--json",
+        ]
+    )
+    if not isinstance(rated, dict):
+        raise SelftestFailure("review.py --rate --json did not return an object")
+    _require_keys(rated, {"id", "topic", "date", "rating", "last_surfaced", "times_surfaced", "_awaiting_rating"})
+    if rated["rating"] != 4 or rated["_awaiting_rating"] is not False:
+        raise SelftestFailure(f"Unexpected rate payload: {rated}")
+
+
+def _check_duplicate_rejected(state_dir: Path) -> None:
+    payload = _run_json(
+        [
+            _script("add_entry.py"),
+            "--state-dir",
+            str(state_dir),
+            "--topic",
+            "Robin Selftest",
+            "--content",
+            "Robin selftest distinctive phrase alpha bravo.",
+            "--description",
+            "A temporary selftest entry used to verify Robin's write path.",
+            "--tags",
+            "selftest,robin",
+            "--json",
+        ],
+        expect_success=False,
+    )
+    if not isinstance(payload, dict) or "duplicates" not in payload:
+        raise SelftestFailure(f"Expected duplicate error payload, got {payload}")
+
+
+def _check_duplicate_allowed(state_dir: Path) -> None:
+    payload = _add_text_entry(state_dir, allow_duplicate=True)
+    if not payload.get("id"):
+        raise SelftestFailure(f"Duplicate add did not return an id: {payload}")
+    topics = _check_topics_json(state_dir)
+    match = next((item for item in topics if item.get("topic") == "robin-selftest"), None)
+    if not match or match.get("entries") < 2:
+        raise SelftestFailure(f"Expected duplicate add to create a second entry, got {topics}")
+
+
+def _check_entries_move_and_delete(state_dir: Path) -> None:
+    payload = _run_json(
+        [
+            _script("add_entry.py"),
+            "--state-dir",
+            str(state_dir),
+            "--topic",
+            "Entry Management",
+            "--content",
+            "Robin selftest entry management phrase.",
+            "--description",
+            "A temporary selftest entry used to verify Robin's entry management path.",
+            "--json",
+        ]
+    )
+    if not isinstance(payload, dict) or not payload.get("id"):
+        raise SelftestFailure(f"Expected add payload for entry management check, got {payload}")
+    entry_id = payload["id"]
+
+    moved = _run_json([_script("entries.py"), "--state-dir", str(state_dir), "--move", entry_id, "--topic", "Moved Entries", "--json"])
+    if not isinstance(moved, dict) or moved.get("status") != "moved" or moved.get("to_topic") != "moved-entries":
+        raise SelftestFailure(f"Expected move payload, got {moved}")
+
+    deleted = _run_json([_script("entries.py"), "--state-dir", str(state_dir), "--delete", entry_id, "--json"])
+    if not isinstance(deleted, dict) or deleted.get("status") != "deleted":
+        raise SelftestFailure(f"Expected delete payload, got {deleted}")
+
+
+def _check_local_video_rejected(state_dir: Path) -> None:
+    video = state_dir / "clip.mp4"
+    video.write_bytes(b"fake video")
+    payload = _run_json(
+        [
+            _script("add_entry.py"),
+            "--state-dir",
+            str(state_dir),
+            "--topic",
+            "Robin Selftest",
+            "--entry-type",
+            "video",
+            "--media-path",
+            str(video),
+            "--description",
+            "A rejection-path selftest entry.",
+            "--creator",
+            "Robin",
+            "--published-at",
+            "2026",
+            "--summary",
+            "A fake local video path.",
+            "--json",
+        ],
+        expect_success=False,
+    )
+    if not isinstance(payload, dict) or "error" not in payload:
+        raise SelftestFailure(f"Expected error payload, got {payload}")
+
+
+def _check_missing_media_metadata_rejected(state_dir: Path) -> None:
+    payload = _run_json(
+        [
+            _script("add_entry.py"),
+            "--state-dir",
+            str(state_dir),
+            "--topic",
+            "Robin Selftest",
+            "--entry-type",
+            "video",
+            "--media-url",
+            "https://example.com/watch?v=selftest",
+            "--description",
+            "A rejection-path selftest entry.",
+            "--published-at",
+            "2026",
+            "--summary",
+            "Missing creator should reject this media entry.",
+            "--json",
+        ],
+        expect_success=False,
+    )
+    if not isinstance(payload, dict) or "error" not in payload:
+        raise SelftestFailure(f"Expected error payload, got {payload}")
+
+
+def _check_doctor_json(state_dir: Path) -> None:
+    payload = _run_json([_script("doctor.py"), "--state-dir", str(state_dir), "--json"])
+    if not isinstance(payload, dict):
+        raise SelftestFailure("doctor.py --json did not return an object")
+    _require_keys(payload, {"ok", "errors", "warnings", "diagnostics"})
+    if payload["ok"] is not True or payload["errors"] != 0:
+        raise SelftestFailure(f"Expected healthy doctor payload, got {payload}")
+
+
+def _check_reindex_after_cleanup(state_dir: Path) -> None:
+    for filename in ("robin-selftest.md", "entry-management.md", "moved-entries.md"):
+        topic_file = state_dir / "topics" / filename
+        if topic_file.exists():
+            topic_file.unlink()
+    payload = _run_json([_script("reindex.py"), "--state-dir", str(state_dir), "--json"])
+    if not isinstance(payload, dict):
+        raise SelftestFailure("reindex.py --json did not return an object")
+    _require_keys(payload, {"entries_found", "items_indexed", "rated", "unrated"})
+    if payload["entries_found"] != 0 or payload["items_indexed"] != 0:
+        raise SelftestFailure(f"Expected empty index after cleanup, got {payload}")
+
+
+def _run_setup_checks(reporter: Reporter, state_dir: Path) -> None:
+    reporter.check("robin-config.json exists and parses", lambda: _check_setup(state_dir))
+    reporter.check("topics.py returns valid JSON", lambda: _check_topics_json(state_dir))
+    reporter.check("doctor.py returns healthy JSON", lambda: _check_doctor_json(state_dir))
+
+
+def _run_full_selftest(reporter: Reporter, state_dir: Path) -> None:
+    # This order is intentional: review/rate validates the single-entry path
+    # before the duplicate acceptance check adds a second entry.
+    reporter.check("temporary state directory initialized", lambda: _write_config(state_dir))
+    _run_setup_checks(reporter, state_dir)
+    added = reporter.check("add text entry returns expected shape", lambda: _add_text_entry(state_dir))
+    reporter.check("topics.py reports added topic", lambda: _check_topic_added(state_dir))
+    if isinstance(added, dict):
+        reporter.check("search finds added entry", lambda: _check_search_finds_entry(state_dir, added["id"]))
+    else:
+        reporter.check("search finds added entry", lambda: _fail_selftest("add step failed"))
+    reporter.check("review surfaces an item and rate updates state", lambda: _check_review_and_rate(state_dir))
+    reporter.check("duplicate text entry is rejected by default", lambda: _check_duplicate_rejected(state_dir))
+    reporter.check("duplicate text entry is accepted with override", lambda: _check_duplicate_allowed(state_dir))
+    reporter.check("entries.py moves and deletes an entry", lambda: _check_entries_move_and_delete(state_dir))
+    reporter.check("video with local file is rejected", lambda: _check_local_video_rejected(state_dir))
+    reporter.check("media entry missing creator is rejected", lambda: _check_missing_media_metadata_rejected(state_dir))
+    reporter.check("reindex after cleanup succeeds", lambda: _check_reindex_after_cleanup(state_dir))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run Robin integration checks")
+    parser.add_argument(
+        "--state-dir",
+        help="Existing Robin state directory to validate non-destructively. Full functional tests use a temp dir.",
+    )
+    parser.add_argument("--keep-temp", action="store_true", help="Keep the temporary selftest state directory")
+    args = parser.parse_args()
+
+    reporter = Reporter()
+    temp_dir: str | None = None
+    state_dir = Path(args.state_dir).expanduser().resolve() if args.state_dir else None
+    try:
+        if state_dir:
+            _run_setup_checks(reporter, state_dir)
+        else:
+            temp_dir = tempfile.mkdtemp(prefix="robin-selftest-")
+            state_dir = Path(temp_dir) / "data" / "robin"
+            _run_full_selftest(reporter, state_dir)
+    finally:
+        if state_dir is not None:
+            reporter.print_report(state_dir)
+        if temp_dir:
+            if reporter.ok and not args.keep_temp:
+                shutil.rmtree(temp_dir, ignore_errors=True)
+            else:
+                print(f"Temporary files kept at: {temp_dir}")
+
+    raise SystemExit(0 if reporter.ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/productivity/robin/scripts/topics.py
+++ b/optional-skills/productivity/robin/scripts/topics.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""
+topics.py — List all Robin topics
+
+Usage:
+  python3 topics.py --state-dir /path/to/data/robin         # List all topics with stats
+  python3 topics.py --state-dir /path/to/data/robin --json  # Output as JSON
+
+Or set:
+  ROBIN_STATE_DIR=/path/to/data/robin
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from robin.cli import topics_main
+
+
+def main():
+    topics_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/skills/test_robin_skill.py
+++ b/tests/skills/test_robin_skill.py
@@ -1,0 +1,145 @@
+"""Hermetic tests for the Robin optional skill.
+
+Stdlib + pytest only; NO live network and NO package installation. Each test runs
+against an isolated temporary Robin state directory and drives the bundled CLI
+entry points directly.
+
+    scripts/run_tests.sh tests/skills/test_robin_skill.py -q
+    python3 -m pytest tests/skills/test_robin_skill.py -q
+"""
+from __future__ import annotations
+
+import contextlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Resolve the skill's runtime package across layouts: hermes-agent (tests/skills/ ->
+# optional-skills/productivity/robin/scripts) and the standalone Robin dev repo (src/).
+_HERE = Path(__file__).resolve()
+_CANDIDATES = [
+    _HERE.parents[2] / "optional-skills" / "productivity" / "robin" / "scripts",
+    _HERE.parents[2] / "src",
+]
+SCRIPTS = next((c for c in _CANDIDATES if (c / "robin" / "cli.py").exists()), _CANDIDATES[0])
+sys.path.insert(0, str(SCRIPTS))
+
+from robin.cli import (  # noqa: E402
+    add_main,
+    doctor_main,
+    entries_main,
+    review_main,
+    search_main,
+    topics_main,
+)
+from robin.config import media_path, topics_path  # noqa: E402
+
+
+@contextlib.contextmanager
+def robin_state(tmp_path):
+    """Yield a fresh, initialized Robin state directory."""
+    state = tmp_path / "data" / "robin"
+    (state / "topics").mkdir(parents=True)
+    (state / "media").mkdir(parents=True)
+    config = {
+        "topics_dir": "topics",
+        "media_dir": "media",
+        "min_items_before_review": 1,
+        "review_cooldown_days": 60,
+    }
+    (state / "robin-config.json").write_text(json.dumps(config), encoding="utf-8")
+    (state / "robin-review-index.json").write_text(json.dumps({"items": {}}), encoding="utf-8")
+    yield state
+
+
+def _add(state, capsys, **flags):
+    argv = ["--state-dir", str(state), "--json"]
+    for key, value in flags.items():
+        argv += [f"--{key.replace('_', '-')}", value]
+    add_main(argv)
+    return json.loads(capsys.readouterr().out)
+
+
+def test_add_and_search_roundtrip(tmp_path, capsys):
+    with robin_state(tmp_path) as state:
+        added = _add(state, capsys, topic="AI", content="Useful note", description="Short label", tags="ai,notes")
+        assert added["entry_type"] == "text"
+
+        search_main(["--state-dir", str(state), "Useful", "--json"])
+        result = json.loads(capsys.readouterr().out)
+        assert result["count"] == 1
+        assert result["entries"][0]["id"] == added["id"]
+
+        # Query is positional; tag and topic filters also work.
+        search_main(["--state-dir", str(state), "--tags", "ai,notes", "--json"])
+        assert json.loads(capsys.readouterr().out)["count"] == 1
+
+
+def test_add_source_entry(tmp_path, capsys):
+    with robin_state(tmp_path) as state:
+        added = _add(
+            state, capsys,
+            topic="Reading", content="Key takeaway", description="Article title",
+            source="https://example.com",
+        )
+        assert added["topic"].lower() == "reading"
+        assert added["entry_type"] == "text"
+
+
+def test_review_surfaces_and_rate(tmp_path, capsys):
+    with robin_state(tmp_path) as state:
+        added = _add(state, capsys, topic="AI", content="Recall me", description="A note to resurface")
+
+        review_main(["--state-dir", str(state), "--json"])
+        surfaced = json.loads(capsys.readouterr().out)
+        assert surfaced["status"] == "ok"
+        assert surfaced["id"] == added["id"]
+
+        review_main(["--state-dir", str(state), "--rate", added["id"], "5", "--json"])
+        rated = json.loads(capsys.readouterr().out)
+        assert rated["rating"] == 5
+
+
+def test_entries_move_and_delete(tmp_path, capsys):
+    with robin_state(tmp_path) as state:
+        added = _add(state, capsys, topic="AI", content="Movable", description="An entry to move then delete")
+
+        entries_main(["--state-dir", str(state), "--move", added["id"], "--topic", "New Topic", "--json"])
+        capsys.readouterr()
+        search_main(["--state-dir", str(state), "--topic", "New Topic", "--json"])
+        assert json.loads(capsys.readouterr().out)["count"] == 1
+
+        entries_main(["--state-dir", str(state), "--delete", added["id"], "--json"])
+        capsys.readouterr()
+        search_main(["--state-dir", str(state), "Movable", "--json"])
+        assert json.loads(capsys.readouterr().out)["count"] == 0
+
+
+def test_topics_lists_saved_topic(tmp_path, capsys):
+    with robin_state(tmp_path) as state:
+        _add(state, capsys, topic="AI", content="Note", description="A short description here")
+        topics_main(["--state-dir", str(state), "--json"])
+        out = json.loads(capsys.readouterr().out)
+        assert "ai" in json.dumps(out).lower()
+
+
+def test_doctor_reports_healthy(tmp_path, capsys):
+    with robin_state(tmp_path) as state:
+        _add(state, capsys, topic="AI", content="Note", description="A short description here")
+        with pytest.raises(SystemExit) as exc:
+            doctor_main(["--state-dir", str(state), "--json"])
+        assert exc.value.code in (0, None)
+
+
+@pytest.mark.parametrize("field, fn", [("topics_dir", topics_path), ("media_dir", media_path)])
+@pytest.mark.parametrize("bad_value", ["/etc", "../escape", "topics/../../escape"])
+def test_content_paths_cannot_escape_state_dir(tmp_path, field, fn, bad_value):
+    with robin_state(tmp_path) as state:
+        with pytest.raises(SystemExit, match="must be a relative path inside the state directory"):
+            fn({field: bad_value}, str(state))
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## Summary

Adds Robin as an official optional Hermes skill under `optional-skills/productivity/robin`.

Robin is a local commonplace-book skill for saving, organizing, searching, reviewing, moving, deleting, and diagnosing durable knowledge entries. The optional skill is self-contained: it includes the CLI wrappers, stdlib-only Robin runtime package, and a reference guide so users can run it from the installed skill directory without separately installing `robin-commonplace`.

## What changed

- Added `optional-skills/productivity/robin/SKILL.md` with Hermes optional-skill metadata.
- Added Robin helper scripts and bundled runtime under `optional-skills/productivity/robin/scripts/`.
- Added the full CLI/reference guide under `optional-skills/productivity/robin/references/guide.md`.
- Updated the copied wrappers to import the bundled `scripts/robin` package.

## Validation

- `python3 optional-skills/productivity/robin/scripts/selftest.py`
- `python3 optional-skills/productivity/robin/scripts/doctor.py --state-dir <tmp-state> --json`
- `git diff --cached --check`

## Notes

The skill requires terminal access and supports macOS/Linux. It stores user data in an explicit Robin state directory such as `~/.hermes/data/robin`.
