### PR TITLE
feat(gateway): echo voice-message transcripts back to the user

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -724,6 +724,8 @@ platform_toolsets:
 # Set the corresponding API key in .env: GROQ_API_KEY, OPENAI_API_KEY, or MISTRAL_API_KEY.
 stt:
   enabled: true
+  # send_transcription: false                      # Echo each transcript back to the user as a separate message before the agent replies
+  # send_transcription_header: "🎤 Heard:\n\n"      # Optional prefix for the echo message; empty string (default) sends the bare transcript
   # provider: "local"          # auto-detected if omitted
   local:
     model: "base"              # tiny | base | small | medium | large-v3 | turbo

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -247,6 +247,8 @@ class GatewayConfig:
 
     # STT settings
     stt_enabled: bool = True  # Whether to auto-transcribe inbound voice messages
+    stt_send_transcription: bool = False  # Echo the transcript back to the user as a separate message before the agent responds
+    stt_send_transcription_header: str = ""  # Optional prefix (e.g. "🎤 **Voice Transcription**\n\n"). Empty means no header.
 
     # Session isolation in shared chats
     group_sessions_per_user: bool = True  # Isolate group/channel sessions per participant when user IDs are available
@@ -368,6 +370,8 @@ class GatewayConfig:
             "sessions_dir": str(self.sessions_dir),
             "always_log_local": self.always_log_local,
             "stt_enabled": self.stt_enabled,
+            "stt_send_transcription": self.stt_send_transcription,
+            "stt_send_transcription_header": self.stt_send_transcription_header,
             "group_sessions_per_user": self.group_sessions_per_user,
             "thread_sessions_per_user": self.thread_sessions_per_user,
             "unauthorized_dm_behavior": self.unauthorized_dm_behavior,
@@ -412,6 +416,12 @@ class GatewayConfig:
         stt_enabled = data.get("stt_enabled")
         if stt_enabled is None:
             stt_enabled = data.get("stt", {}).get("enabled") if isinstance(data.get("stt"), dict) else None
+        
+        stt_block = data.get("stt") if isinstance(data.get("stt"), dict) else {}
+        stt_send_transcription = stt_block.get("send_transcription")
+        stt_send_transcription_header = stt_block.get("send_transcription_header") or ""
+        if not isinstance(stt_send_transcription_header, str):
+            stt_send_transcription_header = str(stt_send_transcription_header)
 
         group_sessions_per_user = data.get("group_sessions_per_user")
         thread_sessions_per_user = data.get("thread_sessions_per_user")
@@ -437,6 +447,8 @@ class GatewayConfig:
             sessions_dir=sessions_dir,
             always_log_local=data.get("always_log_local", True),
             stt_enabled=_coerce_bool(stt_enabled, True),
+            stt_send_transcription=_coerce_bool(stt_send_transcription, False),
+            stt_send_transcription_header=stt_send_transcription_header,
             group_sessions_per_user=_coerce_bool(group_sessions_per_user, True),
             thread_sessions_per_user=_coerce_bool(thread_sessions_per_user, False),
             unauthorized_dm_behavior=unauthorized_dm_behavior,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3519,6 +3519,9 @@ class GatewayRunner:
         if canonical == "yolo":
             return await self._handle_yolo_command(event)
 
+        if canonical == "stt":
+            return await self._handle_stt_command(event)
+
         if canonical == "model":
             return await self._handle_model_command(event)
 
@@ -3820,6 +3823,7 @@ class GatewayRunner:
                 message_text = await self._enrich_message_with_transcription(
                     message_text,
                     audio_paths,
+                    source=source,
                 )
                 _stt_fail_markers = (
                     "No STT provider",
@@ -6932,6 +6936,77 @@ class GatewayRunner:
             logger.warning("Failed to save tool_progress mode: %s", e)
             return f"{descriptions[new_mode]}\n_(could not save to config: {e})_"
 
+    async def _handle_stt_command(self, event: MessageEvent) -> str:
+        """Handle /stt — toggle gateway STT features. Persists to config.yaml.
+
+        Supported forms:
+          /stt                       → show status
+          /stt status                → show status
+          /stt echo                  → toggle transcription echo on/off
+          /stt echo on|off           → set transcription echo explicitly
+          /stt echo status           → show just the echo setting
+        """
+        import yaml
+
+        args = event.get_command_args().strip().lower().split()
+
+        if not args or args[0] == "status":
+            send_on = getattr(self.config, "stt_send_transcription", False)
+            header = getattr(self.config, "stt_send_transcription_header", "") or ""
+            header_preview = repr(header) if header else "(none)"
+            stt_on = getattr(self.config, "stt_enabled", True)
+            return (
+                "🎤 **STT Status**\n"
+                f"• Auto-transcribe inbound voice: **{'ON' if stt_on else 'OFF'}**\n"
+                f"• Echo transcription back to chat: **{'ON' if send_on else 'OFF'}**\n"
+                f"• Transcription header: {header_preview}\n\n"
+                "Use `/stt echo on|off` to toggle the echo."
+            )
+
+        sub = args[0]
+        if sub != "echo":
+            return (
+                f"Unknown subcommand: `{sub}`.\n"
+                "Usage: `/stt [echo [on|off|status]]`"
+            )
+
+        action = args[1] if len(args) > 1 else None
+        current = getattr(self.config, "stt_send_transcription", False)
+
+        if action in ("on", "enable"):
+            new_value = True
+        elif action in ("off", "disable"):
+            new_value = False
+        elif action == "status":
+            return f"🎤 Transcription echo is currently **{'ON' if current else 'OFF'}**."
+        elif action is None:
+            new_value = not current
+        else:
+            return (
+                f"Unknown option: `{action}`.\n"
+                "Usage: `/stt echo [on|off|status]`"
+            )
+
+        self.config.stt_send_transcription = new_value
+
+        config_path = _hermes_home / "config.yaml"
+        try:
+            user_config: dict = {}
+            if config_path.exists():
+                with open(config_path, encoding="utf-8") as f:
+                    user_config = yaml.safe_load(f) or {}
+            if not isinstance(user_config.get("stt"), dict):
+                user_config["stt"] = {}
+            user_config["stt"]["send_transcription"] = new_value
+            atomic_yaml_write(config_path, user_config)
+            return f"🎤 Echo: **{'ON' if new_value else 'OFF'}**"
+        except Exception as e:
+            logger.warning("Failed to save stt.send_transcription: %s", e)
+            return (
+                f"🎤 Echo: **{'ON' if new_value else 'OFF'}** (in-memory only)\n"
+                f"_(could not save to config: {e})_"
+            )
+
     async def _handle_compress_command(self, event: MessageEvent) -> str:
         """Handle /compress command -- manually compress conversation context.
 
@@ -8182,6 +8257,7 @@ class GatewayRunner:
         self,
         user_text: str,
         audio_paths: List[str],
+        source: Optional[SessionSource] = None,
     ) -> str:
         """
         Auto-transcribe user voice/audio messages using the configured STT provider
@@ -8190,6 +8266,9 @@ class GatewayRunner:
         Args:
             user_text:   The user's original caption / message text.
             audio_paths: List of local file paths to cached audio files.
+            source:      MessageSource — when provided and stt_send_transcription
+                         is enabled, the transcript is echoed back to the chat as
+                         a separate message before the agent responds.
 
         Returns:
             The enriched message string with transcriptions prepended.
@@ -8208,6 +8287,9 @@ class GatewayRunner:
 
         from tools.transcription_tools import transcribe_audio
 
+        stt_send_transcription = getattr(self.config, "stt_send_transcription", False)
+        stt_send_transcription_header = getattr(self.config, "stt_send_transcription_header", "") or ""
+
         enriched_parts = []
         for path in audio_paths:
             try:
@@ -8219,6 +8301,10 @@ class GatewayRunner:
                         f'[The user sent a voice message~ '
                         f'Here\'s what they said: "{transcript}"]'
                     )
+                    if stt_send_transcription and source:
+                        await self._echo_transcription(
+                            source, stt_send_transcription_header + transcript
+                        )
                 else:
                     error = result.get("error", "unknown error")
                     if (
@@ -8262,6 +8348,17 @@ class GatewayRunner:
                 return f"{prefix}\n\n{user_text}"
             return prefix
         return user_text
+
+    async def _echo_transcription(self, source: SessionSource, message: str) -> None:
+        """Send a transcript echo back to the user; a send failure only warns."""
+        adapter = self.adapters.get(source.platform)
+        if not adapter:
+            return
+        metadata = {"thread_id": source.thread_id} if source.thread_id else None
+        try:
+            await adapter.send(source.chat_id, message, metadata=metadata)
+        except Exception as exc:
+            logger.warning("Failed to send transcription echo: %s", exc)
 
     def _build_process_event_source(self, evt: dict):
         """Resolve the canonical source for a synthetic background-process event.

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -127,6 +127,10 @@ COMMAND_REGISTRY: list[CommandDef] = [
                args_hint="[name]"),
     CommandDef("voice", "Toggle voice mode", "Configuration",
                args_hint="[on|off|tts|status]", subcommands=("on", "off", "tts", "status")),
+    CommandDef("stt", "Configure speech-to-text gateway features",
+               "Configuration", gateway_only=True,
+               args_hint="echo [on|off|status]",
+               subcommands=("echo",)),
 
     # Tools & Skills
     CommandDef("tools", "Manage tools: /tools [list|disable|enable] [name...]", "Tools & Skills",

--- a/tests/gateway/test_stt_command.py
+++ b/tests/gateway/test_stt_command.py
@@ -1,0 +1,235 @@
+"""Tests for gateway /stt command (toggle stt.send_transcription via /stt echo, persist to config.yaml)."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import yaml
+
+import gateway.run as gateway_run
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+def _make_event(text="/stt", platform=Platform.TELEGRAM, user_id="12345", chat_id="67890"):
+    source = SessionSource(
+        platform=platform,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name="testuser",
+    )
+    return MessageEvent(text=text, source=source)
+
+
+def _make_runner(config: GatewayConfig | None = None):
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.config = config if config is not None else GatewayConfig()
+    runner.adapters = {}
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.hooks.loaded_hooks = []
+    return runner
+
+
+class TestStatusSubcommand:
+
+    @pytest.mark.asyncio
+    async def test_bare_command_shows_status(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+        runner = _make_runner(GatewayConfig(
+            stt_enabled=True,
+            stt_send_transcription=True,
+            stt_send_transcription_header="🎤 Heard:\n\n",
+        ))
+
+        result = await runner._handle_stt_command(_make_event("/stt"))
+
+        assert "STT Status" in result
+        assert "Auto-transcribe inbound voice" in result
+        assert "Echo transcription back to chat" in result
+        assert "ON" in result
+
+    @pytest.mark.asyncio
+    async def test_status_subcommand_equivalent_to_bare(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+        runner = _make_runner()
+        result = await runner._handle_stt_command(_make_event("/stt status"))
+        assert "STT Status" in result
+
+    @pytest.mark.asyncio
+    async def test_status_shows_none_for_empty_header(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+        runner = _make_runner(GatewayConfig(stt_send_transcription_header=""))
+        result = await runner._handle_stt_command(_make_event("/stt"))
+        assert "(none)" in result
+
+
+class TestEchoToggle:
+
+    @pytest.mark.asyncio
+    async def test_toggle_from_off_to_on(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text("stt:\n  enabled: true\n", encoding="utf-8")
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+        runner = _make_runner(GatewayConfig(stt_send_transcription=False))
+        result = await runner._handle_stt_command(_make_event("/stt echo"))
+
+        assert "ON" in result
+        assert runner.config.stt_send_transcription is True
+        saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert saved["stt"]["send_transcription"] is True
+
+    @pytest.mark.asyncio
+    async def test_toggle_from_on_to_off(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "stt:\n  enabled: true\n  send_transcription: true\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+        runner = _make_runner(GatewayConfig(stt_send_transcription=True))
+        result = await runner._handle_stt_command(_make_event("/stt echo"))
+
+        assert "OFF" in result
+        assert runner.config.stt_send_transcription is False
+        saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert saved["stt"]["send_transcription"] is False
+
+    @pytest.mark.asyncio
+    async def test_explicit_on(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+        runner = _make_runner(GatewayConfig(stt_send_transcription=True))
+        # Already on — explicit "on" should keep it on (idempotent)
+        result = await runner._handle_stt_command(_make_event("/stt echo on"))
+
+        assert "ON" in result
+        assert runner.config.stt_send_transcription is True
+        saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert saved["stt"]["send_transcription"] is True
+
+    @pytest.mark.asyncio
+    async def test_explicit_off(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+        runner = _make_runner(GatewayConfig(stt_send_transcription=False))
+        result = await runner._handle_stt_command(_make_event("/stt echo off"))
+
+        assert "OFF" in result
+        assert runner.config.stt_send_transcription is False
+        saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert saved["stt"]["send_transcription"] is False
+
+    @pytest.mark.asyncio
+    async def test_echo_status_subcommand(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+        runner = _make_runner(GatewayConfig(stt_send_transcription=True))
+        result = await runner._handle_stt_command(
+            _make_event("/stt echo status")
+        )
+        assert "ON" in result
+        # status subcommand should NOT mutate state
+        assert runner.config.stt_send_transcription is True
+
+    @pytest.mark.asyncio
+    async def test_repeated_toggle_flips_back_and_forth(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text("stt:\n  enabled: true\n", encoding="utf-8")
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+        runner = _make_runner(GatewayConfig(stt_send_transcription=False))
+
+        expected = [True, False, True, False]
+        for want in expected:
+            await runner._handle_stt_command(_make_event("/stt echo"))
+            saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+            assert saved["stt"]["send_transcription"] is want
+            assert runner.config.stt_send_transcription is want
+
+    @pytest.mark.asyncio
+    async def test_preserves_other_stt_keys(self, tmp_path, monkeypatch):
+        """Toggling send_transcription must not clobber sibling stt.* keys."""
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "stt:\n"
+            "  enabled: true\n"
+            "  provider: openai\n"
+            "  send_transcription_header: \"🎤 Heard:\\n\\n\"\n"
+            "  openai:\n"
+            "    model: whisper-1\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+        runner = _make_runner(GatewayConfig(stt_send_transcription=False))
+        await runner._handle_stt_command(_make_event("/stt echo on"))
+
+        saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert saved["stt"]["send_transcription"] is True
+        assert saved["stt"]["enabled"] is True
+        assert saved["stt"]["provider"] == "openai"
+        assert saved["stt"]["send_transcription_header"] == "🎤 Heard:\n\n"
+        assert saved["stt"]["openai"] == {"model": "whisper-1"}
+
+class TestErrorHandling:
+
+    @pytest.mark.asyncio
+    async def test_unknown_subcommand_returns_usage(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+        runner = _make_runner()
+        result = await runner._handle_stt_command(_make_event("/stt bogus"))
+        assert "Unknown subcommand" in result
+        assert "echo" in result
+
+    @pytest.mark.asyncio
+    async def test_unknown_action_returns_usage(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+        runner = _make_runner()
+        result = await runner._handle_stt_command(
+            _make_event("/stt echo maybe")
+        )
+        assert "Unknown option" in result
+
+    @pytest.mark.asyncio
+    async def test_creates_stt_block_if_missing(self, tmp_path, monkeypatch):
+        """If config.yaml has no stt: block, the command creates it."""
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text("voice:\n  record_key: ctrl+b\n", encoding="utf-8")
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+        runner = _make_runner(GatewayConfig(stt_send_transcription=False))
+        await runner._handle_stt_command(_make_event("/stt echo on"))
+
+        saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        assert saved["stt"] == {"send_transcription": True}
+        assert saved["voice"] == {"record_key": "ctrl+b"}  # sibling preserved
+
+
+def test_stt_is_in_gateway_known_commands():
+    """The /stt command is recognized by the gateway dispatch."""
+    from hermes_cli.commands import GATEWAY_KNOWN_COMMANDS
+    assert "stt" in GATEWAY_KNOWN_COMMANDS
+
+
+def test_stt_has_echo_subcommand():
+    """Tab-complete should know about 'echo'."""
+    from hermes_cli.commands import SUBCOMMANDS
+    assert "echo" in SUBCOMMANDS.get("/stt", [])

--- a/tests/gateway/test_stt_config.py
+++ b/tests/gateway/test_stt_config.py
@@ -16,6 +16,19 @@ def test_gateway_config_stt_disabled_from_dict_nested():
     assert config.stt_enabled is False
 
 
+def test_gateway_config_stt_send_transcription_defaults_and_nested_yaml():
+    """Defaults are off + empty header; both keys load from the nested stt.* block."""
+    default = GatewayConfig.from_dict({})
+    assert default.stt_send_transcription is False
+    assert default.stt_send_transcription_header == ""
+
+    configured = GatewayConfig.from_dict(
+        {"stt": {"send_transcription": True, "send_transcription_header": "🎤 Heard:\n\n"}}
+    )
+    assert configured.stt_send_transcription is True
+    assert configured.stt_send_transcription_header == "🎤 Heard:\n\n"
+
+
 def test_load_gateway_config_bridges_stt_enabled_from_config_yaml(tmp_path, monkeypatch):
     hermes_home = tmp_path / ".hermes"
     hermes_home.mkdir()
@@ -114,3 +127,78 @@ async def test_prepare_inbound_message_text_transcribes_queued_voice_event():
     assert result is not None
     assert "queued voice transcript" in result
     assert "voice message" in result.lower()
+
+
+# --- Integration tests for stt_send_transcription (echo) ---
+
+
+def _echo_runner(*, enabled: bool, header: str = "", send_side_effect=None):
+    """Build a GatewayRunner wired to a mock Telegram adapter for echo tests."""
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        stt_enabled=True,
+        stt_send_transcription=enabled,
+        stt_send_transcription_header=header,
+    )
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="123456", chat_type="dm")
+    adapter = AsyncMock()
+    if send_side_effect is not None:
+        adapter.send.side_effect = send_side_effect
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    return runner, source, adapter
+
+
+@pytest.mark.asyncio
+async def test_enrich_message_with_transcription_echoes_with_configured_header():
+    """When enabled, the transcript is echoed via the adapter with the configured header prepended."""
+    runner, source, adapter = _echo_runner(
+        enabled=True, header="🎤 **Voice Transcription**\n\n"
+    )
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={"success": True, "transcript": "hello world"},
+    ):
+        result = await runner._enrich_message_with_transcription(
+            "", ["/tmp/voice.ogg"], source=source,
+        )
+
+    assert "hello world" in result
+    adapter.send.assert_called_once()
+    assert adapter.send.call_args.args == (
+        "123456",
+        "🎤 **Voice Transcription**\n\nhello world",
+    )
+
+
+@pytest.mark.asyncio
+async def test_enrich_message_with_transcription_does_not_echo_when_disabled():
+    runner, source, adapter = _echo_runner(enabled=False)
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={"success": True, "transcript": "hello world"},
+    ):
+        result = await runner._enrich_message_with_transcription(
+            "", ["/tmp/voice.ogg"], source=source,
+        )
+
+    assert "hello world" in result
+    adapter.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_enrich_message_with_transcription_tolerates_echo_send_failure():
+    """A failing echo send must not break the enriched transcript returned to the agent."""
+    runner, source, _adapter = _echo_runner(
+        enabled=True, send_side_effect=Exception("network error"),
+    )
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        return_value={"success": True, "transcript": "hello world"},
+    ):
+        result = await runner._enrich_message_with_transcription(
+            "", ["/tmp/voice.ogg"], source=source,
+        )
+
+    assert "hello world" in result

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1018,6 +1018,8 @@ Hashes are deterministic — the same user always maps to the same hash, so the 
 ```yaml
 stt:
   provider: "local"            # "local" | "groq" | "openai" | "mistral"
+  send_transcription: false    # Echo the transcript back to the user as a separate message before the agent replies
+  send_transcription_header: ""  # Optional prefix for the echo message (e.g. "🎤 **Voice Transcription**\n\n"). Empty = no header.
   local:
     model: "base"              # tiny, base, small, medium, large-v3
   openai:
@@ -1041,6 +1043,30 @@ STT_OPENAI_MODEL=whisper-1
 GROQ_BASE_URL=https://api.groq.com/openai/v1
 STT_OPENAI_BASE_URL=https://api.openai.com/v1
 ```
+
+### Echo Transcription Back to the User (Gateway)
+
+When using Hermes via messaging platforms (Telegram, Discord, etc.), you can have the gateway echo each voice-message transcript back as a separate message before the agent replies:
+
+```yaml
+stt:
+  enabled: true
+  send_transcription: true  # Echo the transcript back to the user
+  send_transcription_header: "🎤 **Voice Transcription**\n\n"  # Optional prefix; omit or leave empty for a bare transcript
+```
+
+**How it works:**
+1. You send a voice message.
+2. Hermes sends a separate message containing the transcript, optionally prefixed with `send_transcription_header`.
+3. The agent then replies normally to the transcribed message.
+
+By default, `send_transcription_header` is empty, so the echo is just the bare transcript. Set it to any string (emojis and `\n` allowed) to add a header. If a platform ever delivers multiple audio clips in a single message, each clip gets its own echo.
+
+This is useful for verifying accuracy on technical terms, names, or complex instructions. The setting is opt-in and defaults to `false`.
+
+:::tip
+Echo failures are handled gracefully — if the echo message fails to send (network error, etc.), the agent still replies normally with the transcript in its context.
+:::
 
 ## Voice Mode (CLI)
 


### PR DESCRIPTION
## Summary

Opt-in gateway behavior that echoes the transcript of an incoming voice message back to the user as its own chat message before the agent replies. Useful for verifying STT accuracy on technical terms, names, and instructions on messaging platforms (Telegram, Discord, Slack, etc.).

The echo is off by default and controlled by two new keys under `stt:` in `config.yaml`:

- `send_transcription` (bool, default `false`) — enable/disable the echo
- `send_transcription_header` (string, default `""`) — optional prefix, e.g. `"🎤 **Voice Transcription**\n\n"`

A new gateway slash command toggles the echo at runtime and persists the change to `config.yaml` (same pattern as `/verbose`):

- `/stt` or `/stt status` — show current STT state
- `/stt echo` — toggle on/off
- `/stt echo on|off` — set explicitly
- `/stt echo status` — show just the echo state

Echo send failures are swallowed with a warning; the agent still replies normally with the transcript in context.

## Test plan

- [ ] `pytest tests/gateway/test_stt_command.py tests/gateway/test_stt_config.py -v` — 31 tests covering config load, the echo path in `_enrich_message_with_transcription`, every form of `/stt`, toggle/status/unknown-subcommand paths, and that sibling `stt.*` keys are preserved on save
- [ ] Manual: set `stt.send_transcription: true` in `~/.hermes/config.yaml`, send a voice message via Telegram — confirm transcript echoes before the agent replies
- [ ] Manual: run `/stt` to view status, `/stt echo off` to disable, verify `config.yaml` shows `stt.send_transcription: false`, send another voice message and confirm no echo
- [ ] Manual: restart the gateway and confirm the toggled value persists

## Files touched

- `gateway/config.py` — two new `GatewayConfig` fields loaded from the nested `stt:` block
- `gateway/run.py` — echo in `_enrich_message_with_transcription`, new `_echo_transcription` helper, new `_handle_stt_command` + dispatch case
- `hermes_cli/commands.py` — `/stt` registered in `COMMAND_REGISTRY`
- `cli-config.yaml.example`, `website/docs/user-guide/configuration.md` — docs + example config
- `tests/gateway/test_stt_command.py`, `tests/gateway/test_stt_config.py` — test coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)