### PR TITLE
fix(vision): resolve Nous vision model correctly in auto-detect path

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -152,6 +152,7 @@ _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = {
 _PROVIDER_VISION_MODELS: Dict[str, str] = {
     "xiaomi": "mimo-v2-omni",
     "zai": "glm-5v-turbo",
+    "nous": "xiaomi/mimo-v2-omni",
 }
 
 # OpenRouter app attribution headers
@@ -933,20 +934,28 @@ def _try_nous(vision: bool = False) -> Tuple[Optional[OpenAI], Optional[str]]:
         model = _NOUS_MODEL
     # Free-tier users can't use paid auxiliary models — use the free
     # models instead: mimo-v2-omni for vision, mimo-v2-pro for text tasks.
+    # For vision tasks, always use mimo-v2-omni regardless of tier —
+    # Nous inference API does not support image inputs for gemini models.
     try:
         from hermes_cli.models import check_nous_free_tier
         if check_nous_free_tier():
             model = _NOUS_FREE_TIER_VISION_MODEL if vision else _NOUS_FREE_TIER_AUX_MODEL
             logger.debug("Free-tier Nous account — using %s for auxiliary/%s",
                          model, "vision" if vision else "text")
+        elif vision:
+            model = _NOUS_FREE_TIER_VISION_MODEL
+            logger.debug("Nous vision task — using %s (gemini models lack "
+                         "image support on Nous inference API)", model)
     except Exception:
-        pass
+        if vision:
+            model = _NOUS_FREE_TIER_VISION_MODEL
+    if vision:
+        logger.debug("Nous vision: final model = %s", model)
     if runtime is not None:
         api_key, base_url = runtime
     else:
         api_key = _nous_api_key(nous or {})
         base_url = str((nous or {}).get("inference_base_url") or _nous_base_url()).rstrip("/")
-
     return (
         OpenAI(
             api_key=api_key,
@@ -1610,7 +1619,13 @@ def resolve_provider_client(
 
     # ── Nous Portal (OAuth) ──────────────────────────────────────────
     if provider == "nous":
-        client, default = _try_nous()
+        # Detect vision tasks: either explicit model override from
+        # _PROVIDER_VISION_MODELS, or caller passed a known vision model.
+        _is_vision = (
+            model in _PROVIDER_VISION_MODELS.values()
+            or (model or "").strip().lower() == "mimo-v2-omni"
+        )
+        client, default = _try_nous(vision=_is_vision)
         if client is None:
             logger.warning("resolve_provider_client: nous requested "
                            "but Nous Portal not configured (run: hermes auth)")

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -129,6 +129,7 @@ AUTHOR_MAP = {
     "brooklyn.bb.nicholson@gmail.com": "brooklynnicholson",
     "withapurpose37@gmail.com": "StefanIsMe",
     "4317663+helix4u@users.noreply.github.com": "helix4u",
+    "ifkellx@users.noreply.github.com": "Ifkellx",
     "331214+counterposition@users.noreply.github.com": "counterposition",
     "blspear@gmail.com": "BrennerSpear",
     "akhater@gmail.com": "akhater",


### PR DESCRIPTION
Salvage of #12687 (@Ifkellx) onto current main.

## Summary
Nous vision tasks now resolve to `xiaomi/mimo-v2-omni` (the actual multimodal model on the Nous inference API) instead of silently falling through to `google/gemini-3-flash-preview` / `xiaomi/mimo-v2-pro`, which return 404/400 for image inputs.

Pairs with #13682 (merged) — that one fixed the stale-credential side of Tom-in-Tampa's vision report; this one fixes the wrong-model-selected side.

## Changes
- `agent/auxiliary_client.py`: add `nous" → "xiaomi/mimo-v2-omni"` to `_PROVIDER_VISION_MODELS`, so the auto-detect chain's paid-tier Nous lookup picks the multimodal model.
- `agent/auxiliary_client.py`: when `_try_nous()` is called with `vision=True` against a paid account, force `mimo-v2-omni` (gemini-3-flash-preview doesn't accept images on the Nous inference API).
- `agent/auxiliary_client.py`: `resolve_provider_client("nous", model=...)` now detects vision models (membership in `_PROVIDER_VISION_MODELS.values()` or bare `mimo-v2-omni`) and passes `vision=True` to `_try_nous()`. Previously the auto-detect path always called `_try_nous()` without `vision=True`.
- `scripts/release.py`: add Ifkellx to AUTHOR_MAP so release-notes CI doesn't attribute to a placeholder.

## Validation
- `scripts/run_tests.sh tests/agent/test_auxiliary_client.py tests/agent/test_auxiliary_named_custom_providers.py tests/hermes_cli/test_xiaomi_provider.py` → 134 passed
- `scripts/run_tests.sh tests/agent/test_vision_resolved_args.py tests/agent/test_nous_rate_guard.py tests/agent/test_auxiliary_main_first.py tests/hermes_cli/test_tools_config.py` → 72 passed

Closes #12687.