### PR TITLE
fix(skills): respect HERMES_SESSION_PLATFORM in _is_skill_disabled

### DIFF
--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -507,13 +507,33 @@ def _get_disabled_skill_names() -> Set[str]:
     return get_disabled_skill_names()
 
 
+def _get_session_platform() -> str:
+    """Resolve the current platform from gateway session context.
+
+    Mirrors the platform-resolution logic in
+    ``agent.skill_utils.get_disabled_skill_names`` so that
+    ``_is_skill_disabled`` respects ``HERMES_SESSION_PLATFORM``.
+    """
+    try:
+        from gateway.session_context import get_session_env
+        return get_session_env("HERMES_SESSION_PLATFORM") or ""
+    except Exception:
+        return ""
+
+
 def _is_skill_disabled(name: str, platform: str = None) -> bool:
-    """Check if a skill is disabled in config."""
+    """Check if a skill is disabled in config.
+
+    Resolves the active platform from (in order of precedence):
+    1. Explicit ``platform`` argument
+    2. ``HERMES_PLATFORM`` environment variable
+    3. ``HERMES_SESSION_PLATFORM`` from gateway session context
+    """
     try:
         from hermes_cli.config import load_config
         config = load_config()
         skills_cfg = config.get("skills", {})
-        resolved_platform = platform or os.getenv("HERMES_PLATFORM")
+        resolved_platform = platform or os.getenv("HERMES_PLATFORM") or _get_session_platform()
         if resolved_platform:
             platform_disabled = skills_cfg.get("platform_disabled", {}).get(resolved_platform)
             if platform_disabled is not None:


### PR DESCRIPTION
Salvage of #13506 onto current main. @zhanggttry's commit cherry-picked with authorship preserved.

## Summary
`skill_view()` now rejects skills that are platform-disabled for the active gateway session. Before this, `_is_skill_disabled()` only checked the explicit `platform` argument and `HERMES_PLATFORM` env var, missing `HERMES_SESSION_PLATFORM` set by the gateway session context — so a Discord session could still view skills listed under `skills.platform_disabled.discord`.

Root cause: `_is_skill_disabled()` in `tools/skills_tool.py` diverged from `agent/skill_utils.get_disabled_skill_names()`, which already resolves `get_session_env('HERMES_SESSION_PLATFORM')` as the third tier of precedence.

## Changes
- `tools/skills_tool.py`: new `_get_session_platform()` helper + third-tier fallback in `_is_skill_disabled()`. Also drops a redundant in-function `import logging as _logging` (module-level import already present).

## Precedence (now consistent with `skill_utils`)
1. Explicit `platform` argument
2. `HERMES_PLATFORM` env var
3. `HERMES_SESSION_PLATFORM` from gateway session context

## Validation
| | Before | After |
|---|---|---|
| Discord session, skill disabled on discord | `success: true` (leaked) | `success: false` — "Skill '…' is disabled" |
| Telegram session, only discord disabled | `success: true` | `success: true` |
| Explicit `platform='slack'` arg | respected | respected |
| `HERMES_PLATFORM=slack` over session=discord | env wins | env wins |

Tests: `tests/tools/test_skills_tool.py` 72/72 pass. E2E repro from #13027 now correctly blocks the skill.

Closes #13027.
Original PR: #13506.