### PR TITLE
fix(cli): handle terminal disconnect during shutdown

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -105,13 +105,19 @@ def _request_cli_exit_on_signal(app, signum: int, agent=None, agent_running: boo
     arbitrary redraw/reset stack frame.
     """
     if agent is not None and agent_running:
-        agent.interrupt(f"received signal {signum}")
         try:
-            grace = float(os.getenv("HERMES_SIGTERM_GRACE", "1.5"))
-        except (TypeError, ValueError):
-            grace = 1.5
-        if grace > 0:
-            time.sleep(grace)
+            agent.interrupt(f"received signal {signum}")
+            try:
+                grace = float(os.getenv("HERMES_SIGTERM_GRACE", "1.5"))
+            except (TypeError, ValueError):
+                grace = 1.5
+            if grace > 0:
+                time.sleep(grace)
+        except Exception:
+            logger.debug(
+                "Best-effort agent interrupt during signal shutdown failed",
+                exc_info=True,
+            )
 
     if getattr(app, "is_running", False):
         app.exit(exception=EOFError())

--- a/cli.py
+++ b/cli.py
@@ -13,6 +13,7 @@ Usage:
     python cli.py --list-tools             # List available tools and exit
 """
 
+import errno
 import logging
 import os
 import shutil
@@ -33,6 +34,90 @@ from datetime import datetime
 from typing import List, Dict, Any, Optional
 
 logger = logging.getLogger(__name__)
+
+
+def _is_terminal_disconnect_error(exc: BaseException | None) -> bool:
+    """Return True for expected stdio/tty teardown errors during shutdown.
+
+    The classic prompt_toolkit CLI can lose its controlling terminal before the
+    event loop fully unwinds (SSH disconnect, SIGHUP/SIGTERM from a supervisor,
+    parent PTY teardown).  In that window prompt_toolkit may still try to
+    redraw/reset and hit stdout/stderr errors like ``EIO`` (macOS ``Input/output
+    error``), ``EPIPE``/``BrokenPipeError``, ``EBADF``, or ``ValueError: I/O
+    operation on closed file``.  These are expected terminal-loss conditions,
+    not actionable crashes.
+    """
+    if exc is None:
+        return False
+    if isinstance(exc, BrokenPipeError):
+        return True
+    if isinstance(exc, OSError) and getattr(exc, "errno", None) in {
+        errno.EIO,
+        errno.EPIPE,
+        errno.EBADF,
+    }:
+        return True
+    text = str(exc).lower()
+    return (
+        "input/output error" in text
+        or "broken pipe" in text
+        or "bad file descriptor" in text
+        or "i/o operation on closed file" in text
+    )
+
+
+def _should_suppress_cli_asyncio_exception(loop, context: dict[str, Any]) -> bool:
+    """Return True for known-benign asyncio noise during CLI teardown.
+
+    We still route everything else to ``loop.default_exception_handler`` so real
+    bugs remain visible.
+    """
+    exc = context.get("exception")
+    if isinstance(exc, RuntimeError) and "Event loop is closed" in str(exc):
+        return True
+    if isinstance(exc, RuntimeError) and "aclose(): asynchronous generator is already running" in str(exc):
+        return True
+    if isinstance(exc, KeyError) and "is not registered" in str(exc):
+        return True
+    if _is_terminal_disconnect_error(exc):
+        return True
+
+    message = str(context.get("message") or "")
+    if "Task was destroyed but it is pending!" not in message:
+        return False
+
+    task_repr = " ".join(
+        str(context.get(key) or "")
+        for key in ("task", "future", "handle", "source_traceback")
+    )
+    return (
+        "run_in_terminal" in task_repr
+        or "prompt_toolkit.application" in task_repr
+        or "in_terminal" in task_repr
+    )
+
+
+def _request_cli_exit_on_signal(app, signum: int, agent=None, agent_running: bool = False) -> bool:
+    """Best-effort graceful exit path for SIGHUP/SIGTERM in classic CLI mode.
+
+    Returns True when prompt_toolkit accepted an ``app.exit(exception=EOFError())``
+    request, allowing the caller to avoid injecting ``KeyboardInterrupt`` into an
+    arbitrary redraw/reset stack frame.
+    """
+    if agent is not None and agent_running:
+        agent.interrupt(f"received signal {signum}")
+        try:
+            grace = float(os.getenv("HERMES_SIGTERM_GRACE", "1.5"))
+        except (TypeError, ValueError):
+            grace = 1.5
+        if grace > 0:
+            time.sleep(grace)
+
+    if getattr(app, "is_running", False):
+        app.exit(exception=EOFError())
+        return True
+    return False
+
 
 # Suppress startup messages for clean CLI experience
 os.environ["HERMES_QUIET"] = "1"  # Our own modules
@@ -10565,22 +10650,23 @@ class HermesCLI:
             spawned with ``os.setsid`` and therefore survives as an orphan
             with PPID=1.
 
-            Grace window (``HERMES_SIGTERM_GRACE``, default 1.5 s) gives
-            the daemon time to: detect the interrupt (next 200 ms poll) →
-            call _kill_process (SIGTERM + 1 s wait + SIGKILL if needed) →
-            return from _wait_for_process.  ``time.sleep`` releases the
-            GIL so the daemon actually runs during the window.
+            After the grace window, prefer ``app.exit(exception=EOFError())``
+            over raising ``KeyboardInterrupt`` directly.  ``KeyboardInterrupt``
+            makes prompt_toolkit unwind through its redraw/reset path, which can
+            still flush stdout after the controlling PTY has disappeared and
+            trigger ``OSError: [Errno 5] Input/output error`` on macOS.  Asking
+            the application to exit with EOFError follows the same user-visible
+            shutdown path without the redraw-on-dead-tty crash.
             """
             logger.debug("Received signal %s, triggering graceful shutdown", signum)
             try:
-                if getattr(self, "agent", None) and getattr(self, "_agent_running", False):
-                    self.agent.interrupt(f"received signal {signum}")
-                    try:
-                        _grace = float(os.getenv("HERMES_SIGTERM_GRACE", "1.5"))
-                    except (TypeError, ValueError):
-                        _grace = 1.5
-                    if _grace > 0:
-                        time.sleep(_grace)
+                if _request_cli_exit_on_signal(
+                    app,
+                    signum,
+                    agent=getattr(self, "agent", None),
+                    agent_running=getattr(self, "_agent_running", False),
+                ):
+                    return
             except Exception:
                 pass  # never block signal handling
             raise KeyboardInterrupt()
@@ -10593,19 +10679,14 @@ class HermesCLI:
         except Exception:
             pass  # Signal handlers may fail in restricted environments
         
-        # Install a custom asyncio exception handler that suppresses the
-        # "Event loop is closed" RuntimeError from httpx transport cleanup
-        # and the "0 is not registered" KeyError from broken stdin (#6393).
-        # The RuntimeError fix is defense-in-depth — the primary fix is
-        # neuter_async_httpx_del which disables __del__ entirely.  The
-        # KeyError fix handles macOS + uv-managed Python environments where
-        # fd 0 is not reliably available to the asyncio selector.
+        # Install a custom asyncio exception handler that suppresses known-benign
+        # shutdown noise: cached httpx cleanup on a closed loop, selector
+        # registration failures from broken stdin (#6393), and prompt_toolkit
+        # redraw/reset errors after the controlling terminal has already
+        # disappeared (SSH disconnect, SIGHUP/SIGTERM, parent PTY teardown).
         def _suppress_closed_loop_errors(loop, context):
-            exc = context.get("exception")
-            if isinstance(exc, RuntimeError) and "Event loop is closed" in str(exc):
-                return  # silently suppress
-            if isinstance(exc, KeyError) and "is not registered" in str(exc):
-                return  # suppress selector registration failures (#6393)
+            if _should_suppress_cli_asyncio_exception(loop, context):
+                return  # silently suppress expected shutdown noise
             # Fall back to default handler for everything else
             loop.default_exception_handler(context)
 
@@ -10637,10 +10718,13 @@ class HermesCLI:
                 app.run()
         except (EOFError, KeyboardInterrupt, BrokenPipeError):
             pass
-        except (KeyError, OSError) as _stdin_err:
-            # Catch selector registration failures from broken stdin (#6393).
-            # This is the fallback for cases that slip past the fstat() guard.
-            if "is not registered" in str(_stdin_err) or "Bad file descriptor" in str(_stdin_err):
+        except (KeyError, OSError, ValueError) as _stdin_err:
+            # Catch selector registration failures from broken stdin (#6393)
+            # plus terminal disconnect teardown (macOS EIO / closed stdio) so
+            # prompt_toolkit shutdown doesn't explode when the PTY disappears.
+            if _is_terminal_disconnect_error(_stdin_err):
+                pass
+            elif "is not registered" in str(_stdin_err) or "Bad file descriptor" in str(_stdin_err):
                 print(
                     f"\nError: stdin is not usable ({_stdin_err}).\n"
                     "This can happen with certain Python installations (e.g. uv-managed cPython on macOS).\n"

--- a/tests/cli/test_cli_terminal_disconnect.py
+++ b/tests/cli/test_cli_terminal_disconnect.py
@@ -106,3 +106,17 @@ def test_request_cli_exit_on_signal_falls_back_when_app_not_running(cli_mod, mon
     assert exited is False
     agent.interrupt.assert_called_once_with("received signal 15")
     app.exit.assert_not_called()
+
+
+def test_request_cli_exit_on_signal_still_exits_when_interrupt_fails(cli_mod, monkeypatch):
+    app = Mock(is_running=True)
+    agent = Mock()
+    agent.interrupt.side_effect = RuntimeError("boom")
+    monkeypatch.setenv("HERMES_SIGTERM_GRACE", "0")
+
+    exited = cli_mod._request_cli_exit_on_signal(app, 15, agent=agent, agent_running=True)
+
+    assert exited is True
+    agent.interrupt.assert_called_once_with("received signal 15")
+    app.exit.assert_called_once()
+    assert isinstance(app.exit.call_args.kwargs["exception"], EOFError)

--- a/tests/cli/test_cli_terminal_disconnect.py
+++ b/tests/cli/test_cli_terminal_disconnect.py
@@ -1,0 +1,108 @@
+"""Regression tests for classic CLI terminal-disconnect shutdown handling."""
+
+import importlib
+import os
+import sys
+from unittest.mock import MagicMock, Mock
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+@pytest.fixture()
+def cli_mod():
+    """Import ``cli`` with prompt_toolkit stubbed out for lightweight unit tests."""
+    clean_env = {"LLM_MODEL": "", "HERMES_MAX_ITERATIONS": ""}
+    prompt_toolkit_stubs = {
+        "prompt_toolkit": MagicMock(),
+        "prompt_toolkit.history": MagicMock(),
+        "prompt_toolkit.styles": MagicMock(),
+        "prompt_toolkit.patch_stdout": MagicMock(),
+        "prompt_toolkit.application": MagicMock(),
+        "prompt_toolkit.layout": MagicMock(),
+        "prompt_toolkit.layout.processors": MagicMock(),
+        "prompt_toolkit.filters": MagicMock(),
+        "prompt_toolkit.layout.dimension": MagicMock(),
+        "prompt_toolkit.layout.menus": MagicMock(),
+        "prompt_toolkit.widgets": MagicMock(),
+        "prompt_toolkit.key_binding": MagicMock(),
+        "prompt_toolkit.completion": MagicMock(),
+        "prompt_toolkit.formatted_text": MagicMock(),
+        "prompt_toolkit.auto_suggest": MagicMock(),
+    }
+
+    from unittest.mock import patch
+
+    with patch.dict(sys.modules, prompt_toolkit_stubs), patch.dict("os.environ", clean_env, clear=False):
+        import cli as mod
+
+        yield importlib.reload(mod)
+
+
+@pytest.mark.parametrize(
+    ("exc", "expected"),
+    [
+        (BrokenPipeError(), True),
+        (OSError(5, "Input/output error"), True),
+        (OSError(9, "Bad file descriptor"), True),
+        (ValueError("I/O operation on closed file"), True),
+        (RuntimeError("aclose(): asynchronous generator is already running"), False),
+        (OSError(1, "Operation not permitted"), False),
+        (None, False),
+    ],
+)
+def test_is_terminal_disconnect_error(cli_mod, exc, expected):
+    assert cli_mod._is_terminal_disconnect_error(exc) is expected
+
+
+def test_should_suppress_asyncio_exception_for_terminal_disconnect(cli_mod):
+    loop = Mock()
+    context = {"exception": OSError(5, "Input/output error")}
+    assert cli_mod._should_suppress_cli_asyncio_exception(loop, context) is True
+
+
+def test_should_suppress_asyncio_exception_for_asyncgen_close_race(cli_mod):
+    loop = Mock()
+    context = {"exception": RuntimeError("aclose(): asynchronous generator is already running")}
+    assert cli_mod._should_suppress_cli_asyncio_exception(loop, context) is True
+
+
+def test_should_suppress_pending_prompt_toolkit_task_noise(cli_mod):
+    loop = Mock()
+    context = {
+        "message": "Task was destroyed but it is pending!",
+        "task": "<Task pending coro=<run_in_terminal.<locals>.run() done>>",
+    }
+    assert cli_mod._should_suppress_cli_asyncio_exception(loop, context) is True
+
+
+def test_should_not_suppress_unrelated_asyncio_exception(cli_mod):
+    loop = Mock()
+    context = {"exception": RuntimeError("boom")}
+    assert cli_mod._should_suppress_cli_asyncio_exception(loop, context) is False
+
+
+def test_request_cli_exit_on_signal_exits_app_without_keyboardinterrupt(cli_mod, monkeypatch):
+    app = Mock(is_running=True)
+    agent = Mock()
+    monkeypatch.setenv("HERMES_SIGTERM_GRACE", "0")
+
+    exited = cli_mod._request_cli_exit_on_signal(app, 1, agent=agent, agent_running=True)
+
+    assert exited is True
+    agent.interrupt.assert_called_once_with("received signal 1")
+    app.exit.assert_called_once()
+    assert isinstance(app.exit.call_args.kwargs["exception"], EOFError)
+
+
+def test_request_cli_exit_on_signal_falls_back_when_app_not_running(cli_mod, monkeypatch):
+    app = Mock(is_running=False)
+    agent = Mock()
+    monkeypatch.setenv("HERMES_SIGTERM_GRACE", "0")
+
+    exited = cli_mod._request_cli_exit_on_signal(app, 15, agent=agent, agent_running=True)
+
+    assert exited is False
+    agent.interrupt.assert_called_once_with("received signal 15")
+    app.exit.assert_not_called()


### PR DESCRIPTION
## AI reproduction prompt

You are reproducing a classic Hermes CLI shutdown bug in `cli.py`.

Goal: prove that the classic prompt_toolkit CLI can crash noisily when its controlling terminal disappears during shutdown, then verify the fix.

Environment assumptions:
- macOS is the easiest repro target, but any PTY/SSH environment that can deliver `SIGHUP`/`SIGTERM` works
- Run the classic CLI (`hermes`), not the TUI
- The repo uses prompt_toolkit 3.x

Repro steps on the unfixed branch:
1. Start the classic CLI in a terminal/PTY:
   `hermes`
2. From another shell, send `SIGHUP` or `SIGTERM` to the Hermes process while it is sitting in the prompt loop:
   `kill -HUP <pid>`
3. Inspect `~/.hermes/logs/agent.log`
4. Expected failure signature on the unfixed branch:
   - `ERROR asyncio: unhandled exception during asyncio.run() shutdown`
   - `OSError: [Errno 5] Input/output error`
   - often followed by async cleanup noise such as:
     - `RuntimeError: aclose(): asynchronous generator is already running`
     - `Task was destroyed but it is pending!`

What to verify on the fixed branch:
- Signal-driven shutdown should prefer `app.exit(exception=EOFError())` instead of forcing `KeyboardInterrupt` through prompt_toolkit redraw/reset frames
- Known-benign terminal-disconnect teardown noise should be suppressed
- New targeted unit tests should pass:
  `pytest -n 0 tests/cli/test_cli_terminal_disconnect.py tests/cli/test_cli_init.py -q`

## Summary
- fix classic CLI shutdown when the controlling terminal disappears during `SIGHUP`/`SIGTERM`
- avoid prompt_toolkit redraw/reset crashes on dead stdio
- add focused regression tests for terminal-disconnect handling

## Root cause
The classic CLI signal handler raised `KeyboardInterrupt` directly during `SIGHUP`/`SIGTERM`. When prompt_toolkit was already unwinding or redrawing against a dead PTY/stdout, that forced shutdown through redraw/reset paths that tried to flush dead stdio and produced noisy teardown failures such as `OSError: [Errno 5] Input/output error` and follow-on asyncio cleanup noise.

## What changed
- add `_is_terminal_disconnect_error(...)` to classify expected dead-stdio teardown errors
- add `_should_suppress_cli_asyncio_exception(...)` to suppress known-benign asyncio shutdown noise while preserving unrelated exceptions
- add `_request_cli_exit_on_signal(...)` so the classic CLI can request `app.exit(exception=EOFError())` after the existing interrupt grace window
- keep the old `KeyboardInterrupt` fallback only when prompt_toolkit is not running or does not accept the exit request
- extend the top-level classic CLI shutdown exception handling to treat dead-stdio `OSError`/`ValueError` as expected terminal-loss conditions
- add regression tests covering terminal-disconnect classification, asyncio-noise suppression, and signal-exit behavior

## Test plan
- [x] `source venv/bin/activate && pytest -n 0 tests/cli/test_cli_terminal_disconnect.py tests/cli/test_cli_init.py -q`
- [x] `source venv/bin/activate && python -m compileall cli.py tests/cli/test_cli_terminal_disconnect.py`

## Notes
- this change is intentionally scoped to the classic prompt_toolkit CLI shutdown path
- unrelated asyncio exceptions still fall through to the default exception handler
