### PR TITLE
fix(anthropic): move oversized OAuth system prompt to user prefix

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1362,6 +1362,31 @@ def build_anthropic_kwargs(
                 text = text.replace("Nous Research", "Anthropic")
                 block["text"] = text
 
+        # 2b. Move extra system blocks into a user-message prefix.
+        #     The Claude Code / OAuth subscription route applies an internal
+        #     size/content check on the `system` field.  When Hermes ships a
+        #     large custom system prompt (agent instructions, tool guides,
+        #     operator personas), the check rejects the request with a
+        #     confusing 400:
+        #         "You're out of extra usage. Add more at
+        #          claude.ai/settings/usage and keep going."
+        #     The same request succeeds with a pay-per-token API key.
+        #     Workaround: keep only the CC identity block in `system` and
+        #     fold the rest into a `[CONTEXT]...[/CONTEXT]` user-message
+        #     prefix followed by an assistant "Understood." acknowledgment.
+        #     Content is preserved verbatim — only the transport slot changes.
+        if isinstance(system, list) and len(system) > 1:
+            overflow_blocks = system[1:]
+            system = system[:1]
+            overflow_text = "\n\n".join(
+                b.get("text", "") for b in overflow_blocks
+                if isinstance(b, dict) and b.get("type") == "text" and b.get("text")
+            )
+            if overflow_text:
+                ctx_msg = {"role": "user", "content": f"[CONTEXT]\n{overflow_text}\n[/CONTEXT]"}
+                ack_msg = {"role": "assistant", "content": "Understood."}
+                anthropic_messages = [ctx_msg, ack_msg] + anthropic_messages
+
         # 3. Prefix tool names with mcp_ (Claude Code convention)
         if anthropic_tools:
             for tool in anthropic_tools:


### PR DESCRIPTION
## Problem

OAuth / Claude Code subscription requests via `anthropic_messages` fail with a 400 when the system field contains custom content beyond the CC identity block:

```
400 invalid_request_error: You're out of extra usage.
Add more at claude.ai/settings/usage and keep going.
```

The error wording points at quota, but the account actually has usage available. The same payload sent directly with a pay-per-token API key returns 200. The check is specific to the OAuth / subscription route and triggered by the size/content of `system` once it goes beyond the basic CC identity string.

This breaks any downstream that ships a non-trivial system prompt (custom agents, extended tool guides) while using a Claude Code subscription token.

## Fix

Keep only the CC identity block in `system` and fold any additional system blocks into a `[CONTEXT]...[/CONTEXT]` user-message prefix followed by an assistant `Understood.` acknowledgement. Content is preserved verbatim — only the transport slot changes.

The change is inside the existing `if is_oauth:` branch in `build_anthropic_kwargs`, so it only affects OAuth code paths. Non-OAuth requests (x-api-key, Bedrock, third-party Anthropic-compat endpoints) are untouched.

## Test

Reproduced and verified against the Anthropic API on the latest main (b2111a2b):

- Before: large system via OAuth → 400 invalid_request_error with the quota text.
- After: same content, CC identity in `system` + rest in `[CONTEXT]` user prefix → 200, response text identical, latency unchanged.

Integration tested in a production Hermes 0.10.0 deployment running Opus 4.7 via OAuth with a ~3k-token system prompt: 400 errors cleared, message flow back to normal (4 api_calls / 36s on a cold session with tools).

No changes to non-OAuth paths. No behavioural change expected for users with `system` containing only the CC identity block.
