### PR TITLE
fix(doctor): skip /models health check for MiniMax-CN (Closes #13757)

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -920,7 +920,8 @@ def run_doctor(args):
         ("Alibaba/DashScope", ("DASHSCOPE_API_KEY",),                         "https://dashscope-intl.aliyuncs.com/compatible-mode/v1/models", "DASHSCOPE_BASE_URL", True),
         # MiniMax: the /anthropic endpoint doesn't support /models, but the /v1 endpoint does.
         ("MiniMax",          ("MINIMAX_API_KEY",),                            "https://api.minimax.io/v1/models",    "MINIMAX_BASE_URL", True),
-        ("MiniMax (China)",  ("MINIMAX_CN_API_KEY",),                         "https://api.minimaxi.com/v1/models",  "MINIMAX_CN_BASE_URL", True),
+        # MiniMax-CN (api.minimaxi.com) does not have a /models endpoint; skip the health check.
+        ("MiniMax (China)",  ("MINIMAX_CN_API_KEY",),                         None,                                  "MINIMAX_CN_BASE_URL", False),
         ("Vercel AI Gateway",       ("AI_GATEWAY_API_KEY",),                          "https://ai-gateway.vercel.sh/v1/models", "AI_GATEWAY_BASE_URL", True),
         ("Kilo Code",        ("KILOCODE_API_KEY",),                            "https://api.kilo.ai/api/gateway/models",  "KILOCODE_BASE_URL", True),
         ("OpenCode Zen",     ("OPENCODE_ZEN_API_KEY",),                        "https://opencode.ai/zen/v1/models",  "OPENCODE_ZEN_BASE_URL", True),


### PR DESCRIPTION
## Summary
MiniMax-CN (`api.minimaxi.com`) does not have a `/v1/models` endpoint — it returns HTTP 404. The health check was incorrectly configured with a URL and `_supports_health_check=True`, causing a spurious failure.

Follow the same pattern as OpenCode Go: set `url=None` and `_supports_health_check=False` so `hermes doctor` prints `(key configured)` without probing a non-existent endpoint.

## Changes
- `hermes_cli/doctor.py`: MiniMax-CN entry changed from `(url, True)` to `(None, False)`

## Testing
`curl -s -o /dev/null -w "%{http_code}" "https://api.minimaxi.com/v1/models"` → 404
`curl -s -X POST "https://api.minimaxi.com/v1/chat/completions" ...` → 200

Closes #13757