### PR TITLE
fix(models): raise auto-correct cutoff from 0.9 to 0.98 (Closes #13692)

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2214,7 +2214,7 @@ def validate_requested_model(
                 }
 
             # Auto-correct if the top match is very similar (e.g. typo)
-            auto = get_close_matches(requested_for_lookup, api_models, n=1, cutoff=0.9)
+            auto = get_close_matches(requested_for_lookup, api_models, n=1, cutoff=0.98)
             if auto:
                 return {
                     "accepted": True,
@@ -2276,7 +2276,7 @@ def validate_requested_model(
                     "message": None,
                 }
             # Auto-correct if the top match is very similar (e.g. typo)
-            auto = get_close_matches(requested_for_lookup, codex_models, n=1, cutoff=0.9)
+            auto = get_close_matches(requested_for_lookup, codex_models, n=1, cutoff=0.98)
             if auto:
                 return {
                     "accepted": True,
@@ -2318,7 +2318,7 @@ def validate_requested_model(
                 }
             # Auto-correct close matches (case-insensitive)
             catalog_lower_list = list(catalog_lower.keys())
-            auto = get_close_matches(requested_for_lookup.lower(), catalog_lower_list, n=1, cutoff=0.9)
+            auto = get_close_matches(requested_for_lookup.lower(), catalog_lower_list, n=1, cutoff=0.98)
             if auto:
                 corrected = catalog_lower[auto[0]]
                 return {
@@ -2363,7 +2363,7 @@ def validate_requested_model(
             # endpoints even though it's not in /models).  Warn but allow.
 
             # Auto-correct if the top match is very similar (e.g. typo)
-            auto = get_close_matches(requested_for_lookup, api_models, n=1, cutoff=0.9)
+            auto = get_close_matches(requested_for_lookup, api_models, n=1, cutoff=0.98)
             if auto:
                 return {
                     "accepted": True,
@@ -2452,7 +2452,7 @@ def validate_requested_model(
             }
         catalog_lower_list = list(catalog_lower.keys())
         auto = get_close_matches(
-            requested_for_lookup.lower(), catalog_lower_list, n=1, cutoff=0.9
+            requested_for_lookup.lower(), catalog_lower_list, n=1, cutoff=0.98
         )
         if auto:
             corrected = catalog_lower[auto[0]]


### PR DESCRIPTION
## Summary
Raise the `get_close_matches` auto-correct cutoff from `0.9` to `0.98` across 5 `n=1` calls in `hermes_cli/models.py`.

## Why
At `cutoff=0.9`, consecutive version IDs like `kimi-k2p6` and `kimi-k2p5` (similarity **0.971**) trigger false-positive auto-correct — the user requests K2.6 but silently gets K2.5. Raising to `0.98` stops this while still catching single-char typos (similarity ~0.94 falls through to suggestion path instead).

## Changes
- `hermes_cli/models.py`: 5 `cutoff=0.9` → `cutoff=0.98` on `n=1` auto-correct calls (custom provider path, OpenAI Codex path, catalog fallback ×2)
- `n=3` suggestion calls left at `0.5`/`0.4` cutoff — unchanged

## Testing
`cutoff=0.9` + `kimi-k2p6` → `kimi-k2p5` (wrong)  
`cutoff=0.98` + `kimi-k2p6` → `Note: not found` + suggestions (correct)

Closes #13692