### PR TITLE
fix(tui): calm the Activity feed — revert auto-expand-on-error, demote log noise

### DIFF
--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createGatewayEventHandler } from '../app/createGatewayEventHandler.js'
-import { resetOverlayState } from '../app/overlayStore.js'
+import { getOverlayState, resetOverlayState } from '../app/overlayStore.js'
 import { turnController } from '../app/turnController.js'
-import { resetTurnState } from '../app/turnStore.js'
+import { getTurnState, resetTurnState } from '../app/turnStore.js'
 import { patchUiState, resetUiState } from '../app/uiStore.js'
 import { estimateTokensRough } from '../lib/text.js'
 import type { Msg } from '../types.js'
@@ -272,5 +272,43 @@ describe('createGatewayEventHandler', () => {
       panelData: { title: 'Setup Required' },
       role: 'system'
     })
+  })
+
+  it('keeps gateway noise informational and approval out of Activity', async () => {
+    const appended: Msg[] = []
+    const ctx = buildCtx(appended)
+    ctx.gateway.rpc = vi.fn(async () => {
+      throw new Error('cold start')
+    })
+
+    const onEvent = createGatewayEventHandler(ctx)
+
+    onEvent({ payload: { line: 'Traceback: noisy but non-fatal' }, type: 'gateway.stderr' } as any)
+    onEvent({ payload: { preview: 'bad framing' }, type: 'gateway.protocol_error' } as any)
+    onEvent({
+      payload: { command: 'rm -rf /tmp/nope', description: 'dangerous command' },
+      type: 'approval.request'
+    } as any)
+    onEvent({ payload: {}, type: 'gateway.ready' } as any)
+
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(getOverlayState().approval).toMatchObject({ description: 'dangerous command' })
+    expect(getTurnState().activity).toMatchObject([
+      { text: 'Traceback: noisy but non-fatal', tone: 'info' },
+      { text: 'protocol noise detected · /logs to inspect', tone: 'info' },
+      { text: 'protocol noise: bad framing', tone: 'info' },
+      { text: 'command catalog unavailable: cold start', tone: 'info' }
+    ])
+  })
+
+  it('still surfaces terminal turn failures as errors', () => {
+    const appended: Msg[] = []
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    onEvent({ payload: { message: 'boom' }, type: 'error' } as any)
+
+    expect(getTurnState().activity).toMatchObject([{ text: 'boom', tone: 'error' }])
   })
 })

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -11,7 +11,6 @@ import { patchOverlayState } from './overlayStore.js'
 import { turnController } from './turnController.js'
 import { getUiState, patchUiState } from './uiStore.js'
 
-const ERRLIKE_RE = /\b(error|traceback|exception|failed|spawn)\b/i
 const NO_PROVIDER_RE = /\bNo (?:LLM|inference) provider configured\b/i
 
 const statusFromBusy = () => (getUiState().busy ? 'running…' : 'ready')
@@ -111,7 +110,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
           turnController.pushActivity(String(r.warning), 'warn')
         }
       })
-      .catch((e: unknown) => turnController.pushActivity(`command catalog unavailable: ${rpcErrorMessage(e)}`, 'warn'))
+      .catch((e: unknown) => turnController.pushActivity(`command catalog unavailable: ${rpcErrorMessage(e)}`, 'info'))
 
     if (!STARTUP_RESUME_ID) {
       patchUiState({ status: 'forging session…' })
@@ -201,7 +200,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
       case 'gateway.stderr': {
         const line = String(ev.payload.line).slice(0, 120)
 
-        turnController.pushActivity(line, ERRLIKE_RE.test(line) ? 'error' : 'warn')
+        turnController.pushActivity(line, 'info')
 
         return
       }
@@ -222,11 +221,11 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
         if (!turnController.protocolWarned) {
           turnController.protocolWarned = true
-          turnController.pushActivity('protocol noise detected · /logs to inspect', 'warn')
+          turnController.pushActivity('protocol noise detected · /logs to inspect', 'info')
         }
 
         if (ev.payload?.preview) {
-          turnController.pushActivity(`protocol noise: ${String(ev.payload.preview).slice(0, 120)}`, 'warn')
+          turnController.pushActivity(`protocol noise: ${String(ev.payload.preview).slice(0, 120)}`, 'info')
         }
 
         return
@@ -299,7 +298,6 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         const description = String(ev.payload.description ?? 'dangerous command')
 
         patchOverlayState({ approval: { command: String(ev.payload.command ?? ''), description } })
-        turnController.pushActivity(`approval needed · ${description}`, 'warn')
         setStatus('approval needed')
 
         return

--- a/ui-tui/src/components/thinking.tsx
+++ b/ui-tui/src/components/thinking.tsx
@@ -1,5 +1,5 @@
 import { Box, NoSelect, Text } from '@hermes/ink'
-import { memo, type ReactNode, useEffect, useMemo, useState } from 'react'
+import { memo, useEffect, useMemo, useState, type ReactNode } from 'react'
 import spinners, { type BrailleSpinnerName } from 'unicode-animations'
 
 import { THINKING_COT_MAX } from '../config/limits.js'
@@ -595,17 +595,6 @@ export const ToolTrail = memo(function ToolTrail({
       setOpenMeta(false)
     }
   }, [detailsMode])
-
-  const latestErrorId = useMemo(
-    () => activity.reduce((max, i) => (i.tone === 'error' && i.id > max ? i.id : max), -1),
-    [activity]
-  )
-
-  useEffect(() => {
-    if (latestErrorId >= 0) {
-      setOpenMeta(true)
-    }
-  }, [latestErrorId])
 
   const cot = useMemo(() => thinkingPreview(reasoning, 'full', THINKING_COT_MAX), [reasoning])
 


### PR DESCRIPTION
## Summary

Restore the old-CLI contract where **only complete failures tint the Activity chevron red**. Everything else is still visible for debugging but no longer commandeers attention.

Two small commits:

1. **`fix(tui): don't force-open Activity on every error`** — reverts the auto-expand-on-new-error effect from `93b47d96`. The effect overrode the user's chosen `detailsMode` and visually interrupted every turn. Red/yellow chevron tint stays as the passive signal; click to read, same as Thinking and Tool calls.

2. **`fix(tui): demote gateway log-noise from Activity to info tone`** — reclassifies the noisy sources in `createGatewayEventHandler.ts`:
   - `gateway.stderr` → always `info` (drops the `ERRLIKE_RE` regex)
   - `gateway.protocol_error` (both pushes) → `info`
   - `commands.catalog` cold-start failure → `info`
   - `approval.request` → no Activity entry (the overlay is the signal)

   Kept as `error`: terminal `error` event, `gateway.start_timeout`, gateway-exited, explicit `status.update` error/warn kinds.

## Motivation

The old CLI silently swallowed ~99% of stderr and protocol noise — only complete failures ever surfaced. The new event pipeline surfaced that unfiltered firehose into the Activity feed as `error`/`warn` tones, and the auto-expand compounded it into a per-turn attention-grab. This restores the signal-to-noise ratio of the old CLI while keeping the information accessible via the (now-dim) Activity chevron and `/logs`.

## Net effect

| Source | Before | After |
|---|---|---|
| `gateway.stderr` | `error`/`warn` by regex | `info` |
| `gateway.protocol_error` | `warn` (×2) | `info` (×2) |
| `commands.catalog` fail | `warn` | `info` |
| `approval.request` | `warn` | _(not pushed)_ |
| terminal `error` event | `error` | `error` (unchanged) |
| `gateway.start_timeout` | `error` | `error` (unchanged) |
| gateway exited | `error` | `error` (unchanged) |

In normal operation the Activity chevron stays dim — no eye-grab. Red chevron genuinely means "something broke, worth a click".

## Explicitly deferred (not in this branch)

- Per-section config keys (`display.open_thinking/tools/activity`) for the "always A+B, never C" mental model. Revisit if source triage doesn't quiet things enough.
- Opt-in `display.auto_expand_errors` flag for users who liked the pop-up.

## Test plan

- [x] `npm test` in `ui-tui/` — 24 files, 186 tests, green
- [x] Added regression test: gateway noise lands as `info`, approval stays out of Activity, real `error` event still tints red
- [ ] Manual: run the TUI, trigger stderr noise (e.g. a subprocess warning) — confirm Activity chevron stays dim/closed
- [ ] Manual: kill the gateway mid-turn — confirm Activity chevron tints red, still collapsed by default