### PR TITLE
fix: correct browser toolset availability check

### DIFF
--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -160,6 +160,34 @@ class TestToolsetAvailability:
         assert reqs["ok"] is True
         assert reqs["nope"] is False
 
+    def test_toolset_check_fn_overrides_first_tool_check(self):
+        reg = ToolRegistry()
+
+        reg.register(
+            name="browser_cdp",
+            toolset="browser",
+            schema=_make_schema("browser_cdp"),
+            handler=_dummy_handler,
+            check_fn=lambda: False,
+            toolset_check_fn=lambda: True,
+        )
+        reg.register(
+            name="browser_navigate",
+            toolset="browser",
+            schema=_make_schema("browser_navigate"),
+            handler=_dummy_handler,
+            check_fn=lambda: True,
+        )
+
+        assert reg.is_toolset_available("browser") is True
+
+        defs = reg.get_definitions({"browser_cdp", "browser_navigate"})
+        assert {d["function"]["name"] for d in defs} == {"browser_navigate"}
+
+        available, unavailable = reg.check_tool_availability()
+        assert "browser" in available
+        assert not any(item["name"] == "browser" for item in unavailable)
+
     def test_get_all_tool_names(self):
         reg = ToolRegistry()
         reg.register(

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -370,6 +370,21 @@ BROWSER_CDP_SCHEMA: Dict[str, Any] = {
 }
 
 
+def _browser_toolset_check() -> bool:
+    """Toolset-level availability check for the ``browser`` toolset.
+
+    The browser toolset should be considered available when any supported
+    browser backend is usable. ``browser_cdp`` itself remains a stricter,
+    optional escape hatch that is only exposed when a CDP endpoint exists.
+    """
+    try:
+        from tools.browser_tool import check_browser_requirements  # type: ignore[import-not-found]
+    except ImportError as exc:  # pragma: no cover — defensive
+        logger.debug("browser toolset check: browser_tool import failed: %s", exc)
+        return False
+    return bool(check_browser_requirements())
+
+
 def _browser_cdp_check() -> bool:
     """Availability check for browser_cdp.
 
@@ -412,5 +427,6 @@ registry.register(
         task_id=kw.get("task_id"),
     ),
     check_fn=_browser_cdp_check,
+    toolset_check_fn=_browser_toolset_check,
     emoji="🧪",
 )

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -185,6 +185,7 @@ class ToolRegistry:
         description: str = "",
         emoji: str = "",
         max_result_size_chars: int | float | None = None,
+        toolset_check_fn: Callable | None = None,
     ):
         """Register a tool.  Called at module-import time by each tool file."""
         with self._lock:
@@ -223,7 +224,9 @@ class ToolRegistry:
                 emoji=emoji,
                 max_result_size_chars=max_result_size_chars,
             )
-            if check_fn and toolset not in self._toolset_checks:
+            if toolset_check_fn is not None:
+                self._toolset_checks[toolset] = toolset_check_fn
+            elif check_fn and toolset not in self._toolset_checks:
                 self._toolset_checks[toolset] = check_fn
 
     def deregister(self, name: str) -> None:


### PR DESCRIPTION
## Summary
- add an explicit toolset-level availability override for registry registrations
- register the browser toolset against normal browser availability, not `browser_cdp` availability
- add a regression test that keeps `browser_cdp` hidden while the overall `browser` toolset remains available

## Problem
`hermes doctor` could report `browser (system dependency not met)` even when the standard browser tool surface (`browser_navigate`, `browser_snapshot`, etc.) worked correctly.

The root cause was that `tools.browser_cdp_tool` is imported before `tools.browser_tool`, so the registry captured `browser_cdp`'s stricter `check_fn` as the browser toolset-level check. That check requires a CDP endpoint, which is correct for `browser_cdp` itself but too strict for the whole browser toolset.

## Testing
- `./venv/bin/python -m pytest tests/tools/test_registry.py -q -o 'addopts='`
- `./venv/bin/python -m pytest tests/hermes_cli/test_doctor.py -q -o 'addopts='`

Closes #13545
