### PR TITLE
fix: correctly aggregate mixed toolset availability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -954,9 +954,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
-      "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/tests/tools/test_registry_toolset_availability.py
+++ b/tests/tools/test_registry_toolset_availability.py
@@ -1,0 +1,61 @@
+from tools.registry import ToolRegistry
+
+
+def _dummy_handler(args, **kwargs):
+    return "{}"
+
+
+def _make_schema(name: str):
+    return {
+        "name": name,
+        "description": name,
+        "parameters": {"type": "object", "properties": {}},
+    }
+
+
+def test_toolset_availability_uses_any_available_tool_in_group():
+    reg = ToolRegistry()
+    reg.register(
+        name="browser_cdp",
+        toolset="browser",
+        schema=_make_schema("browser_cdp"),
+        handler=_dummy_handler,
+        check_fn=lambda: False,
+    )
+    reg.register(
+        name="browser_navigate",
+        toolset="browser",
+        schema=_make_schema("browser_navigate"),
+        handler=_dummy_handler,
+        check_fn=lambda: True,
+    )
+
+    available, unavailable = reg.check_tool_availability()
+
+    assert "browser" in available
+    assert all(item["name"] != "browser" for item in unavailable)
+
+
+def test_unavailable_toolset_unions_env_requirements_across_tools():
+    reg = ToolRegistry()
+    reg.register(
+        name="cloud_a",
+        toolset="cloud",
+        schema=_make_schema("cloud_a"),
+        handler=_dummy_handler,
+        check_fn=lambda: False,
+        requires_env=["API_KEY_A"],
+    )
+    reg.register(
+        name="cloud_b",
+        toolset="cloud",
+        schema=_make_schema("cloud_b"),
+        handler=_dummy_handler,
+        check_fn=lambda: False,
+        requires_env=["API_KEY_B"],
+    )
+
+    _, unavailable = reg.check_tool_availability()
+    cloud = next(item for item in unavailable if item["name"] == "cloud")
+
+    assert cloud["env_vars"] == ["API_KEY_A", "API_KEY_B"]

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -132,6 +132,34 @@ class ToolRegistry:
             logger.debug("Toolset %s check raised; marking unavailable", toolset)
             return False
 
+    def _get_toolset_status(
+        self,
+        toolset: str,
+        entries: List[ToolEntry],
+        fallback_check: Callable | None = None,
+    ) -> tuple[bool, List[str], List[str]]:
+        """Return availability, env vars, and tool names for a toolset snapshot.
+
+        Toolsets can contain tools with different requirement checks. Consider the
+        toolset available when any tool in the group is available, while still
+        reporting the union of required env vars across all tools in the group.
+        """
+        tool_entries = [entry for entry in entries if entry.toolset == toolset]
+
+        env_vars: List[str] = []
+        tool_names: List[str] = []
+        available = False
+
+        for entry in tool_entries:
+            tool_names.append(entry.name)
+            for env in entry.requires_env:
+                if env not in env_vars:
+                    env_vars.append(env)
+            if self._evaluate_toolset_check(toolset, entry.check_fn or fallback_check):
+                available = True
+
+        return available, env_vars, tool_names
+
     def get_entry(self, name: str) -> Optional[ToolEntry]:
         """Return a registered tool entry by name, or None."""
         with self._lock:
@@ -350,21 +378,26 @@ class ToolRegistry:
         return {entry.name: entry.toolset for entry in self._snapshot_entries()}
 
     def is_toolset_available(self, toolset: str) -> bool:
-        """Check if a toolset's requirements are met.
+        """Check if a toolset has at least one available tool.
 
-        Returns False (rather than crashing) when the check function raises
-        an unexpected exception (e.g. network error, missing import, bad config).
+        Returns False (rather than crashing) when all relevant checks raise or
+        fail. Toolsets with heterogeneous checks are available when any tool in
+        the group is available.
         """
-        with self._lock:
-            check = self._toolset_checks.get(toolset)
-        return self._evaluate_toolset_check(toolset, check)
+        entries, toolset_checks = self._snapshot_state()
+        available, _env_vars, _tools = self._get_toolset_status(
+            toolset,
+            entries,
+            toolset_checks.get(toolset),
+        )
+        return available
 
     def check_toolset_requirements(self) -> Dict[str, bool]:
         """Return ``{toolset: available_bool}`` for every toolset."""
         entries, toolset_checks = self._snapshot_state()
         toolsets = sorted({entry.toolset for entry in entries})
         return {
-            toolset: self._evaluate_toolset_check(toolset, toolset_checks.get(toolset))
+            toolset: self._get_toolset_status(toolset, entries, toolset_checks.get(toolset))[0]
             for toolset in toolsets
         }
 
@@ -372,22 +405,18 @@ class ToolRegistry:
         """Return toolset metadata for UI display."""
         toolsets: Dict[str, dict] = {}
         entries, toolset_checks = self._snapshot_state()
-        for entry in entries:
-            ts = entry.toolset
-            if ts not in toolsets:
-                toolsets[ts] = {
-                    "available": self._evaluate_toolset_check(
-                        ts, toolset_checks.get(ts)
-                    ),
-                    "tools": [],
-                    "description": "",
-                    "requirements": [],
-                }
-            toolsets[ts]["tools"].append(entry.name)
-            if entry.requires_env:
-                for env in entry.requires_env:
-                    if env not in toolsets[ts]["requirements"]:
-                        toolsets[ts]["requirements"].append(env)
+        for ts in sorted({entry.toolset for entry in entries}):
+            available, env_vars, tool_names = self._get_toolset_status(
+                ts,
+                entries,
+                toolset_checks.get(ts),
+            )
+            toolsets[ts] = {
+                "available": available,
+                "tools": tool_names,
+                "description": "",
+                "requirements": env_vars,
+            }
         return toolsets
 
     def get_toolset_requirements(self) -> Dict[str, dict]:
@@ -415,20 +444,20 @@ class ToolRegistry:
         """Return (available_toolsets, unavailable_info) like the old function."""
         available = []
         unavailable = []
-        seen = set()
         entries, toolset_checks = self._snapshot_state()
-        for entry in entries:
-            ts = entry.toolset
-            if ts in seen:
-                continue
-            seen.add(ts)
-            if self._evaluate_toolset_check(ts, toolset_checks.get(ts)):
+        for ts in sorted({entry.toolset for entry in entries}):
+            is_available, env_vars, tool_names = self._get_toolset_status(
+                ts,
+                entries,
+                toolset_checks.get(ts),
+            )
+            if is_available:
                 available.append(ts)
             else:
                 unavailable.append({
                     "name": ts,
-                    "env_vars": entry.requires_env,
-                    "tools": [e.name for e in entries if e.toolset == ts],
+                    "env_vars": env_vars,
+                    "tools": tool_names,
                 })
         return available, unavailable
 


### PR DESCRIPTION
## Summary
- fix toolset availability checks so a mixed-requirement toolset is considered available when any tool in the group is actually usable
- union toolset env-var requirements across all tools when reporting unavailable toolsets
- add regression coverage for mixed toolset checks and aggregated env-var reporting
- bump `basic-ftp` from 5.2.2 to 5.3.0 in `package-lock.json` to clear the current npm audit warning

## Why
`hermes doctor` was reporting the `browser` toolset as unavailable even though the normal browser tools worked locally. The browser toolset mixes stricter checks (`browser_cdp`) with standard browser checks, and the registry-level toolset availability logic only considered one check function for the whole toolset.

This change makes toolset availability reflect the actual set of tools in the group instead of whichever tool registered first.

## Verification
- `pytest tests/test_toolsets.py tests/tools/test_browser_homebrew_paths.py tests/hermes_cli/test_doctor.py tests/tools/test_mcp_dynamic_discovery.py tests/tools/test_registry_toolset_availability.py -q`
- `npm audit --json`
- `hermes doctor`
