### PR TITLE
fix(web): deep-merge config on PUT /api/config to preserve unrelated sections

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1083,6 +1083,13 @@ def convert_messages_to_anthropic(
                     "name": fn.get("name", ""),
                     "input": parsed_args,
                 })
+            # Kimi's /coding endpoint (Anthropic protocol) requires assistant
+            # tool-call messages to carry reasoning_content when thinking is
+            # enabled.  Preserve it as a thinking block so Kimi can validate
+            # the message history.  See hermes-agent#13848.
+            reasoning_content = m.get("reasoning_content")
+            if reasoning_content and isinstance(reasoning_content, str):
+                blocks.append({"type": "thinking", "thinking": reasoning_content})
             # Anthropic rejects empty assistant content
             effective = blocks or content
             if not effective or effective == "":

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1263,13 +1263,21 @@ def _get_provider_chain() -> List[tuple]:
 def _is_payment_error(exc: Exception) -> bool:
     """Detect payment/credit/quota exhaustion errors.
 
-    Returns True for HTTP 402 (Payment Required) and for 429/other errors
-    whose message indicates billing exhaustion rather than rate limiting.
+    Returns True for HTTP 402 (Payment Required), HTTP 403 responses from
+    OpenRouter that indicate key/spend-limit exhaustion, and for 429/other
+    errors whose message indicates billing exhaustion rather than rate limiting.
     """
     status = getattr(exc, "status_code", None)
     if status == 402:
         return True
     err_lower = str(exc).lower()
+    # OpenRouter 403 key-limit / spend-limit errors are payment exhaustion
+    if status == 403:
+        if any(kw in err_lower for kw in (
+            "key limit", "spending limit", "spend limit",
+            "total limit", "credit limit", "quota exceeded",
+        )):
+            return True
     # OpenRouter and other providers include "credits" or "afford" in 402 bodies,
     # but sometimes wrap them in 429 or other codes.
     if status in (402, 429, None):

--- a/cli.py
+++ b/cli.py
@@ -10364,7 +10364,20 @@ class HermesCLI:
             'voice-status-recording': 'bg:#1a1a2e #FF4444 bold',
         }
         style = PTStyle.from_dict(self._build_tui_style_dict())
-        
+
+        # Disable CPR (Cursor Position Report) queries — prompt_toolkit sends
+        # \x1b[6n (Device Status Report) to detect cursor position, and the
+        # terminal replies with \x1b[row;colR. Over SSH/cloudflared tunnels
+        # these responses leak as raw text like "20;1R21;1R" and flood the
+        # display. Disabling CPR forces prompt_toolkit to use heuristic
+        # fallback instead, eliminating the leak with no visible side effects.
+        _cpr_disabled_output = None
+        try:
+            from prompt_toolkit.output.vt100 import Vt100_Output
+            _cpr_disabled_output = Vt100_Output.from_pty(sys.stdout, enable_cpr=False)
+        except Exception:
+            pass
+
         # Create the application
         app = Application(
             layout=layout,
@@ -10372,6 +10385,7 @@ class HermesCLI:
             style=style,
             full_screen=False,
             mouse_support=False,
+            output=_cpr_disabled_output,
             **({'cursor': _STEADY_CURSOR} if _STEADY_CURSOR is not None else {}),
         )
         self._app = app  # Store reference for clarify_callback

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3091,6 +3091,23 @@ _COMMENTED_SECTIONS = """
 """
 
 
+def merge_and_save_config(partial: Dict[str, Any]) -> None:
+    """Deep-merge a partial config into the on-disk config and save.
+
+    Reads the raw on-disk config (without merging defaults or expanding env
+    vars), applies *partial* on top via ``_deep_merge``, then saves the
+    result.  Keys in *partial* overwrite existing values; keys absent from
+    *partial* are preserved.
+
+    This is the safe entry point for web UI / API callers that only manage
+    a subset of config sections (e.g. agent, display) and must not destroy
+    unrelated sections (model, fallback_model, auxiliary, etc.).
+    """
+    existing = read_raw_config()
+    merged = _deep_merge(existing, partial)
+    save_config(merged)
+
+
 def save_config(config: Dict[str, Any]):
     """Save configuration to ~/.hermes/config.yaml."""
     if is_managed():

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -45,6 +45,7 @@ from hermes_cli.config import (
     remove_env_value,
     check_config_version,
     redact_key,
+    _deep_merge,
 )
 from gateway.status import get_running_pid, read_runtime_status
 
@@ -941,7 +942,10 @@ def _denormalize_config_from_web(config: Dict[str, Any]) -> Dict[str, Any]:
 @app.put("/api/config")
 async def update_config(body: ConfigUpdate):
     try:
-        save_config(_denormalize_config_from_web(body.config))
+        existing = load_config()
+        incoming = _denormalize_config_from_web(body.config)
+        merged = _deep_merge(existing, incoming)
+        save_config(merged)
         return {"ok": True}
     except Exception as e:
         _log.exception("PUT /api/config failed")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -45,7 +45,8 @@ from hermes_cli.config import (
     remove_env_value,
     check_config_version,
     redact_key,
-    _deep_merge,
+    merge_and_save_config,
+    read_raw_config,
 )
 from gateway.status import get_running_pid, read_runtime_status
 
@@ -942,10 +943,8 @@ def _denormalize_config_from_web(config: Dict[str, Any]) -> Dict[str, Any]:
 @app.put("/api/config")
 async def update_config(body: ConfigUpdate):
     try:
-        existing = load_config()
         incoming = _denormalize_config_from_web(body.config)
-        merged = _deep_merge(existing, incoming)
-        save_config(merged)
+        merge_and_save_config(incoming)
         return {"ok": True}
     except Exception as e:
         _log.exception("PUT /api/config failed")

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -93,6 +93,7 @@ AUTHOR_MAP = {
     "nocoo@users.noreply.github.com": "nocoo",
     "30841158+n-WN@users.noreply.github.com": "n-WN",
     "tsuijinglei@gmail.com": "hiddenpuppy",
+    "jerome@clawwork.ai": "HiddenPuppy",
     "leoyuan0099@gmail.com": "keyuyuan",
     "bxzt2006@163.com": "Only-Code-A",
     "i@troy-y.org": "TroyMitchell911",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -92,6 +92,7 @@ AUTHOR_MAP = {
     "135070653+sgaofen@users.noreply.github.com": "sgaofen",
     "nocoo@users.noreply.github.com": "nocoo",
     "30841158+n-WN@users.noreply.github.com": "n-WN",
+    "tsuijinglei@gmail.com": "hiddenpuppy",
     "leoyuan0099@gmail.com": "keyuyuan",
     "bxzt2006@163.com": "Only-Code-A",
     "i@troy-y.org": "TroyMitchell911",


### PR DESCRIPTION
## Summary

Fixes #13396

## Problem

PUT `/api/config` replaces the entire `~/.hermes/config.yaml` file with the provided payload. If a dashboard UI sends only the sections it manages (e.g. `agent`, `display`), everything else (`model`, `custom_providers`, `compression`, `auxiliary`, `fallback_model`, etc.) is silently deleted.

## Impact

- Third-party dashboards (e.g. outsourc-e/hermes-workspace Settings screen) silently destroy user-managed fields they don't know about
- Users have to re-edit config.yaml from memory
- Happens invisibly — no warning, no backup before the overwrite

## Fix

In `update_config()`, load the existing config first, deep-merge the incoming payload into it, then save the merged result. Keys present in the payload overwrite existing values; keys absent from the payload are preserved.

The `_deep_merge` function already exists in `hermes_cli/config.py` and is used elsewhere for the same purpose.

## Changes

- `hermes_cli/web_server.py`: `update_config()` — added `load_config()` + `_deep_merge()` before `save_config()`

## Verification

- [ ] `curl -X PUT /api/config` with partial payload → inspect config.yaml → unrelated sections preserved
- [ ] Keys in payload correctly overwrite existing values

## Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Requires documentation update