### PR TITLE
fix: force-clean stale PID file on gateway startup

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10970,6 +10970,31 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # cleanly before touching any external service.
     import atexit
     from gateway.status import write_pid_file, remove_pid_file, get_running_pid
+
+    # ── Stale PID force-cleanup ──────────────────────────────────────
+    # Pre-startup defense: if a PID file exists but the process is dead,
+    # clean it up BEFORE the duplicate-instance guard runs.  This covers
+    # the edge case where the previous gateway crashed hard (SIGKILL,
+    # OOM-kill) and atexit never fired.
+    _pid_path = get_hermes_home() / "gateway.pid"
+    if _pid_path.exists():
+        try:
+            _raw = _pid_path.read_text().strip()
+            _record = json.loads(_raw) if _raw.startswith("{") else {"pid": int(_raw)}
+        except (json.JSONDecodeError, ValueError):
+            _record = None
+        if _record and "pid" in _record:
+            _old_pid = _record["pid"]
+            _alive = False
+            try:
+                os.kill(_old_pid, 0)  # signal 0 = existence check
+                _alive = True
+            except (ProcessLookupError, PermissionError):
+                pass
+            if not _alive:
+                logger.info("Stale PID file (PID %d not running) — force-cleaning.", _old_pid)
+                _pid_path.unlink(missing_ok=True)
+
     _current_pid = get_running_pid()
     if _current_pid is not None and _current_pid != os.getpid():
         logger.error(


### PR DESCRIPTION
## Problem

When the gateway crashes hard (SIGKILL, OOM-kill, segfault), the atexit handler never fires, leaving a stale `gateway.pid` file. On restart, the duplicate-instance guard can fail to detect the dead process under certain race conditions, preventing the gateway from starting and requiring manual intervention to delete the PID file.

## Solution

Add a pre-startup force-cleanup block in `gateway/run.py` that runs BEFORE the existing `get_running_pid()` duplicate-instance guard:

1. Reads the PID file
2. Checks if the recorded PID is actually alive via `os.kill(pid, 0)`
3. If dead → force-deletes the stale PID file with a log message
4. Then the normal duplicate-instance guard continues

This catches the most common crash scenario: previous gateway dies hard, PID file stays, next startup cleans it up automatically.

## Testing

- Verified that the existing `get_running_pid()` handles PID reuse (start_time mismatch) and cmdline validation
- The new block covers the simpler "process is dead but PID file remains" case that users hit in practice
- `json`, `os`, `logger`, and `get_hermes_home` are all already in scope
