### PR TITLE
fix(cron): propagate agent failures instead of silently marking as success

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -963,6 +963,32 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 f"— last activity: {_last_desc}"
             )
 
+        # Check if the agent reported a failure (e.g. 403 auth, context overflow).
+        # run_conversation() returns {"failed": True, "completed": False, "error": "..."}
+        # on non-retryable API errors — we must propagate that as a cron failure,
+        # not silently swallow it.
+        agent_failed = result.get("failed") or not result.get("completed", True)
+        if agent_failed:
+            agent_error = result.get("error") or "Agent reported failure (no error detail)"
+            logger.error("Job '%s' agent returned failure: %s", job_name, agent_error)
+            output = f"""# Cron Job: {job_name} (FAILED)
+
+**Job ID:** {job_id}
+**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}
+**Schedule:** {job.get('schedule_display', 'N/A')}
+
+## Prompt
+
+{prompt}
+
+## Error
+
+```
+{agent_error}
+```
+"""
+            return False, output, "", agent_error
+
         final_response = result.get("final_response", "") or ""
         # Strip leaked placeholder text that upstream may inject on empty completions.
         if final_response.strip() == "(No response generated)":
@@ -970,7 +996,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         # Use a separate variable for log display; keep final_response clean
         # for delivery logic (empty response = no delivery).
         logged_response = final_response if final_response else "(No response generated)"
-        
+
         output = f"""# Cron Job: {job_name}
 
 **Job ID:** {job_id}
@@ -985,7 +1011,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
 
 {logged_response}
 """
-        
+
         logger.info("Job '%s' completed successfully", job_name)
         return True, output, final_response, None
         


### PR DESCRIPTION
## What does this PR do?

Fixes silent cron job failures when the agent encounters non-retryable errors.

## Problem

When `run_conversation()` encounters a non-retryable API error (403 auth, rate limit, context overflow), it returns:
```python
{"failed": True, "completed": False, "error": "API key expired"}
```

The cron scheduler doesn't check these fields and incorrectly marks the job as successful with "(No response generated)" — a **silent failure**. Users think their scheduled tasks succeeded when they actually failed.

## Solution

Added a check for `failed: True` or `completed: False` before processing the response. Agent failures now:
- Return `False` (failure status)
- Include the actual error message in the output
- Log the failure with `logger.error()`

## Changes Made

- `cron/scheduler.py`: Added agent failure check before processing `final_response`

## How to Test

1. Create a cron job that will trigger an agent error (e.g., invalid API key)
2. Run the job manually: `hermes cron run <job_id>`
3. Check status: `hermes cron list`
4. Status should show error with message, not "ok"

## Related Issues

While not an exact match, this addresses the same class of problems as:
- #5861 (silent delivery failures)
- #2788 (no useful failure information)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix
- [x] I've tested manually