### PR TITLE
fix(gateway): add missing display config helper API

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -2,6 +2,8 @@
 
 Provides ``resolve_display_setting()`` — the single entry-point for reading
 display settings with platform-specific overrides and sensible defaults.
+Also exports helper APIs for callers/tests that need the resolved display
+bundle or the built-in defaults for a platform.
 
 Resolution order (first non-None wins):
     1. ``display.platforms.<platform>.<key>``  — explicit per-platform user override
@@ -168,6 +170,26 @@ def resolve_display_setting(
         return val
 
     return fallback
+
+
+def get_platform_defaults(platform_key: str) -> dict[str, Any]:
+    """Return the built-in display defaults for one platform.
+
+    Unknown platforms fall back to the global defaults only. A fresh dict is
+    returned so callers cannot mutate module-level defaults.
+    """
+    defaults = dict(_GLOBAL_DEFAULTS)
+    plat_defaults = _PLATFORM_DEFAULTS.get(platform_key) or {}
+    defaults.update(plat_defaults)
+    return defaults
+
+
+def get_effective_display(user_config: dict, platform_key: str) -> dict[str, Any]:
+    """Return the fully resolved display settings for one platform."""
+    return {
+        setting: resolve_display_setting(user_config, platform_key, setting)
+        for setting in OVERRIDEABLE_KEYS
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -327,3 +327,61 @@ class TestStreamingPerPlatform:
             }
         }
         assert resolve_display_setting(config, "email", "streaming") is True
+
+
+# ---------------------------------------------------------------------------
+# Helper API
+# ---------------------------------------------------------------------------
+
+class TestHelperAPI:
+    """Public helper wrappers stay aligned with the resolver contract."""
+
+    def test_get_platform_defaults_known_platform(self):
+        """Known platforms merge platform-tier defaults over global defaults."""
+        from gateway.display_config import get_platform_defaults
+
+        defaults = get_platform_defaults("telegram")
+
+        assert defaults == {
+            "tool_progress": "all",
+            "show_reasoning": False,
+            "tool_preview_length": 40,
+            "streaming": None,
+        }
+
+    def test_get_platform_defaults_unknown_platform(self):
+        """Unknown platforms fall back to the built-in global defaults."""
+        from gateway.display_config import get_platform_defaults
+
+        defaults = get_platform_defaults("unknown_platform")
+
+        assert defaults == {
+            "tool_progress": "all",
+            "show_reasoning": False,
+            "tool_preview_length": 0,
+            "streaming": None,
+        }
+
+    def test_get_effective_display_resolves_all_keys(self):
+        """Helper returns the same per-key values as resolve_display_setting()."""
+        from gateway.display_config import get_effective_display
+
+        config = {
+            "display": {
+                "tool_progress": "new",
+                "show_reasoning": True,
+                "platforms": {
+                    "telegram": {
+                        "tool_preview_length": "80",
+                        "streaming": False,
+                    }
+                },
+            }
+        }
+
+        assert get_effective_display(config, "telegram") == {
+            "tool_progress": "new",
+            "show_reasoning": True,
+            "tool_preview_length": 80,
+            "streaming": False,
+        }


### PR DESCRIPTION
## What does this PR do?

Adds the missing `gateway.display_config` helper API expected by the committed test suite.

Specifically:
- adds `get_platform_defaults(platform_key)` to expose built-in display defaults safely
- adds `get_effective_display(user_config, platform_key)` to return the fully resolved display bundle for a platform
- adds focused regression tests covering known-platform defaults, unknown-platform fallback, and effective per-platform resolution

This fixes the contract drift described in issue #13705, where tests referenced helper functions that were not implemented/exported.

Fixes #13705

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- updated `gateway/display_config.py`
- updated `tests/gateway/test_display_config.py`

## How to Test

1. Run:
   `py -3 -m pytest tests\gateway\test_display_config.py -q -o addopts="" --basetemp C:\Users\cgold\Desktop\hermes\hermes-agent\.pytest-tmp\run -p no:cacheprovider`
2. Confirm the test file passes
3. Verify the new helpers are importable from `gateway.display_config`

## Platform Tested

- Windows 11
