### PR TITLE
fix(gateway): remove stale PID files before startup

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -216,10 +216,7 @@ def _cleanup_invalid_pid_path(pid_path: Path, *, cleanup_stale: bool) -> None:
     if not cleanup_stale:
         return
     try:
-        if pid_path == _get_pid_path():
-            remove_pid_file()
-        else:
-            pid_path.unlink(missing_ok=True)
+        pid_path.unlink(missing_ok=True)
     except Exception:
         pass
 

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -51,6 +51,25 @@ class TestGatewayPidState:
         assert status.get_running_pid() is None
         assert not pid_path.exists()
 
+    def test_get_running_pid_removes_stale_current_home_pid(self, tmp_path, monkeypatch):
+        """Regression: stale PID files in HERMES_HOME blocked O_EXCL startup."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        pid_path = tmp_path / "gateway.pid"
+        pid_path.write_text(json.dumps({
+            "pid": 99999,
+            "kind": "hermes-gateway",
+            "argv": ["python", "-m", "hermes_cli.main", "gateway", "run"],
+            "start_time": 123,
+        }))
+
+        def fake_kill(pid, sig):
+            raise ProcessLookupError
+
+        monkeypatch.setattr(status.os, "kill", fake_kill)
+
+        assert status.get_running_pid() is None
+        assert not pid_path.exists()
+
     def test_get_running_pid_accepts_gateway_metadata_when_cmdline_unavailable(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         pid_path = tmp_path / "gateway.pid"


### PR DESCRIPTION
## Summary\n- force-unlink PID files after they have already been classified as invalid or stale\n- add a regression test for stale gateway.pid in HERMES_HOME blocking O_EXCL startup\n\nFixes #13655\n\n## Tests\n- uv run --extra dev python -m pytest tests/gateway/test_status.py -q\n- scripts/run_tests.sh tests/gateway/test_status.py