### PR TITLE
fix(feishu): use BaseRequest for /bot/v3/info probe (fixes #13846)

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -3457,14 +3457,18 @@ class FeishuAdapter(BasePlatformAdapter):
         # uses via probe_bot().
         if not self._bot_open_id or not self._bot_name:
             try:
-                resp = await asyncio.to_thread(
-                    self._client.request,
-                    method="GET",
-                    url="/open-apis/bot/v3/info",
-                    body=None,
-                    raw_response=True,
+                req = (
+                    lark.BaseRequest.builder()
+                    .http_method(lark.HttpMethod.GET)
+                    .uri("/open-apis/bot/v3/info")
+                    .token_types({lark.AccessTokenType.TENANT})
+                    .build()
                 )
-                content = getattr(resp, "content", None)
+                resp = await asyncio.to_thread(self._client.request, req)
+                raw = getattr(resp, "raw", None)
+                content = getattr(raw, "content", None) if raw is not None else None
+                if isinstance(content, bytes):
+                    content = content.decode("utf-8")
                 if content:
                     payload = json.loads(content)
                     parsed = _parse_bot_response(payload) or {}
@@ -4237,7 +4241,7 @@ def _parse_bot_response(data: dict) -> Optional[dict]:
         return None
     bot = data.get("bot") or data.get("data", {}).get("bot") or {}
     return {
-        "bot_name": bot.get("bot_name"),
+        "bot_name": bot.get("app_name"),
         "bot_open_id": bot.get("open_id"),
     }
 
@@ -4246,13 +4250,21 @@ def _probe_bot_sdk(app_id: str, app_secret: str, domain: str) -> Optional[dict]:
     """Probe bot info using lark_oapi SDK."""
     try:
         client = _build_onboard_client(app_id, app_secret, domain)
-        resp = client.request(
-            method="GET",
-            url="/open-apis/bot/v3/info",
-            body=None,
-            raw_response=True,
+        req = (
+            lark.BaseRequest.builder()
+            .http_method(lark.HttpMethod.GET)
+            .uri("/open-apis/bot/v3/info")
+            .token_types({lark.AccessTokenType.TENANT})
+            .build()
         )
-        return _parse_bot_response(json.loads(resp.content))
+        resp = client.request(req)
+        raw = getattr(resp, "raw", None)
+        content = getattr(raw, "content", None) if raw is not None else None
+        if isinstance(content, bytes):
+            content = content.decode("utf-8")
+        if not content:
+            return None
+        return _parse_bot_response(json.loads(content))
     except Exception as exc:
         logger.debug("[Feishu onboard] SDK probe failed: %s", exc)
         return None

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2680,18 +2680,22 @@ class TestHydrateBotIdentity(unittest.TestCase):
             {
                 "code": 0,
                 "bot": {
-                    "bot_name": "Hermes Bot",
+                    "app_name": "Hermes Bot",
                     "open_id": "ou_hermes_hydrated",
                 },
             }
         ).encode("utf-8")
-        response = SimpleNamespace(content=payload)
+        response = SimpleNamespace(raw=SimpleNamespace(content=payload))
         adapter._client.request = Mock(return_value=response)
 
         asyncio.run(adapter._hydrate_bot_identity())
 
         self.assertEqual(adapter._bot_open_id, "ou_hermes_hydrated")
         self.assertEqual(adapter._bot_name, "Hermes Bot")
+        # Regression #13846: hydration must call Client.request with a single
+        # BaseRequest positionally, not method=/url=/body= kwargs.
+        call_args = adapter._client.request.call_args
+        self.assertEqual(call_args.kwargs, {})
         # Application-info fallback must NOT run when bot_name is already set.
         self.assertFalse(
             adapter._client.application.v6.application.get.called
@@ -2727,12 +2731,12 @@ class TestHydrateBotIdentity(unittest.TestCase):
             {
                 "code": 0,
                 "bot": {
-                    "bot_name": "Hermes Bot",
+                    "app_name": "Hermes Bot",
                     "open_id": "ou_probe_DIFFERENT",
                 },
             }
         ).encode("utf-8")
-        adapter._client.request = Mock(return_value=SimpleNamespace(content=payload))
+        adapter._client.request = Mock(return_value=SimpleNamespace(raw=SimpleNamespace(content=payload)))
 
         asyncio.run(adapter._hydrate_bot_identity())
 
@@ -2764,9 +2768,9 @@ class TestHydrateBotIdentity(unittest.TestCase):
         adapter = self._make_adapter()
         adapter._client = Mock()
         payload = json.dumps(
-            {"code": 0, "bot": {"bot_name": "Hermes", "open_id": "ou_hermes"}}
+            {"code": 0, "bot": {"app_name": "Hermes", "open_id": "ou_hermes"}}
         ).encode("utf-8")
-        adapter._client.request = Mock(return_value=SimpleNamespace(content=payload))
+        adapter._client.request = Mock(return_value=SimpleNamespace(raw=SimpleNamespace(content=payload)))
 
         asyncio.run(adapter._hydrate_bot_identity())
 

--- a/tests/gateway/test_feishu_onboard.py
+++ b/tests/gateway/test_feishu_onboard.py
@@ -277,7 +277,7 @@ class TestProbeBot:
         from gateway.platforms.feishu import probe_bot
 
         token_resp = _mock_urlopen({"code": 0, "tenant_access_token": "t-123"})
-        bot_resp = _mock_urlopen({"code": 0, "bot": {"bot_name": "HttpBot", "open_id": "ou_http"}})
+        bot_resp = _mock_urlopen({"code": 0, "bot": {"app_name": "HttpBot", "open_id": "ou_http"}})
         mock_urlopen_fn.side_effect = [token_resp, bot_resp]
 
         result = probe_bot("cli_app", "secret", "feishu")


### PR DESCRIPTION
## What does this PR do?

Fixes a `TypeError` in the Feishu adapter's bot identity probe that silently dropped every group @mention since commit `01424856` (PR #12654, 2026-04-19).

`_hydrate_bot_identity` and `_probe_bot_sdk` call `lark_oapi.Client.request` with `method=` / `url=` / `body=` / `raw_response=` kwargs, but the real signature is `request(request: BaseRequest, option=None)`. Every startup raised `TypeError`, caught by a `DEBUG`-level `except` — invisible at `INFO`. As a result `_bot_open_id` / `_bot_user_id` / `_bot_name` stayed empty, so `_message_mentions_bot` returned `False` for every candidate and `_should_accept_group_message` silently dropped every group message. DMs kept working because they skip the mention gate.

Fix: construct a `BaseRequest` via `lark.BaseRequest.builder()` and pass it positionally at both call sites. Also fixes a secondary bug in `_parse_bot_response` — `/open-apis/bot/v3/info` actually returns `app_name`, not `bot_name`.

See #13846 for the full root-cause write-up (including the live API response that proves the `app_name` field name).

## Related Issue

Fixes #13846

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/feishu.py` — `_hydrate_bot_identity`: rebuild probe with `lark.BaseRequest.builder()`, read content from `resp.raw.content`, decode bytes.
- `gateway/platforms/feishu.py` — `_parse_bot_response`: read `app_name` instead of `bot_name`.
- `gateway/platforms/feishu.py` — `_probe_bot_sdk`: same builder fix as above, plus a `None`-check on the decoded content.
- `tests/gateway/test_feishu.py` — update 3 `TestHydrateBotIdentity` mocks to return `resp.raw.content` and use the `app_name` field; add a regression assertion that `Client.request` is not called with kwargs.
- `tests/gateway/test_feishu_onboard.py` — update `test_http_fallback_when_sdk_unavailable` fixture to use `app_name`.

## How to Test

1. **Automated**: `pytest tests/gateway/test_feishu.py tests/gateway/test_feishu_onboard.py -q` — all 151 tests pass, including the new regression guard for kwargs-style `Client.request` calls.
2. **Manual (reproducing the old bug)**: fresh deploy with no `FEISHU_BOT_OPEN_ID` / `FEISHU_BOT_NAME` env vars, `logging.level: DEBUG` in `config.yaml`, start `hermes gateway run`. Before this PR: `grep '/bot/v3/info probe failed' logs/agent.log` shows the `TypeError` traceback. After: probe succeeds, `_bot_open_id` and `_bot_name` populate from the API response.
3. **Manual (golden path)**: @bot in a group chat via a real mention from the Feishu suggestion dropdown (not typed text). Before this PR the bot does not respond; after, it does.

Verified locally against `lark-oapi==1.5.5`: `resp.raw.content` is `bytes` containing `{"bot":{"app_name":"...","open_id":"ou_..."},"code":0,"msg":"ok"}`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/gateway/test_feishu*.py -q` and all tests pass
- [x] I've added tests for my changes (regression assertion for the kwargs pattern)
- [x] I've tested on my platform: Windows 11 / WSL2 (Docker, `debian:13.4` container, Python 3.13.5)

### Documentation & Housekeeping

- [x] N/A — no docs/config/schema changes needed (purely a bug fix to an existing probe path)
