### PR TITLE
fix(telegram): preserve voice notes and recover from missing thread/reply targets

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -15,6 +15,7 @@ import re
 import socket as _socket
 import subprocess
 import sys
+import tempfile
 import uuid
 from abc import ABC, abstractmethod
 from urllib.parse import urlsplit
@@ -1894,8 +1895,15 @@ class BasePlatformAdapter(ABC):
                             speech_text = re.sub(r'[*_`#\[\]()]', '', text_content)[:4000].strip()
                             if not speech_text:
                                 raise ValueError("Empty text after markdown cleanup")
+                            tts_kwargs = {"text": speech_text}
+                            if event.source.platform == Platform.TELEGRAM:
+                                telegram_tts_dir = Path(tempfile.gettempdir()) / "hermes_voice"
+                                telegram_tts_dir.mkdir(parents=True, exist_ok=True)
+                                tts_kwargs["output_path"] = str(
+                                    telegram_tts_dir / f"tts_{datetime.now().strftime('%Y%m%d_%H%M%S')}.ogg"
+                                )
                             tts_result_str = await asyncio.to_thread(
-                                text_to_speech_tool, text=speech_text
+                                text_to_speech_tool, **tts_kwargs
                             )
                             tts_data = _json.loads(tts_result_str)
                             _tts_path = tts_data.get("file_path")

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1711,33 +1711,99 @@ class TelegramAdapter(BasePlatformAdapter):
         """Send audio as a native Telegram voice message or audio file."""
         if not self._bot:
             return SendResult(success=False, error="Not connected")
-        
+
         try:
             import os
             if not os.path.exists(audio_path):
                 return SendResult(success=False, error=self._missing_media_path_error("Audio", audio_path))
-            
-            with open(audio_path, "rb") as audio_file:
-                # .ogg files -> send as voice (round playable bubble)
-                if audio_path.endswith((".ogg", ".opus")):
-                    _voice_thread = self._metadata_thread_id(metadata)
-                    msg = await self._bot.send_voice(
-                        chat_id=int(chat_id),
-                        voice=audio_file,
-                        caption=caption[:1024] if caption else None,
-                        reply_to_message_id=int(reply_to) if reply_to else None,
-                        message_thread_id=self._message_thread_id_for_send(_voice_thread),
-                    )
-                else:
-                    # .mp3 and others -> send as audio file
-                    _audio_thread = self._metadata_thread_id(metadata)
-                    msg = await self._bot.send_audio(
-                        chat_id=int(chat_id),
-                        audio=audio_file,
-                        caption=caption[:1024] if caption else None,
-                        reply_to_message_id=int(reply_to) if reply_to else None,
-                        message_thread_id=self._message_thread_id_for_send(_audio_thread),
-                    )
+
+            try:
+                from telegram.error import NetworkError as _NetErr
+            except ImportError:
+                _NetErr = OSError  # type: ignore[misc,assignment]
+
+            try:
+                from telegram.error import BadRequest as _BadReq
+            except ImportError:
+                _BadReq = None  # type: ignore[assignment,misc]
+
+            try:
+                from telegram.error import TimedOut as _TimedOut
+            except (ImportError, AttributeError):
+                _TimedOut = None  # type: ignore[assignment,misc]
+
+            send_as_voice = audio_path.endswith((".ogg", ".opus"))
+            thread_id = self._metadata_thread_id(metadata)
+            effective_thread_id = self._message_thread_id_for_send(thread_id)
+            reply_to_id = int(reply_to) if reply_to else None
+
+            msg = None
+            for _send_attempt in range(3):
+                try:
+                    with open(audio_path, "rb") as audio_file:
+                        send_kwargs = {
+                            "chat_id": int(chat_id),
+                            "caption": caption[:1024] if caption else None,
+                            "reply_to_message_id": reply_to_id,
+                            "message_thread_id": effective_thread_id,
+                        }
+                        if send_as_voice:
+                            send_kwargs["voice"] = audio_file
+                            msg = await self._bot.send_voice(**send_kwargs)
+                        else:
+                            send_kwargs["audio"] = audio_file
+                            msg = await self._bot.send_audio(**send_kwargs)
+                    break
+                except _NetErr as send_err:
+                    if _BadReq and isinstance(send_err, _BadReq):
+                        if self._is_thread_not_found_error(send_err) and effective_thread_id is not None:
+                            logger.warning(
+                                "[%s] Thread %s not found during voice/audio send, retrying without message_thread_id",
+                                self.name,
+                                effective_thread_id,
+                            )
+                            effective_thread_id = None
+                            continue
+                        err_lower = str(send_err).lower()
+                        if "message to be replied not found" in err_lower and reply_to_id is not None:
+                            logger.warning(
+                                "[%s] Voice/audio reply target deleted, retrying without reply_to: %s",
+                                self.name,
+                                send_err,
+                            )
+                            reply_to_id = None
+                            continue
+                        raise
+                    if _TimedOut and isinstance(send_err, _TimedOut):
+                        raise
+                    if _send_attempt < 2:
+                        wait = 2 ** _send_attempt
+                        logger.warning(
+                            "[%s] Network error on voice/audio send (attempt %d/3), retrying in %ds: %s",
+                            self.name,
+                            _send_attempt + 1,
+                            wait,
+                            send_err,
+                        )
+                        await asyncio.sleep(wait)
+                        continue
+                    raise
+                except Exception as send_err:
+                    retry_after = getattr(send_err, "retry_after", None)
+                    if retry_after is not None or "retry after" in str(send_err).lower():
+                        if _send_attempt < 2:
+                            wait = float(retry_after) if retry_after is not None else 1.0
+                            logger.warning(
+                                "[%s] Telegram flood control on voice/audio send (attempt %d/3), retrying in %.1fs: %s",
+                                self.name,
+                                _send_attempt + 1,
+                                wait,
+                                send_err,
+                            )
+                            await asyncio.sleep(wait)
+                            continue
+                    raise
+
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
             logger.error(
@@ -1746,7 +1812,13 @@ class TelegramAdapter(BasePlatformAdapter):
                 e,
                 exc_info=True,
             )
-            return await super().send_voice(chat_id, audio_path, caption, reply_to)
+            return await super().send_voice(
+                chat_id=chat_id,
+                audio_path=audio_path,
+                caption=caption,
+                reply_to=reply_to,
+                metadata=metadata,
+            )
     
     async def send_image_file(
         self,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6158,17 +6158,26 @@ class GatewayRunner:
         audio_path = None
         actual_path = None
         try:
-            from tools.tts_tool import text_to_speech_tool, _strip_markdown_for_tts
+            from tools.tts_tool import (
+                text_to_speech_tool,
+                _strip_markdown_for_tts,
+                _load_tts_config,
+                _get_provider,
+            )
 
             tts_text = _strip_markdown_for_tts(text[:4000])
             if not tts_text:
                 return
 
-            # Use .mp3 extension so edge-tts conversion to opus works correctly.
-            # The TTS tool may convert to .ogg — use file_path from result.
+            provider = _get_provider(_load_tts_config())
+            prefers_native_ogg = (
+                event.source.platform.value == "telegram"
+                and provider in {"elevenlabs", "openai", "mistral", "gemini"}
+            )
+            requested_ext = ".ogg" if prefers_native_ogg else ".mp3"
             audio_path = os.path.join(
                 tempfile.gettempdir(), "hermes_voice",
-                f"tts_reply_{_uuid.uuid4().hex[:12]}.mp3",
+                f"tts_reply_{_uuid.uuid4().hex[:12]}{requested_ext}",
             )
             os.makedirs(os.path.dirname(audio_path), exist_ok=True)
 

--- a/tests/gateway/test_telegram_auto_tts_path.py
+++ b/tests/gateway/test_telegram_auto_tts_path.py
@@ -1,0 +1,63 @@
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType
+from gateway.session import SessionSource, build_session_key
+
+
+class _StubAdapter(BasePlatformAdapter):
+    async def connect(self):
+        pass
+
+    async def disconnect(self):
+        pass
+
+    async def send(self, chat_id, content=None, text=None, **kwargs):
+        return None
+
+    async def get_chat_info(self, chat_id):
+        return {}
+
+
+@pytest.mark.asyncio
+async def test_telegram_voice_input_auto_tts_requests_ogg_output(tmp_path, monkeypatch):
+    adapter = _StubAdapter(PlatformConfig(enabled=True, token="t"), Platform.TELEGRAM)
+    adapter._keep_typing = AsyncMock(return_value=None)
+    adapter._run_processing_hook = AsyncMock(return_value=None)
+    adapter._send_with_retry = AsyncMock(return_value=None)
+    adapter.play_tts = AsyncMock(return_value=None)
+    adapter._message_handler = AsyncMock(return_value="Hello from Hermes")
+
+    captured = {}
+    output_file = tmp_path / "reply.ogg"
+    output_file.write_bytes(b"ogg-bytes")
+
+    def fake_tts_tool(*, text, output_path=None):
+        captured["text"] = text
+        captured["output_path"] = output_path
+        return json.dumps({"success": True, "file_path": str(output_file)})
+
+    monkeypatch.setattr("tools.tts_tool.text_to_speech_tool", fake_tts_tool)
+    monkeypatch.setattr("tools.tts_tool.check_tts_requirements", lambda: True)
+
+    event = MessageEvent(
+        text="",
+        message_type=MessageType.VOICE,
+        source=SessionSource(platform=Platform.TELEGRAM, chat_id="42", chat_type="dm"),
+    )
+    event.message_id = "msg42"
+    session_key = build_session_key(event.source)
+
+    await adapter._process_message_background(event, session_key)
+
+    assert captured["output_path"] is not None
+    assert captured["output_path"].endswith(".ogg")
+    adapter.play_tts.assert_awaited_once()
+    played_path = adapter.play_tts.await_args.kwargs["audio_path"]
+    assert played_path.endswith(".ogg")
+    assert adapter._send_with_retry.await_count == 1

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -355,3 +355,85 @@ async def test_send_retries_retry_after_errors():
     assert result.success is True
     assert result.message_id == "300"
     assert attempt[0] == 2
+
+
+@pytest.mark.asyncio
+async def test_send_voice_retries_without_thread_on_thread_not_found(tmp_path):
+    """Voice sends should retry without thread_id when Telegram rejects the topic."""
+    adapter = _make_adapter()
+    audio_path = tmp_path / "reply.ogg"
+    audio_path.write_bytes(b"ogg-bytes")
+
+    call_log = []
+
+    async def mock_send_voice(**kwargs):
+        call_log.append(dict(kwargs))
+        tid = kwargs.get("message_thread_id")
+        if tid is not None:
+            raise FakeBadRequest("Message thread not found")
+        return SimpleNamespace(message_id=401)
+
+    adapter._bot = SimpleNamespace(send_voice=mock_send_voice, send_audio=None)
+
+    result = await adapter.send_voice(
+        chat_id="123",
+        audio_path=str(audio_path),
+        metadata={"thread_id": "99999"},
+    )
+
+    assert result.success is True
+    assert result.message_id == "401"
+    assert len(call_log) == 2
+    assert call_log[0]["message_thread_id"] == 99999
+    assert call_log[1]["message_thread_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_send_voice_retries_without_reply_target_when_missing(tmp_path):
+    """Voice sends should recover when the replied-to Telegram message vanished."""
+    adapter = _make_adapter()
+    audio_path = tmp_path / "reply.ogg"
+    audio_path.write_bytes(b"ogg-bytes")
+
+    call_log = []
+
+    async def mock_send_voice(**kwargs):
+        call_log.append(dict(kwargs))
+        reply_to = kwargs.get("reply_to_message_id")
+        if reply_to is not None:
+            raise FakeBadRequest("Message to be replied not found")
+        return SimpleNamespace(message_id=402)
+
+    adapter._bot = SimpleNamespace(send_voice=mock_send_voice, send_audio=None)
+
+    result = await adapter.send_voice(
+        chat_id="123",
+        audio_path=str(audio_path),
+        reply_to="50",
+    )
+
+    assert result.success is True
+    assert result.message_id == "402"
+    assert len(call_log) == 2
+    assert call_log[0]["reply_to_message_id"] == 50
+    assert call_log[1]["reply_to_message_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_send_voice_mp3_uses_send_audio(tmp_path):
+    """Non-OGG audio should go through Telegram send_audio, not send_voice."""
+    adapter = _make_adapter()
+    audio_path = tmp_path / "reply.mp3"
+    audio_path.write_bytes(b"mp3-bytes")
+
+    send_voice = pytest.fail
+
+    async def mock_send_audio(**kwargs):
+        return SimpleNamespace(message_id=403)
+
+    adapter._bot = SimpleNamespace(send_voice=send_voice, send_audio=mock_send_audio)
+
+    result = await adapter.send_voice(chat_id="123", audio_path=str(audio_path))
+
+    assert result.success is True
+    assert result.message_id == "403"

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -387,6 +387,31 @@ class TestSendVoiceReply:
         assert call_args.kwargs.get("chat_id") == "123"
 
     @pytest.mark.asyncio
+    async def test_telegram_elevenlabs_requests_ogg_tempfile(self, runner):
+        mock_adapter = AsyncMock()
+        mock_adapter.send_voice = AsyncMock()
+        event = _make_event()
+        runner.adapters[event.source.platform] = mock_adapter
+
+        captured = {}
+
+        def _fake_tts(*, text, output_path):
+            captured["text"] = text
+            captured["output_path"] = output_path
+            return json.dumps({"success": True, "file_path": output_path})
+
+        with patch("tools.tts_tool.text_to_speech_tool", side_effect=_fake_tts), \
+             patch("tools.tts_tool._strip_markdown_for_tts", side_effect=lambda t: t), \
+             patch("tools.tts_tool._load_tts_config", return_value={"provider": "elevenlabs"}), \
+             patch("os.path.isfile", return_value=True), \
+             patch("os.unlink"), \
+             patch("os.makedirs"):
+            await runner._send_voice_reply(event, "Hello world")
+
+        assert captured["output_path"].endswith(".ogg")
+        mock_adapter.send_voice.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_empty_text_after_strip_skips(self, runner):
         event = _make_event()
 

--- a/tests/tools/test_tool_backend_helpers.py
+++ b/tests/tools/test_tool_backend_helpers.py
@@ -22,6 +22,7 @@ from tools.tool_backend_helpers import (
     managed_nous_tools_enabled,
     normalize_browser_cloud_provider,
     normalize_modal_mode,
+    resolve_elevenlabs_api_key,
     resolve_modal_backend_state,
     resolve_openai_audio_api_key,
 )
@@ -280,6 +281,37 @@ class TestResolveModalBackendState:
         result = self._resolve(monkeypatch, "bogus", has_direct=True, managed_ready=False)
         assert result["requested_mode"] == "auto"
         assert result["mode"] == "auto"
+
+
+# ---------------------------------------------------------------------------
+# resolve_elevenlabs_api_key
+# ---------------------------------------------------------------------------
+class TestResolveElevenlabsApiKey:
+    """Priority: env var first, then macOS Keychain fallback."""
+
+    def test_env_key_preferred(self, monkeypatch):
+        monkeypatch.setenv("ELEVENLABS_API_KEY", "env-key")
+        monkeypatch.setattr(
+            "tools.tool_backend_helpers._read_macos_keychain_generic_password",
+            lambda service: "keychain-key",
+        )
+        assert resolve_elevenlabs_api_key() == "env-key"
+
+    def test_keychain_fallback_used(self, monkeypatch):
+        monkeypatch.delenv("ELEVENLABS_API_KEY", raising=False)
+        monkeypatch.setattr(
+            "tools.tool_backend_helpers._read_macos_keychain_generic_password",
+            lambda service: "keychain-key" if service == "openclaw/elevenlabs-api-key" else "",
+        )
+        assert resolve_elevenlabs_api_key() == "keychain-key"
+
+    def test_no_key_returns_empty(self, monkeypatch):
+        monkeypatch.delenv("ELEVENLABS_API_KEY", raising=False)
+        monkeypatch.setattr(
+            "tools.tool_backend_helpers._read_macos_keychain_generic_password",
+            lambda service: "",
+        )
+        assert resolve_elevenlabs_api_key() == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_tts_speed.py
+++ b/tests/tools/test_tts_speed.py
@@ -8,7 +8,13 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def clean_env(monkeypatch):
-    for key in ("OPENAI_API_KEY", "MINIMAX_API_KEY", "HERMES_SESSION_PLATFORM"):
+    for key in (
+        "OPENAI_API_KEY",
+        "MINIMAX_API_KEY",
+        "HERMES_SESSION_PLATFORM",
+        "HERMES_SESSION_KEY",
+        "ELEVENLABS_API_KEY",
+    ):
         monkeypatch.delenv(key, raising=False)
 
 
@@ -57,6 +63,103 @@ class TestEdgeTtsSpeed:
         comm_cls = self._run({"speed": 1.0}, tmp_path)
         kwargs = comm_cls.call_args[1]
         assert "rate" not in kwargs
+
+
+# ---------------------------------------------------------------------------
+# ElevenLabs credential resolution
+# ---------------------------------------------------------------------------
+
+class TestElevenLabsCredentials:
+    def test_generate_elevenlabs_uses_resolved_api_key(self, tmp_path):
+        chunks = [b"abc", b"def"]
+        mock_client = MagicMock()
+        mock_client.text_to_speech.convert.return_value = chunks
+        mock_cls = MagicMock(return_value=mock_client)
+
+        with patch("tools.tts_tool._import_elevenlabs", return_value=mock_cls), \
+             patch("tools.tts_tool.resolve_elevenlabs_api_key", return_value="resolved-key"):
+            from tools.tts_tool import _generate_elevenlabs
+
+            out = tmp_path / "out.ogg"
+            result = _generate_elevenlabs("Hello", str(out), {"elevenlabs": {}})
+
+        assert result == str(out)
+        assert out.read_bytes() == b"abcdef"
+        assert mock_cls.call_args.kwargs["api_key"] == "resolved-key"
+
+    def test_check_requirements_accepts_keychain_fallback(self):
+        with patch("tools.tts_tool._import_edge_tts", side_effect=ImportError), \
+             patch("tools.tts_tool._import_elevenlabs", return_value=MagicMock()), \
+             patch("tools.tts_tool.resolve_elevenlabs_api_key", return_value="resolved-key"):
+            from tools.tts_tool import check_tts_requirements
+
+            assert check_tts_requirements() is True
+
+
+class TestSessionPlatformDetection:
+    def test_prefers_explicit_session_platform(self, monkeypatch):
+        from tools.tts_tool import _get_session_platform
+
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+        monkeypatch.setenv("HERMES_SESSION_KEY", "agent:main:discord:dm:123")
+
+        assert _get_session_platform() == "telegram"
+
+    def test_falls_back_to_session_key_platform(self, monkeypatch):
+        from tools.tts_tool import _get_session_platform
+
+        monkeypatch.setenv("HERMES_SESSION_KEY", "agent:main:telegram:dm:12345")
+
+        assert _get_session_platform() == "telegram"
+
+    def test_telegram_session_key_defaults_elevenlabs_to_ogg(self, tmp_path, monkeypatch):
+        import json
+
+        from tools.tts_tool import text_to_speech_tool
+
+        monkeypatch.setenv("HERMES_SESSION_KEY", "agent:main:telegram:dm:12345")
+
+        chunks = [b"abc", b"def"]
+        mock_client = MagicMock()
+        mock_client.text_to_speech.convert.return_value = chunks
+        mock_cls = MagicMock(return_value=mock_client)
+
+        with patch("tools.tts_tool._load_tts_config", return_value={"provider": "elevenlabs"}), \
+             patch("tools.tts_tool._import_elevenlabs", return_value=mock_cls), \
+             patch("tools.tts_tool.resolve_elevenlabs_api_key", return_value="resolved-key"):
+            result = json.loads(text_to_speech_tool("Hello from Telegram", output_path=None))
+
+        assert result["success"] is True
+        assert result["provider"] == "elevenlabs"
+        assert result["file_path"].endswith(".ogg")
+        assert result["voice_compatible"] is True
+        assert "[[audio_as_voice]]" in result["media_tag"]
+
+    def test_telegram_custom_mp3_path_is_coerced_to_ogg_for_voice_delivery(self, tmp_path, monkeypatch):
+        import json
+
+        from tools.tts_tool import text_to_speech_tool
+
+        monkeypatch.setenv("HERMES_SESSION_KEY", "agent:main:telegram:dm:12345")
+
+        chunks = [b"abc", b"def"]
+        mock_client = MagicMock()
+        mock_client.text_to_speech.convert.return_value = chunks
+        mock_cls = MagicMock(return_value=mock_client)
+
+        requested = tmp_path / "voice-note-test.mp3"
+
+        with patch("tools.tts_tool._load_tts_config", return_value={"provider": "elevenlabs"}), \
+             patch("tools.tts_tool._import_elevenlabs", return_value=mock_cls), \
+             patch("tools.tts_tool.resolve_elevenlabs_api_key", return_value="resolved-key"):
+            result = json.loads(text_to_speech_tool("Hello from Telegram", output_path=str(requested)))
+
+        assert result["success"] is True
+        assert result["provider"] == "elevenlabs"
+        assert result["file_path"].endswith("voice-note-test.ogg")
+        assert result["voice_compatible"] is True
+        assert "[[audio_as_voice]]" in result["media_tag"]
+        assert not requested.exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tools/tool_backend_helpers.py
+++ b/tools/tool_backend_helpers.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import os
+import platform
+import subprocess
 from pathlib import Path
 from typing import Any, Dict
 
@@ -10,6 +12,33 @@ from typing import Any, Dict
 _DEFAULT_BROWSER_PROVIDER = "local"
 _DEFAULT_MODAL_MODE = "auto"
 _VALID_MODAL_MODES = {"auto", "direct", "managed"}
+_ELEVENLABS_KEYCHAIN_SERVICES = (
+    "openclaw/elevenlabs-api-key",
+    "elevenlabs-api-key",
+    "ELEVENLABS_API_KEY",
+    "elevenlabs",
+)
+
+
+def _read_macos_keychain_generic_password(service: str) -> str:
+    """Return a generic-password secret from macOS Keychain, or "" if missing."""
+    if platform.system() != "Darwin" or not service:
+        return ""
+
+    try:
+        result = subprocess.run(
+            ["security", "find-generic-password", "-s", service, "-w"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+    except Exception:
+        return ""
+
+    if result.returncode != 0:
+        return ""
+    return (result.stdout or "").strip()
 
 
 def managed_nous_tools_enabled() -> bool:
@@ -104,6 +133,19 @@ def resolve_openai_audio_api_key() -> str:
         os.getenv("VOICE_TOOLS_OPENAI_KEY", "")
         or os.getenv("OPENAI_API_KEY", "")
     ).strip()
+
+
+def resolve_elevenlabs_api_key() -> str:
+    """Return ElevenLabs API key from env or macOS Keychain fallback."""
+    direct = os.getenv("ELEVENLABS_API_KEY", "").strip()
+    if direct:
+        return direct
+
+    for service in _ELEVENLABS_KEYCHAIN_SERVICES:
+        secret = _read_macos_keychain_generic_password(service)
+        if secret:
+            return secret
+    return ""
 
 
 def prefers_gateway(config_section: str) -> bool:

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -45,7 +45,12 @@ from hermes_constants import display_hermes_home
 
 logger = logging.getLogger(__name__)
 from tools.managed_tool_gateway import resolve_managed_tool_gateway
-from tools.tool_backend_helpers import managed_nous_tools_enabled, prefers_gateway, resolve_openai_audio_api_key
+from tools.tool_backend_helpers import (
+    managed_nous_tools_enabled,
+    prefers_gateway,
+    resolve_elevenlabs_api_key,
+    resolve_openai_audio_api_key,
+)
 from tools.xai_http import hermes_xai_user_agent
 
 # ---------------------------------------------------------------------------
@@ -143,6 +148,31 @@ def _get_provider(tts_config: Dict[str, Any]) -> str:
     return (tts_config.get("provider") or DEFAULT_PROVIDER).lower().strip()
 
 
+def _get_session_platform() -> str:
+    """Best-effort platform detection for tool-side delivery decisions.
+
+    Primary source is the gateway session context var/env mirror
+    ``HERMES_SESSION_PLATFORM``. Some gateway entrypoints only expose the
+    session key (for example ``agent:main:telegram:dm:12345``), so fall back to
+    parsing ``HERMES_SESSION_KEY`` when the explicit platform value is absent.
+    """
+    from gateway.session_context import get_session_env
+
+    platform = get_session_env("HERMES_SESSION_PLATFORM", "").strip().lower()
+    if platform:
+        return platform
+
+    session_key = get_session_env("HERMES_SESSION_KEY", "").strip()
+    if session_key:
+        parts = session_key.split(":")
+        if len(parts) >= 3 and parts[0] == "agent":
+            candidate = parts[2].strip().lower()
+            if candidate:
+                return candidate
+
+    return ""
+
+
 # ===========================================================================
 # ffmpeg Opus conversion (Edge TTS MP3 -> OGG Opus for Telegram)
 # ===========================================================================
@@ -231,9 +261,12 @@ def _generate_elevenlabs(text: str, output_path: str, tts_config: Dict[str, Any]
     Returns:
         Path to the saved audio file.
     """
-    api_key = os.getenv("ELEVENLABS_API_KEY", "")
+    api_key = resolve_elevenlabs_api_key()
     if not api_key:
-        raise ValueError("ELEVENLABS_API_KEY not set. Get one at https://elevenlabs.io/")
+        raise ValueError(
+            "ELEVENLABS_API_KEY not set and no macOS Keychain fallback was found. "
+            "Get one at https://elevenlabs.io/"
+        )
 
     el_config = tts_config.get("elevenlabs", {})
     voice_id = el_config.get("voice_id", DEFAULT_ELEVENLABS_VOICE_ID)
@@ -793,17 +826,22 @@ def text_to_speech_tool(
     tts_config = _load_tts_config()
     provider = _get_provider(tts_config)
 
-    # Detect platform from gateway env var to choose the best output format.
+    # Detect platform from session context to choose the best output format.
     # Telegram voice bubbles require Opus (.ogg); OpenAI and ElevenLabs can
-    # produce Opus natively (no ffmpeg needed).  Edge TTS always outputs MP3
+    # produce Opus natively (no ffmpeg needed). Edge TTS always outputs MP3
     # and needs ffmpeg for conversion.
-    from gateway.session_context import get_session_env
-    platform = get_session_env("HERMES_SESSION_PLATFORM", "").lower()
+    platform = _get_session_platform()
     want_opus = (platform == "telegram")
 
     # Determine output path
     if output_path:
         file_path = Path(output_path).expanduser()
+        # Telegram voice replies should stay voice-compatible even when callers
+        # provide a custom filename. Preserve the basename but coerce the
+        # extension to .ogg for providers that can generate Opus natively.
+        if want_opus and provider in ("openai", "elevenlabs", "mistral", "gemini"):
+            if file_path.suffix.lower() not in {".ogg", ".opus"}:
+                file_path = file_path.with_suffix(".ogg")
     else:
         timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
         out_dir = Path(DEFAULT_OUTPUT_DIR)
@@ -977,7 +1015,7 @@ def check_tts_requirements() -> bool:
         pass
     try:
         _import_elevenlabs()
-        if os.getenv("ELEVENLABS_API_KEY"):
+        if resolve_elevenlabs_api_key():
             return True
     except ImportError:
         pass
@@ -1097,9 +1135,12 @@ def stream_tts_to_speaker(
         model_id = el_config.get("streaming_model_id",
                                  el_config.get("model_id", model_id))
 
-        api_key = os.getenv("ELEVENLABS_API_KEY", "")
+        api_key = resolve_elevenlabs_api_key()
         if not api_key:
-            logger.warning("ELEVENLABS_API_KEY not set; streaming TTS audio disabled")
+            logger.warning(
+                "ELEVENLABS_API_KEY not set and no macOS Keychain fallback was found; "
+                "streaming TTS audio disabled"
+            )
         else:
             try:
                 ElevenLabs = _import_elevenlabs()


### PR DESCRIPTION
## Summary

This cleans up Telegram voice-note delivery so auto-TTS replies stay native voice notes and the send path degrades gracefully when Telegram rejects stale thread or reply targets.

## What changed

- preserve Telegram auto-TTS replies as `.ogg` / voice-note friendly output instead of defaulting everything through an `.mp3` temp path
- teach the Telegram adapter to:
  - send `.ogg` / `.opus` files via `send_voice`
  - retry without `message_thread_id` when Telegram returns `Message thread not found`
  - retry without `reply_to_message_id` when the replied-to message is gone
  - keep using `send_audio` for non-OGG files
- prefer native `.ogg` temp output for Telegram auto voice replies when the active TTS provider can produce it directly
- add regression coverage for:
  - Telegram auto-TTS output path selection
  - missing thread fallback
  - missing reply-target fallback
  - MP3-vs-voice send behavior
  - helper/config behavior touched by the TTS path

## Why

We had two ugly failure modes in Telegram:

1. voice replies could fall back to regular audio/file behavior because the auto-TTS path started from an `.mp3` temp filename
2. sends could fail outright when Telegram topics or replied-to messages disappeared between generation and delivery

This patch keeps the voice-note path native and makes delivery more tolerant of stale Telegram metadata.

## Testing

```bash
pytest -q tests/gateway/test_telegram_auto_tts_path.py \
          tests/gateway/test_voice_command.py \
          tests/tools/test_tool_backend_helpers.py \
          tests/tools/test_tts_speed.py \
          tests/gateway/test_telegram_thread_fallback.py
```

Result: `251 passed`
