### PR TITLE
fix(agent): preserve dots in model names for Bedrock Mantle endpoints

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6620,6 +6620,7 @@ class AIAgent:
             # AWS Bedrock runtime endpoints — defense-in-depth when
             # ``provider`` is unset but ``base_url`` still names Bedrock.
             or "bedrock-runtime." in base
+            or "bedrock-mantle." in base
         )
 
     def _is_qwen_portal(self) -> bool:

--- a/tests/agent/test_bedrock_integration.py
+++ b/tests/agent/test_bedrock_integration.py
@@ -326,11 +326,35 @@ class TestBedrockPreserveDotsFlag:
         from run_agent import AIAgent
         assert AIAgent._anthropic_preserve_dots(agent) is True
 
+    def test_bedrock_mantle_us_east_1_url_preserves_dots(self):
+        """Bedrock Mantle (``bedrock-mantle.{region}.api.aws``) is an
+        OpenAI-compatible proxy that also exposes an ``/anthropic``
+        path.  Model IDs such as ``anthropic.claude-opus-4-7`` must
+        keep their dots — the endpoint rejects the hyphenated form
+        with HTTP 404."""
+        from types import SimpleNamespace
+        agent = SimpleNamespace(
+            provider="custom",
+            base_url="https://bedrock-mantle.us-east-1.api.aws/anthropic",
+        )
+        from run_agent import AIAgent
+        assert AIAgent._anthropic_preserve_dots(agent) is True
+
+    def test_bedrock_mantle_eu_west_1_url_preserves_dots(self):
+        """Alternative region for Bedrock Mantle."""
+        from types import SimpleNamespace
+        agent = SimpleNamespace(
+            provider="custom",
+            base_url="https://bedrock-mantle.eu-west-1.api.aws/anthropic",
+        )
+        from run_agent import AIAgent
+        assert AIAgent._anthropic_preserve_dots(agent) is True
+
     def test_non_bedrock_aws_url_does_not_preserve_dots(self):
         """Unrelated AWS endpoints (e.g. ``s3.us-east-1.amazonaws.com``)
         must not accidentally activate the dot-preservation heuristic —
-        the heuristic is scoped to the ``bedrock-runtime.`` substring
-        specifically."""
+        the heuristic is scoped to the ``bedrock-runtime.`` and
+        ``bedrock-mantle.`` substrings specifically."""
         from types import SimpleNamespace
         agent = SimpleNamespace(
             provider="custom",


### PR DESCRIPTION
## What does this PR do?

Fixes `_anthropic_preserve_dots()` to recognize Bedrock Mantle (`bedrock-mantle.{region}.api.aws`) URLs, preserving dots in model IDs instead of converting them to dashes.

## Related Issue

Fixes #13816

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- **`run_agent.py`** (`_anthropic_preserve_dots`): Added `"bedrock-mantle."` to the base-URL heuristic alongside the existing `"bedrock-runtime."` check.
- **`tests/agent/test_bedrock_integration.py`** (`TestBedrockPreserveDotsFlag`): Added two tests for Bedrock Mantle URLs (us-east-1, eu-west-1) and updated the negative test docstring.

## How to Test

1. Configure `config.yaml` with a Bedrock Mantle endpoint:
```yaml
model:
  default: anthropic.claude-opus-4-7
  provider: custom
  base_url: https://bedrock-mantle.us-east-1.api.aws/anthropic
  api_mode: anthropic_messages
```
2. Start a chat session -- the model name should be sent as `anthropic.claude-opus-4-7` (dots preserved), not `anthropic-claude-opus-4-7` (dots mangled to dashes).

Or run the tests:
```bash
scripts/run_tests.sh tests/agent/test_bedrock_integration.py -v
```

## Checklist

### Code
- [x] I have read the [Contributing Guide](CONTRIBUTING.md)
- [x] My commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have searched for existing PRs to avoid duplicates
- [x] This PR contains only related changes
- [x] `pytest tests/ -q` passes (42/42 in test_bedrock_integration.py; 1 pre-existing failure in test_minimax_provider.py unrelated to this change)
- [x] I have added tests that prove my fix is effective
- [x] I have tested on: Linux

### Documentation & Housekeeping
- [x] Considered cross-platform impact (URL string matching only -- no platform-specific behavior)