### PR TITLE
fix(cron): drop webhook from _KNOWN_DELIVERY_PLATFORMS schema mismatch

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -42,10 +42,13 @@ logger = logging.getLogger(__name__)
 
 # Valid delivery platforms — used to validate user-supplied platform names
 # in cron delivery targets, preventing env var enumeration via crafted names.
+# Must stay in sync with the platform_map inside _deliver_result() below; see
+# gh-13707 for why this list previously included "webhook" which had no
+# matching entry in platform_map and therefore failed every delivery.
 _KNOWN_DELIVERY_PLATFORMS = frozenset({
     "telegram", "discord", "slack", "whatsapp", "signal",
     "matrix", "mattermost", "homeassistant", "dingtalk", "feishu",
-    "wecom", "wecom_callback", "weixin", "sms", "email", "webhook", "bluebubbles",
+    "wecom", "wecom_callback", "weixin", "sms", "email", "bluebubbles",
     "qqbot",
 })
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -263,6 +263,18 @@ class TestResolveDeliveryTarget:
             "thread_id": None,
         }
 
+    def test_webhook_not_in_known_delivery_platforms(self):
+        """Regression for gh-13707: webhook is not a cron delivery platform.
+
+        The gateway run.py explicitly filters Platform.WEBHOOK out of messaging
+        platforms, and _deliver_result's platform_map does not include webhook,
+        so advertising it as a known cron delivery target only produced
+        'unknown platform webhook' failures at delivery time.
+        """
+        from cron.scheduler import _KNOWN_DELIVERY_PLATFORMS
+
+        assert "webhook" not in _KNOWN_DELIVERY_PLATFORMS
+
 
 class TestDeliverResultWrapping:
     """Verify that cron deliveries are wrapped with header/footer and no longer mirrored."""


### PR DESCRIPTION
## Summary

Fixes #13707. `cron.scheduler._KNOWN_DELIVERY_PLATFORMS` advertises `webhook` as a valid cron delivery target, but the actual `_deliver_result()` platform_map has no `Platform.WEBHOOK` entry — so a configured `deliver=\"webhook:...\"` target passes earlier validation and then fails at delivery time with `unknown platform 'webhook'`.

Webhook is inbound-only in this codebase (`gateway/run.py:742` explicitly filters `Platform.WEBHOOK` out of messaging platforms), so the correct fix is to stop advertising it as a delivery target rather than wire up a send path that doesn't exist.

## Fix

- Drop `\"webhook\"` from `_KNOWN_DELIVERY_PLATFORMS`
- Add code-comment pinning this set to the `platform_map` inside `_deliver_result`
- Add regression test asserting webhook is not in the allowlist

## Test

54 tests in `tests/cron/test_scheduler.py` pass locally. Regression test fails without the fix (asserts the invariant directly).

Closes #13707.