### PR TITLE
fix(cache): surface cache-hit telemetry for all providers

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -9907,22 +9907,27 @@ class AIAgent:
                         if self.verbose_logging:
                             logging.debug(f"Token usage: prompt={usage_dict['prompt_tokens']:,}, completion={usage_dict['completion_tokens']:,}, total={usage_dict['total_tokens']:,}")
                         
-                        # Log cache hit stats when prompt caching is active
-                        if self._use_prompt_caching:
-                            if self.api_mode == "anthropic_messages":
-                                _tcs = self._get_anthropic_transport()
-                                _cache = _tcs.extract_cache_stats(response)
-                                cached = _cache["cached_tokens"] if _cache else 0
-                                written = _cache["creation_tokens"] if _cache else 0
-                            else:
-                                # OpenRouter uses prompt_tokens_details.cached_tokens
-                                details = getattr(response.usage, 'prompt_tokens_details', None)
-                                cached = getattr(details, 'cached_tokens', 0) or 0 if details else 0
-                                written = getattr(details, 'cache_write_tokens', 0) or 0 if details else 0
-                            prompt = usage_dict["prompt_tokens"]
+                        # Surface cache hit stats for any provider that reports
+                        # them — not just those where we inject cache_control
+                        # markers.  OpenAI/Kimi/DeepSeek/Qwen all do automatic
+                        # server-side prefix caching and return
+                        # ``prompt_tokens_details.cached_tokens``; users
+                        # previously could not see their cache % because this
+                        # line was gated on ``_use_prompt_caching``, which is
+                        # only True for Anthropic-style marker injection.
+                        # ``canonical_usage`` is already normalised from all
+                        # three API shapes (Anthropic / Codex / OpenAI-chat)
+                        # so we can rely on its values directly.
+                        cached = canonical_usage.cache_read_tokens
+                        written = canonical_usage.cache_write_tokens
+                        prompt = usage_dict["prompt_tokens"]
+                        if (cached or written) and not self.quiet_mode:
                             hit_pct = (cached / prompt * 100) if prompt > 0 else 0
-                            if not self.quiet_mode:
-                                self._vprint(f"{self.log_prefix}   💾 Cache: {cached:,}/{prompt:,} tokens ({hit_pct:.0f}% hit, {written:,} written)")
+                            self._vprint(
+                                f"{self.log_prefix}   💾 Cache: "
+                                f"{cached:,}/{prompt:,} tokens "
+                                f"({hit_pct:.0f}% hit, {written:,} written)"
+                            )
                     
                     has_retried_429 = False  # Reset on success
                     # Clear Nous rate limit state on successful request —


### PR DESCRIPTION
The `💾 Cache: N/M tokens` footer is currently hidden from every provider that uses automatic server-side prefix caching (OpenAI, Kimi, DeepSeek, Qwen-on-OpenRouter). This PR unblocks it.

## Summary
Users on OpenAI/Kimi/DeepSeek/Qwen-via-OpenRouter couldn't tell whether their cache was hitting without grepping agent.log. The display line was gated on `self._use_prompt_caching`, which is only True when hermes injects Anthropic-style markers — but automatic-cache providers don't need injection and were silently ignored.

## Root cause
`normalize_usage()` already unifies all three API shapes (Anthropic / Codex / OpenAI-chat) into `canonical_usage.cache_read_tokens` + `.cache_write_tokens`. The display path ignored that and re-implemented extraction behind the `_use_prompt_caching` gate, which meant anyone whose provider handled caching server-side got zero visibility.

## Changes
- `run_agent.py`: drop the `_use_prompt_caching` gate on the `💾 Cache` footer. Read `cached` / `written` from `canonical_usage` directly. Fire the footer whenever either value is non-zero. Removes the duplicated per-API-shape extraction code.

## Validation
| | Before | After |
|---|---|---|
| OpenRouter Claude (cache via markers) | footer shown | footer shown |
| Native Anthropic (cache via markers) | footer shown | footer shown |
| OpenAI GPT-5 (server-side automatic) | silent | footer shown when cached > 0 |
| Kimi / DeepSeek (server-side automatic) | silent | footer shown when cached > 0 |
| Qwen on OpenCode Go (markers, after #13528) | footer shown | footer shown |
| Provider that doesn't report cache | silent | silent (unchanged) |

Targeted tests pass (69/69) across `tests/run_agent/test_anthropic_prompt_cache_policy.py`, `tests/agent/test_prompt_caching.py`, `tests/agent/test_usage_pricing.py`, `tests/run_agent/test_context_token_tracking.py`, `tests/run_agent/test_fallback_model.py`. `py_compile` clean.

Follow-up to #13528 — together these address audit items 1 and 2 from today's cache-integrity review.