### PR TITLE
Mark gateway restart exit as successful

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1232,6 +1232,7 @@ Environment="HERMES_HOME={hermes_home}"
 Restart=on-failure
 RestartSec=30
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
+SuccessExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
 KillMode=mixed
 KillSignal=SIGTERM
 ExecReload=/bin/kill -USR1 $MAINPID
@@ -1264,6 +1265,7 @@ Environment="HERMES_HOME={hermes_home}"
 Restart=on-failure
 RestartSec=30
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
+SuccessExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
 KillMode=mixed
 KillSignal=SIGTERM
 ExecReload=/bin/kill -USR1 $MAINPID

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -91,6 +91,7 @@ class TestGeneratedSystemdUnits:
         assert "ExecStop=" not in unit
         assert "ExecReload=/bin/kill -USR1 $MAINPID" in unit
         assert f"RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
+        assert f"SuccessExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
         assert "TimeoutStopSec=60" in unit
 
     def test_user_unit_includes_resolved_node_directory_in_path(self, monkeypatch):
@@ -107,6 +108,7 @@ class TestGeneratedSystemdUnits:
         assert "ExecStop=" not in unit
         assert "ExecReload=/bin/kill -USR1 $MAINPID" in unit
         assert f"RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
+        assert f"SuccessExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
         assert "TimeoutStopSec=60" in unit
         assert "WantedBy=multi-user.target" in unit
 


### PR DESCRIPTION
## Summary

- mark Hermes gateway service restart exit code `75` as a successful systemd exit status
- keep `RestartForceExitStatus=75` so systemd still restarts the gateway for intentional service-restart flows
- add unit-generation assertions for both user and system services

## Why

Hermes already uses exit code `75` to request a service-managed restart after draining active gateway work. With `RestartForceExitStatus=75` alone, systemd restarts the service but can still report the old gateway process as a failed exit. Adding `SuccessExitStatus=75` preserves the restart behavior while keeping controlled restarts out of the failure path.

## Validation

- `.venv/bin/python -m pytest -o addopts='' tests/hermes_cli/test_gateway_service.py -q`
- `.venv/bin/python -m pytest -o addopts='' tests/gateway/test_gateway_shutdown.py -q`
