### PR TITLE
fix(tui): tool inline_diff renders inline with the active turn

### DIFF
--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -195,6 +195,26 @@ describe('createGatewayEventHandler', () => {
     expect((appended[0]?.text.match(/```diff/g) ?? []).length).toBe(1)
   })
 
+  it('keeps tool trail terse when inline_diff is present', () => {
+    const appended: Msg[] = []
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+    const diff = '--- a/foo.ts\n+++ b/foo.ts\n@@\n-old\n+new'
+
+    onEvent({
+      payload: { inline_diff: diff, name: 'review_diff', summary: diff, tool_id: 'tool-1' },
+      type: 'tool.complete'
+    } as any)
+    onEvent({
+      payload: { text: 'done' },
+      type: 'message.complete'
+    } as any)
+
+    expect(appended).toHaveLength(1)
+    expect(appended[0]?.tools?.[0]).toContain('Review Diff')
+    expect(appended[0]?.tools?.[0]).not.toContain('--- a/foo.ts')
+    expect(appended[0]?.text).toContain('```diff')
+  })
+
   it('shows setup panel for missing provider startup error', () => {
     const appended: Msg[] = []
     const onEvent = createGatewayEventHandler(buildCtx(appended))

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -146,7 +146,8 @@ describe('createGatewayEventHandler', () => {
   it('routes inline_diff into the active segment stream, not historyItems', () => {
     const appended: Msg[] = []
     const onEvent = createGatewayEventHandler(buildCtx(appended))
-    const diff = '--- a/foo.ts\n+++ b/foo.ts\n@@\n-old\n+new'
+    const diff = '\u001b[31m--- a/foo.ts\u001b[0m\n\u001b[32m+++ b/foo.ts\u001b[0m\n@@\n-old\n+new'
+    const cleaned = '--- a/foo.ts\n+++ b/foo.ts\n@@\n-old\n+new'
 
     onEvent({
       payload: { context: 'foo.ts', name: 'patch', tool_id: 'tool-1' },
@@ -161,7 +162,10 @@ describe('createGatewayEventHandler', () => {
     // held in segmentMessages so the transcript renders it inline with the
     // current turn rather than above it.
     expect(appended).toHaveLength(0)
-    expect(turnController.segmentMessages).toContainEqual({ role: 'system', text: diff })
+    expect(turnController.segmentMessages).toContainEqual(
+      expect.objectContaining({ kind: 'trail', role: 'system', text: '' })
+    )
+    expect(turnController.segmentMessages).toContainEqual({ role: 'system', text: cleaned })
 
     onEvent({
       payload: { text: 'patch applied' },
@@ -170,9 +174,10 @@ describe('createGatewayEventHandler', () => {
 
     // After the turn closes, the diff lands in history in the order the
     // gateway emitted it — before the assistant's final text, not above it.
-    expect(appended).toHaveLength(2)
-    expect(appended[0]).toMatchObject({ role: 'system', text: diff })
-    expect(appended[1]).toMatchObject({ role: 'assistant', text: 'patch applied' })
+    expect(appended).toHaveLength(3)
+    expect(appended[0]).toMatchObject({ kind: 'trail', role: 'system', text: '' })
+    expect(appended[1]).toMatchObject({ role: 'system', text: cleaned })
+    expect(appended[2]).toMatchObject({ role: 'assistant', text: 'patch applied' })
   })
 
   it('shows setup panel for missing provider startup error', () => {

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -143,7 +143,7 @@ describe('createGatewayEventHandler', () => {
     expect(appended[0]?.thinkingTokens).toBe(estimateTokensRough(fromServer))
   })
 
-  it('routes inline_diff into the active segment stream, not historyItems', () => {
+  it('attaches inline_diff to the assistant completion body', () => {
     const appended: Msg[] = []
     const onEvent = createGatewayEventHandler(buildCtx(appended))
     const diff = '\u001b[31m--- a/foo.ts\u001b[0m\n\u001b[32m+++ b/foo.ts\u001b[0m\n@@\n-old\n+new'
@@ -158,26 +158,21 @@ describe('createGatewayEventHandler', () => {
       type: 'tool.complete'
     } as any)
 
-    // While streaming, nothing has flowed to historyItems yet — diff must be
-    // held in segmentMessages so the transcript renders it inline with the
-    // current turn rather than above it.
+    // Diff is buffered for message.complete and sanitized (ANSI stripped).
     expect(appended).toHaveLength(0)
-    expect(turnController.segmentMessages).toContainEqual(
-      expect.objectContaining({ kind: 'trail', role: 'system', text: '' })
-    )
-    expect(turnController.segmentMessages).toContainEqual({ role: 'system', text: cleaned })
+    expect(turnController.pendingInlineDiffs).toEqual([cleaned])
 
     onEvent({
       payload: { text: 'patch applied' },
       type: 'message.complete'
     } as any)
 
-    // After the turn closes, the diff lands in history in the order the
-    // gateway emitted it — before the assistant's final text, not above it.
-    expect(appended).toHaveLength(3)
-    expect(appended[0]).toMatchObject({ kind: 'trail', role: 'system', text: '' })
-    expect(appended[1]).toMatchObject({ role: 'system', text: cleaned })
-    expect(appended[2]).toMatchObject({ role: 'assistant', text: 'patch applied' })
+    // Diff is rendered in the same assistant message body as the completion.
+    expect(appended).toHaveLength(1)
+    expect(appended[0]).toMatchObject({ role: 'assistant' })
+    expect(appended[0]?.text).toContain('patch applied')
+    expect(appended[0]?.text).toContain('```diff')
+    expect(appended[0]?.text).toContain(cleaned)
   })
 
   it('shows setup panel for missing provider startup error', () => {

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -143,6 +143,38 @@ describe('createGatewayEventHandler', () => {
     expect(appended[0]?.thinkingTokens).toBe(estimateTokensRough(fromServer))
   })
 
+  it('routes inline_diff into the active segment stream, not historyItems', () => {
+    const appended: Msg[] = []
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+    const diff = '--- a/foo.ts\n+++ b/foo.ts\n@@\n-old\n+new'
+
+    onEvent({
+      payload: { context: 'foo.ts', name: 'patch', tool_id: 'tool-1' },
+      type: 'tool.start'
+    } as any)
+    onEvent({
+      payload: { inline_diff: diff, summary: 'patched', tool_id: 'tool-1' },
+      type: 'tool.complete'
+    } as any)
+
+    // While streaming, nothing has flowed to historyItems yet — diff must be
+    // held in segmentMessages so the transcript renders it inline with the
+    // current turn rather than above it.
+    expect(appended).toHaveLength(0)
+    expect(turnController.segmentMessages).toContainEqual({ role: 'system', text: diff })
+
+    onEvent({
+      payload: { text: 'patch applied' },
+      type: 'message.complete'
+    } as any)
+
+    // After the turn closes, the diff lands in history in the order the
+    // gateway emitted it — before the assistant's final text, not above it.
+    expect(appended).toHaveLength(2)
+    expect(appended[0]).toMatchObject({ role: 'system', text: diff })
+    expect(appended[1]).toMatchObject({ role: 'assistant', text: 'patch applied' })
+  })
+
   it('shows setup panel for missing provider startup error', () => {
     const appended: Msg[] = []
     const onEvent = createGatewayEventHandler(buildCtx(appended))

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -175,6 +175,26 @@ describe('createGatewayEventHandler', () => {
     expect(appended[0]?.text).toContain(cleaned)
   })
 
+  it('does not append inline_diff twice when assistant text already contains it', () => {
+    const appended: Msg[] = []
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+    const cleaned = '--- a/foo.ts\n+++ b/foo.ts\n@@\n-old\n+new'
+    const assistantText = `Done. Here's the inline diff:\n\n\`\`\`diff\n${cleaned}\n\`\`\``
+
+    onEvent({
+      payload: { inline_diff: cleaned, summary: 'patched', tool_id: 'tool-1' },
+      type: 'tool.complete'
+    } as any)
+    onEvent({
+      payload: { text: assistantText },
+      type: 'message.complete'
+    } as any)
+
+    expect(appended).toHaveLength(1)
+    expect(appended[0]?.text).toBe(assistantText)
+    expect((appended[0]?.text.match(/```diff/g) ?? []).length).toBe(1)
+  })
+
   it('shows setup panel for missing provider startup error', () => {
     const appended: Msg[] = []
     const onEvent = createGatewayEventHandler(buildCtx(appended))

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -195,6 +195,45 @@ describe('createGatewayEventHandler', () => {
     expect((appended[0]?.text.match(/```diff/g) ?? []).length).toBe(1)
   })
 
+  it('strips the CLI "┊ review diff" header from queued inline diffs', () => {
+    const appended: Msg[] = []
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+    const raw = '  \u001b[33m┊ review diff\u001b[0m\n--- a/foo.ts\n+++ b/foo.ts\n@@\n-old\n+new'
+
+    onEvent({
+      payload: { inline_diff: raw, summary: 'patched', tool_id: 'tool-1' },
+      type: 'tool.complete'
+    } as any)
+    onEvent({
+      payload: { text: 'done' },
+      type: 'message.complete'
+    } as any)
+
+    expect(appended).toHaveLength(1)
+    expect(appended[0]?.text).not.toContain('┊ review diff')
+    expect(appended[0]?.text).toContain('--- a/foo.ts')
+  })
+
+  it('suppresses inline_diff when assistant already wrote a diff fence', () => {
+    const appended: Msg[] = []
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+    const inlineDiff = '--- a/foo.ts\n+++ b/foo.ts\n@@\n-old\n+new'
+    const assistantText = 'Done. Clean swap:\n\n```diff\n-old\n+new\n```'
+
+    onEvent({
+      payload: { inline_diff: inlineDiff, summary: 'patched', tool_id: 'tool-1' },
+      type: 'tool.complete'
+    } as any)
+    onEvent({
+      payload: { text: assistantText },
+      type: 'message.complete'
+    } as any)
+
+    expect(appended).toHaveLength(1)
+    expect(appended[0]?.text).toBe(assistantText)
+    expect((appended[0]?.text.match(/```diff/g) ?? []).length).toBe(1)
+  })
+
   it('keeps tool trail terse when inline_diff is present', () => {
     const appended: Msg[] = []
     const onEvent = createGatewayEventHandler(buildCtx(appended))

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -272,12 +272,10 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
             return
           }
 
-          // Push into the active turn's segment stream so the diff renders
-          // inline with the assistant's output.  Routing through `sys()`
-          // lands it in the completed-history section above the streaming
-          // bubble — which is why blitz testers saw diffs "appear at the
-          // top, out of sequence" with the rest of the turn.
-          turnController.appendSegmentMessage({ role: 'system', text: diffText })
+          // Keep inline diffs attached to the assistant completion body so
+          // they render in the same message flow, not as a standalone system
+          // artifact that can look out-of-place around tool rows.
+          turnController.queueInlineDiff(diffText)
         }
 
         return

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -263,19 +263,27 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         return
 
       case 'tool.complete':
-        turnController.recordToolComplete(ev.payload.tool_id, ev.payload.name, ev.payload.error, ev.payload.summary)
+        {
+          const inlineDiffText =
+            ev.payload.inline_diff && getUiState().inlineDiffs ? stripAnsi(String(ev.payload.inline_diff)).trim() : ''
 
-        if (ev.payload.inline_diff && getUiState().inlineDiffs) {
-          const diffText = stripAnsi(String(ev.payload.inline_diff))
+          turnController.recordToolComplete(
+            ev.payload.tool_id,
+            ev.payload.name,
+            ev.payload.error,
+            inlineDiffText ? '' : ev.payload.summary
+          )
 
-          if (!diffText.trim()) {
+          if (!inlineDiffText) {
             return
           }
 
           // Keep inline diffs attached to the assistant completion body so
           // they render in the same message flow, not as a standalone system
           // artifact that can look out-of-place around tool rows.
-          turnController.queueInlineDiff(diffText)
+          turnController.queueInlineDiff(inlineDiffText)
+
+          return
         }
 
         return

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -2,7 +2,7 @@ import { STREAM_BATCH_MS } from '../config/timing.js'
 import { buildSetupRequiredSections, SETUP_REQUIRED_TITLE } from '../content/setup.js'
 import type { CommandsCatalogResponse, GatewayEvent, GatewaySkin } from '../gatewayTypes.js'
 import { rpcErrorMessage } from '../lib/rpc.js'
-import { formatToolCall } from '../lib/text.js'
+import { formatToolCall, stripAnsi } from '../lib/text.js'
 import { fromSkin } from '../theme.js'
 import type { Msg, SubagentProgress } from '../types.js'
 
@@ -266,12 +266,18 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         turnController.recordToolComplete(ev.payload.tool_id, ev.payload.name, ev.payload.error, ev.payload.summary)
 
         if (ev.payload.inline_diff && getUiState().inlineDiffs) {
+          const diffText = stripAnsi(String(ev.payload.inline_diff))
+
+          if (!diffText.trim()) {
+            return
+          }
+
           // Push into the active turn's segment stream so the diff renders
           // inline with the assistant's output.  Routing through `sys()`
           // lands it in the completed-history section above the streaming
           // bubble — which is why blitz testers saw diffs "appear at the
           // top, out of sequence" with the rest of the turn.
-          turnController.appendSegmentMessage({ role: 'system', text: ev.payload.inline_diff })
+          turnController.appendSegmentMessage({ role: 'system', text: diffText })
         }
 
         return

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -266,7 +266,12 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         turnController.recordToolComplete(ev.payload.tool_id, ev.payload.name, ev.payload.error, ev.payload.summary)
 
         if (ev.payload.inline_diff && getUiState().inlineDiffs) {
-          sys(ev.payload.inline_diff)
+          // Push into the active turn's segment stream so the diff renders
+          // inline with the assistant's output.  Routing through `sys()`
+          // lands it in the completed-history section above the streaming
+          // bubble — which is why blitz testers saw diffs "appear at the
+          // top, out of sequence" with the rest of the turn.
+          turnController.appendSegmentMessage({ role: 'system', text: ev.payload.inline_diff })
         }
 
         return

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -190,6 +190,16 @@ class TurnController {
    */
   appendSegmentMessage(msg: Msg) {
     this.flushStreamingSegment()
+
+    if (this.pendingSegmentTools.length) {
+      this.segmentMessages = [
+        ...this.segmentMessages,
+        { kind: 'trail', role: 'system', text: '', tools: this.pendingSegmentTools }
+      ]
+      this.pendingSegmentTools = []
+      patchTurnState({ streamPendingTools: [] })
+    }
+
     this.segmentMessages = [...this.segmentMessages, msg]
     patchTurnState({ streamSegments: this.segmentMessages })
   }

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -39,6 +39,7 @@ class TurnController {
   bufRef = ''
   interrupted = false
   lastStatusNote = ''
+  pendingInlineDiffs: string[] = []
   persistedToolLabels = new Set<string>()
   protocolWarned = false
   reasoningText = ''
@@ -76,6 +77,7 @@ class TurnController {
     this.activeTools = []
     this.streamTimer = clear(this.streamTimer)
     this.bufRef = ''
+    this.pendingInlineDiffs = []
     this.pendingSegmentTools = []
     this.segmentMessages = []
 
@@ -182,26 +184,14 @@ class TurnController {
     }, REASONING_PULSE_MS)
   }
 
-  /**
-   * Append an inline artifact (e.g. tool-complete inline diff) to the active
-   * turn's segment stream. Routing through `historyItems` via `sys()` lands
-   * the artifact above the currently-streaming assistant bubble; adding it
-   * here keeps the paint order aligned with the order the gateway emitted.
-   */
-  appendSegmentMessage(msg: Msg) {
-    this.flushStreamingSegment()
+  queueInlineDiff(diffText: string) {
+    const text = diffText.trim()
 
-    if (this.pendingSegmentTools.length) {
-      this.segmentMessages = [
-        ...this.segmentMessages,
-        { kind: 'trail', role: 'system', text: '', tools: this.pendingSegmentTools }
-      ]
-      this.pendingSegmentTools = []
-      patchTurnState({ streamPendingTools: [] })
+    if (!text) {
+      return
     }
 
-    this.segmentMessages = [...this.segmentMessages, msg]
-    patchTurnState({ streamSegments: this.segmentMessages })
+    this.pendingInlineDiffs = [...this.pendingInlineDiffs, text]
   }
 
   pushActivity(text: string, tone: ActivityItem['tone'] = 'info', replaceLabel?: string) {
@@ -238,6 +228,7 @@ class TurnController {
     this.idle()
     this.clearReasoning()
     this.clearStatusTimer()
+    this.pendingInlineDiffs = []
     this.pendingSegmentTools = []
     this.segmentMessages = []
     this.turnTools = []
@@ -248,6 +239,10 @@ class TurnController {
     const rawText = (payload.rendered ?? payload.text ?? this.bufRef).trimStart()
     const split = splitReasoning(rawText)
     const finalText = split.text
+    const inlineDiffBlock = this.pendingInlineDiffs.length
+      ? `\`\`\`diff\n${this.pendingInlineDiffs.join('\n\n')}\n\`\`\``
+      : ''
+    const mergedText = [finalText, inlineDiffBlock].filter(Boolean).join('\n\n')
     const existingReasoning = this.reasoningText.trim() || String(payload.reasoning ?? '').trim()
     const savedReasoning = [existingReasoning, existingReasoning ? '' : split.reasoning].filter(Boolean).join('\n\n')
     const savedReasoningTokens = savedReasoning ? estimateTokensRough(savedReasoning) : 0
@@ -255,10 +250,10 @@ class TurnController {
     const tools = this.pendingSegmentTools
     const finalMessages = [...this.segmentMessages]
 
-    if (finalText) {
+    if (mergedText) {
       finalMessages.push({
         role: 'assistant',
-        text: finalText,
+        text: mergedText,
         thinking: savedReasoning || undefined,
         thinkingTokens: savedReasoning ? savedReasoningTokens : undefined,
         toolTokens: savedToolTokens || undefined,
@@ -275,7 +270,7 @@ class TurnController {
     this.bufRef = ''
     patchTurnState({ activity: [], outcome: '' })
 
-    return { finalMessages, finalText, wasInterrupted }
+    return { finalMessages, finalText: mergedText, wasInterrupted }
   }
 
   recordMessageDelta({ rendered, text }: { rendered?: string; text?: string }) {
@@ -381,6 +376,7 @@ class TurnController {
     this.bufRef = ''
     this.interrupted = false
     this.lastStatusNote = ''
+    this.pendingInlineDiffs = []
     this.pendingSegmentTools = []
     this.protocolWarned = false
     this.segmentMessages = []
@@ -426,6 +422,7 @@ class TurnController {
     this.endReasoningPhase()
     this.clearReasoning()
     this.activeTools = []
+    this.pendingInlineDiffs = []
     this.turnTools = []
     this.toolTokenAcc = 0
     this.persistedToolLabels.clear()

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -185,7 +185,13 @@ class TurnController {
   }
 
   queueInlineDiff(diffText: string) {
-    const text = diffText.trim()
+    // Strip CLI chrome the gateway emits before the unified diff (e.g. a
+    // leading "┊ review diff" header written by `_emit_inline_diff` for the
+    // terminal printer). That header only makes sense as stdout dressing,
+    // not inside a markdown ```diff block.
+    const text = diffText
+      .replace(/^\s*┊[^\n]*\n?/, '')
+      .trim()
 
     if (!text || this.pendingInlineDiffs.includes(text)) {
       return
@@ -239,7 +245,13 @@ class TurnController {
     const rawText = (payload.rendered ?? payload.text ?? this.bufRef).trimStart()
     const split = splitReasoning(rawText)
     const finalText = split.text
-    const remainingInlineDiffs = this.pendingInlineDiffs.filter(diff => !finalText.includes(diff))
+    // Skip appending if the assistant already narrated the diff inside a
+    // markdown fence of its own — otherwise we render two stacked diff
+    // blocks for the same edit.
+    const assistantAlreadyHasDiff = /```(?:diff|patch)\b/i.test(finalText)
+    const remainingInlineDiffs = assistantAlreadyHasDiff
+      ? []
+      : this.pendingInlineDiffs.filter(diff => !finalText.includes(diff))
     const inlineDiffBlock = remainingInlineDiffs.length
       ? `\`\`\`diff\n${remainingInlineDiffs.join('\n\n')}\n\`\`\``
       : ''

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -182,6 +182,18 @@ class TurnController {
     }, REASONING_PULSE_MS)
   }
 
+  /**
+   * Append an inline artifact (e.g. tool-complete inline diff) to the active
+   * turn's segment stream. Routing through `historyItems` via `sys()` lands
+   * the artifact above the currently-streaming assistant bubble; adding it
+   * here keeps the paint order aligned with the order the gateway emitted.
+   */
+  appendSegmentMessage(msg: Msg) {
+    this.flushStreamingSegment()
+    this.segmentMessages = [...this.segmentMessages, msg]
+    patchTurnState({ streamSegments: this.segmentMessages })
+  }
+
   pushActivity(text: string, tone: ActivityItem['tone'] = 'info', replaceLabel?: string) {
     patchTurnState(state => {
       const base = replaceLabel

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -187,7 +187,7 @@ class TurnController {
   queueInlineDiff(diffText: string) {
     const text = diffText.trim()
 
-    if (!text) {
+    if (!text || this.pendingInlineDiffs.includes(text)) {
       return
     }
 
@@ -239,8 +239,9 @@ class TurnController {
     const rawText = (payload.rendered ?? payload.text ?? this.bufRef).trimStart()
     const split = splitReasoning(rawText)
     const finalText = split.text
-    const inlineDiffBlock = this.pendingInlineDiffs.length
-      ? `\`\`\`diff\n${this.pendingInlineDiffs.join('\n\n')}\n\`\`\``
+    const remainingInlineDiffs = this.pendingInlineDiffs.filter(diff => !finalText.includes(diff))
+    const inlineDiffBlock = remainingInlineDiffs.length
+      ? `\`\`\`diff\n${remainingInlineDiffs.join('\n\n')}\n\`\`\``
       : ''
     const mergedText = [finalText, inlineDiffBlock].filter(Boolean).join('\n\n')
     const existingReasoning = this.reasoningText.trim() || String(payload.reasoning ?? '').trim()


### PR DESCRIPTION
## Summary
After blitz testing, routing `inline_diff` through `sys(text)` landed the diff in `historyItems` (above the `StreamingAssistant` pane), so code-review diffs visually floated above the rest of the current turn. Later iterations also showed duplicated diffs when the agent narrated its own fenced diff in the reply.

Final design:
- `tool.complete` sanitizes `inline_diff` (strips ANSI + the CLI's leading `┊ review diff` chrome line) and buffers it in `turnController.pendingInlineDiffs` via `queueInlineDiff`.
- On `message.complete`, the buffered diffs are merged into the assistant completion body as a fenced ```diff block **appended after the assistant text**, so the diff renders in the same message flow as the agent's response.
- Dedupe guards:
  - skip queued diffs whose text already appears verbatim in the assistant's final text
  - skip appending the fenced block entirely if the assistant message already contains a ```diff (or ```patch) fence of its own
- Tool trail stays terse when `inline_diff` is present (tool-row summary is suppressed so we don't double-render diff content under the tool row).

## Issue
Row 8 from the TUI v2 blitz test: _"code review diffs get appended to the top of current interaction thread"_, plus follow-up feedback that duplicate/awkward diff renderings remained even after the initial inline fix.

## Test plan
- [x] `npx vitest run src/__tests__/createGatewayEventHandler.test.ts` — covers inline diff merging, ANSI stripping, header stripping, dedupe when assistant echoes the same diff, dedupe when assistant already wrote a `\`\`\`diff` fence, and terse tool-trail behavior.
- [x] `npx vitest run` — 172 passing
- [x] `npx tsc --noEmit` clean
- [ ] Manual: ask the agent to edit a file; verify (1) one clean diff block inline with the assistant message, (2) no duplicate when the agent narrates its own fenced diff, (3) terse tool trail row beside the diff.
