### PR TITLE
fix(docker): preserve /workspace for submounts

### DIFF
--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -48,6 +48,24 @@ def _make_dummy_env(**kwargs):
     )
 
 
+def _docker_run_args(calls):
+    run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
+    assert run_calls, "docker run should have been called"
+    return run_calls[0][0]
+
+
+def _docker_volume_specs(run_args):
+    specs = []
+    index = 0
+    while index < len(run_args):
+        if run_args[index] == "-v" and index + 1 < len(run_args):
+            specs.append(run_args[index + 1])
+            index += 2
+            continue
+        index += 1
+    return specs
+
+
 def test_ensure_docker_available_logs_and_raises_when_not_found(monkeypatch, caplog):
     """When docker cannot be found, raise a clear error before container setup."""
 
@@ -128,9 +146,7 @@ def test_auto_mount_host_cwd_adds_volume(monkeypatch, tmp_path):
     )
 
     # Find the docker run call and check its args
-    run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
-    assert run_calls, "docker run should have been called"
-    run_args_str = " ".join(run_calls[0][0])
+    run_args_str = " ".join(_docker_run_args(calls))
     assert f"{project_dir}:/workspace" in run_args_str
 
 
@@ -148,9 +164,7 @@ def test_auto_mount_disabled_by_default(monkeypatch, tmp_path):
         auto_mount_cwd=False,
     )
 
-    run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
-    assert run_calls, "docker run should have been called"
-    run_args_str = " ".join(run_calls[0][0])
+    run_args_str = " ".join(_docker_run_args(calls))
     assert f"{project_dir}:/workspace" not in run_args_str
 
 
@@ -171,11 +185,31 @@ def test_auto_mount_skipped_when_workspace_already_mounted(monkeypatch, tmp_path
         volumes=[f"{other_dir}:/workspace"],
     )
 
-    run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
-    assert run_calls, "docker run should have been called"
-    run_args_str = " ".join(run_calls[0][0])
+    run_args_str = " ".join(_docker_run_args(calls))
     assert f"{other_dir}:/workspace" in run_args_str
     assert run_args_str.count(":/workspace") == 1
+
+
+def test_auto_mount_not_skipped_for_workspace_submount(monkeypatch, tmp_path):
+    """Submounts under /workspace should not suppress the main /workspace mount."""
+    project_dir = tmp_path / "my-project"
+    project_dir.mkdir()
+    other_dir = tmp_path / "other"
+    other_dir.mkdir()
+
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env(
+        cwd="/workspace",
+        host_cwd=str(project_dir),
+        auto_mount_cwd=True,
+        volumes=[f"{other_dir}:/workspace/code"],
+    )
+
+    volume_specs = _docker_volume_specs(_docker_run_args(calls))
+    assert f"{project_dir}:/workspace" in volume_specs
+    assert f"{other_dir}:/workspace/code" in volume_specs
 
 
 def test_auto_mount_replaces_persistent_workspace_bind(monkeypatch, tmp_path):
@@ -194,11 +228,44 @@ def test_auto_mount_replaces_persistent_workspace_bind(monkeypatch, tmp_path):
         task_id="test-persistent-auto-mount",
     )
 
-    run_calls = [c for c in calls if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "run"]
-    assert run_calls, "docker run should have been called"
-    run_args_str = " ".join(run_calls[0][0])
+    run_args_str = " ".join(_docker_run_args(calls))
     assert f"{project_dir}:/workspace" in run_args_str
     assert "/sandboxes/docker/test-persistent-auto-mount/workspace:/workspace" not in run_args_str
+
+
+def test_workspace_submount_keeps_persistent_workspace_bind(monkeypatch, tmp_path):
+    """Persistent workspace bind should remain when only a /workspace subpath is mounted."""
+    other_dir = tmp_path / "other"
+    other_dir.mkdir()
+
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env(
+        cwd="/workspace",
+        persistent_filesystem=True,
+        task_id="test-persistent-submount",
+        volumes=[f"{other_dir}:/workspace/notes"],
+    )
+
+    volume_specs = _docker_volume_specs(_docker_run_args(calls))
+    assert "/sandboxes/docker/test-persistent-submount/workspace:/workspace" in volume_specs
+    assert f"{other_dir}:/workspace/notes" in volume_specs
+
+
+@pytest.mark.parametrize(
+    ("spec", "expected"),
+    [
+        ("/host/foo:/workspace:rw", "/workspace"),
+        ("/host/foo:/workspace/code:rw", "/workspace/code"),
+        ("/host/foo:/workspace/notes:rw", "/workspace/notes"),
+        (r"C:\src:/workspace:rw", "/workspace"),
+        (r"C:\src:/workspace/shared:rw", "/workspace/shared"),
+    ],
+)
+def test_docker_volume_destination(spec, expected):
+    """Destination parsing should distinguish exact /workspace from submounts."""
+    assert docker_env._docker_volume_destination(spec) == expected
 
 
 def test_non_persistent_cleanup_removes_container(monkeypatch):

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -31,6 +31,7 @@ _DOCKER_SEARCH_PATHS = [
 
 _docker_executable: Optional[str] = None  # resolved once, cached
 _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_DOCKER_VOLUME_DEST_RE = re.compile(r"^.+:(?P<dst>/[^:]*?)(?::[^:]+)?$")
 
 
 def _normalize_forward_env_names(forward_env: list[str] | None) -> list[str]:
@@ -86,6 +87,16 @@ def _normalize_env_dict(env: dict | None) -> dict[str, str]:
         normalized[key] = value
 
     return normalized
+
+
+def _docker_volume_destination(spec: str) -> str:
+    """Return the container destination path from a docker ``-v`` spec."""
+    match = _DOCKER_VOLUME_DEST_RE.match(spec.strip())
+    if not match:
+        return ""
+
+    destination = match.group("dst").rstrip("/")
+    return destination or "/"
 
 
 def _load_hermes_env_vars() -> dict[str, str]:
@@ -312,7 +323,7 @@ class DockerEnvironment(BaseEnvironment):
                 continue
             if ":" in vol:
                 volume_args.extend(["-v", vol])
-                if ":/workspace" in vol:
+                if _docker_volume_destination(vol) == "/workspace":
                     workspace_explicitly_mounted = True
             else:
                 logger.warning(f"Docker volume '{vol}' missing colon, skipping")


### PR DESCRIPTION
## Summary

- only treat exact `/workspace` mounts as explicit workspace overrides
- keep Hermes' normal `/workspace` bind/tmpfs when the user mounts subpaths like `/workspace/code` or `/workspace/notes`
- add regression tests for `/workspace` submounts and Windows-style source paths

## Root Cause

`DockerEnvironment` used a raw substring check for `:/workspace` when deciding whether the user had explicitly mounted `/workspace`.

That made submounts like `/host/foo:/workspace/code:rw` and `/host/foo:/workspace/notes:rw` look like exact `/workspace` mounts, which incorrectly disabled Hermes' built-in per-session `/workspace` bind/tmpfs.

## Validation

- `python -m py_compile tools/environments/docker.py tests/tools/test_docker_environment.py`
- `scripts/run_tests.sh tests/tools/test_docker_environment.py` could not run in this checkout because no project virtualenv was present at `.venv` or `venv`
