### PR TITLE
fix(website): auto-run skill extraction on npm build

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
+    "prestart": "node scripts/prebuild.mjs",
     "start": "docusaurus start",
+    "prebuild": "node scripts/prebuild.mjs",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",

--- a/website/scripts/prebuild.mjs
+++ b/website/scripts/prebuild.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+// Runs website/scripts/extract-skills.py before docusaurus build/start so
+// that website/src/data/skills.json (imported by src/pages/skills/index.tsx)
+// exists without contributors needing to remember to run the Python script
+// manually. CI workflows still run the extraction explicitly, which is a
+// no-op duplicate but matches their historical behaviour.
+//
+// If python3 or its deps (pyyaml) aren't available on the local machine, we
+// fall back to writing an empty skills.json so `npm run build` still
+// succeeds — the Skills Hub page just shows an empty state. CI always has
+// the deps installed, so production deploys get real data.
+
+import { spawnSync } from "node:child_process";
+import { mkdirSync, writeFileSync, existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const websiteDir = resolve(scriptDir, "..");
+const extractScript = join(scriptDir, "extract-skills.py");
+const outputFile = join(websiteDir, "src", "data", "skills.json");
+
+function writeEmptyFallback(reason) {
+  mkdirSync(dirname(outputFile), { recursive: true });
+  writeFileSync(outputFile, "[]\n");
+  console.warn(
+    `[prebuild] extract-skills.py skipped (${reason}); wrote empty skills.json. ` +
+      `Install python3 + pyyaml locally for a populated Skills Hub page.`,
+  );
+}
+
+if (!existsSync(extractScript)) {
+  writeEmptyFallback("extract script missing");
+  process.exit(0);
+}
+
+const result = spawnSync("python3", [extractScript], {
+  stdio: "inherit",
+  cwd: websiteDir,
+});
+
+if (result.error && result.error.code === "ENOENT") {
+  writeEmptyFallback("python3 not found");
+  process.exit(0);
+}
+
+if (result.status !== 0) {
+  writeEmptyFallback(`extract-skills.py exited with status ${result.status}`);
+  process.exit(0);
+}


### PR DESCRIPTION
## Summary
`npm run build` (and `npm start`) in `website/` now Just Works for anyone cloning the repo — no more `Module not found: Can't resolve '../../data/skills.json'`.

## Root cause
`website/src/pages/skills/index.tsx` imports `src/data/skills.json`, but that file is git-ignored (`website/.gitignore:10`) and generated at build time by `website/scripts/extract-skills.py`. CI workflows (`deploy-site.yml`, `docs-site-checks.yml`) run the Python script explicitly before `npm run build`, so prod and PR checks always work. But a contributor running `npm run build` locally had no way to know about the generation step, and Docusaurus failed hard on the missing import.

## Changes
- `website/scripts/prebuild.mjs` — new Node hook that shells out to `python3 website/scripts/extract-skills.py`. If python3 / pyyaml aren't available locally, it writes an empty `[]` `skills.json` and warns on stderr instead of failing — the Skills Hub page renders with an empty state, the rest of the site builds normally. CI always has the deps, so prod still gets the full catalog.
- `website/package.json` — adds `prebuild` and `prestart` scripts (npm invokes these automatically before `build` and `start`).

## Validation
| | Before | After |
|---|---|---|
| Fresh `npm run build` locally | Fails: `Module not found: skills.json` | Builds in ~20s, Skills Hub populated (10,664-line skills.json generated) |
| CI deploy-site.yml / docs-site-checks.yml | Run extract-skills.py manually, then build | Same manual step runs; prebuild hook is a harmless no-op re-run |
| No python3 available | N/A (build always broke) | Builds with empty Skills Hub + warning on stderr |

Zero changes to CI workflows — the explicit `python3 extract-skills.py` step still runs, and the prebuild hook is just belt-and-suspenders.

Docs-infra only, no behavioral changes for agent runtime.
