### PR TITLE
Prefer fallback for Gemini CloudCode rate limits

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5158,6 +5158,21 @@ class AIAgent:
 
         return False, has_retried_429
 
+    def _credential_pool_may_recover_rate_limit(self) -> bool:
+        """Whether a rate-limit retry should wait for same-provider credentials."""
+        pool = self._credential_pool
+        if pool is None:
+            return False
+        if (
+            self.provider == "google-gemini-cli"
+            or str(getattr(self, "base_url", "")).startswith("cloudcode-pa://")
+        ):
+            # CloudCode/Gemini quota windows are usually account-level throttles.
+            # Prefer the configured fallback immediately instead of waiting out
+            # Retry-After while a pooled OAuth credential may still appear usable.
+            return False
+        return pool.has_available()
+
     def _anthropic_messages_create(self, api_kwargs: dict):
         if self.api_mode == "anthropic_messages":
             self._try_refresh_anthropic_client_credentials()
@@ -10378,8 +10393,7 @@ class AIAgent:
                         # still recover.  The pool's retry-then-rotate cycle needs
                         # at least one more attempt to fire — jumping to a fallback
                         # provider here short-circuits it.
-                        pool = self._credential_pool
-                        pool_may_recover = pool is not None and pool.has_available()
+                        pool_may_recover = self._credential_pool_may_recover_rate_limit()
                         if not pool_may_recover:
                             self._emit_status("⚠️ Rate limited — switching to fallback provider...")
                             if self._try_activate_fallback():

--- a/tests/agent/test_gemini_fast_fallback.py
+++ b/tests/agent/test_gemini_fast_fallback.py
@@ -1,0 +1,32 @@
+from run_agent import AIAgent
+
+
+class AvailablePool:
+    def has_available(self):
+        return True
+
+
+def make_agent(provider: str, base_url: str):
+    agent = object.__new__(AIAgent)
+    agent.provider = provider
+    agent.base_url = base_url
+    agent._credential_pool = AvailablePool()
+    return agent
+
+
+def test_cloudcode_gemini_rate_limit_prefers_fallback_over_pool():
+    agent = make_agent("google-gemini-cli", "cloudcode-pa://google")
+
+    assert agent._credential_pool_may_recover_rate_limit() is False
+
+
+def test_cloudcode_base_url_prefers_fallback_even_with_alias_provider():
+    agent = make_agent("custom-provider", "cloudcode-pa://google")
+
+    assert agent._credential_pool_may_recover_rate_limit() is False
+
+
+def test_non_cloudcode_provider_can_recover_with_available_pool():
+    agent = make_agent("openrouter", "https://openrouter.ai/api/v1")
+
+    assert agent._credential_pool_may_recover_rate_limit() is True


### PR DESCRIPTION
## Summary
- keep same-provider credential-pool recovery for most providers
- prefer configured fallback immediately for google-gemini-cli / cloudcode-pa rate limits
- add focused regression tests for the CloudCode fallback decision

## Testing
- /Users/justinkausel/Documents/GitHub/hermes-agent/.venv/bin/python -m pytest -o addopts='' tests/agent/test_gemini_fast_fallback.py -q
- /Users/justinkausel/Documents/GitHub/hermes-agent/.venv/bin/python -m py_compile run_agent.py
- VPS: /root/src/hermes-agent/venv/bin/python -m py_compile run_agent.py
- VPS: timeout 120 /root/src/hermes-agent/venv/bin/hermes chat -Q -q 'Reply exactly: GEMINI_DRIVER_OK'