### PR TITLE
fix(gateway): resolve home_channel for bare platform delivery targets

### DIFF
--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -229,11 +229,22 @@ class DeliveryRouter:
     ) -> Dict[str, Any]:
         """Deliver content to a messaging platform."""
         adapter = self.adapters.get(target.platform)
-        
+
         if not adapter:
             raise ValueError(f"No adapter configured for {target.platform.value}")
-        
-        if not target.chat_id:
+
+        # Bare platform targets (e.g. "telegram") parse as chat_id=None, which
+        # the docstring and DeliveryTarget.parse() explicitly document as
+        # "send to the platform home channel". Resolve the configured
+        # home_channel here instead of rejecting the target. (#13704)
+        chat_id = target.chat_id
+        thread_id = target.thread_id
+        if not chat_id:
+            platform_cfg = self.config.platforms.get(target.platform)
+            if platform_cfg and platform_cfg.home_channel:
+                chat_id = platform_cfg.home_channel.chat_id
+
+        if not chat_id:
             raise ValueError(f"No chat ID for {target.platform.value} delivery")
         
         # Guard: truncate oversized cron output to stay within platform limits
@@ -247,9 +258,9 @@ class DeliveryRouter:
             )
         
         send_metadata = dict(metadata or {})
-        if target.thread_id and "thread_id" not in send_metadata:
-            send_metadata["thread_id"] = target.thread_id
-        return await adapter.send(target.chat_id, content, metadata=send_metadata or None)
+        if thread_id and "thread_id" not in send_metadata:
+            send_metadata["thread_id"] = thread_id
+        return await adapter.send(chat_id, content, metadata=send_metadata or None)
 
 
 

--- a/tests/gateway/test_delivery.py
+++ b/tests/gateway/test_delivery.py
@@ -1,7 +1,9 @@
 """Tests for the delivery routing module."""
 
-from gateway.config import Platform
-from gateway.delivery import DeliveryTarget
+import asyncio
+
+from gateway.config import GatewayConfig, HomeChannel, Platform, PlatformConfig
+from gateway.delivery import DeliveryRouter, DeliveryTarget
 from gateway.session import SessionSource
 
 
@@ -63,6 +65,77 @@ class TestTargetToStringRoundtrip:
         reparsed = DeliveryTarget.parse(s)
         assert reparsed.platform == Platform.TELEGRAM
         assert reparsed.chat_id == "999"
+
+
+class _RecordingAdapter:
+    def __init__(self):
+        self.calls = []
+
+    async def send(self, chat_id, content, metadata=None):
+        self.calls.append({"chat_id": chat_id, "content": content, "metadata": metadata})
+        return {"ok": True, "chat_id": chat_id}
+
+
+class TestDeliverToPlatformHomeChannel:
+    def test_bare_platform_target_resolves_configured_home_channel(self):
+        # Bare "telegram" target (chat_id=None) must resolve the configured
+        # home_channel instead of raising "No chat ID for telegram delivery".
+        # Regression for gh-13704.
+        cfg = GatewayConfig(platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                enabled=True,
+                token="x",
+                home_channel=HomeChannel(
+                    platform=Platform.TELEGRAM,
+                    chat_id="home123",
+                    name="Home",
+                ),
+            )
+        })
+        adapter = _RecordingAdapter()
+        router = DeliveryRouter(cfg, {Platform.TELEGRAM: adapter})
+
+        result = asyncio.run(router.deliver("hello", [DeliveryTarget.parse("telegram")]))
+
+        assert result["telegram"]["success"] is True
+        assert adapter.calls == [
+            {"chat_id": "home123", "content": "hello", "metadata": None},
+        ]
+
+    def test_bare_platform_target_without_home_channel_raises(self):
+        cfg = GatewayConfig(platforms={
+            Platform.TELEGRAM: PlatformConfig(enabled=True, token="x"),
+        })
+        adapter = _RecordingAdapter()
+        router = DeliveryRouter(cfg, {Platform.TELEGRAM: adapter})
+
+        result = asyncio.run(router.deliver("hello", [DeliveryTarget.parse("telegram")]))
+
+        assert result["telegram"]["success"] is False
+        assert "No chat ID" in result["telegram"]["error"]
+        assert adapter.calls == []
+
+    def test_explicit_chat_id_takes_precedence_over_home_channel(self):
+        cfg = GatewayConfig(platforms={
+            Platform.TELEGRAM: PlatformConfig(
+                enabled=True,
+                token="x",
+                home_channel=HomeChannel(
+                    platform=Platform.TELEGRAM,
+                    chat_id="home123",
+                    name="Home",
+                ),
+            )
+        })
+        adapter = _RecordingAdapter()
+        router = DeliveryRouter(cfg, {Platform.TELEGRAM: adapter})
+
+        result = asyncio.run(router.deliver("hi", [DeliveryTarget.parse("telegram:555")]))
+
+        assert result["telegram:555"]["success"] is True
+        assert adapter.calls == [
+            {"chat_id": "555", "content": "hi", "metadata": None},
+        ]
 
 
 


### PR DESCRIPTION
## Summary

Fixes #13704. `DeliveryTarget.parse('telegram')` returns `chat_id=None` and the module docstring + parse docstring both explicitly document that as *'send to the platform home channel'*. But the actual delivery path rejects the same target with `No chat ID for telegram delivery`, so a documented delivery mode always fails at runtime.

## Fix

In `_deliver_to_platform`, when `target.chat_id` is missing, look up `self.config.platforms[target.platform].home_channel.chat_id` and use that. Only raise if no home channel is configured either.

Explicit chat_id on the target still takes precedence (existing behavior preserved).

## Test

Added 3 regression tests in `tests/gateway/test_delivery.py`:
1. Bare platform target with home_channel → sends to the home channel (was the crash path).
2. Bare platform target WITHOUT home_channel → still raises 'No chat ID' (preserves error for misconfigured cases).
3. Explicit chat_id on target with home_channel configured → uses explicit chat_id (precedence preserved).

All 13 tests in `tests/gateway/test_delivery.py` pass locally.

## Scope

1 file in production, 1 file in tests. Purely additive semantics for valid configs — the only behavior that flips is the documented-but-broken code path going from raise to success.

Closes #13704.