### PR TITLE
fix(acp): reject unadvertised auth methods

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -351,7 +351,8 @@ class HermesACPAgent(acp.Agent):
         )
 
     async def authenticate(self, method_id: str, **kwargs: Any) -> AuthenticateResponse | None:
-        if has_provider():
+        provider = detect_provider()
+        if provider and method_id == provider:
             return AuthenticateResponse()
         return None
 

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -97,8 +97,8 @@ class TestAuthenticate:
     @pytest.mark.asyncio
     async def test_authenticate_with_provider_configured(self, agent, monkeypatch):
         monkeypatch.setattr(
-            "acp_adapter.server.has_provider",
-            lambda: True,
+            "acp_adapter.server.detect_provider",
+            lambda: "openrouter",
         )
         resp = await agent.authenticate(method_id="openrouter")
         assert isinstance(resp, AuthenticateResponse)
@@ -106,10 +106,19 @@ class TestAuthenticate:
     @pytest.mark.asyncio
     async def test_authenticate_without_provider(self, agent, monkeypatch):
         monkeypatch.setattr(
-            "acp_adapter.server.has_provider",
-            lambda: False,
+            "acp_adapter.server.detect_provider",
+            lambda: None,
         )
         resp = await agent.authenticate(method_id="openrouter")
+        assert resp is None
+
+    @pytest.mark.asyncio
+    async def test_authenticate_rejects_unadvertised_method(self, agent, monkeypatch):
+        monkeypatch.setattr(
+            "acp_adapter.server.detect_provider",
+            lambda: "openrouter",
+        )
+        resp = await agent.authenticate(method_id="anthropic")
         assert resp is None
 
 


### PR DESCRIPTION
## Summary
- validate `method_id` against the runtime provider advertised during ACP initialization
- keep authentication behavior unchanged when the requested method matches the configured provider
- add a regression test covering a mismatched `method_id`

Fixes #13452

## Root Cause
`HermesACPAgent.initialize()` advertises a single auth method derived from `detect_provider()`, but `authenticate()` previously ignored the requested `method_id` and returned success whenever any provider was configured. That allowed clients to authenticate with method ids the server never advertised.

## Validation
- `PYTHONPATH=/Users/zzl/.hermes/hermes-agent-pr-13452 /Users/zzl/.hermes/hermes-agent-update-20260421/venv/bin/python -m pytest -o addopts= tests/acp/test_server.py -q`
- `PYTHONPATH=/Users/zzl/.hermes/hermes-agent-pr-13452 /Users/zzl/.hermes/hermes-agent-update-20260421/venv/bin/python -m py_compile acp_adapter/server.py tests/acp/test_server.py`
- `git diff --check`
