### PR TITLE
fix(tools): honor tts.openai.base_url + api_key from config

### DIFF
--- a/tests/tools/test_tts_openai_config.py
+++ b/tests/tools/test_tts_openai_config.py
@@ -1,0 +1,90 @@
+"""Regression tests for OpenAI-compatible TTS config resolution."""
+
+from types import SimpleNamespace
+
+from tools import tts_tool
+
+
+def _disable_managed_gateway(monkeypatch) -> None:
+    monkeypatch.setattr(tts_tool, "prefers_gateway", lambda _tool: False)
+    monkeypatch.setattr(tts_tool, "resolve_managed_tool_gateway", lambda _tool: None)
+
+
+def test_config_credentials_take_precedence_over_environment(monkeypatch):
+    _disable_managed_gateway(monkeypatch)
+    monkeypatch.setattr(
+        tts_tool,
+        "_load_tts_config",
+        lambda: {
+            "openai": {
+                "api_key": "config-key",
+                "base_url": "http://localhost:8080/v1",
+            }
+        },
+    )
+    monkeypatch.setattr(
+        tts_tool,
+        "resolve_openai_audio_api_key",
+        lambda: "environment-key",
+    )
+
+    assert tts_tool._resolve_openai_audio_client_config() == (
+        "config-key",
+        "http://localhost:8080/v1",
+        False,
+    )
+
+
+def test_config_base_url_combines_with_environment_key(monkeypatch):
+    _disable_managed_gateway(monkeypatch)
+    monkeypatch.setattr(
+        tts_tool,
+        "_load_tts_config",
+        lambda: {"openai": {"base_url": "http://localhost:8080/v1"}},
+    )
+    monkeypatch.setattr(
+        tts_tool,
+        "resolve_openai_audio_api_key",
+        lambda: "environment-key",
+    )
+
+    assert tts_tool._resolve_openai_audio_client_config() == (
+        "environment-key",
+        "http://localhost:8080/v1",
+        False,
+    )
+
+
+def test_gateway_preference_preserves_managed_result(monkeypatch):
+    monkeypatch.setattr(tts_tool, "prefers_gateway", lambda _tool: True)
+    monkeypatch.setattr(
+        tts_tool,
+        "_load_tts_config",
+        lambda: {"openai": {"api_key": "config-key"}},
+    )
+    monkeypatch.setattr(
+        tts_tool,
+        "resolve_managed_tool_gateway",
+        lambda _tool: SimpleNamespace(
+            nous_user_token="managed-token",
+            gateway_origin="https://gateway.example",
+        ),
+    )
+
+    assert tts_tool._resolve_openai_audio_client_config() == (
+        "managed-token",
+        "https://gateway.example/v1",
+        True,
+    )
+
+
+def test_config_only_credentials_make_openai_available(monkeypatch):
+    monkeypatch.setattr(
+        tts_tool,
+        "_load_tts_config",
+        lambda: {"openai": {"api_key": "config-key"}},
+    )
+    monkeypatch.setattr(tts_tool, "resolve_openai_audio_api_key", lambda: "")
+    monkeypatch.setattr(tts_tool, "resolve_managed_tool_gateway", lambda _tool: None)
+
+    assert tts_tool._has_openai_audio_backend() is True

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2682,18 +2682,42 @@ def check_tts_requirements() -> bool:
 def _resolve_openai_audio_client_config() -> tuple[str, str, bool]:
     """Return ``(api_key, base_url, is_managed)`` for the OpenAI audio client.
 
+    Resolution order (when ``tts.use_gateway`` is not set):
+      1. ``tts.openai.api_key`` + ``tts.openai.base_url`` from config.yaml
+         — lets users point TTS at a local / self-hosted OpenAI-compatible
+         endpoint (e.g. llama.cpp, qwen3-tts) without any env vars.
+      2. ``VOICE_TOOLS_OPENAI_KEY`` / ``OPENAI_API_KEY`` env vars, combined
+         with ``tts.openai.base_url`` from config if present.
+      3. Managed Nous tool gateway (``openai-audio``).
+
+    Mirrors the STT resolver in ``tools.transcription_tools`` so both
+    halves of the audio pipeline treat config the same way.
+
     ``is_managed`` is True when the config resolves to the Nous managed audio
     gateway (a restricted proxy), so callers can coerce the request to what the
     gateway supports. When ``tts.use_gateway`` is set the gateway is preferred
     even if direct OpenAI credentials are present.
     """
-    direct_api_key = resolve_openai_audio_api_key()
-    if direct_api_key and not prefers_gateway("tts"):
-        return direct_api_key, DEFAULT_OPENAI_BASE_URL, False
+    gateway_preferred = prefers_gateway("tts")
+
+    tts_config = _load_tts_config()
+    openai_cfg = tts_config.get("openai", {}) if isinstance(tts_config, dict) else {}
+    cfg_api_key = (openai_cfg.get("api_key") or "").strip() if isinstance(openai_cfg, dict) else ""
+    cfg_base_url = (openai_cfg.get("base_url") or "").strip() if isinstance(openai_cfg, dict) else ""
+
+    if not gateway_preferred:
+        if cfg_api_key:
+            return cfg_api_key, (cfg_base_url or DEFAULT_OPENAI_BASE_URL), False
+        direct_api_key = resolve_openai_audio_api_key()
+        if direct_api_key:
+            return direct_api_key, (cfg_base_url or DEFAULT_OPENAI_BASE_URL), False
 
     managed_gateway = resolve_managed_tool_gateway("openai-audio")
     if managed_gateway is None:
-        message = "Neither VOICE_TOOLS_OPENAI_KEY nor OPENAI_API_KEY is set"
+        message = (
+            "Neither tts.openai.api_key in config nor "
+            "VOICE_TOOLS_OPENAI_KEY/OPENAI_API_KEY is set"
+        )
         if managed_nous_tools_enabled() or prefers_gateway("tts"):
             message += (
                 ". "
@@ -2712,7 +2736,14 @@ def _resolve_openai_audio_client_config() -> tuple[str, str, bool]:
 
 def _has_openai_audio_backend() -> bool:
     """Return True when OpenAI audio can use direct credentials or the managed gateway."""
-    return bool(resolve_openai_audio_api_key() or resolve_managed_tool_gateway("openai-audio"))
+    tts_config = _load_tts_config()
+    openai_cfg = tts_config.get("openai", {}) if isinstance(tts_config, dict) else {}
+    config_api_key = openai_cfg.get("api_key") if isinstance(openai_cfg, dict) else None
+    return bool(
+        config_api_key
+        or resolve_openai_audio_api_key()
+        or resolve_managed_tool_gateway("openai-audio")
+    )
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

`tools/tts_tool.py::_resolve_openai_audio_client_config` is env-only — it reads `VOICE_TOOLS_OPENAI_KEY` / `OPENAI_API_KEY` and always returns `DEFAULT_OPENAI_BASE_URL`, ignoring the `tts.openai.api_key` and `tts.openai.base_url` keys in `config.yaml`.

Users pointing TTS at a self-hosted or local OpenAI-compatible endpoint (llama.cpp, qwen3-tts, Ollama with a TTS backend, etc.) either had to set a fake env var **and** couldn't redirect the host, or got \`Neither VOICE_TOOLS_OPENAI_KEY nor OPENAI_API_KEY is set\` and no audio ever played — even with a fully-populated \`tts.openai\` config block.

The STT side (`tools/transcription_tools.py::_resolve_openai_audio_client_config`) already reads config first, then env, then the managed gateway. This PR mirrors that pattern for TTS so both halves of the audio pipeline treat config the same way.

## Resolution order (when `tts.use_gateway` is not set)

1. `tts.openai.api_key` + `tts.openai.base_url` from `config.yaml`
2. `VOICE_TOOLS_OPENAI_KEY` / `OPENAI_API_KEY` env var, combined with `tts.openai.base_url` from config if present
3. Managed Nous tool gateway (`openai-audio`)

No behavior change when neither config nor env is set — still raises `ValueError`, just with an updated message pointing at the config key as well.

## Test plan

- [x] Reproduction: with \`tts.openai.api_key=dummy-no-auth\` + \`tts.openai.base_url=http://localhost:4003/v1\` in config and no env vars set → TTS now successfully hits the local endpoint and produces audio. Before this change: \`ValueError: Neither VOICE_TOOLS_OPENAI_KEY nor OPENAI_API_KEY is set\`.
- [x] Regression: with only \`OPENAI_API_KEY\` set in env → falls back to that env key, uses \`tts.openai.base_url\` if present else \`DEFAULT_OPENAI_BASE_URL\` (same as old behavior when config had no \`base_url\`).
- [x] Regression: with \`tts.use_gateway: true\` in config → still prefers the managed gateway regardless of direct creds.
- [x] Tested on macOS (Darwin 25.4.0) against a local OpenAI-compatible server.

## Notes

- No API/signature changes. Same function name, same return type.
- Pure resolver fix — no LiveKit / voice-platform coupling.