### PR TITLE
feat(tts,stt): add Deepgram Aura TTS and Nova-3 STT provider

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -618,7 +618,7 @@ DEFAULT_CONFIG = {
     # limit (OpenAI 4096, xAI 15000, MiniMax 10000, ElevenLabs 5k-40k model-aware,
     # Gemini 5000, Edge 5000, Mistral 4000, NeuTTS/KittenTTS 2000).
     "tts": {
-        "provider": "edge",  # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" | "neutts" (local)
+        "provider": "edge",  # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" | "deepgram" | "neutts" (local)
         "edge": {
             "voice": "en-US-AriaNeural",
             # Popular: AriaNeural, JennyNeural, AndrewNeural, BrianNeural, SoniaNeural
@@ -642,6 +642,9 @@ DEFAULT_CONFIG = {
             "model": "voxtral-mini-tts-2603",
             "voice_id": "c69964a6-ab8b-4f8a-9465-ec0925096ec8",  # Paul - Neutral
         },
+        "deepgram": {
+            "model": "aura-2-thalia-en",  # Voice IS the model ID. 102 voices: see API-REFERENCE.md
+        },
         "neutts": {
             "ref_audio": "",  # Path to reference voice audio (empty = bundled default)
             "ref_text": "",   # Path to reference voice transcript (empty = bundled default)
@@ -652,7 +655,7 @@ DEFAULT_CONFIG = {
     
     "stt": {
         "enabled": True,
-        "provider": "local",  # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "mistral" (Voxtral Transcribe)
+        "provider": "local",  # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "mistral" (Voxtral Transcribe) | "deepgram" (Nova-3)
         "local": {
             "model": "base",  # tiny, base, small, medium, large-v3
             "language": "",  # auto-detect by default; set to "en", "es", "fr", etc. to force
@@ -662,6 +665,9 @@ DEFAULT_CONFIG = {
         },
         "mistral": {
             "model": "voxtral-mini-latest",  # voxtral-mini-latest, voxtral-mini-2602
+        },
+        "deepgram": {
+            "model": "nova-3",  # nova-3, nova-2, nova-2-phonecall, nova-2-medical, etc.
         },
     },
 
@@ -1409,6 +1415,13 @@ OPTIONAL_ENV_VARS = {
         "description": "Mistral API key for Voxtral TTS and transcription (STT)",
         "prompt": "Mistral API key",
         "url": "https://console.mistral.ai/",
+        "password": True,
+        "category": "tool",
+    },
+    "DEEPGRAM_API_KEY": {
+        "description": "Deepgram API key for Aura TTS (102 voices) and Nova-3 transcription (STT)",
+        "prompt": "Deepgram API key",
+        "url": "https://console.deepgram.com/",
         "password": True,
         "category": "tool",
     },

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -453,6 +453,8 @@ def _print_setup_summary(config: dict, hermes_home):
         tool_status.append(("Text-to-Speech (MiniMax)", True, None))
     elif tts_provider == "mistral" and get_env_value("MISTRAL_API_KEY"):
         tool_status.append(("Text-to-Speech (Mistral Voxtral)", True, None))
+    elif tts_provider == "deepgram" and get_env_value("DEEPGRAM_API_KEY"):
+        tool_status.append(("Text-to-Speech (Deepgram Aura)", True, None))
     elif tts_provider == "gemini" and (get_env_value("GEMINI_API_KEY") or get_env_value("GOOGLE_API_KEY")):
         tool_status.append(("Text-to-Speech (Google Gemini)", True, None))
     elif tts_provider == "neutts":
@@ -972,6 +974,7 @@ def _setup_tts_provider(config: dict):
         "xai": "xAI TTS",
         "minimax": "MiniMax TTS",
         "mistral": "Mistral Voxtral TTS",
+        "deepgram": "Deepgram Aura TTS",
         "gemini": "Google Gemini TTS",
         "neutts": "NeuTTS",
         "kittentts": "KittenTTS",
@@ -996,12 +999,13 @@ def _setup_tts_provider(config: dict):
             "xAI TTS (Grok voices, needs API key)",
             "MiniMax TTS (high quality with voice cloning, needs API key)",
             "Mistral Voxtral TTS (multilingual, native Opus, needs API key)",
+            "Deepgram Aura TTS (102 voices, 7 languages, native Opus, needs API key)",
             "Google Gemini TTS (30 prebuilt voices, prompt-controllable, needs API key)",
             "NeuTTS (local on-device, free, ~300MB model download)",
             "KittenTTS (local on-device, free, lightweight ~25-80MB ONNX)",
         ]
     )
-    providers.extend(["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "neutts", "kittentts"])
+    providers.extend(["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "deepgram", "gemini", "neutts", "kittentts"])
     choices.append(f"Keep current ({current_label})")
     keep_current_idx = len(choices) - 1
     idx = prompt_choice("Select TTS provider:", choices, keep_current_idx)
@@ -1103,6 +1107,18 @@ def _setup_tts_provider(config: dict):
             if api_key:
                 save_env_value("MISTRAL_API_KEY", api_key)
                 print_success("Mistral TTS API key saved")
+            else:
+                print_warning("No API key provided. Falling back to Edge TTS.")
+                selected = "edge"
+
+    elif selected == "deepgram":
+        existing = get_env_value("DEEPGRAM_API_KEY")
+        if not existing:
+            print()
+            api_key = prompt("Deepgram API key for TTS/STT", password=True)
+            if api_key:
+                save_env_value("DEEPGRAM_API_KEY", api_key)
+                print_success("Deepgram API key saved (works for both TTS and STT)")
             else:
                 print_warning("No API key provided. Falling back to Edge TTS.")
                 selected = "edge"

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -174,6 +174,15 @@ TOOL_CATEGORIES = {
                 "tts_provider": "mistral",
             },
             {
+                "name": "Deepgram (Aura TTS)",
+                "badge": "paid",
+                "tag": "102 voices, 7 languages, native Opus",
+                "env_vars": [
+                    {"key": "DEEPGRAM_API_KEY", "prompt": "Deepgram API key", "url": "https://console.deepgram.com/"},
+                ],
+                "tts_provider": "deepgram",
+            },
+            {
                 "name": "Google Gemini TTS",
                 "badge": "preview",
                 "tag": "30 prebuilt voices, controllable via prompts",

--- a/tests/tools/test_tts_deepgram.py
+++ b/tests/tools/test_tts_deepgram.py
@@ -1,0 +1,118 @@
+"""Tests for the Deepgram (Aura) TTS provider in tools/tts_tool.py."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch):
+    for key in ("DEEPGRAM_API_KEY", "HERMES_SESSION_PLATFORM"):
+        monkeypatch.delenv(key, raising=False)
+
+
+class TestGenerateDeepgramTts:
+    def test_missing_api_key_raises_value_error(self, tmp_path):
+        from tools.tts_tool import _generate_deepgram_tts
+
+        output_path = str(tmp_path / "test.mp3")
+        with pytest.raises(ValueError, match="DEEPGRAM_API_KEY"):
+            _generate_deepgram_tts("Hello", output_path, {})
+
+    def test_successful_generation(self, tmp_path, monkeypatch):
+        from tools.tts_tool import _generate_deepgram_tts
+
+        monkeypatch.setenv("DEEPGRAM_API_KEY", "test-key")
+        audio_content = b"fake-mp3-bytes"
+        mock_response = MagicMock()
+        mock_response.content = audio_content
+        mock_response.status_code = 200
+
+        with patch("tools.tts_tool.requests.post", return_value=mock_response) as mock_post:
+            output_path = str(tmp_path / "test.mp3")
+            result = _generate_deepgram_tts("Hello world", output_path, {})
+
+            assert result == output_path
+            assert (tmp_path / "test.mp3").read_bytes() == audio_content
+            mock_post.assert_called_once()
+            call_kwargs = mock_post.call_args
+            assert call_kwargs[1]["json"] == {"text": "Hello world"}
+            assert call_kwargs[1]["params"]["model"] == "aura-2-thalia-en"
+            assert call_kwargs[1]["params"]["encoding"] == "mp3"
+
+    @pytest.mark.parametrize(
+        "extension, expected_encoding",
+        [(".ogg", "opus"), (".wav", "linear16"), (".flac", "flac"), (".mp3", "mp3")],
+    )
+    def test_encoding_from_extension(self, tmp_path, monkeypatch, extension, expected_encoding):
+        from tools.tts_tool import _generate_deepgram_tts
+
+        monkeypatch.setenv("DEEPGRAM_API_KEY", "test-key")
+        mock_response = MagicMock()
+        mock_response.content = b"audio"
+        mock_response.status_code = 200
+
+        with patch("tools.tts_tool.requests.post", return_value=mock_response) as mock_post:
+            output_path = str(tmp_path / f"test{extension}")
+            _generate_deepgram_tts("Test", output_path, {})
+            assert mock_post.call_args[1]["params"]["encoding"] == expected_encoding
+
+    def test_model_from_config_overrides_default(self, tmp_path, monkeypatch):
+        from tools.tts_tool import _generate_deepgram_tts
+
+        monkeypatch.setenv("DEEPGRAM_API_KEY", "test-key")
+        mock_response = MagicMock()
+        mock_response.content = b"audio"
+        mock_response.status_code = 200
+
+        with patch("tools.tts_tool.requests.post", return_value=mock_response) as mock_post:
+            output_path = str(tmp_path / "test.mp3")
+            _generate_deepgram_tts("Test", output_path, {"deepgram": {"model": "aura-2-orion-en"}})
+            assert mock_post.call_args[1]["params"]["model"] == "aura-2-orion-en"
+
+    def test_http_error_raises_runtime_error(self, tmp_path, monkeypatch):
+        from tools.tts_tool import _generate_deepgram_tts
+
+        monkeypatch.setenv("DEEPGRAM_API_KEY", "test-key")
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        mock_response.text = "Bad Request"
+        mock_response.raise_for_status.side_effect = Exception("400")
+
+        with patch("tools.tts_tool.requests.post", return_value=mock_response):
+            output_path = str(tmp_path / "test.mp3")
+            with pytest.raises(RuntimeError):
+                _generate_deepgram_tts("Test", output_path, {})
+
+    def test_auth_header_uses_token_not_bearer(self, tmp_path, monkeypatch):
+        from tools.tts_tool import _generate_deepgram_tts
+
+        monkeypatch.setenv("DEEPGRAM_API_KEY", "my-secret-key")
+        mock_response = MagicMock()
+        mock_response.content = b"audio"
+        mock_response.status_code = 200
+
+        with patch("tools.tts_tool.requests.post", return_value=mock_response) as mock_post:
+            output_path = str(tmp_path / "test.mp3")
+            _generate_deepgram_tts("Test", output_path, {})
+            headers = mock_post.call_args[1]["headers"]
+            assert headers["Authorization"] == "Token my-secret-key"
+            assert "Bearer" not in headers["Authorization"]
+
+
+class TestTtsDispatcherDeepgram:
+    def test_dispatcher_routes_to_deepgram(self, tmp_path, monkeypatch):
+        from tools.tts_tool import text_to_speech_tool
+
+        monkeypatch.setenv("DEEPGRAM_API_KEY", "test-key")
+        mock_response = MagicMock()
+        mock_response.content = b"fake-audio"
+        mock_response.status_code = 200
+
+        with patch("tools.tts_tool.requests.post", return_value=mock_response):
+            monkeypatch.setenv("HERMES_SESSION_PLATFORM", "")
+            result = text_to_speech_tool("Hello", config_override={"tts": {"provider": "deepgram"}})
+            import json
+            data = json.loads(result)
+            assert data["success"] is True
+            assert data["provider"] == "deepgram"

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -67,6 +67,7 @@ DEFAULT_LOCAL_STT_LANGUAGE = "en"
 DEFAULT_STT_MODEL = os.getenv("STT_OPENAI_MODEL", "whisper-1")
 DEFAULT_GROQ_STT_MODEL = os.getenv("STT_GROQ_MODEL", "whisper-large-v3-turbo")
 DEFAULT_MISTRAL_STT_MODEL = os.getenv("STT_MISTRAL_MODEL", "voxtral-mini-latest")
+DEFAULT_DEEPGRAM_STT_MODEL = os.getenv("STT_DEEPGRAM_MODEL", "nova-3")
 LOCAL_STT_COMMAND_ENV = "HERMES_LOCAL_STT_COMMAND"
 LOCAL_STT_LANGUAGE_ENV = "HERMES_LOCAL_STT_LANGUAGE"
 COMMON_LOCAL_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
@@ -242,6 +243,14 @@ def _get_provider(stt_config: dict) -> str:
             )
             return "none"
 
+        if provider == "deepgram":
+            if os.getenv("DEEPGRAM_API_KEY"):
+                return "deepgram"
+            logger.warning(
+                "STT provider 'deepgram' configured but DEEPGRAM_API_KEY not set"
+            )
+            return "none"
+
         return provider  # Unknown — let it fail downstream
 
     # --- Auto-detect (no explicit provider): local > groq > openai > mistral -
@@ -259,6 +268,9 @@ def _get_provider(stt_config: dict) -> str:
     if _HAS_MISTRAL and os.getenv("MISTRAL_API_KEY"):
         logger.info("No local STT available, using Mistral Voxtral Transcribe API")
         return "mistral"
+    if os.getenv("DEEPGRAM_API_KEY"):
+        logger.info("No local STT available, using Deepgram Nova-3 STT API")
+        return "deepgram"
     return "none"
 
 # ---------------------------------------------------------------------------
@@ -574,6 +586,65 @@ def _transcribe_mistral(file_path: str, model_name: str) -> Dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# Provider: deepgram (Nova-3 STT API)
+# ---------------------------------------------------------------------------
+
+
+def _transcribe_deepgram(file_path: str, model_name: str) -> Dict[str, Any]:
+    """Transcribe using Deepgram Nova-3 STT API.
+
+    Uses the Deepgram REST API directly (no SDK required).
+    Requires ``DEEPGRAM_API_KEY`` environment variable.
+    """
+    import requests
+
+    api_key = os.getenv("DEEPGRAM_API_KEY")
+    if not api_key:
+        return {"success": False, "transcript": "", "error": "DEEPGRAM_API_KEY not set"}
+
+    try:
+        url = "https://api.deepgram.com/v1/listen"
+        params = {
+            "model": model_name,
+            "smart_format": "true",
+            "punctuate": "true",
+        }
+        headers = {
+            "Authorization": f"Token {api_key}",
+        }
+
+        with open(file_path, "rb") as audio_file:
+            response = requests.post(
+                url,
+                params=params,
+                headers=headers,
+                data=audio_file,
+                timeout=120,
+            )
+        response.raise_for_status()
+
+        result = response.json()
+        channels = result.get("results", {}).get("channels", [])
+        if channels:
+            alternatives = channels[0].get("alternatives", [])
+            if alternatives:
+                transcript_text = alternatives[0].get("transcript", "").strip()
+                logger.info(
+                    "Transcribed %s via Deepgram API (%s, %d chars)",
+                    Path(file_path).name, model_name, len(transcript_text),
+                )
+                return {"success": True, "transcript": transcript_text, "provider": "deepgram"}
+
+        return {"success": False, "transcript": "", "error": "Deepgram returned empty transcript"}
+
+    except PermissionError:
+        return {"success": False, "transcript": "", "error": f"Permission denied: {file_path}"}
+    except Exception as e:
+        logger.error("Deepgram transcription failed: %s", e, exc_info=True)
+        return {"success": False, "transcript": "", "error": f"Deepgram transcription failed: {type(e).__name__}"}
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -640,6 +711,11 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         mistral_cfg = stt_config.get("mistral", {})
         model_name = model or mistral_cfg.get("model", DEFAULT_MISTRAL_STT_MODEL)
         return _transcribe_mistral(file_path, model_name)
+
+    if provider == "deepgram":
+        deepgram_cfg = stt_config.get("deepgram", {})
+        model_name = model or deepgram_cfg.get("model", DEFAULT_DEEPGRAM_STT_MODEL)
+        return _transcribe_deepgram(file_path, model_name)
 
     # No provider available
     return {

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2,12 +2,13 @@
 """
 Text-to-Speech Tool Module
 
-Supports seven TTS providers:
+Supports eight TTS providers:
 - Edge TTS (default, free, no API key): Microsoft Edge neural voices
 - ElevenLabs (premium): High-quality voices, needs ELEVENLABS_API_KEY
 - OpenAI TTS: Good quality, needs OPENAI_API_KEY
 - MiniMax TTS: High-quality with voice cloning, needs MINIMAX_API_KEY
 - Mistral (Voxtral TTS): Multilingual, native Opus, needs MISTRAL_API_KEY
+- Deepgram (Aura TTS): Fast, 102 voices, 7 languages, native Opus, needs DEEPGRAM_API_KEY
 - Google Gemini TTS: Controllable, 30 prebuilt voices, needs GEMINI_API_KEY
 - NeuTTS (local, free, no API key): On-device TTS via neutts_cli, needs neutts installed
 
@@ -96,6 +97,8 @@ DEFAULT_ELEVENLABS_STREAMING_MODEL_ID = "eleven_flash_v2_5"
 DEFAULT_OPENAI_MODEL = "gpt-4o-mini-tts"
 DEFAULT_KITTENTTS_MODEL = "KittenML/kitten-tts-nano-0.8-int8"  # 25MB
 DEFAULT_KITTENTTS_VOICE = "Jasper"
+DEFAULT_DEEPGRAM_MODEL = "aura-2-thalia-en"
+DEFAULT_DEEPGRAM_BASE_URL = "https://api.deepgram.com/v1/speak"
 DEFAULT_OPENAI_VOICE = "alloy"
 DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1"
 DEFAULT_MINIMAX_MODEL = "speech-2.8-hd"
@@ -785,6 +788,61 @@ def _check_kittentts_available() -> bool:
         return False
 
 
+# ===========================================================================
+# Provider: Deepgram Aura TTS
+# ===========================================================================
+def _generate_deepgram_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate audio using Deepgram Aura TTS API.
+
+    Deepgram returns raw audio bytes via a simple HTTP POST.
+    Supports native Opus output for Telegram voice bubbles.
+    No SDK required — uses the requests library.
+
+    Documented params: model (voice), encoding, container, bit_rate, sample_rate.
+    """
+    import requests
+
+    api_key = os.getenv("DEEPGRAM_API_KEY", "")
+    if not api_key:
+        raise ValueError("DEEPGRAM_API_KEY not set. Get one at https://console.deepgram.com/")
+
+    dg_config = tts_config.get("deepgram", {})
+    model = dg_config.get("model", DEFAULT_DEEPGRAM_MODEL)
+    base_url = dg_config.get("base_url", DEFAULT_DEEPGRAM_BASE_URL)
+
+    # Determine encoding from output file extension
+    if output_path.endswith(".ogg"):
+        encoding = "opus"
+    elif output_path.endswith(".wav"):
+        encoding = "linear16"
+    elif output_path.endswith(".flac"):
+        encoding = "flac"
+    else:
+        encoding = "mp3"
+
+    url = base_url
+    params = {"model": model, "encoding": encoding}
+    headers = {
+        "Authorization": f"Token {api_key}",
+        "Content-Type": "application/json",
+    }
+
+    try:
+        response = requests.post(url, params=params, json={"text": text}, headers=headers, timeout=60)
+        response.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        logger.error("Deepgram TTS HTTP error: %s %s", response.status_code, response.text[:200])
+        raise RuntimeError(f"Deepgram TTS API error (HTTP {response.status_code}): {response.text[:200]}") from e
+    except Exception as e:
+        logger.error("Deepgram TTS failed: %s", e, exc_info=True)
+        raise RuntimeError(f"Deepgram TTS failed: {type(e).__name__}") from e
+
+    with open(output_path, "wb") as f:
+        f.write(response.content)
+
+    return output_path
+
+
 def _default_neutts_ref_audio() -> str:
     """Return path to the bundled default voice reference audio."""
     return str(Path(__file__).parent / "neutts_samples" / "jo.wav")
@@ -968,7 +1026,7 @@ def text_to_speech_tool(
         out_dir.mkdir(parents=True, exist_ok=True)
         # Use .ogg for Telegram with providers that support native Opus output,
         # otherwise fall back to .mp3 (Edge TTS will attempt ffmpeg conversion later).
-        if want_opus and provider in ("openai", "elevenlabs", "mistral", "gemini"):
+        if want_opus and provider in ("openai", "elevenlabs", "mistral", "gemini", "deepgram"):
             file_path = out_dir / f"tts_{timestamp}.ogg"
         else:
             file_path = out_dir / f"tts_{timestamp}.mp3"
@@ -1048,6 +1106,10 @@ def text_to_speech_tool(
             logger.info("Generating speech with KittenTTS (local, ~25MB)...")
             _generate_kittentts(text, file_str, tts_config)
 
+        elif provider == "deepgram":
+            logger.info("Generating speech with Deepgram TTS...")
+            _generate_deepgram_tts(text, file_str, tts_config)
+
         else:
             # Default: Edge TTS (free), with NeuTTS as local fallback
             edge_available = True
@@ -1092,7 +1154,7 @@ def text_to_speech_tool(
             if opus_path:
                 file_str = opus_path
                 voice_compatible = True
-        elif provider in ("elevenlabs", "openai", "mistral", "gemini"):
+        elif provider in ("elevenlabs", "openai", "mistral", "gemini", "deepgram"):
             voice_compatible = file_str.endswith(".ogg")
 
         file_size = os.path.getsize(file_str)

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -14,7 +14,7 @@ If you have a paid [Nous Portal](https://portal.nousresearch.com) subscription, 
 
 ## Text-to-Speech
 
-Convert text to speech with nine providers:
+Convert text to speech with ten providers:
 
 | Provider | Quality | Cost | API Key |
 |----------|---------|------|---------|
@@ -23,6 +23,7 @@ Convert text to speech with nine providers:
 | **OpenAI TTS** | Good | Paid | `VOICE_TOOLS_OPENAI_KEY` |
 | **MiniMax TTS** | Excellent | Paid | `MINIMAX_API_KEY` |
 | **Mistral (Voxtral TTS)** | Excellent | Paid | `MISTRAL_API_KEY` |
+| **Deepgram (Aura TTS)** | Excellent | Paid | `DEEPGRAM_API_KEY` |
 | **Google Gemini TTS** | Excellent | Free tier | `GEMINI_API_KEY` |
 | **xAI TTS** | Excellent | Paid | `XAI_API_KEY` |
 | **NeuTTS** | Good | Free (local) | None needed |
@@ -42,7 +43,7 @@ Convert text to speech with nine providers:
 ```yaml
 # In ~/.hermes/config.yaml
 tts:
-  provider: "edge"              # "edge" | "elevenlabs" | "openai" | "minimax" | "mistral" | "gemini" | "xai" | "neutts" | "kittentts"
+  provider: "edge"              # "edge" | "elevenlabs" | "openai" | "minimax" | "mistral" | "deepgram" | "gemini" | "xai" | "neutts" | "kittentts"
   speed: 1.0                    # Global speed multiplier (provider-specific settings override this)
   edge:
     voice: "en-US-AriaNeural"   # 322 voices, 74 languages
@@ -64,6 +65,8 @@ tts:
   mistral:
     model: "voxtral-mini-tts-2603"
     voice_id: "c69964a6-ab8b-4f8a-9465-ec0925096ec8"  # Paul - Neutral (default)
+  deepgram:
+    model: "aura-2-thalia-en"    # Voice IS the model. 102 voices across 7 languages (en, es, de, it, nl, fr, ja)
   gemini:
     model: "gemini-2.5-flash-preview-tts"  # or gemini-2.5-pro-preview-tts
     voice: "Kore"               # 30 prebuilt voices: Zephyr, Puck, Kore, Enceladus, Gacrux, etc.
@@ -91,7 +94,7 @@ tts:
 
 Telegram voice bubbles require Opus/OGG audio format:
 
-- **OpenAI, ElevenLabs, and Mistral** produce Opus natively — no extra setup
+- **OpenAI, ElevenLabs, Mistral, and Deepgram** produce Opus natively — no extra setup
 - **Edge TTS** (default) outputs MP3 and needs **ffmpeg** to convert:
 - **MiniMax TTS** outputs MP3 and needs **ffmpeg** to convert for Telegram voice bubbles
 - **Google Gemini TTS** outputs raw PCM and uses **ffmpeg** to encode Opus directly for Telegram voice bubbles
@@ -125,6 +128,8 @@ Voice messages sent on Telegram, Discord, WhatsApp, Slack, or Signal are automat
 | **Local Whisper** (default) | Good | Free | None needed |
 | **Groq Whisper API** | Good–Best | Free tier | `GROQ_API_KEY` |
 | **OpenAI Whisper API** | Good–Best | Paid | `VOICE_TOOLS_OPENAI_KEY` or `OPENAI_API_KEY` |
+| **Mistral (Voxtral Transcribe)** | Excellent | Paid | `MISTRAL_API_KEY` |
+| **Deepgram (Nova-3)** | Excellent | Paid | `DEEPGRAM_API_KEY` |
 
 :::info Zero Config
 Local transcription works out of the box when `faster-whisper` is installed. If that's unavailable, Hermes can also use a local `whisper` CLI from common install locations (like `/opt/homebrew/bin`) or a custom command via `HERMES_LOCAL_STT_COMMAND`.
@@ -135,13 +140,15 @@ Local transcription works out of the box when `faster-whisper` is installed. If 
 ```yaml
 # In ~/.hermes/config.yaml
 stt:
-  provider: "local"           # "local" | "groq" | "openai" | "mistral"
+  provider: "local"           # "local" | "groq" | "openai" | "mistral" | "deepgram"
   local:
     model: "base"             # tiny, base, small, medium, large-v3
   openai:
     model: "whisper-1"        # whisper-1, gpt-4o-mini-transcribe, gpt-4o-transcribe
   mistral:
     model: "voxtral-mini-latest"  # voxtral-mini-latest, voxtral-mini-2602
+  deepgram:
+    model: "nova-3"             # nova-3 (latest), nova-2, nova-2-phonecall, nova-2-medical
 ```
 
 ### Provider Details
@@ -162,6 +169,8 @@ stt:
 
 **Mistral API (Voxtral Transcribe)** — Requires `MISTRAL_API_KEY`. Uses Mistral's [Voxtral Transcribe](https://docs.mistral.ai/capabilities/audio/speech_to_text/) models. Supports 13 languages, speaker diarization, and word-level timestamps. Install with `pip install hermes-agent[mistral]`.
 
+**Deepgram API (Nova-3)** — Requires `DEEPGRAM_API_KEY`. Deepgram's [Nova-3](https://developers.deepgram.com/docs/models-languages-overview) model with smart formatting and punctuation. Same key enables Aura TTS (102 voices, 7 languages).
+
 **Custom local CLI fallback** — Set `HERMES_LOCAL_STT_COMMAND` if you want Hermes to call a local transcription command directly. The command template supports `{input_path}`, `{output_dir}`, `{language}`, and `{model}` placeholders.
 
 ### Fallback Behavior
@@ -171,4 +180,5 @@ If your configured provider isn't available, Hermes automatically falls back:
 - **Groq key not set** → Falls back to local transcription, then OpenAI
 - **OpenAI key not set** → Falls back to local transcription, then Groq
 - **Mistral key/SDK not set** → Skipped in auto-detect; falls through to next available provider
+- **Deepgram key not set** → Skipped in auto-detect; falls through to next available provider
 - **Nothing available** → Voice messages pass through with an accurate note to the user


### PR DESCRIPTION
Adds Deepgram as a TTS and STT provider. One `DEEPGRAM_API_KEY` enables both capabilities.

**Why Deepgram:**
- **102 voices** (vs OpenAI's 6, Mistral's 1)
- **7 languages** (en, es, de, it, nl, fr, ja)
- **Native Opus output** — Telegram voice bubbles without ffmpeg conversion
- **406 STT models** including domain-specific (phonecall, medical, finance, meeting)
- **$200 free credit** at signup

**Changes:**

| File | Change |
|------|--------|
| `tools/tts_tool.py` | Add `_generate_deepgram_tts()` — REST POST to `/v1/speak`, Token auth, auto-detects encoding from file extension. Wire into provider dispatch, native-Opus list, voice_compatible list. |
| `tools/transcription_tools.py` | Add `_transcribe_deepgram()` — REST POST to `/v1/listen` with `smart_format` + `punctuate`. Provider detection in `_get_provider()`. Auto-detect fallback chain after Mistral. |
| `hermes_cli/config.py` | Add `tts.deepgram` and `stt.deepgram` config sections. `DEEPGRAM_API_KEY` in `OPTIONAL_ENV_VARS`. |
| `hermes_cli/setup.py` | Provider label, setup wizard choice, API key prompt flow, setup summary row. |
| `hermes_cli/tools_config.py` | Deepgram entry in TTS toolset picker. |
| `website/docs/user-guide/features/tts.md` | Provider tables, config examples, Opus note, STT provider details, fallback chain. |
| `tests/tools/test_tts_deepgram.py` | 6 test cases matching existing provider test patterns. |

**Config:**

```yaml
# ~/.hermes/config.yaml
tts:
  provider: "deepgram"
  deepgram:
    model: "aura-2-thalia-en"   # 102 voices across 7 languages

stt:
  provider: "deepgram"
  deepgram:
    model: "nova-3"             # nova-3, nova-2, nova-2-phonecall, nova-2-medical
```

**Setup:**
```bash
export DEEPGRAM_API_KEY=your_key
# Or: hermes setup → pick Deepgram → enter API key
```

**Tested:**
- TTS: MP3 output, Opus/OGG for Telegram voice bubbles
- STT: Nova-3 transcription with smart_format and punctuation
- Single API key shared between TTS and STT
- Setup wizard flow works end to end
- Rebased on latest main