### PR TITLE
fix(cli): suppress OSError EIO during interrupt shutdown (Closes #13720)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -22,6 +22,7 @@ import re
 import concurrent.futures
 import base64
 import atexit
+import errno
 import tempfile
 import time
 import uuid
@@ -10659,7 +10660,7 @@ class HermesCLI:
         except (KeyError, OSError) as _stdin_err:
             # Catch selector registration failures from broken stdin (#6393).
             # This is the fallback for cases that slip past the fstat() guard.
-            if "is not registered" in str(_stdin_err) or "Bad file descriptor" in str(_stdin_err):
+            if "is not registered" in str(_stdin_err) or "Bad file descriptor" in str(_stdin_err) or getattr(_stdin_err, "errno", 0) == errno.EIO:
                 print(
                     f"\nError: stdin is not usable ({_stdin_err}).\n"
                     "This can happen with certain Python installations (e.g. uv-managed cPython on macOS).\n"


### PR DESCRIPTION
## Summary
When the user interrupts a long-running task, prompt_toolkit flushes stdout. If stdout is in a broken state (pipe closed, terminal gone), this raises `OSError` with `errno.EIO` — which crashed the CLI.

**Root cause:** The `except (KeyError, OSError)` block at `cli.py:~10660` only handled `"is not registered"` and `"Bad file descriptor"` string checks. `errno.EIO` fell through to `raise`, crashing the CLI with `OSError: [Errno 5] Input/output error`.

**Fix:** Add `getattr(_stdin_err, "errno", 0) == errno.EIO` to the condition so EIO errors are silently suppressed instead of raised.

## Changes
- `cli.py`: Add `errno` import + EIO check in the `except (KeyError, OSError)` handler

## Testing
Simulate: run a long task, interrupt with Ctrl+C while stdout is broken → no crash

Closes #13720