### PR TITLE
[security] fix(tui+cli): approval overlays accept blind keystrokes / thread-local callback bypass

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8371,6 +8371,17 @@ class HermesCLI:
 
             def run_agent():
                 nonlocal result
+                # Set callbacks inside the agent thread so thread-local storage
+                # in terminal_tool is populated for this thread.  The main thread
+                # registration (run() line ~9046) is invisible here because
+                # _callback_tls is threading.local().  Matches the pattern used
+                # by acp_adapter/server.py for ACP sessions.
+                set_sudo_password_callback(self._sudo_password_callback)
+                set_approval_callback(self._approval_callback)
+                try:
+                    set_secret_capture_callback(self._secret_capture_callback)
+                except Exception:
+                    pass
                 agent_message = _voice_prefix + message if _voice_prefix else message
                 # Prepend pending model switch note so the model knows about the switch
                 _msn = getattr(self, '_pending_model_switch_note', None)
@@ -8396,6 +8407,15 @@ class HermesCLI:
                         "failed": True,
                         "error": _summary,
                     }
+                finally:
+                    # Clear thread-local callbacks so a reused thread doesn't
+                    # hold stale references to a disposed CLI instance.
+                    try:
+                        set_sudo_password_callback(None)
+                        set_approval_callback(None)
+                        set_secret_capture_callback(None)
+                    except Exception:
+                        pass
 
             # Start agent in background thread (daemon so it cannot keep the
             # process alive when the user closes the terminal tab — SIGHUP

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -173,6 +173,17 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
     const live = getUiState()
 
     if (isBlocked) {
+      // When approval/clarify/confirm overlays are active, their own useInput
+      // handlers must receive keystrokes (arrow keys, numbers, Enter).  Only
+      // intercept Ctrl+C here so the user can deny/dismiss — all other keys
+      // fall through to the component-level handlers.
+      if (overlay.approval || overlay.clarify || overlay.confirm) {
+        if (isCtrl(key, ch, 'c')) {
+          cancelOverlayFromCtrlC()
+        }
+        return
+      }
+
       if (overlay.pager) {
         if (key.return || ch === ' ') {
           const nextOffset = overlay.pager.offset + pagerPageSize


### PR DESCRIPTION
## Security: Approval Overlay Blind Keystroke Bypass + CLI Thread-Local Callback Invisible to Agent

Discovered while replicating #13618 (TUI approval overlay freezes terminal).

### Bug 1: TUI — Blind Keystroke Approval (Security)

**Severity: High** — dangerous commands can execute without informed user consent.

When the Ink TUI displays an approval overlay (dangerous command detected), the overlay appears visually frozen — arrow keys, number keys, and Enter produce no visible feedback. However, Ink's `EventEmitter` delivers keystrokes to **all** registered `useInput` listeners, not just the first. The `ApprovalPrompt` component still receives and processes keystrokes even though `useInputHandlers` has already consumed the event.

This means a user pressing keys during the frozen state can:
- **Press `1`** → silently approve the command once
- **Press `2`** → approve ALL dangerous commands for the rest of the session (`approve_session()`)
- **Press `3`** → write to the permanent allowlist on disk (`approve_permanent()` + `save_permanent_allowlist()`)
- **Press `4`** → deny (the only safe option)

The user sees a frozen overlay and has no idea their keystrokes are being processed. Subsequent dangerous commands in the same session (or permanently, if `always` was selected) execute without any approval prompt.

**Root cause:** `useInputHandlers` (app-level) registers on the same `inputEmitter` as `ApprovalPrompt` (component-level). Ink fires ALL listeners. The `return` in `useInputHandlers` only exits that handler — it does not stop propagation.

**Fix:** In `useInputHandlers`, when `overlay.approval || overlay.clarify || overlay.confirm` is active, only intercept `Ctrl+C` (for deny/dismiss). All other keystrokes pass through so the overlay renders visual feedback and the user can make an informed selection.

**Note:** This fix makes the overlay responsive but does not change the EventEmitter fan-out behavior. A deeper hardening would be to consolidate overlay input handling into a single handler with explicit routing, but that is a larger refactor.

### Bug 2: CLI — Thread-Local Callback Invisible to Agent Thread

**Severity: Medium** — approval prompt appears but cannot be interacted with, terminal unusable for 60s.

In the legacy CLI (prompt_toolkit), `_callback_tls` in `tools/terminal_tool.py` is `threading.local()`. `set_approval_callback()` is called in the **main thread** during `run()` initialization (cli.py:~9046), but the agent runs in a **background thread** (`threading.Thread(target=run_agent)`). The agent thread calls `_get_approval_callback()` → returns `None` (different thread-local slot) → falls back to `prompt_dangerous_approval()` with `stdin` `input()` → prompt_toolkit owns the terminal → user sees the approval text but cannot respond. Terminal is unusable until 60s timeout expires with default "deny".

**Fix:** Set callbacks inside `run_agent()` (the thread target function), matching the pattern already used by `acp_adapter/server.py` for ACP sessions. Clear callbacks to `None` in a `finally` block on thread exit to prevent stale references.

### Files Changed

- `ui-tui/src/app/useInputHandlers.ts` — skip keystroke consumption for approval/clarify/confirm overlays
- `cli.py` — set terminal_tool callbacks inside agent thread, clear on exit

### Testing

- All 8 existing approval UI tests pass (`tests/cli/test_cli_approval_ui.py`)
- TUI TypeScript compiles clean (`tsc --noEmit`)
- Manual verification: Ink EventEmitter fires all registered listeners regardless of early return

Closes #13618