### PR TITLE
feat(skills): add read-book and book-to-notes skills

### DIFF
--- a/skills/note-taking/book-to-notes/SKILL.md
+++ b/skills/note-taking/book-to-notes/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: book-to-notes
+description: Read a book (PDF/EPUB) incrementally, extract key concepts chapter by chapter, and store findings into a Zettelkasten or wiki. Optimized for long texts that exceed context window limits.
+version: 1.1.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [reading, knowledge-extraction, zettelkasten, pdf, epubs, learning]
+    category: note-taking
+    related_skills: [read-book, ocr-and-documents, obsidian, llm-wiki]
+    requires_toolsets: [terminal, files, delegate]
+---
+
+# Book-to-Notes Workflow
+
+Read a book incrementally and extract structured knowledge for your note system.
+
+## Configuration
+
+This skill writes to a configurable vault. Set your preferred path via environment variable:
+
+```bash
+# In ~/.hermes/.env
+BOOK_VAULT_PATH="~/notes"
+```
+
+If unset, defaults to `~/notes/`.
+
+Typical vault structure:
+```
+~/notes/
+├── books/              # Source PDFs/EPUBs and extracted text
+├── reading-journal/    # Chapter summaries and reading logs
+├── zettelkasten/       # Atomic notes (one idea per file)
+└── concepts/           # Wiki-style concept pages linking atomic notes
+```
+
+## Step 1: Acquire the Book
+
+**Prefer local files over remote URLs.** URLs rot. If the user provides a URL, download it immediately to a persistent location.
+
+```bash
+# Download to persistent storage (NOT /tmp/)
+curl -sL "$URL" -o ~/books/bookname.pdf
+```
+
+**Pitfall:** `/tmp/` gets cleared between sessions or on reboot. Always use `~/books/` or another persistent path.
+
+## Step 2: Extract Text
+
+For **text-based PDFs**, `pdftotext` (from poppler-utils) is often pre-installed and faster than Python libraries:
+
+```bash
+pdftotext book.pdf book.txt
+```
+
+For **scanned PDFs**, **EPUBs**, or **complex layouts**, use the `ocr-and-documents` skill (pymupdf or marker-pdf).
+
+For **EPUB** specifically:
+```bash
+# EPUBs are ZIP files with HTML chapters
+unzip -q book.epub -d book_extracted/
+# Text is usually in OEBPS/Text/ or similar
+find book_extracted/ -name "*.html" -o -name "*.xhtml" | sort
+```
+
+## Step 3: Split into Chapters
+
+**Goal:** Create manageable chunks (~2K-10K lines each) that fit in context windows.
+
+```bash
+# Split by "CHAPTER N" markers (case-insensitive)
+python3 -c "
+import re, sys
+with open('book.txt') as f:
+    text = f.read()
+# Match CHAPTER followed by number or roman numeral
+chapters = re.split(r'\n\s*(CHAPTER\s+[0-9IVX]+|Chapter\s+[0-9]+)\s*\n', text)
+# chapters[0] = front matter, chapters[1] = 'CHAPTER 1', chapters[2] = content, etc.
+for i in range(1, len(chapters), 2):
+    num = chapters[i].strip().replace(' ', '_')
+    content = chapters[i+1] if i+1 < len(chapters) else ''
+    with open(f'ch_{num}.txt', 'w') as out:
+        out.write(content)
+        print(f'Wrote {num}: {len(content)} chars')
+"
+```
+
+**Alternative:** Split by page ranges if chapter markers are unreliable:
+```bash
+# Extract pages 1-50
+pdftotext -f 1 -l 50 book.pdf ch1.txt
+```
+
+**Store splits persistently** alongside the source PDF.
+
+## Step 4: Incremental Reading
+
+Read **one chapter per tool call** (or two if they're short). For each chapter:
+
+1. **Read the chapter** with `read_file`
+2. **Extract immediately** — don't defer synthesis. Extract:
+   - Core concepts (name + definition)
+   - Models/frameworks (list components)
+   - Key arguments and evidence
+   - Notable quotes (verbatim, with page numbers if available)
+   - Connections to other chapters or ideas
+
+3. **Write a chapter summary** as you go — a 5-10 bullet summary per chapter prevents re-reading.
+
+### Quality Checklist for Subagent Extraction
+
+When delegating chapter extraction to a subagent, provide the **Reading Tool** (`templates/reading-tool.md`) as its instructions. This enforces:
+- Two-pass extraction (structural → conceptual)
+- Concept crystallization with boundaries and implications
+- Cross-chapter threading
+- Explicit failure-mode guards against parroting, compressing, and inventing
+
+Load the tool with: `skill_view(name="book-to-notes", file_path="templates/reading-tool.md")`
+
+## Step 5: Synthesize and Store
+
+After reading all chapters (or enough for the user's purpose):
+
+1. **Create atomic notes** in the Zettelkasten (one idea per note, sentence-titled)
+2. **Create a concept page** in the wiki linking to atomic notes
+3. **Tag and link** — connect new concepts to existing notes
+
+**Storage location:** Use your configured vault (default `~/notes/`):
+- Source: `~/notes/books/Book_Title.md`
+- Notes: `~/notes/zettelkasten/`
+- Wiki: `~/notes/concepts/`
+
+## Pitfalls
+
+| Pitfall | Solution |
+|---------|----------|
+| `/tmp/` cleared | Use `~/books/` or your vault's books directory |
+| URL dies | Download immediately; keep local copy |
+| Context overflow | One chapter per call; extract as you read |
+| Re-reading same content | Write chapter summaries immediately |
+| Chapter regex fails | Inspect first 100 lines of text; adjust regex |
+| PDF is scanned/image-based | Fall back to `ocr-and-documents` skill (marker-pdf) |
+| EPUB has no clear chapter files | Unzip and inspect structure; often `OEBPS/Text/ch*.html` |
+
+## Example: Full Session
+
+```bash
+# 1. Acquire
+curl -sL "$URL" -o ~/books/flow.pdf
+
+# 2. Extract
+pdftotext ~/books/flow.pdf ~/books/flow.txt
+
+# 3. Split
+python3 scripts/split_book.py ~/books/flow.txt ~/books/flow_chapters/
+
+# 4. Read & extract (repeat per chapter)
+# ... read_file calls ...
+
+# 5. Store
+# ... write_file to vault ...
+```
+
+## Agent Architecture for Autonomous Reading
+
+When building a *reusable system* for an agent to read books unattended, prefer **subagent delegation with disk-state** over cron-based autonomous loops for books under ~400 pages.
+
+### The Pattern (v0.1)
+
+```
+state/
+├── status.json      # {"book":"Title","total_chapters":N,"current":3,"phase":"extracting"}
+└── resume.md        # Laser-focus context for the next subagent run
+
+chapters/
+├── ch_001.txt
+├── ch_002.txt
+└── ...
+
+outputs/
+├── chapter_summaries/
+├── atomic_notes/
+└── wiki_drafts/
+```
+
+**Why this works:**
+- Each subagent run reads `resume.md` + 1-2 chapters, writes outputs, updates `status.json`
+- No persistent memory needed between runs — the disk is the state machine
+- The parent agent spawns a subagent per work unit, then regains control
+- Human can inspect `status.json` at any time to see progress
+
+### Architecture Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| **Reject flush tool for < 400 pages** | Context management via `resume.md` is sufficient; flush adds complexity without benefit |
+| **Defer cron jobs to v1.0** | Premature autonomy hides failures; manual subagent runs let you verify quality first |
+| **One chapter per subagent call** | Prevents context overflow; keeps each unit focused and debuggable |
+| **Resume.md as laser-focus state** | Contains only: book thesis so far, open threads, next task, nothing else |
+| **Status.json as ground truth** | Machine-readable; cheap to parse; survives across sessions |
+
+### Incremental Roadmap
+
+- **v0.1** (today): Manual subagent runs, disk state, one chapter at a time
+- **v0.2**: Add synthesis pass — subagent reads all chapter summaries and builds the concept map
+- **v0.3**: Add triage — pre-read TOC + intro to generate `questions_to_answer.md`, skip irrelevant chapters
+- **v1.0**: Cron schedule + automatic flushing only when books exceed 400 pages or context limits demand it
+
+### When to Stop Reading
+
+You don't need to read every chapter. Stop when you have:
+- The core framework/model (usually Chapters 1-4)
+- The applied techniques (usually later chapters)
+- Enough to answer the user's specific question
+
+If the user says "use what you learn to help me do X," prioritize chapters relevant to X over completeness.

--- a/skills/note-taking/book-to-notes/scripts/split_book.py
+++ b/skills/note-taking/book-to-notes/scripts/split_book.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""
+Split a book text file into chapter files.
+
+Usage:
+    python split_book.py book.txt output_dir/
+    python split_book.py book.txt output_dir/ --pattern "CHAPTER\s+[0-9]+"
+    python split_book.py book.txt output_dir/ --by-pages 50  # split every N pages (if page markers exist)
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+def split_by_chapter(text, pattern=None):
+    """Split text by chapter markers. Returns list of (chapter_title, content) tuples."""
+    if pattern is None:
+        # Common patterns: CHAPTER 1, Chapter I, CHAPTER ONE
+        patterns = [
+            r'(?:^|\n)\s*(CHAPTER\s+[0-9IVXLC]+)\s*\n',
+            r'(?:^|\n)\s*(Chapter\s+[0-9]+)\s*\n',
+            r'(?:^|\n)\s*(PART\s+[0-9IVXLC]+)\s*\n',
+            r'(?:^|\n)\s*(BOOK\s+[0-9IVXLC]+)\s*\n',
+        ]
+        for pat in patterns:
+            matches = list(re.finditer(pat, text))
+            if len(matches) >= 2:
+                pattern = pat
+                break
+        
+        if pattern is None:
+            print("No chapter markers found. Falling back to page-based split.", file=sys.stderr)
+            return None
+    
+    parts = re.split(pattern, text)
+    if len(parts) < 3:
+        return None
+    
+    chapters = []
+    # parts[0] = front matter
+    for i in range(1, len(parts), 2):
+        title = parts[i].strip()
+        content = parts[i + 1] if i + 1 < len(parts) else ""
+        chapters.append((title, content))
+    
+    return chapters
+
+
+def split_by_pages(text, pages_per_chunk):
+    """Split by form feed characters (page breaks in pdftotext output)."""
+    pages = text.split('\f')
+    chunks = []
+    current = []
+    for i, page in enumerate(pages):
+        current.append(page)
+        if (i + 1) % pages_per_chunk == 0:
+            chunks.append((f"Pages_{i+2-pages_per_chunk}-{i+1}", "\n".join(current)))
+            current = []
+    if current:
+        start = len(pages) - len(current) + 1
+        chunks.append((f"Pages_{start}-{len(pages)}", "\n".join(current)))
+    return chunks
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Split a book into chapter files")
+    parser.add_argument("input", help="Input text file")
+    parser.add_argument("output_dir", help="Output directory for chapter files")
+    parser.add_argument("--pattern", help="Regex pattern for chapter markers")
+    parser.add_argument("--by-pages", type=int, help="Split every N pages (if page breaks exist)")
+    parser.add_argument("--prefix", default="ch", help="Filename prefix")
+    args = parser.parse_args()
+    
+    in_path = Path(args.input)
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    
+    text = in_path.read_text(encoding="utf-8")
+    
+    if args.by_pages:
+        chapters = split_by_pages(text, args.by_pages)
+    else:
+        chapters = split_by_chapter(text, args.pattern)
+        if chapters is None:
+            chapters = split_by_pages(text, 50)
+    
+    if not chapters:
+        print("Could not split book.", file=sys.stderr)
+        sys.exit(1)
+    
+    for i, (title, content) in enumerate(chapters):
+        safe_title = re.sub(r'[^\w]', '_', title)[:50]
+        filename = f"{args.prefix}_{i+1:03d}_{safe_title}.txt"
+        out_path = out_dir / filename
+        out_path.write_text(content, encoding="utf-8")
+        print(f"Wrote: {filename} ({len(content)} chars)")
+    
+    print(f"\nSplit into {len(chapters)} files in {out_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/note-taking/book-to-notes/templates/reading-tool.md
+++ b/skills/note-taking/book-to-notes/templates/reading-tool.md
@@ -1,0 +1,65 @@
+# Reading Tool — Quality Checklist for Subagent Chapter Extraction
+
+Use this checklist when extracting from a book chapter. Do not return to the parent agent until every check is satisfied.
+
+## Pre-Read Scan (30 seconds)
+- [ ] Skim the chapter: headings, first paragraph, last paragraph, any diagrams or tables
+- [ ] Identify the chapter's question or thesis in one sentence
+- [ ] Note the chapter type: argument, narrative, technical how-to, or mixed
+
+## Argument Mapping
+- [ ] Extract the author's central claim (not a summary — the actual claim)
+- [ ] List the evidence or reasoning offered (bullet points)
+- [ ] Flag any unstated assumptions
+- [ ] Note where the author shifts from observation to prescription
+
+## Two-Pass Extraction
+- [ ] Pass 1 — Structural: What is the shape of the argument? (premise → evidence → conclusion)
+- [ ] Pass 2 — Conceptual: What ideas here are portable to other contexts? (abstract the principle from the example)
+- [ ] If a concept has a name the author invented, preserve that exact term
+- [ ] If a concept has no name, coin a neutral phrase and explain why you chose it
+
+## Concept Crystallization
+For each significant concept extracted:
+- [ ] Definition: What is it? (1-2 sentences, author's own words where possible)
+- [ ] Mechanism: How does it work? (the causal chain or process)
+- [ ] Boundary: When does it apply, and when does it not?
+- [ ] Example: One concrete instance from the text
+- [ ] Implication: If this is true, what follows? (your own inference, not the author's)
+
+## Cross-Chapter Threading
+- [ ] Note any references to previous chapters (what is being built upon?)
+- [ ] Flag any promises made for future chapters (what should the reader expect?)
+- [ ] If this chapter contradicts an earlier one, name the contradiction explicitly
+
+## Failure Modes to Avoid
+- **The Parrot**: Repeating the author's words without mapping the argument structure
+- **The Compressor**: Reducing a nuanced argument to a single vague sentence
+- **The Inventor**: Adding your own ideas without clearly labeling them as yours
+- **The Skipper**: Missing the chapter's actual thesis because you focused on a colorful example
+- **The Isolator**: Extracting concepts as if they exist in a vacuum, ignoring the book's larger project
+
+## Output Format
+Return your extraction as structured markdown with these sections:
+```markdown
+## Chapter [N]: [Title]
+
+### Thesis
+[One sentence central claim]
+
+### Argument Structure
+1. [Premise/evidence]
+2. [Reasoning step]
+3. [Conclusion]
+
+### Key Concepts
+- **[Concept Name]**: [definition] — [mechanism] — [boundary] — [example] — [implication]
+
+### Threads
+- Builds on: [earlier chapter/idea]
+- Promises: [future chapter/idea]
+- Contradicts: [if applicable]
+
+### Unclear / Suspicious
+- [Anything that doesn't make sense or seems weak]
+```

--- a/skills/note-taking/read-book/SKILL.md
+++ b/skills/note-taking/read-book/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: read-book
+description: "Read a book deeply — not as a parrot, but as a thinker. A Socratic protocol for analytical, critical, and syntopical reading that produces original understanding, not summaries."
+version: 2.2.0
+author: Juanes Figueroa
+license: MIT
+metadata:
+  hermes:
+    tags: [reading, learning, critical-thinking, synthesis, knowledge-integration, socratic]
+    category: note-taking
+    related_skills: [book-to-notes, llm-wiki, obsidian]
+---
+
+# Read Book — Deep Reading Protocol
+
+> "Reading a book is a different activity than understanding a book."
+
+Most agents read like parrots: they chunk, summarize, and repeat. This skill treats reading as **knowledge construction** — the book is raw material; the understanding is what the reader builds with it.
+
+Based on Adler's *How to Read a Book*, the Zettelkasten method, and the Feynman technique.
+
+## When This Skill Activates
+
+Use when the user:
+- Asks to "read" or "understand" a book (not just "summarize" or "extract notes")
+- Wants to critically evaluate an author's arguments
+- Needs to integrate a book's ideas into an existing knowledge base
+- Is reading for a purpose: decision, teaching, writing, or worldview update
+
+## Division of Labor
+
+| Human | Agent |
+|-------|-------|
+| Provides the book (PDF/EPUB/text) and purpose | Executes the reading protocol |
+| Answers clarifying questions about their context | Maintains the reading journal |
+| Validates or corrects synthesized understanding | Connects to existing knowledge |
+| Decides what to do with the output | Produces original synthesis |
+
+## Pre-Reading: The Contract
+
+Before opening the book, establish three things:
+
+1. **Purpose** — Why are we reading this? (decision, teaching, worldview, curiosity)
+2. **Prior Knowledge** — What does the reader already believe about this topic?
+3. **Skepticism Budget** — How much should we trust this author? (domain expert? journalist? philosopher?)
+
+```
+Purpose: _______________
+Prior knowledge query: scan the user's wiki/Zettelkasten for related concepts
+Skepticism budget: expert / informed / novice / ideologue
+```
+
+## The Four Passes
+
+### Pass 1: Structural Diagnosis (10% of effort)
+
+Goal: Understand what kind of book this is and what question it answers.
+
+**Actions:**
+- Read the title, subtitle, preface, introduction, and table of contents
+- Read the conclusion or final chapter
+- Skim chapter headings and first/last paragraphs
+- Identify: What is the author's *problem*? What is their *solution*?
+
+**Output — Structural Map:**
+```markdown
+# Structural Map: [Title]
+
+## The Author's Question
+[What problem is this book trying to solve?]
+
+## The Author's Answer
+[One sentence: the core thesis]
+
+## Architecture
+- Part I: [function in the argument]
+- Part II: [function in the argument]
+- ...
+
+## Key Terms
+[Terms the author uses in a special sense — define them in the author's words]
+
+## Genre & Skepticism Budget
+[What kind of book is this? How should we read it?]
+```
+
+### Pass 2: Emphatic Reading (40% of effort)
+
+Goal: Understand the author *on their own terms*. Suspend disbelief.
+
+**Actions:**
+- Read chapter by chapter
+- For each chapter: identify the *question* it answers and the *answer* it gives
+- Track arguments and evidence, not just topics
+- Flag key terms, important propositions, and supporting arguments
+
+**Output — Chapter Digest (one per chapter):**
+```markdown
+## Chapter [N]: [Title]
+
+### Question
+[What is this chapter trying to answer?]
+
+### Answer
+[The chapter's thesis, in the author's voice]
+
+### Argument
+1. [Premise/evidence]
+2. [Premise/evidence]
+3. [Conclusion]
+
+### Key Terms
+- [term]: [author's definition]
+
+### Important Propositions
+- [Proposition the author wants you to accept]
+
+### Unclear / Suspicious
+- [Anything that doesn't make sense yet — flag for Pass 3]
+```
+
+**Rule:** Do not critique yet. Do not connect to outside knowledge yet. The goal is to be able to explain the author's position so well that the author would say "yes, that's exactly what I meant."
+
+### Pass 3: Critical Reading (30% of effort)
+
+Goal: Evaluate the argument. The author is now a conversation partner, not an authority.
+
+**Questions to answer:**
+1. **Is it true?** — What is the evidence? Is it sufficient? Are there counter-examples?
+2. **Is it complete?** — What is left unsaid? What would a hostile reader point out?
+3. **Are the terms consistent?** — Does the author use key terms the same way throughout?
+4. **Are the premises sound?** — What assumptions underpin the argument? Are they justified?
+5. **Does it follow?** — If the premises are true, does the conclusion actually follow?
+
+**Output — Critical Appraisal:**
+```markdown
+# Critical Appraisal
+
+## What I Accept
+[Propositions that are well-supported and consistent with what I know]
+
+## What I Question
+[Propositions with weak evidence, questionable assumptions, or logical gaps]
+
+## What's Missing
+[Important considerations the author ignores]
+
+## Internal Tensions
+[Contradictions or inconsistencies within the book]
+```
+
+### Pass 4: Syntopical Reading (20% of effort)
+
+Goal: Integrate the book into the reader's growing knowledge system.
+
+**Actions:**
+- Query the user's existing notes/wiki for related concepts
+- Map agreements: "This confirms what I already believe about X"
+- Map contradictions: "This contradicts my note on Y — which is stronger?"
+- Map novelties: "This is new — it changes my model of Z"
+- Identify what the reader must now *unlearn* or *update*
+
+**Output — Knowledge Integration Map:**
+```markdown
+# Knowledge Integration
+
+## Confirms
+- [Existing concept] ← [Book's proposition]
+
+## Contradicts
+- [Existing concept] vs [Book's proposition] — resolution: ___________
+
+## Extends
+- [Existing concept] + [Book's proposition] = [New, richer concept]
+
+## New
+- [Concept that didn't exist in my system before]
+
+## Requires Unlearning
+- [Previous belief that must be revised or abandoned]
+```
+
+## Final Synthesis: The Original Production
+
+A summary is a waste of time. The reader must produce something **original**:
+
+**Choose one:**
+1. **A reframed model** — The book's ideas reorganized around a different question
+2. **A critique** — A substantive argument against the book's thesis
+3. **An application** — "Given this is true, what should I do differently?"
+4. **A teaching** — An explanation of the core ideas for a specific audience
+5. **A synthesis essay** — Connecting this book to 2-3 others on the same topic
+
+**Output — Original Production:**
+```markdown
+# Original Production: [Title]
+
+## My Question
+[Not the author's question — the question *I* now have because of this book]
+
+## My Answer
+[The understanding I have constructed, in my own words]
+
+## Key Moves
+[The intellectual operations that got me here — not what the book said]
+
+## Open Questions
+[What I still don't know and need to investigate next]
+```
+
+## The Reading Journal
+
+Maintain a running markdown file while reading:
+
+```bash
+BOOK_NAME="The_Author_Title"
+JOURNAL="~/reading-journal/${BOOK_NAME}.md"
+```
+
+Structure:
+```markdown
+# Reading Journal: [Title]
+
+## Pre-Reading Contract
+[purpose, prior knowledge, skepticism budget]
+
+## Structural Map
+[Pass 1 output]
+
+## Chapter Digests
+[Pass 2 outputs]
+
+## Critical Appraisal
+[Pass 3 output]
+
+## Knowledge Integration
+[Pass 4 output]
+
+## Original Production
+[Final synthesis]
+```
+
+## Execution Rules
+
+1. **Never summarize without evaluating.** A summary that doesn't say what is true, false, and questionable is just noise.
+2. **Ask before assuming.** If the user has a wiki or Zettelkasten, query it before Pass 4. Don't guess what they know.
+3. **One chapter at a time.** Don't read ahead. Each chapter digest must be complete before moving on.
+4. **Flag, don't resolve.** In Pass 2, flag things that seem wrong. Don't resolve them until Pass 3.
+5. **The author is not always right.** Critical reading is not impolite — it's the point.
+6. **Produce or waste.** If there's no original production at the end, the reading was entertainment, not learning.
+
+## Storage
+
+Store the final outputs in the user's knowledge system:
+- **Reading Journal:** `~/reading-journal/` or user's preferred path
+- **Integration:** Link to relevant wiki pages or Zettelkasten notes
+- **Original Production:** Consider publishing or filing as a permanent note


### PR DESCRIPTION
Add two complementary note-taking skills for deep reading and knowledge extraction from long-form texts, filling the missing ingestion layer for the LLM Wiki.

## What does this PR do?

The `llm-wiki` skill provides an excellent architecture for persistent knowledge — raw sources, cross-linked concept pages, schema enforcement, and querying. But its ingestion flow assumes the agent can hold the **entire source in context**. This works for articles and papers, but fails for books: a 300-page text is ~100k tokens, which degrades quality and buries early chapters.

This PR adds the missing long-form ingestion layer:

**`read-book`** — A Socratic four-pass reading protocol (structural → emphatic → critical → syntopical) based on Adler's *How to Read a Book*. The agent does not summarize; it produces original understanding: reframed models, critiques, applications, or teachings.

**`book-to-notes`** — A Zettelkasten ingestion pipeline for books too long for single-context processing. Uses subagent delegation with disk-state pattern:
- Parent agent never holds the book
- Subagents extract atomic notes (one idea per file, sentence-titled, linked, source-provenanced)
- Synthesis pass reads only the atomic notes to build wiki concept pages

Tested end-to-end on *Flow: The Psychology of Optimal Experience* (Csikszentmihalyi, 314 pages): 5 subagent chunks, 66 atomic notes, 39 preserved quotes, 12 cross-linked concept pages.

Both skills are vault-agnostic (default `~/notes/`, configurable via `BOOK_VAULT_PATH`) and feed directly into the existing `llm-wiki` skill's concept/entity layer.

## Related Issue

No existing issue. This is a new capability gap identified during real-world usage.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [x] 🎯 New skill (bundled or hub)

## Changes Made

- `skills/note-taking/read-book/SKILL.md` — Deep reading protocol (Adler's four passes: structural, emphatic, critical, syntopical)
- `skills/note-taking/book-to-notes/SKILL.md` — Zettelkasten extraction pipeline with subagent delegation, disk-state pattern, and architecture decisions
- `skills/note-taking/book-to-notes/scripts/split_book.py` — Cross-platform chapter splitting utility (pure Python stdlib + pathlib)
- `skills/note-taking/book-to-notes/templates/reading-tool.md` — Subagent quality checklist enforcing two-pass extraction, concept crystallization, and anti-parroting guards

## How to Test

1. Place a PDF or text book in a persistent directory (e.g., `~/books/`)
2. Run `pdftotext book.pdf book.txt` to extract text (Unix; on Windows use `ocr-and-documents` skill or pymupdf fallback)
3. Ask Hermes: "Use the book-to-notes skill to read ~/books/flow.txt and extract concepts into ~/notes/"
4. Verify subagents produce atomic notes in the output directory
5. Verify synthesis generates concept pages linking atomic notes
6. For read-book protocol: Ask "Use the read-book skill to help me understand [book]" and verify the four-pass structure (structural map → chapter digests → critical appraisal → knowledge integration)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (ran `pytest tests/cli -q` — 476 passed; skills are markdown files, not exercised by core test suite)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — N/A for skill addition; script tested manually
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
- [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `split_book.py` is pure Python stdlib + pathlib; pdftotext recommendation is Unix-only but skill documents EPUB and OCR fallbacks
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- [x] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-it-be-a-skill-or-a-tool)
- [x] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#adding-a-skill) (frontmatter, trigger conditions, steps, pitfalls)
- [x] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools) — `split_book.py` is pure stdlib. `pdftotext` is recommended but advisory; skill documents EPUB and OCR fallbacks
- [x] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"` — skills load in `hermes skills list` and `hermes chat`; tested ingestion pipeline on 314-page book producing 66 atomic notes and 12 concept pages

## Screenshots / Logs

Tested on *Flow: The Psychology of Optimal Experience* (Mihaly Csikszentmihalyi, 314 pages, 10 chapters)

