### PR TITLE
feat(cron): add configurable header/footer templates (Closes #13771)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -310,23 +310,36 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
     # Optionally wrap the content with a header/footer so the user knows this
     # is a cron delivery.  Wrapping is on by default; set cron.wrap_response: false
-    # in config.yaml for clean output.
+    # in config.yaml for clean output.  When enabled, header_template and
+    # footer_template can be customized (supports {task_name} and {job_id}).
     wrap_response = True
+    header_template = None
+    footer_template = None
     try:
         user_cfg = load_config()
-        wrap_response = user_cfg.get("cron", {}).get("wrap_response", True)
+        cron_cfg = user_cfg.get("cron", {})
+        wrap_response = cron_cfg.get("wrap_response", True)
+        header_template = cron_cfg.get("header_template")
+        footer_template = cron_cfg.get("footer_template")
     except Exception:
         pass
 
     if wrap_response:
         task_name = job.get("name", job["id"])
         job_id = job.get("id", "")
+        # Default templates used when not customized in config.yaml
+        _header = (
+            header_template
+            or "Cronjob Response: {task_name}\n(job_id: {job_id})\n-------------\n\n"
+        )
+        _footer = (
+            footer_template
+            or "\n\nTo stop or manage this job, send me a new message (e.g. \"stop reminder {task_name}\")."
+        )
         delivery_content = (
-            f"Cronjob Response: {task_name}\n"
-            f"(job_id: {job_id})\n"
-            f"-------------\n\n"
-            f"{content}\n\n"
-            f"To stop or manage this job, send me a new message (e.g. \"stop reminder {task_name}\")."
+            _header.format(task_name=task_name, job_id=job_id)
+            + content
+            + _footer.format(task_name=task_name, job_id=job_id)
         )
     else:
         delivery_content = content


### PR DESCRIPTION
## Summary
Add `cron.header_template` and `cron.footer_template` config options so deployments can customize cron delivery wrapper text. Both support `{task_name}` and `{job_id}` placeholders. Empty/false disables that section.

## Config example
```yaml
cron:
  wrap_response: true
  header_template: "Cronjob: {task_name} (id={job_id})\n---\n"
  footer_template: "\n\nReply to manage."
```

## Changes
- `cron/scheduler.py`: Read `header_template`/`footer_template` from config; use `.format()` to fill placeholders; defaults preserve existing wording

Closes #13771