### PR TITLE
fix(gemini): validate native model switches against the AI Studio catalog

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2344,6 +2344,51 @@ def validate_requested_model(
                 ),
             }
 
+    # Google AI Studio routes Gemini through the native Gemini API rather than
+    # an OpenAI-compatible /models endpoint. Validate against the curated
+    # catalog so /model switches keep working after the native adapter change.
+    if normalized == "gemini":
+        try:
+            catalog_models = provider_model_ids(normalized)
+        except Exception:
+            catalog_models = []
+        if catalog_models:
+            catalog_lower = {m.lower(): m for m in catalog_models}
+            requested_lower = requested_for_lookup.lower()
+            if requested_lower in catalog_lower:
+                return {
+                    "accepted": True,
+                    "persist": True,
+                    "recognized": True,
+                    "message": None,
+                }
+            catalog_lower_list = list(catalog_lower.keys())
+            auto = get_close_matches(requested_lower, catalog_lower_list, n=1, cutoff=0.9)
+            if auto:
+                corrected = catalog_lower[auto[0]]
+                return {
+                    "accepted": True,
+                    "persist": True,
+                    "recognized": True,
+                    "corrected_model": corrected,
+                    "message": f"Auto-corrected `{requested}` → `{corrected}`",
+                }
+            suggestions = get_close_matches(requested_lower, catalog_lower_list, n=3, cutoff=0.5)
+            suggestion_text = ""
+            if suggestions:
+                suggestion_text = "\n  Similar models: " + ", ".join(f"`{catalog_lower[s]}`" for s in suggestions)
+            return {
+                "accepted": True,
+                "persist": True,
+                "recognized": False,
+                "message": (
+                    f"Note: `{requested}` was not found in the Google AI Studio catalog."
+                    f"{suggestion_text}"
+                    "\n  Google AI Studio does not expose a /models endpoint for the native Gemini API,"
+                    "\n  so Hermes cannot verify the model name over the wire."
+                ),
+            }
+
     # Probe the live API to check if the model actually exists
     api_models = fetch_api_models(api_key, base_url)
 

--- a/tests/hermes_cli/test_gemini_model_validation.py
+++ b/tests/hermes_cli/test_gemini_model_validation.py
@@ -1,0 +1,44 @@
+"""Tests for Gemini model validation via the static provider catalog.
+
+Google AI Studio's native Gemini API does not expose an OpenAI-compatible
+``/models`` listing, so ``validate_requested_model()`` must not reject valid
+Gemini model switches just because the old probe path is unreachable.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.models import validate_requested_model
+
+
+class TestGeminiModelValidation:
+    @pytest.fixture(autouse=True)
+    def _isolate_gemini(self):
+        probe_payload = {
+            "models": None,
+            "probed_url": "https://generativelanguage.googleapis.com/v1beta/models",
+            "resolved_base_url": "https://generativelanguage.googleapis.com/v1beta",
+            "suggested_base_url": None,
+            "used_fallback": False,
+        }
+        with patch("hermes_cli.models.fetch_api_models", return_value=None), \
+             patch("hermes_cli.models.probe_api_models", return_value=probe_payload):
+            yield
+
+    def test_known_gemini_model_accepted_via_catalog_when_api_probe_unavailable(self):
+        result = validate_requested_model("gemini-3.1-pro-preview", "gemini")
+
+        assert result["accepted"] is True
+        assert result["persist"] is True
+        assert result["recognized"] is True
+        assert result["message"] is None
+
+    def test_unknown_gemini_model_warns_but_does_not_block_switch(self):
+        result = validate_requested_model("gemini-4-experimental-preview", "gemini")
+
+        assert result["accepted"] is True
+        assert result["persist"] is True
+        assert result["recognized"] is False
+        assert "Google AI Studio" in result["message"]
+        assert "does not expose a /models endpoint" in result["message"]


### PR DESCRIPTION
## Summary
- validate `gemini` /model switches against the built-in Google AI Studio catalog instead of probing an OpenAI-style `/models` endpoint
- keep valid Gemini model switches working after the native Gemini adapter migration
- add regression coverage for recognized and unrecognized Gemini model names when the API probe is unavailable

## Why
Fixes #13186.

Google AI Studio's native Gemini API does not expose an OpenAI-compatible `/models` listing. After the native adapter migration, `validate_requested_model()` still fell through to the generic `/models` probe path, so valid `/model gemini-*` switches were rejected even though the provider's static catalog already knew about those models.

## Verification
- `python3 -m pytest -o addopts='' -q tests/hermes_cli/test_gemini_model_validation.py`
- `python3 -m pytest -o addopts='' -q tests/test_minimax_model_validation.py`
- `python3 -m pytest -o addopts='' -q tests/hermes_cli/test_gemini_provider.py`
