### PR TITLE
fix(cli): honor config terminal settings in /config

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4344,11 +4344,19 @@ class HermesCLI:
 
     def show_config(self):
         """Display current configuration with kawaii ASCII art."""
-        # Get terminal config from environment (which was set from cli-config.yaml)
-        terminal_env = os.getenv("TERMINAL_ENV", "local")
-        terminal_cwd = os.getenv("TERMINAL_CWD", os.getcwd())
-        terminal_timeout = os.getenv("TERMINAL_TIMEOUT", "60")
-        
+        # config.yaml is the source of truth for terminal settings. Environment
+        # variables are only a fallback for legacy/default-only setups.
+        terminal_cfg = self.config.get("terminal", {}) if isinstance(self.config, dict) else {}
+        terminal_env = (
+            terminal_cfg.get("backend")
+            or terminal_cfg.get("env_type")
+            or os.getenv("TERMINAL_ENV", "local")
+        )
+        terminal_cwd = terminal_cfg.get("cwd") or os.getenv("TERMINAL_CWD", os.getcwd())
+        terminal_timeout = terminal_cfg.get("timeout")
+        if terminal_timeout in (None, ""):
+            terminal_timeout = os.getenv("TERMINAL_TIMEOUT", "60")
+
         user_config_path = _hermes_home / 'config.yaml'
         project_config_path = Path(__file__).parent / 'cli-config.yaml'
         if user_config_path.exists():

--- a/tests/cli/test_cli_show_config.py
+++ b/tests/cli/test_cli_show_config.py
@@ -1,0 +1,74 @@
+"""Tests for CLI /config display using config.yaml terminal settings."""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def _make_cli(env_overrides=None, config_overrides=None, **kwargs):
+    """Create a HermesCLI instance with minimal mocking."""
+    import importlib
+
+    _clean_config = {
+        "model": {
+            "default": "anthropic/claude-opus-4.6",
+            "base_url": "https://openrouter.ai/api/v1",
+            "provider": "auto",
+        },
+        "display": {"compact": False, "tool_progress": "all"},
+        "agent": {},
+        "terminal": {"env_type": "local", "cwd": "/from/config", "timeout": 60},
+    }
+    if config_overrides:
+        _clean_config.update(config_overrides)
+    clean_env = {"LLM_MODEL": "", "HERMES_MAX_ITERATIONS": ""}
+    if env_overrides:
+        clean_env.update(env_overrides)
+    prompt_toolkit_stubs = {
+        "prompt_toolkit": MagicMock(),
+        "prompt_toolkit.history": MagicMock(),
+        "prompt_toolkit.styles": MagicMock(),
+        "prompt_toolkit.patch_stdout": MagicMock(),
+        "prompt_toolkit.application": MagicMock(),
+        "prompt_toolkit.layout": MagicMock(),
+        "prompt_toolkit.layout.processors": MagicMock(),
+        "prompt_toolkit.filters": MagicMock(),
+        "prompt_toolkit.layout.dimension": MagicMock(),
+        "prompt_toolkit.layout.menus": MagicMock(),
+        "prompt_toolkit.widgets": MagicMock(),
+        "prompt_toolkit.key_binding": MagicMock(),
+        "prompt_toolkit.completion": MagicMock(),
+        "prompt_toolkit.formatted_text": MagicMock(),
+        "prompt_toolkit.auto_suggest": MagicMock(),
+    }
+    with patch.dict(sys.modules, prompt_toolkit_stubs), \
+         patch.dict("os.environ", clean_env, clear=False):
+        import cli as _cli_mod
+        _cli_mod = importlib.reload(_cli_mod)
+        with patch.object(_cli_mod, "get_tool_definitions", return_value=[]), \
+             patch.dict(_cli_mod.__dict__, {"CLI_CONFIG": _clean_config}):
+            return _cli_mod.HermesCLI(**kwargs)
+
+
+def test_show_config_uses_terminal_settings_from_config(capsys):
+    cli = _make_cli(
+        env_overrides={
+            "TERMINAL_ENV": "docker",
+            "TERMINAL_CWD": "/from/env",
+            "TERMINAL_TIMEOUT": "999",
+        },
+        config_overrides={
+            "terminal": {"backend": "local", "env_type": "local", "cwd": "/from/config", "timeout": 60},
+        },
+    )
+
+    cli.show_config()
+    output = capsys.readouterr().out
+
+    assert "Environment:  local" in output
+    assert "Working Dir:  /from/config" in output
+    assert "Timeout:      60s" in output
+    assert "Environment:  docker" not in output


### PR DESCRIPTION
## Summary
- Fixes #12485
- make `/config` read terminal backend/cwd/timeout from the loaded CLI config before falling back to legacy env vars
- add a regression test covering stale `TERMINAL_*` env vars with a conflicting `config.yaml`

## Problem
Hermes documents `config.yaml` as the source of truth for terminal settings, but `HermesCLI.show_config()` still displayed `TERMINAL_ENV`, `TERMINAL_CWD`, and `TERMINAL_TIMEOUT` directly from the environment. When those legacy env vars were stale, `/config` could claim the terminal backend was `docker` even though the active CLI config had `terminal.backend: local`.

## Fix
Use the loaded CLI terminal config first (`backend` / `env_type`, `cwd`, `timeout`) and only fall back to env vars when the config does not define a value.

## Testing
- `pytest -o addopts= tests/cli/test_cli_show_config.py`
- `pytest -o addopts= tests/hermes_cli/test_placeholder_usage.py`
