### PR TITLE
fix(tui): /skills browse no longer blocks the whole gateway

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -40,13 +40,22 @@ _SLASH_WORKER_TIMEOUT_S = max(5.0, float(os.environ.get("HERMES_TUI_SLASH_TIMEOU
 # ── Async RPC dispatch (#12546) ──────────────────────────────────────
 # A handful of handlers block the dispatcher loop in entry.py for seconds
 # to minutes (slash.exec, cli.exec, shell.exec, session.resume,
-# session.branch). While they're running, inbound RPCs — notably
-# approval.respond and session.interrupt — sit unread in the stdin pipe.
-# We route only those slow handlers onto a small thread pool; everything
-# else stays on the main thread so ordering stays sane for the fast path.
-# write_json is already _stdout_lock-guarded, so concurrent response
-# writes are safe.
-_LONG_HANDLERS = frozenset({"cli.exec", "session.branch", "session.resume", "shell.exec", "slash.exec"})
+# session.branch, skills.manage).  While they're running, inbound RPCs —
+# notably approval.respond and session.interrupt — sit unread in the
+# stdin pipe.  We route only those slow handlers onto a small thread pool;
+# everything else stays on the main thread so ordering stays sane for the
+# fast path.  write_json is already _stdout_lock-guarded, so concurrent
+# response writes are safe.
+_LONG_HANDLERS = frozenset(
+    {
+        "cli.exec",
+        "session.branch",
+        "session.resume",
+        "shell.exec",
+        "skills.manage",
+        "slash.exec",
+    }
+)
 
 _pool = concurrent.futures.ThreadPoolExecutor(
     max_workers=max(2, int(os.environ.get("HERMES_TUI_RPC_POOL_WORKERS", "4") or 4)),


### PR DESCRIPTION
From TUI v2 retest: *"when /skills browse happens i cant do anything. /skills browse blocks everything else."*

## Root cause

\`skills.manage\` action=\`browse\` / \`search\` / \`install\` calls \`hermes_cli.skills_hub\` which fetches 6 remote sources and can take ~15s. The handler ran on the main RPC dispatcher thread in \`tui_gateway/server.py\`, so while the network calls were in flight every other inbound RPC — completions, new slash commands, \`approval.respond\`, \`session.interrupt\` — sat queued in stdin.  The TUI looked frozen.

The gateway already has a thread pool (\`_pool\`) for exactly this pattern, gated by the \`_LONG_HANDLERS\` set (covering \`slash.exec\`, \`shell.exec\`, \`session.resume\`, \`session.branch\`, \`cli.exec\`).

## Fix

Add \`skills.manage\` to \`_LONG_HANDLERS\`. One-line set extension.

The fast actions (\`list\`, \`inspect\`) pay a negligible thread-pool hop; the slow ones stop blocking the main loop.

## Test plan

- [x] \`uv run pytest tests/test_tui_gateway_server.py\` — 47/47 pass
- [ ] Manual: \`/skills browse\` → during the 15s fetch, type \`/tools list\` or hit Tab for completions — expect immediate response, no frozen UI
- [ ] Manual: \`/skills browse\` followed by \`Ctrl+C\` — still cancellable via approval/session mechanics