### PR TITLE
fix(whatsapp): auto-convert mp3/wav→ogg/opus in send-media for native voice bubbles

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -23,8 +23,10 @@ import express from 'express';
 import { Boom } from '@hapi/boom';
 import pino from 'pino';
 import path from 'path';
-import { mkdirSync, readFileSync, writeFileSync, existsSync, readdirSync } from 'fs';
+import { mkdirSync, readFileSync, writeFileSync, existsSync, readdirSync, unlinkSync } from 'fs';
 import { randomBytes } from 'crypto';
+import { execSync } from 'child_process';
+import { tmpdir } from 'os';
 import qrcode from 'qrcode-terminal';
 import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
 
@@ -466,8 +468,31 @@ app.post('/send-media', async (req, res) => {
         msgPayload = { video: buffer, caption: caption || undefined, mimetype: MIME_MAP[ext] || 'video/mp4' };
         break;
       case 'audio': {
-        const audioMime = (ext === 'ogg' || ext === 'opus') ? 'audio/ogg; codecs=opus' : 'audio/mpeg';
-        msgPayload = { audio: buffer, mimetype: audioMime, ptt: ext === 'ogg' || ext === 'opus' };
+        // WhatsApp only renders a native voice bubble (ptt) when the file is ogg/opus.
+        // If the caller passes mp3, wav, m4a etc. (e.g. from Edge TTS / NeuTTS),
+        // silently convert to ogg/opus via ffmpeg so ptt is always honoured.
+        let audioBuffer = buffer;
+        let audioExt = ext;
+        const needsConversion = !['ogg', 'opus'].includes(ext);
+        let tmpPath = null;
+        if (needsConversion) {
+          tmpPath = path.join(tmpdir(), `hermes_voice_${randomBytes(6).toString('hex')}.ogg`);
+          try {
+            execSync(
+              `ffmpeg -y -i ${JSON.stringify(filePath)} -ar 48000 -ac 1 -c:a libopus ${JSON.stringify(tmpPath)}`,
+              { timeout: 30000, stdio: 'pipe' }
+            );
+            audioBuffer = readFileSync(tmpPath);
+            audioExt = 'ogg';
+          } catch (convErr) {
+            // ffmpeg not available or conversion failed — fall back to original format
+            console.warn('[bridge] ffmpeg conversion failed, sending as file attachment:', convErr.message);
+          } finally {
+            try { if (tmpPath && existsSync(tmpPath)) unlinkSync(tmpPath); } catch (_) {}
+          }
+        }
+        const audioMime = (audioExt === 'ogg' || audioExt === 'opus') ? 'audio/ogg; codecs=opus' : 'audio/mpeg';
+        msgPayload = { audio: audioBuffer, mimetype: audioMime, ptt: audioExt === 'ogg' || audioExt === 'opus' };
         break;
       }
       case 'document':


### PR DESCRIPTION
## Problem

As noted by @veloguardian in #4992: `bridge.js` only sets `ptt: true` when the file extension is `.ogg` or `.opus`. If `send_voice()` is called with an `.mp3` or `.wav` file (e.g. from Edge TTS or NeuTTS), the message arrives as a file attachment instead of a voice bubble — silently, with no error.

## Root cause

```js
// Before — ptt only true for ogg/opus
msgPayload = { audio: buffer, mimetype: audioMime, ptt: ext === 'ogg' || ext === 'opus' };
```

## Fix

When `type === 'audio'` and the file is not already ogg/opus, the bridge now runs `ffmpeg` to convert it to ogg/opus in a temp file before sending. This makes the adapter self-sufficient regardless of what format the caller provides.

```js
// After — ffmpeg conversion to ogg/opus, then ptt: true always works
if (!['ogg', 'opus'].includes(ext)) {
  // convert via ffmpeg → tmpPath.ogg
  audioBuffer = readFileSync(tmpPath);
  audioExt = 'ogg';
}
msgPayload = { audio: audioBuffer, mimetype: 'audio/ogg; codecs=opus', ptt: true };
```

**Fallback:** if `ffmpeg` is unavailable or conversion fails, the original buffer is sent with a `console.warn` — previous behaviour, no crash.

## Testing

- Send `.mp3` via `/send-media` with `mediaType: audio` → renders as voice bubble ✅  
- Send `.wav` → renders as voice bubble ✅  
- Send `.ogg` → still works, no conversion (fast path) ✅  
- No `ffmpeg` installed → falls back gracefully, sends as file attachment with warning ✅

Closes the gap identified by @veloguardian on PR #4992.