### PR TITLE
fix(acp): preserve assistant reasoning metadata in session persistence

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -419,6 +419,9 @@ class SessionManager:
                     tool_name=msg.get("tool_name") or msg.get("name"),
                     tool_calls=msg.get("tool_calls"),
                     tool_call_id=msg.get("tool_call_id"),
+                    reasoning=msg.get("reasoning"),
+                    reasoning_details=msg.get("reasoning_details"),
+                    codex_reasoning_items=msg.get("codex_reasoning_items"),
                 )
         except Exception:
             logger.warning("Failed to persist ACP session %s", state.session_id, exc_info=True)

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -343,6 +343,39 @@ class TestPersistence:
         assert restored.history[0].get("tool_calls") is not None
         assert restored.history[1].get("tool_call_id") == "tc_1"
 
+    def test_assistant_reasoning_fields_persisted(self, manager):
+        """ACP session restore should preserve assistant reasoning context."""
+        state = manager.create_session()
+        state.history.append({
+            "role": "assistant",
+            "content": "hello",
+            "reasoning": "step-by-step",
+            "reasoning_details": [
+                {"type": "thinking", "thinking": "first thought"},
+            ],
+            "codex_reasoning_items": [
+                {"type": "reasoning", "id": "rs_123", "encrypted_content": "enc_blob"},
+            ],
+        })
+        manager.save_session(state.session_id)
+
+        with manager._lock:
+            del manager._sessions[state.session_id]
+
+        restored = manager.get_session(state.session_id)
+        assert restored is not None
+        assert restored.history == [{
+            "role": "assistant",
+            "content": "hello",
+            "reasoning": "step-by-step",
+            "reasoning_details": [
+                {"type": "thinking", "thinking": "first thought"},
+            ],
+            "codex_reasoning_items": [
+                {"type": "reasoning", "id": "rs_123", "encrypted_content": "enc_blob"},
+            ],
+        }]
+
     def test_restore_preserves_persisted_provider_snapshot(self, tmp_path, monkeypatch):
         """Restored ACP sessions should keep their original runtime provider."""
         runtime_choice = {"provider": "anthropic"}


### PR DESCRIPTION
## Summary

ACP session persistence was dropping assistant reasoning metadata during save/restore.

This change forwards assistant `reasoning`, `reasoning_details`, and
`codex_reasoning_items` into `SessionDB.append_message()` so restored ACP
sessions retain the same assistant context they had before persistence.

## Why this is a bug

`hermes_state.SessionDB` already supports storing and restoring these fields,
but `acp_adapter.session.SessionManager._persist()` only wrote the basic
message fields. As a result, ACP session restore silently degraded assistant
history by removing reasoning-related metadata.

That created an inconsistent round-trip:
- in-memory ACP history kept reasoning fields
- persisted ACP history lost them after restore

## Changes

- update ACP session persistence to pass:
  - `reasoning`
  - `reasoning_details`
  - `codex_reasoning_items`
- add a regression test covering assistant reasoning round-trip persistence

## Tests

Ran:
- `uv run --with pytest --with pytest-xdist pytest tests/acp/test_session.py -q -n 4`

Result:
- `31 passed`

