### PR TITLE
fix(gateway): accept explicit null home_channel in PlatformConfig.from_dict

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -174,9 +174,10 @@ class PlatformConfig:
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "PlatformConfig":
         home_channel = None
-        if "home_channel" in data:
-            home_channel = HomeChannel.from_dict(data["home_channel"])
-        
+        home_channel_data = data.get("home_channel")
+        if home_channel_data is not None:
+            home_channel = HomeChannel.from_dict(home_channel_data)
+
         return cls(
             enabled=data.get("enabled", False),
             token=data.get("token"),

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -52,6 +52,14 @@ class TestPlatformConfigRoundtrip:
         assert restored.enabled is False
         assert restored.token is None
 
+    def test_explicit_null_home_channel_treated_as_absent(self):
+        # YAML "home_channel: null" is a common way to clear an optional
+        # nested section. Must not crash with TypeError from passing None
+        # to HomeChannel.from_dict(). Regression for gh-13708.
+        restored = PlatformConfig.from_dict({"enabled": True, "home_channel": None})
+        assert restored.enabled is True
+        assert restored.home_channel is None
+
 
 class TestGetConnectedPlatforms:
     def test_returns_enabled_with_token(self):


### PR DESCRIPTION
## Summary

Fixes #13708. `PlatformConfig.from_dict()` crashes on the common YAML pattern of explicitly clearing an optional nested section with `null`:

\`\`\`yaml
platforms:
  telegram:
    enabled: true
    home_channel: null
\`\`\`

Current code only checks for key-presence (\`if \"home_channel\" in data\`) and then unconditionally passes the value into \`HomeChannel.from_dict()\`, which subscripts it like a dict and raises \`TypeError: 'NoneType' object is not subscriptable\`.

## Fix

One-line guard change: switch to \`data.get(\"home_channel\") is not None\` so explicit \`null\` is treated the same as absent.

## Test

Added a regression test covering the explicit-null YAML shape. All 28 tests in \`tests/gateway/test_config.py\` pass locally.

## Scope

Pure bug-fix, purely additive semantics. No behavior change for existing callers (a dict home_channel still round-trips identically; missing home_channel still yields \`None\`). I audited all production and test callers of \`PlatformConfig.from_dict()\` — only one production call site in the same file at L384 (\`load_gateway_config\`) and 5 test sites; none pass \`None\` today so existing contract is preserved.

Closes #13708.