### PR TITLE
fix: allow active tempdir writes in file tools

### DIFF
--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -106,6 +106,10 @@ class TestCheckSensitivePathMacOSBypass:
         from tools.file_tools import _check_sensitive_path
         assert _check_sensitive_path("/tmp/safe_file.txt") is None
 
+    def test_active_tempdir_under_private_var_allowed(self, tmp_path: Path):
+        from tools.file_tools import _check_sensitive_path
+        assert _check_sensitive_path(str(tmp_path / "safe.txt")) is None
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -5,6 +5,7 @@ import errno
 import json
 import logging
 import os
+import tempfile
 import threading
 from pathlib import Path
 from typing import Optional
@@ -114,6 +115,29 @@ _SENSITIVE_PATH_PREFIXES = (
 _SENSITIVE_EXACT_PATHS = {"/var/run/docker.sock", "/run/docker.sock"}
 
 
+def _is_within_active_tempdir(candidate: str) -> bool:
+    """Allow writes under the current process temp dir even on macOS.
+
+    macOS temp paths resolve under /private/var/folders/... which would
+    otherwise trip the /private/var denylist even for harmless test/work files.
+    """
+    try:
+        temp_roots = {
+            os.path.normpath(os.path.expanduser(tempfile.gettempdir())),
+            os.path.normpath(os.path.realpath(tempfile.gettempdir())),
+        }
+        candidate_norm = os.path.normpath(candidate)
+        candidate_real = os.path.normpath(os.path.realpath(candidate))
+        for root in temp_roots:
+            if candidate_norm == root or candidate_real == root:
+                return True
+            if candidate_norm.startswith(root + os.sep) or candidate_real.startswith(root + os.sep):
+                return True
+    except Exception:
+        return False
+    return False
+
+
 def _check_sensitive_path(filepath: str) -> str | None:
     """Return an error message if the path targets a sensitive system location."""
     try:
@@ -125,6 +149,8 @@ def _check_sensitive_path(filepath: str) -> str | None:
         f"Refusing to write to sensitive system path: {filepath}\n"
         "Use the terminal tool with sudo if you need to modify system files."
     )
+    if _is_within_active_tempdir(resolved) or _is_within_active_tempdir(normalized):
+        return None
     for prefix in _SENSITIVE_PATH_PREFIXES:
         if resolved.startswith(prefix) or normalized.startswith(prefix):
             return _err


### PR DESCRIPTION
## Summary
- allow file writes under the active process temp directory
- keep the existing sensitive `/private/var` system-path protection in place
- add a regression test covering macOS temp paths under `/private/var/folders/...`

## Why
Latest upstream introduced delegate/file-state tests that write into macOS temp directories. Those temp paths resolve under `/private/var/folders/...`, and the file-tools sensitive-path guard was blocking them as if they were dangerous system paths. That made harmless temp-file writes fail.

## Test Plan
- [x] `pytest tests/tools/test_file_write_safety.py`
- [x] `pytest tests/tools/test_delegate.py tests/tools/test_file_state_registry.py tests/tools/test_file_write_safety.py`
