### PR TITLE
fix(packaging): add agent.* to setuptools packages.find include

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajector
 hermes_cli = ["web_dist/**/*"]
 
 [tool.setuptools.packages.find]
-include = ["agent", "tools", "tools.*", "hermes_cli", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "acp_adapter", "plugins", "plugins.*"]
+include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "acp_adapter", "plugins", "plugins.*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## What does this PR do?

Adds the missing `agent.*` glob to `[tool.setuptools.packages.find].include` in `pyproject.toml`, so that sub-packages like `agent.transports` are included in the built distribution.

Without this, any install from source (pip, Nix, etc.) is missing `agent/transports/` and crashes at runtime with:

```
ModuleNotFoundError: No module named 'agent.transports'
```

## Related Issue

Fixes #13581

Introduced by commit 432772d (PR #13543), which added the `agent/transports/` sub-package but did not update `pyproject.toml`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `pyproject.toml`: added `"agent.*"` next to `"agent"` in `[tool.setuptools.packages.find].include` — matching the existing pattern used by `tools`, `gateway`, and `plugins`.

## How to Test

1. Build from source: `pip install .`
2. Verify the sub-package is present: `python -c "import agent.transports"` — should succeed instead of raising `ModuleNotFoundError`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've tested on my platform: macOS 15 (Nix build)

### Documentation & Housekeeping

- [x] N/A — no doc changes needed for a packaging fix
