### PR TITLE
docs(tts): document per-provider max_text_length caps from #13743

### DIFF
--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -87,6 +87,43 @@ tts:
 
 **Speed control**: The global `tts.speed` value applies to all providers by default. Each provider can override it with its own `speed` setting (e.g., `tts.openai.speed: 1.5`). Provider-specific speed takes precedence over the global value. Default is `1.0` (normal speed).
 
+
+### Input length limits
+
+Each provider has a documented per-request input-character cap. Hermes truncates text before calling the provider so requests never fail with a length error:
+
+| Provider | Default cap (chars) |
+|----------|---------------------|
+| Edge TTS | 5000 |
+| OpenAI | 4096 |
+| xAI | 15000 |
+| MiniMax | 10000 |
+| Mistral | 4000 |
+| Google Gemini | 5000 |
+| ElevenLabs | Model-aware (see below) |
+| NeuTTS | 2000 |
+| KittenTTS | 2000 |
+
+**ElevenLabs** picks a cap from the configured `model_id`:
+
+| `model_id` | Cap (chars) |
+|------------|-------------|
+| `eleven_flash_v2_5` | 40000 |
+| `eleven_flash_v2` | 30000 |
+| `eleven_multilingual_v2` (default), `eleven_multilingual_v1`, `eleven_english_sts_v2`, `eleven_english_sts_v1` | 10000 |
+| `eleven_v3`, `eleven_ttv_v3` | 5000 |
+| Unknown model | Falls back to provider default (10000) |
+
+**Override per provider** with `max_text_length:` under the provider section of your TTS config:
+
+```yaml
+tts:
+  openai:
+    max_text_length: 8192   # raise or lower the provider cap
+```
+
+Only positive integers are honored. Zero, negative, non-numeric, or boolean values fall through to the provider default, so a broken config can't accidentally disable truncation.
+
 ### Telegram Voice Bubbles & ffmpeg
 
 Telegram voice bubbles require Opus/OGG audio format:


### PR DESCRIPTION
## Summary

PR #13743 replaced the global `MAX_TEXT_LENGTH = 4000` with a per-provider table and a user-override `max_text_length:` key, but `website/docs/user-guide/features/tts.md` documented no length behaviour at all. Users hitting truncation (or wondering why xAI can take 15k chars while Mistral can't) have no way to discover the new caps or the override from the docs.

This PR adds an **Input length limits** subsection to the Voice & TTS page, right after the existing `### Configuration` YAML block. It documents:

- **Provider default caps** as defined in `tools/tts_tool.py` `PROVIDER_MAX_TEXT_LENGTH` (Edge 5000, OpenAI 4096, xAI 15000, MiniMax 10000, Mistral 4000, Gemini 5000, NeuTTS/KittenTTS 2000)
- **ElevenLabs model-aware table** from `ELEVENLABS_MODEL_MAX_TEXT_LENGTH` (flash_v2_5 40k, flash_v2 30k, multilingual_v2 10k default, v3 5k)
- **Override syntax**: `tts.<provider>.max_text_length: <int>` with a YAML example
- **Validation rules** from `_resolve_max_text_length()` (non-positive, non-integer, or boolean values fall through to the provider default so a broken config can't accidentally disable truncation)

All values verified against `tools/tts_tool.py` on `main` (commit 7b79e0f).

## Test plan
- [x] Values cross-checked against `PROVIDER_MAX_TEXT_LENGTH` and `ELEVENLABS_MODEL_MAX_TEXT_LENGTH` dicts in `tools/tts_tool.py`
- [x] Validation rules cross-checked against `_resolve_max_text_length()` and `tests/tools/test_tts_max_text_length.py`
- [x] Docs-only: `website/docs/user-guide/features/tts.md` +37 / -0
