### PR TITLE
fix(gateway): prevent duplicate final send when only cosmetic edit failed

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10536,6 +10536,7 @@ class GatewayRunner:
                     _already_streamed = bool(
                         (_sc and getattr(_sc, "final_response_sent", False))
                         or _previewed
+                        or (_sc and getattr(_sc, "final_content_delivered", False))
                     )
                     first_response = result.get("final_response", "")
                     if first_response and not _already_streamed:
@@ -10679,12 +10680,15 @@ class GatewayRunner:
             # response_previewed means the interim_assistant_callback already
             # sent the final text via the adapter (non-streaming path).
             _previewed = bool(response.get("response_previewed"))
-            if not _is_empty_sentinel and (_streamed or _previewed):
+            _content_delivered = bool(
+                _sc and getattr(_sc, "final_content_delivered", False)
+            )
+            if not _is_empty_sentinel and (_streamed or _previewed or _content_delivered):
                 logger.info(
-                    "Suppressing normal final send for session %s: final delivery already confirmed (streamed=%s previewed=%s).",
+                    "Suppressing normal final send for session %s: "
+                    "final delivery already confirmed (streamed=%s previewed=%s content_delivered=%s).",
                     session_key[:20] if session_key else "?",
-                    _streamed,
-                    _previewed,
+                    _streamed, _previewed, _content_delivered,
                 )
                 response["already_sent"] = True
         

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -100,6 +100,10 @@ class GatewayStreamConsumer:
         self._flood_strikes = 0         # Consecutive flood-control edit failures
         self._current_edit_interval = self.cfg.edit_interval  # Adaptive backoff
         self._final_response_sent = False
+        # Set when the final response content was sent to the user via
+        # streaming, even if the final edit (cursor removal etc.)
+        # subsequently failed.
+        self._final_content_delivered = False
         # Cache adapter lifecycle capability: only platforms that need an
         # explicit finalize call (e.g. DingTalk AI Cards) force us to make
         # a redundant final edit.  Everyone else keeps the fast path.
@@ -122,6 +126,12 @@ class GatewayStreamConsumer:
     def final_response_sent(self) -> bool:
         """True when the stream consumer delivered the final assistant reply."""
         return self._final_response_sent
+
+    @property
+    def final_content_delivered(self) -> bool:
+        """True when the final response content reached the user, even if
+        the subsequent cosmetic edit (cursor removal) failed."""
+        return self._final_content_delivered
 
     def on_segment_break(self) -> None:
         """Finalize the current stream segment and start a fresh message."""
@@ -335,6 +345,8 @@ class GatewayStreamConsumer:
                         self._last_edit_time = time.monotonic()
                         if got_done:
                             self._final_response_sent = self._already_sent
+                            if self._already_sent:
+                                self._final_content_delivered = True
                             return
                         if got_segment_break:
                             self._message_id = None
@@ -382,6 +394,11 @@ class GatewayStreamConsumer:
                     self._last_edit_time = time.monotonic()
 
                 if got_done:
+                    # Record that the final content reached the user even
+                    # if the cosmetic final edit below fails.
+                    if current_update_visible and self._accumulated:
+                        self._final_content_delivered = True
+
                     # Final edit without cursor. If progressive editing failed
                     # mid-stream, send a single continuation/fallback message
                     # here instead of letting the base gateway path send the

--- a/tests/gateway/test_duplicate_reply_suppression.py
+++ b/tests/gateway/test_duplicate_reply_suppression.py
@@ -458,3 +458,59 @@ class TestCancellationHandlerDeliveryConfirmation:
             final_response_sent = True
 
         assert final_response_sent is True  # the bug: partial promoted to final
+
+
+class TestFinalContentDeliveredSuppression:
+    """When stream consumer delivered the final content but the cosmetic
+    final edit (cursor removal) failed, the gateway must suppress the
+    fallback send to prevent duplicate messages.
+
+    Covers the scenario not handled by final_response_sent alone:
+    content reached the user via _send_or_edit, but the subsequent edit
+    that clears a typing cursor or streaming marker failed, leaving
+    final_response_sent=False even though the user already saw the text.
+    """
+
+    def test_content_delivered_but_final_edit_failed_suppresses(self):
+        """final_content_delivered=True + final_response_sent=False
+        must suppress (content already visible to user)."""
+        sc = SimpleNamespace(
+            already_sent=True,
+            final_response_sent=False,
+            final_content_delivered=True,
+        )
+        response = {"final_response": "Hello!", "response_previewed": False}
+
+        _streamed = bool(getattr(sc, "final_response_sent", False))
+        _previewed = bool(response.get("response_previewed"))
+        _content_delivered = bool(getattr(sc, "final_content_delivered", False))
+        _is_empty_sentinel = (
+            not response.get("final_response")
+            or response.get("final_response") == "(empty)"
+        )
+        if not _is_empty_sentinel and (_streamed or _previewed or _content_delivered):
+            response["already_sent"] = True
+
+        assert response.get("already_sent") is True
+
+    def test_intermediate_text_only_does_not_suppress(self):
+        """already_sent=True from intermediate text + final_content_delivered=False
+        must NOT suppress (user still needs the real final answer)."""
+        sc = SimpleNamespace(
+            already_sent=True,
+            final_response_sent=False,
+            final_content_delivered=False,
+        )
+        response = {"final_response": "Real answer", "response_previewed": False}
+
+        _streamed = bool(getattr(sc, "final_response_sent", False))
+        _previewed = bool(response.get("response_previewed"))
+        _content_delivered = bool(getattr(sc, "final_content_delivered", False))
+        _is_empty_sentinel = (
+            not response.get("final_response")
+            or response.get("final_response") == "(empty)"
+        )
+        if not _is_empty_sentinel and (_streamed or _previewed or _content_delivered):
+            response["already_sent"] = True
+
+        assert "already_sent" not in response


### PR DESCRIPTION
# fix(gateway): prevent duplicate final send when only cosmetic edit failed

## What does this PR do?

In the Telegram delivery path, when `GatewayStreamConsumer.got_done` successfully delivers the final response content via `_send_or_edit`, but the **subsequent cosmetic edit** (clearing the typing cursor / streaming marker) fails, `final_response_sent` remains `False` even though the user has already received the final answer on their chat.

The gateway's `_run_agent` then takes the fallback path and re-delivers the same content as a fresh message. The user sees the response twice.

This PR introduces a new flag `_final_content_delivered` on `GatewayStreamConsumer`, set by `got_done` as soon as the final content has reached the user (before the cosmetic edit is attempted). The suppression logic in `_run_agent` now treats this flag as an additional signal — alongside `final_response_sent` and `response_previewed` — that final delivery is already complete.

## Why not just use `already_sent`?

`already_sent` is set by **every** successful chunk send, including intermediate text such as `"Let me search for that..."` emitted alongside a tool call. Using it for suppression would re-introduce the bug that `tests/gateway/test_duplicate_reply_suppression.py::test_partial_stream_output_does_not_set_already_sent` explicitly guards against:

> previously this promoted any partial send (already_sent=True) to final_response_sent — which suppressed the gateway's fallback send even when only intermediate text (e.g. 'Let me search...') had been delivered, not the real answer.

The new `_final_content_delivered` flag is set **only in `got_done`**, so it fires only when the final response content reached the user — never when only intermediate text was delivered. This preserves the upstream's intentional design while closing the duplicate-send gap for the specific case where the cosmetic final edit fails after the content has already been displayed.

## Changes Made

### `gateway/stream_consumer.py`
- New instance variable `_final_content_delivered` (initialized `False` alongside `_final_response_sent`).
- Public `@property final_content_delivered` for read access.
- Set to `True` in two `got_done` paths:
  - Chunked message path: after a split-and-send completes and `_already_sent` is true.
  - Main path: when `current_update_visible` is true and there is accumulated text, recorded **before** the cosmetic final edit is attempted — so a failure of that edit does not undo the fact that the content reached the user.

### `gateway/run.py`
- `_already_streamed` check (post-execution): now also OR-ed with `final_content_delivered`.
- `_run_agent` final suppression: new `_content_delivered` local, combined into the existing `not empty_sentinel and (streamed or previewed or content_delivered)` predicate. Log line extended to include the new signal for diagnosability.

### `tests/gateway/test_duplicate_reply_suppression.py`
- New `TestFinalContentDeliveredSuppression` class with two cases:
  - `test_content_delivered_but_final_edit_failed_suppresses`: the new branch — `final_content_delivered=True` with `final_response_sent=False` must suppress.
  - `test_intermediate_text_only_does_not_suppress`: the existing contract — `already_sent=True` with `final_content_delivered=False` must **not** suppress.

## How to Test

### Reproduction scenario (conceptual)

1. Start a Telegram conversation that triggers a streaming response.
2. Let the stream reach `got_done` and successfully send the final content via `_send_or_edit`.
3. Induce a failure on the subsequent cosmetic edit (e.g. the "remove typing cursor" edit) — transient network failure, Telegram rate-limit, stale message id, etc.
4. Before this PR: `final_response_sent` stays `False`; `_run_agent` falls back to `response["already_sent"]` being unset and re-sends the full response. The user sees the answer twice.
5. After this PR: `_final_content_delivered=True` was set before the failed edit; `_run_agent` suppresses the fallback send. The user sees the answer once.

### Automated tests

```bash
pytest tests/gateway/test_duplicate_reply_suppression.py::TestFinalContentDeliveredSuppression -v
pytest tests/gateway/test_duplicate_reply_suppression.py -v
```

Both new tests pass locally. Full `test_duplicate_reply_suppression.py` suite: 21 passed / 3 pre-existing unrelated failures (same set as before this change; environment-dependent `TestBaseInterruptSuppression`).

Notably, `test_partial_stream_output_does_not_set_already_sent` continues to pass — the upstream-intended behavior for intermediate-text-only sends is preserved.

## Implementation Notes

- `_final_content_delivered` is **not reset** by `_reset_segment_state()`, mirroring the existing behavior of `_already_sent`. Once final content has reached the user in a given agent turn, that fact should not be unset by subsequent segment boundaries.
- `getattr(_sc, "final_content_delivered", False)` is used at both `run.py` call sites so that older `GatewayStreamConsumer` instances (e.g. in tests that build a `SimpleNamespace` stand-in) remain compatible.
- The new flag is deliberately orthogonal to `final_response_sent`: the latter implies "the full done-sequence succeeded including the cosmetic edit", the former implies "the content reached the user, regardless of whether the cosmetic edit succeeded". Treating them as independent signals is what lets the suppression logic cover the failed-edit case without regressing the partial-stream case.

## Checklist

### Code
- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/gateway/test_duplicate_reply_suppression.py -v` with no regression vs. baseline
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Apple Silicon), Python 3.14

### Documentation & Housekeeping
- [x] N/A for all documentation items

## Related

- Sister PR #13495 (`fix(cron): cancel orphan coroutine on delivery timeout before standalone fallback`) addresses the same class of user-observed bug — duplicate delivery — on the cron path. This PR addresses the gateway/Telegram path. They are independent in scope, root cause, and modified files.
