### PR TITLE
fix(gateway): harden timeout env parsing to prevent message handler crashes

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -348,6 +348,32 @@ logger = logging.getLogger(__name__)
 _AGENT_PENDING_SENTINEL = object()
 
 
+def _parse_nonnegative_float_env(name: str, default: float) -> float:
+    """Parse a non-negative float env var, falling back on invalid values."""
+    raw = os.getenv(name)
+    if raw is None or str(raw).strip() == "":
+        return float(default)
+    try:
+        value = float(str(raw).strip())
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid %s value %r; using default %.0f",
+            name,
+            raw,
+            default,
+        )
+        return float(default)
+    if value < 0:
+        logger.warning(
+            "Invalid %s value %r; using default %.0f",
+            name,
+            raw,
+            default,
+        )
+        return float(default)
+    return value
+
+
 def _resolve_runtime_agent_kwargs() -> dict:
     """Resolve provider credentials for gateway-created AIAgent instances."""
     from hermes_cli.runtime_provider import (
@@ -3174,7 +3200,7 @@ class GatewayRunner:
         # wall-clock age alone isn't sufficient.  Evict only when the agent
         # has been *idle* beyond the inactivity threshold (or when the agent
         # object has no activity tracker and wall-clock age is extreme).
-        _raw_stale_timeout = float(os.getenv("HERMES_AGENT_TIMEOUT", 1800))
+        _raw_stale_timeout = _parse_nonnegative_float_env("HERMES_AGENT_TIMEOUT", 1800)
         _stale_ts = self._running_agents_ts.get(_quick_key, 0)
         if _quick_key in self._running_agents and _stale_ts:
             _stale_age = time.time() - _stale_ts
@@ -3403,8 +3429,9 @@ class GatewayRunner:
                     merge_pending_message_event(adapter._pending_messages, _quick_key, event)
                 return None
 
-            _telegram_followup_grace = float(
-                os.getenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", "3.0")
+            _telegram_followup_grace = _parse_nonnegative_float_env(
+                "HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS",
+                3.0,
             )
             _started_at = self._running_agents_ts.get(_quick_key, 0)
             if (
@@ -10195,7 +10222,7 @@ class GatewayRunner:
         # Config: agent.gateway_notify_interval in config.yaml, or
         # HERMES_AGENT_NOTIFY_INTERVAL env var.  Default 600s (10 min).
         # 0 = disable notifications.
-        _NOTIFY_INTERVAL_RAW = float(os.getenv("HERMES_AGENT_NOTIFY_INTERVAL", 600))
+        _NOTIFY_INTERVAL_RAW = _parse_nonnegative_float_env("HERMES_AGENT_NOTIFY_INTERVAL", 600)
         _NOTIFY_INTERVAL = _NOTIFY_INTERVAL_RAW if _NOTIFY_INTERVAL_RAW > 0 else None
         _notify_start = time.time()
 
@@ -10243,9 +10270,9 @@ class GatewayRunner:
             # Config: agent.gateway_timeout in config.yaml, or
             # HERMES_AGENT_TIMEOUT env var (env var takes precedence).
             # Default 1800s (30 min inactivity).  0 = unlimited.
-            _agent_timeout_raw = float(os.getenv("HERMES_AGENT_TIMEOUT", 1800))
+            _agent_timeout_raw = _parse_nonnegative_float_env("HERMES_AGENT_TIMEOUT", 1800)
             _agent_timeout = _agent_timeout_raw if _agent_timeout_raw > 0 else None
-            _agent_warning_raw = float(os.getenv("HERMES_AGENT_TIMEOUT_WARNING", 900))
+            _agent_warning_raw = _parse_nonnegative_float_env("HERMES_AGENT_TIMEOUT_WARNING", 900)
             _agent_warning = _agent_warning_raw if _agent_warning_raw > 0 else None
             _warning_fired = False
             _executor_task = asyncio.ensure_future(

--- a/tests/gateway/test_gateway_inactivity_timeout.py
+++ b/tests/gateway/test_gateway_inactivity_timeout.py
@@ -10,11 +10,9 @@ Tests cover:
 """
 
 import concurrent.futures
-import os
 import sys
 import time
 from pathlib import Path
-from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -240,16 +238,56 @@ class TestStagedInactivityWarning:
 
     def test_warning_env_var_respected(self, monkeypatch):
         """HERMES_AGENT_TIMEOUT_WARNING env var is parsed correctly."""
+        from gateway.run import _parse_nonnegative_float_env
+
         monkeypatch.setenv("HERMES_AGENT_TIMEOUT_WARNING", "600")
-        _warning = float(os.getenv("HERMES_AGENT_TIMEOUT_WARNING", 900))
+        _warning = _parse_nonnegative_float_env("HERMES_AGENT_TIMEOUT_WARNING", 900)
         assert _warning == 600.0
 
     def test_warning_zero_means_disabled(self, monkeypatch):
         """HERMES_AGENT_TIMEOUT_WARNING=0 disables the warning."""
+        from gateway.run import _parse_nonnegative_float_env
+
         monkeypatch.setenv("HERMES_AGENT_TIMEOUT_WARNING", "0")
-        _raw = float(os.getenv("HERMES_AGENT_TIMEOUT_WARNING", 900))
+        _raw = _parse_nonnegative_float_env("HERMES_AGENT_TIMEOUT_WARNING", 900)
         _warning = _raw if _raw > 0 else None
         assert _warning is None
+
+    @pytest.mark.parametrize(
+        ("env_name", "default"),
+        [
+            ("HERMES_AGENT_TIMEOUT", 1800.0),
+            ("HERMES_AGENT_TIMEOUT_WARNING", 900.0),
+            ("HERMES_AGENT_NOTIFY_INTERVAL", 600.0),
+            ("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", 3.0),
+        ],
+    )
+    def test_invalid_numeric_env_values_fall_back_to_defaults(
+        self, monkeypatch, env_name, default
+    ):
+        """Invalid gateway numeric env vars should not crash message handling."""
+        from gateway.run import _parse_nonnegative_float_env
+
+        monkeypatch.setenv(env_name, "not-a-number")
+        assert _parse_nonnegative_float_env(env_name, default) == default
+
+    @pytest.mark.parametrize(
+        "env_name",
+        [
+            "HERMES_AGENT_TIMEOUT",
+            "HERMES_AGENT_TIMEOUT_WARNING",
+            "HERMES_AGENT_NOTIFY_INTERVAL",
+            "HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS",
+        ],
+    )
+    def test_negative_numeric_env_values_fall_back_to_defaults(
+        self, monkeypatch, env_name
+    ):
+        """Negative intervals are invalid and should use the documented default."""
+        from gateway.run import _parse_nonnegative_float_env
+
+        monkeypatch.setenv(env_name, "-1")
+        assert _parse_nonnegative_float_env(env_name, 42.0) == 42.0
 
     def test_unlimited_timeout_no_warning(self):
         """When timeout is unlimited (0), no warning fires either."""


### PR DESCRIPTION
## Summary

This hardens gateway numeric environment/config parsing for agent timeout-related settings.

Previously, invalid values for gateway timing knobs could raise `ValueError` during message handling because several paths called `float(os.getenv(...))` directly. Since config.yaml values are bridged into these env vars, a typo such as `agent.gateway_timeout: abc` could break gateway processing instead of falling back to the documented defaults.

## Changes

- Add a small `_parse_nonnegative_float_env()` helper in `gateway.run`
- Use it for:
  - `HERMES_AGENT_TIMEOUT`
  - `HERMES_AGENT_TIMEOUT_WARNING`
  - `HERMES_AGENT_NOTIFY_INTERVAL`
  - `HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS`
- Preserve existing `0` behavior for disabled/unlimited settings
- Treat invalid and negative values as invalid and fall back to defaults
- Add regression coverage for invalid and negative values

## Why

Gateway timeout/activity tracking should be robust to config/env typos. A malformed numeric setting should not crash message handling.

## Tests
16 passed

```bash
uv run --with pytest --with pytest-xdist pytest tests/gateway/test_gateway_inactivity_timeout.py -q
