### PR TITLE
fix(gateway): persist parent session ID on auto-reset

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -491,6 +491,10 @@ class SessionEntry:
     resume_reason: Optional[str] = None  # e.g. "restart_timeout"
     last_resume_marked_at: Optional[datetime] = None
 
+    # Set when a session was auto-reset; contains the previous session_id
+    # so the parent session can be identified (#12857).
+    parent_session_id: Optional[str] = None
+
     def to_dict(self) -> Dict[str, Any]:
         result = {
             "session_key": self.session_key,
@@ -521,6 +525,7 @@ class SessionEntry:
             "was_auto_reset": self.was_auto_reset,
             "auto_reset_reason": self.auto_reset_reason,
             "reset_had_activity": self.reset_had_activity,
+            "parent_session_id": self.parent_session_id,
         }
         if self.origin:
             result["origin"] = self.origin.to_dict()
@@ -573,6 +578,7 @@ class SessionEntry:
             was_auto_reset=data.get("was_auto_reset", False),
             auto_reset_reason=data.get("auto_reset_reason"),
             reset_had_activity=data.get("reset_had_activity", False),
+            parent_session_id=data.get("parent_session_id"),
         )
 
 
@@ -929,6 +935,7 @@ class SessionStore:
                 was_auto_reset=was_auto_reset,
                 auto_reset_reason=auto_reset_reason,
                 reset_had_activity=reset_had_activity,
+                parent_session_id=db_end_session_id,
             )
 
             self._entries[session_key] = entry
@@ -937,6 +944,7 @@ class SessionStore:
                 "session_id": session_id,
                 "source": source.platform.value,
                 "user_id": source.user_id,
+                "parent_session_id": db_end_session_id,
             }
 
         # SQLite operations outside the lock

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -390,6 +390,10 @@ class SessionEntry:
     resume_reason: Optional[str] = None  # e.g. "restart_timeout"
     last_resume_marked_at: Optional[datetime] = None
 
+    # Set when a session was auto-reset; contains the previous session_id
+    # so the parent session can be identified (#12857).
+    parent_session_id: Optional[str] = None
+
     def to_dict(self) -> Dict[str, Any]:
         result = {
             "session_key": self.session_key,
@@ -416,6 +420,7 @@ class SessionEntry:
                 if self.last_resume_marked_at
                 else None
             ),
+            "parent_session_id": self.parent_session_id,
         }
         if self.origin:
             result["origin"] = self.origin.to_dict()
@@ -464,6 +469,7 @@ class SessionEntry:
             resume_pending=data.get("resume_pending", False),
             resume_reason=data.get("resume_reason"),
             last_resume_marked_at=last_resume_marked_at,
+            parent_session_id=data.get("parent_session_id"),
         )
 
 
@@ -811,6 +817,7 @@ class SessionStore:
                 was_auto_reset=was_auto_reset,
                 auto_reset_reason=auto_reset_reason,
                 reset_had_activity=reset_had_activity,
+                parent_session_id=db_end_session_id,
             )
 
             self._entries[session_key] = entry
@@ -819,6 +826,7 @@ class SessionStore:
                 "session_id": session_id,
                 "source": source.platform.value,
                 "user_id": source.user_id,
+                "parent_session_id": db_end_session_id,
             }
 
         # SQLite operations outside the lock

--- a/tests/gateway/test_session_parent_id.py
+++ b/tests/gateway/test_session_parent_id.py
@@ -1,0 +1,160 @@
+"""Tests for parent_session_id persistence on auto-reset (#12857)."""
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+from gateway.config import GatewayConfig, Platform
+from gateway.session import SessionEntry, SessionSource, SessionStore
+
+
+class TestSessionEntryParentId:
+    """Tests for SessionEntry.parent_session_id field."""
+
+    def test_accepts_parent_session_id_field(self):
+        """SessionEntry should accept parent_session_id in constructor."""
+        entry = SessionEntry(
+            session_key="test_key",
+            session_id="new_session_123",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            parent_session_id="old_session_456",
+        )
+        assert entry.parent_session_id == "old_session_456"
+
+    def test_parent_session_id_defaults_to_none(self):
+        """New sessions should have parent_session_id=None by default."""
+        entry = SessionEntry(
+            session_key="test_key",
+            session_id="new_session",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+        )
+        assert entry.parent_session_id is None
+
+    def test_serialization_roundtrip_includes_parent_session_id(self):
+        """parent_session_id should survive to_dict/from_dict roundtrip."""
+        entry = SessionEntry(
+            session_key="test_key",
+            session_id="new_session_abc",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            parent_session_id="parent_session_xyz",
+        )
+
+        d = entry.to_dict()
+        assert d["parent_session_id"] == "parent_session_xyz"
+
+        restored = SessionEntry.from_dict(d)
+        assert restored.parent_session_id == "parent_session_xyz"
+
+    def test_from_dict_handles_missing_parent_session_id(self):
+        """from_dict should default parent_session_id to None when missing."""
+        data = {
+            "session_key": "test_key",
+            "session_id": "s1",
+            "created_at": "2025-01-01T00:00:00",
+            "updated_at": "2025-01-01T00:00:00",
+            # No parent_session_id — old format
+        }
+        entry = SessionEntry.from_dict(data)
+        assert entry.parent_session_id is None
+
+    def test_from_dict_handles_null_parent_session_id(self):
+        """from_dict should handle explicit null parent_session_id."""
+        data = {
+            "session_key": "test_key",
+            "session_id": "s1",
+            "created_at": "2025-01-01T00:00:00",
+            "updated_at": "2025-01-01T00:00:00",
+            "parent_session_id": None,
+        }
+        entry = SessionEntry.from_dict(data)
+        assert entry.parent_session_id is None
+
+
+class TestGetOrCreateSessionParentId:
+    """Tests for parent_session_id in get_or_create_session auto-reset."""
+
+    def _make_source(self):
+        """Helper to create a test SessionSource."""
+        return SessionSource(
+            platform=Platform.LOCAL,
+            chat_id="test_chat",
+            chat_name="Test Chat",
+            chat_type="dm",
+            user_id="test_user",
+        )
+
+    def _make_store(self, tmp_path):
+        """Helper to create a SessionStore with correct constructor."""
+        config = GatewayConfig()
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            return SessionStore(sessions_dir=tmp_path, config=config)
+
+    def test_parent_session_id_set_on_auto_reset(self, tmp_path):
+        """When session auto-resets, parent_session_id should be the old session_id."""
+        store = self._make_store(tmp_path)
+        source = self._make_source()
+
+        # Create initial session
+        entry1 = store.get_or_create_session(source)
+        old_session_id = entry1.session_id
+        assert entry1.parent_session_id is None
+
+        # Simulate auto-reset by marking the session as suspended
+        entry1.suspended = True
+        store._save()
+
+        # Trigger auto-reset
+        entry2 = store.get_or_create_session(source)
+
+        assert entry2.was_auto_reset is True
+        assert entry2.parent_session_id == old_session_id
+        assert entry2.session_id != old_session_id
+
+    def test_parent_session_id_none_on_fresh_session(self, tmp_path):
+        """A fresh session (no reset) should have parent_session_id=None."""
+        store = self._make_store(tmp_path)
+        source = self._make_source()
+        entry = store.get_or_create_session(source)
+
+        assert entry.was_auto_reset is False
+        assert entry.parent_session_id is None
+
+    def test_parent_session_id_none_when_not_auto_reset(self, tmp_path):
+        """Even with an existing session that doesn't auto-reset, parent_session_id stays None."""
+        store = self._make_store(tmp_path)
+        source = self._make_source()
+
+        # Create initial session
+        entry1 = store.get_or_create_session(source)
+        original_id = entry1.session_id
+
+        # Get same session again (no reset triggered)
+        entry2 = store.get_or_create_session(source)
+
+        assert entry2.session_id == original_id
+        assert entry2.parent_session_id is None
+
+    def test_parent_session_id_forwarded_to_sqlite_on_auto_reset(self, tmp_path):
+        """Auto-reset should persist the parent link in the SQLite session graph."""
+        source = self._make_source()
+        fake_db = MagicMock()
+
+        with patch("hermes_state.SessionDB", return_value=fake_db):
+            store = SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+
+        entry1 = store.get_or_create_session(source)
+        old_session_id = entry1.session_id
+        entry1.suspended = True
+        store._save()
+
+        entry2 = store.get_or_create_session(source)
+
+        fake_db.end_session.assert_called_once_with(old_session_id, "session_reset")
+        fake_db.create_session.assert_called_with(
+            session_id=entry2.session_id,
+            source=source.platform.value,
+            user_id=source.user_id,
+            parent_session_id=old_session_id,
+        )


### PR DESCRIPTION
## What does this PR do?

When the gateway auto-resets a session (e.g. after suspension), the new session had no link back to the previous one. This makes it impossible to trace session lineage for debugging or analytics.

This adds a `parent_session_id` field to `SessionEntry` that gets set to the old session's ID during auto-reset. The field is:
- Persisted through `to_dict()`/`from_dict()` serialization
- Forwarded to the SQLite `create_session()` call for the session graph
- Defaults to `None` for fresh sessions (no reset)
- Backward-compatible with existing session data (missing field defaults to `None`)

## Related Issue

Closes #12857

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `SessionEntry` — new `parent_session_id` field, persisted through `to_dict()` / `from_dict()` serialization, defaults to `None` for fresh sessions
- Auto-reset path sets `parent_session_id` to the old session's ID before swapping in the new entry
- SQLite `create_session()` call now forwards `parent_session_id` for the session graph
- `tests/gateway/test_session_parent_id.py` — 9 tests covering field acceptance, default None, serialization roundtrip, missing/null handling in `from_dict`, auto-reset propagation, fresh session behavior, and SQLite forwarding

## How to Test

1. ```bash
   pytest tests/gateway/test_session_parent_id.py -v
   ```
2. 9 tests pass covering field acceptance, default None, serialization roundtrip, missing/null handling in `from_dict`, auto-reset propagation, fresh session behavior, and SQLite forwarding

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ pytest tests/gateway/test_session_parent_id.py -v
9 tests pass
```
