### PR TITLE
chore(models): drop 3 models from nous portal recommended list

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -130,12 +130,9 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "z-ai/glm-5-turbo",
         "x-ai/grok-4.20-beta",
         "nvidia/nemotron-3-super-120b-a12b",
-        "nvidia/nemotron-3-super-120b-a12b:free",
-        "arcee-ai/trinity-large-preview:free",
         "arcee-ai/trinity-large-thinking",
         "openai/gpt-5.4-pro",
         "openai/gpt-5.4-nano",
-        "openrouter/elephant-alpha",
     ],
     "openai-codex": _codex_curated_models(),
     "copilot-acp": [


### PR DESCRIPTION
## Summary
Removes three slugs from `_PROVIDER_MODELS['nous']` so they no longer appear in the `/model` picker on the nous provider.

## Changes
- `hermes_cli/models.py`: drop `nvidia/nemotron-3-super-120b-a12b:free`, `arcee-ai/trinity-large-preview:free`, `openrouter/elephant-alpha`. Paid nemotron + arcee-thinking variants remain.

## Validation
| | Before | After |
|---|---|---|
| nous picker entries | 29 | 26 |
| py_compile | OK | OK |