### PR TITLE
feat(cli): add list_picker_providers for credential-filtered picker

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4644,6 +4644,7 @@ class GatewayRunner:
         from hermes_cli.model_switch import (
             switch_model as _switch_model, parse_model_flags,
             list_authenticated_providers,
+            list_picker_providers,
         )
         from hermes_cli.providers import get_label
 
@@ -4699,7 +4700,7 @@ class GatewayRunner:
 
             if has_picker:
                 try:
-                    providers = list_authenticated_providers(
+                    providers = list_picker_providers(
                         current_provider=current_provider,
                         user_providers=user_provs,
                         custom_providers=custom_provs,

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1107,3 +1107,59 @@ def list_authenticated_providers(
     results.sort(key=lambda r: (not r["is_current"], -r["total_models"]))
 
     return results
+
+
+def list_picker_providers(
+    current_provider: str = "",
+    user_providers: dict = None,
+    custom_providers: list | None = None,
+    max_models: int = 8,
+) -> List[dict]:
+    """Interactive-picker variant of :func:`list_authenticated_providers`.
+
+    Post-processes the base list so the ``/model`` picker (Telegram/Discord
+    inline keyboards) only surfaces models that are actually callable in the
+    current install:
+
+    - OpenRouter's model list is replaced with the output of
+      :func:`hermes_cli.models.fetch_openrouter_models`, which filters the
+      curated ``OPENROUTER_MODELS`` snapshot against the live OpenRouter
+      catalog.  IDs the live catalog no longer carries drop out, so the
+      picker never offers a model the user can't call.
+    - Provider rows whose model list ends up empty are dropped, except
+      custom endpoints (``is_user_defined=True`` with an ``api_url``) where
+      the user may supply their own model set through config.
+
+    All other providers and metadata fields are passed through unchanged.
+    The typed ``/model <name>`` path is unaffected -- only the interactive
+    picker payload is narrowed.
+    """
+    from hermes_cli.models import fetch_openrouter_models
+
+    providers = list_authenticated_providers(
+        current_provider=current_provider,
+        user_providers=user_providers,
+        custom_providers=custom_providers,
+        max_models=max_models,
+    )
+
+    filtered: List[dict] = []
+    for p in providers:
+        slug = str(p.get("slug", "")).lower()
+        if slug == "openrouter":
+            try:
+                live = fetch_openrouter_models()
+                live_ids = [mid for mid, _ in live]
+            except Exception:
+                live_ids = list(p.get("models", []))
+            p = dict(p)
+            p["models"] = live_ids[:max_models]
+            p["total_models"] = len(live_ids)
+
+        has_models = bool(p.get("models"))
+        is_custom_endpoint = bool(p.get("is_user_defined")) and bool(p.get("api_url"))
+        if not has_models and not is_custom_endpoint:
+            continue
+        filtered.append(p)
+
+    return filtered

--- a/tests/hermes_cli/test_list_picker_providers.py
+++ b/tests/hermes_cli/test_list_picker_providers.py
@@ -1,0 +1,216 @@
+"""Tests for ``list_picker_providers`` — the /model picker filter.
+
+``list_picker_providers`` wraps ``list_authenticated_providers`` and
+post-processes the result for interactive pickers (Telegram, Discord):
+
+- OpenRouter's ``models`` are replaced with the live-filtered output of
+  ``fetch_openrouter_models``, so IDs the live catalog no longer carries
+  drop out.
+- Provider rows with an empty ``models`` list are dropped, except custom
+  endpoints (``is_user_defined=True`` with an ``api_url``) where the user
+  may supply their own model set through config.
+
+These tests exercise the filter in isolation by mocking
+``list_authenticated_providers`` and ``fetch_openrouter_models`` so no
+network or auth state is required.
+"""
+
+import pytest
+from hermes_cli import model_switch
+
+
+def _make_provider(slug, name=None, models=None, *, is_current=False,
+                   is_user_defined=False, source="built-in", api_url=None):
+    """Build a dict shaped like ``list_authenticated_providers`` output."""
+    entry = {
+        "slug": slug,
+        "name": name or slug.title(),
+        "is_current": is_current,
+        "is_user_defined": is_user_defined,
+        "models": list(models or []),
+        "total_models": len(models or []),
+        "source": source,
+    }
+    if api_url is not None:
+        entry["api_url"] = api_url
+    return entry
+
+
+def test_openrouter_models_replaced_with_live_catalog(monkeypatch):
+    """OpenRouter row's ``models`` should come from fetch_openrouter_models."""
+    base = [
+        _make_provider("openrouter", models=["openai/gpt-stale", "old/model"]),
+    ]
+    live = [("openai/gpt-5.4", "recommended"), ("moonshotai/kimi-k2.6", "")]
+
+    monkeypatch.setattr(model_switch, "list_authenticated_providers",
+                        lambda **kw: list(base))
+    monkeypatch.setattr("hermes_cli.models.fetch_openrouter_models",
+                        lambda *a, **kw: list(live))
+
+    result = model_switch.list_picker_providers(max_models=50)
+
+    assert len(result) == 1
+    openrouter = result[0]
+    assert openrouter["slug"] == "openrouter"
+    assert openrouter["models"] == ["openai/gpt-5.4", "moonshotai/kimi-k2.6"]
+    assert openrouter["total_models"] == 2
+
+
+def test_openrouter_falls_back_to_base_models_on_fetch_failure(monkeypatch):
+    """If the live catalog fetch raises, keep whatever base provided."""
+    fallback_models = ["openai/gpt-5.4", "moonshotai/kimi-k2.6"]
+    base = [_make_provider("openrouter", models=fallback_models)]
+
+    def _raise(*_a, **_kw):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(model_switch, "list_authenticated_providers",
+                        lambda **kw: list(base))
+    monkeypatch.setattr("hermes_cli.models.fetch_openrouter_models", _raise)
+
+    result = model_switch.list_picker_providers(max_models=50)
+
+    assert len(result) == 1
+    assert result[0]["models"] == fallback_models
+
+
+def test_openrouter_empty_live_catalog_drops_row(monkeypatch):
+    """If the live catalog returns nothing for OpenRouter, drop the row."""
+    base = [_make_provider("openrouter", models=["something/stale"])]
+
+    monkeypatch.setattr(model_switch, "list_authenticated_providers",
+                        lambda **kw: list(base))
+    monkeypatch.setattr("hermes_cli.models.fetch_openrouter_models",
+                        lambda *a, **kw: [])
+
+    result = model_switch.list_picker_providers(max_models=50)
+
+    assert result == []
+
+
+def test_non_openrouter_rows_passed_through_unchanged(monkeypatch):
+    """Non-OpenRouter providers keep their curated ``models`` as-is."""
+    base = [
+        _make_provider("anthropic", models=["claude-sonnet-4-6", "claude-opus-4-7"]),
+        _make_provider("gemini", models=["gemini-3-flash-preview"]),
+    ]
+
+    monkeypatch.setattr(model_switch, "list_authenticated_providers",
+                        lambda **kw: list(base))
+    # fetch_openrouter_models must not be consulted when there's no openrouter row
+    monkeypatch.setattr("hermes_cli.models.fetch_openrouter_models",
+                        lambda *a, **kw: pytest.fail("should not be called"))
+
+    result = model_switch.list_picker_providers(max_models=50)
+
+    assert [p["slug"] for p in result] == ["anthropic", "gemini"]
+    assert result[0]["models"] == ["claude-sonnet-4-6", "claude-opus-4-7"]
+    assert result[1]["models"] == ["gemini-3-flash-preview"]
+
+
+def test_empty_models_row_dropped(monkeypatch):
+    """Built-in provider with an empty ``models`` list is dropped."""
+    base = [
+        _make_provider("anthropic", models=[]),  # drop
+        _make_provider("openrouter", models=["anything"]),  # replaced by live
+    ]
+
+    monkeypatch.setattr(model_switch, "list_authenticated_providers",
+                        lambda **kw: list(base))
+    monkeypatch.setattr("hermes_cli.models.fetch_openrouter_models",
+                        lambda *a, **kw: [("openai/gpt-5.4", "recommended")])
+
+    result = model_switch.list_picker_providers(max_models=50)
+
+    assert [p["slug"] for p in result] == ["openrouter"]
+
+
+def test_custom_endpoint_with_api_url_kept_when_models_empty(monkeypatch):
+    """User-defined endpoints with an ``api_url`` survive even if models empty.
+
+    Rationale: custom endpoints may accept any model id the user types --
+    the picker still shows the row so the user can enter one manually.
+    """
+    base = [
+        _make_provider("local-ollama", is_user_defined=True,
+                       api_url="http://localhost:11434/v1", models=[],
+                       source="user-config"),
+    ]
+
+    monkeypatch.setattr(model_switch, "list_authenticated_providers",
+                        lambda **kw: list(base))
+    monkeypatch.setattr("hermes_cli.models.fetch_openrouter_models",
+                        lambda *a, **kw: [])
+
+    result = model_switch.list_picker_providers(max_models=50)
+
+    assert len(result) == 1
+    assert result[0]["slug"] == "local-ollama"
+    assert result[0]["models"] == []
+
+
+def test_user_defined_without_api_url_and_empty_models_dropped(monkeypatch):
+    """An is_user_defined row WITHOUT api_url and no models is still dropped.
+
+    The exemption is specifically for custom endpoints that can accept
+    arbitrary model ids; without an api_url there's nothing to point at.
+    """
+    base = [
+        _make_provider("orphan", is_user_defined=True, api_url=None, models=[]),
+    ]
+
+    monkeypatch.setattr(model_switch, "list_authenticated_providers",
+                        lambda **kw: list(base))
+    monkeypatch.setattr("hermes_cli.models.fetch_openrouter_models",
+                        lambda *a, **kw: [])
+
+    result = model_switch.list_picker_providers(max_models=50)
+
+    assert result == []
+
+
+def test_max_models_caps_openrouter_live_output(monkeypatch):
+    """``max_models`` caps how many OpenRouter IDs land in the row."""
+    live = [(f"vendor/model-{i}", "") for i in range(20)]
+    base = [_make_provider("openrouter", models=["placeholder"])]
+
+    monkeypatch.setattr(model_switch, "list_authenticated_providers",
+                        lambda **kw: list(base))
+    monkeypatch.setattr("hermes_cli.models.fetch_openrouter_models",
+                        lambda *a, **kw: list(live))
+
+    result = model_switch.list_picker_providers(max_models=5)
+
+    assert len(result) == 1
+    assert len(result[0]["models"]) == 5
+    assert result[0]["models"] == [mid for mid, _ in live[:5]]
+    # total_models reflects the full live catalog, not the capped slice.
+    assert result[0]["total_models"] == 20
+
+
+def test_passthrough_kwargs_to_base(monkeypatch):
+    """All kwargs (current_provider, user_providers, custom_providers, max_models)
+    must be forwarded to ``list_authenticated_providers`` unchanged.
+    """
+    captured = {}
+
+    def _capture(**kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(model_switch, "list_authenticated_providers", _capture)
+    monkeypatch.setattr("hermes_cli.models.fetch_openrouter_models",
+                        lambda *a, **kw: [])
+
+    model_switch.list_picker_providers(
+        current_provider="openrouter",
+        user_providers={"foo": {"api": "http://x"}},
+        custom_providers=[{"name": "bar", "base_url": "http://y"}],
+        max_models=12,
+    )
+
+    assert captured["current_provider"] == "openrouter"
+    assert captured["user_providers"] == {"foo": {"api": "http://x"}}
+    assert captured["custom_providers"] == [{"name": "bar", "base_url": "http://y"}]
+    assert captured["max_models"] == 12


### PR DESCRIPTION
## What

Adds `list_picker_providers()` — a thin wrapper around `list_authenticated_providers()` that post-processes the result so the interactive `/model` picker (Telegram, Discord) only surfaces models the user can actually call. `_handle_model_command()` in `gateway/run.py` switches to the new helper for the interactive picker payload only.

## Why

Two failure modes today when a user opens `/model`:

1. **Stale OpenRouter IDs** — `OPENROUTER_MODELS` is a static snapshot. When OpenRouter drops or renames a model upstream between Hermes releases, the picker still offers it; tapping it fails at call time.
2. **Empty provider rows** — a credential-pool slug can exist with no actual key material behind it (e.g. leftover from a prior provider that's been env-wiped). The picker shows the row, the user taps, nothing happens.

The filter fixes both without changing `list_authenticated_providers()`, which is also consumed by the CLI text fallback where the unfiltered view is arguably still the right default.

## How it works

- For the `openrouter` row, `models` are replaced with the output of `fetch_openrouter_models()`, which already cross-checks the curated snapshot against the live OpenRouter catalog.
- Rows with an empty `models` list are dropped, **except** custom endpoints (`is_user_defined=True` with an `api_url`) where the user may enter model IDs manually.
- All other fields pass through unchanged.

Typed `/model <name>` and the text fallback list stay on `list_authenticated_providers()`, so nothing is hidden from power users or platforms without an interactive picker.

## How to test

```
pytest tests/hermes_cli/test_list_picker_providers.py -v
```

Nine focused unit tests covering:
- OpenRouter models replaced with live catalog
- Fallback to base models when the live fetch raises
- Empty live catalog drops the OpenRouter row
- Non-OpenRouter rows passed through unchanged
- Empty `models` row dropped
- Custom endpoint with `api_url` kept when models empty
- User-defined row without `api_url` and empty models dropped
- `max_models` caps OpenRouter live output
- All kwargs forwarded to the base function

Manual test: open `/model` in Telegram with a setup that exercises each branch — OpenRouter + a direct provider + a user-defined custom endpoint.

## Platforms tested

- macOS (Darwin 25.4.0, Python 3.11)

## Notes

- No config/schema changes, no new dependencies, no migration path.
- The branch is based on an older `main` (fork was behind by ~800 commits and syncing required a `workflow` OAuth scope I didn't have). The three files touched cherry-picked onto current `main` cleanly in my local worktree — happy to rebase on request.