### PR TITLE
feat: add changelog to update

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -689,6 +689,8 @@ class GatewayRunner:
         # Track pending /update prompt responses per session.
         # Key: session_key, Value: True when a prompt is waiting for user input.
         self._update_prompt_pending: Dict[str, bool] = {}
+        # Track sessions that have seen an update preview and can confirm it.
+        self._pending_update_confirmations: Dict[str, Dict[str, Any]] = {}
 
         # Persistent Honcho managers keyed by gateway session key.
         # This preserves write_frequency="session" semantics across short-lived
@@ -7652,42 +7654,45 @@ class GatewayRunner:
 
         return await loop.run_in_executor(None, _collect_and_upload)
 
-    async def _handle_update_command(self, event: MessageEvent) -> str:
-        """Handle /update command — update Hermes Agent to the latest version.
+    def _parse_update_command_args(self, event: MessageEvent) -> set[str]:
+        raw_args = re.sub(r"[\u2012\u2013\u2014\u2015]", "-", event.get_command_args().strip())
+        if not raw_args:
+            return set()
+        try:
+            parts = shlex.split(raw_args)
+        except ValueError:
+            parts = raw_args.split()
+        return {part.lower() for part in parts if part}
 
-        Spawns ``hermes update`` in a detached session (via ``setsid``) so it
-        survives the gateway restart that ``hermes update`` may trigger. Marker
-        files are written so either the current gateway process or the next one
-        can notify the user when the update finishes.
-        """
+    def _get_update_confirmation_store(self) -> Dict[str, Dict[str, Any]]:
+        store = getattr(self, "_pending_update_confirmations", None)
+        if store is None:
+            store = {}
+            self._pending_update_confirmations = store
+        return store
+
+    def _build_update_preview_message(self, project_root: Path) -> str:
+        from hermes_cli.update_preview import format_update_preview, get_update_preview
+
+        preview = get_update_preview(project_root)
+        if preview is None:
+            return (
+                "⚕ Hermes update preview is unavailable right now.\n\n"
+                "Reply `/update --yes` to continue immediately."
+            )
+        if preview.commit_count == 0:
+            return "✓ Already up to date!"
+        return format_update_preview(
+            preview,
+            confirm_command="`/update confirm`",
+            yes_command="`/update --yes`",
+        )
+
+    def _start_gateway_update(self, event: MessageEvent, hermes_cmd: list[str]) -> str:
         import json
         import shutil
         import subprocess
         from datetime import datetime
-        from hermes_cli.config import is_managed, format_managed_message
-
-        # Block non-messaging platforms (API server, webhooks, ACP)
-        platform = event.source.platform
-        if platform not in self._UPDATE_ALLOWED_PLATFORMS:
-            return "✗ /update is only available from messaging platforms. Run `hermes update` from the terminal."
-
-        if is_managed():
-            return f"✗ {format_managed_message('update Hermes Agent')}"
-
-        project_root = Path(__file__).parent.parent.resolve()
-        git_dir = project_root / '.git'
-
-        if not git_dir.exists():
-            return "✗ Not a git repository — cannot update."
-
-        hermes_cmd = _resolve_hermes_bin()
-        if not hermes_cmd:
-            return (
-                "✗ Could not locate the `hermes` command. "
-                "Hermes is running, but the update command could not find the "
-                "executable on PATH or via the current Python interpreter. "
-                "Try running `hermes update` manually in your terminal."
-            )
 
         pending_path = _hermes_home / ".update_pending.json"
         output_path = _hermes_home / ".update_output.txt"
@@ -7705,24 +7710,15 @@ class GatewayRunner:
         _tmp_pending.replace(pending_path)
         exit_code_path.unlink(missing_ok=True)
 
-        # Spawn `hermes update --gateway` detached so it survives gateway restart.
-        # --gateway enables file-based IPC for interactive prompts (stash
-        # restore, config migration) so the gateway can forward them to the
-        # user instead of silently skipping them.
-        # Use setsid for portable session detach (works under system services
-        # where systemd-run --user fails due to missing D-Bus session).
-        # PYTHONUNBUFFERED ensures output is flushed line-by-line so the
-        # gateway can stream it to the messenger in near-real-time.
         hermes_cmd_str = " ".join(shlex.quote(part) for part in hermes_cmd)
         update_cmd = (
-            f"PYTHONUNBUFFERED=1 {hermes_cmd_str} update --gateway"
+            f"PYTHONUNBUFFERED=1 {hermes_cmd_str} update --gateway --yes"
             f" > {shlex.quote(str(output_path))} 2>&1; "
             f"status=$?; printf '%s' \"$status\" > {shlex.quote(str(exit_code_path))}"
         )
         try:
             setsid_bin = shutil.which("setsid")
             if setsid_bin:
-                # Preferred: setsid creates a new session, fully detached
                 subprocess.Popen(
                     [setsid_bin, "bash", "-c", update_cmd],
                     stdout=subprocess.DEVNULL,
@@ -7730,7 +7726,6 @@ class GatewayRunner:
                     start_new_session=True,
                 )
             else:
-                # Fallback: start_new_session=True calls os.setsid() in child
                 subprocess.Popen(
                     ["bash", "-c", update_cmd],
                     stdout=subprocess.DEVNULL,
@@ -7744,6 +7739,67 @@ class GatewayRunner:
 
         self._schedule_update_notification_watch()
         return "⚕ Starting Hermes update… I'll stream progress here."
+
+    async def _handle_update_command(self, event: MessageEvent) -> str:
+        """Handle /update command — preview changes, then update on confirmation."""
+        from hermes_cli.config import format_managed_message, is_managed
+
+        platform = event.source.platform
+        if platform not in self._UPDATE_ALLOWED_PLATFORMS:
+            return "✗ /update is only available from messaging platforms. Run `hermes update` from the terminal."
+
+        if is_managed():
+            return f"✗ {format_managed_message('update Hermes Agent')}"
+
+        project_root = Path(__file__).parent.parent.resolve()
+        git_dir = project_root / ".git"
+        if not git_dir.exists():
+            return "✗ Not a git repository — cannot update."
+
+        hermes_cmd = _resolve_hermes_bin()
+        if not hermes_cmd:
+            return (
+                "✗ Could not locate the `hermes` command. "
+                "Hermes is running, but the update command could not find the "
+                "executable on PATH or via the current Python interpreter. "
+                "Try running `hermes update` manually in your terminal."
+            )
+
+        session_key = self._session_key_for_source(event.source)
+        confirmation_store = self._get_update_confirmation_store()
+        arg_parts = self._parse_update_command_args(event)
+
+        if "confirm" in arg_parts:
+            if session_key not in confirmation_store:
+                return "No update preview is waiting for confirmation. Run `/update` first."
+            confirmation_store.pop(session_key, None)
+            return self._start_gateway_update(event, hermes_cmd)
+
+        if "--yes" in arg_parts or "-y" in arg_parts:
+            confirmation_store.pop(session_key, None)
+            return self._start_gateway_update(event, hermes_cmd)
+
+        fetch_result = subprocess.run(
+            ["git", "fetch", "origin"],
+            cwd=project_root,
+            capture_output=True,
+            text=True,
+        )
+        if fetch_result.returncode != 0:
+            stderr = (fetch_result.stderr or "").strip()
+            if "Could not resolve host" in stderr or "unable to access" in stderr:
+                return "✗ Network error — cannot reach the remote repository."
+            if "Authentication failed" in stderr or "could not read Username" in stderr:
+                return "✗ Authentication failed — check your git credentials or SSH key."
+            return "✗ Failed to fetch updates from origin."
+
+        preview_message = self._build_update_preview_message(project_root)
+        if preview_message.startswith("✓ Already up to date!"):
+            confirmation_store.pop(session_key, None)
+            return preview_message
+
+        confirmation_store[session_key] = {"timestamp": datetime.now().isoformat()}
+        return preview_message
 
     def _schedule_update_notification_watch(self) -> None:
         """Ensure a background task is watching for update completion."""

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5391,6 +5391,71 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # Always update against main
         branch = "main"
 
+        from hermes_cli.update_preview import (
+            format_update_preview,
+            get_update_preview,
+            resolve_update_base_ref,
+        )
+
+        preview_base_ref = resolve_update_base_ref(PROJECT_ROOT, git_cmd, branch=branch)
+
+        # Check if there are updates
+        result = subprocess.run(
+            git_cmd + ["rev-list", f"{preview_base_ref}..origin/{branch}", "--count"],
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        commit_count = int(result.stdout.strip())
+
+        if commit_count == 0:
+            _invalidate_update_cache()
+            print("✓ Already up to date!")
+            return
+
+        print(f"→ Found {commit_count} new commit(s)")
+
+        update_preview = None
+        try:
+            update_preview = get_update_preview(
+                PROJECT_ROOT,
+                git_cmd=git_cmd,
+                base_ref=preview_base_ref,
+            )
+        except Exception:
+            update_preview = None
+
+        preview_confirmation_required = (
+            not getattr(args, "yes", False)
+            and (
+                gateway_mode
+                or (sys.stdin.isatty() and sys.stdout.isatty())
+            )
+        )
+        if preview_confirmation_required:
+            print()
+            if update_preview is not None:
+                print(
+                    format_update_preview(
+                        update_preview,
+                        yes_command="`hermes update --yes`",
+                    )
+                )
+            else:
+                print("⚕ Update preview unavailable, but new commits are ready to install.")
+            print()
+            if gateway_mode:
+                response = (gw_input_fn("Proceed with update? [y/N]", "n") or "").strip().lower()
+            else:
+                try:
+                    response = input("Proceed with update? [y/N]: ").strip().lower()
+                except EOFError:
+                    response = "n"
+            if response not in ("y", "yes"):
+                print("Update cancelled.")
+                return
+
         # If user is on a non-main branch or detached HEAD, switch to main
         if current_branch != "main":
             label = (
@@ -5414,40 +5479,6 @@ def _cmd_update_impl(args, gateway_mode: bool):
         prompt_for_restore = auto_stash_ref is not None and (
             gateway_mode or (sys.stdin.isatty() and sys.stdout.isatty())
         )
-
-        # Check if there are updates
-        result = subprocess.run(
-            git_cmd + ["rev-list", f"HEAD..origin/{branch}", "--count"],
-            cwd=PROJECT_ROOT,
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        commit_count = int(result.stdout.strip())
-
-        if commit_count == 0:
-            _invalidate_update_cache()
-            # Restore stash and switch back to original branch if we moved
-            if auto_stash_ref is not None:
-                _restore_stashed_changes(
-                    git_cmd,
-                    PROJECT_ROOT,
-                    auto_stash_ref,
-                    prompt_user=prompt_for_restore,
-                    input_fn=gw_input_fn,
-                )
-            if current_branch not in ("main", "HEAD"):
-                subprocess.run(
-                    git_cmd + ["checkout", current_branch],
-                    cwd=PROJECT_ROOT,
-                    capture_output=True,
-                    text=True,
-                    check=False,
-                )
-            print("✓ Already up to date!")
-            return
-
-        print(f"→ Found {commit_count} new commit(s)")
 
         print("→ Pulling updates...")
         update_succeeded = False
@@ -8302,6 +8333,12 @@ Examples:
         action="store_true",
         default=False,
         help="Gateway mode: use file-based IPC for prompts instead of stdin (used internally by /update)",
+    )
+    update_parser.add_argument(
+        "--yes", "-y",
+        action="store_true",
+        default=False,
+        help="Skip the update preview/confirmation prompt and apply updates immediately",
     )
     update_parser.set_defaults(func=cmd_update)
 

--- a/hermes_cli/update_preview.py
+++ b/hermes_cli/update_preview.py
@@ -1,0 +1,300 @@
+"""Helpers for summarizing pending Hermes updates before applying them."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+from hermes_cli import __version__ as CURRENT_VERSION
+
+
+_VERSION_RE = re.compile(r'__version__\s*=\s*"([^"]+)"')
+_RELEASE_FILE_RE = re.compile(r"RELEASE_v(\d+)\.(\d+)\.(\d+)\.md$")
+_LINK_RE = re.compile(r"\[([^\]]+)\]\([^)]+\)")
+
+
+@dataclass(frozen=True)
+class ReleaseSummary:
+    version: str
+    highlights: list[str]
+
+
+@dataclass(frozen=True)
+class UpdatePreview:
+    current_version: str
+    target_version: Optional[str]
+    commit_count: int
+    base_ref: str
+    remote_ref: str
+    commits: list[str]
+    releases: list[ReleaseSummary]
+
+
+def _git_capture(
+    repo_dir: Path,
+    git_cmd: list[str],
+    args: list[str],
+    *,
+    timeout: float = 10.0,
+) -> Optional[str]:
+    try:
+        result = subprocess.run(
+            git_cmd + args,
+            cwd=repo_dir,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except Exception:
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def _git_ok(
+    repo_dir: Path,
+    git_cmd: list[str],
+    args: list[str],
+    *,
+    timeout: float = 5.0,
+) -> bool:
+    try:
+        result = subprocess.run(
+            git_cmd + args,
+            cwd=repo_dir,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except Exception:
+        return False
+    return result.returncode == 0
+
+
+def resolve_update_base_ref(
+    repo_dir: Path,
+    git_cmd: Optional[list[str]] = None,
+    branch: str = "main",
+) -> str:
+    """Return the local ref Hermes should compare against origin/main."""
+    git_cmd = git_cmd or ["git"]
+    current_branch = _git_capture(
+        repo_dir, git_cmd, ["rev-parse", "--abbrev-ref", "HEAD"]
+    )
+    current_branch = (current_branch or "").strip() or "HEAD"
+    if current_branch == branch:
+        return "HEAD"
+    if _git_ok(repo_dir, git_cmd, ["show-ref", "--verify", "--quiet", f"refs/heads/{branch}"]):
+        return branch
+    return "HEAD"
+
+
+def _extract_version(init_text: str) -> Optional[str]:
+    match = _VERSION_RE.search(init_text or "")
+    return match.group(1) if match else None
+
+
+def _clean_markdown(text: str) -> str:
+    cleaned = _LINK_RE.sub(r"\1", text or "")
+    cleaned = cleaned.replace("**", "").replace("`", "")
+    cleaned = " ".join(cleaned.strip().split())
+    return cleaned
+
+
+def _truncate(text: str, limit: int = 220) -> str:
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 3)].rstrip() + "..."
+
+
+def _parse_release_highlights(content: str, max_highlights: int) -> list[str]:
+    highlights: list[str] = []
+    in_highlights = False
+    for raw_line in (content or "").splitlines():
+        line = raw_line.strip()
+        if line.startswith("## "):
+            if in_highlights:
+                break
+            in_highlights = "highlight" in line.lower()
+            continue
+        if in_highlights and line.startswith("- "):
+            highlights.append(_truncate(_clean_markdown(line[2:])))
+            if len(highlights) >= max_highlights:
+                break
+    if highlights:
+        return highlights
+
+    for raw_line in (content or "").splitlines():
+        line = raw_line.strip()
+        if line.startswith("- "):
+            highlights.append(_truncate(_clean_markdown(line[2:])))
+            if len(highlights) >= max_highlights:
+                break
+    return highlights
+
+
+def _release_sort_key(path: str) -> tuple[int, int, int]:
+    match = _RELEASE_FILE_RE.search(path or "")
+    if not match:
+        return (0, 0, 0)
+    return tuple(int(part) for part in match.groups())
+
+
+def _release_version_from_path(path: str) -> Optional[str]:
+    match = _RELEASE_FILE_RE.search(path or "")
+    if not match:
+        return None
+    return f"v{match.group(1)}.{match.group(2)}.{match.group(3)}"
+
+
+def _load_release_summaries(
+    repo_dir: Path,
+    git_cmd: list[str],
+    *,
+    base_ref: str,
+    remote_ref: str,
+    max_releases: int,
+    max_highlights: int,
+) -> list[ReleaseSummary]:
+    changed_files = _git_capture(
+        repo_dir,
+        git_cmd,
+        ["diff", "--name-only", f"{base_ref}..{remote_ref}", "--", ":(glob)RELEASE_v*.md"],
+    )
+    if not changed_files:
+        return []
+
+    release_files = sorted(
+        [line.strip() for line in changed_files.splitlines() if line.strip()],
+        key=_release_sort_key,
+        reverse=True,
+    )
+
+    summaries: list[ReleaseSummary] = []
+    for path in release_files[:max_releases]:
+        content = _git_capture(repo_dir, git_cmd, ["show", f"{remote_ref}:{path}"])
+        if not content:
+            continue
+        version = _release_version_from_path(path)
+        if not version:
+            continue
+        highlights = _parse_release_highlights(content, max_highlights)
+        if highlights:
+            summaries.append(ReleaseSummary(version=version, highlights=highlights))
+    return summaries
+
+
+def get_update_preview(
+    repo_dir: Path,
+    *,
+    git_cmd: Optional[list[str]] = None,
+    base_ref: Optional[str] = None,
+    remote_ref: str = "origin/main",
+    max_commits: int = 6,
+    max_releases: int = 2,
+    max_release_highlights: int = 2,
+) -> Optional[UpdatePreview]:
+    """Build a human-friendly summary of pending updates."""
+    git_cmd = git_cmd or ["git"]
+    base_ref = base_ref or resolve_update_base_ref(repo_dir, git_cmd)
+
+    commit_count_text = _git_capture(
+        repo_dir,
+        git_cmd,
+        ["rev-list", "--count", f"{base_ref}..{remote_ref}"],
+    )
+    if commit_count_text is None:
+        return None
+
+    try:
+        commit_count = int((commit_count_text or "").strip())
+    except ValueError:
+        return None
+
+    commits_text = _git_capture(
+        repo_dir,
+        git_cmd,
+        ["log", "--format=%s", "--no-merges", f"{base_ref}..{remote_ref}"],
+    )
+    commits = []
+    if commits_text:
+        for line in commits_text.splitlines():
+            cleaned = _clean_markdown(line)
+            if cleaned:
+                commits.append(_truncate(cleaned, limit=180))
+            if len(commits) >= max_commits:
+                break
+
+    remote_init = _git_capture(repo_dir, git_cmd, ["show", f"{remote_ref}:hermes_cli/__init__.py"])
+    target_version = _extract_version(remote_init or "")
+
+    releases = _load_release_summaries(
+        repo_dir,
+        git_cmd,
+        base_ref=base_ref,
+        remote_ref=remote_ref,
+        max_releases=max_releases,
+        max_highlights=max_release_highlights,
+    )
+
+    return UpdatePreview(
+        current_version=CURRENT_VERSION,
+        target_version=target_version,
+        commit_count=commit_count,
+        base_ref=base_ref,
+        remote_ref=remote_ref,
+        commits=commits,
+        releases=releases,
+    )
+
+
+def format_update_preview(
+    preview: UpdatePreview,
+    *,
+    confirm_command: Optional[str] = None,
+    yes_command: Optional[str] = None,
+) -> str:
+    """Render an update preview suitable for CLI or gateway output."""
+    commit_word = "commit" if preview.commit_count == 1 else "commits"
+    lines = [
+        "⚕ Hermes update preview",
+        "",
+        f"{preview.commit_count} {commit_word} ready from {preview.remote_ref}.",
+        f"Current version: v{preview.current_version}",
+    ]
+
+    if preview.target_version and preview.target_version != preview.current_version:
+        lines.append(f"Incoming version: v{preview.target_version}")
+
+    compare_ref = "HEAD" if preview.base_ref == "HEAD" else f"local {preview.base_ref}"
+    lines.append(f"Comparing {compare_ref} to {preview.remote_ref}.")
+
+    if preview.commits:
+        lines.extend(["", "Key changes:"])
+        for commit in preview.commits:
+            lines.append(f"- {commit}")
+        remaining = preview.commit_count - len(preview.commits)
+        if remaining > 0:
+            lines.append(f"- ... and {remaining} more")
+
+    if preview.releases:
+        lines.extend(["", "Release highlights:"])
+        for release in preview.releases:
+            lines.append(f"- {release.version}")
+            for highlight in release.highlights:
+                lines.append(f"  - {highlight}")
+
+    if confirm_command or yes_command:
+        lines.append("")
+        if confirm_command and yes_command:
+            lines.append(f"Proceed with {confirm_command} or skip the preview via {yes_command}.")
+        elif confirm_command:
+            lines.append(f"Proceed with {confirm_command}.")
+        else:
+            lines.append(f"Skip the preview via {yes_command}.")
+
+    return "\n".join(lines)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -654,7 +654,7 @@ async def restart_gateway():
 async def update_hermes():
     """Kick off ``hermes update`` in the background."""
     try:
-        proc = _spawn_hermes_action(["update"], "hermes-update")
+        proc = _spawn_hermes_action(["update", "--yes"], "hermes-update")
     except Exception as exc:
         _log.exception("Failed to spawn hermes update")
         raise HTTPException(status_code=500, detail=f"Failed to start update: {exc}")

--- a/tests/gateway/test_update_command.py
+++ b/tests/gateway/test_update_command.py
@@ -34,6 +34,7 @@ def _make_runner():
     runner = object.__new__(GatewayRunner)
     runner.adapters = {}
     runner._voice_mode = {}
+    runner._pending_update_confirmations = {}
     return runner
 
 
@@ -124,7 +125,7 @@ class TestHandleUpdateCommand:
     async def test_fallback_to_sys_executable(self, tmp_path):
         """Falls back to sys.executable -m hermes_cli.main when hermes not on PATH."""
         runner = _make_runner()
-        event = _make_event()
+        event = _make_event(text="/update --yes")
 
         fake_root = tmp_path / "project"
         fake_root.mkdir()
@@ -189,7 +190,7 @@ class TestHandleUpdateCommand:
     async def test_writes_pending_marker(self, tmp_path):
         """Writes .update_pending.json with correct platform and chat info."""
         runner = _make_runner()
-        event = _make_event(platform=Platform.TELEGRAM, chat_id="99999")
+        event = _make_event(text="/update --yes", platform=Platform.TELEGRAM, chat_id="99999")
 
         fake_root = tmp_path / "project"
         fake_root.mkdir()
@@ -218,7 +219,7 @@ class TestHandleUpdateCommand:
     async def test_spawns_setsid(self, tmp_path):
         """Uses setsid when available."""
         runner = _make_runner()
-        event = _make_event()
+        event = _make_event(text="/update --yes")
 
         fake_root = tmp_path / "project"
         fake_root.mkdir()
@@ -247,7 +248,7 @@ class TestHandleUpdateCommand:
     async def test_fallback_when_no_setsid(self, tmp_path):
         """Falls back to start_new_session=True when setsid is not available."""
         runner = _make_runner()
-        event = _make_event()
+        event = _make_event(text="/update --yes")
 
         fake_root = tmp_path / "project"
         fake_root.mkdir()
@@ -287,7 +288,7 @@ class TestHandleUpdateCommand:
     async def test_popen_failure_cleans_up(self, tmp_path):
         """Cleans up pending file and returns error on Popen failure."""
         runner = _make_runner()
-        event = _make_event()
+        event = _make_event(text="/update --yes")
 
         fake_root = tmp_path / "project"
         fake_root.mkdir()
@@ -313,7 +314,7 @@ class TestHandleUpdateCommand:
     async def test_returns_user_friendly_message(self, tmp_path):
         """The success response is user-friendly."""
         runner = _make_runner()
-        event = _make_event()
+        event = _make_event(text="/update --yes")
 
         fake_root = tmp_path / "project"
         fake_root.mkdir()
@@ -331,6 +332,62 @@ class TestHandleUpdateCommand:
             result = await runner._handle_update_command(event)
 
         assert "stream progress" in result
+
+    @pytest.mark.asyncio
+    async def test_default_update_shows_preview_and_waits_for_confirm(self, tmp_path):
+        """Plain /update should preview changes instead of spawning immediately."""
+        runner = _make_runner()
+        event = _make_event()
+
+        fake_root = tmp_path / "project"
+        fake_root.mkdir()
+        (fake_root / ".git").mkdir()
+        (fake_root / "gateway").mkdir()
+        (fake_root / "gateway" / "run.py").touch()
+        fake_file = str(fake_root / "gateway" / "run.py")
+
+        with patch("gateway.run.__file__", fake_file), \
+             patch("gateway.run.subprocess.run", return_value=MagicMock(returncode=0, stderr="")), \
+             patch("gateway.run._resolve_hermes_bin", return_value=["/usr/bin/hermes"]), \
+             patch.object(type(runner), "_build_update_preview_message", return_value="⚕ preview\nProceed with `/update confirm`.") as mock_preview, \
+             patch("subprocess.Popen") as mock_popen:
+            result = await runner._handle_update_command(event)
+
+        assert "preview" in result.lower()
+        assert "/update confirm" in result
+        mock_preview.assert_called_once()
+        mock_popen.assert_not_called()
+        assert runner._pending_update_confirmations
+
+    @pytest.mark.asyncio
+    async def test_update_confirm_starts_after_preview(self, tmp_path):
+        """`/update confirm` should start the detached updater after preview."""
+        runner = _make_runner()
+        event = _make_event(text="/update confirm")
+
+        fake_root = tmp_path / "project"
+        fake_root.mkdir()
+        (fake_root / ".git").mkdir()
+        (fake_root / "gateway").mkdir()
+        (fake_root / "gateway" / "run.py").touch()
+        fake_file = str(fake_root / "gateway" / "run.py")
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+
+        session_key = "agent:main:telegram:dm:67890"
+        runner._pending_update_confirmations[session_key] = {"timestamp": "2026-01-01T00:00:00"}
+        runner._session_key_for_source = MagicMock(return_value=session_key)
+
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.run.__file__", fake_file), \
+             patch("shutil.which", side_effect=lambda x: f"/usr/bin/{x}"), \
+             patch("subprocess.Popen") as mock_popen:
+            result = await runner._handle_update_command(event)
+
+        assert "Starting Hermes update" in result
+        call_args = mock_popen.call_args[0][0]
+        assert "--gateway --yes" in call_args[-1]
+        assert session_key not in runner._pending_update_confirmations
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_update_streaming.py
+++ b/tests/gateway/test_update_streaming.py
@@ -45,6 +45,7 @@ def _make_runner(hermes_home=None):
     runner._pending_messages = {}
     runner._pending_approvals = {}
     runner._failed_platforms = {}
+    runner._pending_update_confirmations = {}
     return runner
 
 
@@ -206,7 +207,7 @@ class TestUpdateCommandGatewayFlag:
     async def test_spawns_with_gateway_flag(self, tmp_path):
         """The spawned update command includes --gateway and PYTHONUNBUFFERED."""
         runner = _make_runner()
-        event = _make_event()
+        event = _make_event(text="/update --yes")
 
         fake_root = tmp_path / "project"
         fake_root.mkdir()
@@ -228,6 +229,7 @@ class TestUpdateCommandGatewayFlag:
         call_args = mock_popen.call_args[0][0]
         cmd_string = call_args[-1] if isinstance(call_args, list) else str(call_args)
         assert "--gateway" in cmd_string
+        assert "--yes" in cmd_string
         assert "PYTHONUNBUFFERED" in cmd_string
         assert "stream progress" in result
 

--- a/tests/hermes_cli/test_update_preview.py
+++ b/tests/hermes_cli/test_update_preview.py
@@ -1,0 +1,115 @@
+"""Tests for update preview helpers and interactive CLI confirmation."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+import sys
+
+
+def test_get_update_preview_summarizes_commits_and_release_notes(tmp_path):
+    from hermes_cli.update_preview import get_update_preview
+
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+
+    def fake_run(cmd, **kwargs):
+        joined = " ".join(str(part) for part in cmd)
+        if "rev-list --count" in joined:
+            return subprocess.CompletedProcess(cmd, 0, stdout="3\n", stderr="")
+        if "log --format=%s --no-merges" in joined:
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout=(
+                    "fix(gateway): break compression loop (#9893)\n"
+                    "feat: add gateway restart flag (#10043)\n"
+                    "fix: strip non-ascii API keys (#6843)\n"
+                ),
+                stderr="",
+            )
+        if f"show origin/main:hermes_cli/__init__.py" in joined:
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout='__version__ = "0.10.0"\n', stderr=""
+            )
+        if "diff --name-only" in joined:
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout="RELEASE_v0.10.0.md\n", stderr=""
+            )
+        if "show origin/main:RELEASE_v0.10.0.md" in joined:
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout=(
+                    "# Hermes Agent v0.10.0\n\n"
+                    "## ✨ Highlights\n\n"
+                    "- **Nous Tool Gateway** — managed tools for subscribers.\n"
+                    "- **Safer updates** — preview changes before applying them.\n"
+                ),
+                stderr="",
+            )
+        raise AssertionError(f"Unexpected git command: {cmd}")
+
+    with patch("hermes_cli.update_preview.subprocess.run", side_effect=fake_run):
+        preview = get_update_preview(repo_dir, git_cmd=["git"], base_ref="main")
+
+    assert preview is not None
+    assert preview.commit_count == 3
+    assert preview.target_version == "0.10.0"
+    assert preview.commits[:2] == [
+        "fix(gateway): break compression loop (#9893)",
+        "feat: add gateway restart flag (#10043)",
+    ]
+    assert preview.releases[0].version == "v0.10.0"
+    assert preview.releases[0].highlights[0].startswith("Nous Tool Gateway")
+
+
+def test_cmd_update_interactive_preview_can_cancel(monkeypatch, tmp_path, capsys):
+    monkeypatch.setitem(
+        sys.modules,
+        "dotenv",
+        SimpleNamespace(load_dotenv=lambda *args, **kwargs: False),
+    )
+    import hermes_cli.main as hermes_main
+    from hermes_cli.update_preview import ReleaseSummary, UpdatePreview
+
+    (tmp_path / ".git").mkdir()
+    monkeypatch.setattr(hermes_main, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(hermes_main, "_get_origin_url", lambda *_args, **_kwargs: "")
+    monkeypatch.setattr(hermes_main, "_is_fork", lambda *_args, **_kwargs: False)
+
+    def fake_run(cmd, **kwargs):
+        if cmd == ["git", "fetch", "origin"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if cmd == ["git", "rev-parse", "--abbrev-ref", "HEAD"]:
+            return SimpleNamespace(returncode=0, stdout="main\n", stderr="")
+        if cmd == ["git", "rev-list", "HEAD..origin/main", "--count"]:
+            return SimpleNamespace(returncode=0, stdout="3\n", stderr="")
+        raise AssertionError(f"Unexpected subprocess call: {cmd}")
+
+    preview = UpdatePreview(
+        current_version="0.9.0",
+        target_version="0.10.0",
+        commit_count=3,
+        base_ref="HEAD",
+        remote_ref="origin/main",
+        commits=["fix(gateway): break compression loop (#9893)"],
+        releases=[ReleaseSummary(version="v0.10.0", highlights=["Nous Tool Gateway"])],
+    )
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+    monkeypatch.setattr("shutil.which", lambda _name: None)
+
+    with patch("hermes_cli.update_preview.resolve_update_base_ref", return_value="HEAD"), \
+         patch("hermes_cli.update_preview.get_update_preview", return_value=preview), \
+         patch("builtins.input", return_value="n"), \
+         patch.object(hermes_main.sys.stdin, "isatty", return_value=True), \
+         patch.object(hermes_main.sys.stdout, "isatty", return_value=True):
+        hermes_main.cmd_update(SimpleNamespace(yes=False))
+
+    output = capsys.readouterr().out
+    assert "Hermes update preview" in output
+    assert "hermes update --yes" in output
+    assert "Update cancelled." in output


### PR DESCRIPTION
## What does this PR do?

This PR adds a preview-first update flow for both the Hermes CLI and gateway so users can review incoming changes before applying a self-update.

Previously, `hermes update` and `/update` immediately start pulling code and reinstalling dependencies. That gives users no chance to inspect what changed, which is risky for a tool that can restart its own gateway process. This change adds a lightweight changelog preview based on pending commits and release notes, then asks for confirmation before proceeding.

This approach reuses the existing `git fetch` flow and shared update logic, keeps the current fast path available with `--yes`, and avoids introducing a separate backend or release metadata format.

## Related Issue

Fixes #13588 

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added shared update preview helpers in `hermes_cli/update_preview.py`
- Updated `hermes update` in `hermes_cli/main.py` to:
  - fetch updates
  - summarize pending commits and release highlights
  - prompt for confirmation in interactive mode
  - support `--yes` / `-y` to skip the preview
- Updated gateway `/update` flow in `gateway/run.py` to:
  - show a preview first
  - require `/update confirm` before applying the update
  - preserve immediate-update behavior via `/update --yes`
- Updated the web update trigger in `hermes_cli/web_server.py` to call `hermes update --yes` so background/non-interactive updates do not block
- Added focused CLI preview tests in `tests/hermes_cli/test_update_preview.py`
- Updated gateway update tests in:
  - `tests/gateway/test_update_command.py`
  - `tests/gateway/test_update_streaming.py`

## How to Test

1. Activate the repo environment and run:
   ```bash
   hermes update

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`