### PR TITLE
feat(agent): add model.preserve_dots opt-in override for Anthropic-compatible proxies

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1563,6 +1563,21 @@ class AIAgent:
             _config_context_length = _model_cfg.get("context_length")
         else:
             _config_context_length = None
+
+        # Read explicit preserve_dots override from model config. Opt-in flag
+        # for third-party Anthropic-compatible proxies (OneAPI, LiteLLM,
+        # FastGPT, company gateways, etc.) whose registered model IDs contain
+        # dots — e.g. ``Claude Opus 4.6`` — and would otherwise be mangled
+        # into ``Claude Opus 4-6`` by ``normalize_model_name``. Consumed by
+        # ``_anthropic_preserve_dots`` below. Only bools are honored; other
+        # types fall through to the provider/base_url allowlist.
+        if isinstance(_model_cfg, dict):
+            _explicit_preserve_dots = _model_cfg.get("preserve_dots")
+            self._model_preserve_dots_override = (
+                _explicit_preserve_dots if isinstance(_explicit_preserve_dots, bool) else None
+            )
+        else:
+            self._model_preserve_dots_override = None
         if _config_context_length is not None:
             try:
                 _config_context_length = int(_config_context_length)
@@ -6603,7 +6618,20 @@ class AIAgent:
         the hyphenated form with
         ``HTTP 400 The provided model identifier is invalid``.
         Regression for #11976; mirrors the opencode-go fix for #5211
-        (commit f77be22c), which extended this same allowlist."""
+        (commit f77be22c), which extended this same allowlist.
+
+        Users on third-party Anthropic-compatible proxies (OneAPI,
+        LiteLLM, FastGPT, company-internal gateways, etc.) whose
+        registered model IDs contain dots — e.g. ``Claude Opus 4.6`` —
+        can opt in explicitly by setting ``model.preserve_dots: true``
+        in ``~/.hermes/config.yaml``. This overrides the auto-detection
+        below so any Anthropic-compatible endpoint can route correctly
+        without Hermes having to hardcode its URL.
+        """
+        override = getattr(self, "_model_preserve_dots_override", None)
+        if isinstance(override, bool):
+            return override
+
         if (getattr(self, "provider", "") or "").lower() in {
             "alibaba", "minimax", "minimax-cn",
             "opencode-go", "opencode-zen",

--- a/tests/agent/test_preserve_dots_override.py
+++ b/tests/agent/test_preserve_dots_override.py
@@ -1,0 +1,125 @@
+"""Tests for the ``model.preserve_dots`` opt-in override.
+
+Third-party Anthropic-compatible proxies (OneAPI, LiteLLM, FastGPT,
+company-internal gateways, etc.) often register model IDs that contain
+dots — e.g. ``Claude Opus 4.6`` routed to AWS Bedrock. Without an opt-in
+override the default ``_anthropic_preserve_dots`` heuristic returns
+False for any URL Hermes doesn't specifically recognize, and
+``normalize_model_name`` converts dots to hyphens, producing
+``Claude Opus 4-6`` — which the proxy cannot match to a registered
+channel (HTTP 503 "no available channel").
+
+These tests lock in the behaviour of the ``model.preserve_dots: true``
+config opt-in:
+
+- ``True``  → always preserve dots, regardless of provider/base_url.
+- ``False`` → always mangle dots, overriding even the built-in
+  allowlist (escape hatch in case the allowlist is wrong for a user).
+- Missing / non-bool → fall back to the existing allowlist (no
+  behaviour change for users who don't set the flag).
+"""
+
+from types import SimpleNamespace
+
+
+class TestPreserveDotsOverrideTrue:
+    """``model.preserve_dots: true`` must force dot-preservation even when
+    neither the provider nor the base URL matches the built-in allowlist."""
+
+    def test_custom_proxy_with_override_preserves_dots(self):
+        """The motivating case: a generic third-party proxy whose URL
+        Hermes doesn't recognize. Without the override, dots would be
+        mangled. With it, they are preserved."""
+        agent = SimpleNamespace(
+            provider="custom",
+            base_url="https://proxy.example.com",
+            _model_preserve_dots_override=True,
+        )
+        from run_agent import AIAgent
+        assert AIAgent._anthropic_preserve_dots(agent) is True
+
+    def test_override_true_wins_over_anthropic_native(self):
+        """Escape hatch: if the user explicitly sets ``preserve_dots:
+        true`` while pointing at a URL Hermes would normally mangle
+        (even api.anthropic.com), the explicit choice wins."""
+        agent = SimpleNamespace(
+            provider="anthropic",
+            base_url="https://api.anthropic.com",
+            _model_preserve_dots_override=True,
+        )
+        from run_agent import AIAgent
+        assert AIAgent._anthropic_preserve_dots(agent) is True
+
+
+class TestPreserveDotsOverrideFalse:
+    """``model.preserve_dots: false`` must force dot-mangling even when
+    the provider/base_url allowlist would otherwise preserve dots —
+    this is an escape hatch for cases where the allowlist is wrong."""
+
+    def test_override_false_wins_over_bedrock_provider(self):
+        """Even with ``provider="bedrock"`` (which normally preserves
+        dots), an explicit False must override."""
+        agent = SimpleNamespace(
+            provider="bedrock",
+            base_url="",
+            _model_preserve_dots_override=False,
+        )
+        from run_agent import AIAgent
+        assert AIAgent._anthropic_preserve_dots(agent) is False
+
+    def test_override_false_wins_over_dashscope_url(self):
+        """Base-URL-based allowlist must also be overridden by an
+        explicit ``preserve_dots: false``."""
+        agent = SimpleNamespace(
+            provider="custom",
+            base_url="https://dashscope.aliyuncs.com",
+            _model_preserve_dots_override=False,
+        )
+        from run_agent import AIAgent
+        assert AIAgent._anthropic_preserve_dots(agent) is False
+
+
+class TestPreserveDotsOverrideUnset:
+    """Missing or non-bool values must not change behaviour — the
+    allowlist is consulted exactly as before this feature landed."""
+
+    def test_no_attribute_falls_back_to_allowlist_true(self):
+        """A ``SimpleNamespace`` without the override attribute exercises
+        the ``getattr(..., None)`` default path. Provider is on the
+        allowlist → dots preserved."""
+        agent = SimpleNamespace(provider="bedrock", base_url="")
+        from run_agent import AIAgent
+        assert AIAgent._anthropic_preserve_dots(agent) is True
+
+    def test_no_attribute_falls_back_to_allowlist_false(self):
+        """Same as above but for a URL not on the allowlist — dots are
+        still mangled, preserving pre-feature behaviour for users who
+        don't opt in."""
+        agent = SimpleNamespace(provider="anthropic", base_url="https://api.anthropic.com")
+        from run_agent import AIAgent
+        assert AIAgent._anthropic_preserve_dots(agent) is False
+
+    def test_none_override_falls_back_to_allowlist(self):
+        """Explicit ``None`` (the value written by ``__init__`` when
+        ``preserve_dots`` is absent or non-bool) must behave the same
+        as a missing attribute."""
+        agent = SimpleNamespace(
+            provider="bedrock",
+            base_url="",
+            _model_preserve_dots_override=None,
+        )
+        from run_agent import AIAgent
+        assert AIAgent._anthropic_preserve_dots(agent) is True
+
+    def test_non_bool_override_is_ignored(self):
+        """Only ``bool`` values are honored. A stray string from
+        hand-edited YAML (e.g. ``preserve_dots: "yes"``) must not
+        activate the override — the ``__init__`` normalization should
+        have written ``None`` instead, but defend in depth."""
+        agent = SimpleNamespace(
+            provider="anthropic",
+            base_url="https://api.anthropic.com",
+            _model_preserve_dots_override="yes",  # type: ignore[arg-type]
+        )
+        from run_agent import AIAgent
+        assert AIAgent._anthropic_preserve_dots(agent) is False


### PR DESCRIPTION
## What

Adds an explicit `model.preserve_dots: true` config flag that forces
`AIAgent._anthropic_preserve_dots()` to return the configured value,
overriding the provider/base-URL allowlist. This lets users point
Hermes at third-party Anthropic-compatible proxies — OneAPI, LiteLLM,
FastGPT, company-internal gateways, etc. — whose registered model IDs
contain dots, without requiring Hermes to hardcode every new proxy URL.

## Why

The default behaviour of `normalize_model_name` converts dots to
hyphens (`claude-opus-4.6` → `claude-opus-4-6`) to match the
Anthropic/OpenRouter convention. `_anthropic_preserve_dots` opts
specific providers (`alibaba`, `minimax`, `opencode-go`, `opencode-zen`,
`zai`, `bedrock`) and base-URL substrings (`dashscope`, `aliyuncs`,
`minimax`, `opencode.ai/zen/`, `bigmodel.cn`, `bedrock-runtime.`) out
of this mangling.

That allowlist doesn't scale. Any corporate or third-party Anthropic-
compatible gateway that registers a dotted model ID silently breaks:

```
HTTP 503: no available channel for model "claude opus 4-6"
```

…even though the operator registered the channel as `Claude Opus 4.6`.
Reproducer: point Hermes at a OneAPI-style proxy with:

```yaml
model:
  default: Claude Opus 4.6
  provider: custom
  base_url: https://<your-oneapi-proxy>
  api_mode: anthropic_messages
  api_key: sk-...
```

…and watch the request body go out as `"model": "Claude Opus 4-6"`.
The proxy can't match that against its catalog and returns 503.

Rather than keep adding one-off URL substrings to the allowlist, this
PR exposes a single opt-in knob. Users who know their proxy needs
dotted model IDs can add one line to `~/.hermes/config.yaml`:

```yaml
model:
  preserve_dots: true
```

…and every future proxy in this class is handled without a Hermes
release.

## Behaviour matrix

| `model.preserve_dots` | Effect |
| --- | --- |
| `true`  | Always preserve dots, regardless of provider / base_url |
| `false` | Always mangle dots — escape hatch if the allowlist is wrong |
| unset / non-bool | Fall back to existing allowlist (no behaviour change) |

The override is read once in `AIAgent.__init__` and cached on the
instance. Existing unit tests that construct lightweight agents via
`SimpleNamespace` don't set the attribute and therefore land on the
fallback path, i.e. **this is fully backwards compatible**.

## How to test

### Automated

```bash
pytest tests/agent/test_preserve_dots_override.py -v
```

Eight new cases covering:

- `preserve_dots: true` on a URL not in the allowlist (core case)
- `preserve_dots: true` overriding `provider=anthropic`
- `preserve_dots: false` overriding `provider=bedrock`
- `preserve_dots: false` overriding `dashscope.aliyuncs.com` URL
- missing / `None` / non-bool attribute values → fall back to allowlist

Related regression suites — `tests/agent/test_bedrock_integration.py`,
`tests/agent/test_anthropic_adapter.py`,
`tests/agent/test_minimax_provider.py` — all still pass (208/208).

### Manual

Against a real OneAPI-style proxy that registers `Claude Opus 4.6`:

1. Configure `~/.hermes/config.yaml`:

   ```yaml
   model:
     default: Claude Opus 4.6
     provider: custom
     base_url: https://<proxy>
     api_mode: anthropic_messages
     api_key: sk-<your-key>
     preserve_dots: true
   ```

2. `hermes chat -q "say hi in exactly 3 words"` → returns a normal
   assistant message. Without `preserve_dots: true` the proxy
   responds with `HTTP 503 no available channel for claude opus 4-6`.

3. Inspect `~/.hermes/sessions/request_dump_*.json` and confirm
   `request.body.model` is the dotted `"Claude Opus 4.6"`.

## Platforms tested

- macOS 14.2.1 (darwin 23.2.0, aarch64), Python 3.11.15

No platform-specific code paths are touched — the change is pure
Python config reading.

## Risks

Minimal:

- Fallback branch is unchanged (users who don't set the flag see
  identical behaviour).
- Non-bool values are defensively rejected in `__init__`, so
  hand-edited YAML like `preserve_dots: "yes"` can't silently
  flip the flag.
- One extra `dict.get()` in the hot path of `_anthropic_preserve_dots`.

## Related

- Same dot-preservation mechanism as the bedrock fix (#11976) and
  the opencode-go fix (#5211, commit f77be22c), now user-extensible
  without code changes.
