### PR TITLE
fix(stt): reuse CPU fallback after CUDA runtime failure

### DIFF
--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -481,6 +481,76 @@ class TestTranscribeLocalExtended:
         assert result["success"] is False
         assert "CUDA out of memory" in result["error"]
 
+    def test_cuda_library_error_retries_on_cpu(self, tmp_path):
+        audio = tmp_path / "test.ogg"
+        audio.write_bytes(b"fake")
+
+        mock_segment = MagicMock()
+        mock_segment.text = "fallback ok"
+        mock_info = MagicMock()
+        mock_info.language = "pt"
+        mock_info.duration = 1.0
+
+        gpu_model = MagicMock()
+        gpu_model.transcribe.side_effect = RuntimeError(
+            "Library libcublas.so.12 is not found or cannot be loaded"
+        )
+
+        cpu_model = MagicMock()
+        cpu_model.transcribe.return_value = ([mock_segment], mock_info)
+
+        mock_whisper_cls = MagicMock(side_effect=[gpu_model, cpu_model])
+
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
+             patch("faster_whisper.WhisperModel", mock_whisper_cls), \
+             patch("tools.transcription_tools._local_model", None), \
+             patch("tools.transcription_tools._local_model_name", None), \
+             patch("tools.transcription_tools._local_model_cache_key", None):
+            from tools.transcription_tools import _transcribe_local
+            result = _transcribe_local(str(audio), "base")
+
+        assert result["success"] is True
+        assert result["transcript"] == "fallback ok"
+        assert mock_whisper_cls.call_count == 2
+        assert mock_whisper_cls.call_args_list[0].kwargs["device"] == "auto"
+        assert mock_whisper_cls.call_args_list[1].kwargs["device"] == "cpu"
+        assert mock_whisper_cls.call_args_list[1].kwargs["compute_type"] == "int8"
+
+    def test_cpu_fallback_is_reused_on_next_call(self, tmp_path):
+        audio = tmp_path / "test.ogg"
+        audio.write_bytes(b"fake")
+
+        mock_segment = MagicMock()
+        mock_segment.text = "fallback ok"
+        mock_info = MagicMock()
+        mock_info.language = "pt"
+        mock_info.duration = 1.0
+
+        gpu_model = MagicMock()
+        gpu_model.transcribe.side_effect = RuntimeError(
+            "Library libcublas.so.12 is not found or cannot be loaded"
+        )
+
+        cpu_model = MagicMock()
+        cpu_model.transcribe.return_value = ([mock_segment], mock_info)
+        unexpected_model = MagicMock()
+        unexpected_model.transcribe.return_value = ([mock_segment], mock_info)
+
+        mock_whisper_cls = MagicMock(side_effect=[gpu_model, cpu_model, unexpected_model])
+
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
+             patch("faster_whisper.WhisperModel", mock_whisper_cls), \
+             patch("tools.transcription_tools._local_model", None), \
+             patch("tools.transcription_tools._local_model_name", None), \
+             patch("tools.transcription_tools._local_model_cache_key", None):
+            from tools.transcription_tools import _transcribe_local
+            first = _transcribe_local(str(audio), "base")
+            second = _transcribe_local(str(audio), "base")
+
+        assert first["success"] is True
+        assert second["success"] is True
+        assert mock_whisper_cls.call_count == 2
+
     def test_multiple_segments_joined(self, tmp_path):
         audio = tmp_path / "test.ogg"
         audio.write_bytes(b"fake")

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -85,6 +85,32 @@ GROQ_MODELS = {"whisper-large-v3", "whisper-large-v3-turbo", "distil-whisper-lar
 # Singleton for the local model — loaded once, reused across calls
 _local_model: Optional[object] = None
 _local_model_name: Optional[str] = None
+_local_model_cache_key: Optional[tuple[str, str, str]] = None
+
+
+def _is_cuda_runtime_error(error: Exception) -> bool:
+    message = str(error).lower()
+    cuda_markers = (
+        "libcublas.so",
+        "cublas",
+        "cuda",
+        "cudnn",
+        "cannot be loaded",
+    )
+    return any(marker in message for marker in cuda_markers)
+
+
+def _load_local_whisper_model(model_name: str, *, device: str, compute_type: str):
+    from faster_whisper import WhisperModel
+
+    logger.info(
+        "Loading faster-whisper model '%s' (device=%s, compute_type=%s)...",
+        model_name,
+        device,
+        compute_type,
+    )
+    return WhisperModel(model_name, device=device, compute_type=compute_type)
+
 
 # ---------------------------------------------------------------------------
 # Config helpers
@@ -300,18 +326,25 @@ def _validate_audio_file(file_path: str) -> Optional[Dict[str, Any]]:
 
 def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
     """Transcribe using faster-whisper (local, free)."""
-    global _local_model, _local_model_name
+    global _local_model, _local_model_name, _local_model_cache_key
 
     if not _HAS_FASTER_WHISPER:
         return {"success": False, "transcript": "", "error": "faster-whisper not installed"}
 
     try:
-        from faster_whisper import WhisperModel
+        auto_cache_key = (model_name, "auto", "auto")
         # Lazy-load the model (downloads on first use, ~150 MB for 'base')
-        if _local_model is None or _local_model_name != model_name:
-            logger.info("Loading faster-whisper model '%s' (first load downloads the model)...", model_name)
-            _local_model = WhisperModel(model_name, device="auto", compute_type="auto")
+        if _local_model is None or _local_model_cache_key not in (
+            auto_cache_key,
+            (model_name, "cpu", "int8"),
+        ):
+            _local_model = _load_local_whisper_model(
+                model_name,
+                device="auto",
+                compute_type="auto",
+            )
             _local_model_name = model_name
+            _local_model_cache_key = auto_cache_key
 
         # Language: config.yaml (stt.local.language) > env var > auto-detect.
         _forced_lang = (
@@ -323,7 +356,26 @@ def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
         if _forced_lang:
             transcribe_kwargs["language"] = _forced_lang
 
-        segments, info = _local_model.transcribe(file_path, **transcribe_kwargs)
+        try:
+            segments, info = _local_model.transcribe(file_path, **transcribe_kwargs)
+        except RuntimeError as e:
+            if not _is_cuda_runtime_error(e):
+                raise
+
+            logger.warning(
+                "Local transcription hit CUDA runtime issue; retrying on CPU: %s",
+                e,
+            )
+            cpu_cache_key = (model_name, "cpu", "int8")
+            if _local_model_cache_key != cpu_cache_key:
+                _local_model = _load_local_whisper_model(
+                    model_name,
+                    device="cpu",
+                    compute_type="int8",
+                )
+                _local_model_name = model_name
+                _local_model_cache_key = cpu_cache_key
+            segments, info = _local_model.transcribe(file_path, **transcribe_kwargs)
         transcript = " ".join(segment.text.strip() for segment in segments)
 
         logger.info(


### PR DESCRIPTION
## What does this PR do?

This PR makes local `faster-whisper` STT more robust when `device="auto"` reaches a cuBLAS/CUDA runtime failure during transcription. Hermes already retries on CPU int8 for the current transcription, but the successful CPU fallback was not being reused on later calls with the same requested model.

This change preserves the active local runtime mode in the in-memory cache key so a working CPU fallback can be reused instead of rebuilding the failing `device="auto"` model on the next transcription.

## Related Issue

Fixes #13568

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Added `_local_model_cache_key` in `tools/transcription_tools.py` to track the requested local whisper model plus active runtime mode.
- Preserved the successful CPU int8 fallback in `_transcribe_local()` after cuBLAS/CUDA runtime failures.
- Added a regression test that verifies the first CUDA runtime failure retries on CPU and succeeds.
- Added a second regression test that verifies the CPU fallback is reused on the next transcription call for the same model instead of re-instantiating the failing `device="auto"` model.
- Updated the fallback-related tests to reset the new cache key between runs.

## How to Test

1. Run `source venv/bin/activate`.
2. Run `pytest tests/tools/test_transcription_tools.py tests/tools/test_transcription.py tests/gateway/test_stt_config.py -q`.
3. Optionally reproduce locally by sending a voice message in an environment where `faster-whisper` hits `RuntimeError: Library libcublas.so.12 is not found or cannot be loaded`; confirm the first transcription falls back to CPU and later calls reuse the CPU fallback instead of repeatedly rebuilding the failing auto/CUDA path.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2 / Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
104 passed in 2.56s
```
