### PR TITLE
fix: stabilize cleanup and config patch points

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -27,6 +27,7 @@ def build_write_denied_paths(home: str) -> set[str]:
             os.path.join(home, ".ssh", "id_ed25519"),
             os.path.join(home, ".ssh", "config"),
             str(hermes_home / ".env"),
+            os.path.join(home, ".hermes", ".env"),
             os.path.join(home, ".bashrc"),
             os.path.join(home, ".zshrc"),
             os.path.join(home, ".profile"),

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -33,6 +33,14 @@ from hermes_constants import OPENROUTER_MODELS_URL
 from utils import base_url_host_matches
 
 
+def _which(command: str) -> str | None:
+    """Return an executable path, tolerating platform monkeypatches in tests."""
+    try:
+        return shutil.which(command)
+    except AttributeError:
+        return None
+
+
 _PROVIDER_ENV_HINTS = (
     "OPENROUTER_API_KEY",
     "OPENAI_API_KEY",
@@ -490,7 +498,7 @@ def run_doctor(args):
     except Exception as e:
         check_warn("Auth provider status", f"(could not check: {e})")
 
-    if shutil.which("codex"):
+    if _which("codex"):
         check_ok("codex CLI")
     else:
         check_warn("codex CLI not found", "(required for openai-codex login)")
@@ -701,13 +709,13 @@ def run_doctor(args):
     print(color("◆ External Tools", Colors.CYAN, Colors.BOLD))
     
     # Git
-    if shutil.which("git"):
+    if _which("git"):
         check_ok("git")
     else:
         check_warn("git not found", "(optional)")
     
     # ripgrep (optional, for faster file search)
-    if shutil.which("rg"):
+    if _which("rg"):
         check_ok("ripgrep (rg)", "(faster file search)")
     else:
         check_warn("ripgrep (rg) not found", "(file search uses grep fallback)")
@@ -716,7 +724,7 @@ def run_doctor(args):
     # Docker (optional)
     terminal_env = os.getenv("TERMINAL_ENV", "local")
     if terminal_env == "docker":
-        if shutil.which("docker"):
+        if _which("docker"):
             # Check if docker daemon is running
             try:
                 result = subprocess.run(["docker", "info"], capture_output=True, timeout=10)
@@ -731,7 +739,7 @@ def run_doctor(args):
             check_fail("docker not found", "(required for TERMINAL_ENV=docker)")
             issues.append("Install Docker or change TERMINAL_ENV")
     else:
-        if shutil.which("docker"):
+        if _which("docker"):
             check_ok("docker", "(optional)")
         else:
             if _is_termux():
@@ -778,7 +786,7 @@ def run_doctor(args):
             issues.append("Install daytona SDK: pip install daytona")
 
     # Node.js + agent-browser (for browser automation tools)
-    if shutil.which("node"):
+    if _which("node"):
         check_ok("Node.js")
         # Check if agent-browser is installed
         agent_browser_path = PROJECT_ROOT / "node_modules" / "agent-browser"
@@ -804,7 +812,7 @@ def run_doctor(args):
             check_warn("Node.js not found", "(optional, needed for browser tools)")
     
     # npm audit for all Node.js packages
-    if shutil.which("npm"):
+    if _which("npm"):
         npm_dirs = [
             (PROJECT_ROOT, "Browser tools (agent-browser)"),
             (PROJECT_ROOT / "scripts" / "whatsapp-bridge", "WhatsApp bridge"),

--- a/run_agent.py
+++ b/run_agent.py
@@ -3876,13 +3876,15 @@ class AIAgent:
 
         # 2. Clean terminal sandbox environments
         try:
-            cleanup_vm(task_id)
+            from tools import terminal_tool
+            terminal_tool.cleanup_vm(task_id)
         except Exception:
             pass
 
         # 3. Clean browser daemon sessions
         try:
-            cleanup_browser(task_id)
+            from tools import browser_tool
+            browser_tool.cleanup_browser(task_id)
         except Exception:
             pass
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -201,7 +201,10 @@ class TestIdempotencyCache:
 
 
 class TestAdapterInit:
-    def test_default_config(self):
+    def test_default_config(self, monkeypatch):
+        monkeypatch.delenv("API_SERVER_PORT", raising=False)
+        monkeypatch.delenv("API_SERVER_HOST", raising=False)
+        monkeypatch.delenv("API_SERVER_KEY", raising=False)
         config = PlatformConfig(enabled=True)
         adapter = APIServerAdapter(config)
         assert adapter._host == "127.0.0.1"

--- a/tests/hermes_cli/test_provider_config_validation.py
+++ b/tests/hermes_cli/test_provider_config_validation.py
@@ -86,7 +86,7 @@ class TestNormalizeCustomProviderEntry:
             "unknownField": "value",
             "anotherBad": 42,
         }
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.config"):
             result = _normalize_custom_provider_entry(entry, provider_key="test")
         assert result is not None
         assert any("unknown config keys" in r.message.lower() for r in caplog.records)
@@ -97,7 +97,7 @@ class TestNormalizeCustomProviderEntry:
             "baseUrl": "https://api.example.com/v1",
             "apiKey": "sk-test-key",
         }
-        with caplog.at_level(logging.WARNING):
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.config"):
             result = _normalize_custom_provider_entry(entry, provider_key="test")
         assert result is not None
         camel_warnings = [r for r in caplog.records if "camelcase" in r.message.lower() or "auto-mapped" in r.message.lower()]

--- a/tests/tools/test_local_interrupt_cleanup.py
+++ b/tests/tools/test_local_interrupt_cleanup.py
@@ -41,6 +41,7 @@ def test_wait_for_process_kills_subprocess_on_keyboardinterrupt():
     """When KeyboardInterrupt arrives mid-poll, the subprocess group must be
     killed before the exception is re-raised."""
     env = LocalEnvironment(cwd="/tmp")
+    marker = f"hermes_interrupt_cleanup_{os.getpid()}_{int(time.monotonic() * 1000)}"
     try:
         result_holder = {}
         proc_holder = {}
@@ -54,7 +55,7 @@ def test_wait_for_process_kills_subprocess_on_keyboardinterrupt():
             # to observe the cleanup, via env.execute(...) — the normal path
             # that goes through _wait_for_process.
             try:
-                result_holder["result"] = env.execute("sleep 30", timeout=60)
+                result_holder["result"] = env.execute(f"exec -a {marker} sleep 30", timeout=60)
             except BaseException as e:  # noqa: BLE001 — we want to observe it
                 result_holder["exception"] = type(e).__name__
 
@@ -67,12 +68,12 @@ def test_wait_for_process_kills_subprocess_on_keyboardinterrupt():
         deadline = time.monotonic() + 5.0
         target_pid = None
         while time.monotonic() < deadline:
-            # Walk our children and grand-children to find one running 'sleep 30'
+            # Walk our children and grand-children to find this test's sleep.
             try:
                 import psutil  # optional — fall back if absent
                 for p in psutil.Process(os.getpid()).children(recursive=True):
                     try:
-                        if "sleep 30" in " ".join(p.cmdline()):
+                        if marker in " ".join(p.cmdline()):
                             target_pid = p.pid
                             break
                     except (psutil.NoSuchProcess, psutil.AccessDenied):
@@ -83,7 +84,7 @@ def test_wait_for_process_kills_subprocess_on_keyboardinterrupt():
                     ["ps", "-eo", "pid,ppid,pgid,cmd"], capture_output=True, text=True,
                 )
                 for line in ps.stdout.splitlines():
-                    if "sleep 30" in line and "grep" not in line:
+                    if marker in line and "grep" not in line:
                         parts = line.split()
                         if parts and parts[0].isdigit():
                             target_pid = int(parts[0])

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -32,7 +32,7 @@ from typing import Any, Dict, Optional
 
 import requests
 
-from hermes_cli.config import load_config
+import hermes_cli.config as hermes_config
 from tools.browser_camofox_state import get_camofox_identity
 from tools.registry import tool_error
 
@@ -46,6 +46,11 @@ _DEFAULT_TIMEOUT = 30  # seconds per HTTP request
 _SNAPSHOT_MAX_CHARS = 80_000  # camofox paginates at this limit
 _vnc_url: Optional[str] = None  # cached from /health response
 _vnc_url_checked = False  # only probe once per process
+
+
+def load_config() -> Dict[str, Any]:
+    """Load Hermes config through the module so tests can patch either path."""
+    return hermes_config.load_config()
 
 
 def get_camofox_url() -> str:
@@ -598,6 +603,4 @@ def camofox_console(clear: bool = False, task_id: Optional[str] = None) -> str:
         "note": "Console log capture is not available with the Camofox backend. "
                 "Use browser_snapshot or browser_vision to inspect page state.",
     })
-
-
 

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -733,10 +733,19 @@ class BaseEnvironment(ABC):
         # Use login shell if snapshot failed (so user's profile still loads)
         login = not self._snapshot_ready
 
-        proc = self._run_bash(
-            wrapped, login=login, timeout=effective_timeout, stdin_data=effective_stdin
-        )
-        result = self._wait_for_process(proc, timeout=effective_timeout)
+        proc: ProcessHandle | None = None
+        try:
+            proc = self._run_bash(
+                wrapped, login=login, timeout=effective_timeout, stdin_data=effective_stdin
+            )
+            result = self._wait_for_process(proc, timeout=effective_timeout)
+        except (KeyboardInterrupt, SystemExit):
+            if proc is not None:
+                try:
+                    self._kill_process(proc)
+                except Exception:
+                    pass
+            raise
         self._update_cwd(result)
 
         return result
@@ -760,4 +769,3 @@ class BaseEnvironment(ABC):
         from tools.terminal_tool import _transform_sudo_command
 
         return _transform_sudo_command(command)
-

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -339,22 +339,28 @@ class LocalEnvironment(BaseEnvironment):
         args = [bash, "-l", "-c", cmd_string] if login else [bash, "-c", cmd_string]
         run_env = _make_run_env(self.env)
 
-        proc = subprocess.Popen(
-            args,
-            text=True,
-            env=run_env,
-            encoding="utf-8",
-            errors="replace",
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
-            preexec_fn=None if _IS_WINDOWS else os.setsid,
-        )
+        proc = None
+        try:
+            proc = subprocess.Popen(
+                args,
+                text=True,
+                env=run_env,
+                encoding="utf-8",
+                errors="replace",
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
+                preexec_fn=None if _IS_WINDOWS else os.setsid,
+            )
 
-        if stdin_data is not None:
-            _pipe_stdin(proc, stdin_data)
+            if stdin_data is not None:
+                _pipe_stdin(proc, stdin_data)
 
-        return proc
+            return proc
+        except (KeyboardInterrupt, SystemExit):
+            if proc is not None:
+                self._kill_process(proc)
+            raise
 
     def _kill_process(self, proc):
         """Kill the entire process group (all children)."""


### PR DESCRIPTION
## Summary

Stabilizes several tests and patch points that were failing in the full suite:

- keep hard agent cleanup patchable through the terminal/browser modules
- keep Camofox config loading patchable via both the module alias and hermes_cli.config
- deny writes to the default ~/.hermes/.env even when HERMES_HOME is test-isolated
- make provider warning capture robust after quiet-mode logger level changes
- avoid shutil.which failures under Windows platform simulation in doctor tests
- isolate API server default-port tests from ambient API_SERVER_* env vars
- close the interrupt window between local process spawn and wait registration
- make local interrupt cleanup tests target their own marked sleep process

## Verification

- scripts/run_tests.sh tests/gateway/test_agent_cache.py tests/tools/test_browser_camofox.py tests/tools/test_browser_camofox_persistence.py tests/tools/test_zombie_process_cleanup.py tests/hermes_cli/test_provider_config_validation.py tests/tools/test_write_deny.py tests/hermes_cli/test_doctor_command_install.py::TestDoctorCommandInstallation::test_windows_skips_check tests/gateway/test_api_server.py::TestAdapterInit::test_default_config tests/tools/test_local_interrupt_cleanup.py::test_wait_for_process_kills_subprocess_on_keyboardinterrupt
- scripts/run_tests.sh