### PR TITLE
Amindadgar PR#8486 retry ci fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ mini-swe-agent/
 # Nix
 .direnv/
 result
+.venv-hb/*

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -472,6 +472,14 @@ agent:
   # Recommended: 20-30 for focused tasks, 50-100 for open exploration
   max_turns: 60
 
+  # Full-request retry budget for retryable API failures (429/5xx/transient transport).
+  # 0 = fail immediately after the first error, 3 = initial attempt + up to 3 retries.
+  max_api_retries: 3
+
+  # Streaming reconnect budget for dropped/read-timeout streams.
+  # Only applies to streaming requests; non-streaming calls use max_api_retries only.
+  max_stream_retries: 2
+
   # Inactivity timeout for gateway agent runs (seconds, 0 = unlimited).
   # The agent can run indefinitely when actively calling tools or receiving
   # API responses.  Only fires after the agent has been idle for this duration.

--- a/cli.py
+++ b/cli.py
@@ -247,6 +247,8 @@ def load_cli_config() -> Dict[str, Any]:
         },
         "agent": {
             "max_turns": 90,  # Default max tool-calling iterations (shared with subagents)
+            "max_api_retries": 3,
+            "max_stream_retries": 2,
             "verbose": False,
             "system_prompt": "",
             "prefill_messages_file": "",
@@ -385,8 +387,9 @@ def load_cli_config() -> Dict[str, Any]:
             logger.warning("Failed to load cli-config.yaml: %s", e)
 
     # Expand ${ENV_VAR} references in config values before bridging to env vars.
-    from hermes_cli.config import _expand_env_vars
+    from hermes_cli.config import _expand_env_vars, _normalize_agent_retry_config
     defaults = _expand_env_vars(defaults)
+    defaults = _normalize_agent_retry_config(defaults)
 
     # Apply terminal config to environment variables (so terminal_tool picks them up)
     terminal_config = defaults.get("terminal", {})
@@ -1706,6 +1709,18 @@ class HermesCLI:
             self.max_turns = int(os.getenv("HERMES_MAX_ITERATIONS"))
         else:
             self.max_turns = 90
+
+        from hermes_cli.config import _coerce_non_negative_int
+
+        agent_cfg = CLI_CONFIG.get("agent", {}) or {}
+        self.max_api_retries = _coerce_non_negative_int(
+            agent_cfg.get("max_api_retries"),
+            default=3,
+        )
+        self.max_stream_retries = _coerce_non_negative_int(
+            agent_cfg.get("max_stream_retries"),
+            default=2,
+        )
         
         # Parse and validate toolsets
         self.enabled_toolsets = toolsets
@@ -2876,8 +2891,8 @@ class HermesCLI:
                 acp_args=runtime.get("args"),
                 credential_pool=runtime.get("credential_pool"),
                 max_iterations=self.max_turns,
-                max_api_retries=int(CLI_CONFIG.get("agent", {}).get("max_api_retries", 3)),
-                max_stream_retries=int(CLI_CONFIG.get("agent", {}).get("max_stream_retries", 2)),
+                max_api_retries=self.max_api_retries,
+                max_stream_retries=self.max_stream_retries,
                 enabled_toolsets=self.enabled_toolsets,
                 verbose_logging=self.verbose,
                 quiet_mode=not self.verbose,
@@ -5619,6 +5634,8 @@ class HermesCLI:
                     acp_command=turn_route["runtime"].get("command"),
                     acp_args=turn_route["runtime"].get("args"),
                     max_iterations=self.max_turns,
+                    max_api_retries=self.max_api_retries,
+                    max_stream_retries=self.max_stream_retries,
                     enabled_toolsets=self.enabled_toolsets,
                     quiet_mode=True,
                     verbose_logging=False,
@@ -5757,6 +5774,8 @@ class HermesCLI:
                     acp_command=turn_route["runtime"].get("command"),
                     acp_args=turn_route["runtime"].get("args"),
                     max_iterations=8,
+                    max_api_retries=self.max_api_retries,
+                    max_stream_retries=self.max_stream_retries,
                     enabled_toolsets=[],
                     quiet_mode=True,
                     verbose_logging=False,

--- a/cli.py
+++ b/cli.py
@@ -2877,6 +2877,7 @@ class HermesCLI:
                 credential_pool=runtime.get("credential_pool"),
                 max_iterations=self.max_turns,
                 max_api_retries=int(CLI_CONFIG.get("agent", {}).get("max_api_retries", 3)),
+                max_stream_retries=int(CLI_CONFIG.get("agent", {}).get("max_stream_retries", 2)),
                 enabled_toolsets=self.enabled_toolsets,
                 verbose_logging=self.verbose,
                 quiet_mode=not self.verbose,

--- a/cli.py
+++ b/cli.py
@@ -2876,6 +2876,7 @@ class HermesCLI:
                 acp_args=runtime.get("args"),
                 credential_pool=runtime.get("credential_pool"),
                 max_iterations=self.max_turns,
+                max_api_retries=int(CLI_CONFIG.get("agent", {}).get("max_api_retries", 3)),
                 enabled_toolsets=self.enabled_toolsets,
                 verbose_logging=self.verbose,
                 quiet_mode=not self.verbose,

--- a/docs/acp-setup.md
+++ b/docs/acp-setup.md
@@ -161,6 +161,10 @@ Edit `~/.hermes/config.yaml`:
 
 ```yaml
 model: openrouter/nous/hermes-3-llama-3.1-70b
+
+agent:
+  max_api_retries: 5
+  max_stream_retries: 5
 ```
 
 Or set the `HERMES_MODEL` environment variable.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -180,6 +180,10 @@ if _config_path.exists():
         if _agent_cfg and isinstance(_agent_cfg, dict):
             if "max_turns" in _agent_cfg:
                 os.environ["HERMES_MAX_ITERATIONS"] = str(_agent_cfg["max_turns"])
+            if "max_api_retries" in _agent_cfg and "HERMES_MAX_API_RETRIES" not in os.environ:
+                os.environ["HERMES_MAX_API_RETRIES"] = str(_agent_cfg["max_api_retries"])
+            if "max_stream_retries" in _agent_cfg and "HERMES_STREAM_RETRIES" not in os.environ:
+                os.environ["HERMES_STREAM_RETRIES"] = str(_agent_cfg["max_stream_retries"])
             # Bridge agent.gateway_timeout → HERMES_AGENT_TIMEOUT env var.
             # Env var from .env takes precedence (already in os.environ).
             if "gateway_timeout" in _agent_cfg and "HERMES_AGENT_TIMEOUT" not in os.environ:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -334,6 +334,8 @@ DEFAULT_CONFIG = {
     "toolsets": ["hermes-cli"],
     "agent": {
         "max_turns": 90,
+        "max_api_retries": 3,
+        "max_stream_retries": 2,
         # Inactivity timeout for gateway agent execution (seconds).
         # The agent can run indefinitely as long as it's actively calling
         # tools or receiving API responses.  Only fires when the agent has
@@ -716,7 +718,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 16,
+    "_config_version": 17,
 }
 
 # =============================================================================
@@ -2227,6 +2229,33 @@ def _normalize_max_turns_config(config: Dict[str, Any]) -> Dict[str, Any]:
     return config
 
 
+def _coerce_non_negative_int(value: Any, *, default: int) -> int:
+    """Parse a config value as a non-negative integer with fallback."""
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed >= 0 else default
+
+
+def _normalize_agent_retry_config(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize retry counts under agent.* with backward-compatible defaults."""
+    config = dict(config)
+    agent_config = dict(config.get("agent") or {})
+
+    agent_config["max_api_retries"] = _coerce_non_negative_int(
+        agent_config.get("max_api_retries"),
+        default=DEFAULT_CONFIG["agent"]["max_api_retries"],
+    )
+    agent_config["max_stream_retries"] = _coerce_non_negative_int(
+        agent_config.get("max_stream_retries"),
+        default=DEFAULT_CONFIG["agent"]["max_stream_retries"],
+    )
+
+    config["agent"] = agent_config
+    return config
+
+
 
 def read_raw_config() -> Dict[str, Any]:
     """Read ~/.hermes/config.yaml as-is, without merging defaults or migrating.
@@ -2270,7 +2299,11 @@ def load_config() -> Dict[str, Any]:
         except Exception as e:
             print(f"Warning: Failed to load config: {e}")
     
-    return _expand_env_vars(_normalize_root_model_keys(_normalize_max_turns_config(config)))
+    return _expand_env_vars(
+        _normalize_root_model_keys(
+            _normalize_agent_retry_config(_normalize_max_turns_config(config))
+        )
+    )
 
 
 _SECURITY_COMMENT = """
@@ -2377,7 +2410,9 @@ def save_config(config: Dict[str, Any]):
 
     ensure_hermes_home()
     config_path = get_config_path()
-    normalized = _normalize_root_model_keys(_normalize_max_turns_config(config))
+    normalized = _normalize_root_model_keys(
+        _normalize_agent_retry_config(_normalize_max_turns_config(config))
+    )
 
     # Build optional commented-out sections for features that are off by
     # default or only relevant when explicitly configured.

--- a/run_agent.py
+++ b/run_agent.py
@@ -41,6 +41,7 @@ from typing import List, Dict, Any, Optional
 from openai import OpenAI
 import fire
 from datetime import datetime
+from email.utils import parsedate_to_datetime
 from pathlib import Path
 
 from hermes_constants import get_hermes_home
@@ -76,7 +77,6 @@ from hermes_constants import OPENROUTER_BASE_URL
 
 # Agent internals extracted to agent/ package for modularity
 from agent.memory_manager import build_memory_context_block
-from agent.retry_utils import jittered_backoff
 from agent.error_classifier import classify_api_error, FailoverReason
 from agent.prompt_builder import (
     DEFAULT_AGENT_IDENTITY, PLATFORM_HINTS,
@@ -570,8 +570,8 @@ class AIAgent:
         checkpoint_max_snapshots: int = 50,
         pass_session_id: bool = False,
         persist_session: bool = True,
-        max_api_retries: int = 3,
-        max_stream_retries: int = 1,
+        max_api_retries: Optional[int] = None,
+        max_stream_retries: Optional[int] = None,
     ):
         """
         Initialize the AI Agent.
@@ -616,8 +616,16 @@ class AIAgent:
 
         self.model = model
         self.max_iterations = max_iterations
-        self.max_api_retries = max_api_retries
-        self.max_stream_retries = max_stream_retries
+        self.max_api_retries = self._resolve_retry_limit(
+            max_api_retries,
+            default=3,
+            env_var="HERMES_MAX_API_RETRIES",
+        )
+        self.max_stream_retries = self._resolve_retry_limit(
+            max_stream_retries,
+            default=2,
+            env_var="HERMES_STREAM_RETRIES",
+        )
         # Shared iteration budget — parent creates, children inherit.
         # Consumed by every LLM turn across parent + all subagents.
         self.iteration_budget = iteration_budget or IterationBudget(max_iterations)
@@ -2644,6 +2652,101 @@ class AIAgent:
 
         return context
 
+    @staticmethod
+    def _coerce_retry_limit(value: Any, *, default: int) -> int:
+        """Parse retry config/env values as non-negative integers."""
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            return default
+        return parsed if parsed >= 0 else default
+
+    @classmethod
+    def _resolve_retry_limit(
+        cls,
+        value: Any,
+        *,
+        default: int,
+        env_var: str | None = None,
+    ) -> int:
+        if value is None and env_var:
+            value = os.getenv(env_var)
+        return cls._coerce_retry_limit(value, default=default)
+
+    @staticmethod
+    def _parse_retry_after_delay(value: Any, *, now: Optional[float] = None) -> Optional[float]:
+        """Parse Retry-After / reset timestamps into a delay in seconds."""
+        if value in (None, ""):
+            return None
+
+        now_ts = time.time() if now is None else now
+
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError):
+            numeric = None
+
+        if numeric is not None:
+            if numeric >= now_ts:
+                return max(0.0, numeric - now_ts)
+            return max(0.0, numeric)
+
+        try:
+            parsed_dt = parsedate_to_datetime(str(value))
+        except (TypeError, ValueError, IndexError, OverflowError):
+            return None
+
+        if parsed_dt.tzinfo is None:
+            parsed_dt = parsed_dt.replace(tzinfo=datetime.now().astimezone().tzinfo)
+        return max(0.0, parsed_dt.timestamp() - now_ts)
+
+    def _rate_limit_retry_after_delay(self, api_error: Exception) -> Optional[float]:
+        """Return a capped Retry-After/reset delay for rate-limited responses."""
+        response = getattr(api_error, "response", None)
+        headers = getattr(response, "headers", None)
+        if headers and hasattr(headers, "get"):
+            raw_retry_after = headers.get("retry-after") or headers.get("Retry-After")
+            parsed_delay = self._parse_retry_after_delay(raw_retry_after)
+            if parsed_delay is not None:
+                return min(parsed_delay, 300.0)
+
+        context = self._extract_api_error_context(api_error)
+        parsed_delay = self._parse_retry_after_delay(context.get("reset_at"))
+        if parsed_delay is not None:
+            return min(parsed_delay, 300.0)
+        return None
+
+    def _compute_retry_wait_time(
+        self,
+        *,
+        retry_count: int,
+        is_rate_limited: bool,
+        api_error: Optional[Exception] = None,
+    ) -> float:
+        """Compute the outer retry wait time for the next API attempt."""
+        retry_index = max(0, retry_count - 1)
+
+        if is_rate_limited:
+            retry_after = None
+            if api_error is not None:
+                retry_after = self._rate_limit_retry_after_delay(api_error)
+            if retry_after is not None:
+                return retry_after
+
+            base_delay = min(5.0 * (2 ** retry_index), 300.0)
+            jitter = random.uniform(-0.2, 0.2) * base_delay
+            return min(300.0, max(0.0, base_delay + jitter))
+
+        return min(float(2 ** retry_index), 60.0)
+
+    def _effective_max_stream_retries(self) -> int:
+        """Return the validated stream retry budget, even on partially-built agents."""
+        return self._resolve_retry_limit(
+            getattr(self, "max_stream_retries", None),
+            default=2,
+            env_var="HERMES_STREAM_RETRIES",
+        )
+
     def _usage_summary_for_api_request_hook(self, response: Any) -> Optional[Dict[str, Any]]:
         """Token buckets for ``post_api_request`` plugins (no raw ``response`` object)."""
         if response is None:
@@ -4254,7 +4357,7 @@ class AIAgent:
         import httpx as _httpx
 
         active_client = client or self._ensure_primary_openai_client(reason="codex_stream_direct")
-        max_stream_retries = self.max_stream_retries
+        max_stream_retries = self._effective_max_stream_retries()
         has_tool_calls = False
         first_delta_fired = False
         # Accumulate streamed text so we can recover if get_final_response()
@@ -5159,7 +5262,7 @@ class AIAgent:
         def _call():
             import httpx as _httpx
 
-            _max_stream_retries = int(os.getenv("HERMES_STREAM_RETRIES", self.max_stream_retries))
+            _max_stream_retries = self._effective_max_stream_retries()
 
             try:
                 for _stream_attempt in range(_max_stream_retries + 1):
@@ -8062,7 +8165,8 @@ class AIAgent:
             
             api_start_time = time.time()
             retry_count = 0
-            max_retries = 3
+            max_retries = self.max_api_retries
+            max_attempts = max_retries + 1
             primary_recovery_attempted = False
             max_compression_attempts = 3
             codex_auth_retry_attempted=False
@@ -8077,7 +8181,7 @@ class AIAgent:
             response = None  # Guard against UnboundLocalError if all retries fail
             api_kwargs = None  # Guard against UnboundLocalError in except handler
 
-            while retry_count < max_retries:
+            while retry_count < max_attempts:
                 try:
                     self._reset_stream_delivery_tracking()
                     api_kwargs = self._build_api_kwargs(api_messages)
@@ -8264,13 +8368,13 @@ class AIAgent:
                             if self.verbose_logging:
                                 logging.debug(f"Response attributes for invalid response: {resp_attrs}")
                         
-                        self._vprint(f"{self.log_prefix}⚠️  Invalid API response (attempt {retry_count}/{max_retries}): {', '.join(error_details)}", force=True)
+                        self._vprint(f"{self.log_prefix}⚠️  Invalid API response (attempt {retry_count}/{max_attempts}): {', '.join(error_details)}", force=True)
                         self._vprint(f"{self.log_prefix}   🏢 Provider: {provider_name}", force=True)
                         cleaned_provider_error = self._clean_error_message(error_msg)
                         self._vprint(f"{self.log_prefix}   📝 Provider message: {cleaned_provider_error}", force=True)
                         self._vprint(f"{self.log_prefix}   ⏱️  Response time: {api_duration:.2f}s (fast response often indicates rate limiting)", force=True)
                         
-                        if retry_count >= max_retries:
+                        if retry_count >= max_attempts:
                             # Try fallback before giving up
                             self._emit_status(f"⚠️ Max retries ({max_retries}) for invalid responses — trying fallback...")
                             if self._try_activate_fallback():
@@ -8289,9 +8393,10 @@ class AIAgent:
                                 "failed": True  # Mark as failure for filtering
                             }
                         
-                        # Longer backoff for rate limiting (likely cause of None choices)
-                        # Jittered exponential: 5s base, 120s cap + random jitter
-                        wait_time = jittered_backoff(retry_count, base_delay=5.0, max_delay=120.0)
+                        wait_time = self._compute_retry_wait_time(
+                            retry_count=retry_count,
+                            is_rate_limited=True,
+                        )
                         self._vprint(f"{self.log_prefix}⏳ Retrying in {wait_time}s (extended backoff for possible rate limit)...", force=True)
                         logging.warning(f"Invalid API response (retry {retry_count}/{max_retries}): {', '.join(error_details)} | Provider: {provider_name}")
                         
@@ -8789,7 +8894,7 @@ class AIAgent:
                     logger.warning(
                         "API call failed (attempt %s/%s) error_type=%s %s summary=%s",
                         retry_count,
-                        max_retries,
+                        max_attempts,
                         error_type,
                         self._client_log_context(),
                         _error_summary,
@@ -8799,7 +8904,7 @@ class AIAgent:
                     _base = getattr(self, "base_url", "unknown")
                     _model = getattr(self, "model", "unknown")
                     _status_code_str = f" [HTTP {status_code}]" if status_code else ""
-                    self._vprint(f"{self.log_prefix}⚠️  API call failed (attempt {retry_count}/{max_retries}): {error_type}{_status_code_str}", force=True)
+                    self._vprint(f"{self.log_prefix}⚠️  API call failed (attempt {retry_count}/{max_attempts}): {error_type}{_status_code_str}", force=True)
                     self._vprint(f"{self.log_prefix}   🔌 Provider: {_provider}  Model: {_model}", force=True)
                     self._vprint(f"{self.log_prefix}   🌐 Endpoint: {_base}", force=True)
                     self._vprint(f"{self.log_prefix}   📝 Error: {_error_summary}", force=True)
@@ -9198,7 +9303,7 @@ class AIAgent:
                             "error": str(api_error),
                         }
 
-                    if retry_count >= max_retries:
+                    if retry_count >= max_attempts:
                         # Before falling back, try rebuilding the primary
                         # client once for transient transport errors (stale
                         # connection pool, TCP reset).  Only attempted once
@@ -9281,27 +9386,20 @@ class AIAgent:
                             "error": _final_summary,
                         }
 
-                    # For rate limits, respect the Retry-After header if present
-                    _retry_after = None
+                    wait_time = self._compute_retry_wait_time(
+                        retry_count=retry_count,
+                        is_rate_limited=is_rate_limited,
+                        api_error=api_error,
+                    )
                     if is_rate_limited:
-                        _resp_headers = getattr(getattr(api_error, "response", None), "headers", None)
-                        if _resp_headers and hasattr(_resp_headers, "get"):
-                            _ra_raw = _resp_headers.get("retry-after") or _resp_headers.get("Retry-After")
-                            if _ra_raw:
-                                try:
-                                    _retry_after = min(int(_ra_raw), 120)  # Cap at 2 minutes
-                                except (TypeError, ValueError):
-                                    pass
-                    wait_time = _retry_after if _retry_after else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
-                    if is_rate_limited:
-                        self._emit_status(f"⏱️ Rate limit reached. Waiting {wait_time}s before retry (attempt {retry_count + 1}/{max_retries})...")
+                        self._emit_status(f"⏱️ Rate limit reached. Waiting {wait_time}s before retry (attempt {retry_count + 1}/{max_attempts})...")
                     else:
-                        self._emit_status(f"⏳ Retrying in {wait_time}s (attempt {retry_count}/{max_retries})...")
+                        self._emit_status(f"⏳ Retrying in {wait_time}s (attempt {retry_count + 1}/{max_attempts})...")
                     logger.warning(
                         "Retrying API call in %ss (attempt %s/%s) %s error=%s",
                         wait_time,
-                        retry_count,
-                        max_retries,
+                        retry_count + 1,
+                        max_attempts,
                         self._client_log_context(),
                         api_error,
                     )

--- a/run_agent.py
+++ b/run_agent.py
@@ -570,6 +570,8 @@ class AIAgent:
         checkpoint_max_snapshots: int = 50,
         pass_session_id: bool = False,
         persist_session: bool = True,
+        max_api_retries: int = 3,
+        max_stream_retries: int = 1,
     ):
         """
         Initialize the AI Agent.
@@ -614,6 +616,8 @@ class AIAgent:
 
         self.model = model
         self.max_iterations = max_iterations
+        self.max_api_retries = max_api_retries
+        self.max_stream_retries = max_stream_retries
         # Shared iteration budget — parent creates, children inherit.
         # Consumed by every LLM turn across parent + all subagents.
         self.iteration_budget = iteration_budget or IterationBudget(max_iterations)
@@ -4250,7 +4254,7 @@ class AIAgent:
         import httpx as _httpx
 
         active_client = client or self._ensure_primary_openai_client(reason="codex_stream_direct")
-        max_stream_retries = 1
+        max_stream_retries = self.max_stream_retries
         has_tool_calls = False
         first_delta_fired = False
         # Accumulate streamed text so we can recover if get_final_response()
@@ -5155,7 +5159,7 @@ class AIAgent:
         def _call():
             import httpx as _httpx
 
-            _max_stream_retries = int(os.getenv("HERMES_STREAM_RETRIES", 2))
+            _max_stream_retries = int(os.getenv("HERMES_STREAM_RETRIES", self.max_stream_retries))
 
             try:
                 for _stream_attempt in range(_max_stream_retries + 1):

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -85,6 +85,23 @@ class TestMaxTurnsResolution:
         assert isinstance(cli.max_turns, int) and cli.max_turns == 90
 
 
+class TestRetryResolution:
+    def test_retry_defaults_are_present(self):
+        cli = _make_cli()
+        assert cli.max_api_retries == 3
+        assert cli.max_stream_retries == 2
+
+    def test_retry_config_values_are_honored(self):
+        cli = _make_cli(config_overrides={"agent": {"max_api_retries": 5, "max_stream_retries": 4}})
+        assert cli.max_api_retries == 5
+        assert cli.max_stream_retries == 4
+
+    def test_invalid_retry_values_fall_back(self):
+        cli = _make_cli(config_overrides={"agent": {"max_api_retries": -1, "max_stream_retries": "bogus"}})
+        assert cli.max_api_retries == 3
+        assert cli.max_stream_retries == 2
+
+
 class TestVerboseAndToolProgress:
     def test_default_verbose_is_bool(self):
         cli = _make_cli()

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -65,6 +65,8 @@ class TestLoadConfigDefaults:
             config = load_config()
             assert config["model"] == DEFAULT_CONFIG["model"]
             assert config["agent"]["max_turns"] == DEFAULT_CONFIG["agent"]["max_turns"]
+            assert config["agent"]["max_api_retries"] == DEFAULT_CONFIG["agent"]["max_api_retries"]
+            assert config["agent"]["max_stream_retries"] == DEFAULT_CONFIG["agent"]["max_stream_retries"]
             assert "max_turns" not in config
             assert "terminal" in config
             assert config["terminal"]["backend"] == "local"
@@ -78,6 +80,20 @@ class TestLoadConfigDefaults:
             config = load_config()
             assert config["agent"]["max_turns"] == 42
             assert "max_turns" not in config
+
+    def test_invalid_agent_retry_values_fall_back_to_defaults(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            config_path = tmp_path / "config.yaml"
+            config_path.write_text(
+                "agent:\n"
+                "  max_api_retries: -1\n"
+                "  max_stream_retries: bogus\n",
+                encoding="utf-8",
+            )
+
+            config = load_config()
+            assert config["agent"]["max_api_retries"] == DEFAULT_CONFIG["agent"]["max_api_retries"]
+            assert config["agent"]["max_stream_retries"] == DEFAULT_CONFIG["agent"]["max_stream_retries"]
 
 
 class TestSaveAndLoadRoundtrip:
@@ -441,6 +457,6 @@ class TestInterimAssistantMessageConfig:
             migrate_config(interactive=False, quiet=True)
             raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
 
-        assert raw["_config_version"] == 16
+        assert raw["_config_version"] == 17
         assert raw["display"]["tool_progress"] == "off"
         assert raw["display"]["interim_assistant_messages"] is True

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3852,8 +3852,9 @@ class TestDeadRetryCode:
     def test_no_unreachable_max_retries_after_backoff(self):
         import inspect
         source = inspect.getsource(AIAgent.run_conversation)
-        occurrences = source.count("if retry_count >= max_retries:")
+        assert "max_attempts = max_retries + 1" in source
+        occurrences = source.count("if retry_count >= max_attempts:")
         assert occurrences == 2, (
-            f"Expected 2 occurrences of 'if retry_count >= max_retries:' "
+            f"Expected 2 occurrences of 'if retry_count >= max_attempts:' "
             f"but found {occurrences}"
         )

--- a/tests/test_api_retry_config.py
+++ b/tests/test_api_retry_config.py
@@ -1,14 +1,5 @@
-"""Tests for PR #5571 -- configurable max_api_retries with improved backoff.
+"""Regression tests for configurable API and stream retries."""
 
-Covers:
-- AIAgent stores max_api_retries param (default 3, configurable)
-- CLI reads max_api_retries from CLI_CONFIG['agent']['max_api_retries']
-- Rate-limit backoff formula: base = 5 * 2^retry_count capped at 300, plus jitter
-- Non-rate-limit backoff formula: 2^retry_count capped at 60
-- Retry-After header is respected when present
-"""
-
-import importlib
 import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -18,52 +9,44 @@ import pytest
 sys.path.insert(0, __file__.replace("tests/test_api_retry_config.py", ""))
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
 def _make_tool_defs(*names: str) -> list:
     return [
         {
             "type": "function",
             "function": {
-                "name": n,
-                "description": f"{n} tool",
+                "name": name,
+                "description": f"{name} tool",
                 "parameters": {"type": "object", "properties": {}},
             },
         }
-        for n in names
+        for name in names
     ]
 
 
-def _make_agent(max_api_retries=3, **kwargs):
-    """Create a minimal AIAgent with mocked tool loading and client."""
+def _make_agent(**kwargs):
     with (
         patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
         patch("run_agent.check_toolset_requirements", return_value={}),
         patch("run_agent.OpenAI"),
     ):
         from run_agent import AIAgent
-        a = AIAgent(
+
+        agent = AIAgent(
             api_key="test-key-1234567890",
-            max_api_retries=max_api_retries,
             quiet_mode=True,
             skip_context_files=True,
             skip_memory=True,
             **kwargs,
         )
-        a.client = MagicMock()
-        return a
-
-
-# ---------------------------------------------------------------------------
-# Fake API response helpers
-# ---------------------------------------------------------------------------
+        agent.client = MagicMock()
+        agent._persist_session = lambda *args, **kwargs: None
+        agent._save_trajectory = lambda *args, **kwargs: None
+        agent._save_session_log = lambda *args, **kwargs: None
+        agent._cleanup_task_resources = lambda *args, **kwargs: None
+        return agent
 
 
 class _RateLimitError(Exception):
-    """Mimics a 429 rate-limit API error."""
     def __init__(self, retry_after=None):
         super().__init__("Error code: 429 - rate limit exceeded")
         self.status_code = 429
@@ -73,15 +56,13 @@ class _RateLimitError(Exception):
         self.response = SimpleNamespace(headers=headers) if headers else None
 
 
-class _ServerError(Exception):
-    """Mimics a 500 transient server error (non-rate-limit)."""
+class _RetryableServerError(Exception):
     def __init__(self):
-        super().__init__("Error code: 500 - internal server error")
-        self.status_code = 500
+        super().__init__("Error code: 503 - overloaded")
+        self.status_code = 503
 
 
 def _chat_completion_response(text="Done"):
-    """Minimal OpenAI-style chat completion response."""
     return SimpleNamespace(
         choices=[
             SimpleNamespace(
@@ -94,359 +75,132 @@ def _chat_completion_response(text="Done"):
     )
 
 
-# ---------------------------------------------------------------------------
-# Core: max_api_retries param storage
-# ---------------------------------------------------------------------------
+def _run_with_error(*, agent, error):
+    call_count = {"n": 0}
+
+    def fake_api(_api_kwargs):
+        call_count["n"] += 1
+        raise error
+
+    agent._interruptible_api_call = fake_api
+
+    time_counter = {"n": 0}
+
+    def fake_time():
+        time_counter["n"] += 1
+        return float(time_counter["n"] * 1000)
+
+    with (
+        patch("run_agent.time.sleep"),
+        patch("run_agent.time.time", side_effect=fake_time),
+    ):
+        result = agent.run_conversation("hello")
+
+    return result, call_count["n"]
 
 
-class TestMaxApiRetriesParam:
-    def test_default_is_three(self):
-        """AIAgent defaults to max_api_retries=3 when not specified."""
+class TestAgentRetrySettings:
+    def test_defaults_are_applied(self):
         agent = _make_agent()
         assert agent.max_api_retries == 3
+        assert agent.max_stream_retries == 2
 
-    def test_custom_value_stored(self):
-        """AIAgent stores the provided max_api_retries value."""
-        agent = _make_agent(max_api_retries=10)
-        assert agent.max_api_retries == 10
+    def test_invalid_values_fall_back_to_defaults(self):
+        agent = _make_agent(max_api_retries=-1, max_stream_retries="bogus")
+        assert agent.max_api_retries == 3
+        assert agent.max_stream_retries == 2
 
-    def test_zero_retries_stored(self):
-        """Edge case: max_api_retries=0 is accepted and stored."""
+    def test_values_are_coerced_to_non_negative_ints(self):
+        agent = _make_agent(max_api_retries="5", max_stream_retries="4")
+        assert agent.max_api_retries == 5
+        assert agent.max_stream_retries == 4
+
+
+class TestRetryDelayComputation:
+    def test_retry_after_is_honored(self):
+        agent = _make_agent()
+        wait_time = agent._compute_retry_wait_time(
+            retry_count=1,
+            is_rate_limited=True,
+            api_error=_RateLimitError(retry_after=45),
+        )
+        assert wait_time == 45
+
+    def test_retry_after_is_capped_at_five_minutes(self):
+        agent = _make_agent()
+        wait_time = agent._compute_retry_wait_time(
+            retry_count=1,
+            is_rate_limited=True,
+            api_error=_RateLimitError(retry_after=600),
+        )
+        assert wait_time == 300
+
+    def test_rate_limit_backoff_uses_centered_jitter(self):
+        agent = _make_agent()
+        with patch("run_agent.random.uniform", return_value=0.2) as mock_uniform:
+            wait_time = agent._compute_retry_wait_time(
+                retry_count=2,
+                is_rate_limited=True,
+            )
+        mock_uniform.assert_called_once_with(-0.2, 0.2)
+        assert wait_time == pytest.approx(12.0)
+
+    def test_generic_retry_backoff_is_exponential_and_capped(self):
+        agent = _make_agent()
+        assert agent._compute_retry_wait_time(retry_count=1, is_rate_limited=False) == 1.0
+        assert agent._compute_retry_wait_time(retry_count=3, is_rate_limited=False) == 4.0
+        assert agent._compute_retry_wait_time(retry_count=8, is_rate_limited=False) == 60.0
+
+
+class TestOuterRetryLoop:
+    def test_max_api_retries_zero_means_no_retry(self):
         agent = _make_agent(max_api_retries=0)
-        assert agent.max_api_retries == 0
+        result, calls = _run_with_error(agent=agent, error=_RetryableServerError())
+        assert result.get("failed") is True
+        assert calls == 1
 
-    def test_large_retries_stored(self):
-        """Large retry count is stored without modification."""
-        agent = _make_agent(max_api_retries=100)
-        assert agent.max_api_retries == 100
+    def test_max_api_retries_two_means_three_total_attempts(self):
+        agent = _make_agent(max_api_retries=2)
+        result, calls = _run_with_error(agent=agent, error=_RetryableServerError())
+        assert result.get("failed") is True
+        assert calls == 3
 
-    def test_attribute_is_integer(self):
-        """max_api_retries is stored as an int."""
+    def test_non_retryable_errors_are_not_retried(self):
         agent = _make_agent(max_api_retries=5)
-        assert isinstance(agent.max_api_retries, int)
+        result, calls = _run_with_error(agent=agent, error=ValueError("bad request args"))
+        assert result.get("failed") is True
+        assert calls == 1
 
 
-# ---------------------------------------------------------------------------
-# CLI config integration
-# ---------------------------------------------------------------------------
+class TestStreamRetryLoop:
+    @patch("run_agent.AIAgent._interruptible_api_call")
+    @patch("run_agent.AIAgent._replace_primary_openai_client")
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_max_stream_retries_respected_and_primary_client_rebuilt(
+        self,
+        mock_close,
+        mock_create,
+        mock_replace_primary,
+        mock_non_stream,
+    ):
+        import httpx
 
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = httpx.ReadTimeout(
+            "stream timed out",
+            request=httpx.Request("POST", "https://example.com/v1/chat/completions"),
+        )
+        mock_create.return_value = mock_client
+        mock_non_stream.return_value = _chat_completion_response("fallback after retries")
 
-def _make_cli(config_overrides=None):
-    """Create a HermesCLI with minimal mocking; mirrors tests/test_cli_init.py."""
-    _clean_config = {
-        "model": {
-            "default": "anthropic/claude-opus-4.6",
-            "base_url": "https://openrouter.ai/api/v1",
-            "provider": "auto",
-        },
-        "display": {"compact": False, "tool_progress": "all"},
-        "agent": {},
-        "terminal": {"env_type": "local"},
-    }
-    if config_overrides:
-        for k, v in config_overrides.items():
-            if isinstance(v, dict) and k in _clean_config:
-                _clean_config[k].update(v)
-            else:
-                _clean_config[k] = v
+        agent = _make_agent(max_stream_retries=4)
+        agent.api_mode = "chat_completions"
+        agent._interrupt_requested = False
 
-    prompt_toolkit_stubs = {
-        m: MagicMock()
-        for m in [
-            "prompt_toolkit",
-            "prompt_toolkit.history",
-            "prompt_toolkit.styles",
-            "prompt_toolkit.patch_stdout",
-            "prompt_toolkit.application",
-            "prompt_toolkit.layout",
-            "prompt_toolkit.layout.processors",
-            "prompt_toolkit.filters",
-            "prompt_toolkit.layout.dimension",
-            "prompt_toolkit.layout.menus",
-            "prompt_toolkit.widgets",
-            "prompt_toolkit.key_binding",
-            "prompt_toolkit.completion",
-            "prompt_toolkit.formatted_text",
-            "prompt_toolkit.auto_suggest",
-        ]
-    }
-    with patch.dict(sys.modules, prompt_toolkit_stubs), patch.dict("os.environ", {}, clear=False):
-        import cli as _cli_mod
-        _cli_mod = importlib.reload(_cli_mod)
-        with (
-            patch.object(_cli_mod, "get_tool_definitions", return_value=[]),
-            patch.dict(_cli_mod.__dict__, {"CLI_CONFIG": _clean_config}),
-        ):
-            return _cli_mod.HermesCLI()
+        response = agent._interruptible_streaming_api_call({})
 
-
-class TestCliMaxApiRetriesConfig:
-    def test_cli_default_max_api_retries_from_empty_config(self):
-        """CLI_CONFIG without max_api_retries defaults to 3 via the fallback."""
-        config = {"agent": {}}
-        retries = int(config.get("agent", {}).get("max_api_retries", 3))
-        assert retries == 3
-
-    def test_cli_reads_max_api_retries_from_config(self):
-        """CLI reads max_api_retries from CLI_CONFIG['agent']['max_api_retries']."""
-        config = {"agent": {"max_api_retries": 7}}
-        retries = int(config.get("agent", {}).get("max_api_retries", 3))
-        assert retries == 7
-
-    def test_cli_creates_agent_with_config_max_api_retries(self):
-        """When CLI_CONFIG sets max_api_retries=7, AIAgent receives max_api_retries=7."""
-        import cli as _cli_mod
-
-        config_with_retries = {
-            "model": {
-                "default": "anthropic/claude-opus-4.6",
-                "base_url": "https://openrouter.ai/api/v1",
-                "provider": "auto",
-            },
-            "display": {"compact": False, "tool_progress": "all"},
-            "agent": {"max_api_retries": 7},
-            "terminal": {"env_type": "local"},
-        }
-
-        prompt_toolkit_stubs = {
-            m: MagicMock()
-            for m in [
-                "prompt_toolkit", "prompt_toolkit.history", "prompt_toolkit.styles",
-                "prompt_toolkit.patch_stdout", "prompt_toolkit.application",
-                "prompt_toolkit.layout", "prompt_toolkit.layout.processors",
-                "prompt_toolkit.filters", "prompt_toolkit.layout.dimension",
-                "prompt_toolkit.layout.menus", "prompt_toolkit.widgets",
-                "prompt_toolkit.key_binding", "prompt_toolkit.completion",
-                "prompt_toolkit.formatted_text", "prompt_toolkit.auto_suggest",
-            ]
-        }
-        with patch.dict(sys.modules, prompt_toolkit_stubs):
-            fresh = importlib.reload(_cli_mod)
-            with (
-                patch.object(fresh, "get_tool_definitions", return_value=[]),
-                patch.dict(fresh.__dict__, {"CLI_CONFIG": config_with_retries}),
-            ):
-                cli_instance = fresh.HermesCLI()
-
-                with (
-                    patch("run_agent.get_tool_definitions", return_value=[]),
-                    patch("run_agent.check_toolset_requirements", return_value={}),
-                    patch("run_agent.OpenAI"),
-                    patch.object(cli_instance, "_ensure_runtime_credentials", return_value=True),
-                    patch.object(cli_instance, "_session_db", MagicMock(), create=True),
-                ):
-                    # _init_agent reads CLI_CONFIG to pass max_api_retries to AIAgent
-                    cli_instance._init_agent(runtime_override={
-                        "api_key": "test-key",
-                        "base_url": "https://openrouter.ai/api/v1",
-                        "provider": "auto",
-                        "api_mode": None,
-                        "command": None,
-                        "args": None,
-                        "credential_pool": None,
-                    })
-                    assert cli_instance.agent is not None
-                    assert cli_instance.agent.max_api_retries == 7
-
-
-# ---------------------------------------------------------------------------
-# Backoff formula verification
-# ---------------------------------------------------------------------------
-
-
-class TestRateLimitBackoffFormula:
-    """Tests the rate-limit exponential backoff: base = 5 * 2^n, + jitter, capped 300."""
-
-    def test_retry_count_0_base_is_5(self):
-        """retry_count=0: base = 5 * (2**0) = 5."""
-        retry_count = 0
-        _base = min(5 * (2 ** retry_count), 300)
-        assert _base == 5
-
-    def test_retry_count_1_base_is_10(self):
-        """retry_count=1: base = 5 * (2**1) = 10."""
-        retry_count = 1
-        _base = min(5 * (2 ** retry_count), 300)
-        assert _base == 10
-
-    def test_retry_count_2_base_is_20(self):
-        """retry_count=2: base = 5 * (2**2) = 20."""
-        retry_count = 2
-        _base = min(5 * (2 ** retry_count), 300)
-        assert _base == 20
-
-    def test_base_capped_at_300(self):
-        """Base is capped at 300 for large retry counts."""
-        import math
-        # 5 * 2^6 = 320 > 300 → should cap at 300
-        retry_count = 6
-        _base = min(5 * (2 ** retry_count), 300)
-        assert _base == 300
-
-    def test_jitter_is_added(self):
-        """Jitter is non-negative and bounded by min(base*0.2, 10)."""
-        import random
-        retry_count = 0
-        _base = min(5 * (2 ** retry_count), 300)
-        # Run 50 samples to verify jitter range
-        for _ in range(50):
-            jitter = random.uniform(0, min(_base * 0.2, 10))
-            wait_time = _base + jitter
-            assert wait_time >= _base, "jitter should not reduce below base"
-            assert wait_time <= _base + min(_base * 0.2, 10), "jitter should not exceed cap"
-
-    def test_jitter_cap_for_large_base(self):
-        """Jitter cap is 10s for large base values."""
-        import random
-        # When base >= 50, jitter cap is min(50*0.2, 10) = 10
-        _base = 50
-        for _ in range(50):
-            jitter = random.uniform(0, min(_base * 0.2, 10))
-            assert jitter <= 10
-
-
-class TestNonRateLimitBackoffFormula:
-    """Tests the non-rate-limit backoff: 2^n capped at 60s."""
-
-    def test_retry_count_0_is_1(self):
-        """retry_count=0: wait = min(2**0, 60) = 1s."""
-        retry_count = 0
-        wait = min(2 ** retry_count, 60)
-        assert wait == 1
-
-    def test_retry_count_1_is_2(self):
-        """retry_count=1: wait = min(2**1, 60) = 2s."""
-        retry_count = 1
-        wait = min(2 ** retry_count, 60)
-        assert wait == 2
-
-    def test_retry_count_5_is_32(self):
-        """retry_count=5: wait = min(2**5, 60) = 32s."""
-        retry_count = 5
-        wait = min(2 ** retry_count, 60)
-        assert wait == 32
-
-    def test_capped_at_60(self):
-        """retry_count=7: wait = min(2**7, 60) = 60s (capped)."""
-        retry_count = 7
-        wait = min(2 ** retry_count, 60)
-        assert wait == 60
-
-    def test_large_retry_count_still_60(self):
-        """Very large retry_count still gives 60s (not more)."""
-        for n in range(7, 20):
-            wait = min(2 ** n, 60)
-            assert wait == 60
-
-
-# ---------------------------------------------------------------------------
-# Retry-After header handling
-# ---------------------------------------------------------------------------
-
-
-class TestRetryAfterHeader:
-    def test_retry_after_header_respected(self):
-        """Retry-After header value is used as wait_time when present."""
-        # Simulate the header parsing logic from run_agent.py
-        retry_after_value = "45"
-        _retry_after = None
-        headers = {"retry-after": retry_after_value}
-        _ra_raw = headers.get("retry-after") or headers.get("Retry-After")
-        if _ra_raw:
-            try:
-                _retry_after = min(int(_ra_raw), 300)
-            except (TypeError, ValueError):
-                pass
-        assert _retry_after == 45
-
-    def test_retry_after_header_capped_at_300(self):
-        """Retry-After header is capped at 300 seconds."""
-        headers = {"retry-after": "600"}
-        _retry_after = None
-        _ra_raw = headers.get("retry-after") or headers.get("Retry-After")
-        if _ra_raw:
-            try:
-                _retry_after = min(int(_ra_raw), 300)
-            except (TypeError, ValueError):
-                pass
-        assert _retry_after == 300
-
-    def test_retry_after_case_insensitive(self):
-        """Retry-After header is matched case-insensitively (both retry-after and Retry-After)."""
-        for key in ("retry-after", "Retry-After"):
-            headers = {key: "30"}
-            _ra_raw = headers.get("retry-after") or headers.get("Retry-After")
-            assert _ra_raw == "30"
-
-    def test_retry_after_invalid_value_ignored(self):
-        """Non-numeric Retry-After header is ignored (falls back to formula)."""
-        headers = {"retry-after": "not-a-number"}
-        _retry_after = None
-        _ra_raw = headers.get("retry-after")
-        if _ra_raw:
-            try:
-                _retry_after = min(int(_ra_raw), 300)
-            except (TypeError, ValueError):
-                pass
-        assert _retry_after is None
-
-
-# ---------------------------------------------------------------------------
-# Integration: agent loop uses max_api_retries
-# ---------------------------------------------------------------------------
-
-
-class TestAgentLoopUsesMaxApiRetries:
-    """Smoke test that the agent loop respects max_api_retries."""
-
-    def _run_with_rate_limit_error(self, max_api_retries):
-        """Run agent; API always raises 429. Returns result dict."""
-        agent = _make_agent(max_api_retries=max_api_retries)
-        agent._persist_session = lambda msgs, history=None: None
-        agent._save_trajectory = lambda *a, **k: None
-        agent._save_session_log = lambda *a, **k: None
-        agent._cleanup_task_resources = lambda *a, **k: None
-
-        call_count = {"n": 0}
-
-        def fake_api(api_kwargs):
-            call_count["n"] += 1
-            raise _RateLimitError()
-
-        agent._interruptible_api_call = fake_api
-
-        # Time stubs: each call advances by 1000s so the inner sleep loop
-        # exits immediately (1000 > max wait_time of 300).
-        time_counter = {"n": 0}
-
-        def fake_time():
-            time_counter["n"] += 1
-            return float(time_counter["n"] * 1000)
-
-        with (
-            patch("time.sleep"),
-            patch("run_agent.time.sleep"),
-            patch("run_agent.time.time", side_effect=fake_time),
-        ):
-            result = agent.run_conversation("hello")
-
-        return result, call_count["n"]
-
-    def test_max_retries_1_makes_one_attempt(self):
-        """With max_api_retries=1, agent gives up after 1 retry."""
-        result, calls = self._run_with_rate_limit_error(max_api_retries=1)
-        assert result.get("failed") or result.get("completed") is False
-        # 1 initial attempt + 1 retry = at most 2 calls before giving up
-        assert calls <= 2
-
-    def test_max_retries_3_default(self):
-        """Default max_api_retries=3; agent makes multiple attempts before giving up."""
-        result, calls = self._run_with_rate_limit_error(max_api_retries=3)
-        assert result.get("failed") or result.get("completed") is False
-
-    def test_higher_max_retries_allows_more_attempts(self):
-        """Higher max_api_retries allows more retry attempts."""
-        result_low, calls_low = self._run_with_rate_limit_error(max_api_retries=1)
-        result_high, calls_high = self._run_with_rate_limit_error(max_api_retries=5)
-        # More retries configured → more actual API calls before giving up
-        assert calls_high >= calls_low
+        assert response.choices[0].message.content == "fallback after retries"
+        assert mock_client.chat.completions.create.call_count == 5
+        assert mock_replace_primary.call_count == 4
+        assert mock_close.call_count >= 4

--- a/tests/test_api_retry_config.py
+++ b/tests/test_api_retry_config.py
@@ -1,0 +1,452 @@
+"""Tests for PR #5571 -- configurable max_api_retries with improved backoff.
+
+Covers:
+- AIAgent stores max_api_retries param (default 3, configurable)
+- CLI reads max_api_retries from CLI_CONFIG['agent']['max_api_retries']
+- Rate-limit backoff formula: base = 5 * 2^retry_count capped at 300, plus jitter
+- Non-rate-limit backoff formula: 2^retry_count capped at 60
+- Retry-After header is respected when present
+"""
+
+import importlib
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, __file__.replace("tests/test_api_retry_config.py", ""))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_tool_defs(*names: str) -> list:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": n,
+                "description": f"{n} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for n in names
+    ]
+
+
+def _make_agent(max_api_retries=3, **kwargs):
+    """Create a minimal AIAgent with mocked tool loading and client."""
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+        a = AIAgent(
+            api_key="test-key-1234567890",
+            max_api_retries=max_api_retries,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            **kwargs,
+        )
+        a.client = MagicMock()
+        return a
+
+
+# ---------------------------------------------------------------------------
+# Fake API response helpers
+# ---------------------------------------------------------------------------
+
+
+class _RateLimitError(Exception):
+    """Mimics a 429 rate-limit API error."""
+    def __init__(self, retry_after=None):
+        super().__init__("Error code: 429 - rate limit exceeded")
+        self.status_code = 429
+        headers = {}
+        if retry_after is not None:
+            headers["retry-after"] = str(retry_after)
+        self.response = SimpleNamespace(headers=headers) if headers else None
+
+
+class _ServerError(Exception):
+    """Mimics a 500 transient server error (non-rate-limit)."""
+    def __init__(self):
+        super().__init__("Error code: 500 - internal server error")
+        self.status_code = 500
+
+
+def _chat_completion_response(text="Done"):
+    """Minimal OpenAI-style chat completion response."""
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content=text, tool_calls=None),
+                finish_reason="stop",
+            )
+        ],
+        usage=SimpleNamespace(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+        model="test-model",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Core: max_api_retries param storage
+# ---------------------------------------------------------------------------
+
+
+class TestMaxApiRetriesParam:
+    def test_default_is_three(self):
+        """AIAgent defaults to max_api_retries=3 when not specified."""
+        agent = _make_agent()
+        assert agent.max_api_retries == 3
+
+    def test_custom_value_stored(self):
+        """AIAgent stores the provided max_api_retries value."""
+        agent = _make_agent(max_api_retries=10)
+        assert agent.max_api_retries == 10
+
+    def test_zero_retries_stored(self):
+        """Edge case: max_api_retries=0 is accepted and stored."""
+        agent = _make_agent(max_api_retries=0)
+        assert agent.max_api_retries == 0
+
+    def test_large_retries_stored(self):
+        """Large retry count is stored without modification."""
+        agent = _make_agent(max_api_retries=100)
+        assert agent.max_api_retries == 100
+
+    def test_attribute_is_integer(self):
+        """max_api_retries is stored as an int."""
+        agent = _make_agent(max_api_retries=5)
+        assert isinstance(agent.max_api_retries, int)
+
+
+# ---------------------------------------------------------------------------
+# CLI config integration
+# ---------------------------------------------------------------------------
+
+
+def _make_cli(config_overrides=None):
+    """Create a HermesCLI with minimal mocking; mirrors tests/test_cli_init.py."""
+    _clean_config = {
+        "model": {
+            "default": "anthropic/claude-opus-4.6",
+            "base_url": "https://openrouter.ai/api/v1",
+            "provider": "auto",
+        },
+        "display": {"compact": False, "tool_progress": "all"},
+        "agent": {},
+        "terminal": {"env_type": "local"},
+    }
+    if config_overrides:
+        for k, v in config_overrides.items():
+            if isinstance(v, dict) and k in _clean_config:
+                _clean_config[k].update(v)
+            else:
+                _clean_config[k] = v
+
+    prompt_toolkit_stubs = {
+        m: MagicMock()
+        for m in [
+            "prompt_toolkit",
+            "prompt_toolkit.history",
+            "prompt_toolkit.styles",
+            "prompt_toolkit.patch_stdout",
+            "prompt_toolkit.application",
+            "prompt_toolkit.layout",
+            "prompt_toolkit.layout.processors",
+            "prompt_toolkit.filters",
+            "prompt_toolkit.layout.dimension",
+            "prompt_toolkit.layout.menus",
+            "prompt_toolkit.widgets",
+            "prompt_toolkit.key_binding",
+            "prompt_toolkit.completion",
+            "prompt_toolkit.formatted_text",
+            "prompt_toolkit.auto_suggest",
+        ]
+    }
+    with patch.dict(sys.modules, prompt_toolkit_stubs), patch.dict("os.environ", {}, clear=False):
+        import cli as _cli_mod
+        _cli_mod = importlib.reload(_cli_mod)
+        with (
+            patch.object(_cli_mod, "get_tool_definitions", return_value=[]),
+            patch.dict(_cli_mod.__dict__, {"CLI_CONFIG": _clean_config}),
+        ):
+            return _cli_mod.HermesCLI()
+
+
+class TestCliMaxApiRetriesConfig:
+    def test_cli_default_max_api_retries_from_empty_config(self):
+        """CLI_CONFIG without max_api_retries defaults to 3 via the fallback."""
+        config = {"agent": {}}
+        retries = int(config.get("agent", {}).get("max_api_retries", 3))
+        assert retries == 3
+
+    def test_cli_reads_max_api_retries_from_config(self):
+        """CLI reads max_api_retries from CLI_CONFIG['agent']['max_api_retries']."""
+        config = {"agent": {"max_api_retries": 7}}
+        retries = int(config.get("agent", {}).get("max_api_retries", 3))
+        assert retries == 7
+
+    def test_cli_creates_agent_with_config_max_api_retries(self):
+        """When CLI_CONFIG sets max_api_retries=7, AIAgent receives max_api_retries=7."""
+        import cli as _cli_mod
+
+        config_with_retries = {
+            "model": {
+                "default": "anthropic/claude-opus-4.6",
+                "base_url": "https://openrouter.ai/api/v1",
+                "provider": "auto",
+            },
+            "display": {"compact": False, "tool_progress": "all"},
+            "agent": {"max_api_retries": 7},
+            "terminal": {"env_type": "local"},
+        }
+
+        prompt_toolkit_stubs = {
+            m: MagicMock()
+            for m in [
+                "prompt_toolkit", "prompt_toolkit.history", "prompt_toolkit.styles",
+                "prompt_toolkit.patch_stdout", "prompt_toolkit.application",
+                "prompt_toolkit.layout", "prompt_toolkit.layout.processors",
+                "prompt_toolkit.filters", "prompt_toolkit.layout.dimension",
+                "prompt_toolkit.layout.menus", "prompt_toolkit.widgets",
+                "prompt_toolkit.key_binding", "prompt_toolkit.completion",
+                "prompt_toolkit.formatted_text", "prompt_toolkit.auto_suggest",
+            ]
+        }
+        with patch.dict(sys.modules, prompt_toolkit_stubs):
+            fresh = importlib.reload(_cli_mod)
+            with (
+                patch.object(fresh, "get_tool_definitions", return_value=[]),
+                patch.dict(fresh.__dict__, {"CLI_CONFIG": config_with_retries}),
+            ):
+                cli_instance = fresh.HermesCLI()
+
+                with (
+                    patch("run_agent.get_tool_definitions", return_value=[]),
+                    patch("run_agent.check_toolset_requirements", return_value={}),
+                    patch("run_agent.OpenAI"),
+                    patch.object(cli_instance, "_ensure_runtime_credentials", return_value=True),
+                    patch.object(cli_instance, "_session_db", MagicMock(), create=True),
+                ):
+                    # _init_agent reads CLI_CONFIG to pass max_api_retries to AIAgent
+                    cli_instance._init_agent(runtime_override={
+                        "api_key": "test-key",
+                        "base_url": "https://openrouter.ai/api/v1",
+                        "provider": "auto",
+                        "api_mode": None,
+                        "command": None,
+                        "args": None,
+                        "credential_pool": None,
+                    })
+                    assert cli_instance.agent is not None
+                    assert cli_instance.agent.max_api_retries == 7
+
+
+# ---------------------------------------------------------------------------
+# Backoff formula verification
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimitBackoffFormula:
+    """Tests the rate-limit exponential backoff: base = 5 * 2^n, + jitter, capped 300."""
+
+    def test_retry_count_0_base_is_5(self):
+        """retry_count=0: base = 5 * (2**0) = 5."""
+        retry_count = 0
+        _base = min(5 * (2 ** retry_count), 300)
+        assert _base == 5
+
+    def test_retry_count_1_base_is_10(self):
+        """retry_count=1: base = 5 * (2**1) = 10."""
+        retry_count = 1
+        _base = min(5 * (2 ** retry_count), 300)
+        assert _base == 10
+
+    def test_retry_count_2_base_is_20(self):
+        """retry_count=2: base = 5 * (2**2) = 20."""
+        retry_count = 2
+        _base = min(5 * (2 ** retry_count), 300)
+        assert _base == 20
+
+    def test_base_capped_at_300(self):
+        """Base is capped at 300 for large retry counts."""
+        import math
+        # 5 * 2^6 = 320 > 300 → should cap at 300
+        retry_count = 6
+        _base = min(5 * (2 ** retry_count), 300)
+        assert _base == 300
+
+    def test_jitter_is_added(self):
+        """Jitter is non-negative and bounded by min(base*0.2, 10)."""
+        import random
+        retry_count = 0
+        _base = min(5 * (2 ** retry_count), 300)
+        # Run 50 samples to verify jitter range
+        for _ in range(50):
+            jitter = random.uniform(0, min(_base * 0.2, 10))
+            wait_time = _base + jitter
+            assert wait_time >= _base, "jitter should not reduce below base"
+            assert wait_time <= _base + min(_base * 0.2, 10), "jitter should not exceed cap"
+
+    def test_jitter_cap_for_large_base(self):
+        """Jitter cap is 10s for large base values."""
+        import random
+        # When base >= 50, jitter cap is min(50*0.2, 10) = 10
+        _base = 50
+        for _ in range(50):
+            jitter = random.uniform(0, min(_base * 0.2, 10))
+            assert jitter <= 10
+
+
+class TestNonRateLimitBackoffFormula:
+    """Tests the non-rate-limit backoff: 2^n capped at 60s."""
+
+    def test_retry_count_0_is_1(self):
+        """retry_count=0: wait = min(2**0, 60) = 1s."""
+        retry_count = 0
+        wait = min(2 ** retry_count, 60)
+        assert wait == 1
+
+    def test_retry_count_1_is_2(self):
+        """retry_count=1: wait = min(2**1, 60) = 2s."""
+        retry_count = 1
+        wait = min(2 ** retry_count, 60)
+        assert wait == 2
+
+    def test_retry_count_5_is_32(self):
+        """retry_count=5: wait = min(2**5, 60) = 32s."""
+        retry_count = 5
+        wait = min(2 ** retry_count, 60)
+        assert wait == 32
+
+    def test_capped_at_60(self):
+        """retry_count=7: wait = min(2**7, 60) = 60s (capped)."""
+        retry_count = 7
+        wait = min(2 ** retry_count, 60)
+        assert wait == 60
+
+    def test_large_retry_count_still_60(self):
+        """Very large retry_count still gives 60s (not more)."""
+        for n in range(7, 20):
+            wait = min(2 ** n, 60)
+            assert wait == 60
+
+
+# ---------------------------------------------------------------------------
+# Retry-After header handling
+# ---------------------------------------------------------------------------
+
+
+class TestRetryAfterHeader:
+    def test_retry_after_header_respected(self):
+        """Retry-After header value is used as wait_time when present."""
+        # Simulate the header parsing logic from run_agent.py
+        retry_after_value = "45"
+        _retry_after = None
+        headers = {"retry-after": retry_after_value}
+        _ra_raw = headers.get("retry-after") or headers.get("Retry-After")
+        if _ra_raw:
+            try:
+                _retry_after = min(int(_ra_raw), 300)
+            except (TypeError, ValueError):
+                pass
+        assert _retry_after == 45
+
+    def test_retry_after_header_capped_at_300(self):
+        """Retry-After header is capped at 300 seconds."""
+        headers = {"retry-after": "600"}
+        _retry_after = None
+        _ra_raw = headers.get("retry-after") or headers.get("Retry-After")
+        if _ra_raw:
+            try:
+                _retry_after = min(int(_ra_raw), 300)
+            except (TypeError, ValueError):
+                pass
+        assert _retry_after == 300
+
+    def test_retry_after_case_insensitive(self):
+        """Retry-After header is matched case-insensitively (both retry-after and Retry-After)."""
+        for key in ("retry-after", "Retry-After"):
+            headers = {key: "30"}
+            _ra_raw = headers.get("retry-after") or headers.get("Retry-After")
+            assert _ra_raw == "30"
+
+    def test_retry_after_invalid_value_ignored(self):
+        """Non-numeric Retry-After header is ignored (falls back to formula)."""
+        headers = {"retry-after": "not-a-number"}
+        _retry_after = None
+        _ra_raw = headers.get("retry-after")
+        if _ra_raw:
+            try:
+                _retry_after = min(int(_ra_raw), 300)
+            except (TypeError, ValueError):
+                pass
+        assert _retry_after is None
+
+
+# ---------------------------------------------------------------------------
+# Integration: agent loop uses max_api_retries
+# ---------------------------------------------------------------------------
+
+
+class TestAgentLoopUsesMaxApiRetries:
+    """Smoke test that the agent loop respects max_api_retries."""
+
+    def _run_with_rate_limit_error(self, max_api_retries):
+        """Run agent; API always raises 429. Returns result dict."""
+        agent = _make_agent(max_api_retries=max_api_retries)
+        agent._persist_session = lambda msgs, history=None: None
+        agent._save_trajectory = lambda *a, **k: None
+        agent._save_session_log = lambda *a, **k: None
+        agent._cleanup_task_resources = lambda *a, **k: None
+
+        call_count = {"n": 0}
+
+        def fake_api(api_kwargs):
+            call_count["n"] += 1
+            raise _RateLimitError()
+
+        agent._interruptible_api_call = fake_api
+
+        # Time stubs: each call advances by 1000s so the inner sleep loop
+        # exits immediately (1000 > max wait_time of 300).
+        time_counter = {"n": 0}
+
+        def fake_time():
+            time_counter["n"] += 1
+            return float(time_counter["n"] * 1000)
+
+        with (
+            patch("time.sleep"),
+            patch("run_agent.time.sleep"),
+            patch("run_agent.time.time", side_effect=fake_time),
+        ):
+            result = agent.run_conversation("hello")
+
+        return result, call_count["n"]
+
+    def test_max_retries_1_makes_one_attempt(self):
+        """With max_api_retries=1, agent gives up after 1 retry."""
+        result, calls = self._run_with_rate_limit_error(max_api_retries=1)
+        assert result.get("failed") or result.get("completed") is False
+        # 1 initial attempt + 1 retry = at most 2 calls before giving up
+        assert calls <= 2
+
+    def test_max_retries_3_default(self):
+        """Default max_api_retries=3; agent makes multiple attempts before giving up."""
+        result, calls = self._run_with_rate_limit_error(max_api_retries=3)
+        assert result.get("failed") or result.get("completed") is False
+
+    def test_higher_max_retries_allows_more_attempts(self):
+        """Higher max_api_retries allows more retry attempts."""
+        result_low, calls_low = self._run_with_rate_limit_error(max_api_retries=1)
+        result_high, calls_high = self._run_with_rate_limit_error(max_api_retries=5)
+        # More retries configured → more actual API calls before giving up
+        assert calls_high >= calls_low


### PR DESCRIPTION
## What does this PR do?

Finishes the retry/backoff work intended for PR #8486 by wiring configurable retry settings all the way from config into `AIAgent`, and by fixing the actual retry behavior in `run_agent.py`.

This change adds:
- `agent.max_api_retries` for full API-call retries
- `agent.max_stream_retries` for transient streaming reconnect retries

It also fixes the outer retry loop so it no longer uses a hardcoded retry count, honors `Retry-After` headers, applies smarter rate-limit vs generic retry backoff, and keeps streaming reconnect recovery separate from full-request retries. This approach stays small and idiomatic by extending the existing retry paths instead of introducing a new abstraction.

## Related Issue

Fixes #5570

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Added `agent.max_api_retries` and `agent.max_stream_retries` defaults and normalization in `hermes_cli/config.py`
- Added CLI-side defaults and runtime plumbing in `cli.py`
- Bridged gateway config into env vars in `gateway/run.py`
- Updated `AIAgent` retry config handling and retry behavior in `run_agent.py`
- Fixed outer retry loop to honor configured retries instead of a hardcoded value
- Added capped `Retry-After` handling and smarter backoff logic for rate limits vs other retryable errors
- Kept non-streaming requests on the outer retry loop only, and streaming reconnects on the inner loop
- Ensured stream retry recovery rebuilds the primary OpenAI client when needed
- Updated retry/config regression tests in:
  - `tests/test_api_retry_config.py`
  - `tests/hermes_cli/test_config.py`
  - `tests/cli/test_cli_init.py`
  - `tests/run_agent/test_run_agent.py`
- Updated config/docs examples in:
  - `cli-config.yaml.example`
  - `docs/acp-setup.md`

## How to Test

1. Set retry config in `~/.hermes/config.yaml`, for example:
   ```yaml
   agent:
     max_api_retries: 5
     max_stream_retries: 5
   ```
2. Run the focused regression suite:
   ```bash
   HERMES_HOME=/tmp/hermes-ci-home python -m pytest \
     tests/run_agent/test_run_agent.py \
     tests/run_agent/test_provider_fallback.py \
     tests/run_agent/test_streaming.py \
     tests/run_agent/test_openai_client_lifecycle.py \
     tests/test_api_retry_config.py \
     tests/hermes_cli/test_config.py \
     tests/cli/test_cli_init.py \
     -q -o addopts=''
   ```
3. Verify the suite passes and confirm retry behavior:
   - outer retries respect `max_api_retries`
   - stream reconnects respect `max_stream_retries`
   - `Retry-After` is honored and capped
   - rate-limit and generic retryable errors use different backoff behavior

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused verification passed locally:

```text
361 passed in 17.93s
```

Command used:

```bash
HERMES_HOME=/tmp/hermes-ci-home python -m pytest \
  tests/run_agent/test_run_agent.py \
  tests/run_agent/test_provider_fallback.py \
  tests/run_agent/test_streaming.py \
  tests/run_agent/test_openai_client_lifecycle.py \
  tests/test_api_retry_config.py \
  tests/hermes_cli/test_config.py \
  tests/cli/test_cli_init.py \
  -q -o addopts=''
```