### PR TITLE
fix(tui_gateway): register shell hooks at startup

### DIFF
--- a/tests/tui_gateway/test_shell_hooks_registration.py
+++ b/tests/tui_gateway/test_shell_hooks_registration.py
@@ -1,0 +1,81 @@
+"""Regression test: tui_gateway must register configured shell hooks.
+
+Without this, shell scripts declared under the ``hooks:`` block of
+``config.yaml`` silently never fire for TUI sessions, even though the
+same hooks work fine in the CLI (``hermes_cli/main.py``) and the
+messaging gateway (``gateway/run.py``).  See issue/PR for diagnosis.
+"""
+
+import importlib
+from unittest.mock import MagicMock, patch
+
+
+def test_main_registers_shell_hooks():
+    """``tui_gateway.entry.main`` must invoke ``register_from_config`` at
+    startup so the TUI honors the same ``hooks:`` block as every other
+    entry point."""
+    register_mock = MagicMock(return_value=[])
+    load_config_mock = MagicMock(return_value={"hooks": {}})
+
+    # Stub the heavy imports pulled in by ``tui_gateway.server`` so the
+    # entry module can load in a unit-test environment.
+    stub_modules = {
+        "hermes_constants": MagicMock(
+            get_hermes_home=MagicMock(return_value="/tmp/hermes_test"),
+        ),
+        "hermes_cli.env_loader": MagicMock(),
+        "hermes_cli.banner": MagicMock(),
+        "hermes_state": MagicMock(),
+    }
+    with patch.dict("sys.modules", stub_modules):
+        with patch(
+            "agent.shell_hooks.register_from_config", register_mock,
+        ), patch(
+            "hermes_cli.config.load_config", load_config_mock,
+        ), patch(
+            "sys.stdin", iter([]),
+        ), patch(
+            "tui_gateway.entry.write_json", return_value=True,
+        ):
+            entry = importlib.import_module("tui_gateway.entry")
+            importlib.reload(entry)
+            entry.main()
+
+    assert register_mock.call_count == 1, (
+        "register_from_config must be called exactly once during TUI "
+        "gateway startup so the hooks: config block actually wires up."
+    )
+    # Mirror gateway/run.py: accept_hooks=False — env/config resolves it.
+    _, kwargs = register_mock.call_args
+    assert kwargs.get("accept_hooks") is False
+
+
+def test_register_failure_does_not_block_startup():
+    """A broken hook config or import error must never prevent the TUI
+    backend from starting — failures are logged at debug, swallowed
+    otherwise."""
+    register_mock = MagicMock(side_effect=RuntimeError("boom"))
+    load_config_mock = MagicMock(return_value={"hooks": {}})
+
+    stub_modules = {
+        "hermes_constants": MagicMock(
+            get_hermes_home=MagicMock(return_value="/tmp/hermes_test"),
+        ),
+        "hermes_cli.env_loader": MagicMock(),
+        "hermes_cli.banner": MagicMock(),
+        "hermes_state": MagicMock(),
+    }
+    with patch.dict("sys.modules", stub_modules):
+        with patch(
+            "agent.shell_hooks.register_from_config", register_mock,
+        ), patch(
+            "hermes_cli.config.load_config", load_config_mock,
+        ), patch(
+            "sys.stdin", iter([]),
+        ), patch(
+            "tui_gateway.entry.write_json", return_value=True,
+        ):
+            entry = importlib.import_module("tui_gateway.entry")
+            importlib.reload(entry)
+            # Must not raise.
+            entry.main()

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -170,6 +170,29 @@ if hasattr(signal, "SIGINT"):
     signal.signal(signal.SIGINT, signal.SIG_IGN)
 
 
+def _register_shell_hooks() -> None:
+    """Wire shell hooks declared in config.yaml.
+
+    Mirrors gateway/run.py so the TUI's Python backend honors the same
+    ``hooks:`` block as the CLI and the messaging gateway.  Without this
+    call shell hooks silently never fire for TUI sessions even though
+    they appear correctly registered at the CLI level.
+
+    accept_hooks=False — register_from_config resolves the effective
+    value from HERMES_ACCEPT_HOOKS / hooks_auto_accept itself.  Failures
+    are logged but must never block TUI startup.
+    """
+    try:
+        from hermes_cli.config import load_config
+        from agent.shell_hooks import register_from_config
+        register_from_config(load_config(), accept_hooks=False)
+    except Exception:
+        logger.debug(
+            "shell-hook registration failed at tui_gateway startup",
+            exc_info=True,
+        )
+
+
 def _log_exit(reason: str) -> None:
     """Record why the gateway subprocess is shutting down.
 
@@ -211,6 +234,7 @@ def wait_for_mcp_discovery(timeout: float = 0.75) -> None:
 
 
 def main():
+    _register_shell_hooks()
     _install_sidecar_publisher()
 
     # MCP tool discovery — runs in a background daemon thread so a slow or


### PR DESCRIPTION
## Problem

Shell hooks declared under the `hooks:` block in `config.yaml` silently never fire for TUI sessions (`hermes --tui`), even though the same hooks work correctly in the interactive CLI and the messaging gateway.

No error appears in the logs — the hooks just never get registered, so `invoke_hook()` has nothing to dispatch to.

## Diagnosis

The shell-hooks feature (commit 3988c3c2, PR #13143) wires `agent.shell_hooks.register_from_config()` into two entry points:

- `hermes_cli/main.py` — interactive CLI
- `gateway/run.py` — Telegram / Discord / Slack / Signal / WhatsApp / etc.

It misses the third entry point: `tui_gateway/entry.py`, the Python JSON-RPC backend that `hermes --tui` spawns. That backend runs the same `AIAgent` loop (and therefore the same `invoke_hook("pre_llm_call", ...)` call site), but never registers the configured shell scripts, so the dispatcher has zero callbacks.

Appears to be an omission rather than intentional — no comment, doc note, or test asserts the exclusion, and the original PR predates an exhaustive entry-point audit.

## Fix

Call `register_from_config()` once at the top of `tui_gateway.entry.main()`, mirroring the existing `gateway/run.py` pattern verbatim:

- Same `accept_hooks=False` (let `register_from_config` resolve effective consent from `HERMES_ACCEPT_HOOKS` / `hooks_auto_accept`).
- Same `try/except + logger.debug` so a broken `hooks:` block can never block TUI startup.
- Idempotent: `register_from_config` already deduplicates via `_registered`, so re-invocation is safe in the unlikely case the entry module is reloaded.

## Tests

`tests/tui_gateway/test_shell_hooks_registration.py` adds two regression tests:

1. `test_main_registers_shell_hooks` — asserts `register_from_config` is invoked exactly once during TUI gateway startup with `accept_hooks=False`.
2. `test_register_failure_does_not_block_startup` — confirms a raising `register_from_config` does not propagate out of `main()`.

Both pass locally:

```
$ python -m pytest tests/tui_gateway/test_shell_hooks_registration.py -o addopts="" -x
======================== 2 passed, 2 warnings in 0.09s =========================
```

## Manual verification

Reproduction setup: a `pre_llm_call` script that emits `{"context": "..."}` and is approved in `shell-hooks-allowlist.json`.

- **Before patch (TUI session):** marker file never written, no `shell hook registered` log line at TUI startup, injected context absent from the LLM turn.
- **After patch (TUI session):** `agent.shell_hooks: shell hook registered: pre_llm_call -> ...` appears at TUI startup, marker file written on first turn, injected context present in the LLM turn.

CLI and messaging-gateway behavior unchanged.

## Risk

Tiny. Three-line change in an init function, mirrors a code path that has shipped for a release. No new dependencies, no protocol changes.