### PR TITLE
[codex] Standardize Hermes dotenv loading to shared env helper

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -11,6 +11,7 @@ import shutil
 from pathlib import Path
 
 from hermes_cli.config import get_project_root, get_hermes_home, get_env_path
+from hermes_cli.env_loader import load_hermes_dotenv
 from hermes_constants import display_hermes_home
 
 PROJECT_ROOT = get_project_root()
@@ -18,15 +19,8 @@ HERMES_HOME = get_hermes_home()
 _DHH = display_hermes_home()  # user-facing display path (e.g. ~/.hermes or ~/.hermes/profiles/coder)
 
 # Load environment variables from ~/.hermes/.env so API key checks work
-from dotenv import load_dotenv
 _env_path = get_env_path()
-if _env_path.exists():
-    try:
-        load_dotenv(_env_path, encoding="utf-8")
-    except UnicodeDecodeError:
-        load_dotenv(_env_path, encoding="latin-1")
-# Also try project .env as dev fallback
-load_dotenv(PROJECT_ROOT / ".env", override=False, encoding="utf-8")
+load_hermes_dotenv(hermes_home=_env_path.parent, project_env=PROJECT_ROOT / ".env")
 
 from hermes_cli.colors import Colors, color
 from hermes_constants import OPENROUTER_MODELS_URL

--- a/hermes_cli/dump.py
+++ b/hermes_cli/dump.py
@@ -14,6 +14,7 @@ import sys
 from pathlib import Path
 
 from hermes_cli.config import get_hermes_home, get_env_path, get_project_root, load_config
+from hermes_cli.env_loader import load_hermes_dotenv
 from hermes_constants import display_hermes_home
 
 
@@ -193,15 +194,11 @@ def run_dump(args):
     show_keys = getattr(args, "show_keys", False)
 
     # Load env from .env file so key checks work
-    from dotenv import load_dotenv
     env_path = get_env_path()
-    if env_path.exists():
-        try:
-            load_dotenv(env_path, encoding="utf-8")
-        except UnicodeDecodeError:
-            load_dotenv(env_path, encoding="latin-1")
-    # Also try project .env as dev fallback
-    load_dotenv(get_project_root() / ".env", override=False, encoding="utf-8")
+    load_hermes_dotenv(
+        hermes_home=env_path.parent,
+        project_env=get_project_root() / ".env",
+    )
 
     project_root = get_project_root()
     hermes_home = get_hermes_home()

--- a/scripts/discord-voice-doctor.py
+++ b/scripts/discord-voice-doctor.py
@@ -176,9 +176,12 @@ def check_env_vars():
 
     # Load .env
     try:
-        from dotenv import load_dotenv
-        if ENV_FILE.exists():
-            load_dotenv(ENV_FILE)
+        from hermes_cli.env_loader import load_hermes_dotenv
+
+        load_hermes_dotenv(
+            hermes_home=ENV_FILE.parent,
+            project_env=PROJECT_ROOT / ".env",
+        )
     except ImportError:
         pass
 


### PR DESCRIPTION
## Summary
This change standardizes Hermes dotenv loading by replacing three remaining ad hoc `dotenv.load_dotenv` call sites with the shared `hermes_cli.env_loader.load_hermes_dotenv` helper.

The affected call sites are:
- `hermes_cli/doctor.py`
- `hermes_cli/dump.py`
- `scripts/discord-voice-doctor.py`

This keeps dotenv precedence logic in one place and removes duplicated fallback handling from those entry points.

## Why
Before this patch, these files each implemented their own local `.env` loading behavior while the repo already had a shared loader with the intended Hermes-home and project `.env` semantics. That duplication made the behavior harder to keep aligned.

## Validation
- `python3 -m py_compile /Users/blucid/.hermes/hermes-agent/hermes_cli/doctor.py /Users/blucid/.hermes/hermes-agent/hermes_cli/dump.py /Users/blucid/.hermes/hermes-agent/scripts/discord-voice-doctor.py`
- `git diff -- hermes_cli/doctor.py hermes_cli/dump.py scripts/discord-voice-doctor.py`
- `rg -n "load_dotenv|load_hermes_dotenv" hermes_cli/doctor.py hermes_cli/dump.py scripts/discord-voice-doctor.py`

Related Linear issue: RGGB-22
