### PR TITLE
fix(copilot-acp): honor line=1 pagination in read_text_file (#13451)

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -560,7 +560,7 @@ class CopilotACPClient:
                 content = path.read_text() if path.exists() else ""
                 line = params.get("line")
                 limit = params.get("limit")
-                if isinstance(line, int) and line > 1:
+                if isinstance(line, int) and line >= 1:
                     lines = content.splitlines(keepends=True)
                     start = line - 1
                     end = start + limit if isinstance(limit, int) and limit > 0 else None

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -94,6 +94,25 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
         self.assertNotIn("abc123def456", content)
         self.assertIn("OPENAI_API_KEY=", content)
 
+    def test_read_text_file_honors_first_page_pagination(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            text_file = root / "sample.txt"
+            text_file.write_text("one\ntwo\nthree\n")
+
+            response = self._dispatch(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 33,
+                    "method": "fs/read_text_file",
+                    "params": {"path": str(text_file), "line": 1, "limit": 1},
+                },
+                cwd=str(root),
+            )
+
+        content = ((response.get("result") or {}).get("content") or "")
+        self.assertEqual(content, "one\n")
+
     def test_write_text_file_reuses_write_denylist(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             home = Path(tmpdir) / "home"


### PR DESCRIPTION
## Summary
- apply fs/read_text_file pagination when line is 1 as well as later pages
- preserve the existing limit-based slicing behavior
- add a regression test covering line=1, limit=1

## Verification
- py -3 -m pytest -o addopts= testsgent	est_copilot_acp_client.py -q
- py -3 -m py_compile agent\copilot_acp_client.py testsgent	est_copilot_acp_client.py
- independent self-review completed before PR creation

Fixes #13451
