### PR TITLE
fix(plugins/memory/honcho): default Honcho SDK HTTP timeout to 30s

### DIFF
--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -138,6 +138,15 @@ def _parse_dialectic_depth_levels(host_val, root_val, depth: int) -> list[str] |
     return None
 
 
+# Default HTTP timeout (seconds) applied when no explicit timeout is
+# configured via HonchoClientConfig.timeout, honcho.timeout / requestTimeout,
+# or HONCHO_TIMEOUT. Honcho calls happen on the post-response path of
+# run_conversation; without a cap the agent can block indefinitely when
+# the Honcho backend is unreachable, preventing the gateway from
+# delivering the already-generated response.
+_DEFAULT_HTTP_TIMEOUT = 30.0
+
+
 def _resolve_optional_float(*values: Any) -> float | None:
     """Return the first non-empty value coerced to a positive float."""
     for value in values:
@@ -645,6 +654,11 @@ def get_honcho_client(config: HonchoClientConfig | None = None) -> Honcho:
                     )
         except Exception:
             pass
+
+    # Fall back to the default so an unconfigured install cannot hang
+    # indefinitely on a stalled Honcho request.
+    if resolved_timeout is None:
+        resolved_timeout = _DEFAULT_HTTP_TIMEOUT
 
     if resolved_base_url:
         logger.info("Initializing Honcho client (base_url: %s, workspace: %s)", resolved_base_url, config.workspace_id)

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -593,6 +593,28 @@ class TestGetHonchoClient:
         not importlib.util.find_spec("honcho"),
         reason="honcho SDK not installed"
     )
+    def test_defaults_to_30s_when_no_timeout_configured(self):
+        from plugins.memory.honcho.client import _DEFAULT_HTTP_TIMEOUT
+
+        fake_honcho = MagicMock(name="Honcho")
+        cfg = HonchoClientConfig(
+            api_key="test-key",
+            workspace_id="hermes",
+            environment="production",
+        )
+
+        with patch("honcho.Honcho", return_value=fake_honcho) as mock_honcho, \
+             patch("hermes_cli.config.load_config", return_value={}):
+            client = get_honcho_client(cfg)
+
+        assert client is fake_honcho
+        mock_honcho.assert_called_once()
+        assert mock_honcho.call_args.kwargs["timeout"] == _DEFAULT_HTTP_TIMEOUT
+
+    @pytest.mark.skipif(
+        not importlib.util.find_spec("honcho"),
+        reason="honcho SDK not installed"
+    )
     def test_hermes_request_timeout_alias_used(self):
         fake_honcho = MagicMock(name="Honcho")
         cfg = HonchoClientConfig(


### PR DESCRIPTION
## Summary

`get_honcho_client()` currently passes **no** `timeout` kwarg to the Honcho SDK when nothing is explicitly configured (neither `HonchoClientConfig.timeout`, `honcho.timeout` / `requestTimeout` in the Hermes config, nor `HONCHO_TIMEOUT`). The underlying httpx client then has no cap, so a stalled request can hang indefinitely.

This is a silent-failure hazard on the **post-response path** of `run_conversation` — `memory_manager.sync_all()` / `queue_prefetch_all()` fire after the agent has already generated its final reply, so a stuck Honcho call blocks `run_conversation` from returning. The gateway never logs `response ready` and never delivers the reply to Telegram / WhatsApp / etc., even though the text is already saved to the session file.

This PR adds a module-level `_DEFAULT_HTTP_TIMEOUT = 30.0` and applies it in `get_honcho_client()` only after all configured sources have been checked, so existing deployments that have tuned the value (including self-hosted instances that need longer) keep their current behavior. Unconfigured installs get a sensible ceiling instead of silent indefinite hangs.

## Repro

Observed on v0.9.0 with the honcho plugin active and a Telegram session.

1. Run any Telegram-origin agent turn.
2. After the model has generated its final assistant text, make app.honcho.dev unreachable (network drop, firewall rule, or natural outage) *while* `sync_all` is running.
3. Without this PR: `_run_agent` never returns, no `response ready` is logged, the Telegram reply is lost despite being present in the session file. The gateway process stays alive (Telegram long-poll is unaffected) but cannot complete the turn or respond to further messages in that chat until restarted. CLOSE-WAIT sockets to Honcho accumulate.
4. With this PR: the call aborts after 30s, `run_conversation` returns, `sync_turn failed: …` is logged as before, and the gateway delivers the already-generated reply.

## Test plan

- [x] `pytest tests/honcho_plugin/ tests/test_honcho_client_config.py` — 160 passed locally (Python 3.12, honcho-ai installed)
- [x] New regression test `TestGetHonchoClient::test_defaults_to_30s_when_no_timeout_configured` asserts the default is passed when neither `HonchoClientConfig.timeout` nor a Hermes config override is set
- [x] Existing `test_passes_timeout_from_config`, `test_hermes_config_timeout_override_used_when_config_timeout_missing`, `test_hermes_request_timeout_alias_used` still pass unchanged — an explicit value continues to win over the default
- [x] Manually verified on Linux (Debian/Ubuntu) against a live Telegram session

## Platforms tested

Linux only. The change is pure Python dict kwarg construction, no platform-sensitive code paths, so Windows / macOS behavior should be identical.