### PR TITLE
fix(gateway): read /status token usage from SQLite

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4972,6 +4972,21 @@ class GatewayRunner:
 
         return "\n".join(lines)
 
+    def _status_total_tokens(self, session_entry: "SessionEntry") -> int:
+        """Return total tokens for /status, preferring SQLite session stats."""
+        if self._session_db:
+            try:
+                row = self._session_db.get_session(session_entry.session_id)
+            except Exception:
+                row = None
+            if row:
+                input_tokens = int(row.get("input_tokens") or 0)
+                output_tokens = int(row.get("output_tokens") or 0)
+                cache_read_tokens = int(row.get("cache_read_tokens") or 0)
+                cache_write_tokens = int(row.get("cache_write_tokens") or 0)
+                return input_tokens + output_tokens + cache_read_tokens + cache_write_tokens
+        return int(getattr(session_entry, "total_tokens", 0) or 0)
+
     async def _handle_status_command(self, event: MessageEvent) -> str:
         """Handle /status command."""
         source = event.source
@@ -4990,6 +5005,8 @@ class GatewayRunner:
             except Exception:
                 title = None
 
+        total_tokens = self._status_total_tokens(session_entry)
+
         lines = [
             "📊 **Hermes Gateway Status**",
             "",
@@ -5000,7 +5017,7 @@ class GatewayRunner:
         lines.extend([
             f"**Created:** {session_entry.created_at.strftime('%Y-%m-%d %H:%M')}",
             f"**Last Activity:** {session_entry.updated_at.strftime('%Y-%m-%d %H:%M')}",
-            f"**Tokens:** {session_entry.total_tokens:,}",
+            f"**Tokens:** {total_tokens:,}",
             f"**Agent Running:** {'Yes ⚡' if is_running else 'No'}",
             "",
             f"**Connected Platforms:** {', '.join(connected_platforms)}",

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -54,6 +54,7 @@ def _make_runner(session_entry: SessionEntry):
     runner._pending_messages = {}
     runner._pending_approvals = {}
     runner._session_db = MagicMock()
+    runner._session_db.get_session.return_value = None
     runner._session_db.get_session_title.return_value = None
     runner._reasoning_config = None
     runner._provider_routing = {}
@@ -111,6 +112,31 @@ async def test_status_command_includes_session_title_when_present():
 
     assert "**Session ID:** `sess-1`" in result
     assert "**Title:** My titled session" in result
+
+
+@pytest.mark.asyncio
+async def test_status_command_prefers_sqlite_token_counts_over_session_store_entry():
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+        total_tokens=0,
+    )
+    runner = _make_runner(session_entry)
+    runner._session_db.get_session.return_value = {
+        "id": "sess-1",
+        "input_tokens": 120,
+        "output_tokens": 45,
+        "cache_read_tokens": 30,
+        "cache_write_tokens": 5,
+    }
+
+    result = await runner._handle_message(_make_event("/status"))
+
+    assert "**Tokens:** 200" in result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

This fixes a gateway `/status` regression where the command can show `Tokens: 0` even when the same session already has substantial token usage persisted in SQLite `state.db`.

Root cause:
- gateway token accounting is now written to SQLite / `SessionDB`
- `/status` still renders `session_entry.total_tokens` from `SessionStore` / `sessions.json`
- that mirror is no longer kept in sync, so it can drift to `0`

This PR fixes the bug by making `/status` prefer the authoritative SQLite session stats first, while keeping `SessionEntry.total_tokens` as a fallback when no DB row exists. That matches the current source of truth and avoids reintroducing another mirrored accounting path that can drift again.

## Related Issue

Fixes #5960
Related: #11087

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`
  - add `_status_total_tokens()` helper
  - read `input_tokens`, `output_tokens`, `cache_read_tokens`, and `cache_write_tokens` from `self._session_db.get_session(session_id)`
  - make `/status` display the SQLite-derived total instead of `session_entry.total_tokens` when DB stats are available
- `tests/gateway/test_status_command.py`
  - seed the mocked session DB with `get_session.return_value = None` by default
  - add a regression test proving `/status` prefers SQLite-backed token counts over a stale `SessionStore` total

## How to Test

1. Reproduce on current `main`
   - run Hermes through the gateway
   - have a longer conversation so the session accumulates token usage
   - run `/status`
   - observe that it can report `Tokens: 0` while the same session has non-zero usage in `state.db`
2. Apply this branch and run:
   - `pytest tests/gateway/test_status_command.py -q`
3. Verify the focused regression path:
   - `python -m py_compile gateway/run.py tests/gateway/test_status_command.py`
   - `git diff --check`
   - confirm `/status` now reports the SQLite-backed total instead of `0`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 / Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

### Screenshots / Logs

Focused validation run:

```text
$ pytest tests/gateway/test_status_[command.py](https://command.py/) -q
10 passed
```

Additional checks:

```text
$ python -m py_compile gateway/[run.py](https://run.py/) tests/gateway/test_status_[command.py](https://command.py/)
# passed

$ git diff --check
# passed
```# Screenshots / Logs

Focused validation run:
 `$ pytest tests/gateway/test_status_[command.py](https://command.py/) -q`
10 passed