### PR TITLE
Fix project .env pre-sanitization in load_hermes_dotenv

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -160,6 +160,8 @@ def load_hermes_dotenv(
     # Fix corrupted .env files before python-dotenv parses them (#8908).
     if user_env.exists():
         _sanitize_env_file_if_needed(user_env)
+    if project_env_path and project_env_path.exists():
+        _sanitize_env_file_if_needed(project_env_path)
 
     if user_env.exists():
         _load_dotenv_with_fallback(user_env, override=True)

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -33,6 +33,25 @@ def test_project_env_overrides_stale_shell_values_when_user_env_missing(tmp_path
     assert os.getenv("OPENAI_BASE_URL") == "https://project.example/v1"
 
 
+def test_project_env_is_sanitized_before_loading(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    project_env = tmp_path / ".env"
+    project_env.write_text(
+        "TELEGRAM_BOT_TOKEN=8356550917:AAGGEkzg06Hrc3Hjb3Sa1jkGVDOdU_lYy2Q"
+        "ANTHROPIC_API_KEY=sk-ant-test123\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    loaded = load_hermes_dotenv(hermes_home=home, project_env=project_env)
+
+    assert loaded == [project_env]
+    assert os.getenv("TELEGRAM_BOT_TOKEN") == "8356550917:AAGGEkzg06Hrc3Hjb3Sa1jkGVDOdU_lYy2Q"
+    assert os.getenv("ANTHROPIC_API_KEY") == "sk-ant-test123"
+
+
 def test_user_env_takes_precedence_over_project_env(tmp_path, monkeypatch):
     home = tmp_path / "hermes"
     home.mkdir()


### PR DESCRIPTION
## Summary

`load_hermes_dotenv()` only pre-sanitized the user env file (`~/.hermes/.env`) before passing it to `python-dotenv`.

When Hermes fell back to a project-level `.env` because no user env file was present, corrupted concatenated lines such as:

`TELEGRAM_BOT_TOKEN=...ANTHROPIC_API_KEY=...`

were loaded without repair. In that case, the first variable could absorb the second key and the second variable would never be set.

This PR applies the same pre-sanitization step to the fallback project `.env` path.

## What changed

- sanitize `project_env_path` before loading it, just like `user_env`
- add a regression test covering a corrupted fallback project `.env`

## Why this matters

This is a real behavior bug in the env-loading path:
- only affects the fallback project `.env` case
- breaks env parsing for corrupted concatenated lines
- can silently produce wrong credentials in process env

The fix is minimal and reuses the existing sanitizer already used for the primary Hermes env file.

## Validation

Passed:

- `tests/hermes_cli/test_env_loader.py::test_project_env_overrides_stale_shell_values_when_user_env_missing`
- `tests/hermes_cli/test_env_loader.py::test_project_env_is_sanitized_before_loading`
- `tests/hermes_cli/test_env_loader.py::test_user_env_takes_precedence_over_project_env`
- `tests/hermes_cli/test_env_sanitize_on_load.py::test_env_loader_sanitizes_before_dotenv`

Also passed:
- `tests/hermes_cli/test_env_loader.py`
- `tests/hermes_cli/test_env_sanitize_on_load.py`

