### PR TITLE
Scope gateway /resume sessions to the current user

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7091,7 +7091,9 @@ class GatewayRunner:
             try:
                 user_source = source.platform.value if source.platform else None
                 sessions = self._session_db.list_sessions_rich(
-                    source=user_source, limit=10
+                    source=user_source,
+                    user_id=source.user_id,
+                    limit=10,
                 )
                 titled = [s for s in sessions if s.get("title")]
                 if not titled:
@@ -7113,7 +7115,11 @@ class GatewayRunner:
                 return f"Could not list sessions: {e}"
 
         # Resolve the name to a session ID
-        target_id = self._session_db.resolve_session_by_title(name)
+        target_id = self._session_db.resolve_session_by_title(
+            name,
+            source=source.platform.value if source.platform else None,
+            user_id=source.user_id,
+        )
         if not target_id:
             return (
                 f"No session found matching '**{name}**'.\n"
@@ -7198,6 +7204,7 @@ class GatewayRunner:
             self._session_db.create_session(
                 session_id=new_session_id,
                 source=source.platform.value if source.platform else "gateway",
+                user_id=source.user_id,
                 model=(self.config.get("model", {}) or {}).get("default") if isinstance(self.config, dict) else None,
                 parent_session_id=parent_session_id,
             )

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -650,16 +650,39 @@ class SessionDB:
             row = cursor.fetchone()
         return row["title"] if row else None
 
-    def get_session_by_title(self, title: str) -> Optional[Dict[str, Any]]:
-        """Look up a session by exact title. Returns session dict or None."""
+    def get_session_by_title(
+        self,
+        title: str,
+        *,
+        source: str | None = None,
+        user_id: str | None = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Look up a session by exact title. Returns session dict or None.
+
+        Optional ``source`` / ``user_id`` filters let gateway callers scope
+        title resolution to the current user's platform lane and avoid
+        cross-user session leakage in shared state.db deployments.
+        """
+        query = "SELECT * FROM sessions WHERE title = ?"
+        params: list[Any] = [title]
+        if source is not None:
+            query += " AND source = ?"
+            params.append(source)
+        if user_id is not None:
+            query += " AND user_id = ?"
+            params.append(user_id)
         with self._lock:
-            cursor = self._conn.execute(
-                "SELECT * FROM sessions WHERE title = ?", (title,)
-            )
+            cursor = self._conn.execute(query, params)
             row = cursor.fetchone()
         return dict(row) if row else None
 
-    def resolve_session_by_title(self, title: str) -> Optional[str]:
+    def resolve_session_by_title(
+        self,
+        title: str,
+        *,
+        source: str | None = None,
+        user_id: str | None = None,
+    ) -> Optional[str]:
         """Resolve a title to a session ID, preferring the latest in a lineage.
 
         If the exact title exists, returns that session's ID.
@@ -668,17 +691,25 @@ class SessionDB:
         latest numbered variant (the most recent continuation).
         """
         # First try exact match
-        exact = self.get_session_by_title(title)
+        exact = self.get_session_by_title(title, source=source, user_id=user_id)
 
         # Also search for numbered variants: "title #2", "title #3", etc.
         # Escape SQL LIKE wildcards (%, _) in the title to prevent false matches
         escaped = title.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        query = (
+            "SELECT id, title, started_at FROM sessions "
+            "WHERE title LIKE ? ESCAPE '\\'"
+        )
+        params: list[Any] = [f"{escaped} #%"]
+        if source is not None:
+            query += " AND source = ?"
+            params.append(source)
+        if user_id is not None:
+            query += " AND user_id = ?"
+            params.append(user_id)
+        query += " ORDER BY started_at DESC"
         with self._lock:
-            cursor = self._conn.execute(
-                "SELECT id, title, started_at FROM sessions "
-                "WHERE title LIKE ? ESCAPE '\\' ORDER BY started_at DESC",
-                (f"{escaped} #%",),
-            )
+            cursor = self._conn.execute(query, params)
             numbered = cursor.fetchall()
 
         if numbered:
@@ -767,6 +798,7 @@ class SessionDB:
         offset: int = 0,
         include_children: bool = False,
         project_compression_tips: bool = True,
+        user_id: str = None,
     ) -> List[Dict[str, Any]]:
         """List sessions with preview (first user message) and last active timestamp.
 
@@ -796,6 +828,9 @@ class SessionDB:
         if source:
             where_clauses.append("s.source = ?")
             params.append(source)
+        if user_id is not None:
+            where_clauses.append("s.user_id = ?")
+            params.append(user_id)
         if exclude_sources:
             placeholders = ",".join("?" for _ in exclude_sources)
             where_clauses.append(f"s.source NOT IN ({placeholders})")

--- a/tests/gateway/test_branch_command.py
+++ b/tests/gateway/test_branch_command.py
@@ -1,0 +1,65 @@
+"""Tests for gateway /branch session metadata."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource, build_session_key
+
+
+def _make_event(text="/branch", user_id="12345", chat_id="67890"):
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name="testuser",
+    )
+    return MessageEvent(text=text, source=source)
+
+
+@pytest.mark.asyncio
+async def test_branch_persists_gateway_user_id(tmp_path):
+    """Branched gateway sessions must preserve the originating user_id."""
+    from gateway.run import GatewayRunner
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    current_session_id = "current_session_001"
+    db.create_session(current_session_id, "telegram", user_id="12345")
+    db.append_message(current_session_id, role="user", content="hello")
+    db.append_message(current_session_id, role="assistant", content="hi")
+
+    event = _make_event(text="/branch Side Quest")
+    session_key = build_session_key(event.source)
+
+    runner = object.__new__(GatewayRunner)
+    runner._session_db = db
+    runner.config = {}
+    runner.adapters = {}
+    runner._voice_mode = {}
+    runner._session_key_for_source = MagicMock(return_value=session_key)
+    runner._evict_cached_agent = MagicMock()
+
+    current_entry = MagicMock()
+    current_entry.session_id = current_session_id
+    current_entry.session_key = session_key
+
+    switched_entry = MagicMock()
+    switched_entry.session_id = "branched-session"
+
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = current_entry
+    runner.session_store.load_transcript.return_value = db.get_messages_as_conversation(
+        current_session_id
+    )
+    runner.session_store.switch_session.return_value = switched_entry
+
+    result = await runner._handle_branch_command(event)
+
+    assert "Branched to" in result
+    branch_session_id = runner.session_store.switch_session.call_args[0][1]
+    branch_session = db.get_session(branch_session_id)
+    assert branch_session["user_id"] == "12345"
+    db.close()

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -80,8 +80,8 @@ class TestHandleResumeCommand:
         """With no argument, lists recently titled sessions."""
         from hermes_state import SessionDB
         db = SessionDB(db_path=tmp_path / "state.db")
-        db.create_session("sess_001", "telegram")
-        db.create_session("sess_002", "telegram")
+        db.create_session("sess_001", "telegram", user_id="12345")
+        db.create_session("sess_002", "telegram", user_id="12345")
         db.set_session_title("sess_001", "Research")
         db.set_session_title("sess_002", "Coding")
 
@@ -91,6 +91,24 @@ class TestHandleResumeCommand:
         assert "Research" in result
         assert "Coding" in result
         assert "Named Sessions" in result
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_list_named_sessions_scoped_to_current_user(self, tmp_path):
+        """Listing named sessions must not leak titles from another user."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("sess_alice", "telegram", user_id="12345")
+        db.set_session_title("sess_alice", "Alice Work")
+        db.create_session("sess_bob", "telegram", user_id="99999")
+        db.set_session_title("sess_bob", "Bob Secrets")
+
+        event = _make_event(text="/resume", user_id="12345")
+        runner = _make_runner(session_db=db, event=event)
+        result = await runner._handle_resume_command(event)
+
+        assert "Alice Work" in result
+        assert "Bob Secrets" not in result
         db.close()
 
     @pytest.mark.asyncio
@@ -112,9 +130,9 @@ class TestHandleResumeCommand:
         """Resolves a title and switches to that session."""
         from hermes_state import SessionDB
         db = SessionDB(db_path=tmp_path / "state.db")
-        db.create_session("old_session_abc", "telegram")
+        db.create_session("old_session_abc", "telegram", user_id="12345")
         db.set_session_title("old_session_abc", "My Project")
-        db.create_session("current_session_001", "telegram")
+        db.create_session("current_session_001", "telegram", user_id="12345")
 
         event = _make_event(text="/resume My Project")
         runner = _make_runner(session_db=db, current_session_id="current_session_001",
@@ -134,7 +152,7 @@ class TestHandleResumeCommand:
         """Returns error for unknown session name."""
         from hermes_state import SessionDB
         db = SessionDB(db_path=tmp_path / "state.db")
-        db.create_session("current_session_001", "telegram")
+        db.create_session("current_session_001", "telegram", user_id="12345")
 
         event = _make_event(text="/resume Nonexistent Session")
         runner = _make_runner(session_db=db, event=event)
@@ -147,7 +165,7 @@ class TestHandleResumeCommand:
         """Returns friendly message when already on the requested session."""
         from hermes_state import SessionDB
         db = SessionDB(db_path=tmp_path / "state.db")
-        db.create_session("current_session_001", "telegram")
+        db.create_session("current_session_001", "telegram", user_id="12345")
         db.set_session_title("current_session_001", "Active Project")
 
         event = _make_event(text="/resume Active Project")
@@ -162,11 +180,11 @@ class TestHandleResumeCommand:
         """Asking for 'My Project' when 'My Project #2' exists gets the latest."""
         from hermes_state import SessionDB
         db = SessionDB(db_path=tmp_path / "state.db")
-        db.create_session("sess_v1", "telegram")
+        db.create_session("sess_v1", "telegram", user_id="12345")
         db.set_session_title("sess_v1", "My Project")
-        db.create_session("sess_v2", "telegram")
+        db.create_session("sess_v2", "telegram", user_id="12345")
         db.set_session_title("sess_v2", "My Project #2")
-        db.create_session("current_session_001", "telegram")
+        db.create_session("current_session_001", "telegram", user_id="12345")
 
         event = _make_event(text="/resume My Project")
         runner = _make_runner(session_db=db, current_session_id="current_session_001",
@@ -180,13 +198,34 @@ class TestHandleResumeCommand:
         db.close()
 
     @pytest.mark.asyncio
+    async def test_resume_rejects_other_users_title(self, tmp_path):
+        """A user must not be able to resume another user's titled session."""
+        from hermes_state import SessionDB
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("alice_current", "telegram", user_id="12345")
+        db.create_session("bob_session", "telegram", user_id="99999")
+        db.set_session_title("bob_session", "Bob Secrets")
+
+        event = _make_event(text="/resume Bob Secrets", user_id="12345")
+        runner = _make_runner(
+            session_db=db,
+            current_session_id="alice_current",
+            event=event,
+        )
+        result = await runner._handle_resume_command(event)
+
+        assert "No session found" in result
+        runner.session_store.switch_session.assert_not_called()
+        db.close()
+
+    @pytest.mark.asyncio
     async def test_resume_clears_running_agent(self, tmp_path):
         """Switching sessions clears any cached running agent."""
         from hermes_state import SessionDB
         db = SessionDB(db_path=tmp_path / "state.db")
-        db.create_session("old_session", "telegram")
+        db.create_session("old_session", "telegram", user_id="12345")
         db.set_session_title("old_session", "Old Work")
-        db.create_session("current_session_001", "telegram")
+        db.create_session("current_session_001", "telegram", user_id="12345")
 
         event = _make_event(text="/resume Old Work")
         runner = _make_runner(session_db=db, current_session_id="current_session_001",
@@ -206,9 +245,9 @@ class TestHandleResumeCommand:
         from hermes_state import SessionDB
 
         db = SessionDB(db_path=tmp_path / "state.db")
-        db.create_session("old_session", "telegram")
+        db.create_session("old_session", "telegram", user_id="12345")
         db.set_session_title("old_session", "Old Work")
-        db.create_session("current_session_001", "telegram")
+        db.create_session("current_session_001", "telegram", user_id="12345")
 
         event = _make_event(text="/resume Old Work")
         runner = _make_runner(


### PR DESCRIPTION
## Summary

Fixes a gateway session isolation bug where `/resume` could list or switch to titled sessions from another user on the same platform.

Gateway `/resume` previously filtered named sessions only by platform source, so two users on Telegram/Discord/etc. sharing the same `state.db` could see each other’s titled sessions and resume them by title. This change scopes gateway resume listing and title resolution by both platform source and `user_id`.

Also preserves `user_id` when creating branched gateway sessions so branched conversations remain visible under the same scoped lookup behavior.

## Changes

- Add optional `source` / `user_id` filters to title-based session lookup.
- Add optional `user_id` filtering to `list_sessions_rich()` without breaking existing positional callers.
- Use platform + user scoping in gateway `/resume`.
- Persist `user_id` for gateway `/branch` sessions.
- Add regression coverage for cross-user `/resume` isolation and branch metadata persistence.

## Tests

- `tests/gateway/test_resume_command.py`
- `tests/gateway/test_branch_command.py`

Result: `12 passed`
