### PR TITLE
fix(skills): respect HERMES_SESSION_PLATFORM in _is_skill_disabled

### DIFF
--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -507,14 +507,33 @@ def _get_disabled_skill_names() -> Set[str]:
     return get_disabled_skill_names()
 
 
+def _get_session_platform() -> str:
+    """Resolve the current platform from gateway session context.
+
+    Mirrors the platform-resolution logic in
+    ``agent.skill_utils.get_disabled_skill_names`` so that
+    ``_is_skill_disabled`` respects ``HERMES_SESSION_PLATFORM``.
+    """
+    try:
+        from gateway.session_context import get_session_env
+        return get_session_env("HERMES_SESSION_PLATFORM") or ""
+    except Exception:
+        return ""
+
+
 def _is_skill_disabled(name: str, platform: str = None) -> bool:
-    """Check if a skill is disabled in config."""
-    import os
+    """Check if a skill is disabled in config.
+
+    Resolves the active platform from (in order of precedence):
+    1. Explicit ``platform`` argument
+    2. ``HERMES_PLATFORM`` environment variable
+    3. ``HERMES_SESSION_PLATFORM`` from gateway session context
+    """
     try:
         from hermes_cli.config import load_config
         config = load_config()
         skills_cfg = config.get("skills", {})
-        resolved_platform = platform or os.getenv("HERMES_PLATFORM")
+        resolved_platform = platform or os.getenv("HERMES_PLATFORM") or _get_session_platform()
         if resolved_platform:
             platform_disabled = skills_cfg.get("platform_disabled", {}).get(resolved_platform)
             if platform_disabled is not None:
@@ -976,8 +995,7 @@ def skill_view(name: str, file_path: str = None, task_id: str = None) -> str:
                 _warnings.append(f"skill file is outside the trusted skills directory (~/.hermes/skills/): {skill_md}")
             if _injection_detected:
                 _warnings.append("skill content contains patterns that may indicate prompt injection")
-            import logging as _logging
-            _logging.getLogger(__name__).warning("Skill security warning for '%s': %s", name, "; ".join(_warnings))
+            logging.getLogger(__name__).warning("Skill security warning for '%s': %s", name, "; ".join(_warnings))
 
         parsed_frontmatter: Dict[str, Any] = {}
         try:


### PR DESCRIPTION
## Summary

Fixes #13027

`skill_view()` could expose skills that were platform-disabled for the active gateway session because `_is_skill_disabled()` only checked the explicit `platform` argument and `os.getenv('HERMES_PLATFORM')`, missing `HERMES_SESSION_PLATFORM` from the gateway session context.

## Changes

- Added `_get_session_platform()` helper function that resolves the platform from `gateway.session_context.get_session_env("HERMES_SESSION_PLATFORM")`, with graceful fallback on import failure
- Updated `_is_skill_disabled()` to include session context in the platform resolution chain, matching the precedence used by `agent.skill_utils.get_disabled_skill_names()`

### Platform resolution precedence (now consistent with `skill_utils`):
1. Explicit `platform` argument
2. `HERMES_PLATFORM` environment variable  
3. `HERMES_SESSION_PLATFORM` from gateway session context

## Testing

The fix follows the exact pattern already established in `agent/skill_utils.py:148-153`:

```python
# Before (skills_tool.py)
resolved_platform = platform or os.getenv("HERMES_PLATFORM")

# After (matches skill_utils.py pattern)
resolved_platform = platform or os.getenv("HERMES_PLATFORM") or _get_session_platform()
```

The reproduction case from #13027 would now correctly reject `skill_view('blocked-skill')` when called within a Discord session where the skill is platform-disabled.

## Files Changed

- `tools/skills_tool.py` — Added `_get_session_platform()` helper, updated `_is_skill_disabled()` to use it