### PR TITLE
fix(wecom): strip @mention prefix in group chats for slash command recognition

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -508,6 +508,11 @@ class WeComAdapter(BasePlatformAdapter):
         self._remember_chat_req_id(chat_id, self._payload_req_id(payload))
 
         text, reply_text = self._extract_text(body)
+        # Strip leading @mention in group chats so slash commands like
+        # "@BotName /approve" are correctly recognized as "/approve".
+        # Mirrors what the Telegram adapter does (re.sub @botname).
+        if is_group and text:
+            text = re.sub(r"^@\S+\s*", "", text).strip()
         media_urls, media_types = await self._extract_media(body)
         message_type = self._derive_message_type(body, text, media_types)
         has_reply_context = bool(reply_text and (text or media_urls))


### PR DESCRIPTION
## Problem

In WeCom (企业微信) group chats, when a user sends `@BotName /approve`, the `event.text` arrives as `"@BotName /approve"` — starting with `@`, not `/`.

This causes `is_command()` to return `False` and `get_command()` to return `None`, so slash commands like `/approve` and `/deny` are not recognized. Instead, the message falls through to the interrupt path, triggering an unintended "⚡ Interrupting current task" response.

## Fix

Strip the leading `@mention` prefix from message text in group chats before creating the `MessageEvent`. This mirrors the existing behavior in the Telegram adapter (line ~2200 of `gateway/run.py`).

## Changes

- `gateway/platforms/wecom.py`: Added 5 lines after `_extract_text()` to strip `@mention` prefix via `re.sub(r"^@\\S+\\s*", "", text).strip()` when `is_group` is True.