### PR TITLE
[codex] Fix gateway update restart race

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -216,10 +216,7 @@ def _cleanup_invalid_pid_path(pid_path: Path, *, cleanup_stale: bool) -> None:
     if not cleanup_stale:
         return
     try:
-        if pid_path == _get_pid_path():
-            remove_pid_file()
-        else:
-            pid_path.unlink(missing_ok=True)
+        pid_path.unlink(missing_ok=True)
     except Exception:
         pass
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5763,6 +5763,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                             text=True,
                             timeout=10,
                         )
+                        units = []
                         for line in result.stdout.strip().splitlines():
                             parts = line.split()
                             if not parts:
@@ -5780,7 +5781,14 @@ def _cmd_update_impl(args, gateway_mode: bool):
                                 text=True,
                                 timeout=5,
                             )
-                            if check.stdout.strip() == "active":
+                            units.append((svc_name, check.stdout.strip()))
+
+                        units.sort(
+                            key=lambda item: (item[0] != "hermes-gateway", item[0])
+                        )
+
+                        for svc_name, state in units:
+                            if state == "active":
                                 restart = subprocess.run(
                                     scope_cmd + ["restart", svc_name],
                                     capture_output=True,
@@ -5833,6 +5841,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
                                     print(
                                         f"  ⚠ Failed to restart {svc_name}: {restart.stderr.strip()}"
                                     )
+                                if (
+                                    svc_name == "hermes-gateway"
+                                    or svc_name.startswith("hermes-gateway-")
+                                ):
+                                    _time.sleep(5)
                     except (FileNotFoundError, subprocess.TimeoutExpired):
                         pass
 

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -51,6 +51,31 @@ class TestGatewayPidState:
         assert status.get_running_pid() is None
         assert not pid_path.exists()
 
+    def test_get_running_pid_removes_stale_current_home_pid_file(self, tmp_path, monkeypatch):
+        """Regression: stale PID files in HERMES_HOME must be removed.
+
+        remove_pid_file() intentionally refuses to delete a PID file owned by
+        another live process.  Stale cleanup has already proven the process is
+        gone, so it must unlink the path directly; otherwise systemd restarts
+        can loop forever on the same stale gateway.pid.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        pid_path = tmp_path / "gateway.pid"
+        pid_path.write_text(json.dumps({
+            "pid": 999999,
+            "kind": "hermes-gateway",
+            "argv": ["python", "-m", "hermes_cli.main", "gateway", "run"],
+            "start_time": 123,
+        }))
+
+        def fake_kill(pid, sig):
+            raise ProcessLookupError
+
+        monkeypatch.setattr(status.os, "kill", fake_kill)
+
+        assert status.get_running_pid() is None
+        assert not pid_path.exists()
+
     def test_get_running_pid_accepts_gateway_metadata_when_cmdline_unavailable(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         pid_path = tmp_path / "gateway.pid"

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -424,6 +424,51 @@ class TestCmdUpdateLaunchdRestart:
 
     @patch("shutil.which", return_value=None)
     @patch("subprocess.run")
+    def test_update_restarts_default_gateway_before_profile_units(
+        self, mock_run, _mock_which, mock_args, monkeypatch,
+    ):
+        """Default gateway should restart before profile gateways.
+
+        systemctl list-units ordering is not a contract.  Restarting a profile
+        gateway first can leave the default profile racing against stale
+        gateway.pid state during the same update.
+        """
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: True)
+        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
+
+        base_side_effect = _make_run_side_effect(
+            commit_count="3",
+            systemd_active=True,
+        )
+        restarted: list[str] = []
+
+        def fake_run(cmd, **kwargs):
+            joined = " ".join(str(c) for c in cmd)
+            if "systemctl --user list-units" in joined:
+                return subprocess.CompletedProcess(
+                    cmd,
+                    0,
+                    stdout=(
+                        "hermes-gateway-scout.service loaded active running Hermes Gateway\n"
+                        "hermes-gateway.service loaded active running Hermes Gateway\n"
+                    ),
+                    stderr="",
+                )
+            if "systemctl --user restart" in joined:
+                restarted.append(cmd[-1])
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+            return base_side_effect(cmd, **kwargs)
+
+        mock_run.side_effect = fake_run
+
+        with patch.object(gateway_cli, "find_gateway_pids", return_value=[]):
+            cmd_update(mock_args)
+
+        assert restarted[:2] == ["hermes-gateway", "hermes-gateway-scout"]
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
     def test_update_no_gateway_running_skips_restart(
         self, mock_run, _mock_which, mock_args, capsys, monkeypatch,
     ):


### PR DESCRIPTION
## Summary

This fixes a gateway restart race seen during `hermes update` when multiple `hermes-gateway*` systemd units are active. The change is not related to STT, Whisper, CUDA, or any local audio configuration.

## Root Cause

`get_running_pid()` already determines when a PID file is stale, but cleanup for the current `HERMES_HOME` path delegated to `remove_pid_file()`. That helper intentionally refuses to delete a PID file owned by another process. For a stale PID record from a previous gateway process, this left `gateway.pid` behind and caused the next systemd start to fail repeatedly with `PID file race lost to another gateway instance`.

Separately, `hermes update` discovered active `hermes-gateway*` units in systemctl output order. If a profile gateway restarted before the default gateway, the default profile could hit stale PID state while another profile was already running.

## Changes

- Unlink stale PID paths directly once stale cleanup has proven the recorded process is gone.
- Sort systemd gateway units so `hermes-gateway` restarts before profile units such as `hermes-gateway-scout`.
- Add a short pause between gateway service restarts to reduce same-update races.
- Add regression tests for stale PID cleanup and multi-profile restart ordering.

## Validation

- `PYTHONPATH=/tmp/hermes-agent-upstream-pr /home/tommaso/.hermes/hermes-agent/venv/bin/python -m pytest /tmp/hermes-agent-upstream-pr/tests/gateway/test_status.py /tmp/hermes-agent-upstream-pr/tests/hermes_cli/test_update_gateway_restart.py -q`
- Result: `68 passed in 3.50s`