### PR TITLE
fix(gateway): add IMAP ID extension and SMTP port 465 support

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -32,6 +32,77 @@ from email import encoders
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+# RFC 2971 — IMAP ID extension
+# Some mail servers (notably 163.com) require client identity info or they
+# reject the connection as "Unsafe Login". We send a minimal ID command after
+# login so the server can identify this client as a legitimate IMAP agent.
+_IMAP_ID_INFO = {
+    "name": "Hermes-Agent",
+    "version": "1.0",
+    "vendor": "Hermes-Agent",
+    "support-email": "support@hermes-agent.local",
+}
+
+
+def _send_imap_id(imap: imaplib.IMAP4) -> None:
+    """Send RFC 2971 ID command if the server advertises it.
+
+    163.com requires this or SELECT INBOX fails with "Unsafe Login".
+    We silently skip if the server doesn't support ID — it's optional per RFC.
+    """
+    try:
+        # Check capabilities first — ID extension must be advertised
+        cap_response = imap.capability()
+        if cap_response[0] != "OK":
+            return
+        # capability() returns bytes in the data list, decode them all
+        caps = " ".join(c.decode() if isinstance(c, bytes) else c for c in cap_response[1]).upper()
+        if "ID" not in caps:
+            return
+
+        # Build ID command per RFC 2971 §3.2
+        # ID args are: ("key1" "val1" "key2" "val2" ...)
+        args = []
+        for key, val in _IMAP_ID_INFO.items():
+            args.append(f'"{key}" "{val}"')
+        id_line = "ID (" + " ".join(args) + ")"
+
+        # Send ID command and read response directly over the socket.
+        # We bypass imaplib's _command/_get_response machinery because the ID
+        # command's parenthesized list argument conflicts with how _command()
+        # tokenises and validates arguments against the Commands table.
+        tag = imap._new_tag()
+        cmd = tag + b' ' + id_line.encode() + b'\r\n'
+        imap.send(cmd)
+
+        # Read lines until we get our tagged response (starts with our tag)
+        while True:
+            line = imap.readline()
+            if line.startswith(tag):
+                # This is our tagged OK/NO/BAD — we're done
+                break
+            # Otherwise it's an untagged or continuation response; keep reading
+        logger.debug("[Email] IMAP ID sent, server responded: %s", line)
+    except Exception:
+        # ID is optional — never fail the connection because of it
+        logger.exception("[Email] IMAP ID command failed (non-fatal)")
+
+
+def _create_smtp_connection(host: str, port: int) -> smtplib.SMTP:
+    """Create an SMTP connection configured for the current mail server.
+
+    Per RFC 8314: port 465 uses implicit TLS (SMTP_SSL), port 587 uses STARTTLS.
+    """
+    if port == 465:
+        # Implicit TLS — use SMTP_SSL right away
+        return smtplib.SMTP_SSL(host, port, timeout=30, context=ssl.create_default_context())
+    else:
+        # Explicit TLS — upgrade plain connection with STARTTLS
+        smtp = smtplib.SMTP(host, port, timeout=30)
+        smtp.starttls(context=ssl.create_default_context())
+        return smtp
+
+
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
@@ -275,6 +346,7 @@ class EmailAdapter(BasePlatformAdapter):
             # Test IMAP connection
             imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
             imap.login(self._address, self._password)
+            _send_imap_id(imap)  # RFC 2971 — required by 163.com, harmless for others
             # Mark all existing messages as seen so we only process new ones
             imap.select("INBOX")
             status, data = imap.uid("search", None, "ALL")
@@ -291,13 +363,12 @@ class EmailAdapter(BasePlatformAdapter):
 
         try:
             # Test SMTP connection
-            smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
-            smtp.starttls(context=ssl.create_default_context())
+            smtp = _create_smtp_connection(self._smtp_host, self._smtp_port)
             smtp.login(self._address, self._password)
             smtp.quit()
             logger.info("[Email] SMTP connection test passed.")
         except Exception as e:
-            logger.error("[Email] SMTP connection failed: %s", e)
+            logger.exception("[Email] SMTP connection failed")
             return False
 
         self._running = True
@@ -343,6 +414,7 @@ class EmailAdapter(BasePlatformAdapter):
             imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
             try:
                 imap.login(self._address, self._password)
+                _send_imap_id(imap)  # RFC 2971 — required by 163.com, harmless for others
                 imap.select("INBOX")
 
                 status, data = imap.uid("search", None, "UNSEEN")
@@ -509,9 +581,8 @@ class EmailAdapter(BasePlatformAdapter):
 
         msg.attach(MIMEText(body, "plain", "utf-8"))
 
-        smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
+        smtp = _create_smtp_connection(self._smtp_host, self._smtp_port)
         try:
-            smtp.starttls(context=ssl.create_default_context())
             smtp.login(self._address, self._password)
             smtp.send_message(msg)
         finally:
@@ -601,9 +672,8 @@ class EmailAdapter(BasePlatformAdapter):
             part.add_header("Content-Disposition", f"attachment; filename={fname}")
             msg.attach(part)
 
-        smtp = smtplib.SMTP(self._smtp_host, self._smtp_port, timeout=30)
+        smtp = _create_smtp_connection(self._smtp_host, self._smtp_port)
         try:
-            smtp.starttls(context=ssl.create_default_context())
             smtp.login(self._address, self._password)
             smtp.send_message(msg)
         finally:

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -1041,3 +1041,75 @@ class TestImapConnectionCleanup(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestSendImapId(unittest.TestCase):
+    """Test the _send_imap_id function for RFC 2971 IMAP ID extension."""
+
+    def test_send_imap_id_when_supported(self):
+        """Should send ID command when server advertises ID capability."""
+        from gateway.platforms.email import _send_imap_id
+
+        mock_imap = MagicMock()
+        mock_imap.capability.return_value = ("OK", [b"IMAP4rev1 ID"])
+        mock_imap._new_tag.return_value = b"A1"
+        mock_imap.readline.return_value = b"A1 OK ID completed"
+
+        _send_imap_id(mock_imap)
+
+        mock_imap.capability.assert_called_once()
+        mock_imap.send.assert_called_once()
+        sent_cmd = mock_imap.send.call_args[0][0]
+        self.assertIn(b"ID", sent_cmd)
+
+    def test_send_imap_id_skips_when_not_supported(self):
+        """Should skip ID command when server doesn't advertise ID capability."""
+        from gateway.platforms.email import _send_imap_id
+
+        mock_imap = MagicMock()
+        mock_imap.capability.return_value = ("OK", [b"IMAP4rev1"])
+
+        _send_imap_id(mock_imap)
+
+        mock_imap.send.assert_not_called()
+
+    def test_send_imap_id_handles_exception(self):
+        """Should not raise on errors (ID is optional per RFC)."""
+        from gateway.platforms.email import _send_imap_id
+
+        mock_imap = MagicMock()
+        mock_imap.capability.side_effect = Exception("Network error")
+
+        # Should not raise
+        _send_imap_id(mock_imap)
+
+
+class TestCreateSmtpConnection(unittest.TestCase):
+    """Test the _create_smtp_connection function for SMTP port handling."""
+
+    @patch("smtplib.SMTP_SSL")
+    def test_port_465_uses_implicit_tls(self, mock_smtp_ssl):
+        """Port 465 should use SMTP_SSL (implicit TLS)."""
+        from gateway.platforms.email import _create_smtp_connection
+
+        mock_server = MagicMock()
+        mock_smtp_ssl.return_value = mock_server
+
+        result = _create_smtp_connection("smtp.example.com", 465)
+
+        mock_smtp_ssl.assert_called_once()
+        self.assertEqual(result, mock_server)
+
+    @patch("smtplib.SMTP")
+    def test_port_587_uses_starttls(self, mock_smtp):
+        """Port 587 should use SMTP with STARTTLS."""
+        from gateway.platforms.email import _create_smtp_connection
+
+        mock_server = MagicMock()
+        mock_smtp.return_value = mock_server
+
+        result = _create_smtp_connection("smtp.example.com", 587)
+
+        mock_smtp.assert_called_once()
+        mock_server.starttls.assert_called_once()
+        self.assertEqual(result, mock_server)


### PR DESCRIPTION
## What does this PR do?

- Add RFC 2971 IMAP ID extension support for providers that require client identification (notably 163.com)
- Fix SMTP connection to properly handle implicit TLS on port 465 per RFC 8314



## Platforms Tested

- macOS (local development)
- Raspberry Pi 4B (Docker container)

## Notes

- The IMAP ID command is sent after every login to ensure compatibility
- ID command failures are logged but don't fail the connection (it's optional per RFC)



## Related Issue

https://github.com/NousResearch/hermes-agent/issues/13558

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

### IMAP ID Extension (RFC 2971)

Some mail servers (notably 163.com) reject connections as "Unsafe Login" if the client doesn't identify itself via the IMAP ID command after login. This PR adds `_send_imap_id()` which:

- Checks if the server advertises ID capability
- Sends a minimal client identity
- Gracefully skips if ID is not supported (per RFC, it's optional)

### SMTP Connection Fix (RFC 8314)

Previously, the code always used STARTTLS regardless of port. Per RFC 8314:
- Port 465 should use implicit TLS (SMTP_SSL)
- Port 587 should use STARTTLS

This fixes connection issues with providers like 163.com that use port 465 for SMTP.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Setup 163.com email in `hermes setup gateway`
2. Add `EMAIL_SMTP_PORT=465` to `~/.hermes/.env`
3. IMAP login now succeeds (previously failed with "Unsafe Login"); SMTP send works correctly on port 465
4. All existing email tests pass in `tests/gateway/test_email.py`

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
  - Some (82) tests failed, all unrelated to this change
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [N/A] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [N/A] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [N/A] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [N/A] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

