### PR TITLE
fix(openrouter): use canonical X-Title; allow env-var override

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -154,10 +154,16 @@ _PROVIDER_VISION_MODELS: Dict[str, str] = {
     "zai": "glm-5v-turbo",
 }
 
-# OpenRouter app attribution headers
+# OpenRouter app attribution headers. Env-var overridable so downstream
+# packagers can set per-deployment attribution without forking; fallbacks
+# match the historical Nous defaults so behavior is unchanged when unset.
+# `X-Title` is the canonical attribution header OpenRouter's dashboard
+# reads; the previous `X-OpenRouter-Title` label was not recognized there.
 _OR_HEADERS = {
-    "HTTP-Referer": "https://hermes-agent.nousresearch.com",
-    "X-OpenRouter-Title": "Hermes Agent",
+    "HTTP-Referer": os.environ.get(
+        "HERMES_OPENROUTER_REFERER", "https://hermes-agent.nousresearch.com"
+    ),
+    "X-Title": os.environ.get("HERMES_OPENROUTER_TITLE", "Hermes Agent"),
     "X-OpenRouter-Categories": "productivity,cli-agent",
 }
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -1164,11 +1164,9 @@ class AIAgent:
                     client_kwargs["args"] = self.acp_args
                 effective_base = base_url
                 if base_url_host_matches(effective_base, "openrouter.ai"):
-                    client_kwargs["default_headers"] = {
-                        "HTTP-Referer": "https://hermes-agent.nousresearch.com",
-                        "X-OpenRouter-Title": "Hermes Agent",
-                        "X-OpenRouter-Categories": "productivity,cli-agent",
-                    }
+                    from agent.auxiliary_client import _OR_HEADERS
+
+                    client_kwargs["default_headers"] = dict(_OR_HEADERS)
                 elif base_url_host_matches(effective_base, "api.githubcopilot.com"):
                     from hermes_cli.models import copilot_default_headers
 

--- a/tests/run_agent/test_provider_attribution_headers.py
+++ b/tests/run_agent/test_provider_attribution_headers.py
@@ -24,7 +24,46 @@ def test_openrouter_base_url_applies_or_headers(mock_openai):
 
     headers = agent._client_kwargs["default_headers"]
     assert headers["HTTP-Referer"] == "https://hermes-agent.nousresearch.com"
-    assert headers["X-OpenRouter-Title"] == "Hermes Agent"
+    assert headers["X-Title"] == "Hermes Agent"
+
+
+@patch("run_agent.OpenAI")
+@patch.dict(
+    "os.environ",
+    {
+        "HERMES_OPENROUTER_TITLE": "DownstreamApp",
+        "HERMES_OPENROUTER_REFERER": "https://downstream.example/app",
+    },
+    clear=False,
+)
+def test_openrouter_attribution_headers_respect_env_vars(mock_openai):
+    # _OR_HEADERS is module-scoped and captures env vars at import time,
+    # so we reload the module under the patched environment to prove the
+    # override plumbing works end-to-end.
+    import importlib
+
+    import agent.auxiliary_client as ac
+
+    importlib.reload(ac)
+
+    mock_openai.return_value = MagicMock()
+    agent_inst = AIAgent(
+        api_key="test-key",
+        base_url="https://openrouter.ai/api/v1",
+        model="test/model",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent_inst._apply_client_headers_for_base_url("https://openrouter.ai/api/v1")
+
+    headers = agent_inst._client_kwargs["default_headers"]
+    assert headers["HTTP-Referer"] == "https://downstream.example/app"
+    assert headers["X-Title"] == "DownstreamApp"
+
+    # Restore the module to avoid leaking the patched _OR_HEADERS into
+    # unrelated tests running in the same process.
+    importlib.reload(ac)
 
 
 @patch("run_agent.OpenAI")


### PR DESCRIPTION
## What does this PR do?

Two fixes to OpenRouter attribution headers:

1. **Rename `X-OpenRouter-Title` → `X-Title`.** OpenRouter's dashboard attributes usage via the canonical `X-Title` header; `X-OpenRouter-Title` is not recognized, so OpenRouter usage currently shows up unlabeled regardless of the value. The sibling `_AI_GATEWAY_HEADERS` dict in `agent/auxiliary_client.py` already uses `X-Title`, so this aligns the two.

2. **Allow per-deployment attribution via env vars** — `HERMES_OPENROUTER_TITLE` and `HERMES_OPENROUTER_REFERER`. Motivation: downstream packagers running many hermes agents on a single OpenRouter key (think: one workspace, multiple bots) need per-agent dashboard attribution without forking. Defaults preserve the historical Nous values, so stock users see no change.

Also drops the inline duplicate of the OpenRouter header literal in `run_agent.py::AIAgent.__init__` and routes it through `_OR_HEADERS` so the two sites stay in sync.

## Related Issue

None — surfaced while integrating hermes into a multi-agent deployment.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/auxiliary_client.py`: `_OR_HEADERS` reads `HERMES_OPENROUTER_REFERER` / `HERMES_OPENROUTER_TITLE` from env with Nous defaults; rename `X-OpenRouter-Title` → `X-Title`.
- `run_agent.py`: drop inline literal in `AIAgent.__init__`'s OpenRouter branch; import `_OR_HEADERS` instead.
- `tests/run_agent/test_provider_attribution_headers.py`: flip existing `X-OpenRouter-Title` assertion to `X-Title`; add a test that proves env-var override plumbing end-to-end.

## How to Test

1. `pytest tests/run_agent/test_provider_attribution_headers.py -v` — all three tests pass.
2. With env vars unset: `_OR_HEADERS["X-Title"] == "Hermes Agent"` (default preserved).
3. With `HERMES_OPENROUTER_TITLE=my-app HERMES_OPENROUTER_REFERER=https://example.com` set before interpreter start: `_OR_HEADERS["X-Title"] == "my-app"`, `_OR_HEADERS["HTTP-Referer"] == "https://example.com"`.
4. Verify in OpenRouter dashboard → Activity that requests carry the configured `X-Title` once deployed against a real key.

## Checklist

- [x] Existing behavior preserved when env vars unset
- [x] Tests updated + new coverage for env-var path
- [x] No breaking API surface (headers dict shape unchanged apart from key rename)