### PR TITLE
fix(browser): update basic-ftp lockfile entry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -954,9 +954,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.2.tgz",
-      "integrity": "sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
+      "integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"


### PR DESCRIPTION
## Summary
- bump the transitive `basic-ftp` lockfile entry from `5.2.2` to `5.3.0`
- clears the browser-side `npm audit` / `hermes doctor` warning in a local Hermes install
- keeps the change scoped to `package-lock.json` only

## Why
A local Hermes install reported one high-severity browser dependency vulnerability coming from the transitive `basic-ftp` entry in `package-lock.json`. Running `npm audit fix` updated only that lockfile node and cleared the warning.

## Verification
- `npm audit --json --registry=https://registry.npmjs.org/` returns 0 vulnerabilities in the repo root after the lockfile update
- `hermes doctor` no longer reports the browser audit warning
