### PR TITLE
Discover plugin commands during CLI dispatch

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1633,8 +1633,8 @@ _skill_commands = scan_skill_commands()
 def _get_plugin_cmd_handler_names() -> set:
     """Return plugin command names (without slash prefix) for dispatch matching."""
     try:
-        from hermes_cli.plugins import get_plugin_manager
-        return set(get_plugin_manager()._plugin_commands.keys())
+        from hermes_cli.plugins import get_plugin_commands
+        return set(get_plugin_commands().keys())
     except Exception:
         return set()
 


### PR DESCRIPTION
## Summary

- makes CLI plugin command dispatch call `get_plugin_commands()`
- ensures enabled plugin slash commands are discovered before the CLI checks whether a command is known

## Why

Fresh Hermes CLI sessions can reject an enabled plugin command as unknown because `_get_plugin_cmd_handler_names()` read the plugin manager's private `_plugin_commands` dict before discovery had run. Calling `get_plugin_commands()` uses the public discovery path and keeps dispatch behavior aligned with help/autocomplete.

## Validation

- `python3 -m py_compile cli.py`
- live VPS verification with `/swarm-status` resolving through a fresh Hermes process
