### PR TITLE
feat(gateway): add clarify flow and Feishu clarify cards

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -33,6 +33,7 @@ from typing import Any
 _GLOBAL_DEFAULTS: dict[str, Any] = {
     "tool_progress": "all",
     "show_reasoning": False,
+    "interim_assistant_messages": True,
     "tool_preview_length": 0,
     "streaming": None,  # None = follow top-level streaming config
 }
@@ -182,7 +183,7 @@ def _normalise(setting: str, value: Any) -> Any:
         if value is True:
             return "all"
         return str(value).lower()
-    if setting in ("show_reasoning", "streaming"):
+    if setting in ("show_reasoning", "streaming", "interim_assistant_messages"):
         if isinstance(value, str):
             return value.lower() in ("true", "1", "yes", "on")
         return bool(value)

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -191,6 +191,7 @@ _APPROVAL_LABEL_MAP: Dict[str, str] = {
     "always": "Approved permanently",
     "deny": "Denied",
 }
+_CLARIFY_ACTION = "clarify_choice"
 _FEISHU_BOT_MSG_TRACK_SIZE = 512                   # LRU size for tracking sent message IDs
 _FEISHU_REPLY_FALLBACK_CODES = frozenset({230011, 231003})  # reply target withdrawn/missing → create fallback
 
@@ -305,6 +306,7 @@ class FeishuAdapterSettings:
     connection_mode: str
     encrypt_key: str
     verification_token: str
+    require_mention: bool
     group_policy: str
     allowed_group_users: frozenset[str]
     bot_open_id: str
@@ -437,6 +439,20 @@ def _coerce_int(value: Any, default: Optional[int] = None, min_value: int = 0) -
 def _coerce_required_int(value: Any, default: int, min_value: int = 0) -> int:
     parsed = _coerce_int(value, default=default, min_value=min_value)
     return default if parsed is None else parsed
+
+
+def _coerce_bool(value: Any, default: bool) -> bool:
+    """Coerce common truthy/falsey values to bool."""
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    normalized = str(value).strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    return default
 
 
 # ---------------------------------------------------------------------------
@@ -1153,6 +1169,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._pending_media_batch_tasks = self._media_batch_state.tasks
         # Exec approval button state (approval_id → {session_key, message_id, chat_id})
         self._approval_state: Dict[int, Dict[str, str]] = {}
+        self._clarify_state: Dict[int, Dict[str, str]] = {}
         self._approval_counter = itertools.count(1)
         # Feishu reaction deletion requires the opaque reaction_id returned
         # by create, so we cache it per message_id.
@@ -1190,6 +1207,10 @@ class FeishuAdapter(BasePlatformAdapter):
             ).strip().lower(),
             encrypt_key=os.getenv("FEISHU_ENCRYPT_KEY", "").strip(),
             verification_token=os.getenv("FEISHU_VERIFICATION_TOKEN", "").strip(),
+            require_mention=_coerce_bool(
+                extra.get("require_mention", os.getenv("FEISHU_REQUIRE_MENTION")),
+                default=True,
+            ),
             group_policy=os.getenv("FEISHU_GROUP_POLICY", "allowlist").strip().lower(),
             allowed_group_users=frozenset(
                 item.strip()
@@ -1246,6 +1267,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._connection_mode = settings.connection_mode
         self._encrypt_key = settings.encrypt_key
         self._verification_token = settings.verification_token
+        self._require_mention = settings.require_mention
         self._group_policy = settings.group_policy
         self._allowed_group_users = set(settings.allowed_group_users)
         self._admins = set(settings.admins)
@@ -1583,6 +1605,75 @@ class FeishuAdapter(BasePlatformAdapter):
             logger.warning("[Feishu] send_exec_approval failed: %s", exc)
             return SendResult(success=False, error=str(exc))
 
+    async def send_clarify_card(
+        self,
+        chat_id: str,
+        question: str,
+        choices: List[str],
+        session_key: str,
+        clarify_id: int,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send an interactive card for a multiple-choice clarify prompt."""
+        if not self._client:
+            return SendResult(success=False, error="Not connected")
+
+        try:
+            trimmed_choices = [str(choice).strip() for choice in choices if str(choice).strip()]
+            if not trimmed_choices:
+                return SendResult(success=False, error="No clarify choices provided")
+
+            def _btn(choice: str) -> dict:
+                label = choice if len(choice) <= 40 else choice[:37] + "..."
+                return {
+                    "tag": "button",
+                    "text": {"tag": "plain_text", "content": label},
+                    "value": {
+                        "hermes_action": _CLARIFY_ACTION,
+                        "clarify_id": clarify_id,
+                        "choice": choice,
+                    },
+                }
+
+            question_preview = question[:3000] + "..." if len(question) > 3000 else question
+            card = {
+                "config": {"wide_screen_mode": True},
+                "header": {
+                    "title": {"content": "❓ 请先确认", "tag": "plain_text"},
+                    "template": "blue",
+                },
+                "elements": [
+                    {"tag": "markdown", "content": question_preview},
+                    {"tag": "action", "actions": [_btn(choice) for choice in trimmed_choices]},
+                    {
+                        "tag": "markdown",
+                        "content": "_如果你想自己输入答案，也可以直接在聊天里回复。_",
+                    },
+                ],
+            }
+
+            payload = json.dumps(card, ensure_ascii=False)
+            response = await self._feishu_send_with_retry(
+                chat_id=chat_id,
+                msg_type="interactive",
+                payload=payload,
+                reply_to=None,
+                metadata=metadata,
+            )
+
+            result = self._finalize_send_result(response, "send_clarify_card failed")
+            if result.success:
+                self._clarify_state[clarify_id] = {
+                    "session_key": session_key,
+                    "message_id": result.message_id or "",
+                    "chat_id": chat_id,
+                    "question": question_preview,
+                }
+            return result
+        except Exception as exc:
+            logger.warning("[Feishu] send_clarify_card failed: %s", exc)
+            return SendResult(success=False, error=str(exc))
+
     @staticmethod
     def _build_resolved_approval_card(*, choice: str, user_name: str) -> Dict[str, Any]:
         """Build raw card JSON for a resolved approval action."""
@@ -1598,6 +1689,32 @@ class FeishuAdapter(BasePlatformAdapter):
                 {
                     "tag": "markdown",
                     "content": f"{icon} **{label}** by {user_name}",
+                },
+            ],
+        }
+
+    @staticmethod
+    def _build_resolved_clarify_card(
+        *,
+        question: str,
+        choice: str,
+        user_name: str,
+    ) -> Dict[str, Any]:
+        """Build raw card JSON for a resolved clarify action."""
+        return {
+            "config": {"wide_screen_mode": True},
+            "header": {
+                "title": {"content": "✅ 已完成选择", "tag": "plain_text"},
+                "template": "green",
+            },
+            "elements": [
+                {
+                    "tag": "markdown",
+                    "content": (
+                        f"**问题：** {question or '未知问题'}\n\n"
+                        f"**选择：** {choice}\n\n"
+                        f"**选择人：** {user_name}"
+                    ),
                 },
             ],
         }
@@ -2102,8 +2219,10 @@ class FeishuAdapter(BasePlatformAdapter):
         action_value = getattr(action, "value", {}) or {}
         hermes_action = action_value.get("hermes_action") if isinstance(action_value, dict) else None
 
-        if hermes_action:
+        if hermes_action in _APPROVAL_CHOICE_MAP:
             return self._handle_approval_card_action(event=event, action_value=action_value, loop=loop)
+        if hermes_action == _CLARIFY_ACTION:
+            return self._handle_clarify_card_action(event=event, action_value=action_value, loop=loop)
 
         self._submit_on_loop(loop, self._handle_card_action_event(data))
         if P2CardActionTriggerResponse is None:
@@ -2144,6 +2263,35 @@ class FeishuAdapter(BasePlatformAdapter):
             response.card = card
         return response
 
+    def _handle_clarify_card_action(self, *, event: Any, action_value: Dict[str, Any], loop: Any) -> Any:
+        """Schedule clarify resolution and build the synchronous callback response."""
+        clarify_id = action_value.get("clarify_id")
+        choice = str(action_value.get("choice", "") or "").strip()
+        if clarify_id is None or not choice:
+            logger.debug("[Feishu] Card action missing clarify_id or choice, ignoring")
+            return P2CardActionTriggerResponse() if P2CardActionTriggerResponse else None
+
+        operator = getattr(event, "operator", None)
+        open_id = str(getattr(operator, "open_id", "") or "")
+        user_name = self._get_cached_sender_name(open_id) or open_id
+        state = self._clarify_state.get(clarify_id, {})
+
+        self._submit_on_loop(loop, self._resolve_clarify(clarify_id, choice, user_name))
+
+        if P2CardActionTriggerResponse is None:
+            return None
+        response = P2CardActionTriggerResponse()
+        if CallBackCard is not None:
+            card = CallBackCard()
+            card.type = "raw"
+            card.data = self._build_resolved_clarify_card(
+                question=state.get("question", ""),
+                choice=choice,
+                user_name=user_name,
+            )
+            response.card = card
+        return response
+
     async def _resolve_approval(self, approval_id: Any, choice: str, user_name: str) -> None:
         """Pop approval state and unblock the waiting agent thread."""
         state = self._approval_state.pop(approval_id, None)
@@ -2159,6 +2307,32 @@ class FeishuAdapter(BasePlatformAdapter):
             )
         except Exception as exc:
             logger.error("Failed to resolve gateway approval from Feishu button: %s", exc)
+
+    async def _resolve_clarify(self, clarify_id: Any, choice: str, user_name: str) -> None:
+        """Pop clarify state and unblock the waiting agent thread."""
+        state = self._clarify_state.pop(clarify_id, None)
+        if not state:
+            logger.debug("[Feishu] Clarify %s already resolved or unknown", clarify_id)
+            return
+        try:
+            from tools.clarify_state import resolve_gateway_clarify
+
+            count = resolve_gateway_clarify(
+                state["session_key"],
+                choice,
+                clarify_id=int(clarify_id),
+            )
+            self.resume_typing_for_chat(state["chat_id"])
+            logger.info(
+                "Feishu button resolved %d clarify prompt(s) for session %s (choice=%s, user=%s)",
+                count, state["session_key"], choice, user_name,
+            )
+        except Exception as exc:
+            logger.error("Failed to resolve gateway clarify from Feishu button: %s", exc)
+
+    def clear_clarify_card_state(self, clarify_id: int) -> None:
+        """Forget stored clarify card state after text fallback or timeout cleanup."""
+        self._clarify_state.pop(int(clarify_id), None)
 
     async def _handle_reaction_event(self, event_type: str, data: Any) -> None:
         """Fetch the reacted-to message; if it was sent by this bot, emit a synthetic text event."""
@@ -3376,6 +3550,8 @@ class FeishuAdapter(BasePlatformAdapter):
         """Require an explicit @mention before group messages enter the agent."""
         if not self._allow_group_message(sender_id, chat_id):
             return False
+        if not self._require_mention:
+            return True
         # @_all is Feishu's @everyone placeholder — always route to the bot.
         raw_content = getattr(message, "content", "") or ""
         if "@_all" in raw_content:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -339,6 +339,139 @@ def _expand_whatsapp_auth_aliases(identifier: str) -> set:
 
     return resolved
 
+
+_PM_BACKGROUND_ROOT = _hermes_home / "pm-background"
+
+
+def _pm_background_now_iso() -> str:
+    return datetime.now().isoformat(timespec="seconds")
+
+
+def _pm_background_clip(value: Any, limit: int = 900) -> str:
+    text = str(value or "").strip()
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1].rstrip() + "…"
+
+
+def _pm_background_safe_id(raw: str) -> str:
+    value = re.sub(r"[^\w.\-]+", "_", str(raw or "").strip())
+    return value or "unknown"
+
+
+def _pm_background_write_json(path: Path, payload: Dict[str, Any]) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_name(
+        f".{path.name}.{os.getpid()}.{int(time.time() * 1000)}.tmp"
+    )
+    tmp_path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    tmp_path.replace(path)
+    return path
+
+
+def _pm_background_read_json(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _pm_background_pending_dir() -> Path:
+    path = _PM_BACKGROUND_ROOT / "pending"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _pm_background_run_dir(run_id: str) -> Path:
+    path = _PM_BACKGROUND_ROOT / "runs" / _pm_background_safe_id(run_id)
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _pm_background_state_path(run_id: str) -> Path:
+    return _pm_background_run_dir(run_id) / "state.json"
+
+
+def _pm_background_events_path(run_id: str) -> Path:
+    return _pm_background_run_dir(run_id) / "events.jsonl"
+
+
+def _pm_background_update_state(run_id: str, **updates: Any) -> Dict[str, Any]:
+    path = _pm_background_state_path(run_id)
+    payload = _pm_background_read_json(path)
+    payload.update({key: value for key, value in updates.items() if value is not None})
+    payload.setdefault("run_id", run_id)
+    payload["updated_at"] = str(updates.get("updated_at") or _pm_background_now_iso())
+    _pm_background_write_json(path, payload)
+    return payload
+
+
+def _pm_background_append_event(run_id: str, event_type: str, message: Any) -> None:
+    path = _pm_background_events_path(run_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    entry = {
+        "timestamp": _pm_background_now_iso(),
+        "type": str(event_type or "info"),
+        "message": str(message or "").strip(),
+    }
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+def _pm_background_executor_env(executor_name: str) -> Dict[str, str]:
+    """Use the real OS home for local coding CLIs that store auth in ~/.*
+
+    Hermes keeps per-profile subprocess HOME isolation by default, which is
+    great for general tool hygiene but breaks existing Codex/Claude/Gemini CLI
+    logins. PM background executor runs are expected to reuse the machine's
+    already-authenticated CLI state, so explicitly opt back into the real HOME
+    for those runs only.
+    """
+    executor = str(executor_name or "").strip().lower()
+    if executor in {"codex", "cc", "gemini"}:
+        return {"HOME": str(Path.home())}
+    return {}
+
+
+def _build_pm_background_executor_message(
+    executor_name: str,
+    prompt: str,
+    run_id: str,
+) -> str:
+    """Wrap PM run prompts in the corresponding reusable Hermes executor skill."""
+    executor = str(executor_name or "").strip().lower()
+    if executor not in {"codex", "cc", "gemini"}:
+        return prompt
+
+    from agent.skill_commands import build_skill_invocation_message
+
+    command_map = {
+        "codex": "/codex",
+        "cc": "/claude-code",
+        "gemini": "/gemini",
+    }
+    runtime_note = (
+        "This invocation was started by PM background execution. Use the repo workdir "
+        "already configured for the run. Keep context lean: do not preload the whole "
+        "repository, read only the files needed for the current task, and summarize "
+        "progress/results instead of dumping long raw logs."
+    )
+    message = build_skill_invocation_message(
+        command_map[executor],
+        prompt,
+        task_id=run_id,
+        runtime_note=runtime_note,
+    )
+    if not message:
+        raise RuntimeError(f"Required executor skill {command_map[executor]} is not available.")
+    return message
+
 logger = logging.getLogger(__name__)
 
 # Sentinel placed into _running_agents immediately when a session starts
@@ -2240,6 +2373,11 @@ class GatewayRunner:
             )
         asyncio.create_task(self._platform_reconnect_watcher())
 
+        # Start PM native background-request watcher.
+        _pm_bg_task = asyncio.create_task(self._pm_background_request_watcher())
+        self._background_tasks.add(_pm_bg_task)
+        _pm_bg_task.add_done_callback(self._background_tasks.discard)
+
         logger.info("Press Ctrl+C to stop")
         
         return True
@@ -3395,6 +3533,10 @@ class GatewayRunner:
                     f"⏳ Agent is running — `/{_cmd_def_inner.name}` can't run "
                     f"mid-turn. Wait for the current response or `/stop` first."
                 )
+
+            from tools.clarify_state import has_blocking_clarify
+            if event.message_type != MessageType.PHOTO and has_blocking_clarify(_quick_key):
+                return await self._handle_clarify_response(event)
 
             if event.message_type == MessageType.PHOTO:
                 logger.debug("PRIORITY photo follow-up for session %s — queueing without interrupt", _quick_key[:20])
@@ -6533,6 +6675,484 @@ class GatewayRunner:
             except Exception:
                 pass
 
+    async def _pm_background_request_watcher(self, interval: float = 1.0) -> None:
+        """Poll for PM-native background requests dropped by shared PM skills."""
+        while True:
+            try:
+                for request_path in sorted(_pm_background_pending_dir().glob("*.json")):
+                    run_id = _pm_background_safe_id(request_path.stem)
+                    run_dir = _pm_background_run_dir(run_id)
+                    claimed_path = run_dir / "request.json"
+
+                    if claimed_path.exists():
+                        try:
+                            request_path.unlink()
+                        except OSError:
+                            pass
+                        continue
+
+                    try:
+                        request_path.replace(claimed_path)
+                    except FileNotFoundError:
+                        continue
+                    except OSError as exc:
+                        logger.debug(
+                            "PM background request claim failed for %s: %s",
+                            request_path,
+                            exc,
+                        )
+                        continue
+
+                    request = _pm_background_read_json(claimed_path)
+                    if not request:
+                        _pm_background_append_event(
+                            run_id,
+                            "error",
+                            "Invalid PM background request payload.",
+                        )
+                        _pm_background_update_state(
+                            run_id,
+                            status="failed",
+                            exit_code=1,
+                            latest_excerpt="Invalid PM background request payload.",
+                        )
+                        continue
+
+                    task = asyncio.create_task(
+                        self._run_pm_background_request(request)
+                    )
+                    self._background_tasks.add(task)
+                    task.add_done_callback(self._background_tasks.discard)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.debug("PM background watcher error", exc_info=True)
+
+            await asyncio.sleep(interval)
+
+    async def _run_pm_background_request(self, request: Dict[str, Any]) -> None:
+        """Execute a PM-managed background task with gateway-native routing."""
+        from run_agent import AIAgent
+        from tools.approval import (
+            register_gateway_notify,
+            reset_current_session_key,
+            set_current_session_key,
+            unregister_gateway_notify,
+        )
+        from tools.clarify_state import request_gateway_clarify
+        from tools.terminal_tool import (
+            clear_task_env_overrides,
+            register_task_env_overrides,
+        )
+
+        run_id = str(request.get("run_id") or "").strip()
+        prompt = str(request.get("prompt") or "").strip()
+        session_key = str(request.get("session_key") or "").strip()
+        executor_name = str(request.get("executor") or "").strip()
+        task_summary = str(request.get("task_summary") or "").strip()
+        workdir = str(request.get("workdir") or "").strip()
+        source_payload = request.get("source") if isinstance(request.get("source"), dict) else {}
+
+        if not run_id:
+            return
+
+        if not prompt:
+            _pm_background_append_event(run_id, "error", "Missing PM background prompt.")
+            _pm_background_update_state(
+                run_id,
+                status="failed",
+                exit_code=1,
+                latest_excerpt="Missing PM background prompt.",
+            )
+            return
+
+        try:
+            source = SessionSource.from_dict(source_payload)
+        except Exception as exc:
+            _pm_background_append_event(run_id, "error", f"Invalid source metadata: {exc}")
+            _pm_background_update_state(
+                run_id,
+                status="failed",
+                exit_code=1,
+                latest_excerpt="Invalid source metadata for PM background request.",
+            )
+            return
+
+        adapter = self.adapters.get(source.platform)
+        if not adapter:
+            _pm_background_append_event(
+                run_id,
+                "error",
+                f"No adapter for platform {source.platform.value}.",
+            )
+            _pm_background_update_state(
+                run_id,
+                status="failed",
+                exit_code=1,
+                latest_excerpt=f"No adapter for platform {source.platform.value}.",
+            )
+            return
+
+        _status_adapter = adapter
+        _status_chat_id = source.chat_id
+        _status_thread_metadata = {"thread_id": source.thread_id} if source.thread_id else None
+        _loop_for_step = asyncio.get_running_loop()
+
+        def _record_progress(event_type: str, message: Any) -> None:
+            excerpt = _pm_background_clip(message, limit=900)
+            if not excerpt:
+                return
+            _pm_background_append_event(run_id, event_type, excerpt)
+            _pm_background_update_state(
+                run_id,
+                status="running",
+                latest_excerpt=excerpt,
+            )
+
+        def _status_callback_sync(event_type: str, message: str) -> None:
+            _record_progress(event_type or "status", message)
+
+        def _tool_progress_callback(
+            event_type: str,
+            name: str,
+            preview: str,
+            args: Any,
+            **kwargs: Any,
+        ) -> None:
+            del args, kwargs
+            if event_type != "tool.started":
+                return
+            label = str(preview or name or "").strip()
+            if label and name and label != name:
+                message = f"{name}: {label}"
+            else:
+                message = name or label or "tool started"
+            _record_progress(event_type, message)
+
+        def _approval_notify_sync(approval_data: dict) -> None:
+            _status_adapter.pause_typing_for_chat(_status_chat_id)
+            cmd = str(approval_data.get("command") or "").strip()
+            desc = str(approval_data.get("description") or "dangerous command").strip()
+            _record_progress("approval", f"等待授权: {desc}")
+
+            if getattr(type(_status_adapter), "send_exec_approval", None) is not None:
+                try:
+                    asyncio.run_coroutine_threadsafe(
+                        _status_adapter.send_exec_approval(
+                            chat_id=_status_chat_id,
+                            command=cmd,
+                            session_key=session_key or run_id,
+                            description=desc,
+                            metadata=_status_thread_metadata,
+                        ),
+                        _loop_for_step,
+                    ).result(timeout=15)
+                    return
+                except Exception as exc:
+                    logger.warning(
+                        "PM background button approval failed, falling back to text: %s",
+                        exc,
+                    )
+
+            cmd_preview = cmd[:200] + "..." if len(cmd) > 200 else cmd
+            msg = (
+                f"⚠️ Dangerous command requires approval for `{run_id}`:\n"
+                f"```\n{cmd_preview}\n```\n"
+                f"Reason: {desc}\n\n"
+                "If the approval card did not render, reply `/approve` or `/deny`."
+            )
+            asyncio.run_coroutine_threadsafe(
+                _status_adapter.send(
+                    _status_chat_id,
+                    msg,
+                    metadata=_status_thread_metadata,
+                ),
+                _loop_for_step,
+            ).result(timeout=15)
+
+        def _format_clarify_prompt(question: str, choices: Optional[List[str]]) -> str:
+            lines = [f"❓ `{run_id}` 需要确认", question]
+            if choices:
+                lines.append("")
+                for idx, choice in enumerate(choices, 1):
+                    lines.append(f"{idx}. {choice}")
+                lines.append("")
+                lines.append("请点击卡片或直接回复编号/答案。")
+            else:
+                lines.append("")
+                lines.append("请直接回复你的答案。")
+            return "\n".join(lines)
+
+        def _clarify_callback_sync(question: str, choices: Optional[List[str]]) -> str:
+            _status_adapter.pause_typing_for_chat(_status_chat_id)
+            pending_clarify_id: dict[str, Optional[int]] = {"value": None}
+            _record_progress("clarify", f"等待确认: {question}")
+
+            def _notify_clarify(clarify_data: dict) -> None:
+                pending_clarify_id["value"] = int(clarify_data.get("clarify_id") or 0)
+                if (
+                    clarify_data.get("choices")
+                    and getattr(type(_status_adapter), "send_clarify_card", None) is not None
+                ):
+                    try:
+                        asyncio.run_coroutine_threadsafe(
+                            _status_adapter.send_clarify_card(
+                                chat_id=_status_chat_id,
+                                question=clarify_data.get("question", question),
+                                choices=clarify_data.get("choices") or [],
+                                session_key=session_key or run_id,
+                                clarify_id=int(clarify_data.get("clarify_id") or 0),
+                                metadata=_status_thread_metadata,
+                            ),
+                            _loop_for_step,
+                        ).result(timeout=15)
+                        return
+                    except Exception as exc:
+                        logger.warning(
+                            "PM background clarify card failed, falling back to text: %s",
+                            exc,
+                        )
+
+                asyncio.run_coroutine_threadsafe(
+                    _status_adapter.send(
+                        _status_chat_id,
+                        _format_clarify_prompt(
+                            clarify_data.get("question", question),
+                            clarify_data.get("choices"),
+                        ),
+                        metadata=_status_thread_metadata,
+                    ),
+                    _loop_for_step,
+                ).result(timeout=15)
+
+            try:
+                timeout_seconds = int(os.getenv("HERMES_CLARIFY_TIMEOUT", "900"))
+            except ValueError:
+                timeout_seconds = 900
+
+            try:
+                return request_gateway_clarify(
+                    session_key=session_key or run_id,
+                    question=question,
+                    choices=choices,
+                    notify_callback=_notify_clarify,
+                    timeout_seconds=timeout_seconds,
+                )
+            except Exception:
+                clear_clarify_state = getattr(type(_status_adapter), "clear_clarify_card_state", None)
+                clarify_id = pending_clarify_id.get("value")
+                if clear_clarify_state is not None and clarify_id:
+                    clear_clarify_state(_status_adapter, clarify_id)
+                raise
+
+        _pm_background_update_state(
+            run_id,
+            status="running",
+            session_id=run_id,
+            session_key=session_key or run_id,
+            workdir=workdir,
+            latest_excerpt=f"Started {executor_name or 'background'} task.",
+            started_at=_pm_background_now_iso(),
+        )
+        _pm_background_append_event(
+            run_id,
+            "status",
+            f"Started {executor_name or 'background'} task.",
+        )
+
+        effective_prompt = _build_pm_background_executor_message(
+            executor_name,
+            prompt,
+            run_id,
+        )
+        task_env_overrides: Dict[str, Any] = {}
+        if workdir:
+            task_env_overrides["cwd"] = workdir
+        executor_env = _pm_background_executor_env(executor_name)
+        if executor_env:
+            task_env_overrides["env"] = executor_env
+        if task_env_overrides:
+            register_task_env_overrides(run_id, task_env_overrides)
+
+        try:
+            user_config = _load_gateway_config()
+            model, runtime_kwargs = self._resolve_session_agent_runtime(
+                source=source,
+                user_config=user_config,
+            )
+            if not runtime_kwargs.get("api_key"):
+                message = "No provider credentials configured for PM background task."
+                _pm_background_append_event(run_id, "error", message)
+                _pm_background_update_state(
+                    run_id,
+                    status="failed",
+                    exit_code=1,
+                    latest_excerpt=message,
+                )
+                await adapter.send(
+                    _status_chat_id,
+                    f"❌ `{run_id}` failed: {message}",
+                    metadata=_status_thread_metadata,
+                )
+                return
+
+            platform_key = _platform_config_key(source.platform)
+            from hermes_cli.tools_config import _get_platform_tools
+
+            enabled_toolsets = sorted(_get_platform_tools(user_config, platform_key))
+            pr = self._provider_routing
+            max_iterations = int(os.getenv("HERMES_MAX_ITERATIONS", "90"))
+            reasoning_config = self._load_reasoning_config()
+            self._reasoning_config = reasoning_config
+            self._service_tier = self._load_service_tier()
+            turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
+
+            def run_sync() -> dict:
+                agent = AIAgent(
+                    model=turn_route["model"],
+                    **turn_route["runtime"],
+                    max_iterations=max_iterations,
+                    quiet_mode=True,
+                    verbose_logging=False,
+                    enabled_toolsets=enabled_toolsets,
+                    reasoning_config=reasoning_config,
+                    service_tier=self._service_tier,
+                    request_overrides=turn_route.get("request_overrides"),
+                    providers_allowed=pr.get("only"),
+                    providers_ignored=pr.get("ignore"),
+                    providers_order=pr.get("order"),
+                    provider_sort=pr.get("sort"),
+                    provider_require_parameters=pr.get("require_parameters", False),
+                    provider_data_collection=pr.get("data_collection"),
+                    session_id=run_id,
+                    platform=platform_key,
+                    user_id=source.user_id,
+                    session_db=self._session_db,
+                    fallback_model=self._fallback_model,
+                )
+                agent.status_callback = _status_callback_sync
+                agent.tool_progress_callback = _tool_progress_callback
+                agent.clarify_callback = _clarify_callback_sync
+
+                approval_session_key = session_key or run_id
+                approval_token = set_current_session_key(approval_session_key)
+                register_gateway_notify(approval_session_key, _approval_notify_sync)
+                try:
+                    return agent.run_conversation(
+                        user_message=effective_prompt,
+                        task_id=run_id,
+                    )
+                finally:
+                    unregister_gateway_notify(approval_session_key)
+                    reset_current_session_key(approval_token)
+
+            result = await _loop_for_step.run_in_executor(None, run_sync)
+            response = str((result or {}).get("final_response") or "").strip()
+            if not response and result and result.get("error"):
+                response = f"Error: {result['error']}"
+
+            final_status = "failed" if (result or {}).get("failed") else "succeeded"
+            exit_code = 1 if final_status == "failed" else 0
+            excerpt = _pm_background_clip(
+                response or "(No response generated)",
+                limit=900,
+            )
+            _pm_background_append_event(run_id, "final", excerpt)
+            _pm_background_update_state(
+                run_id,
+                status=final_status,
+                exit_code=exit_code,
+                latest_excerpt=excerpt,
+                completed_at=_pm_background_now_iso(),
+            )
+            if self._session_db:
+                try:
+                    self._session_db.end_session(
+                        run_id,
+                        f"pm_background_{final_status}",
+                    )
+                except Exception:
+                    logger.debug("Failed to end PM background session %s", run_id, exc_info=True)
+
+            header_lines = [
+                "✅ PM后台任务完成" if final_status == "succeeded" else "❌ PM后台任务失败",
+                f"run_id: `{run_id}`",
+            ]
+            if executor_name:
+                header_lines.append(f"executor: `{executor_name}`")
+            if task_summary:
+                header_lines.append(f"task: {task_summary}")
+            header = "\n".join(header_lines) + "\n\n"
+
+            if response:
+                media_files, response = adapter.extract_media(response)
+                images, text_content = adapter.extract_images(response)
+
+                if text_content:
+                    await adapter.send(
+                        chat_id=_status_chat_id,
+                        content=header + text_content,
+                        metadata=_status_thread_metadata,
+                    )
+                elif not images and not media_files:
+                    await adapter.send(
+                        chat_id=_status_chat_id,
+                        content=header + "(No response generated)",
+                        metadata=_status_thread_metadata,
+                    )
+
+                for image_url, alt_text in (images or []):
+                    try:
+                        await adapter.send_image(
+                            chat_id=_status_chat_id,
+                            image_url=image_url,
+                            caption=alt_text,
+                        )
+                    except Exception:
+                        pass
+
+                for media_path in (media_files or []):
+                    try:
+                        await adapter.send_document(
+                            chat_id=_status_chat_id,
+                            file_path=media_path,
+                        )
+                    except Exception:
+                        pass
+            else:
+                await adapter.send(
+                    chat_id=_status_chat_id,
+                    content=header + "(No response generated)",
+                    metadata=_status_thread_metadata,
+                )
+
+        except Exception as exc:
+            logger.exception("PM background task %s failed", run_id)
+            message = _pm_background_clip(str(exc), limit=900) or "unknown error"
+            _pm_background_append_event(run_id, "error", message)
+            _pm_background_update_state(
+                run_id,
+                status="failed",
+                exit_code=1,
+                latest_excerpt=message,
+                completed_at=_pm_background_now_iso(),
+            )
+            if self._session_db:
+                try:
+                    self._session_db.end_session(run_id, "pm_background_failed")
+                except Exception:
+                    logger.debug("Failed to end PM background session %s", run_id, exc_info=True)
+            try:
+                await adapter.send(
+                    chat_id=_status_chat_id,
+                    content=f"❌ PM后台任务 `{run_id}` 失败：{message}",
+                    metadata=_status_thread_metadata,
+                )
+            except Exception:
+                pass
+        finally:
+            clear_task_env_overrides(run_id)
+
     async def _handle_btw_command(self, event: MessageEvent) -> str:
         """Handle /btw <question> — ephemeral side question in the same chat."""
         question = event.get_command_args().strip()
@@ -7599,6 +8219,38 @@ class GatewayRunner:
         count_msg = f" ({count} commands)" if count > 1 else ""
         logger.info("User denied %d dangerous command(s) via /deny", count)
         return f"❌ Command{'s' if count > 1 else ''} denied{count_msg}."
+
+    async def _handle_clarify_response(self, event: MessageEvent) -> str:
+        """Handle a user reply for a pending gateway clarify prompt."""
+        source = event.source
+        session_key = self._session_key_for_source(source)
+
+        from tools.clarify_state import (
+            has_blocking_clarify,
+            peek_pending_clarify,
+            resolve_gateway_clarify,
+        )
+
+        if not has_blocking_clarify(session_key):
+            return "当前没有待回答的问题。"
+
+        response_text = (event.text or "").strip()
+        if not response_text:
+            return "请回复选项编号、选项文字，或直接输入你的答案。"
+
+        pending = peek_pending_clarify(session_key)
+        count = resolve_gateway_clarify(session_key, response_text)
+        if not count:
+            return "当前没有待回答的问题。"
+
+        _adapter = self.adapters.get(source.platform)
+        if _adapter:
+            clear_clarify_state = getattr(type(_adapter), "clear_clarify_card_state", None)
+            if pending and clear_clarify_state is not None:
+                clear_clarify_state(_adapter, int(pending["clarify_id"]))
+            _adapter.resume_typing_for_chat(source.chat_id)
+
+        return "✅ 已收到你的选择，继续处理中..."
 
     # Platforms where /update is allowed.  ACP, API server, and webhooks are
     # programmatic interfaces that should not trigger system updates.
@@ -9213,12 +9865,15 @@ class GatewayRunner:
         # Natural assistant status messages are intentionally independent from
         # tool progress and token streaming. Users can keep tool_progress quiet
         # in chat platforms while opting into concise mid-turn updates.
+        _resolved_interim_messages = resolve_display_setting(
+            user_config,
+            platform_key,
+            "interim_assistant_messages",
+            True,
+        )
         interim_assistant_messages_enabled = (
             source.platform != Platform.WEBHOOK
-            and is_truthy_value(
-                display_config.get("interim_assistant_messages"),
-                default=True,
-            )
+            and is_truthy_value(_resolved_interim_messages, default=True)
         )
         
         # Queue for progress messages (thread-safe)
@@ -9920,6 +10575,88 @@ class GatewayRunner:
                     ).result(timeout=15)
                 except Exception as _e:
                     logger.error("Failed to send approval request: %s", _e)
+
+            def _format_clarify_prompt(question: str, choices: Optional[List[str]]) -> str:
+                lines = ["❓ **请先确认**", question]
+                if choices:
+                    lines.append("")
+                    for idx, choice in enumerate(choices, 1):
+                        lines.append(f"{idx}. {choice}")
+                    lines.append("")
+                    lines.append("请回复编号、选项文字，或直接输入你的答案。")
+                else:
+                    lines.append("")
+                    lines.append("请直接回复你的答案，我们再继续。")
+                return "\n".join(lines)
+
+            def _clarify_callback_sync(question: str, choices: Optional[List[str]]) -> str:
+                """Block the agent thread until the user answers a clarify prompt."""
+                if not _status_adapter:
+                    raise RuntimeError("Clarify is unavailable without a messaging adapter.")
+
+                _status_adapter.pause_typing_for_chat(_status_chat_id)
+
+                from tools.clarify_state import request_gateway_clarify
+                pending_clarify_id: dict[str, Optional[int]] = {"value": None}
+
+                def _notify_clarify(clarify_data: dict) -> None:
+                    pending_clarify_id["value"] = int(clarify_data.get("clarify_id") or 0)
+                    if (
+                        clarify_data.get("choices")
+                        and getattr(type(_status_adapter), "send_clarify_card", None) is not None
+                    ):
+                        try:
+                            asyncio.run_coroutine_threadsafe(
+                                _status_adapter.send_clarify_card(
+                                    chat_id=_status_chat_id,
+                                    question=clarify_data.get("question", question),
+                                    choices=clarify_data.get("choices") or [],
+                                    session_key=session_key or "",
+                                    clarify_id=int(clarify_data.get("clarify_id") or 0),
+                                    metadata=_status_thread_metadata,
+                                ),
+                                _loop_for_step,
+                            ).result(timeout=15)
+                            return
+                        except Exception as _e:
+                            logger.warning(
+                                "Button-based clarify failed, falling back to text: %s", _e
+                            )
+
+                    msg = _format_clarify_prompt(
+                        clarify_data.get("question", question),
+                        clarify_data.get("choices"),
+                    )
+                    asyncio.run_coroutine_threadsafe(
+                        _status_adapter.send(
+                            _status_chat_id,
+                            msg,
+                            metadata=_status_thread_metadata,
+                        ),
+                        _loop_for_step,
+                    ).result(timeout=15)
+
+                try:
+                    timeout_seconds = int(os.getenv("HERMES_CLARIFY_TIMEOUT", "900"))
+                except ValueError:
+                    timeout_seconds = 900
+
+                try:
+                    return request_gateway_clarify(
+                        session_key=session_key or "",
+                        question=question,
+                        choices=choices,
+                        notify_callback=_notify_clarify,
+                        timeout_seconds=timeout_seconds,
+                    )
+                except Exception:
+                    clear_clarify_state = getattr(type(_status_adapter), "clear_clarify_card_state", None)
+                    clarify_id = pending_clarify_id.get("value")
+                    if clear_clarify_state is not None and clarify_id:
+                        clear_clarify_state(_status_adapter, clarify_id)
+                    raise
+
+            agent.clarify_callback = _clarify_callback_sync
 
             # Prepend pending model switch note so the model knows about the switch
             _pending_notes = getattr(self, '_pending_model_notes', {})
@@ -10673,21 +11410,25 @@ class GatewayRunner:
         if isinstance(response, dict) and not response.get("failed"):
             _final = response.get("final_response") or ""
             _is_empty_sentinel = not _final or _final == "(empty)"
-            _streamed = bool(
-                _sc and getattr(_sc, "final_response_sent", False)
+            _already_streamed = bool(
+                _sc
+                and (
+                    getattr(_sc, "final_response_sent", False)
+                    or getattr(_sc, "already_sent", False)
+                )
             )
             # response_previewed means the interim_assistant_callback already
             # sent the final text via the adapter (non-streaming path).
             _previewed = bool(response.get("response_previewed"))
-            if not _is_empty_sentinel and (_streamed or _previewed):
+            if not _is_empty_sentinel and (_already_streamed or _previewed):
                 logger.info(
                     "Suppressing normal final send for session %s: final delivery already confirmed (streamed=%s previewed=%s).",
                     session_key[:20] if session_key else "?",
-                    _streamed,
+                    _already_streamed,
                     _previewed,
                 )
                 response["already_sent"] = True
-        
+
         return response
 
 

--- a/tests/gateway/test_clarify_responses.py
+++ b/tests/gateway/test_clarify_responses.py
@@ -1,0 +1,134 @@
+"""Tests for gateway clarify response handling."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        source=_make_source(),
+        message_id="m1",
+    )
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="***")}
+    )
+    adapter = MagicMock()
+    adapter.send = AsyncMock()
+    adapter.resume_typing_for_chat = MagicMock()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner.session_store = MagicMock()
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._busy_ack_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._background_tasks = set()
+    runner._session_db = None
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._show_reasoning = False
+    runner._draining = False
+    runner._update_prompt_pending = {}
+    runner._queue_during_drain_enabled = lambda: False
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    return runner
+
+
+class _ClarifyAwareAdapter:
+    def __init__(self):
+        self.send = AsyncMock()
+        self.resume_typing_for_chat = MagicMock()
+        self._clear_clarify_card_state = MagicMock()
+
+    def clear_clarify_card_state(self, clarify_id: int) -> None:
+        self._clear_clarify_card_state(clarify_id)
+
+
+def _clear_clarify_state():
+    from tools import clarify_state as mod
+
+    mod._gateway_queues.clear()
+
+
+class TestGatewayClarifyResponses:
+    def setup_method(self):
+        _clear_clarify_state()
+
+    @pytest.mark.asyncio
+    async def test_handle_clarify_response_resolves_pending_question(self):
+        from tools.clarify_state import _ClarifyEntry, _gateway_queues
+
+        runner = _make_runner()
+        source = _make_source()
+        session_key = runner._session_key_for_source(source)
+        entry = _ClarifyEntry(clarify_id=1, question="Pick", choices=["Alpha", "Beta"])
+        _gateway_queues[session_key] = [entry]
+
+        result = await runner._handle_clarify_response(_make_event("2"))
+
+        assert "继续处理" in result
+        assert entry.event.is_set()
+        assert entry.result == "Beta"
+        runner.adapters[Platform.TELEGRAM].resume_typing_for_chat.assert_called_once_with("c1")
+
+    @pytest.mark.asyncio
+    async def test_handle_clarify_response_clears_card_state_for_text_reply(self):
+        from tools.clarify_state import _ClarifyEntry, _gateway_queues
+
+        runner = _make_runner()
+        runner.adapters[Platform.TELEGRAM] = _ClarifyAwareAdapter()
+        source = _make_source()
+        session_key = runner._session_key_for_source(source)
+        entry = _ClarifyEntry(clarify_id=42, question="Pick", choices=["Alpha", "Beta"])
+        _gateway_queues[session_key] = [entry]
+
+        await runner._handle_clarify_response(_make_event("Alpha"))
+
+        runner.adapters[Platform.TELEGRAM]._clear_clarify_card_state.assert_called_once_with(42)
+
+    @pytest.mark.asyncio
+    async def test_running_session_routes_text_to_clarify_instead_of_interrupt(self):
+        from tools.clarify_state import _ClarifyEntry, _gateway_queues
+
+        runner = _make_runner()
+        event = _make_event("Option A")
+        session_key = runner._session_key_for_source(event.source)
+        _gateway_queues[session_key] = [_ClarifyEntry(clarify_id=1, question="Pick", choices=["Option A", "Option B"])]
+
+        running_agent = MagicMock()
+        runner._running_agents[session_key] = running_agent
+        runner._running_agents_ts[session_key] = 0
+
+        with patch.object(runner, "_handle_clarify_response", new_callable=AsyncMock, return_value="resolved") as mock_handle:
+            result = await runner._handle_message(event)
+
+        assert result == "resolved"
+        mock_handle.assert_awaited_once()
+        running_agent.interrupt.assert_not_called()

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -156,6 +156,19 @@ class TestYAMLNormalisation:
         config = {"display": {"platforms": {"telegram": {"show_reasoning": "true"}}}}
         assert resolve_display_setting(config, "telegram", "show_reasoning") is True
 
+    def test_interim_assistant_messages_string_false(self):
+        """String 'false' is normalised to bool False."""
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "platforms": {
+                    "feishu": {"interim_assistant_messages": "false"},
+                },
+            },
+        }
+        assert resolve_display_setting(config, "feishu", "interim_assistant_messages") is False
+
     def test_tool_preview_length_string(self):
         """String numbers are normalised to int."""
         from gateway.display_config import resolve_display_setting
@@ -218,6 +231,13 @@ class TestPlatformDefaults:
         from gateway.display_config import resolve_display_setting
 
         assert resolve_display_setting({}, "telegram", "streaming") is None
+
+    def test_interim_assistant_messages_defaults_to_true(self):
+        """Interim assistant messages stay enabled unless explicitly overridden."""
+        from gateway.display_config import resolve_display_setting
+
+        assert resolve_display_setting({}, "telegram", "interim_assistant_messages") is True
+        assert resolve_display_setting({}, "feishu", "interim_assistant_messages") is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_feishu_approval_buttons.py
+++ b/tests/gateway/test_feishu_approval_buttons.py
@@ -23,14 +23,16 @@ if _repo not in sys.path:
 def _ensure_feishu_mocks():
     """Provide stubs for lark-oapi / aiohttp.web so the import succeeds."""
     if importlib.util.find_spec("lark_oapi") is None and "lark_oapi" not in sys.modules:
-        mod = MagicMock()
         for name in (
             "lark_oapi", "lark_oapi.api.im.v1",
             "lark_oapi.event", "lark_oapi.event.callback_type",
         ):
+            mod = MagicMock()
+            mod.__spec__ = importlib.machinery.ModuleSpec(name, loader=None)
             sys.modules.setdefault(name, mod)
     if importlib.util.find_spec("aiohttp") is None and "aiohttp" not in sys.modules:
         aio = MagicMock()
+        aio.__spec__ = importlib.machinery.ModuleSpec("aiohttp", loader=None)
         sys.modules.setdefault("aiohttp", aio)
         sys.modules.setdefault("aiohttp.web", aio.web)
 

--- a/tests/gateway/test_feishu_clarify_buttons.py
+++ b/tests/gateway/test_feishu_clarify_buttons.py
@@ -1,0 +1,192 @@
+"""Tests for Feishu interactive clarify/choice cards."""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _ensure_feishu_mocks():
+    """Provide stubs for lark-oapi / aiohttp.web so the import succeeds."""
+    if importlib.util.find_spec("lark_oapi") is None and "lark_oapi" not in sys.modules:
+        for name in (
+            "lark_oapi", "lark_oapi.api.im.v1",
+            "lark_oapi.event", "lark_oapi.event.callback_type",
+        ):
+            mod = MagicMock()
+            mod.__spec__ = importlib.machinery.ModuleSpec(name, loader=None)
+            sys.modules.setdefault(name, mod)
+    if importlib.util.find_spec("aiohttp") is None and "aiohttp" not in sys.modules:
+        aio = MagicMock()
+        aio.__spec__ = importlib.machinery.ModuleSpec("aiohttp", loader=None)
+        sys.modules.setdefault("aiohttp", aio)
+        sys.modules.setdefault("aiohttp.web", aio.web)
+
+
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+_ensure_feishu_mocks()
+
+from gateway.config import PlatformConfig
+import gateway.platforms.feishu as feishu_module
+from gateway.platforms.feishu import FeishuAdapter
+
+
+def _make_adapter() -> FeishuAdapter:
+    config = PlatformConfig(enabled=True)
+    adapter = FeishuAdapter(config)
+    adapter._client = MagicMock()
+    return adapter
+
+
+def _make_card_action_data(
+    action_value: dict,
+    chat_id: str = "oc_12345",
+    open_id: str = "ou_user1",
+    token: str = "tok_abc",
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        event=SimpleNamespace(
+            token=token,
+            context=SimpleNamespace(open_chat_id=chat_id),
+            operator=SimpleNamespace(open_id=open_id),
+            action=SimpleNamespace(
+                tag="button",
+                value=action_value,
+            ),
+        ),
+    )
+
+
+def _close_submitted_coro(coro, _loop):
+    coro.close()
+    return SimpleNamespace(add_done_callback=lambda *_args, **_kwargs: None)
+
+
+class _FakeCallBackCard:
+    def __init__(self):
+        self.type = None
+        self.data = None
+
+
+class _FakeP2Response:
+    def __init__(self):
+        self.card = None
+
+
+@pytest.fixture(autouse=False)
+def _patch_callback_card_types(monkeypatch):
+    monkeypatch.setattr(feishu_module, "P2CardActionTriggerResponse", _FakeP2Response)
+    monkeypatch.setattr(feishu_module, "CallBackCard", _FakeCallBackCard)
+
+
+class TestFeishuClarifyCard:
+    @pytest.mark.asyncio
+    async def test_sends_interactive_clarify_card(self):
+        adapter = _make_adapter()
+        mock_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="msg_101"),
+        )
+
+        with patch.object(
+            adapter,
+            "_feishu_send_with_retry",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ) as mock_send:
+            result = await adapter.send_clarify_card(
+                chat_id="oc_12345",
+                question="Which plan should I draft?",
+                choices=["Fast path", "Safe path"],
+                session_key="agent:main:feishu:group:oc_12345",
+                clarify_id=77,
+            )
+
+        assert result.success is True
+        assert result.message_id == "msg_101"
+        kwargs = mock_send.call_args[1]
+        assert kwargs["msg_type"] == "interactive"
+
+        card = json.loads(kwargs["payload"])
+        assert card["header"]["title"]["content"] == "❓ 请先确认"
+        assert "如果你想自己输入答案" in card["elements"][2]["content"]
+        actions = card["elements"][1]["actions"]
+        assert [item["value"]["choice"] for item in actions] == ["Fast path", "Safe path"]
+        assert all(item["value"]["clarify_id"] == 77 for item in actions)
+
+    @pytest.mark.asyncio
+    async def test_stores_clarify_state_after_send(self):
+        adapter = _make_adapter()
+        mock_response = SimpleNamespace(
+            success=lambda: True,
+            data=SimpleNamespace(message_id="msg_102"),
+        )
+
+        with patch.object(
+            adapter,
+            "_feishu_send_with_retry",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ):
+            await adapter.send_clarify_card(
+                chat_id="oc_12345",
+                question="Choose",
+                choices=["A", "B"],
+                session_key="sess-clarify",
+                clarify_id=88,
+            )
+
+        assert adapter._clarify_state[88]["session_key"] == "sess-clarify"
+        assert adapter._clarify_state[88]["message_id"] == "msg_102"
+
+    @pytest.mark.asyncio
+    async def test_resolve_clarify_calls_gateway_resolver(self):
+        adapter = _make_adapter()
+        adapter._clarify_state[99] = {
+            "session_key": "sess-99",
+            "message_id": "msg_99",
+            "chat_id": "oc_99",
+            "question": "Pick one",
+        }
+        adapter.resume_typing_for_chat = MagicMock()
+
+        with patch("tools.clarify_state.resolve_gateway_clarify", return_value=1) as mock_resolve:
+            await adapter._resolve_clarify(99, "Safe path", "Alice")
+
+        mock_resolve.assert_called_once_with("sess-99", "Safe path", clarify_id=99)
+        adapter.resume_typing_for_chat.assert_called_once_with("oc_99")
+        assert 99 not in adapter._clarify_state
+
+    def test_returns_card_for_clarify_action(self, _patch_callback_card_types):
+        adapter = _make_adapter()
+        adapter._loop = MagicMock()
+        adapter._loop.is_closed = MagicMock(return_value=False)
+        adapter._clarify_state[66] = {
+            "session_key": "sess-66",
+            "message_id": "msg_66",
+            "chat_id": "oc_66",
+            "question": "Which plan should I draft?",
+        }
+        adapter._sender_name_cache["ou_bob"] = ("Bob", 9999999999)
+        data = _make_card_action_data(
+            {"hermes_action": "clarify_choice", "clarify_id": 66, "choice": "Safe path"},
+            open_id="ou_bob",
+        )
+
+        with patch("asyncio.run_coroutine_threadsafe", side_effect=_close_submitted_coro):
+            response = adapter._on_card_action_trigger(data)
+
+        assert response.card is not None
+        assert response.card.type == "raw"
+        card = response.card.data
+        assert card["header"]["title"]["content"] == "✅ 已完成选择"
+        assert "**问题：**" in card["elements"][0]["content"]
+        assert "**选择：** Safe path" in card["elements"][0]["content"]
+        assert "**选择人：** Bob" in card["elements"][0]["content"]

--- a/tests/gateway/test_reasoning_command.py
+++ b/tests/gateway/test_reasoning_command.py
@@ -62,6 +62,24 @@ class _CapturingAgent:
         }
 
 
+class _ClarifyCaptureAgent:
+    """Fake agent that verifies gateway injected a callable clarify callback."""
+
+    last_clarify_callback = None
+
+    def __init__(self, *args, **kwargs):
+        self.tools = []
+
+    def run_conversation(self, user_message: str, conversation_history=None, task_id=None):
+        type(self).last_clarify_callback = getattr(self, "clarify_callback", None)
+        assert callable(self.clarify_callback)
+        return {
+            "final_response": "clarify-ready",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
 class TestReasoningCommand:
     @pytest.mark.asyncio
     async def test_reasoning_in_help_output(self):
@@ -166,6 +184,53 @@ class TestReasoningCommand:
         assert result["final_response"] == "ok"
         assert _CapturingAgent.last_init is not None
         assert _CapturingAgent.last_init["reasoning_config"] == {"enabled": True, "effort": "low"}
+
+    def test_run_agent_binds_clarify_callback_before_agent_execution(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text("agent:\n  reasoning_effort: low\n", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+        monkeypatch.setattr(gateway_run, "_env_path", hermes_home / ".env")
+        monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+        monkeypatch.setattr(
+            gateway_run,
+            "_resolve_runtime_agent_kwargs",
+            lambda: {
+                "provider": "openrouter",
+                "api_mode": "chat_completions",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_key": "test-key",
+            },
+        )
+        fake_run_agent = types.ModuleType("run_agent")
+        fake_run_agent.AIAgent = _ClarifyCaptureAgent
+        monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+        _ClarifyCaptureAgent.last_clarify_callback = None
+        runner = _make_runner()
+
+        source = SessionSource(
+            platform=Platform.LOCAL,
+            chat_id="cli",
+            chat_name="CLI",
+            chat_type="dm",
+            user_id="user-1",
+        )
+
+        result = asyncio.run(
+            runner._run_agent(
+                message="ping",
+                context_prompt="",
+                history=[],
+                source=source,
+                session_id="session-clarify",
+                session_key="agent:main:local:dm",
+            )
+        )
+
+        assert result["final_response"] == "clarify-ready"
+        assert callable(_ClarifyCaptureAgent.last_clarify_callback)
 
     def test_run_agent_includes_enabled_mcp_servers_in_gateway_toolsets(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / "hermes"

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -592,6 +592,31 @@ async def test_run_agent_suppresses_interim_commentary_when_disabled(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_run_agent_respects_platform_interim_commentary_override(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        CommentaryAgent,
+        session_id="sess-commentary-feishu-platform-off",
+        platform=Platform.FEISHU,
+        chat_id="oc_test",
+        chat_type="group",
+        thread_id=None,
+        config_data={
+            "display": {
+                "interim_assistant_messages": True,
+                "platforms": {
+                    "feishu": {"interim_assistant_messages": False},
+                },
+            },
+        },
+    )
+
+    assert result.get("already_sent") is not True
+    assert not any(call["content"] == "I'll inspect the repo first." for call in adapter.sent)
+
+
+@pytest.mark.asyncio
 async def test_run_agent_tool_progress_does_not_control_interim_commentary(monkeypatch, tmp_path):
     """tool_progress=all with interim_assistant_messages=false should not surface commentary."""
     adapter, result = await _run_with_agent(

--- a/tests/tools/test_clarify_state.py
+++ b/tests/tools/test_clarify_state.py
@@ -1,0 +1,82 @@
+"""Tests for blocking gateway clarify state."""
+
+import threading
+import time
+
+from tools import clarify_state as mod
+
+
+def _clear_state():
+    mod._gateway_queues.clear()
+
+
+class TestBlockingGatewayClarify:
+    def setup_method(self):
+        _clear_state()
+
+    def test_request_and_resolve_unblocks_entry(self):
+        session_key = "clarify-session"
+        seen = {}
+        result_box = {}
+
+        def _runner():
+            result_box["result"] = mod.request_gateway_clarify(
+                session_key=session_key,
+                question="Pick one",
+                choices=["Alpha", "Beta"],
+                notify_callback=lambda data: seen.update(data),
+                timeout_seconds=5,
+            )
+
+        thread = threading.Thread(target=_runner)
+        thread.start()
+
+        for _ in range(50):
+            if seen:
+                break
+            time.sleep(0.02)
+
+        assert seen["question"] == "Pick one"
+        assert seen["choices"] == ["Alpha", "Beta"]
+        assert mod.has_blocking_clarify(session_key) is True
+
+        assert mod.resolve_gateway_clarify(session_key, "2") == 1
+        thread.join(timeout=5)
+
+        assert result_box["result"] == "Beta"
+        assert mod.has_blocking_clarify(session_key) is False
+
+    def test_resolve_by_clarify_id_targets_matching_entry(self):
+        session_key = "clarify-id-session"
+        seen = []
+        results = []
+
+        def _ask(question: str):
+            result = mod.request_gateway_clarify(
+                session_key=session_key,
+                question=question,
+                choices=["A", "B"],
+                notify_callback=lambda data: seen.append(data),
+                timeout_seconds=5,
+            )
+            results.append((question, result))
+
+        t1 = threading.Thread(target=_ask, args=("First?",))
+        t2 = threading.Thread(target=_ask, args=("Second?",))
+        t1.start()
+        t2.start()
+
+        for _ in range(50):
+            if len(seen) == 2:
+                break
+            time.sleep(0.02)
+
+        second_id = next(item["clarify_id"] for item in seen if item["question"] == "Second?")
+        assert mod.resolve_gateway_clarify(session_key, "B", clarify_id=second_id) == 1
+        assert mod.resolve_gateway_clarify(session_key, "A") == 1
+
+        t1.join(timeout=5)
+        t2.join(timeout=5)
+
+        assert ("First?", "A") in results
+        assert ("Second?", "B") in results

--- a/tools/clarify_state.py
+++ b/tools/clarify_state.py
@@ -1,0 +1,146 @@
+"""Blocking gateway clarify state for interactive user questions."""
+
+from __future__ import annotations
+
+import itertools
+import threading
+from typing import Callable, Optional
+
+_lock = threading.Lock()
+_clarify_counter = itertools.count(1)
+_gateway_queues: dict[str, list["_ClarifyEntry"]] = {}
+
+
+class _ClarifyEntry:
+    """One pending clarify prompt inside a gateway session."""
+
+    __slots__ = ("event", "clarify_id", "question", "choices", "result")
+
+    def __init__(self, clarify_id: int, question: str, choices: Optional[list[str]]):
+        self.event = threading.Event()
+        self.clarify_id = clarify_id
+        self.question = question
+        self.choices = list(choices) if choices else None
+        self.result: Optional[str] = None
+
+
+def _coerce_response(entry: _ClarifyEntry, response: str) -> str:
+    """Map numeric replies like '1' or '/2' to the actual choice label."""
+    answer = str(response).strip()
+    if not entry.choices:
+        return answer
+
+    numeric = answer[1:].strip() if answer.startswith("/") else answer
+    if numeric.isdigit():
+        idx = int(numeric) - 1
+        if 0 <= idx < len(entry.choices):
+            return entry.choices[idx]
+    return answer
+
+
+def request_gateway_clarify(
+    session_key: str,
+    question: str,
+    choices: Optional[list[str]] = None,
+    notify_callback: Optional[Callable[[dict], None]] = None,
+    timeout_seconds: int = 300,
+) -> str:
+    """Block until the user answers a gateway clarify request."""
+    if not session_key:
+        raise ValueError("session_key is required for gateway clarify requests.")
+    if notify_callback is None:
+        raise RuntimeError("No notify callback is registered for gateway clarify.")
+
+    clarify_id = next(_clarify_counter)
+    entry = _ClarifyEntry(clarify_id=clarify_id, question=question, choices=choices)
+    clarify_data = {
+        "clarify_id": clarify_id,
+        "question": question,
+        "choices": list(entry.choices) if entry.choices else None,
+    }
+
+    with _lock:
+        _gateway_queues.setdefault(session_key, []).append(entry)
+
+    try:
+        notify_callback(clarify_data)
+    except Exception:
+        with _lock:
+            queue = _gateway_queues.get(session_key, [])
+            if entry in queue:
+                queue.remove(entry)
+            if not queue:
+                _gateway_queues.pop(session_key, None)
+        raise
+
+    resolved = entry.event.wait(timeout=timeout_seconds)
+
+    with _lock:
+        queue = _gateway_queues.get(session_key, [])
+        if entry in queue:
+            queue.remove(entry)
+        if not queue:
+            _gateway_queues.pop(session_key, None)
+
+    if not resolved or entry.result is None:
+        raise TimeoutError("Clarify request timed out.")
+
+    return entry.result
+
+
+def resolve_gateway_clarify(
+    session_key: str,
+    response: str,
+    clarify_id: Optional[int] = None,
+) -> int:
+    """Resolve a pending clarify request for a session."""
+    with _lock:
+        queue = _gateway_queues.get(session_key)
+        if not queue:
+            return 0
+
+        target: Optional[_ClarifyEntry] = None
+        if clarify_id is None:
+            target = queue.pop(0)
+        else:
+            for idx, entry in enumerate(queue):
+                if entry.clarify_id == clarify_id:
+                    target = queue.pop(idx)
+                    break
+            if target is None:
+                return 0
+
+        if not queue:
+            _gateway_queues.pop(session_key, None)
+
+    target.result = _coerce_response(target, response)
+    target.event.set()
+    return 1
+
+
+def has_blocking_clarify(session_key: str) -> bool:
+    """Return True when a session has one or more pending clarify prompts."""
+    with _lock:
+        return bool(_gateway_queues.get(session_key))
+
+
+def peek_pending_clarify(session_key: str) -> Optional[dict]:
+    """Return metadata for the oldest pending clarify prompt in a session."""
+    with _lock:
+        queue = _gateway_queues.get(session_key) or []
+        if not queue:
+            return None
+        entry = queue[0]
+        return {
+            "clarify_id": entry.clarify_id,
+            "question": entry.question,
+            "choices": list(entry.choices) if entry.choices else None,
+        }
+
+
+def clear_gateway_clarify(session_key: str) -> None:
+    """Signal all pending clarifies for a session so blocked threads can exit."""
+    with _lock:
+        entries = _gateway_queues.pop(session_key, [])
+    for entry in entries:
+        entry.event.set()

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -107,6 +107,36 @@ def _build_provider_env_blocklist() -> frozenset:
 _HERMES_PROVIDER_ENV_BLOCKLIST = _build_provider_env_blocklist()
 
 
+def _inject_gateway_session_env(target: dict[str, str]) -> None:
+    """Forward gateway session metadata into terminal subprocesses.
+
+    Gateway session state moved from ``os.environ`` to contextvars, which keeps
+    concurrent chats isolated but means external helper scripts no longer see
+    ``HERMES_SESSION_*`` automatically. Rehydrate the active values here so
+    shared PM/helper scripts can discover the current platform/chat/session.
+    """
+    try:
+        from gateway.session_context import get_session_env
+    except Exception:
+        return
+
+    for key in (
+        "HERMES_SESSION_PLATFORM",
+        "HERMES_SESSION_CHAT_ID",
+        "HERMES_SESSION_CHAT_NAME",
+        "HERMES_SESSION_THREAD_ID",
+        "HERMES_SESSION_USER_ID",
+        "HERMES_SESSION_USER_NAME",
+        "HERMES_SESSION_KEY",
+    ):
+        try:
+            value = str(get_session_env(key, "") or "").strip()
+        except Exception:
+            value = ""
+        if value:
+            target[key] = value
+
+
 def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = None) -> dict:
     """Filter Hermes-managed secrets from a subprocess environment."""
     try:
@@ -115,6 +145,7 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
         _is_passthrough = lambda _: False  # noqa: E731
 
     sanitized: dict[str, str] = {}
+    explicit_home = "HOME" in (extra_env or {})
 
     for key, value in (base_env or {}).items():
         if key.startswith(_HERMES_PROVIDER_ENV_FORCE_PREFIX):
@@ -132,9 +163,10 @@ def _sanitize_subprocess_env(base_env: dict | None, extra_env: dict | None = Non
     # Per-profile HOME isolation for background processes (same as _make_run_env).
     from hermes_constants import get_subprocess_home
     _profile_home = get_subprocess_home()
-    if _profile_home:
+    if _profile_home and not explicit_home:
         sanitized["HOME"] = _profile_home
 
+    _inject_gateway_session_env(sanitized)
     return sanitized
 
 
@@ -190,6 +222,8 @@ def _make_run_env(env: dict) -> dict:
     except Exception:
         _is_passthrough = lambda _: False  # noqa: E731
 
+    env = dict(env or {})
+    explicit_home = "HOME" in env
     merged = dict(os.environ | env)
     run_env = {}
     for k, v in merged.items():
@@ -207,9 +241,10 @@ def _make_run_env(env: dict) -> dict:
     # subprocess sees the override — the Python process keeps the real HOME.
     from hermes_constants import get_subprocess_home
     _profile_home = get_subprocess_home()
-    if _profile_home:
+    if _profile_home and not explicit_home:
         run_env["HOME"] = _profile_home
 
+    _inject_gateway_session_env(run_env)
     return run_env
 
 
@@ -293,8 +328,14 @@ class LocalEnvironment(BaseEnvironment):
     """
 
     def __init__(self, cwd: str = "", timeout: int = 60, env: dict = None):
-        super().__init__(cwd=cwd or os.getcwd(), timeout=timeout, env=env)
+        initial_cwd = cwd or os.getcwd()
+        super().__init__(cwd=initial_cwd, timeout=timeout, env=env)
         self.init_session()
+        # init_session captures the login shell's current directory, which is
+        # often the gateway/profile cwd rather than the caller's requested
+        # workspace. Restore the requested cwd so subsequent execute() calls
+        # still honor per-task workdir overrides.
+        self.cwd = initial_cwd
 
     def get_temp_dir(self) -> str:
         """Return a shell-safe writable temp dir for local execution.

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -750,6 +750,7 @@ def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
         - modal_image: str -- Path to Dockerfile or Docker Hub image name
         - docker_image: str -- Docker image name
         - cwd: str -- Working directory inside the sandbox
+        - env: dict[str, str] -- Explicit subprocess environment overrides
 
     Args:
         task_id: The rollout's unique task identifier
@@ -894,6 +895,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
         Environment instance with execute() method
     """
     cc = container_config or {}
+    lc = local_config or {}
     cpu = cc.get("container_cpu", 1)
     memory = cc.get("container_memory", 5120)
     disk = cc.get("container_disk", 51200)
@@ -901,9 +903,10 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
     volumes = cc.get("docker_volumes", [])
     docker_forward_env = cc.get("docker_forward_env", [])
     docker_env = cc.get("docker_env", {})
+    local_env = lc.get("env", {})
 
     if env_type == "local":
-        return _LocalEnvironment(cwd=cwd, timeout=timeout)
+        return _LocalEnvironment(cwd=cwd, timeout=timeout, env=local_env)
     
     elif env_type == "docker":
         return _DockerEnvironment(
@@ -1415,6 +1418,7 @@ def terminal_tool(
         # Check per-task overrides (set by environments like TerminalBench2Env)
         # before falling back to global env var config
         overrides = _task_env_overrides.get(effective_task_id, {})
+        override_env = overrides.get("env") if isinstance(overrides.get("env"), dict) else {}
         
         # Select image based on env type, with per-task override support
         if env_type == "docker":
@@ -1516,6 +1520,7 @@ def terminal_tool(
                         if env_type == "local":
                             local_config = {
                                 "persistent": config.get("local_persistent", False),
+                                "env": override_env,
                             }
 
                         new_env = _create_environment(
@@ -1542,6 +1547,9 @@ def terminal_tool(
                         _last_activity[effective_task_id] = time.time()
                         env = new_env
                     logger.info("%s environment ready for task %s", env_type, effective_task_id[:8])
+
+        if override_env and hasattr(env, "env") and isinstance(getattr(env, "env", None), dict):
+            env.env.update(override_env)
 
         # Pre-exec security checks (tirith + dangerous command detection)
         # Skip check if force=True (user has confirmed they want to run it)

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -992,6 +992,17 @@ Platforms without an override fall back to the global `tool_progress` value. Val
 
 `interim_assistant_messages` is gateway-only. When enabled, Hermes sends completed mid-turn assistant updates as separate chat messages. This is independent from `tool_progress` and does not require gateway streaming.
 
+You can also disable those natural mid-turn status messages for just one platform:
+
+```yaml
+display:
+  interim_assistant_messages: true
+  platforms:
+    feishu:
+      tool_progress: off
+      interim_assistant_messages: false
+```
+
 ## Privacy
 
 ```yaml


### PR DESCRIPTION
## What does this PR do?

Adds a blocking gateway clarify flow so running agent turns can ask users a question, wait for the reply, and continue in the same session. On Feishu, multiple-choice clarify prompts now render as interactive cards with button-based resolution. This PR also forwards gateway session metadata into local terminal subprocesses so helper scripts can keep seeing `HERMES_SESSION_*` after the recent contextvar-based session isolation changes.

## Related Issue

No linked issue for this change.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added blocking gateway clarify state and resolution helpers in `tools/clarify_state.py`
- Wired `gateway/run.py` to route pending clarify replies before normal interrupt handling and bind `agent.clarify_callback`
- Added Feishu clarify cards, callback handling, and resolved-card updates in `gateway/platforms/feishu.py`
- Added `display.interim_assistant_messages` platform override handling and docs for the new behavior
- Forwarded `HERMES_SESSION_*` metadata plus explicit local env overrides through local terminal environments
- Added regression coverage for clarify responses, Feishu button flows, response preview suppression, and display config parsing

## How to Test

1. Run `/Users/galaxyxieyu/.hermes/hermes-agent/venv/bin/python -m pytest -q -o addopts='' tests/gateway/test_run_progress_topics.py`
2. Run `/Users/galaxyxieyu/.hermes/hermes-agent/venv/bin/python -m pytest -q -o addopts='' tests/gateway/test_clarify_responses.py tests/gateway/test_feishu_clarify_buttons.py tests/tools/test_clarify_state.py tests/gateway/test_reasoning_command.py tests/gateway/test_display_config.py tests/gateway/test_feishu_approval_buttons.py`
3. In a gateway chat, trigger a clarify prompt and verify that text replies resume the blocked turn; on Feishu, verify that button replies also resolve the prompt and update the card.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted test runs passed locally:

- `tests/gateway/test_run_progress_topics.py`: 24 passed
- Related clarify / Feishu / display / reasoning tests: 63 passed
