### PR TITLE
fix: self-heal stale gateway runtime state on launchd start/stop

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -212,14 +212,25 @@ def _read_pid_record(pid_path: Optional[Path] = None) -> Optional[dict]:
     return None
 
 
-def _cleanup_invalid_pid_path(pid_path: Path, *, cleanup_stale: bool) -> None:
+def _cleanup_invalid_pid_path(
+    pid_path: Path,
+    *,
+    cleanup_stale: bool,
+    expected_record: Optional[dict] = None,
+) -> None:
     if not cleanup_stale:
         return
     try:
-        if pid_path == _get_pid_path():
-            remove_pid_file()
-        else:
-            pid_path.unlink(missing_ok=True)
+        current_record = _read_pid_record(pid_path)
+        if expected_record is None:
+            if current_record is not None or not pid_path.exists():
+                return
+        elif current_record != expected_record:
+            # Another process may have replaced the stale file with a fresh PID
+            # record between detection and cleanup. Never unlink a changed file.
+            return
+
+        pid_path.unlink(missing_ok=True)
     except Exception:
         pass
 
@@ -426,6 +437,55 @@ def release_scoped_lock(scope: str, identity: str) -> None:
         pass
 
 
+def prune_stale_scoped_locks() -> int:
+    """Remove lock files whose recorded owner is clearly stale.
+
+    This is the conservative counterpart to release_all_scoped_locks(): it only
+    removes invalid/corrupt records or locks whose owning PID is gone (or whose
+    recorded start_time no longer matches the live PID).
+    """
+    lock_dir = _get_lock_dir()
+    removed = 0
+    if not lock_dir.exists():
+        return 0
+
+    for lock_path in lock_dir.glob("*.lock"):
+        existing = _read_json_file(lock_path)
+        stale = existing is None
+        existing_pid = None
+        if existing is not None:
+            try:
+                existing_pid = int(existing["pid"])
+            except (KeyError, TypeError, ValueError):
+                stale = True
+
+        if not stale and existing_pid is not None:
+            try:
+                os.kill(existing_pid, 0)
+            except ProcessLookupError:
+                stale = True
+            except PermissionError:
+                stale = False
+            else:
+                recorded_start = existing.get("start_time") if isinstance(existing, dict) else None
+                current_start = _get_process_start_time(existing_pid)
+                if (
+                    recorded_start is not None
+                    and current_start is not None
+                    and current_start != recorded_start
+                ):
+                    stale = True
+
+        if stale:
+            try:
+                lock_path.unlink(missing_ok=True)
+                removed += 1
+            except OSError:
+                pass
+
+    return removed
+
+
 def release_all_scoped_locks() -> int:
     """Remove all scoped lock files in the lock directory.
 
@@ -591,24 +651,24 @@ def get_running_pid(
     try:
         pid = int(record["pid"])
     except (KeyError, TypeError, ValueError):
-        _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale)
+        _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale, expected_record=record)
         return None
 
     try:
         os.kill(pid, 0)  # signal 0 = existence check, no actual signal sent
     except (ProcessLookupError, PermissionError):
-        _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale)
+        _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale, expected_record=record)
         return None
 
     recorded_start = record.get("start_time")
     current_start = _get_process_start_time(pid)
     if recorded_start is not None and current_start is not None and current_start != recorded_start:
-        _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale)
+        _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale, expected_record=record)
         return None
 
     if not _looks_like_gateway_process(pid):
         if not _record_looks_like_gateway(record):
-            _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale)
+            _cleanup_invalid_pid_path(resolved_pid_path, cleanup_stale=cleanup_stale, expected_record=record)
             return None
 
     return pid

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1813,9 +1813,42 @@ def launchd_uninstall():
     
     print("✓ Service uninstalled")
 
+
+def _repair_stale_gateway_runtime_state() -> dict[str, int | bool]:
+    """Best-effort cleanup for stale runtime artifacts left by dead gateways."""
+    from gateway.status import clear_takeover_marker, get_running_pid, prune_stale_scoped_locks
+
+    profile_home = get_hermes_home()
+    pid_path = profile_home / "gateway.pid"
+    takeover_path = profile_home / ".gateway-takeover.json"
+    pid_file_removed = False
+    takeover_marker_removed = False
+
+    running_pid = get_running_pid()
+    if running_pid is None and pid_path.exists():
+        try:
+            pid_path.unlink(missing_ok=True)
+            pid_file_removed = True
+        except OSError:
+            pass
+
+    if running_pid is None and takeover_path.exists():
+        clear_takeover_marker()
+        takeover_marker_removed = not takeover_path.exists()
+
+    stale_locks_removed = prune_stale_scoped_locks()
+    return {
+        "pid_file_removed": pid_file_removed,
+        "takeover_marker_removed": takeover_marker_removed,
+        "stale_locks_removed": stale_locks_removed,
+    }
+
+
 def launchd_start():
     plist_path = get_launchd_plist_path()
     label = get_launchd_label()
+
+    _repair_stale_gateway_runtime_state()
 
     # Self-heal if the plist is missing entirely (e.g., manual cleanup, failed upgrade)
     if not plist_path.exists():
@@ -1853,6 +1886,7 @@ def launchd_stop():
         else:
             raise
     _wait_for_gateway_exit(timeout=10.0, force_after=5.0)
+    _repair_stale_gateway_runtime_state()
     print("✓ Service stopped")
 
 def _wait_for_gateway_exit(timeout: float = 10.0, force_after: float | None = 5.0) -> bool:

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+from pathlib import Path
 from types import SimpleNamespace
 
 from gateway import status
@@ -104,6 +105,67 @@ class TestGatewayPidState:
 
         assert status.get_running_pid(pid_path, cleanup_stale=False) == os.getpid()
         assert pid_path.exists()
+
+    def test_get_running_pid_cleans_up_stale_foreign_pid_file(self, tmp_path, monkeypatch):
+        """Dead PID files from a previous gateway process must be unlinked.
+
+        Regression: remove_pid_file() only unlinks the current process's record,
+        so get_running_pid() would detect the dead PID but leave gateway.pid
+        behind, causing the next startup to lose the O_EXCL race immediately.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        pid_path = tmp_path / "gateway.pid"
+        pid_path.write_text(json.dumps({
+            "pid": 36458,
+            "kind": "hermes-gateway",
+            "argv": ["python", "-m", "hermes_cli.main", "gateway", "run", "--replace"],
+            "start_time": None,
+        }))
+
+        def fake_kill(pid, sig):
+            raise ProcessLookupError
+
+        monkeypatch.setattr(status.os, "kill", fake_kill)
+
+        assert status.get_running_pid() is None
+        assert not pid_path.exists()
+
+    def test_get_running_pid_does_not_delete_replaced_pid_file(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        pid_path = tmp_path / "gateway.pid"
+        stale_record = {
+            "pid": 36458,
+            "kind": "hermes-gateway",
+            "argv": ["python", "-m", "hermes_cli.main", "gateway", "run", "--replace"],
+            "start_time": None,
+        }
+        fresh_record = {
+            "pid": 99999,
+            "kind": "hermes-gateway",
+            "argv": ["python", "-m", "hermes_cli.main", "gateway", "run", "--replace"],
+            "start_time": None,
+        }
+        pid_path.write_text(json.dumps(stale_record))
+
+        original_read_pid_record = status._read_pid_record
+        calls = {"count": 0}
+
+        def fake_read_pid_record(path=None):
+            target = path or (tmp_path / "gateway.pid")
+            calls["count"] += 1
+            if Path(target) == pid_path and calls["count"] >= 2:
+                pid_path.write_text(json.dumps(fresh_record))
+                return fresh_record
+            return original_read_pid_record(path)
+
+        def fake_kill(pid, sig):
+            raise ProcessLookupError
+
+        monkeypatch.setattr(status, "_read_pid_record", fake_read_pid_record)
+        monkeypatch.setattr(status.os, "kill", fake_kill)
+
+        assert status.get_running_pid() is None
+        assert json.loads(pid_path.read_text()) == fresh_record
 
 
 class TestGatewayRuntimeStatus:
@@ -288,6 +350,44 @@ class TestScopedLocks:
 
         status.release_scoped_lock("telegram-bot-token", "secret")
         assert not lock_path.exists()
+
+    def test_prune_stale_scoped_locks_removes_dead_owner_lock(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "discord-bot-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text(json.dumps({
+            "pid": 36458,
+            "start_time": None,
+            "kind": "hermes-gateway",
+            "metadata": {"platform": "discord"},
+        }))
+
+        def fake_kill(pid, sig):
+            raise ProcessLookupError
+
+        monkeypatch.setattr(status.os, "kill", fake_kill)
+
+        assert status.prune_stale_scoped_locks() == 1
+        assert not lock_path.exists()
+
+    def test_prune_stale_scoped_locks_keeps_live_unreachable_owner_lock(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_GATEWAY_LOCK_DIR", str(tmp_path / "locks"))
+        lock_path = tmp_path / "locks" / "discord-bot-token-2bb80d537b1da3e3.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path.write_text(json.dumps({
+            "pid": 36458,
+            "start_time": None,
+            "kind": "hermes-gateway",
+            "metadata": {"platform": "discord"},
+        }))
+
+        def fake_kill(pid, sig):
+            raise PermissionError
+
+        monkeypatch.setattr(status.os, "kill", fake_kill)
+
+        assert status.prune_stale_scoped_locks() == 0
+        assert lock_path.exists()
 
 
 class TestTakeoverMarker:

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -268,6 +268,29 @@ class TestLaunchdServiceRecovery:
             ["launchctl", "kickstart", target],
         ]
 
+    def test_launchd_start_repairs_stale_runtime_state_before_kickstart(self, tmp_path, monkeypatch):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        repair_calls = []
+        run_calls = []
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_repair_stale_gateway_runtime_state",
+            lambda: repair_calls.append("repair") or {"pid_file_removed": True, "takeover_marker_removed": False, "stale_locks_removed": 1},
+        )
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda cmd, check=False, **kwargs: run_calls.append(cmd) or SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+
+        gateway_cli.launchd_start()
+
+        assert repair_calls == ["repair"]
+        assert run_calls == [["launchctl", "kickstart", f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"]]
+
     def test_launchd_restart_drains_running_gateway_before_kickstart(self, monkeypatch):
         calls = []
         target = f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"
@@ -373,6 +396,25 @@ class TestLaunchdServiceRecovery:
 
         assert len(wait_called) == 1
         assert wait_called[0] == {"timeout": 10.0, "force_after": 5.0}
+
+    def test_launchd_stop_repairs_stale_runtime_state_after_bootout(self, monkeypatch):
+        repair_calls = []
+
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout="", stderr=""),
+        )
+        monkeypatch.setattr(gateway_cli, "_wait_for_gateway_exit", lambda **kwargs: True)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_repair_stale_gateway_runtime_state",
+            lambda: repair_calls.append("repair") or {"pid_file_removed": True, "takeover_marker_removed": False, "stale_locks_removed": 1},
+        )
+
+        gateway_cli.launchd_stop()
+
+        assert repair_calls == ["repair"]
 
     def test_launchd_status_reports_local_stale_plist_when_unloaded(self, tmp_path, monkeypatch, capsys):
         plist_path = tmp_path / "ai.hermes.gateway.plist"


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

