### PR TITLE
fix(tools): skip credential pool binding when delegate base_url is set

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1058,6 +1058,40 @@ class TestChildCredentialPoolResolution(unittest.TestCase):
 
             self.assertEqual(mock_child._credential_pool, mock_pool)
 
+    def test_override_base_url_skips_parent_pool(self):
+        """When override_base_url is set, child should not inherit parent's pool.
+
+        Otherwise _swap_credential() would clobber the child's explicit base_url
+        with the parent's endpoint from the shared pool entry on first API call.
+        """
+        parent = _make_mock_parent()
+        mock_pool = MagicMock()
+        parent._credential_pool = mock_pool
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+
+            _build_child_agent(
+                task_index=0,
+                goal="Test pool skip",
+                context=None,
+                toolsets=["terminal"],
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+                override_base_url="http://localhost:8001/v1",
+            )
+
+            self.assertNotEqual(mock_child._credential_pool, mock_pool)
+            # The override URL must reach the child — verify it is passed
+            # to AIAgent, not the parent's URL. This is the real regression:
+            # before the fix, pool sharing would clobber base_url on first
+            # API call via _swap_credential from the parent's pool entry.
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["base_url"], "http://localhost:8001/v1")
+
 
 class TestChildCredentialLeasing(unittest.TestCase):
     def test_run_single_child_acquires_and_releases_lease(self):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -634,9 +634,12 @@ def _build_child_agent(
 
     # Share a credential pool with the child when possible so subagents can
     # rotate credentials on rate limits instead of getting pinned to one key.
-    child_pool = _resolve_child_credential_pool(effective_provider, parent_agent)
-    if child_pool is not None:
-        child._credential_pool = child_pool
+    # Skip pool binding when override_base_url is set — the child's explicit URL
+    # would be clobbered by pool credential entries that point to the parent's URL.
+    if not override_base_url:
+        child_pool = _resolve_child_credential_pool(effective_provider, parent_agent)
+        if child_pool is not None:
+            child._credential_pool = child_pool
 
     # Register child for interrupt propagation
     if hasattr(parent_agent, '_active_children'):


### PR DESCRIPTION
## What does this PR do?
    
Fixes a bug in delegate_task where delegation.base_url is ignored when the child agent's provider matches the parent's provider ("custom"). The child's explicit base_url is silently overwritten at runtime by _swap_credential() from a shared credential pool entry that points to the parent's endpoint.
    
## Related Issue
    
Fixes #13678
    
## Type of Change
    
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
    
## Changes Made
    
- tools/delegate_tool.py: Added if not override_base_url: guard before _resolve_child_credential_pool() call in _build_child_agent(). When override_base_url is set, the child is not bound to the parent's credential pool, preventing _swap_credential() from overwriting the child's explicit endpoint with the parent's URL on first API call.
    
## How to Test
    
1. Configure parent agent with provider="custom" and base_url="http://localhost:8000"
2. Spawn subagent via delegate_task with delegation.base_url="http://localhost:8001" and delegation.provider="custom" (same provider as parent)
3. The subagent should call http://localhost:8001/v1
4. Before fix: first API call silently redirects to port 8000 (404 or wrong model)
5. After fix: subagent correctly calls port 8001
    
## Code
    
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I've searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run pytest tests/ -q — tests not added for this fix (would require mocking two vLLM endpoints)
- [ ] I've added tests for my changes — same as above
- [x] I've tested on my platform: Debian 13
    
## Documentation & Housekeeping
    
- [x] I've considered cross-platform impact — no OS-specific code in this change
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A (only logic change)
    
## For New Skills
    
N/A — not a skill