### PR TITLE
fix(vision): restore tier-aware Nous vision model selection

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -152,7 +152,6 @@ _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = {
 _PROVIDER_VISION_MODELS: Dict[str, str] = {
     "xiaomi": "mimo-v2-omni",
     "zai": "glm-5v-turbo",
-    "nous": "xiaomi/mimo-v2-omni",
 }
 
 # OpenRouter app attribution headers
@@ -934,23 +933,16 @@ def _try_nous(vision: bool = False) -> Tuple[Optional[OpenAI], Optional[str]]:
         model = _NOUS_MODEL
     # Free-tier users can't use paid auxiliary models — use the free
     # models instead: mimo-v2-omni for vision, mimo-v2-pro for text tasks.
-    # For vision tasks, always use mimo-v2-omni regardless of tier —
-    # Nous inference API does not support image inputs for gemini models.
+    # Paid accounts keep their tier-appropriate models: gemini-3-flash-preview
+    # for both text and vision tasks.
     try:
         from hermes_cli.models import check_nous_free_tier
         if check_nous_free_tier():
             model = _NOUS_FREE_TIER_VISION_MODEL if vision else _NOUS_FREE_TIER_AUX_MODEL
             logger.debug("Free-tier Nous account — using %s for auxiliary/%s",
                          model, "vision" if vision else "text")
-        elif vision:
-            model = _NOUS_FREE_TIER_VISION_MODEL
-            logger.debug("Nous vision task — using %s (gemini models lack "
-                         "image support on Nous inference API)", model)
     except Exception:
-        if vision:
-            model = _NOUS_FREE_TIER_VISION_MODEL
-    if vision:
-        logger.debug("Nous vision: final model = %s", model)
+        pass
     if runtime is not None:
         api_key, base_url = runtime
     else:


### PR DESCRIPTION
## Summary
Paid Nous vision now lands on `google/gemini-3-flash-preview` again. #13699 over-corrected and forced every Nous vision call to `xiaomi/mimo-v2-omni` regardless of account tier; this PR reverts the two bits that caused it while keeping the free-tier behavior intact.

## Changes
- `agent/auxiliary_client.py`: remove `"nous": "xiaomi/mimo-v2-omni"` from `_PROVIDER_VISION_MODELS`. #13696 routes `main_provider == "nous"` through `_resolve_strict_vision_backend` directly, so this entry only served to hijack any other `resolve_provider_client("nous", ...)` lookup onto mimo.
- `agent/auxiliary_client.py`: drop the `elif vision: model = _NOUS_FREE_TIER_VISION_MODEL` paid override in `_try_nous()`. Free-tier branch (via `check_nous_free_tier()`) is unchanged.

## Validation
| scenario | before | after |
|---|---|---|
| Paid Nous vision | xiaomi/mimo-v2-omni | **google/gemini-3-flash-preview** |
| Free Nous vision | xiaomi/mimo-v2-omni | xiaomi/mimo-v2-omni |
| Paid Nous text   | google/gemini-3-flash-preview | google/gemini-3-flash-preview |
| Free Nous text   | xiaomi/mimo-v2-pro | xiaomi/mimo-v2-pro |

Tests: `scripts/run_tests.sh tests/agent/test_auxiliary_client.py tests/agent/test_auxiliary_main_first.py tests/agent/test_auxiliary_named_custom_providers.py tests/hermes_cli/test_xiaomi_provider.py tests/hermes_cli/test_aux_config.py tests/agent/test_vision_resolved_args.py` → 169 passed.

E2E traced all four scenarios with real `_try_nous()` imports.