### PR TITLE
fix(models): raise auto-correct cutoff to prevent version-variant false positives

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2214,7 +2214,7 @@ def validate_requested_model(
                 }
 
             # Auto-correct if the top match is very similar (e.g. typo)
-            auto = get_close_matches(requested_for_lookup, api_models, n=1, cutoff=0.9)
+            auto = get_close_matches(requested_for_lookup, api_models, n=1, cutoff=0.98)
             if auto:
                 return {
                     "accepted": True,
@@ -2276,7 +2276,7 @@ def validate_requested_model(
                     "message": None,
                 }
             # Auto-correct if the top match is very similar (e.g. typo)
-            auto = get_close_matches(requested_for_lookup, codex_models, n=1, cutoff=0.9)
+            auto = get_close_matches(requested_for_lookup, codex_models, n=1, cutoff=0.98)
             if auto:
                 return {
                     "accepted": True,
@@ -2318,7 +2318,7 @@ def validate_requested_model(
                 }
             # Auto-correct close matches (case-insensitive)
             catalog_lower_list = list(catalog_lower.keys())
-            auto = get_close_matches(requested_for_lookup.lower(), catalog_lower_list, n=1, cutoff=0.9)
+            auto = get_close_matches(requested_for_lookup.lower(), catalog_lower_list, n=1, cutoff=0.98)
             if auto:
                 corrected = catalog_lower[auto[0]]
                 return {
@@ -2363,7 +2363,7 @@ def validate_requested_model(
             # endpoints even though it's not in /models).  Warn but allow.
 
             # Auto-correct if the top match is very similar (e.g. typo)
-            auto = get_close_matches(requested_for_lookup, api_models, n=1, cutoff=0.9)
+            auto = get_close_matches(requested_for_lookup, api_models, n=1, cutoff=0.98)
             if auto:
                 return {
                     "accepted": True,


### PR DESCRIPTION
## Problem

`get_close_matches(cutoff=0.9)` in model validation triggers a false-positive auto-correct when a provider ships a new model variant whose ID differs by only a small number of characters from an existing one.

### Concrete reproducer (Fireworks + Kimi K2.6)

Moonshot's `kimi-k2p6` was released 2026-04-17. Accessible via Fireworks inference API but temporarily unlisted in `/v1/models` — a common pattern for early-access releases.

When a user requests `accounts/fireworks/models/kimi-k2p6`:

1. `probe_api_models()` returns `[kimi-k2p5, glm-5p1, ...]` — k2p6 absent
2. `get_close_matches(..., cutoff=0.9)` finds `kimi-k2p5` as match (similarity **0.971** — only 1 char diff in a 35-char ID)
3. Hermes silently substitutes `kimi-k2p6` → `kimi-k2p5`
4. The session runs K2.5 despite the user explicitly requesting K2.6

The user gets a different model than they asked for, and the only signal is a one-line warning that's easy to miss.

### Generalization

The bug applies to **any provider + consecutive version IDs**: Llama 4.x/4.y, Qwen 3.6/3.7, DeepSeek V3.2/V3.3, etc. Any time a new variant lands in the inference API before `/v1/models` is updated, users get silent downgrades.

## Fix

Raise the auto-correct cutoff from `0.9` to `0.98` in the 4 `get_close_matches` calls used for auto-correct:

- Custom provider path
- OpenAI Codex path
- MiniMax catalog path
- Generic catalog fallback

`cutoff=0.5` calls used for suggestion text are intentionally untouched.

### Properties

- **Preserves typo catching:** single-letter substitutions in short identifiers (e.g. `kimi` → `kimmi`, similarity ~0.94) still fall into the existing "not found with suggestions" branch in the code. The model isn't auto-corrected, but the user gets informative suggestions and the call is still accepted.
- **Stops false-positive auto-correct** for consecutive version IDs (similarity ~0.97).
- **Forward-compatible:** when the new model eventually appears in `/v1/models`, the exact-match branch returns early and this auto-correct path is never exercised. The higher cutoff has zero impact at that point.

### Testing

**Before** (`cutoff=0.9`, Kimi K2.6 requested):

```
✓ Model switched: accounts/fireworks/models/kimi-k2p5
⚠ Auto-corrected `accounts/fireworks/models/kimi-k2p6` → `accounts/fireworks/models/kimi-k2p5`
```

**After** (`cutoff=0.98`, Kimi K2.6 requested):

```
✗ Note: `accounts/fireworks/models/kimi-k2p6` was not found in this custom endpoint's
  model listing (https://api.fireworks.ai/inference/v1/models). It may still work if
  the server supports hidden or aliased models.
  Similar models: `accounts/fireworks/models/kimi-k2p5`, `accounts/fireworks/models/glm-5p1`,
                  `accounts/fireworks/models/minimax-m2p7`
```

Inference calls succeed. The user gets the model they asked for, plus an informational note.

Existing `tests/hermes_cli/test_model_validation.py` cases continue to pass — the typos tested there have similarity well below 0.98.

## Alternatives considered

| Approach | Why not chosen |
|---|---|
| Check `models_dev_cache.json` before auto-correcting | Crosses module boundaries, and doesn't help providers not covered by the cache. |
| Length-aware filter (require N-char diff before auto-correct) | Tunable per-provider naming convention, harder to reason about than a single threshold. |
| Per-provider exact-match allowlist | Requires ongoing curation as new models ship. |

The cutoff change is minimal, targeted, and reversible.

## Checklist

- [x] Fix compiles and imports cleanly
- [x] Existing model validation tests pass locally
- [x] Reproducer verified before/after
- [x] No API surface change
- [x] No change to existing typo catching behavior (typos still fall through to "not found with suggestions" branch)