### PR TITLE
fix(cli): disable CPR queries to prevent escape sequence leak over SSH/tunnels

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1083,6 +1083,13 @@ def convert_messages_to_anthropic(
                     "name": fn.get("name", ""),
                     "input": parsed_args,
                 })
+            # Kimi's /coding endpoint (Anthropic protocol) requires assistant
+            # tool-call messages to carry reasoning_content when thinking is
+            # enabled.  Preserve it as a thinking block so Kimi can validate
+            # the message history.  See hermes-agent#13848.
+            reasoning_content = m.get("reasoning_content")
+            if reasoning_content and isinstance(reasoning_content, str):
+                blocks.append({"type": "thinking", "thinking": reasoning_content})
             # Anthropic rejects empty assistant content
             effective = blocks or content
             if not effective or effective == "":

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1263,13 +1263,21 @@ def _get_provider_chain() -> List[tuple]:
 def _is_payment_error(exc: Exception) -> bool:
     """Detect payment/credit/quota exhaustion errors.
 
-    Returns True for HTTP 402 (Payment Required) and for 429/other errors
-    whose message indicates billing exhaustion rather than rate limiting.
+    Returns True for HTTP 402 (Payment Required), HTTP 403 responses from
+    OpenRouter that indicate key/spend-limit exhaustion, and for 429/other
+    errors whose message indicates billing exhaustion rather than rate limiting.
     """
     status = getattr(exc, "status_code", None)
     if status == 402:
         return True
     err_lower = str(exc).lower()
+    # OpenRouter 403 key-limit / spend-limit errors are payment exhaustion
+    if status == 403:
+        if any(kw in err_lower for kw in (
+            "key limit", "spending limit", "spend limit",
+            "total limit", "credit limit", "quota exceeded",
+        )):
+            return True
     # OpenRouter and other providers include "credits" or "afford" in 402 bodies,
     # but sometimes wrap them in 429 or other codes.
     if status in (402, 429, None):

--- a/cli.py
+++ b/cli.py
@@ -10364,7 +10364,20 @@ class HermesCLI:
             'voice-status-recording': 'bg:#1a1a2e #FF4444 bold',
         }
         style = PTStyle.from_dict(self._build_tui_style_dict())
-        
+
+        # Disable CPR (Cursor Position Report) queries — prompt_toolkit sends
+        # \x1b[6n (Device Status Report) to detect cursor position, and the
+        # terminal replies with \x1b[row;colR. Over SSH/cloudflared tunnels
+        # these responses leak as raw text like "20;1R21;1R" and flood the
+        # display. Disabling CPR forces prompt_toolkit to use heuristic
+        # fallback instead, eliminating the leak with no visible side effects.
+        _cpr_disabled_output = None
+        try:
+            from prompt_toolkit.output.vt100 import Vt100_Output
+            _cpr_disabled_output = Vt100_Output.from_pty(sys.stdout, enable_cpr=False)
+        except Exception:
+            pass
+
         # Create the application
         app = Application(
             layout=layout,
@@ -10372,6 +10385,7 @@ class HermesCLI:
             style=style,
             full_screen=False,
             mouse_support=False,
+            output=_cpr_disabled_output,
             **({'cursor': _STEADY_CURSOR} if _STEADY_CURSOR is not None else {}),
         )
         self._app = app  # Store reference for clarify_callback

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -93,6 +93,7 @@ AUTHOR_MAP = {
     "nocoo@users.noreply.github.com": "nocoo",
     "30841158+n-WN@users.noreply.github.com": "n-WN",
     "tsuijinglei@gmail.com": "hiddenpuppy",
+    "jerome@clawwork.ai": "HiddenPuppy",
     "leoyuan0099@gmail.com": "keyuyuan",
     "bxzt2006@163.com": "Only-Code-A",
     "i@troy-y.org": "TroyMitchell911",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -92,6 +92,7 @@ AUTHOR_MAP = {
     "135070653+sgaofen@users.noreply.github.com": "sgaofen",
     "nocoo@users.noreply.github.com": "nocoo",
     "30841158+n-WN@users.noreply.github.com": "n-WN",
+    "tsuijinglei@gmail.com": "hiddenpuppy",
     "leoyuan0099@gmail.com": "keyuyuan",
     "bxzt2006@163.com": "Only-Code-A",
     "i@troy-y.org": "TroyMitchell911",


### PR DESCRIPTION
## Summary

Fixes #13870

## Problem

CPR (Cursor Position Report) responses leak as raw text into the CLI prompt line. Character strings like `20;1R21;1R23;1R24;1R25;1RR1;1R` appear in the prompt, and the CLI may freeze after the agent's final answer.

This happens after `hermes update` on v0.10.0 (2026.4.16).

## Root Cause

prompt_toolkit sends `\x1b[6n` (Device Status Report) escape sequences to query the current cursor position. The terminal replies with `\x1b[row;colR`. Over SSH + cloudflared tunnels, these CPR responses sometimes leak as raw text into the terminal display. This also causes perceived lag because the terminal is processing escape sequences instead of content.

## Fix

Before constructing the `prompt_toolkit.Application`, create a `Vt100_Output` with `enable_cpr=False` and pass it to the Application. This tells prompt_toolkit to skip sending cursor position queries entirely — it uses a heuristic fallback instead.

The UI behavior is identical; the only difference is no `\x1b[6n` queries get sent, so no CPR responses can leak.

## Changes

- `cli.py`: `HermesCLI` — added CPR-disabled Vt100_Output before Application construction

## Verification

- [ ] Run `hermes` interactively over SSH/tunnel — confirm no `20;1R` garbage appears
- [ ] Confirm CLI does not freeze after agent's final answer

## Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Requires documentation update