### PR TITLE
fix: add /opt/data/.local/bin to PATH in Docker image (Closes #13739)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,5 +50,6 @@ RUN uv venv && \
 # ---------- Runtime ----------
 ENV HERMES_WEB_DIST=/opt/hermes/hermes_cli/web_dist
 ENV HERMES_HOME=/opt/data
+ENV PATH="/opt/data/.local/bin:${PATH}"
 VOLUME [ "/opt/data" ]
 ENTRYPOINT [ "/opt/hermes/docker/entrypoint.sh" ]


### PR DESCRIPTION
## Summary
Inside the official Docker image, `hermes profile create` creates wrappers at `/opt/data/.local/bin` but that directory is not on PATH, causing `command not found`.

Add `ENV PATH="/opt/data/.local/bin:${PATH}"` so wrappers are discoverable out of the box without touching shell configs.

## Changes
- `Dockerfile`: Add `ENV PATH="/opt/data/.local/bin:${PATH}"`

Closes #13739