### PR TITLE
fix(copilot): validate supported token prefixes

### DIFF
--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -61,7 +61,14 @@ def validate_copilot_token(token: str) -> tuple[bool, str]:
             "  → `gh auth login` with the default device code flow (produces gho_* tokens)"
         )
 
-    return True, "OK"
+    if any(token.startswith(prefix) for prefix in _SUPPORTED_PREFIXES):
+        return True, "OK"
+
+    supported = ", ".join(_SUPPORTED_PREFIXES)
+    return False, (
+        "Unsupported GitHub token format for the Copilot API. "
+        f"Supported token prefixes: {supported}."
+    )
 
 
 def resolve_copilot_token() -> tuple[str, str]:

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -364,14 +364,23 @@ class TestResolveApiKeyProviderCredentials:
         assert creds["source"] == "GLM_API_KEY"
 
     def test_resolve_copilot_with_github_token(self, monkeypatch):
-        monkeypatch.setenv("GITHUB_TOKEN", "gh-env-secret")
+        monkeypatch.setenv("GITHUB_TOKEN", "gho_env_secret")
         creds = resolve_api_key_provider_credentials("copilot")
         assert creds["provider"] == "copilot"
-        assert creds["api_key"] == "gh-env-secret"
+        assert creds["api_key"] == "gho_env_secret"
         assert creds["base_url"] == "https://api.githubcopilot.com"
         assert creds["source"] == "GITHUB_TOKEN"
 
     def test_resolve_copilot_with_gh_cli_fallback(self, monkeypatch):
+        monkeypatch.setattr("hermes_cli.copilot_auth._try_gh_cli_token", lambda: "gho_cli_secret")
+        creds = resolve_api_key_provider_credentials("copilot")
+        assert creds["provider"] == "copilot"
+        assert creds["api_key"] == "gho_cli_secret"
+        assert creds["base_url"] == "https://api.githubcopilot.com"
+        assert creds["source"] == "gh auth token"
+
+    def test_resolve_copilot_skips_invalid_env_token(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_TOKEN", "gh-env-secret")
         monkeypatch.setattr("hermes_cli.copilot_auth._try_gh_cli_token", lambda: "gho_cli_secret")
         creds = resolve_api_key_provider_credentials("copilot")
         assert creds["provider"] == "copilot"

--- a/tests/hermes_cli/test_copilot_auth.py
+++ b/tests/hermes_cli/test_copilot_auth.py
@@ -35,6 +35,12 @@ class TestTokenValidation:
         valid, msg = validate_copilot_token("")
         assert valid is False
 
+    def test_invalid_token_rejected(self):
+        from hermes_cli.copilot_auth import validate_copilot_token
+        valid, msg = validate_copilot_token("not_a_github_token")
+        assert valid is False
+        assert "Supported token prefixes" in msg
+
 
 
 class TestResolveToken:
@@ -83,6 +89,16 @@ class TestResolveToken:
         monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
         monkeypatch.delenv("GH_TOKEN", raising=False)
         monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        with patch("hermes_cli.copilot_auth._try_gh_cli_token", return_value="gho_from_cli"):
+            token, source = resolve_copilot_token()
+        assert token == "gho_from_cli"
+        assert source == "gh auth token"
+
+    def test_invalid_env_token_falls_back_to_gh_cli(self, monkeypatch):
+        from hermes_cli.copilot_auth import resolve_copilot_token
+        monkeypatch.delenv("COPILOT_GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        monkeypatch.setenv("GITHUB_TOKEN", "not_a_github_token")
         with patch("hermes_cli.copilot_auth._try_gh_cli_token", return_value="gho_from_cli"):
             token, source = resolve_copilot_token()
         assert token == "gho_from_cli"


### PR DESCRIPTION
## Summary
- restrict Copilot token validation to the supported GitHub token families already documented in the module
- reject arbitrary non-empty env token values instead of treating them as usable Copilot credentials
- add regression coverage for invalid env tokens falling back to `gh auth token`

Fixes #12650

## Root Cause
`validate_copilot_token()` only rejected classic `ghp_*` PATs and accepted any other non-empty string. That let garbage values from `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN` block resolution from continuing to a valid `gh auth token` fallback, even though the module already declares the supported token prefixes.

## Validation
- `PYTHONPATH=/Users/zzl/.hermes/hermes-agent-pr-12650 /Users/zzl/.hermes/hermes-agent-update-20260421/venv/bin/python -m pytest -o addopts= tests/hermes_cli/test_copilot_auth.py -q`
- `PYTHONPATH=/Users/zzl/.hermes/hermes-agent-pr-12650 /Users/zzl/.hermes/hermes-agent-update-20260421/venv/bin/python -m pytest -o addopts= tests/hermes_cli/test_api_key_providers.py -k copilot -q`
- `PYTHONPATH=/Users/zzl/.hermes/hermes-agent-pr-12650 /Users/zzl/.hermes/hermes-agent-update-20260421/venv/bin/python -m py_compile hermes_cli/copilot_auth.py tests/hermes_cli/test_copilot_auth.py tests/hermes_cli/test_api_key_providers.py`
- `git diff --check`
