### PR TITLE
fix(discord): honor documented env-wins-over-config precedence for require_mention/free_response_channels

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -2478,19 +2478,34 @@ class DiscordAdapter(BasePlatformAdapter):
         return resolve_channel_prompt(self.config.extra, channel_id, parent_id)
 
     def _discord_require_mention(self) -> bool:
-        """Return whether Discord channel messages require a bot mention."""
+        """Return whether Discord channel messages require a bot mention.
+
+        Precedence matches the documented contract for the discord channel
+        (config.yaml applied as defaults; the equivalent env var wins when
+        set): DISCORD_REQUIRE_MENTION > config.yaml require_mention > default
+        True. (#13685)
+        """
+        env_value = os.getenv("DISCORD_REQUIRE_MENTION")
+        if env_value is not None:
+            return env_value.lower() not in ("false", "0", "no", "off")
         configured = self.config.extra.get("require_mention")
         if configured is not None:
             if isinstance(configured, str):
                 return configured.lower() not in ("false", "0", "no", "off")
             return bool(configured)
-        return os.getenv("DISCORD_REQUIRE_MENTION", "true").lower() not in ("false", "0", "no", "off")
+        return True
 
     def _discord_free_response_channels(self) -> set:
-        """Return Discord channel IDs where no bot mention is required."""
-        raw = self.config.extra.get("free_response_channels")
-        if raw is None:
-            raw = os.getenv("DISCORD_FREE_RESPONSE_CHANNELS", "")
+        """Return Discord channel IDs where no bot mention is required.
+
+        Precedence matches the documented contract (env wins over
+        config.yaml). (#13685)
+        """
+        env_value = os.getenv("DISCORD_FREE_RESPONSE_CHANNELS")
+        if env_value is not None and env_value.strip():
+            raw: Any = env_value
+        else:
+            raw = self.config.extra.get("free_response_channels")
         if isinstance(raw, list):
             return {str(part).strip() for part in raw if str(part).strip()}
         if isinstance(raw, str) and raw.strip():

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -468,3 +468,41 @@ async def test_discord_voice_linked_parent_thread_still_requires_mention(adapter
     await adapter._handle_message(message)
 
     adapter.handle_message.assert_not_awaited()
+
+
+class TestDiscordEnvPrecedenceOverConfig:
+    """Regression for gh-13685: env var must win over config.yaml, matching
+    the documented precedence for the discord channel."""
+
+    def test_env_require_mention_overrides_config_true(self, adapter, monkeypatch):
+        monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+        adapter.config.extra["require_mention"] = True
+        assert adapter._discord_require_mention() is False
+
+    def test_env_require_mention_overrides_config_false(self, adapter, monkeypatch):
+        monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+        adapter.config.extra["require_mention"] = False
+        assert adapter._discord_require_mention() is True
+
+    def test_config_require_mention_used_when_env_unset(self, adapter, monkeypatch):
+        monkeypatch.delenv("DISCORD_REQUIRE_MENTION", raising=False)
+        adapter.config.extra["require_mention"] = False
+        assert adapter._discord_require_mention() is False
+
+    def test_default_require_mention_when_neither_set(self, adapter, monkeypatch):
+        monkeypatch.delenv("DISCORD_REQUIRE_MENTION", raising=False)
+        adapter.config.extra.pop("require_mention", None)
+        assert adapter._discord_require_mention() is True
+
+    def test_env_free_response_channels_overrides_config(self, adapter, monkeypatch):
+        monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "111,222")
+        adapter.config.extra["free_response_channels"] = ["999"]
+        assert adapter._discord_free_response_channels() == {"111", "222"}
+
+    def test_empty_env_free_response_channels_falls_through_to_config(self, adapter, monkeypatch):
+        # Empty env value should not mask a non-empty config list — otherwise
+        # unset vs. empty becomes indistinguishable. Treat empty string as
+        # "env not actively set" and fall through to config.yaml.
+        monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "")
+        adapter.config.extra["free_response_channels"] = ["555"]
+        assert adapter._discord_free_response_channels() == {"555"}


### PR DESCRIPTION
## Summary

Fixes #13685. The [Discord channel docs](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/discord#config-file-configyaml) state:

> Config.yaml settings are applied as defaults — if the equivalent env var is already set, the env var wins.

But \`_discord_require_mention\` and \`_discord_free_response_channels\` in \`gateway/platforms/discord.py\` checked \`config.extra\` first and only fell back to the env var when config was unset — inverting the documented contract for the two most commonly configured Discord gating fields. Since \`require_mention: true\` is the default in a fresh \`config.yaml\`, the env var never wins in practice.

## Fix

Swap the order in both helpers: env var read first, config.extra as fallback, hardcoded default last. An empty-string env value is treated as *not actively set* so unset-vs-empty remains distinguishable (an empty string does not mask a non-empty config list).

## Test

Added 6 regression tests in \`TestDiscordEnvPrecedenceOverConfig\`:
- env TRUE overrides config FALSE for \`require_mention\` (and vice versa)
- config value used when env unset
- default TRUE when neither set
- env list overrides config list for \`free_response_channels\`
- empty env string falls through to config (unset-vs-empty guard)

All 6 new tests pass locally. Pre-existing async tests in the same file fail due to missing \`pytest-asyncio\` in the local venv — unrelated to this change (same 20 failures present on \`main\` without my patch).

## Scope

2 private methods in 1 adapter. Pure precedence swap — no new capability. Rule out: I checked \`PR #9837\` which touches \`reply_to_mode\` (different field), not a rival for these two fields.

Closes #13685.