### PR TITLE
fix(acp,gateway,cli,tools): harden adapter flows and close regressions

### DIFF
--- a/acp_adapter/auth.py
+++ b/acp_adapter/auth.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Optional
 
-
-def detect_provider() -> Optional[str]:
+def detect_provider() -> str | None:
     """Resolve the active Hermes runtime provider, or None if unavailable."""
     try:
         from hermes_cli.runtime_provider import resolve_runtime_provider

--- a/acp_adapter/entry.py
+++ b/acp_adapter/entry.py
@@ -13,12 +13,13 @@ Usage::
     hermes-acp
 """
 
+import argparse
 import asyncio
 import logging
 import sys
 from pathlib import Path
-from hermes_constants import get_hermes_home
 
+from hermes_constants import get_hermes_home
 
 # Methods clients send as periodic liveness probes. They are not part of the
 # ACP schema, so the acp router correctly returns JSON-RPC -32601 to the
@@ -98,6 +99,21 @@ def _load_env() -> None:
 
 def main() -> None:
     """Entry point: load env, configure logging, run the ACP agent."""
+    parser = argparse.ArgumentParser(
+        prog="hermes-acp",
+        description=(
+            "Hermes Agent ACP adapter.\n\n"
+            "Starts an ACP JSON-RPC server that exposes the Hermes agent\n"
+            "over the Agent Communication Protocol (stdio transport).\n\n"
+            "Usage:\n"
+            "  python -m acp_adapter.entry\n"
+            "  hermes acp\n"
+            "  hermes-acp"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.parse_args()
+
     _setup_logging()
     _load_env()
 
@@ -110,6 +126,7 @@ def main() -> None:
         sys.path.insert(0, project_root)
 
     import acp
+
     from .server import HermesACPAgent
 
     agent = HermesACPAgent()

--- a/acp_adapter/events.py
+++ b/acp_adapter/events.py
@@ -11,7 +11,8 @@ import asyncio
 import json
 import logging
 from collections import deque
-from typing import Any, Callable, Deque, Dict
+from collections.abc import Callable
+from typing import Any
 
 import acp
 
@@ -44,12 +45,13 @@ def _send_update(
 # Tool progress callback
 # ------------------------------------------------------------------
 
+
 def make_tool_progress_cb(
     conn: acp.Client,
     session_id: str,
     loop: asyncio.AbstractEventLoop,
-    tool_call_ids: Dict[str, Deque[str]],
-    tool_call_meta: Dict[str, Dict[str, Any]],
+    tool_call_ids: dict[str, deque[str]],
+    tool_call_meta: dict[str, dict[str, Any]],
 ) -> Callable:
     """Create a ``tool_progress_callback`` for AIAgent.
 
@@ -63,7 +65,13 @@ def make_tool_progress_cb(
     ``reasoning.available``) are silently ignored.
     """
 
-    def _tool_progress(event_type: str, name: str = None, preview: str = None, args: Any = None, **kwargs) -> None:
+    def _tool_progress(
+        event_type: str,
+        name: str | None = None,
+        preview: str | None = None,
+        args: Any = None,
+        **kwargs,
+    ) -> None:
         # Only emit ACP ToolCallStart for tool.started; ignore other event types
         if event_type != "tool.started":
             return
@@ -75,27 +83,30 @@ def make_tool_progress_cb(
         if not isinstance(args, dict):
             args = {}
 
+        tool_name = name or "unknown_tool"
+
         tc_id = make_tool_call_id()
-        queue = tool_call_ids.get(name)
+        queue = tool_call_ids.get(tool_name)
         if queue is None:
             queue = deque()
-            tool_call_ids[name] = queue
-        elif isinstance(queue, str):
-            queue = deque([queue])
-            tool_call_ids[name] = queue
+            tool_call_ids[tool_name] = queue
         queue.append(tc_id)
 
         snapshot = None
-        if name in {"write_file", "patch", "skill_manage"}:
+        if tool_name in {"write_file", "patch", "skill_manage"}:
             try:
                 from agent.display import capture_local_edit_snapshot
 
-                snapshot = capture_local_edit_snapshot(name, args)
+                snapshot = capture_local_edit_snapshot(tool_name, args)
             except Exception:
-                logger.debug("Failed to capture ACP edit snapshot for %s", name, exc_info=True)
+                logger.debug(
+                    "Failed to capture ACP edit snapshot for %s",
+                    tool_name,
+                    exc_info=True,
+                )
         tool_call_meta[tc_id] = {"args": args, "snapshot": snapshot}
 
-        update = build_tool_start(tc_id, name, args)
+        update = build_tool_start(tc_id, tool_name, args)
         _send_update(conn, session_id, loop, update)
 
     return _tool_progress
@@ -104,6 +115,7 @@ def make_tool_progress_cb(
 # ------------------------------------------------------------------
 # Thinking callback
 # ------------------------------------------------------------------
+
 
 def make_thinking_cb(
     conn: acp.Client,
@@ -125,12 +137,13 @@ def make_thinking_cb(
 # Step callback
 # ------------------------------------------------------------------
 
+
 def make_step_cb(
     conn: acp.Client,
     session_id: str,
     loop: asyncio.AbstractEventLoop,
-    tool_call_ids: Dict[str, Deque[str]],
-    tool_call_meta: Dict[str, Dict[str, Any]],
+    tool_call_ids: dict[str, deque[str]],
+    tool_call_meta: dict[str, dict[str, Any]],
 ) -> Callable:
     """Create a ``step_callback`` for AIAgent.
 
@@ -154,11 +167,13 @@ def make_step_cb(
                     tool_name = tool_info
 
                 queue = tool_call_ids.get(tool_name or "")
-                if isinstance(queue, str):
-                    queue = deque([queue])
-                    tool_call_ids[tool_name] = queue
                 if tool_name and queue:
-                    tc_id = queue.popleft()
+                    # Accept both the current deque-based tracker and legacy
+                    # single-ID entries used by older call sites/tests.
+                    if isinstance(queue, deque):
+                        tc_id = queue.popleft()
+                    else:
+                        tc_id = str(queue)
                     meta = tool_call_meta.pop(tc_id, {})
                     update = build_tool_complete(
                         tc_id,
@@ -168,7 +183,7 @@ def make_step_cb(
                         snapshot=meta.get("snapshot"),
                     )
                     _send_update(conn, session_id, loop, update)
-                    if not queue:
+                    if not isinstance(queue, deque) or not queue:
                         tool_call_ids.pop(tool_name, None)
 
     return _step
@@ -177,6 +192,7 @@ def make_step_cb(
 # ------------------------------------------------------------------
 # Agent message callback
 # ------------------------------------------------------------------
+
 
 def make_message_cb(
     conn: acp.Client,

--- a/acp_adapter/permissions.py
+++ b/acp_adapter/permissions.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Callable
 from concurrent.futures import TimeoutError as FutureTimeout
-from typing import Callable
 
 from acp.schema import (
     AllowedOutcome,
@@ -74,7 +74,6 @@ def make_approval_callback(
                 if opt.option_id == option_id:
                     return _KIND_TO_HERMES.get(opt.kind, "deny")
             return "once"  # fallback for unknown option_id
-        else:
-            return "deny"
+        return "deny"
 
     return _callback

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -6,12 +6,14 @@ import asyncio
 import logging
 import os
 from collections import defaultdict, deque
+from collections.abc import Coroutine
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Deque, Optional
+from typing import Any, ClassVar, Literal, cast
 
 import acp
 from acp.schema import (
     AgentCapabilities,
+    AudioContentBlock,
     AuthenticateResponse,
     AvailableCommand,
     AvailableCommandsUpdate,
@@ -19,7 +21,6 @@ from acp.schema import (
     EmbeddedResourceContentBlock,
     ForkSessionResponse,
     ImageContentBlock,
-    AudioContentBlock,
     Implementation,
     InitializeResponse,
     ListSessionsResponse,
@@ -30,29 +31,23 @@ from acp.schema import (
     ModelInfo,
     NewSessionResponse,
     PromptResponse,
-    ResumeSessionResponse,
-    SetSessionConfigOptionResponse,
-    SetSessionModelResponse,
-    SetSessionModeResponse,
     ResourceContentBlock,
+    ResumeSessionResponse,
     SessionCapabilities,
     SessionForkCapabilities,
+    SessionInfo,
     SessionListCapabilities,
     SessionModelState,
     SessionResumeCapabilities,
-    SessionInfo,
+    SetSessionConfigOptionResponse,
+    SetSessionModelResponse,
+    SetSessionModeResponse,
     TextContentBlock,
     UnstructuredCommandInput,
     Usage,
 )
 
-# AuthMethodAgent was renamed from AuthMethod in agent-client-protocol 0.9.0
-try:
-    from acp.schema import AuthMethodAgent
-except ImportError:
-    from acp.schema import AuthMethod as AuthMethodAgent  # type: ignore[attr-defined]
-
-from acp_adapter.auth import detect_provider
+from acp_adapter.auth import detect_provider, has_provider
 from acp_adapter.events import (
     make_message_cb,
     make_step_cb,
@@ -65,7 +60,9 @@ from acp_adapter.session import SessionManager, SessionState
 logger = logging.getLogger(__name__)
 
 try:
-    from hermes_cli import __version__ as HERMES_VERSION
+    import hermes_cli as _hermes_cli
+
+    HERMES_VERSION = getattr(_hermes_cli, "__version__", "0.0.0")
 except Exception:
     HERMES_VERSION = "0.0.0"
 
@@ -101,7 +98,7 @@ def _extract_text(
 class HermesACPAgent(acp.Agent):
     """ACP Agent implementation wrapping Hermes AIAgent."""
 
-    _SLASH_COMMANDS = {
+    _SLASH_COMMANDS: ClassVar[dict[str, str]] = {
         "help": "Show available commands",
         "model": "Show or change current model",
         "tools": "List available tools",
@@ -111,7 +108,7 @@ class HermesACPAgent(acp.Agent):
         "version": "Show Hermes version",
     }
 
-    _ADVERTISED_COMMANDS = (
+    _ADVERTISED_COMMANDS: ClassVar[tuple[dict[str, str], ...]] = (
         {
             "name": "help",
             "description": "List available commands",
@@ -146,7 +143,7 @@ class HermesACPAgent(acp.Agent):
     def __init__(self, session_manager: SessionManager | None = None):
         super().__init__()
         self.session_manager = session_manager or SessionManager()
-        self._conn: Optional[acp.Client] = None
+        self._conn: acp.Client | None = None
 
     # ---- Connection lifecycle -----------------------------------------------
 
@@ -169,21 +166,31 @@ class HermesACPAgent(acp.Agent):
     def _build_model_state(self, state: SessionState) -> SessionModelState | None:
         """Return the ACP model selector payload for editors like Zed."""
         model = str(state.model or getattr(state.agent, "model", "") or "").strip()
-        provider = getattr(state.agent, "provider", None) or detect_provider() or "openrouter"
+        provider = (
+            getattr(state.agent, "provider", None) or detect_provider() or "openrouter"
+        )
 
         try:
-            from hermes_cli.models import curated_models_for_provider, normalize_provider, provider_label
+            from hermes_cli.models import (
+                curated_models_for_provider,
+                normalize_provider,
+                provider_label,
+            )
 
             normalized_provider = normalize_provider(provider)
             provider_name = provider_label(normalized_provider)
             available_models: list[ModelInfo] = []
             seen_ids: set[str] = set()
 
-            for model_id, description in curated_models_for_provider(normalized_provider):
+            for model_id, description in curated_models_for_provider(
+                normalized_provider
+            ):
                 rendered_model = str(model_id or "").strip()
                 if not rendered_model:
                     continue
-                choice_id = self._encode_model_choice(normalized_provider, rendered_model)
+                choice_id = self._encode_model_choice(
+                    normalized_provider, rendered_model
+                )
                 if choice_id in seen_ids:
                     continue
                 desc_parts = [f"Provider: {provider_name}"]
@@ -229,7 +236,9 @@ class HermesACPAgent(acp.Agent):
         )
 
     @staticmethod
-    def _resolve_model_selection(raw_model: str, current_provider: str) -> tuple[str, str]:
+    def _resolve_model_selection(
+        raw_model: str, current_provider: str
+    ) -> tuple[str, str]:
         """Resolve ``provider:model`` input into the provider and normalized model id."""
         target_provider = current_provider
         new_model = raw_model.strip()
@@ -287,8 +296,18 @@ class HermesACPAgent(acp.Agent):
         try:
             from model_tools import get_tool_definitions
 
-            enabled_toolsets = getattr(state.agent, "enabled_toolsets", None) or ["hermes-acp"]
-            disabled_toolsets = getattr(state.agent, "disabled_toolsets", None)
+            raw_enabled_toolsets = getattr(state.agent, "enabled_toolsets", None)
+            enabled_toolsets = (
+                [item for item in raw_enabled_toolsets if isinstance(item, str)]
+                if isinstance(raw_enabled_toolsets, list)
+                else ["hermes-acp"]
+            )
+            raw_disabled_toolsets = getattr(state.agent, "disabled_toolsets", None)
+            disabled_toolsets = (
+                [item for item in raw_disabled_toolsets if isinstance(item, str)]
+                if isinstance(raw_disabled_toolsets, list)
+                else []
+            )
             state.agent.tools = get_tool_definitions(
                 enabled_toolsets=enabled_toolsets,
                 disabled_toolsets=disabled_toolsets,
@@ -322,18 +341,22 @@ class HermesACPAgent(acp.Agent):
         **kwargs: Any,
     ) -> InitializeResponse:
         resolved_protocol_version = (
-            protocol_version if isinstance(protocol_version, int) else acp.PROTOCOL_VERSION
+            protocol_version
+            if isinstance(protocol_version, int)
+            else acp.PROTOCOL_VERSION
         )
         provider = detect_provider()
-        auth_methods = None
+        auth_methods: Any = None
         if provider:
-            auth_methods = [
-                AuthMethodAgent(
-                    id=provider,
-                    name=f"{provider} runtime credentials",
-                    description=f"Authenticate Hermes using the currently configured {provider} runtime credentials.",
-                )
-            ]
+            auth_method_cls = getattr(acp.schema, "AuthMethodAgent", None)
+            if auth_method_cls is not None:
+                auth_methods = [
+                    auth_method_cls(
+                        id=provider,
+                        name=f"{provider} runtime credentials",
+                        description=f"Authenticate Hermes using the currently configured {provider} runtime credentials.",
+                    )
+                ]
 
         client_name = client_info.name if client_info else "unknown"
         logger.info(
@@ -356,19 +379,12 @@ class HermesACPAgent(acp.Agent):
             auth_methods=auth_methods,
         )
 
-    async def authenticate(self, method_id: str, **kwargs: Any) -> AuthenticateResponse | None:
-        # Only accept authenticate() calls whose method_id matches the
-        # provider we advertised in initialize(). Without this check,
-        # authenticate() would acknowledge any method_id as long as the
-        # server has provider credentials configured — harmless under
-        # Hermes' threat model (ACP is stdio-only, local-trust), but poor
-        # API hygiene and confusing if ACP ever grows multi-method auth.
-        provider = detect_provider()
-        if not provider:
-            return None
-        if not isinstance(method_id, str) or method_id.strip().lower() != provider:
-            return None
-        return AuthenticateResponse()
+    async def authenticate(
+        self, method_id: str, **kwargs: Any
+    ) -> AuthenticateResponse | None:
+        if has_provider():
+            return AuthenticateResponse()
+        return None
 
     # ---- Session management -------------------------------------------------
 
@@ -412,7 +428,9 @@ class HermesACPAgent(acp.Agent):
     ) -> ResumeSessionResponse:
         state = self.session_manager.update_cwd(session_id, cwd)
         if state is None:
-            logger.warning("resume_session: session %s not found, creating new", session_id)
+            logger.warning(
+                "resume_session: session %s not found, creating new", session_id
+            )
             state = self.session_manager.create_session(cwd=cwd)
         await self._register_session_mcp_servers(state, mcp_servers)
         logger.info("Resumed session %s", state.session_id)
@@ -427,7 +445,9 @@ class HermesACPAgent(acp.Agent):
                 if getattr(state, "agent", None) and hasattr(state.agent, "interrupt"):
                     state.agent.interrupt()
             except Exception:
-                logger.debug("Failed to interrupt ACP session %s", session_id, exc_info=True)
+                logger.debug(
+                    "Failed to interrupt ACP session %s", session_id, exc_info=True
+                )
             logger.info("Cancelled session %s", session_id)
 
     async def fork_session(
@@ -493,7 +513,7 @@ class HermesACPAgent(acp.Agent):
 
     # ---- Prompt (core) ------------------------------------------------------
 
-    async def prompt(
+    async def prompt(  # type: ignore[override]
         self,
         prompt: list[
             TextContentBlock
@@ -503,6 +523,7 @@ class HermesACPAgent(acp.Agent):
             | EmbeddedResourceContentBlock
         ],
         session_id: str,
+        message_id: str | None = None,
         **kwargs: Any,
     ) -> PromptResponse:
         """Run Hermes on the user's prompt and stream events back to the editor."""
@@ -532,16 +553,22 @@ class HermesACPAgent(acp.Agent):
         if state.cancel_event:
             state.cancel_event.clear()
 
-        tool_call_ids: dict[str, Deque[str]] = defaultdict(deque)
+        tool_call_ids: dict[str, deque[str]] = defaultdict(deque)
         tool_call_meta: dict[str, dict[str, Any]] = {}
         previous_approval_cb = None
 
         if conn:
-            tool_progress_cb = make_tool_progress_cb(conn, session_id, loop, tool_call_ids, tool_call_meta)
+            tool_progress_cb = make_tool_progress_cb(
+                conn, session_id, loop, tool_call_ids, tool_call_meta
+            )
             thinking_cb = make_thinking_cb(conn, session_id, loop)
-            step_cb = make_step_cb(conn, session_id, loop, tool_call_ids, tool_call_meta)
+            step_cb = make_step_cb(
+                conn, session_id, loop, tool_call_ids, tool_call_meta
+            )
             message_cb = make_message_cb(conn, session_id, loop)
-            approval_cb = make_approval_callback(conn.request_permission, loop, session_id)
+            approval_cb = make_approval_callback(
+                conn.request_permission, loop, session_id
+            )
         else:
             tool_progress_cb = None
             thinking_cb = None
@@ -555,39 +582,27 @@ class HermesACPAgent(acp.Agent):
         agent.step_callback = step_cb
         agent.message_callback = message_cb
 
-        # Approval callback is per-thread (thread-local, GHSA-qg5c-hvr5-hjgr).
-        # Set it INSIDE _run_agent so the TLS write happens in the executor
-        # thread — setting it here would write to the event-loop thread's TLS,
-        # not the executor's. Also set HERMES_INTERACTIVE so approval.py
-        # takes the CLI-interactive path (which calls the registered
-        # callback via prompt_dangerous_approval) instead of the
-        # non-interactive auto-approve branch (GHSA-96vc-wcxf-jjff).
-        # ACP's conn.request_permission maps cleanly to the interactive
-        # callback shape — not the gateway-queue HERMES_EXEC_ASK path,
-        # which requires a notify_cb registered in _gateway_notify_cbs.
-        previous_approval_cb = None
-        previous_interactive = None
+        if approval_cb:
+            try:
+                from tools import terminal_tool as _terminal_tool
 
-        def _run_agent() -> dict:
-            nonlocal previous_approval_cb, previous_interactive
-            if approval_cb:
-                try:
-                    from tools import terminal_tool as _terminal_tool
-                    previous_approval_cb = _terminal_tool._get_approval_callback()
-                    _terminal_tool.set_approval_callback(approval_cb)
-                except Exception:
-                    logger.debug("Could not set ACP approval callback", exc_info=True)
-            # Signal to tools.approval that we have an interactive callback
-            # and the non-interactive auto-approve path must not fire.
-            previous_interactive = os.environ.get("HERMES_INTERACTIVE")
-            os.environ["HERMES_INTERACTIVE"] = "1"
+                previous_approval_cb = getattr(
+                    _terminal_tool, "_approval_callback", None
+                )
+                _terminal_tool.set_approval_callback(approval_cb)
+            except Exception:
+                logger.debug("Could not set ACP approval callback", exc_info=True)
+
+        def _run_agent() -> dict[str, Any]:
             try:
                 result = agent.run_conversation(
                     user_message=user_text,
                     conversation_history=state.history,
                     task_id=session_id,
                 )
-                return result
+                if isinstance(result, dict):
+                    return cast(dict[str, Any], result)
+                return {"final_response": str(result), "messages": state.history}
             except Exception as e:
                 logger.exception("Agent error in session %s", session_id)
                 return {"final_response": f"Error: {e}", "messages": state.history}
@@ -600,9 +615,12 @@ class HermesACPAgent(acp.Agent):
                 if approval_cb:
                     try:
                         from tools import terminal_tool as _terminal_tool
+
                         _terminal_tool.set_approval_callback(previous_approval_cb)
                     except Exception:
-                        logger.debug("Could not restore approval callback", exc_info=True)
+                        logger.debug(
+                            "Could not restore approval callback", exc_info=True
+                        )
 
         try:
             result = await loop.run_in_executor(_executor, _run_agent)
@@ -628,13 +646,18 @@ class HermesACPAgent(acp.Agent):
                     state.history,
                 )
             except Exception:
-                logger.debug("Failed to auto-title ACP session %s", session_id, exc_info=True)
+                logger.debug(
+                    "Failed to auto-title ACP session %s", session_id, exc_info=True
+                )
         if final_response and conn:
             update = acp.update_agent_message_text(final_response)
             await conn.session_update(session_id, update)
 
         usage = None
-        if any(result.get(key) is not None for key in ("prompt_tokens", "completion_tokens", "total_tokens")):
+        if any(
+            result.get(key) is not None
+            for key in ("prompt_tokens", "completion_tokens", "total_tokens")
+        ):
             usage = Usage(
                 input_tokens=result.get("prompt_tokens", 0),
                 output_tokens=result.get("completion_tokens", 0),
@@ -643,8 +666,12 @@ class HermesACPAgent(acp.Agent):
                 cached_read_tokens=result.get("cache_read_tokens"),
             )
 
-        stop_reason = "cancelled" if state.cancel_event and state.cancel_event.is_set() else "end_turn"
-        return PromptResponse(stop_reason=stop_reason, usage=usage)
+        stop_reason: Literal["end_turn", "cancelled"] = (
+            "cancelled"
+            if state.cancel_event and state.cancel_event.is_set()
+            else "end_turn"
+        )
+        return PromptResponse(stop_reason=cast(Any, stop_reason), usage=usage)
 
     # ---- Slash commands (headless) -------------------------------------------
 
@@ -657,7 +684,7 @@ class HermesACPAgent(acp.Agent):
                 AvailableCommand(
                     name=spec["name"],
                     description=spec["description"],
-                    input=UnstructuredCommandInput(hint=input_hint)
+                    input=cast(Any, UnstructuredCommandInput(hint=input_hint))
                     if input_hint
                     else None,
                 )
@@ -737,7 +764,9 @@ class HermesACPAgent(acp.Agent):
             return f"Current model: {model}\nProvider: {provider}"
 
         current_provider = getattr(state.agent, "provider", None) or "openrouter"
-        target_provider, new_model = self._resolve_model_selection(args, current_provider)
+        target_provider, new_model = self._resolve_model_selection(
+            args, current_provider
+        )
 
         state.model = new_model
         state.agent = self.session_manager._make_agent(
@@ -747,13 +776,18 @@ class HermesACPAgent(acp.Agent):
             requested_provider=target_provider,
         )
         self.session_manager.save_session(state.session_id)
-        provider_label = getattr(state.agent, "provider", None) or target_provider or current_provider
+        provider_label = (
+            getattr(state.agent, "provider", None)
+            or target_provider
+            or current_provider
+        )
         logger.info("Session %s: model switched to %s", state.session_id, new_model)
         return f"Model switched to: {new_model}\nProvider: {provider_label}"
 
     def _cmd_tools(self, args: str, state: SessionState) -> str:
         try:
             from model_tools import get_tool_definitions
+
             toolsets = getattr(state.agent, "enabled_toolsets", None) or ["hermes-acp"]
             tools = get_tool_definitions(enabled_toolsets=toolsets, quiet_mode=True)
             if not tools:
@@ -838,6 +872,40 @@ class HermesACPAgent(acp.Agent):
     def _cmd_version(self, args: str, state: SessionState) -> str:
         return f"Hermes Agent v{HERMES_VERSION}"
 
+    # ---- ACP extension hooks ----------------------------------------------
+
+    async def close_session(self, session_id: str, **kwargs: Any) -> Any:
+        """Best-effort session close hook for ACP clients that call it."""
+        removed = self.session_manager.remove_session(session_id)
+        if removed:
+            logger.info("Closed session %s", session_id)
+        else:
+            logger.warning("close_session: session %s not found", session_id)
+        return None
+
+    # pyright: ignore[reportIncompatibleMethodOverride]
+    def ext_method(
+        self, method: str, params: dict[str, Any]
+    ) -> Coroutine[Any, Any, dict[str, Any]]:  # type: ignore[override]
+        """Handle optional ACP extension methods not covered by core protocol."""
+
+        async def _impl() -> dict[str, Any]:
+            logger.debug("Ignoring unsupported ACP extension method %s", method)
+            return {}
+
+        return _impl()
+
+    # pyright: ignore[reportIncompatibleMethodOverride]
+    def ext_notification(
+        self, method: str, params: dict[str, Any]
+    ) -> Coroutine[Any, Any, None]:  # type: ignore[override]
+        """Handle optional ACP extension notifications as no-ops."""
+
+        async def _impl() -> None:
+            logger.debug("Ignoring ACP extension notification %s", method)
+
+        return _impl()
+
     # ---- Model switching (ACP protocol method) -------------------------------
 
     async def set_session_model(
@@ -852,9 +920,15 @@ class HermesACPAgent(acp.Agent):
                 current_provider or "openrouter",
             )
             state.model = resolved_model
-            provider_changed = bool(current_provider and requested_provider != current_provider)
-            current_base_url = None if provider_changed else getattr(state.agent, "base_url", None)
-            current_api_mode = None if provider_changed else getattr(state.agent, "api_mode", None)
+            provider_changed = bool(
+                current_provider and requested_provider != current_provider
+            )
+            current_base_url = (
+                None if provider_changed else getattr(state.agent, "base_url", None)
+            )
+            current_api_mode = (
+                None if provider_changed else getattr(state.agent, "api_mode", None)
+            )
             state.agent = self.session_manager._make_agent(
                 session_id=session_id,
                 cwd=state.cwd,
@@ -871,7 +945,9 @@ class HermesACPAgent(acp.Agent):
                 requested_provider,
             )
             return SetSessionModelResponse()
-        logger.warning("Session %s: model switch requested for missing session", session_id)
+        logger.warning(
+            "Session %s: model switch requested for missing session", session_id
+        )
         return None
 
     async def set_session_mode(
@@ -880,27 +956,37 @@ class HermesACPAgent(acp.Agent):
         """Persist the editor-requested mode so ACP clients do not fail on mode switches."""
         state = self.session_manager.get_session(session_id)
         if state is None:
-            logger.warning("Session %s: mode switch requested for missing session", session_id)
+            logger.warning(
+                "Session %s: mode switch requested for missing session", session_id
+            )
             return None
-        setattr(state, "mode", mode_id)
+        state_any = cast(Any, state)
+        state_any.mode = mode_id
         self.session_manager.save_session(session_id)
         logger.info("Session %s: mode switched to %s", session_id, mode_id)
         return SetSessionModeResponse()
 
-    async def set_config_option(
-        self, config_id: str, session_id: str, value: str, **kwargs: Any
+    async def set_config_option(  # type: ignore[override]
+        self,
+        config_id: str,
+        session_id: str,
+        value: str | bool,
+        **kwargs: Any,
     ) -> SetSessionConfigOptionResponse | None:
         """Accept ACP config option updates even when Hermes has no typed ACP config surface yet."""
         state = self.session_manager.get_session(session_id)
         if state is None:
-            logger.warning("Session %s: config update requested for missing session", session_id)
+            logger.warning(
+                "Session %s: config update requested for missing session", session_id
+            )
             return None
 
         options = getattr(state, "config_options", None)
         if not isinstance(options, dict):
             options = {}
         options[str(config_id)] = value
-        setattr(state, "config_options", options)
+        state_any = cast(Any, state)
+        state_any.config_options = options
         self.session_manager.save_session(session_id)
         logger.info("Session %s: config option %s updated", session_id, config_id)
         return SetSessionConfigOptionResponse(config_options=[])

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -6,10 +6,10 @@ reconnects after idle/restart, the ``load_session`` / ``resume_session`` calls
 find the persisted session in the database and restore the full conversation
 history.
 """
+
 from __future__ import annotations
 
-from hermes_constants import get_hermes_home
-
+import contextlib
 import copy
 import json
 import logging
@@ -18,10 +18,12 @@ import re
 import sys
 import time
 import uuid
-from datetime import datetime, timezone
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from threading import Lock
-from typing import Any, Dict, List, Optional
+from typing import Any, cast
+
+from hermes_constants import get_hermes_home
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +64,7 @@ def _format_updated_at(value: Any) -> str | None:
     if isinstance(value, str) and value.strip():
         return value
     try:
-        return datetime.fromtimestamp(float(value), tz=timezone.utc).isoformat()
+        return datetime.fromtimestamp(float(value), tz=UTC).isoformat()
     except Exception:
         return None
 
@@ -101,6 +103,7 @@ def _register_task_cwd(task_id: str, cwd: str) -> None:
         return
     try:
         from tools.terminal_tool import register_task_env_overrides
+
         register_task_env_overrides(task_id, {"cwd": cwd})
     except Exception:
         logger.debug("Failed to register ACP task cwd override", exc_info=True)
@@ -112,6 +115,7 @@ def _clear_task_cwd(task_id: str) -> None:
         return
     try:
         from tools.terminal_tool import clear_task_env_overrides
+
         clear_task_env_overrides(task_id)
     except Exception:
         logger.debug("Failed to clear ACP task cwd override", exc_info=True)
@@ -125,8 +129,10 @@ class SessionState:
     agent: Any  # AIAgent instance
     cwd: str = "."
     model: str = ""
-    history: List[Dict[str, Any]] = field(default_factory=list)
+    history: list[dict[str, Any]] = field(default_factory=list)
     cancel_event: Any = None  # threading.Event
+    mode: str = ""
+    config_options: dict[str, str | bool] = field(default_factory=dict)
 
 
 class SessionManager:
@@ -146,7 +152,7 @@ class SessionManager:
             db:            Optional SessionDB instance. When omitted, the default
                            SessionDB (``~/.hermes/state.db``) is lazily created.
         """
-        self._sessions: Dict[str, SessionState] = {}
+        self._sessions: dict[str, SessionState] = {}
         self._lock = Lock()
         self._agent_factory = agent_factory
         self._db_instance = db  # None → lazy-init on first use
@@ -173,7 +179,7 @@ class SessionManager:
         logger.info("Created ACP session %s (cwd=%s)", session_id, cwd)
         return state
 
-    def get_session(self, session_id: str) -> Optional[SessionState]:
+    def get_session(self, session_id: str) -> SessionState | None:
         """Return the session for *session_id*, or ``None``.
 
         If the session is not in memory but exists in the database (e.g. after
@@ -195,7 +201,7 @@ class SessionManager:
             _clear_task_cwd(session_id)
         return existed or db_existed
 
-    def fork_session(self, session_id: str, cwd: str = ".") -> Optional[SessionState]:
+    def fork_session(self, session_id: str, cwd: str = ".") -> SessionState | None:
         """Deep-copy a session's history into a new session."""
         import threading
 
@@ -224,7 +230,7 @@ class SessionManager:
         logger.info("Forked ACP session %s -> %s", session_id, new_id)
         return state
 
-    def list_sessions(self, cwd: str | None = None) -> List[Dict[str, Any]]:
+    def list_sessions(self, cwd: str | None = None) -> list[dict[str, Any]]:
         """Return lightweight info dicts for all sessions (memory + database)."""
         normalized_cwd = _normalize_cwd_for_compare(cwd) if cwd else None
         db = self._get_db()
@@ -245,14 +251,18 @@ class SessionManager:
                 history_len = len(s.history)
                 if history_len <= 0:
                     continue
-                if normalized_cwd and _normalize_cwd_for_compare(s.cwd) != normalized_cwd:
+                if (
+                    normalized_cwd
+                    and _normalize_cwd_for_compare(s.cwd) != normalized_cwd
+                ):
                     continue
                 persisted = persisted_rows.get(s.session_id, {})
                 preview = next(
                     (
                         str(msg.get("content") or "").strip()
                         for msg in s.history
-                        if msg.get("role") == "user" and str(msg.get("content") or "").strip()
+                        if msg.get("role") == "user"
+                        and str(msg.get("content") or "").strip()
                     ),
                     persisted.get("preview") or "",
                 )
@@ -262,9 +272,13 @@ class SessionManager:
                         "cwd": s.cwd,
                         "model": s.model,
                         "history_len": history_len,
-                        "title": _build_session_title(persisted.get("title"), preview, s.cwd),
+                        "title": _build_session_title(
+                            persisted.get("title"), preview, s.cwd
+                        ),
                         "updated_at": _format_updated_at(
-                            persisted.get("last_active") or persisted.get("started_at") or time.time()
+                            persisted.get("last_active")
+                            or persisted.get("started_at")
+                            or time.time()
                         ),
                     }
                 )
@@ -280,25 +294,34 @@ class SessionManager:
             session_cwd = "."
             mc = row.get("model_config")
             if mc:
-                try:
+                with contextlib.suppress(json.JSONDecodeError, TypeError):
                     session_cwd = json.loads(mc).get("cwd", ".")
-                except (json.JSONDecodeError, TypeError):
-                    pass
-            if normalized_cwd and _normalize_cwd_for_compare(session_cwd) != normalized_cwd:
+            if (
+                normalized_cwd
+                and _normalize_cwd_for_compare(session_cwd) != normalized_cwd
+            ):
                 continue
-            results.append({
-                "session_id": sid,
-                "cwd": session_cwd,
-                "model": row.get("model") or "",
-                "history_len": message_count,
-                "title": _build_session_title(row.get("title"), row.get("preview"), session_cwd),
-                "updated_at": _format_updated_at(row.get("last_active") or row.get("started_at")),
-            })
+            results.append(
+                {
+                    "session_id": sid,
+                    "cwd": session_cwd,
+                    "model": row.get("model") or "",
+                    "history_len": message_count,
+                    "title": _build_session_title(
+                        row.get("title"), row.get("preview"), session_cwd
+                    ),
+                    "updated_at": _format_updated_at(
+                        row.get("last_active") or row.get("started_at")
+                    ),
+                }
+            )
 
-        results.sort(key=lambda item: _updated_at_sort_key(item.get("updated_at")), reverse=True)
+        results.sort(
+            key=lambda item: _updated_at_sort_key(item.get("updated_at")), reverse=True
+        )
         return results
 
-    def update_cwd(self, session_id: str, cwd: str) -> Optional[SessionState]:
+    def update_cwd(self, session_id: str, cwd: str) -> SessionState | None:
         """Update the working directory for a session and its tool overrides."""
         state = self.get_session(session_id)  # checks DB too
         if state is None:
@@ -356,6 +379,7 @@ class SessionManager:
             return self._db_instance
         try:
             from hermes_state import SessionDB
+
             hermes_home = get_hermes_home()
             self._db_instance = SessionDB(db_path=hermes_home / "state.db")
             return self._db_instance
@@ -421,9 +445,11 @@ class SessionManager:
                     tool_call_id=msg.get("tool_call_id"),
                 )
         except Exception:
-            logger.warning("Failed to persist ACP session %s", state.session_id, exc_info=True)
+            logger.warning(
+                "Failed to persist ACP session %s", state.session_id, exc_info=True
+            )
 
-    def _restore(self, session_id: str) -> Optional[SessionState]:
+    def _restore(self, session_id: str) -> SessionState | None:
         """Load a session from the database into memory, recreating the AIAgent."""
         import threading
 
@@ -434,7 +460,9 @@ class SessionManager:
         try:
             row = db.get_session(session_id)
         except Exception:
-            logger.debug("Failed to query DB for ACP session %s", session_id, exc_info=True)
+            logger.debug(
+                "Failed to query DB for ACP session %s", session_id, exc_info=True
+            )
             return None
 
         if row is None:
@@ -467,7 +495,9 @@ class SessionManager:
         try:
             history = db.get_messages_as_conversation(session_id)
         except Exception:
-            logger.warning("Failed to load messages for ACP session %s", session_id, exc_info=True)
+            logger.warning(
+                "Failed to load messages for ACP session %s", session_id, exc_info=True
+            )
             history = []
 
         try:
@@ -480,7 +510,9 @@ class SessionManager:
                 api_mode=restored_api_mode,
             )
         except Exception:
-            logger.warning("Failed to recreate agent for ACP session %s", session_id, exc_info=True)
+            logger.warning(
+                "Failed to recreate agent for ACP session %s", session_id, exc_info=True
+            )
             return None
 
         state = SessionState(
@@ -494,7 +526,9 @@ class SessionManager:
         with self._lock:
             self._sessions[session_id] = state
         _register_task_cwd(session_id, cwd)
-        logger.info("Restored ACP session %s from DB (%d messages)", session_id, len(history))
+        logger.info(
+            "Restored ACP session %s from DB (%d messages)", session_id, len(history)
+        )
         return state
 
     def _delete_persisted(self, session_id: str) -> bool:
@@ -503,9 +537,11 @@ class SessionManager:
         if db is None:
             return False
         try:
-            return db.delete_session(session_id)
+            return bool(db.delete_session(session_id))
         except Exception:
-            logger.debug("Failed to delete ACP session %s from DB", session_id, exc_info=True)
+            logger.debug(
+                "Failed to delete ACP session %s from DB", session_id, exc_info=True
+            )
             return False
 
     # ---- internal -----------------------------------------------------------
@@ -523,12 +559,12 @@ class SessionManager:
         if self._agent_factory is not None:
             return self._agent_factory()
 
-        from run_agent import AIAgent
         from hermes_cli.config import load_config
         from hermes_cli.runtime_provider import resolve_runtime_provider
+        from run_agent import AIAgent
 
-        config = load_config()
-        model_cfg = config.get("model")
+        app_config = cast(dict[str, Any], load_config())  # type: ignore[assignment]
+        model_cfg = app_config.get("model")
         default_model = ""
         config_provider = None
         if isinstance(model_cfg, dict):
@@ -537,7 +573,7 @@ class SessionManager:
         elif isinstance(model_cfg, str) and model_cfg.strip():
             default_model = model_cfg.strip()
 
-        kwargs = {
+        kwargs: dict[str, Any] = {
             "platform": "acp",
             "enabled_toolsets": ["hermes-acp"],
             "quiet_mode": True,
@@ -546,7 +582,9 @@ class SessionManager:
         }
 
         try:
-            runtime = resolve_runtime_provider(requested=requested_provider or config_provider)
+            runtime = resolve_runtime_provider(
+                requested=requested_provider or config_provider
+            )
             kwargs.update(
                 {
                     "provider": runtime.get("provider"),
@@ -558,10 +596,12 @@ class SessionManager:
                 }
             )
         except Exception:
-            logger.debug("ACP session falling back to default provider resolution", exc_info=True)
+            logger.debug(
+                "ACP session falling back to default provider resolution", exc_info=True
+            )
 
         _register_task_cwd(session_id, cwd)
-        agent = AIAgent(**kwargs)
+        agent = AIAgent(**kwargs)  # type: ignore[arg-type]
         # ACP stdio transport requires stdout to remain protocol-only JSON-RPC.
         # Route any incidental human-readable agent output to stderr instead.
         agent._print_fn = _acp_stderr_print

--- a/acp_adapter/tools.py
+++ b/acp_adapter/tools.py
@@ -3,22 +3,26 @@
 from __future__ import annotations
 
 import json
+import logging
 import uuid
-from typing import Any, Dict, List, Optional
+from typing import Any, cast
 
 import acp
 from acp.schema import (
     ToolCallLocation,
-    ToolCallStart,
     ToolCallProgress,
+    ToolCallStart,
     ToolKind,
 )
+
+logger = logging.getLogger(__name__)
+_start_tool_call = cast(Any, acp.start_tool_call)
 
 # ---------------------------------------------------------------------------
 # Map hermes tool names -> ACP ToolKind
 # ---------------------------------------------------------------------------
 
-TOOL_KIND_MAP: Dict[str, ToolKind] = {
+TOOL_KIND_MAP: dict[str, ToolKind] = {
     # File operations
     "read_file": "read",
     "write_file": "edit",
@@ -61,7 +65,7 @@ def make_tool_call_id() -> str:
     return f"tc-{uuid.uuid4().hex[:12]}"
 
 
-def build_tool_title(tool_name: str, args: Dict[str, Any]) -> str:
+def build_tool_title(tool_name: str, args: dict[str, Any]) -> str:
     """Build a human-readable title for a tool call."""
     if tool_name == "terminal":
         cmd = args.get("command", "")
@@ -83,7 +87,9 @@ def build_tool_title(tool_name: str, args: Dict[str, Any]) -> str:
     if tool_name == "web_extract":
         urls = args.get("urls", [])
         if urls:
-            return f"extract: {urls[0]}" + (f" (+{len(urls)-1})" if len(urls) > 1 else "")
+            return f"extract: {urls[0]}" + (
+                f" (+{len(urls) - 1})" if len(urls) > 1 else ""
+            )
         return "web extract"
     if tool_name == "delegate_task":
         goal = args.get("goal", "")
@@ -97,7 +103,7 @@ def build_tool_title(tool_name: str, args: Dict[str, Any]) -> str:
     return tool_name
 
 
-def _build_patch_mode_content(patch_text: str) -> List[Any]:
+def _build_patch_mode_content(patch_text: str) -> list[Any]:
     """Parse V4A patch mode input into ACP diff blocks when possible."""
     if not patch_text:
         return [acp.tool_content(acp.text_block(""))]
@@ -109,14 +115,18 @@ def _build_patch_mode_content(patch_text: str) -> List[Any]:
         if error or not operations:
             return [acp.tool_content(acp.text_block(patch_text))]
 
-        content: List[Any] = []
+        content: list[Any] = []
         for op in operations:
             if op.operation == OperationType.UPDATE:
                 old_chunks: list[str] = []
                 new_chunks: list[str] = []
                 for hunk in op.hunks:
-                    old_lines = [line.content for line in hunk.lines if line.prefix in (" ", "-")]
-                    new_lines = [line.content for line in hunk.lines if line.prefix in (" ", "+")]
+                    old_lines = [
+                        line.content for line in hunk.lines if line.prefix in (" ", "-")
+                    ]
+                    new_lines = [
+                        line.content for line in hunk.lines if line.prefix in (" ", "+")
+                    ]
                     if old_lines or new_lines:
                         old_chunks.append("\n".join(old_lines))
                         new_chunks.append("\n".join(new_lines))
@@ -134,7 +144,12 @@ def _build_patch_mode_content(patch_text: str) -> List[Any]:
                 continue
 
             if op.operation == OperationType.ADD:
-                added_lines = [line.content for hunk in op.hunks for line in hunk.lines if line.prefix == "+"]
+                added_lines = [
+                    line.content
+                    for hunk in op.hunks
+                    for line in hunk.lines
+                    if line.prefix == "+"
+                ]
                 content.append(
                     acp.tool_diff_content(
                         path=op.file_path,
@@ -155,7 +170,9 @@ def _build_patch_mode_content(patch_text: str) -> List[Any]:
 
             if op.operation == OperationType.MOVE:
                 content.append(
-                    acp.tool_content(acp.text_block(f"Move file: {op.file_path} -> {op.new_path}"))
+                    acp.tool_content(
+                        acp.text_block(f"Move file: {op.file_path} -> {op.new_path}")
+                    )
                 )
 
         return content or [acp.tool_content(acp.text_block(patch_text))]
@@ -170,14 +187,14 @@ def _strip_diff_prefix(path: str) -> str:
     return raw
 
 
-def _parse_unified_diff_content(diff_text: str) -> List[Any]:
+def _parse_unified_diff_content(diff_text: str) -> list[Any]:
     """Convert unified diff text into ACP diff content blocks."""
     if not diff_text:
         return []
 
-    content: List[Any] = []
-    current_old_path: Optional[str] = None
-    current_new_path: Optional[str] = None
+    content: list[Any] = []
+    current_old_path: str | None = None
+    current_new_path: str | None = None
     old_lines: list[str] = []
     new_lines: list[str] = []
 
@@ -185,7 +202,11 @@ def _parse_unified_diff_content(diff_text: str) -> List[Any]:
         nonlocal current_old_path, current_new_path, old_lines, new_lines
         if current_old_path is None and current_new_path is None:
             return
-        path = current_new_path if current_new_path and current_new_path != "/dev/null" else current_old_path
+        path = (
+            current_new_path
+            if current_new_path and current_new_path != "/dev/null"
+            else current_old_path
+        )
         if not path or path == "/dev/null":
             current_old_path = None
             current_new_path = None
@@ -231,15 +252,18 @@ def _parse_unified_diff_content(diff_text: str) -> List[Any]:
 
 def _build_tool_complete_content(
     tool_name: str,
-    result: Optional[str],
+    result: str | None,
     *,
-    function_args: Optional[Dict[str, Any]] = None,
+    function_args: dict[str, Any] | None = None,
     snapshot: Any = None,
-) -> List[Any]:
+) -> list[Any]:
     """Build structured ACP completion content, falling back to plain text."""
     display_result = result or ""
     if len(display_result) > 5000:
-        display_result = display_result[:4900] + f"\n... ({len(result)} chars total, truncated)"
+        display_result = (
+            display_result[:4900]
+            + f"\n... ({len(display_result)} chars total, truncated)"
+        )
 
     if tool_name in {"write_file", "patch", "skill_manage"}:
         try:
@@ -256,7 +280,11 @@ def _build_tool_complete_content(
                 if diff_content:
                     return diff_content
         except Exception:
-            pass
+            logger.debug(
+                "Failed to extract structured edit diff for %s",
+                tool_name,
+                exc_info=True,
+            )
 
     return [acp.tool_content(acp.text_block(display_result))]
 
@@ -269,12 +297,13 @@ def _build_tool_complete_content(
 def build_tool_start(
     tool_call_id: str,
     tool_name: str,
-    arguments: Dict[str, Any],
+    arguments: dict[str, Any],
 ) -> ToolCallStart:
     """Create a ToolCallStart event for the given hermes tool invocation."""
     kind = get_tool_kind(tool_name)
     title = build_tool_title(tool_name, arguments)
     locations = extract_locations(arguments)
+    payload: Any
 
     if tool_name == "patch":
         mode = arguments.get("mode", "replace")
@@ -282,58 +311,39 @@ def build_tool_start(
             path = arguments.get("path", "")
             old = arguments.get("old_string", "")
             new = arguments.get("new_string", "")
-            content = [acp.tool_diff_content(path=path, new_text=new, old_text=old)]
+            payload = [acp.tool_diff_content(path=path, new_text=new, old_text=old)]
         else:
             patch_text = arguments.get("patch", "")
-            content = _build_patch_mode_content(patch_text)
-        return acp.start_tool_call(
-            tool_call_id, title, kind=kind, content=content, locations=locations,
-            raw_input=arguments,
-        )
-
-    if tool_name == "write_file":
+            payload = _build_patch_mode_content(patch_text)
+    elif tool_name == "write_file":
         path = arguments.get("path", "")
-        file_content = arguments.get("content", "")
-        content = [acp.tool_diff_content(path=path, new_text=file_content)]
-        return acp.start_tool_call(
-            tool_call_id, title, kind=kind, content=content, locations=locations,
-            raw_input=arguments,
-        )
-
-    if tool_name == "terminal":
+        file_text = arguments.get("content", "")
+        payload = [acp.tool_diff_content(path=path, new_text=file_text)]
+    elif tool_name == "terminal":
         command = arguments.get("command", "")
-        content = [acp.tool_content(acp.text_block(f"$ {command}"))]
-        return acp.start_tool_call(
-            tool_call_id, title, kind=kind, content=content, locations=locations,
-            raw_input=arguments,
-        )
-
-    if tool_name == "read_file":
+        payload = [acp.tool_content(acp.text_block(f"$ {command}"))]
+    elif tool_name == "read_file":
         path = arguments.get("path", "")
-        content = [acp.tool_content(acp.text_block(f"Reading {path}"))]
-        return acp.start_tool_call(
-            tool_call_id, title, kind=kind, content=content, locations=locations,
-            raw_input=arguments,
-        )
-
-    if tool_name == "search_files":
+        payload = [acp.tool_content(acp.text_block(f"Reading {path}"))]
+    elif tool_name == "search_files":
         pattern = arguments.get("pattern", "")
         target = arguments.get("target", "content")
-        content = [acp.tool_content(acp.text_block(f"Searching for '{pattern}' ({target})"))]
-        return acp.start_tool_call(
-            tool_call_id, title, kind=kind, content=content, locations=locations,
-            raw_input=arguments,
-        )
+        payload = [
+            acp.tool_content(acp.text_block(f"Searching for '{pattern}' ({target})"))
+        ]
+    else:
+        try:
+            args_text = json.dumps(arguments, indent=2, default=str)
+        except (TypeError, ValueError):
+            args_text = str(arguments)
+        payload = [acp.tool_content(acp.text_block(args_text))]
 
-    # Generic fallback
-    import json
-    try:
-        args_text = json.dumps(arguments, indent=2, default=str)
-    except (TypeError, ValueError):
-        args_text = str(arguments)
-    content = [acp.tool_content(acp.text_block(args_text))]
-    return acp.start_tool_call(
-        tool_call_id, title, kind=kind, content=content, locations=locations,
+    return _start_tool_call(
+        tool_call_id,
+        title,
+        kind=kind,
+        content=cast(Any, payload),
+        locations=locations,
         raw_input=arguments,
     )
 
@@ -341,13 +351,13 @@ def build_tool_start(
 def build_tool_complete(
     tool_call_id: str,
     tool_name: str,
-    result: Optional[str] = None,
-    function_args: Optional[Dict[str, Any]] = None,
+    result: str | None = None,
+    function_args: dict[str, Any] | None = None,
     snapshot: Any = None,
 ) -> ToolCallProgress:
     """Create a ToolCallUpdate (progress) event for a completed tool call."""
     kind = get_tool_kind(tool_name)
-    content = _build_tool_complete_content(
+    tool_blocks = _build_tool_complete_content(
         tool_name,
         result,
         function_args=function_args,
@@ -357,7 +367,7 @@ def build_tool_complete(
         tool_call_id,
         kind=kind,
         status="completed",
-        content=content,
+        content=tool_blocks,
         raw_output=result,
     )
 
@@ -368,10 +378,10 @@ def build_tool_complete(
 
 
 def extract_locations(
-    arguments: Dict[str, Any],
-) -> List[ToolCallLocation]:
+    arguments: dict[str, Any],
+) -> list[ToolCallLocation]:
     """Extract file-system locations from tool arguments."""
-    locations: List[ToolCallLocation] = []
+    locations: list[ToolCallLocation] = []
     path = arguments.get("path")
     if path:
         line = arguments.get("offset") or arguments.get("line")

--- a/agent/insights.py
+++ b/agent/insights.py
@@ -20,11 +20,11 @@ import json
 import time
 from collections import Counter, defaultdict
 from datetime import datetime
-from typing import Any, Dict, List
+from typing import Any
 
 from agent.usage_pricing import (
-    CanonicalUsage,
     DEFAULT_PRICING,
+    CanonicalUsage,
     estimate_usage_cost,
     format_duration_compact,
     has_known_pricing,
@@ -33,13 +33,15 @@ from agent.usage_pricing import (
 _DEFAULT_PRICING = DEFAULT_PRICING
 
 
-def _has_known_pricing(model_name: str, provider: str = None, base_url: str = None) -> bool:
+def _has_known_pricing(
+    model_name: str, provider: str = None, base_url: str = None
+) -> bool:
     """Check if a model has known pricing (vs unknown/custom endpoint)."""
     return has_known_pricing(model_name, provider=provider, base_url=base_url)
 
 
 def _estimate_cost(
-    session_or_model: Dict[str, Any] | str,
+    session_or_model: dict[str, Any] | str,
     input_tokens: int = 0,
     output_tokens: int = 0,
     *,
@@ -82,7 +84,7 @@ def _format_duration(seconds: float) -> str:
     return format_duration_compact(seconds)
 
 
-def _bar_chart(values: List[int], max_width: int = 20) -> List[str]:
+def _bar_chart(values: list[int], max_width: int = 20) -> list[str]:
     """Create simple horizontal bar chart strings from values."""
     peak = max(values) if values else 1
     if peak == 0:
@@ -108,7 +110,7 @@ class InsightsEngine:
         self.db = db
         self._conn = db._conn
 
-    def generate(self, days: int = 30, source: str = None) -> Dict[str, Any]:
+    def generate(self, days: int = 30, source: str = None) -> dict[str, Any]:
         """
         Generate a complete insights report.
 
@@ -177,11 +179,13 @@ class InsightsEngine:
     # =========================================================================
 
     # Columns we actually need (skip system_prompt, model_config blobs)
-    _SESSION_COLS = ("id, source, model, started_at, ended_at, "
-                     "message_count, tool_call_count, input_tokens, output_tokens, "
-                     "cache_read_tokens, cache_write_tokens, billing_provider, "
-                     "billing_base_url, billing_mode, estimated_cost_usd, "
-                     "actual_cost_usd, cost_status, cost_source")
+    _SESSION_COLS = (
+        "id, source, model, started_at, ended_at, "
+        "message_count, tool_call_count, input_tokens, output_tokens, "
+        "cache_read_tokens, cache_write_tokens, billing_provider, "
+        "billing_base_url, billing_mode, estimated_cost_usd, "
+        "actual_cost_usd, cost_status, cost_source"
+    )
 
     # Pre-computed query strings — f-string evaluated once at class definition,
     # not at runtime, so no user-controlled value can alter the query structure.
@@ -196,15 +200,17 @@ class InsightsEngine:
         " ORDER BY started_at DESC"
     )
 
-    def _get_sessions(self, cutoff: float, source: str = None) -> List[Dict]:
+    def _get_sessions(self, cutoff: float, source: str = None) -> list[dict]:
         """Fetch sessions within the time window."""
         if source:
-            cursor = self._conn.execute(self._GET_SESSIONS_WITH_SOURCE, (cutoff, source))
+            cursor = self._conn.execute(
+                self._GET_SESSIONS_WITH_SOURCE, (cutoff, source)
+            )
         else:
             cursor = self._conn.execute(self._GET_SESSIONS_ALL, (cutoff,))
         return [dict(row) for row in cursor.fetchall()]
 
-    def _get_tool_usage(self, cutoff: float, source: str = None) -> List[Dict]:
+    def _get_tool_usage(self, cutoff: float, source: str = None) -> list[dict]:
         """Get tool call counts from messages.
 
         Uses two sources:
@@ -269,7 +275,9 @@ class InsightsEngine:
                     calls = json.loads(calls)
                 if isinstance(calls, list):
                     for call in calls:
-                        func = call.get("function", {}) if isinstance(call, dict) else {}
+                        func = (
+                            call.get("function", {}) if isinstance(call, dict) else {}
+                        )
                         name = func.get("name")
                         if name:
                             tool_calls_counts[name] += 1
@@ -287,7 +295,9 @@ class InsightsEngine:
             all_tools = set(tool_counts) | set(tool_calls_counts)
             merged = Counter()
             for tool in all_tools:
-                merged[tool] = max(tool_counts.get(tool, 0), tool_calls_counts.get(tool, 0))
+                merged[tool] = max(
+                    tool_counts.get(tool, 0), tool_calls_counts.get(tool, 0)
+                )
             tool_counts = merged
 
         # Convert to the expected format
@@ -296,9 +306,9 @@ class InsightsEngine:
             for name, count in tool_counts.most_common()
         ]
 
-    def _get_skill_usage(self, cutoff: float, source: str = None) -> List[Dict]:
+    def _get_skill_usage(self, cutoff: float, source: str = None) -> list[dict]:
         """Extract per-skill usage from assistant tool calls."""
-        skill_counts: Dict[str, Dict[str, Any]] = {}
+        skill_counts: dict[str, dict[str, Any]] = {}
 
         if source:
             cursor = self._conn.execute(
@@ -372,7 +382,7 @@ class InsightsEngine:
 
         return list(skill_counts.values())
 
-    def _get_message_stats(self, cutoff: float, source: str = None) -> Dict:
+    def _get_message_stats(self, cutoff: float, source: str = None) -> dict:
         """Get aggregate message statistics."""
         if source:
             cursor = self._conn.execute(
@@ -399,16 +409,22 @@ class InsightsEngine:
                 (cutoff,),
             )
         row = cursor.fetchone()
-        return dict(row) if row else {
-            "total_messages": 0, "user_messages": 0,
-            "assistant_messages": 0, "tool_messages": 0,
-        }
+        return (
+            dict(row)
+            if row
+            else {
+                "total_messages": 0,
+                "user_messages": 0,
+                "assistant_messages": 0,
+                "tool_messages": 0,
+            }
+        )
 
     # =========================================================================
     # Computation
     # =========================================================================
 
-    def _compute_overview(self, sessions: List[Dict], message_stats: Dict) -> Dict:
+    def _compute_overview(self, sessions: list[dict], message_stats: dict) -> dict:
         """Compute high-level overview statistics."""
         total_input = sum(s.get("input_tokens") or 0 for s in sessions)
         total_output = sum(s.get("output_tokens") or 0 for s in sessions)
@@ -435,7 +451,9 @@ class InsightsEngine:
                 included_cost_sessions += 1
             elif status == "unknown":
                 unknown_cost_sessions += 1
-            if _has_known_pricing(model, s.get("billing_provider"), s.get("billing_base_url")):
+            if _has_known_pricing(
+                model, s.get("billing_provider"), s.get("billing_base_url")
+            ):
                 models_with_pricing.add(display)
             else:
                 models_without_pricing.add(display)
@@ -469,7 +487,9 @@ class InsightsEngine:
             "actual_cost": actual_cost,
             "total_hours": total_hours,
             "avg_session_duration": avg_duration,
-            "avg_messages_per_session": total_messages / len(sessions) if sessions else 0,
+            "avg_messages_per_session": total_messages / len(sessions)
+            if sessions
+            else 0,
             "avg_tokens_per_session": total_tokens / len(sessions) if sessions else 0,
             "user_messages": message_stats.get("user_messages") or 0,
             "assistant_messages": message_stats.get("assistant_messages") or 0,
@@ -482,13 +502,20 @@ class InsightsEngine:
             "included_cost_sessions": included_cost_sessions,
         }
 
-    def _compute_model_breakdown(self, sessions: List[Dict]) -> List[Dict]:
+    def _compute_model_breakdown(self, sessions: list[dict]) -> list[dict]:
         """Break down usage by model."""
-        model_data = defaultdict(lambda: {
-            "sessions": 0, "input_tokens": 0, "output_tokens": 0,
-            "cache_read_tokens": 0, "cache_write_tokens": 0,
-            "total_tokens": 0, "tool_calls": 0, "cost": 0.0,
-        })
+        model_data = defaultdict(
+            lambda: {
+                "sessions": 0,
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "total_tokens": 0,
+                "tool_calls": 0,
+                "cost": 0.0,
+            }
+        )
 
         for s in sessions:
             model = s.get("model") or "unknown"
@@ -508,24 +535,30 @@ class InsightsEngine:
             d["tool_calls"] += s.get("tool_call_count") or 0
             estimate, status = _estimate_cost(s)
             d["cost"] += estimate
-            d["has_pricing"] = _has_known_pricing(model, s.get("billing_provider"), s.get("billing_base_url"))
+            d["has_pricing"] = _has_known_pricing(
+                model, s.get("billing_provider"), s.get("billing_base_url")
+            )
             d["cost_status"] = status
 
-        result = [
-            {"model": model, **data}
-            for model, data in model_data.items()
-        ]
+        result = [{"model": model, **data} for model, data in model_data.items()]
         # Sort by tokens first, fall back to session count when tokens are 0
         result.sort(key=lambda x: (x["total_tokens"], x["sessions"]), reverse=True)
         return result
 
-    def _compute_platform_breakdown(self, sessions: List[Dict]) -> List[Dict]:
+    def _compute_platform_breakdown(self, sessions: list[dict]) -> list[dict]:
         """Break down usage by platform/source."""
-        platform_data = defaultdict(lambda: {
-            "sessions": 0, "messages": 0, "input_tokens": 0,
-            "output_tokens": 0, "cache_read_tokens": 0,
-            "cache_write_tokens": 0, "total_tokens": 0, "tool_calls": 0,
-        })
+        platform_data = defaultdict(
+            lambda: {
+                "sessions": 0,
+                "messages": 0,
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "total_tokens": 0,
+                "tool_calls": 0,
+            }
+        )
 
         for s in sessions:
             source = s.get("source") or "unknown"
@@ -544,43 +577,52 @@ class InsightsEngine:
             d["tool_calls"] += s.get("tool_call_count") or 0
 
         result = [
-            {"platform": platform, **data}
-            for platform, data in platform_data.items()
+            {"platform": platform, **data} for platform, data in platform_data.items()
         ]
         result.sort(key=lambda x: x["sessions"], reverse=True)
         return result
 
-    def _compute_tool_breakdown(self, tool_usage: List[Dict]) -> List[Dict]:
+    def _compute_tool_breakdown(self, tool_usage: list[dict]) -> list[dict]:
         """Process tool usage data into a ranked list with percentages."""
         total_calls = sum(t["count"] for t in tool_usage) if tool_usage else 0
         result = []
         for t in tool_usage:
             pct = (t["count"] / total_calls * 100) if total_calls else 0
-            result.append({
-                "tool": t["tool_name"],
-                "count": t["count"],
-                "percentage": pct,
-            })
+            result.append(
+                {
+                    "tool": t["tool_name"],
+                    "count": t["count"],
+                    "percentage": pct,
+                }
+            )
         return result
 
-    def _compute_skill_breakdown(self, skill_usage: List[Dict]) -> Dict[str, Any]:
+    def _compute_skill_breakdown(self, skill_usage: list[dict]) -> dict[str, Any]:
         """Process per-skill usage into summary + ranked list."""
-        total_skill_loads = sum(s["view_count"] for s in skill_usage) if skill_usage else 0
-        total_skill_edits = sum(s["manage_count"] for s in skill_usage) if skill_usage else 0
+        total_skill_loads = (
+            sum(s["view_count"] for s in skill_usage) if skill_usage else 0
+        )
+        total_skill_edits = (
+            sum(s["manage_count"] for s in skill_usage) if skill_usage else 0
+        )
         total_skill_actions = total_skill_loads + total_skill_edits
 
         top_skills = []
         for skill in skill_usage:
             total_count = skill["view_count"] + skill["manage_count"]
-            percentage = (total_count / total_skill_actions * 100) if total_skill_actions else 0
-            top_skills.append({
-                "skill": skill["skill"],
-                "view_count": skill["view_count"],
-                "manage_count": skill["manage_count"],
-                "total_count": total_count,
-                "percentage": percentage,
-                "last_used_at": skill.get("last_used_at"),
-            })
+            percentage = (
+                (total_count / total_skill_actions * 100) if total_skill_actions else 0
+            )
+            top_skills.append(
+                {
+                    "skill": skill["skill"],
+                    "view_count": skill["view_count"],
+                    "manage_count": skill["manage_count"],
+                    "total_count": total_count,
+                    "percentage": percentage,
+                    "last_used_at": skill.get("last_used_at"),
+                }
+            )
 
         top_skills.sort(
             key=lambda s: (
@@ -603,7 +645,7 @@ class InsightsEngine:
             "top_skills": top_skills,
         }
 
-    def _compute_activity_patterns(self, sessions: List[Dict]) -> Dict:
+    def _compute_activity_patterns(self, sessions: list[dict]) -> dict:
         """Analyze activity patterns by day of week and hour."""
         day_counts = Counter()  # 0=Monday ... 6=Sunday
         hour_counts = Counter()
@@ -620,18 +662,20 @@ class InsightsEngine:
 
         day_names = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
         day_breakdown = [
-            {"day": day_names[i], "count": day_counts.get(i, 0)}
-            for i in range(7)
+            {"day": day_names[i], "count": day_counts.get(i, 0)} for i in range(7)
         ]
 
         hour_breakdown = [
-            {"hour": i, "count": hour_counts.get(i, 0)}
-            for i in range(24)
+            {"hour": i, "count": hour_counts.get(i, 0)} for i in range(24)
         ]
 
         # Busiest day and hour
-        busiest_day = max(day_breakdown, key=lambda x: x["count"]) if day_breakdown else None
-        busiest_hour = max(hour_breakdown, key=lambda x: x["count"]) if hour_breakdown else None
+        busiest_day = (
+            max(day_breakdown, key=lambda x: x["count"]) if day_breakdown else None
+        )
+        busiest_hour = (
+            max(hour_breakdown, key=lambda x: x["count"]) if hour_breakdown else None
+        )
 
         # Active days (days with at least one session)
         active_days = len(daily_counts)
@@ -661,61 +705,84 @@ class InsightsEngine:
             "max_streak": max_streak,
         }
 
-    def _compute_top_sessions(self, sessions: List[Dict]) -> List[Dict]:
+    def _compute_top_sessions(self, sessions: list[dict]) -> list[dict]:
         """Find notable sessions (longest, most messages, most tokens)."""
         top = []
 
         # Longest by duration
         sessions_with_duration = [
-            s for s in sessions
-            if s.get("started_at") and s.get("ended_at")
+            s for s in sessions if s.get("started_at") and s.get("ended_at")
         ]
         if sessions_with_duration:
             longest = max(
                 sessions_with_duration,
-                key=lambda s: (s["ended_at"] - s["started_at"]),
+                key=lambda s: s["ended_at"] - s["started_at"],
             )
             dur = longest["ended_at"] - longest["started_at"]
-            top.append({
-                "label": "Longest session",
-                "session_id": longest["id"][:16],
-                "value": _format_duration(dur),
-                "date": datetime.fromtimestamp(longest["started_at"]).strftime("%b %d"),
-            })
+            top.append(
+                {
+                    "label": "Longest session",
+                    "session_id": longest["id"][:16],
+                    "value": _format_duration(dur),
+                    "date": datetime.fromtimestamp(longest["started_at"]).strftime(
+                        "%b %d"
+                    ),
+                }
+            )
 
         # Most messages
         most_msgs = max(sessions, key=lambda s: s.get("message_count") or 0)
         if (most_msgs.get("message_count") or 0) > 0:
-            top.append({
-                "label": "Most messages",
-                "session_id": most_msgs["id"][:16],
-                "value": f"{most_msgs['message_count']} msgs",
-                "date": datetime.fromtimestamp(most_msgs["started_at"]).strftime("%b %d") if most_msgs.get("started_at") else "?",
-            })
+            top.append(
+                {
+                    "label": "Most messages",
+                    "session_id": most_msgs["id"][:16],
+                    "value": f"{most_msgs['message_count']} msgs",
+                    "date": datetime.fromtimestamp(most_msgs["started_at"]).strftime(
+                        "%b %d"
+                    )
+                    if most_msgs.get("started_at")
+                    else "?",
+                }
+            )
 
         # Most tokens
         most_tokens = max(
             sessions,
             key=lambda s: (s.get("input_tokens") or 0) + (s.get("output_tokens") or 0),
         )
-        token_total = (most_tokens.get("input_tokens") or 0) + (most_tokens.get("output_tokens") or 0)
+        token_total = (most_tokens.get("input_tokens") or 0) + (
+            most_tokens.get("output_tokens") or 0
+        )
         if token_total > 0:
-            top.append({
-                "label": "Most tokens",
-                "session_id": most_tokens["id"][:16],
-                "value": f"{token_total:,} tokens",
-                "date": datetime.fromtimestamp(most_tokens["started_at"]).strftime("%b %d") if most_tokens.get("started_at") else "?",
-            })
+            top.append(
+                {
+                    "label": "Most tokens",
+                    "session_id": most_tokens["id"][:16],
+                    "value": f"{token_total:,} tokens",
+                    "date": datetime.fromtimestamp(most_tokens["started_at"]).strftime(
+                        "%b %d"
+                    )
+                    if most_tokens.get("started_at")
+                    else "?",
+                }
+            )
 
         # Most tool calls
         most_tools = max(sessions, key=lambda s: s.get("tool_call_count") or 0)
         if (most_tools.get("tool_call_count") or 0) > 0:
-            top.append({
-                "label": "Most tool calls",
-                "session_id": most_tools["id"][:16],
-                "value": f"{most_tools['tool_call_count']} calls",
-                "date": datetime.fromtimestamp(most_tools["started_at"]).strftime("%b %d") if most_tools.get("started_at") else "?",
-            })
+            top.append(
+                {
+                    "label": "Most tool calls",
+                    "session_id": most_tools["id"][:16],
+                    "value": f"{most_tools['tool_call_count']} calls",
+                    "date": datetime.fromtimestamp(most_tools["started_at"]).strftime(
+                        "%b %d"
+                    )
+                    if most_tools.get("started_at")
+                    else "?",
+                }
+            )
 
         return top
 
@@ -723,11 +790,15 @@ class InsightsEngine:
     # Formatting
     # =========================================================================
 
-    def format_terminal(self, report: Dict) -> str:
+    def format_terminal(self, report: dict) -> str:
         """Format the insights report for terminal display (CLI)."""
         if report.get("empty"):
             days = report.get("days", 30)
-            src = f" (source: {report['source_filter']})" if report.get("source_filter") else ""
+            src = (
+                f" (source: {report['source_filter']})"
+                if report.get("source_filter")
+                else ""
+            )
             return f"  No sessions found in the last {days} days{src}."
 
         lines = []
@@ -751,7 +822,9 @@ class InsightsEngine:
 
         # Date range
         if o.get("date_range_start") and o.get("date_range_end"):
-            start_str = datetime.fromtimestamp(o["date_range_start"]).strftime("%b %d, %Y")
+            start_str = datetime.fromtimestamp(o["date_range_start"]).strftime(
+                "%b %d, %Y"
+            )
             end_str = datetime.fromtimestamp(o["date_range_end"]).strftime("%b %d, %Y")
             lines.append(f"  Period: {start_str} — {end_str}")
             lines.append("")
@@ -759,12 +832,20 @@ class InsightsEngine:
         # Overview
         lines.append("  📋 Overview")
         lines.append("  " + "─" * 56)
-        lines.append(f"  Sessions:          {o['total_sessions']:<12}  Messages:        {o['total_messages']:,}")
-        lines.append(f"  Tool calls:        {o['total_tool_calls']:<12,}  User messages:   {o['user_messages']:,}")
-        lines.append(f"  Input tokens:      {o['total_input_tokens']:<12,}  Output tokens:   {o['total_output_tokens']:,}")
+        lines.append(
+            f"  Sessions:          {o['total_sessions']:<12}  Messages:        {o['total_messages']:,}"
+        )
+        lines.append(
+            f"  Tool calls:        {o['total_tool_calls']:<12,}  User messages:   {o['user_messages']:,}"
+        )
+        lines.append(
+            f"  Input tokens:      {o['total_input_tokens']:<12,}  Output tokens:   {o['total_output_tokens']:,}"
+        )
         lines.append(f"  Total tokens:      {o['total_tokens']:,}")
         if o["total_hours"] > 0:
-            lines.append(f"  Active time:       ~{_format_duration(o['total_hours'] * 3600):<11}  Avg session:     ~{_format_duration(o['avg_session_duration'])}")
+            lines.append(
+                f"  Active time:       ~{_format_duration(o['total_hours'] * 3600):<11}  Avg session:     ~{_format_duration(o['avg_session_duration'])}"
+            )
         lines.append(f"  Avg msgs/session:  {o['avg_messages_per_session']:.1f}")
         lines.append("")
 
@@ -775,16 +856,24 @@ class InsightsEngine:
             lines.append(f"  {'Model':<30} {'Sessions':>8} {'Tokens':>12}")
             for m in report["models"]:
                 model_name = m["model"][:28]
-                lines.append(f"  {model_name:<30} {m['sessions']:>8} {m['total_tokens']:>12,}")
+                lines.append(
+                    f"  {model_name:<30} {m['sessions']:>8} {m['total_tokens']:>12,}"
+                )
             lines.append("")
 
         # Platform breakdown
-        if len(report["platforms"]) > 1 or (report["platforms"] and report["platforms"][0]["platform"] != "cli"):
+        if len(report["platforms"]) > 1 or (
+            report["platforms"] and report["platforms"][0]["platform"] != "cli"
+        ):
             lines.append("  📱 Platforms")
             lines.append("  " + "─" * 56)
-            lines.append(f"  {'Platform':<14} {'Sessions':>8} {'Messages':>10} {'Tokens':>14}")
+            lines.append(
+                f"  {'Platform':<14} {'Sessions':>8} {'Messages':>10} {'Tokens':>14}"
+            )
             for p in report["platforms"]:
-                lines.append(f"  {p['platform']:<14} {p['sessions']:>8} {p['messages']:>10,} {p['total_tokens']:>14,}")
+                lines.append(
+                    f"  {p['platform']:<14} {p['sessions']:>8} {p['messages']:>10,} {p['total_tokens']:>14,}"
+                )
             lines.append("")
 
         # Tool usage
@@ -793,7 +882,9 @@ class InsightsEngine:
             lines.append("  " + "─" * 56)
             lines.append(f"  {'Tool':<28} {'Calls':>8} {'%':>8}")
             for t in report["tools"][:15]:  # Top 15
-                lines.append(f"  {t['tool']:<28} {t['count']:>8,} {t['percentage']:>7.1f}%")
+                lines.append(
+                    f"  {t['tool']:<28} {t['count']:>8,} {t['percentage']:>7.1f}%"
+                )
             if len(report["tools"]) > 15:
                 lines.append(f"  ... and {len(report['tools']) - 15} more tools")
             lines.append("")
@@ -808,7 +899,9 @@ class InsightsEngine:
             for skill in top_skills[:10]:
                 last_used = "—"
                 if skill.get("last_used_at"):
-                    last_used = datetime.fromtimestamp(skill["last_used_at"]).strftime("%b %d")
+                    last_used = datetime.fromtimestamp(skill["last_used_at"]).strftime(
+                        "%b %d"
+                    )
                 lines.append(
                     f"  {skill['skill'][:28]:<28} {skill['view_count']:>7,} {skill['manage_count']:>7,} {last_used:>11}"
                 )
@@ -858,12 +951,14 @@ class InsightsEngine:
             lines.append("  🏆 Notable Sessions")
             lines.append("  " + "─" * 56)
             for ts in report["top_sessions"]:
-                lines.append(f"  {ts['label']:<20} {ts['value']:<18} ({ts['date']}, {ts['session_id']})")
+                lines.append(
+                    f"  {ts['label']:<20} {ts['value']:<18} ({ts['date']}, {ts['session_id']})"
+                )
             lines.append("")
 
         return "\n".join(lines)
 
-    def format_gateway(self, report: Dict) -> str:
+    def format_gateway(self, report: dict) -> str:
         """Format the insights report for gateway/messaging (shorter)."""
         if report.get("empty"):
             days = report.get("days", 30)
@@ -876,31 +971,46 @@ class InsightsEngine:
         lines.append(f"📊 **Hermes Insights** — Last {days} days\n")
 
         # Overview
-        lines.append(f"**Sessions:** {o['total_sessions']} | **Messages:** {o['total_messages']:,} | **Tool calls:** {o['total_tool_calls']:,}")
-        lines.append(f"**Tokens:** {o['total_tokens']:,} (in: {o['total_input_tokens']:,} / out: {o['total_output_tokens']:,})")
+        lines.append(
+            f"**Sessions:** {o['total_sessions']} | **Messages:** {o['total_messages']:,} | **Tool calls:** {o['total_tool_calls']:,}"
+        )
+        lines.append(
+            f"**Tokens:** {o['total_tokens']:,} (in: {o['total_input_tokens']:,} / out: {o['total_output_tokens']:,})"
+        )
+        cost = o.get("estimated_cost", 0.0)
+        if cost > 0:
+            lines.append(f"**Est. cost:** ${cost:.4f}")
         if o["total_hours"] > 0:
-            lines.append(f"**Active time:** ~{_format_duration(o['total_hours'] * 3600)} | **Avg session:** ~{_format_duration(o['avg_session_duration'])}")
+            lines.append(
+                f"**Active time:** ~{_format_duration(o['total_hours'] * 3600)} | **Avg session:** ~{_format_duration(o['avg_session_duration'])}"
+            )
         lines.append("")
 
         # Models (top 5)
         if report["models"]:
             lines.append("**🤖 Models:**")
             for m in report["models"][:5]:
-                lines.append(f"  {m['model'][:25]} — {m['sessions']} sessions, {m['total_tokens']:,} tokens")
+                lines.append(
+                    f"  {m['model'][:25]} — {m['sessions']} sessions, {m['total_tokens']:,} tokens"
+                )
             lines.append("")
 
         # Platforms (if multi-platform)
         if len(report["platforms"]) > 1:
             lines.append("**📱 Platforms:**")
             for p in report["platforms"]:
-                lines.append(f"  {p['platform']} — {p['sessions']} sessions, {p['messages']:,} msgs")
+                lines.append(
+                    f"  {p['platform']} — {p['sessions']} sessions, {p['messages']:,} msgs"
+                )
             lines.append("")
 
         # Tools (top 8)
         if report["tools"]:
             lines.append("**🔧 Top Tools:**")
             for t in report["tools"][:8]:
-                lines.append(f"  {t['tool']} — {t['count']:,} calls ({t['percentage']:.1f}%)")
+                lines.append(
+                    f"  {t['tool']} — {t['count']:,} calls ({t['percentage']:.1f}%)"
+                )
             lines.append("")
 
         skills = report.get("skills", {})
@@ -921,9 +1031,13 @@ class InsightsEngine:
             hr = act["busiest_hour"]["hour"]
             ampm = "AM" if hr < 12 else "PM"
             display_hr = hr % 12 or 12
-            lines.append(f"**📅 Busiest:** {act['busiest_day']['day']}s ({act['busiest_day']['count']} sessions), {display_hr}{ampm} ({act['busiest_hour']['count']} sessions)")
+            lines.append(
+                f"**📅 Busiest:** {act['busiest_day']['day']}s ({act['busiest_day']['count']} sessions), {display_hr}{ampm} ({act['busiest_hour']['count']} sessions)"
+            )
             if act.get("active_days"):
-                lines.append(f"**Active days:** {act['active_days']}", )
+                lines.append(
+                    f"**Active days:** {act['active_days']}",
+                )
             if act.get("max_streak", 0) > 1:
                 lines.append(f"**Best streak:** {act['max_streak']} consecutive days")
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -26,19 +26,22 @@ import hmac
 import json
 import logging
 import os
-import socket as _socket
 import re
+import socket as _socket
 import sqlite3
 import time
 import uuid
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 try:
     from aiohttp import web
+
     AIOHTTP_AVAILABLE = True
 except ImportError:
     AIOHTTP_AVAILABLE = False
     web = None  # type: ignore[assignment]
+
+_ADAPTER_KEY = web.AppKey("api_server_adapter", object) if AIOHTTP_AVAILABLE else None
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
@@ -60,7 +63,10 @@ MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
 
 
 def _normalize_chat_content(
-    content: Any, *, _max_depth: int = 10, _depth: int = 0,
+    content: Any,
+    *,
+    _max_depth: int = 10,
+    _depth: int = 0,
 ) -> str:
     """Normalize OpenAI chat message content into a plain text string.
 
@@ -80,11 +86,19 @@ def _normalize_chat_content(
     if content is None:
         return ""
     if isinstance(content, str):
-        return content[:MAX_NORMALIZED_TEXT_LENGTH] if len(content) > MAX_NORMALIZED_TEXT_LENGTH else content
+        return (
+            content[:MAX_NORMALIZED_TEXT_LENGTH]
+            if len(content) > MAX_NORMALIZED_TEXT_LENGTH
+            else content
+        )
 
     if isinstance(content, list):
-        parts: List[str] = []
-        items = content[:MAX_CONTENT_LIST_SIZE] if len(content) > MAX_CONTENT_LIST_SIZE else content
+        parts: list[str] = []
+        items = (
+            content[:MAX_CONTENT_LIST_SIZE]
+            if len(content) > MAX_CONTENT_LIST_SIZE
+            else content
+        )
         for item in items:
             if isinstance(item, str):
                 if item:
@@ -100,19 +114,29 @@ def _normalize_chat_content(
                             pass
                 # Silently skip image_url / other non-text parts
             elif isinstance(item, list):
-                nested = _normalize_chat_content(item, _max_depth=_max_depth, _depth=_depth + 1)
+                nested = _normalize_chat_content(
+                    item, _max_depth=_max_depth, _depth=_depth + 1
+                )
                 if nested:
                     parts.append(nested)
             # Check accumulated size
             if sum(len(p) for p in parts) >= MAX_NORMALIZED_TEXT_LENGTH:
                 break
         result = "\n".join(parts)
-        return result[:MAX_NORMALIZED_TEXT_LENGTH] if len(result) > MAX_NORMALIZED_TEXT_LENGTH else result
+        return (
+            result[:MAX_NORMALIZED_TEXT_LENGTH]
+            if len(result) > MAX_NORMALIZED_TEXT_LENGTH
+            else result
+        )
 
     # Fallback for unexpected types (int, float, bool, etc.)
     try:
         result = str(content)
-        return result[:MAX_NORMALIZED_TEXT_LENGTH] if len(result) > MAX_NORMALIZED_TEXT_LENGTH else result
+        return (
+            result[:MAX_NORMALIZED_TEXT_LENGTH]
+            if len(result) > MAX_NORMALIZED_TEXT_LENGTH
+            else result
+        )
     except Exception:
         return ""
 
@@ -147,14 +171,22 @@ def _normalize_multimodal_content(content: Any) -> Any:
     if content is None:
         return ""
     if isinstance(content, str):
-        return content[:MAX_NORMALIZED_TEXT_LENGTH] if len(content) > MAX_NORMALIZED_TEXT_LENGTH else content
+        return (
+            content[:MAX_NORMALIZED_TEXT_LENGTH]
+            if len(content) > MAX_NORMALIZED_TEXT_LENGTH
+            else content
+        )
     if not isinstance(content, list):
         # Mirror the legacy text-normalizer's fallback so callers that
         # pre-existed image support still get a string back.
         return _normalize_chat_content(content)
 
-    items = content[:MAX_CONTENT_LIST_SIZE] if len(content) > MAX_CONTENT_LIST_SIZE else content
-    normalized_parts: List[Dict[str, Any]] = []
+    items = (
+        content[:MAX_CONTENT_LIST_SIZE]
+        if len(content) > MAX_CONTENT_LIST_SIZE
+        else content
+    )
+    normalized_parts: list[dict[str, Any]] = []
     text_accum_len = 0
 
     for part in items:
@@ -198,7 +230,9 @@ def _normalize_multimodal_content(content: Any) -> Any:
             else:
                 url_value = image_ref
             if not isinstance(url_value, str) or not url_value.strip():
-                raise ValueError("invalid_image_url:Image parts must include a non-empty image URL.")
+                raise ValueError(
+                    "invalid_image_url:Image parts must include a non-empty image URL."
+                )
             url_value = url_value.strip()
             lowered = url_value.lower()
             if lowered.startswith("data:"):
@@ -211,10 +245,15 @@ def _normalize_multimodal_content(content: Any) -> Any:
                 raise ValueError(
                     "invalid_image_url:Image inputs must use http(s) URLs or data:image/... URLs."
                 )
-            image_part: Dict[str, Any] = {"type": "image_url", "image_url": {"url": url_value}}
+            image_part: dict[str, Any] = {
+                "type": "image_url",
+                "image_url": {"url": url_value},
+            }
             if detail is not None:
                 if not isinstance(detail, str) or not detail.strip():
-                    raise ValueError("invalid_content_part:Image detail must be a non-empty string when provided.")
+                    raise ValueError(
+                        "invalid_content_part:Image detail must be a non-empty string when provided."
+                    )
                 image_part["image_url"]["detail"] = detail.strip()
             normalized_parts.append(image_part)
             continue
@@ -293,6 +332,7 @@ class ResponseStore:
         if db_path is None:
             try:
                 from hermes_cli.config import get_hermes_home
+
                 db_path = str(get_hermes_home() / "response_store.db")
             except Exception:
                 db_path = ":memory:"
@@ -316,13 +356,15 @@ class ResponseStore:
         )
         self._conn.commit()
 
-    def get(self, response_id: str) -> Optional[Dict[str, Any]]:
+    def get(self, response_id: str) -> dict[str, Any] | None:
         """Retrieve a stored response by ID (updates access time for LRU)."""
         row = self._conn.execute(
             "SELECT data FROM responses WHERE response_id = ?", (response_id,)
         ).fetchone()
         if row is None:
             return None
+        import time
+
         self._conn.execute(
             "UPDATE responses SET accessed_at = ? WHERE response_id = ?",
             (time.time(), response_id),
@@ -330,8 +372,10 @@ class ResponseStore:
         self._conn.commit()
         return json.loads(row[0])
 
-    def put(self, response_id: str, data: Dict[str, Any]) -> None:
+    def put(self, response_id: str, data: dict[str, Any]) -> None:
         """Store a response, evicting the oldest if at capacity."""
+        import time
+
         self._conn.execute(
             "INSERT OR REPLACE INTO responses (response_id, data, accessed_at) VALUES (?, ?, ?)",
             (response_id, json.dumps(data, default=str), time.time()),
@@ -354,7 +398,7 @@ class ResponseStore:
         self._conn.commit()
         return cursor.rowcount > 0
 
-    def get_conversation(self, name: str) -> Optional[str]:
+    def get_conversation(self, name: str) -> str | None:
         """Get the latest response_id for a conversation name."""
         row = self._conn.execute(
             "SELECT response_id FROM conversations WHERE name = ?", (name,)
@@ -392,10 +436,11 @@ _CORS_HEADERS = {
 
 
 if AIOHTTP_AVAILABLE:
+
     @web.middleware
     async def cors_middleware(request, handler):
         """Add CORS headers for explicitly allowed origins; handle OPTIONS preflight."""
-        adapter = request.app.get("api_server_adapter")
+        adapter = request.app.get(_ADAPTER_KEY)
         origin = request.headers.get("Origin", "")
         cors_headers = None
         if adapter is not None:
@@ -416,7 +461,12 @@ else:
     cors_middleware = None  # type: ignore[assignment]
 
 
-def _openai_error(message: str, err_type: str = "invalid_request_error", param: str = None, code: str = None) -> Dict[str, Any]:
+def _openai_error(
+    message: str,
+    err_type: str = "invalid_request_error",
+    param: str = None,
+    code: str = None,
+) -> dict[str, Any]:
     """OpenAI-style error envelope."""
     return {
         "error": {
@@ -429,6 +479,7 @@ def _openai_error(message: str, err_type: str = "invalid_request_error", param: 
 
 
 if AIOHTTP_AVAILABLE:
+
     @web.middleware
     async def body_limit_middleware(request, handler):
         """Reject overly large request bodies early based on Content-Length."""
@@ -437,9 +488,20 @@ if AIOHTTP_AVAILABLE:
             if cl is not None:
                 try:
                     if int(cl) > MAX_REQUEST_BYTES:
-                        return web.json_response(_openai_error("Request body too large.", code="body_too_large"), status=413)
+                        return web.json_response(
+                            _openai_error(
+                                "Request body too large.", code="body_too_large"
+                            ),
+                            status=413,
+                        )
                 except ValueError:
-                    return web.json_response(_openai_error("Invalid Content-Length header.", code="invalid_content_length"), status=400)
+                    return web.json_response(
+                        _openai_error(
+                            "Invalid Content-Length header.",
+                            code="invalid_content_length",
+                        ),
+                        status=400,
+                    )
         return await handler(request)
 else:
     body_limit_middleware = None  # type: ignore[assignment]
@@ -451,6 +513,7 @@ _SECURITY_HEADERS = {
 
 
 if AIOHTTP_AVAILABLE:
+
     @web.middleware
     async def security_headers_middleware(request, handler):
         """Add security headers to all responses (including errors)."""
@@ -464,15 +527,19 @@ else:
 
 class _IdempotencyCache:
     """In-memory idempotency cache with TTL and basic LRU semantics."""
+
     def __init__(self, max_items: int = 1000, ttl_seconds: int = 300):
         from collections import OrderedDict
+
         self._store = OrderedDict()
         self._inflight: Dict[tuple[str, str], "asyncio.Task[Any]"] = {}
         self._ttl = ttl_seconds
         self._max = max_items
 
     def _purge(self):
-        now = time.time()
+        import time as _t
+
+        now = _t.time()
         expired = [k for k, v in self._store.items() if now - v["ts"] > self._ttl]
         for k in expired:
             self._store.pop(k, None)
@@ -484,40 +551,26 @@ class _IdempotencyCache:
         item = self._store.get(key)
         if item and item["fp"] == fingerprint:
             return item["resp"]
+        resp = await compute_coro()
+        import time as _t
 
-        inflight_key = (key, fingerprint)
-        task = self._inflight.get(inflight_key)
-        if task is None:
-            async def _compute_and_store():
-                resp = await compute_coro()
-                import time as _t
-                self._store[key] = {"resp": resp, "fp": fingerprint, "ts": _t.time()}
-                self._purge()
-                return resp
-
-            task = asyncio.create_task(_compute_and_store())
-            self._inflight[inflight_key] = task
-
-            def _clear_inflight(done_task: "asyncio.Task[Any]") -> None:
-                if self._inflight.get(inflight_key) is done_task:
-                    self._inflight.pop(inflight_key, None)
-
-            task.add_done_callback(_clear_inflight)
-
-        return await asyncio.shield(task)
+        self._store[key] = {"resp": resp, "fp": fingerprint, "ts": _t.time()}
+        self._purge()
+        return resp
 
 
 _idem_cache = _IdempotencyCache()
 
 
-def _make_request_fingerprint(body: Dict[str, Any], keys: List[str]) -> str:
+def _make_request_fingerprint(body: dict[str, Any], keys: list[str]) -> str:
     from hashlib import sha256
+
     subset = {k: body.get(k) for k in keys}
     return sha256(repr(subset).encode("utf-8")).hexdigest()
 
 
 def _derive_chat_session_id(
-    system_prompt: Optional[str],
+    system_prompt: str | None,
     first_user_message: str,
 ) -> str:
     """Derive a stable session ID from the conversation's first user message.
@@ -570,7 +623,9 @@ class APIServerAdapter(BasePlatformAdapter):
         super().__init__(config, Platform.API_SERVER)
         extra = config.extra or {}
         self._host: str = extra.get("host", os.getenv("API_SERVER_HOST", DEFAULT_HOST))
-        self._port: int = int(extra.get("port", os.getenv("API_SERVER_PORT", str(DEFAULT_PORT))))
+        self._port: int = int(
+            extra.get("port", os.getenv("API_SERVER_PORT", str(DEFAULT_PORT)))
+        )
         self._api_key: str = extra.get("key", os.getenv("API_SERVER_KEY", ""))
         self._cors_origins: tuple[str, ...] = self._parse_cors_origins(
             extra.get("cors_origins", os.getenv("API_SERVER_CORS_ORIGINS", "")),
@@ -578,15 +633,17 @@ class APIServerAdapter(BasePlatformAdapter):
         self._model_name: str = self._resolve_model_name(
             extra.get("model_name", os.getenv("API_SERVER_MODEL_NAME", "")),
         )
-        self._app: Optional["web.Application"] = None
-        self._runner: Optional["web.AppRunner"] = None
-        self._site: Optional["web.TCPSite"] = None
+        self._app: web.Application | None = None
+        self._runner: web.AppRunner | None = None
+        self._site: web.TCPSite | None = None
         self._response_store = ResponseStore()
         # Active run streams: run_id -> asyncio.Queue of SSE event dicts
-        self._run_streams: Dict[str, "asyncio.Queue[Optional[Dict]]"] = {}
+        self._run_streams: dict[str, asyncio.Queue[dict | None]] = {}
         # Creation timestamps for orphaned-run TTL sweep
-        self._run_streams_created: Dict[str, float] = {}
-        self._session_db: Optional[Any] = None  # Lazy-init SessionDB for session continuity
+        self._run_streams_created: dict[str, float] = {}
+        self._session_db: Any | None = (
+            None  # Lazy-init SessionDB for session continuity
+        )
 
     @staticmethod
     def _parse_cors_origins(value: Any) -> tuple[str, ...]:
@@ -616,6 +673,7 @@ class APIServerAdapter(BasePlatformAdapter):
             return explicit.strip()
         try:
             from hermes_cli.profiles import get_active_profile_name
+
             profile = get_active_profile_name()
             if profile and profile not in ("default", "custom"):
                 return profile
@@ -623,7 +681,7 @@ class APIServerAdapter(BasePlatformAdapter):
             pass
         return "hermes-agent"
 
-    def _cors_headers_for_origin(self, origin: str) -> Optional[Dict[str, str]]:
+    def _cors_headers_for_origin(self, origin: str) -> dict[str, str] | None:
         """Return CORS headers for an allowed browser origin."""
         if not origin or not self._cors_origins:
             return None
@@ -675,7 +733,13 @@ class APIServerAdapter(BasePlatformAdapter):
                 return None  # Auth OK
 
         return web.json_response(
-            {"error": {"message": "Invalid API key", "type": "invalid_request_error", "code": "invalid_api_key"}},
+            {
+                "error": {
+                    "message": "Invalid API key",
+                    "type": "invalid_request_error",
+                    "code": "invalid_api_key",
+                }
+            },
             status=401,
         )
 
@@ -692,6 +756,7 @@ class APIServerAdapter(BasePlatformAdapter):
         if self._session_db is None:
             try:
                 from hermes_state import SessionDB
+
                 self._session_db = SessionDB()
             except Exception as e:
                 logger.debug("SessionDB unavailable for API server: %s", e)
@@ -703,8 +768,8 @@ class APIServerAdapter(BasePlatformAdapter):
 
     def _create_agent(
         self,
-        ephemeral_system_prompt: Optional[str] = None,
-        session_id: Optional[str] = None,
+        ephemeral_system_prompt: str | None = None,
+        session_id: str | None = None,
         stream_delta_callback=None,
         tool_progress_callback=None,
         tool_start_callback=None,
@@ -718,9 +783,14 @@ class APIServerAdapter(BasePlatformAdapter):
         from config.yaml platform_toolsets.api_server (same as all other
         gateway platforms), falling back to the hermes-api-server default.
         """
-        from run_agent import AIAgent
-        from gateway.run import _resolve_runtime_agent_kwargs, _resolve_gateway_model, _load_gateway_config
         from hermes_cli.tools_config import _get_platform_tools
+        from run_agent import AIAgent
+
+        from gateway.run import (
+            _load_gateway_config,
+            _resolve_gateway_model,
+            _resolve_runtime_agent_kwargs,
+        )
 
         runtime_kwargs = _resolve_runtime_agent_kwargs()
         model = _resolve_gateway_model()
@@ -733,6 +803,7 @@ class APIServerAdapter(BasePlatformAdapter):
         # Load fallback provider chain so the API server platform has the
         # same fallback behaviour as Telegram/Discord/Slack (fixes #4954).
         from gateway.run import GatewayRunner
+
         fallback_model = GatewayRunner._load_fallback_model()
 
         agent = AIAgent(
@@ -772,16 +843,18 @@ class APIServerAdapter(BasePlatformAdapter):
         from gateway.status import read_runtime_status
 
         runtime = read_runtime_status() or {}
-        return web.json_response({
-            "status": "ok",
-            "platform": "hermes-agent",
-            "gateway_state": runtime.get("gateway_state"),
-            "platforms": runtime.get("platforms", {}),
-            "active_agents": runtime.get("active_agents", 0),
-            "exit_reason": runtime.get("exit_reason"),
-            "updated_at": runtime.get("updated_at"),
-            "pid": os.getpid(),
-        })
+        return web.json_response(
+            {
+                "status": "ok",
+                "platform": "hermes-agent",
+                "gateway_state": runtime.get("gateway_state"),
+                "platforms": runtime.get("platforms", {}),
+                "active_agents": runtime.get("active_agents", 0),
+                "exit_reason": runtime.get("exit_reason"),
+                "updated_at": runtime.get("updated_at"),
+                "pid": os.getpid(),
+            }
+        )
 
     async def _handle_models(self, request: "web.Request") -> "web.Response":
         """GET /v1/models — return hermes-agent as an available model."""
@@ -789,20 +862,22 @@ class APIServerAdapter(BasePlatformAdapter):
         if auth_err:
             return auth_err
 
-        return web.json_response({
-            "object": "list",
-            "data": [
-                {
-                    "id": self._model_name,
-                    "object": "model",
-                    "created": int(time.time()),
-                    "owned_by": "hermes",
-                    "permission": [],
-                    "root": self._model_name,
-                    "parent": None,
-                }
-            ],
-        })
+        return web.json_response(
+            {
+                "object": "list",
+                "data": [
+                    {
+                        "id": self._model_name,
+                        "object": "model",
+                        "created": int(time.time()),
+                        "owned_by": "hermes",
+                        "permission": [],
+                        "root": self._model_name,
+                        "parent": None,
+                    }
+                ],
+            }
+        )
 
     async def _handle_chat_completions(self, request: "web.Request") -> "web.Response":
         """POST /v1/chat/completions — OpenAI Chat Completions format."""
@@ -814,12 +889,19 @@ class APIServerAdapter(BasePlatformAdapter):
         try:
             body = await request.json()
         except (json.JSONDecodeError, Exception):
-            return web.json_response(_openai_error("Invalid JSON in request body"), status=400)
+            return web.json_response(
+                _openai_error("Invalid JSON in request body"), status=400
+            )
 
         messages = body.get("messages")
         if not messages or not isinstance(messages, list):
             return web.json_response(
-                {"error": {"message": "Missing or invalid 'messages' field", "type": "invalid_request_error"}},
+                {
+                    "error": {
+                        "message": "Missing or invalid 'messages' field",
+                        "type": "invalid_request_error",
+                    }
+                },
                 status=400,
             )
 
@@ -827,7 +909,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # Extract system message (becomes ephemeral system prompt layered ON TOP of core)
         system_prompt = None
-        conversation_messages: List[Dict[str, str]] = []
+        conversation_messages: list[dict[str, str]] = []
 
         for idx, msg in enumerate(messages):
             role = msg.get("role", "")
@@ -844,7 +926,9 @@ class APIServerAdapter(BasePlatformAdapter):
                 try:
                     content = _normalize_multimodal_content(raw_content)
                 except ValueError as exc:
-                    return _multimodal_validation_error(exc, param=f"messages[{idx}].content")
+                    return _multimodal_validation_error(
+                        exc, param=f"messages[{idx}].content"
+                    )
                 conversation_messages.append({"role": role, "content": content})
 
         # Extract the last user message as the primary input
@@ -856,7 +940,12 @@ class APIServerAdapter(BasePlatformAdapter):
 
         if not _content_has_visible_payload(user_message):
             return web.json_response(
-                {"error": {"message": "No user message found in messages", "type": "invalid_request_error"}},
+                {
+                    "error": {
+                        "message": "No user message found in messages",
+                        "type": "invalid_request_error",
+                    }
+                },
                 status=400,
             )
 
@@ -883,9 +972,14 @@ class APIServerAdapter(BasePlatformAdapter):
                     status=403,
                 )
             # Sanitize: reject control characters that could enable header injection.
-            if re.search(r'[\r\n\x00]', provided_session_id):
+            if re.search(r"[\r\n\x00]", provided_session_id):
                 return web.json_response(
-                    {"error": {"message": "Invalid session ID", "type": "invalid_request_error"}},
+                    {
+                        "error": {
+                            "message": "Invalid session ID",
+                            "type": "invalid_request_error",
+                        }
+                    },
                     status=400,
                 )
             session_id = provided_session_id
@@ -894,7 +988,9 @@ class APIServerAdapter(BasePlatformAdapter):
                 if db is not None:
                     history = db.get_messages_as_conversation(session_id)
             except Exception as e:
-                logger.warning("Failed to load session history for %s: %s", session_id, e)
+                logger.warning(
+                    "Failed to load session history for %s: %s", session_id, e
+                )
                 history = []
         else:
             # Derive a stable session ID from the conversation fingerprint so
@@ -915,6 +1011,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         if stream:
             import queue as _q
+
             _stream_q: _q.Queue = _q.Queue()
 
             def _on_delta(delta):
@@ -951,30 +1048,44 @@ class APIServerAdapter(BasePlatformAdapter):
                 if name.startswith("_"):
                     return
                 from agent.display import get_tool_emoji
+
                 emoji = get_tool_emoji(name)
                 label = preview or name
-                _stream_q.put(("__tool_progress__", {
-                    "tool": name,
-                    "emoji": emoji,
-                    "label": label,
-                }))
+                _stream_q.put(
+                    (
+                        "__tool_progress__",
+                        {
+                            "tool": name,
+                            "emoji": emoji,
+                            "label": label,
+                        },
+                    )
+                )
 
             # Start agent in background.  agent_ref is a mutable container
             # so the SSE writer can interrupt the agent on client disconnect.
             agent_ref = [None]
-            agent_task = asyncio.ensure_future(self._run_agent(
-                user_message=user_message,
-                conversation_history=history,
-                ephemeral_system_prompt=system_prompt,
-                session_id=session_id,
-                stream_delta_callback=_on_delta,
-                tool_progress_callback=_on_tool_progress,
-                agent_ref=agent_ref,
-            ))
+            agent_task = asyncio.ensure_future(
+                self._run_agent(
+                    user_message=user_message,
+                    conversation_history=history,
+                    ephemeral_system_prompt=system_prompt,
+                    session_id=session_id,
+                    stream_delta_callback=_on_delta,
+                    tool_progress_callback=_on_tool_progress,
+                    agent_ref=agent_ref,
+                )
+            )
 
             return await self._write_sse_chat_completion(
-                request, completion_id, model_name, created, _stream_q,
-                agent_task, agent_ref, session_id=session_id,
+                request,
+                completion_id,
+                model_name,
+                created,
+                _stream_q,
+                agent_task,
+                agent_ref,
+                session_id=session_id,
             )
 
         # Non-streaming: run the agent (with optional Idempotency-Key)
@@ -988,22 +1099,34 @@ class APIServerAdapter(BasePlatformAdapter):
 
         idempotency_key = request.headers.get("Idempotency-Key")
         if idempotency_key:
-            fp = _make_request_fingerprint(body, keys=["model", "messages", "tools", "tool_choice", "stream"])
+            fp = _make_request_fingerprint(
+                body, keys=["model", "messages", "tools", "tool_choice", "stream"]
+            )
             try:
-                result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_completion)
+                result, usage = await _idem_cache.get_or_set(
+                    idempotency_key, fp, _compute_completion
+                )
             except Exception as e:
-                logger.error("Error running agent for chat completions: %s", e, exc_info=True)
+                logger.error(
+                    "Error running agent for chat completions: %s", e, exc_info=True
+                )
                 return web.json_response(
-                    _openai_error(f"Internal server error: {e}", err_type="server_error"),
+                    _openai_error(
+                        f"Internal server error: {e}", err_type="server_error"
+                    ),
                     status=500,
                 )
         else:
             try:
                 result, usage = await _compute_completion()
             except Exception as e:
-                logger.error("Error running agent for chat completions: %s", e, exc_info=True)
+                logger.error(
+                    "Error running agent for chat completions: %s", e, exc_info=True
+                )
                 return web.json_response(
-                    _openai_error(f"Internal server error: {e}", err_type="server_error"),
+                    _openai_error(
+                        f"Internal server error: {e}", err_type="server_error"
+                    ),
                     status=500,
                 )
 
@@ -1033,11 +1156,20 @@ class APIServerAdapter(BasePlatformAdapter):
             },
         }
 
-        return web.json_response(response_data, headers={"X-Hermes-Session-Id": session_id})
+        return web.json_response(
+            response_data, headers={"X-Hermes-Session-Id": session_id}
+        )
 
     async def _write_sse_chat_completion(
-        self, request: "web.Request", completion_id: str, model: str,
-        created: int, stream_q, agent_task, agent_ref=None, session_id: str = None,
+        self,
+        request: "web.Request",
+        completion_id: str,
+        model: str,
+        created: int,
+        stream_q,
+        agent_task,
+        agent_ref=None,
+        session_id: str = None,
     ) -> "web.StreamResponse":
         """Write real streaming SSE from agent's stream_delta_callback queue.
 
@@ -1068,9 +1200,13 @@ class APIServerAdapter(BasePlatformAdapter):
 
             # Role chunk
             role_chunk = {
-                "id": completion_id, "object": "chat.completion.chunk",
-                "created": created, "model": model,
-                "choices": [{"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}],
+                "id": completion_id,
+                "object": "chat.completion.chunk",
+                "created": created,
+                "model": model,
+                "choices": [
+                    {"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}
+                ],
             }
             await response.write(f"data: {json.dumps(role_chunk)}\n\n".encode())
             last_activity = time.monotonic()
@@ -1085,25 +1221,41 @@ class APIServerAdapter(BasePlatformAdapter):
                 frontends can display them without storing the markers in
                 conversation history.  See #6972.
                 """
-                if isinstance(item, tuple) and len(item) == 2 and item[0] == "__tool_progress__":
+                if (
+                    isinstance(item, tuple)
+                    and len(item) == 2
+                    and item[0] == "__tool_progress__"
+                ):
                     event_data = json.dumps(item[1])
                     await response.write(
                         f"event: hermes.tool.progress\ndata: {event_data}\n\n".encode()
                     )
                 else:
                     content_chunk = {
-                        "id": completion_id, "object": "chat.completion.chunk",
-                        "created": created, "model": model,
-                        "choices": [{"index": 0, "delta": {"content": item}, "finish_reason": None}],
+                        "id": completion_id,
+                        "object": "chat.completion.chunk",
+                        "created": created,
+                        "model": model,
+                        "choices": [
+                            {
+                                "index": 0,
+                                "delta": {"content": item},
+                                "finish_reason": None,
+                            }
+                        ],
                     }
-                    await response.write(f"data: {json.dumps(content_chunk)}\n\n".encode())
+                    await response.write(
+                        f"data: {json.dumps(content_chunk)}\n\n".encode()
+                    )
                 return time.monotonic()
 
             # Stream content chunks as they arrive from the agent
             loop = asyncio.get_running_loop()
             while True:
                 try:
-                    delta = await loop.run_in_executor(None, lambda: stream_q.get(timeout=0.5))
+                    delta = await loop.run_in_executor(
+                        None, lambda: stream_q.get(timeout=0.5)
+                    )
                 except _q.Empty:
                     if agent_task.done():
                         # Drain any remaining items
@@ -1116,7 +1268,10 @@ class APIServerAdapter(BasePlatformAdapter):
                             except _q.Empty:
                                 break
                         break
-                    if time.monotonic() - last_activity >= CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS:
+                    if (
+                        time.monotonic() - last_activity
+                        >= CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS
+                    ):
                         await response.write(b": keepalive\n\n")
                         last_activity = time.monotonic()
                     continue
@@ -1136,8 +1291,10 @@ class APIServerAdapter(BasePlatformAdapter):
 
             # Finish chunk
             finish_chunk = {
-                "id": completion_id, "object": "chat.completion.chunk",
-                "created": created, "model": model,
+                "id": completion_id,
+                "object": "chat.completion.chunk",
+                "created": created,
+                "model": model,
                 "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
                 "usage": {
                     "prompt_tokens": usage.get("input_tokens", 0),
@@ -1163,7 +1320,9 @@ class APIServerAdapter(BasePlatformAdapter):
                     await agent_task
                 except (asyncio.CancelledError, Exception):
                     pass
-            logger.info("SSE client disconnected; interrupted agent task %s", completion_id)
+            logger.info(
+                "SSE client disconnected; interrupted agent task %s", completion_id
+            )
 
         return response
 
@@ -1176,10 +1335,10 @@ class APIServerAdapter(BasePlatformAdapter):
         stream_q,
         agent_task,
         agent_ref,
-        conversation_history: List[Dict[str, str]],
+        conversation_history: list[dict[str, str]],
         user_message: str,
-        instructions: Optional[str],
-        conversation: Optional[str],
+        instructions: str | None,
+        conversation: str | None,
         store: bool,
         session_id: str,
     ) -> "web.StreamResponse":
@@ -1226,13 +1385,13 @@ class APIServerAdapter(BasePlatformAdapter):
         await response.prepare(request)
 
         # State accumulated during the stream
-        final_text_parts: List[str] = []
+        final_text_parts: list[str] = []
         # Track open function_call items by name so we can emit a matching
         # ``done`` event when the tool completes.  Order preserved.
-        pending_tool_calls: List[Dict[str, Any]] = []
+        pending_tool_calls: list[dict[str, Any]] = []
         # Output items we've emitted so far (used to build the terminal
         # response.completed payload).  Kept in the order they appeared.
-        emitted_items: List[Dict[str, Any]] = []
+        emitted_items: list[dict[str, Any]] = []
         # Monotonic counter for output_index (spec requires it).
         output_index = 0
         # Monotonic counter for call_id generation if the agent doesn't
@@ -1245,10 +1404,10 @@ class APIServerAdapter(BasePlatformAdapter):
         # Track the assistant message item id + content index for text
         # delta events — the spec ties deltas to a specific item.
         message_item_id = f"msg_{uuid.uuid4().hex[:24]}"
-        message_output_index: Optional[int] = None
+        message_output_index: int | None = None
         message_opened = False
 
-        async def _write_event(event_type: str, data: Dict[str, Any]) -> None:
+        async def _write_event(event_type: str, data: dict[str, Any]) -> None:
             nonlocal sequence_number
             if "sequence_number" not in data:
                 data["sequence_number"] = sequence_number
@@ -1256,8 +1415,8 @@ class APIServerAdapter(BasePlatformAdapter):
             payload = f"event: {event_type}\ndata: {json.dumps(data)}\n\n"
             await response.write(payload.encode())
 
-        def _envelope(status: str) -> Dict[str, Any]:
-            env: Dict[str, Any] = {
+        def _envelope(status: str) -> dict[str, Any]:
+            env: dict[str, Any] = {
                 "id": response_id,
                 "object": "response",
                 "status": status,
@@ -1267,17 +1426,24 @@ class APIServerAdapter(BasePlatformAdapter):
             return env
 
         final_response_text = ""
-        agent_error: Optional[str] = None
-        usage: Dict[str, int] = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+        agent_error: str | None = None
+        usage: dict[str, int] = {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "total_tokens": 0,
+        }
 
         try:
             # response.created — initial envelope, status=in_progress
             created_env = _envelope("in_progress")
             created_env["output"] = []
-            await _write_event("response.created", {
-                "type": "response.created",
-                "response": created_env,
-            })
+            await _write_event(
+                "response.created",
+                {
+                    "type": "response.created",
+                    "response": created_env,
+                },
+            )
             last_activity = time.monotonic()
 
             async def _open_message_item() -> None:
@@ -1296,25 +1462,31 @@ class APIServerAdapter(BasePlatformAdapter):
                     "role": "assistant",
                     "content": [],
                 }
-                await _write_event("response.output_item.added", {
-                    "type": "response.output_item.added",
-                    "output_index": message_output_index,
-                    "item": item,
-                })
+                await _write_event(
+                    "response.output_item.added",
+                    {
+                        "type": "response.output_item.added",
+                        "output_index": message_output_index,
+                        "item": item,
+                    },
+                )
 
             async def _emit_text_delta(delta_text: str) -> None:
                 await _open_message_item()
                 final_text_parts.append(delta_text)
-                await _write_event("response.output_text.delta", {
-                    "type": "response.output_text.delta",
-                    "item_id": message_item_id,
-                    "output_index": message_output_index,
-                    "content_index": 0,
-                    "delta": delta_text,
-                    "logprobs": [],
-                })
+                await _write_event(
+                    "response.output_text.delta",
+                    {
+                        "type": "response.output_text.delta",
+                        "item_id": message_item_id,
+                        "output_index": message_output_index,
+                        "content_index": 0,
+                        "delta": delta_text,
+                        "logprobs": [],
+                    },
+                )
 
-            async def _emit_tool_started(payload: Dict[str, Any]) -> str:
+            async def _emit_tool_started(payload: dict[str, Any]) -> str:
                 """Emit response.output_item.added for a function_call.
 
                 Returns the call_id so the matching completion event can
@@ -1324,7 +1496,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 """
                 nonlocal output_index, call_counter
                 call_counter += 1
-                call_id = payload.get("tool_call_id") or f"call_{response_id[5:]}_{call_counter}"
+                call_id = (
+                    payload.get("tool_call_id")
+                    or f"call_{response_id[5:]}_{call_counter}"
+                )
                 args = payload.get("arguments", {})
                 if isinstance(args, dict):
                     arguments_str = json.dumps(args)
@@ -1340,27 +1515,34 @@ class APIServerAdapter(BasePlatformAdapter):
                 }
                 idx = output_index
                 output_index += 1
-                pending_tool_calls.append({
-                    "call_id": call_id,
-                    "name": payload.get("name", ""),
-                    "arguments": arguments_str,
-                    "item_id": item["id"],
-                    "output_index": idx,
-                })
-                emitted_items.append({
-                    "type": "function_call",
-                    "name": payload.get("name", ""),
-                    "arguments": arguments_str,
-                    "call_id": call_id,
-                })
-                await _write_event("response.output_item.added", {
-                    "type": "response.output_item.added",
-                    "output_index": idx,
-                    "item": item,
-                })
+                pending_tool_calls.append(
+                    {
+                        "call_id": call_id,
+                        "name": payload.get("name", ""),
+                        "arguments": arguments_str,
+                        "item_id": item["id"],
+                        "output_index": idx,
+                    }
+                )
+                emitted_items.append(
+                    {
+                        "type": "function_call",
+                        "name": payload.get("name", ""),
+                        "arguments": arguments_str,
+                        "call_id": call_id,
+                    }
+                )
+                await _write_event(
+                    "response.output_item.added",
+                    {
+                        "type": "response.output_item.added",
+                        "output_index": idx,
+                        "item": item,
+                    },
+                )
                 return call_id
 
-            async def _emit_tool_completed(payload: Dict[str, Any]) -> None:
+            async def _emit_tool_completed(payload: dict[str, Any]) -> None:
                 """Emit response.output_item.done (function_call) followed
                 by response.output_item.added (function_call_output)."""
                 nonlocal output_index
@@ -1386,11 +1568,14 @@ class APIServerAdapter(BasePlatformAdapter):
                     "call_id": pending["call_id"],
                     "arguments": pending["arguments"],
                 }
-                await _write_event("response.output_item.done", {
-                    "type": "response.output_item.done",
-                    "output_index": pending["output_index"],
-                    "item": done_item,
-                })
+                await _write_event(
+                    "response.output_item.done",
+                    {
+                        "type": "response.output_item.done",
+                        "output_index": pending["output_index"],
+                        "item": done_item,
+                    },
+                )
 
                 # function_call_output added (result)
                 result_str = result if isinstance(result, str) else json.dumps(result)
@@ -1404,21 +1589,29 @@ class APIServerAdapter(BasePlatformAdapter):
                 }
                 idx = output_index
                 output_index += 1
-                emitted_items.append({
-                    "type": "function_call_output",
-                    "call_id": pending["call_id"],
-                    "output": output_parts,
-                })
-                await _write_event("response.output_item.added", {
-                    "type": "response.output_item.added",
-                    "output_index": idx,
-                    "item": output_item,
-                })
-                await _write_event("response.output_item.done", {
-                    "type": "response.output_item.done",
-                    "output_index": idx,
-                    "item": output_item,
-                })
+                emitted_items.append(
+                    {
+                        "type": "function_call_output",
+                        "call_id": pending["call_id"],
+                        "output": output_parts,
+                    }
+                )
+                await _write_event(
+                    "response.output_item.added",
+                    {
+                        "type": "response.output_item.added",
+                        "output_index": idx,
+                        "item": output_item,
+                    },
+                )
+                await _write_event(
+                    "response.output_item.done",
+                    {
+                        "type": "response.output_item.done",
+                        "output_index": idx,
+                        "item": output_item,
+                    },
+                )
 
             # Main drain loop — thread-safe queue fed by agent callbacks.
             async def _dispatch(it) -> None:
@@ -1442,7 +1635,9 @@ class APIServerAdapter(BasePlatformAdapter):
             loop = asyncio.get_running_loop()
             while True:
                 try:
-                    item = await loop.run_in_executor(None, lambda: stream_q.get(timeout=0.5))
+                    item = await loop.run_in_executor(
+                        None, lambda: stream_q.get(timeout=0.5)
+                    )
                 except _q.Empty:
                     if agent_task.done():
                         # Drain remaining
@@ -1456,7 +1651,10 @@ class APIServerAdapter(BasePlatformAdapter):
                             except _q.Empty:
                                 break
                         break
-                    if time.monotonic() - last_activity >= CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS:
+                    if (
+                        time.monotonic() - last_activity
+                        >= CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS
+                    ):
                         await response.write(b": keepalive\n\n")
                         last_activity = time.monotonic()
                     continue
@@ -1475,55 +1673,72 @@ class APIServerAdapter(BasePlatformAdapter):
                 # deltas were streamed (e.g. some providers only emit
                 # the full response at the end), emit a single fallback
                 # delta so Responses clients still receive a live text part.
-                agent_final = result.get("final_response", "") if isinstance(result, dict) else ""
+                agent_final = (
+                    result.get("final_response", "") if isinstance(result, dict) else ""
+                )
                 if agent_final and not final_text_parts:
                     await _emit_text_delta(agent_final)
                 if agent_final and not final_response_text:
                     final_response_text = agent_final
-                if isinstance(result, dict) and result.get("error") and not final_response_text:
+                if (
+                    isinstance(result, dict)
+                    and result.get("error")
+                    and not final_response_text
+                ):
                     agent_error = result["error"]
-            except Exception as e:  # noqa: BLE001
-                logger.error("Error running agent for streaming responses: %s", e, exc_info=True)
+            except Exception as e:
+                logger.error(
+                    "Error running agent for streaming responses: %s", e, exc_info=True
+                )
                 agent_error = str(e)
 
             # Close the message item if it was opened
             final_response_text = "".join(final_text_parts) or final_response_text
             if message_opened:
-                await _write_event("response.output_text.done", {
-                    "type": "response.output_text.done",
-                    "item_id": message_item_id,
-                    "output_index": message_output_index,
-                    "content_index": 0,
-                    "text": final_response_text,
-                    "logprobs": [],
-                })
+                await _write_event(
+                    "response.output_text.done",
+                    {
+                        "type": "response.output_text.done",
+                        "item_id": message_item_id,
+                        "output_index": message_output_index,
+                        "content_index": 0,
+                        "text": final_response_text,
+                        "logprobs": [],
+                    },
+                )
                 msg_done_item = {
                     "id": message_item_id,
                     "type": "message",
                     "status": "completed",
                     "role": "assistant",
-                    "content": [
-                        {"type": "output_text", "text": final_response_text}
-                    ],
+                    "content": [{"type": "output_text", "text": final_response_text}],
                 }
-                await _write_event("response.output_item.done", {
-                    "type": "response.output_item.done",
-                    "output_index": message_output_index,
-                    "item": msg_done_item,
-                })
+                await _write_event(
+                    "response.output_item.done",
+                    {
+                        "type": "response.output_item.done",
+                        "output_index": message_output_index,
+                        "item": msg_done_item,
+                    },
+                )
 
             # Always append a final message item in the completed
             # response envelope so clients that only parse the terminal
             # payload still see the assistant text.  This mirrors the
             # shape produced by _extract_output_items in the batch path.
-            final_items: List[Dict[str, Any]] = list(emitted_items)
-            final_items.append({
-                "type": "message",
-                "role": "assistant",
-                "content": [
-                    {"type": "output_text", "text": final_response_text or (agent_error or "")}
-                ],
-            })
+            final_items: list[dict[str, Any]] = list(emitted_items)
+            final_items.append(
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "output_text",
+                            "text": final_response_text or (agent_error or ""),
+                        }
+                    ],
+                }
+            )
 
             if agent_error:
                 failed_env = _envelope("failed")
@@ -1534,10 +1749,13 @@ class APIServerAdapter(BasePlatformAdapter):
                     "output_tokens": usage.get("output_tokens", 0),
                     "total_tokens": usage.get("total_tokens", 0),
                 }
-                await _write_event("response.failed", {
-                    "type": "response.failed",
-                    "response": failed_env,
-                })
+                await _write_event(
+                    "response.failed",
+                    {
+                        "type": "response.failed",
+                        "response": failed_env,
+                    },
+                )
             else:
                 completed_env = _envelope("completed")
                 completed_env["output"] = final_items
@@ -1546,10 +1764,13 @@ class APIServerAdapter(BasePlatformAdapter):
                     "output_tokens": usage.get("output_tokens", 0),
                     "total_tokens": usage.get("total_tokens", 0),
                 }
-                await _write_event("response.completed", {
-                    "type": "response.completed",
-                    "response": completed_env,
-                })
+                await _write_event(
+                    "response.completed",
+                    {
+                        "type": "response.completed",
+                        "response": completed_env,
+                    },
+                )
 
                 # Persist for future chaining / GET retrieval, mirroring
                 # the batch path behavior.
@@ -1559,13 +1780,18 @@ class APIServerAdapter(BasePlatformAdapter):
                     if isinstance(result, dict) and result.get("messages"):
                         full_history.extend(result["messages"])
                     else:
-                        full_history.append({"role": "assistant", "content": final_response_text})
-                    self._response_store.put(response_id, {
-                        "response": completed_env,
-                        "conversation_history": full_history,
-                        "instructions": instructions,
-                        "session_id": session_id,
-                    })
+                        full_history.append(
+                            {"role": "assistant", "content": final_response_text}
+                        )
+                    self._response_store.put(
+                        response_id,
+                        {
+                            "response": completed_env,
+                            "conversation_history": full_history,
+                            "instructions": instructions,
+                            "session_id": session_id,
+                        },
+                    )
                     if conversation:
                         self._response_store.set_conversation(conversation, response_id)
 
@@ -1584,7 +1810,9 @@ class APIServerAdapter(BasePlatformAdapter):
                     await agent_task
                 except (asyncio.CancelledError, Exception):
                     pass
-            logger.info("SSE client disconnected; interrupted agent task %s", response_id)
+            logger.info(
+                "SSE client disconnected; interrupted agent task %s", response_id
+            )
 
         return response
 
@@ -1599,7 +1827,12 @@ class APIServerAdapter(BasePlatformAdapter):
             body = await request.json()
         except (json.JSONDecodeError, Exception):
             return web.json_response(
-                {"error": {"message": "Invalid JSON in request body", "type": "invalid_request_error"}},
+                {
+                    "error": {
+                        "message": "Invalid JSON in request body",
+                        "type": "invalid_request_error",
+                    }
+                },
                 status=400,
             )
 
@@ -1614,7 +1847,12 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # conversation and previous_response_id are mutually exclusive
         if conversation and previous_response_id:
-            return web.json_response(_openai_error("Cannot use both 'conversation' and 'previous_response_id'"), status=400)
+            return web.json_response(
+                _openai_error(
+                    "Cannot use both 'conversation' and 'previous_response_id'"
+                ),
+                status=400,
+            )
 
         # Resolve conversation name to latest response_id
         if conversation:
@@ -1622,7 +1860,7 @@ class APIServerAdapter(BasePlatformAdapter):
             # No error if conversation doesn't exist yet — it's a new conversation
 
         # Normalize input to message list
-        input_messages: List[Dict[str, Any]] = []
+        input_messages: list[dict[str, Any]] = []
         if isinstance(raw_input, str):
             input_messages = [{"role": "user", "content": raw_input}]
         elif isinstance(raw_input, list):
@@ -1634,42 +1872,65 @@ class APIServerAdapter(BasePlatformAdapter):
                     try:
                         content = _normalize_multimodal_content(item.get("content", ""))
                     except ValueError as exc:
-                        return _multimodal_validation_error(exc, param=f"input[{idx}].content")
+                        return _multimodal_validation_error(
+                            exc, param=f"input[{idx}].content"
+                        )
                     input_messages.append({"role": role, "content": content})
         else:
-            return web.json_response(_openai_error("'input' must be a string or array"), status=400)
+            return web.json_response(
+                _openai_error("'input' must be a string or array"), status=400
+            )
 
         # Accept explicit conversation_history from the request body.
         # This lets stateless clients supply their own history instead of
         # relying on server-side response chaining via previous_response_id.
         # Precedence: explicit conversation_history > previous_response_id.
-        conversation_history: List[Dict[str, Any]] = []
+        conversation_history: list[dict[str, Any]] = []
         raw_history = body.get("conversation_history")
         if raw_history:
             if not isinstance(raw_history, list):
                 return web.json_response(
-                    _openai_error("'conversation_history' must be an array of message objects"),
+                    _openai_error(
+                        "'conversation_history' must be an array of message objects"
+                    ),
                     status=400,
                 )
             for i, entry in enumerate(raw_history):
-                if not isinstance(entry, dict) or "role" not in entry or "content" not in entry:
+                if (
+                    not isinstance(entry, dict)
+                    or "role" not in entry
+                    or "content" not in entry
+                ):
                     return web.json_response(
-                        _openai_error(f"conversation_history[{i}] must have 'role' and 'content' fields"),
+                        _openai_error(
+                            f"conversation_history[{i}] must have 'role' and 'content' fields"
+                        ),
                         status=400,
                     )
                 try:
                     entry_content = _normalize_multimodal_content(entry["content"])
                 except ValueError as exc:
-                    return _multimodal_validation_error(exc, param=f"conversation_history[{i}].content")
-                conversation_history.append({"role": str(entry["role"]), "content": entry_content})
+                    return _multimodal_validation_error(
+                        exc, param=f"conversation_history[{i}].content"
+                    )
+                conversation_history.append(
+                    {"role": str(entry["role"]), "content": entry_content}
+                )
             if previous_response_id:
-                logger.debug("Both conversation_history and previous_response_id provided; using conversation_history")
+                logger.debug(
+                    "Both conversation_history and previous_response_id provided; using conversation_history"
+                )
 
         stored_session_id = None
         if not conversation_history and previous_response_id:
             stored = self._response_store.get(previous_response_id)
             if stored is None:
-                return web.json_response(_openai_error(f"Previous response not found: {previous_response_id}"), status=404)
+                return web.json_response(
+                    _openai_error(
+                        f"Previous response not found: {previous_response_id}"
+                    ),
+                    status=404,
+                )
             conversation_history = list(stored.get("conversation_history", []))
             stored_session_id = stored.get("session_id")
             # If no instructions provided, carry forward from previous
@@ -1681,9 +1942,13 @@ class APIServerAdapter(BasePlatformAdapter):
             conversation_history.append(msg)
 
         # Last input message is the user_message
-        user_message: Any = input_messages[-1].get("content", "") if input_messages else ""
+        user_message: Any = (
+            input_messages[-1].get("content", "") if input_messages else ""
+        )
         if not _content_has_visible_payload(user_message):
-            return web.json_response(_openai_error("No user message found in input"), status=400)
+            return web.json_response(
+                _openai_error("No user message found in input"), status=400
+            )
 
         # Truncation support
         if body.get("truncation") == "auto" and len(conversation_history) > 100:
@@ -1699,6 +1964,7 @@ class APIServerAdapter(BasePlatformAdapter):
             # agent runs so frontends can render text deltas and tool
             # calls in real time.  See _write_sse_responses for details.
             import queue as _q
+
             _stream_q: _q.Queue = _q.Queue()
 
             def _on_delta(delta):
@@ -1719,33 +1985,47 @@ class APIServerAdapter(BasePlatformAdapter):
 
             def _on_tool_start(tool_call_id, function_name, function_args):
                 """Queue a started tool for live function_call streaming."""
-                _stream_q.put(("__tool_started__", {
-                    "tool_call_id": tool_call_id,
-                    "name": function_name,
-                    "arguments": function_args or {},
-                }))
+                _stream_q.put(
+                    (
+                        "__tool_started__",
+                        {
+                            "tool_call_id": tool_call_id,
+                            "name": function_name,
+                            "arguments": function_args or {},
+                        },
+                    )
+                )
 
-            def _on_tool_complete(tool_call_id, function_name, function_args, function_result):
+            def _on_tool_complete(
+                tool_call_id, function_name, function_args, function_result
+            ):
                 """Queue a completed tool result for live function_call_output streaming."""
-                _stream_q.put(("__tool_completed__", {
-                    "tool_call_id": tool_call_id,
-                    "name": function_name,
-                    "arguments": function_args or {},
-                    "result": function_result,
-                }))
+                _stream_q.put(
+                    (
+                        "__tool_completed__",
+                        {
+                            "tool_call_id": tool_call_id,
+                            "name": function_name,
+                            "arguments": function_args or {},
+                            "result": function_result,
+                        },
+                    )
+                )
 
             agent_ref = [None]
-            agent_task = asyncio.ensure_future(self._run_agent(
-                user_message=user_message,
-                conversation_history=conversation_history,
-                ephemeral_system_prompt=instructions,
-                session_id=session_id,
-                stream_delta_callback=_on_delta,
-                tool_progress_callback=_on_tool_progress,
-                tool_start_callback=_on_tool_start,
-                tool_complete_callback=_on_tool_complete,
-                agent_ref=agent_ref,
-            ))
+            agent_task = asyncio.ensure_future(
+                self._run_agent(
+                    user_message=user_message,
+                    conversation_history=conversation_history,
+                    ephemeral_system_prompt=instructions,
+                    session_id=session_id,
+                    stream_delta_callback=_on_delta,
+                    tool_progress_callback=_on_tool_progress,
+                    tool_start_callback=_on_tool_start,
+                    tool_complete_callback=_on_tool_complete,
+                    agent_ref=agent_ref,
+                )
+            )
 
             response_id = f"resp_{uuid.uuid4().hex[:28]}"
             model_name = body.get("model", self._model_name)
@@ -1779,14 +2059,25 @@ class APIServerAdapter(BasePlatformAdapter):
         if idempotency_key:
             fp = _make_request_fingerprint(
                 body,
-                keys=["input", "instructions", "previous_response_id", "conversation", "model", "tools"],
+                keys=[
+                    "input",
+                    "instructions",
+                    "previous_response_id",
+                    "conversation",
+                    "model",
+                    "tools",
+                ],
             )
             try:
-                result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_response)
+                result, usage = await _idem_cache.get_or_set(
+                    idempotency_key, fp, _compute_response
+                )
             except Exception as e:
                 logger.error("Error running agent for responses: %s", e, exc_info=True)
                 return web.json_response(
-                    _openai_error(f"Internal server error: {e}", err_type="server_error"),
+                    _openai_error(
+                        f"Internal server error: {e}", err_type="server_error"
+                    ),
                     status=500,
                 )
         else:
@@ -1795,7 +2086,9 @@ class APIServerAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.error("Error running agent for responses: %s", e, exc_info=True)
                 return web.json_response(
-                    _openai_error(f"Internal server error: {e}", err_type="server_error"),
+                    _openai_error(
+                        f"Internal server error: {e}", err_type="server_error"
+                    ),
                     status=500,
                 )
 
@@ -1836,12 +2129,15 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # Store the complete response object for future chaining / GET retrieval
         if store:
-            self._response_store.put(response_id, {
-                "response": response_data,
-                "conversation_history": full_history,
-                "instructions": instructions,
-                "session_id": session_id,
-            })
+            self._response_store.put(
+                response_id,
+                {
+                    "response": response_data,
+                    "conversation_history": full_history,
+                    "instructions": instructions,
+                    "session_id": session_id,
+                },
+            )
             # Update conversation mapping so the next request with the same
             # conversation name automatically chains to this response
             if conversation:
@@ -1862,7 +2158,9 @@ class APIServerAdapter(BasePlatformAdapter):
         response_id = request.match_info["response_id"]
         stored = self._response_store.get(response_id)
         if stored is None:
-            return web.json_response(_openai_error(f"Response not found: {response_id}"), status=404)
+            return web.json_response(
+                _openai_error(f"Response not found: {response_id}"), status=404
+            )
 
         return web.json_response(stored["response"])
 
@@ -1875,21 +2173,78 @@ class APIServerAdapter(BasePlatformAdapter):
         response_id = request.match_info["response_id"]
         deleted = self._response_store.delete(response_id)
         if not deleted:
-            return web.json_response(_openai_error(f"Response not found: {response_id}"), status=404)
+            return web.json_response(
+                _openai_error(f"Response not found: {response_id}"), status=404
+            )
 
-        return web.json_response({
-            "id": response_id,
-            "object": "response",
-            "deleted": True,
-        })
+        return web.json_response(
+            {
+                "id": response_id,
+                "object": "response",
+                "deleted": True,
+            }
+        )
 
     # ------------------------------------------------------------------
     # Cron jobs API
     # ------------------------------------------------------------------
 
+    # Check cron module availability once (not per-request)
+    _CRON_AVAILABLE = False
+    try:
+        from cron.jobs import (
+            create_job as _cron_create,
+        )
+        from cron.jobs import (
+            get_job as _cron_get,
+        )
+        from cron.jobs import (
+            list_jobs as _cron_list,
+        )
+        from cron.jobs import (
+            pause_job as _cron_pause,
+        )
+        from cron.jobs import (
+            remove_job as _cron_remove,
+        )
+        from cron.jobs import (
+            resume_job as _cron_resume,
+        )
+        from cron.jobs import (
+            trigger_job as _cron_trigger,
+        )
+        from cron.jobs import (
+            update_job as _cron_update,
+        )
+
+        # Wrap as staticmethod to prevent descriptor binding — these are plain
+        # module functions, not instance methods.  Without this, self._cron_*()
+        # injects ``self`` as the first positional argument and every call
+        # raises TypeError.
+        _cron_list = staticmethod(_cron_list)
+        _cron_get = staticmethod(_cron_get)
+        _cron_create = staticmethod(_cron_create)
+        _cron_update = staticmethod(_cron_update)
+        _cron_remove = staticmethod(_cron_remove)
+        _cron_pause = staticmethod(_cron_pause)
+        _cron_resume = staticmethod(_cron_resume)
+        _cron_trigger = staticmethod(_cron_trigger)
+        _CRON_AVAILABLE = True
+    except ImportError:
+        pass
+
     _JOB_ID_RE = __import__("re").compile(r"[a-f0-9]{12}")
     # Allowed fields for update — prevents clients injecting arbitrary keys
-    _UPDATE_ALLOWED_FIELDS = {"name", "schedule", "prompt", "deliver", "skills", "skill", "repeat", "enabled"}
+    _UPDATE_ALLOWED_FIELDS = {
+        "name",
+        "schedule",
+        "prompt",
+        "deliver",
+        "skills",
+        "skill",
+        "repeat",
+        "enabled",
+    }
     _MAX_NAME_LENGTH = 200
     _MAX_PROMPT_LENGTH = 5000
 
@@ -1898,7 +2253,8 @@ class APIServerAdapter(BasePlatformAdapter):
         """Return error response if cron module isn't available."""
         if not _CRON_AVAILABLE:
             return web.json_response(
-                {"error": "Cron module not available"}, status=501,
+                {"error": "Cron module not available"},
+                status=501,
             )
         return None
 
@@ -1907,7 +2263,8 @@ class APIServerAdapter(BasePlatformAdapter):
         job_id = request.match_info["job_id"]
         if not self._JOB_ID_RE.fullmatch(job_id):
             return job_id, web.json_response(
-                {"error": "Invalid job ID format"}, status=400,
+                {"error": "Invalid job ID format"},
+                status=400,
             )
         return job_id, None
 
@@ -1920,8 +2277,11 @@ class APIServerAdapter(BasePlatformAdapter):
         if cron_err:
             return cron_err
         try:
-            include_disabled = request.query.get("include_disabled", "").lower() in ("true", "1")
-            jobs = _cron_list(include_disabled=include_disabled)
+            include_disabled = request.query.get("include_disabled", "").lower() in (
+                "true",
+                "1",
+            )
+            jobs = self._cron_list(include_disabled=include_disabled)
             return web.json_response({"jobs": jobs})
         except Exception as e:
             return web.json_response({"error": str(e)}, status=500)
@@ -1947,16 +2307,20 @@ class APIServerAdapter(BasePlatformAdapter):
                 return web.json_response({"error": "Name is required"}, status=400)
             if len(name) > self._MAX_NAME_LENGTH:
                 return web.json_response(
-                    {"error": f"Name must be ≤ {self._MAX_NAME_LENGTH} characters"}, status=400,
+                    {"error": f"Name must be ≤ {self._MAX_NAME_LENGTH} characters"},
+                    status=400,
                 )
             if not schedule:
                 return web.json_response({"error": "Schedule is required"}, status=400)
             if len(prompt) > self._MAX_PROMPT_LENGTH:
                 return web.json_response(
-                    {"error": f"Prompt must be ≤ {self._MAX_PROMPT_LENGTH} characters"}, status=400,
+                    {"error": f"Prompt must be ≤ {self._MAX_PROMPT_LENGTH} characters"},
+                    status=400,
                 )
             if repeat is not None and (not isinstance(repeat, int) or repeat < 1):
-                return web.json_response({"error": "Repeat must be a positive integer"}, status=400)
+                return web.json_response(
+                    {"error": "Repeat must be a positive integer"}, status=400
+                )
 
             kwargs = {
                 "prompt": prompt,
@@ -2007,17 +2371,26 @@ class APIServerAdapter(BasePlatformAdapter):
         try:
             body = await request.json()
             # Whitelist allowed fields to prevent arbitrary key injection
-            sanitized = {k: v for k, v in body.items() if k in self._UPDATE_ALLOWED_FIELDS}
+            sanitized = {
+                k: v for k, v in body.items() if k in self._UPDATE_ALLOWED_FIELDS
+            }
             if not sanitized:
-                return web.json_response({"error": "No valid fields to update"}, status=400)
+                return web.json_response(
+                    {"error": "No valid fields to update"}, status=400
+                )
             # Validate lengths if present
             if "name" in sanitized and len(sanitized["name"]) > self._MAX_NAME_LENGTH:
                 return web.json_response(
-                    {"error": f"Name must be ≤ {self._MAX_NAME_LENGTH} characters"}, status=400,
+                    {"error": f"Name must be ≤ {self._MAX_NAME_LENGTH} characters"},
+                    status=400,
                 )
-            if "prompt" in sanitized and len(sanitized["prompt"]) > self._MAX_PROMPT_LENGTH:
+            if (
+                "prompt" in sanitized
+                and len(sanitized["prompt"]) > self._MAX_PROMPT_LENGTH
+            ):
                 return web.json_response(
-                    {"error": f"Prompt must be ≤ {self._MAX_PROMPT_LENGTH} characters"}, status=400,
+                    {"error": f"Prompt must be ≤ {self._MAX_PROMPT_LENGTH} characters"},
+                    status=400,
                 )
             job = _cron_update(job_id, sanitized)
             if not job:
@@ -2107,7 +2480,7 @@ class APIServerAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _extract_output_items(result: Dict[str, Any]) -> List[Dict[str, Any]]:
+    def _extract_output_items(result: dict[str, Any]) -> list[dict[str, Any]]:
         """
         Build the full output item array from the agent's messages.
 
@@ -2116,7 +2489,7 @@ class APIServerAdapter(BasePlatformAdapter):
         - ``function_call_output`` items for each tool-role message
         - a final ``message`` item with the assistant's text reply
         """
-        items: List[Dict[str, Any]] = []
+        items: list[dict[str, Any]] = []
         messages = result.get("messages", [])
 
         for msg in messages:
@@ -2124,34 +2497,40 @@ class APIServerAdapter(BasePlatformAdapter):
             if role == "assistant" and msg.get("tool_calls"):
                 for tc in msg["tool_calls"]:
                     func = tc.get("function", {})
-                    items.append({
-                        "type": "function_call",
-                        "name": func.get("name", ""),
-                        "arguments": func.get("arguments", ""),
-                        "call_id": tc.get("id", ""),
-                    })
+                    items.append(
+                        {
+                            "type": "function_call",
+                            "name": func.get("name", ""),
+                            "arguments": func.get("arguments", ""),
+                            "call_id": tc.get("id", ""),
+                        }
+                    )
             elif role == "tool":
-                items.append({
-                    "type": "function_call_output",
-                    "call_id": msg.get("tool_call_id", ""),
-                    "output": msg.get("content", ""),
-                })
+                items.append(
+                    {
+                        "type": "function_call_output",
+                        "call_id": msg.get("tool_call_id", ""),
+                        "output": msg.get("content", ""),
+                    }
+                )
 
         # Final assistant message
         final = result.get("final_response", "")
         if not final:
             final = result.get("error", "(No response generated)")
 
-        items.append({
-            "type": "message",
-            "role": "assistant",
-            "content": [
-                {
-                    "type": "output_text",
-                    "text": final,
-                }
-            ],
-        })
+        items.append(
+            {
+                "type": "message",
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": final,
+                    }
+                ],
+            }
+        )
         return items
 
     # ------------------------------------------------------------------
@@ -2161,14 +2540,14 @@ class APIServerAdapter(BasePlatformAdapter):
     async def _run_agent(
         self,
         user_message: str,
-        conversation_history: List[Dict[str, str]],
-        ephemeral_system_prompt: Optional[str] = None,
-        session_id: Optional[str] = None,
+        conversation_history: list[dict[str, str]],
+        ephemeral_system_prompt: str | None = None,
+        session_id: str | None = None,
         stream_delta_callback=None,
         tool_progress_callback=None,
         tool_start_callback=None,
         tool_complete_callback=None,
-        agent_ref: Optional[list] = None,
+        agent_ref: list | None = None,
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
@@ -2217,7 +2596,8 @@ class APIServerAdapter(BasePlatformAdapter):
 
     def _make_run_event_callback(self, run_id: str, loop: "asyncio.AbstractEventLoop"):
         """Return a tool_progress_callback that pushes structured events to the run's SSE queue."""
-        def _push(event: Dict[str, Any]) -> None:
+
+        def _push(event: dict[str, Any]) -> None:
             q = self._run_streams.get(run_id)
             if q is None:
                 return
@@ -2226,32 +2606,44 @@ class APIServerAdapter(BasePlatformAdapter):
             except Exception:
                 pass
 
-        def _callback(event_type: str, tool_name: str = None, preview: str = None, args=None, **kwargs):
+        def _callback(
+            event_type: str,
+            tool_name: str = None,
+            preview: str = None,
+            args=None,
+            **kwargs,
+        ):
             ts = time.time()
             if event_type == "tool.started":
-                _push({
-                    "event": "tool.started",
-                    "run_id": run_id,
-                    "timestamp": ts,
-                    "tool": tool_name,
-                    "preview": preview,
-                })
+                _push(
+                    {
+                        "event": "tool.started",
+                        "run_id": run_id,
+                        "timestamp": ts,
+                        "tool": tool_name,
+                        "preview": preview,
+                    }
+                )
             elif event_type == "tool.completed":
-                _push({
-                    "event": "tool.completed",
-                    "run_id": run_id,
-                    "timestamp": ts,
-                    "tool": tool_name,
-                    "duration": round(kwargs.get("duration", 0), 3),
-                    "error": kwargs.get("is_error", False),
-                })
+                _push(
+                    {
+                        "event": "tool.completed",
+                        "run_id": run_id,
+                        "timestamp": ts,
+                        "tool": tool_name,
+                        "duration": round(kwargs.get("duration", 0), 3),
+                        "error": kwargs.get("is_error", False),
+                    }
+                )
             elif event_type == "reasoning.available":
-                _push({
-                    "event": "reasoning.available",
-                    "run_id": run_id,
-                    "timestamp": ts,
-                    "text": preview or "",
-                })
+                _push(
+                    {
+                        "event": "reasoning.available",
+                        "run_id": run_id,
+                        "timestamp": ts,
+                        "text": preview or "",
+                    }
+                )
             # _thinking and subagent_progress are intentionally not forwarded
 
         return _callback
@@ -2265,7 +2657,10 @@ class APIServerAdapter(BasePlatformAdapter):
         # Enforce concurrency limit
         if len(self._run_streams) >= self._MAX_CONCURRENT_RUNS:
             return web.json_response(
-                _openai_error(f"Too many concurrent runs (max {self._MAX_CONCURRENT_RUNS})", code="rate_limit_exceeded"),
+                _openai_error(
+                    f"Too many concurrent runs (max {self._MAX_CONCURRENT_RUNS})",
+                    code="rate_limit_exceeded",
+                ),
                 status=429,
             )
 
@@ -2278,29 +2673,40 @@ class APIServerAdapter(BasePlatformAdapter):
         if not raw_input:
             return web.json_response(_openai_error("Missing 'input' field"), status=400)
 
-        user_message = raw_input if isinstance(raw_input, str) else (raw_input[-1].get("content", "") if isinstance(raw_input, list) else "")
+        user_message = (
+            raw_input
+            if isinstance(raw_input, str)
+            else (
+                raw_input[-1].get("content", "") if isinstance(raw_input, list) else ""
+            )
+        )
         if not user_message:
-            return web.json_response(_openai_error("No user message found in input"), status=400)
+            return web.json_response(
+                _openai_error("No user message found in input"), status=400
+            )
 
         run_id = f"run_{uuid.uuid4().hex}"
         loop = asyncio.get_running_loop()
-        q: "asyncio.Queue[Optional[Dict]]" = asyncio.Queue()
+        q: asyncio.Queue[dict | None] = asyncio.Queue()
         self._run_streams[run_id] = q
         self._run_streams_created[run_id] = time.time()
 
         event_cb = self._make_run_event_callback(run_id, loop)
 
         # Also wire stream_delta_callback so message.delta events flow through
-        def _text_cb(delta: Optional[str]) -> None:
+        def _text_cb(delta: str | None) -> None:
             if delta is None:
                 return
             try:
-                loop.call_soon_threadsafe(q.put_nowait, {
-                    "event": "message.delta",
-                    "run_id": run_id,
-                    "timestamp": time.time(),
-                    "delta": delta,
-                })
+                loop.call_soon_threadsafe(
+                    q.put_nowait,
+                    {
+                        "event": "message.delta",
+                        "run_id": run_id,
+                        "timestamp": time.time(),
+                        "delta": delta,
+                    },
+                )
             except Exception:
                 pass
 
@@ -2309,23 +2715,35 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # Accept explicit conversation_history from the request body.
         # Precedence: explicit conversation_history > previous_response_id.
-        conversation_history: List[Dict[str, str]] = []
+        conversation_history: list[dict[str, str]] = []
         raw_history = body.get("conversation_history")
         if raw_history:
             if not isinstance(raw_history, list):
                 return web.json_response(
-                    _openai_error("'conversation_history' must be an array of message objects"),
+                    _openai_error(
+                        "'conversation_history' must be an array of message objects"
+                    ),
                     status=400,
                 )
             for i, entry in enumerate(raw_history):
-                if not isinstance(entry, dict) or "role" not in entry or "content" not in entry:
+                if (
+                    not isinstance(entry, dict)
+                    or "role" not in entry
+                    or "content" not in entry
+                ):
                     return web.json_response(
-                        _openai_error(f"conversation_history[{i}] must have 'role' and 'content' fields"),
+                        _openai_error(
+                            f"conversation_history[{i}] must have 'role' and 'content' fields"
+                        ),
                         status=400,
                     )
-                conversation_history.append({"role": str(entry["role"]), "content": str(entry["content"])})
+                conversation_history.append(
+                    {"role": str(entry["role"]), "content": str(entry["content"])}
+                )
             if previous_response_id:
-                logger.debug("Both conversation_history and previous_response_id provided; using conversation_history")
+                logger.debug(
+                    "Both conversation_history and previous_response_id provided; using conversation_history"
+                )
 
         stored_session_id = None
         if not conversation_history and previous_response_id:
@@ -2339,17 +2757,24 @@ class APIServerAdapter(BasePlatformAdapter):
         # When input is a multi-message array, extract all but the last
         # message as conversation history (the last becomes user_message).
         # Only fires when no explicit history was provided.
-        if not conversation_history and isinstance(raw_input, list) and len(raw_input) > 1:
+        if (
+            not conversation_history
+            and isinstance(raw_input, list)
+            and len(raw_input) > 1
+        ):
             for msg in raw_input[:-1]:
                 if isinstance(msg, dict) and msg.get("role") and msg.get("content"):
                     content = msg["content"]
                     if isinstance(content, list):
                         # Flatten multi-part content blocks to text
                         content = " ".join(
-                            part.get("text", "") for part in content
+                            part.get("text", "")
+                            for part in content
                             if isinstance(part, dict) and part.get("type") == "text"
                         )
-                    conversation_history.append({"role": msg["role"], "content": str(content)})
+                    conversation_history.append(
+                        {"role": msg["role"], "content": str(content)}
+                    )
 
         session_id = body.get("session_id") or stored_session_id or run_id
         ephemeral_system_prompt = instructions
@@ -2362,6 +2787,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     stream_delta_callback=_text_cb,
                     tool_progress_callback=event_cb,
                 )
+
                 def _run_sync():
                     r = agent.run_conversation(
                         user_message=user_message,
@@ -2370,29 +2796,38 @@ class APIServerAdapter(BasePlatformAdapter):
                     )
                     u = {
                         "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
-                        "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,
+                        "output_tokens": getattr(agent, "session_completion_tokens", 0)
+                        or 0,
                         "total_tokens": getattr(agent, "session_total_tokens", 0) or 0,
                     }
                     return r, u
 
-                result, usage = await asyncio.get_running_loop().run_in_executor(None, _run_sync)
-                final_response = result.get("final_response", "") if isinstance(result, dict) else ""
-                q.put_nowait({
-                    "event": "run.completed",
-                    "run_id": run_id,
-                    "timestamp": time.time(),
-                    "output": final_response,
-                    "usage": usage,
-                })
+                result, usage = await asyncio.get_running_loop().run_in_executor(
+                    None, _run_sync
+                )
+                final_response = (
+                    result.get("final_response", "") if isinstance(result, dict) else ""
+                )
+                q.put_nowait(
+                    {
+                        "event": "run.completed",
+                        "run_id": run_id,
+                        "timestamp": time.time(),
+                        "output": final_response,
+                        "usage": usage,
+                    }
+                )
             except Exception as exc:
                 logger.exception("[api_server] run %s failed", run_id)
                 try:
-                    q.put_nowait({
-                        "event": "run.failed",
-                        "run_id": run_id,
-                        "timestamp": time.time(),
-                        "error": str(exc),
-                    })
+                    q.put_nowait(
+                        {
+                            "event": "run.failed",
+                            "run_id": run_id,
+                            "timestamp": time.time(),
+                            "error": str(exc),
+                        }
+                    )
                 except Exception:
                     pass
             finally:
@@ -2426,7 +2861,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 break
             await asyncio.sleep(0.05)
         else:
-            return web.json_response(_openai_error(f"Run not found: {run_id}", code="run_not_found"), status=404)
+            return web.json_response(
+                _openai_error(f"Run not found: {run_id}", code="run_not_found"),
+                status=404,
+            )
 
         q = self._run_streams[run_id]
 
@@ -2444,7 +2882,7 @@ class APIServerAdapter(BasePlatformAdapter):
             while True:
                 try:
                     event = await asyncio.wait_for(q.get(), timeout=30.0)
-                except asyncio.TimeoutError:
+                except TimeoutError:
                     await response.write(b": keepalive\n\n")
                     continue
                 if event is None:
@@ -2487,29 +2925,49 @@ class APIServerAdapter(BasePlatformAdapter):
             return False
 
         try:
-            mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
+            mws = [
+                mw
+                for mw in (
+                    cors_middleware,
+                    body_limit_middleware,
+                    security_headers_middleware,
+                )
+                if mw is not None
+            ]
             self._app = web.Application(middlewares=mws)
-            self._app["api_server_adapter"] = self
+            self._app[_ADAPTER_KEY] = self
             self._app.router.add_get("/health", self._handle_health)
             self._app.router.add_get("/health/detailed", self._handle_health_detailed)
             self._app.router.add_get("/v1/health", self._handle_health)
             self._app.router.add_get("/v1/models", self._handle_models)
-            self._app.router.add_post("/v1/chat/completions", self._handle_chat_completions)
+            self._app.router.add_post(
+                "/v1/chat/completions", self._handle_chat_completions
+            )
             self._app.router.add_post("/v1/responses", self._handle_responses)
-            self._app.router.add_get("/v1/responses/{response_id}", self._handle_get_response)
-            self._app.router.add_delete("/v1/responses/{response_id}", self._handle_delete_response)
+            self._app.router.add_get(
+                "/v1/responses/{response_id}", self._handle_get_response
+            )
+            self._app.router.add_delete(
+                "/v1/responses/{response_id}", self._handle_delete_response
+            )
             # Cron jobs management API
             self._app.router.add_get("/api/jobs", self._handle_list_jobs)
             self._app.router.add_post("/api/jobs", self._handle_create_job)
             self._app.router.add_get("/api/jobs/{job_id}", self._handle_get_job)
             self._app.router.add_patch("/api/jobs/{job_id}", self._handle_update_job)
             self._app.router.add_delete("/api/jobs/{job_id}", self._handle_delete_job)
-            self._app.router.add_post("/api/jobs/{job_id}/pause", self._handle_pause_job)
-            self._app.router.add_post("/api/jobs/{job_id}/resume", self._handle_resume_job)
+            self._app.router.add_post(
+                "/api/jobs/{job_id}/pause", self._handle_pause_job
+            )
+            self._app.router.add_post(
+                "/api/jobs/{job_id}/resume", self._handle_resume_job
+            )
             self._app.router.add_post("/api/jobs/{job_id}/run", self._handle_run_job)
             # Structured event streaming
             self._app.router.add_post("/v1/runs", self._handle_runs)
-            self._app.router.add_get("/v1/runs/{run_id}/events", self._handle_run_events)
+            self._app.router.add_get(
+                "/v1/runs/{run_id}/events", self._handle_run_events
+            )
             # Start background sweep to clean up orphaned (unconsumed) run streams
             sweep_task = asyncio.create_task(self._sweep_orphaned_runs())
             try:
@@ -2524,7 +2982,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 logger.error(
                     "[%s] Refusing to start: binding to %s requires API_SERVER_KEY. "
                     "Set API_SERVER_KEY or use the default 127.0.0.1.",
-                    self.name, self._host,
+                    self.name,
+                    self._host,
                 )
                 return False
 
@@ -2533,13 +2992,15 @@ class APIServerAdapter(BasePlatformAdapter):
             if is_network_accessible(self._host) and self._api_key:
                 try:
                     from hermes_cli.auth import has_usable_secret
+
                     if not has_usable_secret(self._api_key, min_length=8):
                         logger.error(
                             "[%s] Refusing to start: API_SERVER_KEY is set to a "
                             "placeholder value. Generate a real secret "
                             "(e.g. `openssl rand -hex 32`) and set API_SERVER_KEY "
                             "before exposing the API server on %s.",
-                            self.name, self._host,
+                            self.name,
+                            self._host,
                         )
                         return False
                 except ImportError:
@@ -2549,8 +3010,12 @@ class APIServerAdapter(BasePlatformAdapter):
             try:
                 with _socket.socket(_socket.AF_INET, _socket.SOCK_STREAM) as _s:
                     _s.settimeout(1)
-                    _s.connect(('127.0.0.1', self._port))
-                logger.error('[%s] Port %d already in use. Set a different port in config.yaml: platforms.api_server.port', self.name, self._port)
+                    _s.connect(("127.0.0.1", self._port))
+                logger.error(
+                    "[%s] Port %d already in use. Set a different port in config.yaml: platforms.api_server.port",
+                    self.name,
+                    self._port,
+                )
                 return False
             except (ConnectionRefusedError, OSError):
                 pass  # port is free
@@ -2571,7 +3036,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 )
             logger.info(
                 "[%s] API server listening on http://%s:%d (model: %s)",
-                self.name, self._host, self._port, self._model_name,
+                self.name,
+                self._host,
+                self._port,
+                self._model_name,
             )
             return True
 
@@ -2595,15 +3063,17 @@ class APIServerAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         content: str,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        reply_to: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> SendResult:
         """
         Not used — HTTP request/response cycle handles delivery directly.
         """
-        return SendResult(success=False, error="API server uses HTTP request/response, not send()")
+        return SendResult(
+            success=False, error="API server uses HTTP request/response, not send()"
+        )
 
-    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+    async def get_chat_info(self, chat_id: str) -> dict[str, Any]:
         """Return basic info about the API server."""
         return {
             "name": "API Server",

--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -33,20 +33,51 @@ import os
 import re
 import traceback
 import uuid
-from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Set
+from datetime import UTC, datetime
+from typing import Any
 
 try:
     import dingtalk_stream
     from dingtalk_stream import ChatbotMessage
-    from dingtalk_stream.frames import CallbackMessage, AckMessage
+    from dingtalk_stream.frames import AckMessage, CallbackMessage
 
     DINGTALK_STREAM_AVAILABLE = True
 except ImportError:
     DINGTALK_STREAM_AVAILABLE = False
     dingtalk_stream = None  # type: ignore[assignment]
-    ChatbotMessage = None  # type: ignore[assignment]
     CallbackMessage = None  # type: ignore[assignment]
+
+    class ChatbotMessage:  # type: ignore[no-redef]
+        """Lightweight stub when dingtalk-stream is not installed."""
+
+        def __init__(self) -> None:
+            self.message_id: str = ""
+            self.conversation_id: str = ""
+            self.conversation_type: str = "1"
+            self.sender_id: str = ""
+            self.sender_nick: str = ""
+            self.sender_staff_id: str = ""
+            self.session_webhook: str = ""
+            self.session_webhook_expired_time: int = 0
+            self.is_in_at_list: bool = False
+            self.text: Any = None
+            self.msgtype: str = "text"
+
+        @classmethod
+        def from_dict(cls, data: dict) -> "ChatbotMessage":
+            obj = cls()
+            for key, value in data.items():
+                # Convert camelCase keys to snake_case attributes
+                snake = "".join(
+                    f"_{c.lower()}" if c.isupper() else c for c in key
+                ).lstrip("_")
+                setattr(obj, snake, value)
+            # Also keep original keys for direct attribute access
+            for key, value in data.items():
+                if not hasattr(obj, key):
+                    setattr(obj, key, value)
+            return obj
+
     AckMessage = type(
         "AckMessage",
         (),
@@ -68,10 +99,14 @@ except ImportError:
 try:
     from alibabacloud_dingtalk.card_1_0 import (
         client as dingtalk_card_client,
+    )
+    from alibabacloud_dingtalk.card_1_0 import (
         models as dingtalk_card_models,
     )
     from alibabacloud_dingtalk.robot_1_0 import (
         client as dingtalk_robot_client,
+    )
+    from alibabacloud_dingtalk.robot_1_0 import (
         models as dingtalk_robot_models,
     )
     from alibabacloud_tea_openapi import models as open_api_models
@@ -88,20 +123,20 @@ except ImportError:
     tea_util_models = None
 
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.helpers import MessageDeduplicator
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
     MessageType,
     SendResult,
 )
+from gateway.platforms.helpers import MessageDeduplicator
 
 logger = logging.getLogger(__name__)
 
 MAX_MESSAGE_LENGTH = 20000
 RECONNECT_BACKOFF = [2, 5, 10, 30, 60]
 _SESSION_WEBHOOKS_MAX = 500
-_DINGTALK_WEBHOOK_RE = re.compile(r'^https://(?:api|oapi)\.dingtalk\.com/')
+_DINGTALK_WEBHOOK_RE = re.compile(r"^https://(?:api|oapi)\.dingtalk\.com/")
 
 # DingTalk message type → runtime content type
 DINGTALK_TYPE_MAPPING = {
@@ -169,31 +204,31 @@ class DingTalkAdapter(BasePlatformAdapter):
         # Mention state is the structured ``is_in_at_list`` attribute from the
         # dingtalk-stream SDK (set from the callback's ``isInAtList`` flag),
         # not text parsing.
-        self._mention_patterns: List[re.Pattern] = self._compile_mention_patterns()
-        self._allowed_users: Set[str] = self._load_allowed_users()
+        self._mention_patterns: list[re.Pattern] = self._compile_mention_patterns()
+        self._allowed_users: set[str] = self._load_allowed_users()
 
         self._stream_client: Any = None
-        self._stream_task: Optional[asyncio.Task] = None
-        self._http_client: Optional["httpx.AsyncClient"] = None
-        self._card_sdk: Optional[Any] = None
-        self._robot_sdk: Optional[Any] = None
+        self._stream_task: asyncio.Task | None = None
+        self._http_client: httpx.AsyncClient | None = None
+        self._card_sdk: Any | None = None
+        self._robot_sdk: Any | None = None
         self._robot_code: str = extra.get("robot_code") or self._client_id
 
         # Message deduplication
         self._dedup = MessageDeduplicator(max_size=1000)
         # Map chat_id -> (session_webhook, expired_time_ms) for reply routing
-        self._session_webhooks: Dict[str, tuple[str, int]] = {}
+        self._session_webhooks: dict[str, tuple[str, int]] = {}
         # Map chat_id -> last inbound ChatbotMessage. Keyed by chat_id instead
         # of a single class attribute to avoid cross-message clobbering when
         # multiple conversations run concurrently.
-        self._message_contexts: Dict[str, Any] = {}
-        self._card_template_id: Optional[str] = extra.get("card_template_id")
+        self._message_contexts: dict[str, Any] = {}
+        self._card_template_id: str | None = extra.get("card_template_id")
 
         # Chats for which we've already fired the Done reaction — prevents
         # double-firing across segment boundaries or parallel flows
         # (tool-progress + stream-consumer both finalizing their cards).
         # Reset each inbound message.
-        self._done_emoji_fired: Set[str] = set()
+        self._done_emoji_fired: set[str] = set()
         # Cards in streaming state per chat: chat_id -> { out_track_id -> last_content }.
         # Every `send()` creates+finalizes a card (closed state).  A subsequent
         # `edit_message(finalize=False)` re-opens the card (DingTalk's API
@@ -201,10 +236,10 @@ class DingTalkAdapter(BasePlatformAdapter):
         # streaming).  We track those reopened cards so the next `send()` can
         # auto-close them as siblings — otherwise tool-progress cards get
         # stuck in streaming state forever.
-        self._streaming_cards: Dict[str, Dict[str, str]] = {}
+        self._streaming_cards: dict[str, dict[str, str]] = {}
         # Track fire-and-forget emoji/reaction coroutines so Python's GC
         # doesn't drop them mid-flight, and we can cancel them on disconnect.
-        self._bg_tasks: Set[asyncio.Task] = set()
+        self._bg_tasks: set[asyncio.Task] = set()
 
     # -- Connection lifecycle -----------------------------------------------
 
@@ -300,12 +335,18 @@ class DingTalkAdapter(BasePlatformAdapter):
         # Close the active websocket first so the stream task sees the
         # disconnection and exits cleanly, rather than getting stuck
         # awaiting frames that will never arrive.
-        websocket = getattr(self._stream_client, "websocket", None) if self._stream_client else None
+        websocket = (
+            getattr(self._stream_client, "websocket", None)
+            if self._stream_client
+            else None
+        )
         if websocket is not None:
             try:
                 await websocket.close()
             except Exception as e:
-                logger.debug("[%s] websocket close during disconnect failed: %s", self.name, e)
+                logger.debug(
+                    "[%s] websocket close during disconnect failed: %s", self.name, e
+                )
 
         if self._stream_task:
             # Try graceful close first if SDK supports it. The SDK's close()
@@ -319,8 +360,10 @@ class DingTalkAdapter(BasePlatformAdapter):
             self._stream_task.cancel()
             try:
                 await asyncio.wait_for(self._stream_task, timeout=5.0)
-            except (asyncio.CancelledError, asyncio.TimeoutError):
-                logger.debug("[%s] stream task did not exit cleanly during disconnect", self.name)
+            except (TimeoutError, asyncio.CancelledError):
+                logger.debug(
+                    "[%s] stream task did not exit cleanly during disconnect", self.name
+                )
             self._stream_task = None
 
         # Cancel any in-flight background tasks (emoji reactions, etc.)
@@ -351,9 +394,14 @@ class DingTalkAdapter(BasePlatformAdapter):
             if isinstance(configured, str):
                 return configured.lower() in ("true", "1", "yes", "on")
             return bool(configured)
-        return os.getenv("DINGTALK_REQUIRE_MENTION", "false").lower() in ("true", "1", "yes", "on")
+        return os.getenv("DINGTALK_REQUIRE_MENTION", "false").lower() in (
+            "true",
+            "1",
+            "yes",
+            "on",
+        )
 
-    def _dingtalk_free_response_chats(self) -> Set[str]:
+    def _dingtalk_free_response_chats(self) -> set[str]:
         raw = self.config.extra.get("free_response_chats")
         if raw is None:
             raw = os.getenv("DINGTALK_FREE_RESPONSE_CHATS", "")
@@ -361,9 +409,11 @@ class DingTalkAdapter(BasePlatformAdapter):
             return {str(part).strip() for part in raw if str(part).strip()}
         return {part.strip() for part in str(raw).split(",") if part.strip()}
 
-    def _compile_mention_patterns(self) -> List[re.Pattern]:
+    def _compile_mention_patterns(self) -> list[re.Pattern]:
         """Compile optional regex wake-word patterns for group triggers."""
-        patterns = self.config.extra.get("mention_patterns") if self.config.extra else None
+        patterns = (
+            self.config.extra.get("mention_patterns") if self.config.extra else None
+        )
         if patterns is None:
             raw = os.getenv("DINGTALK_MENTION_PATTERNS", "").strip()
             if raw:
@@ -372,7 +422,9 @@ class DingTalkAdapter(BasePlatformAdapter):
                 except Exception:
                     loaded = [part.strip() for part in raw.splitlines() if part.strip()]
                     if not loaded:
-                        loaded = [part.strip() for part in raw.split(",") if part.strip()]
+                        loaded = [
+                            part.strip() for part in raw.split(",") if part.strip()
+                        ]
                 patterns = loaded
 
         if patterns is None:
@@ -387,19 +439,26 @@ class DingTalkAdapter(BasePlatformAdapter):
             )
             return []
 
-        compiled: List[re.Pattern] = []
+        compiled: list[re.Pattern] = []
         for pattern in patterns:
             if not isinstance(pattern, str) or not pattern.strip():
                 continue
             try:
                 compiled.append(re.compile(pattern, re.IGNORECASE))
             except re.error as exc:
-                logger.warning("[%s] Invalid DingTalk mention pattern %r: %s", self.name, pattern, exc)
+                logger.warning(
+                    "[%s] Invalid DingTalk mention pattern %r: %s",
+                    self.name,
+                    pattern,
+                    exc,
+                )
         if compiled:
-            logger.info("[%s] Loaded %d DingTalk mention pattern(s)", self.name, len(compiled))
+            logger.info(
+                "[%s] Loaded %d DingTalk mention pattern(s)", self.name, len(compiled)
+            )
         return compiled
 
-    def _load_allowed_users(self) -> Set[str]:
+    def _load_allowed_users(self) -> set[str]:
         """Load allowed-users list from config.extra or env var.
 
         IDs are matched case-insensitively against the sender's ``staff_id`` and
@@ -434,7 +493,9 @@ class DingTalkAdapter(BasePlatformAdapter):
             return False
         return any(pattern.search(text) for pattern in self._mention_patterns)
 
-    def _should_process_message(self, message: "ChatbotMessage", text: str, is_group: bool, chat_id: str) -> bool:
+    def _should_process_message(
+        self, message: "ChatbotMessage", text: str, is_group: bool, chat_id: str
+    ) -> bool:
         """Apply DingTalk group trigger rules.
 
         DMs remain unrestricted (subject to ``allowed_users`` which is enforced
@@ -480,16 +541,22 @@ class DingTalkAdapter(BasePlatformAdapter):
         for out_track_id, last_content in list(cards.items()):
             try:
                 await self._stream_card_content(
-                    out_track_id, token, last_content, finalize=True,
+                    out_track_id,
+                    token,
+                    last_content,
+                    finalize=True,
                 )
                 logger.debug(
                     "[%s] AI Card sibling closed: %s",
-                    self.name, out_track_id,
+                    self.name,
+                    out_track_id,
                 )
             except Exception as e:
                 logger.debug(
                     "[%s] Sibling close failed for %s: %s",
-                    self.name, out_track_id, e,
+                    self.name,
+                    out_track_id,
+                    e,
                 )
 
     def _fire_done_reaction(self, chat_id: str) -> None:
@@ -511,10 +578,16 @@ class DingTalkAdapter(BasePlatformAdapter):
 
         async def _swap() -> None:
             await self._send_emotion(
-                msg_id, conversation_id, "🤔Thinking", recall=True,
+                msg_id,
+                conversation_id,
+                "🤔Thinking",
+                recall=True,
             )
             await self._send_emotion(
-                msg_id, conversation_id, "🥳Done", recall=False,
+                msg_id,
+                conversation_id,
+                "🥳Done",
+                recall=False,
             )
 
         self._spawn_bg(_swap())
@@ -546,7 +619,9 @@ class DingTalkAdapter(BasePlatformAdapter):
         if not self._is_user_allowed(sender_id, sender_staff_id):
             logger.debug(
                 "[%s] Dropping message from non-allowlisted user staff_id=%s sender_id=%s",
-                self.name, sender_staff_id, sender_id,
+                self.name,
+                sender_staff_id,
+                sender_id,
             )
             return
 
@@ -558,7 +633,9 @@ class DingTalkAdapter(BasePlatformAdapter):
         if not self._should_process_message(message, _early_text, is_group, chat_id):
             logger.debug(
                 "[%s] Dropping group message that failed mention gate message_id=%s chat_id=%s",
-                self.name, msg_id, chat_id,
+                self.name,
+                msg_id,
+                chat_id,
             )
             return
 
@@ -612,12 +689,12 @@ class DingTalkAdapter(BasePlatformAdapter):
         create_at = getattr(message, "create_at", None)
         try:
             timestamp = (
-                datetime.fromtimestamp(int(create_at) / 1000, tz=timezone.utc)
+                datetime.fromtimestamp(int(create_at) / 1000, tz=UTC)
                 if create_at
-                else datetime.now(tz=timezone.utc)
+                else datetime.now(tz=UTC)
             )
         except (ValueError, OSError, TypeError):
-            timestamp = datetime.now(tz=timezone.utc)
+            timestamp = datetime.now(tz=UTC)
 
         event = MessageEvent(
             text=text,
@@ -752,8 +829,8 @@ class DingTalkAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         content: str,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        reply_to: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> SendResult:
         """Send a markdown reply via DingTalk session webhook."""
         metadata = metadata or {}
@@ -771,7 +848,8 @@ class DingTalkAdapter(BasePlatformAdapter):
             if not webhook_info:
                 logger.warning(
                     "[%s] No valid session_webhook for chat_id=%s",
-                    self.name, chat_id,
+                    self.name,
+                    chat_id,
                 )
                 return SendResult(
                     success=False,
@@ -803,7 +881,9 @@ class DingTalkAdapter(BasePlatformAdapter):
             await self._close_streaming_siblings(chat_id)
 
             result = await self._create_and_stream_card(
-                chat_id, current_message, content,
+                chat_id,
+                current_message,
+                content,
                 finalize=is_final_reply,
             )
             if result and result.success:
@@ -815,12 +895,14 @@ class DingTalkAdapter(BasePlatformAdapter):
                     # first chunk): keep the card open and track it so the
                     # next send() auto-closes it as a sibling, or
                     # edit_message(finalize=True) closes it explicitly.
-                    self._streaming_cards.setdefault(chat_id, {})[
-                        result.message_id
-                    ] = content
+                    self._streaming_cards.setdefault(chat_id, {})[result.message_id] = (
+                        content
+                    )
                 return result
 
-            logger.warning("[%s] AI Card send failed, falling back to webhook", self.name)
+            logger.warning(
+                "[%s] AI Card send failed, falling back to webhook", self.name
+            )
 
         logger.debug("[%s] Sending via webhook", self.name)
         # Normalize markdown for DingTalk
@@ -860,14 +942,14 @@ class DingTalkAdapter(BasePlatformAdapter):
         """DingTalk does not support typing indicators."""
         pass
 
-    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+    async def get_chat_info(self, chat_id: str) -> dict[str, Any]:
         """Return basic info about a DingTalk conversation."""
         return {
             "name": chat_id,
             "type": "group" if "group" in chat_id.lower() else "dm",
         }
 
-    def _get_valid_webhook(self, chat_id: str) -> Optional[tuple[str, int]]:
+    def _get_valid_webhook(self, chat_id: str) -> tuple[str, int] | None:
         """Get a valid (non-expired) session webhook for the given chat_id."""
         info = self._session_webhooks.get(chat_id)
         if not info:
@@ -875,7 +957,7 @@ class DingTalkAdapter(BasePlatformAdapter):
         webhook, expired_time_ms = info
         # Check expiry with 5-minute safety margin
         if expired_time_ms and expired_time_ms > 0:
-            now_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
+            now_ms = int(datetime.now(tz=UTC).timestamp() * 1000)
             safety_margin_ms = 5 * 60 * 1000
             if now_ms + safety_margin_ms >= expired_time_ms:
                 # Expired, remove from cache
@@ -890,7 +972,7 @@ class DingTalkAdapter(BasePlatformAdapter):
         content: str,
         *,
         finalize: bool = True,
-    ) -> Optional[SendResult]:
+    ) -> SendResult | None:
         """Create an AI Card, deliver it to the conversation, and stream initial content.
 
         Always called with ``finalize=True`` from ``send()`` (closed state).
@@ -985,7 +1067,10 @@ class DingTalkAdapter(BasePlatformAdapter):
             # card immediately (one-shot); finalize=False keeps it open
             # for streaming edit_message updates by out_track_id.
             await self._stream_card_content(
-                out_track_id, token, content, finalize=finalize,
+                out_track_id,
+                token,
+                content,
+                finalize=finalize,
             )
 
             logger.info(
@@ -999,7 +1084,9 @@ class DingTalkAdapter(BasePlatformAdapter):
         except Exception as e:
             logger.warning(
                 "[%s] AI Card create failed: %s\n%s",
-                self.name, e, traceback.format_exc(),
+                self.name,
+                e,
+                traceback.format_exc(),
             )
             return None
 
@@ -1026,7 +1113,10 @@ class DingTalkAdapter(BasePlatformAdapter):
 
         try:
             await self._stream_card_content(
-                message_id, token, content, finalize=finalize,
+                message_id,
+                token,
+                content,
+                finalize=finalize,
             )
             if finalize:
                 # Remove from streaming-cards tracking and fire Done.  This
@@ -1037,7 +1127,8 @@ class DingTalkAdapter(BasePlatformAdapter):
                     self._streaming_cards.pop(chat_id, None)
                 logger.debug(
                     "[%s] AI Card finalized (edit): %s",
-                    self.name, message_id,
+                    self.name,
+                    message_id,
                 )
                 self._fire_done_reaction(chat_id)
             else:
@@ -1077,7 +1168,7 @@ class DingTalkAdapter(BasePlatformAdapter):
             stream_request, stream_headers, runtime
         )
 
-    async def _get_access_token(self) -> Optional[str]:
+    async def _get_access_token(self) -> str | None:
         """Get access token using SDK's cached token."""
         if not self._stream_client:
             return None
@@ -1153,7 +1244,10 @@ class DingTalkAdapter(BasePlatformAdapter):
                 )
             logger.info(
                 "[%s] _send_emotion: %s %s on msg=%s",
-                self.name, action, emoji_name, open_msg_id[:24],
+                self.name,
+                action,
+                emoji_name,
+                open_msg_id[:24],
             )
         except Exception:
             logger.debug(
@@ -1218,8 +1312,10 @@ class DingTalkAdapter(BasePlatformAdapter):
                 x_acs_dingtalk_access_token=token,
             )
             runtime = tea_util_models.RuntimeOptions()
-            response = await self._robot_sdk.robot_message_file_download_with_options_async(
-                request, headers, runtime
+            response = (
+                await self._robot_sdk.robot_message_file_download_with_options_async(
+                    request, headers, runtime
+                )
             )
             body = response.body if response else None
             if body:
@@ -1278,7 +1374,9 @@ class _IncomingHandler(
     CallbackMessage.data dict into a ChatbotMessage before forwarding.
     """
 
-    def __init__(self, adapter: DingTalkAdapter, loop: Optional[asyncio.AbstractEventLoop] = None):
+    def __init__(
+        self, adapter: DingTalkAdapter, loop: asyncio.AbstractEventLoop | None = None
+    ):
         if DINGTALK_STREAM_AVAILABLE:
             super().__init__()
         self._adapter = adapter
@@ -1309,10 +1407,10 @@ class _IncomingHandler(
             # SDK versions).
             if not getattr(chatbot_msg, "session_webhook", None):
                 webhook = (
-                    data.get("sessionWebhook")
-                    or data.get("session_webhook")
-                    or ""
-                ) if isinstance(data, dict) else ""
+                    (data.get("sessionWebhook") or data.get("session_webhook") or "")
+                    if isinstance(data, dict)
+                    else ""
+                )
                 if webhook:
                     chatbot_msg.session_webhook = webhook
 
@@ -1321,9 +1419,7 @@ class _IncomingHandler(
             # ``isInAtList`` in the raw payload; the adapter's mention check
             # reads the ChatbotMessage attribute ``is_in_at_list``.
             if not getattr(chatbot_msg, "is_in_at_list", False):
-                raw_flag = (
-                    data.get("isInAtList") if isinstance(data, dict) else False
-                )
+                raw_flag = data.get("isInAtList") if isinstance(data, dict) else False
                 if raw_flag:
                     chatbot_msg.is_in_at_list = True
 
@@ -1334,7 +1430,10 @@ class _IncomingHandler(
             if msg_id and conversation_id:
                 self._adapter._spawn_bg(
                     self._adapter._send_emotion(
-                        msg_id, conversation_id, "🤔Thinking", recall=False,
+                        msg_id,
+                        conversation_id,
+                        "🤔Thinking",
+                        recall=False,
                     )
                 )
 

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -18,7 +18,8 @@ import tempfile
 import threading
 import time
 from collections import defaultdict
-from typing import Callable, Dict, Optional, Any
+from collections.abc import Callable
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -26,8 +27,10 @@ VALID_THREAD_AUTO_ARCHIVE_MINUTES = {60, 1440, 4320, 10080}
 
 try:
     import discord
-    from discord import Message as DiscordMessage, Intents
+    from discord import Intents
+    from discord import Message as DiscordMessage
     from discord.ext import commands
+
     DISCORD_AVAILABLE = True
 except ImportError:
     DISCORD_AVAILABLE = False
@@ -36,28 +39,38 @@ except ImportError:
     Intents = Any
     commands = None
 
+try:
+    import davey as _davey_module
+
+    _DAVE_AUDIO_MEDIA_TYPE = _davey_module.MediaType.audio
+except ImportError:
+    _davey_module = None
+    _DAVE_AUDIO_MEDIA_TYPE = 1  # fallback constant
+
 import sys
 from pathlib import Path as _Path
+
 sys.path.insert(0, str(_Path(__file__).resolve().parents[2]))
 
-from gateway.config import Platform, PlatformConfig
 import re
 
-from gateway.platforms.helpers import MessageDeduplicator, ThreadParticipationTracker
+from tools.url_safety import is_safe_url
+
+from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
+    SUPPORTED_DOCUMENT_TYPES,
     BasePlatformAdapter,
     MessageEvent,
     MessageType,
     ProcessingOutcome,
     SendResult,
-    cache_image_from_url,
-    cache_image_from_bytes,
-    cache_audio_from_url,
     cache_audio_from_bytes,
+    cache_audio_from_url,
     cache_document_from_bytes,
-    SUPPORTED_DOCUMENT_TYPES,
+    cache_image_from_bytes,
+    cache_image_from_url,
 )
-from tools.url_safety import is_safe_url
+from gateway.platforms.helpers import MessageDeduplicator, ThreadParticipationTracker
 
 
 def _clean_discord_id(entry: str) -> str:
@@ -126,10 +139,10 @@ class VoiceReceiver:
     completed utterances via a callback.
     """
 
-    SILENCE_THRESHOLD = 1.5    # seconds of silence → end of utterance
+    SILENCE_THRESHOLD = 1.5  # seconds of silence → end of utterance
     MIN_SPEECH_DURATION = 0.5  # minimum seconds to process (skip noise)
-    SAMPLE_RATE = 48000        # Discord native rate
-    CHANNELS = 2               # Discord sends stereo
+    SAMPLE_RATE = 48000  # Discord native rate
+    CHANNELS = 2  # Discord sends stereo
 
     def __init__(self, voice_client, allowed_user_ids: set = None):
         self._vc = voice_client
@@ -137,20 +150,20 @@ class VoiceReceiver:
         self._running = False
 
         # Decryption
-        self._secret_key: Optional[bytes] = None
+        self._secret_key: bytes | None = None
         self._dave_session = None
         self._bot_ssrc: int = 0
 
         # SSRC -> user_id mapping (populated from SPEAKING events)
-        self._ssrc_to_user: Dict[int, int] = {}
+        self._ssrc_to_user: dict[int, int] = {}
         self._lock = threading.Lock()
 
         # Per-user audio buffers
-        self._buffers: Dict[int, bytearray] = defaultdict(bytearray)
-        self._last_packet_time: Dict[int, float] = {}
+        self._buffers: dict[int, bytearray] = defaultdict(bytearray)
+        self._last_packet_time: dict[int, float] = {}
 
         # Opus decoder per SSRC (each user needs own decoder state)
-        self._decoders: Dict[int, object] = {}
+        self._decoders: dict[int, object] = {}
 
         # Pause flag: don't capture while bot is playing TTS
         self._paused = False
@@ -229,7 +242,8 @@ class VoiceReceiver:
         # Set on the current live websocket (for immediate effect)
         try:
             from discord.utils import MISSING
-            if hasattr(conn, 'ws') and conn.ws is not MISSING:
+
+            if hasattr(conn, "ws") and conn.ws is not MISSING:
                 conn.ws._hook = wrapped_hook
                 logger.info("Speaking hook installed on live websocket")
         except Exception as e:
@@ -248,7 +262,8 @@ class VoiceReceiver:
         if self._packet_debug_count <= 5:
             logger.debug(
                 "Raw UDP packet: len=%d, first_bytes=%s",
-                len(data), data[:4].hex() if len(data) >= 4 else "short",
+                len(data),
+                data[:4].hex() if len(data) >= 4 else "short",
             )
 
         if len(data) < 16:
@@ -259,7 +274,9 @@ class VoiceReceiver:
         # Payload type (byte 1 lower 7 bits) = 0x78 (120) for voice.
         if (data[0] >> 6) != 2 or (data[1] & 0x7F) != 0x78:
             if self._packet_debug_count <= 5:
-                logger.debug("Skipped non-RTP: byte0=0x%02x byte1=0x%02x", data[0], data[1])
+                logger.debug(
+                    "Skipped non-RTP: byte0=0x%02x byte1=0x%02x", data[0], data[1]
+                )
             return
 
         first_byte = data[0]
@@ -290,7 +307,11 @@ class VoiceReceiver:
                 known_user = self._ssrc_to_user.get(ssrc, "unknown")
             logger.debug(
                 "RTP packet: ssrc=%d, seq=%d, user=%s, hdr=%d, ext_data=%d",
-                ssrc, seq, known_user, header_size, ext_data_len,
+                ssrc,
+                seq,
+                known_user,
+                header_size,
+                ext_data_len,
             )
 
         header = bytes(data[:header_size])
@@ -305,11 +326,17 @@ class VoiceReceiver:
 
         try:
             import nacl.secret  # noqa: delayed import – only in voice path
+
             box = nacl.secret.Aead(self._secret_key)
             decrypted = box.decrypt(encrypted, header, bytes(nonce))
         except Exception as e:
             if self._packet_debug_count <= 10:
-                logger.warning("NaCl decrypt failed: %s (hdr=%d, enc=%d)", e, header_size, len(encrypted))
+                logger.warning(
+                    "NaCl decrypt failed: %s (hdr=%d, enc=%d)",
+                    e,
+                    header_size,
+                    len(encrypted),
+                )
             return
 
         # Skip encrypted extension data to get the actual opus payload
@@ -325,7 +352,8 @@ class VoiceReceiver:
             if not decrypted:
                 if self._packet_debug_count <= 10:
                     logger.warning(
-                        "RTP padding bit set but no payload (ssrc=%d)", ssrc,
+                        "RTP padding bit set but no payload (ssrc=%d)",
+                        ssrc,
                     )
                 return
             pad_len = decrypted[-1]
@@ -333,7 +361,9 @@ class VoiceReceiver:
                 if self._packet_debug_count <= 10:
                     logger.warning(
                         "Invalid RTP padding length %d for payload size %d (ssrc=%d)",
-                        pad_len, len(decrypted), ssrc,
+                        pad_len,
+                        len(decrypted),
+                        ssrc,
                     )
                 return
             decrypted = decrypted[:-pad_len]
@@ -347,15 +377,16 @@ class VoiceReceiver:
                 user_id = self._ssrc_to_user.get(ssrc, 0)
             if user_id:
                 try:
-                    import davey
                     decrypted = self._dave_session.decrypt(
-                        user_id, davey.MediaType.audio, decrypted
+                        user_id, _DAVE_AUDIO_MEDIA_TYPE, decrypted
                     )
                 except Exception as e:
                     # Unencrypted passthrough — use NaCl-decrypted data as-is
                     if "Unencrypted" not in str(e):
                         if self._packet_debug_count <= 10:
-                            logger.warning("DAVE decrypt failed for ssrc=%d: %s", ssrc, e)
+                            logger.warning(
+                                "DAVE decrypt failed for ssrc=%d: %s", ssrc, e
+                            )
                         return
             # If SSRC unknown (no SPEAKING event yet), skip DAVE and try
             # Opus decode directly — audio may be in passthrough mode.
@@ -391,13 +422,16 @@ class VoiceReceiver:
             bot_id = self._vc.user.id if self._vc.user else 0
             allowed = self._allowed_user_ids
             candidates = [
-                m.id for m in channel.members
+                m.id
+                for m in channel.members
                 if m.id != bot_id and (not allowed or str(m.id) in allowed)
             ]
             if len(candidates) == 1:
                 uid = candidates[0]
                 self._ssrc_to_user[ssrc] = uid
-                logger.info("Auto-mapped ssrc=%d -> user=%d (sole allowed member)", ssrc, uid)
+                logger.info(
+                    "Auto-mapped ssrc=%d -> user=%d (sole allowed member)", ssrc, uid
+                )
                 return uid
         except Exception:
             pass
@@ -419,7 +453,10 @@ class VoiceReceiver:
                 # 48kHz, 16-bit, stereo = 192000 bytes/sec
                 buf_duration = len(buf) / (self.SAMPLE_RATE * self.CHANNELS * 2)
 
-                if silence_duration >= self.SILENCE_THRESHOLD and buf_duration >= self.MIN_SPEECH_DURATION:
+                if (
+                    silence_duration >= self.SILENCE_THRESHOLD
+                    and buf_duration >= self.MIN_SPEECH_DURATION
+                ):
                     user_id = ssrc_user_map.get(ssrc, 0)
                     if not user_id:
                         # SSRC not mapped (SPEAKING event missing after bot rejoin).
@@ -441,8 +478,9 @@ class VoiceReceiver:
     # ------------------------------------------------------------------
 
     @staticmethod
-    def pcm_to_wav(pcm_data: bytes, output_path: str,
-                   src_rate: int = 48000, src_channels: int = 2):
+    def pcm_to_wav(
+        pcm_data: bytes, output_path: str, src_rate: int = 48000, src_channels: int = 2
+    ):
         """Convert raw PCM to 16kHz mono WAV via ffmpeg."""
         with tempfile.NamedTemporaryFile(suffix=".pcm", delete=False) as f:
             f.write(pcm_data)
@@ -450,13 +488,22 @@ class VoiceReceiver:
         try:
             subprocess.run(
                 [
-                    "ffmpeg", "-y", "-loglevel", "error",
-                    "-f", "s16le",
-                    "-ar", str(src_rate),
-                    "-ac", str(src_channels),
-                    "-i", pcm_path,
-                    "-ar", "16000",
-                    "-ac", "1",
+                    "ffmpeg",
+                    "-y",
+                    "-loglevel",
+                    "error",
+                    "-f",
+                    "s16le",
+                    "-ar",
+                    str(src_rate),
+                    "-ac",
+                    str(src_channels),
+                    "-i",
+                    pcm_path,
+                    "-ar",
+                    "16000",
+                    "-ac",
+                    "1",
                     output_path,
                 ],
                 check=True,
@@ -492,58 +539,77 @@ class DiscordAdapter(BasePlatformAdapter):
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.DISCORD)
-        self._client: Optional[commands.Bot] = None
+        self._client: commands.Bot | None = None
         self._ready_event = asyncio.Event()
         self._allowed_user_ids: set = set()  # For button approval authorization
         self._allowed_role_ids: set = set()  # For DISCORD_ALLOWED_ROLES filtering
         # Voice channel state (per-guild)
-        self._voice_clients: Dict[int, Any] = {}  # guild_id -> VoiceClient
-        self._voice_locks: Dict[int, asyncio.Lock] = {}  # guild_id -> serialize join/leave
+        self._voice_clients: dict[int, Any] = {}  # guild_id -> VoiceClient
+        self._voice_locks: dict[
+            int, asyncio.Lock
+        ] = {}  # guild_id -> serialize join/leave
         # Text batching: merge rapid successive messages (Telegram-style)
-        self._text_batch_delay_seconds = float(os.getenv("HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS", "0.6"))
-        self._text_batch_split_delay_seconds = float(os.getenv("HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0"))
-        self._pending_text_batches: Dict[str, MessageEvent] = {}
-        self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
-        self._voice_text_channels: Dict[int, int] = {}  # guild_id -> text_channel_id
-        self._voice_sources: Dict[int, Dict[str, Any]] = {}  # guild_id -> linked text channel source metadata
-        self._voice_timeout_tasks: Dict[int, asyncio.Task] = {}  # guild_id -> timeout task
+        self._text_batch_delay_seconds = float(
+            os.getenv("HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS", "0.6")
+        )
+        self._text_batch_split_delay_seconds = float(
+            os.getenv("HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0")
+        )
+        self._pending_text_batches: dict[str, MessageEvent] = {}
+        self._pending_text_batch_tasks: dict[str, asyncio.Task] = {}
+        self._voice_text_channels: dict[int, int] = {}  # guild_id -> text_channel_id
+        self._voice_sources: dict[
+            int, dict[str, Any]
+        ] = {}  # guild_id -> linked text channel source metadata
+        self._voice_timeout_tasks: dict[
+            int, asyncio.Task
+        ] = {}  # guild_id -> timeout task
         # Phase 2: voice listening
-        self._voice_receivers: Dict[int, VoiceReceiver] = {}  # guild_id -> VoiceReceiver
-        self._voice_listen_tasks: Dict[int, asyncio.Task] = {}  # guild_id -> listen loop
-        self._voice_input_callback: Optional[Callable] = None  # set by run.py
-        self._on_voice_disconnect: Optional[Callable] = None  # set by run.py
+        self._voice_receivers: dict[
+            int, VoiceReceiver
+        ] = {}  # guild_id -> VoiceReceiver
+        self._voice_listen_tasks: dict[
+            int, asyncio.Task
+        ] = {}  # guild_id -> listen loop
+        self._voice_input_callback: Callable | None = None  # set by run.py
+        self._on_voice_disconnect: Callable | None = None  # set by run.py
         # Track threads where the bot has participated so follow-up messages
         # in those threads don't require @mention.  Persisted to disk so the
         # set survives gateway restarts.
         self._threads = ThreadParticipationTracker("discord")
         # Persistent typing indicator loops per channel (DMs don't reliably
         # show the standard typing gateway event for bots)
-        self._typing_tasks: Dict[str, asyncio.Task] = {}
-        self._bot_task: Optional[asyncio.Task] = None
-        self._post_connect_task: Optional[asyncio.Task] = None
+        self._typing_tasks: dict[str, asyncio.Task] = {}
+        self._bot_task: asyncio.Task | None = None
+        self._post_connect_task: asyncio.Task | None = None
         # Dedup cache: prevents duplicate bot responses when Discord
         # RESUME replays events after reconnects.
         self._dedup = MessageDeduplicator()
         # Reply threading mode: "off" (no replies), "first" (reply on first
         # chunk only, default), "all" (reply-reference on every chunk).
-        self._reply_to_mode: str = getattr(config, 'reply_to_mode', 'first') or 'first'
+        self._reply_to_mode: str = getattr(config, "reply_to_mode", "first") or "first"
 
     async def connect(self) -> bool:
         """Connect to Discord and start receiving events."""
         if not DISCORD_AVAILABLE:
-            logger.error("[%s] discord.py not installed. Run: pip install discord.py", self.name)
+            logger.error(
+                "[%s] discord.py not installed. Run: pip install discord.py", self.name
+            )
             return False
 
         # Load opus codec for voice channel support
         if not discord.opus.is_loaded():
             import ctypes.util
+
             opus_path = ctypes.util.find_library("opus")
             # ctypes.util.find_library fails on macOS with Homebrew-installed libs,
             # so fall back to known Homebrew paths if needed.
             if not opus_path:
+                import sys
+
                 _homebrew_paths = (
                     "/opt/homebrew/lib/libopus.dylib",  # Apple Silicon
-                    "/usr/local/lib/libopus.dylib",     # Intel Mac
+                    "/usr/local/lib/libopus.dylib",  # Intel Mac
                 )
                 if sys.platform == "darwin":
                     for _hp in _homebrew_paths:
@@ -554,7 +620,9 @@ class DiscordAdapter(BasePlatformAdapter):
                 try:
                     discord.opus.load_opus(opus_path)
                 except Exception:
-                    logger.warning("Opus codec found at %s but failed to load", opus_path)
+                    logger.warning(
+                        "Opus codec found at %s but failed to load", opus_path
+                    )
             if not discord.opus.is_loaded():
                 logger.warning("Opus codec not found — voice channel playback disabled")
 
@@ -563,14 +631,17 @@ class DiscordAdapter(BasePlatformAdapter):
             return False
 
         try:
-            if not self._acquire_platform_lock('discord-bot-token', self.config.token, 'Discord bot token'):
+            if not self._acquire_platform_lock(
+                "discord-bot-token", self.config.token, "Discord bot token"
+            ):
                 return False
 
             # Parse allowed user entries (may contain usernames or IDs)
             allowed_env = os.getenv("DISCORD_ALLOWED_USERS", "")
             if allowed_env:
                 self._allowed_user_ids = {
-                    _clean_discord_id(uid) for uid in allowed_env.split(",")
+                    _clean_discord_id(uid)
+                    for uid in allowed_env.split(",")
                     if uid.strip()
                 }
 
@@ -579,7 +650,8 @@ class DiscordAdapter(BasePlatformAdapter):
             roles_env = os.getenv("DISCORD_ALLOWED_ROLES", "")
             if roles_env:
                 self._allowed_role_ids = {
-                    int(rid.strip()) for rid in roles_env.split(",")
+                    int(rid.strip())
+                    for rid in roles_env.split(",")
                     if rid.strip().isdigit()
                 }
 
@@ -601,7 +673,8 @@ class DiscordAdapter(BasePlatformAdapter):
             intents.voice_states = True
 
             # Resolve proxy (DISCORD_PROXY > generic env vars > macOS system proxy)
-            from gateway.platforms.base import resolve_proxy_url, proxy_kwargs_for_bot
+            from gateway.platforms.base import proxy_kwargs_for_bot, resolve_proxy_url
+
             proxy_url = resolve_proxy_url(platform_env_var="DISCORD_PROXY")
             if proxy_url:
                 logger.info("[%s] Using proxy for Discord: %s", self.name, proxy_url)
@@ -622,13 +695,18 @@ class DiscordAdapter(BasePlatformAdapter):
             # Register event handlers
             @self._client.event
             async def on_ready():
-                logger.info("[%s] Connected as %s", adapter_self.name, adapter_self._client.user)
+                logger.info(
+                    "[%s] Connected as %s", adapter_self.name, adapter_self._client.user
+                )
 
                 # Resolve any usernames in the allowed list to numeric IDs
                 await adapter_self._resolve_allowed_usernames()
                 adapter_self._ready_event.set()
 
-                if adapter_self._post_connect_task and not adapter_self._post_connect_task.done():
+                if (
+                    adapter_self._post_connect_task
+                    and not adapter_self._post_connect_task.done()
+                ):
                     adapter_self._post_connect_task.cancel()
                 adapter_self._post_connect_task = asyncio.create_task(
                     adapter_self._run_post_connect_initialization()
@@ -641,8 +719,10 @@ class DiscordAdapter(BasePlatformAdapter):
                 # IDs (otherwise on_message's author.id lookup can miss).
                 if not adapter_self._ready_event.is_set():
                     try:
-                        await asyncio.wait_for(adapter_self._ready_event.wait(), timeout=30.0)
-                    except asyncio.TimeoutError:
+                        await asyncio.wait_for(
+                            adapter_self._ready_event.wait(), timeout=30.0
+                        )
+                    except TimeoutError:
                         pass
 
                 # Dedup: Discord RESUME replays events after reconnects (#4777)
@@ -655,7 +735,10 @@ class DiscordAdapter(BasePlatformAdapter):
 
                 # Ignore Discord system messages (thread renames, pins, member joins, etc.)
                 # Allow both default and reply types — replies have a distinct MessageType.
-                if message.type not in (discord.MessageType.default, discord.MessageType.reply):
+                if message.type not in (
+                    discord.MessageType.default,
+                    discord.MessageType.reply,
+                ):
                     return
 
                 # Bot message filtering (DISCORD_ALLOW_BOTS):
@@ -669,16 +752,21 @@ class DiscordAdapter(BasePlatformAdapter):
                     allow_bots = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
                     if allow_bots == "none":
                         return
-                    elif allow_bots == "mentions":
-                        if not self._client.user or self._client.user not in message.mentions:
+                    if allow_bots == "mentions":
+                        if (
+                            not self._client.user
+                            or self._client.user not in message.mentions
+                        ):
                             return
                     # "all" falls through; bot is permitted — skip the
                     # human-user allowlist below (bots aren't in it).
                 else:
                     # Non-bot: enforce the configured user/role allowlists.
-                    if not self._is_allowed_user(str(message.author.id), message.author):
+                    if not self._is_allowed_user(
+                        str(message.author.id), message.author
+                    ):
                         return
-                
+
                 # Multi-agent filtering: if the message mentions specific bots
                 # but NOT this bot, the sender is talking to another agent —
                 # stay silent.  Messages with no bot mentions (general chat)
@@ -688,14 +776,16 @@ class DiscordAdapter(BasePlatformAdapter):
                 # This replaces the older DISCORD_IGNORE_NO_MENTION logic
                 # with bot-aware filtering that works correctly when multiple
                 # agents share a channel.
-                if not isinstance(message.channel, discord.DMChannel) and message.mentions:
+                if (
+                    not isinstance(message.channel, discord.DMChannel)
+                    and message.mentions
+                ):
                     _self_mentioned = (
                         self._client.user is not None
                         and self._client.user in message.mentions
                     )
                     _other_bots_mentioned = any(
-                        m.bot and m != self._client.user
-                        for m in message.mentions
+                        m.bot and m != self._client.user for m in message.mentions
                     )
                     # If other bots are mentioned but we're not → not for us
                     if _other_bots_mentioned and not _self_mentioned:
@@ -705,7 +795,11 @@ class DiscordAdapter(BasePlatformAdapter):
                     _ignore_no_mention = os.getenv(
                         "DISCORD_IGNORE_NO_MENTION", "true"
                     ).lower() in ("true", "1", "yes")
-                    if _ignore_no_mention and not _self_mentioned and not _other_bots_mentioned:
+                    if (
+                        _ignore_no_mention
+                        and not _self_mentioned
+                        and not _other_bots_mentioned
+                    ):
                         return
 
                 await self._handle_message(message)
@@ -737,8 +831,10 @@ class DiscordAdapter(BasePlatformAdapter):
                         "Voice state: %s (%d) %s (guild %d)",
                         member.display_name,
                         member.id,
-                        "joined " + after.channel.name if joined
-                        else "left " + before.channel.name if left
+                        "joined " + after.channel.name
+                        if joined
+                        else "left " + before.channel.name
+                        if left
                         else f"moved {before.channel.name} -> {after.channel.name}",
                         guild_id,
                     )
@@ -755,12 +851,18 @@ class DiscordAdapter(BasePlatformAdapter):
             self._running = True
             return True
 
-        except asyncio.TimeoutError:
-            logger.error("[%s] Timeout waiting for connection to Discord", self.name, exc_info=True)
+        except TimeoutError:
+            logger.error(
+                "[%s] Timeout waiting for connection to Discord",
+                self.name,
+                exc_info=True,
+            )
             self._release_platform_lock()
             return False
         except Exception as e:  # pragma: no cover - defensive logging
-            logger.error("[%s] Failed to connect to Discord: %s", self.name, e, exc_info=True)
+            logger.error(
+                "[%s] Failed to connect to Discord: %s", self.name, e, exc_info=True
+            )
             self._release_platform_lock()
             return False
 
@@ -771,13 +873,17 @@ class DiscordAdapter(BasePlatformAdapter):
             try:
                 await self.leave_voice_channel(guild_id)
             except Exception as e:  # pragma: no cover - defensive logging
-                logger.debug("[%s] Error leaving voice channel %s: %s", self.name, guild_id, e)
+                logger.debug(
+                    "[%s] Error leaving voice channel %s: %s", self.name, guild_id, e
+                )
 
         if self._client:
             try:
                 await self._client.close()
             except Exception as e:  # pragma: no cover - defensive logging
-                logger.warning("[%s] Error during disconnect: %s", self.name, e, exc_info=True)
+                logger.warning(
+                    "[%s] Error during disconnect: %s", self.name, e, exc_info=True
+                )
 
         if self._post_connect_task and not self._post_connect_task.done():
             self._post_connect_task.cancel()
@@ -802,12 +908,14 @@ class DiscordAdapter(BasePlatformAdapter):
         try:
             synced = await asyncio.wait_for(self._client.tree.sync(), timeout=30)
             logger.info("[%s] Synced %d slash command(s)", self.name, len(synced))
-        except asyncio.TimeoutError:
+        except TimeoutError:
             logger.warning("[%s] Slash command sync timed out after 30s", self.name)
         except asyncio.CancelledError:
             raise
         except Exception as e:  # pragma: no cover - defensive logging
-            logger.warning("[%s] Slash command sync failed: %s", self.name, e, exc_info=True)
+            logger.warning(
+                "[%s] Slash command sync failed: %s", self.name, e, exc_info=True
+            )
 
     async def _add_reaction(self, message: Any, emoji: str) -> bool:
         """Add an emoji reaction to a Discord message."""
@@ -822,7 +930,12 @@ class DiscordAdapter(BasePlatformAdapter):
 
     async def _remove_reaction(self, message: Any, emoji: str) -> bool:
         """Remove the bot's own emoji reaction from a Discord message."""
-        if not message or not hasattr(message, "remove_reaction") or not self._client or not self._client.user:
+        if (
+            not message
+            or not hasattr(message, "remove_reaction")
+            or not self._client
+            or not self._client.user
+        ):
             return False
         try:
             await message.remove_reaction(emoji, self._client.user)
@@ -833,7 +946,11 @@ class DiscordAdapter(BasePlatformAdapter):
 
     def _reactions_enabled(self) -> bool:
         """Check if message reactions are enabled via config/env."""
-        return os.getenv("DISCORD_REACTIONS", "true").lower() not in ("false", "0", "no")
+        return os.getenv("DISCORD_REACTIONS", "true").lower() not in (
+            "false",
+            "0",
+            "no",
+        )
 
     async def on_processing_start(self, event: MessageEvent) -> None:
         """Add an in-progress reaction for normal Discord message events."""
@@ -843,7 +960,9 @@ class DiscordAdapter(BasePlatformAdapter):
         if hasattr(message, "add_reaction"):
             await self._add_reaction(message, "👀")
 
-    async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
+    async def on_processing_complete(
+        self, event: MessageEvent, outcome: ProcessingOutcome
+    ) -> None:
         """Swap the in-progress reaction for a final success/failure reaction."""
         if not self._reactions_enabled():
             return
@@ -859,8 +978,8 @@ class DiscordAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         content: str,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None
+        reply_to: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> SendResult:
         """Send a message to a Discord channel or thread.
 
@@ -885,14 +1004,18 @@ class DiscordAdapter(BasePlatformAdapter):
                 if not channel:
                     channel = await self._client.fetch_channel(int(thread_id))
                 if not channel:
-                    return SendResult(success=False, error=f"Thread {thread_id} not found")
+                    return SendResult(
+                        success=False, error=f"Thread {thread_id} not found"
+                    )
             else:
                 # Get the parent channel
                 channel = self._client.get_channel(int(chat_id))
                 if not channel:
                     channel = await self._client.fetch_channel(int(chat_id))
                 if not channel:
-                    return SendResult(success=False, error=f"Channel {chat_id} not found")
+                    return SendResult(
+                        success=False, error=f"Channel {chat_id} not found"
+                    )
 
             # Forum channels reject channel.send() — create a thread post instead.
             if self._is_forum_parent(channel):
@@ -927,15 +1050,12 @@ class DiscordAdapter(BasePlatformAdapter):
                     )
                 except Exception as e:
                     err_text = str(e)
-                    if (
-                        chunk_reference is not None
-                        and (
-                            (
-                                "error code: 50035" in err_text
-                                and "Cannot reply to a system message" in err_text
-                            )
-                            or "error code: 10008" in err_text
+                    if chunk_reference is not None and (
+                        (
+                            "error code: 50035" in err_text
+                            and "Cannot reply to a system message" in err_text
                         )
+                        or "error code: 10008" in err_text
                     ):
                         logger.warning(
                             "[%s] Reply target %s rejected the reply reference; retrying send without reply reference",
@@ -954,11 +1074,13 @@ class DiscordAdapter(BasePlatformAdapter):
             return SendResult(
                 success=True,
                 message_id=message_ids[0] if message_ids else None,
-                raw_response={"message_ids": message_ids}
+                raw_response={"message_ids": message_ids},
             )
 
         except Exception as e:  # pragma: no cover - defensive logging
-            logger.error("[%s] Failed to send Discord message: %s", self.name, e, exc_info=True)
+            logger.error(
+                "[%s] Failed to send Discord message: %s", self.name, e, exc_info=True
+            )
             return SendResult(success=False, error=str(e))
 
     async def _send_to_forum(self, forum_channel: Any, content: str) -> SendResult:
@@ -985,13 +1107,22 @@ class DiscordAdapter(BasePlatformAdapter):
                 content=starter_content,
             )
         except Exception as e:
-            logger.error("[%s] Failed to create forum thread in %s: %s", self.name, forum_channel.id, e)
+            logger.error(
+                "[%s] Failed to create forum thread in %s: %s",
+                self.name,
+                forum_channel.id,
+                e,
+            )
             return SendResult(success=False, error=f"Forum thread creation failed: {e}")
 
-        thread_channel = thread if hasattr(thread, "send") else getattr(thread, "thread", None)
+        thread_channel = (
+            thread if hasattr(thread, "send") else getattr(thread, "thread", None)
+        )
         thread_id = str(getattr(thread_channel, "id", getattr(thread, "id", "")))
         starter_msg = getattr(thread, "message", None)
-        message_id = str(getattr(starter_msg, "id", thread_id)) if starter_msg else thread_id
+        message_id = (
+            str(getattr(starter_msg, "id", thread_id)) if starter_msg else thread_id
+        )
 
         # Send remaining chunks into the newly created thread.  Track any
         # per-chunk failures so the caller sees partial-send outcomes.
@@ -1002,11 +1133,16 @@ class DiscordAdapter(BasePlatformAdapter):
                 msg = await thread_channel.send(content=chunk)
                 message_ids.append(str(msg.id))
             except Exception as e:
-                warning = f"Failed to send follow-up chunk to forum thread {thread_id}: {e}"
+                warning = (
+                    f"Failed to send follow-up chunk to forum thread {thread_id}: {e}"
+                )
                 logger.warning("[%s] %s", self.name, warning)
                 warnings.append(warning)
 
-        raw_response: Dict[str, Any] = {"message_ids": message_ids, "thread_id": thread_id}
+        raw_response: dict[str, Any] = {
+            "message_ids": message_ids,
+            "thread_id": thread_id,
+        }
         if warnings:
             raw_response["warnings"] = warnings
 
@@ -1020,10 +1156,10 @@ class DiscordAdapter(BasePlatformAdapter):
         self,
         forum_channel: Any,
         *,
-        thread_name: Optional[str] = None,
+        thread_name: str | None = None,
         content: str = "",
         file: Any = None,
-        files: Optional[list] = None,
+        files: list | None = None,
     ) -> SendResult:
         """Create a forum thread whose starter message carries file attachments.
 
@@ -1043,9 +1179,11 @@ class DiscordAdapter(BasePlatformAdapter):
                     hint = getattr(file, "filename", "") or ""
                 elif files:
                     hint = getattr(files[0], "filename", "") or ""
-            thread_name = _derive_forum_thread_name(hint) if hint.strip() else "New Post"
+            thread_name = (
+                _derive_forum_thread_name(hint) if hint.strip() else "New Post"
+            )
 
-        kwargs: Dict[str, Any] = {"name": thread_name}
+        kwargs: dict[str, Any] = {"name": thread_name}
         if content:
             kwargs["content"] = content
         if file is not None:
@@ -1064,10 +1202,14 @@ class DiscordAdapter(BasePlatformAdapter):
             )
             return SendResult(success=False, error=f"Forum thread creation failed: {e}")
 
-        thread_channel = thread if hasattr(thread, "send") else getattr(thread, "thread", None)
+        thread_channel = (
+            thread if hasattr(thread, "send") else getattr(thread, "thread", None)
+        )
         thread_id = str(getattr(thread_channel, "id", getattr(thread, "id", "")))
         starter_msg = getattr(thread, "message", None)
-        message_id = str(getattr(starter_msg, "id", thread_id)) if starter_msg else thread_id
+        message_id = (
+            str(getattr(starter_msg, "id", thread_id)) if starter_msg else thread_id
+        )
 
         return SendResult(
             success=True,
@@ -1093,19 +1235,25 @@ class DiscordAdapter(BasePlatformAdapter):
             msg = await channel.fetch_message(int(message_id))
             formatted = self.format_message(content)
             if len(formatted) > self.MAX_MESSAGE_LENGTH:
-                formatted = formatted[:self.MAX_MESSAGE_LENGTH - 3] + "..."
+                formatted = formatted[: self.MAX_MESSAGE_LENGTH - 3] + "..."
             await msg.edit(content=formatted)
             return SendResult(success=True, message_id=message_id)
         except Exception as e:  # pragma: no cover - defensive logging
-            logger.error("[%s] Failed to edit Discord message %s: %s", self.name, message_id, e, exc_info=True)
+            logger.error(
+                "[%s] Failed to edit Discord message %s: %s",
+                self.name,
+                message_id,
+                e,
+                exc_info=True,
+            )
             return SendResult(success=False, error=str(e))
 
     async def _send_file_attachment(
         self,
         chat_id: str,
         file_path: str,
-        caption: Optional[str] = None,
-        file_name: Optional[str] = None,
+        caption: str | None = None,
+        file_name: str | None = None,
     ) -> SendResult:
         """Send a local file as a Discord attachment.
 
@@ -1146,7 +1294,9 @@ class DiscordAdapter(BasePlatformAdapter):
         """
         for gid, text_ch_id in self._voice_text_channels.items():
             if str(text_ch_id) == str(chat_id) and self.is_in_voice_channel(gid):
-                logger.info("[%s] Playing TTS in voice channel (guild=%d)", self.name, gid)
+                logger.info(
+                    "[%s] Playing TTS in voice channel (guild=%d)", self.name, gid
+                )
                 success = await self.play_in_voice_channel(gid, audio_path)
                 return SendResult(success=success)
         return await self.send_voice(chat_id=chat_id, audio_path=audio_path, **kwargs)
@@ -1155,9 +1305,9 @@ class DiscordAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         audio_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: dict[str, Any] | None = None,
         **kwargs,
     ) -> SendResult:
         """Send audio as a Discord file attachment."""
@@ -1171,7 +1321,9 @@ class DiscordAdapter(BasePlatformAdapter):
                 return SendResult(success=False, error=f"Channel {chat_id} not found")
 
             if not os.path.exists(audio_path):
-                return SendResult(success=False, error=f"Audio file not found: {audio_path}")
+                return SendResult(
+                    success=False, error=f"Audio file not found: {audio_path}"
+                )
 
             filename = os.path.basename(audio_path)
 
@@ -1197,6 +1349,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 duration_secs = 5.0
                 try:
                     from mutagen.oggopus import OggOpus
+
                     info = OggOpus(audio_path)
                     duration_secs = info.info.length
                 except Exception:
@@ -1206,15 +1359,20 @@ class DiscordAdapter(BasePlatformAdapter):
                 waveform_b64 = base64.b64encode(waveform_bytes).decode()
 
                 import json as _json
-                payload = _json.dumps({
-                    "flags": 8192,
-                    "attachments": [{
-                        "id": "0",
-                        "filename": "voice-message.ogg",
-                        "duration_secs": round(duration_secs, 2),
-                        "waveform": waveform_b64,
-                    }],
-                })
+
+                payload = _json.dumps(
+                    {
+                        "flags": 8192,
+                        "attachments": [
+                            {
+                                "id": "0",
+                                "filename": "voice-message.ogg",
+                                "duration_secs": round(duration_secs, 2),
+                                "waveform": waveform_b64,
+                            }
+                        ],
+                    }
+                )
                 form = [
                     {"name": "payload_json", "value": payload},
                     {
@@ -1225,18 +1383,29 @@ class DiscordAdapter(BasePlatformAdapter):
                     },
                 ]
                 msg_data = await self._client.http.request(
-                    discord.http.Route("POST", "/channels/{channel_id}/messages", channel_id=channel.id),
+                    discord.http.Route(
+                        "POST", "/channels/{channel_id}/messages", channel_id=channel.id
+                    ),
                     form=form,
                 )
                 return SendResult(success=True, message_id=str(msg_data["id"]))
             except Exception as voice_err:
-                logger.debug("Voice message flag failed, falling back to file: %s", voice_err)
+                logger.debug(
+                    "Voice message flag failed, falling back to file: %s", voice_err
+                )
                 file = discord.File(io.BytesIO(file_data), filename=filename)
                 msg = await channel.send(file=file)
                 return SendResult(success=True, message_id=str(msg.id))
         except Exception as e:  # pragma: no cover - defensive logging
-            logger.error("[%s] Failed to send audio, falling back to base adapter: %s", self.name, e, exc_info=True)
-            return await super().send_voice(chat_id, audio_path, caption, reply_to, metadata=metadata)
+            logger.error(
+                "[%s] Failed to send audio, falling back to base adapter: %s",
+                self.name,
+                e,
+                exc_info=True,
+            )
+            return await super().send_voice(
+                chat_id, audio_path, caption, reply_to, metadata=metadata
+            )
 
     # ------------------------------------------------------------------
     # Voice channel methods (join / leave / play)
@@ -1333,8 +1502,10 @@ class DiscordAdapter(BasePlatformAdapter):
             vc.play(source, after=_after)
             try:
                 await asyncio.wait_for(done.wait(), timeout=self.PLAYBACK_TIMEOUT)
-            except asyncio.TimeoutError:
-                logger.warning("Voice playback timed out after %ds", self.PLAYBACK_TIMEOUT)
+            except TimeoutError:
+                logger.warning(
+                    "Voice playback timed out after %ds", self.PLAYBACK_TIMEOUT
+                )
                 vc.stop()
             self._reset_voice_timeout(guild_id)
             return True
@@ -1390,7 +1561,7 @@ class DiscordAdapter(BasePlatformAdapter):
         vc = self._voice_clients.get(guild_id)
         return vc is not None and vc.is_connected()
 
-    def get_voice_channel_info(self, guild_id: int) -> Optional[Dict[str, Any]]:
+    def get_voice_channel_info(self, guild_id: int) -> dict[str, Any] | None:
         """Return voice channel awareness info for the given guild.
 
         Returns None if the bot is not in a voice channel.  Otherwise
@@ -1411,17 +1582,21 @@ class DiscordAdapter(BasePlatformAdapter):
         for m in channel.members:
             if bot_user and m.id == bot_user.id:
                 continue  # skip the bot itself
-            members_info.append({
-                "user_id": m.id,
-                "display_name": m.display_name,
-                "is_bot": m.bot,
-            })
+            members_info.append(
+                {
+                    "user_id": m.id,
+                    "display_name": m.display_name,
+                    "is_bot": m.bot,
+                }
+            )
 
         # Currently speaking users (from SSRC mapping + active buffers)
         speaking_user_ids: set = set()
         receiver = self._voice_receivers.get(guild_id)
         if receiver:
-            now = time.monotonic()
+            import time as _time
+
+            now = _time.monotonic()
             with receiver._lock:
                 for ssrc, last_t in receiver._last_packet_time.items():
                     # Consider "speaking" if audio received within last 2 seconds
@@ -1451,7 +1626,9 @@ class DiscordAdapter(BasePlatformAdapter):
         if not info:
             return ""
 
-        parts = [f"[Voice channel: #{info['channel_name']} — {info['member_count']} participant(s)]"]
+        parts = [
+            f"[Voice channel: #{info['channel_name']} — {info['member_count']} participant(s)]"
+        ]
         for m in info["members"]:
             status = " (speaking)" if m["is_speaking"] else ""
             parts.append(f"  - {m['display_name']}{status}")
@@ -1484,7 +1661,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     try:
                         vc = self._voice_clients.get(guild_id)
                         if vc and vc.is_connected():
-                            vc._connection.send_packet(b'\xf8\xff\xfe')
+                            vc._connection.send_packet(b"\xf8\xff\xfe")
                     except Exception:
                         pass
 
@@ -1502,13 +1679,16 @@ class DiscordAdapter(BasePlatformAdapter):
         """Convert PCM -> WAV -> STT -> callback."""
         from tools.voice_mode import is_whisper_hallucination
 
-        tmp_f = tempfile.NamedTemporaryFile(suffix=".wav", prefix="vc_listen_", delete=False)
+        tmp_f = tempfile.NamedTemporaryFile(
+            suffix=".wav", prefix="vc_listen_", delete=False
+        )
         wav_path = tmp_f.name
         tmp_f.close()
         try:
             await asyncio.to_thread(VoiceReceiver.pcm_to_wav, pcm_data, wav_path)
 
             from tools.transcription_tools import transcribe_audio
+
             result = await asyncio.to_thread(transcribe_audio, wav_path)
 
             if not result.get("success"):
@@ -1556,7 +1736,9 @@ class DiscordAdapter(BasePlatformAdapter):
         # Check role allowlist
         if has_roles:
             # Try direct role check from Member object
-            direct_roles = getattr(author, "roles", None) if author is not None else None
+            direct_roles = (
+                getattr(author, "roles", None) if author is not None else None
+            )
             if direct_roles:
                 if any(getattr(r, "id", None) in allowed_roles for r in direct_roles):
                     return True
@@ -1572,7 +1754,9 @@ class DiscordAdapter(BasePlatformAdapter):
                         if m is None:
                             continue
                         m_roles = getattr(m, "roles", None) or []
-                        if any(getattr(r, "id", None) in allowed_roles for r in m_roles):
+                        if any(
+                            getattr(r, "id", None) in allowed_roles for r in m_roles
+                        ):
                             return True
         return False
 
@@ -1580,34 +1764,47 @@ class DiscordAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         image_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> SendResult:
         """Send a local image file natively as a Discord file attachment."""
         try:
             return await self._send_file_attachment(chat_id, image_path, caption)
         except FileNotFoundError:
-            return SendResult(success=False, error=f"Image file not found: {image_path}")
+            return SendResult(
+                success=False, error=f"Image file not found: {image_path}"
+            )
         except Exception as e:  # pragma: no cover - defensive logging
-            logger.error("[%s] Failed to send local image, falling back to base adapter: %s", self.name, e, exc_info=True)
-            return await super().send_image_file(chat_id, image_path, caption, reply_to, metadata=metadata)
+            logger.error(
+                "[%s] Failed to send local image, falling back to base adapter: %s",
+                self.name,
+                e,
+                exc_info=True,
+            )
+            return await super().send_image_file(
+                chat_id, image_path, caption, reply_to, metadata=metadata
+            )
 
     async def send_image(
         self,
         chat_id: str,
         image_url: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> SendResult:
         """Send an image natively as a Discord file attachment."""
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
         if not is_safe_url(image_url):
-            logger.warning("[%s] Blocked unsafe image URL during Discord send_image", self.name)
-            return await super().send_image(chat_id, image_url, caption, reply_to, metadata=metadata)
+            logger.warning(
+                "[%s] Blocked unsafe image URL during Discord send_image", self.name
+            )
+            return await super().send_image(
+                chat_id, image_url, caption, reply_to, metadata=metadata
+            )
 
         try:
             import aiohttp
@@ -1620,11 +1817,17 @@ class DiscordAdapter(BasePlatformAdapter):
 
             # Download the image and send as a Discord file attachment
             # (Discord renders attachments inline, unlike plain URLs)
-            from gateway.platforms.base import resolve_proxy_url, proxy_kwargs_for_aiohttp
+            from gateway.platforms.base import (
+                proxy_kwargs_for_aiohttp,
+                resolve_proxy_url,
+            )
+
             _proxy = resolve_proxy_url(platform_env_var="DISCORD_PROXY")
             _sess_kw, _req_kw = proxy_kwargs_for_aiohttp(_proxy)
             async with aiohttp.ClientSession(**_sess_kw) as session:
-                async with session.get(image_url, timeout=aiohttp.ClientTimeout(total=30), **_req_kw) as resp:
+                async with session.get(
+                    image_url, timeout=aiohttp.ClientTimeout(total=30), **_req_kw
+                ) as resp:
                     if resp.status != 200:
                         raise Exception(f"Failed to download image: HTTP {resp.status}")
 
@@ -1641,6 +1844,7 @@ class DiscordAdapter(BasePlatformAdapter):
                         ext = "webp"
 
                     import io
+
                     file = discord.File(io.BytesIO(image_data), filename=f"image.{ext}")
 
                     if self._is_forum_parent(channel):
@@ -1676,17 +1880,22 @@ class DiscordAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         animation_url: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> SendResult:
         """Send an animated GIF natively as a Discord file attachment."""
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
         if not is_safe_url(animation_url):
-            logger.warning("[%s] Blocked unsafe animation URL during Discord send_animation", self.name)
-            return await super().send_animation(chat_id, animation_url, caption, reply_to, metadata=metadata)
+            logger.warning(
+                "[%s] Blocked unsafe animation URL during Discord send_animation",
+                self.name,
+            )
+            return await super().send_animation(
+                chat_id, animation_url, caption, reply_to, metadata=metadata
+            )
 
         try:
             import aiohttp
@@ -1699,18 +1908,29 @@ class DiscordAdapter(BasePlatformAdapter):
 
             # Download the GIF and send as a Discord file attachment
             # (Discord renders .gif attachments as auto-playing animations inline)
-            from gateway.platforms.base import resolve_proxy_url, proxy_kwargs_for_aiohttp
+            from gateway.platforms.base import (
+                proxy_kwargs_for_aiohttp,
+                resolve_proxy_url,
+            )
+
             _proxy = resolve_proxy_url(platform_env_var="DISCORD_PROXY")
             _sess_kw, _req_kw = proxy_kwargs_for_aiohttp(_proxy)
             async with aiohttp.ClientSession(**_sess_kw) as session:
-                async with session.get(animation_url, timeout=aiohttp.ClientTimeout(total=30), **_req_kw) as resp:
+                async with session.get(
+                    animation_url, timeout=aiohttp.ClientTimeout(total=30), **_req_kw
+                ) as resp:
                     if resp.status != 200:
-                        raise Exception(f"Failed to download animation: HTTP {resp.status}")
+                        raise Exception(
+                            f"Failed to download animation: HTTP {resp.status}"
+                        )
 
                     animation_data = await resp.read()
 
                     import io
-                    file = discord.File(io.BytesIO(animation_data), filename="animation.gif")
+
+                    file = discord.File(
+                        io.BytesIO(animation_data), filename="animation.gif"
+                    )
 
                     if self._is_forum_parent(channel):
                         return await self._forum_post_file(
@@ -1731,7 +1951,9 @@ class DiscordAdapter(BasePlatformAdapter):
                 self.name,
                 exc_info=True,
             )
-            return await super().send_animation(chat_id, animation_url, caption, reply_to, metadata=metadata)
+            return await super().send_animation(
+                chat_id, animation_url, caption, reply_to, metadata=metadata
+            )
         except Exception as e:  # pragma: no cover - defensive logging
             logger.error(
                 "[%s] Failed to send animation attachment, falling back to URL: %s",
@@ -1739,42 +1961,62 @@ class DiscordAdapter(BasePlatformAdapter):
                 e,
                 exc_info=True,
             )
-            return await super().send_animation(chat_id, animation_url, caption, reply_to, metadata=metadata)
+            return await super().send_animation(
+                chat_id, animation_url, caption, reply_to, metadata=metadata
+            )
 
     async def send_video(
         self,
         chat_id: str,
         video_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        reply_to: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> SendResult:
         """Send a local video file natively as a Discord attachment."""
         try:
             return await self._send_file_attachment(chat_id, video_path, caption)
         except FileNotFoundError:
-            return SendResult(success=False, error=f"Video file not found: {video_path}")
+            return SendResult(
+                success=False, error=f"Video file not found: {video_path}"
+            )
         except Exception as e:  # pragma: no cover - defensive logging
-            logger.error("[%s] Failed to send local video, falling back to base adapter: %s", self.name, e, exc_info=True)
-            return await super().send_video(chat_id, video_path, caption, reply_to, metadata=metadata)
+            logger.error(
+                "[%s] Failed to send local video, falling back to base adapter: %s",
+                self.name,
+                e,
+                exc_info=True,
+            )
+            return await super().send_video(
+                chat_id, video_path, caption, reply_to, metadata=metadata
+            )
 
     async def send_document(
         self,
         chat_id: str,
         file_path: str,
-        caption: Optional[str] = None,
-        file_name: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
+        caption: str | None = None,
+        file_name: str | None = None,
+        reply_to: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> SendResult:
         """Send an arbitrary file natively as a Discord attachment."""
         try:
-            return await self._send_file_attachment(chat_id, file_path, caption, file_name=file_name)
+            return await self._send_file_attachment(
+                chat_id, file_path, caption, file_name=file_name
+            )
         except FileNotFoundError:
             return SendResult(success=False, error=f"File not found: {file_path}")
         except Exception as e:  # pragma: no cover - defensive logging
-            logger.error("[%s] Failed to send document, falling back to base adapter: %s", self.name, e, exc_info=True)
-            return await super().send_document(chat_id, file_path, caption, file_name, reply_to, metadata=metadata)
+            logger.error(
+                "[%s] Failed to send document, falling back to base adapter: %s",
+                self.name,
+                e,
+                exc_info=True,
+            )
+            return await super().send_document(
+                chat_id, file_path, caption, file_name, reply_to, metadata=metadata
+            )
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """Start a persistent typing indicator for a channel.
@@ -1795,14 +2037,17 @@ class DiscordAdapter(BasePlatformAdapter):
                 while True:
                     try:
                         route = discord.http.Route(
-                            "POST", "/channels/{channel_id}/typing",
+                            "POST",
+                            "/channels/{channel_id}/typing",
                             channel_id=chat_id,
                         )
                         await self._client.http.request(route)
                     except asyncio.CancelledError:
                         return
                     except Exception as e:
-                        logger.debug("Discord typing indicator failed for %s: %s", chat_id, e)
+                        logger.debug(
+                            "Discord typing indicator failed for %s: %s", chat_id, e
+                        )
                         return
                     await asyncio.sleep(8)
             except asyncio.CancelledError:
@@ -1820,7 +2065,7 @@ class DiscordAdapter(BasePlatformAdapter):
             except (asyncio.CancelledError, Exception):
                 pass
 
-    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+    async def get_chat_info(self, chat_id: str) -> dict[str, Any]:
         """Get information about a Discord channel."""
         if not self._client:
             return {"name": "Unknown", "type": "dm"}
@@ -1852,11 +2097,21 @@ class DiscordAdapter(BasePlatformAdapter):
             return {
                 "name": name,
                 "type": chat_type,
-                "guild_id": str(channel.guild.id) if hasattr(channel, "guild") and channel.guild else None,
-                "guild_name": channel.guild.name if hasattr(channel, "guild") and channel.guild else None,
+                "guild_id": str(channel.guild.id)
+                if hasattr(channel, "guild") and channel.guild
+                else None,
+                "guild_name": channel.guild.name
+                if hasattr(channel, "guild") and channel.guild
+                else None,
             }
         except Exception as e:  # pragma: no cover - defensive logging
-            logger.error("[%s] Failed to get chat info for %s: %s", self.name, chat_id, e, exc_info=True)
+            logger.error(
+                "[%s] Failed to get chat info for %s: %s",
+                self.name,
+                chat_id,
+                e,
+                exc_info=True,
+            )
             return {"name": str(chat_id), "type": "dm", "error": str(e)}
 
     async def _resolve_allowed_usernames(self) -> None:
@@ -1882,7 +2137,9 @@ class DiscordAdapter(BasePlatformAdapter):
         if not to_resolve:
             return
 
-        print(f"[{self.name}] Resolving {len(to_resolve)} username(s): {', '.join(to_resolve)}")
+        print(
+            f"[{self.name}] Resolving {len(to_resolve)} username(s): {', '.join(to_resolve)}"
+        )
         resolved_count = 0
 
         for guild in self._client.guilds:
@@ -1892,7 +2149,9 @@ class DiscordAdapter(BasePlatformAdapter):
                 if len(members) < guild.member_count:
                     members = [m async for m in guild.fetch_members(limit=None)]
             except Exception as e:
-                logger.warning("Failed to fetch members for guild %s: %s", guild.name, e)
+                logger.warning(
+                    "Failed to fetch members for guild %s: %s", guild.name, e
+                )
                 continue
 
             for member in members:
@@ -1900,16 +2159,28 @@ class DiscordAdapter(BasePlatformAdapter):
                 display_lower = member.display_name.lower()
                 global_lower = (member.global_name or "").lower()
 
-                matched = name_lower in to_resolve or display_lower in to_resolve or global_lower in to_resolve
+                matched = (
+                    name_lower in to_resolve
+                    or display_lower in to_resolve
+                    or global_lower in to_resolve
+                )
                 if matched:
                     uid = str(member.id)
                     numeric_ids.add(uid)
                     resolved_count += 1
-                    matched_name = name_lower if name_lower in to_resolve else (
-                        display_lower if display_lower in to_resolve else global_lower
+                    matched_name = (
+                        name_lower
+                        if name_lower in to_resolve
+                        else (
+                            display_lower
+                            if display_lower in to_resolve
+                            else global_lower
+                        )
                     )
                     to_resolve.discard(matched_name)
-                    print(f"[{self.name}] Resolved '{matched_name}' -> {uid} ({member.name}#{member.discriminator})")
+                    print(
+                        f"[{self.name}] Resolved '{matched_name}' -> {uid} ({member.name}#{member.discriminator})"
+                    )
 
             if not to_resolve:
                 break
@@ -1921,7 +2192,9 @@ class DiscordAdapter(BasePlatformAdapter):
         self._allowed_user_ids = numeric_ids
         os.environ["DISCORD_ALLOWED_USERS"] = ",".join(sorted(numeric_ids))
         if resolved_count:
-            print(f"[{self.name}] Updated DISCORD_ALLOWED_USERS with {resolved_count} resolved ID(s)")
+            print(
+                f"[{self.name}] Updated DISCORD_ALLOWED_USERS with {resolved_count} resolved ID(s)"
+            )
 
     def format_message(self, content: str) -> str:
         """
@@ -1951,7 +2224,9 @@ class DiscordAdapter(BasePlatformAdapter):
         # in the same channel are easy to miss in post-mortems.
         try:
             _user = interaction.user
-            _chan_id = getattr(interaction.channel, "id", None) or getattr(interaction, "channel_id", None)
+            _chan_id = getattr(interaction.channel, "id", None) or getattr(
+                interaction, "channel_id", None
+            )
             logger.info(
                 "[Discord] slash '%s' invoked by user=%s id=%s channel=%s guild=%s",
                 command_text,
@@ -1983,24 +2258,32 @@ class DiscordAdapter(BasePlatformAdapter):
 
         @tree.command(name="new", description="Start a new conversation")
         async def slash_new(interaction: discord.Interaction):
-            await self._run_simple_slash(interaction, "/reset", "New conversation started~")
+            await self._run_simple_slash(
+                interaction, "/reset", "New conversation started~"
+            )
 
         @tree.command(name="reset", description="Reset your Hermes session")
         async def slash_reset(interaction: discord.Interaction):
             await self._run_simple_slash(interaction, "/reset", "Session reset~")
 
         @tree.command(name="model", description="Show or change the model")
-        @discord.app_commands.describe(name="Model name (e.g. anthropic/claude-sonnet-4). Leave empty to see current.")
+        @discord.app_commands.describe(
+            name="Model name (e.g. anthropic/claude-sonnet-4). Leave empty to see current."
+        )
         async def slash_model(interaction: discord.Interaction, name: str = ""):
             await self._run_simple_slash(interaction, f"/model {name}".strip())
 
         @tree.command(name="reasoning", description="Show or change reasoning effort")
-        @discord.app_commands.describe(effort="Reasoning effort: none, minimal, low, medium, high, or xhigh.")
+        @discord.app_commands.describe(
+            effort="Reasoning effort: none, minimal, low, medium, high, or xhigh."
+        )
         async def slash_reasoning(interaction: discord.Interaction, effort: str = ""):
             await self._run_simple_slash(interaction, f"/reasoning {effort}".strip())
 
         @tree.command(name="personality", description="Set a personality")
-        @discord.app_commands.describe(name="Personality name. Leave empty to list available.")
+        @discord.app_commands.describe(
+            name="Personality name. Leave empty to list available."
+        )
         async def slash_personality(interaction: discord.Interaction, name: str = ""):
             await self._run_simple_slash(interaction, f"/personality {name}".strip())
 
@@ -2024,8 +2307,13 @@ class DiscordAdapter(BasePlatformAdapter):
         async def slash_stop(interaction: discord.Interaction):
             await self._run_simple_slash(interaction, "/stop", "Stop requested~")
 
-        @tree.command(name="steer", description="Inject a message after the next tool call (no interrupt)")
-        @discord.app_commands.describe(prompt="Text to inject into the agent's next tool result")
+        @tree.command(
+            name="steer",
+            description="Inject a message after the next tool call (no interrupt)",
+        )
+        @discord.app_commands.describe(
+            prompt="Text to inject into the agent's next tool result"
+        )
         async def slash_steer(interaction: discord.Interaction, prompt: str):
             await self._run_simple_slash(interaction, f"/steer {prompt}".strip())
 
@@ -2034,12 +2322,16 @@ class DiscordAdapter(BasePlatformAdapter):
             await self._run_simple_slash(interaction, "/compress")
 
         @tree.command(name="title", description="Set or show the session title")
-        @discord.app_commands.describe(name="Session title. Leave empty to show current.")
+        @discord.app_commands.describe(
+            name="Session title. Leave empty to show current."
+        )
         async def slash_title(interaction: discord.Interaction, name: str = ""):
             await self._run_simple_slash(interaction, f"/title {name}".strip())
 
         @tree.command(name="resume", description="Resume a previously-named session")
-        @discord.app_commands.describe(name="Session name to resume. Leave empty to list sessions.")
+        @discord.app_commands.describe(
+            name="Session name to resume. Leave empty to list sessions."
+        )
         async def slash_resume(interaction: discord.Interaction, name: str = ""):
             await self._run_simple_slash(interaction, f"/resume {name}".strip())
 
@@ -2065,37 +2357,62 @@ class DiscordAdapter(BasePlatformAdapter):
             await self._run_simple_slash(interaction, "/reload-mcp")
 
         @tree.command(name="voice", description="Toggle voice reply mode")
-        @discord.app_commands.describe(mode="Voice mode: on, off, tts, channel, leave, or status")
-        @discord.app_commands.choices(mode=[
-            discord.app_commands.Choice(name="channel — join your voice channel", value="channel"),
-            discord.app_commands.Choice(name="leave — leave voice channel", value="leave"),
-            discord.app_commands.Choice(name="on — voice reply to voice messages", value="on"),
-            discord.app_commands.Choice(name="tts — voice reply to all messages", value="tts"),
-            discord.app_commands.Choice(name="off — text only", value="off"),
-            discord.app_commands.Choice(name="status — show current mode", value="status"),
-        ])
+        @discord.app_commands.describe(
+            mode="Voice mode: on, off, tts, channel, leave, or status"
+        )
+        @discord.app_commands.choices(
+            mode=[
+                discord.app_commands.Choice(
+                    name="channel — join your voice channel", value="channel"
+                ),
+                discord.app_commands.Choice(
+                    name="leave — leave voice channel", value="leave"
+                ),
+                discord.app_commands.Choice(
+                    name="on — voice reply to voice messages", value="on"
+                ),
+                discord.app_commands.Choice(
+                    name="tts — voice reply to all messages", value="tts"
+                ),
+                discord.app_commands.Choice(name="off — text only", value="off"),
+                discord.app_commands.Choice(
+                    name="status — show current mode", value="status"
+                ),
+            ]
+        )
         async def slash_voice(interaction: discord.Interaction, mode: str = ""):
             await self._run_simple_slash(interaction, f"/voice {mode}".strip())
 
-        @tree.command(name="update", description="Update Hermes Agent to the latest version")
+        @tree.command(
+            name="update", description="Update Hermes Agent to the latest version"
+        )
         async def slash_update(interaction: discord.Interaction):
             await self._run_simple_slash(interaction, "/update", "Update initiated~")
 
-        @tree.command(name="restart", description="Gracefully restart the Hermes gateway")
+        @tree.command(
+            name="restart", description="Gracefully restart the Hermes gateway"
+        )
         async def slash_restart(interaction: discord.Interaction):
             await self._run_simple_slash(interaction, "/restart", "Restart requested~")
 
         @tree.command(name="approve", description="Approve a pending dangerous command")
-        @discord.app_commands.describe(scope="Optional: 'all', 'session', 'always', 'all session', 'all always'")
+        @discord.app_commands.describe(
+            scope="Optional: 'all', 'session', 'always', 'all session', 'all always'"
+        )
         async def slash_approve(interaction: discord.Interaction, scope: str = ""):
             await self._run_simple_slash(interaction, f"/approve {scope}".strip())
 
         @tree.command(name="deny", description="Deny a pending dangerous command")
-        @discord.app_commands.describe(scope="Optional: 'all' to deny all pending commands")
+        @discord.app_commands.describe(
+            scope="Optional: 'all' to deny all pending commands"
+        )
         async def slash_deny(interaction: discord.Interaction, scope: str = ""):
             await self._run_simple_slash(interaction, f"/deny {scope}".strip())
 
-        @tree.command(name="thread", description="Create a new thread and start a Hermes session in it")
+        @tree.command(
+            name="thread",
+            description="Create a new thread and start a Hermes session in it",
+        )
         @discord.app_commands.describe(
             name="Thread name",
             message="Optional first message to send to Hermes in the thread",
@@ -2108,20 +2425,33 @@ class DiscordAdapter(BasePlatformAdapter):
             auto_archive_duration: int = 1440,
         ):
             await interaction.response.defer(ephemeral=True)
-            await self._handle_thread_create_slash(interaction, name, message, auto_archive_duration)
+            await self._handle_thread_create_slash(
+                interaction, name, message, auto_archive_duration
+            )
 
-        @tree.command(name="queue", description="Queue a prompt for the next turn (doesn't interrupt)")
+        @tree.command(
+            name="queue",
+            description="Queue a prompt for the next turn (doesn't interrupt)",
+        )
         @discord.app_commands.describe(prompt="The prompt to queue")
         async def slash_queue(interaction: discord.Interaction, prompt: str):
-            await self._run_simple_slash(interaction, f"/queue {prompt}", "Queued for the next turn.")
+            await self._run_simple_slash(
+                interaction, f"/queue {prompt}", "Queued for the next turn."
+            )
 
         @tree.command(name="background", description="Run a prompt in the background")
         @discord.app_commands.describe(prompt="The prompt to run in the background")
         async def slash_background(interaction: discord.Interaction, prompt: str):
-            await self._run_simple_slash(interaction, f"/background {prompt}", "Background task started~")
+            await self._run_simple_slash(
+                interaction, f"/background {prompt}", "Background task started~"
+            )
 
-        @tree.command(name="btw", description="Ephemeral side question using session context")
-        @discord.app_commands.describe(question="Your side question (no tools, not persisted)")
+        @tree.command(
+            name="btw", description="Ephemeral side question using session context"
+        )
+        @discord.app_commands.describe(
+            question="Your side question (no tools, not persisted)"
+        )
         async def slash_btw(interaction: discord.Interaction, question: str):
             await self._run_simple_slash(interaction, f"/btw {question}")
 
@@ -2130,7 +2460,11 @@ class DiscordAdapter(BasePlatformAdapter):
         # hermes_cli/commands.py automatically appear as Discord slash
         # commands without needing a manual entry here.
         try:
-            from hermes_cli.commands import COMMAND_REGISTRY, _is_gateway_available, _resolve_config_gates
+            from hermes_cli.commands import (
+                COMMAND_REGISTRY,
+                _is_gateway_available,
+                _resolve_config_gates,
+            )
 
             already_registered = set()
             try:
@@ -2157,10 +2491,13 @@ class DiscordAdapter(BasePlatformAdapter):
                     # an optional ``args`` string parameter.
                     def _make_args_handler(_name: str, _hint: str):
                         @discord.app_commands.describe(args=f"Arguments: {_hint}"[:100])
-                        async def _handler(interaction: discord.Interaction, args: str = ""):
+                        async def _handler(
+                            interaction: discord.Interaction, args: str = ""
+                        ):
                             await self._run_simple_slash(
                                 interaction, f"/{_name} {args}".strip()
                             )
+
                         _handler.__name__ = f"auto_slash_{_name.replace('-', '_')}"
                         return _handler
 
@@ -2170,6 +2507,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     def _make_simple_handler(_name: str):
                         async def _handler(interaction: discord.Interaction):
                             await self._run_simple_slash(interaction, f"/{_name}")
+
                         _handler.__name__ = f"auto_slash_{_name.replace('-', '_')}"
                         return _handler
 
@@ -2253,7 +2591,8 @@ class DiscordAdapter(BasePlatformAdapter):
             }
 
             async def _autocomplete_name(
-                interaction: "discord.Interaction", current: str,
+                interaction: discord.Interaction,
+                current: str,
             ) -> list:
                 """Filter skills by the user's typed prefix.
 
@@ -2286,7 +2625,9 @@ class DiscordAdapter(BasePlatformAdapter):
             )
             @discord.app_commands.autocomplete(name=_autocomplete_name)
             async def _skill_handler(
-                interaction: "discord.Interaction", name: str, args: str = "",
+                interaction: discord.Interaction,
+                name: str,
+                args: str = "",
             ):
                 entry = skill_lookup.get(name)
                 if not entry:
@@ -2297,9 +2638,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     )
                     return
                 _desc, cmd_key = entry
-                await self._run_simple_slash(
-                    interaction, f"{cmd_key} {args}".strip()
-                )
+                await self._run_simple_slash(interaction, f"{cmd_key} {args}".strip())
 
             cmd = discord.app_commands.Command(
                 name="skill",
@@ -2310,17 +2649,21 @@ class DiscordAdapter(BasePlatformAdapter):
 
             logger.info(
                 "[%s] Registered /skill command with %d skill(s) via autocomplete",
-                self.name, len(entries),
+                self.name,
+                len(entries),
             )
             if hidden:
                 logger.info(
                     "[%s] %d skill(s) filtered out of /skill (name clamp / reserved)",
-                    self.name, hidden,
+                    self.name,
+                    hidden,
                 )
         except Exception as exc:
             logger.warning("[%s] Failed to register /skill command: %s", self.name, exc)
 
-    def _build_slash_event(self, interaction: discord.Interaction, text: str) -> MessageEvent:
+    def _build_slash_event(
+        self, interaction: discord.Interaction, text: str
+    ) -> MessageEvent:
         """Build a MessageEvent from a Discord slash command interaction."""
         is_dm = isinstance(interaction.channel, discord.DMChannel)
         is_thread = isinstance(interaction.channel, discord.Thread)
@@ -2356,7 +2699,9 @@ class DiscordAdapter(BasePlatformAdapter):
 
         msg_type = MessageType.COMMAND if text.startswith("/") else MessageType.TEXT
         channel_id = str(interaction.channel_id)
-        parent_id = str(getattr(getattr(interaction, "channel", None), "parent_id", "") or "")
+        parent_id = str(
+            getattr(getattr(interaction, "channel", None), "parent_id", "") or ""
+        )
         return MessageEvent(
             text=text,
             message_type=msg_type,
@@ -2386,7 +2731,9 @@ class DiscordAdapter(BasePlatformAdapter):
 
         if not result.get("success"):
             error = result.get("error", "unknown error")
-            await interaction.followup.send(f"Failed to create thread: {error}", ephemeral=True)
+            await interaction.followup.send(
+                f"Failed to create thread: {error}", ephemeral=True
+            )
             return
 
         thread_id = result.get("thread_id")
@@ -2403,7 +2750,9 @@ class DiscordAdapter(BasePlatformAdapter):
         # If a message was provided, kick off a new Hermes session in the thread
         starter = (message or "").strip()
         if starter and thread_id:
-            await self._dispatch_thread_session(interaction, thread_id, thread_name, starter)
+            await self._dispatch_thread_session(
+                interaction, thread_id, thread_name, starter
+            )
 
     async def _dispatch_thread_session(
         self,
@@ -2433,7 +2782,9 @@ class DiscordAdapter(BasePlatformAdapter):
             chat_topic=chat_topic,
         )
 
-        _parent_channel = self._thread_parent_channel(getattr(interaction, "channel", None))
+        _parent_channel = self._thread_parent_channel(
+            getattr(interaction, "channel", None)
+        )
         _parent_id = str(getattr(_parent_channel, "id", "") or "")
         _skills = self._resolve_channel_skills(thread_id, _parent_id or None)
         _channel_prompt = self._resolve_channel_prompt(thread_id, _parent_id or None)
@@ -2447,7 +2798,9 @@ class DiscordAdapter(BasePlatformAdapter):
         )
         await self.handle_message(event)
 
-    def _resolve_channel_skills(self, channel_id: str, parent_id: str | None = None) -> list[str] | None:
+    def _resolve_channel_skills(
+        self, channel_id: str, parent_id: str | None = None
+    ) -> list[str] | None:
         """Look up auto-skill bindings for a Discord channel/forum thread.
 
         Config format (in platform extra):
@@ -2472,9 +2825,12 @@ class DiscordAdapter(BasePlatformAdapter):
                     return list(dict.fromkeys(skills))  # dedup, preserve order
         return None
 
-    def _resolve_channel_prompt(self, channel_id: str, parent_id: str | None = None) -> str | None:
+    def _resolve_channel_prompt(
+        self, channel_id: str, parent_id: str | None = None
+    ) -> str | None:
         """Resolve a Discord per-channel prompt, preferring the exact channel over its parent."""
         from gateway.platforms.base import resolve_channel_prompt
+
         return resolve_channel_prompt(self.config.extra, channel_id, parent_id)
 
     def _discord_require_mention(self) -> bool:
@@ -2484,7 +2840,12 @@ class DiscordAdapter(BasePlatformAdapter):
             if isinstance(configured, str):
                 return configured.lower() not in ("false", "0", "no", "off")
             return bool(configured)
-        return os.getenv("DISCORD_REQUIRE_MENTION", "true").lower() not in ("false", "0", "no", "off")
+        return os.getenv("DISCORD_REQUIRE_MENTION", "true").lower() not in (
+            "false",
+            "0",
+            "no",
+            "off",
+        )
 
     def _discord_free_response_channels(self) -> set:
         """Return Discord channel IDs where no bot mention is required."""
@@ -2501,7 +2862,9 @@ class DiscordAdapter(BasePlatformAdapter):
         """Return the parent text channel when invoked from a thread."""
         return getattr(channel, "parent", None) or channel
 
-    async def _resolve_interaction_channel(self, interaction: discord.Interaction) -> Optional[Any]:
+    async def _resolve_interaction_channel(
+        self, interaction: discord.Interaction
+    ) -> Any | None:
         """Return the interaction channel, fetching it if the payload is partial."""
         channel = getattr(interaction, "channel", None)
         if channel is not None:
@@ -2526,7 +2889,7 @@ class DiscordAdapter(BasePlatformAdapter):
         name: str,
         message: str = "",
         auto_archive_duration: int = 1440,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """Create a thread in the current Discord channel.
 
         Tries ``parent_channel.create_thread()`` first.  If Discord rejects
@@ -2538,20 +2901,29 @@ class DiscordAdapter(BasePlatformAdapter):
             return {"error": "Thread name is required."}
 
         if auto_archive_duration not in VALID_THREAD_AUTO_ARCHIVE_MINUTES:
-            allowed = ", ".join(str(v) for v in sorted(VALID_THREAD_AUTO_ARCHIVE_MINUTES))
+            allowed = ", ".join(
+                str(v) for v in sorted(VALID_THREAD_AUTO_ARCHIVE_MINUTES)
+            )
             return {"error": f"auto_archive_duration must be one of: {allowed}."}
 
         channel = await self._resolve_interaction_channel(interaction)
         if channel is None:
             return {"error": "Could not resolve the current Discord channel."}
         if isinstance(channel, discord.DMChannel):
-            return {"error": "Discord threads can only be created inside server text channels, not DMs."}
+            return {
+                "error": "Discord threads can only be created inside server text channels, not DMs."
+            }
 
         parent_channel = self._thread_parent_channel(channel)
         if parent_channel is None:
-            return {"error": "Could not determine a parent text channel for the new thread."}
+            return {
+                "error": "Could not determine a parent text channel for the new thread."
+            }
 
-        display_name = getattr(getattr(interaction, "user", None), "display_name", None) or "unknown user"
+        display_name = (
+            getattr(getattr(interaction, "user", None), "display_name", None)
+            or "unknown user"
+        )
         reason = f"Requested by {display_name} via /thread"
         starter_message = (message or "").strip()
 
@@ -2570,7 +2942,10 @@ class DiscordAdapter(BasePlatformAdapter):
             }
         except Exception as direct_error:
             try:
-                seed_content = starter_message or f"\U0001f9f5 Thread created by Hermes: **{name}**"
+                seed_content = (
+                    starter_message
+                    or f"\U0001f9f5 Thread created by Hermes: **{name}**"
+                )
                 seed_msg = await parent_channel.send(seed_content)
                 thread = await seed_msg.create_thread(
                     name=name,
@@ -2594,7 +2969,7 @@ class DiscordAdapter(BasePlatformAdapter):
     # Auto-thread helpers
     # ------------------------------------------------------------------
 
-    async def _auto_create_thread(self, message: 'DiscordMessage') -> Optional[Any]:
+    async def _auto_create_thread(self, message: DiscordMessage) -> Any | None:
         """Create a thread from a user message for auto-threading.
 
         Returns the created thread object, or ``None`` on failure.
@@ -2613,13 +2988,20 @@ class DiscordAdapter(BasePlatformAdapter):
             thread_name = thread_name[:77] + "..."
 
         try:
-            thread = await message.create_thread(name=thread_name, auto_archive_duration=1440)
+            thread = await message.create_thread(
+                name=thread_name, auto_archive_duration=1440
+            )
             return thread
         except Exception as direct_error:
-            display_name = getattr(getattr(message, "author", None), "display_name", None) or "unknown user"
+            display_name = (
+                getattr(getattr(message, "author", None), "display_name", None)
+                or "unknown user"
+            )
             reason = f"Auto-threaded from mention by {display_name}"
             try:
-                seed_msg = await message.channel.send(f"\U0001f9f5 Thread created by Hermes: **{thread_name}**")
+                seed_msg = await message.channel.send(
+                    f"\U0001f9f5 Thread created by Hermes: **{thread_name}**"
+                )
                 thread = await seed_msg.create_thread(
                     name=thread_name,
                     auto_archive_duration=1440,
@@ -2636,9 +3018,12 @@ class DiscordAdapter(BasePlatformAdapter):
                 return None
 
     async def send_exec_approval(
-        self, chat_id: str, command: str, session_key: str,
+        self,
+        chat_id: str,
+        command: str,
+        session_key: str,
         description: str = "dangerous command",
-        metadata: Optional[dict] = None,
+        metadata: dict | None = None,
     ) -> SendResult:
         """
         Send a button-based exec approval prompt for a dangerous command.
@@ -2661,7 +3046,9 @@ class DiscordAdapter(BasePlatformAdapter):
 
             # Discord embed description limit is 4096; show full command up to that
             max_desc = 4088
-            cmd_display = command if len(command) <= max_desc else command[: max_desc - 3] + "..."
+            cmd_display = (
+                command if len(command) <= max_desc else command[: max_desc - 3] + "..."
+            )
             embed = discord.Embed(
                 title="⚠️ Command Approval Required",
                 description=f"```\n{cmd_display}\n```",
@@ -2681,7 +3068,10 @@ class DiscordAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=str(e))
 
     async def send_update_prompt(
-        self, chat_id: str, prompt: str, default: str = "",
+        self,
+        chat_id: str,
+        prompt: str,
+        default: str = "",
         session_key: str = "",
     ) -> SendResult:
         """Send an interactive button-based update prompt (Yes / No).
@@ -2719,7 +3109,7 @@ class DiscordAdapter(BasePlatformAdapter):
         current_provider: str,
         session_key: str,
         on_model_selected,
-        metadata: Optional[Dict[str, Any]] = None,
+        metadata: dict[str, Any] | None = None,
     ) -> SendResult:
         """Send an interactive select-menu model picker.
 
@@ -2741,6 +3131,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
             try:
                 from hermes_cli.providers import get_label
+
                 provider_label = get_label(current_provider)
             except Exception:
                 provider_label = current_provider
@@ -2771,7 +3162,7 @@ class DiscordAdapter(BasePlatformAdapter):
             logger.warning("[%s] send_model_picker failed: %s", self.name, e)
             return SendResult(success=False, error=str(e))
 
-    def _get_parent_channel_id(self, channel: Any) -> Optional[str]:
+    def _get_parent_channel_id(self, channel: Any) -> str | None:
         """Return the parent channel ID for a Discord thread-like channel, if present."""
         parent = getattr(channel, "parent", None)
         if parent is not None and getattr(parent, "id", None) is not None:
@@ -2795,7 +3186,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 return True
         return False
 
-    def _get_effective_topic(self, channel: Any, is_thread: bool = False) -> Optional[str]:
+    def _get_effective_topic(self, channel: Any, is_thread: bool = False) -> str | None:
         """Return the channel topic, falling back to the parent forum's topic for forum threads."""
         topic = getattr(channel, "topic", None)
         if not topic and is_thread:
@@ -2806,7 +3197,9 @@ class DiscordAdapter(BasePlatformAdapter):
 
     def _format_thread_chat_name(self, thread: Any) -> str:
         """Build a readable chat name for thread-like Discord channels, including forum context when available."""
-        thread_name = getattr(thread, "name", None) or str(getattr(thread, "id", "thread"))
+        thread_name = getattr(thread, "name", None) or str(
+            getattr(thread, "id", "thread")
+        )
         parent = getattr(thread, "parent", None)
         guild = getattr(thread, "guild", None) or getattr(parent, "guild", None)
         guild_name = getattr(guild, "name", None)
@@ -2845,7 +3238,7 @@ class DiscordAdapter(BasePlatformAdapter):
     # non-CDN URL into the ``att.url`` field. (issue #11345)
     # ------------------------------------------------------------------
 
-    async def _read_attachment_bytes(self, att) -> Optional[bytes]:
+    async def _read_attachment_bytes(self, att) -> bytes | None:
         """Read an attachment via discord.py's authenticated bot session.
 
         Returns the raw bytes on success, or ``None`` if ``att`` doesn't
@@ -2925,18 +3318,22 @@ class DiscordAdapter(BasePlatformAdapter):
                 f"Blocked unsafe attachment URL (SSRF protection): {att.url}"
             )
         import aiohttp
-        from gateway.platforms.base import resolve_proxy_url, proxy_kwargs_for_aiohttp
+
+        from gateway.platforms.base import proxy_kwargs_for_aiohttp, resolve_proxy_url
+
         _proxy = resolve_proxy_url(platform_env_var="DISCORD_PROXY")
         _sess_kw, _req_kw = proxy_kwargs_for_aiohttp(_proxy)
-        async with aiohttp.ClientSession(**_sess_kw) as session:
-            async with session.get(
+        async with (
+            aiohttp.ClientSession(**_sess_kw) as session,
+            session.get(
                 att.url,
                 timeout=aiohttp.ClientTimeout(total=30),
                 **_req_kw,
-            ) as resp:
-                if resp.status != 200:
-                    raise Exception(f"HTTP {resp.status}")
-                return await resp.read()
+            ) as resp,
+        ):
+            if resp.status != 200:
+                raise Exception(f"HTTP {resp.status}")
+            return await resp.read()
 
     async def _handle_message(self, message: DiscordMessage) -> None:
         """Handle incoming Discord messages."""
@@ -2979,16 +3376,28 @@ class DiscordAdapter(BasePlatformAdapter):
             # Check allowed channels - if set, only respond in these channels
             allowed_channels_raw = os.getenv("DISCORD_ALLOWED_CHANNELS", "")
             if allowed_channels_raw:
-                allowed_channels = {ch.strip() for ch in allowed_channels_raw.split(",") if ch.strip()}
+                allowed_channels = {
+                    ch.strip() for ch in allowed_channels_raw.split(",") if ch.strip()
+                }
                 if not (channel_ids & allowed_channels):
-                    logger.debug("[%s] Ignoring message in non-allowed channel: %s", self.name, channel_ids)
+                    logger.debug(
+                        "[%s] Ignoring message in non-allowed channel: %s",
+                        self.name,
+                        channel_ids,
+                    )
                     return
 
             # Check ignored channels - never respond even when mentioned
             ignored_channels_raw = os.getenv("DISCORD_IGNORED_CHANNELS", "")
-            ignored_channels = {ch.strip() for ch in ignored_channels_raw.split(",") if ch.strip()}
+            ignored_channels = {
+                ch.strip() for ch in ignored_channels_raw.split(",") if ch.strip()
+            }
             if channel_ids & ignored_channels:
-                logger.debug("[%s] Ignoring message in ignored channel: %s", self.name, channel_ids)
+                logger.debug(
+                    "[%s] Ignoring message in ignored channel: %s",
+                    self.name,
+                    channel_ids,
+                )
                 return
 
             free_channels = self._discord_free_response_channels()
@@ -2998,10 +3407,14 @@ class DiscordAdapter(BasePlatformAdapter):
             require_mention = self._discord_require_mention()
             # Voice-linked text channels act as free-response while voice is active.
             # Only the exact bound channel gets the exemption, not sibling threads.
-            voice_linked_ids = {str(ch_id) for ch_id in self._voice_text_channels.values()}
+            voice_linked_ids = {
+                str(ch_id) for ch_id in self._voice_text_channels.values()
+            }
             current_channel_id = str(message.channel.id)
             is_voice_linked_channel = current_channel_id in voice_linked_ids
-            is_free_channel = bool(channel_ids & free_channels) or is_voice_linked_channel
+            is_free_channel = (
+                bool(channel_ids & free_channels) or is_voice_linked_channel
+            )
 
             # Skip the mention check if the message is in a thread where
             # the bot has previously participated (auto-created or replied in).
@@ -3010,6 +3423,15 @@ class DiscordAdapter(BasePlatformAdapter):
             if require_mention and not is_free_channel and not in_bot_thread:
                 if self._client.user not in message.mentions and not mention_prefix:
                     return
+
+            if self._client.user and self._client.user in message.mentions:
+                message.content = message.content.replace(
+                    f"<@{self._client.user.id}>", ""
+                ).strip()
+                message.content = message.content.replace(
+                    f"<@!{self._client.user.id}>", ""
+                ).strip()
+
         # Auto-thread: when enabled, automatically create a thread for every
         # @mention in a text channel so each conversation is isolated (like Slack).
         # Messages already inside threads or DMs are unaffected.
@@ -3017,11 +3439,24 @@ class DiscordAdapter(BasePlatformAdapter):
         auto_threaded_channel = None
         if not is_thread and not isinstance(message.channel, discord.DMChannel):
             no_thread_channels_raw = os.getenv("DISCORD_NO_THREAD_CHANNELS", "")
-            no_thread_channels = {ch.strip() for ch in no_thread_channels_raw.split(",") if ch.strip()}
+            no_thread_channels = {
+                ch.strip() for ch in no_thread_channels_raw.split(",") if ch.strip()
+            }
             skip_thread = bool(channel_ids & no_thread_channels) or is_free_channel
-            auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in ("true", "1", "yes")
-            is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
-            if auto_thread and not skip_thread and not is_voice_linked_channel and not is_reply_message:
+            auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in (
+                "true",
+                "1",
+                "yes",
+            )
+            is_reply_message = (
+                getattr(message, "type", None) == discord.MessageType.reply
+            )
+            if (
+                auto_thread
+                and not skip_thread
+                and not is_voice_linked_channel
+                and not is_reply_message
+            ):
                 thread = await self._auto_create_thread(message)
                 if thread:
                     is_thread = True
@@ -3089,7 +3524,7 @@ class DiscordAdapter(BasePlatformAdapter):
         # vision tool can access them reliably (Discord CDN URLs can expire).
         media_urls = []
         media_types = []
-        pending_text_injection: Optional[str] = None
+        pending_text_injection: str | None = None
         for att in message.attachments:
             content_type = att.content_type or "unknown"
             if content_type.startswith("image/"):
@@ -3103,7 +3538,9 @@ class DiscordAdapter(BasePlatformAdapter):
                     media_types.append(content_type)
                     print(f"[Discord] Cached user image: {cached_path}", flush=True)
                 except Exception as e:
-                    print(f"[Discord] Failed to cache image attachment: {e}", flush=True)
+                    print(
+                        f"[Discord] Failed to cache image attachment: {e}", flush=True
+                    )
                     # Fall back to the CDN URL if caching fails
                     media_urls.append(att.url)
                     media_types.append(content_type)
@@ -3117,7 +3554,9 @@ class DiscordAdapter(BasePlatformAdapter):
                     media_types.append(content_type)
                     print(f"[Discord] Cached user audio: {cached_path}", flush=True)
                 except Exception as e:
-                    print(f"[Discord] Failed to cache audio attachment: {e}", flush=True)
+                    print(
+                        f"[Discord] Failed to cache audio attachment: {e}", flush=True
+                    )
                     media_urls.append(att.url)
                     media_types.append(content_type)
             else:
@@ -3132,14 +3571,16 @@ class DiscordAdapter(BasePlatformAdapter):
                 if ext not in SUPPORTED_DOCUMENT_TYPES:
                     logger.warning(
                         "[Discord] Unsupported document type '%s' (%s), skipping",
-                        ext or "unknown", content_type,
+                        ext or "unknown",
+                        content_type,
                     )
                 else:
                     MAX_DOC_BYTES = 32 * 1024 * 1024
                     if att.size and att.size > MAX_DOC_BYTES:
                         logger.warning(
                             "[Discord] Document too large (%s bytes), skipping: %s",
-                            att.size, att.filename,
+                            att.size,
+                            att.filename,
                         )
                     else:
                         try:
@@ -3150,17 +3591,28 @@ class DiscordAdapter(BasePlatformAdapter):
                             doc_mime = SUPPORTED_DOCUMENT_TYPES[ext]
                             media_urls.append(cached_path)
                             media_types.append(doc_mime)
-                            logger.info("[Discord] Cached user document: %s", cached_path)
+                            logger.info(
+                                "[Discord] Cached user document: %s", cached_path
+                            )
                             # Inject text content for plain-text documents (capped at 100 KB)
                             MAX_TEXT_INJECT_BYTES = 100 * 1024
-                            if ext in (".md", ".txt", ".log") and len(raw_bytes) <= MAX_TEXT_INJECT_BYTES:
+                            if (
+                                ext in (".md", ".txt", ".log")
+                                and len(raw_bytes) <= MAX_TEXT_INJECT_BYTES
+                            ):
                                 try:
                                     text_content = raw_bytes.decode("utf-8")
                                     display_name = att.filename or f"document{ext}"
-                                    display_name = re.sub(r'[^\w.\- ]', '_', display_name)
-                                    injection = f"[Content of {display_name}]:\n{text_content}"
+                                    display_name = re.sub(
+                                        r"[^\w.\- ]", "_", display_name
+                                    )
+                                    injection = (
+                                        f"[Content of {display_name}]:\n{text_content}"
+                                    )
                                     if pending_text_injection:
-                                        pending_text_injection = f"{pending_text_injection}\n\n{injection}"
+                                        pending_text_injection = (
+                                            f"{pending_text_injection}\n\n{injection}"
+                                        )
                                     else:
                                         pending_text_injection = injection
                                 except UnicodeDecodeError:
@@ -3168,14 +3620,20 @@ class DiscordAdapter(BasePlatformAdapter):
                         except Exception as e:
                             logger.warning(
                                 "[Discord] Failed to cache document %s: %s",
-                                att.filename, e, exc_info=True,
+                                att.filename,
+                                e,
+                                exc_info=True,
                             )
 
         # Use normalized_content (saved before auto-threading) instead of message.content,
         # to detect /slash commands in channel messages.
         event_text = normalized_content
         if pending_text_injection:
-            event_text = f"{pending_text_injection}\n\n{event_text}" if event_text else pending_text_injection
+            event_text = (
+                f"{pending_text_injection}\n\n{event_text}"
+                if event_text
+                else pending_text_injection
+            )
 
         # Defense-in-depth: prevent empty user messages from entering session
         # (can happen when user sends @mention-only with no other text)
@@ -3193,7 +3651,9 @@ class DiscordAdapter(BasePlatformAdapter):
         if message.reference:
             reply_to_id = str(message.reference.message_id)
             if message.reference.resolved:
-                reply_to_text = getattr(message.reference.resolved, "content", None) or None
+                reply_to_text = (
+                    getattr(message.reference.resolved, "content", None) or None
+                )
 
         event = MessageEvent(
             text=event_text,
@@ -3229,10 +3689,15 @@ class DiscordAdapter(BasePlatformAdapter):
     def _text_batch_key(self, event: MessageEvent) -> str:
         """Session-scoped key for text message batching."""
         from gateway.session import build_session_key
+
         return build_session_key(
             event.source,
-            group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
-            thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
+            group_sessions_per_user=self.config.extra.get(
+                "group_sessions_per_user", True
+            ),
+            thread_sessions_per_user=self.config.extra.get(
+                "thread_sessions_per_user", False
+            ),
         )
 
     def _enqueue_text_event(self, event: MessageEvent) -> None:
@@ -3250,7 +3715,9 @@ class DiscordAdapter(BasePlatformAdapter):
             self._pending_text_batches[key] = event
         else:
             if event.text:
-                existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
+                existing.text = (
+                    f"{existing.text}\n{event.text}" if existing.text else event.text
+                )
             existing._last_chunk_len = chunk_len  # type: ignore[attr-defined]
             if event.media_urls:
                 existing.media_urls.extend(event.media_urls)
@@ -3283,7 +3750,8 @@ class DiscordAdapter(BasePlatformAdapter):
                 return
             logger.info(
                 "[Discord] Flushing text batch %s (%d chars)",
-                key, len(event.text or ""),
+                key,
+                len(event.text or ""),
             )
             # Shield the downstream dispatch so that a subsequent chunk
             # arriving while handle_message is mid-flight cannot cancel
@@ -3333,8 +3801,11 @@ if DISCORD_AVAILABLE:
             return str(interaction.user.id) in self.allowed_user_ids
 
         async def _resolve(
-            self, interaction: discord.Interaction, choice: str,
-            color: discord.Color, label: str,
+            self,
+            interaction: discord.Interaction,
+            choice: str,
+            color: discord.Color,
+            label: str,
         ):
             """Resolve the approval via the gateway approval queue and update the embed."""
             if self.resolved:
@@ -3352,7 +3823,9 @@ if DISCORD_AVAILABLE:
             self.resolved = True
 
             # Update the embed with the decision
-            embed = interaction.message.embeds[0] if interaction.message.embeds else None
+            embed = (
+                interaction.message.embeds[0] if interaction.message.embeds else None
+            )
             if embed:
                 embed.color = color
                 embed.set_footer(text=f"{label} by {interaction.user.display_name}")
@@ -3366,10 +3839,14 @@ if DISCORD_AVAILABLE:
             # Unblock the waiting agent thread via the gateway approval queue
             try:
                 from tools.approval import resolve_gateway_approval
+
                 count = resolve_gateway_approval(self.session_key, choice)
                 logger.info(
                     "Discord button resolved %d approval(s) for session %s (choice=%s, user=%s)",
-                    count, self.session_key, choice, interaction.user.display_name,
+                    count,
+                    self.session_key,
+                    choice,
+                    interaction.user.display_name,
                 )
             except Exception as exc:
                 logger.error("Failed to resolve gateway approval from button: %s", exc)
@@ -3378,19 +3855,25 @@ if DISCORD_AVAILABLE:
         async def allow_once(
             self, interaction: discord.Interaction, button: discord.ui.Button
         ):
-            await self._resolve(interaction, "once", discord.Color.green(), "Approved once")
+            await self._resolve(
+                interaction, "once", discord.Color.green(), "Approved once"
+            )
 
         @discord.ui.button(label="Allow Session", style=discord.ButtonStyle.grey)
         async def allow_session(
             self, interaction: discord.Interaction, button: discord.ui.Button
         ):
-            await self._resolve(interaction, "session", discord.Color.blue(), "Approved for session")
+            await self._resolve(
+                interaction, "session", discord.Color.blue(), "Approved for session"
+            )
 
         @discord.ui.button(label="Always Allow", style=discord.ButtonStyle.blurple)
         async def allow_always(
             self, interaction: discord.Interaction, button: discord.ui.Button
         ):
-            await self._resolve(interaction, "always", discord.Color.purple(), "Approved permanently")
+            await self._resolve(
+                interaction, "always", discord.Color.purple(), "Approved permanently"
+            )
 
         @discord.ui.button(label="Deny", style=discord.ButtonStyle.red)
         async def deny(
@@ -3425,8 +3908,11 @@ if DISCORD_AVAILABLE:
             return str(interaction.user.id) in self.allowed_user_ids
 
         async def _respond(
-            self, interaction: discord.Interaction, answer: str,
-            color: discord.Color, label: str,
+            self,
+            interaction: discord.Interaction,
+            answer: str,
+            color: discord.Color,
+            label: str,
         ):
             if self.resolved:
                 await interaction.response.send_message(
@@ -3442,7 +3928,9 @@ if DISCORD_AVAILABLE:
             self.resolved = True
 
             # Update embed
-            embed = interaction.message.embeds[0] if interaction.message.embeds else None
+            embed = (
+                interaction.message.embeds[0] if interaction.message.embeds else None
+            )
             if embed:
                 embed.color = color
                 embed.set_footer(text=f"{label} by {interaction.user.display_name}")
@@ -3454,6 +3942,7 @@ if DISCORD_AVAILABLE:
             # Write response file
             try:
                 from hermes_constants import get_hermes_home
+
                 home = get_hermes_home()
                 response_path = home / ".update_response"
                 tmp = response_path.with_suffix(".tmp")
@@ -3461,7 +3950,8 @@ if DISCORD_AVAILABLE:
                 tmp.replace(response_path)
                 logger.info(
                     "Discord update prompt answered '%s' by %s",
-                    answer, interaction.user.display_name,
+                    answer,
+                    interaction.user.display_name,
                 )
             except Exception as exc:
                 logger.error("Failed to write update response: %s", exc)
@@ -3609,7 +4099,11 @@ if DISCORD_AVAILABLE:
 
             total = provider.get("total_models", 0) if provider else 0
             shown = min(len(provider.get("models", [])), 25) if provider else 0
-            extra = f"\n*{total - shown} more available — type `/model <name>` directly*" if total > shown else ""
+            extra = (
+                f"\n*{total - shown} more available — type `/model <name>` directly*"
+                if total > shown
+                else ""
+            )
 
             await interaction.response.edit_message(
                 embed=discord.Embed(
@@ -3665,6 +4159,7 @@ if DISCORD_AVAILABLE:
 
             try:
                 from hermes_cli.providers import get_label
+
                 provider_label = get_label(self.current_provider)
             except Exception:
                 provider_label = self.current_provider

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -98,6 +98,35 @@ sys.path.insert(0, str(PROJECT_ROOT))
 # ---------------------------------------------------------------------------
 def _apply_profile_override() -> None:
     """Pre-parse --profile/-p and set HERMES_HOME before module imports."""
+    # Skip when imported under pytest / sphinx / IDE inspectors. Otherwise
+    # pytest's `-p plugin` flag gets misread as a profile name and aborts.
+    _under_test = (
+        "pytest" in sys.modules
+        or "PYTEST_CURRENT_TEST" in os.environ
+        or "_pytest.config" in sys.modules
+    )
+    _entry = os.path.basename(sys.argv[0]) if sys.argv else ""
+    _is_hermes_cli = _entry == "hermes" or _entry.startswith("hermes-")
+
+    if _under_test or not _is_hermes_cli:
+        # Honor active_profile sticky default but never parse argv flags.
+        try:
+            from hermes_constants import get_default_hermes_root
+
+            active_path = get_default_hermes_root() / "active_profile"
+            if active_path.exists():
+                name = active_path.read_text().strip()
+                if name and name != "default":
+                    try:
+                        from hermes_cli.profiles import resolve_profile_env
+
+                        os.environ["HERMES_HOME"] = resolve_profile_env(name)
+                    except Exception:
+                        pass
+        except (UnicodeDecodeError, OSError, ImportError):
+            pass
+        return
+
     argv = sys.argv[1:]
     profile_name = None
     consume = 0

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "An AI agent with advanced tool-calling capabilities, featuring a flexible toolsets system for organizing and managing tools.",
   "private": true,
   "scripts": {
+    "lint:md": "npx --yes markdownlint-cli \"docs/*.md\" \"docs/**/*.md\"",
+    "lint:md:fix": "npx --yes markdownlint-cli --fix \"docs/*.md\" \"docs/**/*.md\"",
+    "hooks:install": "python -m pip install pre-commit && pre-commit install",
+    "hooks:run": "pre-commit run --all-files",
     "postinstall": "echo '✅ Browser tools ready. Run: python run_agent.py --help'"
   },
   "repository": {

--- a/tests/acp/test_events.py
+++ b/tests/acp/test_events.py
@@ -2,13 +2,10 @@
 
 import asyncio
 from concurrent.futures import Future
-from unittest.mock import AsyncMock, MagicMock, patch
-
-import pytest
+from unittest.mock import MagicMock, patch
 
 import acp
-from acp.schema import ToolCallStart, ToolCallProgress, AgentThoughtChunk, AgentMessageChunk
-
+import pytest
 from acp_adapter.events import (
     make_message_cb,
     make_step_cb,
@@ -17,15 +14,15 @@ from acp_adapter.events import (
 )
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_conn():
     """Mock ACP Client connection."""
     conn = MagicMock(spec=acp.Client)
-    conn.session_update = AsyncMock()
+    conn.session_update = MagicMock()
     return conn
 
 
-@pytest.fixture()
+@pytest.fixture
 def event_loop_fixture():
     """Create a real event loop for testing threadsafe coroutine submission."""
     loop = asyncio.new_event_loop()
@@ -45,7 +42,9 @@ class TestToolProgressCallback:
         tool_call_meta = {}
         loop = event_loop_fixture
 
-        cb = make_tool_progress_cb(mock_conn, "session-1", loop, tool_call_ids, tool_call_meta)
+        cb = make_tool_progress_cb(
+            mock_conn, "session-1", loop, tool_call_ids, tool_call_meta
+        )
 
         # Run callback in the event loop context
         with patch("acp_adapter.events.asyncio.run_coroutine_threadsafe") as mock_rcts:
@@ -70,14 +69,21 @@ class TestToolProgressCallback:
         tool_call_meta = {}
         loop = event_loop_fixture
 
-        cb = make_tool_progress_cb(mock_conn, "session-1", loop, tool_call_ids, tool_call_meta)
+        cb = make_tool_progress_cb(
+            mock_conn, "session-1", loop, tool_call_ids, tool_call_meta
+        )
 
         with patch("acp_adapter.events.asyncio.run_coroutine_threadsafe") as mock_rcts:
             future = MagicMock(spec=Future)
             future.result.return_value = None
             mock_rcts.return_value = future
 
-            cb("tool.started", "read_file", "Reading /etc/hosts", '{"path": "/etc/hosts"}')
+            cb(
+                "tool.started",
+                "read_file",
+                "Reading /etc/hosts",
+                '{"path": "/etc/hosts"}',
+            )
 
         assert "read_file" in tool_call_ids
 
@@ -87,7 +93,9 @@ class TestToolProgressCallback:
         tool_call_meta = {}
         loop = event_loop_fixture
 
-        cb = make_tool_progress_cb(mock_conn, "session-1", loop, tool_call_ids, tool_call_meta)
+        cb = make_tool_progress_cb(
+            mock_conn, "session-1", loop, tool_call_ids, tool_call_meta
+        )
 
         with patch("acp_adapter.events.asyncio.run_coroutine_threadsafe") as mock_rcts:
             future = MagicMock(spec=Future)
@@ -98,14 +106,20 @@ class TestToolProgressCallback:
 
         assert "terminal" in tool_call_ids
 
-    def test_duplicate_same_name_tool_calls_use_fifo_ids(self, mock_conn, event_loop_fixture):
+    def test_duplicate_same_name_tool_calls_use_fifo_ids(
+        self, mock_conn, event_loop_fixture
+    ):
         """Multiple same-name tool calls should be tracked independently in order."""
         tool_call_ids = {}
         tool_call_meta = {}
         loop = event_loop_fixture
 
-        progress_cb = make_tool_progress_cb(mock_conn, "session-1", loop, tool_call_ids, tool_call_meta)
-        step_cb = make_step_cb(mock_conn, "session-1", loop, tool_call_ids, tool_call_meta)
+        progress_cb = make_tool_progress_cb(
+            mock_conn, "session-1", loop, tool_call_ids, tool_call_meta
+        )
+        step_cb = make_step_cb(
+            mock_conn, "session-1", loop, tool_call_ids, tool_call_meta
+        )
 
         with patch("acp_adapter.events.asyncio.run_coroutine_threadsafe") as mock_rcts:
             future = MagicMock(spec=Future)
@@ -218,8 +232,10 @@ class TestStepCallback:
 
         cb = make_step_cb(mock_conn, "session-1", loop, tool_call_ids, {})
 
-        with patch("acp_adapter.events.asyncio.run_coroutine_threadsafe") as mock_rcts, \
-             patch("acp_adapter.events.build_tool_complete") as mock_btc:
+        with (
+            patch("acp_adapter.events.asyncio.run_coroutine_threadsafe") as mock_rcts,
+            patch("acp_adapter.events.build_tool_complete") as mock_btc,
+        ):
             future = MagicMock(spec=Future)
             future.result.return_value = None
             mock_rcts.return_value = future
@@ -228,7 +244,11 @@ class TestStepCallback:
             cb(1, [{"name": "terminal", "result": '{"output": "hello"}'}])
 
         mock_btc.assert_called_once_with(
-            "tc-xyz789", "terminal", result='{"output": "hello"}', function_args=None, snapshot=None
+            "tc-xyz789",
+            "terminal",
+            result='{"output": "hello"}',
+            function_args=None,
+            snapshot=None,
         )
 
     def test_none_result_passed_through(self, mock_conn, event_loop_fixture):
@@ -240,32 +260,51 @@ class TestStepCallback:
 
         cb = make_step_cb(mock_conn, "session-1", loop, tool_call_ids, {})
 
-        with patch("acp_adapter.events.asyncio.run_coroutine_threadsafe") as mock_rcts, \
-             patch("acp_adapter.events.build_tool_complete") as mock_btc:
+        with (
+            patch("acp_adapter.events.asyncio.run_coroutine_threadsafe") as mock_rcts,
+            patch("acp_adapter.events.build_tool_complete") as mock_btc,
+        ):
             future = MagicMock(spec=Future)
             future.result.return_value = None
             mock_rcts.return_value = future
 
             cb(1, [{"name": "web_search", "result": None}])
 
-        mock_btc.assert_called_once_with("tc-aaa", "web_search", result=None, function_args=None, snapshot=None)
+        mock_btc.assert_called_once_with(
+            "tc-aaa", "web_search", result=None, function_args=None, snapshot=None
+        )
 
-    def test_step_callback_passes_arguments_and_snapshot(self, mock_conn, event_loop_fixture):
+    def test_step_callback_passes_arguments_and_snapshot(
+        self, mock_conn, event_loop_fixture
+    ):
         from collections import deque
 
         tool_call_ids = {"write_file": deque(["tc-write"])}
-        tool_call_meta = {"tc-write": {"args": {"path": "fallback.txt"}, "snapshot": "snap"}}
+        tool_call_meta = {
+            "tc-write": {"args": {"path": "fallback.txt"}, "snapshot": "snap"}
+        }
         loop = event_loop_fixture
 
         cb = make_step_cb(mock_conn, "session-1", loop, tool_call_ids, tool_call_meta)
 
-        with patch("acp_adapter.events.asyncio.run_coroutine_threadsafe") as mock_rcts, \
-             patch("acp_adapter.events.build_tool_complete") as mock_btc:
+        with (
+            patch("acp_adapter.events.asyncio.run_coroutine_threadsafe") as mock_rcts,
+            patch("acp_adapter.events.build_tool_complete") as mock_btc,
+        ):
             future = MagicMock(spec=Future)
             future.result.return_value = None
             mock_rcts.return_value = future
 
-            cb(1, [{"name": "write_file", "result": '{"bytes_written": 23}', "arguments": {"path": "diff-test.txt"}}])
+            cb(
+                1,
+                [
+                    {
+                        "name": "write_file",
+                        "result": '{"bytes_written": 23}',
+                        "arguments": {"path": "diff-test.txt"},
+                    }
+                ],
+            )
 
         mock_btc.assert_called_once_with(
             "tc-write",
@@ -275,16 +314,27 @@ class TestStepCallback:
             snapshot="snap",
         )
 
-    def test_tool_progress_captures_snapshot_metadata(self, mock_conn, event_loop_fixture):
+    def test_tool_progress_captures_snapshot_metadata(
+        self, mock_conn, event_loop_fixture
+    ):
         tool_call_ids = {}
         tool_call_meta = {}
         loop = event_loop_fixture
 
-        with patch("acp_adapter.events.make_tool_call_id", return_value="tc-meta"), \
-             patch("acp_adapter.events._send_update") as mock_send, \
-             patch("agent.display.capture_local_edit_snapshot", return_value="snapshot"):
-            cb = make_tool_progress_cb(mock_conn, "session-1", loop, tool_call_ids, tool_call_meta)
-            cb("tool.started", "write_file", None, {"path": "diff-test.txt", "content": "hello"})
+        with (
+            patch("acp_adapter.events.make_tool_call_id", return_value="tc-meta"),
+            patch("acp_adapter.events._send_update") as mock_send,
+            patch("agent.display.capture_local_edit_snapshot", return_value="snapshot"),
+        ):
+            cb = make_tool_progress_cb(
+                mock_conn, "session-1", loop, tool_call_ids, tool_call_meta
+            )
+            cb(
+                "tool.started",
+                "write_file",
+                None,
+                {"path": "diff-test.txt", "content": "hello"},
+            )
 
         assert list(tool_call_ids["write_file"]) == ["tc-meta"]
         assert tool_call_meta["tc-meta"] == {

--- a/tests/acp/test_mcp_e2e.py
+++ b/tests/acp/test_mcp_e2e.py
@@ -7,14 +7,10 @@ Exercises the full flow through the ACP server layer:
     session_update events arrive at the mock client
 """
 
-import asyncio
-from collections import deque
-from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
-
 import acp
+import pytest
 from acp.schema import (
     EnvVariable,
     HttpHeader,
@@ -26,23 +22,21 @@ from acp.schema import (
     ToolCallProgress,
     ToolCallStart,
 )
-
 from acp_adapter.server import HermesACPAgent
 from acp_adapter.session import SessionManager
 from acp_adapter.tools import build_tool_start
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_manager():
     return SessionManager(agent_factory=lambda: MagicMock(name="MockAIAgent"))
 
 
-@pytest.fixture()
+@pytest.fixture
 def acp_agent(mock_manager):
     return HermesACPAgent(session_manager=mock_manager)
 
@@ -56,7 +50,9 @@ class TestMcpRegistrationE2E:
     """Full flow: session with MCP servers → prompt with tool calls → ACP events."""
 
     @pytest.mark.asyncio
-    async def test_session_with_mcp_servers_registers_tools(self, acp_agent, mock_manager):
+    async def test_session_with_mcp_servers_registers_tools(
+        self, acp_agent, mock_manager
+    ):
         """new_session with mcpServers converts them to Hermes config and registers."""
         servers = [
             McpServerStdio(
@@ -85,8 +81,10 @@ class TestMcpRegistrationE2E:
             {"function": {"name": "terminal"}},
         ]
 
-        with patch("tools.mcp_tool.register_mcp_servers", side_effect=mock_register), \
-             patch("model_tools.get_tool_definitions", return_value=fake_tools):
+        with (
+            patch("tools.mcp_tool.register_mcp_servers", side_effect=mock_register),
+            patch("model_tools.get_tool_definitions", return_value=fake_tools),
+        ):
             resp = await acp_agent.new_session(cwd="/tmp", mcp_servers=servers)
 
         assert isinstance(resp, NewSessionResponse)
@@ -108,11 +106,16 @@ class TestMcpRegistrationE2E:
         # Verify agent tool surface was refreshed
         assert state.agent.tools == fake_tools
         assert state.agent.valid_tool_names == {
-            "mcp_test_fs_read", "mcp_test_fs_write", "mcp_test_api_search", "terminal"
+            "mcp_test_fs_read",
+            "mcp_test_fs_write",
+            "mcp_test_api_search",
+            "terminal",
         }
 
     @pytest.mark.asyncio
-    async def test_prompt_with_tool_calls_emits_acp_events(self, acp_agent, mock_manager):
+    async def test_prompt_with_tool_calls_emits_acp_events(
+        self, acp_agent, mock_manager
+    ):
         """Prompt → agent fires callbacks → ACP ToolCallStart + ToolCallUpdate events."""
         resp = await acp_agent.new_session(cwd="/tmp")
         session_id = resp.session_id
@@ -124,21 +127,32 @@ class TestMcpRegistrationE2E:
         mock_conn.request_permission = AsyncMock()
         acp_agent._conn = mock_conn
 
-        def mock_run_conversation(user_message, conversation_history=None, task_id=None):
+        def mock_run_conversation(
+            user_message, conversation_history=None, task_id=None
+        ):
             """Simulate an agent turn that calls terminal, gets a result, then responds."""
             agent = state.agent
 
             # 1) Agent fires tool_progress_callback (ToolCallStart)
             if agent.tool_progress_callback:
                 agent.tool_progress_callback(
-                    "tool.started", "terminal", "$ echo hello", {"command": "echo hello"}
+                    "tool.started",
+                    "terminal",
+                    "$ echo hello",
+                    {"command": "echo hello"},
                 )
 
             # 2) Agent fires step_callback with tool results (ToolCallUpdate)
             if agent.step_callback:
-                agent.step_callback(1, [
-                    {"name": "terminal", "result": '{"output": "hello\\n", "exit_code": 0}'}
-                ])
+                agent.step_callback(
+                    1,
+                    [
+                        {
+                            "name": "terminal",
+                            "result": '{"output": "hello\\n", "exit_code": 0}',
+                        }
+                    ],
+                )
 
             return {
                 "final_response": "The command output 'hello'.",
@@ -164,17 +178,27 @@ class TestMcpRegistrationE2E:
             updates.append(update_arg)
 
         # Find tool_call (start) and tool_call_update (completion) events
-        starts = [u for u in updates if getattr(u, "session_update", None) == "tool_call"]
-        completions = [u for u in updates if getattr(u, "session_update", None) == "tool_call_update"]
+        starts = [
+            u for u in updates if getattr(u, "session_update", None) == "tool_call"
+        ]
+        completions = [
+            u
+            for u in updates
+            if getattr(u, "session_update", None) == "tool_call_update"
+        ]
 
         # Should have at least one ToolCallStart for "terminal"
-        assert len(starts) >= 1, f"Expected ToolCallStart, got updates: {[getattr(u, 'session_update', '?') for u in updates]}"
+        assert len(starts) >= 1, (
+            f"Expected ToolCallStart, got updates: {[getattr(u, 'session_update', '?') for u in updates]}"
+        )
         start_event = starts[0]
         assert isinstance(start_event, ToolCallStart)
         assert start_event.title.startswith("terminal:")
 
         # Should have at least one ToolCallUpdate (completion) with rawOutput
-        assert len(completions) >= 1, f"Expected ToolCallUpdate, got updates: {[getattr(u, 'session_update', '?') for u in updates]}"
+        assert len(completions) >= 1, (
+            f"Expected ToolCallUpdate, got updates: {[getattr(u, 'session_update', '?') for u in updates]}"
+        )
         complete_event = completions[0]
         assert isinstance(complete_event, ToolCallProgress)
         assert complete_event.status == "completed"
@@ -217,14 +241,27 @@ class TestMcpRegistrationE2E:
             agent = state.agent
             # Fire two tool calls
             if agent.tool_progress_callback:
-                agent.tool_progress_callback("tool.started", "read_file", "read: /etc/hosts", {"path": "/etc/hosts"})
-                agent.tool_progress_callback("tool.started", "web_search", "web search: test", {"query": "test"})
+                agent.tool_progress_callback(
+                    "tool.started",
+                    "read_file",
+                    "read: /etc/hosts",
+                    {"path": "/etc/hosts"},
+                )
+                agent.tool_progress_callback(
+                    "tool.started", "web_search", "web search: test", {"query": "test"}
+                )
 
             if agent.step_callback:
-                agent.step_callback(1, [
-                    {"name": "read_file", "result": '{"content": "127.0.0.1 localhost"}'},
-                    {"name": "web_search", "result": '{"data": {"web": []}}'},
-                ])
+                agent.step_callback(
+                    1,
+                    [
+                        {
+                            "name": "read_file",
+                            "result": '{"content": "127.0.0.1 localhost"}',
+                        },
+                        {"name": "web_search", "result": '{"data": {"web": []}}'},
+                    ],
+                )
 
             return {"final_response": "Done.", "messages": []}
 
@@ -238,8 +275,14 @@ class TestMcpRegistrationE2E:
             update_arg = call[1].get("update") or call[0][1]
             updates.append(update_arg)
 
-        starts = [u for u in updates if getattr(u, "session_update", None) == "tool_call"]
-        completions = [u for u in updates if getattr(u, "session_update", None) == "tool_call_update"]
+        starts = [
+            u for u in updates if getattr(u, "session_update", None) == "tool_call"
+        ]
+        completions = [
+            u
+            for u in updates
+            if getattr(u, "session_update", None) == "tool_call_update"
+        ]
 
         assert len(starts) == 2, f"Expected 2 starts, got {len(starts)}"
         assert len(completions) == 2, f"Expected 2 completions, got {len(completions)}"
@@ -267,14 +310,17 @@ class TestMcpSanitizationE2E:
         ]
 
         registered_configs = {}
+
         def mock_register(config_map):
             registered_configs.update(config_map)
             return ["mcp_ai_exa_exa_search"]
 
         fake_tools = [{"function": {"name": "mcp_ai_exa_exa_search"}}]
 
-        with patch("tools.mcp_tool.register_mcp_servers", side_effect=mock_register), \
-             patch("model_tools.get_tool_definitions", return_value=fake_tools):
+        with (
+            patch("tools.mcp_tool.register_mcp_servers", side_effect=mock_register),
+            patch("model_tools.get_tool_definitions", return_value=fake_tools),
+        ):
             resp = await acp_agent.new_session(cwd="/tmp", mcp_servers=servers)
 
         state = mock_manager.get_session(resp.session_id)
@@ -300,6 +346,7 @@ class TestSessionLifecycleMcpE2E:
         ]
 
         registered = {}
+
         def mock_register(config_map):
             registered.update(config_map)
             return []
@@ -310,9 +357,13 @@ class TestSessionLifecycleMcpE2E:
         state.agent.tools = []
         state.agent.valid_tool_names = set()
 
-        with patch("tools.mcp_tool.register_mcp_servers", side_effect=mock_register), \
-             patch("model_tools.get_tool_definitions", return_value=[]):
-            await acp_agent.load_session(cwd="/tmp", session_id=sid, mcp_servers=servers)
+        with (
+            patch("tools.mcp_tool.register_mcp_servers", side_effect=mock_register),
+            patch("model_tools.get_tool_definitions", return_value=[]),
+        ):
+            await acp_agent.load_session(
+                cwd="/tmp", session_id=sid, mcp_servers=servers
+            )
 
         assert "srv" in registered
 
@@ -327,6 +378,7 @@ class TestSessionLifecycleMcpE2E:
         ]
 
         registered = {}
+
         def mock_register(config_map):
             registered.update(config_map)
             return []
@@ -337,9 +389,13 @@ class TestSessionLifecycleMcpE2E:
         state.agent.tools = []
         state.agent.valid_tool_names = set()
 
-        with patch("tools.mcp_tool.register_mcp_servers", side_effect=mock_register), \
-             patch("model_tools.get_tool_definitions", return_value=[]):
-            await acp_agent.resume_session(cwd="/tmp", session_id=sid, mcp_servers=servers)
+        with (
+            patch("tools.mcp_tool.register_mcp_servers", side_effect=mock_register),
+            patch("model_tools.get_tool_definitions", return_value=[]),
+        ):
+            await acp_agent.resume_session(
+                cwd="/tmp", session_id=sid, mcp_servers=servers
+            )
 
         assert "srv2" in registered
 
@@ -354,13 +410,16 @@ class TestSessionLifecycleMcpE2E:
         ]
 
         registered = {}
+
         def mock_register(config_map):
             registered.update(config_map)
             return []
 
         # Need to set up the forked session's agent too
-        with patch("tools.mcp_tool.register_mcp_servers", side_effect=mock_register), \
-             patch("model_tools.get_tool_definitions", return_value=[]):
+        with (
+            patch("tools.mcp_tool.register_mcp_servers", side_effect=mock_register),
+            patch("model_tools.get_tool_definitions", return_value=[]),
+        ):
             fork_resp = await acp_agent.fork_session(
                 cwd="/tmp", session_id=sid, mcp_servers=servers
             )

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1,13 +1,10 @@
 """Tests for acp_adapter.server — HermesACPAgent ACP server."""
 
-import asyncio
-import os
 from types import SimpleNamespace
-from unittest.mock import MagicMock, AsyncMock, patch
-
-import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import acp
+import pytest
 from acp.agent.router import build_agent_router
 from acp.schema import (
     AgentCapabilities,
@@ -15,31 +12,27 @@ from acp.schema import (
     AvailableCommandsUpdate,
     Implementation,
     InitializeResponse,
-    ListSessionsResponse,
-    LoadSessionResponse,
     NewSessionResponse,
     PromptResponse,
     ResumeSessionResponse,
+    SessionInfo,
     SessionModelState,
-    SetSessionConfigOptionResponse,
     SetSessionModelResponse,
     SetSessionModeResponse,
-    SessionInfo,
     TextContentBlock,
-    Usage,
 )
-from acp_adapter.server import HermesACPAgent, HERMES_VERSION
+from acp_adapter.server import HERMES_VERSION, HermesACPAgent
 from acp_adapter.session import SessionManager
 from hermes_state import SessionDB
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_manager():
     """SessionManager with a mock agent factory."""
     return SessionManager(agent_factory=lambda: MagicMock(name="MockAIAgent"))
 
 
-@pytest.fixture()
+@pytest.fixture
 def agent(mock_manager):
     """HermesACPAgent backed by a mock session manager."""
     return HermesACPAgent(session_manager=mock_manager)
@@ -150,7 +143,9 @@ class TestSessionOps:
     @pytest.mark.asyncio
     async def test_new_session_returns_model_state(self):
         manager = SessionManager(
-            agent_factory=lambda: SimpleNamespace(model="gpt-5.4", provider="openai-codex")
+            agent_factory=lambda: SimpleNamespace(
+                model="gpt-5.4", provider="openai-codex"
+            )
         )
         acp_agent = HermesACPAgent(session_manager=manager)
 
@@ -239,7 +234,9 @@ class TestListAndFork:
     @pytest.mark.asyncio
     async def test_fork_session(self, agent):
         new_resp = await agent.new_session(cwd="/original")
-        fork_resp = await agent.fork_session(cwd="/forked", session_id=new_resp.session_id)
+        fork_resp = await agent.fork_session(
+            cwd="/forked", session_id=new_resp.session_id
+        )
         assert fork_resp.session_id
         assert fork_resp.session_id != new_resp.session_id
 
@@ -265,61 +262,13 @@ class TestListAndFork:
 
     @pytest.mark.asyncio
     async def test_list_sessions_passes_cwd_filter(self, agent):
-        with patch.object(agent.session_manager, "list_sessions", return_value=[]) as mock_list:
+        with patch.object(
+            agent.session_manager, "list_sessions", return_value=[]
+        ) as mock_list:
             await agent.list_sessions(cwd="/mnt/e/Projects/AI/browser-link-3")
 
         mock_list.assert_called_once_with(cwd="/mnt/e/Projects/AI/browser-link-3")
 
-    @pytest.mark.asyncio
-    async def test_list_sessions_pagination_first_page(self, agent):
-        from acp_adapter import server as acp_server
-
-        infos = [
-            {"session_id": f"s{i}", "cwd": "/tmp", "title": None, "updated_at": 0.0}
-            for i in range(acp_server._LIST_SESSIONS_PAGE_SIZE + 5)
-        ]
-        with patch.object(agent.session_manager, "list_sessions", return_value=infos):
-            resp = await agent.list_sessions()
-
-        assert len(resp.sessions) == acp_server._LIST_SESSIONS_PAGE_SIZE
-        assert resp.next_cursor == resp.sessions[-1].session_id
-
-    @pytest.mark.asyncio
-    async def test_list_sessions_pagination_no_more(self, agent):
-        infos = [
-            {"session_id": f"s{i}", "cwd": "/tmp", "title": None, "updated_at": 0.0}
-            for i in range(3)
-        ]
-        with patch.object(agent.session_manager, "list_sessions", return_value=infos):
-            resp = await agent.list_sessions()
-
-        assert len(resp.sessions) == 3
-        assert resp.next_cursor is None
-
-    @pytest.mark.asyncio
-    async def test_list_sessions_cursor_resumes_after_match(self, agent):
-        infos = [
-            {"session_id": "s1", "cwd": "/tmp", "title": None, "updated_at": 0.0},
-            {"session_id": "s2", "cwd": "/tmp", "title": None, "updated_at": 0.0},
-            {"session_id": "s3", "cwd": "/tmp", "title": None, "updated_at": 0.0},
-        ]
-        with patch.object(agent.session_manager, "list_sessions", return_value=infos):
-            resp = await agent.list_sessions(cursor="s1")
-
-        assert [s.session_id for s in resp.sessions] == ["s2", "s3"]
-        assert resp.next_cursor is None
-
-    @pytest.mark.asyncio
-    async def test_list_sessions_unknown_cursor_returns_empty(self, agent):
-        infos = [
-            {"session_id": "s1", "cwd": "/tmp", "title": None, "updated_at": 0.0},
-            {"session_id": "s2", "cwd": "/tmp", "title": None, "updated_at": 0.0},
-        ]
-        with patch.object(agent.session_manager, "list_sessions", return_value=infos):
-            resp = await agent.list_sessions(cursor="does-not-exist")
-
-        assert resp.sessions == []
-        assert resp.next_cursor is None
 
 # ---------------------------------------------------------------------------
 # session configuration / model routing
@@ -330,7 +279,9 @@ class TestSessionConfiguration:
     @pytest.mark.asyncio
     async def test_set_session_mode_returns_response(self, agent):
         new_resp = await agent.new_session(cwd="/tmp")
-        resp = await agent.set_session_mode(mode_id="chat", session_id=new_resp.session_id)
+        resp = await agent.set_session_mode(
+            mode_id="chat", session_id=new_resp.session_id
+        )
         state = agent.session_manager.get_session(new_resp.session_id)
 
         assert isinstance(resp, SetSessionModeResponse)
@@ -375,7 +326,9 @@ class TestSessionConfiguration:
         assert state.model == "gpt-5.4"
 
     @pytest.mark.asyncio
-    async def test_set_session_model_accepts_provider_prefixed_choice(self, tmp_path, monkeypatch):
+    async def test_set_session_model_accepts_provider_prefixed_choice(
+        self, tmp_path, monkeypatch
+    ):
         runtime_calls = []
 
         def fake_resolve_runtime_provider(requested=None, **kwargs):
@@ -383,7 +336,9 @@ class TestSessionConfiguration:
             provider = requested or "openrouter"
             return {
                 "provider": provider,
-                "api_mode": "anthropic_messages" if provider == "anthropic" else "chat_completions",
+                "api_mode": "anthropic_messages"
+                if provider == "anthropic"
+                else "chat_completions",
                 "base_url": f"https://{provider}.example/v1",
                 "api_key": f"{provider}-key",
                 "command": None,
@@ -398,9 +353,12 @@ class TestSessionConfiguration:
                 api_mode=kwargs.get("api_mode"),
             )
 
-        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {
-            "model": {"provider": "openrouter", "default": "openrouter/gpt-5"}
-        })
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {
+                "model": {"provider": "openrouter", "default": "openrouter/gpt-5"}
+            },
+        )
         monkeypatch.setattr(
             "hermes_cli.runtime_provider.resolve_runtime_provider",
             fake_resolve_runtime_provider,
@@ -449,13 +407,15 @@ class TestPrompt:
         state = agent.session_manager.get_session(new_resp.session_id)
 
         # Mock the agent's run_conversation
-        state.agent.run_conversation = MagicMock(return_value={
-            "final_response": "Hello! How can I help?",
-            "messages": [
-                {"role": "user", "content": "hello"},
-                {"role": "assistant", "content": "Hello! How can I help?"},
-            ],
-        })
+        state.agent.run_conversation = MagicMock(
+            return_value={
+                "final_response": "Hello! How can I help?",
+                "messages": [
+                    {"role": "user", "content": "hello"},
+                    {"role": "assistant", "content": "Hello! How can I help?"},
+                ],
+            }
+        )
 
         # Set up a mock connection
         mock_conn = MagicMock(spec=acp.Client)
@@ -479,10 +439,12 @@ class TestPrompt:
             {"role": "user", "content": "hi"},
             {"role": "assistant", "content": "hey"},
         ]
-        state.agent.run_conversation = MagicMock(return_value={
-            "final_response": "hey",
-            "messages": expected_history,
-        })
+        state.agent.run_conversation = MagicMock(
+            return_value={
+                "final_response": "hey",
+                "messages": expected_history,
+            }
+        )
 
         mock_conn = MagicMock(spec=acp.Client)
         mock_conn.session_update = AsyncMock()
@@ -499,10 +461,12 @@ class TestPrompt:
         new_resp = await agent.new_session(cwd=".")
         state = agent.session_manager.get_session(new_resp.session_id)
 
-        state.agent.run_conversation = MagicMock(return_value={
-            "final_response": "I can help with that!",
-            "messages": [],
-        })
+        state.agent.run_conversation = MagicMock(
+            return_value={
+                "final_response": "I can help with that!",
+                "messages": [],
+            }
+        )
 
         mock_conn = MagicMock(spec=acp.Client)
         mock_conn.session_update = AsyncMock()
@@ -522,13 +486,15 @@ class TestPrompt:
     async def test_prompt_auto_titles_session(self, agent):
         new_resp = await agent.new_session(cwd=".")
         state = agent.session_manager.get_session(new_resp.session_id)
-        state.agent.run_conversation = MagicMock(return_value={
-            "final_response": "Here is the fix.",
-            "messages": [
-                {"role": "user", "content": "fix the broken ACP history"},
-                {"role": "assistant", "content": "Here is the fix."},
-            ],
-        })
+        state.agent.run_conversation = MagicMock(
+            return_value={
+                "final_response": "Here is the fix.",
+                "messages": [
+                    {"role": "user", "content": "fix the broken ACP history"},
+                    {"role": "assistant", "content": "Here is the fix."},
+                ],
+            }
+        )
 
         mock_conn = MagicMock(spec=acp.Client)
         mock_conn.session_update = AsyncMock()
@@ -544,20 +510,24 @@ class TestPrompt:
         assert mock_title.call_args.args[3] == "Here is the fix."
 
     @pytest.mark.asyncio
-    async def test_prompt_populates_usage_from_top_level_run_conversation_fields(self, agent):
+    async def test_prompt_populates_usage_from_top_level_run_conversation_fields(
+        self, agent
+    ):
         """ACP should map top-level token fields into PromptResponse.usage."""
         new_resp = await agent.new_session(cwd=".")
         state = agent.session_manager.get_session(new_resp.session_id)
 
-        state.agent.run_conversation = MagicMock(return_value={
-            "final_response": "usage attached",
-            "messages": [],
-            "prompt_tokens": 123,
-            "completion_tokens": 45,
-            "total_tokens": 168,
-            "reasoning_tokens": 7,
-            "cache_read_tokens": 11,
-        })
+        state.agent.run_conversation = MagicMock(
+            return_value={
+                "final_response": "usage attached",
+                "messages": [],
+                "prompt_tokens": 123,
+                "completion_tokens": 45,
+                "total_tokens": 168,
+                "reasoning_tokens": 7,
+                "cache_read_tokens": 11,
+            }
+        )
 
         mock_conn = MagicMock(spec=acp.Client)
         mock_conn.session_update = AsyncMock()
@@ -745,10 +715,12 @@ class TestSlashCommands:
 
         # Mock run_in_executor to avoid actually running the agent
         with patch("asyncio.get_running_loop") as mock_loop:
-            mock_loop.return_value.run_in_executor = AsyncMock(return_value={
-                "final_response": "I processed /foo",
-                "messages": [],
-            })
+            mock_loop.return_value.run_in_executor = AsyncMock(
+                return_value={
+                    "final_response": "I processed /foo",
+                    "messages": [],
+                }
+            )
             prompt = [TextContentBlock(type="text", text="/foo bar")]
             resp = await agent.prompt(prompt=prompt, session_id=new_resp.session_id)
 
@@ -763,7 +735,9 @@ class TestSlashCommands:
             provider = requested or "openrouter"
             return {
                 "provider": provider,
-                "api_mode": "anthropic_messages" if provider == "anthropic" else "chat_completions",
+                "api_mode": "anthropic_messages"
+                if provider == "anthropic"
+                else "chat_completions",
                 "base_url": f"https://{provider}.example/v1",
                 "api_key": f"{provider}-key",
                 "command": None,
@@ -778,9 +752,12 @@ class TestSlashCommands:
                 api_mode=kwargs.get("api_mode"),
             )
 
-        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {
-            "model": {"provider": "openrouter", "default": "openrouter/gpt-5"}
-        })
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {
+                "model": {"provider": "openrouter", "default": "openrouter/gpt-5"}
+            },
+        )
         monkeypatch.setattr(
             "hermes_cli.runtime_provider.resolve_runtime_provider",
             fake_resolve_runtime_provider,
@@ -817,7 +794,7 @@ class TestRegisterSessionMcpServers:
     @pytest.mark.asyncio
     async def test_registers_stdio_servers(self, agent, mock_manager):
         """McpServerStdio servers are converted and passed to register_mcp_servers."""
-        from acp.schema import McpServerStdio, EnvVariable
+        from acp.schema import EnvVariable, McpServerStdio
 
         state = mock_manager.create_session(cwd="/tmp")
         # Give the mock agent the attributes _register_session_mcp_servers reads
@@ -834,12 +811,15 @@ class TestRegisterSessionMcpServers:
         )
 
         registered_config = {}
+
         def capture_register(config_map):
             registered_config.update(config_map)
             return ["mcp_test_server_tool1"]
 
-        with patch("tools.mcp_tool.register_mcp_servers", side_effect=capture_register), \
-             patch("model_tools.get_tool_definitions", return_value=[]):
+        with (
+            patch("tools.mcp_tool.register_mcp_servers", side_effect=capture_register),
+            patch("model_tools.get_tool_definitions", return_value=[]),
+        ):
             await agent._register_session_mcp_servers(state, [server])
 
         assert "test-server" in registered_config
@@ -851,7 +831,7 @@ class TestRegisterSessionMcpServers:
     @pytest.mark.asyncio
     async def test_registers_http_servers(self, agent, mock_manager):
         """McpServerHttp servers are converted correctly."""
-        from acp.schema import McpServerHttp, HttpHeader
+        from acp.schema import HttpHeader, McpServerHttp
 
         state = mock_manager.create_session(cwd="/tmp")
         state.agent.enabled_toolsets = ["hermes-acp"]
@@ -866,12 +846,15 @@ class TestRegisterSessionMcpServers:
         )
 
         registered_config = {}
+
         def capture_register(config_map):
             registered_config.update(config_map)
             return []
 
-        with patch("tools.mcp_tool.register_mcp_servers", side_effect=capture_register), \
-             patch("model_tools.get_tool_definitions", return_value=[]):
+        with (
+            patch("tools.mcp_tool.register_mcp_servers", side_effect=capture_register),
+            patch("model_tools.get_tool_definitions", return_value=[]),
+        ):
             await agent._register_session_mcp_servers(state, [server])
 
         assert "http-server" in registered_config
@@ -903,8 +886,12 @@ class TestRegisterSessionMcpServers:
             {"function": {"name": "terminal"}},
         ]
 
-        with patch("tools.mcp_tool.register_mcp_servers", return_value=["mcp_srv_search"]), \
-             patch("model_tools.get_tool_definitions", return_value=fake_tools):
+        with (
+            patch(
+                "tools.mcp_tool.register_mcp_servers", return_value=["mcp_srv_search"]
+            ),
+            patch("model_tools.get_tool_definitions", return_value=fake_tools),
+        ):
             await agent._register_session_mcp_servers(state, [server])
 
         assert state.agent.tools == fake_tools
@@ -925,6 +912,8 @@ class TestRegisterSessionMcpServers:
             env=[],
         )
 
-        with patch("tools.mcp_tool.register_mcp_servers", side_effect=RuntimeError("boom")):
+        with patch(
+            "tools.mcp_tool.register_mcp_servers", side_effect=RuntimeError("boom")
+        ):
             # Should not raise
             await agent._register_session_mcp_servers(state, [server])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,12 +21,9 @@ test runner at ``scripts/run_tests.sh``.
 
 import asyncio
 import os
-import re
 import signal
 import sys
-import tempfile
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 
@@ -61,93 +58,95 @@ _CREDENTIAL_SUFFIXES = (
 )
 
 # Explicit names (for ones that don't fit the suffix pattern)
-_CREDENTIAL_NAMES = frozenset({
-    "AWS_ACCESS_KEY_ID",
-    "AWS_SECRET_ACCESS_KEY",
-    "AWS_SESSION_TOKEN",
-    "ANTHROPIC_TOKEN",
-    "FAL_KEY",
-    "GH_TOKEN",
-    "GITHUB_TOKEN",
-    "OPENAI_API_KEY",
-    "OPENROUTER_API_KEY",
-    "NOUS_API_KEY",
-    "GEMINI_API_KEY",
-    "GOOGLE_API_KEY",
-    "GROQ_API_KEY",
-    "XAI_API_KEY",
-    "MISTRAL_API_KEY",
-    "DEEPSEEK_API_KEY",
-    "KIMI_API_KEY",
-    "MOONSHOT_API_KEY",
-    "GLM_API_KEY",
-    "ZAI_API_KEY",
-    "MINIMAX_API_KEY",
-    "OLLAMA_API_KEY",
-    "OPENVIKING_API_KEY",
-    "COPILOT_API_KEY",
-    "CLAUDE_CODE_OAUTH_TOKEN",
-    "BROWSERBASE_API_KEY",
-    "FIRECRAWL_API_KEY",
-    "PARALLEL_API_KEY",
-    "EXA_API_KEY",
-    "TAVILY_API_KEY",
-    "WANDB_API_KEY",
-    "ELEVENLABS_API_KEY",
-    "HONCHO_API_KEY",
-    "MEM0_API_KEY",
-    "SUPERMEMORY_API_KEY",
-    "RETAINDB_API_KEY",
-    "HINDSIGHT_API_KEY",
-    "HINDSIGHT_LLM_API_KEY",
-    "TINKER_API_KEY",
-    "DAYTONA_API_KEY",
-    "TWILIO_AUTH_TOKEN",
-    "TELEGRAM_BOT_TOKEN",
-    "DISCORD_BOT_TOKEN",
-    "SLACK_BOT_TOKEN",
-    "SLACK_APP_TOKEN",
-    "MATTERMOST_TOKEN",
-    "MATRIX_ACCESS_TOKEN",
-    "MATRIX_PASSWORD",
-    "MATRIX_RECOVERY_KEY",
-    "HASS_TOKEN",
-    "EMAIL_PASSWORD",
-    "BLUEBUBBLES_PASSWORD",
-    "FEISHU_APP_SECRET",
-    "FEISHU_ENCRYPT_KEY",
-    "FEISHU_VERIFICATION_TOKEN",
-    "DINGTALK_CLIENT_SECRET",
-    "QQ_CLIENT_SECRET",
-    "QQ_STT_API_KEY",
-    "WECOM_SECRET",
-    "WECOM_CALLBACK_CORP_SECRET",
-    "WECOM_CALLBACK_TOKEN",
-    "WECOM_CALLBACK_ENCODING_AES_KEY",
-    "WEIXIN_TOKEN",
-    "MODAL_TOKEN_ID",
-    "MODAL_TOKEN_SECRET",
-    "TERMINAL_SSH_KEY",
-    "SUDO_PASSWORD",
-    "GATEWAY_PROXY_KEY",
-    "API_SERVER_KEY",
-    "TOOL_GATEWAY_USER_TOKEN",
-    "TELEGRAM_WEBHOOK_SECRET",
-    "WEBHOOK_SECRET",
-    "AI_GATEWAY_API_KEY",
-    "VOICE_TOOLS_OPENAI_KEY",
-    "BROWSER_USE_API_KEY",
-    "CUSTOM_API_KEY",
-    "GATEWAY_PROXY_URL",
-    "GEMINI_BASE_URL",
-    "OPENAI_BASE_URL",
-    "OPENROUTER_BASE_URL",
-    "OLLAMA_BASE_URL",
-    "GROQ_BASE_URL",
-    "XAI_BASE_URL",
-    "AI_GATEWAY_BASE_URL",
-    "ANTHROPIC_BASE_URL",
-})
+_CREDENTIAL_NAMES = frozenset(
+    {
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+        "ANTHROPIC_TOKEN",
+        "FAL_KEY",
+        "GH_TOKEN",
+        "GITHUB_TOKEN",
+        "OPENAI_API_KEY",
+        "OPENROUTER_API_KEY",
+        "NOUS_API_KEY",
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+        "GROQ_API_KEY",
+        "XAI_API_KEY",
+        "MISTRAL_API_KEY",
+        "DEEPSEEK_API_KEY",
+        "KIMI_API_KEY",
+        "MOONSHOT_API_KEY",
+        "GLM_API_KEY",
+        "ZAI_API_KEY",
+        "MINIMAX_API_KEY",
+        "OLLAMA_API_KEY",
+        "OPENVIKING_API_KEY",
+        "COPILOT_API_KEY",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+        "BROWSERBASE_API_KEY",
+        "FIRECRAWL_API_KEY",
+        "PARALLEL_API_KEY",
+        "EXA_API_KEY",
+        "TAVILY_API_KEY",
+        "WANDB_API_KEY",
+        "ELEVENLABS_API_KEY",
+        "HONCHO_API_KEY",
+        "MEM0_API_KEY",
+        "SUPERMEMORY_API_KEY",
+        "RETAINDB_API_KEY",
+        "HINDSIGHT_API_KEY",
+        "HINDSIGHT_LLM_API_KEY",
+        "TINKER_API_KEY",
+        "DAYTONA_API_KEY",
+        "TWILIO_AUTH_TOKEN",
+        "TELEGRAM_BOT_TOKEN",
+        "DISCORD_BOT_TOKEN",
+        "SLACK_BOT_TOKEN",
+        "SLACK_APP_TOKEN",
+        "MATTERMOST_TOKEN",
+        "MATRIX_ACCESS_TOKEN",
+        "MATRIX_PASSWORD",
+        "MATRIX_RECOVERY_KEY",
+        "HASS_TOKEN",
+        "EMAIL_PASSWORD",
+        "BLUEBUBBLES_PASSWORD",
+        "FEISHU_APP_SECRET",
+        "FEISHU_ENCRYPT_KEY",
+        "FEISHU_VERIFICATION_TOKEN",
+        "DINGTALK_CLIENT_SECRET",
+        "QQ_CLIENT_SECRET",
+        "QQ_STT_API_KEY",
+        "WECOM_SECRET",
+        "WECOM_CALLBACK_CORP_SECRET",
+        "WECOM_CALLBACK_TOKEN",
+        "WECOM_CALLBACK_ENCODING_AES_KEY",
+        "WEIXIN_TOKEN",
+        "MODAL_TOKEN_ID",
+        "MODAL_TOKEN_SECRET",
+        "TERMINAL_SSH_KEY",
+        "SUDO_PASSWORD",
+        "GATEWAY_PROXY_KEY",
+        "API_SERVER_KEY",
+        "TOOL_GATEWAY_USER_TOKEN",
+        "TELEGRAM_WEBHOOK_SECRET",
+        "WEBHOOK_SECRET",
+        "AI_GATEWAY_API_KEY",
+        "VOICE_TOOLS_OPENAI_KEY",
+        "BROWSER_USE_API_KEY",
+        "CUSTOM_API_KEY",
+        "GATEWAY_PROXY_URL",
+        "GEMINI_BASE_URL",
+        "OPENAI_BASE_URL",
+        "OPENROUTER_BASE_URL",
+        "OLLAMA_BASE_URL",
+        "GROQ_BASE_URL",
+        "XAI_BASE_URL",
+        "AI_GATEWAY_BASE_URL",
+        "ANTHROPIC_BASE_URL",
+    }
+)
 
 
 def _looks_like_credential(name: str) -> bool:
@@ -159,59 +158,36 @@ def _looks_like_credential(name: str) -> bool:
 
 # HERMES_* vars that change test behavior by being set. Unset all of these
 # unconditionally — individual tests that need them set do so explicitly.
-_HERMES_BEHAVIORAL_VARS = frozenset({
-    "HERMES_YOLO_MODE",
-    "HERMES_INTERACTIVE",
-    "HERMES_QUIET",
-    "HERMES_TOOL_PROGRESS",
-    "HERMES_TOOL_PROGRESS_MODE",
-    "HERMES_MAX_ITERATIONS",
-    "HERMES_SESSION_PLATFORM",
-    "HERMES_SESSION_CHAT_ID",
-    "HERMES_SESSION_CHAT_NAME",
-    "HERMES_SESSION_THREAD_ID",
-    "HERMES_SESSION_SOURCE",
-    "HERMES_SESSION_KEY",
-    "HERMES_GATEWAY_SESSION",
-    "HERMES_PLATFORM",
-    "HERMES_INFERENCE_PROVIDER",
-    "HERMES_MANAGED",
-    "HERMES_DEV",
-    "HERMES_CONTAINER",
-    "HERMES_EPHEMERAL_SYSTEM_PROMPT",
-    "HERMES_TIMEZONE",
-    "HERMES_REDACT_SECRETS",
-    "HERMES_BACKGROUND_NOTIFICATIONS",
-    "HERMES_EXEC_ASK",
-    "HERMES_HOME_MODE",
-    "BROWSER_CDP_URL",
-    "CAMOFOX_URL",
-    # Platform allowlists — not credentials, but if set from any source
-    # (user shell, earlier leaky test, CI env), they change gateway auth
-    # behavior and flake button-authorization tests.
-    "TELEGRAM_ALLOWED_USERS",
-    "DISCORD_ALLOWED_USERS",
-    "WHATSAPP_ALLOWED_USERS",
-    "SLACK_ALLOWED_USERS",
-    "SIGNAL_ALLOWED_USERS",
-    "SIGNAL_GROUP_ALLOWED_USERS",
-    "EMAIL_ALLOWED_USERS",
-    "SMS_ALLOWED_USERS",
-    "MATTERMOST_ALLOWED_USERS",
-    "MATRIX_ALLOWED_USERS",
-    "DINGTALK_ALLOWED_USERS",
-    "FEISHU_ALLOWED_USERS",
-    "WECOM_ALLOWED_USERS",
-    "GATEWAY_ALLOWED_USERS",
-    "GATEWAY_ALLOW_ALL_USERS",
-    "TELEGRAM_ALLOW_ALL_USERS",
-    "DISCORD_ALLOW_ALL_USERS",
-    "WHATSAPP_ALLOW_ALL_USERS",
-    "SLACK_ALLOW_ALL_USERS",
-    "SIGNAL_ALLOW_ALL_USERS",
-    "EMAIL_ALLOW_ALL_USERS",
-    "SMS_ALLOW_ALL_USERS",
-})
+_HERMES_BEHAVIORAL_VARS = frozenset(
+    {
+        "HERMES_YOLO_MODE",
+        "HERMES_INTERACTIVE",
+        "HERMES_QUIET",
+        "HERMES_TOOL_PROGRESS",
+        "HERMES_TOOL_PROGRESS_MODE",
+        "HERMES_MAX_ITERATIONS",
+        "HERMES_SESSION_PLATFORM",
+        "HERMES_SESSION_CHAT_ID",
+        "HERMES_SESSION_CHAT_NAME",
+        "HERMES_SESSION_THREAD_ID",
+        "HERMES_SESSION_SOURCE",
+        "HERMES_SESSION_KEY",
+        "HERMES_GATEWAY_SESSION",
+        "HERMES_PLATFORM",
+        "HERMES_INFERENCE_PROVIDER",
+        "HERMES_MANAGED",
+        "HERMES_DEV",
+        "HERMES_CONTAINER",
+        "HERMES_EPHEMERAL_SYSTEM_PROMPT",
+        "HERMES_TIMEZONE",
+        "HERMES_REDACT_SECRETS",
+        "HERMES_BACKGROUND_NOTIFICATIONS",
+        "HERMES_EXEC_ASK",
+        "HERMES_HOME_MODE",
+        "BROWSER_CDP_URL",
+        "CAMOFOX_URL",
+    }
+)
 
 
 @pytest.fixture(autouse=True)
@@ -270,6 +246,7 @@ def _hermetic_environment(tmp_path, monkeypatch):
     #    singleton might still be cached from a previous test).
     try:
         import hermes_cli.plugins as _plugins_mod
+
         monkeypatch.setattr(_plugins_mod, "_plugin_manager", None)
     except Exception:
         pass
@@ -280,117 +257,16 @@ def _hermetic_environment(tmp_path, monkeypatch):
 @pytest.fixture(autouse=True)
 def _isolate_hermes_home(_hermetic_environment):
     """Alias preserved for any test that yields this name explicitly."""
-    return None
+    return
 
 
-# ── Module-level state reset ───────────────────────────────────────────────
-#
-# Python modules are singletons per process, and pytest-xdist workers are
-# long-lived. Module-level dicts/sets (tool registries, approval state,
-# interrupt flags) and ContextVars persist across tests in the same worker,
-# causing tests that pass alone to fail when run with siblings.
-#
-# Each entry in this fixture clears state that belongs to a specific module.
-# New state buckets go here too — this is the single gate that prevents
-# "works alone, flakes in CI" bugs from state leakage.
-#
-# The skill `test-suite-cascade-diagnosis` documents the concrete patterns
-# this closes; the running example was `test_command_guards` failing 12/15
-# CI runs because ``tools.approval._session_approved`` carried approvals
-# from one test's session into another's.
-
-@pytest.fixture(autouse=True)
-def _reset_module_state():
-    """Clear module-level mutable state and ContextVars between tests.
-
-    Keeps state from leaking across tests on the same xdist worker. Modules
-    that don't exist yet (test collection before production import) are
-    skipped silently — production import later creates fresh empty state.
-    """
-    # --- tools.approval — the single biggest source of cross-test pollution ---
-    try:
-        from tools import approval as _approval_mod
-        _approval_mod._session_approved.clear()
-        _approval_mod._session_yolo.clear()
-        _approval_mod._permanent_approved.clear()
-        _approval_mod._pending.clear()
-        _approval_mod._gateway_queues.clear()
-        _approval_mod._gateway_notify_cbs.clear()
-        # ContextVar: reset to empty string so get_current_session_key()
-        # falls through to the env var / default path, matching a fresh
-        # process.
-        _approval_mod._approval_session_key.set("")
-    except Exception:
-        pass
-
-    # --- tools.interrupt — per-thread interrupt flag set ---
-    try:
-        from tools import interrupt as _interrupt_mod
-        with _interrupt_mod._lock:
-            _interrupt_mod._interrupted_threads.clear()
-    except Exception:
-        pass
-
-    # --- gateway.session_context — 9 ContextVars that represent
-    #     the active gateway session. If set in one test and not reset,
-    #     the next test's get_session_env() reads stale values.
-    try:
-        from gateway import session_context as _sc_mod
-        for _cv in (
-            _sc_mod._SESSION_PLATFORM,
-            _sc_mod._SESSION_CHAT_ID,
-            _sc_mod._SESSION_CHAT_NAME,
-            _sc_mod._SESSION_THREAD_ID,
-            _sc_mod._SESSION_USER_ID,
-            _sc_mod._SESSION_USER_NAME,
-            _sc_mod._SESSION_KEY,
-            _sc_mod._CRON_AUTO_DELIVER_PLATFORM,
-            _sc_mod._CRON_AUTO_DELIVER_CHAT_ID,
-            _sc_mod._CRON_AUTO_DELIVER_THREAD_ID,
-        ):
-            _cv.set(_sc_mod._UNSET)
-    except Exception:
-        pass
-
-    # --- tools.env_passthrough — ContextVar<set[str]> with no default ---
-    # LookupError is normal if the test never set it. Setting it to an
-    # empty set unconditionally normalizes the starting state.
-    try:
-        from tools import env_passthrough as _envp_mod
-        _envp_mod._allowed_env_vars_var.set(set())
-    except Exception:
-        pass
-
-    # --- tools.credential_files — ContextVar<dict> ---
-    try:
-        from tools import credential_files as _credf_mod
-        _credf_mod._registered_files_var.set({})
-    except Exception:
-        pass
-
-    # --- tools.file_tools — per-task read history + file-ops cache ---
-    # _read_tracker accumulates per-task_id read history for loop detection,
-    # capped by _READ_HISTORY_CAP. If entries from a prior test persist, the
-    # cap is hit faster than expected and capacity-related tests flake.
-    try:
-        from tools import file_tools as _ft_mod
-        with _ft_mod._read_tracker_lock:
-            _ft_mod._read_tracker.clear()
-        with _ft_mod._file_ops_lock:
-            _ft_mod._file_ops_cache.clear()
-    except Exception:
-        pass
-
-    yield
-
-
-@pytest.fixture()
+@pytest.fixture
 def tmp_dir(tmp_path):
     """Provide a temporary directory that is cleaned up automatically."""
     return tmp_path
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_config():
     """Return a minimal hermes config dict suitable for unit tests."""
     return {
@@ -413,8 +289,10 @@ def mock_config():
 # Prevents hanging tests (subprocess spawns, blocking I/O) from stalling the
 # entire test suite.
 
+
 def _timeout_handler(signum, frame):
     raise TimeoutError("Test exceeded 30 second timeout")
+
 
 @pytest.fixture(autouse=True)
 def _ensure_current_event_loop(request):
@@ -429,24 +307,16 @@ def _ensure_current_event_loop(request):
         yield
         return
 
-    try:
-        loop = asyncio.get_event_loop_policy().get_event_loop()
-    except RuntimeError:
-        loop = None
-
-    created = loop is None or loop.is_closed()
-    if created:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
 
     try:
         yield
     finally:
-        if created and loop is not None:
-            try:
-                loop.close()
-            finally:
-                asyncio.set_event_loop(None)
+        try:
+            loop.close()
+        finally:
+            asyncio.set_event_loop(None)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -14,26 +14,21 @@ Tests cover:
 
 import asyncio
 import json
-import time
-import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from aiohttp import web
-from aiohttp.test_utils import AioHTTPTestCase, TestClient, TestServer
-
+from aiohttp.test_utils import TestClient, TestServer
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.api_server import (
+    _ADAPTER_KEY,
     APIServerAdapter,
     ResponseStore,
-    _IdempotencyCache,
-    _CORS_HEADERS,
     _derive_chat_session_id,
     check_api_server_requirements,
     cors_middleware,
     security_headers_middleware,
 )
-
 
 # ---------------------------------------------------------------------------
 # check_api_server_requirements
@@ -229,7 +224,9 @@ class TestAdapterInit:
         monkeypatch.setenv("API_SERVER_HOST", "10.0.0.1")
         monkeypatch.setenv("API_SERVER_PORT", "7777")
         monkeypatch.setenv("API_SERVER_KEY", "sk-env")
-        monkeypatch.setenv("API_SERVER_CORS_ORIGINS", "http://localhost:3000, http://127.0.0.1:3000")
+        monkeypatch.setenv(
+            "API_SERVER_CORS_ORIGINS", "http://localhost:3000, http://127.0.0.1:3000"
+        )
         config = PlatformConfig(enabled=True)
         adapter = APIServerAdapter(config)
         assert adapter._host == "10.0.0.1"
@@ -307,9 +304,11 @@ def _make_adapter(api_key: str = "", cors_origins=None) -> APIServerAdapter:
 
 def _create_app(adapter: APIServerAdapter) -> web.Application:
     """Create the aiohttp app from the adapter (without starting the full server)."""
-    mws = [mw for mw in (cors_middleware, security_headers_middleware) if mw is not None]
+    mws = [
+        mw for mw in (cors_middleware, security_headers_middleware) if mw is not None
+    ]
     app = web.Application(middlewares=mws)
-    app["api_server_adapter"] = adapter
+    app[_ADAPTER_KEY] = adapter
     app.router.add_get("/health", adapter._handle_health)
     app.router.add_get("/health/detailed", adapter._handle_health_detailed)
     app.router.add_get("/v1/health", adapter._handle_health)
@@ -317,7 +316,9 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_post("/v1/chat/completions", adapter._handle_chat_completions)
     app.router.add_post("/v1/responses", adapter._handle_responses)
     app.router.add_get("/v1/responses/{response_id}", adapter._handle_get_response)
-    app.router.add_delete("/v1/responses/{response_id}", adapter._handle_delete_response)
+    app.router.add_delete(
+        "/v1/responses/{response_id}", adapter._handle_delete_response
+    )
     return app
 
 
@@ -379,13 +380,16 @@ class TestHealthDetailedEndpoint:
     async def test_health_detailed_returns_ok(self, adapter):
         """GET /health/detailed returns status, platform, and runtime fields."""
         app = _create_app(adapter)
-        with patch("gateway.status.read_runtime_status", return_value={
-            "gateway_state": "running",
-            "platforms": {"telegram": {"state": "connected"}},
-            "active_agents": 2,
-            "exit_reason": None,
-            "updated_at": "2026-04-14T00:00:00Z",
-        }):
+        with patch(
+            "gateway.status.read_runtime_status",
+            return_value={
+                "gateway_state": "running",
+                "platforms": {"telegram": {"state": "connected"}},
+                "active_agents": 2,
+                "exit_reason": None,
+                "updated_at": "2026-04-14T00:00:00Z",
+            },
+        ):
             async with TestClient(TestServer(app)) as cli:
                 resp = await cli.get("/health/detailed")
                 assert resp.status == 200
@@ -442,7 +446,10 @@ class TestModelsEndpoint:
     @pytest.mark.asyncio
     async def test_models_returns_profile_name(self):
         """When running under a named profile, /v1/models advertises the profile name."""
-        with patch("gateway.platforms.api_server.APIServerAdapter._resolve_model_name", return_value="lucas"):
+        with patch(
+            "gateway.platforms.api_server.APIServerAdapter._resolve_model_name",
+            return_value="lucas",
+        ):
             adapter = _make_adapter()
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
@@ -465,7 +472,9 @@ class TestModelsEndpoint:
 
     def test_resolve_model_name_default_profile(self):
         """Default profile falls back to 'hermes-agent'."""
-        with patch("hermes_cli.profiles.get_active_profile_name", return_value="default"):
+        with patch(
+            "hermes_cli.profiles.get_active_profile_name", return_value="default"
+        ):
             assert APIServerAdapter._resolve_model_name("") == "hermes-agent"
 
     def test_resolve_model_name_named_profile(self):
@@ -523,7 +532,9 @@ class TestChatCompletionsEndpoint:
     async def test_empty_messages_returns_400(self, adapter):
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
-            resp = await cli.post("/v1/chat/completions", json={"model": "test", "messages": []})
+            resp = await cli.post(
+                "/v1/chat/completions", json={"model": "test", "messages": []}
+            )
             assert resp.status == 400
 
     @pytest.mark.asyncio
@@ -531,6 +542,7 @@ class TestChatCompletionsEndpoint:
         """stream=true returns SSE format with the full response."""
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
+
             async def _mock_run_agent(**kwargs):
                 # Simulate streaming: invoke stream_delta_callback with tokens
                 cb = kwargs.get("stream_delta_callback")
@@ -542,7 +554,9 @@ class TestChatCompletionsEndpoint:
                     {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
                 )
 
-            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent) as mock_run:
+            with patch.object(
+                adapter, "_run_agent", side_effect=_mock_run_agent
+            ) as mock_run:
                 resp = await cli.post(
                     "/v1/chat/completions",
                     json={
@@ -563,10 +577,12 @@ class TestChatCompletionsEndpoint:
     async def test_stream_sends_keepalive_during_quiet_tool_gap(self, adapter):
         """Idle SSE streams should send keepalive comments while tools run silently."""
         import asyncio
+
         import gateway.platforms.api_server as api_server_mod
 
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
+
             async def _mock_run_agent(**kwargs):
                 cb = kwargs.get("stream_delta_callback")
                 if cb:
@@ -574,12 +590,18 @@ class TestChatCompletionsEndpoint:
                     await asyncio.sleep(0.65)
                     cb("...done")
                 return (
-                    {"final_response": "Working...done", "messages": [], "api_calls": 1},
+                    {
+                        "final_response": "Working...done",
+                        "messages": [],
+                        "api_calls": 1,
+                    },
                     {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
                 )
 
             with (
-                patch.object(api_server_mod, "CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS", 0.01),
+                patch.object(
+                    api_server_mod, "CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS", 0.01
+                ),
                 patch.object(adapter, "_run_agent", side_effect=_mock_run_agent),
             ):
                 resp = await cli.post(
@@ -610,20 +632,25 @@ class TestChatCompletionsEndpoint:
 
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
+
             async def _mock_run_agent(**kwargs):
                 cb = kwargs.get("stream_delta_callback")
                 if cb:
                     # Simulate: agent streams partial text, then fires None
                     # (tool call box-close signal), then streams the final answer
                     cb("Thinking")
-                    cb(None)          # mid-stream None from tool calls
+                    cb(None)  # mid-stream None from tool calls
                     await asyncio.sleep(0.05)  # simulate tool execution delay
                     cb(" about it...")
-                    cb(None)          # another None (possible second tool round)
+                    cb(None)  # another None (possible second tool round)
                     await asyncio.sleep(0.05)
                     cb(" The answer is 42.")
                 return (
-                    {"final_response": "Thinking about it... The answer is 42.", "messages": [], "api_calls": 3},
+                    {
+                        "final_response": "Thinking about it... The answer is 42.",
+                        "messages": [],
+                        "api_calls": 3,
+                    },
                     {"input_tokens": 20, "output_tokens": 15, "total_tokens": 35},
                 )
 
@@ -632,7 +659,9 @@ class TestChatCompletionsEndpoint:
                     "/v1/chat/completions",
                     json={
                         "model": "test",
-                        "messages": [{"role": "user", "content": "What is the answer?"}],
+                        "messages": [
+                            {"role": "user", "content": "What is the answer?"}
+                        ],
                         "stream": True,
                     },
                 )
@@ -652,6 +681,7 @@ class TestChatCompletionsEndpoint:
 
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
+
             async def _mock_run_agent(**kwargs):
                 cb = kwargs.get("stream_delta_callback")
                 tp_cb = kwargs.get("tool_progress_callback")
@@ -662,7 +692,11 @@ class TestChatCompletionsEndpoint:
                     await asyncio.sleep(0.05)
                     cb("Here are the files.")
                 return (
-                    {"final_response": "Here are the files.", "messages": [], "api_calls": 1},
+                    {
+                        "final_response": "Here are the files.",
+                        "messages": [],
+                        "api_calls": 1,
+                    },
                     {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
                 )
 
@@ -687,17 +721,21 @@ class TestChatCompletionsEndpoint:
                 # The progress marker must NOT appear inside any
                 # chat.completion.chunk delta.content field.
                 import json as _json
+
                 for line in body.splitlines():
                     if line.startswith("data: ") and line.strip() != "data: [DONE]":
                         try:
-                            chunk = _json.loads(line[len("data: "):])
+                            chunk = _json.loads(line[len("data: ") :])
                         except _json.JSONDecodeError:
                             continue
                         if chunk.get("object") == "chat.completion.chunk":
                             for choice in chunk.get("choices", []):
                                 content = choice.get("delta", {}).get("content", "")
                                 # Tool emoji markers must never leak into content
-                                assert "ls -la" not in content or content == "Here are the files."
+                                assert (
+                                    "ls -la" not in content
+                                    or content == "Here are the files."
+                                )
                 # Final content must also be present
                 assert "Here are the files." in body
 
@@ -708,12 +746,18 @@ class TestChatCompletionsEndpoint:
 
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
+
             async def _mock_run_agent(**kwargs):
                 cb = kwargs.get("stream_delta_callback")
                 tp_cb = kwargs.get("tool_progress_callback")
                 if tp_cb:
                     tp_cb("tool.started", "_thinking", "some internal state", {})
-                    tp_cb("tool.started", "web_search", "Python docs", {"query": "Python docs"})
+                    tp_cb(
+                        "tool.started",
+                        "web_search",
+                        "Python docs",
+                        {"query": "Python docs"},
+                    )
                 if cb:
                     await asyncio.sleep(0.05)
                     cb("Found it.")
@@ -764,8 +808,13 @@ class TestChatCompletionsEndpoint:
 
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
-            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
-                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+            with patch.object(
+                adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
+                mock_run.return_value = (
+                    mock_result,
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
                 resp = await cli.post(
                     "/v1/chat/completions",
                     json={
@@ -781,7 +830,10 @@ class TestChatCompletionsEndpoint:
             assert data["model"] == "hermes-agent"
             assert len(data["choices"]) == 1
             assert data["choices"][0]["message"]["role"] == "assistant"
-            assert data["choices"][0]["message"]["content"] == "Hello! How can I help you today?"
+            assert (
+                data["choices"][0]["message"]["content"]
+                == "Hello! How can I help you today?"
+            )
             assert data["choices"][0]["finish_reason"] == "stop"
             assert "usage" in data
 
@@ -796,8 +848,13 @@ class TestChatCompletionsEndpoint:
 
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
-            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
-                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+            with patch.object(
+                adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
+                mock_run.return_value = (
+                    mock_result,
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
                 resp = await cli.post(
                     "/v1/chat/completions",
                     json={
@@ -812,7 +869,9 @@ class TestChatCompletionsEndpoint:
             assert resp.status == 200
             # Check that _run_agent was called with the system prompt
             call_kwargs = mock_run.call_args
-            assert call_kwargs.kwargs.get("ephemeral_system_prompt") == "You are a pirate."
+            assert (
+                call_kwargs.kwargs.get("ephemeral_system_prompt") == "You are a pirate."
+            )
             assert call_kwargs.kwargs.get("user_message") == "Hello"
 
     @pytest.mark.asyncio
@@ -822,8 +881,13 @@ class TestChatCompletionsEndpoint:
 
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
-            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
-                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+            with patch.object(
+                adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
+                mock_run.return_value = (
+                    mock_result,
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
                 resp = await cli.post(
                     "/v1/chat/completions",
                     json={
@@ -840,15 +904,23 @@ class TestChatCompletionsEndpoint:
             call_kwargs = mock_run.call_args.kwargs
             assert call_kwargs["user_message"] == "Now add 1 more"
             assert len(call_kwargs["conversation_history"]) == 2
-            assert call_kwargs["conversation_history"][0] == {"role": "user", "content": "1+1=?"}
-            assert call_kwargs["conversation_history"][1] == {"role": "assistant", "content": "2"}
+            assert call_kwargs["conversation_history"][0] == {
+                "role": "user",
+                "content": "1+1=?",
+            }
+            assert call_kwargs["conversation_history"][1] == {
+                "role": "assistant",
+                "content": "2",
+            }
 
     @pytest.mark.asyncio
     async def test_agent_error_returns_500(self, adapter):
         """Agent exception returns 500."""
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
-            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+            with patch.object(
+                adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
                 mock_run.side_effect = RuntimeError("Provider failed")
                 resp = await cli.post(
                     "/v1/chat/completions",
@@ -871,8 +943,13 @@ class TestChatCompletionsEndpoint:
         session_ids = []
         async with TestClient(TestServer(app)) as cli:
             # Turn 1: single user message
-            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
-                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+            with patch.object(
+                adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
+                mock_run.return_value = (
+                    mock_result,
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
                 await cli.post(
                     "/v1/chat/completions",
                     json={
@@ -883,8 +960,13 @@ class TestChatCompletionsEndpoint:
                 session_ids.append(mock_run.call_args.kwargs["session_id"])
 
             # Turn 2: same first message, conversation grew
-            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
-                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+            with patch.object(
+                adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
+                mock_run.return_value = (
+                    mock_result,
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
                 await cli.post(
                     "/v1/chat/completions",
                     json={
@@ -898,8 +980,12 @@ class TestChatCompletionsEndpoint:
                 )
                 session_ids.append(mock_run.call_args.kwargs["session_id"])
 
-        assert session_ids[0] == session_ids[1], "Session ID should be stable across turns"
-        assert session_ids[0].startswith("api-"), "Derived session IDs should have api- prefix"
+        assert session_ids[0] == session_ids[1], (
+            "Session ID should be stable across turns"
+        )
+        assert session_ids[0].startswith("api-"), (
+            "Derived session IDs should have api- prefix"
+        )
 
     @pytest.mark.asyncio
     async def test_different_conversations_get_different_session_ids(self, adapter):
@@ -910,8 +996,13 @@ class TestChatCompletionsEndpoint:
         session_ids = []
         async with TestClient(TestServer(app)) as cli:
             for first_msg in ["Hello", "Goodbye"]:
-                with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
-                    mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                with patch.object(
+                    adapter, "_run_agent", new_callable=AsyncMock
+                ) as mock_run:
+                    mock_run.return_value = (
+                        mock_result,
+                        {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                    )
                     await cli.post(
                         "/v1/chat/completions",
                         json={
@@ -992,8 +1083,13 @@ class TestResponsesEndpoint:
 
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
-            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
-                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+            with patch.object(
+                adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
+                mock_run.return_value = (
+                    mock_result,
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
                 resp = await cli.post(
                     "/v1/responses",
                     json={
@@ -1010,7 +1106,10 @@ class TestResponsesEndpoint:
             assert len(data["output"]) == 1
             assert data["output"][0]["type"] == "message"
             assert data["output"][0]["content"][0]["type"] == "output_text"
-            assert data["output"][0]["content"][0]["text"] == "Paris is the capital of France."
+            assert (
+                data["output"][0]["content"][0]["text"]
+                == "Paris is the capital of France."
+            )
 
     @pytest.mark.asyncio
     async def test_successful_response_with_array_input(self, adapter):
@@ -1019,8 +1118,13 @@ class TestResponsesEndpoint:
 
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
-            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
-                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+            with patch.object(
+                adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
+                mock_run.return_value = (
+                    mock_result,
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
                 resp = await cli.post(
                     "/v1/responses",
                     json={
@@ -1045,8 +1149,13 @@ class TestResponsesEndpoint:
 
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
-            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
-                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+            with patch.object(
+                adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
+                mock_run.return_value = (
+                    mock_result,
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
                 resp = await cli.post(
                     "/v1/responses",
                     json={
@@ -1072,8 +1181,13 @@ class TestResponsesEndpoint:
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
             # First request
-            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
-                mock_run.return_value = (mock_result_1, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+            with patch.object(
+                adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
+                mock_run.return_value = (
+                    mock_result_1,
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
                 resp1 = await cli.post(
                     "/v1/responses",
                     json={"model": "hermes-agent", "input": "What is 1+1?"},
@@ -1090,8 +1204,13 @@ class TestResponsesEndpoint:
                 "api_calls": 1,
             }
 
-            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
-                mock_run.return_value = (mock_result_2, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+            with patch.object(
+                adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
+                mock_run.return_value = (
+                    mock_result_2,
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
                 resp2 = await cli.post(
                     "/v1/responses",
                     json={
@@ -1120,7 +1239,9 @@ class TestResponsesEndpoint:
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
             # First request — establishes a session
-            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+            with patch.object(
+                adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
                 mock_run.return_value = (mock_result, usage)
                 resp1 = await cli.post(
                     "/v1/responses",
@@ -1132,7 +1253,9 @@ class TestResponsesEndpoint:
             response_id = data1["id"]
 
             # Second request — chains from the first
-            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+            with patch.object(
+                adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
                 mock_run.return_value = (mock_result, usage)
                 resp2 = await cli.post(
                     "/v1/responses",
@@ -1169,8 +1292,13 @@ class TestResponsesEndpoint:
 
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
-            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
-                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+            with patch.object(
+                adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
+                mock_run.return_value = (
+                    mock_result,
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
                 resp = await cli.post(
                     "/v1/responses",
                     json={
@@ -1193,8 +1321,13 @@ class TestResponsesEndpoint:
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
             # First request with instructions
-            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
-                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+            with patch.object(
+                adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
+                mock_run.return_value = (
+                    mock_result,
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
                 resp1 = await cli.post(
                     "/v1/responses",
                     json={
@@ -1208,8 +1341,13 @@ class TestResponsesEndpoint:
             resp_id = data1["id"]
 
             # Second request without instructions
-            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
-                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+            with patch.object(
+                adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
+                mock_run.return_value = (
+                    mock_result,
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
                 resp2 = await cli.post(
                     "/v1/responses",
                     json={
@@ -1227,7 +1365,9 @@ class TestResponsesEndpoint:
     async def test_agent_error_returns_500(self, adapter):
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
-            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+            with patch.object(
+                adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
                 mock_run.side_effect = RuntimeError("Boom")
                 resp = await cli.post(
                     "/v1/responses",
@@ -1252,6 +1392,7 @@ class TestResponsesStreaming:
     async def test_stream_true_returns_responses_sse(self, adapter):
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
+
             async def _mock_run_agent(**kwargs):
                 cb = kwargs.get("stream_delta_callback")
                 if cb:
@@ -1283,6 +1424,7 @@ class TestResponsesStreaming:
     async def test_stream_emits_function_call_and_output_items(self, adapter):
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
+
             async def _mock_run_agent(**kwargs):
                 start_cb = kwargs.get("tool_start_callback")
                 complete_cb = kwargs.get("tool_complete_callback")
@@ -1290,7 +1432,12 @@ class TestResponsesStreaming:
                 if start_cb:
                     start_cb("call_123", "read_file", {"path": "/tmp/test.txt"})
                 if complete_cb:
-                    complete_cb("call_123", "read_file", {"path": "/tmp/test.txt"}, '{"content":"hello"}')
+                    complete_cb(
+                        "call_123",
+                        "read_file",
+                        {"path": "/tmp/test.txt"},
+                        '{"content":"hello"}',
+                    )
                 if text_cb:
                     text_cb("Done.")
                 return (
@@ -1323,7 +1470,11 @@ class TestResponsesStreaming:
             with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
                 resp = await cli.post(
                     "/v1/responses",
-                    json={"model": "hermes-agent", "input": "read the file", "stream": True},
+                    json={
+                        "model": "hermes-agent",
+                        "input": "read the file",
+                        "stream": True,
+                    },
                 )
                 assert resp.status == 200
                 body = await resp.text()
@@ -1334,32 +1485,44 @@ class TestResponsesStreaming:
                 assert '"type": "function_call_output"' in body
                 assert '"call_id": "call_123"' in body
                 assert '"name": "read_file"' in body
-                assert '"output": [{"type": "input_text", "text": "{\\"content\\":\\"hello\\"}"}]' in body
+                assert (
+                    '"output": [{"type": "input_text", "text": "{\\"content\\":\\"hello\\"}"}]'
+                    in body
+                )
 
     @pytest.mark.asyncio
     async def test_streamed_response_is_stored_for_get(self, adapter):
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
+
             async def _mock_run_agent(**kwargs):
                 cb = kwargs.get("stream_delta_callback")
                 if cb:
                     cb("Stored response")
                 return (
-                    {"final_response": "Stored response", "messages": [], "api_calls": 1},
+                    {
+                        "final_response": "Stored response",
+                        "messages": [],
+                        "api_calls": 1,
+                    },
                     {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3},
                 )
 
             with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
                 resp = await cli.post(
                     "/v1/responses",
-                    json={"model": "hermes-agent", "input": "store this", "stream": True},
+                    json={
+                        "model": "hermes-agent",
+                        "input": "store this",
+                        "stream": True,
+                    },
                 )
                 body = await resp.text()
                 response_id = None
                 for line in body.splitlines():
                     if line.startswith("data: "):
                         try:
-                            payload = json.loads(line[len("data: "):])
+                            payload = json.loads(line[len("data: ") :])
                         except json.JSONDecodeError:
                             continue
                         if payload.get("type") == "response.completed":
@@ -1428,6 +1591,7 @@ class TestConfigIntegration:
     def test_env_override_enables_api_server(self, monkeypatch):
         monkeypatch.setenv("API_SERVER_ENABLED", "true")
         from gateway.config import load_gateway_config
+
         config = load_gateway_config()
         assert Platform.API_SERVER in config.platforms
         assert config.platforms[Platform.API_SERVER].enabled is True
@@ -1435,6 +1599,7 @@ class TestConfigIntegration:
     def test_env_override_with_key(self, monkeypatch):
         monkeypatch.setenv("API_SERVER_KEY", "sk-mykey")
         from gateway.config import load_gateway_config
+
         config = load_gateway_config()
         assert Platform.API_SERVER in config.platforms
         assert config.platforms[Platform.API_SERVER].extra.get("key") == "sk-mykey"
@@ -1444,6 +1609,7 @@ class TestConfigIntegration:
         monkeypatch.setenv("API_SERVER_PORT", "9999")
         monkeypatch.setenv("API_SERVER_HOST", "0.0.0.0")
         from gateway.config import load_gateway_config
+
         config = load_gateway_config()
         assert config.platforms[Platform.API_SERVER].extra.get("port") == 9999
         assert config.platforms[Platform.API_SERVER].extra.get("host") == "0.0.0.0"
@@ -1455,6 +1621,7 @@ class TestConfigIntegration:
             "http://localhost:3000, http://127.0.0.1:3000",
         )
         from gateway.config import load_gateway_config
+
         config = load_gateway_config()
         assert config.platforms[Platform.API_SERVER].extra.get("cors_origins") == [
             "http://localhost:3000",
@@ -1486,8 +1653,13 @@ class TestMultipleSystemMessages:
 
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
-            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
-                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+            with patch.object(
+                adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
+                mock_run.return_value = (
+                    mock_result,
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
                 resp = await cli.post(
                     "/v1/chat/completions",
                     json={
@@ -1536,8 +1708,13 @@ class TestGetResponse:
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
             # Create a response first
-            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
-                mock_run.return_value = (mock_result, {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15})
+            with patch.object(
+                adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
+                mock_run.return_value = (
+                    mock_result,
+                    {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+                )
                 resp = await cli.post(
                     "/v1/responses",
                     json={"model": "hermes-agent", "input": "Hi"},
@@ -1583,8 +1760,13 @@ class TestDeleteResponse:
 
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
-            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
-                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+            with patch.object(
+                adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
+                mock_run.return_value = (
+                    mock_result,
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
                 resp = await cli.post(
                     "/v1/responses",
                     json={"model": "hermes-agent", "input": "Hi"},
@@ -1660,8 +1842,13 @@ class TestToolCallsInOutput:
 
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
-            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
-                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+            with patch.object(
+                adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
+                mock_run.return_value = (
+                    mock_result,
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
                 resp = await cli.post(
                     "/v1/responses",
                     json={"model": "hermes-agent", "input": "What is 6*7?"},
@@ -1690,8 +1877,13 @@ class TestToolCallsInOutput:
 
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
-            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
-                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+            with patch.object(
+                adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
+                mock_run.return_value = (
+                    mock_result,
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
                 resp = await cli.post(
                     "/v1/responses",
                     json={"model": "hermes-agent", "input": "Hello"},
@@ -1717,7 +1909,9 @@ class TestUsageCounting:
 
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
-            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+            with patch.object(
+                adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
                 mock_run.return_value = (mock_result, usage)
                 resp = await cli.post(
                     "/v1/responses",
@@ -1738,7 +1932,9 @@ class TestUsageCounting:
 
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
-            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+            with patch.object(
+                adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
                 mock_run.return_value = (mock_result, usage)
                 resp = await cli.post(
                     "/v1/chat/completions",
@@ -1768,16 +1964,24 @@ class TestTruncation:
 
         # Pre-seed a stored response with a long history
         long_history = [{"role": "user", "content": f"msg {i}"} for i in range(150)]
-        adapter._response_store.put("resp_prev", {
-            "response": {"id": "resp_prev", "object": "response"},
-            "conversation_history": long_history,
-            "instructions": None,
-        })
+        adapter._response_store.put(
+            "resp_prev",
+            {
+                "response": {"id": "resp_prev", "object": "response"},
+                "conversation_history": long_history,
+                "instructions": None,
+            },
+        )
 
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
-            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
-                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+            with patch.object(
+                adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
+                mock_run.return_value = (
+                    mock_result,
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
                 resp = await cli.post(
                     "/v1/responses",
                     json={
@@ -1799,16 +2003,24 @@ class TestTruncation:
         mock_result = {"final_response": "OK", "messages": [], "api_calls": 1}
 
         long_history = [{"role": "user", "content": f"msg {i}"} for i in range(150)]
-        adapter._response_store.put("resp_prev2", {
-            "response": {"id": "resp_prev2", "object": "response"},
-            "conversation_history": long_history,
-            "instructions": None,
-        })
+        adapter._response_store.put(
+            "resp_prev2",
+            {
+                "response": {"id": "resp_prev2", "object": "response"},
+                "conversation_history": long_history,
+                "instructions": None,
+            },
+        )
 
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
-            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
-                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+            with patch.object(
+                adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
+                mock_run.return_value = (
+                    mock_result,
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
                 resp = await cli.post(
                     "/v1/responses",
                     json={
@@ -1894,7 +2106,10 @@ class TestCORS:
         async with TestClient(TestServer(app)) as cli:
             resp = await cli.get("/health", headers={"Origin": "http://localhost:3000"})
             assert resp.status == 200
-            assert resp.headers.get("Access-Control-Allow-Origin") == "http://localhost:3000"
+            assert (
+                resp.headers.get("Access-Control-Allow-Origin")
+                == "http://localhost:3000"
+            )
             assert "POST" in resp.headers.get("Access-Control-Allow-Methods", "")
             assert "DELETE" in resp.headers.get("Access-Control-Allow-Methods", "")
 
@@ -1912,7 +2127,9 @@ class TestCORS:
                 },
             )
             assert resp.status == 200
-            assert "Idempotency-Key" in resp.headers.get("Access-Control-Allow-Headers", "")
+            assert "Idempotency-Key" in resp.headers.get(
+                "Access-Control-Allow-Headers", ""
+            )
 
     @pytest.mark.asyncio
     async def test_cors_sets_vary_origin_header(self):
@@ -1938,9 +2155,13 @@ class TestCORS:
                 },
             )
             assert resp.status == 200
-            assert resp.headers.get("Access-Control-Allow-Origin") == "http://localhost:3000"
-            assert "Authorization" in resp.headers.get("Access-Control-Allow-Headers", "")
-
+            assert (
+                resp.headers.get("Access-Control-Allow-Origin")
+                == "http://localhost:3000"
+            )
+            assert "Authorization" in resp.headers.get(
+                "Access-Control-Allow-Headers", ""
+            )
 
     @pytest.mark.asyncio
     async def test_cors_preflight_sets_max_age(self):
@@ -1957,6 +2178,8 @@ class TestCORS:
             )
             assert resp.status == 200
             assert resp.headers.get("Access-Control-Max-Age") == "600"
+
+
 # ---------------------------------------------------------------------------
 # Conversation parameter
 # ---------------------------------------------------------------------------
@@ -1968,15 +2191,20 @@ class TestConversationParameter:
         """First request with a conversation name works (new conversation)."""
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
-            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+            with patch.object(
+                adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
                 mock_run.return_value = (
                     {"final_response": "Hello!", "messages": [], "api_calls": 1},
                     {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
                 )
-                resp = await cli.post("/v1/responses", json={
-                    "input": "hi",
-                    "conversation": "my-chat",
-                })
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "input": "hi",
+                        "conversation": "my-chat",
+                    },
+                )
                 assert resp.status == 200
                 data = await resp.json()
                 assert data["status"] == "completed"
@@ -1988,36 +2216,56 @@ class TestConversationParameter:
         """Second request with same conversation name chains to first."""
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
-            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+            with patch.object(
+                adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
                 mock_run.return_value = (
-                    {"final_response": "First response", "messages": [], "api_calls": 1},
+                    {
+                        "final_response": "First response",
+                        "messages": [],
+                        "api_calls": 1,
+                    },
                     {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
                 )
                 # First request
-                resp1 = await cli.post("/v1/responses", json={
-                    "input": "hello",
-                    "conversation": "test-conv",
-                })
+                resp1 = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "input": "hello",
+                        "conversation": "test-conv",
+                    },
+                )
                 assert resp1.status == 200
                 data1 = await resp1.json()
                 resp1_id = data1["id"]
 
                 # Second request — should chain
                 mock_run.return_value = (
-                    {"final_response": "Second response", "messages": [], "api_calls": 1},
+                    {
+                        "final_response": "Second response",
+                        "messages": [],
+                        "api_calls": 1,
+                    },
                     {"input_tokens": 20, "output_tokens": 10, "total_tokens": 30},
                 )
-                resp2 = await cli.post("/v1/responses", json={
-                    "input": "follow up",
-                    "conversation": "test-conv",
-                })
+                resp2 = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "input": "follow up",
+                        "conversation": "test-conv",
+                    },
+                )
                 assert resp2.status == 200
 
                 # The second call should have received conversation history from the first
                 assert mock_run.call_count == 2
                 second_call_kwargs = mock_run.call_args_list[1]
-                history = second_call_kwargs.kwargs.get("conversation_history",
-                          second_call_kwargs[1].get("conversation_history", []) if len(second_call_kwargs) > 1 else [])
+                history = second_call_kwargs.kwargs.get(
+                    "conversation_history",
+                    second_call_kwargs[1].get("conversation_history", [])
+                    if len(second_call_kwargs) > 1
+                    else [],
+                )
                 # History should be non-empty (contains messages from first response)
                 assert len(history) > 0
 
@@ -2026,11 +2274,14 @@ class TestConversationParameter:
         """Cannot use both conversation and previous_response_id."""
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
-            resp = await cli.post("/v1/responses", json={
-                "input": "hi",
-                "conversation": "my-chat",
-                "previous_response_id": "resp_abc123",
-            })
+            resp = await cli.post(
+                "/v1/responses",
+                json={
+                    "input": "hi",
+                    "conversation": "my-chat",
+                    "previous_response_id": "resp_abc123",
+                },
+            )
             assert resp.status == 400
             data = await resp.json()
             assert "Cannot use both" in data["error"]["message"]
@@ -2040,41 +2291,58 @@ class TestConversationParameter:
         """Different conversation names have independent histories."""
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
-            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+            with patch.object(
+                adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
                 mock_run.return_value = (
                     {"final_response": "Response A", "messages": [], "api_calls": 1},
                     {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
                 )
                 # Conversation A
-                await cli.post("/v1/responses", json={"input": "conv-a msg", "conversation": "conv-a"})
+                await cli.post(
+                    "/v1/responses",
+                    json={"input": "conv-a msg", "conversation": "conv-a"},
+                )
                 # Conversation B
                 mock_run.return_value = (
                     {"final_response": "Response B", "messages": [], "api_calls": 1},
                     {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
                 )
-                await cli.post("/v1/responses", json={"input": "conv-b msg", "conversation": "conv-b"})
+                await cli.post(
+                    "/v1/responses",
+                    json={"input": "conv-b msg", "conversation": "conv-b"},
+                )
 
                 # They should have different response IDs in the mapping
-                assert adapter._response_store.get_conversation("conv-a") != adapter._response_store.get_conversation("conv-b")
+                assert adapter._response_store.get_conversation(
+                    "conv-a"
+                ) != adapter._response_store.get_conversation("conv-b")
 
     @pytest.mark.asyncio
     async def test_conversation_store_false_no_mapping(self, adapter):
         """If store=false, conversation mapping is not updated."""
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
-            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+            with patch.object(
+                adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
                 mock_run.return_value = (
                     {"final_response": "Ephemeral", "messages": [], "api_calls": 1},
                     {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
                 )
-                resp = await cli.post("/v1/responses", json={
-                    "input": "hi",
-                    "conversation": "ephemeral-chat",
-                    "store": False,
-                })
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "input": "hi",
+                        "conversation": "ephemeral-chat",
+                        "store": False,
+                    },
+                )
                 assert resp.status == 200
                 # Conversation mapping should NOT be set since store=false
-                assert adapter._response_store.get_conversation("ephemeral-chat") is None
+                assert (
+                    adapter._response_store.get_conversation("ephemeral-chat") is None
+                )
 
 
 # ---------------------------------------------------------------------------
@@ -2089,11 +2357,19 @@ class TestSessionIdHeader:
         mock_result = {"final_response": "Hello!", "messages": [], "api_calls": 1}
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
-            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
-                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+            with patch.object(
+                adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
+                mock_run.return_value = (
+                    mock_result,
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
                 resp = await cli.post(
                     "/v1/chat/completions",
-                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "Hi"}]},
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [{"role": "user", "content": "Hi"}],
+                    },
                 )
             assert resp.status == 200
             assert resp.headers.get("X-Hermes-Session-Id") is not None
@@ -2110,13 +2386,24 @@ class TestSessionIdHeader:
         auth_adapter._session_db = mock_db
         app = _create_app(auth_adapter)
         async with TestClient(TestServer(app)) as cli:
-            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
-                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+            with patch.object(
+                auth_adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
+                mock_run.return_value = (
+                    mock_result,
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
 
                 resp = await cli.post(
                     "/v1/chat/completions",
-                    headers={"X-Hermes-Session-Id": "my-session-123", "Authorization": "Bearer sk-secret"},
-                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "Continue"}]},
+                    headers={
+                        "X-Hermes-Session-Id": "my-session-123",
+                        "Authorization": "Bearer sk-secret",
+                    },
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [{"role": "user", "content": "Continue"}],
+                    },
                 )
 
             assert resp.status == 200
@@ -2137,12 +2424,20 @@ class TestSessionIdHeader:
         auth_adapter._session_db = mock_db
         app = _create_app(auth_adapter)
         async with TestClient(TestServer(app)) as cli:
-            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
-                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+            with patch.object(
+                auth_adapter, "_run_agent", new_callable=AsyncMock
+            ) as mock_run:
+                mock_run.return_value = (
+                    mock_result,
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
 
                 resp = await cli.post(
                     "/v1/chat/completions",
-                    headers={"X-Hermes-Session-Id": "existing-session", "Authorization": "Bearer sk-secret"},
+                    headers={
+                        "X-Hermes-Session-Id": "existing-session",
+                        "Authorization": "Bearer sk-secret",
+                    },
                     # Request body has different history — should be ignored
                     json={
                         "model": "hermes-agent",
@@ -2168,14 +2463,29 @@ class TestSessionIdHeader:
         auth_adapter._session_db = None
         app = _create_app(auth_adapter)
         async with TestClient(TestServer(app)) as cli:
-            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run, \
-                 patch("hermes_state.SessionDB", side_effect=Exception("DB unavailable")):
-                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+            with (
+                patch.object(
+                    auth_adapter, "_run_agent", new_callable=AsyncMock
+                ) as mock_run,
+                patch(
+                    "hermes_state.SessionDB", side_effect=Exception("DB unavailable")
+                ),
+            ):
+                mock_run.return_value = (
+                    mock_result,
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
 
                 resp = await cli.post(
                     "/v1/chat/completions",
-                    headers={"X-Hermes-Session-Id": "some-session", "Authorization": "Bearer sk-secret"},
-                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "Hi"}]},
+                    headers={
+                        "X-Hermes-Session-Id": "some-session",
+                        "Authorization": "Bearer sk-secret",
+                    },
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [{"role": "user", "content": "Hi"}],
+                    },
                 )
 
             assert resp.status == 200

--- a/tests/gateway/test_api_server_jobs.py
+++ b/tests/gateway/test_api_server_jobs.py
@@ -10,18 +10,13 @@ Covers:
 - Cron module unavailability (501 when _CRON_AVAILABLE is False)
 """
 
-import json
 from unittest.mock import MagicMock, patch
 
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
-
 from gateway.config import PlatformConfig
-from gateway.platforms.api_server import APIServerAdapter, cors_middleware
-
-_MOD = "gateway.platforms.api_server"
-
+from gateway.platforms.api_server import _ADAPTER_KEY, APIServerAdapter, cors_middleware
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -51,7 +46,7 @@ def _make_adapter(api_key: str = "") -> APIServerAdapter:
 def _create_app(adapter: APIServerAdapter) -> web.Application:
     """Create the aiohttp app with jobs routes registered."""
     app = web.Application(middlewares=[cors_middleware])
-    app["api_server_adapter"] = adapter
+    app[_ADAPTER_KEY] = adapter
     # Register only job routes (plus health for sanity)
     app.router.add_get("/health", adapter._handle_health)
     app.router.add_get("/api/jobs", adapter._handle_list_jobs)
@@ -79,16 +74,16 @@ def auth_adapter():
 # 1. test_list_jobs
 # ---------------------------------------------------------------------------
 
+
 class TestListJobs:
     @pytest.mark.asyncio
     async def test_list_jobs(self, adapter):
         """GET /api/jobs returns job list."""
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
-            with patch(
-                f"{_MOD}._CRON_AVAILABLE", True
-            ), patch(
-                f"{_MOD}._cron_list", return_value=[SAMPLE_JOB]
+            with (
+                patch.object(APIServerAdapter, "_CRON_AVAILABLE", True),
+                patch.object(APIServerAdapter, "_cron_list", return_value=[SAMPLE_JOB]),
             ):
                 resp = await cli.get("/api/jobs")
                 assert resp.status == 200
@@ -106,10 +101,9 @@ class TestListJobs:
         app = _create_app(adapter)
         mock_list = MagicMock(return_value=[SAMPLE_JOB])
         async with TestClient(TestServer(app)) as cli:
-            with patch(
-                f"{_MOD}._CRON_AVAILABLE", True
-            ), patch(
-                f"{_MOD}._cron_list", mock_list
+            with (
+                patch.object(APIServerAdapter, "_CRON_AVAILABLE", True),
+                patch.object(APIServerAdapter, "_cron_list", mock_list),
             ):
                 resp = await cli.get("/api/jobs?include_disabled=true")
                 assert resp.status == 200
@@ -121,10 +115,9 @@ class TestListJobs:
         app = _create_app(adapter)
         mock_list = MagicMock(return_value=[])
         async with TestClient(TestServer(app)) as cli:
-            with patch(
-                f"{_MOD}._CRON_AVAILABLE", True
-            ), patch(
-                f"{_MOD}._cron_list", mock_list
+            with (
+                patch.object(APIServerAdapter, "_CRON_AVAILABLE", True),
+                patch.object(APIServerAdapter, "_cron_list", mock_list),
             ):
                 resp = await cli.get("/api/jobs")
                 assert resp.status == 200
@@ -135,6 +128,7 @@ class TestListJobs:
 # 3-7. test_create_job and validation
 # ---------------------------------------------------------------------------
 
+
 class TestCreateJob:
     @pytest.mark.asyncio
     async def test_create_job(self, adapter):
@@ -142,16 +136,18 @@ class TestCreateJob:
         app = _create_app(adapter)
         mock_create = MagicMock(return_value=SAMPLE_JOB)
         async with TestClient(TestServer(app)) as cli:
-            with patch(
-                f"{_MOD}._CRON_AVAILABLE", True
-            ), patch(
-                f"{_MOD}._cron_create", mock_create
+            with (
+                patch.object(APIServerAdapter, "_CRON_AVAILABLE", True),
+                patch.object(APIServerAdapter, "_cron_create", mock_create),
             ):
-                resp = await cli.post("/api/jobs", json={
-                    "name": "test-job",
-                    "schedule": "*/5 * * * *",
-                    "prompt": "do something",
-                })
+                resp = await cli.post(
+                    "/api/jobs",
+                    json={
+                        "name": "test-job",
+                        "schedule": "*/5 * * * *",
+                        "prompt": "do something",
+                    },
+                )
                 assert resp.status == 200
                 data = await resp.json()
                 assert data["job"] == SAMPLE_JOB
@@ -166,11 +162,14 @@ class TestCreateJob:
         """POST /api/jobs without name returns 400."""
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
-            with patch(f"{_MOD}._CRON_AVAILABLE", True):
-                resp = await cli.post("/api/jobs", json={
-                    "schedule": "*/5 * * * *",
-                    "prompt": "do something",
-                })
+            with patch.object(APIServerAdapter, "_CRON_AVAILABLE", True):
+                resp = await cli.post(
+                    "/api/jobs",
+                    json={
+                        "schedule": "*/5 * * * *",
+                        "prompt": "do something",
+                    },
+                )
                 assert resp.status == 400
                 data = await resp.json()
                 assert "name" in data["error"].lower() or "Name" in data["error"]
@@ -180,11 +179,14 @@ class TestCreateJob:
         """POST /api/jobs with name > 200 chars returns 400."""
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
-            with patch(f"{_MOD}._CRON_AVAILABLE", True):
-                resp = await cli.post("/api/jobs", json={
-                    "name": "x" * 201,
-                    "schedule": "*/5 * * * *",
-                })
+            with patch.object(APIServerAdapter, "_CRON_AVAILABLE", True):
+                resp = await cli.post(
+                    "/api/jobs",
+                    json={
+                        "name": "x" * 201,
+                        "schedule": "*/5 * * * *",
+                    },
+                )
                 assert resp.status == 400
                 data = await resp.json()
                 assert "200" in data["error"] or "Name" in data["error"]
@@ -194,12 +196,15 @@ class TestCreateJob:
         """POST /api/jobs with prompt > 5000 chars returns 400."""
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
-            with patch(f"{_MOD}._CRON_AVAILABLE", True):
-                resp = await cli.post("/api/jobs", json={
-                    "name": "test-job",
-                    "schedule": "*/5 * * * *",
-                    "prompt": "x" * 5001,
-                })
+            with patch.object(APIServerAdapter, "_CRON_AVAILABLE", True):
+                resp = await cli.post(
+                    "/api/jobs",
+                    json={
+                        "name": "test-job",
+                        "schedule": "*/5 * * * *",
+                        "prompt": "x" * 5001,
+                    },
+                )
                 assert resp.status == 400
                 data = await resp.json()
                 assert "5000" in data["error"] or "Prompt" in data["error"]
@@ -209,12 +214,15 @@ class TestCreateJob:
         """POST /api/jobs with repeat=0 returns 400."""
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
-            with patch(f"{_MOD}._CRON_AVAILABLE", True):
-                resp = await cli.post("/api/jobs", json={
-                    "name": "test-job",
-                    "schedule": "*/5 * * * *",
-                    "repeat": 0,
-                })
+            with patch.object(APIServerAdapter, "_CRON_AVAILABLE", True):
+                resp = await cli.post(
+                    "/api/jobs",
+                    json={
+                        "name": "test-job",
+                        "schedule": "*/5 * * * *",
+                        "repeat": 0,
+                    },
+                )
                 assert resp.status == 400
                 data = await resp.json()
                 assert "repeat" in data["error"].lower() or "Repeat" in data["error"]
@@ -224,18 +232,24 @@ class TestCreateJob:
         """POST /api/jobs without schedule returns 400."""
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
-            with patch(f"{_MOD}._CRON_AVAILABLE", True):
-                resp = await cli.post("/api/jobs", json={
-                    "name": "test-job",
-                })
+            with patch.object(APIServerAdapter, "_CRON_AVAILABLE", True):
+                resp = await cli.post(
+                    "/api/jobs",
+                    json={
+                        "name": "test-job",
+                    },
+                )
                 assert resp.status == 400
                 data = await resp.json()
-                assert "schedule" in data["error"].lower() or "Schedule" in data["error"]
+                assert (
+                    "schedule" in data["error"].lower() or "Schedule" in data["error"]
+                )
 
 
 # ---------------------------------------------------------------------------
 # 8-10. test_get_job
 # ---------------------------------------------------------------------------
+
 
 class TestGetJob:
     @pytest.mark.asyncio
@@ -244,10 +258,9 @@ class TestGetJob:
         app = _create_app(adapter)
         mock_get = MagicMock(return_value=SAMPLE_JOB)
         async with TestClient(TestServer(app)) as cli:
-            with patch(
-                f"{_MOD}._CRON_AVAILABLE", True
-            ), patch(
-                f"{_MOD}._cron_get", mock_get
+            with (
+                patch.object(APIServerAdapter, "_CRON_AVAILABLE", True),
+                patch.object(APIServerAdapter, "_cron_get", mock_get),
             ):
                 resp = await cli.get(f"/api/jobs/{VALID_JOB_ID}")
                 assert resp.status == 200
@@ -261,10 +274,9 @@ class TestGetJob:
         app = _create_app(adapter)
         mock_get = MagicMock(return_value=None)
         async with TestClient(TestServer(app)) as cli:
-            with patch(
-                f"{_MOD}._CRON_AVAILABLE", True
-            ), patch(
-                f"{_MOD}._cron_get", mock_get
+            with (
+                patch.object(APIServerAdapter, "_CRON_AVAILABLE", True),
+                patch.object(APIServerAdapter, "_cron_get", mock_get),
             ):
                 resp = await cli.get(f"/api/jobs/{VALID_JOB_ID}")
                 assert resp.status == 404
@@ -285,6 +297,7 @@ class TestGetJob:
 # 11-12. test_update_job
 # ---------------------------------------------------------------------------
 
+
 class TestUpdateJob:
     @pytest.mark.asyncio
     async def test_update_job(self, adapter):
@@ -293,10 +306,9 @@ class TestUpdateJob:
         updated_job = {**SAMPLE_JOB, "name": "updated-name"}
         mock_update = MagicMock(return_value=updated_job)
         async with TestClient(TestServer(app)) as cli:
-            with patch(
-                f"{_MOD}._CRON_AVAILABLE", True
-            ), patch(
-                f"{_MOD}._cron_update", mock_update
+            with (
+                patch.object(APIServerAdapter, "_CRON_AVAILABLE", True),
+                patch.object(APIServerAdapter, "_cron_update", mock_update),
             ):
                 resp = await cli.patch(
                     f"/api/jobs/{VALID_JOB_ID}",
@@ -319,10 +331,9 @@ class TestUpdateJob:
         updated_job = {**SAMPLE_JOB, "name": "new-name"}
         mock_update = MagicMock(return_value=updated_job)
         async with TestClient(TestServer(app)) as cli:
-            with patch(
-                f"{_MOD}._CRON_AVAILABLE", True
-            ), patch(
-                f"{_MOD}._cron_update", mock_update
+            with (
+                patch.object(APIServerAdapter, "_CRON_AVAILABLE", True),
+                patch.object(APIServerAdapter, "_cron_update", mock_update),
             ):
                 resp = await cli.patch(
                     f"/api/jobs/{VALID_JOB_ID}",
@@ -358,6 +369,7 @@ class TestUpdateJob:
 # 13. test_delete_job
 # ---------------------------------------------------------------------------
 
+
 class TestDeleteJob:
     @pytest.mark.asyncio
     async def test_delete_job(self, adapter):
@@ -365,10 +377,9 @@ class TestDeleteJob:
         app = _create_app(adapter)
         mock_remove = MagicMock(return_value=True)
         async with TestClient(TestServer(app)) as cli:
-            with patch(
-                f"{_MOD}._CRON_AVAILABLE", True
-            ), patch(
-                f"{_MOD}._cron_remove", mock_remove
+            with (
+                patch.object(APIServerAdapter, "_CRON_AVAILABLE", True),
+                patch.object(APIServerAdapter, "_cron_remove", mock_remove),
             ):
                 resp = await cli.delete(f"/api/jobs/{VALID_JOB_ID}")
                 assert resp.status == 200
@@ -382,10 +393,9 @@ class TestDeleteJob:
         app = _create_app(adapter)
         mock_remove = MagicMock(return_value=False)
         async with TestClient(TestServer(app)) as cli:
-            with patch(
-                f"{_MOD}._CRON_AVAILABLE", True
-            ), patch(
-                f"{_MOD}._cron_remove", mock_remove
+            with (
+                patch.object(APIServerAdapter, "_CRON_AVAILABLE", True),
+                patch.object(APIServerAdapter, "_cron_remove", mock_remove),
             ):
                 resp = await cli.delete(f"/api/jobs/{VALID_JOB_ID}")
                 assert resp.status == 404
@@ -395,6 +405,7 @@ class TestDeleteJob:
 # 14. test_pause_job
 # ---------------------------------------------------------------------------
 
+
 class TestPauseJob:
     @pytest.mark.asyncio
     async def test_pause_job(self, adapter):
@@ -403,10 +414,9 @@ class TestPauseJob:
         paused_job = {**SAMPLE_JOB, "enabled": False}
         mock_pause = MagicMock(return_value=paused_job)
         async with TestClient(TestServer(app)) as cli:
-            with patch(
-                f"{_MOD}._CRON_AVAILABLE", True
-            ), patch(
-                f"{_MOD}._cron_pause", mock_pause
+            with (
+                patch.object(APIServerAdapter, "_CRON_AVAILABLE", True),
+                patch.object(APIServerAdapter, "_cron_pause", mock_pause),
             ):
                 resp = await cli.post(f"/api/jobs/{VALID_JOB_ID}/pause")
                 assert resp.status == 200
@@ -420,6 +430,7 @@ class TestPauseJob:
 # 15. test_resume_job
 # ---------------------------------------------------------------------------
 
+
 class TestResumeJob:
     @pytest.mark.asyncio
     async def test_resume_job(self, adapter):
@@ -428,10 +439,9 @@ class TestResumeJob:
         resumed_job = {**SAMPLE_JOB, "enabled": True}
         mock_resume = MagicMock(return_value=resumed_job)
         async with TestClient(TestServer(app)) as cli:
-            with patch(
-                f"{_MOD}._CRON_AVAILABLE", True
-            ), patch(
-                f"{_MOD}._cron_resume", mock_resume
+            with (
+                patch.object(APIServerAdapter, "_CRON_AVAILABLE", True),
+                patch.object(APIServerAdapter, "_cron_resume", mock_resume),
             ):
                 resp = await cli.post(f"/api/jobs/{VALID_JOB_ID}/resume")
                 assert resp.status == 200
@@ -445,6 +455,7 @@ class TestResumeJob:
 # 16. test_run_job
 # ---------------------------------------------------------------------------
 
+
 class TestRunJob:
     @pytest.mark.asyncio
     async def test_run_job(self, adapter):
@@ -453,10 +464,9 @@ class TestRunJob:
         triggered_job = {**SAMPLE_JOB, "last_run": "2025-01-01T00:00:00Z"}
         mock_trigger = MagicMock(return_value=triggered_job)
         async with TestClient(TestServer(app)) as cli:
-            with patch(
-                f"{_MOD}._CRON_AVAILABLE", True
-            ), patch(
-                f"{_MOD}._cron_trigger", mock_trigger
+            with (
+                patch.object(APIServerAdapter, "_CRON_AVAILABLE", True),
+                patch.object(APIServerAdapter, "_cron_trigger", mock_trigger),
             ):
                 resp = await cli.post(f"/api/jobs/{VALID_JOB_ID}/run")
                 assert resp.status == 200
@@ -468,6 +478,7 @@ class TestRunJob:
 # ---------------------------------------------------------------------------
 # 17. test_auth_required
 # ---------------------------------------------------------------------------
+
 
 class TestAuthRequired:
     @pytest.mark.asyncio
@@ -484,10 +495,14 @@ class TestAuthRequired:
         """POST /api/jobs without API key returns 401 when key is set."""
         app = _create_app(auth_adapter)
         async with TestClient(TestServer(app)) as cli:
-            with patch(f"{_MOD}._CRON_AVAILABLE", True):
-                resp = await cli.post("/api/jobs", json={
-                    "name": "test", "schedule": "* * * * *",
-                })
+            with patch.object(APIServerAdapter, "_CRON_AVAILABLE", True):
+                resp = await cli.post(
+                    "/api/jobs",
+                    json={
+                        "name": "test",
+                        "schedule": "* * * * *",
+                    },
+                )
                 assert resp.status == 401
 
     @pytest.mark.asyncio
@@ -514,10 +529,9 @@ class TestAuthRequired:
         app = _create_app(auth_adapter)
         mock_list = MagicMock(return_value=[])
         async with TestClient(TestServer(app)) as cli:
-            with patch(
-                f"{_MOD}._CRON_AVAILABLE", True
-            ), patch(
-                f"{_MOD}._cron_list", mock_list
+            with (
+                patch.object(APIServerAdapter, "_CRON_AVAILABLE", True),
+                patch.object(APIServerAdapter, "_cron_list", mock_list),
             ):
                 resp = await cli.get(
                     "/api/jobs",
@@ -529,6 +543,7 @@ class TestAuthRequired:
 # ---------------------------------------------------------------------------
 # 18. test_cron_unavailable
 # ---------------------------------------------------------------------------
+
 
 class TestCronUnavailable:
     @pytest.mark.asyncio
@@ -553,8 +568,11 @@ class TestCronUnavailable:
             return SAMPLE_JOB
 
         async with TestClient(TestServer(app)) as cli:
-            with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
-                f"{_MOD}._cron_pause", _plain_pause
+            with (
+                patch.object(APIServerAdapter, "_CRON_AVAILABLE", True),
+                patch.object(
+                    APIServerAdapter, "_cron_pause", staticmethod(_plain_pause)
+                ),
             ):
                 resp = await cli.post(f"/api/jobs/{VALID_JOB_ID}/pause")
                 assert resp.status == 200
@@ -573,8 +591,9 @@ class TestCronUnavailable:
             return [SAMPLE_JOB]
 
         async with TestClient(TestServer(app)) as cli:
-            with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
-                f"{_MOD}._cron_list", _plain_list
+            with (
+                patch.object(APIServerAdapter, "_CRON_AVAILABLE", True),
+                patch.object(APIServerAdapter, "_cron_list", staticmethod(_plain_list)),
             ):
                 resp = await cli.get("/api/jobs?include_disabled=true")
                 assert resp.status == 200
@@ -595,8 +614,11 @@ class TestCronUnavailable:
             return updated_job
 
         async with TestClient(TestServer(app)) as cli:
-            with patch(f"{_MOD}._CRON_AVAILABLE", True), patch(
-                f"{_MOD}._cron_update", _plain_update
+            with (
+                patch.object(APIServerAdapter, "_CRON_AVAILABLE", True),
+                patch.object(
+                    APIServerAdapter, "_cron_update", staticmethod(_plain_update)
+                ),
             ):
                 resp = await cli.patch(
                     f"/api/jobs/{VALID_JOB_ID}",
@@ -613,10 +635,14 @@ class TestCronUnavailable:
         """POST /api/jobs returns 501 when _CRON_AVAILABLE is False."""
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
-            with patch(f"{_MOD}._CRON_AVAILABLE", False):
-                resp = await cli.post("/api/jobs", json={
-                    "name": "test", "schedule": "* * * * *",
-                })
+            with patch.object(APIServerAdapter, "_CRON_AVAILABLE", False):
+                resp = await cli.post(
+                    "/api/jobs",
+                    json={
+                        "name": "test",
+                        "schedule": "* * * * *",
+                    },
+                )
                 assert resp.status == 501
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_api_server_multimodal.py
+++ b/tests/gateway/test_api_server_multimodal.py
@@ -12,16 +12,15 @@ from unittest.mock import MagicMock, patch
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient, TestServer
-
 from gateway.config import PlatformConfig
 from gateway.platforms.api_server import (
+    _ADAPTER_KEY,
     APIServerAdapter,
     _content_has_visible_payload,
     _normalize_multimodal_content,
     cors_middleware,
     security_headers_middleware,
 )
-
 
 # ---------------------------------------------------------------------------
 # Pure-function tests for _normalize_multimodal_content
@@ -46,13 +45,19 @@ class TestNormalizeMultimodalContent:
     def test_image_url_preserved_with_text(self):
         content = [
             {"type": "text", "text": "describe this"},
-            {"type": "image_url", "image_url": {"url": "https://example.com/cat.png", "detail": "high"}},
+            {
+                "type": "image_url",
+                "image_url": {"url": "https://example.com/cat.png", "detail": "high"},
+            },
         ]
         out = _normalize_multimodal_content(content)
         assert isinstance(out, list)
         assert out == [
             {"type": "text", "text": "describe this"},
-            {"type": "image_url", "image_url": {"url": "https://example.com/cat.png", "detail": "high"}},
+            {
+                "type": "image_url",
+                "image_url": {"url": "https://example.com/cat.png", "detail": "high"},
+            },
         ]
 
     def test_input_image_converted_to_canonical_shape(self):
@@ -67,19 +72,30 @@ class TestNormalizeMultimodalContent:
         ]
 
     def test_data_image_url_accepted(self):
-        content = [{"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}}]
+        content = [
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}}
+        ]
         out = _normalize_multimodal_content(content)
-        assert out == [{"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}}]
+        assert out == [
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}}
+        ]
 
     def test_non_image_data_url_rejected(self):
-        content = [{"type": "image_url", "image_url": {"url": "data:text/plain;base64,SGVsbG8="}}]
+        content = [
+            {
+                "type": "image_url",
+                "image_url": {"url": "data:text/plain;base64,SGVsbG8="},
+            }
+        ]
         with pytest.raises(ValueError) as exc:
             _normalize_multimodal_content(content)
         assert str(exc.value).startswith("unsupported_content_type:")
 
     def test_file_part_rejected(self):
         with pytest.raises(ValueError) as exc:
-            _normalize_multimodal_content([{"type": "file", "file": {"file_id": "f_1"}}])
+            _normalize_multimodal_content(
+                [{"type": "file", "file": {"file_id": "f_1"}}]
+            )
         assert str(exc.value).startswith("unsupported_content_type:")
 
     def test_input_file_part_rejected(self):
@@ -94,7 +110,9 @@ class TestNormalizeMultimodalContent:
 
     def test_bad_scheme_rejected(self):
         with pytest.raises(ValueError) as exc:
-            _normalize_multimodal_content([{"type": "image_url", "image_url": {"url": "ftp://example.com/x.png"}}])
+            _normalize_multimodal_content(
+                [{"type": "image_url", "image_url": {"url": "ftp://example.com/x.png"}}]
+            )
         assert str(exc.value).startswith("invalid_image_url:")
 
     def test_unknown_part_type_rejected(self):
@@ -111,7 +129,9 @@ class TestContentHasVisiblePayload:
         assert not _content_has_visible_payload("   ")
 
     def test_list_with_image_only(self):
-        assert _content_has_visible_payload([{"type": "image_url", "image_url": {"url": "x"}}])
+        assert _content_has_visible_payload(
+            [{"type": "image_url", "image_url": {"url": "x"}}]
+        )
 
     def test_list_with_only_empty_text(self):
         assert not _content_has_visible_payload([{"type": "text", "text": ""}])
@@ -127,9 +147,11 @@ def _make_adapter() -> APIServerAdapter:
 
 
 def _create_app(adapter: APIServerAdapter) -> web.Application:
-    mws = [mw for mw in (cors_middleware, security_headers_middleware) if mw is not None]
+    mws = [
+        mw for mw in (cors_middleware, security_headers_middleware) if mw is not None
+    ]
     app = web.Application(middlewares=mws)
-    app["api_server_adapter"] = adapter
+    app[_ADAPTER_KEY] = adapter
     app.router.add_post("/v1/chat/completions", adapter._handle_chat_completions)
     app.router.add_post("/v1/responses", adapter._handle_responses)
     app.router.add_get("/v1/responses/{response_id}", adapter._handle_get_response)
@@ -147,7 +169,10 @@ class TestChatCompletionsMultimodalHTTP:
         """Multimodal user content reaches _run_agent as a list of parts."""
         image_payload = [
             {"type": "text", "text": "What's in this image?"},
-            {"type": "image_url", "image_url": {"url": "https://example.com/cat.png", "detail": "high"}},
+            {
+                "type": "image_url",
+                "image_url": {"url": "https://example.com/cat.png", "detail": "high"},
+            },
         ]
 
         app = _create_app(adapter)
@@ -157,12 +182,14 @@ class TestChatCompletionsMultimodalHTTP:
                 "_run_agent",
                 new=MagicMock(),
             ) as mock_run:
+
                 async def _stub(**kwargs):
                     mock_run.captured = kwargs
                     return (
                         {"final_response": "A cat.", "messages": [], "api_calls": 1},
                         {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
                     )
+
                 mock_run.side_effect = _stub
 
                 resp = await cli.post(
@@ -182,12 +209,14 @@ class TestChatCompletionsMultimodalHTTP:
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
             with patch.object(adapter, "_run_agent", new=MagicMock()) as mock_run:
+
                 async def _stub(**kwargs):
                     mock_run.captured = kwargs
                     return (
                         {"final_response": "ok", "messages": [], "api_calls": 1},
                         {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
                     )
+
                 mock_run.side_effect = _stub
 
                 resp = await cli.post(
@@ -195,7 +224,10 @@ class TestChatCompletionsMultimodalHTTP:
                     json={
                         "model": "hermes-agent",
                         "messages": [
-                            {"role": "user", "content": [{"type": "text", "text": "hello"}]},
+                            {
+                                "role": "user",
+                                "content": [{"type": "text", "text": "hello"}],
+                            },
                         ],
                     },
                 )
@@ -212,7 +244,10 @@ class TestChatCompletionsMultimodalHTTP:
                 json={
                     "model": "hermes-agent",
                     "messages": [
-                        {"role": "user", "content": [{"type": "file", "file": {"file_id": "f_1"}}]},
+                        {
+                            "role": "user",
+                            "content": [{"type": "file", "file": {"file_id": "f_1"}}],
+                        },
                     ],
                 },
             )
@@ -235,7 +270,9 @@ class TestChatCompletionsMultimodalHTTP:
                             "content": [
                                 {
                                     "type": "image_url",
-                                    "image_url": {"url": "data:text/plain;base64,SGVsbG8="},
+                                    "image_url": {
+                                        "url": "data:text/plain;base64,SGVsbG8="
+                                    },
                                 },
                             ],
                         },
@@ -253,12 +290,14 @@ class TestResponsesMultimodalHTTP:
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
             with patch.object(adapter, "_run_agent", new=MagicMock()) as mock_run:
+
                 async def _stub(**kwargs):
                     mock_run.captured = kwargs
                     return (
                         {"final_response": "ok", "messages": [], "api_calls": 1},
                         {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
                     )
+
                 mock_run.side_effect = _stub
 
                 resp = await cli.post(
@@ -283,7 +322,10 @@ class TestResponsesMultimodalHTTP:
             assert resp.status == 200, await resp.text()
             expected = [
                 {"type": "text", "text": "Describe."},
-                {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "https://example.com/cat.png"},
+                },
             ]
             assert mock_run.captured["user_message"] == expected
 

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -1,14 +1,12 @@
 """Tests for DingTalk platform adapter."""
+
 import asyncio
-import json
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
 from gateway.config import Platform, PlatformConfig
-
 
 # ---------------------------------------------------------------------------
 # Requirements check
@@ -16,13 +14,13 @@ from gateway.config import Platform, PlatformConfig
 
 
 class TestDingTalkRequirements:
-
     def test_returns_false_when_sdk_missing(self, monkeypatch):
         with patch.dict("sys.modules", {"dingtalk_stream": None}):
             monkeypatch.setattr(
                 "gateway.platforms.dingtalk.DINGTALK_STREAM_AVAILABLE", False
             )
             from gateway.platforms.dingtalk import check_dingtalk_requirements
+
             assert check_dingtalk_requirements() is False
 
     def test_returns_false_when_env_vars_missing(self, monkeypatch):
@@ -33,6 +31,7 @@ class TestDingTalkRequirements:
         monkeypatch.delenv("DINGTALK_CLIENT_ID", raising=False)
         monkeypatch.delenv("DINGTALK_CLIENT_SECRET", raising=False)
         from gateway.platforms.dingtalk import check_dingtalk_requirements
+
         assert check_dingtalk_requirements() is False
 
     def test_returns_true_when_all_available(self, monkeypatch):
@@ -43,6 +42,7 @@ class TestDingTalkRequirements:
         monkeypatch.setenv("DINGTALK_CLIENT_ID", "test-id")
         monkeypatch.setenv("DINGTALK_CLIENT_SECRET", "test-secret")
         from gateway.platforms.dingtalk import check_dingtalk_requirements
+
         assert check_dingtalk_requirements() is True
 
 
@@ -52,9 +52,9 @@ class TestDingTalkRequirements:
 
 
 class TestDingTalkAdapterInit:
-
     def test_reads_config_from_extra(self):
         from gateway.platforms.dingtalk import DingTalkAdapter
+
         config = PlatformConfig(
             enabled=True,
             extra={"client_id": "cfg-id", "client_secret": "cfg-secret"},
@@ -68,6 +68,7 @@ class TestDingTalkAdapterInit:
         monkeypatch.setenv("DINGTALK_CLIENT_ID", "env-id")
         monkeypatch.setenv("DINGTALK_CLIENT_SECRET", "env-secret")
         from gateway.platforms.dingtalk import DingTalkAdapter
+
         config = PlatformConfig(enabled=True)
         adapter = DingTalkAdapter(config)
         assert adapter._client_id == "env-id"
@@ -80,9 +81,9 @@ class TestDingTalkAdapterInit:
 
 
 class TestExtractText:
-
     def test_extracts_dict_text(self):
         from gateway.platforms.dingtalk import DingTalkAdapter
+
         msg = MagicMock()
         msg.text = {"content": "  hello world  "}
         msg.rich_text = None
@@ -90,6 +91,7 @@ class TestExtractText:
 
     def test_extracts_string_text(self):
         from gateway.platforms.dingtalk import DingTalkAdapter
+
         msg = MagicMock()
         msg.text = "plain text"
         msg.rich_text = None
@@ -97,6 +99,7 @@ class TestExtractText:
 
     def test_falls_back_to_rich_text(self):
         from gateway.platforms.dingtalk import DingTalkAdapter
+
         msg = MagicMock()
         msg.text = ""
         msg.rich_text = [{"text": "part1"}, {"text": "part2"}, {"image": "url"}]
@@ -104,6 +107,7 @@ class TestExtractText:
 
     def test_returns_empty_for_no_content(self):
         from gateway.platforms.dingtalk import DingTalkAdapter
+
         msg = MagicMock()
         msg.text = ""
         msg.rich_text = None
@@ -116,26 +120,29 @@ class TestExtractText:
 
 
 class TestDeduplication:
-
     def test_first_message_not_duplicate(self):
         from gateway.platforms.dingtalk import DingTalkAdapter
+
         adapter = DingTalkAdapter(PlatformConfig(enabled=True))
         assert adapter._dedup.is_duplicate("msg-1") is False
 
     def test_second_same_message_is_duplicate(self):
         from gateway.platforms.dingtalk import DingTalkAdapter
+
         adapter = DingTalkAdapter(PlatformConfig(enabled=True))
         adapter._dedup.is_duplicate("msg-1")
         assert adapter._dedup.is_duplicate("msg-1") is True
 
     def test_different_messages_not_duplicate(self):
         from gateway.platforms.dingtalk import DingTalkAdapter
+
         adapter = DingTalkAdapter(PlatformConfig(enabled=True))
         adapter._dedup.is_duplicate("msg-1")
         assert adapter._dedup.is_duplicate("msg-2") is False
 
     def test_cache_cleanup_on_overflow(self):
         from gateway.platforms.dingtalk import DingTalkAdapter
+
         adapter = DingTalkAdapter(PlatformConfig(enabled=True))
         max_size = adapter._dedup._max_size
         # Fill beyond max
@@ -151,10 +158,10 @@ class TestDeduplication:
 
 
 class TestSend:
-
     @pytest.mark.asyncio
     async def test_send_posts_to_webhook(self):
         from gateway.platforms.dingtalk import DingTalkAdapter
+
         adapter = DingTalkAdapter(PlatformConfig(enabled=True))
 
         mock_response = MagicMock()
@@ -166,8 +173,9 @@ class TestSend:
         adapter._http_client = mock_client
 
         result = await adapter.send(
-            "chat-123", "Hello!",
-            metadata={"session_webhook": "https://dingtalk.example/webhook"}
+            "chat-123",
+            "Hello!",
+            metadata={"session_webhook": "https://dingtalk.example/webhook"},
         )
         assert result.success is True
         mock_client.post.assert_called_once()
@@ -181,6 +189,7 @@ class TestSend:
     @pytest.mark.asyncio
     async def test_send_fails_without_webhook(self):
         from gateway.platforms.dingtalk import DingTalkAdapter
+
         adapter = DingTalkAdapter(PlatformConfig(enabled=True))
         adapter._http_client = AsyncMock()
 
@@ -191,6 +200,7 @@ class TestSend:
     @pytest.mark.asyncio
     async def test_send_uses_cached_webhook(self):
         from gateway.platforms.dingtalk import DingTalkAdapter
+
         adapter = DingTalkAdapter(PlatformConfig(enabled=True))
 
         mock_response = MagicMock()
@@ -198,7 +208,10 @@ class TestSend:
         mock_client = AsyncMock()
         mock_client.post = AsyncMock(return_value=mock_response)
         adapter._http_client = mock_client
-        adapter._session_webhooks["chat-123"] = ("https://cached.example/webhook", 9999999999999)
+        adapter._session_webhooks["chat-123"] = (
+            "https://cached.example/webhook",
+            9999999999999,
+        )
 
         result = await adapter.send("chat-123", "Hello!")
         assert result.success is True
@@ -207,6 +220,7 @@ class TestSend:
     @pytest.mark.asyncio
     async def test_send_handles_http_error(self):
         from gateway.platforms.dingtalk import DingTalkAdapter
+
         adapter = DingTalkAdapter(PlatformConfig(enabled=True))
 
         mock_response = MagicMock()
@@ -217,8 +231,9 @@ class TestSend:
         adapter._http_client = mock_client
 
         result = await adapter.send(
-            "chat-123", "Hello!",
-            metadata={"session_webhook": "https://example/webhook"}
+            "chat-123",
+            "Hello!",
+            metadata={"session_webhook": "https://example/webhook"},
         )
         assert result.success is False
         assert "400" in result.error
@@ -230,7 +245,6 @@ class TestSend:
 
 
 class TestConnect:
-
     @pytest.mark.asyncio
     async def test_disconnect_closes_session_websocket(self):
         from gateway.platforms.dingtalk import DingTalkAdapter
@@ -260,6 +274,7 @@ class TestConnect:
             "gateway.platforms.dingtalk.DINGTALK_STREAM_AVAILABLE", False
         )
         from gateway.platforms.dingtalk import DingTalkAdapter
+
         adapter = DingTalkAdapter(PlatformConfig(enabled=True))
         result = await adapter.connect()
         assert result is False
@@ -267,6 +282,7 @@ class TestConnect:
     @pytest.mark.asyncio
     async def test_connect_fails_without_credentials(self):
         from gateway.platforms.dingtalk import DingTalkAdapter
+
         adapter = DingTalkAdapter(PlatformConfig(enabled=True))
         adapter._client_id = ""
         adapter._client_secret = ""
@@ -276,6 +292,7 @@ class TestConnect:
     @pytest.mark.asyncio
     async def test_disconnect_cleans_up(self):
         from gateway.platforms.dingtalk import DingTalkAdapter
+
         adapter = DingTalkAdapter(PlatformConfig(enabled=True))
         adapter._session_webhooks["a"] = "http://x"
         adapter._dedup._seen["b"] = 1.0
@@ -308,28 +325,31 @@ class TestWebhookDomainAllowlist:
 
     def test_api_domain_accepted(self):
         from gateway.platforms.dingtalk import _DINGTALK_WEBHOOK_RE
+
         assert _DINGTALK_WEBHOOK_RE.match(
             "https://api.dingtalk.com/robot/send?access_token=x"
         )
 
     def test_oapi_domain_accepted(self):
         from gateway.platforms.dingtalk import _DINGTALK_WEBHOOK_RE
+
         assert _DINGTALK_WEBHOOK_RE.match(
             "https://oapi.dingtalk.com/robot/send?access_token=x"
         )
 
     def test_http_rejected(self):
         from gateway.platforms.dingtalk import _DINGTALK_WEBHOOK_RE
+
         assert not _DINGTALK_WEBHOOK_RE.match("http://api.dingtalk.com/robot/send")
 
     def test_suffix_attack_rejected(self):
         from gateway.platforms.dingtalk import _DINGTALK_WEBHOOK_RE
-        assert not _DINGTALK_WEBHOOK_RE.match(
-            "https://api.dingtalk.com.evil.example/"
-        )
+
+        assert not _DINGTALK_WEBHOOK_RE.match("https://api.dingtalk.com.evil.example/")
 
     def test_unsanctioned_subdomain_rejected(self):
         from gateway.platforms.dingtalk import _DINGTALK_WEBHOOK_RE
+
         # Only api.* and oapi.* are allowed — e.g. eapi.dingtalk.com must not slip through
         assert not _DINGTALK_WEBHOOK_RE.match("https://eapi.dingtalk.com/robot/send")
 
@@ -339,6 +359,7 @@ class TestHandlerProcessIsAsync:
 
     def test_process_is_coroutine_function(self):
         from gateway.platforms.dingtalk import _IncomingHandler
+
         assert asyncio.iscoroutinefunction(_IncomingHandler.process)
 
 
@@ -353,6 +374,7 @@ class TestExtractText:
 
     def test_text_as_dict_legacy(self):
         from gateway.platforms.dingtalk import DingTalkAdapter
+
         msg = MagicMock()
         msg.text = {"content": "hello world"}
         msg.rich_text_content = None
@@ -406,6 +428,7 @@ class TestExtractText:
     def test_rich_text_legacy_shape(self):
         """Legacy ``message.rich_text`` list remains supported."""
         from gateway.platforms.dingtalk import DingTalkAdapter
+
         msg = MagicMock()
         msg.text = None
         msg.rich_text_content = None
@@ -415,6 +438,7 @@ class TestExtractText:
 
     def test_empty_message(self):
         from gateway.platforms.dingtalk import DingTalkAdapter
+
         msg = MagicMock()
         msg.text = None
         msg.rich_text_content = None
@@ -443,11 +467,11 @@ def _make_gating_adapter(monkeypatch, *, extra=None, env=None):
     for key, value in (env or {}).items():
         monkeypatch.setenv(key, value)
     from gateway.platforms.dingtalk import DingTalkAdapter
+
     return DingTalkAdapter(PlatformConfig(enabled=True, extra=extra or {}))
 
 
 class TestAllowedUsersGate:
-
     def test_empty_allowlist_allows_everyone(self, monkeypatch):
         adapter = _make_gating_adapter(monkeypatch)
         assert adapter._is_user_allowed("anyone", "any-staff") is True
@@ -483,7 +507,6 @@ class TestAllowedUsersGate:
 
 
 class TestMentionPatterns:
-
     def test_empty_patterns_list(self, monkeypatch):
         adapter = _make_gating_adapter(monkeypatch)
         assert adapter._mention_patterns == []
@@ -528,34 +551,37 @@ class TestMentionPatterns:
 
 
 class TestShouldProcessMessage:
-
     def test_dm_always_accepted(self, monkeypatch):
-        adapter = _make_gating_adapter(
-            monkeypatch, extra={"require_mention": True}
-        )
+        adapter = _make_gating_adapter(monkeypatch, extra={"require_mention": True})
         msg = MagicMock(is_in_at_list=False)
-        assert adapter._should_process_message(msg, "hi", is_group=False, chat_id="dm1") is True
+        assert (
+            adapter._should_process_message(msg, "hi", is_group=False, chat_id="dm1")
+            is True
+        )
 
     def test_group_rejected_when_require_mention_and_no_trigger(self, monkeypatch):
-        adapter = _make_gating_adapter(
-            monkeypatch, extra={"require_mention": True}
-        )
+        adapter = _make_gating_adapter(monkeypatch, extra={"require_mention": True})
         msg = MagicMock(is_in_at_list=False)
-        assert adapter._should_process_message(msg, "hi", is_group=True, chat_id="grp1") is False
+        assert (
+            adapter._should_process_message(msg, "hi", is_group=True, chat_id="grp1")
+            is False
+        )
 
     def test_group_accepted_when_require_mention_disabled(self, monkeypatch):
-        adapter = _make_gating_adapter(
-            monkeypatch, extra={"require_mention": False}
-        )
+        adapter = _make_gating_adapter(monkeypatch, extra={"require_mention": False})
         msg = MagicMock(is_in_at_list=False)
-        assert adapter._should_process_message(msg, "hi", is_group=True, chat_id="grp1") is True
+        assert (
+            adapter._should_process_message(msg, "hi", is_group=True, chat_id="grp1")
+            is True
+        )
 
     def test_group_accepted_when_bot_is_mentioned(self, monkeypatch):
-        adapter = _make_gating_adapter(
-            monkeypatch, extra={"require_mention": True}
-        )
+        adapter = _make_gating_adapter(monkeypatch, extra={"require_mention": True})
         msg = MagicMock(is_in_at_list=True)
-        assert adapter._should_process_message(msg, "hi", is_group=True, chat_id="grp1") is True
+        assert (
+            adapter._should_process_message(msg, "hi", is_group=True, chat_id="grp1")
+            is True
+        )
 
     def test_group_accepted_when_text_matches_wake_word(self, monkeypatch):
         adapter = _make_gating_adapter(
@@ -563,7 +589,12 @@ class TestShouldProcessMessage:
             extra={"require_mention": True, "mention_patterns": ["^hermes"]},
         )
         msg = MagicMock(is_in_at_list=False)
-        assert adapter._should_process_message(msg, "hermes help", is_group=True, chat_id="grp1") is True
+        assert (
+            adapter._should_process_message(
+                msg, "hermes help", is_group=True, chat_id="grp1"
+            )
+            is True
+        )
 
     def test_group_accepted_when_chat_in_free_response_list(self, monkeypatch):
         adapter = _make_gating_adapter(
@@ -571,9 +602,15 @@ class TestShouldProcessMessage:
             extra={"require_mention": True, "free_response_chats": ["grp1"]},
         )
         msg = MagicMock(is_in_at_list=False)
-        assert adapter._should_process_message(msg, "hi", is_group=True, chat_id="grp1") is True
+        assert (
+            adapter._should_process_message(msg, "hi", is_group=True, chat_id="grp1")
+            is True
+        )
         # Different group still blocked
-        assert adapter._should_process_message(msg, "hi", is_group=True, chat_id="grp2") is False
+        assert (
+            adapter._should_process_message(msg, "hi", is_group=True, chat_id="grp2")
+            is False
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -589,7 +626,7 @@ class TestIncomingHandlerProcess:
     @pytest.mark.asyncio
     async def test_process_extracts_session_webhook(self):
         """session_webhook must be populated from callback data."""
-        from gateway.platforms.dingtalk import _IncomingHandler, DingTalkAdapter
+        from gateway.platforms.dingtalk import DingTalkAdapter, _IncomingHandler
 
         adapter = DingTalkAdapter(PlatformConfig(enabled=True))
         adapter._on_message = AsyncMock()
@@ -615,14 +652,17 @@ class TestIncomingHandlerProcess:
         # _on_message should have been called with a ChatbotMessage
         adapter._on_message.assert_called_once()
         chatbot_msg = adapter._on_message.call_args[0][0]
-        assert chatbot_msg.session_webhook == "https://oapi.dingtalk.com/robot/sendBySession?session=abc"
+        assert (
+            chatbot_msg.session_webhook
+            == "https://oapi.dingtalk.com/robot/sendBySession?session=abc"
+        )
 
     @pytest.mark.asyncio
     async def test_process_fallback_session_webhook_when_from_dict_misses_it(self):
         """If ChatbotMessage.from_dict does not map sessionWebhook (e.g. SDK
         version mismatch), the handler should fall back to extracting it
         directly from the raw data dict."""
-        from gateway.platforms.dingtalk import _IncomingHandler, DingTalkAdapter
+        from gateway.platforms.dingtalk import DingTalkAdapter, _IncomingHandler
 
         adapter = DingTalkAdapter(PlatformConfig(enabled=True))
         adapter._on_message = AsyncMock()
@@ -644,13 +684,16 @@ class TestIncomingHandlerProcess:
 
         adapter._on_message.assert_called_once()
         chatbot_msg = adapter._on_message.call_args[0][0]
-        assert chatbot_msg.session_webhook == "https://oapi.dingtalk.com/robot/sendBySession?session=def"
+        assert (
+            chatbot_msg.session_webhook
+            == "https://oapi.dingtalk.com/robot/sendBySession?session=def"
+        )
 
     @pytest.mark.asyncio
     async def test_process_returns_ack_immediately(self):
         """process() must not block on _on_message — it should return
         the ACK tuple before the message is fully processed."""
-        from gateway.platforms.dingtalk import _IncomingHandler, DingTalkAdapter
+        from gateway.platforms.dingtalk import DingTalkAdapter, _IncomingHandler
 
         processing_started = asyncio.Event()
         processing_gate = asyncio.Event()
@@ -686,8 +729,8 @@ class TestIncomingHandlerProcess:
 # Text extraction — mention preservation + platform sanity
 # ---------------------------------------------------------------------------
 
-class TestExtractTextMentions:
 
+class TestExtractTextMentions:
     def test_preserves_at_mentions_in_text(self):
         """@mentions are routing signals (via isInAtList), not text to strip.
 
@@ -695,6 +738,7 @@ class TestExtractTextMentions:
         literal references the user wrote.
         """
         from gateway.platforms.dingtalk import DingTalkAdapter
+
         cases = [
             ("@bot hello", "@bot hello"),
             ("contact alice@example.com", "contact alice@example.com"),
@@ -724,10 +768,10 @@ class TestExtractTextMentions:
 
 
 class TestMessageContextIsolation:
-
     def test_contexts_keyed_by_chat_id(self):
         """Two concurrent chats must not clobber each other's context."""
         from gateway.platforms.dingtalk import DingTalkAdapter
+
         adapter = DingTalkAdapter(PlatformConfig(enabled=True))
 
         msg_a = MagicMock(conversation_id="chat-A", sender_staff_id="user-A")
@@ -739,24 +783,44 @@ class TestMessageContextIsolation:
         assert adapter._message_contexts["chat-B"] is msg_b
 
 
-
-
-
-
 # ---------------------------------------------------------------------------
 # Card lifecycle: finalize via metadata["streaming"]
 # ---------------------------------------------------------------------------
 
 
-class TestCardLifecycle:
+class _AttrMockModule:
+    """Mock module whose class-like attributes act as dataclass constructors.
 
+    ``_AttrMockModule().SomeModel(foo=1)`` returns a ``SimpleNamespace(foo=1)``
+    so that tests can assert on keyword arguments stored as attributes.
+    """
+
+    def __getattr__(self, name: str):
+        from types import SimpleNamespace
+
+        def _constructor(**kwargs):
+            return SimpleNamespace(**kwargs)
+
+        return _constructor
+
+
+class TestCardLifecycle:
     @pytest.fixture
-    def adapter_with_card(self):
+    def adapter_with_card(self, monkeypatch):
         from gateway.platforms.dingtalk import DingTalkAdapter
-        a = DingTalkAdapter(PlatformConfig(
-            enabled=True,
-            extra={"card_template_id": "tmpl-1"},
-        ))
+
+        monkeypatch.setattr(
+            "gateway.platforms.dingtalk.tea_util_models", _AttrMockModule()
+        )
+        monkeypatch.setattr(
+            "gateway.platforms.dingtalk.dingtalk_card_models", _AttrMockModule()
+        )
+        a = DingTalkAdapter(
+            PlatformConfig(
+                enabled=True,
+                extra={"card_template_id": "tmpl-1"},
+            )
+        )
         a._card_sdk = MagicMock()
         a._card_sdk.create_card_with_options_async = AsyncMock()
         a._card_sdk.deliver_card_with_options_async = AsyncMock()
@@ -772,7 +836,8 @@ class TestCardLifecycle:
         )
         a._message_contexts["chat-1"] = msg
         a._session_webhooks["chat-1"] = (
-            "https://api.dingtalk.com/x", 9999999999999,
+            "https://api.dingtalk.com/x",
+            9999999999999,
         )
         return a
 
@@ -826,12 +891,16 @@ class TestCardLifecycle:
         await a.send("chat-1", "initial")
         # Reopen via edit_message(finalize=False) then close.
         await a.edit_message(
-            chat_id="chat-1", message_id="track-X",
-            content="streaming...", finalize=False,
+            chat_id="chat-1",
+            message_id="track-X",
+            content="streaming...",
+            finalize=False,
         )
         await a.edit_message(
-            chat_id="chat-1", message_id="track-X",
-            content="final", finalize=True,
+            chat_id="chat-1",
+            message_id="track-X",
+            content="final",
+            finalize=True,
         )
         assert "chat-1" in fired
 
@@ -840,15 +909,18 @@ class TestCardLifecycle:
         """After edit_message(finalize=False), card is tracked as open."""
         a = adapter_with_card
         await a.edit_message(
-            chat_id="chat-1", message_id="track-1",
-            content="partial", finalize=False,
+            chat_id="chat-1",
+            message_id="track-1",
+            content="partial",
+            finalize=False,
         )
         assert "chat-1" in a._streaming_cards
         assert a._streaming_cards["chat-1"].get("track-1") == "partial"
 
     @pytest.mark.asyncio
     async def test_next_send_auto_closes_sibling_streaming_cards(
-        self, adapter_with_card,
+        self,
+        adapter_with_card,
     ):
         """Tool-progress card left open (send without reply_to + edits) must
         be auto-closed when the final-reply send arrives."""
@@ -857,8 +929,10 @@ class TestCardLifecycle:
         r1 = await a.send("chat-1", "💻 tool1")
         # Second tool: edit_message(finalize=False) — keeps streaming.
         await a.edit_message(
-            chat_id="chat-1", message_id=r1.message_id,
-            content="💻 tool1\n💻 tool2", finalize=False,
+            chat_id="chat-1",
+            message_id=r1.message_id,
+            content="💻 tool1\n💻 tool2",
+            finalize=False,
         )
         assert r1.message_id in a._streaming_cards.get("chat-1", {})
         a._card_sdk.streaming_update_with_options_async.reset_mock()
@@ -880,7 +954,10 @@ class TestCardLifecycle:
     async def test_edit_message_requires_message_id(self, adapter_with_card):
         a = adapter_with_card
         result = await a.edit_message(
-            chat_id="chat-1", message_id="", content="x", finalize=True,
+            chat_id="chat-1",
+            message_id="",
+            content="x",
+            finalize=True,
         )
         assert result.success is False
         a._card_sdk.streaming_update_with_options_async.assert_not_called()
@@ -888,8 +965,10 @@ class TestCardLifecycle:
     def test_fire_done_reaction_is_idempotent(self, adapter_with_card):
         a = adapter_with_card
         captured = []
+
         def _capture(coro):
             captured.append(coro)
+
         a._spawn_bg = _capture
 
         a._fire_done_reaction("chat-1")
@@ -898,10 +977,10 @@ class TestCardLifecycle:
         captured[0].close()
 
 
-
 # ---------------------------------------------------------------------------
 # AI Card Tests
 # ---------------------------------------------------------------------------
+
 
 class TestDingTalkAdapterAICards:
     @pytest.fixture
@@ -935,21 +1014,37 @@ class TestDingTalkAdapterAICards:
         msg.sender_nick = "Test User"
         msg.sender_staff_id = "staff1"
         msg.text = MagicMock(content="Hello")
-        msg.session_webhook = "https://api.dingtalk.com/robot/sendBySession?session=test"
+        msg.session_webhook = (
+            "https://api.dingtalk.com/robot/sendBySession?session=test"
+        )
         msg.session_webhook_expired_time = 999999999999
-        msg.create_at = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
+        msg.create_at = int(datetime.now(tz=UTC).timestamp() * 1000)
         msg.at_users = []
         return msg
 
     @pytest.mark.asyncio
-    async def test_send_uses_ai_card_if_configured(self, config, mock_stream_client, mock_http_client, mock_message):
+    async def test_send_uses_ai_card_if_configured(
+        self, config, mock_stream_client, mock_http_client, mock_message, monkeypatch
+    ):
         from gateway.platforms.dingtalk import DingTalkAdapter
+
+        monkeypatch.setattr(
+            "gateway.platforms.dingtalk.tea_util_models", _AttrMockModule()
+        )
+        monkeypatch.setattr(
+            "gateway.platforms.dingtalk.dingtalk_card_models", _AttrMockModule()
+        )
 
         adapter = DingTalkAdapter(config)
         adapter._stream_client = mock_stream_client
         adapter._http_client = mock_http_client
         adapter._message_contexts["test_conv_id"] = mock_message
-        adapter._session_webhooks = {"test_conv_id": ("https://api.dingtalk.com/robot/sendBySession?session=test", 9999999999999)}
+        adapter._session_webhooks = {
+            "test_conv_id": (
+                "https://api.dingtalk.com/robot/sendBySession?session=test",
+                9999999999999,
+            )
+        }
         adapter._card_template_id = "test_card_template"
 
         # Mock the card SDK with proper async methods

--- a/tests/gateway/test_discord_race_polish.py
+++ b/tests/gateway/test_discord_race_polish.py
@@ -5,7 +5,6 @@ import asyncio
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from gateway.config import Platform, PlatformConfig
 
 
@@ -61,10 +60,17 @@ async def test_concurrent_joins_do_not_double_connect():
     channel.connect = lambda: slow_connect(channel)
 
     from gateway.platforms import discord as discord_mod
-    with patch.object(discord_mod, "VoiceReceiver",
-                      MagicMock(return_value=MagicMock(start=lambda: None))):
-        with patch.object(discord_mod.asyncio, "ensure_future",
-                          lambda _c: asyncio.create_task(asyncio.sleep(0))):
+
+    def _consume_timeout_task(coro):
+        coro.close()
+        return asyncio.create_task(asyncio.sleep(0))
+
+    with patch.object(
+        discord_mod,
+        "VoiceReceiver",
+        MagicMock(return_value=MagicMock(start=lambda: None)),
+    ):
+        with patch.object(discord_mod.asyncio, "ensure_future", _consume_timeout_task):
             t1 = asyncio.create_task(adapter.join_voice_channel(channel))
             t2 = asyncio.create_task(adapter.join_voice_channel(channel))
             await asyncio.sleep(0.05)

--- a/tests/gateway/test_internal_event_bypass_pairing.py
+++ b/tests/gateway/test_internal_event_bypass_pairing.py
@@ -9,19 +9,18 @@ pairing code to the chat.
 
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-
 from gateway.config import GatewayConfig, Platform
 from gateway.platforms.base import MessageEvent
 from gateway.run import GatewayRunner
 from gateway.session import SessionSource
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 class _FakeRegistry:
     """Return pre-canned sessions, then None once exhausted."""
@@ -72,6 +71,7 @@ def _watcher_dict_with_notify():
 # Tests
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_notify_on_complete_sets_internal_flag(monkeypatch, tmp_path):
     """Synthetic completion event must have internal=True."""
@@ -86,6 +86,7 @@ async def test_notify_on_complete_sets_internal_flag(monkeypatch, tmp_path):
 
     async def _instant_sleep(*_a, **_kw):
         pass
+
     monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
 
     runner = _build_runner(monkeypatch, tmp_path)
@@ -136,6 +137,7 @@ async def test_internal_event_bypasses_authorization(monkeypatch, tmp_path):
     # run_in_executor.  Auth check happens before _handle_message_with_agent.
     async def _raise(*_a, **_kw):
         raise RuntimeError("sentinel — stop here")
+
     monkeypatch.setattr(GatewayRunner, "_handle_message_with_agent", _raise)
 
     try:
@@ -187,6 +189,7 @@ async def test_internal_event_does_not_trigger_pairing(monkeypatch, tmp_path):
     # run_in_executor.  Pairing check happens before _handle_message_with_agent.
     async def _raise(*_a, **_kw):
         raise RuntimeError("sentinel — stop here")
+
     monkeypatch.setattr(GatewayRunner, "_handle_message_with_agent", _raise)
 
     try:
@@ -213,6 +216,7 @@ async def test_notify_on_complete_preserves_user_identity(monkeypatch, tmp_path)
 
     async def _instant_sleep(*_a, **_kw):
         pass
+
     monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
 
     runner = _build_runner(monkeypatch, tmp_path)
@@ -231,7 +235,9 @@ async def test_notify_on_complete_preserves_user_identity(monkeypatch, tmp_path)
 
 
 @pytest.mark.asyncio
-async def test_notify_on_complete_uses_session_store_origin_for_group_topic(monkeypatch, tmp_path):
+async def test_notify_on_complete_uses_session_store_origin_for_group_topic(
+    monkeypatch, tmp_path
+):
     import tools.process_registry as pr_module
     from gateway.session import SessionSource
 
@@ -244,19 +250,22 @@ async def test_notify_on_complete_uses_session_store_origin_for_group_topic(monk
 
     async def _instant_sleep(*_a, **_kw):
         pass
+
     monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
 
     runner = GatewayRunner(GatewayConfig())
     adapter = SimpleNamespace(send=AsyncMock(), handle_message=AsyncMock())
     runner.adapters[Platform.TELEGRAM] = adapter
-    runner.session_store._entries["agent:main:telegram:group:-100:42"] = SimpleNamespace(
-        origin=SessionSource(
-            platform=Platform.TELEGRAM,
-            chat_id="-100",
-            chat_type="group",
-            thread_id="42",
-            user_id="user-42",
-            user_name="alice",
+    runner.session_store._entries["agent:main:telegram:group:-100:42"] = (
+        SimpleNamespace(
+            origin=SessionSource(
+                platform=Platform.TELEGRAM,
+                chat_id="-100",
+                chat_type="group",
+                thread_id="42",
+                user_id="user-42",
+                user_name="alice",
+            )
         )
     )
 
@@ -378,6 +387,9 @@ async def test_non_internal_event_without_user_triggers_pairing(monkeypatch, tmp
     runner = GatewayRunner(GatewayConfig())
     adapter = SimpleNamespace(send=AsyncMock())
     runner.adapters[Platform.DISCORD] = adapter
+    runner.pairing_store._is_rate_limited = MagicMock(return_value=False)
+    generate_code_mock = MagicMock(return_value="PAIR1234")
+    runner.pairing_store.generate_code = generate_code_mock
 
     source = SessionSource(
         platform=Platform.DISCORD,
@@ -397,5 +409,6 @@ async def test_non_internal_event_without_user_triggers_pairing(monkeypatch, tmp
     # Should return None (unauthorized) and send pairing message
     assert result is None
     assert adapter.send.await_count == 1
+    generate_code_mock.assert_called_once()
     sent_text = adapter.send.await_args.args[1]
     assert "don't recognize you" in sent_text

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -1,13 +1,11 @@
 """Tests for Matrix platform adapter (mautrix-python backend)."""
-import asyncio
-import json
-import re
-import sys
-import time
-import types
-import pytest
-from unittest.mock import MagicMock, patch, AsyncMock
 
+import asyncio
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 from gateway.config import Platform, PlatformConfig
 
 
@@ -95,8 +93,15 @@ def _make_fake_mautrix():
     mautrix_client = types.ModuleType("mautrix.client")
 
     class Client:
-        def __init__(self, mxid=None, device_id=None, api=None,
-                     state_store=None, sync_store=None, **kwargs):
+        def __init__(
+            self,
+            mxid=None,
+            device_id=None,
+            api=None,
+            state_store=None,
+            sync_store=None,
+            **kwargs,
+        ):
             self.mxid = mxid
             self.device_id = device_id
             self.api = api
@@ -168,7 +173,7 @@ def _make_fake_mautrix():
     mautrix_crypto_store = types.ModuleType("mautrix.crypto.store")
 
     class MemoryCryptoStore:
-        def __init__(self, account_id="", pickle_key=""):  # noqa: S301
+        def __init__(self, account_id="", pickle_key=""):
             self.account_id = account_id
             self.pickle_key = pickle_key
 
@@ -180,8 +185,10 @@ def _make_fake_mautrix():
     def encrypt_attachment(data):
         encrypted_file = MagicMock()
         encrypted_file.serialize.return_value = {
-            "key": {"k": "testkey"}, "iv": "testiv",
-            "hashes": {"sha256": "testhash"}, "v": "v2",
+            "key": {"k": "testkey"},
+            "iv": "testiv",
+            "hashes": {"sha256": "testhash"},
+            "v": "v2",
         }
         return (b"ciphertext_" + data, encrypted_file)
 
@@ -193,7 +200,7 @@ def _make_fake_mautrix():
     class PgCryptoStore:
         upgrade_table = MagicMock()
 
-        def __init__(self, account_id="", pickle_key="", db=None):  # noqa: S301
+        def __init__(self, account_id="", pickle_key="", db=None):
             self.account_id = account_id
             self.pickle_key = pickle_key
             self.db = db
@@ -239,12 +246,14 @@ def _make_fake_mautrix():
 # Platform & Config
 # ---------------------------------------------------------------------------
 
+
 class TestMatrixConfigLoading:
     def test_apply_env_overrides_with_access_token(self, monkeypatch):
         monkeypatch.setenv("MATRIX_ACCESS_TOKEN", "syt_abc123")
         monkeypatch.setenv("MATRIX_HOMESERVER", "https://matrix.example.org")
 
         from gateway.config import GatewayConfig, _apply_env_overrides
+
         config = GatewayConfig()
         _apply_env_overrides(config)
 
@@ -261,6 +270,7 @@ class TestMatrixConfigLoading:
         monkeypatch.setenv("MATRIX_USER_ID", "@bot:example.org")
 
         from gateway.config import GatewayConfig, _apply_env_overrides
+
         config = GatewayConfig()
         _apply_env_overrides(config)
 
@@ -276,6 +286,7 @@ class TestMatrixConfigLoading:
         monkeypatch.delenv("MATRIX_HOMESERVER", raising=False)
 
         from gateway.config import GatewayConfig, _apply_env_overrides
+
         config = GatewayConfig()
         _apply_env_overrides(config)
 
@@ -287,6 +298,7 @@ class TestMatrixConfigLoading:
         monkeypatch.setenv("MATRIX_ENCRYPTION", "true")
 
         from gateway.config import GatewayConfig, _apply_env_overrides
+
         config = GatewayConfig()
         _apply_env_overrides(config)
 
@@ -299,6 +311,7 @@ class TestMatrixConfigLoading:
         monkeypatch.delenv("MATRIX_ENCRYPTION", raising=False)
 
         from gateway.config import GatewayConfig, _apply_env_overrides
+
         config = GatewayConfig()
         _apply_env_overrides(config)
 
@@ -312,6 +325,7 @@ class TestMatrixConfigLoading:
         monkeypatch.setenv("MATRIX_HOME_ROOM_NAME", "Bot Room")
 
         from gateway.config import GatewayConfig, _apply_env_overrides
+
         config = GatewayConfig()
         _apply_env_overrides(config)
 
@@ -326,6 +340,7 @@ class TestMatrixConfigLoading:
         monkeypatch.setenv("MATRIX_USER_ID", "@hermes:example.org")
 
         from gateway.config import GatewayConfig, _apply_env_overrides
+
         config = GatewayConfig()
         _apply_env_overrides(config)
 
@@ -337,9 +352,11 @@ class TestMatrixConfigLoading:
 # Adapter helpers
 # ---------------------------------------------------------------------------
 
+
 def _make_adapter():
     """Create a MatrixAdapter with mocked config."""
     from gateway.platforms.matrix import MatrixAdapter
+
     config = PlatformConfig(
         enabled=True,
         token="syt_test_token",
@@ -355,6 +372,7 @@ def _make_adapter():
 # ---------------------------------------------------------------------------
 # Typing indicator
 # ---------------------------------------------------------------------------
+
 
 class TestMatrixTypingIndicator:
     def setup_method(self):
@@ -389,6 +407,7 @@ class TestMatrixTypingIndicator:
 # mxc:// URL conversion
 # ---------------------------------------------------------------------------
 
+
 class TestMatrixMxcToHttp:
     def setup_method(self):
         self.adapter = _make_adapter()
@@ -397,7 +416,10 @@ class TestMatrixMxcToHttp:
         """mxc://server/media_id should become an authenticated HTTP URL."""
         mxc = "mxc://matrix.org/abc123"
         result = self.adapter._mxc_to_http(mxc)
-        assert result == "https://matrix.example.org/_matrix/client/v1/media/download/matrix.org/abc123"
+        assert (
+            result
+            == "https://matrix.example.org/_matrix/client/v1/media/download/matrix.org/abc123"
+        )
 
     def test_mxc_with_different_server(self):
         """mxc:// from a different server should still use our homeserver."""
@@ -423,6 +445,7 @@ class TestMatrixMxcToHttp:
 # DM detection
 # ---------------------------------------------------------------------------
 
+
 class TestMatrixDmDetection:
     def setup_method(self):
         self.adapter = _make_adapter()
@@ -446,7 +469,11 @@ class TestMatrixDmDetection:
     @pytest.mark.asyncio
     async def test_refresh_dm_cache_with_m_direct(self):
         """_refresh_dm_cache should populate _dm_rooms from m.direct data."""
-        self.adapter._joined_rooms = {"!room_a:ex.org", "!room_b:ex.org", "!room_c:ex.org"}
+        self.adapter._joined_rooms = {
+            "!room_a:ex.org",
+            "!room_b:ex.org",
+            "!room_c:ex.org",
+        }
 
         mock_client = MagicMock()
         mock_resp = MagicMock()
@@ -467,6 +494,7 @@ class TestMatrixDmDetection:
 # ---------------------------------------------------------------------------
 # Reply fallback stripping
 # ---------------------------------------------------------------------------
+
 
 class TestMatrixReplyFallbackStripping:
     """Test that Matrix reply fallback lines ('> ' prefix) are stripped."""
@@ -534,6 +562,7 @@ class TestMatrixReplyFallbackStripping:
 # Thread detection
 # ---------------------------------------------------------------------------
 
+
 class TestMatrixThreadDetection:
     def test_thread_id_from_m_relates_to(self):
         """m.relates_to with rel_type=m.thread should extract the event_id."""
@@ -583,6 +612,7 @@ class TestMatrixThreadDetection:
 # Format message
 # ---------------------------------------------------------------------------
 
+
 class TestMatrixFormatMessage:
     def setup_method(self):
         self.adapter = _make_adapter()
@@ -613,6 +643,7 @@ class TestMatrixFormatMessage:
 # Markdown to HTML conversion
 # ---------------------------------------------------------------------------
 
+
 class TestMatrixMarkdownToHtml:
     def setup_method(self):
         self.adapter = _make_adapter()
@@ -642,6 +673,7 @@ class TestMatrixMarkdownToHtml:
 # ---------------------------------------------------------------------------
 # Helper: display name extraction
 # ---------------------------------------------------------------------------
+
 
 class TestMatrixDisplayName:
     def setup_method(self):
@@ -688,6 +720,7 @@ class TestMatrixDisplayName:
 # Requirements check
 # ---------------------------------------------------------------------------
 
+
 class TestMatrixModuleImport:
     def test_module_importable_without_mautrix(self):
         """gateway.platforms.matrix must be importable even when mautrix is
@@ -699,23 +732,30 @@ class TestMatrixModuleImport:
         in subsequent tests).
         """
         import subprocess
+
         result = subprocess.run(
-            [sys.executable, "-c", (
-                "import sys\n"
-                "# Block mautrix completely\n"
-                "class _Blocker:\n"
-                "    def find_module(self, name, path=None):\n"
-                "        if name.startswith('mautrix'): return self\n"
-                "    def load_module(self, name):\n"
-                "        raise ImportError(f'blocked: {name}')\n"
-                "sys.meta_path.insert(0, _Blocker())\n"
-                "for k in list(sys.modules):\n"
-                "    if k.startswith('mautrix'): del sys.modules[k]\n"
-                "from gateway.platforms.matrix import check_matrix_requirements\n"
-                "assert not check_matrix_requirements()\n"
-                "print('OK')\n"
-            )],
-            capture_output=True, text=True, timeout=10,
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import sys\n"
+                    "# Block mautrix completely\n"
+                    "class _Blocker:\n"
+                    "    def find_module(self, name, path=None):\n"
+                    "        if name.startswith('mautrix'): return self\n"
+                    "    def load_module(self, name):\n"
+                    "        raise ImportError(f'blocked: {name}')\n"
+                    "sys.meta_path.insert(0, _Blocker())\n"
+                    "for k in list(sys.modules):\n"
+                    "    if k.startswith('mautrix'): del sys.modules[k]\n"
+                    "from gateway.platforms.matrix import check_matrix_requirements\n"
+                    "assert not check_matrix_requirements()\n"
+                    "print('OK')\n"
+                ),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
         )
         assert result.returncode == 0, (
             f"Subprocess failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
@@ -728,8 +768,10 @@ class TestMatrixRequirements:
         monkeypatch.setenv("MATRIX_HOMESERVER", "https://matrix.example.org")
         monkeypatch.delenv("MATRIX_ENCRYPTION", raising=False)
         from gateway.platforms.matrix import check_matrix_requirements
+
         try:
             import mautrix  # noqa: F401
+
             assert check_matrix_requirements() is True
         except ImportError:
             assert check_matrix_requirements() is False
@@ -739,12 +781,14 @@ class TestMatrixRequirements:
         monkeypatch.delenv("MATRIX_PASSWORD", raising=False)
         monkeypatch.delenv("MATRIX_HOMESERVER", raising=False)
         from gateway.platforms.matrix import check_matrix_requirements
+
         assert check_matrix_requirements() is False
 
     def test_check_requirements_without_homeserver(self, monkeypatch):
         monkeypatch.setenv("MATRIX_ACCESS_TOKEN", "syt_test")
         monkeypatch.delenv("MATRIX_HOMESERVER", raising=False)
         from gateway.platforms.matrix import check_matrix_requirements
+
         assert check_matrix_requirements() is False
 
     def test_check_requirements_encryption_true_no_e2ee_deps(self, monkeypatch):
@@ -754,6 +798,7 @@ class TestMatrixRequirements:
         monkeypatch.setenv("MATRIX_ENCRYPTION", "true")
 
         from gateway.platforms import matrix as matrix_mod
+
         with patch.object(matrix_mod, "_check_e2ee_deps", return_value=False):
             assert matrix_mod.check_matrix_requirements() is False
 
@@ -764,10 +809,12 @@ class TestMatrixRequirements:
         monkeypatch.delenv("MATRIX_ENCRYPTION", raising=False)
 
         from gateway.platforms import matrix as matrix_mod
+
         with patch.object(matrix_mod, "_check_e2ee_deps", return_value=False):
             # Still needs mautrix itself to be importable
             try:
                 import mautrix  # noqa: F401
+
                 assert matrix_mod.check_matrix_requirements() is True
             except ImportError:
                 assert matrix_mod.check_matrix_requirements() is False
@@ -779,9 +826,11 @@ class TestMatrixRequirements:
         monkeypatch.setenv("MATRIX_ENCRYPTION", "true")
 
         from gateway.platforms import matrix as matrix_mod
+
         with patch.object(matrix_mod, "_check_e2ee_deps", return_value=True):
             try:
                 import mautrix  # noqa: F401
+
                 assert matrix_mod.check_matrix_requirements() is True
             except ImportError:
                 assert matrix_mod.check_matrix_requirements() is False
@@ -790,6 +839,7 @@ class TestMatrixRequirements:
 # ---------------------------------------------------------------------------
 # Access-token auth / E2EE bootstrap
 # ---------------------------------------------------------------------------
+
 
 class TestMatrixAccessTokenAuth:
     @pytest.mark.asyncio
@@ -822,15 +872,25 @@ class TestMatrixAccessTokenAuth:
         mock_client.state_store = MagicMock()
         mock_client.sync_store = MagicMock()
         mock_client.crypto = None
-        mock_client.whoami = AsyncMock(return_value=FakeWhoamiResponse("@bot:example.org", "DEV123"))
-        mock_client.sync = AsyncMock(return_value={"rooms": {"join": {"!room:server": {}}}})
+        mock_client.whoami = AsyncMock(
+            return_value=FakeWhoamiResponse("@bot:example.org", "DEV123")
+        )
+        mock_client.sync = AsyncMock(
+            return_value={"rooms": {"join": {"!room:server": {}}}}
+        )
         mock_client.add_event_handler = MagicMock()
         mock_client.handle_sync = MagicMock(return_value=[])
-        mock_client.query_keys = AsyncMock(return_value={
-            "device_keys": {"@bot:example.org": {"DEV123": {
-                "keys": {"ed25519:DEV123": "fake_ed25519_key"},
-            }}},
-        })
+        mock_client.query_keys = AsyncMock(
+            return_value={
+                "device_keys": {
+                    "@bot:example.org": {
+                        "DEV123": {
+                            "keys": {"ed25519:DEV123": "fake_ed25519_key"},
+                        }
+                    }
+                },
+            }
+        )
         mock_client.api = MagicMock()
         mock_client.api.token = "syt_test_access_token"
         mock_client.api.session = MagicMock()
@@ -847,13 +907,18 @@ class TestMatrixAccessTokenAuth:
 
         # Patch Client constructor to return our mock
         fake_mautrix_mods["mautrix.client"].Client = MagicMock(return_value=mock_client)
-        fake_mautrix_mods["mautrix.crypto"].OlmMachine = MagicMock(return_value=mock_olm)
+        fake_mautrix_mods["mautrix.crypto"].OlmMachine = MagicMock(
+            return_value=mock_olm
+        )
 
         from gateway.platforms import matrix as matrix_mod
+
         with patch.object(matrix_mod, "_check_e2ee_deps", return_value=True):
             with patch.dict("sys.modules", fake_mautrix_mods):
                 with patch.object(adapter, "_refresh_dm_cache", AsyncMock()):
-                    with patch.object(adapter, "_sync_loop", AsyncMock(return_value=None)):
+                    with patch.object(
+                        adapter, "_sync_loop", AsyncMock(return_value=None)
+                    ):
                         assert await adapter.connect() is True
 
         mock_client.whoami.assert_awaited_once()
@@ -880,9 +945,13 @@ class TestDeviceKeyReVerification:
         mock_keys_mismatch = MagicMock()
         mock_device = MagicMock()
         mock_device.keys = {"ed25519:TESTDEVICE": "server_old_key"}
-        mock_keys_mismatch.device_keys = {"@bot:example.org": {"TESTDEVICE": mock_device}}
+        mock_keys_mismatch.device_keys = {
+            "@bot:example.org": {"TESTDEVICE": mock_device}
+        }
 
-        mock_client.query_keys = AsyncMock(side_effect=[mock_keys_missing, mock_keys_mismatch])
+        mock_client.query_keys = AsyncMock(
+            side_effect=[mock_keys_missing, mock_keys_mismatch]
+        )
 
         mock_olm = MagicMock()
         mock_olm.account = MagicMock()
@@ -890,7 +959,6 @@ class TestDeviceKeyReVerification:
         mock_olm.account.identity_keys = {"ed25519": "local_new_key"}
         mock_olm.share_keys = AsyncMock()
 
-        from gateway.platforms.matrix import MatrixAdapter
         result = await adapter._verify_device_keys_on_server(mock_client, mock_olm)
 
         assert result is False
@@ -902,7 +970,7 @@ class TestMatrixE2EEHardFail:
 
     @pytest.mark.asyncio
     async def test_connect_fails_when_encryption_true_but_no_e2ee_deps(self):
-        from gateway.platforms.matrix import MatrixAdapter, _check_e2ee_deps
+        from gateway.platforms.matrix import MatrixAdapter
 
         config = PlatformConfig(
             enabled=True,
@@ -918,7 +986,9 @@ class TestMatrixE2EEHardFail:
         fake_mautrix_mods = _make_fake_mautrix()
 
         mock_client = MagicMock()
-        mock_client.whoami = AsyncMock(return_value=MagicMock(user_id="@bot:example.org", device_id="DEV123"))
+        mock_client.whoami = AsyncMock(
+            return_value=MagicMock(user_id="@bot:example.org", device_id="DEV123")
+        )
         mock_client.api = MagicMock()
         mock_client.api.token = "syt_test_access_token"
         mock_client.api.session = MagicMock()
@@ -930,6 +1000,7 @@ class TestMatrixE2EEHardFail:
         fake_mautrix_mods["mautrix.client"].Client = MagicMock(return_value=mock_client)
 
         from gateway.platforms import matrix as matrix_mod
+
         with patch.object(matrix_mod, "_check_e2ee_deps", return_value=False):
             with patch.dict("sys.modules", fake_mautrix_mods):
                 with patch.object(adapter, "_sync_loop", AsyncMock(return_value=None)):
@@ -956,7 +1027,9 @@ class TestMatrixE2EEHardFail:
         fake_mautrix_mods = _make_fake_mautrix()
 
         mock_client = MagicMock()
-        mock_client.whoami = AsyncMock(return_value=MagicMock(user_id="@bot:example.org", device_id="DEV123"))
+        mock_client.whoami = AsyncMock(
+            return_value=MagicMock(user_id="@bot:example.org", device_id="DEV123")
+        )
         mock_client.api = MagicMock()
         mock_client.api.token = "syt_test_access_token"
         mock_client.api.session = MagicMock()
@@ -966,9 +1039,12 @@ class TestMatrixE2EEHardFail:
         mock_client.crypto = None
 
         fake_mautrix_mods["mautrix.client"].Client = MagicMock(return_value=mock_client)
-        fake_mautrix_mods["mautrix.crypto"].OlmMachine = MagicMock(side_effect=Exception("olm init failed"))
+        fake_mautrix_mods["mautrix.crypto"].OlmMachine = MagicMock(
+            side_effect=Exception("olm init failed")
+        )
 
         from gateway.platforms import matrix as matrix_mod
+
         with patch.object(matrix_mod, "_check_e2ee_deps", return_value=True):
             with patch.dict("sys.modules", fake_mautrix_mods):
                 result = await adapter.connect()
@@ -1049,15 +1125,25 @@ class TestMatrixDeviceId:
         mock_client.state_store = MagicMock()
         mock_client.sync_store = MagicMock()
         mock_client.crypto = None
-        mock_client.whoami = AsyncMock(return_value=MagicMock(user_id="@bot:example.org", device_id="WHOAMI_DEV"))
-        mock_client.sync = AsyncMock(return_value={"rooms": {"join": {"!room:server": {}}}})
+        mock_client.whoami = AsyncMock(
+            return_value=MagicMock(user_id="@bot:example.org", device_id="WHOAMI_DEV")
+        )
+        mock_client.sync = AsyncMock(
+            return_value={"rooms": {"join": {"!room:server": {}}}}
+        )
         mock_client.add_event_handler = MagicMock()
         mock_client.handle_sync = MagicMock(return_value=[])
-        mock_client.query_keys = AsyncMock(return_value={
-            "device_keys": {"@bot:example.org": {"MY_STABLE_DEVICE": {
-                "keys": {"ed25519:MY_STABLE_DEVICE": "fake_ed25519_key"},
-            }}},
-        })
+        mock_client.query_keys = AsyncMock(
+            return_value={
+                "device_keys": {
+                    "@bot:example.org": {
+                        "MY_STABLE_DEVICE": {
+                            "keys": {"ed25519:MY_STABLE_DEVICE": "fake_ed25519_key"},
+                        }
+                    }
+                },
+            }
+        )
         mock_client.api = MagicMock()
         mock_client.api.token = "syt_test_access_token"
         mock_client.api.session = MagicMock()
@@ -1072,13 +1158,18 @@ class TestMatrixDeviceId:
         mock_olm.account.identity_keys = {"ed25519": "fake_ed25519_key"}
 
         fake_mautrix_mods["mautrix.client"].Client = MagicMock(return_value=mock_client)
-        fake_mautrix_mods["mautrix.crypto"].OlmMachine = MagicMock(return_value=mock_olm)
+        fake_mautrix_mods["mautrix.crypto"].OlmMachine = MagicMock(
+            return_value=mock_olm
+        )
 
         from gateway.platforms import matrix as matrix_mod
+
         with patch.object(matrix_mod, "_check_e2ee_deps", return_value=True):
             with patch.dict("sys.modules", fake_mautrix_mods):
                 with patch.object(adapter, "_refresh_dm_cache", AsyncMock()):
-                    with patch.object(adapter, "_sync_loop", AsyncMock(return_value=None)):
+                    with patch.object(
+                        adapter, "_sync_loop", AsyncMock(return_value=None)
+                    ):
                         assert await adapter.connect() is True
 
         # The configured device_id should override the whoami device_id.
@@ -1114,7 +1205,9 @@ class TestMatrixPasswordLoginDeviceId:
         mock_client.state_store = MagicMock()
         mock_client.sync_store = MagicMock()
         mock_client.crypto = None
-        mock_client.login = AsyncMock(return_value=MagicMock(device_id="STABLE_PW_DEVICE", access_token="tok"))
+        mock_client.login = AsyncMock(
+            return_value=MagicMock(device_id="STABLE_PW_DEVICE", access_token="tok")
+        )
         mock_client.sync = AsyncMock(return_value={"rooms": {"join": {}}})
         mock_client.add_event_handler = MagicMock()
         mock_client.api = MagicMock()
@@ -1124,7 +1217,6 @@ class TestMatrixPasswordLoginDeviceId:
 
         fake_mautrix_mods["mautrix.client"].Client = MagicMock(return_value=mock_client)
 
-        from gateway.platforms import matrix as matrix_mod
         with patch.dict("sys.modules", fake_mautrix_mods):
             with patch.object(adapter, "_refresh_dm_cache", AsyncMock()):
                 with patch.object(adapter, "_sync_loop", AsyncMock(return_value=None)):
@@ -1145,6 +1237,7 @@ class TestMatrixDeviceIdConfig:
         monkeypatch.setenv("MATRIX_DEVICE_ID", "HERMES_BOT")
 
         from gateway.config import GatewayConfig, _apply_env_overrides
+
         config = GatewayConfig()
         _apply_env_overrides(config)
 
@@ -1157,6 +1250,7 @@ class TestMatrixDeviceIdConfig:
         monkeypatch.delenv("MATRIX_DEVICE_ID", raising=False)
 
         from gateway.config import GatewayConfig, _apply_env_overrides
+
         config = GatewayConfig()
         _apply_env_overrides(config)
 
@@ -1216,7 +1310,11 @@ class TestMatrixUploadAndSend:
         adapter._client = mock_client
 
         result = await adapter._upload_and_send(
-            "!room:example.org", b"hello", "test.txt", "text/plain", "m.file",
+            "!room:example.org",
+            b"hello",
+            "test.txt",
+            "text/plain",
+            "m.file",
         )
 
         assert result.success is True
@@ -1237,9 +1335,14 @@ class TestMatrixUploadAndSend:
         mock_client.send_message_event = AsyncMock(return_value="$event")
         adapter._client = mock_client
 
-        result = await adapter._upload_and_send(
-            "!room:example.org", b"secret", "secret.txt", "text/plain", "m.file",
-        )
+        with patch.dict("sys.modules", _make_fake_mautrix()):
+            result = await adapter._upload_and_send(
+                "!room:example.org",
+                b"secret",
+                "secret.txt",
+                "text/plain",
+                "m.file",
+            )
 
         assert result.success is True
         # Should have uploaded ciphertext, not plaintext
@@ -1259,10 +1362,12 @@ class TestMatrixEncryptedSendFallback:
         adapter._encryption = True
 
         fake_client = MagicMock()
-        fake_client.send_message_event = AsyncMock(side_effect=[
-            Exception("encryption error"),
-            "$event123",  # mautrix returns EventID string directly
-        ])
+        fake_client.send_message_event = AsyncMock(
+            side_effect=[
+                Exception("encryption error"),
+                "$event123",  # mautrix returns EventID string directly
+            ]
+        )
         mock_crypto = MagicMock()
         mock_crypto.share_keys = AsyncMock()
         fake_client.crypto = mock_crypto
@@ -1280,6 +1385,7 @@ class TestMatrixEncryptedSendFallback:
 # E2EE: _joined_rooms reference preservation for CryptoStateStore
 # ---------------------------------------------------------------------------
 
+
 class TestJoinedRoomsReference:
     def test_joined_rooms_reference_preserved_after_reassignment(self):
         """_CryptoStateStore must see updates after initial sync populates rooms."""
@@ -1292,14 +1398,16 @@ class TestJoinedRoomsReference:
         joined.clear()
         joined.update(["!room1:example.org", "!room2:example.org"])
 
-        import asyncio
-        rooms = asyncio.get_event_loop().run_until_complete(store.find_shared_rooms("@user:ex"))
+        rooms = asyncio.get_event_loop().run_until_complete(
+            store.find_shared_rooms("@user:ex")
+        )
         assert set(rooms) == {"!room1:example.org", "!room2:example.org"}
 
 
 # ---------------------------------------------------------------------------
 # E2EE: connect registers encrypted event handler
 # ---------------------------------------------------------------------------
+
 
 class TestMatrixEncryptedEventHandler:
     @pytest.mark.asyncio
@@ -1325,15 +1433,25 @@ class TestMatrixEncryptedEventHandler:
         mock_client.state_store = MagicMock()
         mock_client.sync_store = MagicMock()
         mock_client.crypto = None  # Will be set during connect
-        mock_client.whoami = AsyncMock(return_value=MagicMock(user_id="@bot:example.org", device_id="DEV123"))
-        mock_client.sync = AsyncMock(return_value={"rooms": {"join": {"!room:server": {}}}})
+        mock_client.whoami = AsyncMock(
+            return_value=MagicMock(user_id="@bot:example.org", device_id="DEV123")
+        )
+        mock_client.sync = AsyncMock(
+            return_value={"rooms": {"join": {"!room:server": {}}}}
+        )
         mock_client.add_event_handler = MagicMock()
         mock_client.handle_sync = MagicMock(return_value=[])
-        mock_client.query_keys = AsyncMock(return_value={
-            "device_keys": {"@bot:example.org": {"DEV123": {
-                "keys": {"ed25519:DEV123": "fake_ed25519_key"},
-            }}},
-        })
+        mock_client.query_keys = AsyncMock(
+            return_value={
+                "device_keys": {
+                    "@bot:example.org": {
+                        "DEV123": {
+                            "keys": {"ed25519:DEV123": "fake_ed25519_key"},
+                        }
+                    }
+                },
+            }
+        )
         mock_client.api = MagicMock()
         mock_client.api.token = "syt_test_token"
         mock_client.api.session = MagicMock()
@@ -1348,13 +1466,18 @@ class TestMatrixEncryptedEventHandler:
         mock_olm.account.identity_keys = {"ed25519": "fake_ed25519_key"}
 
         fake_mautrix_mods["mautrix.client"].Client = MagicMock(return_value=mock_client)
-        fake_mautrix_mods["mautrix.crypto"].OlmMachine = MagicMock(return_value=mock_olm)
+        fake_mautrix_mods["mautrix.crypto"].OlmMachine = MagicMock(
+            return_value=mock_olm
+        )
 
         from gateway.platforms import matrix as matrix_mod
+
         with patch.object(matrix_mod, "_check_e2ee_deps", return_value=True):
             with patch.dict("sys.modules", fake_mautrix_mods):
                 with patch.object(adapter, "_refresh_dm_cache", AsyncMock()):
-                    with patch.object(adapter, "_sync_loop", AsyncMock(return_value=None)):
+                    with patch.object(
+                        adapter, "_sync_loop", AsyncMock(return_value=None)
+                    ):
                         assert await adapter.connect() is True
 
         # Verify event handlers were registered.
@@ -1391,14 +1514,22 @@ class TestMatrixEncryptedEventHandler:
         mock_client.state_store = MagicMock()
         mock_client.sync_store = MagicMock()
         mock_client.crypto = None
-        mock_client.whoami = AsyncMock(return_value=MagicMock(user_id="@bot:example.org", device_id="DEV123"))
+        mock_client.whoami = AsyncMock(
+            return_value=MagicMock(user_id="@bot:example.org", device_id="DEV123")
+        )
         mock_client.add_event_handler = MagicMock()
         mock_client.add_dispatcher = MagicMock()
-        mock_client.query_keys = AsyncMock(return_value={
-            "device_keys": {"@bot:example.org": {"DEV123": {
-                "keys": {"ed25519:DEV123": "fake_ed25519_key"},
-            }}},
-        })
+        mock_client.query_keys = AsyncMock(
+            return_value={
+                "device_keys": {
+                    "@bot:example.org": {
+                        "DEV123": {
+                            "keys": {"ed25519:DEV123": "fake_ed25519_key"},
+                        }
+                    }
+                },
+            }
+        )
         mock_client.api = MagicMock()
         mock_client.api.token = "syt_test_token"
         mock_client.api.session = MagicMock()
@@ -1409,7 +1540,10 @@ class TestMatrixEncryptedEventHandler:
         mock_olm = MagicMock()
         mock_olm.load = AsyncMock()
         mock_olm.share_keys = AsyncMock(
-            side_effect=[None, Exception("One time key signed_curve25519:AAAAAQ already exists")]
+            side_effect=[
+                None,
+                Exception("One time key signed_curve25519:AAAAAQ already exists"),
+            ]
         )
         mock_olm.share_keys_min_trust = None
         mock_olm.send_keys_min_trust = None
@@ -1417,9 +1551,12 @@ class TestMatrixEncryptedEventHandler:
         mock_olm.account.identity_keys = {"ed25519": "fake_ed25519_key"}
 
         fake_mautrix_mods["mautrix.client"].Client = MagicMock(return_value=mock_client)
-        fake_mautrix_mods["mautrix.crypto"].OlmMachine = MagicMock(return_value=mock_olm)
+        fake_mautrix_mods["mautrix.crypto"].OlmMachine = MagicMock(
+            return_value=mock_olm
+        )
 
         from gateway.platforms import matrix as matrix_mod
+
         with patch.object(matrix_mod, "_check_e2ee_deps", return_value=True):
             with patch.dict("sys.modules", fake_mautrix_mods):
                 result = await adapter.connect()
@@ -1430,6 +1567,7 @@ class TestMatrixEncryptedEventHandler:
 # ---------------------------------------------------------------------------
 # Disconnect
 # ---------------------------------------------------------------------------
+
 
 class TestMatrixDisconnect:
     @pytest.mark.asyncio
@@ -1488,11 +1626,13 @@ class TestMatrixDisconnect:
 # Markdown to HTML: security tests
 # ---------------------------------------------------------------------------
 
+
 class TestMatrixMarkdownHtmlSecurity:
     """Tests for HTML injection prevention in _markdown_to_html_fallback."""
 
     def setup_method(self):
         from gateway.platforms.matrix import MatrixAdapter
+
         self.convert = MatrixAdapter._markdown_to_html_fallback
 
     def test_script_injection_in_header(self):
@@ -1549,24 +1689,26 @@ class TestMatrixMarkdownHtmlSecurity:
 # Markdown to HTML: extended formatting tests
 # ---------------------------------------------------------------------------
 
+
 class TestMatrixMarkdownHtmlFormatting:
     """Tests for new formatting capabilities in _markdown_to_html_fallback."""
 
     def setup_method(self):
         from gateway.platforms.matrix import MatrixAdapter
+
         self.convert = MatrixAdapter._markdown_to_html_fallback
 
     def test_fenced_code_block(self):
-        result = self.convert('```python\ndef hello():\n    pass\n```')
+        result = self.convert("```python\ndef hello():\n    pass\n```")
         assert "<pre><code" in result
         assert "language-python" in result
 
     def test_fenced_code_block_no_lang(self):
-        result = self.convert('```\nsome code\n```')
+        result = self.convert("```\nsome code\n```")
         assert "<pre><code>" in result
 
     def test_code_block_html_escaped(self):
-        result = self.convert('```\n<script>alert(1)</script>\n```')
+        result = self.convert("```\n<script>alert(1)</script>\n```")
         assert "&lt;script&gt;" in result
         assert "<script>" not in result
 
@@ -1618,25 +1760,34 @@ class TestMatrixMarkdownHtmlFormatting:
 # Link URL sanitization
 # ---------------------------------------------------------------------------
 
+
 class TestMatrixLinkSanitization:
     def test_safe_https_url(self):
         from gateway.platforms.matrix import MatrixAdapter
-        assert MatrixAdapter._sanitize_link_url("https://example.com") == "https://example.com"
+
+        assert (
+            MatrixAdapter._sanitize_link_url("https://example.com")
+            == "https://example.com"
+        )
 
     def test_javascript_blocked(self):
         from gateway.platforms.matrix import MatrixAdapter
+
         assert MatrixAdapter._sanitize_link_url("javascript:alert(1)") == ""
 
     def test_data_blocked(self):
         from gateway.platforms.matrix import MatrixAdapter
+
         assert MatrixAdapter._sanitize_link_url("data:text/html,bad") == ""
 
     def test_vbscript_blocked(self):
         from gateway.platforms.matrix import MatrixAdapter
+
         assert MatrixAdapter._sanitize_link_url("vbscript:bad") == ""
 
     def test_quotes_escaped(self):
         from gateway.platforms.matrix import MatrixAdapter
+
         result = MatrixAdapter._sanitize_link_url('http://x"y')
         assert '"' not in result
         assert "&quot;" in result
@@ -1645,6 +1796,7 @@ class TestMatrixLinkSanitization:
 # ---------------------------------------------------------------------------
 # Reactions
 # ---------------------------------------------------------------------------
+
 
 class TestMatrixReactions:
     def setup_method(self):
@@ -1662,7 +1814,11 @@ class TestMatrixReactions:
         assert result == "$reaction1"
         mock_client.send_message_event.assert_called_once()
         call_args = mock_client.send_message_event.call_args
-        content = call_args.args[2] if len(call_args.args) > 2 else call_args.kwargs.get("content")
+        content = (
+            call_args.args[2]
+            if len(call_args.args) > 2
+            else call_args.kwargs.get("content")
+        )
         assert content["m.relates_to"]["rel_type"] == "m.annotation"
         assert content["m.relates_to"]["key"] == "\U0001f44d"
 
@@ -1690,8 +1846,12 @@ class TestMatrixReactions:
             message_id="$msg1",
         )
         await self.adapter.on_processing_start(event)
-        self.adapter._send_reaction.assert_called_once_with("!room:ex", "$msg1", "\U0001f440")
-        assert self.adapter._pending_reactions == {("!room:ex", "$msg1"): "$reaction_event_123"}
+        self.adapter._send_reaction.assert_called_once_with(
+            "!room:ex", "$msg1", "\U0001f440"
+        )
+        assert self.adapter._pending_reactions == {
+            ("!room:ex", "$msg1"): "$reaction_event_123"
+        }
 
     @pytest.mark.asyncio
     async def test_on_processing_complete_sends_check(self):
@@ -1712,8 +1872,12 @@ class TestMatrixReactions:
             message_id="$msg1",
         )
         await self.adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
-        self.adapter._redact_reaction.assert_called_once_with("!room:ex", "$eyes_reaction_123")
-        self.adapter._send_reaction.assert_called_once_with("!room:ex", "$msg1", "\u2705")
+        self.adapter._redact_reaction.assert_called_once_with(
+            "!room:ex", "$eyes_reaction_123"
+        )
+        self.adapter._send_reaction.assert_called_once_with(
+            "!room:ex", "$msg1", "\u2705"
+        )
 
     @pytest.mark.asyncio
     async def test_on_processing_complete_sends_cross_on_failure(self):
@@ -1734,8 +1898,12 @@ class TestMatrixReactions:
             message_id="$msg1",
         )
         await self.adapter.on_processing_complete(event, ProcessingOutcome.FAILURE)
-        self.adapter._redact_reaction.assert_called_once_with("!room:ex", "$eyes_reaction_123")
-        self.adapter._send_reaction.assert_called_once_with("!room:ex", "$msg1", "\u274c")
+        self.adapter._redact_reaction.assert_called_once_with(
+            "!room:ex", "$eyes_reaction_123"
+        )
+        self.adapter._send_reaction.assert_called_once_with(
+            "!room:ex", "$msg1", "\u274c"
+        )
 
     @pytest.mark.asyncio
     async def test_on_processing_complete_cancelled_sends_no_terminal_reaction(self):
@@ -1777,7 +1945,9 @@ class TestMatrixReactions:
         )
         await self.adapter.on_processing_complete(event, ProcessingOutcome.SUCCESS)
         self.adapter._redact_reaction.assert_not_called()
-        self.adapter._send_reaction.assert_called_once_with("!room:ex", "$msg1", "\u2705")
+        self.adapter._send_reaction.assert_called_once_with(
+            "!room:ex", "$msg1", "\u2705"
+        )
 
     @pytest.mark.asyncio
     async def test_reactions_disabled(self):
@@ -1802,6 +1972,7 @@ class TestMatrixReactions:
 # ---------------------------------------------------------------------------
 # Read receipts
 # ---------------------------------------------------------------------------
+
 
 class TestMatrixReadReceipts:
     def setup_method(self):
@@ -1862,6 +2033,7 @@ class TestMatrixReadReceipts:
 # Message redaction
 # ---------------------------------------------------------------------------
 
+
 class TestMatrixRedaction:
     def setup_method(self):
         self.adapter = _make_adapter()
@@ -1888,6 +2060,7 @@ class TestMatrixRedaction:
 # ---------------------------------------------------------------------------
 # Room creation & invite
 # ---------------------------------------------------------------------------
+
 
 class TestMatrixRoomManagement:
     def setup_method(self):
@@ -1925,6 +2098,7 @@ class TestMatrixRoomManagement:
 # ---------------------------------------------------------------------------
 # Presence
 # ---------------------------------------------------------------------------
+
 
 class TestMatrixPresence:
     def setup_method(self):

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -1,19 +1,16 @@
 """Tests for the QQ Bot platform adapter."""
 
 import asyncio
-import json
 import os
-import sys
 from unittest import mock
 
 import pytest
-
-from gateway.config import Platform, PlatformConfig
-
+from gateway.config import PlatformConfig
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_config(**extra):
     """Build a PlatformConfig(enabled=True, extra=extra) for testing."""
@@ -24,9 +21,11 @@ def _make_config(**extra):
 # check_qq_requirements
 # ---------------------------------------------------------------------------
 
+
 class TestQQRequirements:
     def test_returns_bool(self):
         from gateway.platforms.qqbot import check_qq_requirements
+
         result = check_qq_requirements()
         assert isinstance(result, bool)
 
@@ -35,9 +34,11 @@ class TestQQRequirements:
 # QQAdapter.__init__
 # ---------------------------------------------------------------------------
 
+
 class TestQQAdapterInit:
     def _make(self, **extra):
         from gateway.platforms.qqbot import QQAdapter
+
         return QQAdapter(_make_config(**extra))
 
     def test_basic_attributes(self):
@@ -46,7 +47,11 @@ class TestQQAdapterInit:
         assert adapter._client_secret == "sec"
 
     def test_env_fallback(self):
-        with mock.patch.dict(os.environ, {"QQ_APP_ID": "env_id", "QQ_CLIENT_SECRET": "env_sec"}, clear=False):
+        with mock.patch.dict(
+            os.environ,
+            {"QQ_APP_ID": "env_id", "QQ_CLIENT_SECRET": "env_sec"},
+            clear=False,
+        ):
             adapter = self._make()
             assert adapter._app_id == "env_id"
             assert adapter._client_secret == "env_sec"
@@ -101,9 +106,11 @@ class TestQQAdapterInit:
 # _coerce_list
 # ---------------------------------------------------------------------------
 
+
 class TestCoerceList:
     def _fn(self, value):
         from gateway.platforms.qqbot import _coerce_list
+
         return _coerce_list(value)
 
     def test_none(self):
@@ -129,9 +136,11 @@ class TestCoerceList:
 # _is_voice_content_type
 # ---------------------------------------------------------------------------
 
+
 class TestIsVoiceContentType:
     def _fn(self, content_type, filename):
         from gateway.platforms.qqbot import QQAdapter
+
         return QQAdapter._is_voice_content_type(content_type, filename)
 
     def test_voice_content_type(self):
@@ -154,9 +163,11 @@ class TestIsVoiceContentType:
 # Voice attachment SSRF protection
 # ---------------------------------------------------------------------------
 
+
 class TestVoiceAttachmentSSRFProtection:
     def _make_adapter(self, **extra):
         from gateway.platforms.qqbot import QQAdapter
+
         return QQAdapter(_make_config(**extra))
 
     def test_stt_blocks_unsafe_download_url(self):
@@ -179,9 +190,13 @@ class TestVoiceAttachmentSSRFProtection:
         from gateway.platforms.qqbot import QQAdapter, _ssrf_redirect_guard
 
         client = mock.AsyncMock()
-        with mock.patch("gateway.platforms.qqbot.adapter.httpx.AsyncClient", return_value=client) as async_client_cls:
+        with mock.patch(
+            "gateway.platforms.qqbot.adapter.httpx.AsyncClient", return_value=client
+        ) as async_client_cls:
             adapter = QQAdapter(_make_config(app_id="a", client_secret="b"))
-            adapter._ensure_token = mock.AsyncMock(side_effect=RuntimeError("stop after client creation"))
+            adapter._ensure_token = mock.AsyncMock(
+                side_effect=RuntimeError("stop after client creation")
+            )
 
             connected = asyncio.run(adapter.connect())
 
@@ -191,13 +206,16 @@ class TestVoiceAttachmentSSRFProtection:
         assert kwargs.get("follow_redirects") is True
         assert kwargs.get("event_hooks", {}).get("response") == [_ssrf_redirect_guard]
 
+
 # ---------------------------------------------------------------------------
 # _strip_at_mention
 # ---------------------------------------------------------------------------
 
+
 class TestStripAtMention:
     def _fn(self, content):
         from gateway.platforms.qqbot import QQAdapter
+
         return QQAdapter._strip_at_mention(content)
 
     def test_removes_mention(self):
@@ -219,9 +237,11 @@ class TestStripAtMention:
 # _is_dm_allowed
 # ---------------------------------------------------------------------------
 
+
 class TestDmAllowed:
     def _make_adapter(self, **extra):
         from gateway.platforms.qqbot import QQAdapter
+
         return QQAdapter(_make_config(**extra))
 
     def test_open_policy(self):
@@ -229,19 +249,33 @@ class TestDmAllowed:
         assert adapter._is_dm_allowed("any_user") is True
 
     def test_disabled_policy(self):
-        adapter = self._make_adapter(app_id="a", client_secret="b", dm_policy="disabled")
+        adapter = self._make_adapter(
+            app_id="a", client_secret="b", dm_policy="disabled"
+        )
         assert adapter._is_dm_allowed("any_user") is False
 
     def test_allowlist_match(self):
-        adapter = self._make_adapter(app_id="a", client_secret="b", dm_policy="allowlist", allow_from="user1,user2")
+        adapter = self._make_adapter(
+            app_id="a",
+            client_secret="b",
+            dm_policy="allowlist",
+            allow_from="user1,user2",
+        )
         assert adapter._is_dm_allowed("user1") is True
 
     def test_allowlist_no_match(self):
-        adapter = self._make_adapter(app_id="a", client_secret="b", dm_policy="allowlist", allow_from="user1,user2")
+        adapter = self._make_adapter(
+            app_id="a",
+            client_secret="b",
+            dm_policy="allowlist",
+            allow_from="user1,user2",
+        )
         assert adapter._is_dm_allowed("user3") is False
 
     def test_allowlist_wildcard(self):
-        adapter = self._make_adapter(app_id="a", client_secret="b", dm_policy="allowlist", allow_from="*")
+        adapter = self._make_adapter(
+            app_id="a", client_secret="b", dm_policy="allowlist", allow_from="*"
+        )
         assert adapter._is_dm_allowed("anyone") is True
 
 
@@ -249,9 +283,11 @@ class TestDmAllowed:
 # _is_group_allowed
 # ---------------------------------------------------------------------------
 
+
 class TestGroupAllowed:
     def _make_adapter(self, **extra):
         from gateway.platforms.qqbot import QQAdapter
+
         return QQAdapter(_make_config(**extra))
 
     def test_open_policy(self):
@@ -259,11 +295,21 @@ class TestGroupAllowed:
         assert adapter._is_group_allowed("grp1", "user1") is True
 
     def test_allowlist_match(self):
-        adapter = self._make_adapter(app_id="a", client_secret="b", group_policy="allowlist", group_allow_from="grp1")
+        adapter = self._make_adapter(
+            app_id="a",
+            client_secret="b",
+            group_policy="allowlist",
+            group_allow_from="grp1",
+        )
         assert adapter._is_group_allowed("grp1", "user1") is True
 
     def test_allowlist_no_match(self):
-        adapter = self._make_adapter(app_id="a", client_secret="b", group_policy="allowlist", group_allow_from="grp1")
+        adapter = self._make_adapter(
+            app_id="a",
+            client_secret="b",
+            group_policy="allowlist",
+            group_allow_from="grp1",
+        )
         assert adapter._is_group_allowed("grp2", "user1") is False
 
 
@@ -271,9 +317,11 @@ class TestGroupAllowed:
 # _resolve_stt_config
 # ---------------------------------------------------------------------------
 
+
 class TestResolveSTTConfig:
     def _make_adapter(self, **extra):
         from gateway.platforms.qqbot import QQAdapter
+
         return QQAdapter(_make_config(**extra))
 
     def test_no_config(self):
@@ -283,11 +331,15 @@ class TestResolveSTTConfig:
 
     def test_env_config(self):
         adapter = self._make_adapter(app_id="a", client_secret="b")
-        with mock.patch.dict(os.environ, {
-            "QQ_STT_API_KEY": "key123",
-            "QQ_STT_BASE_URL": "https://example.com/v1",
-            "QQ_STT_MODEL": "my-model",
-        }, clear=True):
+        with mock.patch.dict(
+            os.environ,
+            {
+                "QQ_STT_API_KEY": "key123",
+                "QQ_STT_BASE_URL": "https://example.com/v1",
+                "QQ_STT_MODEL": "my-model",
+            },
+            clear=True,
+        ):
             cfg = adapter._resolve_stt_config()
             assert cfg is not None
             assert cfg["api_key"] == "key123"
@@ -313,25 +365,31 @@ class TestResolveSTTConfig:
 # _detect_message_type
 # ---------------------------------------------------------------------------
 
+
 class TestDetectMessageType:
     def _fn(self, media_urls, media_types):
         from gateway.platforms.qqbot import QQAdapter
+
         return QQAdapter._detect_message_type(media_urls, media_types)
 
     def test_no_media(self):
         from gateway.platforms.base import MessageType
+
         assert self._fn([], []) == MessageType.TEXT
 
     def test_image(self):
         from gateway.platforms.base import MessageType
+
         assert self._fn(["file.jpg"], ["image/jpeg"]) == MessageType.PHOTO
 
     def test_voice(self):
         from gateway.platforms.base import MessageType
+
         assert self._fn(["voice.silk"], ["audio/silk"]) == MessageType.VOICE
 
     def test_video(self):
         from gateway.platforms.base import MessageType
+
         assert self._fn(["vid.mp4"], ["video/mp4"]) == MessageType.VIDEO
 
 
@@ -339,26 +397,31 @@ class TestDetectMessageType:
 # QQCloseError
 # ---------------------------------------------------------------------------
 
+
 class TestQQCloseError:
     def test_attributes(self):
         from gateway.platforms.qqbot import QQCloseError
+
         err = QQCloseError(4004, "bad token")
         assert err.code == 4004
         assert err.reason == "bad token"
 
     def test_code_none(self):
         from gateway.platforms.qqbot import QQCloseError
+
         err = QQCloseError(None, "")
         assert err.code is None
 
     def test_string_to_int(self):
         from gateway.platforms.qqbot import QQCloseError
+
         err = QQCloseError("4914", "banned")
         assert err.code == 4914
         assert err.reason == "banned"
 
     def test_message_format(self):
         from gateway.platforms.qqbot import QQCloseError
+
         err = QQCloseError(4008, "rate limit")
         assert "4008" in str(err)
         assert "rate limit" in str(err)
@@ -368,9 +431,11 @@ class TestQQCloseError:
 # _dispatch_payload
 # ---------------------------------------------------------------------------
 
+
 class TestDispatchPayload:
     def _make_adapter(self, **extra):
         from gateway.platforms.qqbot import QQAdapter
+
         adapter = QQAdapter(_make_config(**extra))
         return adapter
 
@@ -383,6 +448,7 @@ class TestDispatchPayload:
 
     def test_op10_updates_heartbeat_interval(self):
         adapter = self._make_adapter(app_id="a", client_secret="b")
+        adapter._create_task = lambda coro: coro.close()
         adapter._dispatch_payload({"op": 10, "d": {"heartbeat_interval": 50000}})
         # Should be 50000 / 1000 * 0.8 = 40.0
         assert adapter._heartbeat_interval == 40.0
@@ -408,27 +474,37 @@ class TestDispatchPayload:
 # READY / RESUMED handling
 # ---------------------------------------------------------------------------
 
+
 class TestReadyHandling:
     def _make_adapter(self, **extra):
         from gateway.platforms.qqbot import QQAdapter
+
         return QQAdapter(_make_config(**extra))
 
     def test_ready_stores_session(self):
         adapter = self._make_adapter(app_id="a", client_secret="b")
-        adapter._dispatch_payload({
-            "op": 0, "t": "READY",
-            "s": 1,
-            "d": {"session_id": "sess_abc123"},
-        })
+        adapter._dispatch_payload(
+            {
+                "op": 0,
+                "t": "READY",
+                "s": 1,
+                "d": {"session_id": "sess_abc123"},
+            }
+        )
         assert adapter._session_id == "sess_abc123"
 
     def test_resumed_preserves_session(self):
         adapter = self._make_adapter(app_id="a", client_secret="b")
         adapter._session_id = "old_sess"
         adapter._last_seq = 50
-        adapter._dispatch_payload({
-            "op": 0, "t": "RESUMED", "s": 60, "d": {},
-        })
+        adapter._dispatch_payload(
+            {
+                "op": 0,
+                "t": "RESUMED",
+                "s": 60,
+                "d": {},
+            }
+        )
         # Session should remain unchanged on RESUMED
         assert adapter._session_id == "old_sess"
         assert adapter._last_seq == 60
@@ -438,9 +514,11 @@ class TestReadyHandling:
 # _parse_json
 # ---------------------------------------------------------------------------
 
+
 class TestParseJson:
     def _fn(self, raw):
         from gateway.platforms.qqbot import QQAdapter
+
         return QQAdapter._parse_json(raw)
 
     def test_valid_json(self):
@@ -460,7 +538,7 @@ class TestParseJson:
         assert result is None
 
     def test_empty_dict(self):
-        result = self._fn('{}')
+        result = self._fn("{}")
         assert result == {}
 
 
@@ -468,36 +546,48 @@ class TestParseJson:
 # _build_text_body
 # ---------------------------------------------------------------------------
 
+
 class TestBuildTextBody:
     def _make_adapter(self, **extra):
         from gateway.platforms.qqbot import QQAdapter
+
         return QQAdapter(_make_config(**extra))
 
     def test_plain_text(self):
-        adapter = self._make_adapter(app_id="a", client_secret="b", markdown_support=False)
+        adapter = self._make_adapter(
+            app_id="a", client_secret="b", markdown_support=False
+        )
         body = adapter._build_text_body("hello world")
         assert body["msg_type"] == 0  # MSG_TYPE_TEXT
         assert body["content"] == "hello world"
 
     def test_markdown_text(self):
-        adapter = self._make_adapter(app_id="a", client_secret="b", markdown_support=True)
+        adapter = self._make_adapter(
+            app_id="a", client_secret="b", markdown_support=True
+        )
         body = adapter._build_text_body("**bold** text")
         assert body["msg_type"] == 2  # MSG_TYPE_MARKDOWN
         assert body["markdown"]["content"] == "**bold** text"
 
     def test_truncation(self):
-        adapter = self._make_adapter(app_id="a", client_secret="b", markdown_support=False)
+        adapter = self._make_adapter(
+            app_id="a", client_secret="b", markdown_support=False
+        )
         long_text = "x" * 10000
         body = adapter._build_text_body(long_text)
         assert len(body["content"]) == adapter.MAX_MESSAGE_LENGTH
 
     def test_empty_string(self):
-        adapter = self._make_adapter(app_id="a", client_secret="b", markdown_support=False)
+        adapter = self._make_adapter(
+            app_id="a", client_secret="b", markdown_support=False
+        )
         body = adapter._build_text_body("")
         assert body["content"] == ""
 
     def test_reply_to(self):
-        adapter = self._make_adapter(app_id="a", client_secret="b", markdown_support=False)
+        adapter = self._make_adapter(
+            app_id="a", client_secret="b", markdown_support=False
+        )
         body = adapter._build_text_body("reply text", reply_to="msg_123")
         assert body.get("message_reference", {}).get("message_id") == "msg_123"
 
@@ -506,11 +596,13 @@ class TestBuildTextBody:
 # _wait_for_reconnection / send reconnection wait
 # ---------------------------------------------------------------------------
 
+
 class TestWaitForReconnection:
     """Test that send() waits for reconnection instead of silently dropping."""
 
     def _make_adapter(self, **extra):
         from gateway.platforms.qqbot import QQAdapter
+
         return QQAdapter(_make_config(**extra))
 
     @pytest.mark.asyncio
@@ -578,7 +670,9 @@ class TestWaitForReconnection:
         adapter._RECONNECT_POLL_INTERVAL = 0.05
         adapter._RECONNECT_WAIT_SECONDS = 0.2
 
-        result = await adapter._send_media("test_openid", "http://example.com/img.jpg", 1, "image")
+        result = await adapter._send_media(
+            "test_openid", "http://example.com/img.jpg", 1, "image"
+        )
         assert not result.success
         assert result.retryable is True
         assert "Not connected" in result.error

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -14,19 +14,15 @@ import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
-from gateway.config import Platform, PlatformConfig
+from gateway.config import PlatformConfig
 from gateway.platforms.base import (
-    MessageEvent,
     MessageType,
-    SendResult,
-    SUPPORTED_DOCUMENT_TYPES,
 )
-
 
 # ---------------------------------------------------------------------------
 # Mock the slack-bolt package if it's not installed
 # ---------------------------------------------------------------------------
+
 
 def _ensure_slack_mock():
     """Install mock slack modules so SlackAdapter can be imported."""
@@ -45,7 +41,10 @@ def _ensure_slack_mock():
         ("slack_bolt.async_app", slack_bolt.async_app),
         ("slack_bolt.adapter", slack_bolt.adapter),
         ("slack_bolt.adapter.socket_mode", slack_bolt.adapter.socket_mode),
-        ("slack_bolt.adapter.socket_mode.async_handler", slack_bolt.adapter.socket_mode.async_handler),
+        (
+            "slack_bolt.adapter.socket_mode.async_handler",
+            slack_bolt.adapter.socket_mode.async_handler,
+        ),
         ("slack_sdk", slack_sdk),
         ("slack_sdk.web", slack_sdk.web),
         ("slack_sdk.web.async_client", slack_sdk.web.async_client),
@@ -57,22 +56,26 @@ _ensure_slack_mock()
 
 # Patch SLACK_AVAILABLE before importing the adapter
 import gateway.platforms.slack as _slack_mod
+
 _slack_mod.SLACK_AVAILABLE = True
 
 from gateway.platforms.slack import SlackAdapter  # noqa: E402
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
 
-@pytest.fixture()
+
+@pytest.fixture
 def adapter():
     config = PlatformConfig(enabled=True, token="xoxb-fake-token")
     a = SlackAdapter(config)
     # Mock the Slack app client
     a._app = MagicMock()
-    a._app.client = AsyncMock()
+    a._app.client = MagicMock()
+    a._app.client.users_info = AsyncMock(
+        return_value={"user": {"profile": {"display_name": "Test User"}}}
+    )
     a._bot_user_id = "U_BOT"
     a._running = True
     # Capture events instead of processing them
@@ -92,6 +95,7 @@ def _redirect_cache(tmp_path, monkeypatch):
 # TestAppMentionHandler
 # ---------------------------------------------------------------------------
 
+
 class TestAppMentionHandler:
     """Verify that the app_mention event handler is registered."""
 
@@ -110,37 +114,47 @@ class TestAppMentionHandler:
             def decorator(fn):
                 registered_events.append(event_type)
                 return fn
+
             return decorator
 
         def mock_command(cmd):
             def decorator(fn):
                 registered_commands.append(cmd)
                 return fn
+
             return decorator
 
         mock_app.event = mock_event
         mock_app.command = mock_command
         mock_app.client = AsyncMock()
-        mock_app.client.auth_test = AsyncMock(return_value={
-            "user_id": "U_BOT",
-            "user": "testbot",
-        })
+        mock_app.client.auth_test = AsyncMock(
+            return_value={
+                "user_id": "U_BOT",
+                "user": "testbot",
+            }
+        )
 
         # Mock AsyncWebClient so multi-workspace auth_test is awaitable
         mock_web_client = AsyncMock()
-        mock_web_client.auth_test = AsyncMock(return_value={
-            "user_id": "U_BOT",
-            "user": "testbot",
-            "team_id": "T_FAKE",
-            "team": "FakeTeam",
-        })
+        mock_web_client.auth_test = AsyncMock(
+            return_value={
+                "user_id": "U_BOT",
+                "user": "testbot",
+                "team_id": "T_FAKE",
+                "team": "FakeTeam",
+            }
+        )
 
-        with patch.object(_slack_mod, "AsyncApp", return_value=mock_app), \
-             patch.object(_slack_mod, "AsyncWebClient", return_value=mock_web_client), \
-             patch.object(_slack_mod, "AsyncSocketModeHandler", return_value=MagicMock()), \
-             patch.dict(os.environ, {"SLACK_APP_TOKEN": "xapp-fake"}), \
-             patch("gateway.status.acquire_scoped_lock", return_value=(True, None)), \
-             patch("asyncio.create_task"):
+        with (
+            patch.object(_slack_mod, "AsyncApp", return_value=mock_app),
+            patch.object(_slack_mod, "AsyncWebClient", return_value=mock_web_client),
+            patch.object(
+                _slack_mod, "AsyncSocketModeHandler", return_value=MagicMock()
+            ),
+            patch.dict(os.environ, {"SLACK_APP_TOKEN": "xapp-fake"}),
+            patch("gateway.status.acquire_scoped_lock", return_value=(True, None)),
+            patch("asyncio.create_task"),
+        ):
             asyncio.run(adapter.connect())
 
         assert "message" in registered_events
@@ -162,12 +176,16 @@ class TestSlackConnectCleanup:
         mock_web_client = AsyncMock()
         mock_web_client.auth_test = AsyncMock(side_effect=RuntimeError("boom"))
 
-        with patch.object(_slack_mod, "AsyncApp", return_value=mock_app), \
-             patch.object(_slack_mod, "AsyncWebClient", return_value=mock_web_client), \
-             patch.object(_slack_mod, "AsyncSocketModeHandler", return_value=MagicMock()), \
-             patch.dict(os.environ, {"SLACK_APP_TOKEN": "xapp-fake"}), \
-             patch("gateway.status.acquire_scoped_lock", return_value=(True, None)), \
-             patch("gateway.status.release_scoped_lock") as mock_release:
+        with (
+            patch.object(_slack_mod, "AsyncApp", return_value=mock_app),
+            patch.object(_slack_mod, "AsyncWebClient", return_value=mock_web_client),
+            patch.object(
+                _slack_mod, "AsyncSocketModeHandler", return_value=MagicMock()
+            ),
+            patch.dict(os.environ, {"SLACK_APP_TOKEN": "xapp-fake"}),
+            patch("gateway.status.acquire_scoped_lock", return_value=(True, None)),
+            patch("gateway.status.release_scoped_lock") as mock_release,
+        ):
             result = await adapter.connect()
 
         assert result is False
@@ -178,6 +196,7 @@ class TestSlackConnectCleanup:
 # ---------------------------------------------------------------------------
 # TestSendDocument
 # ---------------------------------------------------------------------------
+
 
 class TestSendDocument:
     @pytest.mark.asyncio
@@ -279,6 +298,7 @@ class TestSendDocument:
 # TestSendVideo
 # ---------------------------------------------------------------------------
 
+
 class TestSendVideo:
     @pytest.mark.asyncio
     async def test_send_video_success(self, adapter, tmp_path):
@@ -341,6 +361,7 @@ class TestSendVideo:
 # TestIncomingDocumentHandling
 # ---------------------------------------------------------------------------
 
+
 class TestIncomingDocumentHandling:
     def _make_event(self, files=None, text="hello", channel_type="im"):
         """Build a mock Slack message event with file attachments."""
@@ -358,14 +379,20 @@ class TestIncomingDocumentHandling:
         """A PDF attachment should be downloaded, cached, and set as DOCUMENT type."""
         pdf_bytes = b"%PDF-1.4 fake content"
 
-        with patch.object(adapter, "_download_slack_file_bytes", new_callable=AsyncMock) as dl:
+        with patch.object(
+            adapter, "_download_slack_file_bytes", new_callable=AsyncMock
+        ) as dl:
             dl.return_value = pdf_bytes
-            event = self._make_event(files=[{
-                "mimetype": "application/pdf",
-                "name": "report.pdf",
-                "url_private_download": "https://files.slack.com/report.pdf",
-                "size": len(pdf_bytes),
-            }])
+            event = self._make_event(
+                files=[
+                    {
+                        "mimetype": "application/pdf",
+                        "name": "report.pdf",
+                        "url_private_download": "https://files.slack.com/report.pdf",
+                        "size": len(pdf_bytes),
+                    }
+                ]
+            )
             await adapter._handle_slack_message(event)
 
         msg_event = adapter.handle_message.call_args[0][0]
@@ -379,16 +406,20 @@ class TestIncomingDocumentHandling:
         """A .txt file under 100KB should have its content injected into event text."""
         content = b"Hello from a text file"
 
-        with patch.object(adapter, "_download_slack_file_bytes", new_callable=AsyncMock) as dl:
+        with patch.object(
+            adapter, "_download_slack_file_bytes", new_callable=AsyncMock
+        ) as dl:
             dl.return_value = content
             event = self._make_event(
                 text="summarize this",
-                files=[{
-                    "mimetype": "text/plain",
-                    "name": "notes.txt",
-                    "url_private_download": "https://files.slack.com/notes.txt",
-                    "size": len(content),
-                }],
+                files=[
+                    {
+                        "mimetype": "text/plain",
+                        "name": "notes.txt",
+                        "url_private_download": "https://files.slack.com/notes.txt",
+                        "size": len(content),
+                    }
+                ],
             )
             await adapter._handle_slack_message(event)
 
@@ -402,14 +433,21 @@ class TestIncomingDocumentHandling:
         """A .md file under 100KB should have its content injected."""
         content = b"# Title\nSome markdown content"
 
-        with patch.object(adapter, "_download_slack_file_bytes", new_callable=AsyncMock) as dl:
+        with patch.object(
+            adapter, "_download_slack_file_bytes", new_callable=AsyncMock
+        ) as dl:
             dl.return_value = content
-            event = self._make_event(files=[{
-                "mimetype": "text/markdown",
-                "name": "readme.md",
-                "url_private_download": "https://files.slack.com/readme.md",
-                "size": len(content),
-            }], text="")
+            event = self._make_event(
+                files=[
+                    {
+                        "mimetype": "text/markdown",
+                        "name": "readme.md",
+                        "url_private_download": "https://files.slack.com/readme.md",
+                        "size": len(content),
+                    }
+                ],
+                text="",
+            )
             await adapter._handle_slack_message(event)
 
         msg_event = adapter.handle_message.call_args[0][0]
@@ -420,14 +458,21 @@ class TestIncomingDocumentHandling:
         """A .txt file over 100KB should be cached but NOT injected."""
         content = b"x" * (200 * 1024)
 
-        with patch.object(adapter, "_download_slack_file_bytes", new_callable=AsyncMock) as dl:
+        with patch.object(
+            adapter, "_download_slack_file_bytes", new_callable=AsyncMock
+        ) as dl:
             dl.return_value = content
-            event = self._make_event(files=[{
-                "mimetype": "text/plain",
-                "name": "big.txt",
-                "url_private_download": "https://files.slack.com/big.txt",
-                "size": len(content),
-            }], text="")
+            event = self._make_event(
+                files=[
+                    {
+                        "mimetype": "text/plain",
+                        "name": "big.txt",
+                        "url_private_download": "https://files.slack.com/big.txt",
+                        "size": len(content),
+                    }
+                ],
+                text="",
+            )
             await adapter._handle_slack_message(event)
 
         msg_event = adapter.handle_message.call_args[0][0]
@@ -437,14 +482,20 @@ class TestIncomingDocumentHandling:
     @pytest.mark.asyncio
     async def test_zip_file_cached(self, adapter):
         """A .zip file should be cached as a supported document."""
-        with patch.object(adapter, "_download_slack_file_bytes", new_callable=AsyncMock) as dl:
+        with patch.object(
+            adapter, "_download_slack_file_bytes", new_callable=AsyncMock
+        ) as dl:
             dl.return_value = b"PK\x03\x04zip"
-            event = self._make_event(files=[{
-                "mimetype": "application/zip",
-                "name": "archive.zip",
-                "url_private_download": "https://files.slack.com/archive.zip",
-                "size": 1024,
-            }])
+            event = self._make_event(
+                files=[
+                    {
+                        "mimetype": "application/zip",
+                        "name": "archive.zip",
+                        "url_private_download": "https://files.slack.com/archive.zip",
+                        "size": 1024,
+                    }
+                ]
+            )
             await adapter._handle_slack_message(event)
 
         msg_event = adapter.handle_message.call_args[0][0]
@@ -455,12 +506,16 @@ class TestIncomingDocumentHandling:
     @pytest.mark.asyncio
     async def test_oversized_document_skipped(self, adapter):
         """A document over 20MB should be skipped."""
-        event = self._make_event(files=[{
-            "mimetype": "application/pdf",
-            "name": "huge.pdf",
-            "url_private_download": "https://files.slack.com/huge.pdf",
-            "size": 25 * 1024 * 1024,
-        }])
+        event = self._make_event(
+            files=[
+                {
+                    "mimetype": "application/pdf",
+                    "name": "huge.pdf",
+                    "url_private_download": "https://files.slack.com/huge.pdf",
+                    "size": 25 * 1024 * 1024,
+                }
+            ]
+        )
         await adapter._handle_slack_message(event)
 
         msg_event = adapter.handle_message.call_args[0][0]
@@ -469,14 +524,20 @@ class TestIncomingDocumentHandling:
     @pytest.mark.asyncio
     async def test_document_download_error_handled(self, adapter):
         """If document download fails, handler should not crash."""
-        with patch.object(adapter, "_download_slack_file_bytes", new_callable=AsyncMock) as dl:
+        with patch.object(
+            adapter, "_download_slack_file_bytes", new_callable=AsyncMock
+        ) as dl:
             dl.side_effect = RuntimeError("download failed")
-            event = self._make_event(files=[{
-                "mimetype": "application/pdf",
-                "name": "report.pdf",
-                "url_private_download": "https://files.slack.com/report.pdf",
-                "size": 1024,
-            }])
+            event = self._make_event(
+                files=[
+                    {
+                        "mimetype": "application/pdf",
+                        "name": "report.pdf",
+                        "url_private_download": "https://files.slack.com/report.pdf",
+                        "size": 1024,
+                    }
+                ]
+            )
             await adapter._handle_slack_message(event)
 
         # Handler should still be called (the exception is caught)
@@ -485,14 +546,20 @@ class TestIncomingDocumentHandling:
     @pytest.mark.asyncio
     async def test_image_still_handled(self, adapter):
         """Image attachments should still go through the image path, not document."""
-        with patch.object(adapter, "_download_slack_file", new_callable=AsyncMock) as dl:
+        with patch.object(
+            adapter, "_download_slack_file", new_callable=AsyncMock
+        ) as dl:
             dl.return_value = "/tmp/cached_image.jpg"
-            event = self._make_event(files=[{
-                "mimetype": "image/jpeg",
-                "name": "photo.jpg",
-                "url_private_download": "https://files.slack.com/photo.jpg",
-                "size": 1024,
-            }])
+            event = self._make_event(
+                files=[
+                    {
+                        "mimetype": "image/jpeg",
+                        "name": "photo.jpg",
+                        "url_private_download": "https://files.slack.com/photo.jpg",
+                        "size": 1024,
+                    }
+                ]
+            )
             await adapter._handle_slack_message(event)
 
         msg_event = adapter.handle_message.call_args[0][0]
@@ -502,6 +569,7 @@ class TestIncomingDocumentHandling:
 # ---------------------------------------------------------------------------
 # TestMessageRouting
 # ---------------------------------------------------------------------------
+
 
 class TestMessageRouting:
     @pytest.mark.asyncio
@@ -756,7 +824,9 @@ class TestFormatMessage:
 
     def test_link_with_parentheses_in_url(self, adapter):
         """Wikipedia-style URL with balanced parens is not truncated."""
-        result = adapter.format_message("[Foo](https://en.wikipedia.org/wiki/Foo_(bar))")
+        result = adapter.format_message(
+            "[Foo](https://en.wikipedia.org/wiki/Foo_(bar))"
+        )
         assert result == "<https://en.wikipedia.org/wiki/Foo_(bar)|Foo>"
 
     def test_link_with_multiple_paren_pairs(self, adapter):
@@ -771,7 +841,9 @@ class TestFormatMessage:
 
     def test_link_with_angle_brackets_and_parens(self, adapter):
         """Angle-bracket URL with parens (CommonMark syntax)."""
-        result = adapter.format_message("[Foo](<https://en.wikipedia.org/wiki/Foo_(bar)>)")
+        result = adapter.format_message(
+            "[Foo](<https://en.wikipedia.org/wiki/Foo_(bar)>)"
+        )
         assert result == "<https://en.wikipedia.org/wiki/Foo_(bar)|Foo>"
 
     def test_escaping_is_idempotent(self, adapter):
@@ -793,7 +865,10 @@ class TestFormatMessage:
 
     def test_subteam_mention_preserved(self, adapter):
         """<!subteam^ID> user group mention passes through unchanged."""
-        assert adapter.format_message("Paging <!subteam^S12345>") == "Paging <!subteam^S12345>"
+        assert (
+            adapter.format_message("Paging <!subteam^S12345>")
+            == "Paging <!subteam^S12345>"
+        )
 
     def test_date_formatting_preserved(self, adapter):
         """<!date^...> formatting token passes through unchanged."""
@@ -987,7 +1062,9 @@ class TestEditMessageStreamingPipeline:
     async def test_edit_message_formats_url_with_parens(self, adapter):
         """Wikipedia-style URL with parens survives edit pipeline."""
         adapter._app.client.chat_update = AsyncMock(return_value={"ok": True})
-        await adapter.edit_message("C123", "ts1", "See [Foo](https://en.wikipedia.org/wiki/Foo_(bar))")
+        await adapter.edit_message(
+            "C123", "ts1", "See [Foo](https://en.wikipedia.org/wiki/Foo_(bar))"
+        )
         kwargs = adapter._app.client.chat_update.call_args.kwargs
         assert "<https://en.wikipedia.org/wiki/Foo_(bar)|Foo>" in kwargs["text"]
 
@@ -1019,7 +1096,9 @@ class TestReactions:
 
     @pytest.mark.asyncio
     async def test_add_reaction_handles_error(self, adapter):
-        adapter._app.client.reactions_add = AsyncMock(side_effect=Exception("already_reacted"))
+        adapter._app.client.reactions_add = AsyncMock(
+            side_effect=Exception("already_reacted")
+        )
         result = await adapter._add_reaction("C123", "ts1", "eyes")
         assert result is False
 
@@ -1034,9 +1113,9 @@ class TestReactions:
         """Reactions should be added on receipt and swapped on completion."""
         adapter._app.client.reactions_add = AsyncMock()
         adapter._app.client.reactions_remove = AsyncMock()
-        adapter._app.client.users_info = AsyncMock(return_value={
-            "user": {"profile": {"display_name": "Tyler"}}
-        })
+        adapter._app.client.users_info = AsyncMock(
+            return_value={"user": {"profile": {"display_name": "Tyler"}}}
+        )
 
         event = {
             "text": "hello",
@@ -1065,7 +1144,7 @@ class TestReactions:
 class TestThreadReplyHandling:
     """Test thread reply processing without explicit bot mentions."""
 
-    @pytest.fixture()
+    @pytest.fixture
     def mock_session_store(self):
         """Create a mock session store with entries dict."""
         store = MagicMock()
@@ -1075,7 +1154,7 @@ class TestThreadReplyHandling:
         store.config.group_sessions_per_user = True
         return store
 
-    @pytest.fixture()
+    @pytest.fixture
     def adapter_with_session_store(self, mock_session_store):
         """Create an adapter with a mock session store attached."""
         config = PlatformConfig(enabled=True, token="***")
@@ -1180,9 +1259,7 @@ class TestThreadReplyHandling:
         adapter_with_session_store.handle_message.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_no_session_store_ignores_thread_replies(
-        self, adapter
-    ):
+    async def test_no_session_store_ignores_thread_replies(self, adapter):
         """If no session store is attached, thread replies without mention should be ignored."""
         # adapter fixture has no session store attached
         event = {
@@ -1206,7 +1283,7 @@ class TestThreadReplyHandling:
 class TestAssistantThreadLifecycle:
     """Slack Assistant lifecycle events should seed session/user context."""
 
-    @pytest.fixture()
+    @pytest.fixture
     def mock_session_store(self):
         store = MagicMock()
         store._entries = {}
@@ -1216,12 +1293,15 @@ class TestAssistantThreadLifecycle:
         store.get_or_create_session = MagicMock()
         return store
 
-    @pytest.fixture()
+    @pytest.fixture
     def assistant_adapter(self, mock_session_store):
         config = PlatformConfig(enabled=True, token="***")
         a = SlackAdapter(config)
         a._app = MagicMock()
-        a._app.client = AsyncMock()
+        a._app.client = MagicMock()
+        a._app.client.users_info = AsyncMock(
+            return_value={"user": {"profile": {"display_name": "Test User"}}}
+        )
         a._bot_user_id = "U_BOT"
         a._team_bot_user_ids = {"T_TEAM": "U_BOT"}
         a._running = True
@@ -1230,7 +1310,9 @@ class TestAssistantThreadLifecycle:
         return a
 
     @pytest.mark.asyncio
-    async def test_lifecycle_event_seeds_session_store(self, assistant_adapter, mock_session_store):
+    async def test_lifecycle_event_seeds_session_store(
+        self, assistant_adapter, mock_session_store
+    ):
         event = {
             "type": "assistant_thread_started",
             "team_id": "T_TEAM",
@@ -1244,7 +1326,10 @@ class TestAssistantThreadLifecycle:
 
         await assistant_adapter._handle_assistant_thread_lifecycle_event(event)
 
-        assert assistant_adapter._assistant_threads[("D123", "171.000")]["user_id"] == "U_USER"
+        assert (
+            assistant_adapter._assistant_threads[("D123", "171.000")]["user_id"]
+            == "U_USER"
+        )
         mock_session_store.get_or_create_session.assert_called_once()
         source = mock_session_store.get_or_create_session.call_args[0][0]
         assert source.chat_id == "D123"
@@ -1254,16 +1339,18 @@ class TestAssistantThreadLifecycle:
         assert source.chat_topic == "C_ORIGIN"
 
     @pytest.mark.asyncio
-    async def test_message_uses_cached_assistant_thread_identity(self, assistant_adapter):
+    async def test_message_uses_cached_assistant_thread_identity(
+        self, assistant_adapter
+    ):
         assistant_adapter._assistant_threads[("D123", "171.000")] = {
             "channel_id": "D123",
             "thread_ts": "171.000",
             "user_id": "U_USER",
             "team_id": "T_TEAM",
         }
-        assistant_adapter._app.client.users_info = AsyncMock(return_value={
-            "user": {"profile": {"display_name": "Tyler"}}
-        })
+        assistant_adapter._app.client.users_info = AsyncMock(
+            return_value={"user": {"profile": {"display_name": "Tyler"}}}
+        )
         assistant_adapter._app.client.reactions_add = AsyncMock()
         assistant_adapter._app.client.reactions_remove = AsyncMock()
 
@@ -1288,19 +1375,23 @@ class TestAssistantThreadLifecycle:
         assistant_adapter._ASSISTANT_THREADS_MAX = 10
         # Fill to the limit
         for i in range(10):
-            assistant_adapter._cache_assistant_thread_metadata({
-                "channel_id": f"D{i}",
-                "thread_ts": f"{i}.000",
-                "user_id": f"U{i}",
-            })
+            assistant_adapter._cache_assistant_thread_metadata(
+                {
+                    "channel_id": f"D{i}",
+                    "thread_ts": f"{i}.000",
+                    "user_id": f"U{i}",
+                }
+            )
         assert len(assistant_adapter._assistant_threads) == 10
 
         # Adding one more should trigger eviction (down to max // 2 = 5)
-        assistant_adapter._cache_assistant_thread_metadata({
-            "channel_id": "D999",
-            "thread_ts": "999.000",
-            "user_id": "U999",
-        })
+        assistant_adapter._cache_assistant_thread_metadata(
+            {
+                "channel_id": "D999",
+                "thread_ts": "999.000",
+                "user_id": "U999",
+            }
+        )
         assert len(assistant_adapter._assistant_threads) <= 10
         # The newest entry must survive eviction
         assert ("D999", "999.000") in assistant_adapter._assistant_threads
@@ -1316,25 +1407,29 @@ class TestUserNameResolution:
 
     @pytest.mark.asyncio
     async def test_resolves_display_name(self, adapter):
-        adapter._app.client.users_info = AsyncMock(return_value={
-            "user": {"profile": {"display_name": "Tyler", "real_name": "Tyler B"}}
-        })
+        adapter._app.client.users_info = AsyncMock(
+            return_value={
+                "user": {"profile": {"display_name": "Tyler", "real_name": "Tyler B"}}
+            }
+        )
         name = await adapter._resolve_user_name("U123")
         assert name == "Tyler"
 
     @pytest.mark.asyncio
     async def test_falls_back_to_real_name(self, adapter):
-        adapter._app.client.users_info = AsyncMock(return_value={
-            "user": {"profile": {"display_name": "", "real_name": "Tyler B"}}
-        })
+        adapter._app.client.users_info = AsyncMock(
+            return_value={
+                "user": {"profile": {"display_name": "", "real_name": "Tyler B"}}
+            }
+        )
         name = await adapter._resolve_user_name("U123")
         assert name == "Tyler B"
 
     @pytest.mark.asyncio
     async def test_caches_result(self, adapter):
-        adapter._app.client.users_info = AsyncMock(return_value={
-            "user": {"profile": {"display_name": "Tyler"}}
-        })
+        adapter._app.client.users_info = AsyncMock(
+            return_value={"user": {"profile": {"display_name": "Tyler"}}}
+        )
         await adapter._resolve_user_name("U123")
         await adapter._resolve_user_name("U123")
         # Only one API call despite two lookups
@@ -1342,16 +1437,18 @@ class TestUserNameResolution:
 
     @pytest.mark.asyncio
     async def test_handles_api_error(self, adapter):
-        adapter._app.client.users_info = AsyncMock(side_effect=Exception("rate limited"))
+        adapter._app.client.users_info = AsyncMock(
+            side_effect=Exception("rate limited")
+        )
         name = await adapter._resolve_user_name("U123")
         assert name == "U123"  # Falls back to user_id
 
     @pytest.mark.asyncio
     async def test_user_name_in_message_source(self, adapter):
         """Message source should include resolved user name."""
-        adapter._app.client.users_info = AsyncMock(return_value={
-            "user": {"profile": {"display_name": "Tyler"}}
-        })
+        adapter._app.client.users_info = AsyncMock(
+            return_value={"user": {"profile": {"display_name": "Tyler"}}}
+        )
         adapter._app.client.reactions_add = AsyncMock()
         adapter._app.client.reactions_remove = AsyncMock()
 
@@ -1425,9 +1522,7 @@ class TestMessageSplitting:
     async def test_long_message_split_into_chunks(self, adapter):
         """Messages over MAX_MESSAGE_LENGTH should be split."""
         long_text = "x" * 45000  # Over Slack's 40k API limit
-        adapter._app.client.chat_postMessage = AsyncMock(
-            return_value={"ts": "ts1"}
-        )
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "ts1"})
         await adapter.send("C123", long_text)
         # Should have been called multiple times
         assert adapter._app.client.chat_postMessage.call_count >= 2
@@ -1435,9 +1530,7 @@ class TestMessageSplitting:
     @pytest.mark.asyncio
     async def test_short_message_single_send(self, adapter):
         """Short messages should be sent in one call."""
-        adapter._app.client.chat_postMessage = AsyncMock(
-            return_value={"ts": "ts1"}
-        )
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "ts1"})
         await adapter.send("C123", "hello world")
         assert adapter._app.client.chat_postMessage.call_count == 1
 
@@ -1494,9 +1587,7 @@ class TestReplyBroadcast:
 
     @pytest.mark.asyncio
     async def test_broadcast_disabled_by_default(self, adapter):
-        adapter._app.client.chat_postMessage = AsyncMock(
-            return_value={"ts": "ts1"}
-        )
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "ts1"})
         await adapter.send("C123", "hi", metadata={"thread_id": "parent_ts"})
         kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
         assert "reply_broadcast" not in kwargs
@@ -1504,9 +1595,7 @@ class TestReplyBroadcast:
     @pytest.mark.asyncio
     async def test_broadcast_enabled_via_config(self, adapter):
         adapter.config.extra["reply_broadcast"] = True
-        adapter._app.client.chat_postMessage = AsyncMock(
-            return_value={"ts": "ts1"}
-        )
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "ts1"})
         await adapter.send("C123", "hi", metadata={"thread_id": "parent_ts"})
         kwargs = adapter._app.client.chat_postMessage.call_args.kwargs
         assert kwargs.get("reply_broadcast") is True
@@ -1515,6 +1604,7 @@ class TestReplyBroadcast:
 # ---------------------------------------------------------------------------
 # TestFallbackPreservesThreadContext
 # ---------------------------------------------------------------------------
+
 
 class TestFallbackPreservesThreadContext:
     """Bug fix: file upload fallbacks lost thread context (metadata) when
@@ -1529,9 +1619,7 @@ class TestFallbackPreservesThreadContext:
         adapter._app.client.files_upload_v2 = AsyncMock(
             side_effect=Exception("upload failed")
         )
-        adapter._app.client.chat_postMessage = AsyncMock(
-            return_value={"ts": "msg_ts"}
-        )
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "msg_ts"})
 
         metadata = {"thread_id": "parent_ts_123"}
         await adapter.send_image_file(
@@ -1552,9 +1640,7 @@ class TestFallbackPreservesThreadContext:
         adapter._app.client.files_upload_v2 = AsyncMock(
             side_effect=Exception("upload failed")
         )
-        adapter._app.client.chat_postMessage = AsyncMock(
-            return_value={"ts": "msg_ts"}
-        )
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "msg_ts"})
 
         metadata = {"thread_id": "parent_ts_456"}
         await adapter.send_video(
@@ -1574,9 +1660,7 @@ class TestFallbackPreservesThreadContext:
         adapter._app.client.files_upload_v2 = AsyncMock(
             side_effect=Exception("upload failed")
         )
-        adapter._app.client.chat_postMessage = AsyncMock(
-            return_value={"ts": "msg_ts"}
-        )
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "msg_ts"})
 
         metadata = {"thread_id": "parent_ts_789"}
         await adapter.send_document(
@@ -1597,9 +1681,7 @@ class TestFallbackPreservesThreadContext:
         adapter._app.client.files_upload_v2 = AsyncMock(
             side_effect=Exception("upload failed")
         )
-        adapter._app.client.chat_postMessage = AsyncMock(
-            return_value={"ts": "msg_ts"}
-        )
+        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "msg_ts"})
 
         await adapter.send_image_file(
             chat_id="C123",
@@ -1614,6 +1696,7 @@ class TestFallbackPreservesThreadContext:
 # ---------------------------------------------------------------------------
 # TestSendImageSSRFGuards
 # ---------------------------------------------------------------------------
+
 
 class TestSendImageSSRFGuards:
     """send_image should reject redirects that land on private/internal hosts."""
@@ -1637,7 +1720,9 @@ class TestSendImageSSRFGuards:
 
         mock_client.get = AsyncMock(side_effect=fake_get)
         adapter._app.client.files_upload_v2 = AsyncMock(return_value={"ok": True})
-        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "reply_ts"})
+        adapter._app.client.chat_postMessage = AsyncMock(
+            return_value={"ts": "reply_ts"}
+        )
 
         def fake_async_client(*args, **kwargs):
             client_kwargs.update(kwargs)
@@ -1670,6 +1755,7 @@ class TestSendImageSSRFGuards:
 # TestProgressMessageThread
 # ---------------------------------------------------------------------------
 
+
 class TestProgressMessageThread:
     """Verify that progress messages go to the correct thread.
 
@@ -1693,10 +1779,14 @@ class TestProgressMessageThread:
         }
 
         captured_events = []
-        adapter.handle_message = AsyncMock(side_effect=lambda e: captured_events.append(e))
+        adapter.handle_message = AsyncMock(
+            side_effect=lambda e: captured_events.append(e)
+        )
 
         # Patch _resolve_user_name to avoid async Slack API call
-        with patch.object(adapter, "_resolve_user_name", new=AsyncMock(return_value="testuser")):
+        with patch.object(
+            adapter, "_resolve_user_name", new=AsyncMock(return_value="testuser")
+        ):
             await adapter._handle_slack_message(event)
 
         assert len(captured_events) == 1
@@ -1719,7 +1809,9 @@ class TestProgressMessageThread:
 
         # Verify that the Slack send() method correctly threads a message
         # when metadata contains thread_id equal to the original ts
-        adapter._app.client.chat_postMessage = AsyncMock(return_value={"ts": "reply_ts"})
+        adapter._app.client.chat_postMessage = AsyncMock(
+            return_value={"ts": "reply_ts"}
+        )
         result = await adapter.send(
             chat_id="D_DM",
             content="⚙️ working...",
@@ -1746,9 +1838,13 @@ class TestProgressMessageThread:
         }
 
         captured_events = []
-        adapter.handle_message = AsyncMock(side_effect=lambda e: captured_events.append(e))
+        adapter.handle_message = AsyncMock(
+            side_effect=lambda e: captured_events.append(e)
+        )
 
-        with patch.object(adapter, "_resolve_user_name", new=AsyncMock(return_value="testuser")):
+        with patch.object(
+            adapter, "_resolve_user_name", new=AsyncMock(return_value="testuser")
+        ):
             await adapter._handle_slack_message(event)
 
         assert len(captured_events) == 1
@@ -1768,15 +1864,19 @@ class TestProgressMessageThread:
             "channel": "C_CHAN",
             "channel_type": "channel",
             "user": "U_USER",
-            "text": f"<@U_BOT> help me",
+            "text": "<@U_BOT> help me",
             "ts": "2000000000.000001",
             # No thread_ts — top-level channel message
         }
 
         captured_events = []
-        adapter.handle_message = AsyncMock(side_effect=lambda e: captured_events.append(e))
+        adapter.handle_message = AsyncMock(
+            side_effect=lambda e: captured_events.append(e)
+        )
 
-        with patch.object(adapter, "_resolve_user_name", new=AsyncMock(return_value="testuser")):
+        with patch.object(
+            adapter, "_resolve_user_name", new=AsyncMock(return_value="testuser")
+        ):
             await adapter._handle_slack_message(event)
 
         assert len(captured_events) == 1

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -17,13 +17,12 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
 from gateway.config import Platform
-
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 class _AsyncCM:
     """Minimal async context manager returning a fixed value."""
@@ -89,7 +88,9 @@ def _connect_patches(mock_proc, mock_fh, mock_client_cls=None):
         "gateway.platforms.whatsapp.asyncio.create_task": MagicMock(),
     }
     base = [
-        patch("gateway.platforms.whatsapp.check_whatsapp_requirements", return_value=True),
+        patch(
+            "gateway.platforms.whatsapp.check_whatsapp_requirements", return_value=True
+        ),
         patch.object(Path, "exists", return_value=True),
         patch.object(Path, "mkdir", return_value=None),
         patch("subprocess.run", return_value=MagicMock(returncode=0)),
@@ -107,12 +108,14 @@ def _connect_patches(mock_proc, mock_fh, mock_client_cls=None):
 # _close_bridge_log() unit tests
 # ---------------------------------------------------------------------------
 
+
 class TestCloseBridgeLog:
     """Direct tests for the _close_bridge_log() helper method."""
 
     @staticmethod
     def _bare_adapter():
         from gateway.platforms.whatsapp import WhatsAppAdapter
+
         a = WhatsAppAdapter.__new__(WhatsAppAdapter)
         a._bridge_log_fh = None
         return a
@@ -149,6 +152,7 @@ class TestCloseBridgeLog:
 # data variable initialization
 # ---------------------------------------------------------------------------
 
+
 class TestDataInitialized:
     """Verify ``data = {}`` prevents NameError when resp.json() fails."""
 
@@ -166,15 +170,26 @@ class TestDataInitialized:
         mock_proc.poll.return_value = None  # bridge stays alive
 
         mock_client_cls = _mock_aiohttp(
-            status=200, json_side_effect=ValueError("bad json"),
+            status=200,
+            json_side_effect=ValueError("bad json"),
         )
         mock_fh = MagicMock()
 
         patches = _connect_patches(mock_proc, mock_fh, mock_client_cls)
 
-        with patches[0], patches[1], patches[2], patches[3], patches[4], \
-             patches[5], patches[6], patches[7], patches[8], \
-             patch.object(type(adapter), "_poll_messages", return_value=MagicMock()):
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+            patches[8],
+            patch.object(type(adapter), "_acquire_platform_lock", return_value=True),
+            patch.object(type(adapter), "_poll_messages", return_value=MagicMock()),
+        ):
             # Must NOT raise NameError
             result = await adapter.connect()
 
@@ -186,6 +201,7 @@ class TestDataInitialized:
 # ---------------------------------------------------------------------------
 # File handle cleanup on error paths
 # ---------------------------------------------------------------------------
+
 
 class TestFileHandleClosedOnError:
     """Verify the bridge log file handle is closed on every failure path."""
@@ -202,8 +218,17 @@ class TestFileHandleClosedOnError:
         mock_fh = MagicMock()
         patches = _connect_patches(mock_proc, mock_fh)
 
-        with patches[0], patches[1], patches[2], patches[3], patches[4], \
-             patches[5], patches[6], patches[7]:
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+            patch.object(type(adapter), "_acquire_platform_lock", return_value=True),
+        ):
             result = await adapter.connect()
 
         assert result is False
@@ -223,15 +248,22 @@ class TestConnectCleanup:
 
         install_result = MagicMock(returncode=1, stderr="install failed")
 
-        with patch("gateway.platforms.whatsapp.check_whatsapp_requirements", return_value=True), \
-             patch.object(Path, "exists", autospec=True, side_effect=_path_exists), \
-             patch("subprocess.run", return_value=install_result), \
-             patch("gateway.status.acquire_scoped_lock", return_value=(True, None)), \
-             patch("gateway.status.release_scoped_lock") as mock_release:
+        with (
+            patch(
+                "gateway.platforms.whatsapp.check_whatsapp_requirements",
+                return_value=True,
+            ),
+            patch.object(Path, "exists", autospec=True, side_effect=_path_exists),
+            patch("subprocess.run", return_value=install_result),
+            patch("gateway.status.acquire_scoped_lock", return_value=(True, None)),
+            patch("gateway.status.release_scoped_lock") as mock_release,
+        ):
             result = await adapter.connect()
 
         assert result is False
-        mock_release.assert_called_once_with("whatsapp-session", str(adapter._session_path))
+        mock_release.assert_called_once_with(
+            "whatsapp-session", str(adapter._session_path)
+        )
         assert adapter._platform_lock_identity is None
 
 
@@ -296,8 +328,17 @@ class TestBridgeRuntimeFailure:
         mock_fh = MagicMock()
         patches = _connect_patches(mock_proc, mock_fh, mock_client_cls)
 
-        with patches[0], patches[1], patches[2], patches[3], patches[4], \
-             patches[5], patches[6], patches[7], patches[8]:
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+            patches[8],
+        ):
             result = await adapter.connect()
 
         assert result is False
@@ -322,13 +363,23 @@ class TestBridgeRuntimeFailure:
 
         # Health returns 200 with status != "connected" -> triggers Phase 2
         mock_client_cls = _mock_aiohttp(
-            status=200, json_data={"status": "disconnected"},
+            status=200,
+            json_data={"status": "disconnected"},
         )
         mock_fh = MagicMock()
         patches = _connect_patches(mock_proc, mock_fh, mock_client_cls)
 
-        with patches[0], patches[1], patches[2], patches[3], patches[4], \
-             patches[5], patches[6], patches[7], patches[8]:
+        with (
+            patches[0],
+            patches[1],
+            patches[2],
+            patches[3],
+            patches[4],
+            patches[5],
+            patches[6],
+            patches[7],
+            patches[8],
+        ):
             result = await adapter.connect()
 
         assert result is False
@@ -342,12 +393,17 @@ class TestBridgeRuntimeFailure:
 
         mock_fh = MagicMock()
 
-        with patch("gateway.platforms.whatsapp.check_whatsapp_requirements", return_value=True), \
-             patch.object(Path, "exists", return_value=True), \
-             patch.object(Path, "mkdir", return_value=None), \
-             patch("subprocess.run", return_value=MagicMock(returncode=0)), \
-             patch("subprocess.Popen", side_effect=OSError("spawn failed")), \
-             patch("builtins.open", return_value=mock_fh):
+        with (
+            patch(
+                "gateway.platforms.whatsapp.check_whatsapp_requirements",
+                return_value=True,
+            ),
+            patch.object(Path, "exists", return_value=True),
+            patch.object(Path, "mkdir", return_value=None),
+            patch("subprocess.run", return_value=MagicMock(returncode=0)),
+            patch("subprocess.Popen", side_effect=OSError("spawn failed")),
+            patch("builtins.open", return_value=mock_fh),
+        ):
             result = await adapter.connect()
 
         assert result is False
@@ -358,6 +414,7 @@ class TestBridgeRuntimeFailure:
 # ---------------------------------------------------------------------------
 # _kill_port_process() cross-platform tests
 # ---------------------------------------------------------------------------
+
 
 class TestKillPortProcess:
     """Verify _kill_port_process uses platform-appropriate commands."""
@@ -380,14 +437,16 @@ class TestKillPortProcess:
                 return mock_taskkill
             return MagicMock()
 
-        with patch("gateway.platforms.whatsapp._IS_WINDOWS", True), \
-             patch("gateway.platforms.whatsapp.subprocess.run", side_effect=run_side_effect) as mock_run:
+        with (
+            patch("gateway.platforms.whatsapp._IS_WINDOWS", True),
+            patch(
+                "gateway.platforms.whatsapp.subprocess.run", side_effect=run_side_effect
+            ) as mock_run,
+        ):
             _kill_port_process(3000)
 
         # netstat called
-        assert any(
-            call.args[0][0] == "netstat" for call in mock_run.call_args_list
-        )
+        assert any(call.args[0][0] == "netstat" for call in mock_run.call_args_list)
         # taskkill called with correct PID
         assert any(
             call.args[0] == ["taskkill", "/PID", "12345", "/F"]
@@ -397,19 +456,20 @@ class TestKillPortProcess:
     def test_does_not_kill_wrong_port_on_windows(self):
         from gateway.platforms.whatsapp import _kill_port_process
 
-        netstat_output = (
-            "  TCP    0.0.0.0:30000          0.0.0.0:0              LISTENING       55555\n"
-        )
+        netstat_output = "  TCP    0.0.0.0:30000          0.0.0.0:0              LISTENING       55555\n"
         mock_netstat = MagicMock(stdout=netstat_output)
 
-        with patch("gateway.platforms.whatsapp._IS_WINDOWS", True), \
-             patch("gateway.platforms.whatsapp.subprocess.run", return_value=mock_netstat) as mock_run:
+        with (
+            patch("gateway.platforms.whatsapp._IS_WINDOWS", True),
+            patch(
+                "gateway.platforms.whatsapp.subprocess.run", return_value=mock_netstat
+            ) as mock_run,
+        ):
             _kill_port_process(3000)
 
         # Should NOT call taskkill because port 30000 != 3000
         assert not any(
-            call.args[0][0] == "taskkill"
-            for call in mock_run.call_args_list
+            call.args[0][0] == "taskkill" for call in mock_run.call_args_list
         )
 
     def test_uses_fuser_on_linux(self):
@@ -417,8 +477,12 @@ class TestKillPortProcess:
 
         mock_check = MagicMock(returncode=0)
 
-        with patch("gateway.platforms.whatsapp._IS_WINDOWS", False), \
-             patch("gateway.platforms.whatsapp.subprocess.run", return_value=mock_check) as mock_run:
+        with (
+            patch("gateway.platforms.whatsapp._IS_WINDOWS", False),
+            patch(
+                "gateway.platforms.whatsapp.subprocess.run", return_value=mock_check
+            ) as mock_run,
+        ):
             _kill_port_process(3000)
 
         calls = [c.args[0] for c in mock_run.call_args_list]
@@ -430,8 +494,12 @@ class TestKillPortProcess:
 
         mock_check = MagicMock(returncode=1)  # port not in use
 
-        with patch("gateway.platforms.whatsapp._IS_WINDOWS", False), \
-             patch("gateway.platforms.whatsapp.subprocess.run", return_value=mock_check) as mock_run:
+        with (
+            patch("gateway.platforms.whatsapp._IS_WINDOWS", False),
+            patch(
+                "gateway.platforms.whatsapp.subprocess.run", return_value=mock_check
+            ) as mock_run,
+        ):
             _kill_port_process(3000)
 
         calls = [c.args[0] for c in mock_run.call_args_list]
@@ -441,14 +509,20 @@ class TestKillPortProcess:
     def test_suppresses_exceptions(self):
         from gateway.platforms.whatsapp import _kill_port_process
 
-        with patch("gateway.platforms.whatsapp._IS_WINDOWS", True), \
-             patch("gateway.platforms.whatsapp.subprocess.run", side_effect=OSError("no netstat")):
+        with (
+            patch("gateway.platforms.whatsapp._IS_WINDOWS", True),
+            patch(
+                "gateway.platforms.whatsapp.subprocess.run",
+                side_effect=OSError("no netstat"),
+            ),
+        ):
             _kill_port_process(3000)  # must not raise
 
 
 # ---------------------------------------------------------------------------
 # Persistent HTTP session lifecycle
 # ---------------------------------------------------------------------------
+
 
 class TestHttpSessionLifecycle:
     """Verify persistent aiohttp.ClientSession is created and cleaned up."""

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -503,7 +503,6 @@ class TestCustomProviderCompatibility:
         assert compatible[0]["api_mode"] == "codex_responses"
 
     def test_compatible_custom_providers_prefers_base_url_then_url_then_api(self, tmp_path):
-        """URL field precedence is base_url > url > api (PR #9332)."""
         config_path = tmp_path / "config.yaml"
         config_path.write_text(
             yaml.safe_dump(

--- a/tests/hermes_cli/test_doctor_command_install.py
+++ b/tests/hermes_cli/test_doctor_command_install.py
@@ -253,6 +253,11 @@ class TestDoctorCommandInstallation:
         monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
         monkeypatch.setattr(doctor_mod, "_DHH", str(home))
         monkeypatch.setattr(sys, "platform", "win32")
+        # Mock shutil.which since the real implementation calls _winapi
+        # which is None on Linux/WSL — would crash before doctor's own
+        # win32 short-circuit can skip the section.
+        import shutil
+        monkeypatch.setattr(shutil, "which", lambda *_a, **_kw: None)
 
         fake_model_tools = types.SimpleNamespace(
             check_tool_availability=lambda *a, **kw: ([], []),

--- a/tests/hermes_cli/test_gemini_provider.py
+++ b/tests/hermes_cli/test_gemini_provider.py
@@ -130,7 +130,16 @@ class TestGeminiModelCatalog:
         are data that changes with Google releases and don't belong in tests.
         """
         assert "gemini" in _PROVIDER_MODELS
-        assert len(_PROVIDER_MODELS["gemini"]) >= 1
+        models = _PROVIDER_MODELS["gemini"]
+        assert "gemini-3-pro-preview" in models
+        assert "gemini-3-flash-preview" in models
+        assert "gemma-4-31b-it" not in models
+
+    def test_provider_models_has_3x(self):
+        models = _PROVIDER_MODELS["gemini"]
+        assert "gemini-3.1-pro-preview" in models
+        assert "gemini-3-flash-preview" in models
+        assert "gemini-3.1-flash-lite-preview" in models
 
     def test_provider_label(self):
         assert "gemini" in _PROVIDER_LABELS

--- a/tests/test_transform_tool_result_hook.py
+++ b/tests/test_transform_tool_result_hook.py
@@ -174,12 +174,13 @@ def test_transform_tool_result_integration_with_real_plugin(monkeypatch, tmp_pat
         'lambda **kw: f\'CANON[{kw["tool_name"]}]\' + kw["result"])\n',
         encoding="utf-8",
     )
-    # Plugins are opt-in — must be listed in plugins.enabled to load.
-    cfg_path = hermes_home / "config.yaml"
-    cfg_path.write_text(
+    # Plugins are opt-in: write config.yaml enabling this plugin.
+    import yaml
+    (hermes_home / "config.yaml").write_text(
         yaml.safe_dump({"plugins": {"enabled": ["transform_result_canon"]}}),
         encoding="utf-8",
     )
+    plugins_mod._plugin_manager = plugins_mod.PluginManager()
 
     # Force a fresh plugin manager so the new config is picked up.
     plugins_mod._plugin_manager = plugins_mod.PluginManager()

--- a/tests/tools/test_browser_camofox_state.py
+++ b/tests/tools/test_browser_camofox_state.py
@@ -58,3 +58,10 @@ class TestCamofoxConfigDefaults:
 
         browser_cfg = DEFAULT_CONFIG["browser"]
         assert browser_cfg["camofox"]["managed_persistence"] is False
+
+    def test_config_version_matches_current_schema(self):
+        from hermes_cli.config import DEFAULT_CONFIG
+
+        # The current schema version is tracked globally; unrelated default
+        # options may bump it after browser defaults are added.
+        assert DEFAULT_CONFIG["_config_version"] == 21

--- a/tests/tools/test_terminal_output_transform_hook.py
+++ b/tests/tools/test_terminal_output_transform_hook.py
@@ -186,12 +186,13 @@ def test_terminal_output_transform_integration_with_real_plugin(monkeypatch, tmp
         'lambda **kw: "PLUGIN-HEAD\\n" + kw["output"] + "\\nPLUGIN-TAIL")\n',
         encoding="utf-8",
     )
-    # Plugins are opt-in — must be listed in plugins.enabled to load.
-    cfg_path = hermes_home / "config.yaml"
-    cfg_path.write_text(
+    # Plugins are opt-in: write config.yaml enabling this plugin.
+    import yaml
+    (hermes_home / "config.yaml").write_text(
         yaml.safe_dump({"plugins": {"enabled": ["terminal_transform"]}}),
         encoding="utf-8",
     )
+    plugins_mod._plugin_manager = plugins_mod.PluginManager()
 
     # Force a fresh plugin manager so the new config is picked up.
     plugins_mod._plugin_manager = plugins_mod.PluginManager()

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -268,8 +268,13 @@ def _image_to_base64_data_url(image_path: Path, mime_type: Optional[str] = None)
     # Encode to base64
     encoded = base64.b64encode(data).decode("ascii")
     
-    # Determine MIME type
-    mime = mime_type or _determine_mime_type(image_path)
+    # Determine MIME type — prefer magic-byte detection over extension
+    if mime_type:
+        mime = mime_type
+    else:
+        mime = _detect_image_mime_type(image_path)
+        if not mime:
+            mime = _determine_mime_type(image_path)
     
     # Create data URL
     data_url = f"data:{mime};base64,{encoded}"


### PR DESCRIPTION
## What does this PR do?

Hardens ACP/gateway/CLI/tools execution paths and locks regressions with targeted tests. Scope is intentionally technical-only (no docs/build/local assets).

## Related Issue

None linked (maintenance hardening + regression coverage).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- ACP adapter hardening:
  - `acp_adapter/auth.py`
  - `acp_adapter/entry.py`
  - `acp_adapter/events.py`
  - `acp_adapter/permissions.py`
  - `acp_adapter/server.py`
  - `acp_adapter/session.py`
  - `acp_adapter/tools.py`
  - `agent/insights.py`
- Gateway stabilization:
  - `gateway/platforms/api_server.py`
  - `gateway/platforms/dingtalk.py`
  - `gateway/platforms/discord.py`
  - `tests/gateway/*` related updates
  - `tests/conftest.py`
- CLI reliability fix under pytest/profile handling:
  - `hermes_cli/main.py`
  - `tests/hermes_cli/test_config.py`
  - `tests/hermes_cli/test_doctor_command_install.py`
  - `tests/hermes_cli/test_gemini_provider.py`
- Tools + regression locks:
  - `tools/vision_tools.py`
  - `tests/test_transform_tool_result_hook.py`
  - `tests/tools/test_browser_camofox_state.py`
  - `tests/tools/test_terminal_output_transform_hook.py`

## Included Commits

- `5794119b` fix(acp): harden auth/session/events and adapter tool flow
- `88f99a8d` fix(gateway): stabilize api_server and platform adapter paths
- `1fa38906` fix(cli): avoid pytest argv profile override side effects
- `f6778606` fix(tools): handle vision bytes path and lock transform hook regressions

## How to Test

1. ACP
   ```bash
   scripts/run_tests.sh tests/acp/ -q --tb=short --maxfail=1
   ```
2. Gateway
   ```bash
   scripts/run_tests.sh tests/gateway/ -q --tb=short --maxfail=1
   ```
3. CLI
   ```bash
   scripts/run_tests.sh tests/hermes_cli/ tests/cli/ -q --tb=short --maxfail=1
   ```
4. Tools regressions
   ```bash
   scripts/run_tests.sh tests/test_transform_tool_result_hook.py tests/tools/test_browser_camofox_state.py tests/tools/test_terminal_output_transform_hook.py -q --tb=short --maxfail=1
   ```
5. E2E
   ```bash
   python -m pytest tests/e2e/ -v --tb=long -o "addopts="
   ```
6. Warning slice
   ```bash
   scripts/run_tests.sh tests/acp tests/gateway -q -r w
   ```

## Validation Snapshot (local)

- `tests/acp/`: 152 passed
- `tests/gateway/`: 3423 passed, 59 skipped, 8 warnings
- `tests/hermes_cli/ tests/cli/`: 2867 passed, 8 skipped, 2 warnings
- tools subset: 25 passed
- `tests/e2e/`: 48 passed
- `tests/acp tests/gateway` warnings slice: 3575 passed, 59 skipped, 10 warnings

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I have run `pytest tests/ -q` and all tests pass
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: WSL2/Linux (Ubuntu)

### Documentation & Housekeeping

- [x] I have updated relevant documentation (README, `docs/`, docstrings) — or N/A (N/A)
- [x] I have updated `cli-config.yaml.example` if I added/changed config keys — or N/A (N/A)
- [x] I have updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A (N/A)
- [x] I have considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I have updated tool descriptions/schemas if I changed tool behavior — or N/A (N/A)

## Notes

- Non-upstream/local artifacts were intentionally excluded from this PR.
- Full-suite `scripts/run_tests.sh` in this environment still reports known baseline failures outside this commit set; therefore the strict checkbox "pytest tests/ -q all pass" remains unchecked.