### PR TITLE
docs: fix typo 'seperate' → 'separate' in ACL LaTeX template (Closes #13738)

### DIFF
--- a/skills/research/research-paper-writing/templates/acl/acl_lualatex.tex
+++ b/skills/research/research-paper-writing/templates/acl/acl_lualatex.tex
@@ -46,7 +46,7 @@
 % \author{Author 1 \\ Address line \\  ... \\ Address line
 %         \And  ... \And
 %         Author n \\ Address line \\ ... \\ Address line}
-% To start a seperate ``row'' of authors use \AND, as in
+% To start a separate ``row'' of authors use \AND, as in
 % \author{Author 1 \\ Address line \\  ... \\ Address line
 %         \AND
 %         Author 2 \\ Address line \\ ... \\ Address line \And


### PR DESCRIPTION
## Summary
Fix a typo in the ACL LaTeX template comment: 'seperate' → 'separate'.

## Changes
- `skills/research/research-paper-writing/templates/acl/acl_lualatex.tex`: Fix comment typo

Closes #13738