### PR TITLE
fix(agent): prefer /props over /v1/props for llama.cpp server detection

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -501,11 +501,11 @@ def detect_local_server_type(base_url: str, api_key: str = "") -> Optional[str]:
                         pass
             except Exception:
                 pass
-            # llama.cpp exposes /v1/props (older builds used /props without the /v1 prefix)
+            # llama.cpp exposes /props at server root (older builds used /v1/props)
             try:
-                r = client.get(f"{server_url}/v1/props")
+                r = client.get(f"{server_url}/props")
                 if r.status_code != 200:
-                    r = client.get(f"{server_url}/props")  # fallback for older builds
+                    r = client.get(f"{server_url}/v1/props")  # fallback for older builds
                 if r.status_code == 200 and "default_generation_settings" in r.text:
                     return "llamacpp"
             except Exception:
@@ -760,12 +760,12 @@ def fetch_endpoint_model_metadata(
             )
             if is_llamacpp:
                 try:
-                    # Try /v1/props first (current llama.cpp); fall back to /props for older builds
+                    # Try /props first (llama.cpp native); fall back to /v1/props for older builds (#13091)
                     base = candidate.rstrip("/").replace("/v1", "")
                     _verify = _resolve_requests_verify()
-                    props_resp = requests.get(base + "/v1/props", headers=headers, timeout=5, verify=_verify)
+                    props_resp = requests.get(base + "/props", headers=headers, timeout=5, verify=_verify)
                     if not props_resp.ok:
-                        props_resp = requests.get(base + "/props", headers=headers, timeout=5, verify=_verify)
+                        props_resp = requests.get(base + "/v1/props", headers=headers, timeout=5, verify=_verify)
                     if props_resp.ok:
                         props = props_resp.json()
                         gen_settings = props.get("default_generation_settings", {})

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -356,11 +356,11 @@ def detect_local_server_type(base_url: str, api_key: str = "") -> Optional[str]:
                         pass
             except Exception:
                 pass
-            # llama.cpp exposes /v1/props (older builds used /props without the /v1 prefix)
+            # llama.cpp exposes /props at server root (older builds used /v1/props)
             try:
-                r = client.get(f"{server_url}/v1/props")
+                r = client.get(f"{server_url}/props")
                 if r.status_code != 200:
-                    r = client.get(f"{server_url}/props")  # fallback for older builds
+                    r = client.get(f"{server_url}/v1/props")  # fallback for older builds
                 if r.status_code == 200 and "default_generation_settings" in r.text:
                     return "llamacpp"
             except Exception:
@@ -606,11 +606,11 @@ def fetch_endpoint_model_metadata(
             )
             if is_llamacpp:
                 try:
-                    # Try /v1/props first (current llama.cpp); fall back to /props for older builds
+                    # Try /props first (llama.cpp native); fall back to /v1/props for older builds
                     base = candidate.rstrip("/").replace("/v1", "")
-                    props_resp = requests.get(base + "/v1/props", headers=headers, timeout=5)
+                    props_resp = requests.get(base + "/props", headers=headers, timeout=5)
                     if not props_resp.ok:
-                        props_resp = requests.get(base + "/props", headers=headers, timeout=5)
+                        props_resp = requests.get(base + "/v1/props", headers=headers, timeout=5)
                     if props_resp.ok:
                         props = props_resp.json()
                         gen_settings = props.get("default_generation_settings", {})

--- a/tests/agent/test_llamacpp_props_order.py
+++ b/tests/agent/test_llamacpp_props_order.py
@@ -1,0 +1,145 @@
+"""Tests for llama.cpp /props endpoint probe order (bug #13091).
+
+Verifies that detect_local_server_type() and fetch_endpoint_model_metadata()
+try /props BEFORE /v1/props when detecting/fetching from llama.cpp servers,
+since llama.cpp exposes /props at server root (not under /v1/).
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+def _make_fail_response():
+    """Return a mock response that indicates the endpoint is not this server type."""
+    resp = MagicMock()
+    resp.status_code = 404
+    return resp
+
+
+class TestLlamaCppPropsProbeOrder:
+    """Test that /props is tried before /v1/props for llama.cpp detection."""
+
+    def test_props_tried_before_v1_props(self):
+        """When /props returns 200, /v1/props should NOT be called."""
+        with patch("httpx.Client") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client_class.return_value.__enter__.return_value = mock_client
+
+            # Sequence of responses for each probe:
+            # 1. LM Studio /api/v1/models -> 404
+            # 2. Ollama /api/tags -> 404
+            # 3. llama.cpp /props -> 200 OK
+            # 4. llama.cpp /v1/props -> should NOT be called
+            mock_client.get.side_effect = [
+                _make_fail_response(),  # LM Studio
+                _make_fail_response(),  # Ollama
+                MagicMock(status_code=200, text='{"default_generation_settings": {"n_ctx": 4096}}'),  # /props
+            ]
+
+            from agent.model_metadata import detect_local_server_type
+            result = detect_local_server_type("http://localhost:8080")
+
+            assert result == "llamacpp"
+            # Verify /props was tried first (after LM Studio and Ollama probes)
+            props_call = mock_client.get.call_args_list[2]
+            assert "/props" in props_call[0][0]
+            assert "/v1/props" not in props_call[0][0]
+            # Verify only 3 calls (no /v1/props fallback needed)
+            assert mock_client.get.call_count == 3
+
+    def test_fallback_to_v1_props_when_props_404(self):
+        """When /props returns 404, /v1/props should be tried as fallback."""
+        with patch("httpx.Client") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client_class.return_value.__enter__.return_value = mock_client
+
+            # Sequence of responses:
+            # 1. LM Studio /api/v1/models -> 404
+            # 2. Ollama /api/tags -> 404
+            # 3. llama.cpp /props -> 404
+            # 4. llama.cpp /v1/props -> 200 OK
+            mock_client.get.side_effect = [
+                _make_fail_response(),  # LM Studio
+                _make_fail_response(),  # Ollama
+                MagicMock(status_code=404),  # /props
+                MagicMock(status_code=200, text='{"default_generation_settings": {"n_ctx": 4096}}'),  # /v1/props
+            ]
+
+            from agent.model_metadata import detect_local_server_type
+            result = detect_local_server_type("http://localhost:8080")
+
+            assert result == "llamacpp"
+            # Verify /props was tried first
+            props_call = mock_client.get.call_args_list[2]
+            assert "/props" in props_call[0][0]
+            # Verify /v1/props was called as fallback
+            v1_props_call = mock_client.get.call_args_list[3]
+            assert "/v1/props" in v1_props_call[0][0]
+            assert mock_client.get.call_count == 4
+
+    def test_no_detection_when_both_fail(self):
+        """When both /props and /v1/props fail, should not return llamacpp."""
+        with patch("httpx.Client") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client_class.return_value.__enter__.return_value = mock_client
+
+            mock_client.get.side_effect = [
+                _make_fail_response(),  # LM Studio
+                _make_fail_response(),  # Ollama
+                MagicMock(status_code=404),  # /props
+                MagicMock(status_code=404),  # /v1/props
+                _make_fail_response(),  # vLLM
+            ]
+
+            from agent.model_metadata import detect_local_server_type
+            result = detect_local_server_type("http://localhost:8080")
+
+            assert result is None
+
+    def test_props_must_have_correct_content(self):
+        """Response must contain 'default_generation_settings' to be recognized."""
+        with patch("httpx.Client") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client_class.return_value.__enter__.return_value = mock_client
+
+            # /props returns 200 but wrong content
+            wrong_response = MagicMock()
+            wrong_response.status_code = 200
+            wrong_response.text = '{"error": "something else"}'
+
+            mock_client.get.side_effect = [
+                _make_fail_response(),  # LM Studio
+                _make_fail_response(),  # Ollama
+                wrong_response,  # /props
+                wrong_response,  # /v1/props
+            ]
+
+            from agent.model_metadata import detect_local_server_type
+            result = detect_local_server_type("http://localhost:8080")
+
+            # Should not detect as llamacpp since content is wrong
+            assert result is None
+
+    def test_v1_normalized_to_root_for_props_probe(self):
+        """When base_url ends with /v1, the /v1 suffix should be stripped before probing."""
+        with patch("httpx.Client") as mock_client_class:
+            mock_client = MagicMock()
+            mock_client_class.return_value.__enter__.return_value = mock_client
+
+            mock_client.get.side_effect = [
+                _make_fail_response(),  # LM Studio (at /v1/api/v1/models... wait)
+                _make_fail_response(),  # Ollama
+                MagicMock(status_code=200, text='{"default_generation_settings": {"n_ctx": 4096}}'),  # /props at root
+            ]
+
+            from agent.model_metadata import detect_local_server_type
+            # URL has /v1 suffix — should be stripped to / before probing
+            result = detect_local_server_type("http://localhost:8080/v1")
+
+            assert result == "llamacpp"
+            # Should probe /props at root, not /v1/props
+            props_call = mock_client.get.call_args_list[2]
+            called_url = props_call[0][0]
+            assert "/props" in called_url
+            # Should NOT have double /v1/v1/props
+            assert "/v1/v1" not in called_url


### PR DESCRIPTION
## What does this PR do?

llama.cpp exposes its properties endpoint at `/props` (server root), not `/v1/props`. The code had the probe order reversed — trying `/v1/props` first and falling back to `/props`. This caused detection failures or unnecessary latency when hitting current llama.cpp builds.

Swaps the probe order in both:
- `detect_local_server_type()` — server type detection
- `fetch_endpoint_model_metadata()` — model metadata fetching

Now tries `/props` first (native llama.cpp path), with `/v1/props` as fallback for older builds.

## Related Issue

Closes #13091

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `detect_local_server_type()`: swap probe order — try `/props` first, fall back to `/v1/props`
- `fetch_endpoint_model_metadata()`: same swap

## How to Test

1. Run the new tests:
   ```bash
   pytest tests/agent/test_llamacpp_props_order.py -v
   ```
2. 5 tests covering: correct probe order, fallback to `/v1/props` on 404, both-fail returns None, content validation (must contain `default_generation_settings`), and `/v1` URL suffix normalization.

Platform tested: macOS 15 (Apple Silicon).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Apple Silicon)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
pytest tests/agent/test_llamacpp_props_order.py -v
5 passed
```
