### PR TITLE
feat: add terminal compaction and queued minions plumbing

### DIFF
--- a/.hermes/plugins/terminal_compact/__init__.py
+++ b/.hermes/plugins/terminal_compact/__init__.py
@@ -1,0 +1,41 @@
+"""Hermes terminal compaction plugin."""
+
+from __future__ import annotations
+
+import logging
+
+from .rewrite import rewrite_command
+
+logger = logging.getLogger(__name__)
+
+
+def _pre_tool_call(tool_name, args, **kwargs):
+    if tool_name != "terminal":
+        return None
+    if not isinstance(args, dict):
+        return None
+
+    command = args.get("command")
+    if not isinstance(command, str) or not command.strip():
+        return None
+
+    if args.get("background") is True or args.get("pty") is True:
+        return None
+
+    rewritten = rewrite_command(command)
+    if not rewritten or rewritten.command == command:
+        return None
+
+    logger.info("[terminal_compact] %s -> %s (%s)", command, rewritten.command, rewritten.reason)
+
+    new_args = dict(args)
+    new_args["command"] = rewritten.command
+    return {
+        "action": "rewrite_args",
+        "args": new_args,
+        "reason": rewritten.reason,
+    }
+
+
+def register(ctx):
+    ctx.register_hook("pre_tool_call", _pre_tool_call)

--- a/.hermes/plugins/terminal_compact/plugin.yaml
+++ b/.hermes/plugins/terminal_compact/plugin.yaml
@@ -1,0 +1,5 @@
+name: terminal_compact
+version: 0.1.0
+description: Safe terminal command compaction for noisy read-only workflows
+provides_hooks:
+  - pre_tool_call

--- a/.hermes/plugins/terminal_compact/rewrite.py
+++ b/.hermes/plugins/terminal_compact/rewrite.py
@@ -1,0 +1,131 @@
+"""Narrow rewrite registry for Hermes terminal compaction v1."""
+
+from __future__ import annotations
+
+import shlex
+from dataclasses import dataclass
+from typing import Optional
+
+
+UNSAFE_TOKENS = ("&&", "||", "|", ";", "<<", ">", ">>")
+DENY_PREFIXES = (
+    "rm ",
+    "mv ",
+    "cp ",
+    "chmod ",
+    "chown ",
+    "sudo ",
+    "git push",
+    "git commit",
+    "git reset",
+    "git clean",
+    "docker rm",
+    "docker stop",
+    "docker kill",
+)
+
+
+@dataclass(frozen=True)
+class RewriteResult:
+    command: str
+    reason: str
+
+
+def _unsafe(command: str) -> bool:
+    stripped = command.strip()
+    if not stripped:
+        return True
+    if any(token in stripped for token in UNSAFE_TOKENS):
+        return True
+    lowered = stripped.lower()
+    return any(lowered.startswith(prefix) for prefix in DENY_PREFIXES)
+
+
+def _split(command: str) -> list[str]:
+    try:
+        return shlex.split(command)
+    except ValueError:
+        return []
+
+
+def rewrite_command(command: str) -> Optional[RewriteResult]:
+    if _unsafe(command):
+        return None
+
+    parts = _split(command)
+    if not parts:
+        return None
+
+    if parts[:2] == ["git", "status"]:
+        return RewriteResult(
+            command="git status --short --branch",
+            reason="compact git status",
+        )
+
+    if parts[:2] == ["git", "diff"]:
+        return RewriteResult(
+            command="git diff --stat --patch --unified=1",
+            reason="compact git diff",
+        )
+
+    if parts[:2] == ["git", "log"]:
+        return RewriteResult(
+            command="git log --oneline --decorate -n 20",
+            reason="compact git log",
+        )
+
+    if parts[0] == "pytest":
+        if "-q" in parts or "--quiet" in parts:
+            return None
+        return RewriteResult(
+            command=f"{command} -q --maxfail=5",
+            reason="failure-focused pytest",
+        )
+
+    if parts[:2] == ["cargo", "test"]:
+        if "--" in parts:
+            return None
+        return RewriteResult(
+            command=f"{command} -- --nocapture",
+            reason="cargo test with visible failures",
+        )
+
+    if parts[:2] == ["npm", "test"]:
+        if "--" in parts:
+            return None
+        return RewriteResult(
+            command="npm test -- --runInBand",
+            reason="serialized npm test output",
+        )
+
+    if parts[:2] == ["pnpm", "test"]:
+        if "--" in parts:
+            return None
+        return RewriteResult(
+            command="pnpm test -- --runInBand",
+            reason="serialized pnpm test output",
+        )
+
+    if parts[:2] == ["docker", "ps"]:
+        return RewriteResult(
+            command="docker ps --format 'table {{.Names}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}'",
+            reason="compact docker ps",
+        )
+
+    if parts[0] == "ls":
+        if "-1" in parts:
+            return None
+        return RewriteResult(
+            command=f"{command} -1",
+            reason="one-entry-per-line ls",
+        )
+
+    if parts[0] == "rg":
+        if "--max-count" in parts:
+            return None
+        return RewriteResult(
+            command=f"{command} --max-count 5",
+            reason="bound ripgrep output",
+        )
+
+    return None

--- a/agent/background_jobs.py
+++ b/agent/background_jobs.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from dataclasses import asdict, dataclass, field
+from typing import Any, Mapping
+
+from agent.job_protocol import (
+    build_background_job_envelope,
+    build_cron_job_envelope,
+    build_delegation_job_envelope,
+)
+
+
+@dataclass
+class QueueSubmission:
+    task_id: str
+    backend: str
+    accepted: bool = True
+    queue: str | None = None
+    message: str | None = None
+    raw_response: str = ""
+
+
+@dataclass
+class QueueRequest:
+    task_id: str
+    kind: str
+    payload: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class BackgroundTaskRequest:
+    task_id: str
+    prompt: str
+    origin: str
+    platform: str
+    session_id: str | None = None
+    user_id: str | None = None
+    user_name: str | None = None
+    chat_id: str | None = None
+    thread_id: str | None = None
+
+
+@dataclass
+class DelegationTaskRequest:
+    task_id: str
+    goal: str
+    context: str | None = None
+    toolsets: list[str] | None = None
+    model: str | None = None
+    max_iterations: int | None = None
+    parent_session_id: str | None = None
+    parent_platform: str | None = None
+    task_index: int = 0
+    task_count: int = 1
+
+
+@dataclass
+class CronTaskRequest:
+    task_id: str
+    job_id: str
+    job_name: str
+    prompt: str
+    schedule_display: str | None = None
+    deliver: str | None = None
+    origin: dict[str, Any] | None = None
+    model: dict[str, Any] | str | None = None
+    skills: list[str] | None = None
+    script: str | None = None
+
+
+def preview_prompt(prompt: str, limit: int = 60) -> str:
+    prompt = (prompt or "").strip()
+    if len(prompt) <= limit:
+        return prompt
+    return prompt[:limit] + "..."
+
+
+def _normalize_backend(value: str | None) -> str:
+    raw = (value or "local").strip().lower()
+    if raw in {"", "local", "thread", "inline"}:
+        return "local"
+    if raw in {"command", "cmd", "external", "queue", "minions", "gbrain"}:
+        return "command"
+    return raw
+
+
+def _backend_key(prefix: str) -> str:
+    return f"HERMES_{prefix}_BACKEND"
+
+
+def _enqueue_key(prefix: str) -> str:
+    return f"HERMES_{prefix}_ENQUEUE_CMD"
+
+
+def _timeout_key(prefix: str) -> str:
+    return f"HERMES_{prefix}_ENQUEUE_TIMEOUT"
+
+
+def get_queue_backend(prefix: str, env: Mapping[str, str] | None = None) -> str:
+    env = env or os.environ
+    return _normalize_backend(env.get(_backend_key(prefix)))
+
+
+def queue_backend_enabled(prefix: str, env: Mapping[str, str] | None = None) -> bool:
+    return get_queue_backend(prefix, env) != "local"
+
+
+def _submission_from_response(
+    request: QueueRequest,
+    prefix: str,
+    stdout: str,
+    env: Mapping[str, str],
+) -> QueueSubmission:
+    parsed: dict[str, Any] = {}
+    if stdout:
+        try:
+            maybe = json.loads(stdout)
+            if isinstance(maybe, dict):
+                parsed = maybe
+        except json.JSONDecodeError:
+            parsed = {}
+    backend = str(parsed.get("backend") or env.get(_backend_key(prefix)) or "command")
+    return QueueSubmission(
+        task_id=str(parsed.get("task_id") or request.task_id),
+        backend=backend,
+        accepted=bool(parsed.get("accepted", True)),
+        queue=parsed.get("queue"),
+        message=parsed.get("message") or (stdout if stdout and not parsed else None),
+        raw_response=stdout,
+    )
+
+
+def enqueue_queue_request(
+    request: QueueRequest,
+    *,
+    prefix: str,
+    env: Mapping[str, str] | None = None,
+    timeout: float | None = None,
+) -> QueueSubmission:
+    env = env or os.environ
+    backend = get_queue_backend(prefix, env)
+    if backend == "local":
+        return QueueSubmission(task_id=request.task_id, backend="local")
+
+    command = (env.get(_enqueue_key(prefix)) or "").strip()
+    if not command:
+        raise ValueError(
+            f"{_backend_key(prefix)} is set to an external mode, but "
+            f"{_enqueue_key(prefix)} is empty."
+        )
+
+    outbound = request.payload
+    if not isinstance(outbound, dict) or "version" not in outbound or "kind" not in outbound:
+        outbound = asdict(request)
+    payload = json.dumps(outbound, ensure_ascii=False)
+    run_timeout = timeout if timeout is not None else float(env.get(_timeout_key(prefix), "15"))
+    proc = subprocess.run(
+        command,
+        input=payload,
+        text=True,
+        shell=True,
+        capture_output=True,
+        timeout=run_timeout,
+        check=False,
+    )
+    stdout = (proc.stdout or "").strip()
+    stderr = (proc.stderr or "").strip()
+    if proc.returncode != 0:
+        detail = stderr or stdout or f"exit {proc.returncode}"
+        raise RuntimeError(f"{prefix.lower()} enqueue command failed: {detail}")
+    return _submission_from_response(request, prefix, stdout, env)
+
+
+def get_background_backend(env: Mapping[str, str] | None = None) -> str:
+    return get_queue_backend("BACKGROUND", env)
+
+
+def background_backend_enabled(env: Mapping[str, str] | None = None) -> bool:
+    return queue_backend_enabled("BACKGROUND", env)
+
+
+def enqueue_background_task(
+    request: BackgroundTaskRequest,
+    env: Mapping[str, str] | None = None,
+    timeout: float | None = None,
+) -> QueueSubmission:
+    return enqueue_queue_request(
+        QueueRequest(
+            task_id=request.task_id,
+            kind="background",
+            payload=build_background_job_envelope(request),
+        ),
+        prefix="BACKGROUND",
+        env=env,
+        timeout=timeout,
+    )
+
+
+def enqueue_background_task_via_command(
+    request: BackgroundTaskRequest,
+    env: Mapping[str, str] | None = None,
+    timeout: float | None = None,
+) -> QueueSubmission:
+    return enqueue_queue_request(
+        QueueRequest(
+            task_id=request.task_id,
+            kind="background",
+            payload=build_background_job_envelope(request),
+        ),
+        prefix="BACKGROUND",
+        env={**(env or os.environ), _backend_key("BACKGROUND"): "command"},
+        timeout=timeout,
+    )
+
+
+def delegation_backend_enabled(env: Mapping[str, str] | None = None) -> bool:
+    return queue_backend_enabled("DELEGATION", env)
+
+
+def enqueue_delegate_task(
+    request: DelegationTaskRequest,
+    env: Mapping[str, str] | None = None,
+    timeout: float | None = None,
+) -> dict[str, Any]:
+    submission = enqueue_queue_request(
+        QueueRequest(
+            task_id=request.task_id,
+            kind="delegation",
+            payload=build_delegation_job_envelope(request),
+        ),
+        prefix="DELEGATION",
+        env=env,
+        timeout=timeout,
+    )
+    return asdict(submission)
+
+
+def cron_backend_enabled(env: Mapping[str, str] | None = None) -> bool:
+    return queue_backend_enabled("CRON", env)
+
+
+def enqueue_cron_task(
+    request: CronTaskRequest,
+    env: Mapping[str, str] | None = None,
+    timeout: float | None = None,
+) -> dict[str, Any]:
+    submission = enqueue_queue_request(
+        QueueRequest(
+            task_id=request.task_id,
+            kind="cron",
+            payload=build_cron_job_envelope(request),
+        ),
+        prefix="CRON",
+        env=env,
+        timeout=timeout,
+    )
+    return asdict(submission)

--- a/agent/gbrain_cli_jobs.py
+++ b/agent/gbrain_cli_jobs.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from typing import Any
+
+
+def build_shell_submit_command(
+    *,
+    params: dict[str, Any],
+    cli_path: str = "gbrain",
+    allow_shell_jobs: bool = False,
+    follow: bool = False,
+    queue: str | None = None,
+    timeout_ms: int | None = None,
+    max_attempts: int | None = None,
+) -> dict[str, Any]:
+    command = [cli_path, "jobs", "submit", "shell", "--params", json.dumps(params, ensure_ascii=False)]
+    if queue:
+        command.extend(["--queue", queue])
+    if timeout_ms is not None:
+        command.extend(["--timeout-ms", str(timeout_ms)])
+    if max_attempts is not None:
+        command.extend(["--max-attempts", str(max_attempts)])
+    if follow:
+        command.append("--follow")
+    env = os.environ.copy()
+    if allow_shell_jobs:
+        env["GBRAIN_ALLOW_SHELL_JOBS"] = "1"
+    return {"command": command, "env": env}
+
+
+def submit_shell_job(
+    *,
+    params: dict[str, Any],
+    cli_path: str = "gbrain",
+    allow_shell_jobs: bool = False,
+    follow: bool = False,
+    queue: str | None = None,
+    timeout_ms: int | None = None,
+    max_attempts: int | None = None,
+    timeout: float = 60,
+) -> dict[str, Any]:
+    spec = build_shell_submit_command(
+        params=params,
+        cli_path=cli_path,
+        allow_shell_jobs=allow_shell_jobs,
+        follow=follow,
+        queue=queue,
+        timeout_ms=timeout_ms,
+        max_attempts=max_attempts,
+    )
+    proc = subprocess.run(
+        spec["command"],
+        env=spec["env"],
+        text=True,
+        capture_output=True,
+        timeout=timeout,
+        check=False,
+    )
+    stdout = (proc.stdout or "").strip()
+    stderr = (proc.stderr or "").strip()
+    if proc.returncode != 0:
+        raise RuntimeError(stderr or stdout or f"gbrain shell submit failed with exit {proc.returncode}")
+    if stdout:
+        try:
+            return json.loads(stdout)
+        except json.JSONDecodeError:
+            return {"ok": True, "raw": stdout}
+    return {"ok": True}

--- a/agent/gbrain_minions_transport.py
+++ b/agent/gbrain_minions_transport.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Any
+
+import requests
+
+
+def _headers(api_key: str | None = None) -> dict[str, str]:
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    return headers
+
+
+def _post_json(payload: dict[str, Any], *, url: str, api_key: str | None = None, timeout: float = 30) -> dict[str, Any]:
+    if not url or not str(url).strip():
+        raise ValueError("URL is required")
+    response = requests.post(
+        str(url).strip(),
+        json=payload,
+        headers=_headers(api_key),
+        timeout=timeout,
+    )
+    response.raise_for_status()
+    try:
+        return response.json()
+    except Exception:
+        return {"ok": True, "raw": getattr(response, "text", "")}
+
+
+def post_enqueue_envelope(
+    envelope: dict[str, Any],
+    *,
+    url: str,
+    api_key: str | None = None,
+    timeout: float = 30,
+) -> dict[str, Any]:
+    return _post_json(envelope, url=url, api_key=api_key, timeout=timeout)
+
+
+def post_completion_envelope(
+    envelope: dict[str, Any],
+    *,
+    url: str,
+    api_key: str | None = None,
+    timeout: float = 30,
+) -> dict[str, Any]:
+    return _post_json(envelope, url=url, api_key=api_key, timeout=timeout)

--- a/agent/job_callbacks.py
+++ b/agent/job_callbacks.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+
+def _completion_text(envelope: dict[str, Any]) -> str:
+    final_output = (envelope.get("final_output") or "").strip()
+    if final_output:
+        return final_output
+    summary = (envelope.get("summary") or "").strip()
+    if summary:
+        return summary
+    error = (envelope.get("error") or "").strip()
+    if error:
+        return error
+    return ""
+
+
+def _sessions_dir() -> Path:
+    return get_hermes_home() / "sessions"
+
+
+def _load_session_entry(session_id: str) -> dict[str, Any] | None:
+    sessions_file = _sessions_dir() / "sessions.json"
+    if not sessions_file.exists():
+        return None
+    try:
+        data = json.loads(sessions_file.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    for entry in data.values():
+        if isinstance(entry, dict) and entry.get("session_id") == session_id:
+            return entry
+    return None
+
+
+def _append_transcript_message(session_id: str, message: dict[str, Any]) -> None:
+    sessions_dir = _sessions_dir()
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+    transcript_path = sessions_dir / f"{session_id}.jsonl"
+    with open(transcript_path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(message, ensure_ascii=False) + "\n")
+    try:
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.ensure_session(session_id, source="callback")
+            db.append_message(
+                session_id=session_id,
+                role=message.get("role", "assistant"),
+                content=message.get("content"),
+                tool_name=message.get("tool_name"),
+                tool_calls=message.get("tool_calls"),
+                tool_call_id=message.get("tool_call_id"),
+            )
+        finally:
+            db.close()
+    except Exception:
+        pass
+
+
+def deliver_completion(
+    envelope: dict[str, Any],
+    *,
+    adapters=None,
+    loop=None,
+) -> str | None:
+    callback = envelope.get("callback") or {"type": "none"}
+    callback_type = str(callback.get("type") or "none").lower()
+    if callback_type in {"", "none"}:
+        return None
+    if callback_type == "platform":
+        target = callback.get("target") or {}
+        platform = target.get("platform")
+        chat_id = target.get("chat_id")
+        thread_id = target.get("thread_id")
+        if not platform or not chat_id:
+            return "platform callback missing target platform/chat_id"
+
+        deliver = f"{platform}:{chat_id}"
+        if thread_id not in (None, ""):
+            deliver = f"{deliver}:{thread_id}"
+
+        job = {
+            "id": envelope.get("task_id") or "queued-task",
+            "name": envelope.get("kind") or "queued-task",
+            "deliver": deliver,
+            "origin": {
+                "platform": platform,
+                "chat_id": str(chat_id),
+                "thread_id": None if thread_id in (None, "") else str(thread_id),
+            },
+        }
+
+        from cron.scheduler import _deliver_result
+
+        return _deliver_result(job, _completion_text(envelope), adapters=adapters, loop=loop)
+    if callback_type == "session":
+        session_id = callback.get("session_id")
+        if not session_id:
+            return "session callback missing session_id"
+        message = {
+            "role": "assistant",
+            "content": _completion_text(envelope),
+            "tool_name": None,
+            "tool_calls": None,
+            "tool_call_id": None,
+        }
+        _append_transcript_message(session_id, message)
+
+        session_entry = _load_session_entry(session_id)
+        origin = (session_entry or {}).get("origin") or {}
+        platform = origin.get("platform")
+        chat_id = origin.get("chat_id")
+        if not platform or not chat_id or platform == "local":
+            return None
+
+        deliver = f"{platform}:{chat_id}"
+        thread_id = origin.get("thread_id")
+        if thread_id not in (None, ""):
+            deliver = f"{deliver}:{thread_id}"
+        job = {
+            "id": envelope.get("task_id") or session_id,
+            "name": envelope.get("kind") or "delegation",
+            "deliver": deliver,
+            "origin": {
+                "platform": platform,
+                "chat_id": str(chat_id),
+                "thread_id": None if thread_id in (None, "") else str(thread_id),
+            },
+        }
+        from cron.scheduler import _deliver_result
+
+        return _deliver_result(job, message["content"], adapters=adapters, loop=loop)
+    return f"unsupported callback type '{callback_type}'"

--- a/agent/job_protocol.py
+++ b/agent/job_protocol.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from agent.background_jobs import BackgroundTaskRequest, CronTaskRequest, DelegationTaskRequest
+
+PROTOCOL_VERSION = "1.0"
+
+
+def _platform_callback(platform: str, chat_id: str, thread_id: str | None = None) -> dict[str, Any]:
+    return {
+        "type": "platform",
+        "target": {
+            "platform": str(platform),
+            "chat_id": str(chat_id),
+            "thread_id": str(thread_id) if thread_id not in (None, "") else None,
+        },
+    }
+
+
+def _session_callback(session_id: str | None, platform: str | None) -> dict[str, Any]:
+    if not session_id:
+        return {"type": "none"}
+    callback: dict[str, Any] = {"type": "session", "session_id": str(session_id)}
+    if platform:
+        callback["platform"] = str(platform)
+    return callback
+
+
+def _parse_deliver_target(deliver: str | None) -> dict[str, Any] | None:
+    if not deliver or deliver == "origin":
+        return None
+    parts = str(deliver).split(":")
+    if len(parts) < 2:
+        return None
+    platform = parts[0].strip()
+    chat_id = parts[1].strip()
+    thread_id = parts[2].strip() if len(parts) > 2 and parts[2].strip() else None
+    if not platform or not chat_id:
+        return None
+    return {"platform": platform, "chat_id": chat_id, "thread_id": thread_id}
+
+
+def build_background_job_envelope(request: BackgroundTaskRequest) -> dict[str, Any]:
+    callback = {"type": "none"}
+    if request.chat_id and request.platform:
+        callback = _platform_callback(request.platform, request.chat_id, request.thread_id)
+    return {
+        "version": PROTOCOL_VERSION,
+        "kind": "background",
+        "task_id": request.task_id,
+        "payload": {
+            "prompt": request.prompt,
+            "origin": request.origin,
+            "platform": request.platform,
+            "session_id": request.session_id,
+            "user_id": request.user_id,
+            "user_name": request.user_name,
+            "chat_id": request.chat_id,
+            "thread_id": request.thread_id,
+        },
+        "callback": callback,
+    }
+
+
+def build_delegation_job_envelope(request: DelegationTaskRequest) -> dict[str, Any]:
+    return {
+        "version": PROTOCOL_VERSION,
+        "kind": "delegation",
+        "task_id": request.task_id,
+        "payload": {
+            "goal": request.goal,
+            "context": request.context,
+            "toolsets": request.toolsets,
+            "model": request.model,
+            "max_iterations": request.max_iterations,
+            "task_index": request.task_index,
+            "task_count": request.task_count,
+        },
+        "callback": _session_callback(request.parent_session_id, request.parent_platform),
+    }
+
+
+def build_cron_job_envelope(request: CronTaskRequest) -> dict[str, Any]:
+    target = _parse_deliver_target(request.deliver)
+    if target is None and request.origin:
+        platform = request.origin.get("platform")
+        chat_id = request.origin.get("chat_id")
+        if platform and chat_id:
+            target = {
+                "platform": platform,
+                "chat_id": chat_id,
+                "thread_id": request.origin.get("thread_id"),
+            }
+    callback = {"type": "none"}
+    if target:
+        callback = _platform_callback(target["platform"], target["chat_id"], target.get("thread_id"))
+    return {
+        "version": PROTOCOL_VERSION,
+        "kind": "cron",
+        "task_id": request.task_id,
+        "payload": {
+            "job_id": request.job_id,
+            "job_name": request.job_name,
+            "prompt": request.prompt,
+            "schedule_display": request.schedule_display,
+            "deliver": request.deliver,
+            "origin": request.origin,
+            "model": request.model,
+            "skills": request.skills,
+            "script": request.script,
+        },
+        "callback": callback,
+    }
+
+
+def build_completion_envelope(
+    *,
+    kind: str,
+    task_id: str,
+    status: str,
+    callback: dict[str, Any],
+    summary: str | None = None,
+    final_output: str | None = None,
+    error: str | None = None,
+    artifacts: list[dict[str, Any]] | None = None,
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    envelope = {
+        "version": PROTOCOL_VERSION,
+        "kind": kind,
+        "task_id": task_id,
+        "status": status,
+        "summary": summary,
+        "final_output": final_output,
+        "artifacts": artifacts or [],
+        "metadata": metadata or {},
+        "callback": callback,
+    }
+    if error is not None:
+        envelope["error"] = error
+    return envelope

--- a/agent/minions_reference.py
+++ b/agent/minions_reference.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Callable
+
+from agent.job_callbacks import deliver_completion
+from agent.job_protocol import build_completion_envelope
+
+
+def _spool_root(spool_dir: str | Path | None = None) -> Path:
+    if spool_dir is not None:
+        return Path(spool_dir)
+    env = os.getenv("HERMES_MINIONS_SPOOL_DIR", "").strip()
+    if env:
+        return Path(env).expanduser()
+    return Path.home() / ".hermes" / "minions-reference"
+
+
+def _queue_file(spool_root: Path, envelope: dict[str, Any]) -> Path:
+    return spool_root / "queue" / str(envelope["kind"]) / f"{envelope['task_id']}.json"
+
+
+def _completed_file(spool_root: Path, completion: dict[str, Any]) -> Path:
+    return spool_root / "completed" / str(completion["kind"]) / f"{completion['task_id']}.json"
+
+
+def enqueue_job(envelope: dict[str, Any], *, spool_dir: str | Path | None = None) -> dict[str, Any]:
+    spool_root = _spool_root(spool_dir)
+    queue_file = _queue_file(spool_root, envelope)
+    queue_file.parent.mkdir(parents=True, exist_ok=True)
+    _atomic_write_json(queue_file, envelope)
+    return {
+        "task_id": envelope["task_id"],
+        "backend": "reference-minions",
+        "queue": str(envelope["kind"]),
+        "message": f"queued at {queue_file}",
+    }
+
+
+def list_queued_jobs(*, spool_dir: str | Path | None = None) -> list[Path]:
+    spool_root = _spool_root(spool_dir)
+    queue_root = spool_root / "queue"
+    if not queue_root.exists():
+        return []
+    return sorted(p for p in queue_root.rglob("*.json") if p.is_file())
+
+
+def process_next_job(
+    *,
+    spool_dir: str | Path | None = None,
+    runner: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+    adapters=None,
+    loop=None,
+) -> dict[str, Any] | None:
+    jobs = list_queued_jobs(spool_dir=spool_dir)
+    if not jobs:
+        return None
+    queue_file = jobs[0]
+    envelope = json.loads(queue_file.read_text(encoding="utf-8"))
+    queue_file.unlink()
+
+    job_runner = runner or default_runner
+    completion = job_runner(envelope)
+    completed_file = _completed_file(_spool_root(spool_dir), completion)
+    completed_file.parent.mkdir(parents=True, exist_ok=True)
+    _atomic_write_json(completed_file, completion)
+    deliver_completion(completion, adapters=adapters, loop=loop)
+    return completion
+
+
+def default_runner(envelope: dict[str, Any]) -> dict[str, Any]:
+    payload = envelope.get("payload") or {}
+    kind = envelope.get("kind")
+    if kind == "background":
+        text = f"[reference-minions] Background task complete: {payload.get('prompt', '')}".strip()
+    elif kind == "delegation":
+        text = f"[reference-minions] Delegated task complete: {payload.get('goal', '')}".strip()
+    elif kind == "cron":
+        text = f"[reference-minions] Cron job complete: {payload.get('job_name', '')}".strip()
+    else:
+        text = f"[reference-minions] Completed {kind or 'job'}"
+    return build_completion_envelope(
+        kind=str(kind),
+        task_id=str(envelope.get("task_id")),
+        status="succeeded",
+        callback=envelope.get("callback") or {"type": "none"},
+        summary=text,
+        final_output=text,
+        metadata={"worker": "reference-minions"},
+    )
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.stem}.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(payload, f, ensure_ascii=False, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1974,6 +1974,27 @@ class APIServerAdapter(BasePlatformAdapter):
         except Exception as e:
             return web.json_response({"error": str(e)}, status=500)
 
+    async def _handle_minions_completion(self, request: "web.Request") -> "web.Response":
+        """POST /api/minions/completions — accept queued worker completions."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            envelope = await request.json()
+        except (json.JSONDecodeError, Exception):
+            return web.json_response({"error": "Invalid JSON in request body"}, status=400)
+
+        if not isinstance(envelope, dict):
+            return web.json_response({"error": "Completion payload must be a JSON object"}, status=400)
+
+        from agent.job_callbacks import deliver_completion
+
+        error = deliver_completion(envelope)
+        if error:
+            return web.json_response({"error": str(error)}, status=400)
+        return web.json_response({"ok": True})
+
     async def _handle_get_job(self, request: "web.Request") -> "web.Response":
         """GET /api/jobs/{job_id} — get a single cron job."""
         auth_err = self._check_auth(request)
@@ -2507,6 +2528,7 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_post("/api/jobs/{job_id}/pause", self._handle_pause_job)
             self._app.router.add_post("/api/jobs/{job_id}/resume", self._handle_resume_job)
             self._app.router.add_post("/api/jobs/{job_id}/run", self._handle_run_job)
+            self._app.router.add_post("/api/minions/completions", self._handle_minions_completion)
             # Structured event streaming
             self._app.router.add_post("/v1/runs", self._handle_runs)
             self._app.router.add_get("/v1/runs/{run_id}/events", self._handle_run_events)

--- a/scripts/gbrain_minions_complete.py
+++ b/scripts/gbrain_minions_complete.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+from agent.gbrain_minions_transport import post_completion_envelope
+
+
+def main() -> int:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        print(json.dumps({"error": "expected JSON completion envelope on stdin"}))
+        return 1
+    envelope = json.loads(raw)
+    result = post_completion_envelope(
+        envelope,
+        url=os.getenv("HERMES_GBRAIN_COMPLETION_URL", ""),
+        api_key=os.getenv("HERMES_GBRAIN_COMPLETION_KEY") or os.getenv("API_SERVER_KEY") or None,
+        timeout=float(os.getenv("HERMES_GBRAIN_TIMEOUT", "30")),
+    )
+    print(json.dumps(result, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/gbrain_minions_enqueue.py
+++ b/scripts/gbrain_minions_enqueue.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+from agent.gbrain_minions_transport import post_enqueue_envelope
+
+
+def main() -> int:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        print(json.dumps({"error": "expected JSON envelope on stdin"}))
+        return 1
+    envelope = json.loads(raw)
+    result = post_enqueue_envelope(
+        envelope,
+        url=os.getenv("HERMES_GBRAIN_ENQUEUE_URL", ""),
+        api_key=os.getenv("HERMES_GBRAIN_API_KEY") or None,
+        timeout=float(os.getenv("HERMES_GBRAIN_TIMEOUT", "30")),
+    )
+    print(json.dumps(result, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/minions_reference_enqueue.py
+++ b/scripts/minions_reference_enqueue.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import sys
+
+from agent.minions_reference import enqueue_job
+
+
+def main() -> int:
+    raw = sys.stdin.read()
+    if not raw.strip():
+        print(json.dumps({"error": "expected JSON envelope on stdin"}))
+        return 1
+    envelope = json.loads(raw)
+    ack = enqueue_job(envelope)
+    print(json.dumps(ack, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/minions_reference_worker.py
+++ b/scripts/minions_reference_worker.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+
+from agent.minions_reference import process_next_job
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Process one queued reference-minions job.")
+    parser.add_argument("--spool-dir", default=None, help="Override spool directory")
+    parser.add_argument("--once", action="store_true", help="Process at most one job and exit")
+    args = parser.parse_args()
+
+    completion = process_next_job(spool_dir=args.spool_dir)
+    if completion is None:
+        print(json.dumps({"status": "idle"}, ensure_ascii=False))
+        return 0
+    print(json.dumps(completion, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/agent/test_background_jobs.py
+++ b/tests/agent/test_background_jobs.py
@@ -1,0 +1,87 @@
+import json
+from unittest.mock import Mock, patch
+
+import pytest
+
+from agent.background_jobs import (
+    BackgroundTaskRequest,
+    background_backend_enabled,
+    enqueue_background_task,
+    enqueue_background_task_via_command,
+    get_background_backend,
+    preview_prompt,
+)
+
+
+def _request() -> BackgroundTaskRequest:
+    return BackgroundTaskRequest(
+        task_id="bg_test",
+        prompt="map the repo",
+        origin="gateway",
+        platform="telegram",
+        session_id="bg_test",
+        user_id="123",
+        chat_id="456",
+    )
+
+
+def test_preview_prompt_truncates_cleanly():
+    assert preview_prompt("abc", limit=10) == "abc"
+    assert preview_prompt("x" * 12, limit=10) == ("x" * 10) + "..."
+
+
+def test_backend_aliases_normalize_to_command(monkeypatch):
+    monkeypatch.setenv("HERMES_BACKGROUND_BACKEND", "minions")
+    assert get_background_backend() == "command"
+    assert background_backend_enabled() is True
+
+
+def test_enqueue_background_task_local_is_noop(monkeypatch):
+    monkeypatch.delenv("HERMES_BACKGROUND_BACKEND", raising=False)
+    submission = enqueue_background_task(_request())
+    assert submission.backend == "local"
+    assert submission.task_id == "bg_test"
+    assert submission.accepted is True
+
+
+def test_command_backend_requires_command(monkeypatch):
+    monkeypatch.setenv("HERMES_BACKGROUND_BACKEND", "command")
+    monkeypatch.delenv("HERMES_BACKGROUND_ENQUEUE_CMD", raising=False)
+    with pytest.raises(ValueError):
+        enqueue_background_task(_request())
+
+
+def test_command_backend_parses_json_response(monkeypatch):
+    monkeypatch.setenv("HERMES_BACKGROUND_ENQUEUE_CMD", "enqueue")
+    proc = Mock(returncode=0, stdout=json.dumps({
+        "task_id": "remote-123",
+        "backend": "minions",
+        "queue": "background",
+        "message": "accepted",
+    }), stderr="")
+    with patch("agent.background_jobs.subprocess.run", return_value=proc) as mock_run:
+        submission = enqueue_background_task_via_command(_request(), env={
+            "HERMES_BACKGROUND_BACKEND": "command",
+            "HERMES_BACKGROUND_ENQUEUE_CMD": "enqueue",
+        })
+
+    payload = json.loads(mock_run.call_args.kwargs["input"])
+    assert payload["version"]
+    assert payload["kind"] == "background"
+    assert payload["payload"]["prompt"] == "map the repo"
+    assert payload["callback"]["type"] == "platform"
+    assert submission.task_id == "remote-123"
+    assert submission.backend == "minions"
+    assert submission.queue == "background"
+    assert submission.message == "accepted"
+    assert mock_run.call_args.kwargs["input"]
+
+
+def test_command_backend_surfaces_failures():
+    proc = Mock(returncode=9, stdout="", stderr="boom")
+    with patch("agent.background_jobs.subprocess.run", return_value=proc):
+        with pytest.raises(RuntimeError, match="boom"):
+            enqueue_background_task_via_command(_request(), env={
+                "HERMES_BACKGROUND_BACKEND": "command",
+                "HERMES_BACKGROUND_ENQUEUE_CMD": "enqueue",
+            })

--- a/tests/agent/test_gbrain_cli_jobs.py
+++ b/tests/agent/test_gbrain_cli_jobs.py
@@ -1,0 +1,44 @@
+import json
+from unittest.mock import Mock, patch
+
+import pytest
+
+from agent.gbrain_cli_jobs import build_shell_submit_command, submit_shell_job
+
+
+def test_build_shell_submit_command_includes_required_flags():
+    cmd = build_shell_submit_command(
+        params={"cmd": "bash scripts/sync.sh", "cwd": "/abs"},
+        cli_path="gbrain",
+        allow_shell_jobs=True,
+        follow=False,
+        queue="default",
+        timeout_ms=300000,
+        max_attempts=3,
+    )
+    command = cmd["command"]
+    env = cmd["env"]
+    assert command[:4] == ["gbrain", "jobs", "submit", "shell"]
+    assert "--params" in command
+    assert "--queue" in command
+    assert env["GBRAIN_ALLOW_SHELL_JOBS"] == "1"
+
+
+def test_submit_shell_job_parses_json_stdout():
+    proc = Mock(returncode=0, stdout=json.dumps({"id": 42, "status": "waiting"}), stderr="")
+    with patch("agent.gbrain_cli_jobs.subprocess.run", return_value=proc) as run_mock:
+        result = submit_shell_job(
+            params={"cmd": "echo hi", "cwd": "/tmp"},
+            cli_path="gbrain",
+            allow_shell_jobs=True,
+        )
+
+    assert result["id"] == 42
+    assert run_mock.call_args.kwargs["env"]["GBRAIN_ALLOW_SHELL_JOBS"] == "1"
+
+
+def test_submit_shell_job_surfaces_nonzero_exit():
+    proc = Mock(returncode=1, stdout="", stderr="boom")
+    with patch("agent.gbrain_cli_jobs.subprocess.run", return_value=proc):
+        with pytest.raises(RuntimeError, match="boom"):
+            submit_shell_job(params={"cmd": "echo hi", "cwd": "/tmp"}, cli_path="gbrain")

--- a/tests/agent/test_gbrain_minions_transport.py
+++ b/tests/agent/test_gbrain_minions_transport.py
@@ -1,0 +1,53 @@
+import json
+from unittest.mock import Mock, patch
+
+import pytest
+
+from agent.gbrain_minions_transport import post_completion_envelope, post_enqueue_envelope
+
+
+def test_post_enqueue_envelope_uses_bearer_auth_and_returns_json():
+    envelope = {"version": "1.0", "kind": "background", "task_id": "bg_1"}
+    response = Mock()
+    response.raise_for_status = Mock()
+    response.json.return_value = {"task_id": "bg_1", "backend": "gbrain", "queue": "background"}
+
+    with patch("agent.gbrain_minions_transport.requests.post", return_value=response) as post_mock:
+        result = post_enqueue_envelope(
+            envelope,
+            url="https://gbrain.example/jobs",
+            api_key="secret",
+            timeout=12,
+        )
+
+    assert result["backend"] == "gbrain"
+    kwargs = post_mock.call_args.kwargs
+    assert kwargs["headers"]["Authorization"] == "Bearer secret"
+    assert kwargs["timeout"] == 12
+    assert kwargs["json"] == envelope
+
+
+def test_post_enqueue_envelope_requires_url():
+    with pytest.raises(ValueError):
+        post_enqueue_envelope({"task_id": "bg_1"}, url="")
+
+
+def test_post_completion_envelope_sends_json_and_accepts_text_response():
+    completion = {"version": "1.0", "kind": "background", "task_id": "bg_1", "status": "succeeded"}
+    response = Mock()
+    response.raise_for_status = Mock()
+    response.json.side_effect = ValueError("not json")
+    response.text = "accepted"
+
+    with patch("agent.gbrain_minions_transport.requests.post", return_value=response) as post_mock:
+        result = post_completion_envelope(
+            completion,
+            url="https://hermes.example/api/minions/completions",
+            api_key="secret",
+            timeout=7,
+        )
+
+    assert result == {"ok": True, "raw": "accepted"}
+    kwargs = post_mock.call_args.kwargs
+    assert kwargs["headers"]["Authorization"] == "Bearer secret"
+    assert kwargs["json"] == completion

--- a/tests/agent/test_job_callbacks.py
+++ b/tests/agent/test_job_callbacks.py
@@ -1,0 +1,120 @@
+from pathlib import Path
+from unittest.mock import patch
+
+from agent.job_callbacks import deliver_completion
+from agent.job_protocol import build_completion_envelope
+
+
+def test_deliver_completion_uses_cron_delivery_for_platform_callbacks():
+    envelope = build_completion_envelope(
+        kind="background",
+        task_id="bg_1",
+        status="succeeded",
+        callback={"type": "platform", "target": {"platform": "telegram", "chat_id": "456", "thread_id": "12"}},
+        summary="done",
+        final_output="all good",
+    )
+
+    with patch("cron.scheduler._deliver_result", return_value=None) as deliver_mock:
+        error = deliver_completion(envelope)
+
+    assert error is None
+    job = deliver_mock.call_args.args[0]
+    assert job["id"] == "bg_1"
+    assert job["deliver"] == "telegram:456:12"
+    assert job["origin"] == {"platform": "telegram", "chat_id": "456", "thread_id": "12"}
+    assert deliver_mock.call_args.args[1] == "all good"
+
+
+def test_deliver_completion_returns_none_for_noop_callback():
+    envelope = build_completion_envelope(
+        kind="delegation",
+        task_id="delegate_1",
+        status="queued",
+        callback={"type": "none"},
+        summary="queued",
+    )
+
+    assert deliver_completion(envelope) is None
+
+
+def test_deliver_completion_session_callback_appends_to_transcript_and_delivers(tmp_path):
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir(parents=True)
+    (sessions_dir / "sessions.json").write_text(
+        """
+        {
+          "telegram:user:123": {
+            "session_key": "telegram:user:123",
+            "session_id": "sess_1",
+            "created_at": "2026-04-21T00:00:00",
+            "updated_at": "2026-04-21T00:00:00",
+            "platform": "telegram",
+            "chat_type": "dm",
+            "origin": {
+              "platform": "telegram",
+              "chat_id": "456",
+              "user_id": "123",
+              "thread_id": "12"
+            }
+          }
+        }
+        """.strip(),
+        encoding="utf-8",
+    )
+
+    envelope = build_completion_envelope(
+        kind="delegation",
+        task_id="delegate_1",
+        status="succeeded",
+        callback={"type": "session", "session_id": "sess_1", "platform": "telegram"},
+        summary="done",
+        final_output="delegated result",
+    )
+
+    with patch("agent.job_callbacks.get_hermes_home", return_value=tmp_path), \
+         patch("hermes_state.SessionDB") as mock_db_cls, \
+         patch("cron.scheduler._deliver_result", return_value=None) as deliver_mock:
+        error = deliver_completion(envelope)
+
+    assert error is None
+    transcript = (sessions_dir / "sess_1.jsonl").read_text(encoding="utf-8")
+    assert "delegated result" in transcript
+    mock_db = mock_db_cls.return_value
+    mock_db.ensure_session.assert_called_once_with("sess_1", source="callback")
+    mock_db.append_message.assert_called_once()
+    job = deliver_mock.call_args.args[0]
+    assert job["deliver"] == "telegram:456:12"
+    assert deliver_mock.call_args.args[1] == "delegated result"
+
+
+def test_deliver_completion_session_callback_without_origin_only_reconciles_locally(tmp_path):
+    envelope = build_completion_envelope(
+        kind="delegation",
+        task_id="delegate_1",
+        status="succeeded",
+        callback={"type": "session", "session_id": "sess_local", "platform": "cli"},
+        summary="done",
+        final_output="delegated result",
+    )
+
+    with patch("agent.job_callbacks.get_hermes_home", return_value=tmp_path), \
+         patch("hermes_state.SessionDB"):
+        error = deliver_completion(envelope)
+
+    assert error is None
+    transcript = (tmp_path / "sessions" / "sess_local.jsonl").read_text(encoding="utf-8")
+    assert "delegated result" in transcript
+
+
+def test_deliver_completion_session_callback_requires_session_id():
+    envelope = build_completion_envelope(
+        kind="delegation",
+        task_id="delegate_1",
+        status="failed",
+        callback={"type": "session"},
+        error="boom",
+    )
+
+    error = deliver_completion(envelope)
+    assert error == "session callback missing session_id"

--- a/tests/agent/test_job_protocol.py
+++ b/tests/agent/test_job_protocol.py
@@ -1,0 +1,123 @@
+import json
+
+from agent.background_jobs import BackgroundTaskRequest, CronTaskRequest, DelegationTaskRequest
+from agent.job_protocol import (
+    PROTOCOL_VERSION,
+    build_background_job_envelope,
+    build_completion_envelope,
+    build_cron_job_envelope,
+    build_delegation_job_envelope,
+)
+
+
+def test_background_job_envelope_includes_platform_callback():
+    envelope = build_background_job_envelope(
+        BackgroundTaskRequest(
+            task_id="bg_1",
+            prompt="map the repo",
+            origin="gateway",
+            platform="telegram",
+            session_id="bg_1",
+            user_id="123",
+            user_name="victor",
+            chat_id="456",
+            thread_id="789",
+        )
+    )
+
+    assert envelope["version"] == PROTOCOL_VERSION
+    assert envelope["kind"] == "background"
+    assert envelope["task_id"] == "bg_1"
+    assert envelope["callback"]["type"] == "platform"
+    assert envelope["callback"]["target"] == {
+        "platform": "telegram",
+        "chat_id": "456",
+        "thread_id": "789",
+    }
+
+
+def test_delegation_job_envelope_includes_session_callback():
+    envelope = build_delegation_job_envelope(
+        DelegationTaskRequest(
+            task_id="delegate_1",
+            goal="research idea",
+            context="ctx",
+            toolsets=["web"],
+            model="gpt-test",
+            max_iterations=12,
+            parent_session_id="session_123",
+            parent_platform="telegram",
+            task_index=1,
+            task_count=3,
+        )
+    )
+
+    assert envelope["kind"] == "delegation"
+    assert envelope["callback"] == {
+        "type": "session",
+        "session_id": "session_123",
+        "platform": "telegram",
+    }
+    assert envelope["payload"]["goal"] == "research idea"
+    assert envelope["payload"]["task_index"] == 1
+
+
+def test_cron_job_envelope_prefers_deliver_target():
+    envelope = build_cron_job_envelope(
+        CronTaskRequest(
+            task_id="cron_1",
+            job_id="job_1",
+            job_name="daily digest",
+            prompt="summarize",
+            schedule_display="0 9 * * *",
+            deliver="telegram:-1001:55",
+            origin={"platform": "telegram", "chat_id": "123", "thread_id": "44"},
+            skills=["blogwatcher"],
+        )
+    )
+
+    assert envelope["kind"] == "cron"
+    assert envelope["callback"]["type"] == "platform"
+    assert envelope["callback"]["target"] == {
+        "platform": "telegram",
+        "chat_id": "-1001",
+        "thread_id": "55",
+    }
+    assert envelope["payload"]["job_id"] == "job_1"
+
+
+def test_completion_envelope_keeps_callback_and_artifacts():
+    callback = {"type": "platform", "target": {"platform": "telegram", "chat_id": "456", "thread_id": None}}
+    envelope = build_completion_envelope(
+        kind="background",
+        task_id="bg_1",
+        status="succeeded",
+        callback=callback,
+        summary="done",
+        final_output="all good",
+        artifacts=[{"kind": "file", "path": "/tmp/out.md"}],
+        metadata={"attempt": 2},
+    )
+
+    assert envelope == {
+        "version": PROTOCOL_VERSION,
+        "kind": "background",
+        "task_id": "bg_1",
+        "status": "succeeded",
+        "summary": "done",
+        "final_output": "all good",
+        "artifacts": [{"kind": "file", "path": "/tmp/out.md"}],
+        "metadata": {"attempt": 2},
+        "callback": callback,
+    }
+
+
+def test_completion_envelope_is_json_serializable():
+    envelope = build_completion_envelope(
+        kind="cron",
+        task_id="cron_1",
+        status="failed",
+        callback={"type": "none"},
+        error="boom",
+    )
+    json.dumps(envelope)

--- a/tests/agent/test_minions_reference.py
+++ b/tests/agent/test_minions_reference.py
@@ -1,0 +1,80 @@
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from agent.job_protocol import build_background_job_envelope, build_completion_envelope
+
+
+def _background_envelope() -> dict:
+    from agent.background_jobs import BackgroundTaskRequest
+
+    return build_background_job_envelope(
+        BackgroundTaskRequest(
+            task_id="bg_1",
+            prompt="map the repo",
+            origin="gateway",
+            platform="telegram",
+            session_id="bg_1",
+            user_id="123",
+            chat_id="456",
+            thread_id="789",
+        )
+    )
+
+
+def test_enqueue_job_writes_queue_file(tmp_path):
+    from agent.minions_reference import enqueue_job
+
+    ack = enqueue_job(_background_envelope(), spool_dir=tmp_path)
+
+    queued_file = tmp_path / "queue" / "background" / "bg_1.json"
+    assert queued_file.exists()
+    assert json.loads(queued_file.read_text(encoding="utf-8"))["task_id"] == "bg_1"
+    assert ack["task_id"] == "bg_1"
+    assert ack["backend"] == "reference-minions"
+    assert ack["queue"] == "background"
+
+
+def test_process_next_job_runs_default_worker_and_delivers(tmp_path):
+    from agent.minions_reference import enqueue_job, process_next_job
+
+    enqueue_job(_background_envelope(), spool_dir=tmp_path)
+
+    with patch("agent.minions_reference.deliver_completion", return_value=None) as deliver_mock:
+        completion = process_next_job(spool_dir=tmp_path)
+
+    assert completion is not None
+    assert completion["task_id"] == "bg_1"
+    assert completion["status"] == "succeeded"
+    assert "map the repo" in (completion.get("final_output") or "")
+    completed_file = tmp_path / "completed" / "background" / "bg_1.json"
+    assert completed_file.exists()
+    deliver_mock.assert_called_once_with(completion, adapters=None, loop=None)
+
+
+def test_process_next_job_uses_custom_runner(tmp_path):
+    from agent.minions_reference import enqueue_job, process_next_job
+
+    enqueue_job(_background_envelope(), spool_dir=tmp_path)
+
+    def runner(envelope: dict) -> dict:
+        return build_completion_envelope(
+            kind=envelope["kind"],
+            task_id=envelope["task_id"],
+            status="succeeded",
+            callback=envelope["callback"],
+            summary="custom done",
+            final_output="custom output",
+        )
+
+    with patch("agent.minions_reference.deliver_completion", return_value=None):
+        completion = process_next_job(spool_dir=tmp_path, runner=runner)
+
+    assert completion["summary"] == "custom done"
+    assert completion["final_output"] == "custom output"
+
+
+def test_process_next_job_returns_none_when_queue_empty(tmp_path):
+    from agent.minions_reference import process_next_job
+
+    assert process_next_job(spool_dir=tmp_path) is None

--- a/tests/gateway/test_api_server_minions_completion.py
+++ b/tests/gateway/test_api_server_minions_completion.py
@@ -1,0 +1,88 @@
+import json
+from unittest.mock import patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter, cors_middleware
+
+
+def _make_adapter(api_key: str = "") -> APIServerAdapter:
+    extra = {}
+    if api_key:
+        extra["key"] = api_key
+    return APIServerAdapter(PlatformConfig(enabled=True, extra=extra))
+
+
+def _create_app(adapter: APIServerAdapter) -> web.Application:
+    app = web.Application(middlewares=[cors_middleware])
+    app["api_server_adapter"] = adapter
+    app.router.add_post("/api/minions/completions", adapter._handle_minions_completion)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_minions_completion_endpoint_delivers_completion():
+    adapter = _make_adapter()
+    app = _create_app(adapter)
+    envelope = {
+        "version": "1.0",
+        "kind": "background",
+        "task_id": "bg_1",
+        "status": "succeeded",
+        "callback": {"type": "none"},
+        "summary": "done",
+    }
+    async with TestClient(TestServer(app)) as cli:
+        with patch("agent.job_callbacks.deliver_completion", return_value=None) as deliver_mock:
+            resp = await cli.post("/api/minions/completions", json=envelope)
+            assert resp.status == 200
+            data = await resp.json()
+            assert data == {"ok": True}
+            deliver_mock.assert_called_once_with(envelope)
+
+
+@pytest.mark.asyncio
+async def test_minions_completion_endpoint_requires_auth_when_configured():
+    adapter = _make_adapter(api_key="sk-secret")
+    app = _create_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post("/api/minions/completions", json={"task_id": "x"})
+        assert resp.status == 401
+
+
+@pytest.mark.asyncio
+async def test_minions_completion_endpoint_rejects_invalid_json():
+    adapter = _make_adapter()
+    app = _create_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.post(
+            "/api/minions/completions",
+            data="{not valid}",
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status == 400
+        data = await resp.json()
+        assert "error" in data
+
+
+@pytest.mark.asyncio
+async def test_minions_completion_endpoint_reports_delivery_errors():
+    adapter = _make_adapter()
+    app = _create_app(adapter)
+    envelope = {
+        "version": "1.0",
+        "kind": "background",
+        "task_id": "bg_1",
+        "status": "failed",
+        "callback": {"type": "session"},
+        "error": "boom",
+    }
+    async with TestClient(TestServer(app)) as cli:
+        with patch("agent.job_callbacks.deliver_completion", return_value="bad callback"):
+            resp = await cli.post("/api/minions/completions", json=envelope)
+            assert resp.status == 400
+            data = await resp.json()
+            assert data["error"] == "bad callback"

--- a/tests/test_terminal_compact_plugin.py
+++ b/tests/test_terminal_compact_plugin.py
@@ -39,6 +39,7 @@ def test_project_plugin_loads_and_rewrites_terminal_calls(monkeypatch):
     repo_root = Path(__file__).resolve().parents[1]
     monkeypatch.chdir(repo_root)
     monkeypatch.setenv("HERMES_ENABLE_PROJECT_PLUGINS", "true")
+    monkeypatch.setattr("hermes_cli.plugins._get_enabled_plugins", lambda: {"terminal_compact"})
 
     mgr = PluginManager()
     mgr.discover_and_load()

--- a/tests/test_terminal_compact_plugin.py
+++ b/tests/test_terminal_compact_plugin.py
@@ -1,0 +1,62 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+from hermes_cli.plugins import PluginManager
+
+
+def _load_rewrite_module():
+    path = Path(__file__).resolve().parents[1] / ".hermes" / "plugins" / "terminal_compact" / "rewrite.py"
+    spec = importlib.util.spec_from_file_location("terminal_compact_rewrite", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_rewrite_command_skips_dangerous_prefixes():
+    rewrite = _load_rewrite_module()
+    assert rewrite.rewrite_command("rm -rf tmp") is None
+    assert rewrite.rewrite_command("git push origin main") is None
+
+
+def test_rewrite_command_skips_shell_chains():
+    rewrite = _load_rewrite_module()
+    assert rewrite.rewrite_command("git status && git diff") is None
+    assert rewrite.rewrite_command("rg foo | head") is None
+
+
+def test_rewrite_command_rewrites_git_status():
+    rewrite = _load_rewrite_module()
+    result = rewrite.rewrite_command("git status")
+    assert result is not None
+    assert result.command == "git status --short --branch"
+    assert result.reason == "compact git status"
+
+
+def test_project_plugin_loads_and_rewrites_terminal_calls(monkeypatch):
+    repo_root = Path(__file__).resolve().parents[1]
+    monkeypatch.chdir(repo_root)
+    monkeypatch.setenv("HERMES_ENABLE_PROJECT_PLUGINS", "true")
+
+    mgr = PluginManager()
+    mgr.discover_and_load()
+
+    assert "terminal_compact" in mgr._plugins
+    plugin = mgr._plugins["terminal_compact"]
+    assert plugin.enabled is True
+
+    result = mgr.invoke_hook(
+        "pre_tool_call",
+        tool_name="terminal",
+        args={"command": "git status"},
+        task_id="t1",
+        session_id="s1",
+        tool_call_id="c1",
+    )
+    assert result == [{
+        "action": "rewrite_args",
+        "args": {"command": "git status --short --branch"},
+        "reason": "compact git status",
+    }]

--- a/website/docs/developer-guide/gbrain-minions-http-transport.md
+++ b/website/docs/developer-guide/gbrain-minions-http-transport.md
@@ -1,0 +1,153 @@
+---
+title: "GBrain / Minions HTTP Transport"
+description: "Real HTTP transport adapter for Hermes queue envelopes and Minions completion callbacks"
+---
+
+# GBrain / Minions HTTP Transport
+
+This is the real transport adapter shape after the file-spool reference worker.
+
+It keeps the same queue protocol, but swaps the transport layer for HTTP.
+
+Files:
+
+- `agent/gbrain_minions_transport.py`
+- `scripts/gbrain_minions_enqueue.py`
+- `scripts/gbrain_minions_complete.py`
+- `gateway/platforms/api_server.py` (`POST /api/minions/completions`)
+
+## What this gives you
+
+- Hermes can enqueue job envelopes to a remote GBrain/Minions HTTP endpoint
+- Minions workers can POST completion envelopes back into Hermes
+- Hermes can then deliver or reconcile those results through the existing callback path
+
+So the loop is:
+
+1. Hermes builds envelope
+2. enqueue shim POSTs to GBrain/Minions
+3. worker executes
+4. completion shim POSTs back to Hermes
+5. Hermes callback handler delivers or reconciles result
+
+## Enqueue script
+
+Hermes side:
+
+```bash
+python scripts/gbrain_minions_enqueue.py
+```
+
+It reads a queue envelope from stdin and POSTs it to:
+
+- `HERMES_GBRAIN_ENQUEUE_URL`
+
+Optional auth:
+
+- `HERMES_GBRAIN_API_KEY`
+
+Timeout:
+
+- `HERMES_GBRAIN_TIMEOUT` (default `30`)
+
+### Example Hermes wiring
+
+```bash
+export HERMES_BACKGROUND_BACKEND=command
+export HERMES_BACKGROUND_ENQUEUE_CMD='python scripts/gbrain_minions_enqueue.py'
+
+export HERMES_DELEGATION_BACKEND=command
+export HERMES_DELEGATION_ENQUEUE_CMD='python scripts/gbrain_minions_enqueue.py'
+
+export HERMES_CRON_BACKEND=command
+export HERMES_CRON_ENQUEUE_CMD='python scripts/gbrain_minions_enqueue.py'
+
+export HERMES_GBRAIN_ENQUEUE_URL='https://gbrain.example/api/minions/jobs'
+export HERMES_GBRAIN_API_KEY='replace-me'
+```
+
+## Completion script
+
+Worker side:
+
+```bash
+python scripts/gbrain_minions_complete.py
+```
+
+It reads a completion envelope from stdin and POSTs it to Hermes:
+
+- `HERMES_GBRAIN_COMPLETION_URL`
+
+Optional auth:
+
+- `HERMES_GBRAIN_COMPLETION_KEY`
+- falls back to `API_SERVER_KEY`
+
+Timeout:
+
+- `HERMES_GBRAIN_TIMEOUT`
+
+## Hermes callback receiver
+
+Hermes now exposes a receiver endpoint on the API server:
+
+```text
+POST /api/minions/completions
+```
+
+Auth behavior:
+
+- if `API_SERVER_KEY` is set, Bearer auth is required
+- if no API key is configured, the endpoint accepts requests without auth
+- don’t expose that to the internet without a real key unless you enjoy pain
+
+### Example completion URL
+
+```bash
+export API_SERVER_ENABLED=true
+export API_SERVER_HOST=127.0.0.1
+export API_SERVER_PORT=8086
+export API_SERVER_KEY='replace-me'
+
+export HERMES_GBRAIN_COMPLETION_URL='http://127.0.0.1:8086/api/minions/completions'
+export HERMES_GBRAIN_COMPLETION_KEY='replace-me'
+```
+
+## What Minions must do
+
+Your actual GBrain/Minions worker only needs three responsibilities:
+
+1. accept the Hermes job envelope
+2. execute based on `kind` + `payload`
+3. emit a completion envelope back to Hermes
+
+Do not mutate the envelope format per queue backend. That would be dumb.
+
+## Suggested server endpoints on the GBrain side
+
+This Hermes adapter assumes something roughly like:
+
+- `POST /api/minions/jobs` -> enqueue envelope -> return ack JSON
+
+Ack example:
+
+```json
+{
+  "task_id": "bg_123",
+  "backend": "gbrain-minions",
+  "queue": "background",
+  "message": "accepted"
+}
+```
+
+Completion callback is handled on the Hermes side, not GBrain side.
+
+## Why this is clean
+
+Because transport and protocol are separate.
+
+- file spool reference worker = local proof lane
+- HTTP transport = real remote lane
+- same envelope contract in both cases
+
+That means you can change BullMQ, Redis, Postgres, Railway, or some cursed in-house queue later without ripping Hermes apart.

--- a/website/docs/developer-guide/gbrain-shell-jobs-for-hermes-cron.md
+++ b/website/docs/developer-guide/gbrain-shell-jobs-for-hermes-cron.md
@@ -1,0 +1,143 @@
+---
+title: "Morph GBrain Shell Jobs into Hermes Cron"
+description: "Use GBrain v0.14 shell jobs to move deterministic cron work off the Hermes/OpenClaw gateway"
+---
+
+# Morph GBrain Shell Jobs into Hermes Cron
+
+GBrain v0.14 added a proper `shell` Minion job type.
+That is worth stealing.
+
+Not for everything. For **deterministic cron work**.
+
+Think:
+- token refresh
+- sync script
+- scrape + write
+- API fetch + file update
+- anything that does not need reasoning
+
+That work should not boot a full LLM session through the gateway. That's Einstein doing cash-register duty.
+
+## What Hermes now supports
+
+Hermes cron jobs can carry an optional `shell` block.
+When present, `cron/scheduler.py` submits the work to the `gbrain jobs submit shell` CLI instead of launching an agent turn.
+
+Example job shape:
+
+```json
+{
+  "name": "sync deterministic feeds",
+  "schedule": "*/15 * * * *",
+  "prompt": "",
+  "shell": {
+    "cmd": "bash scripts/sync.sh",
+    "cwd": "/abs/path/to/workspace",
+    "queue": "default",
+    "timeout_ms": 300000,
+    "max_attempts": 3
+  }
+}
+```
+
+Required inside `shell`:
+
+- exactly one of `cmd` or `argv`
+- `cwd` must be absolute
+
+Optional:
+
+- `env`
+- `queue`
+- `timeout_ms`
+- `max_attempts`
+- `follow`
+
+## Runtime behavior
+
+When a cron job has `shell`, Hermes does this:
+
+1. builds GBrain shell-job params
+2. shells out to `gbrain jobs submit shell --params ...`
+3. returns a cron run result marked `SHELL JOB SUBMITTED`
+4. does **not** start `AIAgent`
+
+That means:
+- zero LLM tokens for the deterministic cron
+- job visibility lives in GBrain Minions
+- gateway CPU stays free for actual conversations
+
+## Config knobs
+
+Environment variables:
+
+```bash
+export HERMES_GBRAIN_CLI_PATH='gbrain'
+export HERMES_GBRAIN_ALLOW_SHELL_JOBS=1
+export HERMES_GBRAIN_AUTO_SHELL_CRON=1
+export HERMES_GBRAIN_TIMEOUT=60
+```
+
+Default behavior already assumes `HERMES_GBRAIN_ALLOW_SHELL_JOBS=1` unless you explicitly turn it off.
+
+`HERMES_GBRAIN_AUTO_SHELL_CRON=1` adds the no-brainer path: if a cron has **no prompt**, **no skills**, and only a `script`, Hermes auto-routes it to a GBrain shell job instead of booting `AIAgent` just to run Python. That gives existing script-only crons the calculator lane without making you hand-write a `shell` block every time.
+
+## API server support
+
+`POST /api/jobs` now accepts a `shell` field and passes it through to cron job creation.
+
+So you can create these jobs via the Hermes API server, not just by editing JSON by hand.
+
+## Example: move a sync off the gateway
+
+Before:
+- cron fires
+- Hermes/OpenClaw starts a full agent turn
+- same deterministic script every time
+- tokens burned for no good reason
+
+After:
+
+```json
+{
+  "name": "nightly sync",
+  "schedule": "0 2 * * *",
+  "prompt": "",
+  "shell": {
+    "cmd": "bash scripts/sync.sh",
+    "cwd": "/srv/brain",
+    "timeout_ms": 600000,
+    "max_attempts": 3
+  }
+}
+```
+
+Now the gateway only submits the job. GBrain Minions owns execution.
+
+## When to use this
+
+Use GBrain shell jobs for:
+- deterministic cron tasks
+- repeatable scripts
+- zero-judgment collectors
+- anything you'd trust in a shell script already
+
+Do **not** use this for:
+- research
+- synthesis
+- prioritization
+- writing
+- any task that actually needs judgment
+
+Those still belong in agent jobs.
+
+## Best pattern
+
+The good split is:
+
+- deterministic scheduled work -> `shell` Minion jobs
+- judgment-heavy background work -> queue protocol + worker callbacks
+- interactive reasoning -> live agent turn
+
+That's the clean architecture. Not everything needs an LLM. Some things need a damn script.

--- a/website/docs/developer-guide/job-queue-protocol.md
+++ b/website/docs/developer-guide/job-queue-protocol.md
@@ -1,0 +1,264 @@
+---
+title: "Job Queue Protocol"
+description: "Canonical enqueue and completion payloads for external queue backends like GBrain Minions"
+---
+
+# Job Queue Protocol
+
+Hermes can hand work to an external queue/worker system instead of executing everything in-process. This page defines the **canonical payloads** for that handoff.
+
+Use this when wiring Hermes to **GBrain Minions**, BullMQ workers, or any other durable execution layer.
+
+## Why this exists
+
+Without a contract, every queue bridge turns into bespoke JSON sludge.
+That gets old fast.
+
+The protocol solves three things:
+
+1. **enqueue shape** — what Hermes sends to workers
+2. **callback shape** — what workers send back after execution
+3. **routing contract** — how a worker knows where the result should go
+
+## Version
+
+Current protocol version:
+
+`1.0`
+
+Workers should reject unknown major versions instead of guessing.
+
+## Job kinds
+
+Hermes currently emits three queueable job kinds:
+
+- `background`
+- `delegation`
+- `cron`
+
+All three share the same envelope.
+
+## Enqueue envelope
+
+Top-level fields:
+
+- `version` — protocol version
+- `kind` — `background | delegation | cron`
+- `task_id` — Hermes-generated stable ID for this queued task
+- `payload` — kind-specific body
+- `callback` — how the worker should report completion
+
+### Background job example
+
+```json
+{
+  "version": "1.0",
+  "kind": "background",
+  "task_id": "bg_143022_a1b2c3",
+  "payload": {
+    "prompt": "Analyze the logs in /var/log and summarize any errors from today",
+    "origin": "gateway",
+    "platform": "telegram",
+    "session_id": "bg_143022_a1b2c3",
+    "user_id": "123",
+    "user_name": "victor",
+    "chat_id": "456",
+    "thread_id": "789"
+  },
+  "callback": {
+    "type": "platform",
+    "target": {
+      "platform": "telegram",
+      "chat_id": "456",
+      "thread_id": "789"
+    }
+  }
+}
+```
+
+### Delegation job example
+
+```json
+{
+  "version": "1.0",
+  "kind": "delegation",
+  "task_id": "delegate_1712345678_0",
+  "payload": {
+    "goal": "Research topic A",
+    "context": "Focus on pricing and new launches",
+    "toolsets": ["web", "file"],
+    "model": "gpt-5.4",
+    "max_iterations": 45,
+    "task_index": 0,
+    "task_count": 2
+  },
+  "callback": {
+    "type": "session",
+    "session_id": "sess_123",
+    "platform": "telegram"
+  }
+}
+```
+
+### Cron job example
+
+```json
+{
+  "version": "1.0",
+  "kind": "cron",
+  "task_id": "cron_job-123_20260421_154500",
+  "payload": {
+    "job_id": "job-123",
+    "job_name": "daily digest",
+    "prompt": "Check the feeds and summarize anything new.",
+    "schedule_display": "0 9 * * *",
+    "deliver": "telegram:-1001:55",
+    "origin": {
+      "platform": "telegram",
+      "chat_id": "123",
+      "thread_id": "44"
+    },
+    "model": null,
+    "skills": ["blogwatcher"],
+    "script": null
+  },
+  "callback": {
+    "type": "platform",
+    "target": {
+      "platform": "telegram",
+      "chat_id": "-1001",
+      "thread_id": "55"
+    }
+  }
+}
+```
+
+## Callback contract
+
+Workers should return completion data using the same routing callback Hermes originally provided.
+
+Top-level fields:
+
+- `version`
+- `kind`
+- `task_id`
+- `status`
+- `summary`
+- `final_output`
+- `error` (only when present)
+- `artifacts`
+- `metadata`
+- `callback`
+
+### Completion example
+
+```json
+{
+  "version": "1.0",
+  "kind": "background",
+  "task_id": "bg_143022_a1b2c3",
+  "status": "succeeded",
+  "summary": "Found 3 production errors",
+  "final_output": "Found 3 production errors in the last 24h...",
+  "artifacts": [
+    {"kind": "file", "path": "/tmp/error-report.md"}
+  ],
+  "metadata": {
+    "attempt": 1,
+    "worker": "minion-7"
+  },
+  "callback": {
+    "type": "platform",
+    "target": {
+      "platform": "telegram",
+      "chat_id": "456",
+      "thread_id": "789"
+    }
+  }
+}
+```
+
+## Callback types
+
+### `platform`
+
+Worker should send the final result to a platform destination.
+
+Supported target shape:
+
+```json
+{
+  "type": "platform",
+  "target": {
+    "platform": "telegram",
+    "chat_id": "456",
+    "thread_id": "789"
+  }
+}
+```
+
+Hermes includes a helper in `agent.job_callbacks.deliver_completion()` that converts this into the same delivery path cron uses.
+
+### `session`
+
+Worker completed a delegated subtask that should be reconciled back into a Hermes session.
+
+Current behavior:
+- Hermes appends the result into the session transcript (`~/.hermes/sessions/<session_id>.jsonl` and SQLite when available)
+- if the session can be resolved back to a messaging origin, Hermes also delivers the final text back to that chat/thread
+
+That gives queued delegation a real closed loop instead of a dead drop.
+
+### `none`
+
+Worker should not deliver anything back automatically.
+
+## Worker expectations
+
+A clean Minions worker should:
+
+1. parse the envelope
+2. branch on `kind`
+3. execute using the `payload`
+4. build a completion envelope
+5. honor `callback`
+
+## Recommended Minions adapter shape
+
+For a BullMQ-style worker, keep the bridge thin:
+
+- Hermes enqueue command: stdin envelope -> queue add
+- Minions worker: queue job -> execute -> completion envelope
+- Delivery step: call Hermes helper or your own platform sender
+
+Do **not** mutate the protocol per queue backend. BullMQ, Redis streams, Postgres jobs, and SQS should all carry the same logical envelope.
+
+## Code references
+
+Canonical builders live in:
+
+- `agent.job_protocol`
+- `agent.background_jobs`
+- `agent.job_callbacks`
+
+For a tiny working example, see:
+
+- `agent.minions_reference`
+- `scripts/minions_reference_enqueue.py`
+- `scripts/minions_reference_worker.py`
+- [Reference Minions Worker](/docs/developer-guide/reference-minions-worker)
+
+For the real HTTP transport shape, see:
+
+- `agent.gbrain_minions_transport`
+- `scripts/gbrain_minions_enqueue.py`
+- `scripts/gbrain_minions_complete.py`
+- [GBrain / Minions HTTP Transport](/docs/developer-guide/gbrain-minions-http-transport)
+
+For deterministic zero-token cron work, see:
+
+- `agent.gbrain_cli_jobs`
+- `cron/scheduler.py` (`job.shell` support + auto-routing for script-only crons)
+- [Morph GBrain Shell Jobs into Hermes Cron](/docs/developer-guide/gbrain-shell-jobs-for-hermes-cron)
+
+Those are the source of truth. If docs and code ever disagree, the code wins.

--- a/website/docs/developer-guide/reference-minions-worker.md
+++ b/website/docs/developer-guide/reference-minions-worker.md
@@ -1,0 +1,119 @@
+---
+title: "Reference Minions Worker"
+description: "Tiny file-spool worker and enqueue shim for wiring Hermes to external queues during development"
+---
+
+# Reference Minions Worker
+
+This is the smallest working bridge between Hermes and an external worker lane.
+
+It is not fancy. That’s the point.
+
+Use it to prove the queue contract end to end before wiring Hermes into real GBrain Minions, BullMQ, Railway workers, or whatever else you want to run.
+
+## What it gives you
+
+- one enqueue shim that accepts Hermes job envelopes on stdin
+- one worker that processes queued jobs from a local spool directory
+- one default runner that turns queue payloads into completion envelopes
+- callback delivery through Hermes' own callback helper
+
+Files:
+
+- `scripts/minions_reference_enqueue.py`
+- `scripts/minions_reference_worker.py`
+- `agent/minions_reference.py`
+
+## Spool layout
+
+By default the reference worker uses:
+
+`~/.hermes/minions-reference/`
+
+Structure:
+
+- `queue/<kind>/<task_id>.json`
+- `completed/<kind>/<task_id>.json`
+
+Set `HERMES_MINIONS_SPOOL_DIR` to override it.
+
+## Wire Hermes into the reference enqueue shim
+
+Point Hermes at the generic enqueue script:
+
+```bash
+export HERMES_BACKGROUND_BACKEND=command
+export HERMES_BACKGROUND_ENQUEUE_CMD='python scripts/minions_reference_enqueue.py'
+
+export HERMES_DELEGATION_BACKEND=command
+export HERMES_DELEGATION_ENQUEUE_CMD='python scripts/minions_reference_enqueue.py'
+
+export HERMES_CRON_BACKEND=command
+export HERMES_CRON_ENQUEUE_CMD='python scripts/minions_reference_enqueue.py'
+```
+
+That’s enough for Hermes to stop executing those lanes locally and start dropping envelopes into the spool queue.
+
+## Run the worker
+
+Process one queued job:
+
+```bash
+python scripts/minions_reference_worker.py --once
+```
+
+Typical output:
+
+```json
+{"version":"1.0","kind":"background","task_id":"bg_...","status":"succeeded",...}
+```
+
+If no work is waiting:
+
+```json
+{"status":"idle"}
+```
+
+## End-to-end smoke test
+
+1. export the backend env vars above
+2. start Hermes
+3. run `/background summarize this repo`
+4. in another shell, run:
+
+```bash
+python scripts/minions_reference_worker.py --once
+```
+
+Expected result:
+- Hermes enqueues the job instead of running it inline
+- worker writes a completion file under `completed/background/`
+- callback delivery sends the result back through Hermes
+
+## What the default worker actually does
+
+The reference runner is intentionally dumb:
+
+- background -> echoes the prompt as completed work
+- delegation -> echoes the delegated goal
+- cron -> echoes the cron job name
+
+That makes it runnable with zero external dependencies.
+
+If you want real execution, replace the default runner with your own worker logic.
+
+## Recommended upgrade path
+
+Use this reference lane only to validate the protocol and callback flow.
+Then replace the storage/runner pieces in this order:
+
+1. file spool -> BullMQ / GBrain / Postgres queue
+2. default runner -> real task executor
+3. ad hoc worker loop -> supervised process / container / serverless job
+
+Do not change the envelope format while upgrading. The protocol is the stable seam.
+
+## Why this exists
+
+Because architecture diagrams don’t execute shit.
+You need a tiny working lane before you build the serious one.

--- a/website/docs/developer-guide/terminal-compression-v1.md
+++ b/website/docs/developer-guide/terminal-compression-v1.md
@@ -1,0 +1,35 @@
+---
+title: Terminal Compression v1
+---
+
+# Terminal Compression v1
+
+Hermes terminal compression v1 is a narrow plugin-driven rewrite layer for the `terminal` tool.
+
+## Rules
+- only rewrites `terminal`
+- only rewrites foreground, non-PTY calls
+- never rewrites chained commands, redirects, heredocs, or dangerous commands
+- first valid `pre_tool_call` directive wins
+
+## Supported actions
+- `block`
+- `rewrite_args`
+
+## Why this exists
+This gives Hermes one small RTK-style win without importing RTK's whole command universe.
+
+## v1 allowlist
+- `git status`
+- `git diff`
+- `git log`
+- `pytest`
+- `cargo test`
+- `npm test`
+- `pnpm test`
+- `docker ps`
+- `ls`
+- `rg`
+
+## Debugging
+If project plugins are enabled, the `terminal_compact` plugin logs each rewrite with its reason.


### PR DESCRIPTION
## Summary
- add pre-tool rewrite directives so plugins can block or rewrite tool args before dispatch
- add a repo-local `terminal_compact` plugin plus coverage for safe terminal command compaction
- add queued job protocol helpers, reference worker scripts, GBrain Minions transport hooks, and the API server completion callback endpoint

## Why this is split this way
This PR is two related infrastructure slices:
1. terminal compaction via plugin-driven rewrite directives
2. durable queued-job / minions callback plumbing

They touch adjacent execution paths and were verified together.

## Key files
- `hermes_cli/plugins.py`
- `model_tools.py`
- `.hermes/plugins/terminal_compact/*`
- `agent/background_jobs.py`
- `agent/job_protocol.py`
- `agent/job_callbacks.py`
- `agent/gbrain_minions_transport.py`
- `gateway/platforms/api_server.py`

## Test Plan
```bash
source venv/bin/activate
python -m pytest \
  tests/test_terminal_compact_plugin.py \
  tests/hermes_cli/test_plugins.py \
  tests/test_model_tools.py \
  tests/agent/test_background_jobs.py \
  tests/agent/test_job_protocol.py \
  tests/agent/test_job_callbacks.py \
  tests/agent/test_minions_reference.py \
  tests/agent/test_gbrain_cli_jobs.py \
  tests/agent/test_gbrain_minions_transport.py \
  tests/gateway/test_api_server_minions_completion.py -q
```

## Notes
Local machine cleanup also killed orphaned `tradingview-mcp-server` processes and disabled the local TradingView MCP config to stop respawn, but those config changes are **not** part of this PR.
