### PR TITLE
fix(acp): preserve persisted session history on save failures

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -409,17 +409,9 @@ class SessionManager:
                 except Exception:
                     logger.debug("Failed to update ACP session metadata", exc_info=True)
 
-            # Replace stored messages with current history.
-            db.clear_messages(state.session_id)
-            for msg in state.history:
-                db.append_message(
-                    session_id=state.session_id,
-                    role=msg.get("role", "user"),
-                    content=msg.get("content"),
-                    tool_name=msg.get("tool_name") or msg.get("name"),
-                    tool_calls=msg.get("tool_calls"),
-                    tool_call_id=msg.get("tool_call_id"),
-                )
+            # Replace stored messages with current history in one transaction so
+            # a bad message cannot clear the previously persisted conversation.
+            db.replace_messages(state.session_id, state.history)
         except Exception:
             logger.warning("Failed to persist ACP session %s", state.session_id, exc_info=True)
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -986,6 +986,67 @@ class SessionDB:
 
         return self._execute_write(_do)
 
+    def replace_messages(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
+        """Atomically replace all messages for a session.
+
+        Used by ACP session persistence, which rewrites the in-memory history.
+        Serialization happens before the write transaction so malformed input
+        cannot clear the previously persisted conversation.
+        """
+        rows = []
+        tool_call_count = 0
+        timestamp = time.time()
+
+        for index, msg in enumerate(messages):
+            tool_calls = msg.get("tool_calls")
+            reasoning_details = msg.get("reasoning_details")
+            codex_reasoning_items = msg.get("codex_reasoning_items")
+            tool_calls_json = json.dumps(tool_calls) if tool_calls else None
+            reasoning_details_json = (
+                json.dumps(reasoning_details) if reasoning_details else None
+            )
+            codex_items_json = (
+                json.dumps(codex_reasoning_items) if codex_reasoning_items else None
+            )
+
+            if tool_calls is not None:
+                tool_call_count += len(tool_calls) if isinstance(tool_calls, list) else 1
+
+            rows.append(
+                (
+                    session_id,
+                    msg.get("role", "user"),
+                    msg.get("content"),
+                    msg.get("tool_call_id"),
+                    tool_calls_json,
+                    msg.get("tool_name") or msg.get("name"),
+                    timestamp + (index * 0.000001),
+                    msg.get("token_count"),
+                    msg.get("finish_reason"),
+                    msg.get("reasoning"),
+                    reasoning_details_json,
+                    codex_items_json,
+                )
+            )
+
+        def _do(conn):
+            conn.execute("DELETE FROM messages WHERE session_id = ?", (session_id,))
+            if rows:
+                conn.executemany(
+                    """INSERT INTO messages (session_id, role, content, tool_call_id,
+                       tool_calls, tool_name, timestamp, token_count, finish_reason,
+                       reasoning, reasoning_details, codex_reasoning_items)
+                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                    rows,
+                )
+            conn.execute(
+                """UPDATE sessions SET message_count = ?, tool_call_count = ?
+                   WHERE id = ?""",
+                (len(rows), tool_call_count, session_id),
+            )
+
+        self._execute_write(_do)
+
     def get_messages(self, session_id: str) -> List[Dict[str, Any]]:
         """Load all messages for a session, ordered by timestamp."""
         with self._lock:

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -183,6 +183,25 @@ class TestPersistence:
         assert len(messages) == 1
         assert messages[0]["content"] == "test"
 
+    def test_save_session_preserves_existing_messages_on_append_failure(self, manager):
+        state = manager.create_session()
+        state.history.append({"role": "user", "content": "original"})
+        manager.save_session(state.session_id)
+
+        state.history = [
+            {"role": "user", "content": "replacement"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"bad": object()}],
+            },
+        ]
+        manager.save_session(state.session_id)
+
+        db = manager._get_db()
+        messages = db.get_messages_as_conversation(state.session_id)
+        assert messages == [{"role": "user", "content": "original"}]
+
     def test_remove_session_deletes_from_db(self, manager):
         state = manager.create_session()
         db = manager._get_db()


### PR DESCRIPTION
## Summary
- Add `SessionDB.replace_messages()` to atomically rewrite a session's messages.
- Use the atomic replacement path for ACP session persistence.
- Add regression coverage proving a failed ACP save does not erase previously persisted history.

## Why
ACP session persistence previously cleared stored messages before appending the current in-memory history. If one of the later appends failed, for example because structured tool call data could not be serialized, the already persisted conversation was lost. That could break session restore after an editor/server restart.

The new path pre-serializes message fields before the write transaction, then deletes and inserts messages in one transaction. Bad input now leaves the previously persisted conversation intact.

## Test Plan
- `uv run --extra dev python -m pytest tests/acp/test_session.py::TestPersistence::test_save_session_preserves_existing_messages_on_append_failure -q`
- `uv run --extra dev python -m pytest tests/acp/test_session.py -q`
- `git diff --check -- acp_adapter/session.py hermes_state.py tests/acp/test_session.py`
