### PR TITLE
fix(prompt): tell CLI agents not to emit MEDIA:/path tags

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -350,7 +350,13 @@ PLATFORM_HINTS = {
     ),
     "cli": (
         "You are a CLI AI Agent. Try not to use markdown but simple text "
-        "renderable inside a terminal."
+        "renderable inside a terminal. "
+        "File delivery: there is no attachment channel — the user reads your "
+        "response directly in their terminal. Do NOT emit MEDIA:/path tags "
+        "(those are only intercepted on messaging platforms like Telegram, "
+        "Discord, Slack, etc.; on the CLI they render as literal text). "
+        "When referring to a file you created or changed, just state its "
+        "absolute path in plain text; the user can open it from there."
     ),
     "sms": (
         "You are communicating via SMS. Keep responses concise and use plain text "

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -789,6 +789,24 @@ class TestPromptBuilderConstants:
         assert "cron" in PLATFORM_HINTS
         assert "cli" in PLATFORM_HINTS
 
+    def test_cli_hint_does_not_suggest_media_tags(self):
+        # Regression: MEDIA:/path tags are intercepted only by messaging
+        # gateway platforms. On the CLI they render as literal text and
+        # confuse users. The CLI hint must steer the agent away from them.
+        cli_hint = PLATFORM_HINTS["cli"]
+        assert "MEDIA:" in cli_hint, (
+            "CLI hint should mention MEDIA: in order to tell the agent "
+            "NOT to use it (negative guidance)."
+        )
+        # Must contain explicit "don't" language near the MEDIA reference.
+        assert any(
+            marker in cli_hint.lower()
+            for marker in ("do not emit media", "not intercepted", "do not", "don't")
+        ), "CLI hint should explicitly discourage MEDIA: tags."
+        # Messaging hints should still advertise MEDIA: positively (sanity
+        # check that this test is calibrated correctly).
+        assert "include MEDIA:" in PLATFORM_HINTS["telegram"]
+
 
 # =========================================================================
 # Environment hints


### PR DESCRIPTION
CLI users no longer see stray `MEDIA:/abs/path` lines in responses when the agent delivers files.

## Root cause
`MEDIA:<path>` tags are only intercepted by messaging gateway platforms (Telegram, Discord, Slack, WhatsApp, Signal, BlueBubbles, email, etc.). On the CLI there is no attachment channel, so those tags render as literal text. The `cli` entry in `PLATFORM_HINTS` was the one platform hint that said nothing about file delivery, while several tool schemas (`browser_tool`, `tts_tool`) generically recommend `MEDIA:<path>` for sharing output — so agents default to that pattern on the CLI too.

## Changes
- `agent/prompt_builder.py`: extend the `cli` platform hint to explicitly state there is no attachment channel, tell the agent not to emit `MEDIA:/path` tags, and point it at plain absolute paths instead.
- `tests/agent/test_prompt_builder.py`: regression test asserting the CLI hint carries negative guidance about `MEDIA:` while messaging hints keep positive guidance.

## Validation
| | Before | After |
|---|---|---|
| CLI hint mentions MEDIA: | no | yes, with "do not" framing |
| `tests/agent/test_prompt_builder.py -k 'platform_hints or cli_hint'` | 1 passed | 2 passed |

Reported live by @teknium1 during a CLI session where the agent included `MEDIA:/abs/path` lines for image outputs and they rendered as raw text.