### PR TITLE
fix(anthropic_adapter): preserve reasoning_content for Kimi /coding tool-call messages

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1083,6 +1083,13 @@ def convert_messages_to_anthropic(
                     "name": fn.get("name", ""),
                     "input": parsed_args,
                 })
+            # Kimi's /coding endpoint (Anthropic protocol) requires assistant
+            # tool-call messages to carry reasoning_content when thinking is
+            # enabled.  Preserve it as a thinking block so Kimi can validate
+            # the message history.  See hermes-agent#13848.
+            reasoning_content = m.get("reasoning_content")
+            if reasoning_content and isinstance(reasoning_content, str):
+                blocks.append({"type": "thinking", "thinking": reasoning_content})
             # Anthropic rejects empty assistant content
             effective = blocks or content
             if not effective or effective == "":

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -92,6 +92,7 @@ AUTHOR_MAP = {
     "135070653+sgaofen@users.noreply.github.com": "sgaofen",
     "nocoo@users.noreply.github.com": "nocoo",
     "30841158+n-WN@users.noreply.github.com": "n-WN",
+    "tsuijinglei@gmail.com": "hiddenpuppy",
     "leoyuan0099@gmail.com": "keyuyuan",
     "bxzt2006@163.com": "Only-Code-A",
     "i@troy-y.org": "TroyMitchell911",


### PR DESCRIPTION
## Summary

Fixes #13848

## Problem

When using `kimi-for-coding` (Kimi's `/coding` endpoint via Anthropic Messages protocol), any session that triggers tool calls becomes permanently broken after several rounds.

The Moonshot API returns HTTP 400:
```
thinking is enabled but reasoning_content is missing in assistant tool call message at index 2
```

This happens because:
1. Kimi's `/coding` endpoint speaks Anthropic Messages protocol but has its own thinking semantics
2. When `thinking.enabled` is sent, Kimi validates message history and requires every prior assistant tool-call message to carry OpenAI-style `reasoning_content`
3. The Anthropic path never populated that field
4. `convert_messages_to_anthropic` strips all Anthropic thinking blocks on third-party endpoints
5. The corrupted message stays in conversation history and gets replayed every subsequent turn

## Fix

In `convert_messages_to_anthropic`, when processing an assistant message that contains both `tool_calls` and `reasoning_content`, preserve the `reasoning_content` as a `{"type": "thinking", "thinking": ...}` block appended to the Anthropic content blocks.

This allows Kimi to validate the message history while keeping the change minimal and only affecting messages that have both tool_calls and reasoning_content.

## Changes

- `agent/anthropic_adapter.py`: `convert_messages_to_anthropic()` — added reasoning_content preservation for assistant tool-call messages

## Verification

- [ ] `pnpm check` / `pytest` passes
- [ ] Manual: configure Hermes Agent with kimi-for-coding, start a session with tool calls, confirm no HTTP 400 after multiple rounds

## Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Requires documentation update