### PR TITLE
fix(banner): center banner_logo in terminal

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from hermes_constants import get_hermes_home
 from typing import Dict, List, Optional
 
+from rich.align import Align
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
@@ -530,6 +531,6 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
     term_width = shutil.get_terminal_size().columns
     if term_width >= 95:
         _logo = _bskin.banner_logo if _bskin and hasattr(_bskin, 'banner_logo') and _bskin.banner_logo else HERMES_AGENT_LOGO
-        console.print(_logo)
+        console.print(Align.center(_logo))
         console.print()
     console.print(outer_panel)


### PR DESCRIPTION
## Summary

In `hermes_cli/banner.py`, the `banner_logo` was printed left-aligned with `console.print(_logo)`. The screenshot generator already uses `Align.center(logo)` — now the live banner does too.

**Root cause:** Line 533 called `console.print(_logo)` directly without centering.

**Fix:** Wrap `_logo` with `Align.center()`.

## Changes
- `hermes_cli/banner.py`: `from rich.align import Align` + `console.print(Align.center(_logo))`

Closes #13800