### PR TITLE
fix(acp): paginate list_sessions with cursor/next_cursor

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -447,6 +447,22 @@ class HermesACPAgent(acp.Agent):
         **kwargs: Any,
     ) -> ListSessionsResponse:
         infos = self.session_manager.list_sessions(cwd=cwd)
+
+        if cursor:
+            # Find the cursor index
+            for idx, s in enumerate(infos):
+                if s["session_id"] == cursor:
+                    infos = infos[idx + 1:]
+                    break
+            else:
+                # Cursor not found, return empty
+                infos = []
+
+        # Cap limit
+        limit = kwargs.get("limit", 50)
+        has_more = len(infos) > limit
+        infos = infos[:limit]
+
         sessions = []
         for s in infos:
             updated_at = s.get("updated_at")
@@ -460,7 +476,9 @@ class HermesACPAgent(acp.Agent):
                     updated_at=updated_at,
                 )
             )
-        return ListSessionsResponse(sessions=sessions)
+            
+        next_cursor = sessions[-1].session_id if has_more and sessions else None
+        return ListSessionsResponse(sessions=sessions, nextCursor=next_cursor)
 
     # ---- Prompt (core) ------------------------------------------------------
 

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -71,6 +71,11 @@ except Exception:
 # Thread pool for running AIAgent (synchronous) in parallel.
 _executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="acp-agent")
 
+# Server-side page size for list_sessions. The ACP ListSessionsRequest schema
+# does not expose a client-side limit, so this is a fixed cap that clients
+# paginate against using `cursor` / `next_cursor`.
+_LIST_SESSIONS_PAGE_SIZE = 50
+
 
 def _extract_text(
     prompt: list[
@@ -446,22 +451,27 @@ class HermesACPAgent(acp.Agent):
         cwd: str | None = None,
         **kwargs: Any,
     ) -> ListSessionsResponse:
+        """List ACP sessions with optional ``cwd`` filtering and cursor pagination.
+
+        ``cwd`` is passed through to ``SessionManager.list_sessions`` which already
+        normalizes and filters by working directory. ``cursor`` is a ``session_id``
+        previously returned as ``next_cursor``; results resume after that entry.
+        Server-side page size is capped at ``_LIST_SESSIONS_PAGE_SIZE``; when more
+        results remain, ``next_cursor`` is set to the last returned ``session_id``.
+        """
         infos = self.session_manager.list_sessions(cwd=cwd)
 
         if cursor:
-            # Find the cursor index
             for idx, s in enumerate(infos):
                 if s["session_id"] == cursor:
                     infos = infos[idx + 1:]
                     break
             else:
-                # Cursor not found, return empty
+                # Unknown cursor -> empty page (do not fall back to full list).
                 infos = []
 
-        # Cap limit
-        limit = kwargs.get("limit", 50)
-        has_more = len(infos) > limit
-        infos = infos[:limit]
+        has_more = len(infos) > _LIST_SESSIONS_PAGE_SIZE
+        infos = infos[:_LIST_SESSIONS_PAGE_SIZE]
 
         sessions = []
         for s in infos:
@@ -476,9 +486,9 @@ class HermesACPAgent(acp.Agent):
                     updated_at=updated_at,
                 )
             )
-            
+
         next_cursor = sessions[-1].session_id if has_more and sessions else None
-        return ListSessionsResponse(sessions=sessions, nextCursor=next_cursor)
+        return ListSessionsResponse(sessions=sessions, next_cursor=next_cursor)
 
     # ---- Prompt (core) ------------------------------------------------------
 

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -270,6 +270,57 @@ class TestListAndFork:
 
         mock_list.assert_called_once_with(cwd="/mnt/e/Projects/AI/browser-link-3")
 
+    @pytest.mark.asyncio
+    async def test_list_sessions_pagination_first_page(self, agent):
+        from acp_adapter import server as acp_server
+
+        infos = [
+            {"session_id": f"s{i}", "cwd": "/tmp", "title": None, "updated_at": 0.0}
+            for i in range(acp_server._LIST_SESSIONS_PAGE_SIZE + 5)
+        ]
+        with patch.object(agent.session_manager, "list_sessions", return_value=infos):
+            resp = await agent.list_sessions()
+
+        assert len(resp.sessions) == acp_server._LIST_SESSIONS_PAGE_SIZE
+        assert resp.next_cursor == resp.sessions[-1].session_id
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_pagination_no_more(self, agent):
+        infos = [
+            {"session_id": f"s{i}", "cwd": "/tmp", "title": None, "updated_at": 0.0}
+            for i in range(3)
+        ]
+        with patch.object(agent.session_manager, "list_sessions", return_value=infos):
+            resp = await agent.list_sessions()
+
+        assert len(resp.sessions) == 3
+        assert resp.next_cursor is None
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_cursor_resumes_after_match(self, agent):
+        infos = [
+            {"session_id": "s1", "cwd": "/tmp", "title": None, "updated_at": 0.0},
+            {"session_id": "s2", "cwd": "/tmp", "title": None, "updated_at": 0.0},
+            {"session_id": "s3", "cwd": "/tmp", "title": None, "updated_at": 0.0},
+        ]
+        with patch.object(agent.session_manager, "list_sessions", return_value=infos):
+            resp = await agent.list_sessions(cursor="s1")
+
+        assert [s.session_id for s in resp.sessions] == ["s2", "s3"]
+        assert resp.next_cursor is None
+
+    @pytest.mark.asyncio
+    async def test_list_sessions_unknown_cursor_returns_empty(self, agent):
+        infos = [
+            {"session_id": "s1", "cwd": "/tmp", "title": None, "updated_at": 0.0},
+            {"session_id": "s2", "cwd": "/tmp", "title": None, "updated_at": 0.0},
+        ]
+        with patch.object(agent.session_manager, "list_sessions", return_value=infos):
+            resp = await agent.list_sessions(cursor="does-not-exist")
+
+        assert resp.sessions == []
+        assert resp.next_cursor is None
+
 # ---------------------------------------------------------------------------
 # session configuration / model routing
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Salvage of #13460 by @aniruddhaadak80 — closes #13450.

## Summary
ACP `list_sessions` now respects `cursor` and returns `next_cursor` when more results remain. The page cap is a named module constant; `cwd` filtering (which already existed) is unchanged.

## Changes
- `acp_adapter/server.py`: cursor-based pagination, `_LIST_SESSIONS_PAGE_SIZE = 50` module constant, docstring explaining `cwd`/`cursor` semantics. Unknown cursor returns an empty page (no fallback to full list).
- `tests/acp/test_server.py`: 4 new tests — first-page w/ next_cursor, single-page no next_cursor, cursor resumes after match, unknown cursor returns empty.

## Follow-ups on top of #13460
- Replaced `kwargs.get('limit', 50)` with the module constant. `ListSessionsRequest` has no `limit` field in the ACP schema, so the kwarg path was dead.
- Switched `nextCursor=` kwarg to the declared field name `next_cursor=` (the schema sets `populate_by_name=True`, so both work; field name is consistent with the rest of the file).

## Validation
| | Before | After |
|---|---|---|
| `list_sessions(cursor=...)` | Cursor ignored, full list returned | Page resumes after cursor |
| `ListSessionsResponse.next_cursor` | Always `None` | Set to last `session_id` when more remain |
| 60 sessions, 2 cwds | — | page1=50 + next_cursor, page2=10, cwd filter=30, unknown cursor=[] |
| Tests | 2 `list_sessions` tests | 6 (all passing via `scripts/run_tests.sh`) |