### PR TITLE
fix(approval): block dangerous command flags via GNU long-option abbreviations

### DIFF
--- a/tests/tools/test_gnu_long_option_abbreviation_bypass.py
+++ b/tests/tools/test_gnu_long_option_abbreviation_bypass.py
@@ -1,0 +1,170 @@
+"""Tests for GNU long-option abbreviation bypass in DANGEROUS_PATTERNS.
+
+GNU tools accept unique long-option prefix abbreviations at runtime
+(e.g. `rm --recur` resolves to `rm --recursive`).  Patterns that only
+matched the full flag name could be bypassed by passing a valid abbreviation
+that the regex did not cover.
+
+Affected patterns and their minimum distinguishing prefix:
+  rm/chmod/chown  --recursive  →  --recur[a-z]*
+  sed             --in-place   →  --in-plac[a-z]*
+  git push        --force      →  --forc[a-z]*
+"""
+
+import pytest
+
+from tools.approval import detect_dangerous_command
+
+
+class TestRmRecursiveLongOptionAbbreviation:
+    """rm --recur* abbreviations must be caught just like --recursive."""
+
+    def test_rm_recursive_full_still_detected(self):
+        dangerous, _, desc = detect_dangerous_command("rm --recursive /tmp/dir")
+        assert dangerous is True
+        assert "delete" in desc.lower()
+
+    def test_rm_recur_abbreviation_detected(self):
+        dangerous, _, desc = detect_dangerous_command("rm --recur /home/user")
+        assert dangerous is True, "rm --recur is a valid abbreviation of --recursive"
+        assert "delete" in desc.lower()
+
+    def test_rm_recurs_abbreviation_detected(self):
+        dangerous, _, desc = detect_dangerous_command("rm --recurs /home/user")
+        assert dangerous is True
+
+    def test_rm_recursi_abbreviation_detected(self):
+        dangerous, _, desc = detect_dangerous_command("rm --recursi /var/log")
+        assert dangerous is True
+
+    def test_rm_recursiv_abbreviation_detected(self):
+        dangerous, _, desc = detect_dangerous_command("rm --recursiv /var/log")
+        assert dangerous is True
+
+    def test_rm_regular_file_not_flagged(self):
+        dangerous, _, _ = detect_dangerous_command("rm ./file.txt")
+        assert dangerous is False
+
+
+class TestChmodRecursiveLongOptionAbbreviation:
+    """chmod --recur* abbreviations with dangerous permissions must be caught."""
+
+    def test_chmod_recursive_full_still_detected(self):
+        dangerous, _, desc = detect_dangerous_command("chmod --recursive 777 /var")
+        assert dangerous is True
+        assert "writable" in desc.lower() or "permission" in desc.lower()
+
+    def test_chmod_recur_777_detected(self):
+        dangerous, _, desc = detect_dangerous_command("chmod --recur 777 /etc/")
+        assert dangerous is True, "chmod --recur 777 is a valid abbreviation of --recursive"
+
+    def test_chmod_recurs_666_detected(self):
+        dangerous, _, desc = detect_dangerous_command("chmod --recurs 666 /srv")
+        assert dangerous is True
+
+    def test_chmod_recur_o_plus_w_detected(self):
+        dangerous, _, desc = detect_dangerous_command("chmod --recur o+w /home")
+        assert dangerous is True
+
+    def test_chmod_recur_safe_permissions_not_flagged(self):
+        """--recur with non-dangerous permissions (e.g. 755) must not be flagged."""
+        dangerous, _, _ = detect_dangerous_command("chmod --recur 755 /opt/app")
+        assert dangerous is False
+
+
+class TestChownRecursiveLongOptionAbbreviation:
+    """chown --recur* abbreviations targeting root must be caught."""
+
+    def test_chown_recursive_full_still_detected(self):
+        dangerous, _, desc = detect_dangerous_command("chown --recursive root /etc")
+        assert dangerous is True
+        assert "chown" in desc.lower() or "root" in desc.lower()
+
+    def test_chown_recur_root_detected(self):
+        dangerous, _, desc = detect_dangerous_command("chown --recur root /etc")
+        assert dangerous is True, "chown --recur root is a valid abbreviation of --recursive"
+
+    def test_chown_recurs_root_detected(self):
+        dangerous, _, _ = detect_dangerous_command("chown --recurs root:root /var")
+        assert dangerous is True
+
+    def test_chown_recur_non_root_not_flagged(self):
+        """--recur* chown to a non-root user must not be flagged."""
+        dangerous, _, _ = detect_dangerous_command("chown --recur nobody /opt/app")
+        assert dangerous is False
+
+
+class TestSedInPlaceLongOptionAbbreviation:
+    """sed --in-plac* abbreviations writing to /etc must be caught."""
+
+    def test_sed_in_place_full_still_detected(self):
+        dangerous, _, desc = detect_dangerous_command(
+            "sed --in-place 's/old/new/' /etc/hosts"
+        )
+        assert dangerous is True
+        assert "system config" in desc.lower() or "in-place" in desc.lower()
+
+    def test_sed_in_plac_abbreviation_detected(self):
+        dangerous, _, desc = detect_dangerous_command(
+            "sed --in-plac 's/foo/bar/' /etc/passwd"
+        )
+        assert dangerous is True, "sed --in-plac is a valid abbreviation of --in-place"
+
+    def test_sed_in_place_safe_path_not_flagged(self):
+        """--in-place on a non-/etc path must not be flagged."""
+        dangerous, _, _ = detect_dangerous_command(
+            "sed --in-place 's/old/new/' /tmp/config.txt"
+        )
+        assert dangerous is False
+
+    def test_sed_short_i_flag_still_detected(self):
+        """Existing -i pattern must not regress."""
+        dangerous, _, _ = detect_dangerous_command("sed -i 's/x/y/' /etc/passwd")
+        assert dangerous is True
+
+
+class TestGitPushForceLongOptionAbbreviation:
+    """git push --forc* abbreviations must be caught."""
+
+    def test_git_push_force_full_still_detected(self):
+        dangerous, _, desc = detect_dangerous_command("git push --force origin main")
+        assert dangerous is True
+        assert "force" in desc.lower()
+
+    def test_git_push_forc_abbreviation_detected(self):
+        dangerous, _, desc = detect_dangerous_command("git push --forc origin main")
+        assert dangerous is True, "git push --forc is a valid abbreviation of --force"
+
+    def test_git_push_forced_variant_detected(self):
+        """--forced (hypothetical) must also be caught by the prefix match."""
+        dangerous, _, _ = detect_dangerous_command("git push --forced origin main")
+        assert dangerous is True
+
+    def test_git_push_short_f_still_detected(self):
+        """Existing -f pattern must not regress."""
+        dangerous, _, _ = detect_dangerous_command("git push -f origin main")
+        assert dangerous is True
+
+    def test_git_push_no_force_not_flagged(self):
+        dangerous, _, _ = detect_dangerous_command("git push origin main")
+        assert dangerous is False
+
+    def test_git_push_upstream_not_flagged(self):
+        dangerous, _, _ = detect_dangerous_command("git push --set-upstream origin feature")
+        assert dangerous is False
+
+
+class TestFullFormRegressions:
+    """All full-form long flags must still be detected after the prefix change."""
+
+    @pytest.mark.parametrize("cmd", [
+        "rm --recursive /important",
+        "chmod --recursive 777 /etc",
+        "chown --recursive root /etc",
+        "sed --in-place 's/x/y/' /etc/passwd",
+        "git push --force origin main",
+    ])
+    def test_full_form_still_detected(self, cmd):
+        dangerous, key, _ = detect_dangerous_command(cmd)
+        assert dangerous is True, f"Full-form long flag not detected in: {cmd!r}"
+        assert key is not None

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -76,11 +76,11 @@ _SENSITIVE_WRITE_TARGET = (
 DANGEROUS_PATTERNS = [
     (r'\brm\s+(-[^\s]*\s+)*/', "delete in root path"),
     (r'\brm\s+-[^\s]*r', "recursive delete"),
-    (r'\brm\s+--recursive\b', "recursive delete (long flag)"),
+    (r'\brm\s+--recur[a-z]*\b', "recursive delete (long flag)"),
     (r'\bchmod\s+(-[^\s]*\s+)*(777|666|o\+[rwx]*w|a\+[rwx]*w)\b', "world/other-writable permissions"),
-    (r'\bchmod\s+--recursive\b.*(777|666|o\+[rwx]*w|a\+[rwx]*w)', "recursive world/other-writable (long flag)"),
+    (r'\bchmod\s+--recur[a-z]*\b.*(777|666|o\+[rwx]*w|a\+[rwx]*w)', "recursive world/other-writable (long flag)"),
     (r'\bchown\s+(-[^\s]*)?R\s+root', "recursive chown to root"),
-    (r'\bchown\s+--recursive\b.*root', "recursive chown to root (long flag)"),
+    (r'\bchown\s+--recur[a-z]*\b.*root', "recursive chown to root (long flag)"),
     (r'\bmkfs\b', "format filesystem"),
     (r'\bdd\s+.*if=', "disk copy"),
     (r'>\s*/dev/sd', "write to block device"),
@@ -121,14 +121,14 @@ DANGEROUS_PATTERNS = [
     # File copy/move/edit into sensitive system paths
     (r'\b(cp|mv|install)\b.*\s/etc/', "copy/move file into /etc/"),
     (r'\bsed\s+-[^\s]*i.*\s/etc/', "in-place edit of system config"),
-    (r'\bsed\s+--in-place\b.*\s/etc/', "in-place edit of system config (long flag)"),
+    (r'\bsed\s+--in-plac[a-z]*\b.*\s/etc/', "in-place edit of system config (long flag)"),
     # Script execution via heredoc — bypasses the -e/-c flag patterns above.
     # `python3 << 'EOF'` feeds arbitrary code via stdin without -c/-e flags.
     (r'\b(python[23]?|perl|ruby|node)\s+<<', "script execution via heredoc"),
     # Git destructive operations that can lose uncommitted work or rewrite
     # shared history. Not captured by rm/chmod/etc patterns.
     (r'\bgit\s+reset\s+--hard\b', "git reset --hard (destroys uncommitted changes)"),
-    (r'\bgit\s+push\b.*--force\b', "git force push (rewrites remote history)"),
+    (r'\bgit\s+push\b.*--forc[a-z]*\b', "git force push (rewrites remote history)"),
     (r'\bgit\s+push\b.*-f\b', "git force push short flag (rewrites remote history)"),
     (r'\bgit\s+clean\s+-[^\s]*f', "git clean with force (deletes untracked files)"),
     (r'\bgit\s+branch\s+-D\b', "git branch force delete"),


### PR DESCRIPTION
# fix(approval): block dangerous command flags via GNU long-option abbreviations

## What does this PR do?

`DANGEROUS_PATTERNS` matched long flags by exact string (e.g. `--recursive`, `--force`), but GNU tools accept unique-prefix abbreviations at runtime. An attacker could pass `rm --recur /home` or `git push --forc origin main` to bypass detection while the shell expands them to the denied full flag.

This fix changes the 5 affected patterns to prefix-match (`--recur[a-z]*`, `--forc[a-z]*`, `--in-plac[a-z]*`), covering all valid GNU abbreviations fail-closed.

## Related Issue

Fixes #

## Type of Change

- [x] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tools/approval.py` — replace exact long-flag matches with prefix patterns in 5 `DANGEROUS_PATTERNS` entries:
  - `rm --recursive` → `--recur[a-z]*`
  - `chmod --recursive` → `--recur[a-z]*`
  - `chown --recursive` → `--recur[a-z]*`
  - `sed --in-place` → `--in-plac[a-z]*`
  - `git push --force` → `--forc[a-z]*`
- `tests/tools/test_gnu_long_option_abbreviation_bypass.py` — 30 test cases covering bypass attempts and regressions for all 5 patterns

## How to Test

1. Run `pytest tests/tools/test_gnu_long_option_abbreviation_bypass.py -v`
2. Verify abbreviated flags are detected: `rm --recur /home`, `git push --forc origin main`, `sed --in-plac 's/x/y/' /etc/passwd`
3. Verify full forms still detected and safe commands not flagged

## Checklist

### Code

- [x] My commit messages follow Conventional Commits
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've considered cross-platform impact — N/A (regex-only change)
