### PR TITLE
fix(telegram): preserve busy-session queue payloads

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1713,6 +1713,7 @@ class BasePlatformAdapter(ABC):
                     self.name, cmd, session_key,
                 )
                 try:
+                    setattr(event, "_busy_session_bypass", True)
                     _thread_meta = {"thread_id": event.source.thread_id} if event.source.thread_id else None
                     response = await self._message_handler(event)
                     if response:

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2375,6 +2375,26 @@ class TelegramAdapter(BasePlatformAdapter):
         event.text = self._clean_bot_trigger_text(event.text)
         self._enqueue_text_event(event)
     
+    def _should_batch_command_event(self, event: MessageEvent) -> bool:
+        """Return True when a slash command should wait for Telegram split follow-ups.
+
+        Telegram routes the first chunk of a long slash command through the COMMAND
+        handler, but any continuation chunks arrive as plain TEXT updates. If we
+        dispatch the first chunk immediately, later chunks can be misinterpreted as
+        a brand-new follow-up. Batch only commands whose semantics depend on
+        preserving long free-form arguments across Telegram's client-side splits.
+        """
+        cmd = event.get_command()
+        if not cmd:
+            return False
+        try:
+            from hermes_cli.commands import resolve_command as _resolve_gateway_command
+            _cmd_def = _resolve_gateway_command(cmd)
+        except Exception:
+            _cmd_def = None
+        canonical_cmd = _cmd_def.name if _cmd_def else cmd
+        return canonical_cmd in {"queue", "background", "btw", "plan"} and utf16_len(event.text or "") >= self._SPLIT_THRESHOLD
+
     async def _handle_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming command messages."""
         if not update.message or not update.message.text:
@@ -2383,6 +2403,9 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         
         event = self._build_message_event(update.message, MessageType.COMMAND, update_id=update.update_id)
+        if self._should_batch_command_event(event):
+            self._enqueue_text_event(event)
+            return
         await self.handle_message(event)
     
     async def _handle_location_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3222,7 +3222,10 @@ class GatewayRunner:
                 self._release_running_agent_state(_quick_key)
 
         _busy_session_bypass = bool(getattr(event, "_busy_session_bypass", False))
-        from hermes_cli.commands import resolve_command as _resolve_cmd_inner
+        from hermes_cli.commands import (
+            ACTIVE_SESSION_BYPASS_COMMANDS as _DEDICATED_HANDLERS,
+            resolve_command as _resolve_cmd_inner,
+        )
         _evt_cmd = event.get_command()
         _cmd_def_inner = _resolve_cmd_inner(_evt_cmd) if _evt_cmd else None
         _requires_busy_semantics = (

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3279,16 +3279,25 @@ class GatewayRunner:
             # /queue <prompt> — queue without interrupting
             if _cmd_def_inner and _cmd_def_inner.name == "queue":
                 queued_text = event.get_command_args().strip()
-                if not queued_text:
+                has_media = bool(getattr(event, "media_urls", None))
+                if not queued_text and not has_media:
                     return "Usage: /queue <prompt>"
                 adapter = self.adapters.get(source.platform)
                 if adapter:
                     queued_event = MessageEvent(
                         text=queued_text,
-                        message_type=MessageType.TEXT,
+                        message_type=event.message_type if has_media else MessageType.TEXT,
                         source=event.source,
+                        raw_message=event.raw_message,
                         message_id=event.message_id,
+                        media_urls=list(getattr(event, "media_urls", []) or []),
+                        media_types=list(getattr(event, "media_types", []) or []),
+                        reply_to_message_id=event.reply_to_message_id,
+                        reply_to_text=event.reply_to_text,
+                        auto_skill=event.auto_skill,
                         channel_prompt=event.channel_prompt,
+                        internal=event.internal,
+                        timestamp=event.timestamp,
                     )
                     adapter._pending_messages[_quick_key] = queued_event
                 return "Queued for the next turn."

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3221,15 +3221,21 @@ class GatewayRunner:
                 )
                 self._release_running_agent_state(_quick_key)
 
-        if _quick_key in self._running_agents:
+        _busy_session_bypass = bool(getattr(event, "_busy_session_bypass", False))
+        from hermes_cli.commands import resolve_command as _resolve_cmd_inner
+        _evt_cmd = event.get_command()
+        _cmd_def_inner = _resolve_cmd_inner(_evt_cmd) if _evt_cmd else None
+        _requires_busy_semantics = (
+            _busy_session_bypass
+            and _cmd_def_inner is not None
+            and _cmd_def_inner.name in ("queue", "model")
+        )
+
+        if _quick_key in self._running_agents or _requires_busy_semantics:
             if event.get_command() == "status":
                 return await self._handle_status_command(event)
 
             # Resolve the command once for all early-intercept checks below.
-            from hermes_cli.commands import (
-                ACTIVE_SESSION_BYPASS_COMMANDS as _DEDICATED_HANDLERS,
-                resolve_command as _resolve_cmd_inner,
-            )
             _evt_cmd = event.get_command()
             _cmd_def_inner = _resolve_cmd_inner(_evt_cmd) if _evt_cmd else None
 
@@ -3271,7 +3277,7 @@ class GatewayRunner:
                 return await self._handle_reset_command(event)
 
             # /queue <prompt> — queue without interrupting
-            if event.get_command() in ("queue", "q"):
+            if _cmd_def_inner and _cmd_def_inner.name == "queue":
                 queued_text = event.get_command_args().strip()
                 if not queued_text:
                     return "Usage: /queue <prompt>"

--- a/tests/gateway/test_base_topic_sessions.py
+++ b/tests/gateway/test_base_topic_sessions.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -61,6 +62,25 @@ def _make_event(chat_id: str, thread_id: str, message_id: str = "1") -> MessageE
     )
 
 
+def _make_gateway_runner(adapter: BasePlatformAdapter):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._busy_ack_ts = {}
+    runner._draining = False
+    runner._restart_requested = False
+    runner._update_prompt_pending = {}
+    runner._is_user_authorized = lambda _source: True
+    runner.hooks = SimpleNamespace(emit=AsyncMock())
+    runner.config = {}
+    runner.adapters = {adapter.platform: adapter}
+    runner._handle_message_with_agent = AsyncMock(return_value="SHOULD_NOT_RUN")
+    return runner
+
+
 class TestBasePlatformTopicSessions:
     @pytest.mark.asyncio
     async def test_handle_message_does_not_interrupt_different_topic(self, monkeypatch):
@@ -106,6 +126,218 @@ class TestBasePlatformTopicSessions:
 
         assert scheduled == []
         assert adapter.get_pending_message(build_session_key(pending_event.source)) == pending_event
+
+    @pytest.mark.asyncio
+    async def test_busy_queue_command_bypasses_active_session_guard(self):
+        adapter = DummyTelegramAdapter()
+        adapter._busy_session_handler = AsyncMock(return_value=True)
+        handled = []
+
+        async def handler(event):
+            handled.append(event.text)
+            return "Queued for the next turn."
+
+        adapter.set_message_handler(handler)
+
+        active_event = _make_event("-1001", "10")
+        adapter._active_sessions[build_session_key(active_event.source)] = asyncio.Event()
+
+        queue_event = MessageEvent(
+            text="/queue remember this",
+            source=active_event.source,
+            message_id="2",
+        )
+        await adapter.handle_message(queue_event)
+
+        assert handled == ["/queue remember this"]
+        adapter._busy_session_handler.assert_not_awaited()
+        assert adapter.sent == [
+            {
+                "chat_id": "-1001",
+                "content": "Queued for the next turn.",
+                "reply_to": "2",
+                "metadata": {"thread_id": "10"},
+            }
+        ]
+        assert adapter._pending_messages == {}
+        assert not adapter._active_sessions[build_session_key(active_event.source)].is_set()
+
+    @pytest.mark.asyncio
+    async def test_busy_queue_alias_bypasses_active_session_guard(self):
+        adapter = DummyTelegramAdapter()
+        adapter._busy_session_handler = AsyncMock(return_value=True)
+        handled = []
+
+        async def handler(event):
+            handled.append(event.text)
+            return "Queued via alias."
+
+        adapter.set_message_handler(handler)
+
+        active_event = _make_event("-1001", "10")
+        adapter._active_sessions[build_session_key(active_event.source)] = asyncio.Event()
+
+        queue_event = MessageEvent(
+            text="/q remember this too",
+            source=active_event.source,
+            message_id="3",
+        )
+        await adapter.handle_message(queue_event)
+
+        assert handled == ["/q remember this too"]
+        adapter._busy_session_handler.assert_not_awaited()
+        assert adapter.sent == [
+            {
+                "chat_id": "-1001",
+                "content": "Queued via alias.",
+                "reply_to": "3",
+                "metadata": {"thread_id": "10"},
+            }
+        ]
+        assert adapter._pending_messages == {}
+        assert not adapter._active_sessions[build_session_key(active_event.source)].is_set()
+
+    @pytest.mark.asyncio
+    async def test_busy_model_command_bypasses_active_session_guard(self):
+        adapter = DummyTelegramAdapter()
+        adapter._busy_session_handler = AsyncMock(return_value=True)
+        handled = []
+
+        async def handler(event):
+            handled.append(event.text)
+            return "Agent is running — wait or /stop first, then switch models."
+
+        adapter.set_message_handler(handler)
+
+        active_event = _make_event("-1001", "10")
+        adapter._active_sessions[build_session_key(active_event.source)] = asyncio.Event()
+
+        model_event = MessageEvent(
+            text="/model gpt-5",
+            source=active_event.source,
+            message_id="4",
+        )
+        await adapter.handle_message(model_event)
+
+        assert handled == ["/model gpt-5"]
+        adapter._busy_session_handler.assert_not_awaited()
+        assert adapter.sent == [
+            {
+                "chat_id": "-1001",
+                "content": "Agent is running — wait or /stop first, then switch models.",
+                "reply_to": "4",
+                "metadata": {"thread_id": "10"},
+            }
+        ]
+        assert adapter._pending_messages == {}
+        assert not adapter._active_sessions[build_session_key(active_event.source)].is_set()
+
+    @pytest.mark.asyncio
+    async def test_busy_queue_reaches_runner_busy_semantics_during_handoff(self):
+        adapter = DummyTelegramAdapter()
+        runner = _make_gateway_runner(adapter)
+        adapter.set_message_handler(runner._handle_message)
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-1001",
+            chat_type="group",
+            thread_id="10",
+            user_id="u1",
+            user_name="tester",
+        )
+        session_key = build_session_key(source)
+        adapter._active_sessions[session_key] = asyncio.Event()
+
+        queue_event = MessageEvent(
+            text="/queue remember this",
+            source=source,
+            message_id="5a",
+        )
+        await adapter.handle_message(queue_event)
+
+        runner._handle_message_with_agent.assert_not_awaited()
+        assert adapter.sent == [
+            {
+                "chat_id": "-1001",
+                "content": "Queued for the next turn.",
+                "reply_to": "5a",
+                "metadata": {"thread_id": "10"},
+            }
+        ]
+        assert session_key in adapter._pending_messages
+        assert adapter._pending_messages[session_key].text == "remember this"
+
+    @pytest.mark.asyncio
+    async def test_busy_queue_alias_reaches_runner_busy_semantics_during_handoff(self):
+        adapter = DummyTelegramAdapter()
+        runner = _make_gateway_runner(adapter)
+        adapter.set_message_handler(runner._handle_message)
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-1001",
+            chat_type="group",
+            thread_id="10",
+            user_id="u1",
+            user_name="tester",
+        )
+        session_key = build_session_key(source)
+        adapter._active_sessions[session_key] = asyncio.Event()
+
+        queue_event = MessageEvent(
+            text="/q remember this too",
+            source=source,
+            message_id="5",
+        )
+        await adapter.handle_message(queue_event)
+
+        runner._handle_message_with_agent.assert_not_awaited()
+        assert adapter.sent == [
+            {
+                "chat_id": "-1001",
+                "content": "Queued for the next turn.",
+                "reply_to": "5",
+                "metadata": {"thread_id": "10"},
+            }
+        ]
+        assert session_key in adapter._pending_messages
+        assert adapter._pending_messages[session_key].text == "remember this too"
+
+    @pytest.mark.asyncio
+    async def test_busy_model_reaches_runner_busy_semantics_during_handoff(self):
+        adapter = DummyTelegramAdapter()
+        runner = _make_gateway_runner(adapter)
+        adapter.set_message_handler(runner._handle_message)
+
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-1001",
+            chat_type="group",
+            thread_id="10",
+            user_id="u1",
+            user_name="tester",
+        )
+        session_key = build_session_key(source)
+        adapter._active_sessions[session_key] = asyncio.Event()
+
+        model_event = MessageEvent(
+            text="/model gpt-5",
+            source=source,
+            message_id="6",
+        )
+        await adapter.handle_message(model_event)
+
+        runner._handle_message_with_agent.assert_not_awaited()
+        assert adapter.sent == [
+            {
+                "chat_id": "-1001",
+                "content": "Agent is running — wait or /stop first, then switch models.",
+                "reply_to": "6",
+                "metadata": {"thread_id": "10"},
+            }
+        ]
+        assert adapter._pending_messages == {}
 
     @pytest.mark.asyncio
     async def test_process_message_background_replies_in_same_topic(self):

--- a/tests/gateway/test_busy_session_bypass_race.py
+++ b/tests/gateway/test_busy_session_bypass_race.py
@@ -1,0 +1,83 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource, build_session_key
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        user_name="tester",
+        chat_id="c1",
+        chat_type="dm",
+    )
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=_make_source(),
+        message_id="m1",
+    )
+
+
+def _make_runner_and_adapter():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._busy_ack_ts = {}
+    runner._draining = False
+    runner._restart_requested = False
+    runner._update_prompt_pending = {}
+    runner._is_user_authorized = lambda _source: True
+    runner.hooks = SimpleNamespace(emit=AsyncMock())
+    runner.config = {}
+
+    adapter = MagicMock()
+    adapter._pending_messages = {}
+    adapter._active_sessions = {}
+    runner.adapters = {Platform.TELEGRAM: adapter}
+
+    runner._handle_message_with_agent = AsyncMock(return_value="SHOULD_NOT_RUN")
+    return runner, adapter
+
+
+@pytest.mark.asyncio
+async def test_busy_bypass_queue_uses_busy_semantics_without_running_agent():
+    runner, adapter = _make_runner_and_adapter()
+    event = _make_event("/queue remember this")
+    session_key = build_session_key(event.source)
+    adapter._active_sessions[session_key] = asyncio.Event()
+    setattr(event, "_busy_session_bypass", True)
+
+    result = await runner._handle_message(event)
+
+    assert result == "Queued for the next turn."
+    runner._handle_message_with_agent.assert_not_awaited()
+    assert session_key in adapter._pending_messages
+    assert adapter._pending_messages[session_key].text == "remember this"
+
+
+@pytest.mark.asyncio
+async def test_busy_bypass_model_rejects_without_running_agent():
+    runner, adapter = _make_runner_and_adapter()
+    event = _make_event("/model gpt-5")
+    session_key = build_session_key(event.source)
+    adapter._active_sessions[session_key] = asyncio.Event()
+    setattr(event, "_busy_session_bypass", True)
+
+    result = await runner._handle_message(event)
+
+    assert result == "Agent is running — wait or /stop first, then switch models."
+    runner._handle_message_with_agent.assert_not_awaited()
+    assert adapter._pending_messages == {}

--- a/tests/gateway/test_busy_session_bypass_race.py
+++ b/tests/gateway/test_busy_session_bypass_race.py
@@ -69,6 +69,58 @@ async def test_busy_bypass_queue_uses_busy_semantics_without_running_agent():
 
 
 @pytest.mark.asyncio
+async def test_busy_bypass_queue_preserves_photo_media_without_running_agent():
+    runner, adapter = _make_runner_and_adapter()
+    event = MessageEvent(
+        text="/queue look at this image",
+        message_type=MessageType.PHOTO,
+        source=_make_source(),
+        message_id="m-photo",
+        media_urls=["/tmp/photo-a.jpg"],
+        media_types=["image/jpeg"],
+    )
+    session_key = build_session_key(event.source)
+    adapter._active_sessions[session_key] = asyncio.Event()
+    setattr(event, "_busy_session_bypass", True)
+
+    result = await runner._handle_message(event)
+
+    assert result == "Queued for the next turn."
+    queued = adapter._pending_messages[session_key]
+    assert queued.text == "look at this image"
+    assert queued.message_type == MessageType.PHOTO
+    assert queued.media_urls == ["/tmp/photo-a.jpg"]
+    assert queued.media_types == ["image/jpeg"]
+    runner._handle_message_with_agent.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_busy_bypass_queue_allows_media_without_prompt_text():
+    runner, adapter = _make_runner_and_adapter()
+    event = MessageEvent(
+        text="/queue",
+        message_type=MessageType.DOCUMENT,
+        source=_make_source(),
+        message_id="m-doc",
+        media_urls=["/tmp/file.pdf"],
+        media_types=["application/pdf"],
+    )
+    session_key = build_session_key(event.source)
+    adapter._active_sessions[session_key] = asyncio.Event()
+    setattr(event, "_busy_session_bypass", True)
+
+    result = await runner._handle_message(event)
+
+    assert result == "Queued for the next turn."
+    queued = adapter._pending_messages[session_key]
+    assert queued.text == ""
+    assert queued.message_type == MessageType.DOCUMENT
+    assert queued.media_urls == ["/tmp/file.pdf"]
+    assert queued.media_types == ["application/pdf"]
+    runner._handle_message_with_agent.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_busy_bypass_model_rejects_without_running_agent():
     runner, adapter = _make_runner_and_adapter()
     event = _make_event("/model gpt-5")

--- a/tests/gateway/test_telegram_text_batching.py
+++ b/tests/gateway/test_telegram_text_batching.py
@@ -6,6 +6,7 @@ from the same session and aggregate them before dispatching.
 """
 
 import asyncio
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -25,9 +26,12 @@ def _make_adapter():
     adapter._pending_text_batches = {}
     adapter._pending_text_batch_tasks = {}
     adapter._text_batch_delay_seconds = 0.1  # fast for tests
+    adapter._text_batch_split_delay_seconds = 0.3  # fast for split-message tests
     adapter._active_sessions = {}
     adapter._pending_messages = {}
     adapter._message_handler = AsyncMock()
+    adapter._should_process_message = MagicMock(return_value=True)
+    adapter._bot = None
     adapter.handle_message = AsyncMock()
     return adapter
 
@@ -108,6 +112,46 @@ class TestTextBatching:
         await asyncio.sleep(0.2)
 
         assert adapter.handle_message.call_count == 2
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("command_name", "continuation_text"),
+        [
+            ("queue", "and this is the queued continuation chunk"),
+            ("background", "and this is the background continuation chunk"),
+            ("btw", "and this is the btw continuation chunk"),
+            ("plan", "and this is the plan continuation chunk"),
+        ],
+    )
+    async def test_long_command_split_is_aggregated_before_dispatch(self, command_name, continuation_text):
+        """Long slash commands with free-form args should wait for TEXT continuations."""
+        adapter = _make_adapter()
+        long_command = f"/{command_name} " + ("A" * 4010)
+        command_event = MessageEvent(
+            text=long_command,
+            message_type=MessageType.COMMAND,
+            source=SessionSource(platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm"),
+        )
+        continuation_event = _make_event(continuation_text)
+
+        command_update = SimpleNamespace(update_id=1, message=SimpleNamespace(text=long_command))
+        text_update = SimpleNamespace(update_id=2, message=SimpleNamespace(text=continuation_event.text))
+        adapter._build_message_event = MagicMock(side_effect=[command_event, continuation_event])
+
+        await adapter._handle_command(command_update, None)
+        adapter.handle_message.assert_not_called()
+
+        await asyncio.sleep(0.05)
+        await adapter._handle_text_message(text_update, None)
+        adapter.handle_message.assert_not_called()
+
+        await asyncio.sleep(0.35)
+
+        adapter.handle_message.assert_called_once()
+        dispatched = adapter.handle_message.call_args[0][0]
+        assert dispatched.message_type == MessageType.COMMAND
+        assert dispatched.text.startswith(f"/{command_name} ")
+        assert continuation_text in dispatched.text
 
     @pytest.mark.asyncio
     async def test_batch_cleans_up_after_flush(self):


### PR DESCRIPTION
## Summary
- preserve `/queue` media/reply metadata when a busy session queues the next turn
- batch long Telegram slash commands (`/queue`, `/background`, `/btw`, `/plan`) so split follow-up chunks stay attached to the original command
- route busy-session bypass handling through canonical command resolution and restore dedicated active-session bypass imports

## Why
Telegram can split long slash-command messages client-side. The first chunk arrives as a command update, but continuation chunks arrive as plain text. Without batching and canonical busy-session handling, queued prompts could lose media payloads or treat continuation chunks as a brand-new follow-up.

## Validation run locally
Local test runs used the repo's declared dev test stack from `pyproject.toml` (`pytest`, `pytest-asyncio`, `pytest-xdist`) via:
- Python: `/home/yangp/.hermes/hermes-agent/venv/bin/python3`
- Pytest: `/home/yangp/.hermes/hermes-agent/venv/lib/python3.11/site-packages/pytest` (`9.0.3`)

### PR-focused regression coverage
- `python3 -m pytest tests/gateway/test_busy_session_bypass_race.py tests/gateway/test_telegram_text_batching.py tests/gateway/test_base_topic_sessions.py -v`
  - Result: `26 passed`
- `python3 -m pytest tests/gateway/test_session_race_guard.py tests/gateway/test_busy_session_bypass_race.py tests/gateway/test_telegram_text_batching.py tests/gateway/test_base_topic_sessions.py -q`
  - Result: `42 passed`
- `python3 -m pytest tests/gateway/test_discord_send.py tests/gateway/test_send_image_file.py -q`
  - Result: `38 passed`

### Full suite context
- `python3 -m pytest tests/ -v`
  - Result in this WSL2/Linux environment after the regression fix: `14074 passed, 75 failed, 35 skipped`
  - Several remaining failures reproduce on `upstream/main` in the same environment and do not appear unique to this PR, including failures in `tests/tools/test_voice_mode.py`, `tests/tools/test_browser_camofox.py`, `tests/tools/test_write_deny.py`, `tests/tools/test_zombie_process_cleanup.py`, `tests/gateway/test_agent_cache.py`, `tests/run_agent/test_real_interrupt_subagent.py`, and parts of `tests/gateway/test_approve_deny_commands.py`.

## Platforms tested
- Linux (WSL2, Python 3.11)
