### PR TITLE
fix(docker): exclude runtime data/ from build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,3 +14,6 @@ node_modules
 .env
 
 *.md
+
+# Runtime data (bind-mounted at /opt/data; must not leak into build context)
+data/


### PR DESCRIPTION
## What does this PR do?

Adds `data/` to `.dockerignore` so runtime state written under the bind-mounted `/opt/data` volume does not leak back into the Docker build context.

Without this exclusion, any dangling symlink, unix socket, or character device the container happens to create under `/opt/data` breaks the next `docker compose build` with `invalid file request`. PulseAudio is the common trigger: it creates `data/.config/pulse/<host>-runtime -> /tmp/pulse-<random>`, whose target only exists inside the container, and Docker's tar packer aborts when it tries to resolve the broken symlink on the host.

Even on the success path, every rebuild ships `data/logs/`, `data/sessions/`, `data/memories/`, etc. to the daemon for no reason.

## Related Issue

Fixes #13925

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `.dockerignore` — add `data/` (3 lines: blank + comment + entry)

That's it.

## How to Test

**Reproduce the bug on `main`**:

```bash
cat > docker-compose.yml <<'EOF'
services:
  hermes:
    build: .
    image: hermes-agent:local
    stdin_open: true
    tty: true
    volumes:
      - ./data:/opt/data
EOF

docker compose build                    # succeeds (data/ empty)
docker compose run --rm hermes doctor   # container writes XDG runtime symlink into /opt/data
docker compose build                    # FAILS: invalid file request data/.config/pulse/<host>-runtime
```

**With this PR applied**: the second `docker compose build` succeeds, context tarball shrinks (runtime logs/sessions/memories no longer shipped), and the image is unchanged (Dockerfile never copied `/opt/data` into layers anyway — it's a `VOLUME`).

## Relation to existing work

- #6092 (open) adds Python/IDE ignore patterns but does **not** include `data/`.
- #4444 (open) is a full multi-stage Dockerfile refactor that also adds `data/` as part of a broader `.dockerignore` rewrite. This PR is the minimal interim for users who want rebuilds to keep working on current `main` without waiting for that refactor to land; if #4444 merges first, this one becomes a no-op and can be closed.
- #8904 (merged) and #8838 (closed) address `.venv` only.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit message follows [Conventional Commits](https://www.conventionalcommits.org/) (`fix(docker):`)
- [x] I searched for existing PRs — #6092, #4444, #8904, #8838 all touch `.dockerignore`, none fix this specific `data/` leak on current `main`
- [x] My PR contains **only** changes related to this fix (single file, 3 lines)
- [x] I've tested on my platform: Windows 11 / Docker Desktop with WSL2 backend (Docker 28.5.2, Compose v2.40.3)

### Documentation & Housekeeping

- [x] N/A — no behavior change, no new config, no schema change
