### PR TITLE
feat(gateway): recognize .pdf in MEDIA: tag extraction

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1343,7 +1343,7 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a)(?=[\s`"',;:)\]}]|$)|\S+)[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|pdf)(?=[\s`"',;:)\]}]|$)|\S+)[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()


### PR DESCRIPTION
## Summary
MEDIA:`/path/to/report.pdf` now delivers as a native attachment across gateway platforms, same as images/audio/video.

## Changes
- `gateway/platforms/base.py`: add `pdf` to the `extract_media` regex alternation

## Why not extract_local_files too
Kept `_LOCAL_MEDIA_EXTS` untouched on purpose. Auto-sending every bare `.pdf` path the agent mentions would flood users with documents the model referenced but didn't intend to deliver. MEDIA: is the explicit opt-in signal; bare-path expansion stays image/video only.

## Validation
E2E against current main's regex:
- `MEDIA:/tmp/report.pdf` → extracted
- `MEDIA:"/tmp/my report.pdf"` (quoted with space) → extracted
- `MEDIA:`/tmp/doc.pdf`` (backticked) → extracted
- `MEDIA:/tmp/out.pdf.` (trailing punctuation) → extracted without period
- Bare `/tmp/thoughts.pdf` without MEDIA: → NOT extracted (intended)
- All existing types (.png .ogg .mp4 .opus + [[audio_as_voice]]) → still extract correctly

`tests/gateway/test_send_image_file.py`: 23/23 pass.

## Credit
Thanks to @notoriousmic (#13555) for surfacing the PDF-delivery gap.