### PR TITLE
fix(docker): put profile-wrapper dir /opt/data/.local/bin on PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,5 +50,10 @@ RUN uv venv && \
 # ---------- Runtime ----------
 ENV HERMES_WEB_DIST=/opt/hermes/hermes_cli/web_dist
 ENV HERMES_HOME=/opt/data
+# Put the profile-wrapper directory on PATH so `hermes profile create
+# <name>` wrappers land somewhere shells can find them without the user
+# having to touch ~/.bashrc (which the hermes user doesn't own a copy
+# of — only /etc/skel/.bashrc exists in the base image). (#13739)
+ENV PATH="/opt/data/.local/bin:${PATH}"
 VOLUME [ "/opt/data" ]
 ENTRYPOINT [ "/opt/hermes/docker/entrypoint.sh" ]


### PR DESCRIPTION
## Summary

Fixes #13739. \`hermes profile create <name>\` writes a wrapper script to \`/opt/data/.local/bin\` (derived from \`\$HERMES_HOME\`), but that path is not on the container's \`PATH\`. Additionally the \`hermes\` user has no personal \`~/.bashrc\` — only \`/etc/skel/.bashrc\` exists — so the tool's suggested remediation ('add to ~/.bashrc') does not apply cleanly inside the official image.

Repro per the issue:
\`\`\`
docker run -it nousresearch/hermes-agent:latest bash
/opt/hermes/.venv/bin/hermes profile create hermes-test
hermes-test   # command not found
\`\`\`

## Fix

One-line Dockerfile \`ENV\` after the existing \`HERMES_HOME\` line:

\`\`\`dockerfile
ENV PATH=\"/opt/data/.local/bin:\${PATH}\"
\`\`\`

Since the Dockerfile already pins \`HERMES_HOME=/opt/data\`, the derived wrapper directory is known at build time.

## Relationship to other open PRs

Orthogonal to #12199 (adds \`/opt/hermes/.venv/bin\` to PATH so the \`hermes\` binary is callable in \`docker exec\` shells). Different directory, different concern — both can coexist as additive \`ENV PATH=...\` lines.

## Test

Behavior change is a single ENV directive in the image — verified locally by building the image and running:
\`\`\`
$ docker run --rm -it <built-image> bash -c 'echo \$PATH | tr : \\n | grep \".local/bin\"'
/opt/data/.local/bin
\`\`\`

Closes #13739.