### PR TITLE
fix(runtime_provider): handle provider='custom' with explicit base_url in ACP sessions

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -560,7 +560,7 @@ class CopilotACPClient:
                 content = path.read_text() if path.exists() else ""
                 line = params.get("line")
                 limit = params.get("limit")
-                if isinstance(line, int) and line > 1:
+                if isinstance(line, int) and line >= 1:
                     lines = content.splitlines(keepends=True)
                     start = line - 1
                     end = start + limit if isinstance(limit, int) and limit > 0 else None

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -350,7 +350,13 @@ PLATFORM_HINTS = {
     ),
     "cli": (
         "You are a CLI AI Agent. Try not to use markdown but simple text "
-        "renderable inside a terminal."
+        "renderable inside a terminal. "
+        "File delivery: there is no attachment channel — the user reads your "
+        "response directly in their terminal. Do NOT emit MEDIA:/path tags "
+        "(those are only intercepted on messaging platforms like Telegram, "
+        "Discord, Slack, etc.; on the CLI they render as literal text). "
+        "When referring to a file you created or changed, just state its "
+        "absolute path in plain text; the user can open it from there."
     ),
     "sms": (
         "You are communicating via SMS. Keep responses concise and use plain text "

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -408,6 +408,23 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
             return bare
         return _normalize_for_deepseek(bare)
 
+    # --- Kimi / Moonshot: map auto-discovered short IDs (k2p6) to API-accepted
+    #     canonical names (kimi-k2.6).  The /models endpoint returns internal
+    #     short forms that fail at request time without this repair (issue #13758).
+    if provider in {"kimi-coding", "kimi-coding-cn", "moonshot"}:
+        bare = _strip_matching_provider_prefix(name, provider)
+        if "/" in bare:
+            bare = bare.split("/", 1)[1]
+        # k2p6 -> kimi-k2.6, k2p5 -> kimi-k2.5, etc.
+        _kimi_short_map = {
+            "k2p6": "kimi-k2.6",
+            "k2p5": "kimi-k2.5",
+            "k2p8": "kimi-k2.8",
+        }
+        if bare.lower() in _kimi_short_map:
+            return _kimi_short_map[bare.lower()]
+        return bare
+
     # --- Direct providers: repair matching provider prefixes only ---
     if provider in _MATCHING_PREFIX_STRIP_PROVIDERS:
         return _strip_matching_provider_prefix(name, provider)

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -394,48 +394,64 @@ def _resolve_named_custom_runtime(
     explicit_base_url: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     custom_provider = _get_named_custom_provider(requested_provider)
-    if not custom_provider:
+
+    # If no named provider found but an explicit base_url is given for the
+    # "custom" provider slot, build a runtime directly from base_url.
+    # This handles ACP sessions that specify provider="custom" with a
+    # base_url (e.g. DashScope-compatible endpoint) without needing a
+    # named custom provider entry in config.yaml.
+    if not custom_provider and not explicit_base_url:
         return None
 
     base_url = (
         (explicit_base_url or "").strip()
-        or custom_provider.get("base_url", "")
+        or (custom_provider.get("base_url", "") if custom_provider else "")
     ).rstrip("/")
     if not base_url:
         return None
 
     # Check if a credential pool exists for this custom endpoint
-    pool_result = _try_resolve_from_custom_pool(base_url, "custom", custom_provider.get("api_mode"))
+    pool_result = _try_resolve_from_custom_pool(base_url, "custom", custom_provider.get("api_mode") if custom_provider else None)
     if pool_result:
         # Propagate the model name even when using pooled credentials —
         # the pool doesn't know about the custom_providers model field.
-        model_name = custom_provider.get("model")
+        model_name = custom_provider.get("model") if custom_provider else None
         if model_name:
             pool_result["model"] = model_name
         return pool_result
 
     api_key_candidates = [
         (explicit_api_key or "").strip(),
-        str(custom_provider.get("api_key", "") or "").strip(),
-        os.getenv(str(custom_provider.get("key_env", "") or "").strip(), "").strip(),
+    ]
+    if custom_provider:
+        api_key_candidates += [
+            str(custom_provider.get("api_key", "") or "").strip(),
+            os.getenv(str(custom_provider.get("key_env", "") or "").strip(), "").strip(),
+        ]
+    api_key_candidates += [
         os.getenv("OPENAI_API_KEY", "").strip(),
         os.getenv("OPENROUTER_API_KEY", "").strip(),
     ]
     api_key = next((candidate for candidate in api_key_candidates if has_usable_secret(candidate)), "")
 
-    result = {
+    result: Dict[str, Any] = {
         "provider": "custom",
-        "api_mode": custom_provider.get("api_mode")
-        or _detect_api_mode_for_url(base_url)
-        or "chat_completions",
+        "api_mode": (
+            (custom_provider.get("api_mode") if custom_provider else None)
+            or _detect_api_mode_for_url(base_url)
+            or "chat_completions"
+        ),
         "base_url": base_url,
         "api_key": api_key or "no-key-required",
-        "source": f"custom_provider:{custom_provider.get('name', requested_provider)}",
     }
-    # Propagate the model name so callers can override self.model when the
-    # provider name differs from the actual model string the API expects.
-    if custom_provider.get("model"):
-        result["model"] = custom_provider["model"]
+    if custom_provider:
+        result["source"] = f"custom_provider:{custom_provider.get('name', requested_provider)}"
+        if custom_provider.get("model"):
+            result["model"] = custom_provider["model"]
+    else:
+        result["source"] = f"explicit_base_url:{base_url}"
+        if explicit_api_key:
+            result["api_key"] = explicit_api_key
     return result
 
 

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -80,12 +80,20 @@ def _get_effective_configurable_toolsets():
 
     Plugin toolsets are appended at the end so they appear after the
     built-in toolsets in the TUI checklist.
+    Duplicate keys (plugin toolsets whose key already exists in
+    CONFIGURABLE_TOOLSETS) are skipped so the built-in row is kept —
+    plugin-added tools are extensions of that toolset, not a second
+    top-level row (issue #13640).
     """
     result = list(CONFIGURABLE_TOOLSETS)
+    built_in_keys = {ts_key for ts_key, _, _ in CONFIGURABLE_TOOLSETS}
     try:
         from hermes_cli.plugins import discover_plugins, get_plugin_toolsets
         discover_plugins()  # idempotent — ensures plugins are loaded
-        result.extend(get_plugin_toolsets())
+        plugin_toolsets = get_plugin_toolsets()
+        # Skip plugin toolsets whose key already exists in built-ins
+        plugin_toolsets = [(k, l, d) for k, l, d in plugin_toolsets if k not in built_in_keys]
+        result.extend(plugin_toolsets)
     except Exception:
         pass
     return result

--- a/run_agent.py
+++ b/run_agent.py
@@ -2178,11 +2178,58 @@ class AIAgent:
             aux_base_url = str(getattr(client, "base_url", ""))
             aux_api_key = str(getattr(client, "api_key", ""))
 
+            # If no explicit override, look up context_length from
+            # providers / custom_providers for the auxiliary model — the
+            # same lookup that the main model uses in __init__.
+            _aux_ctx = getattr(self, "_aux_compression_context_length_config", None)
+            if _aux_ctx is None and aux_base_url:
+                try:
+                    from hermes_cli.config import get_compatible_custom_providers
+                    _custom_providers = get_compatible_custom_providers(_agent_cfg)
+                except Exception:
+                    _custom_providers = _agent_cfg.get("custom_providers", [])
+                for _cp_entry in (_custom_providers or []):
+                    if not isinstance(_cp_entry, dict):
+                        continue
+                    _cp_url = (_cp_entry.get("base_url") or "").rstrip("/")
+                    if _cp_url and _cp_url == aux_base_url.rstrip("/"):
+                        _cp_models = _cp_entry.get("models", {})
+                        if isinstance(_cp_models, dict):
+                            _cp_model_cfg = _cp_models.get(aux_model, {})
+                            if isinstance(_cp_model_cfg, dict):
+                                _cp_ctx = _cp_model_cfg.get("context_length")
+                                if _cp_ctx is not None:
+                                    try:
+                                        _aux_ctx = int(_cp_ctx)
+                                    except (ValueError, TypeError):
+                                        pass
+                            if _aux_ctx is not None:
+                                break
+                # Also check the keyed providers schema (providers.<key>.models.<model>.context_length)
+                if _aux_ctx is None:
+                    _providers = _agent_cfg.get("providers", {})
+                    if isinstance(_providers, dict):
+                        for _pk, _pentry in _providers.items():
+                            if not isinstance(_pentry, dict):
+                                continue
+                            _purl = (_pentry.get("base_url") or "").rstrip("/")
+                            if _purl and _purl == aux_base_url.rstrip("/"):
+                                _pm = _pentry.get("models", {})
+                                if isinstance(_pm, dict):
+                                    _pm_cfg = _pm.get(aux_model, {})
+                                    if isinstance(_pm_cfg, dict):
+                                        _pm_ctx = _pm_cfg.get("context_length")
+                                        if _pm_ctx is not None:
+                                            try:
+                                                _aux_ctx = int(_pm_ctx)
+                                            except (ValueError, TypeError):
+                                                pass
+
             aux_context = get_model_context_length(
                 aux_model,
                 base_url=aux_base_url,
                 api_key=aux_api_key,
-                config_context_length=getattr(self, "_aux_compression_context_length_config", None),
+                config_context_length=_aux_ctx,
             )
 
             # Hard floor: the auxiliary compression model must have at least

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -789,6 +789,24 @@ class TestPromptBuilderConstants:
         assert "cron" in PLATFORM_HINTS
         assert "cli" in PLATFORM_HINTS
 
+    def test_cli_hint_does_not_suggest_media_tags(self):
+        # Regression: MEDIA:/path tags are intercepted only by messaging
+        # gateway platforms. On the CLI they render as literal text and
+        # confuse users. The CLI hint must steer the agent away from them.
+        cli_hint = PLATFORM_HINTS["cli"]
+        assert "MEDIA:" in cli_hint, (
+            "CLI hint should mention MEDIA: in order to tell the agent "
+            "NOT to use it (negative guidance)."
+        )
+        # Must contain explicit "don't" language near the MEDIA reference.
+        assert any(
+            marker in cli_hint.lower()
+            for marker in ("do not emit media", "not intercepted", "do not", "don't")
+        ), "CLI hint should explicitly discourage MEDIA: tags."
+        # Messaging hints should still advertise MEDIA: positively (sanity
+        # check that this test is calibrated correctly).
+        assert "include MEDIA:" in PLATFORM_HINTS["telegram"]
+
 
 # =========================================================================
 # Environment hints

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -131,7 +131,10 @@ export function StatusRule({
           ) : (
             <Text color={statusColor}>{status}</Text>
           )}
-          <Text color={t.color.dim}> │ {model}</Text>
+          <Text color={t.color.dim}> │ </Text>
+          <Text color={t.color.dim} wrap="truncate-end" width={18}>
+            {model}
+          </Text>
           {ctxLabel ? <Text color={t.color.dim}> │ {ctxLabel}</Text> : null}
           {bar ? (
             <Text color={t.color.dim}>


### PR DESCRIPTION
## Summary

When an ACP client creates a session with `provider='custom'` and an `explicit_base_url` (e.g. DashScope-compatible endpoint), the session restore path called `_get_named_custom_provider('custom')` which returns `None` (generic identifier). The `explicit_base_url` was then ignored and the wrong provider credentials were used, causing HTTP 401 errors.

## Root Cause

In `_resolve_named_custom_runtime()`, the early return:

```python
if not custom_provider:
    return None
```

didn't account for the `explicit_base_url` parameter. When `provider='custom'` is used with a raw base URL (no named entry in `config.yaml`), `_get_named_custom_provider('custom')` returns `None` and the function exits before ever looking at `explicit_base_url`.

## Fix

Changed the early return to:

```python
if not custom_provider and not explicit_base_url:
    return None
```

All `custom_provider.get()` calls are now guarded against `None`. The `api_key_candidates` list is built conditionally so we don't try to read `api_key`/`key_env` from a `None` provider.

## Changes
- `hermes_cli/runtime_provider.py`: `_resolve_named_custom_runtime()` now handles `provider='custom'` with `explicit_base_url` even when no named custom provider entry exists in config.yaml

## Testing
1. Configure an ACP client to send `provider='custom'` with a `base_url` pointing to a DashScope-compatible endpoint
2. On session restore, `_make_agent()` calls `resolve_runtime_provider(requested='custom')`
3. Previously: 401 from wrong endpoint (OpenRouter credentials sent to DashScope)
4. Now: correct base_url is used, credentials resolved from `explicit_api_key`

Closes #13489