### PR TITLE
fix: improve Telegram topic fallback and gateway runtime diagnostics

### DIFF
--- a/.plans/session-2026-04-18-0108.md
+++ b/.plans/session-2026-04-18-0108.md
@@ -1,0 +1,57 @@
+# Registro de sessão — 2026-04-18 01:08 -03
+
+Contexto
+- Solicitação inicial: executar `hermes update`
+- Ambiente: instância Hermes no macOS com gateway via launchd e wrapper Keychain
+
+O que foi feito
+1. Executei `hermes update`
+2. Detectei conflito na restauração automática do stash em `uv.lock`
+3. Inspecionei o stash preservado pelo update
+4. Reapliquei as mudanças locais no repo `~/.hermes/hermes-agent`
+5. Resolvi o conflito de `uv.lock` mantendo compatibilidade com `pyproject.toml`
+6. Regenerei o lock com `uv lock`
+7. Revalidei o gateway e corrigi a divergência do LaunchAgent com `hermes gateway start`
+8. Confirmei preservação do wrapper Keychain no LaunchAgent
+9. Verifiquei que `telegram` ficou `connected`
+10. Revisei o diff staged e identifiquei o escopo real das mudanças
+11. Analisei consistência do pacote `skill_intake`
+12. Corrigi o contrato/schema de `skill_intake` para refletir os quatro modos suportados
+13. Tornei o teste `test_skill_intake_plugin_local.py` hermético, removendo dependência de `~/.hermes/plugins`
+14. Reexecutei os testes relevantes
+15. Adicionei os arquivos ao index e criei commit local
+16. Preparei mensagem de PR em `.plans/skill-intake-pr-message.md`
+
+Resultados verificados
+- Gateway:
+  - LaunchAgent carregado
+  - definição compatível com a instalação atual
+  - `Program` aponta para `~/.hermes/scripts/hermes-with-keychain.sh`
+- Estado do gateway:
+  - `telegram.state = connected`
+- Testes:
+  - `tests/hermes_cli/test_commands.py`: 111 passed
+  - suíte `skill_intake`: 26 passed
+
+Commit criado
+- SHA: `65785ad0`
+- Mensagem: `fix: harden skill intake contract and tests`
+
+Observação importante
+- O commit ficou mais amplo do que apenas `skill_intake`.
+- Escopo real incluído no commit:
+  - `skill_intake`
+  - preservação do wrapper Keychain no gateway macOS
+  - descoberta de plugin slash commands
+  - limpeza residual do WhatsApp bridge
+  - updates de lockfiles
+
+Arquivos de apoio gerados
+- `.plans/skill-intake-pr-message.md`
+- este registro: `.plans/session-2026-04-18-0108.md`
+
+Pendências em aberto
+- Existem arquivos untracked em `.plans/` que ainda não foram commitados
+- Se houver intenção de abrir PR limpo, o ideal é considerar separar o commit amplo em 2 PRs:
+  - PR A: `skill_intake`
+  - PR B: gateway macOS + plugin discovery + cleanup operacional

--- a/.plans/skill-intake-commit-plan.md
+++ b/.plans/skill-intake-commit-plan.md
@@ -1,0 +1,121 @@
+# skill_intake — Suggested Commit Sequence
+
+## Goal
+
+Break the work into reviewable commits that preserve the story of the feature:
+- architecture and docs first
+- audit pipeline next
+- conversion and traceability next
+- governance and integration last
+
+## Suggested commit sequence
+
+### Commit 1
+`docs: add skill_intake architecture and planning artifacts`
+
+Files:
+- `.plans/skill-intake-pipeline.md`
+- `.plans/skill-intake/output-schema.json`
+- `.plans/skill-intake/policy-matrix.md`
+- sample result JSONs
+- `.plans/skill-intake-v2-summary.md`
+- `.plans/skill-intake-readme.md`
+- `.plans/skill-intake-pr-ready-summary.md`
+- `.plans/skill-intake-v2.1-plan.md`
+- `.plans/skill-intake-delivery-package.md`
+
+### Commit 2
+`feat: add skill_intake audit tool and toolset integration`
+
+Files:
+- `tools/skill_intake_tool.py` (initial audit mode)
+- `toolsets.py`
+- `tests/tools/test_skill_intake_tool.py` (audit-focused baseline)
+
+### Commit 3
+`feat: support remote GitHub/raw audit provenance in skill_intake`
+
+Files:
+- `tools/skill_intake_tool.py`
+- `tests/tools/test_skill_intake_tool.py`
+
+Focus:
+- remote classification
+- remote fetch attempts
+- provenance baseline
+
+### Commit 4
+`feat: add generic skill conversion pipeline to skill_intake`
+
+Files:
+- `tools/skill_intake_tool.py`
+- `tests/tools/test_skill_intake_tool.py`
+
+Focus:
+- convert mode
+- generated draft skill
+- mapping/discarded basics
+- out_dir persistence
+
+### Commit 5
+`feat: add re-audit and admit stages to skill_intake`
+
+Files:
+- `tools/skill_intake_tool.py`
+- `tests/tools/test_skill_intake_tool.py`
+
+Focus:
+- re-audit
+- readiness
+- policy gate
+- admit mode
+
+### Commit 6
+`feat: refine generic conversion semantics for skill_intake`
+
+Files:
+- `tools/skill_intake_tool.py`
+- `tests/tools/test_skill_intake_tool.py`
+
+Focus:
+- section inference
+- prerequisites
+- commands
+- examples
+- pitfalls / verification
+- temporary-context discard improvements
+
+### Commit 7
+`feat: support OpenClaw-like packages in skill_intake convert`
+
+Files:
+- `tools/skill_intake_tool.py`
+- `tests/tools/test_skill_intake_tool.py`
+
+Focus:
+- detect OpenClaw-like package
+- preserve `scripts/` and `references/`
+- mapping for preserved assets
+
+### Commit 8
+`test: add integration coverage for skill_intake pipeline`
+
+Files:
+- `tests/tools/test_skill_intake_tool_integration.py`
+
+Focus:
+- generic end-to-end flow
+- OpenClaw-like end-to-end flow
+
+## If you want a shorter sequence
+
+Condensed version:
+1. docs/spec
+2. audit + remote provenance
+3. convert + out_dir + generic refinement
+4. re-audit + admit
+5. OpenClaw-like + integration tests
+
+## Review recommendation
+
+If opening as one PR, still preserve the sequence in the PR description as milestones so reviewers can follow the evolution.

--- a/.plans/skill-intake-delivery-package.md
+++ b/.plans/skill-intake-delivery-package.md
@@ -1,0 +1,133 @@
+# skill_intake — Delivery Package Index
+
+## Executive conclusion
+
+The `skill_intake` V2 baseline is functionally complete and documented.
+
+This package indexes the main artifacts produced during the build-out so review, handoff, and next-phase planning are straightforward.
+
+---
+
+## Core implementation
+
+### Tool implementation
+- `tools/skill_intake_tool.py`
+
+What it contains:
+- `audit`
+- `convert`
+- `re-audit`
+- `admit`
+- generic conversion heuristics
+- OpenClaw-like package support
+- provenance
+- policy gate
+
+---
+
+## Test coverage
+
+### Unit / focused tests
+- `tests/tools/test_skill_intake_tool.py`
+
+Covers:
+- audit local / remote basics
+- generic conversion
+- prerequisites / commands / examples extraction
+- discarded temporary context
+- out_dir persistence
+- OpenClaw-like package conversion
+- re-audit
+- admit
+
+### Integration-style tests
+- `tests/tools/test_skill_intake_tool_integration.py`
+
+Covers:
+- end-to-end generic flow
+- end-to-end OpenClaw-like flow
+
+---
+
+## Design / planning artifacts
+
+### Master implementation plan
+- `.plans/skill-intake-pipeline.md`
+
+### V2 executive summary
+- `.plans/skill-intake-v2-summary.md`
+
+### Operational README
+- `.plans/skill-intake-readme.md`
+
+### PR-ready review summary
+- `.plans/skill-intake-pr-ready-summary.md`
+
+### V2.1 follow-up plan
+- `.plans/skill-intake-v2.1-plan.md`
+
+---
+
+## Spec artifacts
+
+Directory:
+- `.plans/skill-intake/`
+
+Key files:
+- `output-schema.json`
+- `policy-matrix.md`
+- `sample-audit-result.json`
+- `sample-convert-result.json`
+- `sample-reaudit-result.json`
+- `sample-admit-result.json`
+
+---
+
+## Validation commands
+
+### Focused tool tests
+```bash
+uv run --extra dev python -m pytest tests/tools/test_skill_intake_tool.py -q -o 'addopts='
+```
+
+### Integration tests
+```bash
+uv run --extra dev python -m pytest tests/tools/test_skill_intake_tool_integration.py -q -o 'addopts='
+```
+
+### Regression subset
+```bash
+uv run --extra dev python -m pytest tests/test_toolsets.py tests/tools/test_skill_intake_tool.py tests/tools/test_skill_intake_tool_integration.py -q -o 'addopts='
+```
+
+Latest validated subset result during delivery:
+- all targeted tests passing
+
+---
+
+## Current V2 scope delivered
+
+- audit-first intake workflow
+- candidate classification
+- compatibility scoring/classification
+- security heuristic scanning
+- semantic portability scoring
+- conversion to Hermes draft
+- discarded tracking
+- source-to-output mapping
+- optional out_dir persistence
+- re-audit readiness
+- policy-based admission
+- OpenClaw-like package preservation
+
+---
+
+## Recommended next step after handoff
+
+Treat V2 as complete.
+
+Move to V2.1 with this order:
+1. richer provenance
+2. larger / more realistic fixtures
+3. eval planning
+4. sandbox / CI hardening

--- a/.plans/skill-intake-pipeline.md
+++ b/.plans/skill-intake-pipeline.md
@@ -1,0 +1,296 @@
+# Skill Intake Pipeline Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Build a governed intake pipeline for third-party and legacy skills with explicit stages for audit, convert, re-audit, and admit.
+
+**Architecture:** Implement a single shared engine with separate operational stages. Keep compatibility, security, semantic portability, and admission policy as distinct concerns so conversion never implies trust. Start with V1 operational skill + V2 audit-first tool, then layer convert, re-audit, and admit.
+
+**Tech Stack:** Python 3, Hermes tool registry, pytest, JSON schema validation, Markdown/YAML parsing.
+
+---
+
+## Product decision
+
+Recommended product name: `skill-intake`
+
+Top-level commands:
+- `skill-intake audit SOURCE`
+- `skill-intake convert SOURCE --out DIR`
+- `skill-intake re-audit DIR`
+- `skill-intake admit DIR --policy conservative`
+
+Core rule:
+- audit -> convert -> re-audit -> admit
+- conversion never implies approval
+- admission requires explicit policy gate
+
+## Scope
+
+Supported inputs:
+- local file
+- local directory
+- raw URL
+- GitHub file URL
+- GitHub tree URL
+- GitHub repo URL
+- native Hermes skill
+- Agent Skills-compatible package
+- `CLAUDE.md`
+- OpenClaw-like skill package
+- procedural markdown / README-style workflow docs
+
+Explicit non-goals for first shipping slice:
+- auto-install after conversion
+- auto-publish to registries
+- executing third-party scripts during routine audit
+- trust-by-origin shortcuts
+
+## Deliverables
+
+1. V1 operational skill installed in local Hermes profile
+2. V2 technical spec and JSON schemas
+3. Policy matrix and governance docs
+4. Future code skeleton for Hermes integration
+
+---
+
+## Target file layout in Hermes repo
+
+```text
+hermes-agent/
+├── .plans/
+│   ├── skill-intake-pipeline.md
+│   └── skill-intake/
+│       ├── output-schema.json
+│       ├── policy-matrix.md
+│       ├── sample-audit-result.json
+│       ├── sample-convert-result.json
+│       ├── sample-reaudit-result.json
+│       └── sample-admit-result.json
+├── tools/
+│   └── skill_intake_tool.py              # future V2 tool implementation
+├── tests/
+│   └── tools/
+│       └── test_skill_intake_tool.py     # future tests
+```
+
+---
+
+## Data model
+
+### Source model
+- `source`
+- `source_type`
+- `resolved_at`
+- `provenance`
+  - `git_owner`
+  - `git_repo`
+  - `git_ref`
+  - `git_commit`
+  - `content_hashes`
+
+### Discovery model
+- `entrypoints_found`
+- `skill_candidates`
+- `manifest`
+
+### Compatibility report
+- `score` 0-100
+- `classification` A/B/C/D
+- `checks[]`
+
+### Security report
+- `risk_score` 0-100
+- `risk_level` info/low/medium/high/critical
+- `findings[]`
+
+### Semantic report
+- `score` 0-100
+- `findings[]`
+
+### Quality report
+- `score` 0-100
+- `eval_plan` optional
+
+### Decision model
+- `recommendation.action` install/adapt/quarantine/reject
+- `admission.status` approved/approved_with_warning/review_required/rejected
+
+---
+
+## Rule packs
+
+### Compatibility
+Pass checks:
+- `SKILL.md` exists
+- frontmatter YAML exists
+- `name` present and valid
+- `description` present
+- directory structure reasonable
+
+Warn checks:
+- metadata missing
+- compatibility field missing where needed
+- monolithic docs requiring restructuring
+
+Fail checks:
+- no procedural entrypoint
+- invalid or absent frontmatter
+- invalid skill slug
+- not skill-like
+
+### Semantic portability
+Checks:
+- clear usage trigger
+- repeatable procedure
+- verification steps present
+- pitfalls present or inferable
+- temporary context absent
+- repo coupling not excessive
+- reusable imperative language present
+
+### Security / supply-chain
+Checks:
+- `curl|bash` or equivalent
+- remote binary execution
+- unpinned dependencies
+- no checksum on downloads
+- privilege escalation (`sudo`)
+- credential store access
+- keychain / `.env` / SSH / cloud credential reads
+- hidden telemetry or webhooks
+- prompt injection / safety bypass language
+- obfuscated shell or base64 payloads
+- broad recursive delete or traversal patterns
+
+---
+
+## Policy profiles
+
+### conservative
+- critical => rejected
+- high => rejected
+- medium => review_required
+- low => approved_with_warning
+- info => approved
+
+### balanced
+- critical => rejected
+- high => review_required
+- medium => approved_with_warning
+- low => approved
+
+### permissive
+- critical => review_required
+- high => approved_with_warning
+- medium => approved
+- low => approved
+
+Recommendation: default to `conservative`.
+
+---
+
+## Implementation phases
+
+### Phase 0: V1 operational skill
+**Objective:** Standardize manual/semiautomatic intake before building the native tool.
+
+**Files:**
+- Create: `~/.hermes/skills/autonomous-ai-agents/hermes-skill-intake-audit/SKILL.md`
+- Optional later: references for policy matrix/schema
+
+**Acceptance criteria:**
+- Skill exists and loads via `skills_list`/`skill_view`
+- Instructions explicitly separate audit, convert, re-audit, admit
+- Output labels fact/inference/risk/recommendation are defined
+
+### Phase 1: Spec artifacts
+**Objective:** Persist design documents in repo for future implementation.
+
+**Files:**
+- Create: `~/.hermes/hermes-agent/.plans/skill-intake/output-schema.json`
+- Create: `~/.hermes/hermes-agent/.plans/skill-intake/policy-matrix.md`
+- Create: sample result JSON files under the same directory
+
+**Acceptance criteria:**
+- Files exist and are internally consistent
+- Sample outputs validate conceptually against schema
+
+### Phase 2: V2 audit tool
+**Objective:** Implement read-only intake analysis as the first native tool.
+
+**Files:**
+- Create: `tools/skill_intake_tool.py`
+- Modify: `toolsets.py`
+- Create: `tests/tools/test_skill_intake_tool.py`
+
+**Acceptance criteria:**
+- Supports `mode=audit`
+- Handles local file, local dir, and GitHub URL
+- Returns structured JSON with compatibility, security, semantic sections
+
+### Phase 3: Conversion
+**Objective:** Convert CLAUDE.md / generic markdown / OpenClaw-like packages to Hermes draft format.
+
+**Files:**
+- Modify: `tools/skill_intake_tool.py`
+- Add helper modules if code size warrants refactor
+- Extend tests with conversion fixtures
+
+**Acceptance criteria:**
+- Supports `mode=convert`
+- Produces `SKILL.md` draft plus report
+- Preserves provenance and discarded-content log
+
+### Phase 4: Re-audit and admit
+**Objective:** Close the governance loop.
+
+**Acceptance criteria:**
+- Re-audit consumes converted directory
+- Admit applies policy profile
+- Installation remains an explicit later step
+
+### Phase 5: Eval planning / optional sandbox
+**Objective:** Measure whether admitted skills improve real execution safely.
+
+**Acceptance criteria:**
+- Generates eval skeletons
+- Can compare with-skill vs without-skill later
+
+---
+
+## Test strategy
+
+Fixtures to include:
+- native Hermes skill
+- valid Agent Skills skill
+- `CLAUDE.md` workflow
+- OpenClaw-like package
+- docs-only candidate
+- malicious candidate with `curl|bash`
+- candidate with secret-exfil instructions
+
+Core tests:
+- audit local file
+- audit local directory
+- audit GitHub repo URL
+- convert CLAUDE.md
+- convert docs-only candidate rejected or downgraded appropriately
+- re-audit converted output
+- admit decision per policy profile
+
+---
+
+## Open product decisions
+
+1. Should converted drafts ever be auto-installed? Recommendation: no.
+2. Should trust policies consider repo owner/reputation? Not in V2 baseline.
+3. Should sandboxed script execution be part of audit? Not by default.
+4. Should quality score be heuristic-only in V2? Yes.
+
+---
+
+## Recommended next implementation step
+
+After this plan is saved, implement Phase 0 and Phase 1 first. Do not start with conversion code before the audit model and policy artifacts are stable.

--- a/.plans/skill-intake-pr-message.md
+++ b/.plans/skill-intake-pr-message.md
@@ -1,0 +1,62 @@
+Título sugerido
+fix: harden skill intake pipeline and preserve macOS gateway wrapper
+
+Resumo
+Este PR consolida duas linhas de correção que ficaram no mesmo commit local:
+
+1. Skill intake
+- adiciona o built-in tool `skill_intake`
+- expõe `skill_intake` no toolset `skills`
+- implementa os modos `audit`, `convert`, `re-audit` e `admit`
+- corrige o contrato/schema para refletir os quatro modos realmente suportados
+- adiciona testes unitários, integration-style e um teste hermético do wrapper/plugin local
+
+2. Gateway macOS / higiene operacional
+- preserva o wrapper `~/.hermes/scripts/hermes-with-keychain.sh` na geração do LaunchAgent quando aplicável
+- força descoberta de plugin slash commands antes de autocomplete/menu/registro
+- atualiza lockfiles relacionados
+- remove resíduo legado do WhatsApp bridge
+
+Motivação
+- evitar perda silenciosa do wrapper Keychain em instâncias macOS com launchd
+- tornar o pipeline de skill intake utilizável de ponta a ponta
+- alinhar o schema do tool com a implementação real
+- remover um teste dependente do ambiente local e torná-lo reproduzível em CI
+
+Principais mudanças
+- `tools/skill_intake_tool.py`
+  - implementação do pipeline completo de intake
+  - correção do texto do schema/documentação interna
+- `toolsets.py`
+  - inclui `skill_intake` no toolset `skills`
+- `tests/tools/test_skill_intake_tool.py`
+  - cobertura unitária do tool
+- `tests/tools/test_skill_intake_tool_integration.py`
+  - cobertura do fluxo convert -> re-audit -> admit
+- `tests/tools/test_skill_intake_plugin_local.py`
+  - wrapper/plugin testado de forma hermética, sem depender de `~/.hermes/plugins`
+- `hermes_cli/gateway.py`
+  - prioriza o wrapper Keychain ao gerar o LaunchAgent no macOS
+- `hermes_cli/commands.py` + `tests/hermes_cli/test_commands.py`
+  - descoberta de plugins antes da exposição de slash commands
+
+Validação
+- `python -m pytest tests/hermes_cli/test_commands.py -q`
+- `python -m pytest tests/tools/test_skill_intake_tool.py tests/tools/test_skill_intake_tool_integration.py tests/tools/test_skill_intake_plugin_local.py -q`
+
+Resultados observados
+- `tests/hermes_cli/test_commands.py`: 111 passed
+- skill intake suite: 26 passed
+
+Riscos / observações
+- o commit local atual mistura skill intake + hardening do gateway macOS + limpeza de legado WhatsApp
+- para um PR mais limpo, pode valer separar em dois PRs:
+  - PR A: skill intake
+  - PR B: gateway macOS + plugin command discovery + cleanup operacional
+
+Checklist
+- [x] schema alinhado com a implementação
+- [x] teste de plugin tornou-se hermético
+- [x] toolset `skills` expõe `skill_intake`
+- [x] regressão de comandos/plugin coberta por teste
+- [x] wrapper Keychain preservado na geração do LaunchAgent macOS

--- a/.plans/skill-intake-pr-ready-summary.md
+++ b/.plans/skill-intake-pr-ready-summary.md
@@ -1,0 +1,73 @@
+# skill_intake V2 — PR-ready summary and checklist
+
+## Summary
+
+This change introduces and hardens `skill_intake`, a governed pipeline for evaluating and transforming candidate skills before admission into Hermes.
+
+Delivered stages:
+- `audit`
+- `convert`
+- `re-audit`
+- `admit`
+
+Key capabilities:
+- local and remote source classification
+- compatibility, security, and semantic portability scoring
+- conversion to Hermes draft skill format
+- `discarded` and `mapping` outputs for traceability
+- optional artifact persistence via `out_dir`
+- OpenClaw-like package preservation of `scripts/` and `references/`
+- policy-based admission decisions
+- focused integration tests
+
+## Key files
+
+### Added / implemented
+- `tools/skill_intake_tool.py`
+- `tests/tools/test_skill_intake_tool.py`
+- `tests/tools/test_skill_intake_tool_integration.py`
+- `.plans/skill-intake-v2-summary.md`
+- `.plans/skill-intake-readme.md`
+- `.plans/skill-intake-pipeline.md`
+- `.plans/skill-intake/output-schema.json`
+- `.plans/skill-intake/policy-matrix.md`
+
+### Modified
+- `toolsets.py`
+
+## Validation performed
+
+```bash
+uv run --extra dev python -m pytest tests/tools/test_skill_intake_tool.py -q -o 'addopts='
+uv run --extra dev python -m pytest tests/tools/test_skill_intake_tool_integration.py -q -o 'addopts='
+uv run --extra dev python -m pytest tests/test_toolsets.py tests/tools/test_skill_intake_tool.py tests/tools/test_skill_intake_tool_integration.py -q -o 'addopts='
+```
+
+Latest result:
+- all targeted tests passing
+
+## Reviewer checklist
+
+### Product / workflow
+- [ ] `audit -> convert -> re-audit -> admit` is preserved
+- [ ] conversion does not imply approval
+- [ ] admission is policy-gated
+
+### Technical
+- [ ] tool schema matches supported modes and args
+- [ ] local provenance is emitted
+- [ ] remote provenance is emitted at current baseline
+- [ ] generated skill output contains traceability (`discarded`, `mapping`)
+- [ ] OpenClaw-like package assets are preserved
+
+### Tests
+- [ ] unit tests cover generic conversion
+- [ ] unit tests cover temporary-context discard
+- [ ] unit tests cover OpenClaw-like package handling
+- [ ] integration tests cover end-to-end flow
+
+### Follow-ups (not blocking V2)
+- [ ] richer remote provenance
+- [ ] larger fixtures
+- [ ] eval planning
+- [ ] sandbox/CI hardening

--- a/.plans/skill-intake-readme.md
+++ b/.plans/skill-intake-readme.md
@@ -1,0 +1,120 @@
+# skill_intake
+
+## What it is
+
+`skill_intake` is a governed intake pipeline for candidate skills.
+
+It supports four stages:
+- `audit`
+- `convert`
+- `re-audit`
+- `admit`
+
+Use it to inspect third-party or legacy skill material before trusting or installing it.
+
+## Core rule
+
+Always use the pipeline in this order:
+1. `audit`
+2. `convert`
+3. `re-audit`
+4. `admit`
+
+Do not convert and install directly.
+
+## Supported inputs
+
+- local file
+- local directory
+- raw URL
+- GitHub file URL
+- GitHub tree URL
+- GitHub repo URL
+- `CLAUDE.md` / project-instructions markdown
+- generic workflow markdown
+- OpenClaw-like package (`AGENT.md` + `scripts/` and/or `references/`)
+
+## Modes
+
+### audit
+Evaluates:
+- compatibility
+- security risk
+- semantic portability
+- recommendation
+- provenance
+
+Example payload:
+```json
+{"mode":"audit","source":"./candidate-skill"}
+```
+
+### convert
+Generates a Hermes draft skill.
+
+Capabilities:
+- `discarded` tracking
+- `mapping` from source to generated output
+- optional `out_dir`
+- preservation of `references/` and `scripts/` for OpenClaw-like packages
+
+Example payload:
+```json
+{"mode":"convert","source":"./CLAUDE.md","out_dir":"./out"}
+```
+
+### re-audit
+Revalidates converted output and produces readiness:
+- `ready`
+- `review`
+- `blocked`
+
+Example payload:
+```json
+{"mode":"re-audit","generated_skill":{...}}
+```
+
+### admit
+Applies policy gate:
+- `conservative`
+- `balanced`
+- `permissive`
+
+Example payload:
+```json
+{"mode":"admit","reaudit_result":{...},"policy":"conservative"}
+```
+
+## Current conversion output structure
+
+Typical generated `SKILL.md` sections:
+- `When to use`
+- `Prerequisites`
+- `Steps`
+- `Commands`
+- `Examples`
+- `Pitfalls`
+- `Verification`
+
+## Tests
+
+Focused tests:
+```bash
+uv run --extra dev python -m pytest tests/tools/test_skill_intake_tool.py -q -o 'addopts='
+uv run --extra dev python -m pytest tests/tools/test_skill_intake_tool_integration.py -q -o 'addopts='
+```
+
+Regression subset:
+```bash
+uv run --extra dev python -m pytest tests/test_toolsets.py tests/tools/test_skill_intake_tool.py tests/tools/test_skill_intake_tool_integration.py -q -o 'addopts='
+```
+
+## Current status
+
+V2 baseline is functionally complete.
+
+Post-V2 work belongs in V2.1+:
+- richer provenance
+- larger fixtures
+- eval planning
+- sandbox/CI hardening

--- a/.plans/skill-intake-v2-summary.md
+++ b/.plans/skill-intake-v2-summary.md
@@ -1,0 +1,106 @@
+# Skill Intake V2 Summary
+
+## Executive conclusion
+
+`skill_intake` reached a solid V2 baseline in the Hermes repo.
+
+The pipeline now supports:
+- `audit`
+- `convert`
+- `re-audit`
+- `admit`
+
+This is no longer a prototype. It is a functional, test-covered intake pipeline for candidate skills.
+
+## What V2 delivers
+
+### 1. Audit
+- local file and directory support
+- basic remote GitHub/raw URL support
+- compatibility scoring/classification
+- security heuristic scanning
+- semantic portability scoring
+- recommendation output
+- provenance for local and remote sources
+
+### 2. Convert
+- generic markdown / workflow conversion
+- project-instructions conversion (`CLAUDE.md`-style)
+- OpenClaw-like package preservation for `scripts/` and `references/`
+- `discarded` tracking for temporary context
+- `mapping` from source to generated artifacts
+- optional persistence via `out_dir`
+
+### 3. Re-audit
+- revalidation of generated drafts
+- readiness states: `ready`, `review`, `blocked`
+
+### 4. Admit
+- policy-driven admission gate
+- profiles: `conservative`, `balanced`, `permissive`
+- decision output with required actions
+
+## Quality improvements completed
+
+### Generic converter
+The generic converter now extracts or infers:
+- `When to use`
+- `Prerequisites`
+- `Steps`
+- `Commands`
+- `Examples`
+- `Pitfalls`
+- `Verification`
+
+### OpenClaw-like support
+Current heuristic:
+- directory with `AGENT.md`
+- plus `scripts/` or `references/`
+
+Preserved in output:
+- scripts
+- references
+- mapping entries for preserved assets
+
+## Provenance now available
+
+### Local
+- `local_path`
+- `local_kind`
+- `asset_counts` for scripts/references on directories
+
+### Remote
+- `source_url`
+- `source_type`
+- `remote_fetch.fetched`
+- `remote_fetch.attempts`
+- `remote_fetch.fetched_count`
+
+## Validation status
+
+Current validation baseline:
+- `tests/tools/test_skill_intake_tool.py`
+- `tests/test_toolsets.py`
+
+Latest checked result during build-out:
+- targeted tool tests passing
+- toolset regression passing
+
+## What remains after V2
+
+This is post-V2 work, not required to call V2 complete:
+- richer remote provenance (repo/ref/commit where resolvable)
+- broader OpenClaw-specific fixture coverage
+- eval planning / with-skill vs without-skill comparison
+- sandbox / CI hardening
+- deeper semantic classification of examples vs references
+
+## Recommended next phase
+
+Call the current state `V2 complete`.
+
+Recommended next phase order:
+1. integrated tests with more realistic fixtures
+2. provenance refinement
+3. eval planning
+4. sandbox / CI hardening

--- a/.plans/skill-intake-v2.1-modular-refactor.md
+++ b/.plans/skill-intake-v2.1-modular-refactor.md
@@ -1,0 +1,124 @@
+# skill_intake V2.1 — Modular Refactor Proposal
+
+## Conclusion
+
+Do a light modular refactor, not a rewrite.
+
+Current `tools/skill_intake_tool.py` is functional and test-covered, but it is beginning to concentrate too many responsibilities in one file. The right next step is to extract helpers into a small module cluster while preserving the current external tool interface.
+
+## Refactor goals
+
+1. keep public behavior stable
+2. preserve current test suite
+3. reduce cognitive load per file
+4. make further V2.1 work easier (provenance, eval planning, richer fixtures)
+
+## Recommended target layout
+
+```text
+tools/
+├── skill_intake_tool.py          # thin tool entrypoint + registry registration
+├── skill_intake/
+│   ├── __init__.py
+│   ├── schemas.py                # tool schema + enums/constants if desired
+│   ├── source_resolution.py      # source classification + provenance + remote fetch
+│   ├── discovery.py              # local/remote discovery + candidate typing
+│   ├── semantics.py              # semantic scoring + section extraction + discard logic
+│   ├── conversion.py             # draft generation + out_dir persistence + OpenClaw-like asset handling
+│   ├── governance.py             # re-audit + admit + policy helpers
+│   └── reporting.py              # optional: common result-shaping helpers
+```
+
+## Suggested extraction sequence
+
+### Step 1
+Extract source/provenance helpers.
+
+Move:
+- `_classify_source`
+- `_github_blob_to_raw`
+- `_build_remote_candidates`
+- `_fetch_remote_text_entries`
+- `_build_local_provenance`
+
+Target:
+- `tools/skill_intake/source_resolution.py`
+
+### Step 2
+Extract discovery helpers.
+
+Move:
+- `_collect_local_files`
+- `_safe_read_text`
+- `_discover_text_entries`
+- `_discover_local`
+- OpenClaw-like candidate typing hook
+
+Target:
+- `tools/skill_intake/discovery.py`
+
+### Step 3
+Extract semantic/conversion helpers.
+
+Move:
+- `_extract_title_and_body`
+- `_extract_description`
+- `_split_discarded_lines`
+- `_extract_semantic_sections`
+- `_build_skill_md`
+- `_collect_openclaw_assets`
+- `_write_converted_skill_artifacts`
+
+Target:
+- `tools/skill_intake/semantics.py`
+- `tools/skill_intake/conversion.py`
+
+### Step 4
+Extract governance helpers.
+
+Move:
+- `_compatibility_for_remote`
+- `_compatibility_from_discovery`
+- `_security_report`
+- `_quality_report`
+- `_recommendation`
+- `re_audit_converted_candidate`
+- `admit_skill_candidate`
+
+Target:
+- `tools/skill_intake/governance.py`
+
+### Step 5
+Leave `skill_intake_tool.py` as a thin wrapper.
+
+Keep in file:
+- tool schema import/reference
+- mode dispatch
+- `registry.register(...)`
+
+## Non-goals
+
+Do NOT in the same refactor:
+- redesign output contracts
+- change policy semantics
+- change test expectations unless fixing a real bug
+- add major new features
+
+## Why this refactor is enough
+
+Because the system is already functionally complete for V2.
+The risk now is maintainability, not missing core workflow.
+
+This modular split gives you:
+- easier review
+- easier targeted tests
+- easier future extensions
+- lower chance of accidental regressions
+
+## Recommended order after refactor
+
+1. modular refactor
+2. richer provenance
+3. larger fixtures
+4. eval planning
+5. sandbox / CI hardening

--- a/.plans/skill-intake-v2.1-plan.md
+++ b/.plans/skill-intake-v2.1-plan.md
@@ -1,0 +1,107 @@
+# skill_intake V2.1 Plan
+
+> **For Hermes:** Execute after V2 baseline is considered complete. Keep scope tight and bias toward realism, provenance, and operational hardening.
+
+**Goal:** Improve confidence, realism, and operational rigor of `skill_intake` without redesigning the pipeline.
+
+**Architecture:** Preserve the current 4-stage pipeline (`audit`, `convert`, `re-audit`, `admit`) and harden around it using richer fixtures, stronger provenance, and better evaluation support.
+
+**Tech Stack:** Python 3, pytest, Hermes tool registry, local fixtures, optional remote metadata resolution.
+
+---
+
+## Priorities
+
+1. richer provenance
+2. larger / more realistic fixtures
+3. eval planning
+4. sandbox / CI hardening
+
+---
+
+## Task 1: Provenance enrichment
+
+**Objective:** Add stronger provenance for remote and converted sources.
+
+**Files:**
+- Modify: `tools/skill_intake_tool.py`
+- Extend: `tests/tools/test_skill_intake_tool.py`
+
+**Targets:**
+- repo owner / repo name when reliably parsed
+- ref/branch if discoverable
+- raw URL normalization trace
+- conversion timestamp / origin metadata in generated outputs
+
+**Verification:**
+- unit tests assert added provenance fields without breaking current output contracts
+
+---
+
+## Task 2: Larger realistic fixtures
+
+**Objective:** Improve confidence with more realistic source samples.
+
+**Files:**
+- Create: `tests/tools/fixtures/skill_intake/` (if desired)
+- Extend: `tests/tools/test_skill_intake_tool_integration.py`
+
+**Targets:**
+- larger CLAUDE-style workflow
+- larger generic workflow markdown
+- richer OpenClaw-like package
+- at least one risky candidate with preserved findings
+
+**Verification:**
+- integration tests remain fast and deterministic
+
+---
+
+## Task 3: Eval planning
+
+**Objective:** Generate eval skeletons for future with-skill vs without-skill comparisons.
+
+**Files:**
+- Modify: `tools/skill_intake_tool.py`
+- Extend tests as needed
+
+**Targets:**
+- optional eval plan output from `audit` or `re-audit`
+- minimal structure for scenarios / expected outcomes
+
+**Verification:**
+- output is structured and deterministic
+
+---
+
+## Task 4: Sandbox / CI hardening plan
+
+**Objective:** Prepare the pipeline for safer operational rollout.
+
+**Files:**
+- Docs only in V2.1 if implementation is too large
+- Potential plan doc for CI / sandbox follow-up
+
+**Targets:**
+- define non-goals for execution of third-party code
+- define CI gates for `skill_intake`
+- define how to keep tests stable and cheap
+
+**Verification:**
+- docs/checklist exists and is actionable
+
+---
+
+## Exit criteria for V2.1
+
+- provenance improved in a test-covered way
+- integration fixtures more realistic
+- eval planning baseline exists
+- sandbox / CI hardening path documented
+
+## Not in scope for V2.1
+
+- auto-install of converted skills
+- auto-publish
+- executing third-party scripts by default
+- full remote SCM metadata resolution if it adds fragility

--- a/.plans/skill-intake-v2.1-roadmap.md
+++ b/.plans/skill-intake-v2.1-roadmap.md
@@ -1,0 +1,103 @@
+# skill_intake V2.1 — Executive Backlog / Roadmap
+
+## Positioning
+
+V2 is complete.
+
+V2.1 should not redesign the pipeline. It should harden and simplify operations around the existing 4-stage flow:
+- audit
+- convert
+- re-audit
+- admit
+
+## Objective
+
+Increase confidence, realism, and maintainability with the smallest possible changes.
+
+## Priority order
+
+### P1 — Modular refactor (lightweight)
+Goal:
+- reduce maintenance cost in `tools/skill_intake_tool.py`
+- keep behavior stable
+
+Scope:
+- extract helpers by responsibility
+- keep the public tool interface unchanged
+
+Deliverable:
+- thin `skill_intake_tool.py`
+- helper modules for source resolution, discovery, semantics, conversion, governance
+
+### P2 — Richer provenance
+Goal:
+- improve traceability for remote and converted sources
+
+Scope:
+- stronger remote metadata when reliably available
+- normalized source metadata in conversion results
+- clearer provenance for generated artifacts
+
+Deliverable:
+- richer provenance fields
+- tests that assert them
+
+### P3 — Larger realistic fixtures
+Goal:
+- increase confidence with more representative inputs
+
+Scope:
+- richer generic workflow fixture
+- richer CLAUDE-style instructions fixture
+- richer OpenClaw-like package fixture
+- one intentionally risky fixture
+
+Deliverable:
+- more realistic integration coverage
+
+### P4 — Eval planning
+Goal:
+- prepare for with-skill vs without-skill quality comparison
+
+Scope:
+- output a lightweight eval plan structure
+- no full eval harness yet
+
+Deliverable:
+- deterministic eval-plan artifact from audit or re-audit
+
+### P5 — Sandbox / CI hardening
+Goal:
+- prepare safer operational rollout
+
+Scope:
+- document CI gate expectations
+- document non-goals for third-party code execution
+- optionally prepare a minimal hardening checklist
+
+Deliverable:
+- hardening note/checklist
+
+## Suggested execution sequence
+
+1. modular refactor
+2. richer provenance
+3. realistic fixtures
+4. eval planning
+5. sandbox / CI hardening
+
+## Exit criteria for V2.1
+
+- codebase easier to maintain
+- provenance materially better
+- integration tests more realistic
+- eval planning exists at baseline
+- hardening path is documented
+
+## What not to do in V2.1
+
+- no auto-install of converted skills
+- no auto-publish
+- no implicit trust by source
+- no execution of third-party scripts by default
+- no rewrite of the admission model

--- a/.plans/skill-intake/output-schema.json
+++ b/.plans/skill-intake/output-schema.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://hermes-agent.nousresearch.com/schemas/skill-intake-result.json",
+  "title": "Skill Intake Result",
+  "type": "object",
+  "required": ["version", "command"],
+  "properties": {
+    "version": {"type": "string"},
+    "command": {"type": "string", "enum": ["audit", "convert", "re-audit", "admit"]},
+    "target": {"type": "object"},
+    "source": {"type": "object"},
+    "compatibility": {
+      "type": "object",
+      "properties": {
+        "score": {"type": "integer", "minimum": 0, "maximum": 100},
+        "classification": {"type": "string", "enum": ["A", "B", "C", "D"]},
+        "summary": {"type": "string"},
+        "checks": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["id", "status"],
+            "properties": {
+              "id": {"type": "string"},
+              "status": {"type": "string", "enum": ["pass", "warn", "fail"]},
+              "severity": {"type": "string", "enum": ["info", "low", "medium", "high", "critical"]},
+              "message": {"type": "string"}
+            },
+            "additionalProperties": true
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "security": {
+      "type": "object",
+      "properties": {
+        "risk_score": {"type": "integer", "minimum": 0, "maximum": 100},
+        "risk_level": {"type": "string", "enum": ["info", "low", "medium", "high", "critical"]},
+        "summary": {"type": "string"},
+        "findings": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["id", "severity"],
+            "properties": {
+              "id": {"type": "string"},
+              "severity": {"type": "string", "enum": ["info", "low", "medium", "high", "critical"]},
+              "path": {"type": "string"},
+              "evidence": {"type": "string"},
+              "message": {"type": "string"}
+            },
+            "additionalProperties": true
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "semantic_portability": {
+      "type": "object",
+      "properties": {
+        "score": {"type": "integer", "minimum": 0, "maximum": 100},
+        "summary": {"type": "string"},
+        "findings": {"type": "array", "items": {"type": "object"}}
+      },
+      "additionalProperties": true
+    },
+    "quality": {
+      "type": "object",
+      "properties": {
+        "score": {"type": "integer", "minimum": 0, "maximum": 100},
+        "summary": {"type": "string"},
+        "eval_plan": {"type": "object"}
+      },
+      "additionalProperties": true
+    },
+    "recommendation": {
+      "type": "object",
+      "properties": {
+        "action": {"type": "string", "enum": ["install", "adapt", "quarantine", "reject"]},
+        "reason": {"type": "string"}
+      },
+      "additionalProperties": true
+    },
+    "conversion": {"type": "object", "additionalProperties": true},
+    "generated_skill": {"type": "object", "additionalProperties": true},
+    "readiness": {"type": "object", "additionalProperties": true},
+    "policy": {"type": ["string", "object"]},
+    "decision": {"type": "object", "additionalProperties": true},
+    "controls": {"type": "object", "additionalProperties": true}
+  },
+  "additionalProperties": true
+}

--- a/.plans/skill-intake/policy-matrix.md
+++ b/.plans/skill-intake/policy-matrix.md
@@ -1,0 +1,73 @@
+# Skill Intake Policy Matrix
+
+## Default recommendation
+
+Use `conservative` as the default profile.
+
+Reason:
+- favors governance over convenience
+- blocks risky imports early
+- keeps conversion subordinate to audit
+
+## Policy profiles
+
+### conservative
+- critical => rejected
+- high => rejected
+- medium => review_required
+- low => approved_with_warning
+- info => approved
+
+### balanced
+- critical => rejected
+- high => review_required
+- medium => approved_with_warning
+- low => approved
+- info => approved
+
+### permissive
+- critical => review_required
+- high => approved_with_warning
+- medium => approved
+- low => approved
+- info => approved
+
+## Additional admission rules
+
+1. Conversion never implies approval.
+2. Re-audit is mandatory after conversion.
+3. Compatibility and security must remain separate axes.
+4. A structurally valid skill may still be rejected on risk.
+5. Repo/source reputation may inform review later, but must not override critical findings in V2.
+
+## Risk examples
+
+### critical
+- explicit secret exfiltration
+- instructions to bypass system/developer controls
+- remote arbitrary execution with hidden payloads
+
+### high
+- curl|bash
+- sudo without clear necessity
+- download-and-run without checksum
+- reading SSH keys, cloud creds, browser cookies, Keychain, `.env`
+
+### medium
+- unpinned dependencies
+- implicit telemetry/webhooks
+- dangerous wildcard file operations
+- strong repo-specific coupling or hidden assumptions
+
+### low
+- weak metadata
+- missing compatibility notes
+- missing pitfalls/verification guidance
+
+## Outcome mapping
+
+- A/B + low => admit or approve with warning
+- B/C + low => convert then re-audit
+- any + medium => human review
+- any + high => quarantine/reject by policy
+- D + critical => reject

--- a/.plans/skill-intake/sample-admit-result.json
+++ b/.plans/skill-intake/sample-admit-result.json
@@ -1,0 +1,17 @@
+{
+  "version": "2.0",
+  "command": "admit",
+  "policy": "conservative",
+  "decision": {
+    "status": "review_required",
+    "approved": false,
+    "reason": "Risco residual médio com finding de remote_exec."
+  },
+  "controls": {
+    "required_actions": [
+      "Remover curl|bash",
+      "Pinar dependências",
+      "Reexecutar re-audit"
+    ]
+  }
+}

--- a/.plans/skill-intake/sample-audit-result.json
+++ b/.plans/skill-intake/sample-audit-result.json
@@ -1,0 +1,51 @@
+{
+  "version": "2.0",
+  "command": "audit",
+  "target": {
+    "source": "https://github.com/example/repo",
+    "source_type": "github_repo",
+    "resolved_at": "2026-04-17T22:00:00Z",
+    "provenance": {
+      "git_owner": "example",
+      "git_repo": "repo",
+      "git_ref": "main",
+      "git_commit": "abc123"
+    }
+  },
+  "discovery": {
+    "entrypoints_found": ["CLAUDE.md", "docs/workflow.md"],
+    "skill_candidates": [
+      {"path": "CLAUDE.md", "candidate_type": "claude_project_instructions"}
+    ]
+  },
+  "compatibility": {
+    "score": 61,
+    "classification": "C",
+    "summary": "Reaproveitável semanticamente, mas não nativo Hermes.",
+    "checks": [
+      {"id": "entrypoint.skill_md", "status": "fail", "severity": "medium", "message": "SKILL.md ausente"},
+      {"id": "frontmatter.yaml", "status": "fail", "severity": "medium", "message": "Frontmatter YAML ausente"},
+      {"id": "content.procedural", "status": "pass", "severity": "info", "message": "Workflow reutilizável encontrado"}
+    ]
+  },
+  "security": {
+    "risk_score": 47,
+    "risk_level": "medium",
+    "summary": "Há instruções de execução remota e dependências não pinadas.",
+    "findings": [
+      {"id": "remote_exec.curl_pipe_bash", "severity": "high", "path": "CLAUDE.md", "evidence": "curl https://... | bash", "message": "Execução remota sem verificação"}
+    ]
+  },
+  "semantic_portability": {
+    "score": 79,
+    "summary": "Conteúdo forte para conversão, com trigger e passos identificáveis."
+  },
+  "quality": {
+    "score": 58,
+    "summary": "Faltam verification steps e pitfalls."
+  },
+  "recommendation": {
+    "action": "adapt",
+    "reason": "Boa portabilidade semântica, mas formato não compatível e risco médio."
+  }
+}

--- a/.plans/skill-intake/sample-convert-result.json
+++ b/.plans/skill-intake/sample-convert-result.json
@@ -1,0 +1,24 @@
+{
+  "version": "2.0",
+  "command": "convert",
+  "source": {
+    "source": "https://github.com/example/repo",
+    "audit_reference": "audit-2026-04-17-001"
+  },
+  "conversion": {
+    "target_format": "hermes",
+    "mode": "balanced",
+    "output_dir": "/tmp/skill-intake/output/my-skill",
+    "generated_files": ["SKILL.md", "references/original-context.md", "scripts/setup.sh"],
+    "discarded": [
+      {"path": "CLAUDE.md", "section": "Current Sprint Notes", "reason": "temporary_context"}
+    ]
+  },
+  "generated_skill": {
+    "name": "my-skill",
+    "description": "Executa workflow X. Use quando Y."
+  },
+  "warnings": [
+    "Alguns comandos perigosos foram preservados no draft e marcados no relatório."
+  ]
+}

--- a/.plans/skill-intake/sample-reaudit-result.json
+++ b/.plans/skill-intake/sample-reaudit-result.json
@@ -1,0 +1,27 @@
+{
+  "version": "2.0",
+  "command": "re-audit",
+  "target": {
+    "path": "/tmp/skill-intake/output/my-skill"
+  },
+  "compatibility": {
+    "score": 92,
+    "classification": "A",
+    "summary": "Estruturalmente compatível com Hermes."
+  },
+  "security": {
+    "risk_score": 33,
+    "risk_level": "medium",
+    "summary": "Estrutura corrigida, mas ainda há instruções de instalação remota."
+  },
+  "semantic_portability": {
+    "score": 88
+  },
+  "quality": {
+    "score": 74
+  },
+  "readiness": {
+    "status": "review",
+    "reason": "Compatível, porém requer revisão humana por risco residual médio."
+  }
+}

--- a/docs/research/assistentes-pessoais-ia-100-use-cases-whitepaper-executivo.md
+++ b/docs/research/assistentes-pessoais-ia-100-use-cases-whitepaper-executivo.md
@@ -1,0 +1,485 @@
+# Whitepaper Executivo — Assistentes Pessoais com IA
+
+**Subtítulo:** 100 use cases, padrões de maturidade e implicações estratégicas  
+**Data:** 2026-04-18  
+**Autor:** ONE1  
+**Base:** síntese executiva derivada do documento `docs/research/assistentes-pessoais-ia-100-use-cases.md`
+
+---
+
+## Sumário
+
+1. Tese executiva  
+2. O que a pesquisa mostra de fato  
+3. O erro conceitual mais comum  
+4. Taxonomia dos 100 use cases  
+5. Onde o mercado já é maduro  
+6. Onde ainda há ruído e hype  
+7. Os 20 use cases mais fortes  
+8. Modelo operacional dos vencedores  
+9. Riscos estruturais  
+10. Implicações para produto, operação e arquitetura  
+11. Conclusão  
+12. Apêndices
+
+---
+
+## 1) Tese executiva
+
+**Assistentes pessoais com IA não estão vencendo por autonomia total. Estão vencendo por redução de atrito.**
+
+A pesquisa aponta uma regularidade: os casos mais bem-sucedidos não são os que tentam substituir julgamento humano em contextos ambíguos, mas os que fazem bem um conjunto restrito de funções operacionais:
+
+1. **capturar** entrada com baixa fricção;  
+2. **triar** ruído versus relevância;  
+3. **resumir** excesso de contexto;  
+4. **converter** texto e evento em ação;  
+5. **revisar** o que aconteceu e o que exige follow-up.
+
+Em outras palavras, o mercado real está premiando menos “Jarvis” e mais **copilotos confiáveis de alto uso**.
+
+---
+
+## 2) O que a pesquisa mostra de fato
+
+### 2.1 Padrão dominante
+
+O padrão dominante observado em produtos, documentação pública e workflows amplamente discutidos é:
+
+**AI + workflow + aprovação humana**
+
+Não:
+
+**AI autônoma + memória perfeita + execução irrestrita**
+
+### 2.2 Onde há evidência forte
+
+As famílias de produto mais consistentes são:
+- email assistido;
+- scheduling e calendar AI;
+- meeting assistants;
+- PKM/notes com recuperação semântica;
+- leitura e PDF chat;
+- finanças pessoais assistidas;
+- comparação de produtos e compra assistida;
+- travel planning;
+- smart home com linguagem natural.
+
+### 2.3 O que foi validado
+
+Uma amostra de players com presença pública ativa foi verificada durante a pesquisa, incluindo:
+- Motion;
+- Reclaim;
+- Superhuman;
+- Shortwave;
+- Otter;
+- Fireflies;
+- Notion AI;
+- Readwise Reader;
+- Reflect;
+- Mem;
+- Capacities;
+- Sunsama;
+- Rocket Money;
+- Monarch;
+- ChatPDF;
+- RemNote.
+
+### 2.4 Limite da evidência
+
+A pesquisa é forte como **mapa de padrões de mercado**, não como censo quantitativo.  
+A classificação de maturidade é uma **inferência analítica** baseada em recorrência, clareza de proposta de valor e estabilidade do workflow.
+
+---
+
+## 3) O erro conceitual mais comum
+
+O erro mais comum ao analisar assistentes pessoais com IA é tratar a categoria como se fosse uma só.
+
+Na prática, ela se divide em pelo menos quatro subcategorias distintas:
+
+1. **Copiloto de comunicação**  
+   Email, mensagens, follow-up, resposta e triagem.
+
+2. **Copiloto de organização pessoal**  
+   Agenda, tasks, reminders, revisões e coordenação do dia.
+
+3. **Copiloto de conhecimento e memória**  
+   Notas, leitura, síntese, second brain, recuperação contextual.
+
+4. **Copiloto de execução do mundo real**  
+   Compras, viagens, burocracia, finanças, casa e rotinas.
+
+Misturar essas quatro categorias em uma promessa única quase sempre degrada clareza de produto e governança operacional.
+
+---
+
+## 4) Taxonomia dos 100 use cases
+
+Os 100 use cases pesquisados se distribuem em 8 blocos:
+
+1. Email, mensagens e follow-up  
+2. Agenda, scheduling e coordenação do dia  
+3. Reuniões, calls e memória operacional  
+4. Notas, second brain e captura  
+5. Pesquisa pessoal, leitura e síntese  
+6. Tasks, execução e produtividade pessoal  
+7. Compras, consumo e pesquisa assistida  
+8. Viagens e deslocamento
+
+### Leitura executiva da taxonomia
+
+- **Blocos 1, 2 e 3** concentram os casos mais maduros e frequentes.  
+- **Blocos 4 e 5** concentram os casos mais relevantes para conhecimento e vantagem cognitiva.  
+- **Blocos 6, 7 e 8** concentram os casos com maior potencial de utilidade pessoal concreta no dia a dia.  
+- O valor aumenta quando há integração entre blocos.
+
+---
+
+## 5) Onde o mercado já é maduro
+
+### 5.1 Comunicação assistida
+
+Os casos mais maduros são:
+- redação assistida de email;
+- resumo de threads;
+- smart reply;
+- priorização de inbox;
+- follow-up por regra;
+- resumo de mensagens e catch-up de ausência.
+
+**Por que amadureceu:**  
+porque trabalha sobre artefatos semi-estruturados, alta frequência de uso e valor imediatamente percebido.
+
+### 5.2 Scheduling e agenda
+
+Os casos mais maduros são:
+- encontrar janelas de agenda;
+- time blocking;
+- buffers;
+- proteção de foco;
+- reagendamento após conflito.
+
+**Por que amadureceu:**  
+porque boa parte da lógica é determinística e reversível.
+
+### 5.3 Meeting intelligence
+
+Os casos mais maduros são:
+- transcrição;
+- resumo;
+- action items;
+- decisões;
+- atualização de CRM;
+- follow-up pós-reunião.
+
+**Por que amadureceu:**  
+porque o ROI é claro e o custo manual que substitui é alto.
+
+### 5.4 Leitura e PDF
+
+Os casos mais maduros são:
+- resumo de artigo;
+- resumo de PDF;
+- chat com PDF;
+- explicação simplificada de texto técnico;
+- fichamento estruturado.
+
+**Por que amadureceu:**  
+porque reduz esforço cognitivo sem exigir autonomia operacional sensível.
+
+---
+
+## 6) Onde ainda há ruído e hype
+
+### 6.1 Chief-of-staff pessoal contínuo
+
+A promessa é sedutora: um agente que coordena dia, semana, prioridades, follow-ups e decisões.  
+**Problema:** isso exige memória confiável, critérios de priorização robustos e forte governança de contexto. Ainda é frágil.
+
+### 6.2 Digest inteligente sem ruído
+
+Em tese, ótimo. Na prática, frequentemente vira clipping bonito.  
+O problema central não é resumir notícia. É filtrar relevância real.
+
+### 6.3 Memória pessoal profunda e confiável
+
+“Pergunte qualquer coisa sobre sua vida, trabalho e pensamento passado.”  
+A proposta é forte, mas a confiabilidade ainda depende muito de ingestão, schema e disciplina operacional.
+
+### 6.4 Negociação e execução autônoma
+
+Comprar, remarcar, negociar ou decidir automaticamente ainda enfrenta barreiras reais:
+- confiança;
+- erro irreversível;
+- ambiguidade contextual;
+- risco reputacional;
+- acesso a credenciais e sistemas.
+
+---
+
+## 7) Os 20 use cases mais fortes
+
+Os 20 casos com melhor combinação de **valor + maturidade + frequência + clareza de ROI** são:
+
+1. redação assistida de email  
+2. resumo de threads longas  
+3. priorização de inbox  
+4. follow-up automático por regra  
+5. encontrar janelas comuns para reunião  
+6. time blocking automático para tarefas  
+7. proteção de blocos de foco  
+8. transcrição automática de reunião  
+9. resumo automático de reunião  
+10. extração de action items  
+11. conversar com o próprio acervo  
+12. OCR de documentos e screenshots  
+13. resumo de PDF  
+14. chat com PDF  
+15. transformar leitura em fichamento estruturado  
+16. captura de tasks por linguagem natural  
+17. geração de checklist para processo pessoal  
+18. comparação de produtos  
+19. resumo de reviews e reclamações  
+20. montagem de roteiro personalizado de viagem
+
+### Leitura do ranking
+
+O ranking reforça um ponto: os vencedores atuais são casos que:
+- têm frequência alta;
+- produzem ganho rápido;
+- operam em cima de dados razoavelmente acessíveis;
+- exigem pouca coragem do usuário para confiar;
+- preservam reversibilidade.
+
+---
+
+## 8) Modelo operacional dos vencedores
+
+Os casos mais fortes seguem um modelo operacional simples:
+
+### Etapa 1 — Entrada barata
+Exemplo: voz, texto solto, email, thread, reunião, PDF, agenda.
+
+### Etapa 2 — Estruturação mínima
+Classificar, resumir, extrair entidades, detectar next steps.
+
+### Etapa 3 — Transformação em ação
+Task, checklist, resposta, briefing, follow-up, reminder, revisão.
+
+### Etapa 4 — Supervisão humana
+O usuário aprova, ajusta ou ignora.
+
+### Etapa 5 — Aprendizado operacional
+O sistema melhora regras, templates e preferências, não “filosofia geral”.
+
+### Implicação
+
+O diferencial não está em um modelo supostamente mais inteligente no abstrato.  
+Está na **qualidade da ingestão, das regras, da integração e da governança**.
+
+---
+
+## 9) Riscos estruturais
+
+### 9.1 Ruído operacional
+Um assistente que capta demais, resume demais e gera texto demais aumenta entropia em vez de reduzir.
+
+### 9.2 Falsa priorização
+A IA tende a soar convincente mesmo quando o critério de ordenação é ruim.
+
+### 9.3 Inferência vendida como fato
+Muito perigoso em:
+- reuniões;
+- finanças;
+- contratos;
+- saúde;
+- logística e viagem.
+
+### 9.4 Dependência excessiva de integração
+Grande parte do valor prometido evapora quando APIs, permissões ou sincronização falham.
+
+### 9.5 Falta de governança de entrada
+Sem critérios claros sobre o que entra, o sistema degrada em acúmulo de contexto inútil.
+
+---
+
+## 10) Implicações para produto, operação e arquitetura
+
+### 10.1 Para produto
+A posição mais forte não é “assistente pessoal geral”.  
+É um wedge mais específico, por exemplo:
+- briefing diário e coordenação pessoal;
+- copiloto de leitura e síntese;
+- copiloto de follow-up e agenda;
+- assistente de travel e bureaucracy ops.
+
+### 10.2 Para operação
+A ordem correta de implementação tende a ser:
+1. captura;  
+2. triagem;  
+3. resumo;  
+4. transformação em task/checklist;  
+5. revisão diária/semanal.
+
+### 10.3 Para arquitetura
+Se a meta for confiabilidade, a arquitetura deve priorizar:
+- memória austera e governável;
+- separação entre fatos, inferências e preferências;
+- workflow reversível;
+- integração explícita por fonte;
+- revisão humana para side effects relevantes.
+
+### 10.4 Para governança informacional
+O valor de longo prazo depende menos da geração de texto e mais de:
+- schema mínimo;
+- taxonomia útil;
+- critério de ingestão;
+- cadência de revisão;
+- prevenção de duplicação e obsolescência.
+
+---
+
+## 11) Conclusão
+
+A pesquisa indica que o mercado já validou dezenas de use cases de assistentes pessoais com IA, mas o valor não está distribuído de forma uniforme.
+
+Os casos vencedores compartilham cinco características:
+- resolvem atrito recorrente;
+- têm frequência alta de uso;
+- operam sobre contexto acessível;
+- preservam reversibilidade;
+- ajudam o usuário a agir com menos ruído.
+
+**Conclusão executiva final:**  
+A fronteira real dos assistentes pessoais com IA não é “fazer tudo pelo usuário”. É **aumentar clareza operacional sem sequestrar julgamento**.
+
+---
+
+## 12) Apêndices
+
+### Apêndice A — Os 100 use cases em blocos
+
+#### A.1 Email, mensagens e follow-up
+1. redação assistida de email  
+2. reescrita por tom  
+3. resumo de threads longas  
+4. smart reply contextual  
+5. priorização de inbox  
+6. classificação por intenção  
+7. detecção de emails sem resposta  
+8. follow-up automático por regra  
+9. sugestão de melhor timing de follow-up  
+10. extração de tarefas do email  
+11. extração de dados estruturados  
+12. resumo de canais de chat  
+13. catch-up de ausência  
+14. detecção de perguntas sem resposta em grupos  
+15. transformar mensagem em task/ticket
+
+#### A.2 Agenda, scheduling e coordenação do dia
+16. encontrar janelas comuns para reunião  
+17. negociação de horário em linguagem natural  
+18. time blocking automático para tarefas  
+19. proteção de blocos de foco  
+20. reagendamento após conflito  
+21. otimização por energia/contexto  
+22. inserção automática de buffers  
+23. briefing matinal do dia  
+24. preparação de lista “o que preciso hoje”  
+25. priorização do dia a partir de agenda + backlog  
+26. daily note automatizada  
+27. weekly review automatizada  
+28. replanejamento autônomo contínuo do dia  
+29. atualização de status pessoal baseada em agenda + mensagens  
+30. preparação pré-reunião
+
+#### A.3 Reuniões, calls e memória operacional
+31. transcrição automática de reunião  
+32. resumo automático de reunião  
+33. extração de action items  
+34. registro de decisões tomadas  
+35. detecção de pendências implícitas  
+36. follow-up pós-reunião pronto para envio  
+37. atualização de CRM após call  
+38. coaching de conversa  
+39. consolidação de múltiplas reuniões em memória única de projeto  
+40. busca semântica em histórico de reuniões
+
+#### A.4 Notas, second brain e captura
+41. inbox universal de notas  
+42. limpeza de notas brutas  
+43. auto-tagging semântico  
+44. conversar com o próprio acervo  
+45. sugestão de notas relacionadas  
+46. resumo de notas longas  
+47. transformar nota em documento/publicação  
+48. journaling assistido  
+49. recap de daily notes por semana ou mês  
+50. captura multimodal  
+51. OCR de screenshots, documentos e quadros  
+52. enriquecimento com entidades  
+53. deduplicação de notas redundantes  
+54. refatoração de acervo antigo  
+55. “manual do meu cérebro” sempre atualizado
+
+#### A.5 Pesquisa pessoal, leitura e síntese
+56. resumo de artigo web  
+57. resumo de PDF  
+58. chat com PDF  
+59. explicação simplificada de paper ou texto técnico  
+60. extração de argumentos e contra-argumentos  
+61. transformar leitura em fichamento estruturado  
+62. exportar highlights com síntese para notas  
+63. síntese cruzada de múltiplas fontes pessoais  
+64. comparar o que você já leu sobre A vs B  
+65. timeline de quando você pensou ou decidiu algo  
+66. detectar lacunas do que falta estudar  
+67. criar outline de artigo, apresentação ou memo  
+68. digest de notícias por tema  
+69. resumo semanal do que foi consumido  
+70. briefing rápido antes de escrever ou falar sobre um tema
+
+#### A.6 Tasks, execução e produtividade pessoal
+71. captura de tasks por linguagem natural  
+72. priorização automática de backlog pessoal  
+73. quebra de objetivo em subtarefas  
+74. geração de checklist para processo pessoal  
+75. planejamento semanal pessoal  
+76. replanejamento quando o dia descarrila  
+77. coaching de hábitos leves  
+78. accountability bot pessoal  
+79. execução entre apps por comando natural  
+80. preenchimento assistido de formulários repetitivos
+
+#### A.7 Compras, consumo e pesquisa assistida
+81. comparar produtos por especificação e necessidade  
+82. resumir reviews e reclamações  
+83. sugerir melhor custo-benefício  
+84. encontrar cupom, cashback e otimizar checkout  
+85. montar lista de compras por cardápio e estoque  
+86. reposição automática de itens recorrentes  
+87. planejar compras por evento  
+88. recomendar substitutos mais baratos ou melhores  
+89. alertar melhor momento para comprar  
+90. negociar compra ou serviço automaticamente
+
+#### A.8 Viagens e deslocamento
+91. montagem de roteiro personalizado de viagem  
+92. comparação de voos e hospedagem  
+93. replanejamento em caso de atraso ou cancelamento  
+94. checklist documental de viagem  
+95. sugestões contextuais durante a viagem  
+96. gestão de despesas da viagem em tempo real  
+97. consolidar reservas e itinerários em uma visão única  
+98. avisos operacionais antes de sair  
+99. concierge pessoal contínuo de viagem  
+100. planejamento de bagagem conforme roteiro e clima
+
+---
+
+### Apêndice B — Recomendação de leitura do documento base
+
+Para análise completa, listas originais e formulação detalhada dos blocos, consultar:
+
+`docs/research/assistentes-pessoais-ia-100-use-cases.md`

--- a/docs/research/assistentes-pessoais-ia-100-use-cases.md
+++ b/docs/research/assistentes-pessoais-ia-100-use-cases.md
@@ -1,0 +1,463 @@
+# Assistentes Pessoais com IA — 100 Use Cases
+
+**Data:** 2026-04-18  
+**Autor:** ONE1  
+**Status:** Draft robusto em Markdown  
+**Escopo:** pesquisa estruturada sobre use cases de assistentes pessoais com IA baseada em padrões recorrentes observados em produtos, documentação pública, ecossistemas de produtividade/PKM, fintechs, travel tech, smart home e ferramentas de automação.
+
+---
+
+## Resumo executivo
+
+A internet mostra um padrão claro: os assistentes pessoais com IA que geram valor real não são os que prometem autonomia total, mas os que conseguem fazer bem cinco coisas:
+
+1. **capturar** informação com baixa fricção;  
+2. **triar** o que importa;  
+3. **resumir** excesso de contexto;  
+4. **transformar texto solto em ação**;  
+5. **revisar periodicamente** o que aconteceu e o que ficou pendente.
+
+A maturidade de mercado é mais alta em:
+- email assistido;
+- scheduling;
+- transcrição/resumo de reuniões;
+- leitura e chat com PDF;
+- captura e organização básica de notas;
+- comparação de produtos;
+- categorização financeira;
+- rotinas simples de smart home.
+
+As categorias mais promissoras, mas ainda frágeis, são:
+- chief-of-staff pessoal contínuo;
+- memória pessoal confiável de longo prazo;
+- digest inteligente sem ruído;
+- negociação autônoma;
+- replanejamento ponta a ponta sem supervisão.
+
+---
+
+## Metodologia
+
+### Como esta pesquisa foi construída
+
+Esta síntese foi construída a partir de três frentes:
+
+1. **Padrões recorrentes em sites e páginas de produto**  
+   Exemplos de famílias de produto: email AI, scheduling AI, meeting assistants, PKM, readers, PDF chat, fintechs pessoais, apps de viagem, smart home.
+
+2. **Documentação pública e descrições oficiais de features**  
+   Útil para verificar se um use case existe de fato como proposta de valor explícita.
+
+3. **Workflows e recorrência de uso em ecossistemas públicos**  
+   Produtividade, PKM, automação, creator workflows, leitura, estudo, finanças pessoais, travel planning e household ops.
+
+### Amostra de verificação ao vivo
+
+Durante a pesquisa, foi validada uma amostra de produtos com páginas ativas, incluindo:
+- Motion
+- Reclaim
+- Superhuman
+- Shortwave
+- Otter
+- Fireflies
+- Notion AI
+- Readwise Reader
+- Reflect
+- Mem
+- Capacities
+- Sunsama
+- Rocket Money
+- Monarch
+- ChatPDF
+- RemNote
+
+### Limitações
+
+- Nem toda URL pública responde bem a requests automatizados; alguns domínios retornaram `403`, `404` ou `429` em checagens pontuais.
+- A classificação de maturidade abaixo é uma **inferência analítica**, baseada em recorrência e clareza de proposta de valor, não uma auditoria formal de market share.
+- O documento foca mais em **use cases reais e recorrentes** do que em promessas futuristas.
+
+---
+
+## Tese central
+
+**Assistente pessoal com IA que funciona não é o que pensa por você. É o que reduz atrito, preserva contexto e devolve clareza com boa cadência operacional.**
+
+Em termos práticos, os use cases vencedores tendem a seguir um destes formatos:
+- copiloto de escrita;
+- triagem e priorização;
+- resumo e síntese;
+- transformação em task/checklist;
+- busca contextual;
+- automação parcial com aprovação humana.
+
+---
+
+## Taxonomia dos 100 use cases
+
+Os 100 casos abaixo foram organizados em 8 blocos:
+
+1. Email, mensagens e follow-up  
+2. Agenda, scheduling e coordenação do dia  
+3. Reuniões, calls e memória operacional  
+4. Notas, second brain e captura  
+5. Pesquisa pessoal, leitura e síntese  
+6. Tasks, execução e produtividade pessoal  
+7. Compras, consumo e pesquisa assistida  
+8. Viagens e deslocamento
+
+### Legenda de maturidade
+- **[A] Alta** — solução amplamente visível e já relativamente consolidada.
+- **[M] Média** — valor claro, adoção crescente, mas ainda com fricções.
+- **[E] Emergente** — existe como workflow ou promessa, mas ainda é frágil.
+
+---
+
+# 1) Email, mensagens e follow-up
+
+1. **[A] Redação assistida de email** — cria rascunhos com base no contexto.  
+2. **[A] Reescrita por tom** — formal, diplomático, direto, curto.  
+3. **[A] Resumo de threads longas** — condensa histórico em bullets úteis.  
+4. **[A] Smart reply contextual** — sugere respostas rápidas realmente acionáveis.  
+5. **[A] Priorização de inbox** — separa urgente, importante, FYI e ruído.  
+6. **[M] Classificação por intenção** — cobrança, suporte, venda, reunião, aprovação.  
+7. **[A] Detecção de emails sem resposta** — encontra pendências esquecidas.  
+8. **[A] Follow-up automático por regra** — reenviar/cobrar se não houver resposta.  
+9. **[M] Sugestão de melhor timing de follow-up** — decide quando insistir.  
+10. **[M] Extração de tarefas do email** — transforma thread em task.  
+11. **[M] Extração de dados estruturados** — contato, prazo, valor, owner.  
+12. **[A] Resumo de canais de chat** — Slack, Teams, Telegram, Discord.  
+13. **[A] Catch-up de ausência** — “o que perdi nas últimas horas?”.  
+14. **[M] Detecção de perguntas sem resposta em grupos** — reduz abandono.  
+15. **[A] Transformar mensagem em task/ticket** — conversa vira item executável.
+
+### Observações do bloco
+- Este é um dos blocos mais maduros da pesquisa.
+- O valor vem de reduzir sobrecarga cognitiva, não de “responder tudo sozinho”.
+- O risco principal é classificar errado ou priorizar ruído.
+
+---
+
+# 2) Agenda, scheduling e coordenação do dia
+
+16. **[A] Encontrar janelas comuns para reunião**.  
+17. **[M] Negociação de horário em linguagem natural**.  
+18. **[A] Time blocking automático para tarefas**.  
+19. **[A] Proteção de blocos de foco**.  
+20. **[A] Reagendamento após conflito**.  
+21. **[M] Otimização por energia/contexto** — tarefa certa no melhor horário.  
+22. **[A] Inserção automática de buffers**.  
+23. **[M] Briefing matinal do dia** — agenda, riscos, follow-ups, foco.  
+24. **[M] Preparação de lista “o que preciso hoje”** — documentos, deslocamentos, itens.  
+25. **[M] Priorização do dia a partir de agenda + backlog**.  
+26. **[M] Daily note automatizada** — compõe calendário + tasks + notas.  
+27. **[M] Weekly review automatizada** — consolida entregas, travas, aprendizados.  
+28. **[E] Replanejamento autônomo contínuo do dia**.  
+29. **[M] Atualização de status pessoal baseada em agenda + mensagens**.  
+30. **[M] Preparação pré-reunião** — pessoas, histórico e materiais.
+
+### Observações do bloco
+- Scheduling é forte quando a automação é determinística.
+- A parte “conversacional” ainda erra mais do que deveria.
+- Daily note e weekly review são promissoras, mas dependem de governança de entrada.
+
+---
+
+# 3) Reuniões, calls e memória operacional
+
+31. **[A] Transcrição automática de reunião**.  
+32. **[A] Resumo automático de reunião**.  
+33. **[A] Extração de action items** com owner e prazo.  
+34. **[A] Registro de decisões tomadas**.  
+35. **[M] Detecção de pendências implícitas**.  
+36. **[M] Follow-up pós-reunião pronto para envio**.  
+37. **[A] Atualização de CRM após call**.  
+38. **[M] Coaching de conversa** — objeções, clareza, talk ratio.  
+39. **[M] Consolidação de múltiplas reuniões em memória única de projeto**.  
+40. **[M] Busca semântica em histórico de reuniões**.
+
+### Observações do bloco
+- Meeting assistants são uma das verticais mais sólidas do mercado atual.
+- O ROI é claro: menos trabalho manual pós-reunião.
+- O risco é transformar inferência em “decisão registrada” sem validação.
+
+---
+
+# 4) Notas, second brain e captura
+
+41. **[A] Inbox universal de notas** — texto solto vira nota organizada.  
+42. **[A] Limpeza de notas brutas** — brain dump para formato legível.  
+43. **[A] Auto-tagging semântico**.  
+44. **[A] Conversar com o próprio acervo**.  
+45. **[M] Sugestão de notas relacionadas**.  
+46. **[A] Resumo de notas longas**.  
+47. **[A] Transformar nota em documento/publicação**.  
+48. **[M] Journaling assistido**.  
+49. **[M] Recap de daily notes por semana ou mês**.  
+50. **[A] Captura multimodal** — voz, imagem, texto.  
+51. **[A] OCR de screenshots, documentos e quadros**.  
+52. **[M] Enriquecimento com entidades** — pessoa, empresa, projeto, conceito.  
+53. **[M] Deduplicação de notas redundantes**.  
+54. **[M] Refatoração de acervo antigo**.  
+55. **[E] “Manual do meu cérebro” sempre atualizado**.
+
+### Observações do bloco
+- O second brain com IA já é real, mas ainda muito heterogêneo.
+- O valor cresce quando a captura é barata e a recuperação é boa.
+- O risco é criar um acervo inflado e pouco governável.
+
+---
+
+# 5) Pesquisa pessoal, leitura e síntese
+
+56. **[A] Resumo de artigo web**.  
+57. **[A] Resumo de PDF**.  
+58. **[A] Chat com PDF**.  
+59. **[A] Explicação simplificada de paper ou texto técnico**.  
+60. **[M] Extração de argumentos e contra-argumentos**.  
+61. **[A] Transformar leitura em fichamento estruturado**.  
+62. **[A] Exportar highlights com síntese para notas**.  
+63. **[M] Síntese cruzada de múltiplas fontes pessoais**.  
+64. **[M] Comparar o que você já leu sobre A vs B**.  
+65. **[M] Timeline de quando você pensou ou decidiu algo**.  
+66. **[M] Detectar lacunas do que falta estudar**.  
+67. **[A] Criar outline de artigo, apresentação ou memo**.  
+68. **[M] Digest de notícias por tema**.  
+69. **[M] Resumo semanal do que foi consumido**.  
+70. **[M] Briefing rápido antes de escrever ou falar sobre um tema**.
+
+### Observações do bloco
+- A categoria leitura/PDF é hoje uma das mais claras em valor percebido.
+- Digest temático é útil, mas só com filtro forte e escopo restrito.
+- O principal risco é ruído travestido de inteligência.
+
+---
+
+# 6) Tasks, execução e produtividade pessoal
+
+71. **[A] Captura de tasks por linguagem natural**.  
+72. **[M] Priorização automática de backlog pessoal**.  
+73. **[A] Quebra de objetivo em subtarefas**.  
+74. **[A] Geração de checklist para processo pessoal** — mudança, IR, viagem.  
+75. **[M] Planejamento semanal pessoal**.  
+76. **[M] Replanejamento quando o dia descarrila**.  
+77. **[M] Coaching de hábitos leves** — água, sono, leitura, treino.  
+78. **[M] Accountability bot pessoal** — check-ins e cobrança leve.  
+79. **[A] Execução entre apps por comando natural** — calendar + reminders + messaging.  
+80. **[M] Preenchimento assistido de formulários repetitivos**.
+
+### Observações do bloco
+- O valor tende a ser alto quando o sistema transforma ambiguidade em próximo passo concreto.
+- A parte mais madura é decomposição e checklist; a mais frágil é priorização totalmente autônoma.
+
+---
+
+# 7) Compras, consumo e pesquisa assistida
+
+81. **[A] Comparar produtos por especificação e necessidade**.  
+82. **[A] Resumir reviews e reclamações**.  
+83. **[M] Sugerir melhor custo-benefício**.  
+84. **[A] Encontrar cupom, cashback e otimizar checkout**.  
+85. **[M] Montar lista de compras por cardápio e estoque**.  
+86. **[M] Reposição automática de itens recorrentes**.  
+87. **[A] Planejar compras por evento** — festa, bebê, mudança, viagem.  
+88. **[M] Recomendar substitutos mais baratos ou melhores**.  
+89. **[M] Alertar melhor momento para comprar**.  
+90. **[E] Negociar compra ou serviço automaticamente**.
+
+### Observações do bloco
+- Comparação e síntese de reviews já são muito fortes.
+- A compra autônoma ainda enfrenta barreiras de confiança e contexto.
+
+---
+
+# 8) Viagens e deslocamento
+
+91. **[A] Montagem de roteiro personalizado de viagem**.  
+92. **[A] Comparação de voos e hospedagem**.  
+93. **[M] Replanejamento em caso de atraso ou cancelamento**.  
+94. **[A] Checklist documental de viagem**.  
+95. **[M] Sugestões contextuais durante a viagem** — comer, deslocar, evitar fila.  
+96. **[M] Gestão de despesas da viagem em tempo real**.  
+97. **[M] Consolidar reservas e itinerários em uma visão única**.  
+98. **[M] Avisos operacionais antes de sair** — trânsito, clima, documentos.  
+99. **[E] Concierge pessoal contínuo de viagem**.  
+100. **[M] Planejamento de bagagem conforme roteiro e clima**.
+
+### Observações do bloco
+- Travel planning é um dos usos mais intuitivos de IA para consumidores.
+- O valor cai quando a resposta é genérica e não contextualizada.
+
+---
+
+## Padrões transversais encontrados
+
+### 1. A maior parte do valor está em microautomação
+Os casos mais recorrentes não dependem de “autonomia geral”. Eles dependem de pequenas automações de alta frequência.
+
+### 2. O mercado premia redução de fricção, não complexidade técnica invisível
+Captura rápida, resumo bom, follow-up certo e checklist acionável são mais úteis do que um agente supostamente genial sem confiabilidade.
+
+### 3. Os sistemas mais úteis combinam múltiplas fontes
+Os melhores resultados aparecem quando o assistente cruza:
+- email;
+- calendário;
+- mensagens;
+- reuniões;
+- tasks;
+- notas;
+- documentos.
+
+### 4. O padrão dominante ainda é “AI + workflow + human approval”
+Autonomia total continua rara e arriscada.
+
+### 5. A qualidade do filtro importa mais que a qualidade da prosa
+Um resumo eloquente de informação irrelevante continua sendo ruído.
+
+---
+
+## Ranking analítico de maturidade por macrobloco
+
+### Mais maduros
+1. Email assistido  
+2. Scheduling e agenda  
+3. Reuniões e meeting notes  
+4. Resumo de leitura / PDF chat  
+5. Comparação de produtos e síntese de reviews
+
+### Média-alta maturidade
+6. Notes/second brain com IA  
+7. Finanças pessoais assistidas  
+8. Tasks e checklist operacionais
+
+### Mais promissores, mas instáveis
+9. Memória pessoal profunda  
+10. Digest temático sem ruído  
+11. Chief-of-staff pessoal contínuo  
+12. Concierge autônomo de viagem/vida pessoal
+
+---
+
+## Top 20 use cases com melhor combinação de valor + maturidade
+
+1. Redação assistida de email  
+2. Resumo de threads longas  
+3. Priorização de inbox  
+4. Follow-up automático por regra  
+5. Encontrar janelas comuns para reunião  
+6. Time blocking automático para tarefas  
+7. Proteção de blocos de foco  
+8. Transcrição automática de reunião  
+9. Resumo automático de reunião  
+10. Extração de action items  
+11. Conversar com o próprio acervo  
+12. OCR de documentos e screenshots  
+13. Resumo de PDF  
+14. Chat com PDF  
+15. Transformar leitura em fichamento estruturado  
+16. Captura de tasks por linguagem natural  
+17. Geração de checklist para processo pessoal  
+18. Comparação de produtos  
+19. Resumo de reviews e reclamações  
+20. Montagem de roteiro personalizado de viagem
+
+---
+
+## Principais riscos
+
+### 1. Ruído operacional
+Se o assistente captura demais, resume demais e classifica demais, ele aumenta entropia em vez de reduzir.
+
+### 2. Falsa priorização
+O sistema pode parecer convincente ao ordenar tarefas, emails e decisões, mas usar critérios ruins.
+
+### 3. Inferência vendida como fato
+Isso é especialmente perigoso em:
+- reunião;
+- finanças;
+- burocracia;
+- saúde;
+- viagem com restrições reais.
+
+### 4. Dependência de integração fraca
+Boa parte do valor prometido depende de APIs, permissões e qualidade de ingestão.
+
+### 5. Falta de governança
+Sem regras explícitas, a IA começa a poluir o sistema com informação semiútil.
+
+---
+
+## Oportunidades de produto e implementação
+
+### Se o objetivo for produto B2C/B2B2C
+As oportunidades mais fortes parecem estar em:
+- assistente de rotina diária com briefing + triagem + follow-up;
+- second brain governável com recuperação semântica boa;
+- assistente de leitura e síntese pessoal;
+- coordenação operacional pessoal com foco em agenda, tarefas e burocracia;
+- travel assistant focado em contexto, não só em roteiro bonito.
+
+### Se o objetivo for stack pessoal de automação
+A ordem recomendada de implementação é:
+1. captura;
+2. triagem;
+3. resumo;
+4. transformação em task/checklist;
+5. revisão diária/semanal.
+
+---
+
+## Implicação estratégica
+
+A pesquisa sugere que “assistente pessoal com IA” não deve ser pensado como uma categoria única. Existem, na prática, pelo menos quatro subcategorias:
+
+1. **copiloto de comunicação**  
+2. **copiloto de organização pessoal**  
+3. **copiloto de conhecimento e memória**  
+4. **copiloto de execução do mundo real**
+
+O erro comum é tentar atacar as quatro ao mesmo tempo.
+
+---
+
+## Conclusão final
+
+O mercado já validou dezenas de use cases de assistentes pessoais com IA, mas a distribuição de valor é desigual. Os vencedores atuais são os que:
+- operam em cima de dados estruturados ou semi-estruturados;
+- têm frequência alta de uso;
+- exigem pouco risco para o usuário;
+- resolvem atrito recorrente;
+- devolvem clareza em vez de produzir texto bonito.
+
+**Em uma frase:** a fronteira real não é “fazer tudo pelo usuário”; é **ajudar o usuário a decidir e agir com menos ruído**.
+
+---
+
+## Apêndice A — Exemplos de famílias de produto citadas durante a pesquisa
+
+- Motion  
+- Reclaim  
+- Superhuman  
+- Shortwave  
+- Otter  
+- Fireflies  
+- Notion AI  
+- Readwise Reader  
+- Reflect  
+- Mem  
+- Capacities  
+- Sunsama  
+- Rocket Money  
+- Monarch  
+- ChatPDF  
+- RemNote
+
+---
+
+## Apêndice B — Próximos desdobramentos possíveis
+
+1. transformar os 100 casos em planilha com scoring;  
+2. recortar top 20 para ONE1/Hermes + Obsidian;  
+3. montar matriz `valor x maturidade x risco x implementabilidade`;  
+4. separar commodity vs oportunidade real de produto;  
+5. construir roadmap V1/V2/V3 de um assistente pessoal operacional.

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1035,7 +1035,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         except Exception as md_error:
                             # Markdown parsing failed, try plain text
                             if "parse" in str(md_error).lower() or "markdown" in str(md_error).lower():
-                                logger.warning("[%s] MarkdownV2 parse failed, falling back to plain text: %s", self.name, md_error)
+                                logger.debug("[%s] MarkdownV2 parse failed, falling back to plain text: %s", self.name, md_error)
                                 plain_chunk = _strip_mdv2(chunk)
                                 msg = await self._bot.send_message(
                                     chat_id=int(chat_id),
@@ -1329,6 +1329,11 @@ class TelegramAdapter(BasePlatformAdapter):
                 return slug
 
         try:
+            from telegram.error import BadRequest as _BadReq
+        except ImportError:
+            _BadReq = None  # type: ignore[assignment,misc]
+
+        try:
             # Build provider buttons — 2 per row
             buttons: list = []
             for p in providers:
@@ -1354,14 +1359,38 @@ class TelegramAdapter(BasePlatformAdapter):
             )
 
             thread_id = metadata.get("thread_id") if metadata else None
-            msg = await self._bot.send_message(
-                chat_id=int(chat_id),
-                text=text,
-                parse_mode=ParseMode.MARKDOWN,
-                reply_markup=keyboard,
-                message_thread_id=int(thread_id) if thread_id else None,
-                **self._link_preview_kwargs(),
-            )
+            effective_thread_id = self._message_thread_id_for_send(thread_id)
+            try:
+                msg = await self._bot.send_message(
+                    chat_id=int(chat_id),
+                    text=text,
+                    parse_mode=ParseMode.MARKDOWN,
+                    reply_markup=keyboard,
+                    message_thread_id=effective_thread_id,
+                    **self._link_preview_kwargs(),
+                )
+            except Exception as send_err:
+                if (
+                    _BadReq
+                    and isinstance(send_err, _BadReq)
+                    and self._is_thread_not_found_error(send_err)
+                    and effective_thread_id is not None
+                ):
+                    logger.info(
+                        "[%s] Model picker thread %s not found, retrying without message_thread_id",
+                        self.name,
+                        effective_thread_id,
+                    )
+                    msg = await self._bot.send_message(
+                        chat_id=int(chat_id),
+                        text=text,
+                        parse_mode=ParseMode.MARKDOWN,
+                        reply_markup=keyboard,
+                        message_thread_id=None,
+                        **self._link_preview_kwargs(),
+                    )
+                else:
+                    raise
 
             # Store picker state keyed by chat_id
             self._model_picker_state[str(chat_id)] = {

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10934,7 +10934,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 and str(os.getpid()) not in line.split()[1:2]  # exclude self
             ]
             if _hermes_procs:
-                logger.warning(
+                logger.debug(
                     "Shutdown diagnostic — other hermes processes running:\n  %s",
                     "\n  ".join(_hermes_procs),
                 )

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -9,6 +9,7 @@ import sys
 import subprocess
 import shutil
 from pathlib import Path
+from functools import lru_cache
 
 from hermes_cli.config import get_project_root, get_hermes_home, get_env_path
 from hermes_constants import display_hermes_home
@@ -100,18 +101,59 @@ def _honcho_is_configured_for_doctor() -> bool:
         return False
 
 
+@lru_cache(maxsize=1)
+def _gateway_runtime_env_presence() -> set[str]:
+    """Best-effort set of env vars present in the running gateway process."""
+    present: set[str] = set()
+    try:
+        from hermes_cli.gateway import get_gateway_runtime_snapshot
+
+        snapshot = get_gateway_runtime_snapshot()
+        if not snapshot.gateway_pids:
+            return present
+
+        for pid in snapshot.gateway_pids:
+            try:
+                result = subprocess.run(
+                    ["ps", "eww", "-p", str(pid)],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+            except (FileNotFoundError, subprocess.TimeoutExpired):
+                continue
+            if result.returncode != 0:
+                continue
+            for chunk in result.stdout.split():
+                if "=" not in chunk:
+                    continue
+                key, _value = chunk.split("=", 1)
+                if key and key.isupper():
+                    present.add(key)
+    except Exception:
+        return set()
+    return present
+
+
+def _has_runtime_env_var(name: str) -> bool:
+    return name in _gateway_runtime_env_presence()
+
+
 def _apply_doctor_tool_availability_overrides(available: list[str], unavailable: list[dict]) -> tuple[list[str], list[dict]]:
     """Adjust runtime-gated tool availability for doctor diagnostics."""
-    if not _honcho_is_configured_for_doctor():
-        return available, unavailable
-
     updated_available = list(available)
     updated_unavailable = []
     for item in unavailable:
         if item.get("name") == "honcho":
-            if "honcho" not in updated_available:
+            if _honcho_is_configured_for_doctor() and "honcho" not in updated_available:
                 updated_available.append("honcho")
-            continue
+                continue
+        if item.get("name") == "web":
+            missing_vars = item.get("missing_vars") or item.get("env_vars") or []
+            if missing_vars and any(_has_runtime_env_var(var) for var in missing_vars):
+                if "web" not in updated_available:
+                    updated_available.append("web")
+                continue
         updated_unavailable.append(item)
     return updated_available, updated_unavailable
 
@@ -1083,6 +1125,8 @@ def run_doctor(args):
     github_token = get_env_value("GITHUB_TOKEN") or get_env_value("GH_TOKEN")
     if github_token:
         check_ok("GitHub token configured (authenticated API access)")
+    elif _has_runtime_env_var("GITHUB_TOKEN") or _has_runtime_env_var("GH_TOKEN"):
+        check_ok("GitHub token configured via running gateway", "(Keychain/runtime-backed)")
     else:
         check_warn("No GITHUB_TOKEN", f"(60 req/hr rate limit — set in {_DHH}/.env for better rates)")
 

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -8,6 +8,7 @@ import os
 import sys
 import subprocess
 from pathlib import Path
+from functools import lru_cache
 
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 
@@ -82,6 +83,59 @@ def _effective_provider_label() -> str:
 from hermes_constants import is_termux as _is_termux
 
 
+@lru_cache(maxsize=1)
+def _gateway_runtime_env_presence() -> set[str]:
+    """Best-effort set of env vars present in the running gateway process.
+
+    This lets status reflect secrets injected by a launch wrapper (for example
+    macOS Keychain-backed gateway services) even when they are intentionally not
+    stored in ~/.hermes/.env for regular shell sessions.
+    """
+    present: set[str] = set()
+    try:
+        from hermes_cli.gateway import get_gateway_runtime_snapshot
+
+        snapshot = get_gateway_runtime_snapshot()
+        if not snapshot.gateway_pids:
+            return present
+
+        for pid in snapshot.gateway_pids:
+            try:
+                result = subprocess.run(
+                    ["ps", "eww", "-p", str(pid)],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                )
+            except (FileNotFoundError, subprocess.TimeoutExpired):
+                continue
+            if result.returncode != 0:
+                continue
+
+            for chunk in result.stdout.split():
+                if "=" not in chunk:
+                    continue
+                key, _value = chunk.split("=", 1)
+                if key and key.isupper():
+                    present.add(key)
+    except Exception:
+        return set()
+    return present
+
+
+def _env_value_or_gateway_presence(env_var: str) -> tuple[str, bool, bool]:
+    """Return (value, present, runtime_only) for an env var.
+
+    runtime_only=True means the variable is absent from the current CLI env/.env
+    but present in the running gateway process.
+    """
+    value = get_env_value(env_var) or ""
+    if value:
+        return value, True, False
+    runtime_present = env_var in _gateway_runtime_env_presence()
+    return "", runtime_present, runtime_present
+
+
 def show_status(args):
     """Show status of all Hermes Agent components."""
     show_all = getattr(args, 'all', False)
@@ -136,9 +190,10 @@ def show_status(args):
     }
     
     for name, env_var in keys.items():
-        value = get_env_value(env_var) or ""
-        has_key = bool(value)
-        display = redact_key(value) if not show_all else value
+        value, has_key, runtime_only = _env_value_or_gateway_presence(env_var)
+        display = redact_key(value) if value and not show_all else value
+        if runtime_only:
+            display = "(runtime via gateway)"
         print(f"  {name:<12}  {check_mark(has_key)} {display}")
 
     from hermes_cli.auth import get_anthropic_key
@@ -321,8 +376,7 @@ def show_status(args):
     }
     
     for name, (token_var, home_var) in platforms.items():
-        token = os.getenv(token_var, "")
-        has_token = bool(token)
+        _token_value, has_token, runtime_only = _env_value_or_gateway_presence(token_var)
         
         home_channel = ""
         if home_var:
@@ -331,7 +385,10 @@ def show_status(args):
         if not home_channel and home_var == "QQBOT_HOME_CHANNEL":
             home_channel = os.getenv("QQ_HOME_CHANNEL", "")
         
-        status = "configured" if has_token else "not configured"
+        if runtime_only:
+            status = "configured via running gateway"
+        else:
+            status = "configured" if has_token else "not configured"
         if home_channel:
             status += f" (home: {home_channel})"
         

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -210,6 +210,50 @@ async def test_send_retries_without_thread_on_thread_not_found():
 
 
 @pytest.mark.asyncio
+async def test_send_model_picker_retries_without_thread_on_thread_not_found(monkeypatch):
+    """Model picker should retry without thread_id when Telegram rejects the topic."""
+    adapter = _make_adapter()
+    adapter._model_picker_state = {}
+
+    from gateway.platforms import telegram as telegram_mod
+
+    monkeypatch.setattr(
+        telegram_mod,
+        "InlineKeyboardButton",
+        lambda text, callback_data: {"text": text, "callback_data": callback_data},
+    )
+    monkeypatch.setattr(telegram_mod, "InlineKeyboardMarkup", lambda rows: {"rows": rows})
+    monkeypatch.setattr(telegram_mod, "ParseMode", SimpleNamespace(MARKDOWN="Markdown"))
+
+    call_log = []
+
+    async def mock_send_message(**kwargs):
+        call_log.append(dict(kwargs))
+        if kwargs.get("message_thread_id") is not None:
+            raise FakeBadRequest("Message thread not found")
+        return SimpleNamespace(message_id=77)
+
+    adapter._bot = SimpleNamespace(send_message=mock_send_message)
+
+    result = await adapter.send_model_picker(
+        chat_id="-100123",
+        providers=[{"name": "OpenAI", "slug": "openai", "models": ["gpt-5.4"], "total_models": 1}],
+        current_model="gpt-5.4",
+        current_provider="openai",
+        session_key="agent:main:telegram:group:-100123:99999",
+        on_model_selected=lambda *_args, **_kwargs: None,
+        metadata={"thread_id": "99999"},
+    )
+
+    assert result.success is True
+    assert result.message_id == "77"
+    assert len(call_log) == 2
+    assert call_log[0]["message_thread_id"] == 99999
+    assert call_log[1]["message_thread_id"] is None
+    assert adapter._model_picker_state["-100123"]["msg_id"] == 77
+
+
+@pytest.mark.asyncio
 async def test_send_raises_on_other_bad_request():
     """Non-thread BadRequest errors should NOT be retried — they fail immediately."""
     adapter = _make_adapter()

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -73,6 +73,32 @@ class TestDoctorToolAvailabilityOverrides:
         assert available == []
         assert unavailable == [honcho_entry]
 
+    def test_marks_web_available_when_any_runtime_backend_env_var_exists(self, monkeypatch):
+        monkeypatch.setattr(
+            doctor,
+            "_gateway_runtime_env_presence",
+            lambda: {"FIRECRAWL_API_URL"},
+        )
+
+        web_entry = {
+            "name": "web",
+            "env_vars": [
+                "EXA_API_KEY",
+                "PARALLEL_API_KEY",
+                "TAVILY_API_KEY",
+                "FIRECRAWL_API_KEY",
+                "FIRECRAWL_API_URL",
+            ],
+            "tools": ["web_search", "web_extract"],
+        }
+        available, unavailable = doctor._apply_doctor_tool_availability_overrides(
+            [],
+            [web_entry],
+        )
+
+        assert available == ["web"]
+        assert unavailable == []
+
 
 class TestHonchoDoctorConfigDetection:
     def test_reports_configured_when_enabled_with_api_key(self, monkeypatch):


### PR DESCRIPTION
## Summary
### Functional changes
- retry Telegram model picker without `message_thread_id` when the topic no longer exists
- reflect gateway runtime credentials in `hermes doctor` and `hermes status`
- add/update targeted tests for doctor/status and Telegram thread fallback

### Documentation commits in this PR
- planning artifacts for the `skill-intake` workstream under `.plans/`
- research docs under `docs/research/`

## Validation
- `python -m pytest tests/hermes_cli/test_doctor.py tests/hermes_cli/test_status.py tests/gateway/test_telegram_thread_fallback.py -q`
- result: `35 passed`
- `hermes doctor`
- `hermes status`

## Review guidance
- if you want to review only behavior changes first, focus on these files:
  - `gateway/platforms/telegram.py`
  - `gateway/run.py`
  - `hermes_cli/doctor.py`
  - `hermes_cli/status.py`
  - `tests/gateway/test_telegram_thread_fallback.py`
  - `tests/hermes_cli/test_doctor.py`

## Notes
- `package-lock.json` churn from update was reviewed and reverted
- gateway Keychain wrapper setup was preserved during update verification
- GitHub currently reports no CI checks for this branch/PR
