### PR TITLE
fix(agent): preserve focus topic in summary fallback retry

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -807,7 +807,10 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                 )
                 self.summary_model = ""  # empty = use main model
                 self._summary_failure_cooldown_until = 0.0  # no cooldown
-                return self._generate_summary(turns_to_summarize)  # retry immediately
+                return self._generate_summary(
+                    turns_to_summarize,
+                    focus_topic=focus_topic,
+                )  # retry immediately
 
             # Transient errors (timeout, rate limit, network) — shorter cooldown
             _transient_cooldown = 60

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -241,6 +241,43 @@ class TestSummaryFailureCooldown:
         assert second is None
         assert mock_call.call_count == 1
 
+    def test_missing_summary_model_retries_with_main_model_and_preserves_focus_topic(self):
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(model="main-model", quiet_mode=True)
+
+        c.summary_model = "missing-summary-model"
+
+        turns = [
+            {"role": "user", "content": "Investigate the database schema"},
+            {"role": "assistant", "content": "Working on it"},
+        ]
+
+        seen_kwargs = []
+
+        class ModelNotFoundError(Exception):
+            status_code = 404
+
+        def _mock_call_llm(**kwargs):
+            seen_kwargs.append(kwargs)
+            if len(seen_kwargs) == 1:
+                raise ModelNotFoundError("model_not_found")
+
+            mock_response = MagicMock()
+            mock_response.choices = [MagicMock()]
+            mock_response.choices[0].message.content = "ok"
+            return mock_response
+
+        with patch("agent.context_compressor.call_llm", side_effect=_mock_call_llm):
+            summary = c._generate_summary(turns, focus_topic="database schema")
+
+        assert summary == f"{SUMMARY_PREFIX}\nok"
+        assert len(seen_kwargs) == 2
+        assert seen_kwargs[0]["model"] == "missing-summary-model"
+        assert "model" not in seen_kwargs[1]
+        assert 'FOCUS TOPIC: "database schema"' in seen_kwargs[1]["messages"][0]["content"]
+        assert c.summary_model == ""
+        assert c._summary_model_fallen_back is False
+
 
 class TestSummaryPrefixNormalization:
     def test_legacy_prefix_is_replaced(self):


### PR DESCRIPTION
## What does this PR do?

Fixes the context-compression fallback retry path so a missing `summary_model` retries on the main model with the original `focus_topic` preserved.

On current `main`, the fallback branch already retries with `turns_to_summarize`, but it drops `focus_topic`. That means `/compress <focus>` guidance is lost precisely when the summary model is unavailable and compression falls back to the main model. This PR preserves the original focus hint and adds a regression test for the fallback path.

## Related Issue

Fixes #13905

## Type of Change

- [x] ?? Bug fix (non-breaking change that fixes an issue)
- [ ] ? New feature (non-breaking change that adds functionality)
- [ ] ?? Security fix
- [ ] ?? Documentation update
- [x] ? Tests (adding or improving test coverage)
- [ ] ?? Refactor (no behavior change)
- [ ] ?? New skill (bundled or hub)

## Changes Made

- Updated `agent/context_compressor.py` so the summary-model fallback retry calls `_generate_summary(turns_to_summarize, focus_topic=focus_topic)`.
- Added a regression test in `tests/agent/test_context_compressor.py` covering a missing summary model (404) and verifying that:
  - the first attempt uses `summary_model`
  - the retry falls back to the main model
  - the retry prompt still contains the original `focus_topic`

## How to Test

1. Run `scripts/run_tests.sh tests/agent/test_context_compressor.py tests/agent/test_compress_focus.py`
2. Confirm the full target set passes.
3. Inspect `agent/context_compressor.py` and verify the fallback retry preserves `focus_topic` when `summary_model` is unavailable.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 + WSL (Ubuntu, Python 3.11.15)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A

## Screenshots / Logs

```text
scripts/run_tests.sh tests/agent/test_context_compressor.py tests/agent/test_compress_focus.py
53 passed in 3.04s
```