### PR TITLE
fix(gemini): preserve JSON array tool results in native adapter

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -173,7 +173,12 @@ def _translate_tool_result_to_gemini(
         parsed = json.loads(content) if content.strip().startswith(("{", "[")) else None
     except json.JSONDecodeError:
         parsed = None
-    response = parsed if isinstance(parsed, dict) else {"output": content}
+    if isinstance(parsed, dict):
+        response = parsed
+    elif parsed is not None:
+        response = {"output": parsed}
+    else:
+        response = {"output": content}
     return {
         "functionResponse": {
             "name": name,


### PR DESCRIPTION
## Summary
- Tool results returned as JSON arrays were being dropped and re-serialized as raw strings inside `functionResponse.response.output` in `agent/gemini_native_adapter.py`.
- `_translate_tool_result_to_gemini` only kept `parsed` when it was a `dict`; any other successfully-parsed JSON value (most commonly a list) fell through to `{"output": content}`, where `content` is the original unparsed string.
- Fix keeps dicts as-is, wraps non-dict parsed values (lists, numbers, etc.) in `{"output": parsed}` so the structure survives, and only falls back to the raw string when parsing actually failed.

## Test plan
- [ ] Send a Gemini tool call whose tool returns a JSON array and confirm `functionResponse.response.output` is a list on the wire, not a string.
- [ ] Existing dict-shaped tool results still round-trip unchanged.
- [ ] Non-JSON tool output still falls back to `{"output": "<string>"}`.