### PR TITLE
fix(docker): forward HERMES_RPC_DIR to sandbox containers for execute_code RPC

### DIFF
--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -36,6 +36,7 @@ import threading
 import unittest
 from unittest.mock import patch, MagicMock
 
+from tools.environments.docker import get_docker_rpc_dir
 from tools.code_execution_tool import (
     SANDBOX_ALLOWED_TOOLS,
     execute_code,
@@ -173,6 +174,42 @@ class TestExecuteCodeRemoteTempDir(unittest.TestCase):
         self.assertIn("HERMES_RPC_DIR=/data/data/com.termux/files/usr/tmp/hermes_exec_", run_cmd)
         self.assertIn("rm -rf /data/data/com.termux/files/usr/tmp/hermes_exec_", cleanup_cmd)
         self.assertNotIn("mkdir -p /tmp/hermes_exec_", mkdir_cmd)
+
+    def test_execute_remote_uses_task_specific_docker_rpc_dir(self):
+        class FakeEnv:
+            def __init__(self):
+                self.commands = []
+
+            def get_temp_dir(self):
+                return "/tmp"
+
+            def execute(self, command, cwd=None, timeout=None):
+                self.commands.append((command, cwd, timeout))
+                if "command -v python3" in command:
+                    return {"output": "OK\n"}
+                if "python3 script.py" in command:
+                    return {"output": "hello\n", "returncode": 0}
+                return {"output": ""}
+
+        env = FakeEnv()
+        fake_thread = MagicMock()
+
+        with patch("tools.code_execution_tool._load_config", return_value={"timeout": 30, "max_tool_calls": 5}), \
+             patch("tools.code_execution_tool._get_or_create_env", return_value=(env, "docker")), \
+             patch("tools.code_execution_tool._ship_file_to_remote"), \
+             patch("tools.code_execution_tool.threading.Thread", return_value=fake_thread):
+            result = json.loads(_execute_remote("print('hello')", "task/one", ["terminal"]))
+
+        self.assertEqual(result["status"], "success")
+        rpc_dir = get_docker_rpc_dir("task/one")
+        mkdir_cmd = env.commands[1][0]
+        run_cmd = next(cmd for cmd, _, _ in env.commands if "python3 script.py" in cmd)
+        cleanup_cmds = [cmd for cmd, _, _ in env.commands if "rm -rf" in cmd]
+
+        self.assertIn("mkdir -p /tmp/hermes_exec_", mkdir_cmd)
+        self.assertIn(f"rm -rf {rpc_dir} && mkdir -p {rpc_dir}", mkdir_cmd)
+        self.assertIn(f"HERMES_RPC_DIR={rpc_dir}", run_cmd)
+        self.assertTrue(any(cmd.endswith(f"rm -rf {rpc_dir}") for cmd in cleanup_cmds))
 
 
 @unittest.skipIf(sys.platform == "win32", "UDS not available on Windows")

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -36,6 +36,7 @@ import threading
 import unittest
 from unittest.mock import patch, MagicMock
 
+from tools.environments.docker import get_docker_rpc_dir
 from tools.code_execution_tool import (
     SANDBOX_ALLOWED_TOOLS,
     execute_code,
@@ -157,6 +158,42 @@ class TestExecuteCodeRemoteTempDir(unittest.TestCase):
         self.assertIn("HERMES_RPC_DIR=/data/data/com.termux/files/usr/tmp/hermes_exec_", run_cmd)
         self.assertIn("rm -rf /data/data/com.termux/files/usr/tmp/hermes_exec_", cleanup_cmd)
         self.assertNotIn("mkdir -p /tmp/hermes_exec_", mkdir_cmd)
+
+    def test_execute_remote_uses_task_specific_docker_rpc_dir(self):
+        class FakeEnv:
+            def __init__(self):
+                self.commands = []
+
+            def get_temp_dir(self):
+                return "/tmp"
+
+            def execute(self, command, cwd=None, timeout=None):
+                self.commands.append((command, cwd, timeout))
+                if "command -v python3" in command:
+                    return {"output": "OK\n"}
+                if "python3 script.py" in command:
+                    return {"output": "hello\n", "returncode": 0}
+                return {"output": ""}
+
+        env = FakeEnv()
+        fake_thread = MagicMock()
+
+        with patch("tools.code_execution_tool._load_config", return_value={"timeout": 30, "max_tool_calls": 5}), \
+             patch("tools.code_execution_tool._get_or_create_env", return_value=(env, "docker")), \
+             patch("tools.code_execution_tool._ship_file_to_remote"), \
+             patch("tools.code_execution_tool.threading.Thread", return_value=fake_thread):
+            result = json.loads(_execute_remote("print('hello')", "task/one", ["terminal"]))
+
+        self.assertEqual(result["status"], "success")
+        rpc_dir = get_docker_rpc_dir("task/one")
+        mkdir_cmd = env.commands[1][0]
+        run_cmd = next(cmd for cmd, _, _ in env.commands if "python3 script.py" in cmd)
+        cleanup_cmds = [cmd for cmd, _, _ in env.commands if "rm -rf" in cmd]
+
+        self.assertIn("mkdir -p /tmp/hermes_exec_", mkdir_cmd)
+        self.assertIn(f"rm -rf {rpc_dir} && mkdir -p {rpc_dir}", mkdir_cmd)
+        self.assertIn(f"HERMES_RPC_DIR={rpc_dir}", run_cmd)
+        self.assertTrue(any(cmd.endswith(f"rm -rf {rpc_dir}") for cmd in cleanup_cmds))
 
 
 @unittest.skipIf(sys.platform == "win32", "UDS not available on Windows")

--- a/tests/tools/test_docker_rpc_dir.py
+++ b/tests/tools/test_docker_rpc_dir.py
@@ -1,0 +1,121 @@
+"""Tests for HERMES_RPC_DIR injection into Docker sandbox (#13142)."""
+
+import pytest
+from unittest.mock import patch
+
+
+class TestCreateEnvironmentRpcDir:
+    """Tests for _create_environment injecting HERMES_RPC_DIR."""
+
+    @pytest.fixture(autouse=True)
+    def _import(self):
+        """Import _create_environment with all deps mocked."""
+        # We need to mock the heavy imports that terminal_tool does at module level
+        with patch("tools.environments.docker.subprocess.run"), \
+             patch("tools.environments.docker.find_docker", return_value="/usr/bin/docker"):
+            from tools.environments.docker import get_docker_rpc_dir
+            from tools.terminal_tool import _create_environment, _DockerEnvironment
+            self._create_environment = _create_environment
+            self._DockerEnvironment = _DockerEnvironment
+            self._get_docker_rpc_dir = get_docker_rpc_dir
+
+    def test_docker_env_includes_hermes_rpc_dir(self):
+        """DockerEnvironment receives HERMES_RPC_DIR in its env dict."""
+        with patch.object(self._DockerEnvironment, "__init__", return_value=None) as mock_init:
+            mock_init.return_value = None
+            self._create_environment(
+                env_type="docker",
+                image="python:3.11",
+                cwd="/workspace",
+                timeout=60,
+                container_config={"docker_env": {"FOO": "bar"}},
+            )
+            mock_init.assert_called_once()
+            call_kwargs = mock_init.call_args[1]
+            assert call_kwargs["env"]["HERMES_RPC_DIR"] == self._get_docker_rpc_dir("default")
+            assert call_kwargs["env"]["FOO"] == "bar"
+
+    def test_docker_env_preserves_existing_vars(self):
+        """Existing docker_env vars are preserved when HERMES_RPC_DIR is added."""
+        with patch.object(self._DockerEnvironment, "__init__", return_value=None) as mock_init:
+            mock_init.return_value = None
+            self._create_environment(
+                env_type="docker",
+                image="python:3.11",
+                cwd="/workspace",
+                timeout=60,
+                container_config={"docker_env": {"MY_VAR": "hello", "NUM": "42"}},
+            )
+            call_kwargs = mock_init.call_args[1]
+            assert call_kwargs["env"]["MY_VAR"] == "hello"
+            assert call_kwargs["env"]["NUM"] == "42"
+            assert call_kwargs["env"]["HERMES_RPC_DIR"] == self._get_docker_rpc_dir("default")
+
+    def test_docker_env_does_not_override_explicit_hermes_rpc_dir(self):
+        """If HERMES_RPC_DIR is already in docker_env, it is not overridden."""
+        with patch.object(self._DockerEnvironment, "__init__", return_value=None) as mock_init:
+            mock_init.return_value = None
+            self._create_environment(
+                env_type="docker",
+                image="python:3.11",
+                cwd="/workspace",
+                timeout=60,
+                container_config={"docker_env": {"HERMES_RPC_DIR": "/custom/rpc/path"}},
+            )
+            call_kwargs = mock_init.call_args[1]
+            assert call_kwargs["env"]["HERMES_RPC_DIR"] == "/custom/rpc/path"
+
+    def test_docker_env_empty_config(self):
+        """When docker_env is not specified, HERMES_RPC_DIR is still injected."""
+        with patch.object(self._DockerEnvironment, "__init__", return_value=None) as mock_init:
+            mock_init.return_value = None
+            self._create_environment(
+                env_type="docker",
+                image="python:3.11",
+                cwd="/workspace",
+                timeout=60,
+                container_config={},
+            )
+            call_kwargs = mock_init.call_args[1]
+            assert call_kwargs["env"]["HERMES_RPC_DIR"] == self._get_docker_rpc_dir("default")
+
+    def test_docker_env_uses_task_specific_rpc_dir(self):
+        """DockerEnvironment should receive the same task-specific RPC dir as execute_code."""
+        with patch.object(self._DockerEnvironment, "__init__", return_value=None) as mock_init:
+            self._create_environment(
+                env_type="docker",
+                image="python:3.11",
+                cwd="/workspace",
+                timeout=60,
+                task_id="task/one",
+                container_config={},
+            )
+            call_kwargs = mock_init.call_args[1]
+            assert call_kwargs["env"]["HERMES_RPC_DIR"] == self._get_docker_rpc_dir("task/one")
+
+
+class TestLocalEnvironmentUnaffected:
+    """Verify local environment is not touched by the fix."""
+
+    @pytest.fixture(autouse=True)
+    def _import(self):
+        with patch("tools.environments.docker.subprocess.run"), \
+             patch("tools.environments.docker.find_docker", return_value="/usr/bin/docker"):
+            from tools.terminal_tool import _create_environment, _LocalEnvironment
+            self._create_environment = _create_environment
+            self._LocalEnvironment = _LocalEnvironment
+
+    def test_local_environment_no_rpc_dir(self):
+        """LocalEnvironment does not receive HERMES_RPC_DIR."""
+        with patch.object(self._LocalEnvironment, "__init__", return_value=None) as mock_init:
+            mock_init.return_value = None
+            self._create_environment(
+                env_type="local",
+                image="",
+                cwd="/workspace",
+                timeout=60,
+            )
+            mock_init.assert_called_once()
+            call_kwargs = mock_init.call_args[1]
+            # LocalEnvironment takes cwd and timeout, no env param
+            assert "env" not in call_kwargs

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -47,6 +47,8 @@ import uuid
 _IS_WINDOWS = platform.system() == "Windows"
 from typing import Any, Dict, List, Optional
 
+from tools.environments.docker import get_docker_rpc_dir
+
 # Availability gate.  On Windows we fall back to loopback TCP for the
 # sandbox RPC transport (AF_UNIX is unreliable on Windows Python) — see
 # ``_use_tcp_rpc`` in ``_execute_local`` below.  That makes execute_code
@@ -866,7 +868,10 @@ def _execute_remote(
     temp_dir = _env_temp_dir(env)
     sandbox_dir = f"{temp_dir}/hermes_exec_{sandbox_id}"
     quoted_sandbox_dir = shlex.quote(sandbox_dir)
-    quoted_rpc_dir = shlex.quote(f"{sandbox_dir}/rpc")
+    rpc_dir = f"{sandbox_dir}/rpc"
+    if env_type == "docker":
+        rpc_dir = get_docker_rpc_dir(effective_task_id)
+    quoted_rpc_dir = shlex.quote(rpc_dir)
 
     tool_call_log: list = []
     tool_call_counter = [0]
@@ -894,7 +899,9 @@ def _execute_remote(
 
         # Create sandbox directory on remote
         env.execute(
-            f"mkdir -p {quoted_rpc_dir}", cwd="/", timeout=10,
+            f"mkdir -p {quoted_sandbox_dir} && rm -rf {quoted_rpc_dir} && mkdir -p {quoted_rpc_dir}",
+            cwd="/",
+            timeout=10,
         )
 
         # Generate and ship files
@@ -908,7 +915,7 @@ def _execute_remote(
         rpc_thread = threading.Thread(
             target=_rpc_poll_loop,
             args=(
-                env, f"{sandbox_dir}/rpc", effective_task_id,
+                env, rpc_dir, effective_task_id,
                 tool_call_log, tool_call_counter, max_tool_calls,
                 sandbox_tools, stop_event,
             ),
@@ -918,7 +925,7 @@ def _execute_remote(
 
         # Build environment variable prefix for the script
         env_prefix = (
-            f"HERMES_RPC_DIR={shlex.quote(f'{sandbox_dir}/rpc')} "
+            f"HERMES_RPC_DIR={quoted_rpc_dir} "
             f"PYTHONDONTWRITEBYTECODE=1"
         )
         tz = os.getenv("HERMES_TIMEZONE", "").strip()
@@ -970,6 +977,13 @@ def _execute_remote(
             )
         except Exception:
             logger.debug("Failed to clean up remote sandbox %s", sandbox_dir)
+        if rpc_dir != f"{sandbox_dir}/rpc":
+            try:
+                env.execute(
+                    f"rm -rf {quoted_rpc_dir}", cwd="/", timeout=15,
+                )
+            except Exception:
+                logger.debug("Failed to clean up remote RPC dir %s", rpc_dir)
 
     duration = round(time.monotonic() - exec_start, 2)
 

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -47,6 +47,8 @@ import uuid
 _IS_WINDOWS = platform.system() == "Windows"
 from typing import Any, Dict, List, Optional
 
+from tools.environments.docker import get_docker_rpc_dir
+
 # Availability gate: UDS requires a POSIX OS
 logger = logging.getLogger(__name__)
 
@@ -732,7 +734,10 @@ def _execute_remote(
     temp_dir = _env_temp_dir(env)
     sandbox_dir = f"{temp_dir}/hermes_exec_{sandbox_id}"
     quoted_sandbox_dir = shlex.quote(sandbox_dir)
-    quoted_rpc_dir = shlex.quote(f"{sandbox_dir}/rpc")
+    rpc_dir = f"{sandbox_dir}/rpc"
+    if env_type == "docker":
+        rpc_dir = get_docker_rpc_dir(effective_task_id)
+    quoted_rpc_dir = shlex.quote(rpc_dir)
 
     tool_call_log: list = []
     tool_call_counter = [0]
@@ -760,7 +765,9 @@ def _execute_remote(
 
         # Create sandbox directory on remote
         env.execute(
-            f"mkdir -p {quoted_rpc_dir}", cwd="/", timeout=10,
+            f"mkdir -p {quoted_sandbox_dir} && rm -rf {quoted_rpc_dir} && mkdir -p {quoted_rpc_dir}",
+            cwd="/",
+            timeout=10,
         )
 
         # Generate and ship files
@@ -774,7 +781,7 @@ def _execute_remote(
         rpc_thread = threading.Thread(
             target=_rpc_poll_loop,
             args=(
-                env, f"{sandbox_dir}/rpc", effective_task_id,
+                env, rpc_dir, effective_task_id,
                 tool_call_log, tool_call_counter, max_tool_calls,
                 sandbox_tools, stop_event,
             ),
@@ -784,7 +791,7 @@ def _execute_remote(
 
         # Build environment variable prefix for the script
         env_prefix = (
-            f"HERMES_RPC_DIR={shlex.quote(f'{sandbox_dir}/rpc')} "
+            f"HERMES_RPC_DIR={quoted_rpc_dir} "
             f"PYTHONDONTWRITEBYTECODE=1"
         )
         tz = os.getenv("HERMES_TIMEZONE", "").strip()
@@ -836,6 +843,13 @@ def _execute_remote(
             )
         except Exception:
             logger.debug("Failed to clean up remote sandbox %s", sandbox_dir)
+        if rpc_dir != f"{sandbox_dir}/rpc":
+            try:
+                env.execute(
+                    f"rm -rf {quoted_rpc_dir}", cwd="/", timeout=15,
+                )
+            except Exception:
+                logger.debug("Failed to clean up remote RPC dir %s", rpc_dir)
 
     duration = round(time.monotonic() - exec_start, 2)
 

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -11,6 +11,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 import uuid
 from typing import Optional
 
@@ -86,6 +87,13 @@ def _normalize_env_dict(env: dict | None) -> dict[str, str]:
         normalized[key] = value
 
     return normalized
+
+
+def get_docker_rpc_dir(task_id: str) -> str:
+    """Return the shared RPC directory path used for a Docker task."""
+    safe_task_id = re.sub(r"[^A-Za-z0-9_.-]+", "_", task_id or "default")
+    safe_task_id = safe_task_id.strip("._") or "default"
+    return os.path.join(tempfile.gettempdir(), "hermes_rpc", safe_task_id)
 
 
 def _load_hermes_env_vars() -> dict[str, str]:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -886,7 +886,10 @@ def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None
 from tools.environments.local import LocalEnvironment as _LocalEnvironment
 from tools.environments.singularity import SingularityEnvironment as _SingularityEnvironment
 from tools.environments.ssh import SSHEnvironment as _SSHEnvironment
-from tools.environments.docker import DockerEnvironment as _DockerEnvironment
+from tools.environments.docker import (
+    DockerEnvironment as _DockerEnvironment,
+    get_docker_rpc_dir as _get_docker_rpc_dir,
+)
 from tools.environments.modal import ModalEnvironment as _ModalEnvironment
 from tools.environments.managed_modal import ManagedModalEnvironment as _ManagedModalEnvironment
 from tools.managed_tool_gateway import is_managed_tool_gateway_ready
@@ -1139,6 +1142,13 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
         return _LocalEnvironment(cwd=cwd, timeout=timeout)
     
     elif env_type == "docker":
+        # Inject HERMES_RPC_DIR into docker_env so it is available to all
+        # exec calls (including the RPC polling thread started by execute_code).
+        # This solves the bug where hermes_tools.py could not read
+        # HERMES_RPC_DIR because it was only set inline for the python3
+        # script.py process and not the container's persistent environment.
+        docker_env_with_rpc = dict(docker_env)
+        docker_env_with_rpc.setdefault("HERMES_RPC_DIR", _get_docker_rpc_dir(task_id))
         return _DockerEnvironment(
             image=image, cwd=cwd, timeout=timeout,
             cpu=cpu, memory=memory, disk=disk,
@@ -1147,7 +1157,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
             host_cwd=host_cwd,
             auto_mount_cwd=cc.get("docker_mount_cwd_to_workspace", False),
             forward_env=docker_forward_env,
-            env=docker_env,
+            env=docker_env_with_rpc,
             run_as_host_user=cc.get("docker_run_as_host_user", False),
             extra_args=docker_extra_args,
         )

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -667,7 +667,10 @@ def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None
 from tools.environments.local import LocalEnvironment as _LocalEnvironment
 from tools.environments.singularity import SingularityEnvironment as _SingularityEnvironment
 from tools.environments.ssh import SSHEnvironment as _SSHEnvironment
-from tools.environments.docker import DockerEnvironment as _DockerEnvironment
+from tools.environments.docker import (
+    DockerEnvironment as _DockerEnvironment,
+    get_docker_rpc_dir as _get_docker_rpc_dir,
+)
 from tools.environments.modal import ModalEnvironment as _ModalEnvironment
 from tools.environments.managed_modal import ManagedModalEnvironment as _ManagedModalEnvironment
 from tools.managed_tool_gateway import is_managed_tool_gateway_ready
@@ -883,6 +886,13 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
         return _LocalEnvironment(cwd=cwd, timeout=timeout)
     
     elif env_type == "docker":
+        # Inject HERMES_RPC_DIR into docker_env so it is available to all
+        # exec calls (including the RPC polling thread started by execute_code).
+        # This solves the bug where hermes_tools.py could not read
+        # HERMES_RPC_DIR because it was only set inline for the python3
+        # script.py process and not the container's persistent environment.
+        docker_env_with_rpc = dict(docker_env)
+        docker_env_with_rpc.setdefault("HERMES_RPC_DIR", _get_docker_rpc_dir(task_id))
         return _DockerEnvironment(
             image=image, cwd=cwd, timeout=timeout,
             cpu=cpu, memory=memory, disk=disk,
@@ -891,7 +901,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
             host_cwd=host_cwd,
             auto_mount_cwd=cc.get("docker_mount_cwd_to_workspace", False),
             forward_env=docker_forward_env,
-            env=docker_env,
+            env=docker_env_with_rpc,
         )
     
     elif env_type == "singularity":


### PR DESCRIPTION
## What does this PR do?

When `execute_code` runs inside a Docker sandbox, `hermes_tools.py` needs `HERMES_RPC_DIR` to communicate tool calls back to the host. Previously, `HERMES_RPC_DIR` was only set inline for the `python3 script.py` process, not in the container's persistent environment — so the RPC polling thread and any child processes couldn't read it, resulting in `tool_calls_made: 0`.

## Related Issue

Closes #13142

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

Three-file fix:

- **`tools/environments/docker.py`**: New `get_docker_rpc_dir(task_id)` function that returns a deterministic, task-scoped path under `$TMPDIR/hermes_rpc/<safe_task_id>`. Task ID is sanitized for filesystem safety.
- **`tools/code_execution_tool.py`**: For Docker environments, uses the task-scoped RPC dir (not nested under the sandbox dir). Creates it explicitly, passes it via env prefix, and cleans it up separately.
- **`tools/terminal_tool.py`**: Injects `HERMES_RPC_DIR` into `docker_env` via `setdefault` so all container exec calls see it. Respects explicit overrides already set in config.

## How to Test

1. Run:
   ```bash
   pytest tests/tools/test_docker_rpc_dir.py tests/tools/test_code_execution.py -v
   ```
2. 8 focused tests (70 total including existing): Docker env injection, existing var preservation, explicit override protection, empty config handling, task-specific dirs, local env unaffected, and end-to-end `_execute_remote` with task-scoped RPC dir.
3. Tested on: macOS 15 (Apple Silicon)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
pytest tests/tools/test_docker_rpc_dir.py tests/tools/test_code_execution.py -v
# 70 tests including 8 new focused tests, all pass
```
