### PR TITLE
fix tools delegate: allow local no-auth endpoints for direct delegation

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -652,7 +652,7 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertEqual(creds["api_key"], "env-openai-key")
         self.assertEqual(creds["provider"], "custom")
 
-    def test_direct_endpoint_does_not_fall_back_to_openrouter_api_key_env(self):
+    def test_direct_endpoint_without_key_uses_placeholder_not_openrouter_env(self):
         parent = _make_mock_parent(depth=0)
         cfg = {
             "model": "qwen2.5-coder",
@@ -666,9 +666,9 @@ class TestDelegationCredentialResolution(unittest.TestCase):
             },
             clear=False,
         ):
-            with self.assertRaises(ValueError) as ctx:
-                _resolve_delegation_credentials(cfg, parent)
-        self.assertIn("OPENAI_API_KEY", str(ctx.exception))
+            creds = _resolve_delegation_credentials(cfg, parent)
+        self.assertEqual(creds["api_key"], "no-key-required")
+        self.assertEqual(creds["provider"], "custom")
 
     @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
     def test_nous_provider_resolves_nous_credentials(self, mock_resolve):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -63,6 +63,7 @@ MAX_DEPTH = 1  # flat by default: parent (0) -> child (1); grandchild rejected u
 # stays as the default fallback and is still the symbol tests import.
 _MIN_SPAWN_DEPTH = 1
 _MAX_SPAWN_DEPTH_CAP = 3
+_LOCAL_NO_AUTH_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
 
 
 def _normalize_role(r: Optional[str]) -> str:
@@ -1254,10 +1255,13 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     configured_api_key = str(cfg.get("api_key") or "").strip() or None
 
     if configured_base_url:
+        hostname = base_url_hostname(configured_base_url)
         api_key = (
             configured_api_key
             or os.getenv("OPENAI_API_KEY", "").strip()
         )
+        if not api_key and hostname in _LOCAL_NO_AUTH_HOSTS:
+            api_key = "no-key-required"
         if not api_key:
             raise ValueError(
                 "Delegation base_url is configured but no API key was found. "
@@ -1273,7 +1277,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         ):
             provider = "openai-codex"
             api_mode = "codex_responses"
-        elif base_url_hostname(configured_base_url) == "api.anthropic.com":
+        elif hostname == "api.anthropic.com":
             provider = "anthropic"
             api_mode = "anthropic_messages"
 


### PR DESCRIPTION
## Summary

Fix delegation credential resolution for local direct endpoints that do not require authentication.

When `delegation.base_url` points at a local OpenAI-compatible server, such as `localhost`, `127.0.0.1`, or `::1`, delegation now uses the existing `"no-key-required"` placeholder if neither `delegation.api_key` nor `OPENAI_API_KEY` is configured.

## Why

Local OpenAI-compatible servers like LM Studio, Ollama-compatible proxies, llama.cpp, and local vLLM setups commonly run without API key authentication. Before this change, configuring `delegation.base_url` for one of those endpoints failed before the child agent could start unless `OPENAI_API_KEY` was set, even though the endpoint itself did not require auth.

This made local subagent delegation stricter than the rest of Hermes' custom endpoint behavior.

## Changes

- Allow no-auth placeholder credentials only for local direct delegation hosts:
  - `localhost`
  - `127.0.0.1`
  - `::1`
- Preserve existing precedence when credentials are provided:
  - `delegation.api_key`
  - `OPENAI_API_KEY`
  - local no-auth placeholder
- Preserve the existing guard that direct delegation endpoints must not fall back to `OPENROUTER_API_KEY`.
- Add regression coverage for local no-key delegation.

## Testing

```powershell
uv run --extra dev python -m pytest tests/tools/test_delegate.py::TestDelegationCredentialResolution::test_direct_endpoint_without_key_uses_placeholder_not_openrouter_env -q -n 4
uv run --extra dev python -m pytest tests/tools/test_delegate.py -q -n 4

Results: 68 passed, 4 warnings
