### PR TITLE
fix(telegram): accept username-format chat_id in send and edit_message

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -278,6 +278,15 @@ def _render_table_block_for_telegram(table_block: list[str]) -> str:
     return "\n\n".join(rendered_groups)
 
 
+
+
+def _normalize_chat_id(chat_id: str):
+    """Return int chat IDs as int, preserving Telegram @username targets."""
+    try:
+        return int(chat_id)
+    except (TypeError, ValueError):
+        return chat_id
+
 def _wrap_markdown_tables(text: str) -> str:
     """Rewrite GFM-style pipe tables into Telegram-friendly bullet groups.
 
@@ -1837,6 +1846,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 ]
             
             message_ids = []
+            chat_id_arg = _normalize_chat_id(chat_id)
             thread_id = self._metadata_thread_id(metadata)
             requested_thread_id = self._message_thread_id_for_send(thread_id)
             used_thread_fallback = False
@@ -1905,7 +1915,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         # Try Markdown first, fall back to plain text if it fails
                         try:
                             msg = await self._bot.send_message(
-                                chat_id=int(chat_id),
+                                chat_id=chat_id_arg,
                                 text=chunk,
                                 parse_mode=ParseMode.MARKDOWN_V2,
                                 reply_to_message_id=reply_to_id,
@@ -1919,7 +1929,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                 logger.warning("[%s] MarkdownV2 parse failed, falling back to plain text: %s", self.name, md_error)
                                 plain_chunk = _strip_mdv2(chunk)
                                 msg = await self._bot.send_message(
-                                    chat_id=int(chat_id),
+                                    chat_id=chat_id_arg,
                                     text=plain_chunk,
                                     parse_mode=None,
                                     reply_to_message_id=reply_to_id,
@@ -2137,9 +2147,10 @@ class TelegramAdapter(BasePlatformAdapter):
             )
 
         try:
+            chat_id_arg = _normalize_chat_id(chat_id)
             if not finalize:
                 await self._bot.edit_message_text(
-                    chat_id=int(chat_id),
+                    chat_id=chat_id_arg,
                     message_id=int(message_id),
                     text=content,
                 )
@@ -2148,7 +2159,7 @@ class TelegramAdapter(BasePlatformAdapter):
             formatted = self.format_message(content)
             try:
                 await self._bot.edit_message_text(
-                    chat_id=int(chat_id),
+                    chat_id=chat_id_arg,
                     message_id=int(message_id),
                     text=formatted,
                     parse_mode=ParseMode.MARKDOWN_V2,
@@ -2159,7 +2170,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     return SendResult(success=True, message_id=message_id)
                 # Fallback: retry without markdown formatting
                 await self._bot.edit_message_text(
-                    chat_id=int(chat_id),
+                    chat_id=chat_id_arg,
                     message_id=int(message_id),
                     text=content,
                 )
@@ -2195,7 +2206,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 await asyncio.sleep(wait)
                 try:
                     await self._bot.edit_message_text(
-                        chat_id=int(chat_id),
+                        chat_id=chat_id_arg,
                         message_id=int(message_id),
                         text=content,
                     )

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -121,6 +121,20 @@ def _strip_mdv2(text: str) -> str:
     return cleaned
 
 
+def _normalize_chat_id(chat_id: str) -> str:
+    """Convert chat_id to int if numeric, otherwise return as-is.
+
+    Telegram Bot API accepts both numeric IDs (e.g. ``123456789``) and
+    username strings (e.g. ``@channel_name`` or ``@some_user``).  This
+    helper avoids ``ValueError`` when ``TELEGRAM_HOME_CHANNEL`` is set to a
+    username instead of a numeric ID.
+    """
+    try:
+        return int(chat_id)
+    except (ValueError, TypeError):
+        return chat_id
+
+
 # ---------------------------------------------------------------------------
 # Markdown table → code block conversion
 # ---------------------------------------------------------------------------
@@ -535,7 +549,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
             changed = False
             for chat_entry in dm_topics:
-                if int(chat_entry.get("chat_id", 0)) != int(chat_id):
+                if int(chat_entry.get("chat_id", 0)) != _normalize_chat_id(chat_id):
                     continue
                 for t in chat_entry.get("topics", []):
                     if t.get("name") == topic_name and not t.get("thread_id"):
@@ -623,7 +637,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 icon_emoji = topic_conf.get("icon_custom_emoji_id")
 
                 thread_id = await self._create_dm_topic(
-                    chat_id=int(chat_id),
+                    chat_id=_normalize_chat_id(chat_id),
                     name=topic_name,
                     icon_color=icon_color,
                     icon_custom_emoji_id=icon_emoji,
@@ -636,7 +650,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         self.name, cache_key, thread_id,
                     )
                     # Persist thread_id to config so we don't recreate on next restart
-                    self._persist_dm_topic_thread_id(int(chat_id), topic_name, thread_id)
+                    self._persist_dm_topic_thread_id(_normalize_chat_id(chat_id), topic_name, thread_id)
 
     async def connect(self) -> bool:
         """Connect to Telegram via polling or webhook.
@@ -1005,7 +1019,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         # Try Markdown first, fall back to plain text if it fails
                         try:
                             msg = await self._bot.send_message(
-                                chat_id=int(chat_id),
+                                chat_id=_normalize_chat_id(chat_id),
                                 text=chunk,
                                 parse_mode=ParseMode.MARKDOWN_V2,
                                 reply_to_message_id=reply_to_id,
@@ -1018,7 +1032,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                 logger.warning("[%s] MarkdownV2 parse failed, falling back to plain text: %s", self.name, md_error)
                                 plain_chunk = _strip_mdv2(chunk)
                                 msg = await self._bot.send_message(
-                                    chat_id=int(chat_id),
+                                    chat_id=_normalize_chat_id(chat_id),
                                     text=plain_chunk,
                                     parse_mode=None,
                                     reply_to_message_id=reply_to_id,
@@ -1116,7 +1130,7 @@ class TelegramAdapter(BasePlatformAdapter):
             formatted = self.format_message(content)
             try:
                 await self._bot.edit_message_text(
-                    chat_id=int(chat_id),
+                    chat_id=_normalize_chat_id(chat_id),
                     message_id=int(message_id),
                     text=formatted,
                     parse_mode=ParseMode.MARKDOWN_V2,
@@ -1127,7 +1141,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     return SendResult(success=True, message_id=message_id)
                 # Fallback: retry without markdown formatting
                 await self._bot.edit_message_text(
-                    chat_id=int(chat_id),
+                    chat_id=_normalize_chat_id(chat_id),
                     message_id=int(message_id),
                     text=content,
                 )
@@ -1146,7 +1160,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 ) + "…"
                 try:
                     await self._bot.edit_message_text(
-                        chat_id=int(chat_id),
+                        chat_id=_normalize_chat_id(chat_id),
                         message_id=int(message_id),
                         text=truncated,
                     )
@@ -1168,7 +1182,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 await asyncio.sleep(wait)
                 try:
                     await self._bot.edit_message_text(
-                        chat_id=int(chat_id),
+                        chat_id=_normalize_chat_id(chat_id),
                         message_id=int(message_id),
                         text=content,
                     )
@@ -1209,7 +1223,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 ]
             ])
             msg = await self._bot.send_message(
-                chat_id=int(chat_id),
+                chat_id=_normalize_chat_id(chat_id),
                 text=text,
                 parse_mode=ParseMode.MARKDOWN,
                 reply_markup=keyboard,
@@ -1264,7 +1278,7 @@ class TelegramAdapter(BasePlatformAdapter):
             ])
 
             kwargs: Dict[str, Any] = {
-                "chat_id": int(chat_id),
+                "chat_id": _normalize_chat_id(chat_id),
                 "text": text,
                 "parse_mode": ParseMode.HTML,
                 "reply_markup": keyboard,
@@ -1335,7 +1349,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
             thread_id = metadata.get("thread_id") if metadata else None
             msg = await self._bot.send_message(
-                chat_id=int(chat_id),
+                chat_id=_normalize_chat_id(chat_id),
                 text=text,
                 parse_mode=ParseMode.MARKDOWN,
                 reply_markup=keyboard,
@@ -1721,7 +1735,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 if audio_path.endswith((".ogg", ".opus")):
                     _voice_thread = self._metadata_thread_id(metadata)
                     msg = await self._bot.send_voice(
-                        chat_id=int(chat_id),
+                        chat_id=_normalize_chat_id(chat_id),
                         voice=audio_file,
                         caption=caption[:1024] if caption else None,
                         reply_to_message_id=int(reply_to) if reply_to else None,
@@ -1731,7 +1745,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     # .mp3 and others -> send as audio file
                     _audio_thread = self._metadata_thread_id(metadata)
                     msg = await self._bot.send_audio(
-                        chat_id=int(chat_id),
+                        chat_id=_normalize_chat_id(chat_id),
                         audio=audio_file,
                         caption=caption[:1024] if caption else None,
                         reply_to_message_id=int(reply_to) if reply_to else None,
@@ -1767,7 +1781,7 @@ class TelegramAdapter(BasePlatformAdapter):
             _thread = self._metadata_thread_id(metadata)
             with open(image_path, "rb") as image_file:
                 msg = await self._bot.send_photo(
-                    chat_id=int(chat_id),
+                    chat_id=_normalize_chat_id(chat_id),
                     photo=image_file,
                     caption=caption[:1024] if caption else None,
                     reply_to_message_id=int(reply_to) if reply_to else None,
@@ -1806,7 +1820,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
             with open(file_path, "rb") as f:
                 msg = await self._bot.send_document(
-                    chat_id=int(chat_id),
+                    chat_id=_normalize_chat_id(chat_id),
                     document=f,
                     filename=display_name,
                     caption=caption[:1024] if caption else None,
@@ -1838,7 +1852,7 @@ class TelegramAdapter(BasePlatformAdapter):
             _thread = self._metadata_thread_id(metadata)
             with open(video_path, "rb") as f:
                 msg = await self._bot.send_video(
-                    chat_id=int(chat_id),
+                    chat_id=_normalize_chat_id(chat_id),
                     video=f,
                     caption=caption[:1024] if caption else None,
                     reply_to_message_id=int(reply_to) if reply_to else None,
@@ -1874,7 +1888,7 @@ class TelegramAdapter(BasePlatformAdapter):
             # Telegram can send photos directly from URLs (up to ~5MB)
             _photo_thread = self._metadata_thread_id(metadata)
             msg = await self._bot.send_photo(
-                chat_id=int(chat_id),
+                chat_id=_normalize_chat_id(chat_id),
                 photo=image_url,
                 caption=caption[:1024] if caption else None,  # Telegram caption limit
                 reply_to_message_id=int(reply_to) if reply_to else None,
@@ -1897,7 +1911,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     image_data = resp.content
                 
                 msg = await self._bot.send_photo(
-                    chat_id=int(chat_id),
+                    chat_id=_normalize_chat_id(chat_id),
                     photo=image_data,
                     caption=caption[:1024] if caption else None,
                     reply_to_message_id=int(reply_to) if reply_to else None,
@@ -1929,7 +1943,7 @@ class TelegramAdapter(BasePlatformAdapter):
         try:
             _anim_thread = self._metadata_thread_id(metadata)
             msg = await self._bot.send_animation(
-                chat_id=int(chat_id),
+                chat_id=_normalize_chat_id(chat_id),
                 animation=animation_url,
                 caption=caption[:1024] if caption else None,
                 reply_to_message_id=int(reply_to) if reply_to else None,
@@ -1954,14 +1968,14 @@ class TelegramAdapter(BasePlatformAdapter):
                 message_thread_id = self._message_thread_id_for_typing(_typing_thread)
                 try:
                     await self._bot.send_chat_action(
-                        chat_id=int(chat_id),
+                        chat_id=_normalize_chat_id(chat_id),
                         action="typing",
                         message_thread_id=message_thread_id,
                     )
                 except Exception as e:
                     if message_thread_id is not None and self._is_thread_not_found_error(e):
                         await self._bot.send_chat_action(
-                            chat_id=int(chat_id),
+                            chat_id=_normalize_chat_id(chat_id),
                             action="typing",
                             message_thread_id=None,
                         )
@@ -1982,7 +1996,7 @@ class TelegramAdapter(BasePlatformAdapter):
             return {"name": "Unknown", "type": "dm"}
         
         try:
-            chat = await self._bot.get_chat(int(chat_id))
+            chat = await self._bot.get_chat(_normalize_chat_id(chat_id))
             
             chat_type = "dm"
             if chat.type == ChatType.GROUP:
@@ -3053,7 +3067,7 @@ class TelegramAdapter(BasePlatformAdapter):
             return False
         try:
             await self._bot.set_message_reaction(
-                chat_id=int(chat_id),
+                chat_id=_normalize_chat_id(chat_id),
                 message_id=int(message_id),
                 reaction=emoji,
             )

--- a/tests/gateway/test_telegram_chat_id.py
+++ b/tests/gateway/test_telegram_chat_id.py
@@ -1,0 +1,180 @@
+"""Tests for Telegram username-format chat_id support in gateway/platforms/telegram.py.
+
+Covers: _normalize_chat_id helper, send() with username chat_id, edit_message
+with username chat_id.
+
+Bug: #13206 — TELEGRAM_HOME_CHANNEL set to a username like @some_user caused
+int(chat_id) to raise ValueError in send and edit_message paths.
+"""
+
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+from gateway.platforms.telegram import (
+    TelegramAdapter,
+    _normalize_chat_id,
+)
+
+
+# ---------------------------------------------------------------------------
+# _normalize_chat_id
+# ---------------------------------------------------------------------------
+
+class TestNormalizeChatId:
+    """Unit tests for the _normalize_chat_id helper."""
+
+    def test_numeric_string_returns_int(self):
+        assert _normalize_chat_id("12345") == 12345
+        assert isinstance(_normalize_chat_id("12345"), int)
+
+    def test_negative_numeric_string_returns_int(self):
+        assert _normalize_chat_id("-1001234567") == -1001234567
+        assert isinstance(_normalize_chat_id("-1001234567"), int)
+
+    def test_username_string_returns_str(self):
+        assert _normalize_chat_id("@channel_name") == "@channel_name"
+        assert isinstance(_normalize_chat_id("@channel_name"), str)
+
+    def test_username_without_at_returns_str(self):
+        # plain username without @
+        result = _normalize_chat_id("some_user")
+        assert result == "some_user"
+        assert isinstance(result, str)
+
+    def test_leading_at_sign_stripped_user(self):
+        # username with @ should be returned as-is per Telegram Bot API
+        result = _normalize_chat_id("@valid_user")
+        assert result == "@valid_user"
+
+    def test_chat_id_already_int_passthrough(self):
+        # When chat_id arrives as a string representation of an int
+        # (e.g. from env vars), it gets converted to int
+        assert _normalize_chat_id("999999999") == 999999999
+
+
+# ---------------------------------------------------------------------------
+# send() with username chat_id
+# ---------------------------------------------------------------------------
+
+class TestSendWithUsernameChatId:
+    """Integration tests for TelegramAdapter.send() with username-format chat_id."""
+
+    @pytest.fixture
+    def adapter(self):
+        config = PlatformConfig(enabled=True, token="fake-token")
+        return TelegramAdapter(config)
+
+    @pytest.fixture
+    def mock_bot(self):
+        bot = MagicMock()
+        bot.send_message = AsyncMock(return_value=MagicMock(message_id=42))
+        return bot
+
+    @pytest.mark.asyncio
+    async def test_send_message_with_username_chat_id(self, adapter, mock_bot):
+        """send() should not crash when chat_id is a Telegram username."""
+        adapter._bot = mock_bot
+
+        result = await adapter.send(
+            chat_id="@some_user",
+            content="Hello from the test",
+            reply_to=None,
+            metadata=None,
+        )
+
+        assert result.success is True
+        # Verify the bot was called with the username string, not int()
+        mock_bot.send_message.assert_called_once()
+        call_kwargs = mock_bot.send_message.call_args.kwargs
+        assert call_kwargs["chat_id"] == "@some_user"
+        assert call_kwargs["text"] == "Hello from the test"
+
+    @pytest.mark.asyncio
+    async def test_send_message_with_numeric_chat_id_still_works(self, adapter, mock_bot):
+        """send() should still handle numeric chat_id correctly."""
+        adapter._bot = mock_bot
+
+        result = await adapter.send(
+            chat_id="123456789",
+            content="Hello numeric",
+            reply_to=None,
+            metadata=None,
+        )
+
+        assert result.success is True
+        call_kwargs = mock_bot.send_message.call_args.kwargs
+        assert call_kwargs["chat_id"] == 123456789  # converted to int
+
+    @pytest.mark.asyncio
+    async def test_send_message_with_negative_chat_id(self, adapter, mock_bot):
+        """send() should handle negative numeric chat_id (Telegram supergroup format)."""
+        adapter._bot = mock_bot
+
+        result = await adapter.send(
+            chat_id="-1001234567890",
+            content="Hello supergroup",
+            reply_to=None,
+            metadata=None,
+        )
+
+        assert result.success is True
+        call_kwargs = mock_bot.send_message.call_args.kwargs
+        assert call_kwargs["chat_id"] == -1001234567890
+
+
+# ---------------------------------------------------------------------------
+# edit_message with username chat_id
+# ---------------------------------------------------------------------------
+
+class TestEditMessageWithUsernameChatId:
+    """Integration tests for TelegramAdapter.edit_message() with username-format chat_id."""
+
+    @pytest.fixture
+    def adapter(self):
+        config = PlatformConfig(enabled=True, token="fake-token")
+        return TelegramAdapter(config)
+
+    @pytest.fixture
+    def mock_bot(self):
+        bot = MagicMock()
+        bot.edit_message_text = AsyncMock(return_value=MagicMock(message_id=42))
+        return bot
+
+    @pytest.mark.asyncio
+    async def test_edit_message_with_username_chat_id(self, adapter, mock_bot):
+        """edit_message() should not crash when chat_id is a Telegram username."""
+        adapter._bot = mock_bot
+
+        result = await adapter.edit_message(
+            chat_id="@channel_name",
+            message_id="12345",
+            content="Updated text",
+        )
+
+        assert result.success is True
+        mock_bot.edit_message_text.assert_called_once()
+        call_kwargs = mock_bot.edit_message_text.call_args.kwargs
+        assert call_kwargs["chat_id"] == "@channel_name"
+        # message_id should still be int
+        assert call_kwargs["message_id"] == 12345
+
+    @pytest.mark.asyncio
+    async def test_edit_message_with_numeric_chat_id_still_works(self, adapter, mock_bot):
+        """edit_message() should still handle numeric chat_id correctly."""
+        adapter._bot = mock_bot
+
+        result = await adapter.edit_message(
+            chat_id="123456789",
+            message_id="999",
+            content="Updated numeric",
+        )
+
+        assert result.success is True
+        call_kwargs = mock_bot.edit_message_text.call_args.kwargs
+        assert call_kwargs["chat_id"] == 123456789
+        assert call_kwargs["message_id"] == 999

--- a/tests/gateway/test_telegram_chat_id.py
+++ b/tests/gateway/test_telegram_chat_id.py
@@ -1,0 +1,202 @@
+"""Tests for Telegram username-format chat_id support in gateway/platforms/telegram.py.
+
+Covers: _normalize_chat_id helper, send() with username chat_id, edit_message
+with username chat_id.
+
+Bug: #13206 — TELEGRAM_HOME_CHANNEL set to a username like @some_user caused
+int(chat_id) to raise ValueError in send and edit_message paths.
+"""
+
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+# ---------------------------------------------------------------------------
+# Mock the telegram package if it's not installed
+# ---------------------------------------------------------------------------
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ParseMode.MARKDOWN = "Markdown"
+    mod.constants.ParseMode.HTML = "HTML"
+    mod.constants.ChatType.GROUP = "group"
+    mod.constants.ChatType.SUPERGROUP = "supergroup"
+    mod.constants.ChatType.CHANNEL = "channel"
+    mod.constants.ChatType.PRIVATE = "private"
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+
+
+_ensure_telegram_mock()
+
+from gateway.platforms.telegram import (  # noqa: E402
+    TelegramAdapter,
+    _normalize_chat_id,
+)
+
+
+# ---------------------------------------------------------------------------
+# _normalize_chat_id
+# ---------------------------------------------------------------------------
+
+class TestNormalizeChatId:
+    """Unit tests for the _normalize_chat_id helper."""
+
+    def test_numeric_string_returns_int(self):
+        assert _normalize_chat_id("12345") == 12345
+        assert isinstance(_normalize_chat_id("12345"), int)
+
+    def test_negative_numeric_string_returns_int(self):
+        assert _normalize_chat_id("-1001234567") == -1001234567
+        assert isinstance(_normalize_chat_id("-1001234567"), int)
+
+    def test_username_string_returns_str(self):
+        assert _normalize_chat_id("@channel_name") == "@channel_name"
+        assert isinstance(_normalize_chat_id("@channel_name"), str)
+
+    def test_username_without_at_returns_str(self):
+        # plain username without @
+        result = _normalize_chat_id("some_user")
+        assert result == "some_user"
+        assert isinstance(result, str)
+
+    def test_leading_at_sign_stripped_user(self):
+        # username with @ should be returned as-is per Telegram Bot API
+        result = _normalize_chat_id("@valid_user")
+        assert result == "@valid_user"
+
+    def test_chat_id_already_int_passthrough(self):
+        # When chat_id arrives as a string representation of an int
+        # (e.g. from env vars), it gets converted to int
+        assert _normalize_chat_id("999999999") == 999999999
+
+
+# ---------------------------------------------------------------------------
+# send() with username chat_id
+# ---------------------------------------------------------------------------
+
+class TestSendWithUsernameChatId:
+    """Integration tests for TelegramAdapter.send() with username-format chat_id."""
+
+    @pytest.fixture
+    def adapter(self):
+        config = PlatformConfig(enabled=True, token="fake-token")
+        return TelegramAdapter(config)
+
+    @pytest.fixture
+    def mock_bot(self):
+        bot = MagicMock()
+        bot.send_message = AsyncMock(return_value=MagicMock(message_id=42))
+        return bot
+
+    @pytest.mark.asyncio
+    async def test_send_message_with_username_chat_id(self, adapter, mock_bot):
+        """send() should not crash when chat_id is a Telegram username."""
+        adapter._bot = mock_bot
+
+        result = await adapter.send(
+            chat_id="@some_user",
+            content="Hello from the test",
+            reply_to=None,
+            metadata=None,
+        )
+
+        assert result.success is True
+        # Verify the bot was called with the username string, not int()
+        mock_bot.send_message.assert_called_once()
+        call_kwargs = mock_bot.send_message.call_args.kwargs
+        assert call_kwargs["chat_id"] == "@some_user"
+        assert call_kwargs["text"] == "Hello from the test"
+
+    @pytest.mark.asyncio
+    async def test_send_message_with_numeric_chat_id_still_works(self, adapter, mock_bot):
+        """send() should still handle numeric chat_id correctly."""
+        adapter._bot = mock_bot
+
+        result = await adapter.send(
+            chat_id="123456789",
+            content="Hello numeric",
+            reply_to=None,
+            metadata=None,
+        )
+
+        assert result.success is True
+        call_kwargs = mock_bot.send_message.call_args.kwargs
+        assert call_kwargs["chat_id"] == 123456789  # converted to int
+
+    @pytest.mark.asyncio
+    async def test_send_message_with_negative_chat_id(self, adapter, mock_bot):
+        """send() should handle negative numeric chat_id (Telegram supergroup format)."""
+        adapter._bot = mock_bot
+
+        result = await adapter.send(
+            chat_id="-1001234567890",
+            content="Hello supergroup",
+            reply_to=None,
+            metadata=None,
+        )
+
+        assert result.success is True
+        call_kwargs = mock_bot.send_message.call_args.kwargs
+        assert call_kwargs["chat_id"] == -1001234567890
+
+
+# ---------------------------------------------------------------------------
+# edit_message with username chat_id
+# ---------------------------------------------------------------------------
+
+class TestEditMessageWithUsernameChatId:
+    """Integration tests for TelegramAdapter.edit_message() with username-format chat_id."""
+
+    @pytest.fixture
+    def adapter(self):
+        config = PlatformConfig(enabled=True, token="fake-token")
+        return TelegramAdapter(config)
+
+    @pytest.fixture
+    def mock_bot(self):
+        bot = MagicMock()
+        bot.edit_message_text = AsyncMock(return_value=MagicMock(message_id=42))
+        return bot
+
+    @pytest.mark.asyncio
+    async def test_edit_message_with_username_chat_id(self, adapter, mock_bot):
+        """edit_message() should not crash when chat_id is a Telegram username."""
+        adapter._bot = mock_bot
+
+        result = await adapter.edit_message(
+            chat_id="@channel_name",
+            message_id="12345",
+            content="Updated text",
+        )
+
+        assert result.success is True
+        mock_bot.edit_message_text.assert_called_once()
+        call_kwargs = mock_bot.edit_message_text.call_args.kwargs
+        assert call_kwargs["chat_id"] == "@channel_name"
+        # message_id should still be int
+        assert call_kwargs["message_id"] == 12345
+
+    @pytest.mark.asyncio
+    async def test_edit_message_with_numeric_chat_id_still_works(self, adapter, mock_bot):
+        """edit_message() should still handle numeric chat_id correctly."""
+        adapter._bot = mock_bot
+
+        result = await adapter.edit_message(
+            chat_id="123456789",
+            message_id="999",
+            content="Updated numeric",
+        )
+
+        assert result.success is True
+        call_kwargs = mock_bot.edit_message_text.call_args.kwargs
+        assert call_kwargs["chat_id"] == 123456789
+        assert call_kwargs["message_id"] == 999


### PR DESCRIPTION
## What does this PR do?

`TELEGRAM_HOME_CHANNEL` (and other chat_id sources) can be set to a Telegram username like `@channel_name` instead of a numeric ID. Every call site in `TelegramAdapter` used `int(chat_id)`, which raises `ValueError` for username strings.

This PR adds a `_normalize_chat_id()` helper that converts numeric strings to `int` and passes usernames through unchanged — matching the Telegram Bot API which accepts both formats. All 24 call sites in `telegram.py` (`send`, `edit_message`, media methods, typing indicators, reactions) now use this helper.

## Related Issue

Closes #13206

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `_normalize_chat_id()` helper to `gateway/telegram.py` that returns `int` for numeric strings and passes usernames (`@name`) through unchanged.
- Update all 24 call sites in `TelegramAdapter` — `send`, `edit_message`, media methods, typing indicators, reactions — to use the helper instead of `int(chat_id)`.
- Add 11 tests in `tests/gateway/test_telegram_chat_id.py` covering: `_normalize_chat_id` unit tests, `send()` with username/numeric/negative IDs, `edit_message()` with username/numeric IDs.

## How to Test

1. Set `TELEGRAM_HOME_CHANNEL` to a username like `@my_channel`.
2. Send a message through the gateway — should succeed instead of crashing with `ValueError`.
3. Run the regression tests:
   ```bash
   pytest tests/gateway/test_telegram_chat_id.py -v
   ```

Platform tested: macOS 15 (Apple Silicon).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ pytest tests/gateway/test_telegram_chat_id.py -v
11 tests pass.
```
