### PR TITLE
fix(auxiliary): preserve 'custom:' prefix in _normalize_aux_provider (Closes #13762)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -83,7 +83,10 @@ def _normalize_aux_provider(provider: Optional[str]) -> str:
         suffix = normalized.split(":", 1)[1].strip()
         if not suffix:
             return "custom"
-        normalized = suffix
+        # Preserve the "custom:" prefix so downstream _get_named_custom_provider
+        # lookups (which check startswith("custom:")) can still match named custom
+        # providers. The suffix is already lowercased by .strip().lower() above.
+        return f"custom:{suffix}"
     if normalized == "codex":
         return "openai-codex"
     if normalized == "main":


### PR DESCRIPTION
## Summary
When `_normalize_aux_provider()` was given `custom:GLM-Aux`, it stripped the `custom:` prefix and returned just `glm-aux`. The downstream `_get_named_custom_provider()` checks `startswith("custom:")`, so named custom providers defined in `config.yaml` were unreachable for auxiliary tasks.

## Fix
Return `f"custom:{suffix}"` (preserving the prefix) instead of `normalized = suffix` (which drops it). The suffix is already lowercased by `.strip().lower()` so behavior is unchanged.

## Changes
- `agent/auxiliary_client.py`: In `_normalize_aux_provider()`, return `f"custom:{suffix}"` instead of reassigning `normalized = suffix`

## How it works
`_get_named_custom_provider` receives `custom:glm-aux` → skips the `AuthError` path (not a built-in) → goes on to match against `f"custom:{name_norm}"` entries from config.yaml.

Closes #13762