### PR TITLE
fix(skills): handle bytes in bundle content hash

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -695,6 +695,27 @@ class TestCheckForSkillUpdates:
 
         assert bundle_content_hash(bundle) == content_hash(skill_dir)
 
+    def test_bundle_content_hash_accepts_bytes_content(self, tmp_path):
+        from tools.skills_guard import content_hash
+
+        bundle = SkillBundle(
+            name="demo-skill",
+            files={
+                "SKILL.md": b"# Demo Skill\n",
+                "references/checklist.md": "- [ ] security\n",
+            },
+            source="github",
+            identifier="owner/repo/demo-skill",
+            trust_level="community",
+        )
+        skill_dir = tmp_path / "demo-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_bytes(b"# Demo Skill\n")
+        (skill_dir / "references").mkdir()
+        (skill_dir / "references" / "checklist.md").write_text("- [ ] security\n")
+
+        assert bundle_content_hash(bundle) == content_hash(skill_dir)
+
     def test_reports_update_when_remote_hash_differs(self):
         lock = MagicMock()
         lock.list_installed.return_value = [{

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -2630,7 +2630,11 @@ def bundle_content_hash(bundle: SkillBundle) -> str:
     """Compute a deterministic hash for an in-memory skill bundle."""
     h = hashlib.sha256()
     for rel_path in sorted(bundle.files):
-        h.update(bundle.files[rel_path].encode("utf-8"))
+        content = bundle.files[rel_path]
+        if isinstance(content, bytes):
+            h.update(content)
+        else:
+            h.update(content.encode("utf-8"))
     return f"sha256:{h.hexdigest()[:16]}"
 
 


### PR DESCRIPTION
## Summary
- handle `bytes` entries in `bundle_content_hash()` without calling `.encode()`
- preserve the existing hash behavior for text bundle files
- add a regression test covering mixed `bytes` and `str` bundle content

Fixes #13408

## Root Cause
`bundle_content_hash()` assumed every `bundle.files[...]` value was a `str` and always called `.encode("utf-8")`. `SkillBundle.files` is already typed as `Dict[str, Union[str, bytes]]`, so any bundle containing raw `bytes` would crash during `hermes skills update` with `AttributeError`.

## Validation
- `/Users/zzl/.hermes/hermes-agent-update-20260421/venv/bin/python -m pytest -o addopts= tests/tools/test_skills_hub.py -q`
- `/Users/zzl/.hermes/hermes-agent-update-20260421/venv/bin/python -m py_compile tools/skills_hub.py tests/tools/test_skills_hub.py`
- `git diff --check`
