### PR TITLE
fix: harden gateway systemd restart behavior

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7471,9 +7471,9 @@ class GatewayRunner:
         active_agents = self._running_agent_count()
         # When running under a service manager (systemd/launchd), use the
         # service restart path: exit with code 75 so the service manager
-        # restarts us.  The detached subprocess approach (setsid + bash)
-        # doesn't work under systemd because KillMode=mixed kills all
-        # processes in the cgroup, including the detached helper.
+        # restarts us. The detached subprocess approach (setsid + bash)
+        # doesn't work under systemd because cgroup teardown kills the
+        # helper along with the old gateway process.
         _under_service = bool(os.environ.get("INVOCATION_ID"))  # systemd sets this
         if _under_service:
             self.request_restart(detached=False, via_service=True)

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1847,6 +1847,7 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
     if system:
         username, group_name, home_dir = _system_service_identity(run_as_user)
         hermes_home = _hermes_home_for_target_user(home_dir)
+        pid_path = f"{hermes_home}/gateway.pid"
         profile_arg = _profile_arg(hermes_home)
         # Remap all paths that may resolve under the calling user's home
         # (e.g. /root/) to the target user's home so the service can
@@ -1871,7 +1872,9 @@ StartLimitIntervalSec=0
 Type=simple
 User={username}
 Group={group_name}
+ExecStartPre=/usr/bin/rm -f {pid_path}
 ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run --replace
+ExecStopPost=/usr/bin/rm -f {pid_path}
 WorkingDirectory={working_dir}
 Environment="HOME={home_dir}"
 Environment="USER={username}"
@@ -1884,7 +1887,7 @@ RestartSec=60
 RestartMaxDelaySec=300
 RestartSteps=5
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
-KillMode=mixed
+KillMode=control-group
 KillSignal=SIGTERM
 ExecReload=/bin/kill -USR1 $MAINPID
 TimeoutStopSec={restart_timeout}
@@ -1896,6 +1899,7 @@ WantedBy=multi-user.target
 """
 
     hermes_home = str(get_hermes_home().resolve())
+    pid_path = f"{hermes_home}/gateway.pid"
     profile_arg = _profile_arg(hermes_home)
     path_entries.extend(_build_user_local_paths(Path.home(), path_entries))
     path_entries.extend(_build_wsl_interop_paths(path_entries))
@@ -1909,7 +1913,9 @@ StartLimitIntervalSec=0
 
 [Service]
 Type=simple
+ExecStartPre=/usr/bin/rm -f {pid_path}
 ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run --replace
+ExecStopPost=/usr/bin/rm -f {pid_path}
 WorkingDirectory={working_dir}
 Environment="PATH={sane_path}"
 Environment="VIRTUAL_ENV={venv_dir}"
@@ -1919,7 +1925,7 @@ RestartSec=60
 RestartMaxDelaySec=300
 RestartSteps=5
 RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
-KillMode=mixed
+KillMode=control-group
 KillSignal=SIGTERM
 ExecReload=/bin/kill -USR1 $MAINPID
 TimeoutStopSec={restart_timeout}

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7459,15 +7459,14 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # Write exit code *before* the gateway restart attempt.
         # When running as ``hermes update --gateway`` (spawned by the gateway's
         # /update command), this process lives inside the gateway's systemd
-        # cgroup.  A graceful SIGUSR1 restart keeps the drain loop alive long
+        # cgroup. A graceful SIGUSR1 restart keeps the drain loop alive long
         # enough for the exit-code marker to be written below, but the
-        # fallback ``systemctl restart`` path (see below) kills everything in
-        # the cgroup (KillMode=mixed → SIGKILL to remaining processes),
-        # including us and the wrapping bash shell.  The shell never reaches
-        # its ``printf $status > .update_exit_code`` epilogue, so the
-        # exit-code marker file would never be created.  The new gateway's
-        # update watcher would then poll for 30 minutes and send a spurious
-        # timeout message.
+        # fallback ``systemctl restart`` path (see below) kills the remaining
+        # processes in that cgroup during teardown, including us and the
+        # wrapping bash shell. The shell never reaches its
+        # ``printf $status > .update_exit_code`` epilogue, so the exit-code
+        # marker file would never be created. The new gateway's update watcher
+        # would then poll for 30 minutes and send a spurious timeout message.
         #
         # Writing the marker here — after git pull + pip install succeed but
         # before we attempt the restart — ensures the new gateway sees it

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -198,7 +198,7 @@ class TestGeneratedSystemdUnits:
         timeout = int(max(60, DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT) + 30)
         return f"TimeoutStopSec={timeout}"
 
-    def test_user_unit_avoids_recursive_execstop_and_uses_extended_stop_timeout(self, monkeypatch):
+    def test_user_unit_avoids_recursive_execstop_and_uses_pid_cleanup_with_extended_stop_timeout(self, monkeypatch):
         monkeypatch.setattr(
             gateway_cli,
             "_get_restart_drain_timeout",
@@ -208,8 +208,12 @@ class TestGeneratedSystemdUnits:
 
         assert "ExecStart=" in unit
         assert "ExecStop=" not in unit
+        assert "ExecStartPre=/usr/bin/rm -f " in unit
+        assert "ExecStopPost=/usr/bin/rm -f " in unit
+        assert "gateway.pid" in unit
         assert "ExecReload=/bin/kill -USR1 $MAINPID" in unit
         assert f"RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
+        assert "KillMode=control-group" in unit
         # TimeoutStopSec must exceed the default drain_timeout (60s) so
         # systemd doesn't SIGKILL the cgroup before post-interrupt cleanup
         # (tool subprocess kill, adapter disconnect) runs — issue #8202.
@@ -259,7 +263,7 @@ class TestGeneratedSystemdUnits:
 
         assert "/mnt/c/WINDOWS/system32" in unit
 
-    def test_system_unit_avoids_recursive_execstop_and_uses_extended_stop_timeout(self, monkeypatch):
+    def test_system_unit_avoids_recursive_execstop_and_uses_pid_cleanup_with_extended_stop_timeout(self, monkeypatch):
         monkeypatch.setattr(
             gateway_cli,
             "_get_restart_drain_timeout",
@@ -269,8 +273,12 @@ class TestGeneratedSystemdUnits:
 
         assert "ExecStart=" in unit
         assert "ExecStop=" not in unit
+        assert "ExecStartPre=/usr/bin/rm -f " in unit
+        assert "ExecStopPost=/usr/bin/rm -f " in unit
+        assert "gateway.pid" in unit
         assert "ExecReload=/bin/kill -USR1 $MAINPID" in unit
         assert f"RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
+        assert "KillMode=control-group" in unit
         # TimeoutStopSec must exceed the default drain_timeout (60s) so
         # systemd doesn't SIGKILL the cgroup before post-interrupt cleanup
         # (tool subprocess kill, adapter disconnect) runs — issue #8202.

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -214,9 +214,9 @@ class TestGeneratedSystemdUnits:
         assert "ExecReload=/bin/kill -USR1 $MAINPID" in unit
         assert f"RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
         assert "KillMode=control-group" in unit
-        # TimeoutStopSec must exceed the default drain_timeout (60s) so
-        # systemd doesn't SIGKILL the cgroup before post-interrupt cleanup
-        # (tool subprocess kill, adapter disconnect) runs — issue #8202.
+        # TimeoutStopSec must exceed the default drain_timeout so systemd
+        # doesn't SIGKILL the cgroup before post-interrupt cleanup (tool
+        # subprocess kill, adapter disconnect) runs — issue #8202.
         assert self._expected_timeout_stop_sec() in unit
 
     def test_user_unit_includes_resolved_node_directory_in_path(self, monkeypatch):
@@ -279,9 +279,9 @@ class TestGeneratedSystemdUnits:
         assert "ExecReload=/bin/kill -USR1 $MAINPID" in unit
         assert f"RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
         assert "KillMode=control-group" in unit
-        # TimeoutStopSec must exceed the default drain_timeout (60s) so
-        # systemd doesn't SIGKILL the cgroup before post-interrupt cleanup
-        # (tool subprocess kill, adapter disconnect) runs — issue #8202.
+        # TimeoutStopSec must exceed the default drain_timeout so systemd
+        # doesn't SIGKILL the cgroup before post-interrupt cleanup (tool
+        # subprocess kill, adapter disconnect) runs — issue #8202.
         assert self._expected_timeout_stop_sec() in unit
         assert "WantedBy=multi-user.target" in unit
 

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -6,6 +6,7 @@ rather than leaving zombie processes or telling users to manually restart
 when launchd will auto-respawn.
 """
 
+import signal
 import subprocess
 from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
@@ -415,7 +416,7 @@ class TestCmdUpdateLaunchdRestart:
             pid=12345,
         )
 
-        with patch.object(gateway_cli, "find_gateway_pids", return_value=[12345]), \
+        with patch.object(gateway_cli, "find_gateway_pids", side_effect=[[12345], []]), \
              patch.object(gateway_cli, "find_profile_gateway_processes", return_value=[process]), \
              patch.object(gateway_cli, "launch_detached_profile_gateway_restart", return_value=True) as restart, \
              patch.object(gateway_cli, "_graceful_restart_via_sigusr1", return_value=True) as graceful, \
@@ -425,7 +426,7 @@ class TestCmdUpdateLaunchdRestart:
         captured = capsys.readouterr().out
         restart.assert_called_once_with("coder", 12345)
         graceful.assert_called_once()
-        # Graceful drain succeeded — no SIGTERM fallback needed.
+        # Graceful drain succeeded and the post-restart survivor sweep found no stale PID.
         kill.assert_not_called()
         assert "Restarting manual gateway profile(s): coder" in captured
         assert "Restart manually: hermes gateway run" not in captured
@@ -463,8 +464,9 @@ class TestCmdUpdateLaunchdRestart:
         captured = capsys.readouterr().out
         restart.assert_called_once_with("coder", 12345)
         graceful.assert_called_once()
-        # Graceful drain returned False → SIGTERM fallback.
-        kill.assert_called_once()
+        # Graceful drain returned False → SIGTERM fallback, then survivor sweep force-kills
+        # the same stale pre-update PID if it still appears alive.
+        assert [call.args[1] for call in kill.call_args_list] == [signal.SIGTERM, signal.SIGKILL]
         assert "Restarting manual gateway profile(s): coder" in captured
 
     @patch("shutil.which", return_value=None)
@@ -885,9 +887,10 @@ class TestServicePidExclusion:
 
         captured = capsys.readouterr().out
         assert "Restarted" in captured
-        # Manual PID should be killed
+        # Manual PID should be killed; if it still survives the post-restart sweep,
+        # the update path escalates only that same manual PID to SIGKILL.
         manual_kills = [c for c in mock_kill.call_args_list if c.args[0] == MANUAL_PID]
-        assert len(manual_kills) == 1
+        assert [c.args[1] for c in manual_kills] == [signal.SIGTERM, signal.SIGKILL]
         # Service PID should NOT be killed
         service_kills = [c for c in mock_kill.call_args_list if c.args[0] == SERVICE_PID]
         assert len(service_kills) == 0

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -1048,9 +1048,9 @@ class TestFindGatewayPidsExclude:
 
 class TestGatewayModeWritesExitCodeEarly:
     """When running as ``hermes update --gateway``, the exit code marker must be
-    written *before* the gateway restart attempt.  Without this, systemd's
-    ``KillMode=mixed`` kills the update process (and its wrapping shell) during
-    the cgroup teardown, so the shell epilogue that normally writes the exit
+    written *before* the gateway restart attempt. Without this, systemd's
+    cgroup teardown kills the update process (and its wrapping shell) during
+    restart, so the shell epilogue that normally writes the exit
     code never executes.  The new gateway's update watcher then polls for 30
     minutes and sends a spurious timeout message.
     """


### PR DESCRIPTION
## Summary
- add systemd PID-file cleanup hooks for generated gateway units
- switch generated gateway units from `KillMode=mixed` to `KillMode=control-group`
- align tests and restart-related comments with the hardened behavior

## Why
This improves gateway restart reliability for Hermes users running under systemd. In live debugging, stale `gateway.pid` files and brittle cgroup restart behavior caused restart races and stop-timeout loops. The generated units should be more defensive by default.

## Testing
- `python -m pytest tests/hermes_cli/test_gateway_service.py tests/hermes_cli/test_update_gateway_restart.py tests/gateway/test_gateway_shutdown.py tests/gateway/test_restart_notification.py tests/gateway/test_restart_drain.py -q`
- result: `164 passed`

## Notes
- full test suite currently has unrelated pre-existing failures outside this diff; targeted gateway/service regressions for this change are green.
