### PR TITLE
fix: include plugin-registered tools in built-in toolsets

### DIFF
--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -32,6 +32,21 @@ class TestGetToolset:
         assert ts is not None
         assert "web_search" in ts["tools"]
 
+    def test_merges_registry_tools_into_builtin_toolset(self, monkeypatch):
+        reg = ToolRegistry()
+        reg.register(
+            name="web_search_plus",
+            toolset="web",
+            schema=_make_schema("web_search_plus", "Plugin web search"),
+            handler=_dummy_handler,
+        )
+
+        monkeypatch.setattr("tools.registry.registry", reg)
+
+        ts = get_toolset("web")
+        assert ts is not None
+        assert set(ts["tools"]) == {"web_search", "web_extract", "web_search_plus"}
+
     def test_unknown_returns_none(self):
         assert get_toolset("nonexistent") is None
 

--- a/toolsets.py
+++ b/toolsets.py
@@ -428,13 +428,18 @@ def get_toolset(name: str) -> Optional[Dict[str, Any]]:
         None: If toolset not found
     """
     toolset = TOOLSETS.get(name)
-    if toolset:
-        return toolset
 
     try:
         from tools.registry import registry
     except Exception:
-        return None
+        return toolset if toolset else None
+
+    if toolset:
+        merged_tools = sorted(
+            set(toolset.get("tools", []))
+            | set(registry.get_tool_names_for_toolset(name))
+        )
+        return {**toolset, "tools": merged_tools}
 
     registry_toolset = name
     description = f"Plugin toolset: {name}"


### PR DESCRIPTION
## Summary
- merge registry tools into statically defined toolsets in `get_toolset()`
- preserve current behavior for registry-only/plugin-owned toolsets
- add a regression test covering a plugin tool registered into the built-in `web` toolset

## Problem
Built-in toolsets like `web` are defined statically in `toolsets.py`. When a plugin registers an additional tool into one of those existing toolsets, `get_toolset()` returned the static definition immediately and never consulted the registry. As a result, plugin tools could register successfully but still be omitted from the resolved tool surface.

## Repro
1. Register a plugin tool with `toolset="web"`
2. Call `get_toolset("web")`
3. Observe that only the built-in tools are returned

## Fix
When `get_toolset()` resolves a built-in toolset, merge its static tools with any registry tools for the same toolset before returning.

## Test Plan
- `source venv/bin/activate && pytest tests/test_toolsets.py::TestGetToolset::test_merges_registry_tools_into_builtin_toolset -v`
- `source venv/bin/activate && pytest tests/test_toolsets.py -q`
