### PR TITLE
feat: tool loop detection and intervention

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -376,6 +376,15 @@ DEFAULT_CONFIG = {
         # Sends a status message every N seconds so the user knows the
         # agent hasn't died during long tasks.  0 = disable notifications.
         "gateway_notify_interval": 600,
+        # Cross-turn tool loop detection — tracks (tool_name, args) pairs
+        # across turns and applies escalation when the model repeats the same
+        # tool call without making progress.
+        "loop_detection": {
+            "enabled": True,
+            "max_repeats_before_nudge": 2,    # repeat count at which to inject nudge
+            "max_repeats_before_reprompt": 4, # repeat count at which to break and re-prompt
+            "max_repeats_before_stop": 5,     # repeat count at which to hard stop
+        },
     },
     
     "terminal": {

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -381,9 +381,9 @@ DEFAULT_CONFIG = {
         # tool call without making progress.
         "loop_detection": {
             "enabled": True,
-            "max_repeats_before_nudge": 2,    # repeat count at which to inject nudge
-            "max_repeats_before_reprompt": 4, # repeat count at which to break and re-prompt
-            "max_repeats_before_stop": 5,     # repeat count at which to hard stop
+            "max_repeats_before_nudge": 3,    # repeat count at which to inject nudge
+            "max_repeats_before_reprompt": 5, # repeat count at which to break and re-prompt
+            "max_repeats_before_stop": 6,     # repeat count at which to hard stop
         },
     },
     

--- a/run_agent.py
+++ b/run_agent.py
@@ -4294,9 +4294,9 @@ class AIAgent:
             return {"action": "none"}
         
         # Load config thresholds
-        max_repeats_nudge = 2
-        max_repeats_reprompt = 4
-        max_repeats_stop = 5
+        max_repeats_nudge = 3
+        max_repeats_reprompt = 5
+        max_repeats_stop = 6
         
         # Load loop_detection config from user's config.yaml
         try:

--- a/run_agent.py
+++ b/run_agent.py
@@ -4256,6 +4256,132 @@ class AIAgent:
 
         return None
 
+    @staticmethod
+    def _hash_tool_args(args: str) -> str:
+        """Normalize and hash tool arguments for cross-turn comparison.
+        
+        Sorts JSON keys and strips whitespace so minor formatting differences
+        don't prevent loop detection. Returns first 16 chars of SHA256 hash.
+        """
+        import hashlib
+        try:
+            normalized = json.dumps(json.loads(args), sort_keys=True, separators=(',', ':'))
+            return hashlib.sha256(normalized.encode()).hexdigest()[:16]
+        except (json.JSONDecodeError, TypeError):
+            # Fallback: hash the raw string
+            return hashlib.sha256(args.strip().encode()).hexdigest()[:16]
+
+    def _check_tool_loop(self, tool_calls: list, tool_results: list) -> dict:
+        """Check for cross-turn tool call loops and apply escalation.
+        
+        Tracks (tool_name, args_hash) pairs across turns. After each tool
+        execution, records which tools were called. On the next turn, checks
+        if the model repeats the same (tool, args) pair.
+        
+        Args:
+            tool_calls: List of tool call objects from the current assistant message
+            tool_results: List of tool result strings corresponding to tool_calls
+            
+        Returns:
+            dict with keys:
+              - action: "none", "nudge", "reprompt", or "stop"
+              - nudge_message: (if action is "nudge" or "reprompt") The message to inject
+              - result_preview: (if action is "nudge" or "reprompt") Preview of the last result
+              - tool_name: (if action is "nudge" or "reprompt") The repeated tool name
+              - args: (if action is "nudge" or "reprompt") The repeated tool arguments
+        """
+        if not tool_calls:
+            return {"action": "none"}
+        
+        # Load config thresholds
+        max_repeats_nudge = 2
+        max_repeats_reprompt = 4
+        max_repeats_stop = 5
+        
+        # Load loop_detection config from user's config.yaml
+        try:
+            from hermes_cli.config import get_hermes_home, get_config_path
+            import yaml
+            config_path = get_config_path()
+            if config_path.exists():
+                with open(config_path, "r", encoding="utf-8") as f:
+                    user_config = yaml.safe_load(f) or {}
+                loop_config = (
+                    user_config.get("agent", {}).get("loop_detection", {})
+                    if isinstance(user_config.get("agent"), dict)
+                    else {}
+                )
+                if loop_config.get("enabled", True):
+                    max_repeats_nudge = loop_config.get("max_repeats_before_nudge", max_repeats_nudge)
+                    max_repeats_reprompt = loop_config.get("max_repeats_before_reprompt", max_repeats_reprompt)
+                    max_repeats_stop = loop_config.get("max_repeats_before_stop", max_repeats_stop)
+                else:
+                    return {"action": "none"}
+        except Exception:
+            # Config load failed — use defaults
+            pass
+        
+        # Track each tool call in this turn
+        for tc, result in zip(tool_calls, tool_results):
+            tool_name = tc.function.name
+            args_hash = self._hash_tool_args(tc.function.arguments)
+            key = f"{tool_name}::{args_hash}"
+            
+            # Only track tools with non-empty results
+            if not result or not result.strip():
+                continue
+            
+            # Update repeat counter
+            current_count = self._tool_repeat_tracker.get(key, 0) + 1
+            self._tool_repeat_tracker[key] = current_count
+            
+            # Check if we've hit a threshold
+            if current_count == max_repeats_nudge:
+                # Level 1: targeted nudge
+                result_preview = result[:200].replace('\n', ' ')
+                args_str = tc.function.arguments[:100].replace('\n', ' ')
+                return {
+                    "action": "nudge",
+                    "nudge_level": 1,
+                    "nudge_message": f"You called `{tool_name}({args_str})` on the previous turn and received this result: `{result_preview}`. Please process this result instead of calling the same tool again.",
+                    "result_preview": result_preview,
+                    "tool_name": tool_name,
+                    "args": tc.function.arguments,
+                }
+            elif current_count == max_repeats_nudge + 1:
+                # Level 2: stronger nudge
+                result_preview = result[:200].replace('\n', ' ')
+                args_str = tc.function.arguments[:100].replace('\n', ' ')
+                return {
+                    "action": "nudge",
+                    "nudge_level": 2,
+                    "nudge_message": f"You have called `{tool_name}({args_str})` {current_count} times consecutively without making progress. The result was: `{result_preview}`. Do NOT call this tool again with the same arguments. Take a different approach or respond with your final answer.",
+                    "result_preview": result_preview,
+                    "tool_name": tool_name,
+                    "args": tc.function.arguments,
+                }
+            elif current_count == max_repeats_reprompt:
+                # Level 3: break + re-prompt
+                result_preview = result[:200].replace('\n', ' ')
+                self._loop_reprompt_issued = True
+                return {
+                    "action": "reprompt",
+                    "nudge_message": f"You called `{tool_name}` with the same arguments {current_count} times. Pay close attention to the tool signature and the responses you received. Further attempts will require the user to intervene.",
+                    "result_preview": result_preview,
+                    "tool_name": tool_name,
+                    "args": tc.function.arguments,
+                }
+            elif current_count >= max_repeats_stop:
+                # Level 4: hard stop
+                self._loop_reprompt_issued = True
+                return {
+                    "action": "stop",
+                    "tool_name": tool_name,
+                    "repeat_count": current_count,
+                }
+        
+        return {"action": "none"}
+
     def _invalidate_system_prompt(self):
         """
         Invalidate the cached system prompt, forcing a rebuild on the next turn.
@@ -8612,6 +8738,10 @@ class AIAgent:
         self._last_content_tools_all_housekeeping = False
         self._mute_post_response = False
         self._unicode_sanitization_passes = 0
+        
+        # Tool loop detection — tracks (tool_name, args_hash) across turns
+        self._tool_repeat_tracker: Dict[str, int] = {}  # {(tool_name, args_hash): repeat_count}
+        self._loop_reprompt_issued = False  # whether re-prompt was already delivered this turn
 
         # Pre-turn connection health check: detect and clean up dead TCP
         # connections left over from provider outages or dropped streams.
@@ -11202,6 +11332,96 @@ class AIAgent:
 
                     self._execute_tool_calls(assistant_message, messages, effective_task_id, api_call_count)
 
+                    # Collect tool results from messages (appended by _execute_tool_calls)
+                    _tool_results = []
+                    for m in messages:
+                        if isinstance(m, dict) and m.get("role") == "tool":
+                            _tool_results.append(m.get("content", ""))
+                    
+                    # ── Cross-turn tool loop detection ──────────────────
+                    _loop_result = self._check_tool_loop(
+                        assistant_message.tool_calls, _tool_results
+                    )
+                    if _loop_result["action"] == "nudge":
+                        # Level 1-2: inject targeted nudge
+                        nudge_level = _loop_result.get("nudge_level", 1)
+                        repeat_count = self._tool_repeat_tracker.get(
+                            f"{_loop_result['tool_name']}::{self._hash_tool_args(_loop_result['args'])}", 0
+                        )
+                        if nudge_level == 1:
+                            logger.warning(
+                                "Tool loop detected: %s repeated %d times — injecting nudge",
+                                _loop_result["tool_name"],
+                                repeat_count,
+                            )
+                            self._emit_status(
+                                f"⚠️ Model repeated `{_loop_result['tool_name']}` — nudging to process results"
+                            )
+                        else:
+                            logger.warning(
+                                "Tool loop persistent: %s repeated %d times — stronger nudge",
+                                _loop_result["tool_name"],
+                                repeat_count,
+                            )
+                            self._emit_status(
+                                f"⚠️ Model still repeating `{_loop_result['tool_name']}` — stronger warning"
+                            )
+                        # Append empty assistant message + nudge (mirrors post-tool empty nudge pattern)
+                        _nudge_msg = self._build_assistant_message(assistant_message, finish_reason)
+                        _nudge_msg["content"] = "(empty)"
+                        messages.append(_nudge_msg)
+                        messages.append({
+                            "role": "user",
+                            "content": _loop_result["nudge_message"],
+                        })
+                        continue
+                    elif _loop_result["action"] == "reprompt":
+                        # Level 3: break + re-prompt + continue
+                        logger.warning(
+                            "Tool loop detected: %s repeated %d times — breaking for re-prompt",
+                            _loop_result["tool_name"],
+                            self._tool_repeat_tracker.get(
+                                f"{_loop_result['tool_name']}::{self._hash_tool_args(_loop_result['args'])}", 0
+                            ),
+                        )
+                        self._emit_status(
+                            f"⚠️ Model stuck in tool loop — breaking for re-prompt"
+                        )
+                        # Inject re-prompt message and continue (don't exit loop)
+                        _reprompt_msg = self._build_assistant_message(assistant_message, finish_reason)
+                        _reprompt_msg["content"] = "(empty)"
+                        messages.append(_reprompt_msg)
+                        messages.append({
+                            "role": "user",
+                            "content": _loop_result["nudge_message"],
+                        })
+                        # Append the last tool result so the model has the context it missed
+                        last_result = _tool_results[-1] if _tool_results else ""
+                        if last_result:
+                            messages.append({
+                                "role": "tool",
+                                "tool_call_id": assistant_message.tool_calls[-1].id,
+                                "content": last_result,
+                            })
+                        continue
+                    elif _loop_result["action"] == "stop":
+                        # Level 4: hard stop
+                        logger.warning(
+                            "Tool loop terminated: %s repeated %d times — hard stop",
+                            _loop_result["tool_name"],
+                            _loop_result["repeat_count"],
+                        )
+                        self._emit_status(
+                            f"❌ Model entered tool loop calling `{_loop_result['tool_name']}` "
+                            f"{_loop_result['repeat_count']} times — terminated"
+                        )
+                        # Append assistant message and break
+                        assistant_msg = self._build_assistant_message(assistant_message, finish_reason)
+                        messages.append(assistant_msg)
+                        _turn_exit_reason = "tool_loop_terminated"
+                        final_response = ""
+                        break
+                    
                     # Reset per-turn retry counters after successful tool
                     # execution so a single truncation doesn't poison the
                     # entire conversation.

--- a/tests/run_agent/test_tool_loop_detection.py
+++ b/tests/run_agent/test_tool_loop_detection.py
@@ -1,0 +1,308 @@
+"""Unit tests for cross-turn tool loop detection.
+
+Covers the following functionality:
+  - _hash_tool_args()              — argument normalization and hashing
+  - _check_tool_loop()             — tracking and escalation logic
+  - Escalation ladder: nudge → stronger nudge → reprompt → hard stop
+"""
+
+import json
+import types
+import unittest.mock as mock
+
+from run_agent import AIAgent
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_tc(name: str, arguments: str = "{}") -> types.SimpleNamespace:
+    """Create a minimal tool_call SimpleNamespace mirroring the OpenAI SDK object."""
+    tc = types.SimpleNamespace()
+    tc.function = types.SimpleNamespace(name=name, arguments=arguments)
+    return tc
+
+
+def make_agent():
+    """Create a minimal AIAgent instance for testing."""
+    # Mock the AIAgent constructor to avoid full initialization
+    with mock.patch.object(AIAgent, '__init__', lambda self: None):
+        agent = AIAgent()
+        agent._tool_repeat_tracker = {}
+        agent._loop_reprompt_issued = False
+        return agent
+
+
+# ---------------------------------------------------------------------------
+# _hash_tool_args
+# ---------------------------------------------------------------------------
+
+class TestHashToolArgs:
+
+    def test_identical_args_same_hash(self):
+        args = '{"query": "test", "limit": 10}'
+        h1 = AIAgent._hash_tool_args(args)
+        h2 = AIAgent._hash_tool_args(args)
+        assert h1 == h2
+
+    def test_different_args_different_hash(self):
+        h1 = AIAgent._hash_tool_args('{"query": "foo"}')
+        h2 = AIAgent._hash_tool_args('{"query": "bar"}')
+        assert h1 != h2
+
+    def test_key_order_normalized(self):
+        """Keys in different order should produce same hash."""
+        h1 = AIAgent._hash_tool_args('{"b": 2, "a": 1}')
+        h2 = AIAgent._hash_tool_args('{"a": 1, "b": 2}')
+        assert h1 == h2
+
+    def test_whitespace_normalized(self):
+        """Extra whitespace should not affect hash."""
+        h1 = AIAgent._hash_tool_args('{"query": "test"}')
+        h2 = AIAgent._hash_tool_args('{"query": "test"}')  # Same after normalization
+        assert h1 == h2
+
+    def test_trailing_space_normalized(self):
+        """Trailing whitespace in args should not affect hash."""
+        h1 = AIAgent._hash_tool_args('{"query": "test"}')
+        h2 = AIAgent._hash_tool_args('{"query": "test"} ')
+        # After JSON normalization, trailing space is stripped
+        assert h1 == h2
+
+    def test_invalid_json_fallback(self):
+        """Invalid JSON should hash the raw string."""
+        h1 = AIAgent._hash_tool_args("not json at all")
+        h2 = AIAgent._hash_tool_args("not json at all")
+        assert h1 == h2
+
+    def test_hash_length(self):
+        """Hash should be 16 chars (first 16 of SHA256)."""
+        h = AIAgent._hash_tool_args('{"x": 1}')
+        assert len(h) == 16
+
+
+# ---------------------------------------------------------------------------
+# _check_tool_loop — tracking
+# ---------------------------------------------------------------------------
+
+class TestToolLoopTracking:
+
+    def test_first_call_no_action(self):
+        """First call to a tool should return 'none'."""
+        agent = make_agent()
+        tc = make_tc("web_search", '{"query": "test"}')
+        result = agent._check_tool_loop([tc], ["search result"])
+        assert result["action"] == "none"
+
+    def test_second_call_triggers_nudge(self):
+        """Second identical call should trigger level 1 nudge."""
+        agent = make_agent()
+        tc = make_tc("web_search", '{"query": "test"}')
+        
+        # First call
+        r1 = agent._check_tool_loop([tc], ["result 1"])
+        assert r1["action"] == "none"
+        
+        # Second call (repeat)
+        r2 = agent._check_tool_loop([tc], ["result 2"])
+        assert r2["action"] == "nudge"
+        assert r2.get("nudge_level") == 1
+
+    def test_third_call_triggers_stronger_nudge(self):
+        """Third identical call should trigger level 2 nudge."""
+        agent = make_agent()
+        tc = make_tc("web_search", '{"query": "test"}')
+        
+        agent._check_tool_loop([tc], ["result 1"])  # 1st
+        agent._check_tool_loop([tc], ["result 2"])  # 2nd (nudge)
+        r3 = agent._check_tool_loop([tc], ["result 3"])  # 3rd
+        
+        assert r3["action"] == "nudge"
+        assert r3.get("nudge_level") == 2
+
+    def test_fourth_call_triggers_reprompt(self):
+        """Fourth identical call should trigger reprompt."""
+        agent = make_agent()
+        tc = make_tc("web_search", '{"query": "test"}')
+        
+        agent._check_tool_loop([tc], ["r1"])  # 1st
+        agent._check_tool_loop([tc], ["r2"])  # 2nd (nudge)
+        agent._check_tool_loop([tc], ["r3"])  # 3rd (stronger nudge)
+        r4 = agent._check_tool_loop([tc], ["r4"])  # 4th
+        
+        assert r4["action"] == "reprompt"
+        assert agent._loop_reprompt_issued is True
+
+    def test_fifth_call_triggers_hard_stop(self):
+        """Fifth identical call should trigger hard stop."""
+        agent = make_agent()
+        tc = make_tc("web_search", '{"query": "test"}')
+        
+        for i in range(1, 5):
+            agent._check_tool_loop([tc], [f"r{i}"])
+        
+        r5 = agent._check_tool_loop([tc], ["r5"])
+        assert r5["action"] == "stop"
+        assert r5["repeat_count"] == 5
+
+    def test_different_tools_not_tracked_together(self):
+        """Different tool names should have separate counters."""
+        agent = make_agent()
+        tc1 = make_tc("web_search", '{"query": "test"}')
+        tc2 = make_tc("terminal", '{"cmd": "ls"}')
+        
+        # First calls to each
+        agent._check_tool_loop([tc1], ["result1"])
+        agent._check_tool_loop([tc2], ["result2"])
+        
+        # Second call to web_search (should trigger nudge)
+        r3 = agent._check_tool_loop([tc1], ["result3"])
+        assert r3["action"] == "nudge"
+        
+        # Second call to terminal (should also trigger nudge - separate counter)
+        r4 = agent._check_tool_loop([tc2], ["result4"])
+        assert r4["action"] == "nudge"
+
+    def test_different_args_not_tracked_together(self):
+        """Same tool with different args should have separate counters."""
+        agent = make_agent()
+        tc1 = make_tc("web_search", '{"query": "foo"}')
+        tc2 = make_tc("web_search", '{"query": "bar"}')
+        
+        # First calls
+        agent._check_tool_loop([tc1], ["result1"])
+        agent._check_tool_loop([tc2], ["result2"])
+        
+        # Second call to first args (should trigger nudge)
+        r3 = agent._check_tool_loop([tc1], ["result3"])
+        assert r3["action"] == "nudge"
+        
+        # Second call to second args (should also trigger nudge - separate counter)
+        r4 = agent._check_tool_loop([tc2], ["result4"])
+        assert r4["action"] == "nudge"
+
+    def test_empty_results_not_tracked(self):
+        """Tools with empty results should not be tracked."""
+        agent = make_agent()
+        tc = make_tc("web_search", '{"query": "test"}')
+        
+        # First call with result
+        agent._check_tool_loop([tc], ["result"])
+        
+        # Second call with empty result (should not increment counter)
+        r2 = agent._check_tool_loop([tc], [""])
+        assert r2["action"] == "none"
+        
+        # Third call with result (should trigger nudge since counter is still at 1)
+        r3 = agent._check_tool_loop([tc], ["result2"])
+        assert r3["action"] == "nudge"
+
+    def test_no_tool_calls_returns_none(self):
+        """Empty tool_calls list should return 'none'."""
+        agent = make_agent()
+        result = agent._check_tool_loop([], [])
+        assert result["action"] == "none"
+
+
+# ---------------------------------------------------------------------------
+# Nudge message content
+# ---------------------------------------------------------------------------
+
+class TestNudgeMessages:
+
+    def test_nudge_level_1_message(self):
+        """Level 1 nudge should reference the previous turn."""
+        agent = make_agent()
+        tc = make_tc("web_search", '{"query": "test"}')
+        
+        agent._check_tool_loop([tc], ["this is a very long result that should be truncated"])
+        r2 = agent._check_tool_loop([tc], ["another result"])
+        
+        assert "previous turn" in r2["nudge_message"].lower()
+        assert "web_search" in r2["nudge_message"]
+        assert "test" in r2["nudge_message"]
+
+    def test_nudge_level_2_message(self):
+        """Level 2 nudge should mention consecutive attempts."""
+        agent = make_agent()
+        tc = make_tc("web_search", '{"query": "test"}')
+        
+        agent._check_tool_loop([tc], ["r1"])
+        agent._check_tool_loop([tc], ["r2"])
+        r3 = agent._check_tool_loop([tc], ["r3"])
+        
+        assert "consecutively" in r3["nudge_message"].lower()
+        assert "web_search" in r3["nudge_message"]
+
+    def test_reprompt_message(self):
+        """Reprompt should mention user intervention."""
+        agent = make_agent()
+        tc = make_tc("web_search", '{"query": "test"}')
+        
+        for i in range(1, 4):
+            agent._check_tool_loop([tc], [f"r{i}"])
+        
+        r4 = agent._check_tool_loop([tc], ["r4"])
+        
+        assert "user to intervene" in r4["nudge_message"].lower()
+        assert "web_search" in r4["nudge_message"]
+
+
+# ---------------------------------------------------------------------------
+# Config loading
+# ---------------------------------------------------------------------------
+
+class TestConfigLoading:
+
+    def test_config_load_succeeds(self):
+        """Config loading should not raise exceptions."""
+        agent = make_agent()
+        tc = make_tc("web_search", '{"query": "test"}')
+        
+        # Should not raise even if config file doesn't exist
+        r1 = agent._check_tool_loop([tc], ["result1"])
+        assert r1["action"] == "none"
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+class TestEdgeCases:
+
+    def test_multiple_tool_calls_in_single_turn(self):
+        """Multiple tool calls in one turn should each be tracked."""
+        agent = make_agent()
+        tc1 = make_tc("web_search", '{"query": "test"}')
+        tc2 = make_tc("terminal", '{"cmd": "ls"}')
+        
+        # First turn with both tools
+        r1 = agent._check_tool_loop([tc1, tc2], ["result1", "result2"])
+        assert r1["action"] == "none"
+        
+        # Second turn with both tools (both should trigger nudge)
+        r2 = agent._check_tool_loop([tc1, tc2], ["result3", "result4"])
+        # Only the first matching tool triggers the return
+        assert r2["action"] == "nudge"
+
+    def test_tool_name_with_special_characters(self):
+        """Tool names with underscores/hyphens should work."""
+        agent = make_agent()
+        tc = make_tc("read_file", '{"path": "/tmp/test"}')
+        
+        agent._check_tool_loop([tc], ["result1"])
+        r2 = agent._check_tool_loop([tc], ["result2"])
+        assert r2["action"] == "nudge"
+
+    def test_large_arguments_handled(self):
+        """Large argument strings should not cause issues."""
+        agent = make_agent()
+        large_args = json.dumps({"query": "test", "extra": "x" * 10000})
+        tc = make_tc("web_search", large_args)
+        
+        r1 = agent._check_tool_loop([tc], ["result1"])
+        assert r1["action"] == "none"
+        
+        r2 = agent._check_tool_loop([tc], ["result2"])
+        assert r2["action"] == "nudge"

--- a/tests/run_agent/test_tool_loop_detection.py
+++ b/tests/run_agent/test_tool_loop_detection.py
@@ -95,8 +95,8 @@ class TestToolLoopTracking:
         result = agent._check_tool_loop([tc], ["search result"])
         assert result["action"] == "none"
 
-    def test_second_call_triggers_nudge(self):
-        """Second identical call should trigger level 1 nudge."""
+    def test_second_call_no_action(self):
+        """Second identical call should still be 'none'."""
         agent = make_agent()
         tc = make_tc("web_search", '{"query": "test"}')
         
@@ -104,47 +104,60 @@ class TestToolLoopTracking:
         r1 = agent._check_tool_loop([tc], ["result 1"])
         assert r1["action"] == "none"
         
-        # Second call (repeat)
+        # Second call
         r2 = agent._check_tool_loop([tc], ["result 2"])
-        assert r2["action"] == "nudge"
-        assert r2.get("nudge_level") == 1
+        assert r2["action"] == "none"
 
-    def test_third_call_triggers_stronger_nudge(self):
-        """Third identical call should trigger level 2 nudge."""
+    def test_third_call_triggers_nudge(self):
+        """Third identical call should trigger level 1 nudge."""
         agent = make_agent()
         tc = make_tc("web_search", '{"query": "test"}')
         
         agent._check_tool_loop([tc], ["result 1"])  # 1st
-        agent._check_tool_loop([tc], ["result 2"])  # 2nd (nudge)
+        agent._check_tool_loop([tc], ["result 2"])  # 2nd
         r3 = agent._check_tool_loop([tc], ["result 3"])  # 3rd
         
         assert r3["action"] == "nudge"
-        assert r3.get("nudge_level") == 2
+        assert r3.get("nudge_level") == 1
 
-    def test_fourth_call_triggers_reprompt(self):
-        """Fourth identical call should trigger reprompt."""
+    def test_fourth_call_triggers_stronger_nudge(self):
+        """Fourth identical call should trigger level 2 nudge."""
+        agent = make_agent()
+        tc = make_tc("web_search", '{"query": "test"}')
+        
+        agent._check_tool_loop([tc], ["result 1"])  # 1st
+        agent._check_tool_loop([tc], ["result 2"])  # 2nd
+        agent._check_tool_loop([tc], ["result 3"])  # 3rd (nudge)
+        r4 = agent._check_tool_loop([tc], ["result 4"])  # 4th
+        
+        assert r4["action"] == "nudge"
+        assert r4.get("nudge_level") == 2
+
+    def test_fifth_call_triggers_reprompt(self):
+        """Fifth identical call should trigger reprompt."""
         agent = make_agent()
         tc = make_tc("web_search", '{"query": "test"}')
         
         agent._check_tool_loop([tc], ["r1"])  # 1st
-        agent._check_tool_loop([tc], ["r2"])  # 2nd (nudge)
-        agent._check_tool_loop([tc], ["r3"])  # 3rd (stronger nudge)
-        r4 = agent._check_tool_loop([tc], ["r4"])  # 4th
+        agent._check_tool_loop([tc], ["r2"])  # 2nd
+        agent._check_tool_loop([tc], ["r3"])  # 3rd (nudge)
+        agent._check_tool_loop([tc], ["r4"])  # 4th (stronger nudge)
+        r5 = agent._check_tool_loop([tc], ["r5"])  # 5th
         
-        assert r4["action"] == "reprompt"
+        assert r5["action"] == "reprompt"
         assert agent._loop_reprompt_issued is True
 
-    def test_fifth_call_triggers_hard_stop(self):
-        """Fifth identical call should trigger hard stop."""
+    def test_sixth_call_triggers_hard_stop(self):
+        """Sixth identical call should trigger hard stop."""
         agent = make_agent()
         tc = make_tc("web_search", '{"query": "test"}')
         
-        for i in range(1, 5):
+        for i in range(1, 6):
             agent._check_tool_loop([tc], [f"r{i}"])
         
-        r5 = agent._check_tool_loop([tc], ["r5"])
-        assert r5["action"] == "stop"
-        assert r5["repeat_count"] == 5
+        r6 = agent._check_tool_loop([tc], ["r6"])
+        assert r6["action"] == "stop"
+        assert r6["repeat_count"] == 6
 
     def test_different_tools_not_tracked_together(self):
         """Different tool names should have separate counters."""
@@ -156,13 +169,21 @@ class TestToolLoopTracking:
         agent._check_tool_loop([tc1], ["result1"])
         agent._check_tool_loop([tc2], ["result2"])
         
-        # Second call to web_search (should trigger nudge)
+        # Second call to web_search (should not trigger yet)
         r3 = agent._check_tool_loop([tc1], ["result3"])
-        assert r3["action"] == "nudge"
+        assert r3["action"] == "none"
         
-        # Second call to terminal (should also trigger nudge - separate counter)
+        # Second call to terminal (should also not trigger yet)
         r4 = agent._check_tool_loop([tc2], ["result4"])
-        assert r4["action"] == "nudge"
+        assert r4["action"] == "none"
+        
+        # Third call to web_search (should trigger nudge)
+        r5 = agent._check_tool_loop([tc1], ["result5"])
+        assert r5["action"] == "nudge"
+        
+        # Third call to terminal (should also trigger nudge - separate counter)
+        r6 = agent._check_tool_loop([tc2], ["result6"])
+        assert r6["action"] == "nudge"
 
     def test_different_args_not_tracked_together(self):
         """Same tool with different args should have separate counters."""
@@ -174,13 +195,21 @@ class TestToolLoopTracking:
         agent._check_tool_loop([tc1], ["result1"])
         agent._check_tool_loop([tc2], ["result2"])
         
-        # Second call to first args (should trigger nudge)
+        # Second call to first args (should not trigger yet)
         r3 = agent._check_tool_loop([tc1], ["result3"])
-        assert r3["action"] == "nudge"
+        assert r3["action"] == "none"
         
-        # Second call to second args (should also trigger nudge - separate counter)
+        # Second call to second args (should also not trigger yet)
         r4 = agent._check_tool_loop([tc2], ["result4"])
-        assert r4["action"] == "nudge"
+        assert r4["action"] == "none"
+        
+        # Third call to first args (should trigger nudge)
+        r5 = agent._check_tool_loop([tc1], ["result5"])
+        assert r5["action"] == "nudge"
+        
+        # Third call to second args (should also trigger nudge - separate counter)
+        r6 = agent._check_tool_loop([tc2], ["result6"])
+        assert r6["action"] == "nudge"
 
     def test_empty_results_not_tracked(self):
         """Tools with empty results should not be tracked."""
@@ -194,9 +223,13 @@ class TestToolLoopTracking:
         r2 = agent._check_tool_loop([tc], [""])
         assert r2["action"] == "none"
         
-        # Third call with result (should trigger nudge since counter is still at 1)
+        # Third call with result (should not trigger nudge since counter is still at 1)
         r3 = agent._check_tool_loop([tc], ["result2"])
-        assert r3["action"] == "nudge"
+        assert r3["action"] == "none"
+        
+        # Fourth call with result (should trigger nudge since counter is at 2)
+        r4 = agent._check_tool_loop([tc], ["result3"])
+        assert r4["action"] == "nudge"
 
     def test_no_tool_calls_returns_none(self):
         """Empty tool_calls list should return 'none'."""
@@ -217,11 +250,12 @@ class TestNudgeMessages:
         tc = make_tc("web_search", '{"query": "test"}')
         
         agent._check_tool_loop([tc], ["this is a very long result that should be truncated"])
-        r2 = agent._check_tool_loop([tc], ["another result"])
+        agent._check_tool_loop([tc], ["another result"])
+        r3 = agent._check_tool_loop([tc], ["third result"])
         
-        assert "previous turn" in r2["nudge_message"].lower()
-        assert "web_search" in r2["nudge_message"]
-        assert "test" in r2["nudge_message"]
+        assert "previous turn" in r3["nudge_message"].lower()
+        assert "web_search" in r3["nudge_message"]
+        assert "test" in r3["nudge_message"]
 
     def test_nudge_level_2_message(self):
         """Level 2 nudge should mention consecutive attempts."""
@@ -230,23 +264,24 @@ class TestNudgeMessages:
         
         agent._check_tool_loop([tc], ["r1"])
         agent._check_tool_loop([tc], ["r2"])
-        r3 = agent._check_tool_loop([tc], ["r3"])
+        agent._check_tool_loop([tc], ["r3"])
+        r4 = agent._check_tool_loop([tc], ["r4"])
         
-        assert "consecutively" in r3["nudge_message"].lower()
-        assert "web_search" in r3["nudge_message"]
+        assert "consecutively" in r4["nudge_message"].lower()
+        assert "web_search" in r4["nudge_message"]
 
     def test_reprompt_message(self):
         """Reprompt should mention user intervention."""
         agent = make_agent()
         tc = make_tc("web_search", '{"query": "test"}')
         
-        for i in range(1, 4):
+        for i in range(1, 5):
             agent._check_tool_loop([tc], [f"r{i}"])
         
-        r4 = agent._check_tool_loop([tc], ["r4"])
+        r5 = agent._check_tool_loop([tc], ["r5"])
         
-        assert "user to intervene" in r4["nudge_message"].lower()
-        assert "web_search" in r4["nudge_message"]
+        assert "user to intervene" in r5["nudge_message"].lower()
+        assert "web_search" in r5["nudge_message"]
 
 
 # ---------------------------------------------------------------------------
@@ -281,10 +316,14 @@ class TestEdgeCases:
         r1 = agent._check_tool_loop([tc1, tc2], ["result1", "result2"])
         assert r1["action"] == "none"
         
-        # Second turn with both tools (both should trigger nudge)
+        # Second turn with both tools (should not trigger yet)
         r2 = agent._check_tool_loop([tc1, tc2], ["result3", "result4"])
+        assert r2["action"] == "none"
+        
+        # Third turn with both tools (both should trigger nudge)
+        r3 = agent._check_tool_loop([tc1, tc2], ["result5", "result6"])
         # Only the first matching tool triggers the return
-        assert r2["action"] == "nudge"
+        assert r3["action"] == "nudge"
 
     def test_tool_name_with_special_characters(self):
         """Tool names with underscores/hyphens should work."""
@@ -292,8 +331,9 @@ class TestEdgeCases:
         tc = make_tc("read_file", '{"path": "/tmp/test"}')
         
         agent._check_tool_loop([tc], ["result1"])
-        r2 = agent._check_tool_loop([tc], ["result2"])
-        assert r2["action"] == "nudge"
+        agent._check_tool_loop([tc], ["result2"])
+        r3 = agent._check_tool_loop([tc], ["result3"])
+        assert r3["action"] == "nudge"
 
     def test_large_arguments_handled(self):
         """Large argument strings should not cause issues."""
@@ -305,4 +345,7 @@ class TestEdgeCases:
         assert r1["action"] == "none"
         
         r2 = agent._check_tool_loop([tc], ["result2"])
-        assert r2["action"] == "nudge"
+        assert r2["action"] == "none"
+        
+        r3 = agent._check_tool_loop([tc], ["result3"])
+        assert r3["action"] == "nudge"


### PR DESCRIPTION
## What does this PR do?

Small local models can get trapped in tool-calling loops when they miss key feedback in tool results. A model might call `web_search(query="foo")`, get "no results found", then call it again with the same args on the next turn, and keep repeating until all iterations are exhausted. The existing `_deduplicate_tool_calls()` only catches repeats within a single turn — it doesn't see cross-turn loops.

This adds cross-turn `(tool_name, args_hash)` tracking that detects when the model repeats the same tool call with the same arguments across turns. An escalation ladder progressively intervenes:

| Repeat Count | Action |
|---|---|
| 3rd | Level 1 nudge: "You called `{tool}` on the previous turn and received this result: `{preview}`. Please process this result instead of calling again." |
| 4th | Level 2 stronger nudge: "You have called `{tool}` {N} times consecutively without making progress. Do NOT call this tool again with the same arguments." |
| 5th | Break + re-prompt: inject synthetic user message + last tool result, give the model one more structured chance |
| 6th | Hard stop: terminate the loop, exit the agent loop with reason `tool_loop_terminated` |

## Related Issue

Inspired by [NousResearch/hermes-agent#481](https://github.com/NousResearch/hermes-agent/issues/481) — "Tool-Call Loop Guard" proposal. This PR implements Phase 1 (basic repetition detection with SHA-256 hashing and escalation ladder). Phase 2 features (ping-pong detection, exempt tools list, context truncation recovery) are not included.

Addresses [NousResearch/hermes-agent#13208](https://github.com/NousResearch/hermes-agent/issues/13208) — the four core flaws identified there (loop detection failure, error pattern recognition, state persistence loss, resource waste) are directly addressed by the escalation ladder and re-prompt mechanism.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `run_agent.py` — added `_hash_tool_args()` and `_check_tool_loop()` methods, integrated into the main loop after `_execute_tool_calls()`
- `hermes_cli/config.py` — added `agent.loop_detection` config block with `enabled`, `max_repeats_before_nudge`, `max_repeats_before_reprompt`, `max_repeats_before_stop`
- `tests/run_agent/test_tool_loop_detection.py` — 24 unit tests covering hash normalization, full escalation ladder, independent counters, empty result exclusion, multi-tool turns, and edge cases

## How to Test

1. Run the test suite: `pytest tests/run_agent/test_tool_loop_detection.py -v` — all 24 tests pass
2. Test with a small model that loops on repeated tool calls — the escalation should trigger at the configured thresholds
3. Verify config overrides work: set `agent.loop_detection.max_repeats_before_nudge: 1` in `~/.hermes/config.yaml` and confirm nudge triggers on the 2nd call

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (55 pre-existing failures unrelated to this change; 14083 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings added to both new methods
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — defaults in `DEFAULT_CONFIG` are sufficient, consistent with other auxiliary config sections
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

When the loop detection triggers, the agent emits status messages like:

```
⚠️ Model repeated `web_search` — nudging to process results
⚠️ Model still repeating `web_search` — stronger warning
⚠️ Model stuck in tool loop — breaking for re-prompt
❌ Model entered tool loop calling `web_search` 6 times — terminated
```
