### PR TITLE
fix(delegate): load .env before resolving subagent credentials

### DIFF
--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -27,6 +27,13 @@ from typing import Any, Dict, List, Optional
 
 from toolsets import TOOLSETS
 
+# Ensure .env is loaded so subagents have access to provider API keys
+from hermes_cli.env_loader import load_hermes_dotenv
+from pathlib import Path
+_hermes_home = Path.home() / ".hermes"
+_project_env = Path(__file__).parent / ".env"
+load_hermes_dotenv(hermes_home=_hermes_home, project_env=_project_env)
+
 
 # Tools that children must never have access to
 DELEGATE_BLOCKED_TOOLS = frozenset([


### PR DESCRIPTION
## Fix

`delegate_task` subagents fail with 404 from providers like `opencode-go` because the child process does not inherit the parent's environment. When `resolve_runtime_provider()` is called in the subagent context, `os.getenv(OPENCODE_GO_API_KEY)` returns empty — the .env file was never loaded in the child process.

This adds `load_hermes_dotenv()` at module load time in `tools/delegate_tool.py`, mirroring what already exists in `run_agent.py` and `hermes_cli/main.py`.

```python
from hermes_cli.env_loader import load_hermes_dotenv
from pathlib import Path
_hermes_home = Path.home() / .hermes
_project_env = Path(__file__).parent / .env
load_hermes_dotenv(hermes_home=_hermes_home, project_env=_project_env)
```

Fixes #13678