### PR TITLE
fix(auxiliary): treat OpenRouter 403 key/spend-limit errors as payment exhaustion for fallback

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1083,6 +1083,13 @@ def convert_messages_to_anthropic(
                     "name": fn.get("name", ""),
                     "input": parsed_args,
                 })
+            # Kimi's /coding endpoint (Anthropic protocol) requires assistant
+            # tool-call messages to carry reasoning_content when thinking is
+            # enabled.  Preserve it as a thinking block so Kimi can validate
+            # the message history.  See hermes-agent#13848.
+            reasoning_content = m.get("reasoning_content")
+            if reasoning_content and isinstance(reasoning_content, str):
+                blocks.append({"type": "thinking", "thinking": reasoning_content})
             # Anthropic rejects empty assistant content
             effective = blocks or content
             if not effective or effective == "":

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1263,13 +1263,21 @@ def _get_provider_chain() -> List[tuple]:
 def _is_payment_error(exc: Exception) -> bool:
     """Detect payment/credit/quota exhaustion errors.
 
-    Returns True for HTTP 402 (Payment Required) and for 429/other errors
-    whose message indicates billing exhaustion rather than rate limiting.
+    Returns True for HTTP 402 (Payment Required), HTTP 403 responses from
+    OpenRouter that indicate key/spend-limit exhaustion, and for 429/other
+    errors whose message indicates billing exhaustion rather than rate limiting.
     """
     status = getattr(exc, "status_code", None)
     if status == 402:
         return True
     err_lower = str(exc).lower()
+    # OpenRouter 403 key-limit / spend-limit errors are payment exhaustion
+    if status == 403:
+        if any(kw in err_lower for kw in (
+            "key limit", "spending limit", "spend limit",
+            "total limit", "credit limit", "quota exceeded",
+        )):
+            return True
     # OpenRouter and other providers include "credits" or "afford" in 402 bodies,
     # but sometimes wrap them in 429 or other codes.
     if status in (402, 429, None):

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -93,6 +93,7 @@ AUTHOR_MAP = {
     "nocoo@users.noreply.github.com": "nocoo",
     "30841158+n-WN@users.noreply.github.com": "n-WN",
     "tsuijinglei@gmail.com": "hiddenpuppy",
+    "jerome@clawwork.ai": "HiddenPuppy",
     "leoyuan0099@gmail.com": "keyuyuan",
     "bxzt2006@163.com": "Only-Code-A",
     "i@troy-y.org": "TroyMitchell911",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -92,6 +92,7 @@ AUTHOR_MAP = {
     "135070653+sgaofen@users.noreply.github.com": "sgaofen",
     "nocoo@users.noreply.github.com": "nocoo",
     "30841158+n-WN@users.noreply.github.com": "n-WN",
+    "tsuijinglei@gmail.com": "hiddenpuppy",
     "leoyuan0099@gmail.com": "keyuyuan",
     "bxzt2006@163.com": "Only-Code-A",
     "i@troy-y.org": "TroyMitchell911",


### PR DESCRIPTION
## Summary

Fixes #13887

## Problem

When auxiliary tasks run with `provider=auto`, OpenRouter returns HTTP 403 for key-limit and spend-limit errors. The existing `_is_payment_error()` only checked for HTTP 402/429/None, so these 403s were **not** classified as payment exhaustion. Auxiliary calls would fail immediately instead of falling back to the next available provider (Codex OAuth, Nous, custom endpoint, etc.).

Screenshot in the issue shows 3 retries with the same model and same error instead of trying a fallback provider.

## Root Cause

- `_is_payment_error()` was too narrow — missing OpenRouter 403 key-limit/spend-limit wording
- The fallback chain (`_try_payment_fallback()`) works correctly but was never reached because the error wasn't classified as payment-related

## Fix

Extend `_is_payment_error()` to also check HTTP 403 responses for OpenRouter-specific payment exhaustion keywords:
- `"key limit"`
- `"spending limit"` / `"spend limit"`
- `"total limit"`
- `"credit limit"`
- `"quota exceeded"`

This is intentionally scoped — only 403s with these specific phrases are treated as payment errors. Other 403s (auth, forbidden, etc.) still raise normally.

## Changes

- `agent/auxiliary_client.py`: `_is_payment_error()` — added 403 + keyword check

## Verification

- [ ] `pytest` passes
- [ ] Manual: configure depleted OpenRouter key, trigger auxiliary call, confirm fallback to next provider

## Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Requires documentation update