### PR TITLE
Fix delegate_task direct endpoint api_mode detection for OpenAI/xAI/Anthropic proxies

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -659,6 +659,45 @@ class TestDelegationCredentialResolution(unittest.TestCase):
                 _resolve_delegation_credentials(cfg, parent)
         self.assertIn("OPENAI_API_KEY", str(ctx.exception))
 
+    def test_direct_openai_endpoint_uses_codex_responses_api_mode(self):
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "model": "gpt-5-mini",
+            "base_url": "https://api.openai.com/v1",
+            "api_key": "openai-key",
+        }
+
+        creds = _resolve_delegation_credentials(cfg, parent)
+
+        self.assertEqual(creds["provider"], "custom")
+        self.assertEqual(creds["api_mode"], "codex_responses")
+
+    def test_direct_xai_endpoint_uses_codex_responses_api_mode(self):
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "model": "grok-code-fast",
+            "base_url": "https://api.x.ai/v1",
+            "api_key": "xai-key",
+        }
+
+        creds = _resolve_delegation_credentials(cfg, parent)
+
+        self.assertEqual(creds["provider"], "custom")
+        self.assertEqual(creds["api_mode"], "codex_responses")
+
+    def test_direct_anthropic_proxy_suffix_uses_anthropic_messages(self):
+        parent = _make_mock_parent(depth=0)
+        cfg = {
+            "model": "claude-sonnet-4",
+            "base_url": "https://proxy.example.com/anthropic",
+            "api_key": "proxy-key",
+        }
+
+        creds = _resolve_delegation_credentials(cfg, parent)
+
+        self.assertEqual(creds["provider"], "custom")
+        self.assertEqual(creds["api_mode"], "anthropic_messages")
+
     @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
     def test_nous_provider_resolves_nous_credentials(self, mock_resolve):
         """Nous provider resolves Nous Portal base_url and api_key."""

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -54,6 +54,16 @@ _DEFAULT_MAX_CONCURRENT_CHILDREN = 3
 MAX_DEPTH = 2  # parent (0) -> child (1) -> grandchild rejected (2)
 
 
+def _detect_direct_endpoint_api_mode(base_url: str) -> Optional[str]:
+    normalized = (base_url or "").strip().lower().rstrip("/")
+    hostname = base_url_hostname(base_url)
+    if hostname in {"api.openai.com", "api.x.ai"}:
+        return "codex_responses"
+    if normalized.endswith("/anthropic"):
+        return "anthropic_messages"
+    return None
+
+
 def _get_max_concurrent_children() -> int:
     """Read delegation.max_concurrent_children from config, falling back to
     DELEGATION_MAX_CONCURRENT_CHILDREN env var, then the default (3).
@@ -1024,7 +1034,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
 
         base_lower = configured_base_url.lower()
         provider = "custom"
-        api_mode = "chat_completions"
+        api_mode = _detect_direct_endpoint_api_mode(configured_base_url) or "chat_completions"
         if (
             base_url_hostname(configured_base_url) == "chatgpt.com"
             and "/backend-api/codex" in base_lower


### PR DESCRIPTION
## Summary

Fix `delegate_task` direct `delegation.base_url` credential resolution so subagents choose the correct transport for supported direct endpoints.

Previously, the direct-endpoint path defaulted to `chat_completions` and only special-cased:
- `chatgpt.com/backend-api/codex`
- `api.anthropic.com`

That left other valid direct endpoints misclassified, including:
- `https://api.openai.com/v1`
- `https://api.x.ai/v1`
- Anthropic-compatible proxies ending in `/anthropic`

## What changed

- Added direct endpoint api_mode detection in `tools/delegate_tool.py`
- Direct OpenAI and xAI endpoints now resolve to `codex_responses`
- Direct endpoints ending in `/anthropic` now resolve to `anthropic_messages`
- Preserved the existing special cases for:
  - Codex backend on `chatgpt.com/backend-api/codex`
  - Native Anthropic API on `api.anthropic.com`

## Why this matters

Without this fix, delegated subagents could be launched with the wrong transport even when the main runtime resolver would have chosen the correct one. In practice, that can break subagent calls against GPT-5/Responses-style endpoints and Anthropic-compatible proxy endpoints.

## Tests

Added regression coverage for:
- direct OpenAI endpoint -> `codex_responses`
- direct xAI endpoint -> `codex_responses`
- direct `/anthropic` proxy endpoint -> `anthropic_messages`

Passed locally:

- `tests/tools/test_delegate.py::TestDelegationCredentialResolution::test_direct_anthropic_proxy_suffix_uses_anthropic_messages`
- `tests/tools/test_delegate.py::TestDelegationCredentialResolution::test_direct_openai_endpoint_uses_codex_responses_api_mode`
- `tests/tools/test_delegate.py::TestDelegationCredentialResolution::test_direct_xai_endpoint_uses_codex_responses_api_mode`

Result:
- `3 passed, 68 deselected`

## Scope

Small bug fix only:
- no feature work
- no refactor
- no behavior change outside direct delegation `base_url` resolution
