### PR TITLE
fix: Python 3.9 PEP-604 compatibility via __future__ annotations

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -9,6 +9,8 @@ Auth supports:
   - OAuth setup-tokens (sk-ant-oat*) → Bearer auth + beta header
   - Claude Code credentials (~/.claude.json or ~/.claude/.credentials.json) → Bearer auth
 """
+from __future__ import annotations
+
 
 import copy
 import json

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -33,6 +33,8 @@ Payment / credit exhaustion fallback:
   auto-detection chain.  This handles the common case where a user depletes
   their OpenRouter balance but has Codex OAuth or another provider available.
 """
+from __future__ import annotations
+
 
 import json
 import logging

--- a/agent/bedrock_adapter.py
+++ b/agent/bedrock_adapter.py
@@ -26,6 +26,8 @@ the same Converse API integration in TypeScript via ``@aws-sdk/client-bedrock``.
 
 Requires: ``boto3`` (optional dependency — only needed when using the Bedrock provider).
 """
+from __future__ import annotations
+
 
 import json
 import logging

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -16,6 +16,8 @@ Improvements over v2:
   - Scaled summary budget (proportional to compressed content)
   - Richer tool call/result detail in summarizer input
 """
+from __future__ import annotations
+
 
 import hashlib
 import json

--- a/agent/display.py
+++ b/agent/display.py
@@ -3,6 +3,8 @@
 Pure display functions and classes with no AIAgent dependency.
 Used by AIAgent._execute_tool_calls for CLI feedback.
 """
+from __future__ import annotations
+
 
 import logging
 import os

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -3,6 +3,8 @@
 Pure utility functions with no AIAgent dependency. Used by ContextCompressor
 and run_agent.py for pre-flight context checks.
 """
+from __future__ import annotations
+
 
 import logging
 import re

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -17,6 +17,8 @@ Data resolution order (like TypeScript OpenCode):
 Other modules should import the dataclasses and query functions from here
 rather than parsing the raw JSON themselves.
 """
+from __future__ import annotations
+
 
 import json
 import logging

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -3,6 +3,8 @@
 All functions are stateless. AIAgent._build_system_prompt() calls these to
 assemble pieces, then combines them with memory and ephemeral prompts.
 """
+from __future__ import annotations
+
 
 import json
 import logging

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -6,6 +6,8 @@ before they reach log files, verbose output, or gateway logs.
 Short tokens (< 18 chars) are fully masked. Longer tokens preserve
 the first 6 and last 4 characters for debuggability.
 """
+from __future__ import annotations
+
 
 import logging
 import os

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -4,6 +4,8 @@ Shared between CLI (cli.py) and gateway (gateway/run.py) so both surfaces
 can invoke skills via /skill-name commands and prompt-only built-ins like
 /plan.
 """
+from __future__ import annotations
+
 
 import json
 import logging

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -4,6 +4,8 @@ This module intentionally avoids importing the tool registry, CLI config, or any
 heavy dependency chain.  It is safe to import at module level without triggering
 tool registration or provider resolution.
 """
+from __future__ import annotations
+
 
 import logging
 import os

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -3,6 +3,8 @@
 Delegates to the existing adapter functions in agent/anthropic_adapter.py.
 This transport owns format conversion and normalization — NOT client lifecycle.
 """
+from __future__ import annotations
+
 
 from typing import Any, Dict, List, Optional
 

--- a/cli.py
+++ b/cli.py
@@ -13,6 +13,8 @@ Usage:
     python cli.py --list-tools             # List available tools and exit
 """
 
+from __future__ import annotations
+
 import logging
 import os
 import shutil

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -4,6 +4,8 @@ Cron job storage and management.
 Jobs are stored in ~/.hermes/cron/jobs.json
 Output is saved to ~/.hermes/cron/output/{job_id}/{timestamp}.md
 """
+from __future__ import annotations
+
 
 import copy
 import json

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -7,6 +7,8 @@ calls this every 60 seconds from a background thread.
 Uses a file-based lock (~/.hermes/cron/.tick.lock) so only one tick
 runs at a time if multiple processes overlap.
 """
+from __future__ import annotations
+
 
 import asyncio
 import concurrent.futures

--- a/environments/benchmarks/yc_bench/yc_bench_env.py
+++ b/environments/benchmarks/yc_bench/yc_bench_env.py
@@ -36,6 +36,8 @@ Key features:
 
 Requires: pip install hermes-agent[yc-bench]
 """
+from __future__ import annotations
+
 
 import asyncio
 import datetime

--- a/environments/hermes_swe_env/hermes_swe_env.py
+++ b/environments/hermes_swe_env/hermes_swe_env.py
@@ -28,6 +28,8 @@ Usage:
         --env.tool_call_parser hermes \\
         --env.terminal_backend modal
 """
+from __future__ import annotations
+
 
 import logging
 import sys

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4,6 +4,8 @@ Base platform adapter interface.
 All platform adapters (Telegram, Discord, WhatsApp) inherit from this
 and implement the required methods.
 """
+from __future__ import annotations
+
 
 import asyncio
 import inspect

--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -25,6 +25,8 @@ Configuration in config.yaml:
           client_id: "your-app-key"      # or DINGTALK_CLIENT_ID env var
           client_secret: "your-secret"   # or DINGTALK_CLIENT_SECRET env var
 """
+from __future__ import annotations
+
 
 import asyncio
 import json

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -7,6 +7,8 @@ Uses slack-bolt (Python) with Socket Mode for:
 - Handling slash commands
 - Thread support
 """
+from __future__ import annotations
+
 
 import asyncio
 import json

--- a/gateway/platforms/sms.py
+++ b/gateway/platforms/sms.py
@@ -17,6 +17,8 @@ Gateway-specific env vars:
   - SMS_ALLOW_ALL_USERS  (true/false)
   - SMS_HOME_CHANNEL     (phone number for cron delivery)
 """
+from __future__ import annotations
+
 
 import asyncio
 import base64

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -6,6 +6,8 @@ Uses python-telegram-bot library for:
 - Sending responses back
 - Handling media and commands
 """
+from __future__ import annotations
+
 
 import asyncio
 import json

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12,6 +12,8 @@ Usage:
     # Or from CLI
     python cli.py --gateway
 """
+from __future__ import annotations
+
 
 import asyncio
 import json

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -10,6 +10,8 @@ separate HERMES_HOME directories naturally get separate PID files — a property
 that will be useful when we add named profiles (multiple agents running
 concurrently under distinct configurations).
 """
+from __future__ import annotations
+
 
 import hashlib
 import json

--- a/hermes_cli/claw.py
+++ b/hermes_cli/claw.py
@@ -8,6 +8,8 @@ Usage:
     hermes claw cleanup              # Archive leftover OpenClaw directories
     hermes claw cleanup --dry-run    # Preview what would be archived
 """
+from __future__ import annotations
+
 
 import importlib.util
 import logging

--- a/hermes_cli/cli_output.py
+++ b/hermes_cli/cli_output.py
@@ -4,6 +4,8 @@ Extracts the identical ``print_info/success/warning/error`` and ``prompt()``
 functions previously duplicated across setup.py, tools_config.py,
 mcp_config.py, and memory_setup.py.
 """
+from __future__ import annotations
+
 
 import getpass
 

--- a/hermes_cli/clipboard.py
+++ b/hermes_cli/clipboard.py
@@ -11,6 +11,8 @@ Platform support:
   WSL2    — powershell.exe via WinForms, Get-Clipboard, file-drop fallback
   Linux   — wl-paste (Wayland), xclip (X11)
 """
+from __future__ import annotations
+
 
 import base64
 import logging

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -11,6 +11,8 @@ This module provides:
 - hermes config set      - Set a specific value
 - hermes config wizard   - Re-run setup wizard
 """
+from __future__ import annotations
+
 
 import copy
 import logging

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -4,6 +4,8 @@ Cron subcommand for hermes CLI.
 Handles standalone cron management commands like list, create, edit,
 pause/resume/run/remove, status, and tick.
 """
+from __future__ import annotations
+
 
 import json
 import sys

--- a/hermes_cli/curses_ui.py
+++ b/hermes_cli/curses_ui.py
@@ -4,6 +4,8 @@ Used by `hermes tools` and `hermes skills` for interactive checklists.
 Provides a curses multi-select with keyboard navigation, plus a
 text-based numbered fallback for terminals without curses support.
 """
+from __future__ import annotations
+
 import sys
 from typing import Callable, List, Optional, Set
 

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3,6 +3,8 @@ Gateway subcommand for hermes CLI.
 
 Handles: hermes gateway [run|start|stop|restart|status|install|uninstall|setup]
 """
+from __future__ import annotations
+
 
 import asyncio
 import os

--- a/hermes_cli/logs.py
+++ b/hermes_cli/logs.py
@@ -16,6 +16,8 @@ Usage examples::
     hermes logs --since 1h         # lines from the last hour
     hermes logs --since 30m -f     # follow, starting 30 min ago
 """
+from __future__ import annotations
+
 
 import re
 import sys

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -42,6 +42,8 @@ Usage:
 
     hermes claw migrate --dry-run  # Preview migration without changes
 """
+from __future__ import annotations
+
 
 import argparse
 import os

--- a/hermes_cli/pairing.py
+++ b/hermes_cli/pairing.py
@@ -7,6 +7,8 @@ Usage:
     hermes pairing revoke <platform> <user_id> # Revoke user access
     hermes pairing clear-pending     # Clear all expired/pending codes
 """
+from __future__ import annotations
+
 
 def pairing_command(args):
     """Handle hermes pairing subcommands."""

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -18,6 +18,8 @@ Usage::
     hermes profile use coder             # set as sticky default
     hermes profile delete coder          # remove profile + alias + service
 """
+from __future__ import annotations
+
 
 import json
 import os

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -10,6 +10,8 @@ Modular wizard with independently-runnable sections:
 
 Config files are stored in ~/.hermes/ for easy access.
 """
+from __future__ import annotations
+
 
 import importlib.util
 import logging

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -9,6 +9,8 @@ Powers both:
 All logic lives in shared do_* functions. The CLI entry point and slash command
 handler are thin wrappers that parse args and delegate.
 """
+from __future__ import annotations
+
 
 import json
 import shutil

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -8,6 +8,8 @@ that need API keys, run through provider-aware configuration.
 Saves per-platform tool configuration to ~/.hermes/config.yaml under
 the `platform_toolsets` key.
 """
+from __future__ import annotations
+
 
 import json as _json
 import logging

--- a/hermes_cli/uninstall.py
+++ b/hermes_cli/uninstall.py
@@ -5,6 +5,8 @@ Provides options for:
 - Full uninstall: Remove everything including configs and data
 - Keep data: Remove code but keep ~/.hermes/ (configs, sessions, logs)
 """
+from __future__ import annotations
+
 
 import os
 import shutil

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -8,6 +8,8 @@ Usage:
     python -m hermes_cli.main web          # Start on http://127.0.0.1:9119
     python -m hermes_cli.main web --port 8080
 """
+from __future__ import annotations
+
 
 import asyncio
 import hmac

--- a/hermes_cli/webhook.py
+++ b/hermes_cli/webhook.py
@@ -9,6 +9,8 @@ Usage:
 Subscriptions persist to ~/.hermes/webhook_subscriptions.json and are
 hot-reloaded by the webhook adapter without a gateway restart.
 """
+from __future__ import annotations
+
 
 import json
 import os

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -2,6 +2,8 @@
 SQLite-backed fact store with entity resolution and trust scoring.
 Single-user Hermes memory store plugin.
 """
+from __future__ import annotations
+
 
 import re
 import sqlite3

--- a/run_agent.py
+++ b/run_agent.py
@@ -20,6 +20,8 @@ Usage:
     response = agent.run_conversation("Tell me about the latest Python updates")
 """
 
+from __future__ import annotations
+
 import asyncio
 import base64
 import concurrent.futures

--- a/scripts/contributor_audit.py
+++ b/scripts/contributor_audit.py
@@ -14,6 +14,8 @@ Usage:
     # Compare against a release notes file
     python scripts/contributor_audit.py --since-tag v2026.4.8 --release-file RELEASE_v0.9.0.md
 """
+from __future__ import annotations
+
 
 import argparse
 import json

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -19,6 +19,8 @@ Usage:
     # Override CalVer date (e.g. for a belated release)
     python scripts/release.py --bump minor --publish --date 2026.3.15
 """
+from __future__ import annotations
+
 
 import argparse
 import re

--- a/tests/agent/test_bedrock_integration.py
+++ b/tests/agent/test_bedrock_integration.py
@@ -8,6 +8,8 @@ are mocked.
 Note: Tests that import ``hermes_cli.auth`` or ``hermes_cli.runtime_provider``
 require Python 3.10+ due to ``str | None`` type syntax in the import chain.
 """
+from __future__ import annotations
+
 
 import os
 from unittest.mock import MagicMock, patch

--- a/tests/agent/test_subagent_progress.py
+++ b/tests/agent/test_subagent_progress.py
@@ -7,6 +7,8 @@ Verifies that:
 - Thinking events are relayed correctly
 - Parallel callbacks don't share state
 """
+from __future__ import annotations
+
 
 import io
 import sys

--- a/tests/cli/test_cli_markdown_rendering.py
+++ b/tests/cli/test_cli_markdown_rendering.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from io import StringIO
 
 from rich.console import Console

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch

--- a/tests/cli/test_worktree_security.py
+++ b/tests/cli/test_worktree_security.py
@@ -1,4 +1,6 @@
 """Security-focused integration tests for CLI worktree setup."""
+from __future__ import annotations
+
 
 import subprocess
 from pathlib import Path

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -8,6 +8,8 @@ These tests exercise the full async message flow:
 
 No LLM, no real platform connections.
 """
+from __future__ import annotations
+
 
 import asyncio
 import sys

--- a/tests/gateway/restart_test_helpers.py
+++ b/tests/gateway/restart_test_helpers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 from unittest.mock import AsyncMock, MagicMock
 

--- a/tests/gateway/test_agent_cache.py
+++ b/tests/gateway/test_agent_cache.py
@@ -8,6 +8,8 @@ Verifies that the agent cache correctly:
 - Evicts on fallback activation
 - Preserves frozen system prompt across turns
 """
+from __future__ import annotations
+
 
 import hashlib
 import json

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -6,6 +6,8 @@ controls verbosity: off | result | error | all (default).
 
 Contributed by @PeterFile (PR #593), reimplemented on current main.
 """
+from __future__ import annotations
+
 
 import asyncio
 from types import SimpleNamespace

--- a/tests/gateway/test_config_cwd_bridge.py
+++ b/tests/gateway/test_config_cwd_bridge.py
@@ -8,6 +8,8 @@ The bridge logic is module-level code in gateway/run.py, so we test
 the semantics by reimplementing the relevant config bridge snippet and
 asserting the expected env var outcomes.
 """
+from __future__ import annotations
+
 
 import os
 import json

--- a/tests/gateway/test_insights_unicode_flags.py
+++ b/tests/gateway/test_insights_unicode_flags.py
@@ -3,6 +3,8 @@
 Telegram on iOS auto-converts -- to em/en dashes. The /insights handler
 normalizes these before parsing --days and --source flags.
 """
+from __future__ import annotations
+
 import re
 import pytest
 

--- a/tests/gateway/test_reasoning_command.py
+++ b/tests/gateway/test_reasoning_command.py
@@ -1,4 +1,6 @@
 """Tests for gateway /reasoning command and hot reload behavior."""
+from __future__ import annotations
+
 
 import asyncio
 import inspect

--- a/tests/gateway/test_restart_redelivery_dedup.py
+++ b/tests/gateway/test_restart_redelivery_dedup.py
@@ -5,6 +5,8 @@ with a network error, Telegram re-delivers the `/restart` message to the new
 gateway process.  Without a dedup guard, the new gateway would process
 `/restart` again and immediately restart — a self-perpetuating loop.
 """
+from __future__ import annotations
+
 import asyncio
 import json
 import time

--- a/tests/gateway/test_restart_resume_pending.py
+++ b/tests/gateway/test_restart_resume_pending.py
@@ -24,6 +24,8 @@ PRs #9850, #9934, #7536):
    PR #7536 remains the single source of escalation — no parallel
    counter is added on ``SessionEntry``.
 """
+from __future__ import annotations
+
 
 import asyncio
 from datetime import datetime, timedelta

--- a/tests/gateway/test_session_store_prune.py
+++ b/tests/gateway/test_session_store_prune.py
@@ -13,6 +13,8 @@ tests pin the prune behaviour:
   * The ``updated_at`` field — not ``created_at`` — drives the decision
     (so a long-running-but-still-active session isn't pruned)
 """
+from __future__ import annotations
+
 
 import json
 import threading

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -7,6 +7,8 @@ Covers: app_mention handler, send_document, send_video,
 Note: slack-bolt may not be installed in the test environment.
 We mock the slack modules at import time to avoid collection errors.
 """
+from __future__ import annotations
+
 
 import asyncio
 import os

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -1,4 +1,6 @@
 """Tests for gateway runtime status tracking."""
+from __future__ import annotations
+
 
 import json
 import os

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -4,6 +4,8 @@ Covers: _escape_mdv2 (pure function), format_message (markdown-to-MarkdownV2
 conversion pipeline), and edge cases that could produce invalid MarkdownV2
 or corrupt user-visible content.
 """
+from __future__ import annotations
+
 
 import re
 import sys

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -1,4 +1,6 @@
 """Tests for the /voice command and auto voice reply in the gateway."""
+from __future__ import annotations
+
 
 import importlib.util
 import json

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -1,4 +1,6 @@
 """Tests for the Weixin platform adapter."""
+from __future__ import annotations
+
 
 import asyncio
 import base64

--- a/tests/gateway/test_whatsapp_group_gating.py
+++ b/tests/gateway/test_whatsapp_group_gating.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 from unittest.mock import AsyncMock
 

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1,4 +1,6 @@
 """Tests for hermes backup and import commands."""
+from __future__ import annotations
+
 
 import json
 import os

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -1,4 +1,6 @@
 """Tests for the central command registry and autocomplete."""
+from __future__ import annotations
+
 
 from prompt_toolkit.completion import CompleteEvent
 from prompt_toolkit.document import Document

--- a/tests/hermes_cli/test_completion.py
+++ b/tests/hermes_cli/test_completion.py
@@ -1,4 +1,6 @@
 """Tests for hermes_cli/completion.py — shell completion script generation."""
+from __future__ import annotations
+
 
 import argparse
 import os

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1,4 +1,6 @@
 """Tests for the Hermes plugin system (hermes_cli.plugins)."""
+from __future__ import annotations
+
 
 import logging
 import os

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 import types
 from types import SimpleNamespace

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1,4 +1,6 @@
 """Tests for the dangerous command approval module."""
+from __future__ import annotations
+
 
 import ast
 from pathlib import Path

--- a/tests/tools/test_command_guards.py
+++ b/tests/tools/test_command_guards.py
@@ -1,4 +1,6 @@
 """Tests for check_all_command_guards() — combined tirith + dangerous command guard."""
+from __future__ import annotations
+
 
 import os
 from unittest.mock import patch, MagicMock

--- a/tests/tools/test_cron_prompt_injection.py
+++ b/tests/tools/test_cron_prompt_injection.py
@@ -6,6 +6,8 @@ variants like "Ignore ALL prior instructions" bypassed the scanner.
 
 Fix: allow optional extra words with `(?:\\w+\\s+)*` groups.
 """
+from __future__ import annotations
+
 
 from tools.cronjob_tools import _scan_cron_prompt
 

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -1,4 +1,6 @@
 """Tests for tools/file_operations.py — deny list, result dataclasses, helpers."""
+from __future__ import annotations
+
 
 import os
 import pytest

--- a/tests/tools/test_fuzzy_match.py
+++ b/tests/tools/test_fuzzy_match.py
@@ -1,4 +1,6 @@
 """Tests for the fuzzy matching module."""
+from __future__ import annotations
+
 
 from tools.fuzzy_match import fuzzy_find_and_replace
 

--- a/tests/tools/test_patch_parser.py
+++ b/tests/tools/test_patch_parser.py
@@ -1,4 +1,6 @@
 """Tests for the V4A patch format parser."""
+from __future__ import annotations
+
 
 from types import SimpleNamespace
 

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -1,4 +1,6 @@
 """Tests for tools/send_message_tool.py."""
+from __future__ import annotations
+
 
 import asyncio
 import json

--- a/tests/tools/test_terminal_compound_background.py
+++ b/tests/tools/test_terminal_compound_background.py
@@ -11,6 +11,8 @@ The rewriter fixes this by wrapping the tail in a brace group —
 ``A && { B & }`` — so B runs as a simple backgrounded command inside
 the current shell. No subshell fork, no wait.
 """
+from __future__ import annotations
+
 
 import pytest
 

--- a/tests/tools/test_terminal_exit_semantics.py
+++ b/tests/tools/test_terminal_exit_semantics.py
@@ -1,4 +1,6 @@
 """Tests for terminal command exit code semantic interpretation."""
+from __future__ import annotations
+
 
 import pytest
 

--- a/tests/tools/test_yolo_mode.py
+++ b/tests/tools/test_yolo_mode.py
@@ -1,4 +1,6 @@
 """Tests for --yolo (HERMES_YOLO_MODE) approval bypass."""
+from __future__ import annotations
+
 
 import os
 import pytest

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -7,6 +7,8 @@ This module is the single source of truth for the dangerous command system:
 - Smart approval via auxiliary LLM (auto-approve low-risk commands)
 - Permanent allowlist persistence (config.yaml)
 """
+from __future__ import annotations
+
 
 import contextvars
 import logging

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -48,6 +48,8 @@ Usage:
     # Click an element
     browser_click("@e5", task_id="task_123")
 """
+from __future__ import annotations
+
 
 import atexit
 import functools

--- a/tools/budget_config.py
+++ b/tools/budget_config.py
@@ -3,6 +3,8 @@
 Overridable at the RL environment level via HermesAgentEnvConfig fields.
 Per-tool resolution: pinned > config overrides > registry > default.
 """
+from __future__ import annotations
+
 
 from dataclasses import dataclass, field
 from typing import Dict

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -4,6 +4,8 @@ Cron job management tools for Hermes Agent.
 Expose a single compressed action-oriented tool to avoid schema/context bloat.
 Compatibility wrappers remain for direct Python callers and legacy tests.
 """
+from __future__ import annotations
+
 
 import json
 import logging

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -24,6 +24,8 @@ Per-guild permissions (MANAGE_ROLES etc.) are NOT pre-checked — Discord
 returns a 403 at call time and :func:`_enrich_403` maps it to
 actionable guidance the model can relay to the user.
 """
+from __future__ import annotations
+
 
 import json
 import logging

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -5,6 +5,8 @@ A session snapshot (env vars, functions, aliases) is captured once at init and
 re-sourced before each command. CWD persists via in-band stdout markers (remote)
 or a temp file (local).
 """
+from __future__ import annotations
+
 
 import codecs
 import json

--- a/tools/environments/daytona.py
+++ b/tools/environments/daytona.py
@@ -4,6 +4,8 @@ Uses the Daytona Python SDK to run commands in cloud sandboxes.
 Supports persistent sandboxes: when enabled, sandboxes are stopped on cleanup
 and resumed on next creation, preserving the filesystem across sessions.
 """
+from __future__ import annotations
+
 
 import logging
 import math

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -4,6 +4,8 @@ Security hardened (cap-drop ALL, no-new-privileges, PID limits),
 configurable resource limits (CPU, memory, disk), and optional filesystem
 persistence via bind mounts.
 """
+from __future__ import annotations
+
 
 import logging
 import os

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -5,6 +5,8 @@ syncs to remote environments transactionally.  Used by SSH, Modal,
 and Daytona.  Docker and Singularity use bind mounts (live host FS
 view) and don't need this.
 """
+from __future__ import annotations
+
 
 import hashlib
 import logging

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1,4 +1,6 @@
 """Local execution environment — spawn-per-call with session snapshot."""
+from __future__ import annotations
+
 
 import os
 import platform

--- a/tools/environments/modal.py
+++ b/tools/environments/modal.py
@@ -3,6 +3,8 @@
 Uses ``Sandbox.create()`` + ``Sandbox.exec()`` instead of the older runtime
 wrapper, while preserving Hermes' persistent snapshot behavior across sessions.
 """
+from __future__ import annotations
+
 
 import asyncio
 import base64

--- a/tools/environments/singularity.py
+++ b/tools/environments/singularity.py
@@ -4,6 +4,8 @@ Security-hardened with --containall, --no-home, capability dropping.
 Supports configurable resource limits and optional filesystem persistence
 via writable overlay directories that survive across sessions.
 """
+from __future__ import annotations
+
 
 import logging
 import os

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -1,4 +1,6 @@
 """SSH remote execution environment with ControlMaster connection persistence."""
+from __future__ import annotations
+
 
 import hashlib
 import logging

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -24,6 +24,8 @@ Usage:
     # Search for content
     result = file_ops.search("TODO", path=".", file_glob="*.py")
 """
+from __future__ import annotations
+
 
 import os
 import re

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 """File Tools Module - LLM agent file manipulation tools."""
+from __future__ import annotations
+
 
 import errno
 import json

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -19,6 +19,8 @@ Architecture:
 Pricing shown in UI strings is as-of the initial commit; we accept drift and
 update when it's noticed.
 """
+from __future__ import annotations
+
 
 import json
 import logging

--- a/tools/interrupt.py
+++ b/tools/interrupt.py
@@ -13,6 +13,8 @@ Usage in tools:
     if is_interrupted():
         return {"output": "[interrupted]", "returncode": 130}
 """
+from __future__ import annotations
+
 
 import logging
 import os

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -31,6 +31,8 @@ Configuration in config.yaml::
           redirect_port: 0                      # 0 = auto-pick free port
           client_name: "My Custom Client"       # default: "Hermes Agent"
 """
+from __future__ import annotations
+
 
 import asyncio
 import json

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -68,6 +68,8 @@ Thread safety:
     _lock so the code is safe regardless of GIL presence (e.g. Python 3.13+
     free-threading).
 """
+from __future__ import annotations
+
 
 import asyncio
 import concurrent.futures

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -22,6 +22,8 @@ Design:
 - Behavioral guidance lives in the tool schema description
 - Frozen snapshot pattern: system prompt is stable, tool responses show live state
 """
+from __future__ import annotations
+
 
 import json
 import logging

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -13,6 +13,8 @@ Import chain (circular-import safe):
            ^
     run_agent.py, cli.py, batch_runner.py, etc.
 """
+from __future__ import annotations
+
 
 import ast
 import importlib

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -4,6 +4,8 @@ Sends a message to a user or channel on any connected messaging platform
 (Telegram, Discord, Slack). Supports listing available targets and resolving
 human-friendly channel names to IDs. Works in both CLI and gateway contexts.
 """
+from __future__ import annotations
+
 
 import asyncio
 import json

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -21,6 +21,8 @@ Usage:
     if not allowed:
         print(format_scan_report(result))
 """
+from __future__ import annotations
+
 
 import re
 import hashlib

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -12,6 +12,8 @@ This is a library module (not an agent tool). It provides:
 
 Used by hermes_cli/skills_hub.py for CLI commands and the /skills slash command.
 """
+from __future__ import annotations
+
 
 import hashlib
 import json

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -65,6 +65,8 @@ Usage:
     # View a reference file within a skill (loads linked file)
     content = skill_view("axolotl", "references/dataset-formats.md")
 """
+from __future__ import annotations
+
 
 import json
 import logging

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -29,6 +29,8 @@ Usage:
     # Execute in background
     result = terminal_tool("python server.py", background=True)
 """
+from __future__ import annotations
+
 
 import importlib.util
 import json

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -19,6 +19,8 @@ verification only — still secure via HTTPS + checksum, just without supply
 chain provenance proof.  Installation runs in a background thread so startup
 never blocks.
 """
+from __future__ import annotations
+
 
 import hashlib
 import json

--- a/tools/todo_tool.py
+++ b/tools/todo_tool.py
@@ -13,6 +13,8 @@ Design:
 - No system prompt mutation, no tool response modification
 - Behavioral guidance lives entirely in the tool schema description
 """
+from __future__ import annotations
+
 
 import json
 from typing import Dict, Any, List, Optional

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -21,6 +21,8 @@ Defense against context-window overflow operates at three levels:
    spilled to disk until the aggregate is under budget. This catches cases
    where many medium-sized results combine to overflow context.
 """
+from __future__ import annotations
+
 
 import logging
 import os

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -15,6 +15,8 @@ Limitations (documented, not fixable at pre-flight level):
     media cache helpers. Web tools use third-party SDKs (Firecrawl/Tavily)
     where redirect handling is on their servers.
 """
+from __future__ import annotations
+
 
 import ipaddress
 import logging

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -8,6 +8,8 @@ Dependencies (optional):
     pip install sounddevice numpy
     or: pip install hermes-agent[voice]
 """
+from __future__ import annotations
+
 
 import logging
 import os

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import atexit
 import concurrent.futures
 import copy

--- a/tui_gateway/slash_worker.py
+++ b/tui_gateway/slash_worker.py
@@ -2,6 +2,8 @@
 
 Protocol: reads JSON lines from stdin {id, command}, writes {id, ok, output|error} to stdout.
 """
+from __future__ import annotations
+
 
 import argparse
 import contextlib

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,7 @@
 """Shared utility functions for hermes-agent."""
 
+from __future__ import annotations
+
 import json
 import logging
 import os


### PR DESCRIPTION
## What it does

Fixes Python 3.9 compatibility crashes caused by PEP-604 union type syntax (`str | None`, `dict | None`, etc.).

## Root cause

PEP-604 syntax (`X | None`) was introduced in Python 3.10. On Python 3.9, any module using this syntax fails at import time with `TypeError`, which cascades into `ImportError` for dependent modules. The most visible symptom was the `/model` command crashing with:

```
cannot import name 'base_url_host_matches' from 'utils'
```

## Changes

- Added `from __future__ import annotations` to 115 Hermes source files that use PEP-604 union type syntax
- This import defers annotation evaluation, making the `X | None` syntax a string literal at parse time (compatible with 3.9+) rather than a runtime type union (3.10+)
- No functional changes — only import additions, no logic modified

## Testing

- **Python 3.9**: ✅ `utils.base_url_host_matches`, `hermes_cli.model_switch`, `cli.HermesCLI` — all imports succeed
- **Python 3.11**: ✅ Full venv reinstall, import chain works correctly
- **`/model` command**: ✅ No longer throws ImportError

## Backward compatibility

Zero breaking changes. `from __future__ import annotations` is compatible with Python 3.7+ and only affects how type annotations are evaluated (deferred to strings instead of runtime types).

**Type**: bugfix
**Breaking**: no
**Affected areas**: import compatibility, CLI commands