### PR TITLE
fix: wire and harden plugin CLI command registration

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7661,26 +7661,7 @@ Examples:
     plugins_parser.set_defaults(func=cmd_plugins)
 
     # =========================================================================
-    # Plugin CLI commands — dynamically registered by memory/general plugins.
-    # Plugins provide a register_cli(subparser) function that builds their
-    # own argparse tree.  No hardcoded plugin commands in main.py.
-    # =========================================================================
-    try:
-        from plugins.memory import discover_plugin_cli_commands
-
-        for cmd_info in discover_plugin_cli_commands():
-            plugin_parser = subparsers.add_parser(
-                cmd_info["name"],
-                help=cmd_info["help"],
-                description=cmd_info.get("description", ""),
-                formatter_class=__import__("argparse").RawDescriptionHelpFormatter,
-            )
-            cmd_info["setup_fn"](plugin_parser)
-    except Exception as _exc:
-        logging.getLogger(__name__).debug("Plugin CLI discovery failed: %s", _exc)
-
-    # =========================================================================
-    # memory command
+    # Built-in memory command
     # =========================================================================
     memory_parser = subparsers.add_parser(
         "memory",
@@ -8556,6 +8537,44 @@ Examples:
         # Unreachable: os.execvp never returns on success (process is replaced)
         # and raises OSError on failure (which propagates as a traceback).
         sys.exit(1)
+
+    # Dynamic plugin CLI commands.
+    # - General plugins register via ctx.register_cli_command(...).
+    # - Memory provider plugins still use discover_plugin_cli_commands().
+    # This runs after built-in subparsers are defined so we can safely detect
+    # and skip command-name collisions with built-ins.
+    def _add_dynamic_plugin_cli_command(cmd_info):
+        name = str((cmd_info or {}).get("name") or "").strip()
+        if not name:
+            logging.getLogger(__name__).warning("Skipping plugin CLI command with empty name")
+            return
+        if name in getattr(subparsers, "choices", {}):
+            logging.getLogger(__name__).warning(
+                "Skipping plugin CLI command '%s' because a built-in or previously registered command already uses that name.",
+                name,
+            )
+            return
+        plugin_parser = subparsers.add_parser(
+            name,
+            help=cmd_info["help"],
+            description=cmd_info.get("description", ""),
+            formatter_class=__import__("argparse").RawDescriptionHelpFormatter,
+        )
+        cmd_info["setup_fn"](plugin_parser)
+        if cmd_info.get("handler_fn") is not None and "func" not in getattr(plugin_parser, "_defaults", {}):
+            plugin_parser.set_defaults(func=cmd_info["handler_fn"])
+
+    try:
+        from hermes_cli.plugins import get_plugin_cli_commands
+        from plugins.memory import discover_plugin_cli_commands
+
+        for cmd_info in get_plugin_cli_commands().values():
+            _add_dynamic_plugin_cli_command(cmd_info)
+
+        for cmd_info in discover_plugin_cli_commands():
+            _add_dynamic_plugin_cli_command(cmd_info)
+    except Exception as _exc:
+        logging.getLogger(__name__).debug("Plugin CLI discovery failed: %s", _exc)
 
     _processed_argv = _coalesce_session_name_args(sys.argv[1:])
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -246,15 +246,31 @@ class PluginContext:
         The *setup_fn* receives an argparse subparser and should add any
         arguments/sub-subparsers.  If *handler_fn* is provided it is set
         as the default dispatch function via ``set_defaults(func=...)``."""
-        self._manager._cli_commands[name] = {
-            "name": name,
+        clean = name.lower().strip().lstrip("/").replace(" ", "-")
+        if not clean:
+            logger.warning(
+                "Plugin '%s' tried to register a CLI command with an empty name.",
+                self.manifest.name,
+            )
+            return
+        if clean in self._manager._cli_commands:
+            existing = self._manager._cli_commands[clean]
+            logger.warning(
+                "Plugin '%s' tried to register CLI command '%s' which is already registered by plugin '%s'. Skipping.",
+                self.manifest.name,
+                clean,
+                existing.get("plugin"),
+            )
+            return
+        self._manager._cli_commands[clean] = {
+            "name": clean,
             "help": help,
             "description": description,
             "setup_fn": setup_fn,
             "handler_fn": handler_fn,
             "plugin": self.manifest.name,
         }
-        logger.debug("Plugin %s registered CLI command: %s", self.manifest.name, name)
+        logger.debug("Plugin %s registered CLI command: %s", self.manifest.name, clean)
 
     # -- slash command registration -------------------------------------------
 
@@ -899,6 +915,15 @@ def get_plugin_commands() -> Dict[str, dict]:
     before any explicit discover_plugins() call.
     """
     return _ensure_plugins_discovered()._plugin_commands
+
+
+def get_plugin_cli_commands() -> Dict[str, dict]:
+    """Return plugin-registered terminal CLI commands.
+
+    Triggers idempotent plugin discovery so argparse setup can include
+    general plugin commands without requiring a separate manual discovery pass.
+    """
+    return _ensure_plugins_discovered()._cli_commands
 
 
 def get_plugin_toolsets() -> List[tuple]:

--- a/tests/hermes_cli/test_plugin_cli_registration.py
+++ b/tests/hermes_cli/test_plugin_cli_registration.py
@@ -51,16 +51,126 @@ class TestRegisterCliCommand:
         assert entry["handler_fn"] is handler
         assert entry["plugin"] == "test-plugin"
 
-    def test_overwrites_on_duplicate(self):
+    def test_normalizes_name(self):
         ctx, mgr = self._make_ctx()
-        ctx.register_cli_command("x", "first", MagicMock())
-        ctx.register_cli_command("x", "second", MagicMock())
-        assert mgr._cli_commands["x"]["help"] == "second"
+        ctx.register_cli_command(" /My Cmd ", "Do something", MagicMock())
+        assert "my-cmd" in mgr._cli_commands
+        assert "/My Cmd " not in mgr._cli_commands
+
+    def test_empty_name_rejected(self, caplog):
+        ctx, mgr = self._make_ctx()
+        with caplog.at_level("WARNING", logger="hermes_cli.plugins"):
+            ctx.register_cli_command(" / ", "Do something", MagicMock())
+        assert mgr._cli_commands == {}
+        assert "empty name" in caplog.text
+
+    def test_duplicate_rejected_preserves_first(self, caplog):
+        ctx, mgr = self._make_ctx()
+        first = MagicMock()
+        second = MagicMock()
+        ctx.register_cli_command("x", "first", first)
+        with caplog.at_level("WARNING", logger="hermes_cli.plugins"):
+            ctx.register_cli_command("x", "second", second)
+        assert mgr._cli_commands["x"]["help"] == "first"
+        assert mgr._cli_commands["x"]["setup_fn"] is first
+        assert "already registered" in caplog.text.lower()
 
     def test_handler_optional(self):
         ctx, mgr = self._make_ctx()
         ctx.register_cli_command("nocb", "test", MagicMock())
         assert mgr._cli_commands["nocb"]["handler_fn"] is None
+
+
+class TestGeneralPluginCliDiscovery:
+    def test_get_plugin_cli_commands_discovers_plugins_lazily(self):
+        import hermes_cli.plugins as plugins_mod
+
+        mgr = PluginManager()
+        manifest = PluginManifest(name="test-plugin", source="user")
+        ctx = PluginContext(manifest, mgr)
+        setup = MagicMock()
+        handler = MagicMock()
+        ctx.register_cli_command(
+            name="mycmd",
+            help="Do something",
+            setup_fn=setup,
+            handler_fn=handler,
+            description="Full description",
+        )
+
+        original = getattr(plugins_mod, "_plugin_manager", None)
+        plugins_mod._plugin_manager = mgr
+        try:
+            cmds = plugins_mod.get_plugin_cli_commands()
+        finally:
+            plugins_mod._plugin_manager = original
+
+        assert "mycmd" in cmds
+        entry = cmds["mycmd"]
+        assert entry["setup_fn"] is setup
+        assert entry["handler_fn"] is handler
+        assert entry["plugin"] == "test-plugin"
+
+    def test_main_registers_general_plugin_cli_commands(self, monkeypatch):
+        import hermes_cli.main as main_mod
+
+        received = {}
+
+        def setup_fn(subparser):
+            subparser.add_argument("--value", required=True)
+
+        def handler_fn(args):
+            received["value"] = args.value
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.get_plugin_cli_commands",
+            lambda: {
+                "plugcmd": {
+                    "name": "plugcmd",
+                    "help": "Plugin command",
+                    "description": "Plugin command description",
+                    "setup_fn": setup_fn,
+                    "handler_fn": handler_fn,
+                    "plugin": "test-plugin",
+                }
+            },
+            raising=False,
+        )
+        monkeypatch.setattr("plugins.memory.discover_plugin_cli_commands", lambda: [], raising=False)
+        monkeypatch.setattr(sys, "argv", ["hermes", "plugcmd", "--value", "ok"])
+
+        main_mod.main()
+
+        assert received == {"value": "ok"}
+
+    def test_main_skips_builtin_name_collision(self, monkeypatch):
+        import hermes_cli.main as main_mod
+
+        handler = MagicMock()
+
+        def setup_fn(subparser):
+            subparser.add_argument("--value")
+
+        monkeypatch.setattr(
+            "hermes_cli.plugins.get_plugin_cli_commands",
+            lambda: {
+                "version": {
+                    "name": "version",
+                    "help": "Plugin command",
+                    "description": "Plugin command description",
+                    "setup_fn": setup_fn,
+                    "handler_fn": handler,
+                    "plugin": "test-plugin",
+                }
+            },
+            raising=False,
+        )
+        monkeypatch.setattr("plugins.memory.discover_plugin_cli_commands", lambda: [], raising=False)
+        monkeypatch.setattr(sys, "argv", ["hermes", "version"])
+
+        main_mod.main()
+
+        handler.assert_not_called()
 
 
 # ── Memory plugin CLI discovery ───────────────────────────────────────────


### PR DESCRIPTION
## Summary
- wire general plugin CLI commands into argparse via lazy plugin discovery
- harden plugin CLI registration with name normalization and duplicate/collision checks
- add regression coverage for lazy discovery, argparse wiring, and collision handling

## Testing
- python -m pytest tests/hermes_cli/test_plugins.py tests/hermes_cli/test_plugin_cli_registration.py -q
- python -m py_compile hermes_cli/plugins.py hermes_cli/main.py tests/hermes_cli/test_plugin_cli_registration.py