### PR TITLE
fix(backup): close SQLite connections on backup failure

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -92,12 +92,12 @@ def _safe_copy_db(src: Path, dst: Path) -> bool:
     Handles WAL mode — produces a consistent snapshot even while
     the DB is being written to.  Falls back to raw copy on failure.
     """
+    conn = None
+    backup_conn = None
     try:
         conn = sqlite3.connect(f"file:{src}?mode=ro", uri=True)
         backup_conn = sqlite3.connect(str(dst))
         conn.backup(backup_conn)
-        backup_conn.close()
-        conn.close()
         return True
     except Exception as exc:
         logger.warning("SQLite safe copy failed for %s: %s", src, exc)
@@ -107,6 +107,11 @@ def _safe_copy_db(src: Path, dst: Path) -> bool:
         except Exception as exc2:
             logger.error("Raw copy also failed for %s: %s", src, exc2)
             return False
+    finally:
+        if backup_conn:
+            backup_conn.close()
+        if conn:
+            conn.close()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

In `_safe_copy_db()`, if `conn.backup(backup_conn)` raises an exception, both the source and destination SQLite connections leak — the `close()` calls on lines 88-89 are in the try block after `backup()`, so they're skipped when the exception jumps to the except handler.

**Before:**
```python
try:
    conn = sqlite3.connect(...)
    backup_conn = sqlite3.connect(...)
    conn.backup(backup_conn)   # if this throws...
    backup_conn.close()         # ...these are skipped
    conn.close()
    return True
except Exception:
    ...  # connections leak
```

**After:**
```python
conn = None
backup_conn = None
try:
    conn = sqlite3.connect(...)
    backup_conn = sqlite3.connect(...)
    conn.backup(backup_conn)
    return True
except Exception:
    ...
finally:
    if backup_conn:
        backup_conn.close()
    if conn:
        conn.close()
```

This ensures both connections are always closed, whether the backup succeeds, fails, or the fallback `shutil.copy2` path is taken.