### PR TITLE
feat: add conservative smart turn routing

### DIFF
--- a/agent/smart_routing.py
+++ b/agent/smart_routing.py
@@ -1,0 +1,187 @@
+"""Conservative per-turn smart model routing.
+
+Routes obviously simple prompts to a cheaper model when
+``smart_model_routing`` is enabled in config.yaml.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Dict, Tuple
+
+logger = logging.getLogger(__name__)
+
+_COMPLEX_PATTERNS = (
+    r"```",
+    r"\btraceback\b",
+    r"\bstack\s+trace\b",
+    r"\berror:\b",
+    r"\bexception\b",
+    r"\bfailing\s+test\b",
+    r"\bdebug\b",
+    r"\bfix\b",
+    r"\bpatch\b",
+    r"\brefactor\b",
+    r"\bimplement\b",
+    r"\bwrite\s+code\b",
+    r"\bcode\b",
+    r"\brepo\b",
+    r"\bfunction\b",
+    r"\bclass\b",
+    r"\bserver\b",
+    r"\bapi\b",
+    r"\bendpoint\b",
+    r"\bsql\b",
+    r"\bmigration\b",
+    r"\bbuild\b",
+    r"\btest\b",
+    r"\bfile\b",
+    r"\bconfig\b",
+    r"\bjson\b",
+    r"\byaml\b",
+    r"\bpython\b",
+    r"\bjavascript\b",
+    r"\btypescript\b",
+    r"\bbash\b",
+    r"\bshell\b",
+    r"\bdocker\b",
+    r"\bgit\b",
+    r"\bterminal\b",
+    r"\btool\b",
+    r"\bport\b",
+    r"/[\w./-]+",
+)
+
+_COMPLEX_RE = re.compile("|".join(_COMPLEX_PATTERNS), re.IGNORECASE)
+
+
+def _load_smart_routing_config() -> Dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+
+        config = load_config()
+        routing = config.get("smart_model_routing", {}) if isinstance(config, dict) else {}
+        return routing if isinstance(routing, dict) else {}
+    except Exception:
+        return {}
+
+
+def _coerce_positive_int(value: Any, default: int) -> int:
+    try:
+        parsed = int(value)
+        return parsed if parsed > 0 else default
+    except Exception:
+        return default
+
+
+def _simple_turn_reason(user_message: str, routing_config: Dict[str, Any] | None = None) -> tuple[bool, str]:
+    routing = routing_config if isinstance(routing_config, dict) else _load_smart_routing_config()
+    text = (user_message or "").strip()
+    if not text:
+        return False, "empty"
+
+    max_chars = _coerce_positive_int(routing.get("max_simple_chars"), 500)
+    max_words = _coerce_positive_int(routing.get("max_simple_words"), 80)
+    words = len(text.split())
+    chars = len(text)
+
+    if chars > max_chars:
+        return False, f"chars>{max_chars}"
+    if words > max_words:
+        return False, f"words>{max_words}"
+    if _COMPLEX_RE.search(text):
+        return False, "technical-pattern"
+    return True, "simple"
+
+
+def is_simple_turn(user_message: str, routing_config: Dict[str, Any] | None = None) -> bool:
+    is_simple, _ = _simple_turn_reason(user_message, routing_config)
+    return is_simple
+
+
+def build_route_notice(
+    default_model: str,
+    default_runtime: Dict[str, Any],
+    effective_model: str,
+    runtime: Dict[str, Any],
+) -> str | None:
+    default_signature = (
+        default_model,
+        default_runtime.get("provider"),
+        default_runtime.get("base_url"),
+        default_runtime.get("api_mode"),
+        default_runtime.get("command"),
+        tuple(default_runtime.get("args") or ()),
+    )
+    effective_signature = (
+        effective_model,
+        runtime.get("provider"),
+        runtime.get("base_url"),
+        runtime.get("api_mode"),
+        runtime.get("command"),
+        tuple(runtime.get("args") or ()),
+    )
+    if effective_signature == default_signature:
+        return None
+    provider = runtime.get("provider") or "unknown-provider"
+    return f"⚡ Smart routing: using {effective_model} via {provider} for this turn."
+
+
+
+def resolve_turn_route(
+    user_message: str,
+    default_model: str,
+    default_runtime: Dict[str, Any],
+    routing_config: Dict[str, Any] | None = None,
+) -> Tuple[str, Dict[str, Any]]:
+    """Return the effective (model, runtime) for a single turn.
+
+    Falls back to the provided default route unless a cheap route is both
+    configured and appropriate for this user message.
+    """
+    routing = routing_config if isinstance(routing_config, dict) else _load_smart_routing_config()
+    if not routing.get("enabled"):
+        return default_model, dict(default_runtime)
+
+    cheap_model = routing.get("cheap_model", {})
+    if not isinstance(cheap_model, dict):
+        return default_model, dict(default_runtime)
+
+    cheap_provider = str(cheap_model.get("provider") or "").strip()
+    cheap_model_name = str(cheap_model.get("model") or "").strip()
+    if not cheap_provider or not cheap_model_name:
+        return default_model, dict(default_runtime)
+
+    is_simple, reason = _simple_turn_reason(user_message, routing)
+    if not is_simple:
+        logger.debug(
+            "Smart routing skipped for %s (%s)",
+            default_model or "default-model",
+            reason,
+        )
+        return default_model, dict(default_runtime)
+
+    runtime = dict(default_runtime)
+    runtime["provider"] = cheap_provider
+    runtime["base_url"] = str(cheap_model.get("base_url") or "").strip() or None
+    runtime["api_mode"] = str(cheap_model.get("api_mode") or "").strip() or None
+
+    explicit_key = cheap_model.get("api_key")
+    if runtime["base_url"]:
+        runtime["api_key"] = "" if explicit_key is None else str(explicit_key)
+    else:
+        runtime["api_key"] = str(explicit_key).strip() if explicit_key not in (None, "") else None
+
+    runtime["command"] = None
+    runtime["args"] = []
+    runtime["credential_pool"] = None
+
+    logger.info(
+        "Smart routing applied: %s (%s) -> %s (%s)",
+        default_model or "default-model",
+        default_runtime.get("provider") or "default-provider",
+        cheap_model_name,
+        cheap_provider,
+    )
+    return cheap_model_name, runtime

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -8,7 +8,7 @@ import logging
 import threading
 from typing import Optional
 
-from agent.auxiliary_client import call_llm
+from agent.auxiliary_client import call_llm, extract_content_or_reasoning
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +42,7 @@ def generate_title(user_message: str, assistant_response: str, timeout: float = 
             temperature=0.3,
             timeout=timeout,
         )
-        title = (response.choices[0].message.content or "").strip()
+        title = extract_content_or_reasoning(response).strip()
         # Clean up: remove quotes, trailing punctuation, prefixes like "Title: "
         title = title.strip('"\'')
         if title.lower().startswith("title:"):

--- a/cli.py
+++ b/cli.py
@@ -3083,14 +3083,16 @@ class HermesCLI:
     def _resolve_turn_agent_config(self, user_message: str) -> dict:
         """Build the effective model/runtime config for a single user turn.
 
-        Always uses the session's primary model/provider.  If the user has
+        Uses the session's primary model/provider by default, but may route
+        obviously simple prompts to a configured cheap model. If the user has
         toggled `/fast` on and the current model supports Priority
         Processing / Anthropic fast mode, attach `request_overrides` so the
         API call is marked accordingly.
         """
         from hermes_cli.models import resolve_fast_mode_overrides
+        from agent.smart_routing import build_route_notice, resolve_turn_route
 
-        runtime = {
+        default_runtime = {
             "api_key": self.api_key,
             "base_url": self.base_url,
             "provider": self.provider,
@@ -3099,11 +3101,13 @@ class HermesCLI:
             "args": list(self.acp_args or []),
             "credential_pool": getattr(self, "_credential_pool", None),
         }
+        effective_model, runtime = resolve_turn_route(user_message, self.model, default_runtime)
         route = {
-            "model": self.model,
+            "model": effective_model,
             "runtime": runtime,
+            "route_notice": build_route_notice(self.model, default_runtime, effective_model, runtime),
             "signature": (
-                self.model,
+                effective_model,
                 runtime["provider"],
                 runtime["base_url"],
                 runtime["api_mode"],
@@ -6175,6 +6179,8 @@ class HermesCLI:
         _cprint("  You can continue chatting — results will appear when done.\n")
 
         turn_route = self._resolve_turn_agent_config(prompt)
+        if turn_route.get("route_notice"):
+            _cprint(f"  {turn_route['route_notice']}")
 
         def run_background():
             try:
@@ -8127,6 +8133,8 @@ class HermesCLI:
         turn_route = self._resolve_turn_agent_config(message)
         if turn_route["signature"] != self._active_agent_route_signature:
             self.agent = None
+        if turn_route.get("route_notice"):
+            _cprint(f"  {turn_route['route_notice']}")
 
         # Initialize agent if needed
         if self.agent is None:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1102,14 +1102,16 @@ class GatewayRunner:
     def _resolve_turn_agent_config(self, user_message: str, model: str, runtime_kwargs: dict) -> dict:
         """Build the effective model/runtime config for a single turn.
 
-        Always uses the session's primary model/provider.  If `/fast` is
+        Uses the session's primary model/provider by default, but may route
+        obviously simple prompts to a configured cheap model. If `/fast` is
         enabled and the model supports Priority Processing / Anthropic fast
         mode, attach `request_overrides` so the API call is marked
         accordingly.
         """
         from hermes_cli.models import resolve_fast_mode_overrides
+        from agent.smart_routing import build_route_notice, resolve_turn_route
 
-        runtime = {
+        default_runtime = {
             "api_key": runtime_kwargs.get("api_key"),
             "base_url": runtime_kwargs.get("base_url"),
             "provider": runtime_kwargs.get("provider"),
@@ -1118,11 +1120,13 @@ class GatewayRunner:
             "args": list(runtime_kwargs.get("args") or []),
             "credential_pool": runtime_kwargs.get("credential_pool"),
         }
+        effective_model, runtime = resolve_turn_route(user_message, model, default_runtime)
         route = {
-            "model": model,
+            "model": effective_model,
             "runtime": runtime,
+            "route_notice": build_route_notice(model, default_runtime, effective_model, runtime),
             "signature": (
-                model,
+                effective_model,
                 runtime["provider"],
                 runtime["base_url"],
                 runtime["api_mode"],
@@ -4415,6 +4419,9 @@ class GatewayRunner:
                 return None
 
             response = agent_result.get("final_response") or ""
+            route_notice = turn_route.get("route_notice")
+            if route_notice:
+                response = f"{route_notice}\n\n{response}" if response else route_notice
 
             # Convert the agent's internal "(empty)" sentinel into a
             # user-friendly message.  "(empty)" means the model failed to
@@ -6449,6 +6456,8 @@ class GatewayRunner:
             response = result.get("final_response", "") if result else ""
             if not response and result and result.get("error"):
                 response = f"Error: {result['error']}"
+            if turn_route.get("route_notice"):
+                response = f"{turn_route['route_notice']}\n\n{response}" if response else turn_route["route_notice"]
 
             # Extract media files from the response
             if response:

--- a/tests/agent/test_credential_pool_routing.py
+++ b/tests/agent/test_credential_pool_routing.py
@@ -34,7 +34,8 @@ class TestCliTurnRoutePool:
 
         from cli import HermesCLI
         bound = HermesCLI._resolve_turn_agent_config.__get__(shell)
-        route = bound("test message")
+        with patch("agent.smart_routing._load_smart_routing_config", return_value={}):
+            route = bound("test message")
 
         assert route["runtime"]["credential_pool"] is fake_pool
 
@@ -61,7 +62,8 @@ class TestGatewayTurnRoutePool:
         }
 
         bound = GatewayRunner._resolve_turn_agent_config.__get__(runner)
-        route = bound("test message", "gpt-5.4", runtime_kwargs)
+        with patch("agent.smart_routing._load_smart_routing_config", return_value={}):
+            route = bound("test message", "gpt-5.4", runtime_kwargs)
 
         assert route["runtime"]["credential_pool"] is fake_pool
 

--- a/tests/agent/test_smart_routing.py
+++ b/tests/agent/test_smart_routing.py
@@ -1,0 +1,157 @@
+from agent.smart_routing import build_route_notice, is_simple_turn, resolve_turn_route
+
+
+def test_is_simple_turn_accepts_short_plain_question():
+    config = {
+        "enabled": True,
+        "max_simple_chars": 500,
+        "max_simple_words": 80,
+    }
+    assert is_simple_turn("what time is it in tokyo?", config) is True
+
+
+def test_is_simple_turn_rejects_debugging_language():
+    config = {
+        "enabled": True,
+        "max_simple_chars": 500,
+        "max_simple_words": 80,
+    }
+    assert is_simple_turn("debug this failing test in my repo", config) is False
+
+
+def test_is_simple_turn_rejects_technical_tooling_language():
+    config = {
+        "enabled": True,
+        "max_simple_chars": 500,
+        "max_simple_words": 80,
+    }
+    assert is_simple_turn("check this api config in json", config) is False
+
+
+def test_resolve_turn_route_uses_default_when_disabled():
+    runtime = {
+        "api_key": "sk-primary",
+        "base_url": "https://openrouter.ai/api/v1",
+        "provider": "openrouter",
+        "api_mode": "chat_completions",
+        "command": None,
+        "args": [],
+        "credential_pool": object(),
+    }
+    model, routed_runtime = resolve_turn_route(
+        "what time is it in tokyo?",
+        "gpt-5",
+        runtime,
+        routing_config={"enabled": False},
+    )
+    assert model == "gpt-5"
+    assert routed_runtime == runtime
+
+
+def test_resolve_turn_route_switches_to_configured_cheap_model():
+    runtime = {
+        "api_key": "sk-primary",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+        "provider": "openai-codex",
+        "api_mode": "codex_responses",
+        "command": None,
+        "args": [],
+        "credential_pool": object(),
+    }
+    model, routed_runtime = resolve_turn_route(
+        "what time is it in tokyo?",
+        "gpt-5.4",
+        runtime,
+        routing_config={
+            "enabled": True,
+            "max_simple_chars": 500,
+            "max_simple_words": 80,
+            "cheap_model": {
+                "provider": "custom",
+                "model": "qwen_qwen3.5-9b",
+                "base_url": "http://192.168.4.135:1234/v1",
+            },
+        },
+    )
+    assert model == "qwen_qwen3.5-9b"
+    assert routed_runtime["provider"] == "custom"
+    assert routed_runtime["base_url"] == "http://192.168.4.135:1234/v1"
+    assert routed_runtime["api_key"] == ""
+    assert routed_runtime["api_mode"] is None
+    assert routed_runtime["credential_pool"] is None
+
+
+def test_resolve_turn_route_keeps_primary_for_complex_prompt():
+    runtime = {
+        "api_key": "***",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+        "provider": "openai-codex",
+        "api_mode": "codex_responses",
+        "command": None,
+        "args": [],
+        "credential_pool": object(),
+    }
+    model, routed_runtime = resolve_turn_route(
+        "debug this failing test in my repo",
+        "gpt-5.4",
+        runtime,
+        routing_config={
+            "enabled": True,
+            "max_simple_chars": 500,
+            "max_simple_words": 80,
+            "cheap_model": {
+                "provider": "custom",
+                "model": "qwen_qwen3.5-9b",
+                "base_url": "http://192.168.4.135:1234/v1",
+            },
+        },
+    )
+    assert model == "gpt-5.4"
+    assert routed_runtime == runtime
+
+
+
+def test_build_route_notice_reports_when_cheap_route_is_used():
+    default_runtime = {
+        "provider": "openai-codex",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+        "api_mode": "codex_responses",
+        "command": None,
+        "args": [],
+    }
+    routed_runtime = {
+        "provider": "custom",
+        "base_url": "http://192.168.4.135:1234/v1",
+        "api_mode": None,
+        "command": None,
+        "args": [],
+    }
+
+    notice = build_route_notice(
+        "gpt-5.4",
+        default_runtime,
+        "qwen_qwen3.5-9b",
+        routed_runtime,
+    )
+
+    assert notice == "⚡ Smart routing: using qwen_qwen3.5-9b via custom for this turn."
+
+
+
+def test_build_route_notice_returns_none_when_route_is_unchanged():
+    default_runtime = {
+        "provider": "openai-codex",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+        "api_mode": "codex_responses",
+        "command": None,
+        "args": [],
+    }
+
+    notice = build_route_notice(
+        "gpt-5.4",
+        default_runtime,
+        "gpt-5.4",
+        dict(default_runtime),
+    )
+
+    assert notice is None

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -1,13 +1,11 @@
 """Tests for agent.title_generator — auto-generated session titles."""
 
-import threading
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from agent.title_generator import (
-    generate_title,
     auto_title_session,
+    generate_title,
     maybe_auto_title,
 )
 
@@ -78,16 +76,32 @@ class TestGenerateTitle:
         with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
             generate_title("x" * 1000, "y" * 1000)
 
-        # The user content in the messages should be truncated
         user_content = captured_kwargs["messages"][1]["content"]
-        assert len(user_content) < 1100  # 500 + 500 + formatting
+        assert len(user_content) < 1100
+
+    def test_uses_reasoning_fallback_when_content_is_empty(self):
+        response = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        content="",
+                        reasoning_content="Routing setup review",
+                    )
+                )
+            ]
+        )
+
+        with patch("agent.title_generator.call_llm", return_value=response):
+            title = generate_title("help me debug hermes routing", "I found the fallback chain")
+
+        assert title == "Routing setup review"
 
 
 class TestAutoTitleSession:
     """Tests for auto_title_session() — the sync worker function."""
 
     def test_skips_if_no_session_db(self):
-        auto_title_session(None, "sess-1", "hi", "hello")  # should not crash
+        auto_title_session(None, "sess-1", "hi", "hello")
 
     def test_skips_if_title_exists(self):
         db = MagicMock()
@@ -118,7 +132,6 @@ class TestMaybeAutoTitle:
     """Tests for maybe_auto_title() — the fire-and-forget entry point."""
 
     def test_skips_if_not_first_exchange(self):
-        """Should not fire for conversations with more than 2 user messages."""
         db = MagicMock()
         history = [
             {"role": "user", "content": "first"},
@@ -131,13 +144,11 @@ class TestMaybeAutoTitle:
 
         with patch("agent.title_generator.auto_title_session") as mock_auto:
             maybe_auto_title(db, "sess-1", "third", "response 3", history)
-            # Wait briefly for any thread to start
             import time
             time.sleep(0.1)
             mock_auto.assert_not_called()
 
     def test_fires_on_first_exchange(self):
-        """Should fire a background thread for the first exchange."""
         db = MagicMock()
         db.get_session_title.return_value = None
         history = [
@@ -147,14 +158,13 @@ class TestMaybeAutoTitle:
 
         with patch("agent.title_generator.auto_title_session") as mock_auto:
             maybe_auto_title(db, "sess-1", "hello", "hi there", history)
-            # Wait for the daemon thread to complete
             import time
             time.sleep(0.3)
             mock_auto.assert_called_once_with(db, "sess-1", "hello", "hi there")
 
     def test_skips_if_no_response(self):
         db = MagicMock()
-        maybe_auto_title(db, "sess-1", "hello", "", [])  # empty response
+        maybe_auto_title(db, "sess-1", "hello", "", [])
 
     def test_skips_if_no_session_db(self):
-        maybe_auto_title(None, "sess-1", "hello", "response", [])  # no db
+        maybe_auto_title(None, "sess-1", "hello", "response", [])

--- a/tests/cli/test_cli_provider_resolution.py
+++ b/tests/cli/test_cli_provider_resolution.py
@@ -200,8 +200,34 @@ def test_runtime_resolution_rebuilds_agent_on_routing_change(monkeypatch):
     assert shell.api_mode == "codex_responses"
 
 
+def test_cli_turn_routing_adds_user_visible_notice_when_cheap_route_applies(monkeypatch):
+    cli = _import_cli()
+    monkeypatch.setattr("agent.smart_routing._load_smart_routing_config", lambda: {
+        "enabled": True,
+        "max_simple_chars": 500,
+        "max_simple_words": 80,
+        "cheap_model": {
+            "provider": "custom",
+            "model": "qwen_qwen3.5-9b",
+            "base_url": "http://192.168.4.135:1234/v1",
+        },
+    })
+    shell = cli.HermesCLI(model="gpt-5.4", compact=True, max_turns=1)
+    shell.provider = "openai-codex"
+    shell.api_mode = "codex_responses"
+    shell.base_url = "https://chatgpt.com/backend-api/codex"
+    shell.api_key = "sk-primary"
+
+    result = shell._resolve_turn_agent_config("what time is it in tokyo?")
+
+    assert result["model"] == "qwen_qwen3.5-9b"
+    assert result["route_notice"] == "⚡ Smart routing: using qwen_qwen3.5-9b via custom for this turn."
+
+
+
 def test_cli_turn_routing_uses_primary_when_disabled(monkeypatch):
     cli = _import_cli()
+    monkeypatch.setattr("agent.smart_routing._load_smart_routing_config", lambda: {})
     shell = cli.HermesCLI(model="gpt-5", compact=True, max_turns=1)
     shell.provider = "openrouter"
     shell.api_mode = "chat_completions"
@@ -212,6 +238,7 @@ def test_cli_turn_routing_uses_primary_when_disabled(monkeypatch):
 
     assert result["model"] == "gpt-5"
     assert result["runtime"]["provider"] == "openrouter"
+    assert result["route_notice"] is None
 
 
 def test_cli_prefers_config_provider_over_stale_env_override(monkeypatch):

--- a/tests/gateway/test_turn_routing.py
+++ b/tests/gateway/test_turn_routing.py
@@ -1,0 +1,60 @@
+from gateway.run import GatewayRunner
+
+
+def _make_runner():
+    runner = object.__new__(GatewayRunner)
+    runner._service_tier = None
+    return runner
+
+
+def test_gateway_turn_routing_adds_user_visible_notice_when_cheap_route_applies(monkeypatch):
+    monkeypatch.setattr("agent.smart_routing._load_smart_routing_config", lambda: {
+        "enabled": True,
+        "max_simple_chars": 500,
+        "max_simple_words": 80,
+        "cheap_model": {
+            "provider": "custom",
+            "model": "qwen_qwen3.5-9b",
+            "base_url": "http://192.168.4.135:1234/v1",
+        },
+    })
+
+    route = GatewayRunner._resolve_turn_agent_config(
+        _make_runner(),
+        "what time is it in tokyo?",
+        "gpt-5.4",
+        {
+            "api_key": "sk-primary",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "provider": "openai-codex",
+            "api_mode": "codex_responses",
+            "command": None,
+            "args": [],
+            "credential_pool": None,
+        },
+    )
+
+    assert route["model"] == "qwen_qwen3.5-9b"
+    assert route["route_notice"] == "⚡ Smart routing: using qwen_qwen3.5-9b via custom for this turn."
+
+
+def test_gateway_turn_routing_has_no_notice_when_route_is_unchanged(monkeypatch):
+    monkeypatch.setattr("agent.smart_routing._load_smart_routing_config", lambda: {})
+
+    route = GatewayRunner._resolve_turn_agent_config(
+        _make_runner(),
+        "what time is it in tokyo?",
+        "gpt-5.4",
+        {
+            "api_key": "sk-primary",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "provider": "openai-codex",
+            "api_mode": "codex_responses",
+            "command": None,
+            "args": [],
+            "credential_pool": None,
+        },
+    )
+
+    assert route["model"] == "gpt-5.4"
+    assert route["route_notice"] is None


### PR DESCRIPTION
## Summary
- add conservative per-turn smart routing for obviously simple prompts
- add user-visible route notices in CLI and gateway replies when cheap routing fires
- harden title generation to fall back to reasoning-only model outputs
- add regression tests for routing, title fallback, and route notices

## Verification
- ./venv/bin/python -m pytest tests/agent/test_smart_routing.py tests/agent/test_title_generator.py tests/agent/test_credential_pool_routing.py tests/cli/test_cli_provider_resolution.py tests/gateway/test_turn_routing.py -q
- 56 passed