### PR TITLE
feat: add HappyHorse video generation tool

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -702,7 +702,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 16,
+    "_config_version": 17,
 }
 
 # =============================================================================
@@ -718,6 +718,7 @@ ENV_VARS_BY_VERSION: Dict[int, List[str]] = {
         "SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "SLACK_ALLOWED_USERS"],
     10: ["TAVILY_API_KEY"],
     11: ["TERMINAL_MODAL_MODE"],
+    17: ["HAPPYHORSE_API_KEY"],
 }
 
 # Required environment variables with metadata for migration prompts.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1071,6 +1071,14 @@ OPTIONAL_ENV_VARS = {
         "password": True,
         "category": "tool",
     },
+    "HAPPYHORSE_API_KEY": {
+        "description": "HappyHorse API key for AI video generation",
+        "prompt": "HappyHorse API key",
+        "url": "https://happyhorse.app/zh/docs",
+        "tools": ["video_generate"],
+        "password": True,
+        "category": "tool",
+    },
     "TINKER_API_KEY": {
         "description": "Tinker API key for RL training",
         "prompt": "Tinker API key",

--- a/model_tools.py
+++ b/model_tools.py
@@ -142,6 +142,7 @@ def _discover_tools():
         "tools.vision_tools",
         "tools.mixture_of_agents_tool",
         "tools.image_generation_tool",
+        "tools.happyhorse_video_tool",
         "tools.skills_tool",
         "tools.skill_manager_tool",
         "tools.browser_tool",

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -8,6 +8,7 @@ import yaml
 
 from hermes_cli.config import (
     DEFAULT_CONFIG,
+    OPTIONAL_ENV_VARS,
     get_hermes_home,
     ensure_hermes_home,
     load_config,
@@ -115,15 +116,21 @@ class TestSaveAndLoadRoundtrip:
 
 
 class TestSaveEnvValueSecure:
+    def test_happyhorse_env_var_metadata_registered(self):
+        info = OPTIONAL_ENV_VARS["HAPPYHORSE_API_KEY"]
+        assert info["category"] == "tool"
+        assert info["password"] is True
+        assert "video_generate" in info["tools"]
+
     def test_save_env_value_writes_without_stdout(self, tmp_path, capsys):
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
-            save_env_value("TENOR_API_KEY", "sk-test-secret")
+            save_env_value("TENOR_API_KEY", "***")
             captured = capsys.readouterr()
             assert captured.out == ""
             assert captured.err == ""
 
             env_values = load_env()
-            assert env_values["TENOR_API_KEY"] == "sk-test-secret"
+            assert env_values["TENOR_API_KEY"] == "***"
 
     def test_secure_save_returns_metadata_only(self, tmp_path):
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
@@ -441,6 +448,6 @@ class TestInterimAssistantMessageConfig:
             migrate_config(interactive=False, quiet=True)
             raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
 
-        assert raw["_config_version"] == 16
+        assert raw["_config_version"] == 17
         assert raw["display"]["tool_progress"] == "off"
         assert raw["display"]["interim_assistant_messages"] is True

--- a/tests/tools/test_happyhorse_video_tool.py
+++ b/tests/tools/test_happyhorse_video_tool.py
@@ -1,0 +1,178 @@
+import importlib
+import json
+from types import SimpleNamespace
+
+import pytest
+
+
+happyhorse_module = importlib.import_module("tools.happyhorse_video_tool")
+
+
+def _response(payload, status_code=200):
+    class FakeResponse:
+        def __init__(self, payload, status_code):
+            self._payload = payload
+            self.status_code = status_code
+            self.text = json.dumps(payload)
+
+        def json(self):
+            return self._payload
+
+        def raise_for_status(self):
+            if self.status_code >= 400:
+                raise happyhorse_module.requests.HTTPError(f"http {self.status_code}")
+
+    return FakeResponse(payload, status_code)
+
+
+def test_check_happyhorse_requirements(monkeypatch):
+    monkeypatch.delenv("HAPPYHORSE_API_KEY", raising=False)
+    assert happyhorse_module.check_happyhorse_requirements() is False
+
+    monkeypatch.setenv("HAPPYHORSE_API_KEY", "sk-test")
+    assert happyhorse_module.check_happyhorse_requirements() is True
+
+
+def test_handle_video_generate_requires_prompt_when_not_multi_shots():
+    result = json.loads(happyhorse_module._handle_video_generate({}))
+    assert result["error"] == "prompt is required unless multi_shots=true with multi_prompt provided"
+
+
+def test_happyhorse_video_generate_submits_text_to_video_request(monkeypatch):
+    monkeypatch.setenv("HAPPYHORSE_API_KEY", "sk-test")
+    captured = {}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["json"] = json
+        captured["timeout"] = timeout
+        return _response({
+            "code": 200,
+            "message": "success",
+            "data": {"task_id": "n92abc123hh10", "status": "IN_PROGRESS"},
+        })
+
+    monkeypatch.setattr(happyhorse_module.requests, "post", fake_post)
+
+    result = json.loads(
+        happyhorse_module.happyhorse_video_generate(
+            prompt="A cinematic sunrise over mountains",
+            mode="pro",
+            duration=5,
+            aspect_ratio="16:9",
+        )
+    )
+
+    assert captured["url"] == "https://happyhorse.app/api/generate"
+    assert captured["headers"]["Authorization"] == "Bearer sk-test"
+    assert captured["json"] == {
+        "model": "happyhorse-1.0/video",
+        "prompt": "A cinematic sunrise over mountains",
+        "mode": "pro",
+        "duration": 5,
+        "aspect_ratio": "16:9",
+        "sound": True,
+        "cfg_scale": 0.5,
+    }
+    assert result["success"] is True
+    assert result["task_id"] == "n92abc123hh10"
+    assert result["status"] == "IN_PROGRESS"
+
+
+def test_happyhorse_video_generate_polls_until_video_url_ready(monkeypatch):
+    monkeypatch.setenv("HAPPYHORSE_API_KEY", "sk-test")
+    calls = {"status": 0}
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        return _response({
+            "code": 200,
+            "message": "success",
+            "data": {"task_id": "n92abc123hh10", "status": "IN_PROGRESS"},
+        })
+
+    def fake_get(url, headers=None, params=None, timeout=None):
+        calls["status"] += 1
+        assert url == "https://happyhorse.app/api/status"
+        assert params == {"task_id": "n92abc123hh10"}
+        if calls["status"] == 1:
+            return _response({
+                "code": 200,
+                "message": "success",
+                "data": {"task_id": "n92abc123hh10", "status": "IN_PROGRESS"},
+            })
+        return _response({
+            "code": 200,
+            "message": "success",
+            "data": {
+                "task_id": "n92abc123hh10",
+                "status": "COMPLETED",
+                "response": {"resultUrls": ["https://cdn.example.com/video.mp4"]},
+            },
+        })
+
+    monkeypatch.setattr(happyhorse_module.requests, "post", fake_post)
+    monkeypatch.setattr(happyhorse_module.requests, "get", fake_get)
+    monkeypatch.setattr(happyhorse_module.time, "sleep", lambda _seconds: None)
+
+    result = json.loads(
+        happyhorse_module.happyhorse_video_generate(
+            prompt="A cinematic sunrise over mountains",
+            wait_for_completion=True,
+            poll_interval=0,
+            timeout=5,
+        )
+    )
+
+    assert calls["status"] == 2
+    assert result["success"] is True
+    assert result["status"] == "COMPLETED"
+    assert result["video_url"] == "https://cdn.example.com/video.mp4"
+
+
+def test_happyhorse_video_generate_treats_success_status_as_terminal_with_video_url(monkeypatch):
+    monkeypatch.setenv("HAPPYHORSE_API_KEY", "sk-test")
+
+    def fake_post(url, headers=None, json=None, timeout=None):
+        return _response({
+            "code": 200,
+            "message": "success",
+            "data": {"task_id": "n92abc123hh10", "status": "IN_PROGRESS"},
+        })
+
+    def fake_get(url, headers=None, params=None, timeout=None):
+        return _response({
+            "code": 200,
+            "message": "success",
+            "data": {
+                "task_id": "n92abc123hh10",
+                "status": "SUCCESS",
+                "response": {"resultUrls": ["https://cdn.example.com/video-success.mp4"]},
+            },
+        })
+
+    monkeypatch.setattr(happyhorse_module.requests, "post", fake_post)
+    monkeypatch.setattr(happyhorse_module.requests, "get", fake_get)
+    monkeypatch.setattr(happyhorse_module.time, "sleep", lambda _seconds: None)
+
+    result = json.loads(
+        happyhorse_module.happyhorse_video_generate(
+            prompt="A cinematic sunrise over mountains",
+            wait_for_completion=True,
+            poll_interval=0,
+            timeout=5,
+        )
+    )
+
+    assert result["success"] is True
+    assert result["status"] == "SUCCESS"
+    assert result["video_url"] == "https://cdn.example.com/video-success.mp4"
+    assert "error" not in result
+
+
+def test_video_generate_tool_registered_and_toolset_resolves():
+    from tools.registry import registry
+    from toolsets import resolve_toolset
+
+    assert registry.get_toolset_for_tool("video_generate") == "image_gen"
+    assert "video_generate" in resolve_toolset("image_gen")

--- a/tools/happyhorse_video_tool.py
+++ b/tools/happyhorse_video_tool.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""HappyHorse video generation tool."""
+
+import json
+import logging
+import os
+import time
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from tools.registry import registry, tool_error
+
+logger = logging.getLogger(__name__)
+
+HAPPYHORSE_BASE_URL = "https://happyhorse.app"
+HAPPYHORSE_MODEL = "happyhorse-1.0/video"
+DEFAULT_TIMEOUT = 60
+DEFAULT_POLL_INTERVAL = 5
+DEFAULT_WAIT_TIMEOUT = 300
+VALID_MODES = {"std", "pro"}
+VALID_ASPECT_RATIOS = {"16:9", "9:16", "1:1"}
+SUCCESS_STATUSES = {"COMPLETED", "SUCCESS"}
+TERMINAL_STATUSES = SUCCESS_STATUSES | {"FAILED", "CANCELLED"}
+
+
+def check_happyhorse_api_key() -> bool:
+    return bool(os.getenv("HAPPYHORSE_API_KEY"))
+
+
+def check_happyhorse_requirements() -> bool:
+    return check_happyhorse_api_key()
+
+
+def _headers(api_key: Optional[str] = None) -> Dict[str, str]:
+    key = api_key or os.getenv("HAPPYHORSE_API_KEY")
+    if not key:
+        raise ValueError("HAPPYHORSE_API_KEY is not set")
+    return {
+        "Authorization": f"Bearer {key}",
+        "Content-Type": "application/json",
+    }
+
+
+def _validate_generate_args(
+    *,
+    prompt: Optional[str],
+    mode: str,
+    duration: int,
+    aspect_ratio: str,
+    image_urls: Optional[List[str]],
+    multi_shots: bool,
+    multi_prompt: Optional[List[Dict[str, Any]]],
+    cfg_scale: float,
+) -> None:
+    if mode not in VALID_MODES:
+        raise ValueError(f"mode must be one of {sorted(VALID_MODES)}")
+    if not isinstance(duration, int) or duration < 3 or duration > 15:
+        raise ValueError("duration must be an integer between 3 and 15")
+    if aspect_ratio not in VALID_ASPECT_RATIOS:
+        raise ValueError(f"aspect_ratio must be one of {sorted(VALID_ASPECT_RATIOS)}")
+    if not isinstance(cfg_scale, (int, float)) or cfg_scale < 0 or cfg_scale > 1:
+        raise ValueError("cfg_scale must be between 0 and 1")
+    if multi_shots:
+        if not multi_prompt:
+            raise ValueError("multi_prompt is required when multi_shots=true")
+    elif not prompt:
+        raise ValueError("prompt is required unless multi_shots=true with multi_prompt provided")
+    if image_urls is not None:
+        if not isinstance(image_urls, list) or not all(isinstance(url, str) and url for url in image_urls):
+            raise ValueError("image_urls must be a list of non-empty strings")
+
+
+def _build_payload(
+    *,
+    prompt: Optional[str],
+    mode: str,
+    duration: int,
+    aspect_ratio: str,
+    image_urls: Optional[List[str]],
+    sound: bool,
+    cfg_scale: float,
+    multi_shots: bool,
+    multi_prompt: Optional[List[Dict[str, Any]]],
+    happyhorse_elements: Optional[List[Dict[str, Any]]],
+) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {
+        "model": HAPPYHORSE_MODEL,
+        "mode": mode,
+        "duration": duration,
+        "aspect_ratio": aspect_ratio,
+        "sound": sound,
+        "cfg_scale": float(cfg_scale),
+    }
+    if prompt:
+        payload["prompt"] = prompt
+    if image_urls:
+        payload["image_urls"] = image_urls
+    if multi_shots:
+        payload["multi_shots"] = True
+        payload["multi_prompt"] = multi_prompt or []
+    if happyhorse_elements:
+        payload["happyhorse_elements"] = happyhorse_elements
+    return payload
+
+
+def get_happyhorse_status(task_id: str, api_key: Optional[str] = None) -> Dict[str, Any]:
+    response = requests.get(
+        f"{HAPPYHORSE_BASE_URL}/api/status",
+        headers=_headers(api_key),
+        params={"task_id": task_id},
+        timeout=DEFAULT_TIMEOUT,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def happyhorse_video_generate(
+    *,
+    prompt: Optional[str] = None,
+    mode: str = "std",
+    duration: int = 5,
+    aspect_ratio: str = "16:9",
+    image_urls: Optional[List[str]] = None,
+    sound: bool = True,
+    cfg_scale: float = 0.5,
+    multi_shots: bool = False,
+    multi_prompt: Optional[List[Dict[str, Any]]] = None,
+    happyhorse_elements: Optional[List[Dict[str, Any]]] = None,
+    wait_for_completion: bool = False,
+    poll_interval: int = DEFAULT_POLL_INTERVAL,
+    timeout: int = DEFAULT_WAIT_TIMEOUT,
+    api_key: Optional[str] = None,
+) -> str:
+    try:
+        _validate_generate_args(
+            prompt=prompt,
+            mode=mode,
+            duration=duration,
+            aspect_ratio=aspect_ratio,
+            image_urls=image_urls,
+            multi_shots=multi_shots,
+            multi_prompt=multi_prompt,
+            cfg_scale=cfg_scale,
+        )
+        payload = _build_payload(
+            prompt=prompt,
+            mode=mode,
+            duration=duration,
+            aspect_ratio=aspect_ratio,
+            image_urls=image_urls,
+            sound=sound,
+            cfg_scale=cfg_scale,
+            multi_shots=multi_shots,
+            multi_prompt=multi_prompt,
+            happyhorse_elements=happyhorse_elements,
+        )
+        response = requests.post(
+            f"{HAPPYHORSE_BASE_URL}/api/generate",
+            headers=_headers(api_key),
+            json=payload,
+            timeout=DEFAULT_TIMEOUT,
+        )
+        response.raise_for_status()
+        response_data = response.json()
+        data = response_data.get("data", {})
+        result: Dict[str, Any] = {
+            "success": True,
+            "task_id": data.get("task_id"),
+            "status": data.get("status"),
+            "response": response_data,
+        }
+
+        if not wait_for_completion:
+            return json.dumps(result, ensure_ascii=False)
+
+        task_id = data.get("task_id")
+        if not task_id:
+            raise ValueError("HappyHorse response did not include task_id")
+        deadline = time.time() + timeout
+        while time.time() <= deadline:
+            status_response = get_happyhorse_status(task_id, api_key=api_key)
+            status_data = status_response.get("data", {})
+            status = status_data.get("status")
+            result.update({
+                "status": status,
+                "status_response": status_response,
+            })
+            if status in SUCCESS_STATUSES:
+                urls = ((status_data.get("response") or {}).get("resultUrls") or [])
+                result["video_url"] = urls[0] if urls else None
+                return json.dumps(result, ensure_ascii=False)
+            if status in TERMINAL_STATUSES:
+                return json.dumps(result, ensure_ascii=False)
+            time.sleep(max(0, poll_interval))
+        result["success"] = False
+        result["error"] = f"Timed out waiting for HappyHorse task {task_id}"
+        return json.dumps(result, ensure_ascii=False)
+    except Exception as exc:
+        logger.exception("HappyHorse video generation failed: %s", exc)
+        return json.dumps(
+            {
+                "success": False,
+                "error": str(exc),
+                "error_type": type(exc).__name__,
+            },
+            ensure_ascii=False,
+        )
+
+
+VIDEO_GENERATE_SCHEMA = {
+    "name": "video_generate",
+    "description": "Generate videos with HappyHorse AI. Supports text-to-video, image-to-video, and optional polling until the final video URL is ready.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": "Video prompt. Required unless multi_shots=true with multi_prompt provided.",
+            },
+            "mode": {
+                "type": "string",
+                "enum": ["std", "pro"],
+                "default": "std",
+            },
+            "duration": {
+                "type": "integer",
+                "minimum": 3,
+                "maximum": 15,
+                "default": 5,
+            },
+            "aspect_ratio": {
+                "type": "string",
+                "enum": ["16:9", "9:16", "1:1"],
+                "default": "16:9",
+            },
+            "image_urls": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional image URLs for image-to-video generation.",
+            },
+            "sound": {
+                "type": "boolean",
+                "default": True,
+            },
+            "cfg_scale": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1,
+                "default": 0.5,
+            },
+            "multi_shots": {
+                "type": "boolean",
+                "default": False,
+            },
+            "multi_prompt": {
+                "type": "array",
+                "description": "Optional multi-shot prompt array.",
+            },
+            "happyhorse_elements": {
+                "type": "array",
+                "description": "Optional HappyHorse character/element definitions.",
+            },
+            "wait_for_completion": {
+                "type": "boolean",
+                "default": False,
+                "description": "When true, poll /api/status until the task completes or times out.",
+            },
+            "poll_interval": {
+                "type": "integer",
+                "minimum": 0,
+                "default": 5,
+            },
+            "timeout": {
+                "type": "integer",
+                "minimum": 1,
+                "default": 300,
+            },
+        },
+        "required": [],
+    },
+}
+
+
+def _handle_video_generate(args, **_kw):
+    if not args.get("multi_shots") and not args.get("prompt"):
+        return tool_error("prompt is required unless multi_shots=true with multi_prompt provided")
+    return happyhorse_video_generate(
+        prompt=args.get("prompt"),
+        mode=args.get("mode", "std"),
+        duration=args.get("duration", 5),
+        aspect_ratio=args.get("aspect_ratio", "16:9"),
+        image_urls=args.get("image_urls"),
+        sound=args.get("sound", True),
+        cfg_scale=args.get("cfg_scale", 0.5),
+        multi_shots=args.get("multi_shots", False),
+        multi_prompt=args.get("multi_prompt"),
+        happyhorse_elements=args.get("happyhorse_elements"),
+        wait_for_completion=args.get("wait_for_completion", False),
+        poll_interval=args.get("poll_interval", DEFAULT_POLL_INTERVAL),
+        timeout=args.get("timeout", DEFAULT_WAIT_TIMEOUT),
+    )
+
+
+registry.register(
+    name="video_generate",
+    toolset="image_gen",
+    schema=VIDEO_GENERATE_SCHEMA,
+    handler=_handle_video_generate,
+    check_fn=check_happyhorse_requirements,
+    requires_env=["HAPPYHORSE_API_KEY"],
+    is_async=False,
+    emoji="🎬",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -36,7 +36,7 @@ _HERMES_CORE_TOOLS = [
     # File manipulation
     "read_file", "write_file", "patch", "search_files",
     # Vision + image generation
-    "vision_analyze", "image_generate",
+    "vision_analyze", "image_generate", "video_generate",
     # Skills
     "skills_list", "skill_view", "skill_manage",
     # Browser automation
@@ -86,8 +86,8 @@ TOOLSETS = {
     },
     
     "image_gen": {
-        "description": "Creative generation tools (images)",
-        "tools": ["image_generate"],
+        "description": "Creative generation tools (images and video)",
+        "tools": ["image_generate", "video_generate"],
         "includes": []
     },
     
@@ -252,7 +252,7 @@ TOOLSETS = {
             # File manipulation
             "read_file", "write_file", "patch", "search_files",
             # Vision + image generation
-            "vision_analyze", "image_generate",
+            "vision_analyze", "image_generate", "video_generate",
             # Skills
             "skills_list", "skill_view", "skill_manage",
             # Browser automation

--- a/website/docs/user-guide/features/image-generation.md
+++ b/website/docs/user-guide/features/image-generation.md
@@ -1,165 +1,217 @@
 ---
-title: Image Generation
-description: Generate high-quality images using FLUX 2 Pro with automatic upscaling via FAL.ai.
-sidebar_label: Image Generation
+title: Image & Video Generation
+description: Generate images with FAL.ai and videos with HappyHorse from Hermes Agent.
+sidebar_label: Image & Video Generation
 sidebar_position: 6
 ---
 
-# Image Generation
+# Image & Video Generation
 
-Hermes Agent can generate images from text prompts using FAL.ai's **FLUX 2 Pro** model with automatic 2x upscaling via the **Clarity Upscaler** for enhanced quality.
+Hermes Agent currently supports two creative generation flows:
 
-## Setup
+- Image generation via FAL.ai (`image_generate`)
+- Video generation via HappyHorse (`video_generate`)
 
-### Get a FAL API Key
+This page is the practical handoff doc for teammates who want to configure the keys, understand the available parameters, and run these tools successfully.
+
+## Quick Setup
+
+Add one or both keys to `~/.hermes/.env`:
+
+```bash
+FAL_KEY=YOUR_FAL_KEY
+HAPPYHORSE_API_KEY=YOUR_HAPPYHORSE_KEY
+```
+
+You can also manage these in the Hermes config UI / Env page. `HAPPYHORSE_API_KEY` now appears there as a tool API key for `video_generate`.
+
+## Tool Availability
+
+- `image_generate` becomes available when `FAL_KEY` is set
+- `video_generate` becomes available when `HAPPYHORSE_API_KEY` is set
+- Both tools are part of the `image_gen` toolset
+
+## Image Generation
+
+Hermes can generate images from text prompts using FAL.ai's FLUX 2 Pro model with automatic 2x upscaling via the Clarity Upscaler.
+
+### Image setup
 
 1. Sign up at [fal.ai](https://fal.ai/)
 2. Generate an API key from your dashboard
-
-### Configure the Key
-
-```bash
-# Add to ~/.hermes/.env
-FAL_KEY=your-fal-api-key-here
-```
-
-### Install the Client Library
+3. Add the key to `~/.hermes/.env`
+4. Install the client library if needed:
 
 ```bash
 pip install fal-client
 ```
 
-:::info
-The image generation tool is automatically available when `FAL_KEY` is set. No additional toolset configuration is needed.
-:::
+### Image usage
 
-## How It Works
-
-When you ask Hermes to generate an image:
-
-1. **Generation** — Your prompt is sent to the FLUX 2 Pro model (`fal-ai/flux-2-pro`)
-2. **Upscaling** — The generated image is automatically upscaled 2x using the Clarity Upscaler (`fal-ai/clarity-upscaler`)
-3. **Delivery** — The upscaled image URL is returned
-
-If upscaling fails for any reason, the original image is returned as a fallback.
-
-## Usage
-
-Simply ask Hermes to create an image:
+Ask Hermes naturally, for example:
 
 ```
 Generate an image of a serene mountain landscape with cherry blossoms
 ```
 
 ```
-Create a portrait of a wise old owl perched on an ancient tree branch
-```
-
-```
 Make me a futuristic cityscape with flying cars and neon lights
 ```
 
-## Parameters
-
-The `image_generate_tool` accepts these parameters:
+### `image_generate` parameters
 
 | Parameter | Default | Range | Description |
 |-----------|---------|-------|-------------|
-| `prompt` | *(required)* | — | Text description of the desired image |
-| `aspect_ratio` | `"landscape"` | `landscape`, `square`, `portrait` | Image aspect ratio |
-| `num_inference_steps` | `50` | 1–100 | Number of denoising steps (more = higher quality, slower) |
+| `prompt` | required | — | Text description of the desired image |
+| `aspect_ratio` | `landscape` | `landscape`, `square`, `portrait` | Image aspect ratio |
+| `num_inference_steps` | `50` | 1–100 | Number of denoising steps |
 | `guidance_scale` | `4.5` | 0.1–20.0 | How closely to follow the prompt |
 | `num_images` | `1` | 1–4 | Number of images to generate |
-| `output_format` | `"png"` | `png`, `jpeg` | Image file format |
-| `seed` | *(random)* | any integer | Random seed for reproducible results |
+| `output_format` | `png` | `png`, `jpeg` | Output format |
+| `seed` | random | any integer | Reproducible generations |
 
-## Aspect Ratios
-
-The tool uses simplified aspect ratio names that map to FLUX 2 Pro image sizes:
+### Image aspect ratios
 
 | Aspect Ratio | Maps To | Best For |
 |-------------|---------|----------|
-| `landscape` | `landscape_16_9` | Wallpapers, banners, scenes |
-| `square` | `square_hd` | Profile pictures, social media posts |
+| `landscape` | `landscape_16_9` | Scenes, banners, wallpapers |
+| `square` | `square_hd` | Social posts, avatars |
 | `portrait` | `portrait_16_9` | Character art, phone wallpapers |
 
-:::tip
-You can also use the raw FLUX 2 Pro size presets directly: `square_hd`, `square`, `portrait_4_3`, `portrait_16_9`, `landscape_4_3`, `landscape_16_9`. Custom sizes up to 2048x2048 are also supported.
-:::
+### Image notes
 
-## Automatic Upscaling
+- Generated images are automatically upscaled 2x
+- If upscaling fails, Hermes returns the original image as fallback
+- URLs are temporary and usually expire after some time
 
-Every generated image is automatically upscaled 2x using FAL.ai's Clarity Upscaler with these settings:
+## Video Generation (HappyHorse)
 
-| Setting | Value |
-|---------|-------|
-| Upscale Factor | 2x |
-| Creativity | 0.35 |
-| Resemblance | 0.6 |
-| Guidance Scale | 4 |
-| Inference Steps | 18 |
-| Positive Prompt | `"masterpiece, best quality, highres"` + your original prompt |
-| Negative Prompt | `"(worst quality, low quality, normal quality:2)"` |
+Hermes can generate videos through HappyHorse using the `video_generate` tool.
 
-The upscaler enhances detail and resolution while preserving the original composition. If the upscaler fails (network issue, rate limit), the original resolution image is returned automatically.
+### Video setup
 
-## Example Prompts
-
-Here are some effective prompts to try:
-
-```
-A candid street photo of a woman with a pink bob and bold eyeliner
-```
-
-```
-Modern architecture building with glass facade, sunset lighting
-```
-
-```
-Abstract art with vibrant colors and geometric patterns
-```
-
-```
-Portrait of a wise old owl perched on ancient tree branch
-```
-
-```
-Futuristic cityscape with flying cars and neon lights
-```
-
-## Debugging
-
-Enable debug logging for image generation:
+1. Get a HappyHorse API key from [HappyHorse Docs](https://happyhorse.app/zh/docs)
+2. Add it to `~/.hermes/.env`:
 
 ```bash
-export IMAGE_TOOLS_DEBUG=true
+HAPPYHORSE_API_KEY=YOUR_HAPPYHORSE_KEY
 ```
 
-Debug logs are saved to `./logs/image_tools_debug_<session_id>.json` with details about each generation request, parameters, timing, and any errors.
+### What the tool supports
 
-## Safety Settings
+- Text-to-video
+- Image-to-video via `image_urls`
+- Optional polling until the final video URL is ready
+- Multi-shot video requests
 
-The image generation tool runs with safety checks disabled by default (`safety_tolerance: 5`, the most permissive setting). This is configured at the code level and is not user-adjustable.
+### `video_generate` parameters
 
-## Platform Delivery
+| Parameter | Default | Range / Values | Description |
+|-----------|---------|----------------|-------------|
+| `prompt` | required unless using `multi_shots` | — | Main video prompt |
+| `mode` | `std` | `std`, `pro` | Quality / cost mode |
+| `duration` | `5` | integer `3`–`15` | Video duration in seconds |
+| `aspect_ratio` | `16:9` | `16:9`, `9:16`, `1:1` | Output frame ratio |
+| `image_urls` | none | list of URLs | Optional source images for image-to-video |
+| `sound` | `true` | boolean | Whether to include sound |
+| `cfg_scale` | `0.5` | `0`–`1` | Prompt adherence strength |
+| `multi_shots` | `false` | boolean | Enables multi-shot generation |
+| `multi_prompt` | none | list | Shot definitions used with `multi_shots=true` |
+| `happyhorse_elements` | none | list | Optional HappyHorse element definitions |
+| `wait_for_completion` | `false` | boolean | Poll until terminal status |
+| `poll_interval` | `5` | integer `>= 0` | Polling interval in seconds |
+| `timeout` | `300` | integer `>= 1` | Max wait time when polling |
 
-Generated images are delivered differently depending on the platform:
+### HappyHorse usage examples
+
+Natural-language request:
+
+```
+Generate a 3-second cinematic sunrise video over misty mountains in 16:9.
+```
+
+If you are calling the tool directly, the effective request shape is:
+
+```json
+{
+  "prompt": "A calm cinematic sunrise over misty mountains, soft golden light, gentle camera movement, realistic nature footage",
+  "mode": "std",
+  "duration": 3,
+  "aspect_ratio": "16:9",
+  "wait_for_completion": true
+}
+```
+
+### HappyHorse response behavior
+
+The tool returns a JSON result with fields such as:
+
+- `success`
+- `task_id`
+- `status`
+- `response`
+- `status_response` when polling is enabled
+- `video_url` when a final result is available
+
+Important live-API note:
+
+- HappyHorse may return terminal success as `SUCCESS`, not only `COMPLETED`
+- Hermes now treats both `SUCCESS` and `COMPLETED` as successful terminal states
+- Final video URLs are read from `data.response.resultUrls[0]`
+
+### HappyHorse operational notes
+
+- Real API usage consumes HappyHorse credits
+- Returned URLs may be temporary
+- If `wait_for_completion=false`, you get back the task submission result immediately
+- If `wait_for_completion=true`, Hermes polls `/api/status` until success, failure, cancellation, or timeout
+
+## Platform delivery
+
+Generated media is delivered differently depending on platform:
 
 | Platform | Delivery method |
 |----------|----------------|
-| **CLI** | Image URL printed as markdown `![description](url)` — click to open in browser |
-| **Telegram** | Image sent as a photo message with the prompt as caption |
-| **Discord** | Image embedded in a message |
-| **Slack** | Image URL in message (Slack unfurls it) |
-| **WhatsApp** | Image sent as a media message |
-| **Other platforms** | Image URL in plain text |
+| CLI | URL or media reference in terminal output |
+| Telegram | Image as photo, video as media/URL depending on handler |
+| Discord | Embedded media or URL |
+| Slack / WhatsApp / others | URL or platform-native media handling |
 
-The agent uses `MEDIA:<url>` syntax in its response, which the platform adapter converts to the appropriate format.
+Hermes internally uses `MEDIA:<url-or-path>` conventions where supported by the platform adapter.
 
-## Limitations
+## Troubleshooting
 
-- **Requires FAL API key** — image generation incurs API costs on your FAL.ai account
-- **No image editing** — this is text-to-image only, no inpainting or img2img
-- **URL-based delivery** — images are returned as temporary FAL.ai URLs, not saved locally. URLs expire after a period (typically hours)
-- **Upscaling adds latency** — the automatic 2x upscale step adds processing time
-- **Max 4 images per request** — `num_images` is capped at 4
+### `video_generate` does not appear
+
+Check:
+
+```bash
+grep '^HAPPYHORSE_API_KEY' ~/.hermes/.env
+```
+
+Then restart Hermes or start a fresh session so tool availability is recomputed.
+
+### Image works but video does not
+
+Check that:
+
+- `HAPPYHORSE_API_KEY` is present
+- the session has the `image_gen` toolset available
+- the request uses a valid `duration`, `aspect_ratio`, and either `prompt` or `multi_prompt`
+
+### Polling times out
+
+A timeout can still happen if the provider is slow. Retry with:
+
+- a longer `timeout`
+- a simpler prompt
+- `wait_for_completion=false` followed by later status polling
+
+## Validation performed for this integration
+
+This HappyHorse integration was validated with:
+
+- unit tests for request construction and polling behavior
+- tests for successful terminal statuses including live `SUCCESS`
+- config metadata tests so the key appears in the Env management UI
+- a real HappyHorse API smoke test producing a final `video_url`


### PR DESCRIPTION
## Summary
- add a HappyHorse-powered `video_generate` tool with polling support for video completion
- register the tool in discovery, toolsets, and config migration/env metadata
- add tests for HappyHorse generation flows, SUCCESS terminal statuses, and config metadata

## Validation
- pytest tests/hermes_cli/test_config.py tests/tools/test_happyhorse_video_tool.py tests/test_toolsets.py tests/tools/test_registry.py -q
- real HappyHorse API smoke test via project venv (3s text-to-video)

## Notes
- HappyHorse returns `SUCCESS` for completed jobs in the live API, so the tool now treats both `COMPLETED` and `SUCCESS` as successful terminal states.