### PR TITLE
fix(skills): honor platform_disabled config in gateway-built system prompts (#13851)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -595,11 +595,12 @@ def _skill_should_show(
 def build_skills_system_prompt(
     available_tools: "set[str] | None" = None,
     available_toolsets: "set[str] | None" = None,
+    platform: "str | None" = None,
 ) -> str:
     """Build a compact skill index for the system prompt.
 
     Two-layer cache:
-      1. In-process LRU dict keyed by (skills_dir, tools, toolsets)
+      1. In-process LRU dict keyed by (skills_dir, tools, toolsets, platform)
       2. Disk snapshot (``.skills_prompt_snapshot.json``) validated by
          mtime/size manifest — survives process restarts
 
@@ -609,6 +610,20 @@ def build_skills_system_prompt(
     scanned alongside the local ``~/.hermes/skills/`` directory.  External dirs
     are read-only — they appear in the index but new skills are always created
     in the local dir.  Local skills take precedence when names collide.
+
+    Args:
+        available_tools: Tool names available in the current session. Used
+            to filter out skills whose ``tools`` frontmatter doesn't match.
+        available_toolsets: Toolset names available in the current session.
+        platform: Explicit platform name (e.g. ``"signal"``). When provided,
+            this is authoritative for resolving ``skills.platform_disabled``
+            *and* is used as an extra cache-key dimension. Callers running
+            inside the gateway (where each ``AIAgent`` is constructed with a
+            known platform) should pass it explicitly — context-var fallbacks
+            are unreliable when skills prompts are built from a different
+            async task than the one that set the session vars (#13851).
+            When *None*, falls back to ``HERMES_PLATFORM`` /
+            ``HERMES_SESSION_PLATFORM`` resolution.
     """
     skills_dir = get_skills_dir()
     external_dirs = get_all_skills_dirs()[1:]  # skip local (index 0)
@@ -621,11 +636,12 @@ def build_skills_system_prompt(
     # produce distinct cache entries (gateway serves multiple platforms).
     from gateway.session_context import get_session_env
     _platform_hint = (
-        os.environ.get("HERMES_PLATFORM")
+        platform
+        or os.environ.get("HERMES_PLATFORM")
         or get_session_env("HERMES_SESSION_PLATFORM")
         or ""
     )
-    disabled = get_disabled_skill_names()
+    disabled = get_disabled_skill_names(platform=_platform_hint or None)
     cache_key = (
         str(skills_dir.resolve()),
         tuple(str(d) for d in external_dirs),

--- a/run_agent.py
+++ b/run_agent.py
@@ -4085,6 +4085,7 @@ class AIAgent:
             skills_prompt = build_skills_system_prompt(
                 available_tools=self.valid_tool_names,
                 available_toolsets=avail_toolsets,
+                platform=self.platform,
             )
         else:
             skills_prompt = ""

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -428,6 +428,121 @@ class TestBuildSkillsSystemPrompt:
         result = build_skills_system_prompt()
         assert "backend-skill" in result
 
+    # ----- Regression: #13851 -----
+    # `skills.platform_disabled.<platform>` was ignored when the Signal (and
+    # any other) gateway built system prompts on an async task that didn't
+    # inherit the session contextvars. The fix adds an explicit `platform=`
+    # parameter to `build_skills_system_prompt()` that is authoritative for
+    # both the cache key and `get_disabled_skill_names()` resolution.
+
+    def _write_platform_disabled_config(self, tmp_path, platform, disabled_names):
+        """Helper to drop a config.yaml with skills.platform_disabled set."""
+        config_path = tmp_path / "config.yaml"
+        import yaml
+        config_path.write_text(yaml.safe_dump({
+            "skills": {
+                "platform_disabled": {platform: list(disabled_names)},
+            }
+        }))
+        return config_path
+
+    def test_explicit_platform_param_disables_skills_for_that_platform(
+        self, monkeypatch, tmp_path
+    ):
+        """Passing platform="signal" must exclude signal-disabled skills from the prompt."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        # Skills under ~/.hermes/skills/misc/{skill}
+        for name in ("weather", "apple-notes"):
+            d = tmp_path / "skills" / "misc" / name
+            d.mkdir(parents=True)
+            (d / "SKILL.md").write_text(
+                f"---\nname: {name}\ndescription: {name} skill\n---\n"
+            )
+        self._write_platform_disabled_config(tmp_path, "signal", ["apple-notes"])
+        # Ensure no env vars leak in
+        monkeypatch.delenv("HERMES_PLATFORM", raising=False)
+        monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
+
+        result = build_skills_system_prompt(platform="signal")
+        assert "weather" in result
+        assert "apple-notes" not in result
+
+    def test_explicit_platform_param_wins_over_env_vars(
+        self, monkeypatch, tmp_path
+    ):
+        """Caller-provided platform= must override HERMES_PLATFORM env."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        for name in ("web-search", "terminal"):
+            d = tmp_path / "skills" / "misc" / name
+            d.mkdir(parents=True)
+            (d / "SKILL.md").write_text(
+                f"---\nname: {name}\ndescription: {name} skill\n---\n"
+            )
+        # Env var says telegram disables terminal; explicit param says signal disables web-search.
+        import yaml
+        (tmp_path / "config.yaml").write_text(yaml.safe_dump({
+            "skills": {
+                "platform_disabled": {
+                    "telegram": ["terminal"],
+                    "signal": ["web-search"],
+                },
+            }
+        }))
+        monkeypatch.setenv("HERMES_PLATFORM", "telegram")
+
+        result = build_skills_system_prompt(platform="signal")
+        # signal disables web-search (explicit param wins)
+        assert "web-search" not in result
+        # telegram would have disabled terminal, but explicit signal param overrode it
+        assert "terminal" in result
+
+    def test_platform_none_falls_back_to_env(self, monkeypatch, tmp_path):
+        """Without explicit platform=, legacy env-based resolution still works."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        for name in ("web-search", "apple-notes"):
+            d = tmp_path / "skills" / "misc" / name
+            d.mkdir(parents=True)
+            (d / "SKILL.md").write_text(
+                f"---\nname: {name}\ndescription: {name} skill\n---\n"
+            )
+        self._write_platform_disabled_config(tmp_path, "signal", ["apple-notes"])
+        monkeypatch.setenv("HERMES_PLATFORM", "signal")
+
+        result = build_skills_system_prompt()  # no platform= kwarg
+        assert "web-search" in result
+        assert "apple-notes" not in result
+
+    def test_platform_in_cache_key_prevents_cross_platform_leak(
+        self, monkeypatch, tmp_path
+    ):
+        """Two back-to-back builds with different platforms must not share cache entries."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        for name in ("web-search", "apple-notes"):
+            d = tmp_path / "skills" / "misc" / name
+            d.mkdir(parents=True)
+            (d / "SKILL.md").write_text(
+                f"---\nname: {name}\ndescription: {name} skill\n---\n"
+            )
+        import yaml
+        (tmp_path / "config.yaml").write_text(yaml.safe_dump({
+            "skills": {
+                "platform_disabled": {
+                    "signal":   ["apple-notes"],
+                    "telegram": ["web-search"],
+                },
+            }
+        }))
+        monkeypatch.delenv("HERMES_PLATFORM", raising=False)
+        monkeypatch.delenv("HERMES_SESSION_PLATFORM", raising=False)
+
+        signal_result = build_skills_system_prompt(platform="signal")
+        telegram_result = build_skills_system_prompt(platform="telegram")
+        # Different platforms → different cache entries → different filtered outputs.
+        assert "apple-notes" not in signal_result
+        assert "web-search" in signal_result
+        assert "web-search" not in telegram_result
+        assert "apple-notes" in telegram_result
+
 
 class TestBuildNousSubscriptionPrompt:
     def test_includes_active_subscription_features(self, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

`build_skills_system_prompt()` resolves the active platform via `HERMES_PLATFORM` (os.environ) and `HERMES_SESSION_PLATFORM` (contextvar). When the gateway builds system prompts on an async task that doesn't inherit the session contextvars — the common path on the Signal gateway — both lookups return empty and `skills.platform_disabled.<platform>` is silently ignored. Every skill ships into the system prompt, which inflates the combined system-prompt+tools payload above the ~25K-char threshold where local LLMs (gemma4:26b, hermes3, qwen3:14b, mistral-small3.1) stop calling tools and just reply with text. Hermes Agent becomes effectively unusable with local models when many skills are installed.

The fix adds an explicit `platform=` parameter to `build_skills_system_prompt()` that is authoritative for both `get_disabled_skill_names()` resolution and the cache key. `run_agent.AIAgent` already carries `self.platform` from the gateway constructor (`AIAgent(platform=platform_key, ...)` in `gateway/run.py:9700`), so we thread it through the only caller site.

Backward compatible: `platform=None` retains the existing env/contextvar fallback chain so CLI, cron, and web-server callers are unchanged.

## Related Issue

Fixes #13851

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/prompt_builder.py` (+19 / −3): add `platform` kwarg to `build_skills_system_prompt()`; it takes priority over `HERMES_PLATFORM` / `HERMES_SESSION_PLATFORM` when resolving the platform hint that's passed into `get_disabled_skill_names()` and used as the cache-key dimension. Updated docstring to describe the gateway contextvar-propagation problem the new parameter solves.
- `run_agent.py` (+1): pass `self.platform` when calling `build_skills_system_prompt` from the agent's system-prompt build path. `AIAgent` already stores the platform on `self.platform` (line 821) from the gateway constructor.
- `tests/agent/test_prompt_builder.py` (+115): four new regression tests under `TestBuildSkillsSystemPrompt`.

Implementation diff (core change):

```diff
 def build_skills_system_prompt(
     available_tools: "set[str] | None" = None,
     available_toolsets: "set[str] | None" = None,
+    platform: "str | None" = None,
 ) -> str:
     ...
     _platform_hint = (
-        os.environ.get("HERMES_PLATFORM")
+        platform
+        or os.environ.get("HERMES_PLATFORM")
         or get_session_env("HERMES_SESSION_PLATFORM")
         or ""
     )
-    disabled = get_disabled_skill_names()
+    disabled = get_disabled_skill_names(platform=_platform_hint or None)
```

```diff
 # run_agent.py
             skills_prompt = build_skills_system_prompt(
                 available_tools=self.valid_tool_names,
                 available_toolsets=avail_toolsets,
+                platform=self.platform,
             )
```

## How to Test

Reporter's scenario:

```yaml
# config.yaml
skills:
  platform_disabled:
    signal:
      - apple-notes
      - apple-reminders
      # ... 107 skill names
```

```bash
hermes gateway run --replace
# Send a message via Signal.
```

Before: all 129 skills appear in the system-prompt index, combined payload ~53K chars, local LLMs don't emit tool calls.
After: only the non-disabled skills appear, payload drops proportionally, local LLMs recover the ability to call tools.

Automated regression suite:

```
pytest tests/agent/test_prompt_builder.py::TestBuildSkillsSystemPrompt -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(skills):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the scoped tests (`tests/agent/test_prompt_builder.py::TestBuildSkillsSystemPrompt`) and all tests pass
- [x] I've added tests for my changes (4 new regression cases)
- [x] I've tested on my platform: macOS 26.5 (arm64), Python 3.11.14 via uv

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (`platform=` is an internal kwarg on an internal helper; docstring updated in-line)
- [x] I've updated `cli-config.yaml.example` — N/A (no new config)
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — pure Python, no OS-specific code paths touched
- [x] I've updated tool descriptions/schemas — N/A

## Not in scope

The issue also mentions `platform_toolsets.signal` being ignored (26 tools passed to the model instead of the configured 7). That's a separate architectural problem — `platform_toolsets` filtering lives in `hermes_cli/tools_config.py` and the gateway invocation path doesn't consult it the same way the skills path does. It belongs in its own PR with its own regression suite, and the skills fix here already delivers the 16K-char savings from the 107 disabled skills — often enough to get the payload back under the local-LLM threshold on its own.

## Screenshots / Logs

### Regression tests added

| Test | Scenario |
|---|---|
| `test_explicit_platform_param_disables_skills_for_that_platform` | `build_skills_system_prompt(platform="signal")` excludes skills listed under `skills.platform_disabled.signal` |
| `test_explicit_platform_param_wins_over_env_vars` | Caller-provided `platform=` overrides `HERMES_PLATFORM` env var |
| `test_platform_none_falls_back_to_env` | No `platform=` kwarg → legacy env-based resolution still works (backward compat) |
| `test_platform_in_cache_key_prevents_cross_platform_leak` | Back-to-back calls with different platforms return correctly filtered outputs (no cache collision) |

### Verification

```
$ python3 -m py_compile agent/prompt_builder.py run_agent.py tests/agent/test_prompt_builder.py
OK

$ uv run --with pytest --with pytest-xdist python -m pytest \
    tests/agent/test_prompt_builder.py::TestBuildSkillsSystemPrompt -q
..............                                                           [100%]
14 passed in 0.66s
```

(14 tests = 10 existing + 4 new regression cases, all green. No existing behavior regressed.)
