### PR TITLE
fix(agent): propagate custom provider context_length to compression feasibility check

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1621,7 +1621,11 @@ class AIAgent:
                                         file=sys.stderr,
                                     )
                     break
-        
+            # Propagate resolved custom_providers context_length to the instance
+            # attribute so downstream code (switch_model, compression feasibility
+            # check) sees the correct value, not the stale one from line 1581.
+            self._config_context_length = _config_context_length
+
         # Select context engine: config-driven (like memory providers).
         # 1. Check config.yaml context.engine setting
         # 2. Check plugins/context_engine/<name>/ directory (repo-shipped)
@@ -2162,11 +2166,24 @@ class AIAgent:
             aux_base_url = str(getattr(client, "base_url", ""))
             aux_api_key = str(getattr(client, "api_key", ""))
 
+            # Resolve config override for the auxiliary model.
+            # 1. Explicit auxiliary.compression.context_length from config
+            # 2. When the aux model matches the main model (same name & base_url),
+            #    fall back to the main model's resolved context_length (which
+            #    includes custom_providers overrides — see __init__ lines 1584-1622).
+            _aux_ctx_cfg = getattr(self, "_aux_compression_context_length_config", None)
+            if _aux_ctx_cfg is None:
+                _main_base = str(getattr(self, "base_url", "")).rstrip("/")
+                if (
+                    aux_base_url.rstrip("/") == _main_base
+                    and aux_model == self.model
+                ):
+                    _aux_ctx_cfg = getattr(self, "_config_context_length", None)
             aux_context = get_model_context_length(
                 aux_model,
                 base_url=aux_base_url,
                 api_key=aux_api_key,
-                config_context_length=getattr(self, "_aux_compression_context_length_config", None),
+                config_context_length=_aux_ctx_cfg,
             )
 
             # Hard floor: the auxiliary compression model must have at least
@@ -2187,7 +2204,24 @@ class AIAgent:
                     f"detected value if it is wrong."
                 )
 
-            threshold = self.context_compressor.threshold_tokens
+            # Re-derive the main model's compression threshold using the same
+            # logic as ContextCompressor.__init__ / update_model:
+            #   threshold = max(int(context_length * threshold_percent), 64K)
+            # This ensures the threshold reflects any custom_providers context_length
+            # that was loaded after self._config_context_length was first stored
+            # (switch_model reads stale self._config_context_length but the
+            # compressor was initialized with the correct derived value).
+            main_ctx = get_model_context_length(
+                self.model,
+                base_url=self.base_url,
+                api_key=self.api_key,
+                config_context_length=getattr(self, "_config_context_length", None),
+                provider=self.provider,
+            )
+            threshold = max(
+                int(main_ctx * self.context_compressor.threshold_percent),
+                MINIMUM_CONTEXT_LENGTH,
+            )
             if aux_context < threshold:
                 # Auto-correct: lower the live session threshold so
                 # compression actually works this session.  The hard floor

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -57,6 +57,7 @@ def _make_agent(
     compressor = MagicMock(spec=ContextCompressor)
     compressor.context_length = main_context
     compressor.threshold_tokens = int(main_context * threshold_percent)
+    compressor.threshold_percent = threshold_percent
     agent.context_compressor = compressor
 
     return agent
@@ -65,13 +66,16 @@ def _make_agent(
 # ── Core warning logic ──────────────────────────────────────────────
 
 
-@patch("agent.model_metadata.get_model_context_length", return_value=80_000)
+@patch("agent.model_metadata.get_model_context_length")
 @patch("agent.auxiliary_client.get_text_auxiliary_client")
 def test_auto_corrects_threshold_when_aux_context_below_threshold(mock_get_client, mock_ctx_len):
     """Auto-correction: aux >= 64K floor but < threshold → lower threshold
     to aux_context so compression still works this session."""
     agent = _make_agent(main_context=200_000, threshold_percent=0.50)
     # threshold = 100,000 — aux has 80,000 (above 64K floor, below threshold)
+    # First call = aux model context probe; second call = main model
+    # (re-deriving the threshold, see #12977).
+    mock_ctx_len.side_effect = [80_000, 200_000]
     mock_client = MagicMock()
     mock_client.base_url = "https://openrouter.ai/api/v1"
     mock_client.api_key = "sk-aux"
@@ -187,7 +191,9 @@ def test_feasibility_check_passes_config_context_length(mock_get_client, mock_ct
     agent._emit_status = lambda msg: None
     agent._check_compression_model_feasibility()
 
-    mock_ctx_len.assert_called_once_with(
+    # Since #12977 the main model context is also probed.  Only the
+    # auxiliary-model call shape is governed by this test.
+    mock_ctx_len.assert_any_call(
         "custom/big-model",
         base_url="http://custom-endpoint:8080/v1",
         api_key="sk-custom",
@@ -211,7 +217,7 @@ def test_feasibility_check_ignores_invalid_context_length(mock_get_client, mock_
     agent._emit_status = lambda msg: None
     agent._check_compression_model_feasibility()
 
-    mock_ctx_len.assert_called_once_with(
+    mock_ctx_len.assert_any_call(
         "custom/model",
         base_url="http://custom:8080/v1",
         api_key="sk-test",
@@ -222,14 +228,7 @@ def test_feasibility_check_ignores_invalid_context_length(mock_get_client, mock_
 
 
 def test_init_feasibility_check_uses_aux_context_override_from_config():
-    """Lazy feasibility check should cache and forward auxiliary.compression.context_length.
-
-    NB: feasibility check is deferred from AIAgent.__init__ to the first
-    actual compression attempt (saves ~400ms cold startup on short sessions
-    that never trigger compression). The test drives the check explicitly
-    via ``agent._check_compression_model_feasibility()`` to assert the
-    config-override threading.
-    """
+    """Real AIAgent init should cache and forward auxiliary.compression.context_length."""
 
     class _StubCompressor:
         def __init__(self, *args, **kwargs):
@@ -270,17 +269,14 @@ def test_init_feasibility_check_uses_aux_context_override_from_config():
             skip_context_files=True,
             skip_memory=True,
         )
-
-        # Config override is captured eagerly in __init__ (still needed
-        # because the threshold-derivation logic at construction time
-        # consults it).
-        assert agent._aux_compression_context_length_config == 1_000_000
-
-        # The expensive feasibility probe is deferred. Drive it manually
-        # to validate the call shape still forwards the override correctly.
+        agent._emit_status = lambda msg: None
         agent._check_compression_model_feasibility()
 
-    mock_ctx_len.assert_called_once_with(
+    assert agent._aux_compression_context_length_config == 1_000_000
+
+    # Since #12977 the main model context is also probed.  Only the
+    # auxiliary-model call shape is governed by this test.
+    mock_ctx_len.assert_any_call(
         "custom/big-model",
         base_url="http://custom-endpoint:8080/v1",
         api_key="sk-custom",
@@ -353,12 +349,14 @@ def test_exact_threshold_boundary_no_warning(mock_get_client, mock_ctx_len):
     assert len(messages) == 0
 
 
-@patch("agent.model_metadata.get_model_context_length", return_value=99_999)
+@patch("agent.model_metadata.get_model_context_length")
 @patch("agent.auxiliary_client.get_text_auxiliary_client")
 def test_just_below_threshold_auto_corrects(mock_get_client, mock_ctx_len):
     """Auto-correct fires when aux context is one token below the threshold
     (and above the 64K hard floor)."""
     agent = _make_agent(main_context=200_000, threshold_percent=0.50)
+    # First call = aux model context probe; second call = main model.
+    mock_ctx_len.side_effect = [99_999, 200_000]
     mock_client = MagicMock()
     mock_client.base_url = "https://openrouter.ai/api/v1"
     mock_client.api_key = "sk-aux"
@@ -378,11 +376,13 @@ def test_just_below_threshold_auto_corrects(mock_get_client, mock_ctx_len):
 # ── Two-phase: __init__ + run_conversation replay ───────────────────
 
 
-@patch("agent.model_metadata.get_model_context_length", return_value=80_000)
+@patch("agent.model_metadata.get_model_context_length")
 @patch("agent.auxiliary_client.get_text_auxiliary_client")
 def test_warning_stored_for_gateway_replay(mock_get_client, mock_ctx_len):
     """__init__ stores the warning; _replay sends it through status_callback."""
     agent = _make_agent(main_context=200_000, threshold_percent=0.50)
+    # First call = aux model context probe; second call = main model.
+    mock_ctx_len.side_effect = [80_000, 200_000]
     mock_client = MagicMock()
     mock_client.base_url = "https://openrouter.ai/api/v1"
     mock_client.api_key = "sk-aux"
@@ -439,12 +439,14 @@ def test_replay_without_callback_is_noop():
     agent._replay_compression_warning()
 
 
-@patch("agent.model_metadata.get_model_context_length", return_value=80_000)
+@patch("agent.model_metadata.get_model_context_length")
 @patch("agent.auxiliary_client.get_text_auxiliary_client")
 def test_run_conversation_clears_warning_after_replay(mock_get_client, mock_ctx_len):
     """After replay in run_conversation, _compression_warning is cleared
     so the warning is not sent again on subsequent turns."""
     agent = _make_agent(main_context=200_000, threshold_percent=0.50)
+    # First call = aux model context probe; second call = main model.
+    mock_ctx_len.side_effect = [80_000, 200_000]
     mock_client = MagicMock()
     mock_client.base_url = "https://openrouter.ai/api/v1"
     mock_client.api_key = "sk-aux"

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -45,6 +45,7 @@ def _make_agent(
     compressor = MagicMock(spec=ContextCompressor)
     compressor.context_length = main_context
     compressor.threshold_tokens = int(main_context * threshold_percent)
+    compressor.threshold_percent = threshold_percent
     agent.context_compressor = compressor
 
     return agent
@@ -53,7 +54,7 @@ def _make_agent(
 # ── Core warning logic ──────────────────────────────────────────────
 
 
-@patch("agent.model_metadata.get_model_context_length", return_value=80_000)
+@patch("agent.model_metadata.get_model_context_length")
 @patch("agent.auxiliary_client.get_text_auxiliary_client")
 def test_auto_corrects_threshold_when_aux_context_below_threshold(mock_get_client, mock_ctx_len):
     """Auto-correction: aux >= 64K floor but < threshold → lower threshold
@@ -64,6 +65,10 @@ def test_auto_corrects_threshold_when_aux_context_below_threshold(mock_get_clien
     mock_client.base_url = "https://openrouter.ai/api/v1"
     mock_client.api_key = "sk-aux"
     mock_get_client.return_value = (mock_client, "google/gemini-3-flash-preview")
+
+    # First call: aux model context_length; second call: main model context_length
+    # (threshold is re-derived from main model after aux is fetched)
+    mock_ctx_len.side_effect = [80_000, 200_000]
 
     messages = []
     agent._emit_status = lambda msg: messages.append(msg)
@@ -159,7 +164,7 @@ def test_feasibility_check_passes_live_main_runtime():
     )
 
 
-@patch("agent.model_metadata.get_model_context_length", return_value=1_000_000)
+@patch("agent.model_metadata.get_model_context_length")
 @patch("agent.auxiliary_client.get_text_auxiliary_client")
 def test_feasibility_check_passes_config_context_length(mock_get_client, mock_ctx_len):
     """auxiliary.compression.context_length from config is forwarded to
@@ -172,18 +177,19 @@ def test_feasibility_check_passes_config_context_length(mock_get_client, mock_ct
     mock_client.api_key = "sk-custom"
     mock_get_client.return_value = (mock_client, "custom/big-model")
 
+    # First call: aux model context_length; second call: main model context_length
+    mock_ctx_len.side_effect = [1_000_000, 200_000]
+
     agent._emit_status = lambda msg: None
     agent._check_compression_model_feasibility()
 
-    mock_ctx_len.assert_called_once_with(
-        "custom/big-model",
-        base_url="http://custom-endpoint:8080/v1",
-        api_key="sk-custom",
-        config_context_length=1_000_000,
-    )
+    # Verify the AUX model call (first) has the config_context_length override
+    aux_call = mock_ctx_len.call_args_list[0]
+    assert aux_call.kwargs["config_context_length"] == 1_000_000
+    assert aux_call.args[0] == "custom/big-model"
 
 
-@patch("agent.model_metadata.get_model_context_length", return_value=128_000)
+@patch("agent.model_metadata.get_model_context_length")
 @patch("agent.auxiliary_client.get_text_auxiliary_client")
 def test_feasibility_check_ignores_invalid_context_length(mock_get_client, mock_ctx_len):
     """Non-integer context_length in config is silently ignored."""
@@ -194,15 +200,16 @@ def test_feasibility_check_ignores_invalid_context_length(mock_get_client, mock_
     mock_client.api_key = "sk-test"
     mock_get_client.return_value = (mock_client, "custom/model")
 
+    # First call: aux model context_length; second call: main model context_length
+    mock_ctx_len.side_effect = [128_000, 200_000]
+
     agent._emit_status = lambda msg: None
     agent._check_compression_model_feasibility()
 
-    mock_ctx_len.assert_called_once_with(
-        "custom/model",
-        base_url="http://custom:8080/v1",
-        api_key="sk-test",
-        config_context_length=None,
-    )
+    # Verify the AUX model call (first) was made with config_context_length=None
+    aux_call = mock_ctx_len.call_args_list[0]
+    assert aux_call.kwargs["config_context_length"] is None
+    assert aux_call.args[0] == "custom/model"
 
 
 def test_init_feasibility_check_uses_aux_context_override_from_config():
@@ -238,8 +245,27 @@ def test_init_feasibility_check_uses_aux_context_override_from_config():
         patch("run_agent.OpenAI"),
         patch("run_agent.ContextCompressor", new=_StubCompressor),
         patch("agent.auxiliary_client.get_text_auxiliary_client", return_value=(mock_client, "custom/big-model")),
-        patch("agent.model_metadata.get_model_context_length", return_value=1_000_000) as mock_ctx_len,
+        patch("agent.model_metadata.get_model_context_length") as mock_ctx_len,
     ):
+        # AIAgent.__init__ calls get_model_context_length multiple times:
+        # 1. ContextCompressor.__init__ (main model) → returns 200_000
+        # 2. _check_compression_model_feasibility: aux call → returns 1_000_000
+        # 3. _check_compression_model_feasibility: main call → returns 200_000
+        # We use a lambda to handle any number of calls gracefully.
+        call_count = {"n": 0}
+        def _side_effect(*args, **kwargs):
+            call_count["n"] += 1
+            n = call_count["n"]
+            # First call: ContextCompressor init — main model, no override
+            if n == 1:
+                return ""
+            # Second call: aux model (in _check_compression_model_feasibility)
+            if n == 2:
+                return 1_000_000
+            # Third call: main model (re-derived threshold)
+            return 200_000
+
+        mock_ctx_len.side_effect = _side_effect
         agent = AIAgent(
             api_key="test-key-1234567890",
             base_url="https://openrouter.ai/api/v1",
@@ -249,12 +275,14 @@ def test_init_feasibility_check_uses_aux_context_override_from_config():
         )
 
     assert agent._aux_compression_context_length_config == 1_000_000
-    mock_ctx_len.assert_called_once_with(
-        "custom/big-model",
-        base_url="http://custom-endpoint:8080/v1",
-        api_key="sk-custom",
-        config_context_length=1_000_000,
-    )
+    # Find the aux model call — it should have config_context_length=1_000_000
+    # and first positional arg "custom/big-model"
+    aux_calls = [
+        c for c in mock_ctx_len.call_args_list
+        if c.args and c.args[0] == "custom/big-model"
+    ]
+    assert len(aux_calls) >= 1
+    assert aux_calls[0].kwargs["config_context_length"] == 1_000_000
 
 
 @patch("agent.auxiliary_client.get_text_auxiliary_client")
@@ -320,7 +348,7 @@ def test_exact_threshold_boundary_no_warning(mock_get_client, mock_ctx_len):
     assert len(messages) == 0
 
 
-@patch("agent.model_metadata.get_model_context_length", return_value=99_999)
+@patch("agent.model_metadata.get_model_context_length")
 @patch("agent.auxiliary_client.get_text_auxiliary_client")
 def test_just_below_threshold_auto_corrects(mock_get_client, mock_ctx_len):
     """Auto-correct fires when aux context is one token below the threshold
@@ -330,6 +358,9 @@ def test_just_below_threshold_auto_corrects(mock_get_client, mock_ctx_len):
     mock_client.base_url = "https://openrouter.ai/api/v1"
     mock_client.api_key = "sk-aux"
     mock_get_client.return_value = (mock_client, "small-model")
+
+    # First call: aux model context_length; second call: main model context_length
+    mock_ctx_len.side_effect = [99_999, 200_000]
 
     messages = []
     agent._emit_status = lambda msg: messages.append(msg)
@@ -345,7 +376,7 @@ def test_just_below_threshold_auto_corrects(mock_get_client, mock_ctx_len):
 # ── Two-phase: __init__ + run_conversation replay ───────────────────
 
 
-@patch("agent.model_metadata.get_model_context_length", return_value=80_000)
+@patch("agent.model_metadata.get_model_context_length")
 @patch("agent.auxiliary_client.get_text_auxiliary_client")
 def test_warning_stored_for_gateway_replay(mock_get_client, mock_ctx_len):
     """__init__ stores the warning; _replay sends it through status_callback."""
@@ -354,6 +385,9 @@ def test_warning_stored_for_gateway_replay(mock_get_client, mock_ctx_len):
     mock_client.base_url = "https://openrouter.ai/api/v1"
     mock_client.api_key = "sk-aux"
     mock_get_client.return_value = (mock_client, "google/gemini-3-flash-preview")
+
+    # First call: aux model context_length; second call: main model context_length
+    mock_ctx_len.side_effect = [80_000, 200_000]
 
     # Phase 1: __init__ — _emit_status prints (CLI) but callback is None
     vprint_messages = []
@@ -406,7 +440,7 @@ def test_replay_without_callback_is_noop():
     agent._replay_compression_warning()
 
 
-@patch("agent.model_metadata.get_model_context_length", return_value=80_000)
+@patch("agent.model_metadata.get_model_context_length")
 @patch("agent.auxiliary_client.get_text_auxiliary_client")
 def test_run_conversation_clears_warning_after_replay(mock_get_client, mock_ctx_len):
     """After replay in run_conversation, _compression_warning is cleared
@@ -416,6 +450,9 @@ def test_run_conversation_clears_warning_after_replay(mock_get_client, mock_ctx_
     mock_client.base_url = "https://openrouter.ai/api/v1"
     mock_client.api_key = "sk-aux"
     mock_get_client.return_value = (mock_client, "small-model")
+
+    # First call: aux model context_length; second call: main model context_length
+    mock_ctx_len.side_effect = [80_000, 200_000]
 
     agent._emit_status = lambda msg: None
     agent._check_compression_model_feasibility()
@@ -438,3 +475,176 @@ def test_run_conversation_clears_warning_after_replay(mock_get_client, mock_ctx_
         agent._compression_warning = None
 
     assert len(callback_events) == 0
+
+
+# ── Bug #12977: custom_providers context_length not propagated ──────
+#
+# The bug: when custom_providers provides a context_length for the main model,
+# _check_compression_model_feasibility did not propagate it to the aux model's
+# get_model_context_length call when the aux model is the same as the main model
+# (fallback scenario).  Additionally, self._config_context_length was never
+# updated with the custom_providers value, so the threshold re-derivation
+# (added in the fix) would also compute the wrong threshold.
+#
+# Three-part fix:
+#   1. Update self._config_context_length after custom_providers resolution
+#      (run_agent.py __init__ line ~1622)
+#   2. When aux model matches main model (same name + base_url), fall back to
+#      self._config_context_length for the aux get_model_context_length call
+#      (run_agent.py _check_compression_model_feasibility)
+#   3. Re-derive threshold from get_model_context_length instead of reading
+#      the potentially-stale threshold_tokens from the compressor
+
+
+@patch("agent.model_metadata.get_model_context_length")
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_aux_gets_custom_provider_context_when_aux_matches_main(
+    mock_get_client, mock_ctx_len,
+):
+    """When the aux compression model is the same as the main model and
+    custom_providers provides a context_length override, the feasibility check
+    must propagate that override to the aux model's context query.
+
+    Scenario (from issue #12977):
+      - custom_providers.models.glm-5.1.context_length: 200000
+      - No separate aux compression model → falls back to main model
+      - compression threshold: 0.65 → correct threshold = 130_000
+      - Built-in default for the model would be 128_000
+
+    Without fix: aux_context = 128_000 (config_context_length=None)
+                 threshold = 130_000 (correctly from compressor)
+                 128_000 < 130_000 → false warning + auto-lower
+
+    With fix:    aux_context = 200_000 (config_context_length propagated)
+                 threshold = 130_000 (re-derived correctly)
+                 200_000 >= 130_000 → no warning (correct)
+    """
+    # Compressor was correctly initialised with 200K from custom_providers
+    agent = _make_agent(main_context=200_000, threshold_percent=0.65)
+    agent._config_context_length = 200_000
+
+    # Aux model = main model (the fallback scenario from the issue)
+    mock_client = MagicMock()
+    mock_client.base_url = "https://openrouter.ai/api/v1"
+    mock_client.api_key = "sk-test"
+    mock_get_client.return_value = (mock_client, "test-main-model")
+
+    # Mock behaviour: return the override when config_context_length is given,
+    # otherwise return the built-in default (128K) — simulates what
+    # get_model_context_length does without the fix.
+    def _ctx_len(model, base_url="", api_key="", config_context_length=None, provider=""):
+        if config_context_length is not None:
+            return config_context_length
+        return 128_000  # built-in default (wrong for this custom_provider model)
+
+    mock_ctx_len.side_effect = _ctx_len
+
+    messages = []
+    agent._emit_status = lambda msg: messages.append(msg)
+
+    agent._check_compression_model_feasibility()
+
+    assert len(messages) == 0, (
+        f"Expected no warning with custom_providers context_length=200K and "
+        f"threshold=130K, but got: {messages}"
+    )
+    assert agent._compression_warning is None
+
+
+@patch("agent.model_metadata.get_model_context_length")
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_different_aux_model_does_not_get_main_config_override(
+    mock_get_client, mock_ctx_len,
+):
+    """When the aux compression model is DIFFERENT from the main model,
+    the main model's config_context_length must NOT be applied to the aux
+    call.  Only when aux_model == self.model AND base_urls match should
+    the fallback activate.
+    """
+    agent = _make_agent(main_context=200_000, threshold_percent=0.50)
+    agent._config_context_length = 1_000_000  # main model's custom override
+
+    # Aux model is DIFFERENT from main model
+    mock_client = MagicMock()
+    mock_client.base_url = "https://openrouter.ai/api/v1"
+    mock_client.api_key = "sk-aux"
+    mock_get_client.return_value = (mock_client, "different-aux-model")
+
+    # The mock should be called with config_context_length=None for the aux
+    # call (since the models differ) and config_context_length=1_000_000 for
+    # the main model call.
+    call_log = []
+
+    def _ctx_len(model, base_url="", api_key="", config_context_length=None, provider=""):
+        call_log.append({"model": model, "config_context_length": config_context_length})
+        if config_context_length is not None:
+            return config_context_length
+        return 200_000  # aux model's own real context
+
+    mock_ctx_len.side_effect = _ctx_len
+
+    messages = []
+    agent._emit_status = lambda msg: messages.append(msg)
+
+    agent._check_compression_model_feasibility()
+
+    # First call: aux model — should NOT get the main model's override
+    aux_call = call_log[0]
+    assert aux_call["model"] == "different-aux-model"
+    assert aux_call["config_context_length"] is None, (
+        "Aux model should NOT receive main model's config_context_length "
+        "when models differ"
+    )
+
+    # Second call: main model — should get the override for threshold derivation
+    main_call = call_log[1]
+    assert main_call["config_context_length"] == 1_000_000, (
+        "Main model threshold derivation should use config_context_length"
+    )
+
+
+@patch("agent.model_metadata.get_model_context_length")
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_false_positive_warning_eliminated_by_custom_provider_propagation(
+    mock_get_client, mock_ctx_len,
+):
+    """Regression test for the exact false-positive scenario from issue #12977.
+
+    User configured custom_providers with context_length: 200000, compression
+    threshold 0.65.  The old code queried the aux model (which IS the main
+    model) with config_context_length=None, getting 128_000 back.  The
+    compressor's threshold_tokens was correctly 130_000 (200K * 0.65), so
+    128_000 < 130_000 triggered a false warning and unnecessary auto-lowering.
+
+    The fix propagates the custom_providers context_length to the aux call
+    when the aux model matches the main model, so aux_context = 200_000.
+    """
+    agent = _make_agent(main_context=200_000, threshold_percent=0.65)
+    agent._config_context_length = 200_000
+
+    mock_client = MagicMock()
+    mock_client.base_url = "https://openrouter.ai/api/v1"
+    mock_client.api_key = "sk-test"
+    mock_get_client.return_value = (mock_client, "test-main-model")
+
+    def _ctx_len(model, base_url="", api_key="", config_context_length=None, provider=""):
+        if config_context_length is not None:
+            return config_context_length
+        return 128_000  # built-in default — the WRONG value
+
+    mock_ctx_len.side_effect = _ctx_len
+
+    messages = []
+    agent._emit_status = lambda msg: messages.append(msg)
+
+    agent._check_compression_model_feasibility()
+
+    # The compressor's threshold_tokens was NOT auto-lowered
+    assert agent.context_compressor.threshold_tokens == 130_000, (
+        f"threshold_tokens should remain 130K (200K*0.65), "
+        f"got {agent.context_compressor.threshold_tokens}"
+    )
+    assert agent._compression_warning is None, (
+        f"Should not warn: aux has 200K >= threshold 130K, "
+        f"but got: {agent._compression_warning}"
+    )


### PR DESCRIPTION
## What does this PR do?

When `custom_providers` sets a `context_length` for the main model (e.g. 200K), the compression feasibility check didn't propagate this to the auxiliary model's `get_model_context_length()` call when the aux model falls back to the main model. This caused a false-positive "compression model too small" warning and unnecessary threshold auto-lowering.

Example from the issue: `custom_providers` sets `context_length=200000`, `threshold=0.65` (130K). Without the fix, the aux query returns the built-in default 128K, which is below 130K — triggering a spurious warning.

Three-part fix in `run_agent.py`:

1. **Persist `_config_context_length`** after `custom_providers` resolution in `__init__` (was only set before the providers loop).
2. **Propagate to aux model query** when `aux_model == self.model` and base URLs match (the fallback scenario).
3. **Re-derive threshold** from `get_model_context_length()` with the correct config override, instead of reading the potentially-stale `threshold_tokens` from the compressor.

## Related Issue

Closes #12977

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `run_agent.py`:
  - Persist `_config_context_length` after `custom_providers` resolution in `__init__`.
  - Propagate `_config_context_length` to the aux-model `get_model_context_length()` call when aux model falls back to the main model and base URLs match.
  - Re-derive threshold from `get_model_context_length()` instead of reading possibly-stale `threshold_tokens` from the compressor.
- `tests/run_agent/test_compression_feasibility.py`:
  - 3 new regression tests covering: custom provider propagation when aux matches main, different aux model does NOT get main's override, and end-to-end false-positive elimination.

## How to Test

1. Run the regression suite:
   ```bash
   pytest tests/run_agent/test_compression_feasibility.py -v
   ```
   19 tests including the 3 new regressions for the exact false-positive scenario from the issue.

Platform tested: macOS 15 (Apple Silicon).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
$ pytest tests/run_agent/test_compression_feasibility.py -v
19 passed (3 new regressions)
```
