### PR TITLE
fix(feishu): proactively update approval card via API to avoid 220340 callback failure

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1083,6 +1083,13 @@ def convert_messages_to_anthropic(
                     "name": fn.get("name", ""),
                     "input": parsed_args,
                 })
+            # Kimi's /coding endpoint (Anthropic protocol) requires assistant
+            # tool-call messages to carry reasoning_content when thinking is
+            # enabled.  Preserve it as a thinking block so Kimi can validate
+            # the message history.  See hermes-agent#13848.
+            reasoning_content = m.get("reasoning_content")
+            if reasoning_content and isinstance(reasoning_content, str):
+                blocks.append({"type": "thinking", "thinking": reasoning_content})
             # Anthropic rejects empty assistant content
             effective = blocks or content
             if not effective or effective == "":

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1263,13 +1263,21 @@ def _get_provider_chain() -> List[tuple]:
 def _is_payment_error(exc: Exception) -> bool:
     """Detect payment/credit/quota exhaustion errors.
 
-    Returns True for HTTP 402 (Payment Required) and for 429/other errors
-    whose message indicates billing exhaustion rather than rate limiting.
+    Returns True for HTTP 402 (Payment Required), HTTP 403 responses from
+    OpenRouter that indicate key/spend-limit exhaustion, and for 429/other
+    errors whose message indicates billing exhaustion rather than rate limiting.
     """
     status = getattr(exc, "status_code", None)
     if status == 402:
         return True
     err_lower = str(exc).lower()
+    # OpenRouter 403 key-limit / spend-limit errors are payment exhaustion
+    if status == 403:
+        if any(kw in err_lower for kw in (
+            "key limit", "spending limit", "spend limit",
+            "total limit", "credit limit", "quota exceeded",
+        )):
+            return True
     # OpenRouter and other providers include "credits" or "afford" in 402 bodies,
     # but sometimes wrap them in 429 or other codes.
     if status in (402, 429, None):

--- a/cli.py
+++ b/cli.py
@@ -10364,7 +10364,20 @@ class HermesCLI:
             'voice-status-recording': 'bg:#1a1a2e #FF4444 bold',
         }
         style = PTStyle.from_dict(self._build_tui_style_dict())
-        
+
+        # Disable CPR (Cursor Position Report) queries — prompt_toolkit sends
+        # \x1b[6n (Device Status Report) to detect cursor position, and the
+        # terminal replies with \x1b[row;colR. Over SSH/cloudflared tunnels
+        # these responses leak as raw text like "20;1R21;1R" and flood the
+        # display. Disabling CPR forces prompt_toolkit to use heuristic
+        # fallback instead, eliminating the leak with no visible side effects.
+        _cpr_disabled_output = None
+        try:
+            from prompt_toolkit.output.vt100 import Vt100_Output
+            _cpr_disabled_output = Vt100_Output.from_pty(sys.stdout, enable_cpr=False)
+        except Exception:
+            pass
+
         # Create the application
         app = Application(
             layout=layout,
@@ -10372,6 +10385,7 @@ class HermesCLI:
             style=style,
             full_screen=False,
             mouse_support=False,
+            output=_cpr_disabled_output,
             **({'cursor': _STEADY_CURSOR} if _STEADY_CURSOR is not None else {}),
         )
         self._app = app  # Store reference for clarify_callback

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2145,11 +2145,33 @@ class FeishuAdapter(BasePlatformAdapter):
         return response
 
     async def _resolve_approval(self, approval_id: Any, choice: str, user_name: str) -> None:
-        """Pop approval state and unblock the waiting agent thread."""
+        """Pop approval state, update the card, and unblock the waiting agent thread."""
         state = self._approval_state.pop(approval_id, None)
         if not state:
             logger.debug("[Feishu] Approval %s already resolved or unknown", approval_id)
             return
+        # Update the approval card to show the resolution — do this BEFORE
+        # resolving the approval so the card is updated even if resolution
+        # fails.  Use the stored message_id so we don't depend on the
+        # callback response path which can fail with 220340 over some
+        # transports.
+        message_id = state.get("message_id")
+        if message_id and self._client:
+            try:
+                card_payload = json.dumps(
+                    self._build_resolved_approval_card(choice=choice, user_name=user_name),
+                    ensure_ascii=False,
+                )
+                body = self._build_update_message_body(msg_type="interactive", content=card_payload)
+                request = self._build_update_message_request(message_id=message_id, request_body=body)
+                response = await asyncio.to_thread(self._client.im.v1.message.update, request)
+                result = self._finalize_send_result(response, "approval card update failed")
+                if result.success:
+                    logger.debug("[Feishu] Updated approval card %s", message_id)
+                else:
+                    logger.warning("[Feishu] Failed to update approval card %s: %s", message_id, result.error)
+            except Exception as exc:
+                logger.warning("[Feishu] Failed to update approval card %s: %s", message_id, exc)
         try:
             from tools.approval import resolve_gateway_approval
             count = resolve_gateway_approval(state["session_key"], choice)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -45,6 +45,7 @@ from hermes_cli.config import (
     remove_env_value,
     check_config_version,
     redact_key,
+    _deep_merge,
 )
 from gateway.status import get_running_pid, read_runtime_status
 
@@ -941,7 +942,10 @@ def _denormalize_config_from_web(config: Dict[str, Any]) -> Dict[str, Any]:
 @app.put("/api/config")
 async def update_config(body: ConfigUpdate):
     try:
-        save_config(_denormalize_config_from_web(body.config))
+        existing = load_config()
+        incoming = _denormalize_config_from_web(body.config)
+        merged = _deep_merge(existing, incoming)
+        save_config(merged)
         return {"ok": True}
     except Exception as e:
         _log.exception("PUT /api/config failed")

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -93,6 +93,7 @@ AUTHOR_MAP = {
     "nocoo@users.noreply.github.com": "nocoo",
     "30841158+n-WN@users.noreply.github.com": "n-WN",
     "tsuijinglei@gmail.com": "hiddenpuppy",
+    "jerome@clawwork.ai": "HiddenPuppy",
     "leoyuan0099@gmail.com": "keyuyuan",
     "bxzt2006@163.com": "Only-Code-A",
     "i@troy-y.org": "TroyMitchell911",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -92,6 +92,7 @@ AUTHOR_MAP = {
     "135070653+sgaofen@users.noreply.github.com": "sgaofen",
     "nocoo@users.noreply.github.com": "nocoo",
     "30841158+n-WN@users.noreply.github.com": "n-WN",
+    "tsuijinglei@gmail.com": "hiddenpuppy",
     "leoyuan0099@gmail.com": "keyuyuan",
     "bxzt2006@163.com": "Only-Code-A",
     "i@troy-y.org": "TroyMitchell911",


### PR DESCRIPTION
## Summary

Fixes #13924

## Problem

When a user clicks an approval button (Allow Once, Session, Always, Deny) on a Feishu interactive card, the action returns error:

> "出错了，请稍后再试 code: 220340"

The approval is never processed — the agent remains blocked.

## Root Cause

The `_handle_approval_card_action()` method returns a `P2CardActionTriggerResponse` with a `CallBackCard` containing the resolved card. Feishu is supposed to update the card inline using this response, but over some transports this callback response path fails with error 220340.

Meanwhile, `_resolve_approval()` is scheduled asynchronously and correctly calls `resolve_gateway_approval()`, but the card is never updated to show the resolution.

## Fix

In `_resolve_approval()`, proactively call `im.v1.message.update` with the resolved card BEFORE calling `resolve_gateway_approval()`. This uses the stored `message_id` from `_approval_state`, so it doesn't depend on the callback response path at all.

- Card is updated even if approval resolution fails
- If the API update also fails, we log a warning but still resolve the approval so the agent isn't blocked
- The callback response is still returned for clients where it works

## Changes

- `gateway/platforms/feishu.py`: `_resolve_approval()` — added proactive card update via `im.v1.message.update`

## Verification

- [ ] Trigger a dangerous command in Feishu
- [ ] Click an approval button
- [ ] Card updates to show "✅ Approved by <user>" or "❌ Denied by <user>"
- [ ] Agent unblocks and continues

## Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Requires documentation update