### PR TITLE
fix(mcp): extract text from EmbeddedResource content blocks in tool results

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -531,6 +531,89 @@ class TestToolHandler:
         assert "error" in result
         assert "not connected" in result["error"]
 
+    def test_embedded_resource_text(self):
+        """Tools returning EmbeddedResource blocks (type: 'resource') should
+        have their nested text extracted from block.resource.text."""
+        from tools.mcp_tool import _make_tool_handler, _servers
+
+        # Simulate an EmbeddedResource content block (no top-level .text)
+        resource_obj = SimpleNamespace(
+            uri="qmd://wiki/test.md",
+            mimeType="text/markdown",
+            text="# Hello\nThis is embedded resource content.",
+        )
+        block = SimpleNamespace(type="resource", resource=resource_obj)
+        mock_result = SimpleNamespace(content=[block], isError=False)
+
+        mock_session = MagicMock()
+        mock_session.call_tool = AsyncMock(return_value=mock_result)
+        server = _make_mock_server("test_srv", session=mock_session)
+        _servers["test_srv"] = server
+
+        try:
+            handler = _make_tool_handler("test_srv", "get", 120)
+            with self._patch_mcp_loop():
+                result = json.loads(handler({"file": "wiki/test.md"}))
+            assert result["result"] == "# Hello\nThis is embedded resource content."
+        finally:
+            _servers.pop("test_srv", None)
+
+    def test_embedded_resource_blob(self):
+        """Binary EmbeddedResource blocks should produce a placeholder."""
+        from tools.mcp_tool import _make_tool_handler, _servers
+
+        resource_obj = SimpleNamespace(
+            uri="qmd://wiki/image.png",
+            mimeType="image/png",
+            blob="iVBORw0KGgo=",
+        )
+        # No .text on the resource — only .blob
+        block = SimpleNamespace(type="resource", resource=resource_obj)
+        mock_result = SimpleNamespace(content=[block], isError=False)
+
+        mock_session = MagicMock()
+        mock_session.call_tool = AsyncMock(return_value=mock_result)
+        server = _make_mock_server("test_srv", session=mock_session)
+        _servers["test_srv"] = server
+
+        try:
+            handler = _make_tool_handler("test_srv", "get_image", 120)
+            with self._patch_mcp_loop():
+                result = json.loads(handler({"file": "image.png"}))
+            assert "binary resource" in result["result"]
+            assert "qmd://wiki/image.png" in result["result"]
+        finally:
+            _servers.pop("test_srv", None)
+
+    def test_mixed_text_and_embedded_resource(self):
+        """Tool results with both TextContent and EmbeddedResource blocks."""
+        from tools.mcp_tool import _make_tool_handler, _servers
+
+        text_block = SimpleNamespace(text="Preamble text")
+        resource_obj = SimpleNamespace(
+            uri="qmd://wiki/doc.md",
+            mimeType="text/markdown",
+            text="# Doc content",
+        )
+        resource_block = SimpleNamespace(type="resource", resource=resource_obj)
+        mock_result = SimpleNamespace(
+            content=[text_block, resource_block], isError=False
+        )
+
+        mock_session = MagicMock()
+        mock_session.call_tool = AsyncMock(return_value=mock_result)
+        server = _make_mock_server("test_srv", session=mock_session)
+        _servers["test_srv"] = server
+
+        try:
+            handler = _make_tool_handler("test_srv", "multi_get", 120)
+            with self._patch_mcp_loop():
+                result = json.loads(handler({"pattern": "*.md"}))
+            assert "Preamble text" in result["result"]
+            assert "# Doc content" in result["result"]
+        finally:
+            _servers.pop("test_srv", None)
+
     def test_exception_during_call(self):
         from tools.mcp_tool import _make_tool_handler, _servers
 

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -236,6 +236,89 @@ class TestToolHandler:
         assert "error" in result
         assert "not connected" in result["error"]
 
+    def test_embedded_resource_text(self):
+        """Tools returning EmbeddedResource blocks (type: 'resource') should
+        have their nested text extracted from block.resource.text."""
+        from tools.mcp_tool import _make_tool_handler, _servers
+
+        # Simulate an EmbeddedResource content block (no top-level .text)
+        resource_obj = SimpleNamespace(
+            uri="qmd://wiki/test.md",
+            mimeType="text/markdown",
+            text="# Hello\nThis is embedded resource content.",
+        )
+        block = SimpleNamespace(type="resource", resource=resource_obj)
+        mock_result = SimpleNamespace(content=[block], isError=False)
+
+        mock_session = MagicMock()
+        mock_session.call_tool = AsyncMock(return_value=mock_result)
+        server = _make_mock_server("test_srv", session=mock_session)
+        _servers["test_srv"] = server
+
+        try:
+            handler = _make_tool_handler("test_srv", "get", 120)
+            with self._patch_mcp_loop():
+                result = json.loads(handler({"file": "wiki/test.md"}))
+            assert result["result"] == "# Hello\nThis is embedded resource content."
+        finally:
+            _servers.pop("test_srv", None)
+
+    def test_embedded_resource_blob(self):
+        """Binary EmbeddedResource blocks should produce a placeholder."""
+        from tools.mcp_tool import _make_tool_handler, _servers
+
+        resource_obj = SimpleNamespace(
+            uri="qmd://wiki/image.png",
+            mimeType="image/png",
+            blob="iVBORw0KGgo=",
+        )
+        # No .text on the resource — only .blob
+        block = SimpleNamespace(type="resource", resource=resource_obj)
+        mock_result = SimpleNamespace(content=[block], isError=False)
+
+        mock_session = MagicMock()
+        mock_session.call_tool = AsyncMock(return_value=mock_result)
+        server = _make_mock_server("test_srv", session=mock_session)
+        _servers["test_srv"] = server
+
+        try:
+            handler = _make_tool_handler("test_srv", "get_image", 120)
+            with self._patch_mcp_loop():
+                result = json.loads(handler({"file": "image.png"}))
+            assert "binary resource" in result["result"]
+            assert "qmd://wiki/image.png" in result["result"]
+        finally:
+            _servers.pop("test_srv", None)
+
+    def test_mixed_text_and_embedded_resource(self):
+        """Tool results with both TextContent and EmbeddedResource blocks."""
+        from tools.mcp_tool import _make_tool_handler, _servers
+
+        text_block = SimpleNamespace(text="Preamble text")
+        resource_obj = SimpleNamespace(
+            uri="qmd://wiki/doc.md",
+            mimeType="text/markdown",
+            text="# Doc content",
+        )
+        resource_block = SimpleNamespace(type="resource", resource=resource_obj)
+        mock_result = SimpleNamespace(
+            content=[text_block, resource_block], isError=False
+        )
+
+        mock_session = MagicMock()
+        mock_session.call_tool = AsyncMock(return_value=mock_result)
+        server = _make_mock_server("test_srv", session=mock_session)
+        _servers["test_srv"] = server
+
+        try:
+            handler = _make_tool_handler("test_srv", "multi_get", 120)
+            with self._patch_mcp_loop():
+                result = json.loads(handler({"pattern": "*.md"}))
+            assert "Preamble text" in result["result"]
+            assert "# Doc content" in result["result"]
+        finally:
+            _servers.pop("test_srv", None)
+
     def test_exception_during_call(self):
         from tools.mcp_tool import _make_tool_handler, _servers
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2369,6 +2369,15 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                 if hasattr(block, "text") and block.text:
                     parts.append(block.text)
                     continue
+                elif hasattr(block, "resource"):
+                    # EmbeddedResource blocks nest text inside block.resource.text
+                    # (MCP spec §5.6.2 — tools may return file content this way)
+                    res = block.resource
+                    if hasattr(res, "text") and res.text:
+                        parts.append(res.text)
+                    elif hasattr(res, "blob") and res.blob:
+                        parts.append(f"[binary resource: {getattr(res, 'uri', 'unknown')}]")
+                    continue
                 image_tag = _cache_mcp_image_block(block)
                 if image_tag:
                     parts.append(image_tag)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1712,6 +1712,14 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             for block in (result.content or []):
                 if hasattr(block, "text"):
                     parts.append(block.text)
+                elif hasattr(block, "resource"):
+                    # EmbeddedResource blocks nest text inside block.resource.text
+                    # (MCP spec §5.6.2 — tools may return file content this way)
+                    res = block.resource
+                    if hasattr(res, "text") and res.text:
+                        parts.append(res.text)
+                    elif hasattr(res, "blob") and res.blob:
+                        parts.append(f"[binary resource: {getattr(res, 'uri', 'unknown')}]")
             text_result = "\n".join(parts) if parts else ""
 
             # Combine content + structuredContent when both are present.


### PR DESCRIPTION
## What does this PR do?

MCP tools that return file/document content use `EmbeddedResource` content blocks (`type: "resource"`) where the text payload lives at `block.resource.text` (per MCP spec [§5.6.2 — Tool Result Content](https://spec.modelcontextprotocol.io/specification/2024-11-05/server/tools/#tool-result-content)). The tool result handler in `_make_tool_handler` only checked for `block.text` (which exists on `TextContent` blocks), silently dropping `EmbeddedResource` blocks and returning empty strings to the agent.

Discovered via the [`@tobilu/qmd`](https://www.npmjs.com/package/@tobilu/qmd) MCP server (v2.1.0), whose `get` and `multi_get` tools return `EmbeddedResource` blocks for document retrieval. Any MCP server returning resource-type content blocks would hit the same issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/mcp_tool.py`: Added `elif hasattr(block, "resource")` branch in `_make_tool_handler`'s content extraction loop to handle `block.resource.text` (`TextResourceContents`) and `block.resource.blob` (`BlobResourceContents`)
- `tests/tools/test_mcp_tool.py`: Added three tests:
  - `test_embedded_resource_text` — EmbeddedResource with text content
  - `test_embedded_resource_blob` — binary blob produces placeholder
  - `test_mixed_text_and_embedded_resource` — mixed TextContent + EmbeddedResource

## How to Test

1. Configure any MCP server that returns `EmbeddedResource` content blocks (e.g. `@tobilu/qmd` v2.1.0 with `get` tool)
2. Call a tool that retrieves document content (e.g. `mcp_qmd_get`)
3. **Before fix:** Tool executes successfully but returns empty string
4. **After fix:** Document content is correctly extracted and returned

Or run the unit tests: `pytest tests/tools/test_mcp_tool.py -q` (169 pass, 3 new)

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — no duplicate
- [x] PR contains only changes related to this fix
- [x] `pytest tests/ -q` passes (169 MCP tool tests)
- [x] Added 3 tests for the fix
- [x] Tested on macOS 26.4 (Apple Silicon)

### Documentation & Housekeeping
- [x] N/A — no config or documentation changes needed
- [x] Cross-platform: change is pure Python, no platform-specific code
