### PR TITLE
fix(gateway-config): warn when non-secret settings conflict between config.yaml and .env (#13582)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -512,9 +512,29 @@ def _coerce_yaml_val_for_compare(node: Any) -> str:
         # The bridges write ``str(bool).lower()`` (e.g. "true"/"false").
         return str(node).lower()
     if isinstance(node, list):
-        # The bridges write comma-joined values.
-        return ",".join(str(v) for v in node)
+        # The bridges write comma-joined values; strip per-item whitespace
+        # and drop empties so it round-trips through the downstream
+        # CSV-normaliser consistently.
+        return ",".join(str(v).strip() for v in node if str(v).strip())
     return str(node)
+
+
+def _normalize_csv_for_compare(raw: str) -> str:
+    """Canonicalise a comma-separated env-var string the way the gateway
+    adapters actually consume it: split on ``,``, strip whitespace from
+    each item, drop empties, and return a deterministically-sorted
+    comma-joined string.
+
+    Without this, ``_warn_yaml_env_conflicts`` produces false-positive
+    warnings when the user has semantically-equivalent values in YAML
+    and env — e.g. ``["c1", "c2"]`` in YAML vs ``"c1, c2"`` or
+    ``"c2,c1"`` in env are all the same set to the runtime but look
+    textually different.  Adapters parse these into sets (order
+    doesn't matter); treating them the same way here keeps the
+    warning signal honest.
+    """
+    items = sorted(s.strip() for s in raw.split(",") if s.strip())
+    return ",".join(items)
 
 
 def _warn_yaml_env_conflicts(yaml_cfg: dict, config_yaml_path: Path) -> None:
@@ -546,7 +566,18 @@ def _warn_yaml_env_conflicts(yaml_cfg: dict, config_yaml_path: Path) -> None:
         if env_val is None or env_val == "":
             continue  # YAML-only — bridges below will honour it
         yaml_val = _coerce_yaml_val_for_compare(node)
-        if env_val.strip().lower() == yaml_val.strip().lower():
+        # Canonicalise both sides so semantically-equivalent list values
+        # (e.g. YAML ``["c1", "c2"]`` ↔ env ``"c1, c2"`` or ``"c2,c1"``)
+        # don't produce false-positive warnings.  Downstream adapters
+        # parse these settings into sets, so order + whitespace should
+        # not be treated as a conflict here either.
+        if isinstance(node, list):
+            yaml_cmp = _normalize_csv_for_compare(yaml_val)
+            env_cmp = _normalize_csv_for_compare(env_val)
+        else:
+            yaml_cmp = yaml_val.strip().lower()
+            env_cmp = env_val.strip().lower()
+        if yaml_cmp == env_cmp:
             continue  # Same effective value — no surprise, no warning
         logger.warning(
             "Gateway config conflict: %s in %s is %r but %s=%r is set in "

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -472,6 +472,93 @@ class GatewayConfig:
         return self.unauthorized_dm_behavior
 
 
+# Non-secret gateway behavior settings that exist in both config.yaml and
+# env-var form.  Environment variables win by design (load_gateway_config
+# docstring below), but users reasonably expect config.yaml to be
+# authoritative for behavior config — so when a key is set in BOTH sources
+# with different values we emit a warning so the user can clean up the
+# stale .env entry.  Tokens / API keys / home-channel IDs are intentionally
+# absent from this list: those are secrets / deployment-specific and env
+# is the correct authoritative location.  See #13582.
+_YAML_ENV_NON_SECRET_MAPPINGS: tuple[tuple[str, str], ...] = (
+    # Discord
+    ("discord.reply_to_mode",           "DISCORD_REPLY_TO_MODE"),
+    ("discord.require_mention",         "DISCORD_REQUIRE_MENTION"),
+    ("discord.auto_thread",             "DISCORD_AUTO_THREAD"),
+    ("discord.reactions",               "DISCORD_REACTIONS"),
+    ("discord.free_response_channels",  "DISCORD_FREE_RESPONSE_CHANNELS"),
+    ("discord.ignored_channels",        "DISCORD_IGNORED_CHANNELS"),
+    ("discord.allowed_channels",        "DISCORD_ALLOWED_CHANNELS"),
+    ("discord.no_thread_channels",      "DISCORD_NO_THREAD_CHANNELS"),
+    # Telegram
+    ("telegram.reply_to_mode",          "TELEGRAM_REPLY_TO_MODE"),
+    ("telegram.require_mention",        "TELEGRAM_REQUIRE_MENTION"),
+    ("telegram.reactions",              "TELEGRAM_REACTIONS"),
+    ("telegram.free_response_chats",    "TELEGRAM_FREE_RESPONSE_CHATS"),
+    ("telegram.ignored_threads",        "TELEGRAM_IGNORED_THREADS"),
+    ("telegram.proxy_url",              "TELEGRAM_PROXY"),
+    # Slack
+    ("slack.require_mention",           "SLACK_REQUIRE_MENTION"),
+    ("slack.allow_bots",                "SLACK_ALLOW_BOTS"),
+    ("slack.free_response_channels",    "SLACK_FREE_RESPONSE_CHANNELS"),
+)
+
+
+def _coerce_yaml_val_for_compare(node: Any) -> str:
+    """Normalise a YAML scalar/list to the same string shape that the
+    YAML-to-env bridges elsewhere in this module use, so ``_warn_yaml_env_conflicts``
+    only warns on genuine value mismatches."""
+    if isinstance(node, bool):
+        # The bridges write ``str(bool).lower()`` (e.g. "true"/"false").
+        return str(node).lower()
+    if isinstance(node, list):
+        # The bridges write comma-joined values.
+        return ",".join(str(v) for v in node)
+    return str(node)
+
+
+def _warn_yaml_env_conflicts(yaml_cfg: dict, config_yaml_path: Path) -> None:
+    """Warn when non-secret gateway settings are set in BOTH ``config.yaml``
+    and the environment with different values.
+
+    Environment variables take priority by design (see ``load_gateway_config``
+    docstring), so this is non-breaking — behavior is unchanged.  The
+    warning exists purely to surface the conflict so users don't silently
+    waste time editing ``config.yaml`` while a stale ``.env`` entry overrides
+    them.  See #13582.
+
+    Only compares values that this module's YAML→env bridges actually
+    touch (per ``_YAML_ENV_NON_SECRET_MAPPINGS``); tokens and credentials
+    are deliberately excluded.
+    """
+    for dotted_key, env_var in _YAML_ENV_NON_SECRET_MAPPINGS:
+        # Walk the dotted path (e.g. "discord.reply_to_mode") through the
+        # parsed YAML.  Missing intermediate keys → no conflict to warn on.
+        node: Any = yaml_cfg
+        for part in dotted_key.split("."):
+            if not isinstance(node, dict) or part not in node:
+                node = None
+                break
+            node = node[part]
+        if node is None:
+            continue
+        env_val = os.getenv(env_var)
+        if env_val is None or env_val == "":
+            continue  # YAML-only — bridges below will honour it
+        yaml_val = _coerce_yaml_val_for_compare(node)
+        if env_val.strip().lower() == yaml_val.strip().lower():
+            continue  # Same effective value — no surprise, no warning
+        logger.warning(
+            "Gateway config conflict: %s in %s is %r but %s=%r is set in "
+            "your environment (typically ~/.hermes/.env).  The env var "
+            "takes priority by design, so the config.yaml value will have "
+            "no effect.  Remove %s from .env to make config.yaml "
+            "authoritative, or update the .env value to match.  (#13582)",
+            dotted_key, config_yaml_path.name, yaml_val,
+            env_var, env_val, env_var,
+        )
+
+
 def load_gateway_config() -> GatewayConfig:
     """
     Load gateway configuration from multiple sources.
@@ -506,6 +593,13 @@ def load_gateway_config() -> GatewayConfig:
         if config_yaml_path.exists():
             with open(config_yaml_path, encoding="utf-8") as f:
                 yaml_cfg = yaml.safe_load(f) or {}
+
+            # Warn when non-secret behavior settings are configured in BOTH
+            # config.yaml AND the environment with different values — the
+            # env var wins silently, which surprises users who reasonably
+            # expect config.yaml edits to take effect after restart.  See
+            # #13582.
+            _warn_yaml_env_conflicts(yaml_cfg, config_yaml_path)
 
             # Map config.yaml keys → GatewayConfig.from_dict() schema.
             # Each key overwrites whatever gateway.json may have set.

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -644,6 +644,65 @@ class TestYamlEnvConflictWarnings:
         assert len(recs) == 1
         assert "discord.allowed_channels" in recs[0].getMessage()
 
+    def test_list_comparison_ignores_whitespace_in_env(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """Downstream adapters parse CSV env vars with per-item stripping.
+        YAML ``["c1", "c2"]`` vs env ``"c1, c2"`` (with whitespace) must
+        be treated as the same value — no false-positive warning."""
+        monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "c1, c2")
+        with caplog.at_level(logging.WARNING, logger="gateway.config"):
+            self._load(tmp_path, monkeypatch,
+                       "discord:\n  allowed_channels:\n    - c1\n    - c2\n")
+        assert self._conflict_records(caplog) == [], (
+            "Whitespace-only difference between YAML list and env CSV must "
+            "not fire a warning — the adapters strip each item before use."
+        )
+
+    def test_list_comparison_ignores_order(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """Downstream adapters parse these CSV settings into sets.
+        YAML ``["c1", "c2"]`` vs env ``"c2,c1"`` is the same set to the
+        runtime — must not fire a false-positive warning."""
+        monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "c2,c1")
+        with caplog.at_level(logging.WARNING, logger="gateway.config"):
+            self._load(tmp_path, monkeypatch,
+                       "discord:\n  allowed_channels:\n    - c1\n    - c2\n")
+        assert self._conflict_records(caplog) == [], (
+            "Reordered CSV env value must not fire a warning — adapters "
+            "treat these as sets, so order is immaterial."
+        )
+
+    def test_list_comparison_ignores_empty_csv_items(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """Env ``"c1,,c2,"`` (trailing / double commas) is equivalent to
+        ``"c1,c2"`` after downstream parsing — must not fire a false-
+        positive warning."""
+        monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "c1,,c2,")
+        with caplog.at_level(logging.WARNING, logger="gateway.config"):
+            self._load(tmp_path, monkeypatch,
+                       "discord:\n  allowed_channels:\n    - c1\n    - c2\n")
+        assert self._conflict_records(caplog) == [], (
+            "Extra-comma / empty-item env CSV must not fire a warning — "
+            "downstream splits and drops empties."
+        )
+
+    def test_list_comparison_still_warns_on_genuine_diff(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """Structural pin: the set-comparison relaxation must not hide a
+        genuine value difference.  YAML ``["c1", "c2"]`` vs env
+        ``"c1,c3"`` is a real mismatch and must still warn."""
+        monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "c1,c3")
+        with caplog.at_level(logging.WARNING, logger="gateway.config"):
+            self._load(tmp_path, monkeypatch,
+                       "discord:\n  allowed_channels:\n    - c1\n    - c2\n")
+        recs = self._conflict_records(caplog)
+        assert len(recs) == 1
+        assert "discord.allowed_channels" in recs[0].getMessage()
+
     def test_multiple_conflicts_each_warn_once(
         self, tmp_path, monkeypatch, caplog
     ):

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -1,5 +1,6 @@
 """Tests for gateway configuration management."""
 
+import logging
 import os
 from unittest.mock import patch
 
@@ -513,3 +514,197 @@ class TestHomeChannelEnvOverrides:
             home = config.platforms[platform].home_channel
             assert home is not None, f"{platform.value}: home_channel should not be None"
             assert (home.chat_id, home.name) == expected, platform.value
+
+
+# ---------------------------------------------------------------------------
+# Regression coverage for #13582 — warn when non-secret gateway settings
+# are set in BOTH config.yaml and the environment.
+#
+# Environment variables win by design, but stale .env entries silently
+# override config.yaml edits (reporter's case: DISCORD_REPLY_TO_MODE=off
+# in .env overriding discord.reply_to_mode: first in config.yaml).  These
+# tests pin that ``_warn_yaml_env_conflicts`` surfaces the conflict as a
+# WARNING-level log record so users can clean up the duplicated value.
+# ---------------------------------------------------------------------------
+
+
+class TestYamlEnvConflictWarnings:
+
+    def _load(self, tmp_path, monkeypatch, yaml_text: str) -> None:
+        """Write config.yaml under HERMES_HOME and call load_gateway_config.
+        ``exist_ok=True`` so tests that invoke ``_load`` multiple times
+        in a single scenario don't trip on directory reuse."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir(exist_ok=True)
+        (hermes_home / "config.yaml").write_text(yaml_text, encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        load_gateway_config()
+
+    def _conflict_records(self, caplog) -> list:
+        """Return only the conflict-warning records ``_warn_yaml_env_conflicts``
+        emitted (filter out other gateway.config warnings)."""
+        return [
+            r for r in caplog.records
+            if r.name == "gateway.config"
+            and r.levelno == logging.WARNING
+            and "Gateway config conflict" in r.getMessage()
+        ]
+
+    def test_reporter_repro_discord_reply_to_mode_warns(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """Reporter's exact scenario: discord.reply_to_mode=first in
+        config.yaml, DISCORD_REPLY_TO_MODE=off in env. Both set, values
+        differ → warning fires (#13582)."""
+        monkeypatch.setenv("DISCORD_REPLY_TO_MODE", "off")
+        with caplog.at_level(logging.WARNING, logger="gateway.config"):
+            self._load(tmp_path, monkeypatch,
+                       "discord:\n  reply_to_mode: first\n")
+        recs = self._conflict_records(caplog)
+        assert len(recs) == 1, (
+            f"Expected exactly 1 conflict warning for discord.reply_to_mode; "
+            f"got {len(recs)}: {[r.getMessage() for r in recs]}"
+        )
+        msg = recs[0].getMessage()
+        assert "discord.reply_to_mode" in msg
+        assert "DISCORD_REPLY_TO_MODE" in msg
+        # Both values surface so the user knows which to change.
+        assert "first" in msg
+        assert "off" in msg
+        # Actionable guidance mentions the env file.
+        assert ".env" in msg
+
+    def test_no_warning_when_yaml_only(self, tmp_path, monkeypatch, caplog):
+        """YAML set, env unset → no conflict to warn about (YAML will
+        bridge to env normally)."""
+        monkeypatch.delenv("DISCORD_REPLY_TO_MODE", raising=False)
+        with caplog.at_level(logging.WARNING, logger="gateway.config"):
+            self._load(tmp_path, monkeypatch,
+                       "discord:\n  reply_to_mode: first\n")
+        assert self._conflict_records(caplog) == []
+
+    def test_no_warning_when_env_only(self, tmp_path, monkeypatch, caplog):
+        """Env set, YAML unset → no conflict (no surprise)."""
+        monkeypatch.setenv("DISCORD_REPLY_TO_MODE", "off")
+        with caplog.at_level(logging.WARNING, logger="gateway.config"):
+            self._load(tmp_path, monkeypatch, "{}\n")
+        assert self._conflict_records(caplog) == []
+
+    def test_no_warning_when_values_match(self, tmp_path, monkeypatch, caplog):
+        """Both set to the same effective value → silent (no-op for user)."""
+        monkeypatch.setenv("DISCORD_REPLY_TO_MODE", "first")
+        with caplog.at_level(logging.WARNING, logger="gateway.config"):
+            self._load(tmp_path, monkeypatch,
+                       "discord:\n  reply_to_mode: first\n")
+        assert self._conflict_records(caplog) == []
+
+    def test_value_match_is_case_insensitive(self, tmp_path, monkeypatch, caplog):
+        """YAML "First" + env "FIRST" = same effective value, no warning."""
+        monkeypatch.setenv("DISCORD_REPLY_TO_MODE", "FIRST")
+        with caplog.at_level(logging.WARNING, logger="gateway.config"):
+            self._load(tmp_path, monkeypatch,
+                       "discord:\n  reply_to_mode: First\n")
+        assert self._conflict_records(caplog) == []
+
+    def test_boolean_yaml_compared_as_lowercased_string(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """YAML ``require_mention: true`` vs env ``DISCORD_REQUIRE_MENTION=false``
+        → conflict (bool must normalise to the same ``true``/``false`` string
+        that the YAML→env bridges later emit)."""
+        monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+        with caplog.at_level(logging.WARNING, logger="gateway.config"):
+            self._load(tmp_path, monkeypatch,
+                       "discord:\n  require_mention: true\n")
+        recs = self._conflict_records(caplog)
+        assert len(recs) == 1
+        assert "discord.require_mention" in recs[0].getMessage()
+
+    def test_list_yaml_compared_as_comma_joined(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """YAML list → env var bridges serialise as comma-joined strings
+        (``DISCORD_ALLOWED_CHANNELS=chan1,chan2``).  Conflict detection
+        must use the same serialisation so list-vs-string env comparison
+        works correctly."""
+        # Matching list + env value: no warning.
+        monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "c1,c2")
+        with caplog.at_level(logging.WARNING, logger="gateway.config"):
+            self._load(tmp_path, monkeypatch,
+                       "discord:\n  allowed_channels:\n    - c1\n    - c2\n")
+        assert self._conflict_records(caplog) == []
+
+        caplog.clear()
+        # Mismatched → warning fires.
+        monkeypatch.setenv("DISCORD_ALLOWED_CHANNELS", "different")
+        with caplog.at_level(logging.WARNING, logger="gateway.config"):
+            self._load(tmp_path, monkeypatch,
+                       "discord:\n  allowed_channels:\n    - c1\n    - c2\n")
+        recs = self._conflict_records(caplog)
+        assert len(recs) == 1
+        assert "discord.allowed_channels" in recs[0].getMessage()
+
+    def test_multiple_conflicts_each_warn_once(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """Multiple conflicting settings → one warning each (no suppression,
+        no duplication)."""
+        monkeypatch.setenv("DISCORD_REPLY_TO_MODE", "off")
+        monkeypatch.setenv("TELEGRAM_REQUIRE_MENTION", "false")
+        with caplog.at_level(logging.WARNING, logger="gateway.config"):
+            self._load(
+                tmp_path, monkeypatch,
+                "discord:\n  reply_to_mode: first\n"
+                "telegram:\n  require_mention: true\n",
+            )
+        recs = self._conflict_records(caplog)
+        assert len(recs) == 2
+        msgs = [r.getMessage() for r in recs]
+        assert any("discord.reply_to_mode" in m for m in msgs)
+        assert any("telegram.require_mention" in m for m in msgs)
+
+    def test_slack_mappings_covered(self, tmp_path, monkeypatch, caplog):
+        """Slack keys are in _YAML_ENV_NON_SECRET_MAPPINGS too — pin that
+        the warning coverage isn't Discord-only."""
+        monkeypatch.setenv("SLACK_REQUIRE_MENTION", "true")
+        with caplog.at_level(logging.WARNING, logger="gateway.config"):
+            self._load(tmp_path, monkeypatch,
+                       "slack:\n  require_mention: false\n")
+        recs = self._conflict_records(caplog)
+        assert len(recs) == 1
+        assert "slack.require_mention" in recs[0].getMessage()
+
+    def test_tokens_not_covered(self, tmp_path, monkeypatch, caplog):
+        """Narrow-scope canary: tokens/credentials are DELIBERATELY absent
+        from ``_YAML_ENV_NON_SECRET_MAPPINGS`` because env is the correct
+        authoritative location for secrets.  Setting a token in both places
+        must NOT produce a warning."""
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "env-token")
+        with caplog.at_level(logging.WARNING, logger="gateway.config"):
+            self._load(
+                tmp_path, monkeypatch,
+                "platforms:\n  discord:\n    token: yaml-token\n",
+            )
+        assert self._conflict_records(caplog) == []
+
+    def test_nested_missing_path_no_warning(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """If the YAML doesn't have the parent key (``discord:``), the
+        conflict walker must not raise even when env var is set."""
+        monkeypatch.setenv("DISCORD_REPLY_TO_MODE", "off")
+        with caplog.at_level(logging.WARNING, logger="gateway.config"):
+            self._load(tmp_path, monkeypatch, "slack:\n  token: xyz\n")
+        assert self._conflict_records(caplog) == []
+
+    def test_empty_env_value_treated_as_unset(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """``DISCORD_REPLY_TO_MODE=""`` (empty string) is treated as unset
+        — consistent with how ``os.getenv`` + downstream code uses it.
+        No warning even though the env var is technically present."""
+        monkeypatch.setenv("DISCORD_REPLY_TO_MODE", "")
+        with caplog.at_level(logging.WARNING, logger="gateway.config"):
+            self._load(tmp_path, monkeypatch,
+                       "discord:\n  reply_to_mode: first\n")
+        assert self._conflict_records(caplog) == []


### PR DESCRIPTION
Fixes #13582.

## TL;DR

Stale non-secret entries in `~/.hermes/.env` silently override their `config.yaml` counterparts. Reporter hit it with `DISCORD_REPLY_TO_MODE=off` in `.env` winning over `discord.reply_to_mode: first` in `config.yaml`, with no diagnostic.

Fix: add a **non-breaking warning pass** that surfaces these conflicts. Env still wins (behavior unchanged); users just see which setting got overridden so they can clean up their `.env`.

## Approach

The issue proposed two options:
- **Option A**: make `config.yaml` authoritative for non-secrets (breaking change)
- **Option B**: warn when both sources specify the same setting (non-breaking)

This PR is **Option B**. A stricter Option A — flipping precedence — is intentionally left for a separate, larger-scope discussion.

## Fix

A small static allow-list of non-secret settings known to have both YAML and env-var forms:

```python
_YAML_ENV_NON_SECRET_MAPPINGS: tuple[tuple[str, str], ...] = (
    # Discord
    ("discord.reply_to_mode",           "DISCORD_REPLY_TO_MODE"),  # reporter's case
    ("discord.require_mention",         "DISCORD_REQUIRE_MENTION"),
    ("discord.auto_thread",             "DISCORD_AUTO_THREAD"),
    ("discord.reactions",               "DISCORD_REACTIONS"),
    ("discord.free_response_channels",  "DISCORD_FREE_RESPONSE_CHANNELS"),
    ("discord.ignored_channels",        "DISCORD_IGNORED_CHANNELS"),
    ("discord.allowed_channels",        "DISCORD_ALLOWED_CHANNELS"),
    ("discord.no_thread_channels",      "DISCORD_NO_THREAD_CHANNELS"),
    # Telegram
    ("telegram.reply_to_mode",          "TELEGRAM_REPLY_TO_MODE"),
    ("telegram.require_mention",        "TELEGRAM_REQUIRE_MENTION"),
    ("telegram.reactions",              "TELEGRAM_REACTIONS"),
    ("telegram.free_response_chats",    "TELEGRAM_FREE_RESPONSE_CHATS"),
    ("telegram.ignored_threads",        "TELEGRAM_IGNORED_THREADS"),
    ("telegram.proxy_url",              "TELEGRAM_PROXY"),
    # Slack
    ("slack.require_mention",           "SLACK_REQUIRE_MENTION"),
    ("slack.allow_bots",                "SLACK_ALLOW_BOTS"),
    ("slack.free_response_channels",    "SLACK_FREE_RESPONSE_CHANNELS"),
)
```

And a single helper called once near the top of `load_gateway_config`:

```python
def _warn_yaml_env_conflicts(yaml_cfg, config_yaml_path):
    for dotted_key, env_var in _YAML_ENV_NON_SECRET_MAPPINGS:
        # walk dotted path, skip if YAML key absent
        # skip if env var absent or empty
        # skip if values match (case-insensitive, same bool/list serialization)
        logger.warning(
            "Gateway config conflict: %s in %s is %r but %s=%r is set in "
            "your environment (typically ~/.hermes/.env). The env var takes "
            "priority by design, so the config.yaml value will have no effect. "
            "Remove %s from .env to make config.yaml authoritative, or update "
            "the .env value to match. (#13582)",
            dotted_key, config_yaml_path.name, yaml_val,
            env_var, env_val, env_var,
        )
```

## Behaviour matrix

| Scenario | Before | After |
| --- | --- | --- |
| YAML and env both set, **values differ** | silent override (bug) | warning + override (env still wins) |
| YAML and env both set, **values match** | silent (consistent) | silent (no user surprise) |
| YAML only | YAML wins | YAML wins (unchanged) |
| Env only | env wins | env wins (unchanged) |
| **Token** (`DISCORD_BOT_TOKEN`) in both | silent | silent (tokens deliberately excluded from allow-list) |
| YAML has list, env has comma-joined string that matches | silent | silent (serialization handled: `[a, b]` ↔ `a,b`) |
| YAML missing parent key, env set | silent | silent (walker doesn't raise) |

## Narrow scope — explicitly not changed

* **Precedence order.** Env still wins. This PR does NOT implement the reporter's Option A (YAML authoritative) because that would break existing deployments relying on `.env` overrides.
* **Tokens / credentials / home-channel IDs.** Deliberately absent from the allow-list. Secrets are env-first by convention. Pinned by `test_tokens_not_covered`.
* **YAML → env bridges.** The existing bridges (`and not os.getenv(...)`) are untouched — the warning runs before them and doesn't interfere.
* **Output level.** WARNING is the right severity: actionable, not fatal. Users can silence it with log config if intentional.

## Regression coverage

`tests/gateway/test_config.py::TestYamlEnvConflictWarnings` — **12 new cases**:

**Bug-surfacing (5)**:
- `test_reporter_repro_discord_reply_to_mode_warns` — reporter's exact scenario
- `test_boolean_yaml_compared_as_lowercased_string` — bool YAML vs `"true"`/`"false"` env
- `test_list_yaml_compared_as_comma_joined` — list YAML vs comma-joined env
- `test_multiple_conflicts_each_warn_once` — independent warnings per setting
- `test_slack_mappings_covered` — non-Discord mappings also fire

**Preserved-behaviour canaries (5)**:
- `test_no_warning_when_yaml_only`
- `test_no_warning_when_env_only`
- `test_no_warning_when_values_match`
- `test_value_match_is_case_insensitive`
- `test_empty_env_value_treated_as_unset`

**Narrow-scope canaries (2)**:
- `test_tokens_not_covered` — `DISCORD_BOT_TOKEN` etc. must NOT trigger
- `test_nested_missing_path_no_warning` — walker doesn't raise

**5 of 12 fail on clean `origin/main` (`04f9ffb7`)** with `assert 0 == 1` (expected 1 warning, got 0) — the scan isn't there yet. The 7 remaining pin preserved behaviour.

## Validation

```bash
source venv/bin/activate
python -m pytest tests/gateway/test_config.py::TestYamlEnvConflictWarnings -q
# 12 passed
```

Broader config-related suites (`test_config.py`, `test_config_cwd_bridge.py`, `test_display_config.py`, `test_session_env.py`, `test_stt_config.py`) → **102 passed, 0 regressions**.

## Pre-empted review questions

**Q. Why a static allow-list instead of introspecting the schema?**
The YAML→env bridges in this file are hand-written per setting — there's no unified schema to derive from. A static allow-list is the minimal, auditable surface that matches reality. If future refactors unify the bridges into a schema, the allow-list can be replaced by that schema.

**Q. Why not make this an error at startup?**
Env is legitimately authoritative in many deployment patterns (Docker, Kubernetes secrets). A warning surfaces the conflict without blocking startup for setups that know what they're doing.

**Q. What if a user sets `ANTHROPIC_API_KEY` in both places?**
Not covered — tokens/credentials are intentionally absent from the allow-list. Secrets belong in env; duplicating them in YAML is a different class of bug (and a security problem in itself). Separate fix if anyone cares about that.

**Q. Could the warning mention which file the env var came from specifically (`.env` vs shell vs Docker)?**
The Python process can't reliably distinguish — `os.getenv` returns a merged view. The warning says "typically ~/.hermes/.env" because that's the most common source; the env var name is named explicitly so the user can grep for it wherever.

---

<sub>Co-authored via LLM assistance; I've reviewed every line and am responsible for correctness.</sub>
