### PR TITLE
fix: keep Feishu thread progress inside thread

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -205,6 +205,7 @@ _FEISHU_REACTION_FAILURE = "CrossMark"
 # delete-failures, not a capacity plan.
 _FEISHU_PROCESSING_REACTION_CACHE_SIZE = 1024
 
+
 # QR onboarding constants
 _ONBOARD_ACCOUNTS_URLS = {
     "feishu": "https://accounts.feishu.cn",
@@ -1530,6 +1531,13 @@ class FeishuAdapter(BasePlatformAdapter):
         try:
             approval_id = next(self._approval_counter)
             cmd_preview = command[:3000] + "..." if len(command) > 3000 else command
+            approval_reply_to = None
+            if metadata:
+                approval_reply_to = (
+                    metadata.get("reply_to")
+                    or metadata.get("event_message_id")
+                    or metadata.get("message_id")
+                )
 
             def _btn(label: str, action_name: str, btn_type: str = "default") -> dict:
                 return {
@@ -1567,7 +1575,7 @@ class FeishuAdapter(BasePlatformAdapter):
                 chat_id=chat_id,
                 msg_type="interactive",
                 payload=payload,
-                reply_to=None,
+                reply_to=approval_reply_to,
                 metadata=metadata,
             )
 
@@ -2392,7 +2400,19 @@ class FeishuAdapter(BasePlatformAdapter):
     def _pop_processing_reaction(self, message_id: str) -> Optional[str]:
         return self._pending_processing_reactions.pop(message_id, None)
 
+    @staticmethod
+    def _should_use_thread_progress_message(event: MessageEvent) -> bool:
+        source = getattr(event, "source", None)
+        return bool(
+            source
+            and getattr(source, "chat_type", None) == "group"
+            and getattr(source, "thread_id", None)
+            and getattr(event, "message_id", None)
+        )
+
     async def on_processing_start(self, event: MessageEvent) -> None:
+        if self._should_use_thread_progress_message(event):
+            return
         if not self._reactions_enabled():
             return
         message_id = event.message_id
@@ -2405,6 +2425,8 @@ class FeishuAdapter(BasePlatformAdapter):
     async def on_processing_complete(
         self, event: MessageEvent, outcome: ProcessingOutcome
     ) -> None:
+        if self._should_use_thread_progress_message(event):
+            return
         if not self._reactions_enabled():
             return
         message_id = event.message_id

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9304,6 +9304,11 @@ class GatewayRunner:
         else:
             _progress_thread_id = source.thread_id
         _progress_metadata = {"thread_id": _progress_thread_id} if _progress_thread_id else None
+        _progress_reply_to = (
+            event_message_id
+            if source.platform == Platform.FEISHU and source.thread_id and event_message_id
+            else None
+        )
 
         async def send_progress_messages():
             if not progress_queue:
@@ -9387,15 +9392,30 @@ class GatewayRunner:
                                     adapter.name,
                                 )
                             can_edit = False
-                            await adapter.send(chat_id=source.chat_id, content=msg, metadata=_progress_metadata)
+                            await adapter.send(
+                                chat_id=source.chat_id,
+                                content=msg,
+                                reply_to=_progress_reply_to,
+                                metadata=_progress_metadata,
+                            )
                     else:
                         if can_edit:
                             # First tool: send all accumulated text as new message
                             full_text = "\n".join(progress_lines)
-                            result = await adapter.send(chat_id=source.chat_id, content=full_text, metadata=_progress_metadata)
+                            result = await adapter.send(
+                                chat_id=source.chat_id,
+                                content=full_text,
+                                reply_to=_progress_reply_to,
+                                metadata=_progress_metadata,
+                            )
                         else:
                             # Editing unsupported: send just this line
-                            result = await adapter.send(chat_id=source.chat_id, content=msg, metadata=_progress_metadata)
+                            result = await adapter.send(
+                                chat_id=source.chat_id,
+                                content=msg,
+                                reply_to=_progress_reply_to,
+                                metadata=_progress_metadata,
+                            )
                         if result.success and result.message_id:
                             progress_msg_id = result.message_id
 
@@ -9478,6 +9498,7 @@ class GatewayRunner:
         _status_adapter = self.adapters.get(source.platform)
         _status_chat_id = source.chat_id
         _status_thread_metadata = {"thread_id": _progress_thread_id} if _progress_thread_id else None
+        _status_reply_to = _progress_reply_to
 
         def _status_callback_sync(event_type: str, message: str) -> None:
             if not _status_adapter or not _run_still_current():
@@ -9487,6 +9508,7 @@ class GatewayRunner:
                     _status_adapter.send(
                         _status_chat_id,
                         message,
+                        reply_to=_status_reply_to,
                         metadata=_status_thread_metadata,
                     ),
                     _loop_for_step,
@@ -9885,7 +9907,10 @@ class GatewayRunner:
                                 command=cmd,
                                 session_key=_approval_session_key,
                                 description=desc,
-                                metadata=_status_thread_metadata,
+                                metadata={
+                                    **(_status_thread_metadata or {}),
+                                    **({"reply_to": _status_reply_to} if _status_reply_to else {}),
+                                } or None,
                             ),
                             _loop_for_step,
                         ).result(timeout=15)


### PR DESCRIPTION
## Summary
- keep Feishu progress updates inside the originating thread instead of leaking into the parent group
- route gateway tool-progress and status callback messages through the same threaded reply path on Feishu

## Testing
- `../../hermes-agent/venv/bin/python -m py_compile gateway/platforms/feishu.py gateway/run.py tests/gateway/test_feishu.py`
- `../../hermes-agent/venv/bin/python -m pytest tests/gateway/test_feishu.py -q -o 'addopts='`