### PR TITLE
Fix file handle leak in _spawn_hermes_action

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -674,28 +674,34 @@ def _spawn_hermes_action(subcommand: List[str], name: str) -> subprocess.Popen:
     _ACTION_LOG_DIR.mkdir(parents=True, exist_ok=True)
     log_path = _ACTION_LOG_DIR / log_file_name
     log_file = open(log_path, "ab", buffering=0)
-    log_file.write(
-        f"\n=== {name} started {time.strftime('%Y-%m-%d %H:%M:%S')} ===\n".encode()
-    )
-
-    cmd = [sys.executable, "-m", "hermes_cli.main", *subcommand]
-
-    popen_kwargs: Dict[str, Any] = {
-        "cwd": str(PROJECT_ROOT),
-        "stdin": subprocess.DEVNULL,
-        "stdout": log_file,
-        "stderr": subprocess.STDOUT,
-        "env": {**os.environ, "HERMES_NONINTERACTIVE": "1"},
-    }
-    if sys.platform == "win32":
-        popen_kwargs["creationflags"] = (
-            subprocess.CREATE_NEW_PROCESS_GROUP  # type: ignore[attr-defined]
-            | getattr(subprocess, "DETACHED_PROCESS", 0)
+    try:
+        log_file.write(
+            f"\n=== {name} started {time.strftime('%Y-%m-%d %H:%M:%S')} ===\n".encode()
         )
-    else:
-        popen_kwargs["start_new_session"] = True
 
-    proc = subprocess.Popen(cmd, **popen_kwargs)
+        cmd = [sys.executable, "-m", "hermes_cli.main", *subcommand]
+
+        popen_kwargs: Dict[str, Any] = {
+            "cwd": str(PROJECT_ROOT),
+            "stdin": subprocess.DEVNULL,
+            "stdout": log_file,
+            "stderr": subprocess.STDOUT,
+            "env": {**os.environ, "HERMES_NONINTERACTIVE": "1"},
+        }
+        if sys.platform == "win32":
+            popen_kwargs["creationflags"] = (
+                subprocess.CREATE_NEW_PROCESS_GROUP  # type: ignore[attr-defined]
+                | getattr(subprocess, "DETACHED_PROCESS", 0)
+            )
+        else:
+            popen_kwargs["start_new_session"] = True
+
+        proc = subprocess.Popen(cmd, **popen_kwargs)
+    except Exception:
+        log_file.close()
+        raise
+    else:
+        log_file.close()
     _ACTION_PROCS[name] = proc
     return proc
 


### PR DESCRIPTION
## Summary

- Fix file handle leak in `hermes_cli/web_server.py` `_spawn_hermes_action()`
- The log file opened at line 597 (`open(log_path, "ab", buffering=0)`) was passed to `subprocess.Popen` as stdout but the Python file object was never explicitly closed
- After `Popen` inherits the file descriptor, the Python file object should be closed; if `Popen()` raises, the file handle leaks entirely
- Wrapped in try/except/else to ensure the file handle is always closed

## Test plan

- [ ] Verify `_spawn_hermes_action` still spawns subprocesses correctly
- [ ] Verify log files are still written to by the subprocess after the Python file handle is closed (subprocess inherits the fd independently)
- [ ] Verify that if `Popen` raises, the file handle is properly closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)