### PR TITLE
fix(gateway): update Telegram progress lines on tool completion

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -437,10 +437,10 @@ def make_codex_app_server_event_bridge(agent) -> Callable[[dict], None]:
 
     Translation map:
       * ``item/started`` for tool-shaped items → ``tool_progress_callback(
-        "tool.started", name, preview, args)``
+        "tool.started", name, preview, args, tool_call_id=...)``
       * ``item/completed`` for tool-shaped items → ``tool_progress_callback(
         "tool.completed", name, None, None, duration=..., is_error=...,
-        result=...)``
+        result=..., tool_call_id=...)``
       * ``item/agentMessage/delta`` → ``_fire_stream_delta(text)`` so chat
         adapters can render the assistant's reply as it streams.
       * ``item/reasoning/delta`` → ``_fire_reasoning_delta(text)``
@@ -484,12 +484,19 @@ def make_codex_app_server_event_bridge(agent) -> Callable[[dict], None]:
         item_id = item.get("id") or ""
         name = _codex_item_to_tool_name(item)
         args = _codex_item_to_args(item)
+        tool_call_id = _stable_call_id(item, name)
         if item_id:
             started[item_id] = (name, args, time.monotonic())
         cb = getattr(agent, "tool_progress_callback", None)
         if cb is not None:
             try:
-                cb("tool.started", name, _codex_item_to_preview(item), args)
+                cb(
+                    "tool.started",
+                    name,
+                    _codex_item_to_preview(item),
+                    args,
+                    tool_call_id=tool_call_id,
+                )
             except Exception:
                 logger.debug(
                     "tool_progress_callback raised on tool.started for %s",
@@ -502,7 +509,7 @@ def make_codex_app_server_event_bridge(agent) -> Callable[[dict], None]:
         start_cb = getattr(agent, "tool_start_callback", None)
         if start_cb is not None:
             try:
-                start_cb(_stable_call_id(item, name), name, args)
+                start_cb(tool_call_id, name, args)
             except Exception:
                 logger.debug(
                     "tool_start_callback raised for %s", name, exc_info=True,
@@ -511,6 +518,7 @@ def make_codex_app_server_event_bridge(agent) -> Callable[[dict], None]:
     def _fire_tool_completed(item: dict) -> None:
         item_id = item.get("id") or ""
         name = _codex_item_to_tool_name(item)
+        tool_call_id = _stable_call_id(item, name)
         prior = started.pop(item_id, None)
         # Prefer codex's own durationMs when present so the bubble shows
         # exact tool wall-time; fall back to our started timestamp; fall
@@ -526,8 +534,16 @@ def make_codex_app_server_event_bridge(agent) -> Callable[[dict], None]:
         cb = getattr(agent, "tool_progress_callback", None)
         if cb is not None:
             try:
-                cb("tool.completed", name, None, None,
-                   duration=duration, is_error=is_error, result=result)
+                cb(
+                    "tool.completed",
+                    name,
+                    None,
+                    None,
+                    duration=duration,
+                    is_error=is_error,
+                    result=result,
+                    tool_call_id=tool_call_id,
+                )
             except Exception:
                 logger.debug(
                     "tool_progress_callback raised on tool.completed for %s",
@@ -537,7 +553,7 @@ def make_codex_app_server_event_bridge(agent) -> Callable[[dict], None]:
         if complete_cb is not None:
             args = prior[1] if prior is not None else _codex_item_to_args(item)
             try:
-                complete_cb(_stable_call_id(item, name), name, args, result)
+                complete_cb(tool_call_id, name, args, result)
             except Exception:
                 logger.debug(
                     "tool_complete_callback raised for %s", name, exc_info=True,

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -584,7 +584,11 @@ def _begin_tool_execution(
             )
             preview = _build_tool_preview(function_name, display_args)
             agent.tool_progress_callback(
-                "tool.started", function_name, preview, display_args
+                "tool.started",
+                function_name,
+                preview,
+                display_args,
+                tool_call_id=tool_call_id,
             )
         except Exception as callback_error:
             logging.debug("Tool progress callback error: %s", callback_error)
@@ -1249,6 +1253,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                     "tool.completed", progress_function_name, None, None,
                     duration=tool_duration, is_error=is_error,
                     result=display_function_result,
+                    tool_call_id=tc.id,
                 )
             except Exception as cb_err:
                 logging.debug(f"Tool progress callback error: {cb_err}")
@@ -1909,6 +1914,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     "tool.completed", function_name, None, None,
                     duration=tool_duration, is_error=_is_error_result,
                     result=display_function_result,
+                    tool_call_id=tool_call.id,
                 )
             except Exception as cb_err:
                 logging.debug(f"Tool progress callback error: {cb_err}")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8750,7 +8750,43 @@ class GatewayRunner:
             if not progress_queue:
                 return
 
-            # Only act on tool.started events (ignore tool.completed, reasoning.available, etc.)
+            # Handle tool.completed: update last matching progress line
+            if event_type == "tool.completed" and tool_name:
+                def _collapse(text):
+                    return " ".join(text.split())
+
+                is_error = kwargs.get("is_error", False)
+                duration = kwargs.get("duration")
+                result_preview = preview  # result snippet passed from run_agent
+
+                # Build a short completion suffix for the progress line
+                _status = "✗" if is_error else "✓"
+                _dur = f" {duration:.1f}s" if duration else ""
+                _suffix = f" {_status}{_dur}"
+
+                # If we have a short result, append it for context
+                _result_snippet = ""
+                if result_preview and not is_error:
+                    # Try to extract a meaningful one-liner from JSON results
+                    try:
+                        import json as _json_mod
+                        _data = _json_mod.loads(result_preview)
+                        if isinstance(_data, dict):
+                            if _data.get("success") is False and _data.get("error"):
+                                _result_snippet = f": {_collapse(str(_data['error']))[:50]}"
+                            elif _data.get("output"):
+                                _output = _collapse(str(_data["output"]))
+                                _result_snippet = f": {_output[:50]}" if len(_output) <= 50 else f": {_output[:47]}..."
+                    except (ValueError, TypeError):
+                        # Non-JSON result — use first line if short
+                        _first = _collapse(result_preview)
+                        if len(_first) <= 60:
+                            _result_snippet = f": {_first}"
+
+                progress_queue.put(("__completed__", tool_name, _suffix + _result_snippet))
+                return
+
+            # Only act on tool.started events (ignore reasoning.available, etc.)
             if event_type not in ("tool.started",):
                 return
 
@@ -8860,6 +8896,23 @@ class GatewayRunner:
                         if progress_lines:
                             progress_lines[-1] = f"{base_msg} (×{count + 1})"
                         msg = progress_lines[-1] if progress_lines else base_msg
+                    elif isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__completed__":
+                        # Handle tool.completed: find and update last line for this tool
+                        _, completed_tool, completion_suffix = raw
+                        _updated = False
+                        for _idx in range(len(progress_lines) - 1, -1, -1):
+                            _line = progress_lines[_idx]
+                            # Match line containing the tool name (emoji + tool_name pattern)
+                            if completed_tool in _line and "✓" not in _line and "✗" not in _line:
+                                progress_lines[_idx] = _line + completion_suffix
+                                _updated = True
+                                break
+                        if not _updated:
+                            # No matching started line; append a standalone completion
+                            from agent.display import get_tool_emoji
+                            _emoji = get_tool_emoji(completed_tool, default="⚙️")
+                            progress_lines.append(f"{_emoji} {completed_tool}{completion_suffix}")
+                        msg = progress_lines[-1] if progress_lines else str(raw)
                     else:
                         msg = raw
                         progress_lines.append(msg)
@@ -8925,6 +8978,17 @@ class GatewayRunner:
                                 _, base_msg, count = raw
                                 if progress_lines:
                                     progress_lines[-1] = f"{base_msg} (×{count + 1})"
+                            elif isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__completed__":
+                                _, completed_tool, completion_suffix = raw
+                                _updated = False
+                                for _idx in range(len(progress_lines) - 1, -1, -1):
+                                    _line = progress_lines[_idx]
+                                    if completed_tool in _line and "✓" not in _line and "✗" not in _line:
+                                        progress_lines[_idx] = _line + completion_suffix
+                                        _updated = True
+                                        break
+                                if not _updated:
+                                    progress_lines.append(f"⚙️ {completed_tool}{completion_suffix}")
                             else:
                                 progress_lines.append(raw)
                         except Exception:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8764,19 +8764,17 @@ class GatewayRunner:
                 _dur = f" {duration:.1f}s" if duration else ""
                 _suffix = f" {_status}{_dur}"
 
-                # If we have a short result, append it for context
+                # If we have a short result, append it for context.
+                # Errors already carry ✗ in the suffix; skip the snippet to
+                # keep the line tight (full error text lives in the reply).
                 _result_snippet = ""
                 if result_preview and not is_error:
                     # Try to extract a meaningful one-liner from JSON results
                     try:
-                        import json as _json_mod
-                        _data = _json_mod.loads(result_preview)
-                        if isinstance(_data, dict):
-                            if _data.get("success") is False and _data.get("error"):
-                                _result_snippet = f": {_collapse(str(_data['error']))[:50]}"
-                            elif _data.get("output"):
-                                _output = _collapse(str(_data["output"]))
-                                _result_snippet = f": {_output[:50]}" if len(_output) <= 50 else f": {_output[:47]}..."
+                        _data = json.loads(result_preview)
+                        if isinstance(_data, dict) and _data.get("output"):
+                            _output = _collapse(str(_data["output"]))
+                            _result_snippet = f": {_output[:50]}" if len(_output) <= 50 else f": {_output[:47]}..."
                     except (ValueError, TypeError):
                         # Non-JSON result — use first line if short
                         _first = _collapse(result_preview)
@@ -8886,6 +8884,28 @@ class GatewayRunner:
             _last_edit_ts = 0.0      # Throttle edits to avoid Telegram flood control
             _PROGRESS_EDIT_INTERVAL = 1.5  # Minimum seconds between edits
 
+            def _apply_completed(lines, completed_tool, completion_suffix):
+                # Match the started-line for `completed_tool` precisely so a
+                # short tool name (e.g. "ls") doesn't collide with substrings
+                # in other lines (e.g. "tools"). Started lines always render
+                # as "{emoji} {tool_name}" followed by "(", ":", "." or EOL.
+                pattern = re.compile(
+                    r"(?:^|\s)" + re.escape(completed_tool) + r"(?=[({:.\s]|$)"
+                )
+                for idx in range(len(lines) - 1, -1, -1):
+                    line = lines[idx]
+                    if "✓" in line or "✗" in line:
+                        continue
+                    if pattern.search(line):
+                        lines[idx] = line + completion_suffix
+                        return
+                # No matching started line; append a standalone completion.
+                from agent.display import get_tool_emoji
+                lines.append(
+                    f"{get_tool_emoji(completed_tool, default='⚙️')} "
+                    f"{completed_tool}{completion_suffix}"
+                )
+
             while True:
                 try:
                     raw = progress_queue.get_nowait()
@@ -8897,21 +8917,8 @@ class GatewayRunner:
                             progress_lines[-1] = f"{base_msg} (×{count + 1})"
                         msg = progress_lines[-1] if progress_lines else base_msg
                     elif isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__completed__":
-                        # Handle tool.completed: find and update last line for this tool
                         _, completed_tool, completion_suffix = raw
-                        _updated = False
-                        for _idx in range(len(progress_lines) - 1, -1, -1):
-                            _line = progress_lines[_idx]
-                            # Match line containing the tool name (emoji + tool_name pattern)
-                            if completed_tool in _line and "✓" not in _line and "✗" not in _line:
-                                progress_lines[_idx] = _line + completion_suffix
-                                _updated = True
-                                break
-                        if not _updated:
-                            # No matching started line; append a standalone completion
-                            from agent.display import get_tool_emoji
-                            _emoji = get_tool_emoji(completed_tool, default="⚙️")
-                            progress_lines.append(f"{_emoji} {completed_tool}{completion_suffix}")
+                        _apply_completed(progress_lines, completed_tool, completion_suffix)
                         msg = progress_lines[-1] if progress_lines else str(raw)
                     else:
                         msg = raw
@@ -8980,15 +8987,7 @@ class GatewayRunner:
                                     progress_lines[-1] = f"{base_msg} (×{count + 1})"
                             elif isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__completed__":
                                 _, completed_tool, completion_suffix = raw
-                                _updated = False
-                                for _idx in range(len(progress_lines) - 1, -1, -1):
-                                    _line = progress_lines[_idx]
-                                    if completed_tool in _line and "✓" not in _line and "✗" not in _line:
-                                        progress_lines[_idx] = _line + completion_suffix
-                                        _updated = True
-                                        break
-                                if not _updated:
-                                    progress_lines.append(f"⚙️ {completed_tool}{completion_suffix}")
+                                _apply_completed(progress_lines, completed_tool, completion_suffix)
                             else:
                                 progress_lines.append(raw)
                         except Exception:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3432,7 +3432,6 @@ class TurnRunner:
                         mark_seen(_hermes_home / "config.yaml", TOOL_PROGRESS_FLAG)
             except Exception as _hint_err:
                 logger.debug("tool-progress onboarding hint failed: %s", _hint_err)
-            return
 
         # "_thinking" is assistant scratch text between tool calls.  It
         # is never ordinary tool progress: only relay it when the platform
@@ -3453,10 +3452,6 @@ class TurnRunner:
         if not ctx.tool_progress_enabled:
             return
 
-        # Only act on tool.started events (ignore tool.completed, reasoning.available, etc.)
-        if event_type not in {"tool.started",}:
-            return
-
         # Never render a progress bubble for the clarify tool.  The
         # adapter's send_clarify IS the user-facing rendering (interactive
         # buttons or the numbered-text fallback), so a progress bubble is
@@ -3467,6 +3462,73 @@ class TurnRunner:
         # rendered prompt (#52374).
         if tool_name == "clarify":
             return
+
+        if event_type == "tool.completed" and tool_name:
+            def _collapse(text):
+                return " ".join(str(text).split())
+
+            is_error = kwargs.get("is_error", False)
+            duration = kwargs.get("duration")
+            result = kwargs.get("result")
+            tool_call_id = str(kwargs.get("tool_call_id") or "")
+
+            status = "✗" if is_error else "✓"
+            try:
+                duration_suffix = f" {float(duration):.1f}s" if duration else ""
+            except (TypeError, ValueError):
+                duration_suffix = ""
+            completion_suffix = f" {status}{duration_suffix}"
+
+            result_snippet = ""
+            if result and not is_error:
+                try:
+                    data = json.loads(result) if isinstance(result, str) else result
+                    if isinstance(data, dict) and data.get("output"):
+                        output = _collapse(data["output"])
+                        result_snippet = (
+                            f": {output[:50]}"
+                            if len(output) <= 50
+                            else f": {output[:47]}..."
+                        )
+                except (ValueError, TypeError):
+                    if isinstance(result, str):
+                        first = _collapse(result)
+                        if len(first) <= 60:
+                            result_snippet = f": {first}"
+
+            ctx.progress_queue.put(
+                (
+                    "__completed__",
+                    tool_call_id,
+                    tool_name,
+                    completion_suffix + result_snippet,
+                )
+            )
+            return
+
+        # Only act on tool.started events (ignore reasoning.available, etc.)
+        if event_type != "tool.started":
+            return
+
+        tool_call_id = str(kwargs.get("tool_call_id") or "")
+
+        def _queue_started(message: str, *, deduplicate: bool = False) -> None:
+            if tool_call_id:
+                # Distinct active calls need distinct lines so completion can
+                # update by call ID even when name and preview are identical.
+                ctx.last_progress_msg[0] = None
+                ctx.repeat_count[0] = 0
+                ctx.progress_queue.put(("__started__", tool_call_id, message))
+                return
+            if deduplicate and message == ctx.last_progress_msg[0]:
+                ctx.repeat_count[0] += 1
+                ctx.progress_queue.put(
+                    ("__dedup__", message, ctx.repeat_count[0])
+                )
+                return
+            ctx.last_progress_msg[0] = message
+            ctx.repeat_count[0] = 0
+            ctx.progress_queue.put(message)
 
         # Suppress tool-progress bubbles once the user has sent `stop`.
         # When the LLM response carries N parallel tool calls, the agent
@@ -3486,6 +3548,11 @@ class TurnRunner:
 
         # "new" mode: only report when tool changes
         if ctx.progress_mode == "new" and tool_name == ctx.last_tool[0]:
+            if tool_call_id:
+                # Keep the call identity in the queue so its eventual
+                # completion stays suppressed too. Otherwise a hidden repeated
+                # start would leak back as a standalone completion line.
+                ctx.progress_queue.put(("__suppressed__", tool_call_id))
             return
         ctx.last_tool[0] = tool_name
 
@@ -3544,7 +3611,7 @@ class TurnRunner:
         if ctx.progress_mode == "verbose":
             if _code_block_full is not None:
                 ctx.last_was_terminal_block[0] = True
-                ctx.progress_queue.put(_code_block_full)
+                _queue_started(_code_block_full)
                 return
             ctx.last_was_terminal_block[0] = False
             if args:
@@ -3561,7 +3628,7 @@ class TurnRunner:
                 msg = f"{emoji} {tool_name}: \"{preview}\""
             else:
                 msg = f"{emoji} {tool_name}..."
-            ctx.progress_queue.put(msg)
+            _queue_started(msg)
             return
 
         # "all" / "new" modes: short preview, respects tool_preview_length
@@ -3601,21 +3668,12 @@ class TurnRunner:
             msg = f"{emoji} {tool_name}..."
             ctx.last_was_terminal_block[0] = False
 
-        # Dedup: collapse consecutive identical progress messages.
-        # Common with execute_code where models iterate with the same
-        # code (same boilerplate imports → identical previews).
-        if msg == ctx.last_progress_msg[0]:
-            ctx.repeat_count[0] += 1
-            # Update the last line in progress_lines with a counter
-            # via a special "dedup" queue message.
-            ctx.progress_queue.put(("__dedup__", msg, ctx.repeat_count[0]))
-            return
-        ctx.last_progress_msg[0] = msg
-        ctx.repeat_count[0] = 0
+        # Legacy/custom callback events without a call ID retain the existing
+        # consecutive-line dedup behavior. Executor events carry IDs and stay
+        # separate so same-name calls can complete independently.
+        _queue_started(msg, deduplicate=True)
 
-        ctx.progress_queue.put(msg)
-
-    async def send_progress_messages(self):
+    async def send_progress_messages(self, *, drain_only: bool = False):
         ctx = self._ctx
         if not ctx.progress_queue:
             return
@@ -3640,8 +3698,14 @@ class TurnRunner:
             return
 
         progress_lines = []      # Accumulated tool lines for the CURRENT editable bubble
+        progress_line_by_call_id: dict[str, int] = {}
         progress_msg_id = None   # ID of the current progress message to edit
-        can_edit = ctx.progress_grouping != "separate"  # "separate" = one message per tool (pre-v0.9 behavior)
+        separate_grouping = ctx.progress_grouping == "separate"
+        can_edit = not separate_grouping  # "separate" = one message per tool (pre-v0.9 behavior)
+        separate_line_by_call_id: dict[str, str] = {}
+        separate_message_by_call_id: dict[str, str] = {}
+        suppressed_call_ids: set[str] = set()
+        separate_last_message_id = None
         _last_edit_ts = 0.0      # Throttle edits to avoid Telegram flood control
         _PROGRESS_EDIT_INTERVAL = 1.5  # Minimum seconds between edits
 
@@ -3703,6 +3767,37 @@ class TurnRunner:
         def _progress_text(lines: list) -> str:
             return "\n".join(str(line) for line in lines)
 
+        def _append_started(call_id: str, line: str) -> str:
+            progress_lines.append(line)
+            if call_id:
+                progress_line_by_call_id[call_id] = len(progress_lines) - 1
+            return line
+
+        def _apply_completed(
+            call_id: str, completed_tool: str, completion_suffix: str
+        ) -> str | None:
+            if call_id in suppressed_call_ids:
+                suppressed_call_ids.discard(call_id)
+                return None
+            line_index = progress_line_by_call_id.pop(call_id, None)
+            if line_index is not None and line_index < len(progress_lines):
+                progress_lines[line_index] = (
+                    f"{progress_lines[line_index]}{completion_suffix}"
+                )
+                return progress_lines[line_index]
+
+            # The start may have been suppressed by "new" mode or rolled into
+            # an older full bubble. Append a standalone completion rather than
+            # risk updating a different same-name call.
+            from agent.display import get_tool_emoji
+
+            line = (
+                f"{get_tool_emoji(completed_tool, default='⚙️')} "
+                f"{completed_tool}{completion_suffix}"
+            )
+            progress_lines.append(line)
+            return line
+
         def _split_progress_groups(lines: list) -> list[list]:
             """Partition progress lines into platform-sized editable bubbles."""
             groups: list[list] = []
@@ -3735,6 +3830,77 @@ class TurnRunner:
             )
             _track_progress_result(result)
             return result
+
+        async def _deliver_separate_raw(raw) -> None:
+            """Deliver one progress event per bubble, editing completion in place."""
+            nonlocal separate_last_message_id
+
+            if isinstance(raw, tuple) and len(raw) == 2 and raw[0] == "__suppressed__":
+                suppressed_call_ids.add(raw[1])
+                return
+
+            if isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__started__":
+                _, call_id, started_line = raw
+                line = str(started_line)
+                result = await _send_progress_text(line)
+                if result.success and result.message_id:
+                    separate_last_message_id = str(result.message_id)
+                    if call_id:
+                        separate_line_by_call_id[call_id] = line
+                        separate_message_by_call_id[call_id] = str(result.message_id)
+                return
+
+            if isinstance(raw, tuple) and len(raw) == 4 and raw[0] == "__completed__":
+                _, call_id, completed_tool, completion_suffix = raw
+                if call_id in suppressed_call_ids:
+                    suppressed_call_ids.discard(call_id)
+                    return
+                started_line = separate_line_by_call_id.pop(call_id, None)
+                if started_line is None:
+                    from agent.display import get_tool_emoji
+
+                    completed_line = (
+                        f"{get_tool_emoji(completed_tool, default='⚙️')} "
+                        f"{completed_tool}{completion_suffix}"
+                    )
+                else:
+                    completed_line = f"{started_line}{completion_suffix}"
+
+                message_id = separate_message_by_call_id.pop(call_id, None)
+                if message_id:
+                    result = await _edit_progress_message(message_id, completed_line)
+                    if result.success:
+                        return
+                result = await _send_progress_text(completed_line)
+                if result.success and result.message_id:
+                    separate_last_message_id = str(result.message_id)
+                return
+
+            if isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__dedup__":
+                _, base_msg, count = raw
+                line = f"{base_msg} (×{count + 1})"
+                if separate_last_message_id:
+                    result = await _edit_progress_message(
+                        separate_last_message_id, line
+                    )
+                    if result.success:
+                        return
+                result = await _send_progress_text(line)
+                if result.success and result.message_id:
+                    separate_last_message_id = str(result.message_id)
+                return
+
+            if isinstance(raw, tuple) and len(raw) >= 1 and raw[0] == "__reset__":
+                ctx.last_progress_msg[0] = None
+                ctx.repeat_count[0] = 0
+                separate_line_by_call_id.clear()
+                separate_message_by_call_id.clear()
+                separate_last_message_id = None
+                return
+
+            result = await _send_progress_text(str(raw))
+            if result.success and result.message_id:
+                separate_last_message_id = str(result.message_id)
 
         async def _roll_progress_overflow_if_needed() -> bool:
             """Start fresh editable progress bubbles before a bubble exceeds limit.
@@ -3777,8 +3943,119 @@ class TurnRunner:
             # The newest continuation is now the only mutable bubble.  Keep
             # just its lines so subsequent edits update it instead of
             # replaying the full historical transcript into new messages.
+            retained_start = len(progress_lines) - len(groups[-1])
+            for call_id, line_index in list(progress_line_by_call_id.items()):
+                if line_index < retained_start:
+                    progress_line_by_call_id.pop(call_id, None)
+                else:
+                    progress_line_by_call_id[call_id] = (
+                        line_index - retained_start
+                    )
             progress_lines = groups[-1]
             return True
+
+        async def _drain_and_flush() -> None:
+            """Drain queued lifecycle events without throttle delays, then flush."""
+            nonlocal progress_msg_id, progress_lines
+            if separate_grouping:
+                while not ctx.progress_queue.empty():
+                    try:
+                        await _deliver_separate_raw(ctx.progress_queue.get_nowait())
+                    except Exception:
+                        break
+                return
+
+            while not ctx.progress_queue.empty():
+                try:
+                    raw = ctx.progress_queue.get_nowait()
+                    if (
+                        isinstance(raw, tuple)
+                        and len(raw) == 2
+                        and raw[0] == "__suppressed__"
+                    ):
+                        suppressed_call_ids.add(raw[1])
+                    elif (
+                        isinstance(raw, tuple)
+                        and len(raw) == 3
+                        and raw[0] == "__dedup__"
+                    ):
+                        _, base_msg, count = raw
+                        if progress_lines:
+                            progress_lines[-1] = f"{base_msg} (×{count + 1})"
+                            await _roll_progress_overflow_if_needed()
+                    elif (
+                        isinstance(raw, tuple)
+                        and len(raw) == 3
+                        and raw[0] == "__started__"
+                    ):
+                        _, call_id, started_line = raw
+                        _append_started(call_id, started_line)
+                        await _roll_progress_overflow_if_needed()
+                    elif (
+                        isinstance(raw, tuple)
+                        and len(raw) == 4
+                        and raw[0] == "__completed__"
+                    ):
+                        _, call_id, completed_tool, completion_suffix = raw
+                        completed_line = _apply_completed(
+                            call_id, completed_tool, completion_suffix
+                        )
+                        if completed_line is not None:
+                            await _roll_progress_overflow_if_needed()
+                    elif (
+                        isinstance(raw, tuple)
+                        and len(raw) >= 1
+                        and raw[0] == "__reset__"
+                    ):
+                        await _roll_progress_overflow_if_needed()
+                        if can_edit and progress_lines:
+                            pending_text = _progress_text(progress_lines)
+                            try:
+                                if progress_msg_id:
+                                    await _edit_progress_message(
+                                        progress_msg_id, pending_text
+                                    )
+                                else:
+                                    await _send_progress_text(pending_text)
+                            except Exception:
+                                pass
+                        progress_msg_id = None
+                        progress_lines = []
+                        progress_line_by_call_id.clear()
+                        ctx.last_progress_msg[0] = None
+                        ctx.repeat_count[0] = 0
+                    else:
+                        progress_lines.append(str(raw))
+                        await _roll_progress_overflow_if_needed()
+                except Exception:
+                    break
+
+            # Fast tools can finish before the normal sender performs its first
+            # send. In that case flush the completed buffer as a new message.
+            if can_edit and progress_lines:
+                await _roll_progress_overflow_if_needed()
+                full_text = _progress_text(progress_lines)
+                try:
+                    if progress_msg_id:
+                        await _edit_progress_message(progress_msg_id, full_text)
+                    else:
+                        await _send_progress_text(full_text)
+                except Exception:
+                    pass
+
+        if drain_only:
+            agent = ctx.agent_holder[0] if ctx.agent_holder else None
+            if not ctx._run_still_current() or (
+                agent is not None and getattr(agent, "is_interrupted", False)
+            ):
+                while not ctx.progress_queue.empty():
+                    try:
+                        ctx.progress_queue.get_nowait()
+                    except Exception:
+                        break
+                return
+            await _drain_and_flush()
+            return
 
         while True:
             try:
@@ -3808,12 +4085,37 @@ class TurnRunner:
                 except Exception:
                     pass
 
+                if separate_grouping:
+                    await _deliver_separate_raw(raw)
+                    await asyncio.sleep(0.3)
+                    if ctx._run_still_current():
+                        _send_typing = getattr(adapter, "send_typing", None)
+                        if callable(_send_typing):
+                            await cast(Callable[..., Awaitable[Any]], _send_typing)(
+                                ctx.source.chat_id,
+                                metadata=ctx._progress_metadata,
+                            )
+                    continue
+
                 # Handle dedup messages: update last line with repeat counter
+                if isinstance(raw, tuple) and len(raw) == 2 and raw[0] == "__suppressed__":
+                    suppressed_call_ids.add(raw[1])
+                    continue
                 if isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__dedup__":
                     _, base_msg, count = raw
                     if progress_lines:
                         progress_lines[-1] = f"{base_msg} (×{count + 1})"
                     msg = progress_lines[-1] if progress_lines else base_msg
+                elif isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__started__":
+                    _, call_id, started_line = raw
+                    msg = _append_started(call_id, started_line)
+                elif isinstance(raw, tuple) and len(raw) == 4 and raw[0] == "__completed__":
+                    _, call_id, completed_tool, completion_suffix = raw
+                    msg = _apply_completed(
+                        call_id, completed_tool, completion_suffix
+                    )
+                    if msg is None:
+                        continue
                 elif isinstance(raw, tuple) and len(raw) >= 1 and raw[0] == "__reset__":
                     # Content bubble just landed on the platform — close off
                     # the current tool-progress bubble so the next tool
@@ -3825,11 +4127,12 @@ class TurnRunner:
                     # linearization regression after PR #7885.)
                     progress_msg_id = None
                     progress_lines = []
+                    progress_line_by_call_id.clear()
                     ctx.last_progress_msg[0] = None
                     ctx.repeat_count[0] = 0
                     continue
                 else:
-                    msg = raw
+                    msg = str(raw)
                     progress_lines.append(msg)
 
                 if await _roll_progress_overflow_if_needed():
@@ -3927,44 +4230,7 @@ class TurnRunner:
             except queue.Empty:
                 await asyncio.sleep(0.3)
             except asyncio.CancelledError:
-                # Drain remaining queued messages
-                while not ctx.progress_queue.empty():
-                    try:
-                        raw = ctx.progress_queue.get_nowait()
-                        if isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__dedup__":
-                            _, base_msg, count = raw
-                            if progress_lines:
-                                progress_lines[-1] = f"{base_msg} (×{count + 1})"
-                                await _roll_progress_overflow_if_needed()
-                        elif isinstance(raw, tuple) and len(raw) >= 1 and raw[0] == "__reset__":
-                            # Content-bubble marker during drain: close off
-                            # the current progress bubble and start a fresh
-                            # one for any tool lines that arrived after.
-                            await _roll_progress_overflow_if_needed()
-                            if can_edit and progress_lines and progress_msg_id:
-                                _pending_text = _progress_text(progress_lines)
-                                try:
-                                    await _edit_progress_message(progress_msg_id, _pending_text)
-                                except Exception:
-                                    pass
-                            progress_msg_id = None
-                            progress_lines = []
-                            ctx.last_progress_msg[0] = None
-                            ctx.repeat_count[0] = 0
-                        else:
-                            progress_lines.append(raw)
-                            await _roll_progress_overflow_if_needed()
-                    except Exception:
-                        break
-                # Final edit with all remaining tools (only if editing works)
-                if can_edit and progress_lines and progress_msg_id:
-                    await _roll_progress_overflow_if_needed()
-                if can_edit and progress_lines and progress_msg_id:
-                    full_text = _progress_text(progress_lines)
-                    try:
-                        await _edit_progress_message(progress_msg_id, full_text)
-                    except Exception:
-                        pass
+                await _drain_and_flush()
                 return
             except Exception as e:
                 logger.error("Progress message error: %s", e)
@@ -24492,6 +24758,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Stop progress sender, interrupt monitor, and notification task
             if progress_task:
                 progress_task.cancel()
+                try:
+                    await progress_task
+                except asyncio.CancelledError:
+                    pass
+                progress_task = None
+                # Cancelling a Task before its coroutine ever starts does not
+                # enter the sender's CancelledError handler. Drain with a fresh
+                # sender state so ultra-fast tool lifecycles are still shown.
+                if turn_ctx.progress_queue and not turn_ctx.progress_queue.empty():
+                    await send_progress_messages(drain_only=True)
             if log_task:
                 log_task.cancel()
             interrupt_monitor.cancel()

--- a/run_agent.py
+++ b/run_agent.py
@@ -8028,8 +8028,13 @@ class AIAgent:
 
                 if self.tool_progress_callback:
                     try:
+                        # Pass a short result preview so the gateway can
+                        # update progress lines with completion status.
+                        _result_preview = None
+                        if function_result:
+                            _result_preview = function_result[:200] if len(function_result) > 200 else function_result
                         self.tool_progress_callback(
-                            "tool.completed", function_name, None, None,
+                            "tool.completed", function_name, _result_preview, None,
                             duration=tool_duration, is_error=is_error,
                         )
                     except Exception as cb_err:
@@ -8402,8 +8407,11 @@ class AIAgent:
 
             if self.tool_progress_callback:
                 try:
+                    _result_preview = None
+                    if function_result:
+                        _result_preview = function_result[:200] if len(function_result) > 200 else function_result
                     self.tool_progress_callback(
-                        "tool.completed", function_name, None, None,
+                        "tool.completed", function_name, _result_preview, None,
                         duration=tool_duration, is_error=_is_error_result,
                     )
                 except Exception as cb_err:

--- a/run_agent.py
+++ b/run_agent.py
@@ -8030,9 +8030,7 @@ class AIAgent:
                     try:
                         # Pass a short result preview so the gateway can
                         # update progress lines with completion status.
-                        _result_preview = None
-                        if function_result:
-                            _result_preview = function_result[:200] if len(function_result) > 200 else function_result
+                        _result_preview = function_result[:200] if function_result else None
                         self.tool_progress_callback(
                             "tool.completed", function_name, _result_preview, None,
                             duration=tool_duration, is_error=is_error,
@@ -8407,9 +8405,7 @@ class AIAgent:
 
             if self.tool_progress_callback:
                 try:
-                    _result_preview = None
-                    if function_result:
-                        _result_preview = function_result[:200] if len(function_result) > 200 else function_result
+                    _result_preview = function_result[:200] if function_result else None
                     self.tool_progress_callback(
                         "tool.completed", function_name, _result_preview, None,
                         duration=tool_duration, is_error=_is_error_result,

--- a/tests/agent/test_codex_app_server_event_bridge.py
+++ b/tests/agent/test_codex_app_server_event_bridge.py
@@ -193,6 +193,7 @@ class TestToolProgressDispatch:
         assert call.args[1] == "exec_command"
         assert "ls /tmp" in call.args[2]  # preview
         assert call.args[3] == {"command": "ls /tmp", "cwd": "/tmp"}
+        assert call.kwargs["tool_call_id"]
 
     def test_command_completed_fires_tool_completed_with_result(self):
         agent = _make_stub_agent()
@@ -220,6 +221,8 @@ class TestToolProgressDispatch:
         assert completed.kwargs["duration"] == pytest.approx(0.042)
         assert completed.kwargs["is_error"] is False
         assert completed.kwargs["result"] == "hi\n"
+        started = agent.tool_progress_callback.call_args_list[0]
+        assert completed.kwargs["tool_call_id"] == started.kwargs["tool_call_id"]
 
 
 
@@ -245,6 +248,7 @@ class TestToolProgressDispatch:
         assert calls[0].args[1] == "web_search"
         assert calls[0].args[2] == "hermes agent docs"
         assert calls[0].args[3] == {"query": "hermes agent docs"}
+        assert calls[1].kwargs["tool_call_id"] == calls[0].kwargs["tool_call_id"]
 
 
 

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -452,6 +452,50 @@ class VerboseAgent:
         }
 
 
+class ToolCompletedAgent:
+    """Agent that emits tool.started then tool.completed to test progress line updates."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        self.tool_progress_callback("tool.started", "terminal", "pwd", {})
+        time.sleep(0.35)
+        self.tool_progress_callback(
+            "tool.completed", "terminal", '{"success": true, "output": "/home/user/project"}',
+            None, duration=1.23, is_error=False,
+        )
+        time.sleep(0.35)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class ToolErrorCompletedAgent:
+    """Agent that emits tool.started then tool.completed with error."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        self.tool_progress_callback("tool.started", "read_file", "/etc/secret", {})
+        time.sleep(0.35)
+        self.tool_progress_callback(
+            "tool.completed", "read_file", None,
+            None, duration=0.5, is_error=True,
+        )
+        time.sleep(0.35)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
 async def _run_with_agent(
     monkeypatch,
     tmp_path,
@@ -784,3 +828,144 @@ async def test_verbose_mode_respects_explicit_tool_preview_length(monkeypatch, t
     assert VerboseAgent.LONG_CODE not in all_content
     # But should still contain the truncated portion with "..."
     assert "..." in all_content
+
+
+# ---------------------------------------------------------------------------
+# Tool completion progress update tests (issue #13584)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tool_completed_updates_progress_line_with_checkmark(monkeypatch, tmp_path):
+    """tool.completed should update the started progress line with ✓ and duration."""
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = ToolCompletedAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    import tools.terminal_tool  # noqa: F401 - register terminal emoji
+
+    adapter = ProgressCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        thread_id=None,
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-completed",
+        session_key="agent:main:telegram:dm:12345",
+    )
+
+    assert result["final_response"] == "done"
+    # The initial send should contain the started line
+    assert adapter.sent
+    initial_content = adapter.sent[0]["content"]
+    assert "terminal" in initial_content
+    assert "pwd" in initial_content
+
+    # The edits should contain the updated line with ✓
+    all_edits = [call["content"] for call in adapter.edits]
+    combined = initial_content + "\n".join(all_edits)
+    assert "✓" in combined, f"Expected ✓ in progress content, got edits: {all_edits}"
+    assert "1.2s" in combined or "1.23s" in combined, f"Expected duration in progress content, got: {all_edits}"
+
+
+@pytest.mark.asyncio
+async def test_tool_completed_error_shows_cross_marker(monkeypatch, tmp_path):
+    """tool.completed with is_error=True should update progress line with ✗."""
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = ToolErrorCompletedAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = ProgressCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        thread_id=None,
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-error-completed",
+        session_key="agent:main:telegram:dm:12345",
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.sent
+    initial_content = adapter.sent[0]["content"]
+    all_edits = [call["content"] for call in adapter.edits]
+    combined = initial_content + "\n".join(all_edits)
+    assert "✗" in combined, f"Expected ✗ in progress content for error, got: {all_edits}"
+
+
+@pytest.mark.asyncio
+async def test_tool_completed_appends_result_snippet_for_short_output(monkeypatch, tmp_path):
+    """tool.completed with short JSON output should append a result snippet."""
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = ToolCompletedAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    import tools.terminal_tool  # noqa: F401
+
+    adapter = ProgressCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        thread_id=None,
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-result-snippet",
+        session_key="agent:main:telegram:dm:12345",
+    )
+
+    assert result["final_response"] == "done"
+    all_edits = [call["content"] for call in adapter.edits]
+    combined = "\n".join(all_edits)
+    # The result snippet from ToolCompletedAgent output: /home/user/project
+    assert "/home/user/project" in combined, f"Expected result snippet in edits: {all_edits}"

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -496,6 +496,75 @@ class ToolErrorCompletedAgent:
         }
 
 
+class ToolPrefixCollisionAgent:
+    """Two tools where one name is a substring of the other; only the
+    matching started-line should receive the completion marker."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        self.tool_progress_callback("tool.started", "ls", "-la", {})
+        time.sleep(0.35)
+        self.tool_progress_callback("tool.started", "list_files", "/tmp", {})
+        time.sleep(0.35)
+        self.tool_progress_callback(
+            "tool.completed", "ls", '{"success": true, "output": "a b c"}',
+            None, duration=0.4, is_error=False,
+        )
+        time.sleep(0.35)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class ToolPlainTextResultAgent:
+    """Result preview is plain text (not JSON) — snippet should fall back
+    to the first-line heuristic."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        self.tool_progress_callback("tool.started", "calculator", "2+2", {})
+        time.sleep(0.35)
+        self.tool_progress_callback(
+            "tool.completed", "calculator", "result is 4",
+            None, duration=0.1, is_error=False,
+        )
+        time.sleep(0.35)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class ToolCompletedNoStartAgent:
+    """Completion fires without a prior started event — handler should
+    append a standalone line rather than silently drop the update."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        self.tool_progress_callback(
+            "tool.completed", "calculator", '{"success": true, "output": "42"}',
+            None, duration=0.2, is_error=False,
+        )
+        time.sleep(0.35)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
 async def _run_with_agent(
     monkeypatch,
     tmp_path,
@@ -969,3 +1038,139 @@ async def test_tool_completed_appends_result_snippet_for_short_output(monkeypatc
     combined = "\n".join(all_edits)
     # The result snippet from ToolCompletedAgent output: /home/user/project
     assert "/home/user/project" in combined, f"Expected result snippet in edits: {all_edits}"
+
+
+@pytest.mark.asyncio
+async def test_tool_completed_does_not_mark_substring_collision(monkeypatch, tmp_path):
+    """Completing 'ls' must not mark the 'list_files' line, even though
+    'ls' appears as a substring of 'list_files'."""
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = ToolPrefixCollisionAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = ProgressCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        thread_id=None,
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-collision",
+        session_key="agent:main:telegram:dm:12345",
+    )
+
+    assert result["final_response"] == "done"
+    final_text = adapter.edits[-1]["content"] if adapter.edits else adapter.sent[0]["content"]
+    lines = final_text.splitlines()
+    ls_line = next((ln for ln in lines if " ls" in f" {ln}" and "list_files" not in ln), None)
+    list_files_line = next((ln for ln in lines if "list_files" in ln), None)
+    assert ls_line is not None and list_files_line is not None, (
+        f"Expected separate ls and list_files lines, got: {lines}"
+    )
+    assert "✓" in ls_line, f"Expected ✓ on the ls line: {ls_line!r}"
+    assert "✓" not in list_files_line and "✗" not in list_files_line, (
+        f"list_files line must not be marked completed: {list_files_line!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_tool_completed_appends_plain_text_result(monkeypatch, tmp_path):
+    """Non-JSON result preview should still produce a short snippet via
+    the first-line fallback in the except branch."""
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = ToolPlainTextResultAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = ProgressCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        thread_id=None,
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-plain",
+        session_key="agent:main:telegram:dm:12345",
+    )
+
+    assert result["final_response"] == "done"
+    combined = "\n".join(call["content"] for call in adapter.edits) or adapter.sent[0]["content"]
+    assert "result is 4" in combined, f"Expected plain-text snippet, got: {combined!r}"
+
+
+@pytest.mark.asyncio
+async def test_tool_completed_without_started_appends_standalone_line(monkeypatch, tmp_path):
+    """If tool.completed fires without a matching started line, a new
+    standalone line is appended so the user still sees the completion."""
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = ToolCompletedNoStartAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    adapter = ProgressCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        thread_id=None,
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-no-start",
+        session_key="agent:main:telegram:dm:12345",
+    )
+
+    assert result["final_response"] == "done"
+    combined = "\n".join(call["content"] for call in adapter.edits) or (
+        adapter.sent[0]["content"] if adapter.sent else ""
+    )
+    assert "calculator" in combined and "✓" in combined, (
+        f"Expected standalone calculator ✓ line, got: {combined!r}"
+    )

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -2,10 +2,14 @@
 
 import asyncio
 import importlib
+import json
+import re
 import sys
+import threading
 import time
 import types
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -19,8 +23,10 @@ class ProgressCaptureAdapter(BasePlatformAdapter):
     def __init__(self, platform=Platform.TELEGRAM):
         super().__init__(PlatformConfig(enabled=True, token="***"), platform)
         self.sent = []
+        self.sent_message_ids = []
         self.edits = []
         self.typing = []
+        self._next_id = 0
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         return True
@@ -28,7 +34,12 @@ class ProgressCaptureAdapter(BasePlatformAdapter):
     async def disconnect(self) -> None:
         return None
 
+    def _mint_id(self):
+        self._next_id += 1
+        return f"progress-{self._next_id}"
+
     async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        message_id = self._mint_id()
         self.sent.append(
             {
                 "chat_id": chat_id,
@@ -37,7 +48,8 @@ class ProgressCaptureAdapter(BasePlatformAdapter):
                 "metadata": metadata,
             }
         )
-        return SendResult(success=True, message_id="progress-1")
+        self.sent_message_ids.append(message_id)
+        return SendResult(success=True, message_id=message_id)
 
     async def edit_message(self, chat_id, message_id, content) -> SendResult:
         self.edits.append(
@@ -66,7 +78,6 @@ class SmallLimitProgressAdapter(ProgressCaptureAdapter):
 
     def __init__(self, platform=Platform.TELEGRAM):
         super().__init__(platform=platform)
-        self._next_id = 0
         self.oversized_edits = []
         self.oversized_sends = []
 
@@ -75,6 +86,7 @@ class SmallLimitProgressAdapter(ProgressCaptureAdapter):
         return f"progress-{self._next_id}"
 
     async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        message_id = self._mint_id()
         if len(content) > self.MAX_MESSAGE_LENGTH:
             self.oversized_sends.append(content)
         self.sent.append(
@@ -85,7 +97,8 @@ class SmallLimitProgressAdapter(ProgressCaptureAdapter):
                 "metadata": metadata,
             }
         )
-        return SendResult(success=True, message_id=self._mint_id())
+        self.sent_message_ids.append(message_id)
+        return SendResult(success=True, message_id=message_id)
 
     async def edit_message(self, chat_id, message_id, content) -> SendResult:
         if len(content) > self.MAX_MESSAGE_LENGTH:
@@ -346,6 +359,203 @@ def _make_runner(adapter):
         stt_enabled=False,
     )
     return runner
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("progress_grouping", ["accumulate", "separate"])
+@pytest.mark.parametrize("progress_mode", ["all", "new"])
+async def test_concurrent_same_name_completions_keep_call_id_outputs(
+    monkeypatch, tmp_path, progress_grouping, progress_mode
+):
+    """Real executor events must update the matching same-name progress line."""
+    import run_agent as real_run_agent
+    import yaml
+
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", progress_mode)
+    (tmp_path / "config.yaml").write_text(
+        yaml.dump(
+            {
+                "display": {
+                    "friendly_tool_labels": False,
+                    "tool_progress": progress_mode,
+                    "tool_progress_grouping": progress_grouping,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    tool_calls = [
+        SimpleNamespace(
+            id="call-alpha",
+            type="function",
+            function=SimpleNamespace(
+                name="web_search", arguments=json.dumps({"query": "alpha"})
+            ),
+        ),
+        SimpleNamespace(
+            id="call-beta",
+            type="function",
+            function=SimpleNamespace(
+                name="web_search", arguments=json.dumps({"query": "beta"})
+            ),
+        ),
+        SimpleNamespace(
+            id="call-gamma",
+            type="function",
+            function=SimpleNamespace(
+                name="web_search", arguments=json.dumps({"query": "gamma"})
+            ),
+        ),
+    ]
+
+    def _response(content, finish_reason, calls=None):
+        message = SimpleNamespace(content=content, tool_calls=calls)
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=message, finish_reason=finish_reason)],
+            model="test/model",
+            usage=None,
+        )
+
+    class ConcurrentExecutorAgent(real_run_agent.AIAgent):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.client = MagicMock()
+            self.client.chat.completions.create.side_effect = [
+                _response("", "tool_calls", tool_calls),
+                _response("done", "stop"),
+            ]
+
+    tool_defs = [
+        {
+            "type": "function",
+            "function": {
+                "name": "web_search",
+                "description": "Search",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+    monkeypatch.setattr(
+        real_run_agent, "get_tool_definitions", lambda *args, **kwargs: tool_defs
+    )
+    monkeypatch.setattr(
+        real_run_agent, "check_toolset_requirements", lambda *args, **kwargs: {}
+    )
+    monkeypatch.setattr(real_run_agent, "OpenAI", MagicMock)
+    monkeypatch.setattr(real_run_agent, "AIAgent", ConcurrentExecutorAgent)
+
+    concurrent_gate = threading.Barrier(3)
+    worker_threads = set()
+
+    def _tool_result(_name, args, _task_id, **_kwargs):
+        worker_threads.add(threading.get_ident())
+        concurrent_gate.wait(timeout=3)
+        if args["query"] == "gamma":
+            return "Error executing web_search: gamma failed"
+        return json.dumps({"output": f"{args['query'].upper()}_RESULT"})
+
+    monkeypatch.setattr(real_run_agent, "handle_function_call", _tool_result)
+
+    adapter = ProgressCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "api_key": "test-key-1234567890",
+            "base_url": "https://example.test/v1",
+            "provider": "custom",
+            "api_mode": "chat_completions",
+            "model": "test/model",
+        },
+    )
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        thread_id=None,
+    )
+    result = await runner._run_agent(
+        message="search twice",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-completed",
+        session_key="agent:main:telegram:dm:12345",
+    )
+
+    assert result["final_response"] == "done"
+    assert len(worker_threads) == 3
+    assert adapter.sent
+
+    all_progress = "\n".join(
+        call["content"] for call in adapter.sent + adapter.edits
+    )
+    if progress_mode == "new":
+        expected = (
+            ("alpha", "ALPHA_RESULT", "✓"),
+            ("beta", "BETA_RESULT", "✓"),
+            ("gamma", None, "✗"),
+        )
+        visible = [entry for entry in expected if entry[0] in all_progress]
+        assert len(visible) == 1
+        visible_query, visible_output, visible_status = visible[0]
+        assert visible_status in all_progress
+        if visible_output is not None:
+            assert visible_output in all_progress
+        for query, output, _status in expected:
+            if query == visible_query:
+                continue
+            assert query not in all_progress
+            if output is not None:
+                assert output not in all_progress
+        if progress_grouping == "separate":
+            assert len(adapter.sent) == 1
+            assert len(adapter.edits) == 1
+        return
+
+    if progress_grouping == "separate":
+        assert len(adapter.sent) == 3
+        assert len(adapter.edits) == 3
+        progress_lines = [edit["content"] for edit in adapter.edits]
+    else:
+        final_progress = (
+            adapter.edits[-1]["content"]
+            if adapter.edits
+            else adapter.sent[-1]["content"]
+        )
+        progress_lines = final_progress.splitlines()
+    alpha_line = next(line for line in progress_lines if "alpha" in line.lower())
+    beta_line = next(line for line in progress_lines if "beta" in line.lower())
+    gamma_line = next(line for line in progress_lines if "gamma" in line.lower())
+    assert "✓" in alpha_line and "ALPHA_RESULT" in alpha_line
+    assert "✓" in beta_line and "BETA_RESULT" in beta_line
+    assert re.search(r"✓ \d+\.\d+s: ALPHA_RESULT", alpha_line)
+    assert re.search(r"✓ \d+\.\d+s: BETA_RESULT", beta_line)
+    assert re.search(r"✗ \d+\.\d+s", gamma_line)
+
+    if progress_grouping == "separate":
+        for query, output in (
+            ("alpha", "ALPHA_RESULT"),
+            ("beta", "BETA_RESULT"),
+            ("gamma", None),
+        ):
+            sent_index = next(
+                i for i, call in enumerate(adapter.sent)
+                if query in call["content"]
+            )
+            message_id = adapter.sent_message_ids[sent_index]
+            completed = next(
+                call for call in adapter.edits
+                if call["message_id"] == message_id
+            )
+            assert query in completed["content"]
+            if output is not None:
+                assert output in completed["content"]
 
 
 @pytest.mark.asyncio
@@ -662,6 +872,95 @@ class VerboseAgent:
         }
 
 
+class ReorderedCompletionAgent:
+    """Emit same-name completions in reverse order to prove ID correlation."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        cb = self.tool_progress_callback
+        assert cb is not None
+        cb(
+            "tool.started",
+            "web_search",
+            "alpha",
+            {"query": "alpha"},
+            tool_call_id="call-alpha",
+        )
+        cb(
+            "tool.started",
+            "web_search",
+            "beta",
+            {"query": "beta"},
+            tool_call_id="call-beta",
+        )
+        cb(
+            "tool.completed",
+            "web_search",
+            None,
+            None,
+            duration=0.2,
+            result=json.dumps({"output": "BETA_RESULT"}),
+            tool_call_id="call-beta",
+        )
+        cb(
+            "tool.completed",
+            "web_search",
+            None,
+            None,
+            duration=0.4,
+            result=json.dumps({"output": "ALPHA_RESULT"}),
+            tool_call_id="call-alpha",
+        )
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class ResetBetweenLifecycleEventsAgent:
+    """Put an assistant bubble between a tool's start and completion."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.interim_assistant_callback = kwargs.get("interim_assistant_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        assert self.tool_progress_callback is not None
+        assert self.interim_assistant_callback is not None
+        self.tool_progress_callback(
+            "tool.started",
+            "web_search",
+            "alpha",
+            {"query": "alpha"},
+            tool_call_id="call-alpha",
+        )
+        time.sleep(0.35)
+        self.interim_assistant_callback(
+            "commentary between lifecycle events", already_streamed=False
+        )
+        time.sleep(0.35)
+        self.tool_progress_callback(
+            "tool.completed",
+            "web_search",
+            None,
+            None,
+            duration=0.7,
+            result=json.dumps({"output": "ALPHA_RESULT"}),
+            tool_call_id="call-alpha",
+        )
+        time.sleep(0.35)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
 async def _run_with_agent(
     monkeypatch,
     tmp_path,
@@ -722,6 +1021,102 @@ async def _run_with_agent(
         session_key=session_key,
     )
     return adapter, result
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("progress_grouping", ["accumulate", "separate"])
+async def test_reversed_same_name_completions_update_their_call_ids(
+    monkeypatch, tmp_path, progress_grouping
+):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        ReorderedCompletionAgent,
+        session_id=f"sess-reversed-completions-{progress_grouping}",
+        config_data={
+            "display": {
+                "friendly_tool_labels": False,
+                "tool_progress": "all",
+                "tool_progress_grouping": progress_grouping,
+                "interim_assistant_messages": False,
+            }
+        },
+    )
+
+    assert result["final_response"] == "done"
+    if progress_grouping == "accumulate":
+        final_progress = (
+            adapter.edits[-1]["content"]
+            if adapter.edits
+            else adapter.sent[-1]["content"]
+        )
+        alpha_line = next(
+            line for line in final_progress.splitlines() if "alpha" in line
+        )
+        beta_line = next(
+            line for line in final_progress.splitlines() if "beta" in line
+        )
+        assert "0.4s" in alpha_line and "ALPHA_RESULT" in alpha_line
+        assert "0.2s" in beta_line and "BETA_RESULT" in beta_line
+        return
+
+    assert len(adapter.sent) == 2
+    assert len(adapter.edits) == 2
+    for query, duration, output in (
+        ("alpha", "0.4s", "ALPHA_RESULT"),
+        ("beta", "0.2s", "BETA_RESULT"),
+    ):
+        sent_index = next(
+            i for i, call in enumerate(adapter.sent)
+            if query in call["content"]
+        )
+        message_id = adapter.sent_message_ids[sent_index]
+        completed = next(
+            call for call in adapter.edits
+            if call["message_id"] == message_id
+        )
+        assert query in completed["content"]
+        assert duration in completed["content"]
+        assert output in completed["content"]
+
+
+@pytest.mark.asyncio
+async def test_separate_progress_reset_does_not_edit_above_new_content(
+    monkeypatch, tmp_path
+):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        ResetBetweenLifecycleEventsAgent,
+        session_id="sess-separate-reset-completion",
+        config_data={
+            "display": {
+                "friendly_tool_labels": False,
+                "tool_progress": "all",
+                "tool_progress_grouping": "separate",
+                "interim_assistant_messages": True,
+            }
+        },
+    )
+
+    assert result["final_response"] == "done"
+    start_index = next(
+        i for i, call in enumerate(adapter.sent)
+        if 'web_search: "alpha"' in call["content"]
+    )
+    commentary_index = next(
+        i for i, call in enumerate(adapter.sent)
+        if call["content"] == "commentary between lifecycle events"
+    )
+    completion_index = next(
+        i for i, call in enumerate(adapter.sent)
+        if "web_search ✓ 0.7s: ALPHA_RESULT" in call["content"]
+    )
+    assert start_index < commentary_index < completion_index
+    assert not any(
+        call["message_id"] == adapter.sent_message_ids[start_index]
+        for call in adapter.edits
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -779,10 +779,18 @@ class TestCodexToolProgressBridge:
         monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
 
         agent = _make_codex_agent()
-        agent.tool_progress_callback = lambda kind, name, preview, args: events.append(
-            (kind, name, preview))
+        agent.tool_progress_callback = (
+            lambda kind, name, preview, args, **kwargs: events.append(
+                (kind, name, preview, kwargs)
+            )
+        )
         with patch.object(agent, "_spawn_background_review", return_value=None):
             agent.run_conversation("run the tests")
 
         assert "on_event" in captured_init and captured_init["on_event"] is not None
-        assert ("tool.started", "exec_command", "pytest") in events
+        started = next(
+            event
+            for event in events
+            if event[:3] == ("tool.started", "exec_command", "pytest")
+        )
+        assert started[3]["tool_call_id"]

--- a/tests/run_agent/test_tool_call_guardrail_runtime.py
+++ b/tests/run_agent/test_tool_call_guardrail_runtime.py
@@ -102,8 +102,13 @@ def test_default_sequential_path_warns_repeated_exact_failure_without_blocking_e
         agent._execute_tool_calls_sequential(msg, messages, "task-1")
 
     mock_hfc.assert_called_once()
-    assert len(starts) == 1
-    assert any(event[0][0] == "tool.completed" for event in progress)
+    assert starts == [(("c-soft", "web_search", args), {})]
+    started_event = next(event for event in progress if event[0][0] == "tool.started")
+    completed_event = next(
+        event for event in progress if event[0][0] == "tool.completed"
+    )
+    assert started_event[1]["tool_call_id"] == "c-soft"
+    assert completed_event[1]["tool_call_id"] == "c-soft"
     assert len(messages) == 1
     assert messages[0]["role"] == "tool"
     assert messages[0]["tool_call_id"] == "c-soft"
@@ -215,9 +220,17 @@ def test_config_enabled_hard_stop_concurrent_path_does_not_submit_blocked_calls_
     assert starts == [("c-allow", "web_search", allowed_args)]
     started_events = [event for event in progress_events if event[0] == "tool.started"]
     completed_events = [event for event in progress_events if event[0] == "tool.completed"]
-    assert started_events == [("tool.started", "web_search", allowed_args, {})]
+    assert started_events == [
+        (
+            "tool.started",
+            "web_search",
+            allowed_args,
+            {"tool_call_id": "c-allow"},
+        )
+    ]
     assert len(completed_events) == 1
     assert completed_events[0][1] == "web_search"
+    assert completed_events[0][3]["tool_call_id"] == "c-allow"
 
 
 def test_relay_rewrite_precedes_sequential_policy_approval_checkpoint_and_dispatch():


### PR DESCRIPTION
## Summary
- update gateway tool progress to handle `tool.completed` events
- pass a short result preview from `run_agent.py` into completion callbacks
- add regression coverage for completion markers and short result snippets in Telegram progress messages

## Test Plan
- `python -m pytest tests/gateway/test_run_progress_topics.py -q`

Closes #13584
