### PR TITLE
fix(agent): propagate approval callbacks to concurrent tool worker threads

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -71,6 +71,12 @@ from model_tools import (
     check_toolset_requirements,
 )
 from tools.terminal_tool import cleanup_vm, get_active_env, is_persistent_env
+from tools.terminal_tool import (
+    set_approval_callback as _set_approval_callback,
+    set_sudo_password_callback as _set_sudo_password_callback,
+    _get_approval_callback,
+    _get_sudo_password_callback,
+)
 from tools.tool_result_storage import maybe_persist_tool_result, enforce_turn_budget
 from tools.interrupt import set_interrupt as _set_interrupt
 from tools.browser_tool import cleanup_browser
@@ -7867,6 +7873,14 @@ class AIAgent:
         self._current_tool = tool_names_str
         self._touch_activity(f"executing {num_tools} tools concurrently: {tool_names_str}")
 
+        # Capture CLI callbacks from the agent thread so worker threads can
+        # register them locally.  Without this, _get_approval_callback() in
+        # terminal_tool returns None in ThreadPoolExecutor workers, causing
+        # the dangerous-command prompt to fall back to input() — which
+        # deadlocks against prompt_toolkit's raw terminal mode (#13617).
+        _parent_approval_cb = _get_approval_callback()
+        _parent_sudo_cb = _get_sudo_password_callback()
+
         def _run_tool(index, tool_call, function_name, function_args):
             """Worker function executed in a thread."""
             # Register this worker tid so the agent can fan out an interrupt
@@ -7893,6 +7907,18 @@ class AIAgent:
                 set_activity_callback(self._touch_activity)
             except Exception:
                 pass
+            # Propagate approval/sudo callbacks to this worker thread.
+            # Mirrors cli.py run_agent() pattern (GHSA-qg5c-hvr5-hjgr).
+            if _parent_approval_cb is not None:
+                try:
+                    _set_approval_callback(_parent_approval_cb)
+                except Exception:
+                    pass
+            if _parent_sudo_cb is not None:
+                try:
+                    _set_sudo_password_callback(_parent_sudo_cb)
+                except Exception:
+                    pass
             start = time.time()
             try:
                 result = self._invoke_tool(function_name, function_args, effective_task_id, tool_call.id, messages=messages)
@@ -7913,6 +7939,13 @@ class AIAgent:
                 self._tool_worker_threads.discard(_worker_tid)
             try:
                 _set_interrupt(False, _worker_tid)
+            except Exception:
+                pass
+            # Clear thread-local callbacks so a recycled worker thread
+            # doesn't hold stale references to a disposed CLI instance.
+            try:
+                _set_approval_callback(None)
+                _set_sudo_password_callback(None)
             except Exception:
                 pass
 


### PR DESCRIPTION
# Bug #13617 Regression: Concurrent tool execution deadlocks on dangerous-command approval

## Summary
When the agent executes a batch of tools concurrently (e.g. `read_file` + `terminal` in the same turn), any dangerous-command approval prompt deadlocks. The user can type a selection but pressing Return has no effect; the prompt times out after 60 seconds and denies the command.

## Root Cause
`_execute_tool_calls_concurrent()` in `run_agent.py` dispatches tool calls to a `ThreadPoolExecutor`. The dangerous-command approval callback (and sudo password callback) are stored in `threading.local()` inside `tools/terminal_tool.py`. Worker threads spawned by the executor cannot see callbacks registered in the parent agent thread, so `_get_approval_callback()` returns `None`.

When the callback is `None`, `tools/approval.py` falls back to plain `input()` in a background daemon thread. However, the Hermes CLI uses **prompt_toolkit**, which puts the terminal in raw mode. The background thread's `input()` competes with prompt_toolkit for stdin. The user can type characters (they may echo), but the Enter key is captured by prompt_toolkit and never reaches `input()`, causing a deadlock until the timeout fires.

## Affected Code Paths
- `run_agent.py` → `AIAgent._execute_tool_calls_concurrent()` → `_run_tool()` worker function
- Any concurrent batch containing `terminal`, `execute_code`, or other tools that trigger dangerous-command detection

## Fix
Capture the parent thread's approval/sudo callbacks before launching the thread pool, then register them locally inside each worker thread (and clear them on exit). This mirrors the existing fix pattern used in `cli.py` for the main agent worker thread.

### Files Changed
- `run_agent.py`

### Key Diff Points
1. Import callback getters/setters from `tools.terminal_tool`
2. Before defining `_run_tool`, snapshot `_get_approval_callback()` and `_get_sudo_password_callback()`
3. Inside `_run_tool`, after `set_activity_callback()`, register the callbacks:
   ```python
   if _parent_approval_cb is not None:
       _set_approval_callback(_parent_approval_cb)
   if _parent_sudo_cb is not None:
       _set_sudo_password_callback(_parent_sudo_cb)
   ```
4. At the end of `_run_tool`, clear them:
   ```python
   _set_approval_callback(None)
   _set_sudo_password_callback(None)
   ```

## Regression Tests
- `tests/cli/test_cli_approval_ui.py::TestApprovalCallbackThreadLocalWiring`
  - `test_main_thread_registration_is_invisible_to_child_thread`
  - `test_child_thread_registration_is_visible_and_cleared_in_finally`

All 10 approval UI tests pass after the fix.

## Related
- Original fix: GHSA-qg5c-hvr5-hjgr / #13617 (made callbacks thread-local)
- The original fix registered callbacks inside the main agent worker thread (`cli.py` ~8378) but missed the concurrent execution path (`run_agent.py` ~7876).
