### PR TITLE
fix: correct delegation tool trace error detection

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -441,7 +441,7 @@ class TestDelegateObservability(unittest.TestCase):
             self.assertEqual(entry["tool_trace"][0]["status"], "ok")
 
     def test_tool_trace_detects_error(self):
-        """Tool results containing 'error' should be marked as error status."""
+        """Tool results containing real errors should be marked as error status."""
         parent = _make_mock_parent(depth=0)
 
         with patch("run_agent.AIAgent") as MockAgent:
@@ -464,6 +464,60 @@ class TestDelegateObservability(unittest.TestCase):
             MockAgent.return_value = mock_child
 
             result = json.loads(delegate_task(goal="Test error trace", parent_agent=parent))
+            trace = result["results"][0]["tool_trace"]
+            self.assertEqual(trace[0]["status"], "error")
+
+    def test_tool_trace_terminal_success_with_error_null_is_ok(self):
+        """Terminal JSON success payloads should not be misclassified just because they contain an error field set to null."""
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.model = "claude-sonnet-4-6"
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.run_conversation.return_value = {
+                "final_response": "ok",
+                "completed": True,
+                "interrupted": False,
+                "api_calls": 1,
+                "messages": [
+                    {"role": "assistant", "tool_calls": [
+                        {"id": "tc_1", "function": {"name": "terminal", "arguments": '{"command": "hostname"}'}}
+                    ]},
+                    {"role": "tool", "tool_call_id": "tc_1", "content": '{"output": "localhost", "exit_code": 0, "error": null}'},
+                ],
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(delegate_task(goal="Test terminal success trace", parent_agent=parent))
+            trace = result["results"][0]["tool_trace"]
+            self.assertEqual(trace[0]["status"], "ok")
+
+    def test_tool_trace_terminal_nonzero_exit_is_error(self):
+        """Terminal JSON payloads with non-zero exit code should be marked as error."""
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.model = "claude-sonnet-4-6"
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.run_conversation.return_value = {
+                "final_response": "failed",
+                "completed": True,
+                "interrupted": False,
+                "api_calls": 1,
+                "messages": [
+                    {"role": "assistant", "tool_calls": [
+                        {"id": "tc_1", "function": {"name": "terminal", "arguments": '{"command": "false"}'}}
+                    ]},
+                    {"role": "tool", "tool_call_id": "tc_1", "content": '{"output": "", "exit_code": 1, "error": null}'},
+                ],
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(delegate_task(goal="Test terminal exit trace", parent_agent=parent))
             trace = result["results"][0]["tool_trace"]
             self.assertEqual(trace[0]["status"], "error")
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -20,6 +20,8 @@ import json
 import logging
 logger = logging.getLogger(__name__)
 import os
+
+from utils import safe_json_loads
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -517,9 +519,27 @@ def _run_single_child(
                             trace_by_id[tc_id] = entry_t
                 elif msg.get("role") == "tool":
                     content = msg.get("content", "")
-                    is_error = bool(
-                        content and "error" in content[:80].lower()
-                    )
+                    parsed = safe_json_loads(content) if isinstance(content, str) else None
+
+                    is_error = False
+                    if isinstance(parsed, dict):
+                        status_value = str(parsed.get("status", "")).lower()
+                        if status_value in {"error", "failed", "blocked", "disabled"}:
+                            is_error = True
+                        elif parsed.get("error") not in (None, "", False):
+                            is_error = True
+                        elif parsed.get("success") is False:
+                            is_error = True
+                        elif "exit_code" in parsed:
+                            try:
+                                is_error = int(parsed.get("exit_code", 0)) != 0
+                            except (TypeError, ValueError):
+                                is_error = False
+                    else:
+                        text = content[:120] if isinstance(content, str) else str(content)[:120]
+                        lowered = text.lower()
+                        is_error = lowered.startswith("error:") or lowered.startswith("error ")
+
                     result_meta = {
                         "result_bytes": len(content),
                         "status": "error" if is_error else "ok",


### PR DESCRIPTION
## Bug Description

Delegation observability was misclassifying successful tool calls as errors in `tool_trace`.

## Root Cause

`tools/delegate_tool.py` used a naive string heuristic that marked a tool result as an error whenever the returned content contained the word `error` near the start. That incorrectly flagged successful terminal JSON payloads like `{\"error\": null, \"exit_code\": 0, ...}`.

## Fix

- parse tool result JSON before classifying status
- treat only real error states / non-empty errors / failed success flags / non-zero exit codes as errors
- keep a conservative text fallback for non-JSON tool payloads
- add regression tests covering `error: null` success payloads and non-zero exit codes

## How to Verify

1. Run `source venv/bin/activate && python -m pytest tests/tools/test_delegate.py -q`
2. Call `delegate_task` with `toolsets=[\"terminal\"]` for a read-only command like `hostname && pwd`
3. Confirm the returned `tool_trace[0].status` is `ok` instead of `error`

## Test Plan

- [x] Added regression test for this bug
- [x] Existing tests still pass
- [x] Manual verification of the fix

## Risk Assessment

Low — the change is narrowly scoped to delegation observability/status classification and is covered by targeted regression tests.
