### PR TITLE
refactor(delegate): remove dead delegation.default_toolsets config key

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -773,7 +773,6 @@ code_execution:
 # Supports single tasks and batch mode (up to 3 parallel).
 delegation:
   max_iterations: 50                          # Max tool-calling turns per child (default: 50)
-  default_toolsets: ["terminal", "file", "web"]  # Default toolsets for subagents
   # model: "google/gemini-3-flash-preview"    # Override model for subagents (empty = inherit parent)
   # provider: "openrouter"                    # Override provider for subagents (empty = inherit parent)
   #                                           # Resolves full credentials (base_url, api_key) automatically.

--- a/cli.py
+++ b/cli.py
@@ -371,7 +371,6 @@ def load_cli_config() -> Dict[str, Any]:
         },
         "delegation": {
             "max_iterations": 45,  # Max tool-calling turns per child agent
-            "default_toolsets": ["terminal", "file", "web"],  # Default toolsets for subagents
             "model": "",       # Subagent model override (empty = inherit parent model)
             "provider": "",    # Subagent provider override (empty = inherit parent provider)
             "base_url": "",    # Direct OpenAI-compatible endpoint for subagents

--- a/tests/hermes_cli/test_config_drift.py
+++ b/tests/hermes_cli/test_config_drift.py
@@ -1,0 +1,25 @@
+"""Regression tests for removed dead config keys.
+
+This file guards against accidental re-introduction of config keys that were
+documented or declared at some point but never actually wired up to read code.
+Future dead-config regressions can accumulate here.
+"""
+
+
+def test_delegation_default_toolsets_removed_from_cli_config():
+    """delegation.default_toolsets was dead config — never read by
+    _load_config() or anywhere else. Removed in M0.5.
+
+    Guards against accidental re-introduction in cli.py's CLI_CONFIG default
+    dict. If this test fails, someone re-added the key without wiring it up
+    to _load_config() in tools/delegate_tool.py.
+    """
+    from cli import CLI_CONFIG
+
+    delegation_cfg = CLI_CONFIG.get("delegation", {})
+    assert "default_toolsets" not in delegation_cfg, (
+        "delegation.default_toolsets was removed in M0.5 because it was "
+        "never read. Do not re-add it; use tools/delegate_tool.py's "
+        "DEFAULT_TOOLSETS module constant or wire a new config key through "
+        "_load_config()."
+    )

--- a/tests/hermes_cli/test_config_drift.py
+++ b/tests/hermes_cli/test_config_drift.py
@@ -5,6 +5,8 @@ documented or declared at some point but never actually wired up to read code.
 Future dead-config regressions can accumulate here.
 """
 
+import inspect
+
 
 def test_delegation_default_toolsets_removed_from_cli_config():
     """delegation.default_toolsets was dead config — never read by
@@ -13,13 +15,22 @@ def test_delegation_default_toolsets_removed_from_cli_config():
     Guards against accidental re-introduction in cli.py's CLI_CONFIG default
     dict. If this test fails, someone re-added the key without wiring it up
     to _load_config() in tools/delegate_tool.py.
-    """
-    from cli import CLI_CONFIG
 
-    delegation_cfg = CLI_CONFIG.get("delegation", {})
-    assert "default_toolsets" not in delegation_cfg, (
-        "delegation.default_toolsets was removed in M0.5 because it was "
-        "never read. Do not re-add it; use tools/delegate_tool.py's "
-        "DEFAULT_TOOLSETS module constant or wire a new config key through "
-        "_load_config()."
+    We inspect the source of load_cli_config() instead of asserting on the
+    runtime CLI_CONFIG dict because CLI_CONFIG is populated by deep-merging
+    the user's ~/.hermes/config.yaml over the defaults (cli.py:359-366).
+    A contributor who still has the legacy key set in their own config
+    would cause a false failure, and HERMES_HOME patching via conftest
+    doesn't help because cli._hermes_home is frozen at module import time
+    (cli.py:76) — before any autouse fixture can fire. Source inspection
+    sidesteps all of that: it tests the defaults literal directly.
+    """
+    from cli import load_cli_config
+
+    source = inspect.getsource(load_cli_config)
+    assert '"default_toolsets"' not in source, (
+        "delegation.default_toolsets was removed because it was never read. "
+        "Do not re-add it to cli.py's CLI_CONFIG default dict; "
+        "use tools/delegate_tool.py's DEFAULT_TOOLSETS module constant or "
+        "wire a new config key through _load_config()."
     )

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -206,7 +206,6 @@ Delegation has a **depth limit of 2** — a parent (depth 0) can spawn children 
 # In ~/.hermes/config.yaml
 delegation:
   max_iterations: 50                        # Max turns per child (default: 50)
-  default_toolsets: ["terminal", "file", "web"]  # Default toolsets
   model: "google/gemini-3-flash-preview"             # Optional provider/model override
   provider: "openrouter"                             # Optional built-in provider
 


### PR DESCRIPTION
## Summary

Removes `delegation.default_toolsets` — documented in the example config and delegation docs, declared in `cli.py`'s `CLI_CONFIG`, but never read by `_load_config()` or any other site. The live fallback is the `DEFAULT_TOOLSETS` module constant in `tools/delegate_tool.py`, which stays.

Cherry-picked from @pefontana's #11215; the concurrency bump, orchestrator role, and nested-delegation pieces are left for separate review on the original PR.

## Changes

- `cli.py`: drop the dead key from `CLI_CONFIG` defaults.
- `cli-config.yaml.example`, `website/docs/user-guide/features/delegation.md`: stop advertising it.
- `tests/hermes_cli/test_config_drift.py`: new regression test that asserts on `load_cli_config`'s source (robust to user config + xdist worker scheduling), so a future refactor that re-adds the key without wiring it up fails loudly.

## Validation

| | Before | After |
|---|---|---|
| `delegation.default_toolsets` advertised | yes (cli.py, example, docs) | no |
| `delegation.default_toolsets` actually read | no | no (unchanged — it was always dead) |
| `tools/delegate_tool.py` `DEFAULT_TOOLSETS` fallback | present | present (unchanged) |
| Subagent toolset restrictions (`DELEGATE_BLOCKED_TOOLS`, parent intersection) | enforced | enforced (unchanged) |

`scripts/run_tests.sh tests/hermes_cli/test_config_drift.py` — 1 passed.

Closes part of #11215.