### PR TITLE
fix(session_search): allow compression-ended parents in search results

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -320,8 +320,8 @@ class TestSessionSearch:
         assert result["sessions_searched"] == 1
         assert current_sid not in [r.get("session_id") for r in result.get("results", [])]
 
-    def test_current_child_session_excludes_parent_lineage(self):
-        """Compression/delegation parents should be excluded for the active child session."""
+    def test_current_child_session_excludes_delegation_parent(self):
+        """Delegation parents (non-compression) should be excluded for the active child session."""
         from unittest.mock import MagicMock
         from tools.session_search_tool import session_search
 
@@ -335,6 +335,7 @@ class TestSessionSearch:
             if session_id == "child_sid":
                 return {"parent_session_id": "parent_sid"}
             if session_id == "parent_sid":
+                # No end_reason — this is a delegation parent, not compression
                 return {"parent_session_id": None}
             return None
 
@@ -348,6 +349,71 @@ class TestSessionSearch:
         assert result["count"] == 0
         assert result["results"] == []
         assert result["sessions_searched"] == 0
+
+    def test_compression_parent_searchable(self):
+        """Compression-ended parents should NOT be excluded — their content is
+        gone from the agent's context window after compaction."""
+        from unittest.mock import MagicMock
+        from tools.session_search_tool import session_search
+
+        mock_db = MagicMock()
+        mock_db.search_messages.return_value = [
+            {"session_id": "parent_sid", "content": "match", "source": "cli",
+             "session_started": 1709500000, "model": "test"},
+        ]
+
+        def _get_session(session_id):
+            if session_id == "child_sid":
+                return {"parent_session_id": "parent_sid"}
+            if session_id == "parent_sid":
+                return {"parent_session_id": None, "end_reason": "compression"}
+            return None
+
+        mock_db.get_session.side_effect = _get_session
+        mock_db.get_messages_as_conversation.return_value = [
+            {"role": "user", "content": "test message"},
+        ]
+
+        result = json.loads(session_search(
+            query="test", db=mock_db, current_session_id="child_sid",
+        ))
+
+        assert result["success"] is True
+        # Compression parent should appear in results, not be excluded
+        assert result["sessions_searched"] >= 1
+
+    def test_multi_level_compression_parent_searchable(self):
+        """Multi-level compaction: A→B→C, both A and B are compression parents.
+        When searching from C, both A and B should be searchable."""
+        from unittest.mock import MagicMock
+        from tools.session_search_tool import session_search
+
+        mock_db = MagicMock()
+        mock_db.search_messages.return_value = [
+            {"session_id": "session_a", "content": "match", "source": "cli",
+             "session_started": 1709500000, "model": "test"},
+        ]
+
+        def _get_session(session_id):
+            if session_id == "session_c":
+                return {"parent_session_id": "session_b"}
+            if session_id == "session_b":
+                return {"parent_session_id": "session_a", "end_reason": "compression"}
+            if session_id == "session_a":
+                return {"parent_session_id": None, "end_reason": "compression"}
+            return None
+
+        mock_db.get_session.side_effect = _get_session
+        mock_db.get_messages_as_conversation.return_value = [
+            {"role": "user", "content": "test message"},
+        ]
+
+        result = json.loads(session_search(
+            query="test", db=mock_db, current_session_id="session_c",
+        ))
+
+        assert result["success"] is True
+        assert result["sessions_searched"] >= 1
 
     def test_limit_none_coerced_to_default(self):
         """Model sends limit=null → should fall back to 3, not TypeError."""

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -10,6 +10,7 @@ from tools.session_search_tool import (
     _format_conversation,
     _truncate_around_matches,
     _get_session_search_max_concurrency,
+    _list_recent_sessions,
     _HIDDEN_SESSION_SOURCES,
     MAX_SESSION_CHARS,
     SESSION_SEARCH_SCHEMA,
@@ -240,6 +241,54 @@ class TestSessionSearchConcurrency:
         assert max_seen["value"] == 1
 
 
+class TestRecentSessionListing:
+    def test_current_child_session_excludes_root_lineage_even_when_child_id_is_longer(self):
+        from unittest.mock import MagicMock
+
+        mock_db = MagicMock()
+        mock_db.list_sessions_rich.return_value = [
+            {
+                "id": "root",
+                "title": "Current conversation",
+                "source": "cli",
+                "started_at": 1709500000,
+                "last_active": 1709500100,
+                "message_count": 4,
+                "preview": "current root",
+                "parent_session_id": None,
+            },
+            {
+                "id": "other_session",
+                "title": "Other conversation",
+                "source": "cli",
+                "started_at": 1709400000,
+                "last_active": 1709400100,
+                "message_count": 3,
+                "preview": "other root",
+                "parent_session_id": None,
+            },
+        ]
+
+        def _get_session(session_id):
+            if session_id == "child_session_id_that_is_definitely_longer":
+                return {"parent_session_id": "root"}
+            if session_id == "root":
+                return {"parent_session_id": None}
+            return None
+
+        mock_db.get_session.side_effect = _get_session
+
+        result = json.loads(_list_recent_sessions(
+            mock_db,
+            limit=5,
+            current_session_id="child_session_id_that_is_definitely_longer",
+        ))
+
+        assert result["success"] is True
+        assert [item["session_id"] for item in result["results"]] == ["other_session"]
+        assert all(item["session_id"] != "root" for item in result["results"])
+
+
 # =========================================================================
 # session_search (dispatcher)
 # =========================================================================
@@ -382,15 +431,16 @@ class TestSessionSearch:
         # Compression parent should appear in results, not be excluded
         assert result["sessions_searched"] >= 1
 
-    def test_multi_level_compression_parent_searchable(self):
+    def test_multi_level_compression_middle_fragment_loads_matched_session(self):
         """Multi-level compaction: A→B→C, both A and B are compression parents.
-        When searching from C, both A and B should be searchable."""
-        from unittest.mock import MagicMock
+        When searching from C and FTS matches B, summarize B rather than
+        collapsing to root A."""
+        from unittest.mock import MagicMock, AsyncMock, patch as _patch
         from tools.session_search_tool import session_search
 
         mock_db = MagicMock()
         mock_db.search_messages.return_value = [
-            {"session_id": "session_a", "content": "match", "source": "cli",
+            {"session_id": "session_b", "content": "match", "source": "cli",
              "session_started": 1709500000, "model": "test"},
         ]
 
@@ -404,16 +454,25 @@ class TestSessionSearch:
             return None
 
         mock_db.get_session.side_effect = _get_session
-        mock_db.get_messages_as_conversation.return_value = [
-            {"role": "user", "content": "test message"},
-        ]
+        loaded_sessions = []
 
-        result = json.loads(session_search(
-            query="test", db=mock_db, current_session_id="session_c",
-        ))
+        def _get_messages(session_id):
+            loaded_sessions.append(session_id)
+            return [{"role": "user", "content": f"test message from {session_id}"}]
+
+        mock_db.get_messages_as_conversation.side_effect = _get_messages
+
+        with _patch("tools.session_search_tool.async_call_llm",
+                    new_callable=AsyncMock,
+                    side_effect=RuntimeError("no provider")):
+            result = json.loads(session_search(
+                query="test", db=mock_db, current_session_id="session_c",
+            ))
 
         assert result["success"] is True
-        assert result["sessions_searched"] >= 1
+        assert result["sessions_searched"] == 1
+        assert loaded_sessions == ["session_b"]
+        assert result["results"][0]["session_id"] == "session_b"
 
     def test_limit_none_coerced_to_default(self):
         """Model sends limit=null → should fall back to 3, not TypeError."""

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -274,12 +274,13 @@ def _list_recent_sessions(db, limit: int, current_session_id: str = None) -> str
             try:
                 sid = current_session_id
                 visited = set()
+                current_root = current_session_id
                 while sid and sid not in visited:
                     visited.add(sid)
+                    current_root = sid
                     s = db.get_session(sid)
                     parent = s.get("parent_session_id") if s else None
                     sid = parent if parent else None
-                current_root = max(visited, key=len) if visited else current_session_id
             except Exception:
                 current_root = current_session_id
 
@@ -372,16 +373,13 @@ def session_search(
                 "message": "No matching sessions found.",
             }, ensure_ascii=False)
 
-        # Resolve child sessions to their parent — delegation stores detailed
-        # content in child sessions, but the user's conversation is the parent.
         def _resolve_to_parent(session_id: str) -> tuple:
-            """Walk delegation chain to find the root parent session ID.
+            """Walk lineage to find the root parent session ID.
 
-            Returns (root_session_id, has_compression_hop) — the second flag
-            is True when at least one session in the chain was ended by context
-            compression.  Compression parents' content is no longer in the
-            agent's context window, so they should be searchable even if they
-            belong to the current lineage.
+            Returns ``(root_session_id, has_compression_hop)``.  Delegation
+            children can be collapsed to their parent conversation. Compression
+            fragments cannot: each fragment contains a distinct slice of raw
+            messages that may no longer be present in the active context.
             """
             visited = set()
             sid = session_id
@@ -413,25 +411,26 @@ def session_search(
             _resolve_to_parent(current_session_id) if current_session_id else (None, False)
         )
 
-        # Group by resolved (parent) session_id, dedup, skip the current
-        # session lineage — but NOT compression parents whose content is no
-        # longer in the agent's context window.
+        # Group matching sessions, dedup, and skip the current context.  Pure
+        # delegation children still collapse to their parent conversation, but
+        # compression chains keep the matched raw session id so we summarize
+        # the fragment that actually contained the FTS hit.
         seen_sessions = {}
         for result in raw_results:
             raw_sid = result["session_id"]
             resolved_sid, has_compression = _resolve_to_parent(raw_sid)
-            # Skip the current session lineage only when the content is still
-            # in the agent's context.  Compression-ended sessions have been
-            # replaced by a compact summary — their original content is only
-            # reachable via search.
-            if _current_root and resolved_sid == _current_root and not has_compression:
-                continue
             if current_session_id and raw_sid == current_session_id:
                 continue
-            if resolved_sid not in seen_sessions:
+            # Skip current-lineage content only when it is still available to
+            # the agent.  Compression fragments are searchable because their
+            # original messages were replaced by summaries in later children.
+            if _current_root and resolved_sid == _current_root and not has_compression:
+                continue
+            result_sid = raw_sid if has_compression else resolved_sid
+            if result_sid not in seen_sessions:
                 result = dict(result)
-                result["session_id"] = resolved_sid
-                seen_sessions[resolved_sid] = result
+                result["session_id"] = result_sid
+                seen_sessions[result_sid] = result
             if len(seen_sessions) >= limit:
                 break
 

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -374,16 +374,26 @@ def session_search(
 
         # Resolve child sessions to their parent — delegation stores detailed
         # content in child sessions, but the user's conversation is the parent.
-        def _resolve_to_parent(session_id: str) -> str:
-            """Walk delegation chain to find the root parent session ID."""
+        def _resolve_to_parent(session_id: str) -> tuple:
+            """Walk delegation chain to find the root parent session ID.
+
+            Returns (root_session_id, has_compression_hop) — the second flag
+            is True when at least one session in the chain was ended by context
+            compression.  Compression parents' content is no longer in the
+            agent's context window, so they should be searchable even if they
+            belong to the current lineage.
+            """
             visited = set()
             sid = session_id
+            has_compression = False
             while sid and sid not in visited:
                 visited.add(sid)
                 try:
                     session = db.get_session(sid)
                     if not session:
                         break
+                    if session.get("end_reason") == "compression":
+                        has_compression = True
                     parent = session.get("parent_session_id")
                     if parent:
                         sid = parent
@@ -397,22 +407,24 @@ def session_search(
                         exc_info=True,
                     )
                     break
-            return sid
+            return sid, has_compression
 
-        current_lineage_root = (
-            _resolve_to_parent(current_session_id) if current_session_id else None
+        _current_root, _ = (
+            _resolve_to_parent(current_session_id) if current_session_id else (None, False)
         )
 
         # Group by resolved (parent) session_id, dedup, skip the current
-        # session lineage. Compression and delegation create child sessions
-        # that still belong to the same active conversation.
+        # session lineage — but NOT compression parents whose content is no
+        # longer in the agent's context window.
         seen_sessions = {}
         for result in raw_results:
             raw_sid = result["session_id"]
-            resolved_sid = _resolve_to_parent(raw_sid)
-            # Skip the current session lineage — the agent already has that
-            # context, even if older turns live in parent fragments.
-            if current_lineage_root and resolved_sid == current_lineage_root:
+            resolved_sid, has_compression = _resolve_to_parent(raw_sid)
+            # Skip the current session lineage only when the content is still
+            # in the agent's context.  Compression-ended sessions have been
+            # replaced by a compact summary — their original content is only
+            # reachable via search.
+            if _current_root and resolved_sid == _current_root and not has_compression:
                 continue
             if current_session_id and raw_sid == current_session_id:
                 continue


### PR DESCRIPTION
## Summary

Allow compression-ended parent sessions to appear in `session_search` results. After context compaction, the agent loses access to original messages (replaced by a compact summary), but the previous lineage exclusion logic skipped them — creating a memory black hole.

Closes #13840
Supersedes #13501 (closed — this version addresses review concerns preemptively)
Related: #5447, #6256, #6507, #8803

## What changed

**`tools/session_search_tool.py`**
- `_resolve_to_parent()` now returns `(root_id, has_compression_hop)` — checks `end_reason == "compression"` during the same `db.get_session()` call it already makes for parent traversal (no additional DB queries)
- Lineage exclusion: delegation parents are still skipped (content is in context); compression parents are allowed through (content is gone)

**`tests/tools/test_session_search.py`** (+3 tests)
- `test_current_child_session_excludes_delegation_parent` — delegation parents still excluded (renamed from old test, clarified intent)
- `test_compression_parent_searchable` — single-level compaction parent appears in results
- `test_multi_level_compression_parent_searchable` — A→B→C chain where both A and B are compression parents

## Design decisions

**Why return a flag from `_resolve_to_parent` instead of a separate helper?**
The parent traversal already calls `db.get_session()` for every hop. Checking `end_reason` in the same loop avoids N+1 queries that a separate `_is_compression_session()` helper would require.

**Why whitelist (allow compression) instead of blacklist (exclude delegation)?**
Current implementation checks `not has_compression` — if a future `end_reason` type is added where content is also lost, it would be excluded by default. This is the safer direction: new end_reasons default to excluded (same as current behavior), compression is the explicit exception. If more end_reasons need the same treatment, they can be added to the compression check.

## Testing

```
$ python -m pytest tests/tools/test_session_search.py -v
37 passed in 2.88s
```

All 37 tests pass (34 existing + 2 new compression tests + 1 renamed delegation test).
