### PR TITLE
feat(discord): add opt-in smart auto-retitling for threads

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -61,6 +61,7 @@ def auto_title_session(
     session_id: str,
     user_message: str,
     assistant_response: str,
+    on_title=None,
 ) -> None:
     """Generate and set a session title if one doesn't already exist.
 
@@ -88,6 +89,11 @@ def auto_title_session(
     try:
         session_db.set_session_title(session_id, title)
         logger.debug("Auto-generated session title: %s", title)
+        if on_title:
+            try:
+                on_title(title)
+            except Exception as e:
+                logger.debug("Auto-title callback failed: %s", e)
     except Exception as e:
         logger.debug("Failed to set auto-generated title: %s", e)
 
@@ -98,6 +104,7 @@ def maybe_auto_title(
     user_message: str,
     assistant_response: str,
     conversation_history: list,
+    on_title=None,
 ) -> None:
     """Fire-and-forget title generation after the first exchange.
 
@@ -118,7 +125,7 @@ def maybe_auto_title(
 
     thread = threading.Thread(
         target=auto_title_session,
-        args=(session_db, session_id, user_message, assistant_response),
+        args=(session_db, session_id, user_message, assistant_response, on_title),
         daemon=True,
         name="auto-title",
     )

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -574,6 +574,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["require_mention"] = platform_cfg["require_mention"]
                 if "free_response_channels" in platform_cfg:
                     bridged["free_response_channels"] = platform_cfg["free_response_channels"]
+                if "smart_thread_titles" in platform_cfg:
+                    bridged["smart_thread_titles"] = platform_cfg["smart_thread_titles"]
                 if "mention_patterns" in platform_cfg:
                     bridged["mention_patterns"] = platform_cfg["mention_patterns"]
                 if "dm_policy" in platform_cfg:
@@ -627,6 +629,8 @@ def load_gateway_config() -> GatewayConfig:
                     if isinstance(frc, list):
                         frc = ",".join(str(v) for v in frc)
                     os.environ["DISCORD_FREE_RESPONSE_CHANNELS"] = str(frc)
+                if "smart_thread_titles" in discord_cfg and not os.getenv("DISCORD_SMART_THREAD_TITLES"):
+                    os.environ["DISCORD_SMART_THREAD_TITLES"] = str(discord_cfg["smart_thread_titles"]).lower()
                 if "auto_thread" in discord_cfg and not os.getenv("DISCORD_AUTO_THREAD"):
                     os.environ["DISCORD_AUTO_THREAD"] = str(discord_cfg["auto_thread"]).lower()
                 if "reactions" in discord_cfg and not os.getenv("DISCORD_REACTIONS"):

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -2497,6 +2497,17 @@ class DiscordAdapter(BasePlatformAdapter):
             return {part.strip() for part in raw.split(",") if part.strip()}
         return set()
 
+    def smart_thread_titles_enabled(self) -> bool:
+        """Return whether Discord auto-thread titles should be summarized/retitled."""
+        configured = self.config.extra.get("smart_thread_titles")
+        if configured is not None:
+            if isinstance(configured, str):
+                return configured.lower() not in ("false", "0", "no", "off")
+            return bool(configured)
+        return os.getenv("DISCORD_SMART_THREAD_TITLES", "false").lower() not in (
+            "false", "0", "no", "off"
+        )
+
     def _thread_parent_channel(self, channel: Any) -> Any:
         """Return the parent text channel when invoked from a thread."""
         return getattr(channel, "parent", None) or channel
@@ -2594,23 +2605,126 @@ class DiscordAdapter(BasePlatformAdapter):
     # Auto-thread helpers
     # ------------------------------------------------------------------
 
-    async def _auto_create_thread(self, message: 'DiscordMessage') -> Optional[Any]:
-        """Create a thread from a user message for auto-threading.
+    async def rename_thread_title(self, thread_id: str, title: str) -> bool:
+        """Rename a Discord thread to *title*.
 
-        Returns the created thread object, or ``None`` on failure.
+        Used by post-first-exchange auto-titling so the visible thread name can
+        catch up with the smarter session title.
         """
-        # Build a short thread name from the message. Strip Discord mention
-        # syntax (users / roles / channels) so thread titles don't end up
-        # showing raw <@id>, <@&id>, or <#id> markers — the ID isn't
-        # meaningful to humans glancing at the thread list (#6336).
-        content = (message.content or "").strip()
-        # <@123>, <@!123>, <@&123>, <#123> — collapse to empty; normalize spaces.
+        if not self._client or not thread_id or not title:
+            return False
+
+        try:
+            channel = self._client.get_channel(int(thread_id))
+            if not channel:
+                channel = await self._client.fetch_channel(int(thread_id))
+            if not channel or not hasattr(channel, "edit"):
+                return False
+
+            clean_title = (title or "").strip()
+            if len(clean_title) > 100:
+                clean_title = clean_title[:97].rstrip() + "..."
+            if not clean_title:
+                return False
+
+            await channel.edit(name=clean_title)
+            return True
+        except Exception as e:
+            logger.debug("[%s] Failed to rename Discord thread %s: %s", self.name, thread_id, e)
+            return False
+
+    def _build_plain_auto_thread_name(self, message_content: str) -> str:
+        """Build the legacy thread title from the raw user message."""
+        content = (message_content or "").strip()
         content = re.sub(r"<@[!&]?\d+>", "", content)
         content = re.sub(r"<#\d+>", "", content)
         content = re.sub(r"\s+", " ", content).strip()
         thread_name = content[:80] if content else "Hermes"
         if len(content) > 80:
             thread_name = thread_name[:77] + "..."
+        return thread_name
+
+    def _build_auto_thread_name(self, message_content: str) -> str:
+        """Build a cleaner thread title from the first user message.
+
+        Raw first-message slices are noisy as hell: mention syntax, polite
+        wrappers, URLs, and long rambly clauses make terrible thread names.
+        This helper tries to keep the useful subject while staying fully
+        deterministic and cheap.
+        """
+
+        content = (message_content or "").strip()
+
+        # Strip Discord mention syntax and raw links.
+        content = re.sub(r"<@[!&]?\d+>", " ", content)
+        content = re.sub(r"<#\d+>", " ", content)
+        content = re.sub(r"https?://\S+", " ", content)
+
+        # Collapse markdown-ish noise without getting fancy.
+        content = content.replace("```", " ").replace("`", " ")
+        content = re.sub(r"\*\*(.*?)\*\*", r"\1", content)
+        content = re.sub(r"\*(.*?)\*", r"\1", content)
+        content = re.sub(r"\[(.*?)\]\((.*?)\)", r"\1", content)
+        content = re.sub(r"\s+", " ", content).strip(" -—:;,.!?\n\t")
+
+        if not content:
+            return "Hermes"
+
+        def _strip_prefixes(text: str) -> str:
+            patterns = [
+                r"^(?:hey|hi|hello|yo)\b[\s,!:.-]*",
+                r"^(?:please\s+)+",
+                r"^(?:can|could|would|will)\s+you\s+",
+                r"^(?:help\s+me\s+(?:with\s+)?)",
+                r"^(?:i\s+need\s+help\s+(?:with\s+)?)",
+                r"^(?:i\s+want\s+(?:you|hermes)\s+to\s+(?:help\s+me\s+)?)",
+                r"^(?:make\s+(?:yourself|this|it)\s+)",
+                r"^(?:what(?:'s| is)\s+(?:the\s+)?(?:next\s+step|best\s+way|right\s+way)\s+(?:for|to)\s+)",
+                r"^(?:how\s+do\s+i\s+)",
+            ]
+            out = text.strip()
+            changed = True
+            while changed and out:
+                changed = False
+                for pattern in patterns:
+                    new_out = re.sub(pattern, "", out, flags=re.IGNORECASE).strip()
+                    if new_out and new_out != out:
+                        out = new_out
+                        changed = True
+            return out
+
+        clauses = [c.strip(" -—:;,.!?\n\t") for c in re.split(r"[\n\r]+|(?<=[?.!])\s+|\s+[—–-]\s+", content) if c.strip()]
+        candidate = clauses[0] if clauses else content
+
+        for clause in clauses:
+            stripped = _strip_prefixes(clause)
+            if len(re.sub(r"[^A-Za-z0-9]", "", stripped)) >= 4:
+                candidate = stripped
+                break
+
+        candidate = _strip_prefixes(candidate)
+        candidate = re.sub(r"\byourself\b", "", candidate, flags=re.IGNORECASE)
+        candidate = re.sub(r"\byou\b", "Hermes", candidate, flags=re.IGNORECASE)
+        candidate = re.sub(r"\s+", " ", candidate).strip(" -—:;,.!?\n\t")
+
+        if not candidate:
+            return "Hermes"
+
+        candidate = candidate[:80].rstrip()
+        if len(candidate) > 77:
+            candidate = candidate[:77].rstrip() + "..."
+
+        return candidate[:1].upper() + candidate[1:] if candidate else "Hermes"
+
+    async def _auto_create_thread(self, message: 'DiscordMessage') -> Optional[Any]:
+        """Create a thread from a user message for auto-threading.
+
+        Returns the created thread object, or ``None`` on failure.
+        """
+        if self.smart_thread_titles_enabled():
+            thread_name = self._build_auto_thread_name(getattr(message, "content", ""))
+        else:
+            thread_name = self._build_plain_auto_thread_name(getattr(message, "content", ""))
 
         try:
             thread = await message.create_thread(name=thread_name, auto_archive_duration=1440)
@@ -2951,6 +3065,7 @@ class DiscordAdapter(BasePlatformAdapter):
         #   discord.allowed_channels: If set, bot ONLY responds in these channels (whitelist)
         #   discord.no_thread_channels: Channel IDs where bot responds directly without creating thread
         #   discord.auto_thread: Auto-create thread on @mention in channels (default: true)
+        #   discord.smart_thread_titles: Summarize and auto-retitle Discord threads (default: false)
 
         thread_id = None
         parent_channel_id = None
@@ -3003,8 +3118,8 @@ class DiscordAdapter(BasePlatformAdapter):
             is_voice_linked_channel = current_channel_id in voice_linked_ids
             is_free_channel = bool(channel_ids & free_channels) or is_voice_linked_channel
 
-            # Skip the mention check if the message is in a thread where
-            # the bot has previously participated (auto-created or replied in).
+            # Skip the mention check only when the message is in a thread where
+            # the bot has previously participated.
             in_bot_thread = is_thread and thread_id in self._threads
 
             if require_mention and not is_free_channel and not in_bot_thread:
@@ -3018,7 +3133,9 @@ class DiscordAdapter(BasePlatformAdapter):
         if not is_thread and not isinstance(message.channel, discord.DMChannel):
             no_thread_channels_raw = os.getenv("DISCORD_NO_THREAD_CHANNELS", "")
             no_thread_channels = {ch.strip() for ch in no_thread_channels_raw.split(",") if ch.strip()}
-            skip_thread = bool(channel_ids & no_thread_channels) or is_free_channel
+            # Free-response channels may still want per-message thread isolation.
+            # Only explicit no-thread channels should suppress auto-threading.
+            skip_thread = bool(channel_ids & no_thread_channels)
             auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in ("true", "1", "yes")
             is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
             if auto_thread and not skip_thread and not is_voice_linked_channel and not is_reply_message:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -297,6 +297,76 @@ from gateway.restart import (
 )
 
 
+def _build_thread_title_callback(adapter, source: SessionSource, loop):
+    """Return a callback that renames Discord threads after auto-titling.
+
+    The title generator runs in a background thread.  This bridges the title
+    back onto the asyncio loop safely so the adapter can rename the visible
+    Discord thread after the first exchange.
+    """
+    if (
+        not adapter
+        or not source
+        or source.platform != Platform.DISCORD
+        or source.chat_type != "thread"
+        or not source.thread_id
+        or not hasattr(adapter, "rename_thread_title")
+        or loop is None
+    ):
+        return None
+    if hasattr(adapter, "smart_thread_titles_enabled") and not adapter.smart_thread_titles_enabled():
+        return None
+
+    def _on_title(title: str) -> None:
+        if not title:
+            return
+        try:
+            asyncio.run_coroutine_threadsafe(
+                adapter.rename_thread_title(source.thread_id, title),
+                loop,
+            )
+        except Exception:
+            logger.debug("Failed to schedule Discord thread retitle", exc_info=True)
+
+    return _on_title
+
+
+def _maybe_auto_title_after_response(
+    session_db,
+    adapter,
+    source: SessionSource,
+    effective_session_id: str,
+    message: str,
+    final_response: str,
+    result_holder,
+    loop,
+) -> None:
+    """Kick off post-response auto-titling using a loop captured on the async side.
+
+    This helper is safe to call from the executor thread that runs the agent.
+    It must not call ``asyncio.get_running_loop()`` itself because worker
+    threads do not have one.
+    """
+    if not final_response or not session_db:
+        return
+
+    try:
+        from agent.title_generator import maybe_auto_title
+
+        all_msgs = result_holder[0].get("messages", []) if result_holder and result_holder[0] else []
+        title_callback = _build_thread_title_callback(adapter, source, loop)
+        maybe_auto_title(
+            session_db,
+            effective_session_id,
+            message,
+            final_response,
+            all_msgs,
+            on_title=title_callback,
+        )
+    except Exception:
+        logger.debug("Failed to start auto-title after response", exc_info=True)
+
+
 def _normalize_whatsapp_identifier(value: str) -> str:
     """Strip WhatsApp JID/LID syntax down to its stable numeric identifier."""
     return (
@@ -10080,20 +10150,21 @@ class GatewayRunner:
             # Reset to 0 so the gateway writes ALL compressed messages.
             _effective_history_offset = 0 if _session_was_split else len(agent_history)
 
-            # Auto-generate session title after first exchange (non-blocking)
-            if final_response and self._session_db:
-                try:
-                    from agent.title_generator import maybe_auto_title
-                    all_msgs = result_holder[0].get("messages", []) if result_holder[0] else []
-                    maybe_auto_title(
-                        self._session_db,
-                        effective_session_id,
-                        message,
-                        final_response,
-                        all_msgs,
-                    )
-                except Exception:
-                    pass
+            # Auto-generate session title after first exchange (non-blocking).
+            # This code runs inside run_sync on a worker thread, so it must use
+            # the event loop captured on the async side instead of calling
+            # asyncio.get_running_loop() here.
+            _adapter = self.adapters.get(source.platform)
+            _maybe_auto_title_after_response(
+                self._session_db,
+                _adapter,
+                source,
+                effective_session_id,
+                message,
+                final_response,
+                result_holder,
+                _loop_for_step,
+            )
 
             return {
                 "final_response": final_response,

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -105,6 +105,16 @@ class TestAutoTitleSession:
             auto_title_session(db, "sess-1", "hi", "hello")
             db.set_session_title.assert_called_once_with("sess-1", "New Title")
 
+    def test_calls_on_title_callback_after_setting_title(self):
+        db = MagicMock()
+        db.get_session_title.return_value = None
+        callback = MagicMock()
+
+        with patch("agent.title_generator.generate_title", return_value="New Title"):
+            auto_title_session(db, "sess-1", "hi", "hello", on_title=callback)
+
+        callback.assert_called_once_with("New Title")
+
     def test_skips_if_generation_fails(self):
         db = MagicMock()
         db.get_session_title.return_value = None
@@ -150,7 +160,21 @@ class TestMaybeAutoTitle:
             # Wait for the daemon thread to complete
             import time
             time.sleep(0.3)
-            mock_auto.assert_called_once_with(db, "sess-1", "hello", "hi there")
+            mock_auto.assert_called_once_with(db, "sess-1", "hello", "hi there", None)
+
+    def test_passes_on_title_callback_through(self):
+        db = MagicMock()
+        callback = MagicMock()
+        history = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi there"},
+        ]
+
+        with patch("agent.title_generator.auto_title_session") as mock_auto:
+            maybe_auto_title(db, "sess-1", "hello", "hi there", history, on_title=callback)
+            import time
+            time.sleep(0.3)
+            mock_auto.assert_called_once_with(db, "sess-1", "hello", "hi there", callback)
 
     def test_skips_if_no_response(self):
         db = MagicMock()

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -393,6 +393,34 @@ def test_build_slash_event_uses_group_context_for_channels(adapter):
 # ------------------------------------------------------------------
 # Auto-thread: _auto_create_thread
 # ------------------------------------------------------------------
+# Smart auto-thread titles
+# ------------------------------------------------------------------
+
+
+def test_build_auto_thread_name_summarizes_request(adapter):
+    name = adapter._build_auto_thread_name(
+        "Can you make yourself auto-retitle threads intelligently? Based on the first message, "
+        "give the thread a title that is a smart summary of its contents"
+    )
+
+    assert name == "Auto-retitle threads intelligently"
+
+
+def test_build_auto_thread_name_strips_polite_openers(adapter):
+    name = adapter._build_auto_thread_name(
+        "<@555> please help me debug Docker networking on WSL2"
+    )
+
+    assert name == "Debug Docker networking on WSL2"
+
+
+def test_build_auto_thread_name_strips_i_want_you_to_help_me_wrapper(adapter):
+    name = adapter._build_auto_thread_name(
+        "I want you to help me manage my todo list using Google Tasks. "
+        "Google Tasks will be the canonical task store that I use with you and OpenClaw together"
+    )
+
+    assert name == "Manage my todo list using Google Tasks"
 
 
 @pytest.mark.asyncio
@@ -412,6 +440,45 @@ async def test_auto_create_thread_uses_message_content_as_name(adapter):
     call_kwargs = message.create_thread.await_args[1]
     assert call_kwargs["name"] == "Hello world, how are you?"
     assert call_kwargs["auto_archive_duration"] == 1440
+
+
+@pytest.mark.asyncio
+async def test_auto_create_thread_uses_summarized_name_when_smart_titles_enabled(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_SMART_THREAD_TITLES", "true")
+    thread = SimpleNamespace(id=999, name="Hello world")
+    message = SimpleNamespace(
+        content=(
+            "Can you make yourself auto-retitle threads intelligently? Based on the first "
+            "message, give the thread a title that is a smart summary of its contents"
+        ),
+        create_thread=AsyncMock(return_value=thread),
+        channel=SimpleNamespace(send=AsyncMock()),
+        author=SimpleNamespace(display_name="Jezza"),
+    )
+
+    result = await adapter._auto_create_thread(message)
+
+    assert result is thread
+    call_kwargs = message.create_thread.await_args[1]
+    assert call_kwargs["name"] == "Auto-retitle threads intelligently"
+
+
+@pytest.mark.asyncio
+async def test_auto_create_thread_uses_plain_sanitized_name_when_smart_titles_disabled(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_SMART_THREAD_TITLES", "false")
+    thread = SimpleNamespace(id=999, name="Hello world")
+    message = SimpleNamespace(
+        content="<@555> please help me debug Docker networking on WSL2",
+        create_thread=AsyncMock(return_value=thread),
+        channel=SimpleNamespace(send=AsyncMock()),
+        author=SimpleNamespace(display_name="Jezza"),
+    )
+
+    result = await adapter._auto_create_thread(message)
+
+    assert result is thread
+    call_kwargs = message.create_thread.await_args[1]
+    assert call_kwargs["name"] == "please help me debug Docker networking on WSL2"
 
 
 @pytest.mark.asyncio
@@ -507,6 +574,18 @@ async def test_auto_create_thread_returns_none_when_direct_and_fallback_fail(ada
 
     result = await adapter._auto_create_thread(message)
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_rename_thread_title_edits_discord_thread(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_SMART_THREAD_TITLES", "true")
+    thread = SimpleNamespace(id=555, edit=AsyncMock())
+    adapter._client.get_channel = MagicMock(return_value=thread)
+
+    ok = await adapter.rename_thread_title("555", "Better Thread Title")
+
+    assert ok is True
+    thread.edit.assert_awaited_once_with(name="Better Thread Title")
 
 
 # ------------------------------------------------------------------
@@ -679,6 +758,29 @@ def test_discord_auto_thread_config_bridge(monkeypatch, tmp_path):
 
     import os
     assert os.getenv("DISCORD_AUTO_THREAD") == "true"
+
+
+def test_discord_smart_thread_titles_config_bridge(monkeypatch, tmp_path):
+    """discord.smart_thread_titles in config.yaml should be bridged to DISCORD_SMART_THREAD_TITLES."""
+    import yaml
+    from pathlib import Path
+
+    hermes_dir = tmp_path / ".hermes"
+    hermes_dir.mkdir()
+    config_path = hermes_dir / "config.yaml"
+    config_path.write_text(yaml.dump({
+        "discord": {"smart_thread_titles": True},
+    }))
+
+    monkeypatch.delenv("DISCORD_SMART_THREAD_TITLES", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_dir))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    from gateway.config import load_gateway_config
+    load_gateway_config()
+
+    import os
+    assert os.getenv("DISCORD_SMART_THREAD_TITLES") == "true"
 
 
 # ------------------------------------------------------------------

--- a/tests/gateway/test_thread_retitling.py
+++ b/tests/gateway/test_thread_retitling.py
@@ -1,0 +1,110 @@
+import asyncio
+import threading
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform
+from gateway.run import _build_thread_title_callback, _maybe_auto_title_after_response
+from gateway.session import SessionSource
+
+
+@pytest.mark.asyncio
+async def test_build_thread_title_callback_schedules_discord_thread_rename():
+    adapter = MagicMock()
+    adapter.rename_thread_title = AsyncMock(return_value=True)
+    adapter.smart_thread_titles_enabled = MagicMock(return_value=True)
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="123",
+        chat_type="thread",
+        thread_id="456",
+    )
+
+    callback = _build_thread_title_callback(adapter, source, asyncio.get_running_loop())
+    assert callback is not None
+
+    callback("Smart Thread Title")
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    adapter.rename_thread_title.assert_awaited_once_with("456", "Smart Thread Title")
+
+
+@pytest.mark.asyncio
+async def test_build_thread_title_callback_ignores_non_discord_threads():
+    adapter = MagicMock()
+    adapter.rename_thread_title = AsyncMock(return_value=True)
+    adapter.smart_thread_titles_enabled = MagicMock(return_value=True)
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type="group",
+        thread_id="456",
+    )
+
+    callback = _build_thread_title_callback(adapter, source, asyncio.get_running_loop())
+    assert callback is None
+
+
+@pytest.mark.asyncio
+async def test_build_thread_title_callback_respects_disabled_setting():
+    adapter = MagicMock()
+    adapter.rename_thread_title = AsyncMock(return_value=True)
+    adapter.smart_thread_titles_enabled = MagicMock(return_value=False)
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="123",
+        chat_type="thread",
+        thread_id="456",
+    )
+
+    callback = _build_thread_title_callback(adapter, source, asyncio.get_running_loop())
+    assert callback is None
+
+
+@pytest.mark.asyncio
+async def test_maybe_auto_title_after_response_uses_captured_loop_from_worker_thread():
+    adapter = MagicMock()
+    adapter.rename_thread_title = AsyncMock(return_value=True)
+    source = SessionSource(
+        platform=Platform.DISCORD,
+        chat_id="123",
+        chat_type="thread",
+        thread_id="456",
+    )
+    result_holder = [{"messages": [{"role": "user", "content": "hello"}]}]
+    session_db = MagicMock()
+    loop = asyncio.get_running_loop()
+
+    observed = {}
+
+    def fake_maybe_auto_title(db, session_id, user_message, assistant_response, all_msgs, on_title=None):
+        observed["db"] = db
+        observed["session_id"] = session_id
+        observed["user_message"] = user_message
+        observed["assistant_response"] = assistant_response
+        observed["all_msgs"] = all_msgs
+        observed["has_callback"] = on_title is not None
+        if on_title:
+            on_title("Smart Thread Title")
+
+    with patch("agent.title_generator.maybe_auto_title", side_effect=fake_maybe_auto_title):
+        worker = threading.Thread(
+            target=_maybe_auto_title_after_response,
+            args=(session_db, adapter, source, "sess-1", "hello", "hi there", result_holder, loop),
+        )
+        worker.start()
+        worker.join()
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    assert observed == {
+        "db": session_db,
+        "session_id": "sess-1",
+        "user_message": "hello",
+        "assistant_response": "hi there",
+        "all_msgs": [{"role": "user", "content": "hello"}],
+        "has_callback": True,
+    }
+    adapter.rename_thread_title.assert_awaited_once_with("456", "Smart Thread Title")


### PR DESCRIPTION
## Summary
- add an opt-in `discord.smart_thread_titles` / `DISCORD_SMART_THREAD_TITLES` setting
- generate smarter initial names for auto-created Discord threads when the setting is enabled
- retitle the visible Discord thread after the first exchange using the existing auto-generated session title
- preserve the legacy plain/sanitized thread naming path when the setting is disabled

## Why
Discord auto-threading is handy, but the default `message.content[:80]` style title is often noisy and ugly. This keeps the existing default behavior intact while giving users an explicit opt-in path for cleaner thread names and a better post-first-exchange title.

## Notes
- default is **off** to avoid surprising users who prefer deterministic first-message titles
- the retitle path only applies to Discord thread sessions and only when smart thread titles are enabled
- no broader Discord thread-join or mention-gating behavior is changed in this PR

## Test Plan
- [x] `python -m pytest tests/agent/test_title_generator.py tests/gateway/test_discord_slash_commands.py tests/gateway/test_thread_retitling.py -q -o 'addopts='`