### PR TITLE
fix(mcp-oauth): preserve URL path when passing server_url to OAuthClientProvider

### DIFF
--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -563,7 +563,7 @@ def build_oauth_auth(
     _maybe_preregister_client(storage, cfg, client_metadata)
 
     return OAuthClientProvider(
-        server_url=_parse_base_url(server_url),
+        server_url=server_url,
         client_metadata=client_metadata,
         storage=storage,
         redirect_handler=_redirect_handler,

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -387,7 +387,7 @@ class MCPOAuthManager:
 
         return _HERMES_PROVIDER_CLS(
             server_name=server_name,
-            server_url=_parse_base_url(entry.server_url),
+            server_url=entry.server_url,
             client_metadata=client_metadata,
             storage=storage,
             redirect_handler=_redirect_handler,


### PR DESCRIPTION
## Problem

When an MCP server endpoint has a path component (e.g. `http://host:7800/mcp`), hermes strips the path via `_parse_base_url()` before passing `server_url` to the MCP SDK's `OAuthClientProvider`. This causes an immediate `OAuthFlowError` on every connection attempt:

```
mcp.client.auth.exceptions.OAuthFlowError: Protected resource http://127.0.0.1:7800/mcp does not match expected http://127.0.0.1:7800
```

The MCP SDK uses `server_url` as the expected resource identifier when validating the Protected Resource Metadata (PRM). If the PRM's `resource` field includes a path (as it should per spec), and the SDK's expected value has no path (because hermes stripped it), validation fails and the connection is permanently dead — no tokens are ever obtained.

The surface symptom is the cryptic `unhandled errors in a TaskGroup (1 sub-exception)` warning that swallows the real error.

## Root cause

`_parse_base_url()` was introduced to extract the origin for OAuth AS discovery. However it is also (incorrectly) used as the `server_url` argument to `OAuthClientProvider`, which the SDK uses for two distinct purposes:
1. **AS discovery** — derives well-known URLs from scheme+host (path is irrelevant here ✓)
2. **Resource validation** — compares the full URL against the PRM `resource` field (path matters here ✗)

Stripping the path satisfies (1) but breaks (2) for any MCP server whose endpoint is not at the root path.

## Fix

Pass the original `server_url` (including path) directly to `OAuthClientProvider` in both `build_oauth_auth()` and `MCPOAuthManager._build_provider()`. The SDK's discovery still works correctly because `build_protected_resource_metadata_discovery_urls` and `build_oauth_authorization_server_metadata_discovery_urls` operate on the scheme+host internally.

## Affected versions

Any hermes version where the MCP server URL has a non-root path (e.g. `/mcp`, `/api/mcp`). Root-path URLs (`http://host/`) were unaffected because stripping a root path is a no-op.

## Testing

Reproduced with a local MCP server at `http://127.0.0.1:7800/mcp` whose PRM declares `resource: http://127.0.0.1:7800/mcp`. Before this fix every connection attempt fails within 50ms with the OAuthFlowError above. After this fix OAuth completes normally.