### PR TITLE
feat: add Feishu group mention gating toggle

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -306,6 +306,7 @@ class FeishuAdapterSettings:
     encrypt_key: str
     verification_token: str
     group_policy: str
+    require_mention_in_groups: bool
     allowed_group_users: frozenset[str]
     bot_open_id: str
     bot_user_id: str
@@ -1191,6 +1192,12 @@ class FeishuAdapter(BasePlatformAdapter):
             encrypt_key=os.getenv("FEISHU_ENCRYPT_KEY", "").strip(),
             verification_token=os.getenv("FEISHU_VERIFICATION_TOKEN", "").strip(),
             group_policy=os.getenv("FEISHU_GROUP_POLICY", "allowlist").strip().lower(),
+            require_mention_in_groups=(
+                str(extra.get("require_mention_in_groups", os.getenv("FEISHU_GROUP_REQUIRE_MENTION", "true")))
+                .strip()
+                .lower()
+                not in ("false", "0", "no")
+            ),
             allowed_group_users=frozenset(
                 item.strip()
                 for item in os.getenv("FEISHU_ALLOWED_USERS", "").split(",")
@@ -1247,6 +1254,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._encrypt_key = settings.encrypt_key
         self._verification_token = settings.verification_token
         self._group_policy = settings.group_policy
+        self._require_mention_in_groups = settings.require_mention_in_groups
         self._allowed_group_users = set(settings.allowed_group_users)
         self._admins = set(settings.admins)
         self._default_group_policy = settings.default_group_policy or settings.group_policy
@@ -3373,9 +3381,11 @@ class FeishuAdapter(BasePlatformAdapter):
         return bool(sender_ids and (sender_ids & self._allowed_group_users))
 
     def _should_accept_group_message(self, message: Any, sender_id: Any, chat_id: str = "") -> bool:
-        """Require an explicit @mention before group messages enter the agent."""
+        """Apply group allowlist policy, then optional mention gating."""
         if not self._allow_group_message(sender_id, chat_id):
             return False
+        if not self._require_mention_in_groups:
+            return True
         # @_all is Feishu's @everyone placeholder — always route to the bot.
         raw_content = getattr(message, "content", "") or ""
         if "@_all" in raw_content:

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -805,6 +805,37 @@ class TestAdapterBehavior(unittest.TestCase):
             )
         )
 
+    @patch.dict(
+        os.environ,
+        {
+            "FEISHU_GROUP_POLICY": "allowlist",
+            "FEISHU_ALLOWED_USERS": "ou_allowed",
+            "FEISHU_GROUP_REQUIRE_MENTION": "false",
+        },
+        clear=True,
+    )
+    def test_group_message_allowlist_without_mention_when_config_disabled(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        plain_message = SimpleNamespace(mentions=[], content="hello")
+
+        self.assertTrue(
+            adapter._should_accept_group_message(
+                plain_message,
+                SimpleNamespace(open_id="ou_allowed", user_id=None),
+                "",
+            )
+        )
+        self.assertFalse(
+            adapter._should_accept_group_message(
+                plain_message,
+                SimpleNamespace(open_id="ou_blocked", user_id=None),
+                "",
+            )
+        )
+
     def test_per_group_allowlist_policy_gates_by_sender(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter


### PR DESCRIPTION
## Summary
- add a Feishu adapter setting to disable group @mention gating when desired
- support `FEISHU_GROUP_REQUIRE_MENTION=false` for bots that should respond to all allowed group messages
- add coverage for allowlist + no-mention group behavior

## Testing
- `../../hermes-agent/venv/bin/python -m py_compile gateway/platforms/feishu.py tests/gateway/test_feishu.py`
- `../../hermes-agent/venv/bin/python -m pytest tests/gateway/test_feishu.py -q -o 'addopts='`
