### PR TITLE
docs: restore memory policy guide and fix docs drift

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+while read -r local_ref local_sha remote_ref remote_sha; do
+  if [[ "$remote_ref" == "refs/heads/main" ]]; then
+    if [[ "${HERMES_ALLOW_MAIN_PUSH:-0}" != "1" ]]; then
+      echo "Blocked direct push to main. Use henry/patches or set HERMES_ALLOW_MAIN_PUSH=1 if intentional." >&2
+      exit 1
+    fi
+  fi
+done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,18 @@ Instructions for AI coding assistants and developers working on the hermes-agent
 source venv/bin/activate  # ALWAYS activate before running Python
 ```
 
+## Local Customization Branch Policy
+
+- `main` must remain a clean tracking branch for `origin/main`.
+- Henry-specific changes belong on `henry/patches`, not as uncommitted drift on `main`.
+- Before syncing upstream, snapshot local work onto a named branch or commit.
+- Use `scripts/sync-local-mods.sh` for updates instead of raw `git pull` on a dirty tree.
+- Keep `core.hooksPath` set to `.githooks` in this repo.
+- Direct pushes to `main` require an explicit override: `HERMES_ALLOW_MAIN_PUSH=1`.
+- If a customization should survive future upgrades, it needs either:
+  - a local commit on `henry/patches`, or
+  - an upstream PR so it stops being a local customization.
+
 ## Project Structure
 
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,24 @@ source venv/bin/activate  # ALWAYS activate before running Python
   - a local commit on `henry/patches`, or
   - an upstream PR so it stops being a local customization.
 
+## Hermes-Native Coding Policy
+
+Use this as the default operating policy for coding and code-review tasks in this repo.
+
+- Ask only when ambiguity materially changes architecture, data model, user-visible behavior, security/privacy posture, destructive actions, or external side effects. Otherwise state the assumption briefly and proceed.
+- Prefer the smallest correct change. No speculative features, no single-use abstractions, no new config knobs, no architecture expansion unless requested.
+- Keep changes surgical. Do not refactor adjacent code, rename for taste, reformat unrelated areas, or remove unrelated dead code.
+- Every changed line should trace to one of: requested behavior, required integration, verification, or cleanup caused by your change.
+- Validate at trust boundaries. Input validation, auth checks, secrets handling, migrations, and external side effects are not “impossible scenarios.”
+- Verify before claiming success. Use the strongest affordable check available: reproducing test > relevant existing tests > typecheck/lint/build > runtime/endpoint check > browser/UI check > reasoned diff inspection.
+- Scale rigor to task size. Do not over-ceremonialize trivial fixes, but do not skip verification for non-trivial work.
+- Do not touch git history, force-push, secrets, migrations, production state, or destructive operations without explicit confirmation.
+- On failure: say what failed, show evidence, narrow the fault domain, try the next reasonable check, then stop and report if still blocked. Do not pivot into unrelated rewrites.
+- Read files before editing them. Inspect diffs before summarizing them. Run checks before declaring completion.
+- If a larger or cleaner fix exists, mention it briefly after solving the requested problem. Do not silently substitute it.
+- Report compactly: what changed, how it was verified, assumptions made, and what remains unverified or risky.
+- No fake completion, no drive-by cleanup, no high-volume low-signal output.
+
 ## Project Structure
 
 ```
@@ -438,6 +456,26 @@ in config.yaml (or `HERMES_BACKGROUND_NOTIFICATIONS` env var):
 - `result` — only the final completion message
 - `error` — only the final message when exit code != 0
 - `off` — no watcher messages at all
+
+### Memory / Knowledge Placement Policy
+
+When deciding where knowledge should live in Hermes Mesh, use this default split:
+
+- **Built-in memory (`MEMORY.md` / `USER.md`)** — small, curated facts Hermes should know every session
+- **External memory providers (for example Hindsight)** — durable cross-session recall for facts that should be rememberable but not always loaded
+- **Session history / session search** — exact narrative recall for what happened, when, and why
+- **Docs / skills** — authoritative architecture, policy, procedures, and reusable playbooks
+
+Operational rules:
+- If Hermes should know it by default every session, put it in built-in memory.
+- If Hermes should remember it across sessions, prefer external memory.
+- If the exact chronology or discussion matters, rely on session history.
+- If humans or operators need an authoritative reference, write docs or a skill instead of trusting memory alone.
+- Docs/inventory/policy beat memory when they conflict.
+- Built-in memory must stay compact; do not let it turn into a second documentation system.
+- Default Hermes Mesh v1 posture: one external memory provider per instance, built-in memory enabled, separate banks per machine/role by default, shared writable external memory only by explicit decision.
+
+See `website/docs/guides/hermes-mesh-memory-policy.md` for the operator-facing version.
 
 ---
 

--- a/docs/local-customization-workflow.md
+++ b/docs/local-customization-workflow.md
@@ -1,0 +1,51 @@
+# Local Customization Workflow
+
+This repo now treats upstream tracking and Henry-specific customizations as separate concerns.
+
+## Branch roles
+
+- `main` — local mirror of `origin/main`; do not treat this as a scratch branch.
+- `henry/patches` — durable local patch stack for Henry-specific behavior that is not upstream yet.
+- `sync/<timestamp>` — disposable integration branch created during update/replay runs.
+- `rescue/<timestamp>` — emergency snapshot branch for dirty work before sync.
+
+## Golden rules
+
+- Never develop directly on a dirty `main`.
+- Keep local customizations as small, named commits.
+- Upstream first when possible. Local patch stacks should stay small.
+- Use `scripts/sync-local-mods.sh`, not raw `git pull`, when you want an upstream refresh that preserves local mods.
+- If a change matters, it must exist as a real commit on `henry/patches` or as an upstream PR.
+
+## Normal update flow
+
+1. Make sure your current work is committed on `henry/patches`.
+2. Fetch upstream and refresh the clean base via `scripts/sync-local-mods.sh`.
+3. Let the script create a disposable sync worktree.
+4. Review any replay conflicts in that disposable worktree.
+5. Run smoke tests before promoting the refreshed patch stack.
+
+## Add a new local customization
+
+1. Start from `henry/patches` or a worktree based on it.
+2. Make one focused change.
+3. Run the narrowest useful tests.
+4. Commit with a message that explains why the change remains local.
+5. If the change belongs upstream, open a PR and plan to drop it from the local patch stack later.
+
+## Override / escape hatches
+
+- Direct pushes to `main` are blocked by `.githooks/pre-push` unless you intentionally set `HERMES_ALLOW_MAIN_PUSH=1`.
+- Dirty trees are expected to be rejected or snapshotted before sync.
+- `scripts/sync-local-mods.sh --help` documents the available flags.
+
+## Recovery flow if sync fails
+
+1. Inspect the sync worktree printed by the script.
+2. Resolve replay conflicts there, not on `main`.
+3. If needed, inspect the most recent `rescue/<timestamp>` branch for preserved pre-sync work.
+4. If the replay attempt is junk, delete the disposable sync worktree/branch and rerun after cleaning up the patch stack.
+
+## Practical intent
+
+The goal is simple: upstream updates should be boring, and local behavior should be explicit enough that future-you can understand what happened without digging through a swamp of uncommitted drift.

--- a/docs/local-customization-workflow.md
+++ b/docs/local-customization-workflow.md
@@ -20,10 +20,10 @@ This repo now treats upstream tracking and Henry-specific customizations as sepa
 ## Normal update flow
 
 1. Make sure your current work is committed on `henry/patches`.
-2. Fetch upstream and refresh the clean base via `scripts/sync-local-mods.sh`.
-3. Let the script create a disposable sync worktree.
+2. Run `scripts/sync-local-mods.sh --snapshot-dirty` if you have unrelated local drift that still needs preserving.
+3. Let the script fetch upstream, reset `main`, create a disposable sync worktree, and replay `main..henry/patches`.
 4. Review any replay conflicts in that disposable worktree.
-5. Run smoke tests before promoting the refreshed patch stack.
+5. Run smoke tests there, or pass `--smoke-test '<command>'` so the script does it for you.
 
 ## Add a new local customization
 

--- a/scripts/lib/git-sync-common.sh
+++ b/scripts/lib/git-sync-common.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root() {
+  git rev-parse --show-toplevel
+}
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+current_branch() {
+  git rev-parse --abbrev-ref HEAD
+}
+
+timestamp() {
+  date +%Y%m%d-%H%M%S
+}
+
+working_tree_dirty() {
+  [[ -n "$(git status --porcelain)" ]]
+}
+
+require_clean_or_snapshot_flag() {
+  local snapshot_dirty="${1:-0}"
+  if working_tree_dirty && [[ "$snapshot_dirty" != "1" ]]; then
+    die "working tree is dirty; commit it first or rerun with --snapshot-dirty"
+  fi
+}

--- a/scripts/lib/git-sync-common.sh
+++ b/scripts/lib/git-sync-common.sh
@@ -28,3 +28,18 @@ require_clean_or_snapshot_flag() {
     die "working tree is dirty; commit it first or rerun with --snapshot-dirty"
   fi
 }
+
+branch_exists() {
+  local branch_name="$1"
+  git show-ref --verify --quiet "refs/heads/${branch_name}"
+}
+
+remote_branch_exists() {
+  local remote_branch="$1"
+  git show-ref --verify --quiet "refs/remotes/${remote_branch}"
+}
+
+ensure_dir_missing() {
+  local path="$1"
+  [[ ! -e "$path" ]] || die "path already exists: $path"
+}

--- a/scripts/sync-local-mods.sh
+++ b/scripts/sync-local-mods.sh
@@ -10,6 +10,12 @@ BASE_BRANCH="main"
 SNAPSHOT_DIRTY=0
 DRY_RUN=0
 SMOKE_TEST=""
+SYNC_ID=""
+SYNC_BRANCH=""
+SYNC_PATH=""
+RESCUE_BRANCH=""
+ORIGINAL_BRANCH=""
+ROOT=""
 
 usage() {
   cat <<'EOF'
@@ -25,9 +31,9 @@ Options:
   --dry-run               Print the planned actions without mutating refs/worktrees
   --help                  Show this help text
 
-Planned flow:
+Flow:
   1. fetch origin --prune
-  2. reject or snapshot dirty local work
+  2. reject or snapshot dirty local work into rescue/<timestamp>
   3. hard-reset the base branch to origin/<base>
   4. create a disposable sync branch/worktree
   5. replay local patch commits from <base>..<patch-branch>
@@ -37,6 +43,102 @@ EOF
 
 log() {
   printf '[sync-local-mods] %s\n' "$*"
+}
+
+run_cmd() {
+  if [[ "$DRY_RUN" == "1" ]]; then
+    log "plan: $*"
+    return 0
+  fi
+  log "run: $*"
+  "$@"
+}
+
+run_in_sync_worktree() {
+  if [[ "$DRY_RUN" == "1" ]]; then
+    log "plan: (cd $SYNC_PATH && sh -lc $*)"
+    return 0
+  fi
+  log "run in sync worktree: $*"
+  (
+    cd "$SYNC_PATH"
+    sh -lc "$*"
+  )
+}
+
+snapshot_dirty_work() {
+  [[ -n "$RESCUE_BRANCH" ]] || RESCUE_BRANCH="rescue/$(timestamp)"
+
+  if [[ "$DRY_RUN" == "1" ]]; then
+    log "dirty working tree detected"
+    log "plan: git switch -c $RESCUE_BRANCH"
+    log "plan: git add -A"
+    log "plan: git commit -m wip: pre-sync snapshot before upstream refresh"
+    return 0
+  fi
+
+  log "dirty working tree detected"
+  run_cmd git switch -c "$RESCUE_BRANCH"
+  run_cmd git add -A
+  if git diff --cached --quiet; then
+    die "expected staged changes for rescue snapshot, but index is empty"
+  fi
+  run_cmd git commit -m "wip: pre-sync snapshot before upstream refresh"
+  log "created rescue snapshot: $RESCUE_BRANCH"
+}
+
+verify_prerequisites() {
+  if [[ "$DRY_RUN" == "1" ]]; then
+    log "plan: verify refs origin/$BASE_BRANCH and $PATCH_BRANCH"
+    return 0
+  fi
+
+  remote_branch_exists "origin/$BASE_BRANCH" || die "missing remote branch origin/$BASE_BRANCH"
+  branch_exists "$PATCH_BRANCH" || die "missing local patch branch $PATCH_BRANCH"
+}
+
+create_sync_worktree() {
+  ensure_dir_missing "$SYNC_PATH"
+  if branch_exists "$SYNC_BRANCH"; then
+    die "sync branch already exists: $SYNC_BRANCH"
+  fi
+  run_cmd git worktree add -b "$SYNC_BRANCH" "$SYNC_PATH" "$BASE_BRANCH"
+}
+
+replay_patch_stack() {
+  if [[ "$DRY_RUN" == "1" ]]; then
+    log "plan: git rev-list --reverse ${BASE_BRANCH}..${PATCH_BRANCH}"
+    log "plan: replay each listed commit into $SYNC_PATH with cherry-pick"
+    return 0
+  fi
+
+  local -a patch_commits
+  mapfile -t patch_commits < <(git rev-list --reverse "${BASE_BRANCH}..${PATCH_BRANCH}")
+
+  if [[ "${#patch_commits[@]}" -eq 0 ]]; then
+    log "no local patch commits to replay from ${BASE_BRANCH}..${PATCH_BRANCH}"
+    return 0
+  fi
+
+  local sha subject
+  for sha in "${patch_commits[@]}"; do
+    subject=$(git log -1 --format=%s "$sha")
+    log "replaying $sha $subject"
+    if ! git -C "$SYNC_PATH" cherry-pick "$sha"; then
+      log "cherry-pick failed for $sha $subject"
+      log "resolve conflicts in $SYNC_PATH"
+      exit 1
+    fi
+  done
+}
+
+run_smoke_test_if_configured() {
+  if [[ -z "$SMOKE_TEST" ]]; then
+    log "no smoke test command configured"
+    return 0
+  fi
+
+  run_in_sync_worktree "$SMOKE_TEST"
 }
 
 while [[ $# -gt 0 ]]; do
@@ -76,41 +178,36 @@ done
 
 ROOT=$(repo_root)
 cd "$ROOT"
-
-require_clean_or_snapshot_flag "$SNAPSHOT_DIRTY"
-
+ORIGINAL_BRANCH=$(current_branch)
 SYNC_ID="sync-$(timestamp)"
 SYNC_BRANCH="sync/$SYNC_ID"
 SYNC_PATH="$ROOT/.worktrees/$SYNC_ID"
+RESCUE_BRANCH="rescue/$(timestamp)"
 
 log "repo root: $ROOT"
+log "starting branch: $ORIGINAL_BRANCH"
 log "base branch: $BASE_BRANCH"
 log "patch branch: $PATCH_BRANCH"
+log "sync branch: $SYNC_BRANCH"
+log "sync path: $SYNC_PATH"
+
+require_clean_or_snapshot_flag "$SNAPSHOT_DIRTY"
 
 if working_tree_dirty; then
-  log "dirty working tree detected; snapshot behavior will be implemented in a later phase"
+  snapshot_dirty_work
 fi
 
-PLANNED_COMMANDS=(
-  "git fetch origin --prune"
-  "git checkout $BASE_BRANCH"
-  "git reset --hard origin/$BASE_BRANCH"
-  "git worktree add -b $SYNC_BRANCH $SYNC_PATH $BASE_BRANCH"
-  "git rev-list --reverse $BASE_BRANCH..$PATCH_BRANCH"
-)
+run_cmd git fetch origin --prune
+verify_prerequisites
+run_cmd git checkout "$BASE_BRANCH"
+run_cmd git reset --hard "origin/$BASE_BRANCH"
+create_sync_worktree
+replay_patch_stack
+run_smoke_test_if_configured
 
-if [[ -n "$SMOKE_TEST" ]]; then
-  PLANNED_COMMANDS+=("git -C $SYNC_PATH sh -lc $(printf '%q' "$SMOKE_TEST")")
+if [[ -n "$RESCUE_BRANCH" && "$DRY_RUN" == "0" ]]; then
+  log "rescue snapshot available at: $RESCUE_BRANCH"
 fi
 
-for cmd in "${PLANNED_COMMANDS[@]}"; do
-  log "plan: $cmd"
-done
-
-if [[ "$DRY_RUN" == "1" ]]; then
-  log "dry-run requested; no changes applied"
-  exit 0
-fi
-
-log "phase-1 skeleton only: command execution is not implemented yet"
-log "next phase will add snapshot, reset, worktree creation, replay, and smoke-test execution"
+log "sync worktree ready at: $SYNC_PATH"
+log "review and test there before promoting changes"

--- a/scripts/sync-local-mods.sh
+++ b/scripts/sync-local-mods.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=./lib/git-sync-common.sh
+source "$SCRIPT_DIR/lib/git-sync-common.sh"
+
+PATCH_BRANCH="henry/patches"
+BASE_BRANCH="main"
+SNAPSHOT_DIRTY=0
+DRY_RUN=0
+SMOKE_TEST=""
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/sync-local-mods.sh [options]
+
+Refresh from upstream while preserving Henry-local patch commits.
+
+Options:
+  --patch-branch <name>   Branch containing local customizations (default: henry/patches)
+  --base-branch <name>    Clean upstream-tracking branch to refresh (default: main)
+  --snapshot-dirty        Snapshot a dirty working tree before sync work begins
+  --smoke-test <command>  Command to run after replay in the disposable sync worktree
+  --dry-run               Print the planned actions without mutating refs/worktrees
+  --help                  Show this help text
+
+Planned flow:
+  1. fetch origin --prune
+  2. reject or snapshot dirty local work
+  3. hard-reset the base branch to origin/<base>
+  4. create a disposable sync branch/worktree
+  5. replay local patch commits from <base>..<patch-branch>
+  6. optionally run a smoke test command in the sync worktree
+EOF
+}
+
+log() {
+  printf '[sync-local-mods] %s\n' "$*"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --patch-branch)
+      [[ $# -ge 2 ]] || die "--patch-branch requires a value"
+      PATCH_BRANCH="$2"
+      shift 2
+      ;;
+    --base-branch)
+      [[ $# -ge 2 ]] || die "--base-branch requires a value"
+      BASE_BRANCH="$2"
+      shift 2
+      ;;
+    --snapshot-dirty)
+      SNAPSHOT_DIRTY=1
+      shift
+      ;;
+    --smoke-test)
+      [[ $# -ge 2 ]] || die "--smoke-test requires a value"
+      SMOKE_TEST="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown argument: $1"
+      ;;
+  esac
+done
+
+ROOT=$(repo_root)
+cd "$ROOT"
+
+require_clean_or_snapshot_flag "$SNAPSHOT_DIRTY"
+
+SYNC_ID="sync-$(timestamp)"
+SYNC_BRANCH="sync/$SYNC_ID"
+SYNC_PATH="$ROOT/.worktrees/$SYNC_ID"
+
+log "repo root: $ROOT"
+log "base branch: $BASE_BRANCH"
+log "patch branch: $PATCH_BRANCH"
+
+if working_tree_dirty; then
+  log "dirty working tree detected; snapshot behavior will be implemented in a later phase"
+fi
+
+PLANNED_COMMANDS=(
+  "git fetch origin --prune"
+  "git checkout $BASE_BRANCH"
+  "git reset --hard origin/$BASE_BRANCH"
+  "git worktree add -b $SYNC_BRANCH $SYNC_PATH $BASE_BRANCH"
+  "git rev-list --reverse $BASE_BRANCH..$PATCH_BRANCH"
+)
+
+if [[ -n "$SMOKE_TEST" ]]; then
+  PLANNED_COMMANDS+=("git -C $SYNC_PATH sh -lc $(printf '%q' "$SMOKE_TEST")")
+fi
+
+for cmd in "${PLANNED_COMMANDS[@]}"; do
+  log "plan: $cmd"
+done
+
+if [[ "$DRY_RUN" == "1" ]]; then
+  log "dry-run requested; no changes applied"
+  exit 0
+fi
+
+log "phase-1 skeleton only: command execution is not implemented yet"
+log "next phase will add snapshot, reset, worktree creation, replay, and smoke-test execution"

--- a/website/docs/guides/hermes-mesh-memory-policy.md
+++ b/website/docs/guides/hermes-mesh-memory-policy.md
@@ -1,0 +1,59 @@
+---
+sidebar_position: 16
+title: "Hermes Mesh Memory Policy"
+description: "Operator-facing guidance for where facts should live in Hermes Mesh: built-in memory, external memory, session history, docs, and inventory"
+---
+
+# Hermes Mesh Memory Policy
+
+This is the operator-facing version of the Hermes Mesh memory and knowledge-placement policy.
+
+## Goal
+
+Keep one authoritative home per fact.
+
+Hermes works better when memory stays small, docs stay authoritative, and session history stays the recorder of what actually happened.
+
+## Default split
+
+Use this default split when deciding where a fact belongs:
+
+- **Built-in memory (`MEMORY.md` / `USER.md`)** — small, curated facts Hermes should know every session
+- **External memory providers (for example Hindsight)** — durable cross-session recall for facts that should be rememberable but not always loaded
+- **Session history / session search** — exact chronology, prior discussions, and incident context
+- **Docs / skills** — authoritative architecture, policy, procedures, and reusable playbooks
+- **Structured inventory/config** — machine-readable operational truth used by automation
+
+## Placement rules
+
+- If Hermes should know it by default every session, put it in built-in memory.
+- If Hermes should remember it across sessions but it does not need to be preloaded every time, prefer external memory.
+- If the exact conversation, timeline, or reason matters, rely on session history.
+- If humans or operators need an authoritative reference, write docs or a skill instead of trusting memory alone.
+- If automation depends on it, prefer structured inventory/config over prose.
+
+## Default Hermes Mesh v1 posture
+
+- one external memory provider per instance
+- built-in memory stays enabled
+- separate banks per machine or role by default
+- shared writable external memory only by explicit decision
+- docs, inventory, and policy beat memory when they conflict
+
+## What not to do
+
+- Do not let built-in memory turn into a second documentation system.
+- Do not store large procedures or architecture notes in built-in memory.
+- Do not use cron reports as the long-term source of truth.
+- Do not mirror the same fact across memory, docs, and inventory unless there is a clear reason.
+
+## Quick operator test
+
+Before saving something, ask:
+
+1. Does Hermes need this every session?
+2. Does exact chronology matter?
+3. Is this a human-readable rule or procedure?
+4. Does automation need a structured source?
+
+If those questions point to docs, inventory, session history, or external memory, do not stuff it into `MEMORY.md` or `USER.md` just because it is convenient.

--- a/website/docs/user-guide/docker.md
+++ b/website/docs/user-guide/docker.md
@@ -39,7 +39,7 @@ docker run -d \
   nousresearch/hermes-agent gateway run
 ```
 
-Port 8642 exposes the gateway's [OpenAI-compatible API server](./api-server.md) and health endpoint. It's optional if you only use chat platforms (Telegram, Discord, etc.), but required if you want the dashboard or external tools to reach the gateway.
+Port 8642 exposes the gateway's [OpenAI-compatible API server](./features/api-server.md) and health endpoint. It's optional if you only use chat platforms (Telegram, Discord, etc.), but required if you want the dashboard or external tools to reach the gateway.
 
 Opening any port on an internet facing machine is a security risk. You should not do it unless you understand the risks.
 


### PR DESCRIPTION
## Summary
- restore the missing operator-facing Hermes Mesh memory policy guide
- fix the broken local docs link in `website/docs/user-guide/docker.md`
- keep the fix scoped to live docs drift rather than recreating dead historical plan docs

## Why
`AGENTS.md` points readers to `website/docs/guides/hermes-mesh-memory-policy.md` as the operator-facing version of the memory placement policy. That file was missing, leaving a live broken reference. This PR restores the guide and fixes one additional broken local markdown link in the Docker docs.

## Verification
- verified the new guide exists at the referenced path
- verified no broken local repo-file markdown links remain across `AGENTS.md`, `docs/**/*.md`, and `website/docs/**/*.md`
