### PR TITLE
fix(gateway): accept explicit null home_channel in PlatformConfig.from_dict (Closes #13721)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -174,7 +174,7 @@ class PlatformConfig:
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "PlatformConfig":
         home_channel = None
-        if "home_channel" in data:
+        if data.get("home_channel") is not None:
             home_channel = HomeChannel.from_dict(data["home_channel"])
         
         return cls(


### PR DESCRIPTION
## Summary
`PlatformConfig.from_dict()` crashed with `TypeError: 'NoneType' object is not subscriptable` when a YAML config explicitly sets `home_channel: null`.

**Root cause:** The guard `if "home_channel" in data` is `True` for null values, so it passes `None` to `HomeChannel.from_dict()` which subscripts it like a dict.

**Fix:** Switch to `if data.get("home_channel") is not None` so explicit `null` is treated the same as an absent key.

## Changes
- `gateway/config.py`: one-line guard change in `PlatformConfig.from_dict`

## Testing
YAML that previously crashed:
```yaml
platforms:
  telegram:
    enabled: true
    home_channel: null
```

Closes #13721