### PR TITLE
fix(skills_hub): verify ClawHub archive and per-file SHA-256 on download

### DIFF
--- a/tests/tools/test_skills_hub_integrity.py
+++ b/tests/tools/test_skills_hub_integrity.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Tests for ClawHub integrity verification in skills_hub.py."""
+
+import hashlib
+import io
+import unittest
+import zipfile
+from unittest.mock import patch
+
+from tools.skills_hub import ClawHubSource
+
+
+def _make_zip(files: dict) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for path, content in files.items():
+            zf.writestr(path, content)
+    return buf.getvalue()
+
+
+class _MockResponse:
+    def __init__(self, status_code=200, json_data=None, content=b"", text=""):
+        self.status_code = status_code
+        self._json_data = json_data
+        self.content = content
+        self.text = text
+
+    def json(self):
+        return self._json_data
+
+
+class TestDownloadZipIntegrity(unittest.TestCase):
+    def setUp(self):
+        self.src = ClawHubSource()
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_hash_match_succeeds(self, mock_get):
+        zip_bytes = _make_zip({"SKILL.md": "# Hello"})
+        expected = hashlib.sha256(zip_bytes).hexdigest()
+        mock_get.return_value = _MockResponse(status_code=200, content=zip_bytes)
+
+        files = self.src._download_zip("test-skill", "1.0.0", expected_sha256=expected)
+
+        self.assertIn("SKILL.md", files)
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_hash_mismatch_raises_value_error(self, mock_get):
+        zip_bytes = _make_zip({"SKILL.md": "# Tampered"})
+        mock_get.return_value = _MockResponse(status_code=200, content=zip_bytes)
+
+        with self.assertRaises(ValueError) as ctx:
+            self.src._download_zip("test-skill", "1.0.0", expected_sha256="a" * 64)
+
+        self.assertIn("integrity check failed", str(ctx.exception))
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_no_expected_hash_proceeds(self, mock_get):
+        zip_bytes = _make_zip({"SKILL.md": "# Hello"})
+        mock_get.return_value = _MockResponse(status_code=200, content=zip_bytes)
+
+        files = self.src._download_zip("test-skill", "1.0.0", expected_sha256=None)
+
+        self.assertIn("SKILL.md", files)
+
+
+class TestExtractFilesIntegrity(unittest.TestCase):
+    def setUp(self):
+        self.src = ClawHubSource()
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_file_hash_match_includes_file(self, mock_get):
+        text = "# Skill content"
+        expected = hashlib.sha256(text.encode("utf-8")).hexdigest()
+        mock_get.return_value = _MockResponse(status_code=200, text=text)
+
+        version_data = {"files": [{"path": "SKILL.md", "rawUrl": "https://files.example/skill-md", "sha256": expected}]}
+        files = self.src._extract_files(version_data)
+
+        self.assertIn("SKILL.md", files)
+        self.assertEqual(files["SKILL.md"], text)
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_file_hash_mismatch_skips_file(self, mock_get):
+        mock_get.return_value = _MockResponse(status_code=200, text="# Tampered")
+
+        version_data = {"files": [{"path": "SKILL.md", "rawUrl": "https://files.example/skill-md", "sha256": "b" * 64}]}
+        files = self.src._extract_files(version_data)
+
+        self.assertNotIn("SKILL.md", files)
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_no_file_hash_proceeds(self, mock_get):
+        mock_get.return_value = _MockResponse(status_code=200, text="# Skill content")
+
+        version_data = {"files": [{"path": "SKILL.md", "rawUrl": "https://files.example/skill-md"}]}
+        files = self.src._extract_files(version_data)
+
+        self.assertIn("SKILL.md", files)
+
+
+class TestResolveVersionIntegrity(unittest.TestCase):
+    def setUp(self):
+        self.src = ClawHubSource()
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_returns_sha256_from_version_metadata(self, mock_get):
+        mock_get.return_value = _MockResponse(status_code=200, json_data={"sha256hash": "c" * 64, "files": []})
+
+        sha256, version_data = self.src._resolve_version_integrity("test-skill", "1.0.0")
+
+        self.assertEqual(sha256, "c" * 64)
+        self.assertIsNotNone(version_data)
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_degraded_mode_when_no_sha256(self, mock_get):
+        mock_get.return_value = _MockResponse(status_code=200, json_data={"files": []})
+
+        with self.assertLogs("tools.skills_hub", level="WARNING") as log:
+            sha256, _ = self.src._resolve_version_integrity("test-skill", "1.0.0")
+
+        self.assertIsNone(sha256)
+        self.assertTrue(any("no sha256hash" in line for line in log.output))
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_returns_none_when_api_unavailable(self, mock_get):
+        mock_get.return_value = _MockResponse(status_code=404)
+
+        sha256, version_data = self.src._resolve_version_integrity("test-skill", "1.0.0")
+
+        self.assertIsNone(sha256)
+        self.assertIsNone(version_data)
+
+
+class TestFetchIntegrity(unittest.TestCase):
+    def setUp(self):
+        self.src = ClawHubSource()
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_fetch_aborts_on_archive_tamper(self, mock_get):
+        zip_bytes = _make_zip({"SKILL.md": "# Malicious"})
+
+        def side_effect(url, *args, **kwargs):
+            if url.endswith("/skills/test-skill"):
+                return _MockResponse(status_code=200, json_data={"slug": "test-skill", "latestVersion": {"version": "1.0.0"}})
+            if url.endswith("/skills/test-skill/versions/1.0.0"):
+                return _MockResponse(status_code=200, json_data={"sha256hash": "d" * 64, "files": []})
+            if url.endswith("/download"):
+                return _MockResponse(status_code=200, content=zip_bytes)
+            return _MockResponse(status_code=404)
+
+        mock_get.side_effect = side_effect
+
+        result = self.src.fetch("test-skill")
+
+        self.assertIsNone(result)
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_fetch_succeeds_with_valid_hash(self, mock_get):
+        zip_bytes = _make_zip({"SKILL.md": "# Hello"})
+        expected = hashlib.sha256(zip_bytes).hexdigest()
+
+        def side_effect(url, *args, **kwargs):
+            if url.endswith("/skills/test-skill"):
+                return _MockResponse(status_code=200, json_data={"slug": "test-skill", "latestVersion": {"version": "1.0.0"}})
+            if url.endswith("/skills/test-skill/versions/1.0.0"):
+                return _MockResponse(status_code=200, json_data={"sha256hash": expected, "files": []})
+            if url.endswith("/download"):
+                return _MockResponse(status_code=200, content=zip_bytes)
+            return _MockResponse(status_code=404)
+
+        mock_get.side_effect = side_effect
+
+        result = self.src.fetch("test-skill")
+
+        self.assertIsNotNone(result)
+        self.assertIn("SKILL.md", result.files)
+
+    @patch("tools.skills_hub.httpx.get")
+    def test_fetch_proceeds_when_no_hash_published(self, mock_get):
+        zip_bytes = _make_zip({"SKILL.md": "# Hello"})
+
+        def side_effect(url, *args, **kwargs):
+            if url.endswith("/skills/test-skill"):
+                return _MockResponse(status_code=200, json_data={"slug": "test-skill", "latestVersion": {"version": "1.0.0"}})
+            if url.endswith("/skills/test-skill/versions/1.0.0"):
+                return _MockResponse(status_code=200, json_data={"files": []})
+            if url.endswith("/download"):
+                return _MockResponse(status_code=200, content=zip_bytes)
+            return _MockResponse(status_code=404)
+
+        mock_get.side_effect = side_effect
+
+        with self.assertLogs("tools.skills_hub", level="WARNING"):
+            result = self.src.fetch("test-skill")
+
+        self.assertIsNotNone(result)
+        self.assertIn("SKILL.md", result.files)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -1629,6 +1629,22 @@ class ClawHubSource(SkillSource):
         _write_index_cache(cache_key, [_skill_meta_to_dict(s) for s in final_results])
         return final_results
 
+    def _resolve_version_integrity(
+        self, slug: str, version: str
+    ) -> Tuple[Optional[str], Optional[Dict[str, Any]]]:
+        version_data = self._get_json(f"{self.BASE_URL}/skills/{slug}/versions/{version}")
+        if not isinstance(version_data, dict):
+            return None, None
+        expected_sha256 = version_data.get("sha256hash")
+        if not isinstance(expected_sha256, str) or not expected_sha256:
+            logger.warning(
+                "ClawHub: no sha256hash for %s v%s — proceeding without archive integrity check",
+                slug,
+                version,
+            )
+            expected_sha256 = None
+        return expected_sha256, version_data
+
     def fetch(self, identifier: str) -> Optional[SkillBundle]:
         slug = identifier.split("/")[-1]
 
@@ -1641,12 +1657,19 @@ class ClawHubSource(SkillSource):
             logger.warning("ClawHub fetch failed for %s: could not resolve latest version", slug)
             return None
 
+        expected_sha256, version_data = self._resolve_version_integrity(slug, latest_version)
+
         # Primary method: download the skill as a ZIP bundle from /download
-        files = self._download_zip(slug, latest_version)
+        try:
+            files = self._download_zip(slug, latest_version, expected_sha256=expected_sha256)
+        except ValueError as exc:
+            logger.error("ClawHub fetch aborted for %s: %s", slug, exc)
+            return None
 
         # Fallback: try the version metadata endpoint for inline/raw content
         if "SKILL.md" not in files:
-            version_data = self._get_json(f"{self.BASE_URL}/skills/{slug}/versions/{latest_version}")
+            if version_data is None:
+                version_data = self._get_json(f"{self.BASE_URL}/skills/{slug}/versions/{latest_version}")
             if isinstance(version_data, dict):
                 # Files may be nested under version_data["version"]["files"]
                 files = self._extract_files(version_data) or files
@@ -1810,13 +1833,24 @@ class ClawHubSource(SkillSource):
 
             raw_url = file_meta.get("rawUrl") or file_meta.get("downloadUrl") or file_meta.get("url")
             if isinstance(raw_url, str) and raw_url.startswith("http"):
+                expected_file_sha256 = file_meta.get("sha256")
                 content = self._fetch_text(raw_url)
                 if content is not None:
+                    if isinstance(expected_file_sha256, str) and expected_file_sha256:
+                        actual = hashlib.sha256(content.encode("utf-8")).hexdigest()
+                        if actual != expected_file_sha256:
+                            logger.warning(
+                                "File integrity check failed for %s: expected %s, got %s — skipping",
+                                fname,
+                                expected_file_sha256,
+                                actual,
+                            )
+                            continue
                     files[fname] = content
 
         return files
 
-    def _download_zip(self, slug: str, version: str) -> Dict[str, str]:
+    def _download_zip(self, slug: str, version: str, *, expected_sha256: Optional[str] = None) -> Dict[str, str]:
         """Download skill as a ZIP bundle from the /download endpoint and extract text files."""
         import io
         import zipfile
@@ -1847,7 +1881,16 @@ class ClawHubSource(SkillSource):
                     logger.debug("ClawHub ZIP download for %s v%s returned %s", slug, version, resp.status_code)
                     return files
 
-                with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
+                content = resp.content
+                if expected_sha256 is not None:
+                    actual_sha256 = hashlib.sha256(content).hexdigest()
+                    if actual_sha256 != expected_sha256:
+                        raise ValueError(
+                            f"Archive integrity check failed for {slug} v{version}: "
+                            f"expected {expected_sha256}, got {actual_sha256}"
+                        )
+
+                with zipfile.ZipFile(io.BytesIO(content)) as zf:
                     for info in zf.infolist():
                         if info.is_dir():
                             continue


### PR DESCRIPTION
## What does this PR do?

`ClawHubSource` downloaded and installed skill archives without verifying them against any server-published hash. A network-level attacker (MITM) could silently replace a downloaded archive with malicious content, and the agent would install it without any indication of tampering.

This PR adds integrity verification to two download paths:

- **Archive download (`_download_zip`)**: fetch `sha256hash` from `/skills/{slug}/versions/{version}` before extracting, and compare it against the SHA-256 of the downloaded ZIP bytes. A mismatch aborts the install.
- **Per-file fallback (`_extract_files`)**: when fetching individual files via `rawUrl`, verify against the optional `sha256` field in the file metadata. Files that fail the check are skipped with a warning.

If the API does not return a hash (degraded mode), a warning is logged and the install proceeds.

## Related Issue

[GHSA-w4h6-jpv9-2gx5](https://github.com/NousResearch/hermes-agent/security/advisories/GHSA-w4h6-jpv9-2gx5)

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/skills_hub.py`: add `_resolve_version_integrity()` to fetch version metadata and extract `sha256hash`
- `tools/skills_hub.py`: update `fetch()` to call `_resolve_version_integrity()` and abort on tamper detection
- `tools/skills_hub.py`: update `_download_zip()` to accept `expected_sha256` and verify archive hash before extraction
- `tools/skills_hub.py`: update `_extract_files()` to verify per-file `sha256` from metadata when available
- `tests/tools/test_skills_hub_integrity.py`: add tests covering hash match, tamper rejection, degraded-mode warning, and per-file integrity

## How to Test

1. Run `pytest tests/tools/test_skills_hub_integrity.py -v` — all 10 integrity tests should pass
2. Run `pytest tests/ -q` — full suite should pass with no regressions

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
