### PR TITLE
fix(bedrock): preserve dots in model names for Bedrock Mantle proxy

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6635,9 +6635,12 @@ class AIAgent:
             or "minimax" in base
             or "opencode.ai/zen/" in base
             or "bigmodel.cn" in base
-            # AWS Bedrock runtime endpoints — defense-in-depth when
+            # AWS Bedrock endpoints — defense-in-depth when
             # ``provider`` is unset but ``base_url`` still names Bedrock.
+            # Covers both ``bedrock-runtime.`` (standard) and
+            # ``bedrock-mantle.`` (Mantle proxy) hostname patterns.
             or "bedrock-runtime." in base
+            or "bedrock-mantle." in base
         )
 
     def _is_qwen_portal(self) -> bool:

--- a/tests/agent/test_bedrock_integration.py
+++ b/tests/agent/test_bedrock_integration.py
@@ -438,3 +438,47 @@ class TestBedrockBuildAnthropicKwargsEndToEnd:
             preserve_dots=False,
         )
         assert kwargs["model"] == "global-anthropic-claude-opus-4-7"
+
+
+class TestBedrockMantlePreserveDots:
+    """Regression tests for #13816 — Bedrock Mantle proxy
+    (``bedrock-mantle.{region}.api.aws``) must also preserve dots in
+    model names, just like ``bedrock-runtime.`` endpoints."""
+
+    def test_bedrock_mantle_us_east_1_preserves_dots(self):
+        """The reporter's exact URL pattern from #13816."""
+        from types import SimpleNamespace
+        agent = SimpleNamespace(
+            provider="custom",
+            base_url="https://bedrock-mantle.us-east-1.api.aws/anthropic",
+        )
+        from run_agent import AIAgent
+        assert AIAgent._anthropic_preserve_dots(agent) is True
+
+    def test_bedrock_mantle_eu_west_1_preserves_dots(self):
+        """Different region — same Mantle hostname pattern."""
+        from types import SimpleNamespace
+        agent = SimpleNamespace(
+            provider="custom",
+            base_url="https://bedrock-mantle.eu-west-1.api.aws",
+        )
+        from run_agent import AIAgent
+        assert AIAgent._anthropic_preserve_dots(agent) is True
+
+    def test_bedrock_mantle_model_name_survives_normalize(self):
+        """End-to-end: ``normalize_model_name`` with preserve_dots=True
+        keeps the Bedrock dotted model ID intact."""
+        from agent.anthropic_adapter import normalize_model_name
+        assert normalize_model_name(
+            "anthropic.claude-opus-4-7", preserve_dots=True
+        ) == "anthropic.claude-opus-4-7"
+
+    def test_non_bedrock_mantle_aws_url_does_not_preserve(self):
+        """Unrelated AWS endpoints must not trigger dot preservation."""
+        from types import SimpleNamespace
+        agent = SimpleNamespace(
+            provider="custom",
+            base_url="https://lambda.us-east-1.api.aws",
+        )
+        from run_agent import AIAgent
+        assert AIAgent._anthropic_preserve_dots(agent) is False


### PR DESCRIPTION
## What does this PR do?

Adds `"bedrock-mantle."` to the base-URL heuristic in `_anthropic_preserve_dots()`, alongside the existing `"bedrock-runtime."` check.

## Related Issue

Fixes #13816

## Root Cause

[Bedrock Mantle](https://docs.aws.amazon.com/bedrock/latest/userguide/mantle.html) (`bedrock-mantle.{region}.api.aws`) is an alternative Anthropic-compatible proxy for AWS Bedrock. It uses the same dotted model IDs as standard Bedrock (e.g. `anthropic.claude-opus-4-7`), but the URL heuristic in `_anthropic_preserve_dots()` only checks for `bedrock-runtime.` — missing the Mantle hostname pattern entirely.

Result: `normalize_model_name()` converts dots to dashes → `anthropic-claude-opus-4-7` → HTTP 404.

## Fix

One-line addition: `or "bedrock-mantle." in base` in the URL heuristic, consistent with the existing `bedrock-runtime.` check.

## Type of Change

- [x] Bug fix (non-breaking change)

## Tests

4 regression tests added in `TestBedrockMantlePreserveDots`:
1. Reporter's exact URL pattern (`bedrock-mantle.us-east-1.api.aws/anthropic`)
2. Different region (`bedrock-mantle.eu-west-1.api.aws`)
3. End-to-end model name normalization with `preserve_dots=True`
4. Negative test: unrelated AWS URLs don't trigger preservation

All 44 tests pass (40 existing + 4 new).