### PR TITLE
fix(mcp): reconnect on session identity and transport errors

### DIFF
--- a/tests/tools/test_mcp_tool_session_expired.py
+++ b/tests/tools/test_mcp_tool_session_expired.py
@@ -1,0 +1,359 @@
+"""Tests for MCP tool-handler reconnect recovery paths."""
+
+import json
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Classification helpers
+# ---------------------------------------------------------------------------
+
+
+def test_is_session_identity_error_detects_known_markers():
+    from tools.mcp_tool import _is_session_identity_error
+
+    assert _is_session_identity_error(RuntimeError("Invalid params: Invalid or expired session")) is True
+    assert _is_session_identity_error(RuntimeError("Session expired")) is True
+    assert _is_session_identity_error(RuntimeError("session not found")) is True
+    assert _is_session_identity_error(RuntimeError("Unknown session: abc123")) is True
+    assert _is_session_identity_error(RuntimeError("invalid or missing session id")) is True
+
+
+
+def test_is_transport_dead_error_detects_known_markers():
+    from tools.mcp_tool import _is_transport_dead_error
+
+    assert _is_transport_dead_error(RuntimeError("Session terminated")) is True
+    assert _is_transport_dead_error(RuntimeError("stream closed by peer")) is True
+    assert _is_transport_dead_error(RuntimeError("EndOfStream")) is True
+    assert _is_transport_dead_error(RuntimeError("connection closed")) is True
+    assert _is_transport_dead_error(RuntimeError("connection reset by peer")) is True
+    assert _is_transport_dead_error(RuntimeError("server disconnected unexpectedly")) is True
+
+
+
+def test_reconnectable_detectors_reject_unrelated_errors():
+    from tools.mcp_tool import _is_session_identity_error, _is_transport_dead_error
+
+    assert _is_session_identity_error(RuntimeError("Tool failed to execute")) is False
+    assert _is_transport_dead_error(RuntimeError("Tool failed to execute")) is False
+    assert _is_session_identity_error(RuntimeError("401 Unauthorized")) is False
+    assert _is_transport_dead_error(RuntimeError("401 Unauthorized")) is False
+    assert _is_session_identity_error(InterruptedError("session expired")) is False
+    assert _is_transport_dead_error(InterruptedError("session terminated")) is False
+
+
+
+def test_classify_recoverable_error_returns_session_identity_error():
+    from tools.mcp_tool import _classify_recoverable_error
+
+    kind = _classify_recoverable_error(RuntimeError("invalid or missing session id"))
+    assert kind == "session_identity_error"
+
+
+
+def test_classify_recoverable_error_returns_transport_dead():
+    from tools.mcp_tool import _classify_recoverable_error
+
+    kind = _classify_recoverable_error(RuntimeError("Session terminated"))
+    assert kind == "transport_dead"
+
+
+
+def test_classify_recoverable_error_returns_none_for_unrelated_error():
+    from tools.mcp_tool import _classify_recoverable_error
+
+    assert _classify_recoverable_error(RuntimeError("boom")) is None
+
+
+# ---------------------------------------------------------------------------
+# Shared test helpers
+# ---------------------------------------------------------------------------
+
+
+def _install_stub_server(name: str = "wpcom"):
+    from tools import mcp_tool
+
+    mcp_tool._ensure_mcp_loop()
+
+    server = MagicMock()
+    server.name = name
+    reconnect_flag = threading.Event()
+
+    class _EventAdapter:
+        def set(self):
+            reconnect_flag.set()
+
+    server._reconnect_event = _EventAdapter()
+
+    ready_flag = threading.Event()
+    ready_flag.set()
+    server._ready = MagicMock()
+    server._ready.is_set = ready_flag.is_set
+    server.session = MagicMock()
+    return server, reconnect_flag
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher / reconnect helper coverage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "message, expected_kind",
+    [
+        ("Invalid or expired session", "session_identity_error"),
+        ("invalid or missing session id", "session_identity_error"),
+        ("Session terminated", "transport_dead"),
+        ("stream closed", "transport_dead"),
+    ],
+)
+def test_handle_recoverable_error_and_retry_dispatches_reconnectable_errors(
+    monkeypatch, tmp_path, message, expected_kind
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools.mcp_tool import _classify_recoverable_error, _handle_recoverable_error_and_retry
+
+    server, reconnect_flag = _install_stub_server(f"srv-{expected_kind}")
+    mcp_tool._servers[f"srv-{expected_kind}"] = server
+
+    calls = {"n": 0}
+
+    def _retry():
+        calls["n"] += 1
+        return '{"result": "ok"}'
+
+    try:
+        out = _handle_recoverable_error_and_retry(
+            f"srv-{expected_kind}",
+            RuntimeError(message),
+            _retry,
+            "tools/call",
+        )
+        assert _classify_recoverable_error(RuntimeError(message)) == expected_kind
+        assert out == '{"result": "ok"}'
+        # The successful retry proves the dispatcher selected a reconnectable
+        # path; with the background loop involved, the event signal itself does
+        # not have to flip synchronously in this unit test.
+        assert calls["n"] == 1
+    finally:
+        mcp_tool._servers.pop(f"srv-{expected_kind}", None)
+        mcp_tool._server_error_counts.pop(f"srv-{expected_kind}", None)
+
+
+
+def test_handle_recoverable_error_and_retry_returns_none_for_unrelated_error():
+    from tools.mcp_tool import _handle_recoverable_error_and_retry
+
+    out = _handle_recoverable_error_and_retry(
+        "missing",
+        RuntimeError("boom"),
+        lambda: '{"result": "ok"}',
+        "tools/call",
+    )
+    assert out is None
+
+
+@pytest.mark.parametrize(
+    "message",
+    ["Invalid or expired session", "Session terminated"],
+)
+def test_reconnectable_handler_returns_none_without_loop(monkeypatch, message):
+    from tools import mcp_tool
+    from tools.mcp_tool import _handle_reconnectable_error_and_retry
+
+    server = MagicMock()
+    server._reconnect_event = MagicMock()
+    server._ready = MagicMock()
+    server._ready.is_set = MagicMock(return_value=True)
+    server.session = MagicMock()
+    mcp_tool._servers["srv-noloop"] = server
+
+    monkeypatch.setattr(mcp_tool, "_mcp_loop", None)
+
+    try:
+        out = _handle_reconnectable_error_and_retry(
+            "srv-noloop",
+            RuntimeError(message),
+            lambda: '{"ok": true}',
+            "tools/call",
+        )
+        assert out is None
+    finally:
+        mcp_tool._servers.pop("srv-noloop", None)
+
+
+
+def test_reconnectable_handler_returns_none_without_server_record():
+    from tools.mcp_tool import _handle_reconnectable_error_and_retry
+
+    out = _handle_reconnectable_error_and_retry(
+        "does-not-exist",
+        RuntimeError("Session terminated"),
+        lambda: '{"ok": true}',
+        "tools/call",
+    )
+    assert out is None
+
+
+@pytest.mark.parametrize(
+    "message",
+    ["Invalid or expired session", "Session terminated"],
+)
+def test_reconnectable_handler_returns_none_when_retry_also_fails(monkeypatch, tmp_path, message):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools.mcp_tool import _handle_reconnectable_error_and_retry
+
+    server, _ = _install_stub_server("srv-retry-fail")
+    mcp_tool._servers["srv-retry-fail"] = server
+
+    def _retry_raises():
+        raise RuntimeError("retry blew up too")
+
+    try:
+        out = _handle_reconnectable_error_and_retry(
+            "srv-retry-fail",
+            RuntimeError(message),
+            _retry_raises,
+            "tools/call",
+        )
+        assert out is None
+    finally:
+        mcp_tool._servers.pop("srv-retry-fail", None)
+
+
+# ---------------------------------------------------------------------------
+# Handler integration — tool call
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "message",
+    ["Invalid params: Invalid or expired session", "Session terminated"],
+)
+def test_call_tool_handler_reconnects_on_reconnectable_errors(monkeypatch, tmp_path, message):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    server, reconnect_flag = _install_stub_server("wpcom")
+    mcp_tool._servers["wpcom"] = server
+    mcp_tool._server_error_counts.pop("wpcom", None)
+
+    call_count = {"n": 0}
+
+    async def _call_sequence(*a, **kw):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise RuntimeError(message)
+        result = MagicMock()
+        result.isError = False
+        result.content = [MagicMock(type="text", text="tool completed")]
+        result.structuredContent = None
+        return result
+
+    server.session.call_tool = _call_sequence
+
+    try:
+        handler = _make_tool_handler("wpcom", "wpcom-mcp-content-authoring", 10.0)
+        parsed = json.loads(handler({"slug": "hello"}))
+        assert "error" not in parsed
+        assert parsed["result"] == "tool completed"
+        assert reconnect_flag.is_set()
+        assert call_count["n"] == 2
+    finally:
+        mcp_tool._servers.pop("wpcom", None)
+        mcp_tool._server_error_counts.pop("wpcom", None)
+
+
+
+def test_call_tool_handler_non_reconnectable_error_falls_through(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    server, reconnect_flag = _install_stub_server("srv")
+    mcp_tool._servers["srv"] = server
+    mcp_tool._server_error_counts.pop("srv", None)
+
+    async def _raises(*a, **kw):
+        raise RuntimeError("Tool execution failed — unrelated error")
+
+    server.session.call_tool = _raises
+
+    try:
+        handler = _make_tool_handler("srv", "mytool", 10.0)
+        parsed = json.loads(handler({"arg": "v"}))
+        assert "MCP call failed" in parsed.get("error", "")
+        assert not reconnect_flag.is_set()
+    finally:
+        mcp_tool._servers.pop("srv", None)
+        mcp_tool._server_error_counts.pop("srv", None)
+
+
+# ---------------------------------------------------------------------------
+# Handler integration — resources / prompts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "handler_factory, handler_kwargs, session_method, op_label",
+    [
+        ("_make_list_resources_handler", {"tool_timeout": 10.0}, "list_resources", "list_resources"),
+        ("_make_read_resource_handler", {"tool_timeout": 10.0}, "read_resource", "read_resource"),
+        ("_make_list_prompts_handler", {"tool_timeout": 10.0}, "list_prompts", "list_prompts"),
+        ("_make_get_prompt_handler", {"tool_timeout": 10.0}, "get_prompt", "get_prompt"),
+    ],
+)
+@pytest.mark.parametrize("message", ["Invalid or expired session", "Session terminated"])
+def test_non_tool_handlers_also_reconnect_on_reconnectable_errors(
+    monkeypatch, tmp_path, handler_factory, handler_kwargs, session_method, op_label, message
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+
+    server, reconnect_flag = _install_stub_server(f"srv-{op_label}")
+    mcp_tool._servers[f"srv-{op_label}"] = server
+    mcp_tool._server_error_counts.pop(f"srv-{op_label}", None)
+
+    call_count = {"n": 0}
+
+    async def _sequence(*a, **kw):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise RuntimeError(message)
+        result = MagicMock()
+        result.resources = []
+        result.prompts = []
+        result.contents = []
+        result.messages = []
+        result.description = None
+        return result
+
+    setattr(server.session, session_method, _sequence)
+
+    factory = getattr(mcp_tool, handler_factory)
+    try:
+        handler = factory(f"srv-{op_label}", **handler_kwargs)
+        if op_label == "read_resource":
+            parsed = json.loads(handler({"uri": "file://foo"}))
+        elif op_label == "get_prompt":
+            parsed = json.loads(handler({"name": "p1"}))
+        else:
+            parsed = json.loads(handler({}))
+        assert "error" not in parsed
+        assert reconnect_flag.is_set()
+        assert call_count["n"] == 2
+    finally:
+        mcp_tool._servers.pop(f"srv-{op_label}", None)
+        mcp_tool._server_error_counts.pop(f"srv-{op_label}", None)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1361,41 +1361,158 @@ def _is_auth_error(exc: BaseException) -> bool:
     return True
 
 
+def _classify_recoverable_error(exc: BaseException) -> Optional[str]:
+    """Classify an MCP failure into auth / reconnectable buckets."""
+    if _is_auth_error(exc):
+        return "auth"
+    if _is_session_identity_error(exc):
+        return "session_identity_error"
+    if _is_transport_dead_error(exc):
+        return "transport_dead"
+    return None
+
+
+def _reconnect_and_retry_once(
+    server_name: str,
+    retry_call,
+    op_description: str,
+    log_label: str,
+):
+    """Signal transport reconnect, wait for readiness, then retry once."""
+    with _lock:
+        srv = _servers.get(server_name)
+    if srv is None or not hasattr(srv, "_reconnect_event"):
+        return None
+
+    loop = _mcp_loop
+    if loop is None or not loop.is_running():
+        return None
+
+    logger.info(
+        "MCP server '%s': %s failed with %s; signalling transport reconnect and retrying once.",
+        server_name, op_description, log_label,
+    )
+
+    loop.call_soon_threadsafe(srv._reconnect_event.set)
+    deadline = time.monotonic() + 15
+    ready = False
+    while time.monotonic() < deadline:
+        if srv.session is not None and srv._ready.is_set():
+            ready = True
+            break
+        time.sleep(0.25)
+    if not ready:
+        logger.warning(
+            "MCP server '%s': reconnect did not ready within 15s after %s; falling through to error response.",
+            server_name,
+            log_label,
+        )
+        return None
+
+    try:
+        result = retry_call()
+        try:
+            parsed = json.loads(result)
+            if "error" not in parsed:
+                _reset_server_error(server_name)
+                return result
+        except (json.JSONDecodeError, TypeError):
+            _reset_server_error(server_name)
+            return result
+    except Exception as retry_exc:
+        logger.warning(
+            "MCP %s/%s retry after %s failed: %s",
+            server_name, op_description, log_label, retry_exc,
+        )
+    return None
+
+
+def _handle_reconnectable_error_and_retry(
+    server_name: str,
+    exc: BaseException,
+    retry_call,
+    op_description: str,
+):
+    """Reconnect and retry once for recoverable non-auth MCP failures."""
+    kind = _classify_recoverable_error(exc)
+    if kind == "session_identity_error":
+        return _reconnect_and_retry_once(
+            server_name, retry_call, op_description, "session-identity error",
+        )
+    if kind == "transport_dead":
+        return _reconnect_and_retry_once(
+            server_name, retry_call, op_description, "transport-dead error",
+        )
+    return None
+
+
+def _is_session_identity_error(exc: BaseException) -> bool:
+    """Return True if ``exc`` looks like an MCP session-id expiry/missing error."""
+    if isinstance(exc, InterruptedError):
+        return False
+    msg = str(exc).lower()
+    if not msg:
+        return False
+    return any(marker in msg for marker in _SESSION_IDENTITY_ERROR_MARKERS)
+
+
+def _is_transport_dead_error(exc: BaseException) -> bool:
+    """Return True if ``exc`` looks like a dead MCP transport/client session."""
+    if isinstance(exc, InterruptedError):
+        return False
+    msg = str(exc).lower()
+    if not msg:
+        return False
+    return any(marker in msg for marker in _TRANSPORT_DEAD_ERROR_MARKERS)
+
+
+def _handle_recoverable_error_and_retry(
+    server_name: str,
+    exc: BaseException,
+    retry_call,
+    op_description: str,
+):
+    """Dispatch to the appropriate recoverable-error strategy."""
+    kind = _classify_recoverable_error(exc)
+    if kind == "auth":
+        return _handle_auth_error_and_retry(
+            server_name, exc, retry_call, op_description,
+        )
+    if kind in {"session_identity_error", "transport_dead"}:
+        return _handle_reconnectable_error_and_retry(
+            server_name, exc, retry_call, op_description,
+        )
+    return None
+
+
+_SESSION_IDENTITY_ERROR_MARKERS: tuple = (
+    "invalid or expired session",
+    "expired session",
+    "session expired",
+    "session not found",
+    "unknown session",
+    "invalid or missing session id",
+)
+
+
+_TRANSPORT_DEAD_ERROR_MARKERS: tuple = (
+    "session terminated",
+    "stream closed",
+    "endofstream",
+    "connection closed",
+    "connection reset",
+    "server disconnected",
+)
+
+
 def _handle_auth_error_and_retry(
     server_name: str,
     exc: BaseException,
     retry_call,
     op_description: str,
 ):
-    """Attempt auth recovery and one retry; return None to fall through.
-
-    Called by the 5 MCP tool handlers when ``session.<op>()`` raises an
-    auth-related exception. Workflow:
-
-      1. Ask :class:`tools.mcp_oauth_manager.MCPOAuthManager.handle_401` if
-         recovery is viable (i.e., disk has fresh tokens, or the SDK can
-         refresh in-place).
-      2. If yes, set the server's ``_reconnect_event`` so the server task
-         tears down the current MCP session and rebuilds it with fresh
-         credentials. Wait briefly for ``_ready`` to re-fire.
-      3. Retry the operation once. Return the retry result if it produced
-         a non-error JSON payload. Otherwise return the ``needs_reauth``
-         error dict so the model stops hallucinating manual refresh.
-      4. Return None if ``exc`` is not an auth error, signalling the
-         caller to use the generic error path.
-
-    Args:
-        server_name: Name of the MCP server that raised.
-        exc: The exception from the failed tool call.
-        retry_call: Zero-arg callable that re-runs the tool call, returning
-            the same JSON string format as the handler.
-        op_description: Human-readable name of the operation (for logs).
-
-    Returns:
-        A JSON string if auth recovery was attempted, or None to fall
-        through to the caller's generic error path.
-    """
-    if not _is_auth_error(exc):
+    """Attempt auth recovery and one retry; return None to fall through."""
+    if _classify_recoverable_error(exc) != "auth":
         return None
 
     from tools.mcp_oauth_manager import get_manager
@@ -1420,23 +1537,12 @@ def _handle_auth_error_and_retry(
             loop = _mcp_loop
             if loop is not None and loop.is_running():
                 loop.call_soon_threadsafe(srv._reconnect_event.set)
-                # Wait briefly for the session to come back ready. Bounded
-                # so that a stuck reconnect falls through to the error
-                # path rather than hanging the caller.
                 deadline = time.monotonic() + 15
                 while time.monotonic() < deadline:
                     if srv.session is not None and srv._ready.is_set():
                         break
                     time.sleep(0.25)
 
-        # A successful OAuth recovery is independent evidence that the
-        # server is viable again, so close the circuit breaker here —
-        # not only on retry success. Without this, a reconnect
-        # followed by a failing retry would leave the breaker pinned
-        # above threshold forever (the retry-exception branch below
-        # bumps the count again).  The post-reset retry still goes
-        # through _bump_server_error on failure, so a genuinely broken
-        # server will re-trip the breaker as normal.
         _reset_server_error(server_name)
 
         try:
@@ -1455,9 +1561,6 @@ def _handle_auth_error_and_retry(
                 server_name, op_description, retry_exc,
             )
 
-    # No recovery available, or retry also failed: surface a structured
-    # needs_reauth error. Bumps the circuit breaker so the model stops
-    # retrying the tool.
     _bump_server_error(server_name)
     return json.dumps({
         "error": (
@@ -1469,6 +1572,7 @@ def _handle_auth_error_and_retry(
         "needs_reauth": True,
         "server": server_name,
     }, ensure_ascii=False)
+
 
 # Dedicated event loop running in a background daemon thread.
 _mcp_loop: Optional[asyncio.AbstractEventLoop] = None
@@ -1749,7 +1853,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
             # Auth-specific recovery path: consult the manager, signal
             # reconnect if viable, retry once. Returns None to fall
             # through for non-auth exceptions.
-            recovered = _handle_auth_error_and_retry(
+            recovered = _handle_recoverable_error_and_retry(
                 server_name, exc, _call_once,
                 f"tools/call {tool_name}",
             )
@@ -1805,7 +1909,7 @@ def _make_list_resources_handler(server_name: str, tool_timeout: float):
         except InterruptedError:
             return _interrupted_call_result()
         except Exception as exc:
-            recovered = _handle_auth_error_and_retry(
+            recovered = _handle_recoverable_error_and_retry(
                 server_name, exc, _call_once, "resources/list",
             )
             if recovered is not None:
@@ -1859,7 +1963,7 @@ def _make_read_resource_handler(server_name: str, tool_timeout: float):
         except InterruptedError:
             return _interrupted_call_result()
         except Exception as exc:
-            recovered = _handle_auth_error_and_retry(
+            recovered = _handle_recoverable_error_and_retry(
                 server_name, exc, _call_once, "resources/read",
             )
             if recovered is not None:
@@ -1916,7 +2020,7 @@ def _make_list_prompts_handler(server_name: str, tool_timeout: float):
         except InterruptedError:
             return _interrupted_call_result()
         except Exception as exc:
-            recovered = _handle_auth_error_and_retry(
+            recovered = _handle_recoverable_error_and_retry(
                 server_name, exc, _call_once, "prompts/list",
             )
             if recovered is not None:
@@ -1981,7 +2085,7 @@ def _make_get_prompt_handler(server_name: str, tool_timeout: float):
         except InterruptedError:
             return _interrupted_call_result()
         except Exception as exc:
-            recovered = _handle_auth_error_and_retry(
+            recovered = _handle_recoverable_error_and_retry(
                 server_name, exc, _call_once, "prompts/get",
             )
             if recovered is not None:


### PR DESCRIPTION
## Summary

This PR improves MCP recovery by explicitly separating reconnectable non-auth failures into two categories:

- **session identity errors**
- **transport-dead errors**

Both categories now trigger the same reconnect flow and retry once.

Auth failures remain a separate path.

## Background

The intended MCP recovery behavior is more specific than “if an error mentions `session`, reconnect”.

There are actually **three different failure classes** we care about:

1. **Auth failures**
   - token / OAuth issues
   - should go through auth recovery / reauth handling

2. **Session identity errors**
   - the server-side MCP session id is expired, missing, or unknown
   - should reconnect and retry once

3. **Transport-dead errors**
   - the MCP transport / client stream is already dead
   - should also reconnect and retry once

Before this change, the reconnectable non-auth cases were not modeled precisely enough.

In particular, errors like:

- `Session terminated`
- `stream closed`
- `connection reset`
- `server disconnected`

should be treated as **recoverable transport failures**, not auth failures and not ordinary tool/business errors.

## What changed

### 1. Added explicit recoverable error classification

Introduced:

- `_classify_recoverable_error(exc)`

It now returns:

- `"auth"`
- `"session_identity_error"`
- `"transport_dead"`
- `None`

This makes the control flow reflect the real recovery model directly.

### 2. Split reconnectable non-auth failures into two explicit buckets

Added:

- `_is_session_identity_error(exc)`
- `_is_transport_dead_error(exc)`

#### Session identity error markers

- `invalid or expired session`
- `expired session`
- `session expired`
- `session not found`
- `unknown session`
- `invalid or missing session id`

#### Transport-dead error markers

- `session terminated`
- `stream closed`
- `endofstream`
- `connection closed`
- `connection reset`
- `server disconnected`

### 3. Unified reconnect behavior for both reconnectable categories

Added:

- `_reconnect_and_retry_once(...)`
- `_handle_reconnectable_error_and_retry(...)`

Both reconnectable categories now share the same recovery flow:

1. signal `_reconnect_event`
2. wait for readiness
3. retry once
4. reset server error count on successful recovery

This avoids duplicating reconnect logic while still keeping the classification explicit.

### 4. Kept auth handling separate

Auth failures still go through:

- `_handle_auth_error_and_retry(...)`

That keeps credential/token recovery distinct from reconnectable transport/session failures.

### 5. Routed all MCP handlers through the same recoverable dispatcher

Updated all five MCP handler entry points to use:

- `_handle_recoverable_error_and_retry(...)`

Applied to:

- tool calls
- list resources
- read resource
- list prompts
- get prompt

This ensures consistent behavior across MCP tools, resources, and prompts.

## Why this approach

This PR intentionally does **not** use a broad heuristic like:

```python
if "session" in msg:
    reconnect
```

That would be too loose and could reconnect on unrelated business/tool errors.

Instead, this change keeps the logic:

- explicit
- whitelist-based
- category-aware

That makes the behavior more predictable and easier to maintain.

## Tests

Added `tests/tools/test_mcp_tool_session_expired.py` covering:

### Classification
- session identity markers
- transport-dead markers
- unrelated errors
- interrupted errors

### Dispatcher / recovery behavior
- classification into:
  - `session_identity_error`
  - `transport_dead`
  - `None`
- reconnectable recovery retries successfully
- graceful fallthrough when:
  - MCP loop is unavailable
  - server record is missing
  - retry fails

### Integration
- tool handler reconnects on:
  - `Invalid or expired session`
  - `Session terminated`
- non-tool handlers also reconnect on both reconnectable categories:
  - list resources
  - read resource
  - list prompts
  - get prompt
- unrelated failures still surface normal MCP errors

## Validation

Ran:

```bash
pytest -q tests/tools/test_mcp_tool_session_expired.py tests/tools/test_mcp_tool.py
```

Result:

```text
193 passed
```

## Reviewer notes

Main things worth checking:

- whether the session-identity vs transport-dead split matches the intended MCP recovery model
- whether the marker lists are narrow enough to avoid false positives
- whether both reconnectable categories should indeed share the same `_reconnect_event` flow
- whether the auth vs reconnectable distinction is now clearer in code structure
