### PR TITLE
fix: support CSV documents in Telegram gateway

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -590,6 +590,7 @@ SUPPORTED_DOCUMENT_TYPES = {
     ".pdf": "application/pdf",
     ".md": "text/markdown",
     ".txt": "text/plain",
+    ".csv": "text/csv",
     ".log": "text/plain",
     ".zip": "application/zip",
     ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2741,7 +2741,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
                 # For text files, inject content into event.text (capped at 100 KB)
                 MAX_TEXT_INJECT_BYTES = 100 * 1024
-                if ext in (".md", ".txt") and len(raw_bytes) <= MAX_TEXT_INJECT_BYTES:
+                if ext in (".md", ".txt", ".csv") and len(raw_bytes) <= MAX_TEXT_INJECT_BYTES:
                     try:
                         text_content = raw_bytes.decode("utf-8")
                         display_name = original_filename or f"document{ext}"

--- a/tests/gateway/test_document_cache.py
+++ b/tests/gateway/test_document_cache.py
@@ -151,7 +151,7 @@ class TestSupportedDocumentTypes:
 
     @pytest.mark.parametrize(
         "ext",
-        [".pdf", ".md", ".txt", ".zip", ".docx", ".xlsx", ".pptx"],
+        [".pdf", ".md", ".txt", ".csv", ".zip", ".docx", ".xlsx", ".pptx"],
     )
     def test_expected_extensions_present(self, ext):
         assert ext in SUPPORTED_DOCUMENT_TYPES

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -215,6 +215,25 @@ class TestDocumentDownloadBlock:
         assert "[Content of notes.txt]" in event.text
 
     @pytest.mark.asyncio
+    async def test_supported_csv_is_cached_and_injects_content(self, adapter):
+        content = b"name,amount\nAlice,10\nBob,20\n"
+        file_obj = _make_file_obj(content)
+        doc = _make_document(
+            file_name="report.csv", mime_type="text/csv",
+            file_size=len(content), file_obj=file_obj,
+        )
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        event = adapter.handle_message.call_args[0][0]
+        assert len(event.media_urls) == 1
+        assert os.path.exists(event.media_urls[0])
+        assert event.media_types == ["text/csv"]
+        assert "name,amount" in event.text
+        assert "[Content of report.csv]" in event.text
+
+    @pytest.mark.asyncio
     async def test_supported_md_injects_content(self, adapter):
         content = b"# Title\nSome markdown"
         file_obj = _make_file_obj(content)


### PR DESCRIPTION
## Bug Description

Telegram users could send CSV attachments, but Hermes did not treat `.csv` as a supported document type. As a result, small CSV files were not surfaced to the agent like other plain-text documents.

## Root Cause

- `SUPPORTED_DOCUMENT_TYPES` did not include `.csv`
- The Telegram document text-injection path only handled `.md` and `.txt`

## Fix

- add `.csv` to `SUPPORTED_DOCUMENT_TYPES`
- allow small UTF-8 CSV documents to be injected into `event.text`
- add regression coverage for the shared document-type registry and Telegram CSV handling

## How to Verify

1. Send a small UTF-8 `.csv` file to Hermes over Telegram
2. Confirm the document is cached and `event.media_types == ["text/csv"]`
3. Confirm the agent receives `[Content of <file>.csv]` plus the CSV body in message text

## Test Plan

- [x] Added regression test for this bug
- [x] Existing targeted tests still pass (`tests/gateway/test_document_cache.py tests/gateway/test_telegram_documents.py`)
- [x] Manual verification of the fix logic

## Risk Assessment

Low — this only expands Telegram document handling to treat `.csv` like existing plain-text document types. Non-UTF-8 CSVs still skip inline injection, matching current `.txt` / `.md` behavior.
