### PR TITLE
fix(cli): suppress minisweagent transcript noise

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1041,6 +1041,7 @@ class AIAgent:
                     'trajectory_compressor',
                     'cron',                 # scheduler (only relevant in daemon mode)
                     'hermes_cli',           # CLI helpers
+                    'minisweagent',        # external sandbox startup logs can leak into TUI transcript
                 ]:
                     logging.getLogger(quiet_logger).setLevel(logging.ERROR)
         

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -142,6 +142,40 @@ def test_aiagent_reuses_existing_errors_log_handler():
             root_logger.addHandler(handler)
 
 
+def test_aiagent_quiet_mode_suppresses_minisweagent_logger():
+    """Quiet mode should suppress third-party sandbox logs in the interactive CLI."""
+    minisweagent_logger = logging.getLogger("minisweagent")
+    tools_logger = logging.getLogger("tools")
+    prev_minisweagent_level = minisweagent_logger.level
+    prev_tools_level = tools_logger.level
+
+    try:
+        minisweagent_logger.setLevel(logging.NOTSET)
+        tools_logger.setLevel(logging.NOTSET)
+
+        with (
+            patch(
+                "run_agent.get_tool_definitions",
+                return_value=_make_tool_defs("web_search"),
+            ),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            AIAgent(
+                api_key="test-k...7890",
+                base_url="https://openrouter.ai/api/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+        assert logging.getLogger("tools").level == logging.ERROR
+        assert logging.getLogger("minisweagent").level == logging.ERROR
+    finally:
+        minisweagent_logger.setLevel(prev_minisweagent_level)
+        tools_logger.setLevel(prev_tools_level)
+
+
 class TestProviderModelNormalization:
     def test_aiagent_strips_matching_native_provider_prefix(self):
         with (


### PR DESCRIPTION
Fixes #1865

## Summary
- add the external `minisweagent` logger to quiet-mode suppression in `run_agent.py`
- keep Docker/minisweagent startup logs out of the normal TUI transcript
- add a regression test covering the quiet-mode logger configuration

## Why
Quiet mode was already suppressing internal infrastructure loggers, but not the external `minisweagent` namespace. When Docker-backed sandboxes start up, those INFO/DEBUG messages can leak directly into the chat transcript and make normal interactive use noisy.

## Verification
- `pytest -o addopts='' tests/run_agent/test_run_agent.py -k "minisweagent_logger or reuses_existing_errors_log_handler"`