### PR TITLE
fix(gemini): accept string-form image_url in multimodal content

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -101,7 +101,13 @@ def _extract_multimodal_parts(content: Any) -> List[Dict[str, Any]]:
             if isinstance(text, str) and text:
                 parts.append({"text": text})
         elif ptype == "image_url":
-            url = ((item.get("image_url") or {}).get("url") or "")
+            image_ref = item.get("image_url")
+            if isinstance(image_ref, dict):
+                url = image_ref.get("url") or ""
+            elif isinstance(image_ref, str):
+                url = image_ref
+            else:
+                continue
             if not isinstance(url, str) or not url.startswith("data:"):
                 continue
             try:


### PR DESCRIPTION
## Summary
- `_extract_multimodal_parts` in `agent/gemini_native_adapter.py` assumed `image_url` on a chat content part was always a dict. When it arrives as a bare string — e.g. `{\"type\": \"image_url\", \"image_url\": \"data:image/png;base64,...\"}` — the line `((item.get(\"image_url\") or {}).get(\"url\") or \"\")` reached `.get(\"url\")` on a string and crashed the whole request with `AttributeError`.
- Hermes treats both shapes (dict and bare string) as valid. `tests/run_agent/test_run_agent_multimodal_prologue.py::test_bare_string_image_url` pins this down, and `agent/codex_responses_adapter.py` handles both defensively.
- Fix: branch on `isinstance(image_ref, dict)` vs `isinstance(image_ref, str)` before reading `.url`, same shape the Codex adapter already uses. Non-dict, non-string `image_url` values are skipped instead of crashing.

## Test plan
- [ ] Send a Gemini native request whose user message contains `{\"type\": \"image_url\", \"image_url\": \"data:image/png;base64,...\"}` and confirm the image is decoded into `inlineData` instead of raising.
- [ ] Existing dict-form `{\"image_url\": {\"url\": \"data:...\"}}` still decodes identically.
- [ ] Non-`data:` URLs (http/https, whether string or dict-form) are still skipped silently — the adapter only supports inline images.