### PR TITLE
fix(gateway): fail Telegram document sends on invalid files

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1719,6 +1719,10 @@ class TelegramAdapter(BasePlatformAdapter):
             )
         return error
 
+    def _invalid_media_path_error(self, label: str, path: str) -> str:
+        """Build an actionable error for paths that exist but are not regular files."""
+        return f"{label} path is not a file: {path}"
+
     async def send_voice(
         self,
         chat_id: str,
@@ -1820,6 +1824,8 @@ class TelegramAdapter(BasePlatformAdapter):
         try:
             if not os.path.exists(file_path):
                 return SendResult(success=False, error=self._missing_media_path_error("File", file_path))
+            if not os.path.isfile(file_path):
+                return SendResult(success=False, error=self._invalid_media_path_error("File", file_path))
 
             display_name = file_name or os.path.basename(file_path)
             _thread = self._metadata_thread_id(metadata)
@@ -1835,8 +1841,13 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
-            print(f"[{self.name}] Failed to send document: {e}")
-            return await super().send_document(chat_id, file_path, caption, file_name, reply_to)
+            logger.error(
+                "[%s] Failed to send Telegram document: %s",
+                self.name,
+                e,
+                exc_info=True,
+            )
+            return SendResult(success=False, error=f"Failed to send Telegram document: {e}")
 
     async def send_video(
         self,

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -582,29 +582,36 @@ class TestSendDocument:
         assert len(call_kwargs["caption"]) == 1024
 
     @pytest.mark.asyncio
-    async def test_send_document_api_error_falls_back(self, connected_adapter, tmp_path):
-        """If Telegram API raises, falls back to base class text message."""
+    async def test_send_document_api_error_returns_failure(self, connected_adapter, tmp_path):
+        """If Telegram API raises, return a real failure instead of fake text fallback."""
         test_file = tmp_path / "file.pdf"
         test_file.write_bytes(b"data")
 
         connected_adapter._bot.send_document = AsyncMock(
             side_effect=RuntimeError("Telegram API error")
         )
-
-        # The base fallback calls self.send() which is also on _bot, so mock it
-        # to avoid cascading errors.
-        connected_adapter.send = AsyncMock(
-            return_value=SendResult(success=True, message_id="fallback")
-        )
+        connected_adapter.send = AsyncMock()
 
         result = await connected_adapter.send_document(
             chat_id="12345",
             file_path=str(test_file),
         )
 
-        # Should have fallen back to base class
-        assert result.success is True
-        assert result.message_id == "fallback"
+        assert result.success is False
+        assert "failed to send telegram document" in result.error.lower()
+        connected_adapter.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_send_document_directory_path_returns_failure(self, connected_adapter, tmp_path):
+        """Existing directories like / or tmp dirs must not fall through to text fallback."""
+        result = await connected_adapter.send_document(
+            chat_id="12345",
+            file_path=str(tmp_path),
+        )
+
+        assert result.success is False
+        assert "path is not a file" in result.error.lower()
+        connected_adapter._bot.send_document.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_send_document_reply_to(self, connected_adapter, tmp_path):


### PR DESCRIPTION
## What does this PR do?

This PR fixes a Telegram document delivery bug where Hermes could fall back to sending plain text like `📎 File: /` instead of a real attachment.

Previously, if `TelegramAdapter.send_document()` received a path that existed but was not a regular file (for example `/`), the upload path would raise an exception and fall back to the base adapter's text-only document sender. That made delivery look successful even though no actual file was sent.

This change fixes that by:
- rejecting existing non-file paths before attempting upload
- returning an explicit failure when Telegram document upload fails
- preventing fallback to misleading plain-text file-path messages

This is the right approach because it preserves correctness: a failed document upload should fail explicitly rather than pretending success with a text fallback.

After this fix, Hermes can successfully send real document attachments through Telegram when given a valid file path, and it now fails explicitly instead of falling back to misleading plain-text file path messages.

## Related Issue

Fixes #13356

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `gateway/platforms/telegram.py`
  - added `_invalid_media_path_error(...)`
  - added `os.path.isfile(...)` validation before Telegram document upload
  - changed document-send exception handling to return `SendResult(success=False, ...)`
  - replaced `print(...)` fallback behavior with structured logging via `logger.error(...)`
- Updated `tests/gateway/test_telegram_documents.py`
  - changed the Telegram API error test to assert explicit failure instead of text fallback
  - added a regression test for directory / non-regular-file paths

## How to Test

1. Run:
   ```bash
   python -m pytest tests/gateway/test_telegram_documents.py -q -o 'addopts='
   ```
2. Verify the test suite passes.
3. Manually verify behavior:
   - send a valid PDF through the Telegram adapter and confirm it is delivered as a real document
   - call `send_document()` with `/` or another directory path and confirm it returns a real failure such as:
     ```text
     File path is not a file: /
     ```
   - confirm Hermes no longer sends fallback text like:
     ```text
     📎 File: /
     ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, feat(scope):, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run pytest tests/ -q and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Docker container / Telegram gateway validation path

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
- [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Test command:
```bash
python -m pytest tests/gateway/test_telegram_documents.py -q -o 'addopts='
```

Result:
```text
37 passed in 4.73s
```

Manual verification:
- valid PDF delivery through Telegram adapter succeeded
- invalid path `/` now returns:
```text
File path is not a file: /
```
- fallback text delivery like `📎 File: /` is no longer used for this failure case
