### PR TITLE
fix(gateway): source ~/.hermes/.env in generated systemd units

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1229,6 +1229,7 @@ Environment="LOGNAME={username}"
 Environment="PATH={sane_path}"
 Environment="VIRTUAL_ENV={venv_dir}"
 Environment="HERMES_HOME={hermes_home}"
+EnvironmentFile=-{hermes_home}/.env
 Restart=on-failure
 RestartSec=30
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
@@ -1261,6 +1262,7 @@ WorkingDirectory={working_dir}
 Environment="PATH={sane_path}"
 Environment="VIRTUAL_ENV={venv_dir}"
 Environment="HERMES_HOME={hermes_home}"
+EnvironmentFile=-{hermes_home}/.env
 Restart=on-failure
 RestartSec=30
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -110,6 +110,42 @@ class TestGeneratedSystemdUnits:
         assert "TimeoutStopSec=60" in unit
         assert "WantedBy=multi-user.target" in unit
 
+    def test_user_unit_loads_hermes_env_file(self):
+        """The user-level unit must source ~/.hermes/.env so API keys in
+        that file (e.g. OPENROUTER_API_KEY, TELEGRAM_BOT_TOKEN) are visible
+        to the gateway process. The leading `-` makes it optional so the
+        unit still starts on fresh installs where .env does not yet exist.
+        """
+        unit = gateway_cli.generate_systemd_unit(system=False)
+
+        assert "EnvironmentFile=-" in unit
+        # The envfile path must be anchored at HERMES_HOME, not a bare `.env`
+        # (which systemd would resolve relative to WorkingDirectory instead).
+        for line in unit.splitlines():
+            if line.startswith("EnvironmentFile="):
+                assert line.endswith("/.env"), f"unexpected EnvironmentFile: {line!r}"
+                assert "=-" in line, f"EnvironmentFile must be optional (leading -): {line!r}"
+                break
+        else:
+            raise AssertionError("user unit is missing EnvironmentFile directive")
+
+    def test_system_unit_loads_hermes_env_file(self):
+        """The system-level unit must source the target user's ~/.hermes/.env
+        so running `sudo hermes gateway install --system` produces a service
+        that can see API keys without a separate /etc/default/hermes-gateway
+        drop-in.
+        """
+        unit = gateway_cli.generate_systemd_unit(system=True)
+
+        assert "EnvironmentFile=-" in unit
+        for line in unit.splitlines():
+            if line.startswith("EnvironmentFile="):
+                assert line.endswith("/.env"), f"unexpected EnvironmentFile: {line!r}"
+                assert "=-" in line, f"EnvironmentFile must be optional (leading -): {line!r}"
+                break
+        else:
+            raise AssertionError("system unit is missing EnvironmentFile directive")
+
 
 class TestGatewayStopCleanup:
     def test_stop_only_kills_current_profile_by_default(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Problem

When `hermes gateway install` (or `restart`) regenerates the systemd unit at `~/.config/systemd/user/hermes-gateway.service` (or `/etc/systemd/system/...`), the template sets `Environment="HERMES_HOME=..."` but never tells systemd to read the `.env` sitting next to it. Hermes' in-process dotenv loader resolves relative to `WorkingDirectory` (`~/.hermes/hermes-agent/`), which on released installs is usually empty or only has `.env.example`. The real `~/.hermes/.env` therefore never reaches the gateway process.

The symptom users hit:

- Interactive shell: `hermes status` → `OpenRouter ✓ sk-o...` (because the shell loaded the .env first).
- Telegram/Discord bot: `No auxiliary LLM provider configured — set OPENROUTER_API_KEY`.
- `journalctl --user -u hermes-gateway` spams `WARNING agent.auxiliary_client: resolve_provider_client: openrouter requested but OPENROUTER_API_KEY not set`.

Reproduced on a fresh Ubuntu 24.04 box running Hermes as a `systemctl --user` service after migrating away from a root-owned install. The workaround (manually adding `EnvironmentFile=-~/.hermes/.env` to the unit) gets overwritten every time `hermes gateway restart` regenerates the unit from the template.

## Fix

Add `EnvironmentFile=-{hermes_home}/.env` to both the user and system unit templates in `generate_systemd_unit()`.

- Leading `-` → optional: fresh installs without `.env` still start cleanly.
- Absolute path at `HERMES_HOME` → avoids systemd resolving `.env` relative to `WorkingDirectory` (which points at the vendored hermes-agent checkout, not at `HERMES_HOME`).

## Tests

Two new assertions in `TestGeneratedSystemdUnits` covering both user and system templates. All `test_gateway_service.py` (98 tests) and `test_gateway_linger.py` (6 tests) pass.

## Scope

Only touches the two unit template string literals and adds tests. No behavioural change for users who already override the unit via a drop-in; for everyone else, API keys stored in `~/.hermes/.env` now reach the gateway process automatically.
