### PR TITLE
test: add Minos control-plane fixtures and coverage

### DIFF
--- a/docs/minos-run-artifacts.md
+++ b/docs/minos-run-artifacts.md
@@ -1,0 +1,64 @@
+# Minos run artifacts
+
+Purpose
+- Define the artifact set for one Minos-controlled coding run.
+- Keep review and validation readable by Minos and the human sponsor.
+
+Run id convention
+- Use one run id format: `minos-YYYYMMDD-HHMMSS-<task-id>`
+- Example: `minos-20260421-231500-task-12`
+- Use UTC timestamps so builder, gate, and Minos artifacts sort consistently.
+
+Artifact directory
+- Store run artifacts under one run directory chosen by Minos for the task.
+- Recommended shape: `<task-root>/runs/<run-id>/`
+
+Required files
+- `task-pack.md`
+  - Produced by: Minos
+  - Human-readable summary artifact: yes; this is the operator brief for the run.
+- `builder-summary.md`
+  - Produced by: builder
+  - Contains: work completed, files changed, verifier command results, blockers/open issues.
+  - Human-readable summary artifact: yes.
+- `gate-summary.md`
+  - Produced by: gate
+  - Contains: pass/fail decision, checks run, findings, required fixes if any.
+  - Human-readable summary artifact: yes.
+- `minos-decision.md`
+  - Produced by: Minos
+  - Contains: review outcome, accept/rework/block decision, next authority decision, and publish status.
+  - Human-readable summary artifact: yes.
+
+Optional files
+- `builder.patch`
+  - Produced by: builder
+  - Patch or diff bundle when Minos wants a portable review artifact.
+- `builder-log.txt`
+  - Produced by: builder
+  - Command log or condensed execution transcript.
+- `gate-log.txt`
+  - Produced by: gate
+  - Raw validation output when summary alone is insufficient.
+- `artifact-manifest.md`
+  - Produced by: Minos
+  - Small index when a run has many attachments.
+
+Producer rules
+- Minos produces the task pack and the final decision record.
+- Builder produces implementation artifacts only; builder does not produce gate findings or publish approvals.
+- Gate produces validation artifacts only; gate does not approve publish.
+- If a file is missing, the stage is incomplete.
+
+Stage minimum summary rule
+- Every stage must leave at least one human-readable summary artifact:
+  - Minos: `task-pack.md` and `minos-decision.md`
+  - builder: `builder-summary.md`
+  - gate: `gate-summary.md`
+
+Content minimums
+- All summaries must include the run id and task id.
+- Builder and gate summaries must list the commands actually run.
+- Minos decision must state whether rework is required.
+- If a repo or remote exists for the run, builder and gate summaries must record GitHub remote visibility status; unknown visibility is non-compliant until resolved.
+- Public GitHub publication is out of scope unless the human explicitly authorizes an exception.

--- a/docs/plans/2026-04-21-minos-coding-control-plane.md
+++ b/docs/plans/2026-04-21-minos-coding-control-plane.md
@@ -1,0 +1,67 @@
+# Minos coding control plane architecture contract
+
+Status: adopted for Task 1
+Audience: operators and maintainers of the Minos coding workflow
+Scope: control-plane ownership, role boundaries, publish authority, and GitHub remote policy
+
+Purpose
+- Define who decides, who builds, who reviews, and who approves publication.
+- Prevent role collapse, uncontrolled autonomy, and unsafe repository publication.
+- Keep GitHub usage private by default for this system.
+
+Roles
+
+1. Minos
+- Owns the control plane.
+- Selects the builder for each work item or execution track.
+- Assigns the execution budget: scope, timebox, token budget, iteration cap, or other explicit stopping constraint.
+- Defines acceptance criteria, workspace boundaries, and review checkpoints.
+- Reviews returned artifacts, decides whether rework is required, and determines whether work is complete.
+- Is the only role that can authorize publish, upstream sync, or equivalent release movement for this system.
+- Enforces the private-GitHub-only policy for remotes, repositories, and publication paths unless the human explicitly changes policy.
+
+2. builder
+- Executes the assigned implementation work inside the approved workspace and budget.
+- Produces code, tests, docs, diffs, and concise execution notes.
+- Does not redefine scope, extend the budget unilaterally, or choose a different publication target.
+- Does not push upstream directly.
+- Stops at the assigned checkpoint and returns artifacts to Minos for review.
+
+3. gate
+- Performs independent validation on the builder output.
+- Checks the requested quality bar: tests, lint, policy compliance, acceptance criteria, and repository safety constraints.
+- Reports pass/fail findings and required fixes to Minos.
+- Has no publish authority and does not replace Minos artifact review.
+
+4. human
+- Sets business intent, risk tolerance, and any policy overrides.
+- Approves exceptions that change system policy, especially any deviation from private GitHub defaults.
+- Resolves priority conflicts or release decisions that Minos escalates.
+
+Control-plane contract
+- Every coding task has one named Minos owner, zero or one active builder, zero or one gate pass per review cycle, and one human sponsor.
+- Minos must set the builder and the budget before execution starts.
+- Builder execution must terminate at a defined checkpoint, budget boundary, or explicit stop condition.
+- Builder artifacts are not publishable until Minos reviews them.
+- Gate validation informs the decision, but Minos retains final internal approval authority before publish is considered.
+- Human approval is required for policy exceptions, risk exceptions, or scope moves that exceed Minos authority.
+
+Private GitHub policy
+- Private GitHub repositories are the default and expected hosting mode.
+- Public GitHub repositories, public remotes, or any publication path that makes the code publicly accessible are out of scope by default.
+- Minos must reject or halt any plan that creates, points to, or publishes to a public GitHub repository unless the human explicitly authorizes that exception.
+- Builders and gate agents must treat unknown remote visibility as non-compliant until Minos or the human confirms it is private.
+- If remote visibility cannot be verified, the safe action is to stop and escalate.
+
+Forbidden anti-patterns
+- One agent does everything: planning, implementation, review, and release in a single unchecked loop.
+- Builder pushes upstream directly.
+- Multiple builders mutate the same shared workspace in parallel.
+- Unbounded autonomous execution without a predeclared budget or stop condition.
+- Accidental creation or use of public GitHub repositories or public remotes.
+
+Operational defaults
+- Prefer one isolated workspace per builder task.
+- Prefer short review loops over long autonomous runs.
+- Prefer explicit re-delegation over silent scope expansion.
+- Treat publication as a separate decision after artifact review, not as the default end of implementation.

--- a/templates/minos-decision.json
+++ b/templates/minos-decision.json
@@ -1,0 +1,13 @@
+{
+  "run_id": "<run-id>",
+  "builder_status": "passed | failed | invalid",
+  "gate_status": "passed | failed | invalid",
+  "next_action": "publish | retry | escalate",
+  "decision_reason": "passed | missing_artifacts | invalid_builder_result | builder_failed | status_mismatch | verifier_failed",
+  "publish_recommended": false,
+  "retry_recommended": false,
+  "human_review_required": true,
+  "blocking_findings": [
+    "<missing artifact, failed verifier, policy issue, or mismatch>"
+  ]
+}

--- a/templates/minos-task-pack.md
+++ b/templates/minos-task-pack.md
@@ -1,0 +1,58 @@
+# Minos task pack
+
+Task id: <minos-task-id>
+Run id: <run-id>
+Minos owner: <named-owner>
+Builder: <builder-name>
+Human sponsor: <human-name-or-handle>
+
+## Objective
+- <one clear outcome>
+
+## Scope
+- In scope: <allowed work>
+- Out of scope: <explicit non-goals>
+- Expected artifacts (see `docs/minos-run-artifacts.md` for canonical names):
+  - `builder-summary.md`
+  - `gate-summary.md` when validation runs
+  - `minos-decision.md` is produced later by Minos
+
+## Workspace
+- Repo/workdir: <absolute path>
+- Allowed paths: <paths builder may modify>
+- Forbidden paths: <paths builder must not modify>
+- GitHub/remote policy: private only; unknown visibility = stop and escalate to Minos
+
+## Inputs
+- Required docs/specs:
+  - <path or URL>
+- Existing files to inspect first:
+  - <path>
+
+## Constraints
+- Success criteria:
+  - <observable requirement>
+  - <observable requirement>
+- Escalation triggers:
+  - missing or conflicting context
+  - change required outside allowed paths
+  - unknown or public GitHub remote visibility
+
+## Verifier commands
+Replace these examples with task-specific commands before execution. Run them before stopping and record the result:
+- Example: `pytest tests/test_target.py`
+- Example: `python -m pytest -q`
+- Example: `ruff check <path>`
+- Example: `git diff --stat`
+
+## Stop conditions
+- Acceptance criteria met and verifier commands completed.
+- Required context is missing or conflicting.
+- A policy or safety issue is found, including unknown or public GitHub remote visibility.
+- A change outside allowed paths is required.
+
+## Handoff back to Minos
+- Status: done | partial | blocked
+- Files changed: <list>
+- Verifier summary: <pass/fail with command output summary>
+- Blockers or follow-ups: <list or none>

--- a/tests/scripts/test_minos_fanout.py
+++ b/tests/scripts/test_minos_fanout.py
@@ -1,0 +1,214 @@
+import importlib.util
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT_ROOT = Path(os.environ.get("HERMES_SCRIPT_ROOT", str(Path.home() / ".hermes" / "scripts")))
+FANOUT_SCRIPT_PATH = SCRIPT_ROOT / "minos_fanout.py"
+fanout_spec = importlib.util.spec_from_file_location("minos_fanout", FANOUT_SCRIPT_PATH)
+minos_fanout = importlib.util.module_from_spec(fanout_spec)
+fanout_spec.loader.exec_module(minos_fanout)
+
+WORKTREE_SCRIPT_PATH = SCRIPT_ROOT / "minos_worktree_run.py"
+worktree_spec = importlib.util.spec_from_file_location("minos_worktree_run", WORKTREE_SCRIPT_PATH)
+minos_worktree_run = importlib.util.module_from_spec(worktree_spec)
+worktree_spec.loader.exec_module(minos_worktree_run)
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture
+def clean_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "config", "user.email", "test@example.com")
+    (repo / "backend.txt").write_text("backend\n", encoding="utf-8")
+    (repo / "frontend.txt").write_text("frontend\n", encoding="utf-8")
+    _git(repo, "add", "backend.txt", "frontend.txt")
+    _git(repo, "commit", "-m", "initial")
+    return repo
+
+
+def _task_pack(repo: Path, lane_id: str, allowed: str) -> Path:
+    path = repo / ".hermes" / "task-packs" / f"{lane_id}.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"# Task pack\n\nRun id: placeholder\n\n## Workspace\n- Allowed paths: {allowed}\n\n## Verifier commands\n- git diff --stat\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _commit_task_packs(repo: Path) -> None:
+    _git(repo, 'add', '.hermes/task-packs')
+    _git(repo, 'commit', '-m', 'add task packs')
+
+
+def test_prepare_fanout_plan_rejects_overlapping_disjoint_scopes(clean_repo: Path):
+    repo = clean_repo
+
+    tasks = [
+        {"lane_id": "a", "allowed_paths": ["src/app.py"]},
+        {"lane_id": "b", "allowed_paths": ["src/app.py"]},
+    ]
+
+    with pytest.raises(ValueError, match="overlap"):
+        minos_fanout.prepare_fanout_plan(repo, "run-200", tasks)
+
+
+
+def test_prepare_fanout_plan_rejects_duplicate_lane_ids(clean_repo: Path):
+    repo = clean_repo
+    tasks = [
+        {"lane_id": "dup", "allowed_paths": ["backend.txt"]},
+        {"lane_id": "dup", "allowed_paths": ["frontend.txt"]},
+    ]
+    with pytest.raises(ValueError, match="Duplicate lane_id"):
+        minos_fanout.prepare_fanout_plan(repo, "run-dup", tasks)
+
+
+def test_prepare_fanout_plan_allows_independent_approach_overlap(clean_repo: Path):
+    repo = clean_repo
+
+    tasks = [
+        {"lane_id": "a", "allowed_paths": ["src/app.py"], "mode": "independent"},
+        {"lane_id": "b", "allowed_paths": ["src/app.py"], "mode": "independent"},
+    ]
+
+    plan = minos_fanout.prepare_fanout_plan(repo, "run-200", tasks)
+    assert len(plan["lanes"]) == 2
+
+
+def test_prepare_fanout_plan_creates_separate_worktree_and_artifact_roots(clean_repo: Path):
+    repo = clean_repo
+
+    tasks = [
+        {"lane_id": "backend", "allowed_paths": ["backend/"]},
+        {"lane_id": "frontend", "allowed_paths": ["frontend/"]},
+    ]
+
+    plan = minos_fanout.prepare_fanout_plan(repo, "run-201", tasks)
+
+    lane_a, lane_b = plan["lanes"]
+    assert lane_a["run_id"] != lane_b["run_id"]
+    assert lane_a["worktree_path"] != lane_b["worktree_path"]
+    assert lane_a["artifact_dir"] != lane_b["artifact_dir"]
+    assert lane_a["worktree_path"] == str(minos_worktree_run.build_worktree_path(repo, lane_a["run_id"]))
+    assert lane_b["artifact_dir"] == str(minos_worktree_run.build_artifact_dir(repo, lane_b["run_id"]))
+
+
+def test_prepare_fanout_plan_disables_automatic_merge(clean_repo: Path):
+    repo = clean_repo
+
+    tasks = [
+        {"lane_id": "backend", "allowed_paths": ["backend/"]},
+        {"lane_id": "frontend", "allowed_paths": ["frontend/"]},
+    ]
+
+    plan = minos_fanout.prepare_fanout_plan(repo, "run-202", tasks)
+    assert plan["auto_merge"] is False
+    assert plan["requires_explicit_review"] is True
+    assert plan["gate_each_lane"] is True
+
+
+def test_execute_fanout_plan_uses_separate_worktrees_without_shared_mutation(clean_repo: Path):
+    repo = clean_repo
+    tasks = [
+        {"lane_id": "backend", "allowed_paths": ["backend.txt"], "task_pack_path": str(_task_pack(repo, 'backend', 'backend.txt'))},
+        {"lane_id": "frontend", "allowed_paths": ["frontend.txt"], "task_pack_path": str(_task_pack(repo, 'frontend', 'frontend.txt'))},
+    ]
+    _commit_task_packs(repo)
+    plan = minos_fanout.prepare_fanout_plan(repo, "run-300", tasks)
+    execution = minos_fanout.execute_fanout_plan(
+        plan,
+        {
+            'backend': ['python3', '-c', "from pathlib import Path; p=Path('backend.txt'); p.write_text('backend changed\\n', encoding='utf-8')"],
+            'frontend': ['python3', '-c', "from pathlib import Path; p=Path('frontend.txt'); p.write_text('frontend changed\\n', encoding='utf-8')"],
+        },
+    )
+    backend_status = Path(execution['lane_results'][0]['builder']['git_status_path']).read_text(encoding='utf-8')
+    frontend_status = Path(execution['lane_results'][1]['builder']['git_status_path']).read_text(encoding='utf-8')
+    assert 'backend.txt' in backend_status
+    assert 'frontend.txt' not in backend_status
+    assert 'frontend.txt' in frontend_status
+    assert 'backend.txt' not in frontend_status
+
+
+def test_execute_fanout_plan_allows_lane_failures_independently(clean_repo: Path):
+    repo = clean_repo
+    tasks = [
+        {"lane_id": "success", "allowed_paths": ["backend.txt"], "task_pack_path": str(_task_pack(repo, 'success', 'backend.txt'))},
+        {"lane_id": "failure", "allowed_paths": ["frontend.txt"], "task_pack_path": str(_task_pack(repo, 'failure', 'frontend.txt'))},
+    ]
+    _commit_task_packs(repo)
+    plan = minos_fanout.prepare_fanout_plan(repo, "run-301", tasks)
+    execution = minos_fanout.execute_fanout_plan(
+        plan,
+        {
+            'success': ['python3', '-c', "from pathlib import Path; Path('backend.txt').write_text('ok\\n', encoding='utf-8')"],
+            'failure': ['python3', '-c', "import sys; sys.exit(4)"],
+        },
+    )
+    by_lane = {lane['lane_id']: lane for lane in execution['lane_results']}
+    assert by_lane['success']['builder']['exit_code'] == 0
+    assert by_lane['failure']['builder']['exit_code'] == 4
+    assert by_lane['success']['scope_ok'] is True
+    assert by_lane['failure']['scope_ok'] is True
+
+
+
+def test_execute_fanout_plan_flags_out_of_scope_mutation(clean_repo: Path):
+    repo = clean_repo
+    tasks = [
+        {"lane_id": "backend", "allowed_paths": ["backend.txt"], "task_pack_path": str(_task_pack(repo, 'backend', 'backend.txt'))},
+        {"lane_id": "frontend", "allowed_paths": ["frontend.txt"], "task_pack_path": str(_task_pack(repo, 'frontend', 'frontend.txt'))},
+    ]
+    _commit_task_packs(repo)
+    plan = minos_fanout.prepare_fanout_plan(repo, "run-303", tasks)
+    execution = minos_fanout.execute_fanout_plan(
+        plan,
+        {
+            'backend': ['python3', '-c', "from pathlib import Path; Path('frontend.txt').write_text('bad\\n', encoding='utf-8')"],
+            'frontend': ['python3', '-c', "from pathlib import Path; Path('frontend.txt').write_text('ok\\n', encoding='utf-8')"],
+        },
+    )
+    backend = next(l for l in execution['lane_results'] if l['lane_id'] == 'backend')
+    assert backend['scope_ok'] is False
+    assert 'frontend.txt' in backend['disallowed_paths']
+
+
+def test_compare_lane_outcomes_requires_per_lane_gate_before_publish(clean_repo: Path):
+    repo = clean_repo
+    tasks = [
+        {"lane_id": "a", "allowed_paths": ["backend.txt"], "task_pack_path": str(_task_pack(repo, 'a', 'backend.txt'))},
+        {"lane_id": "b", "allowed_paths": ["frontend.txt"], "task_pack_path": str(_task_pack(repo, 'b', 'frontend.txt'))},
+    ]
+    _commit_task_packs(repo)
+    plan = minos_fanout.prepare_fanout_plan(repo, "run-302", tasks)
+    execution = minos_fanout.execute_fanout_plan(
+        plan,
+        {
+            'a': ['python3', '-c', "from pathlib import Path; Path('backend.txt').write_text('ok\\n', encoding='utf-8')"],
+            'b': ['python3', '-c', "from pathlib import Path; Path('frontend.txt').write_text('ok\\n', encoding='utf-8')"],
+        },
+    )
+    comparison = minos_fanout.compare_lane_outcomes(
+        execution,
+        {'a': {'gate_passed': True}, 'b': {'gate_passed': False}},
+    )
+    assert comparison['publishable'] is False
+    assert comparison['auto_merge'] is False
+    assert comparison['requires_explicit_review'] is True
+    assert all('scope_ok' in lane for lane in comparison['lane_summaries'])

--- a/tests/scripts/test_minos_gate.py
+++ b/tests/scripts/test_minos_gate.py
@@ -1,0 +1,166 @@
+import importlib.util
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+WORKTREE_SCRIPT_ROOT = Path(os.environ.get("HERMES_SCRIPT_ROOT", str(Path.home() / ".hermes" / "scripts")))
+WORKTREE_SCRIPT_PATH = WORKTREE_SCRIPT_ROOT / "minos_worktree_run.py"
+worktree_spec = importlib.util.spec_from_file_location("minos_worktree_run", WORKTREE_SCRIPT_PATH)
+minos_worktree_run = importlib.util.module_from_spec(worktree_spec)
+worktree_spec.loader.exec_module(minos_worktree_run)
+
+GATE_SCRIPT_PATH = WORKTREE_SCRIPT_ROOT / "minos_gate.py"
+gate_spec = importlib.util.spec_from_file_location("minos_gate", GATE_SCRIPT_PATH)
+minos_gate = importlib.util.module_from_spec(gate_spec)
+gate_spec.loader.exec_module(minos_gate)
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture
+def clean_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "config", "user.email", "test@example.com")
+    (repo / "README.md").write_text("hello\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "initial")
+    return repo
+
+
+def _task_pack(repo: Path, verifier_commands: list[str]) -> Path:
+    task_pack = repo / "task-pack.md"
+    body = [
+        "# Minos task pack",
+        "",
+        "## Verifier commands",
+        "Replace these examples with task-specific commands before execution. Run them before stopping and record the result:",
+    ]
+    body.extend([f"- {cmd}" for cmd in verifier_commands])
+    body.extend(["", "## Stop conditions", "- done"])
+    task_pack.write_text("\n".join(body) + "\n", encoding="utf-8")
+    return task_pack
+
+
+def _bootstrap(repo: Path, verifier_commands: list[str], run_id: str = "run-001") -> dict[str, str]:
+    return minos_worktree_run.bootstrap_run(
+        repo_path=repo,
+        task_pack_path=_task_pack(repo, verifier_commands),
+        run_id=run_id,
+    )
+
+
+def _seed_builder_artifacts(bootstrap: dict[str, str], exit_code: int = 0) -> Path:
+    artifact_dir = Path(bootstrap["artifact_dir"])
+    (artifact_dir / "builder-summary.md").write_text("summary\n", encoding="utf-8")
+    (artifact_dir / "builder-result.json").write_text(
+        json.dumps({"exit_code": exit_code}) + "\n",
+        encoding="utf-8",
+    )
+    (artifact_dir / "git-status.txt").write_text(" M README.md\n", encoding="utf-8")
+    (artifact_dir / "git-diff.patch").write_text(
+        "diff --git a/README.md b/README.md\nindex ce01362..95d8f88 100644\n--- a/README.md\n+++ b/README.md\n@@ -1 +1 @@\n-hello\n+patched from builder\n",
+        encoding="utf-8",
+    )
+    return artifact_dir
+
+
+def test_gate_creates_fresh_validation_lane(clean_repo: Path):
+    bootstrap = _bootstrap(clean_repo, ["python3 -c \"print('ok')\""])
+    _seed_builder_artifacts(bootstrap)
+    with pytest.raises(RuntimeError, match="Gate worktree path already exists"):
+        with pytest.MonkeyPatch.context() as mp:
+            def _no_cleanup(repo_path, worktree_path, branch_name):
+                return None
+            mp.setattr(minos_gate, "_cleanup_gate_worktree", _no_cleanup)
+            minos_gate.run_gate(bootstrap)
+            minos_gate.run_gate(bootstrap)
+
+
+def test_gate_replays_verifier_commands_from_task_pack(clean_repo: Path):
+    bootstrap = _bootstrap(clean_repo, ["python3 -c \"from pathlib import Path; print(Path('README.md').read_text().strip())\""])
+    _seed_builder_artifacts(bootstrap)
+    result = minos_gate.run_gate(bootstrap)
+
+    summary = Path(result["gate_summary_path"]).read_text(encoding="utf-8")
+    command_log = Path(result["gate_log_path"]).read_text(encoding="utf-8")
+    assert "python3 -c \"from pathlib import Path; print(Path('README.md').read_text().strip())\"" in summary
+    assert "patched from builder" in command_log
+    assert result["gate_passed"] is True
+
+
+def test_gate_checks_required_builder_artifacts(clean_repo: Path):
+    bootstrap = _bootstrap(clean_repo, ["python3 -c \"print('ok')\""])
+    artifact_dir = Path(bootstrap["artifact_dir"])
+    (artifact_dir / "builder-summary.md").write_text("summary\n", encoding="utf-8")
+    # intentionally omit builder-result.json and other required artifacts
+
+    result = minos_gate.run_gate(bootstrap)
+
+    persisted = json.loads(Path(result["gate_result_path"]).read_text(encoding="utf-8"))
+    assert result["gate_passed"] is False
+    assert persisted["gate_passed"] is False
+    missing = "\n".join(persisted["missing_artifacts"])
+    assert "builder-result.json" in missing
+    assert "git-diff.patch" in missing
+
+
+def test_gate_writes_final_pass_fail_bundle(clean_repo: Path):
+    bootstrap = _bootstrap(clean_repo, ["python3 -c \"import sys; sys.exit(2)\""])
+    _seed_builder_artifacts(bootstrap, exit_code=0)
+
+    result = minos_gate.run_gate(bootstrap)
+
+    result_path = Path(result["gate_result_path"])
+    summary_path = Path(result["gate_summary_path"])
+    decision_path = Path(result["decision_path"])
+    assert result_path.exists()
+    assert summary_path.exists()
+    assert decision_path.exists()
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    decision = json.loads(decision_path.read_text(encoding="utf-8"))
+    assert payload["gate_passed"] is False
+    assert payload["command_results"][0]["exit_code"] == 2
+    assert payload["builder_exit_code"] == 0
+    assert payload["status_mismatch"] is None
+    assert decision["run_id"] == "run-001"
+    assert decision["builder_status"] == "passed"
+    assert decision["gate_status"] == "failed"
+    assert decision["next_action"] == "retry"
+    assert decision["decision_reason"] == "verifier_failed"
+    assert decision["publish_recommended"] is False
+    assert decision["retry_recommended"] is True
+    assert decision["human_review_required"] is False
+    assert "FAILED" in summary_path.read_text(encoding="utf-8")
+
+
+
+def test_gate_fails_when_artifact_status_mismatches_patch(clean_repo: Path):
+    bootstrap = _bootstrap(clean_repo, ["python3 -c \"print('ok')\""])
+    artifact_dir = _seed_builder_artifacts(bootstrap, exit_code=0)
+    (artifact_dir / "git-status.txt").write_text(" M SOME_OTHER_FILE\n", encoding="utf-8")
+
+    result = minos_gate.run_gate(bootstrap)
+
+    payload = json.loads(Path(result["gate_result_path"]).read_text(encoding="utf-8"))
+    decision = json.loads(Path(result["decision_path"]).read_text(encoding="utf-8"))
+    assert payload["gate_passed"] is False
+    assert payload["status_mismatch"] is not None
+    assert "README.md" in payload["status_mismatch"]["actual"]
+    assert decision["next_action"] == "escalate"
+    assert decision["decision_reason"] == "status_mismatch"
+    assert decision["blocking_findings"]
+    assert decision["human_review_required"] is True

--- a/tests/scripts/test_minos_publish.py
+++ b/tests/scripts/test_minos_publish.py
@@ -1,0 +1,201 @@
+import importlib.util
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT_ROOT = Path(os.environ.get("HERMES_SCRIPT_ROOT", str(Path.home() / ".hermes" / "scripts")))
+PUBLISH_SCRIPT_PATH = SCRIPT_ROOT / "minos_publish.py"
+publish_spec = importlib.util.spec_from_file_location("minos_publish", PUBLISH_SCRIPT_PATH)
+minos_publish = importlib.util.module_from_spec(publish_spec)
+publish_spec.loader.exec_module(minos_publish)
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture
+def repo_with_branch(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "config", "user.email", "test@example.com")
+    (repo / "README.md").write_text("hello\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "initial")
+    _git(repo, "checkout", "-b", "minos/run-001")
+    return repo
+
+
+def _write_decision(repo: Path, payload: dict) -> Path:
+    artifact_dir = repo / ".hermes" / "runs" / "run-001"
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    path = artifact_dir / "minos-decision.json"
+    path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+    return path
+
+
+def test_publish_rejects_without_decision_artifact(repo_with_branch: Path):
+    with pytest.raises(FileNotFoundError, match="decision"):
+        minos_publish.publish_run(
+            repo_path=repo_with_branch,
+            run_id="run-001",
+            remote_name="origin",
+            remote_url="git@github.com:soulsplitters-a11y/private-repo.git",
+            remote_visibility="private",
+            dry_run=True,
+        )
+
+
+def test_publish_rejects_without_gate_pass_even_if_publish_flags_claim_yes(repo_with_branch: Path, monkeypatch):
+    monkeypatch.setattr(minos_publish, "resolve_github_visibility", lambda *_args, **_kwargs: "private")
+    _write_decision(
+        repo_with_branch,
+        {
+            "run_id": "run-001",
+            "builder_status": "passed",
+            "gate_status": "failed",
+            "next_action": "publish",
+            "decision_reason": "passed",
+            "publish_recommended": True,
+            "retry_recommended": False,
+            "human_review_required": False,
+            "blocking_findings": [],
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="gate pass"):
+        minos_publish.publish_run(
+            repo_path=repo_with_branch,
+            run_id="run-001",
+            remote_name="origin",
+            remote_url="git@github.com:soulsplitters-a11y/private-repo.git",
+            remote_visibility="private",
+            dry_run=True,
+        )
+
+
+def test_publish_rejects_when_decision_bundle_failed(repo_with_branch: Path, monkeypatch):
+    monkeypatch.setattr(minos_publish, "resolve_github_visibility", lambda *_args, **_kwargs: "private")
+    _write_decision(
+        repo_with_branch,
+        {
+            "run_id": "run-001",
+            "builder_status": "passed",
+            "gate_status": "failed",
+            "next_action": "retry",
+            "decision_reason": "verifier_failed",
+            "publish_recommended": False,
+            "retry_recommended": True,
+            "human_review_required": False,
+            "blocking_findings": ["verifier failed"],
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="publish"):
+        minos_publish.publish_run(
+            repo_path=repo_with_branch,
+            run_id="run-001",
+            remote_name="origin",
+            remote_url="git@github.com:soulsplitters-a11y/private-repo.git",
+            remote_visibility="private",
+            dry_run=True,
+        )
+
+
+def test_publish_allows_when_decision_bundle_passed(repo_with_branch: Path, monkeypatch):
+    monkeypatch.setattr(minos_publish, "resolve_github_visibility", lambda *_args, **_kwargs: "private")
+    _write_decision(
+        repo_with_branch,
+        {
+            "run_id": "run-001",
+            "builder_status": "passed",
+            "gate_status": "passed",
+            "next_action": "publish",
+            "decision_reason": "passed",
+            "publish_recommended": True,
+            "retry_recommended": False,
+            "human_review_required": False,
+            "blocking_findings": [],
+        },
+    )
+
+    result = minos_publish.publish_run(
+        repo_path=repo_with_branch,
+        run_id="run-001",
+        remote_name="origin",
+        remote_url="git@github.com:soulsplitters-a11y/private-repo.git",
+        remote_visibility="private",
+        dry_run=True,
+    )
+
+    assert result["allowed"] is True
+    assert result["branch_name"] == "minos/run-001"
+    assert result["remote_name"] == "origin"
+
+
+def test_publish_rejects_public_github_destination(repo_with_branch: Path, monkeypatch):
+    monkeypatch.setattr(minos_publish, "resolve_github_visibility", lambda *_args, **_kwargs: "public")
+    _write_decision(
+        repo_with_branch,
+        {
+            "run_id": "run-001",
+            "builder_status": "passed",
+            "gate_status": "passed",
+            "next_action": "publish",
+            "decision_reason": "passed",
+            "publish_recommended": True,
+            "retry_recommended": False,
+            "human_review_required": False,
+            "blocking_findings": [],
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="public GitHub"):
+        minos_publish.publish_run(
+            repo_path=repo_with_branch,
+            run_id="run-001",
+            remote_name="origin",
+            remote_url="git@github.com:soulsplitters-a11y/public-repo.git",
+            remote_visibility="public",
+            dry_run=True,
+        )
+
+
+def test_publish_rejects_branch_mismatch(repo_with_branch: Path, monkeypatch):
+    monkeypatch.setattr(minos_publish, "resolve_github_visibility", lambda *_args, **_kwargs: "private")
+    _write_decision(
+        repo_with_branch,
+        {
+            "run_id": "run-001",
+            "builder_status": "passed",
+            "gate_status": "passed",
+            "next_action": "publish",
+            "decision_reason": "passed",
+            "publish_recommended": True,
+            "retry_recommended": False,
+            "human_review_required": False,
+            "blocking_findings": [],
+        },
+    )
+    _git(repo_with_branch, "checkout", "-b", "some-other-branch")
+
+    with pytest.raises(RuntimeError, match="approved branch"):
+        minos_publish.publish_run(
+            repo_path=repo_with_branch,
+            run_id="run-001",
+            remote_name="origin",
+            remote_url="git@github.com:soulsplitters-a11y/private-repo.git",
+            remote_visibility="private",
+            dry_run=True,
+        )

--- a/tests/scripts/test_minos_worktree_run.py
+++ b/tests/scripts/test_minos_worktree_run.py
@@ -1,0 +1,218 @@
+import importlib.util
+import json
+import os
+import subprocess
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+
+SCRIPT_ROOT = Path(os.environ.get("HERMES_SCRIPT_ROOT", str(Path.home() / ".hermes" / "scripts")))
+SCRIPT_PATH = SCRIPT_ROOT / "minos_worktree_run.py"
+
+
+spec = importlib.util.spec_from_file_location("minos_worktree_run", SCRIPT_PATH)
+minos_worktree_run = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(minos_worktree_run)
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture
+def clean_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.name", "Test User")
+    _git(repo, "config", "user.email", "test@example.com")
+    (repo / "README.md").write_text("hello\n", encoding="utf-8")
+    _git(repo, "add", "README.md")
+    _git(repo, "commit", "-m", "initial")
+    return repo
+
+
+def _task_pack(repo: Path) -> Path:
+    task_pack = repo / "task-pack.md"
+    task_pack.write_text("# task pack\n", encoding="utf-8")
+    return task_pack
+
+
+def test_bootstrap_rejects_dirty_repo(clean_repo: Path):
+    (clean_repo / "README.md").write_text("dirty\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="dirty"):
+        minos_worktree_run.bootstrap_run(
+            repo_path=clean_repo,
+            task_pack_path=_task_pack(clean_repo),
+            run_id="run-001",
+        )
+
+
+def test_bootstrap_creates_worktree_in_deterministic_location(clean_repo: Path):
+    result = minos_worktree_run.bootstrap_run(
+        repo_path=clean_repo,
+        task_pack_path=_task_pack(clean_repo),
+        run_id="run-001",
+    )
+
+    expected = clean_repo / ".hermes" / "worktrees" / "run-001"
+    assert Path(result["worktree_path"]) == expected
+    assert expected.exists()
+    assert (expected / ".git").exists()
+
+
+def test_bootstrap_creates_artifact_dir(clean_repo: Path):
+    result = minos_worktree_run.bootstrap_run(
+        repo_path=clean_repo,
+        task_pack_path=_task_pack(clean_repo),
+        run_id="run-001",
+    )
+
+    artifact_dir = clean_repo / ".hermes" / "runs" / "run-001"
+    assert Path(result["artifact_dir"]) == artifact_dir
+    assert artifact_dir.exists()
+
+
+def test_bootstrap_records_branch_name(clean_repo: Path):
+    result = minos_worktree_run.bootstrap_run(
+        repo_path=clean_repo,
+        task_pack_path=_task_pack(clean_repo),
+        run_id="run-001",
+    )
+
+    metadata_path = clean_repo / ".hermes" / "runs" / "run-001" / "bootstrap.json"
+    assert metadata_path.exists()
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    assert metadata["branch_name"] == "minos/run-001"
+    assert result["branch_name"] == "minos/run-001"
+
+
+def test_bootstrap_rejects_invalid_run_id(clean_repo: Path):
+    for run_id in ("../bad", "bad.lock"):
+        with pytest.raises(ValueError, match="run_id"):
+            minos_worktree_run.bootstrap_run(
+                repo_path=clean_repo,
+                task_pack_path=_task_pack(clean_repo),
+                run_id=run_id,
+            )
+
+
+def test_bootstrap_rolls_back_worktree_when_metadata_write_fails(clean_repo: Path):
+    task_pack = _task_pack(clean_repo)
+    with mock.patch.object(minos_worktree_run, "write_bootstrap_metadata", side_effect=OSError("disk full")):
+        with pytest.raises(OSError, match="disk full"):
+            minos_worktree_run.bootstrap_run(
+                repo_path=clean_repo,
+                task_pack_path=task_pack,
+                run_id="run-001",
+            )
+
+    worktrees = _git(clean_repo, "worktree", "list", "--porcelain").stdout
+    assert str(clean_repo / ".hermes" / "worktrees" / "run-001") not in worktrees
+    branches = _git(clean_repo, "branch", "--list", "minos/run-001").stdout.strip()
+    assert branches == ""
+    assert not (clean_repo / ".hermes" / "runs" / "run-001").exists()
+
+
+def test_bootstrap_does_not_leave_artifact_dir_on_branch_conflict(clean_repo: Path):
+    task_pack = _task_pack(clean_repo)
+    _git(clean_repo, "branch", "minos/run-001")
+
+    with pytest.raises(RuntimeError, match="Branch already exists"):
+        minos_worktree_run.bootstrap_run(
+            repo_path=clean_repo,
+            task_pack_path=task_pack,
+            run_id="run-001",
+        )
+
+    assert not (clean_repo / ".hermes" / "runs" / "run-001").exists()
+
+
+def test_execute_builder_run_captures_stdout_stderr_and_exit_code(clean_repo: Path):
+    bootstrap = minos_worktree_run.bootstrap_run(
+        repo_path=clean_repo,
+        task_pack_path=_task_pack(clean_repo),
+        run_id="run-001",
+    )
+
+    result = minos_worktree_run.execute_builder_run(
+        bootstrap,
+        [
+            "python3",
+            "-c",
+            "import sys; print('hello-out'); print('hello-err', file=sys.stderr); sys.exit(3)",
+        ],
+    )
+
+    assert result["exit_code"] == 3
+    log_path = Path(result["builder_log_path"])
+    assert log_path.exists()
+    log_text = log_path.read_text(encoding="utf-8")
+    assert "hello-out" in log_text
+    assert "hello-err" in log_text
+
+    result_path = Path(result["builder_result_path"])
+    persisted = json.loads(result_path.read_text(encoding="utf-8"))
+    assert persisted["exit_code"] == 3
+
+
+
+def test_execute_builder_run_writes_summary_file(clean_repo: Path):
+    bootstrap = minos_worktree_run.bootstrap_run(
+        repo_path=clean_repo,
+        task_pack_path=_task_pack(clean_repo),
+        run_id="run-001",
+    )
+
+    result = minos_worktree_run.execute_builder_run(
+        bootstrap,
+        ["python3", "-c", "print('summary test')"],
+    )
+
+    summary_path = Path(result["builder_summary_path"])
+    assert summary_path.exists()
+    summary = summary_path.read_text(encoding="utf-8")
+    assert "run-001" in summary
+    assert "exit code: 0" in summary.lower()
+    assert "builder log: builder.log" in summary.lower()
+    assert "git status: git-status.txt" in summary.lower()
+    assert "stdout preview: summary test" in summary.lower()
+
+
+
+def test_execute_builder_run_records_git_status_and_diff(clean_repo: Path):
+    bootstrap = minos_worktree_run.bootstrap_run(
+        repo_path=clean_repo,
+        task_pack_path=_task_pack(clean_repo),
+        run_id="run-001",
+    )
+
+    result = minos_worktree_run.execute_builder_run(
+        bootstrap,
+        [
+            "python3",
+            "-c",
+            "from pathlib import Path; p = Path('README.md'); p.write_text(p.read_text() + 'more\\n', encoding='utf-8'); Path('NEW.txt').write_text('brand new\\n', encoding='utf-8'); Path('newdir').mkdir(); Path('newdir/nested.txt').write_text('nested file\\n', encoding='utf-8')",
+        ],
+    )
+
+    status_text = Path(result["git_status_path"]).read_text(encoding="utf-8")
+    diff_text = Path(result["git_diff_path"]).read_text(encoding="utf-8")
+    assert "README.md" in status_text
+    assert "NEW.txt" in status_text
+    assert "newdir" in status_text
+    assert "README.md" in diff_text
+    assert "+more" in diff_text
+    assert "NEW.txt" in diff_text
+    assert "+brand new" in diff_text
+    assert "newdir/nested.txt" in diff_text
+    assert "+nested file" in diff_text
+    assert "Users/atlas" not in diff_text


### PR DESCRIPTION
## Summary
- add Minos control-plane architecture and artifact docs
- add Minos task-pack and decision templates
- add test coverage for worktree run, gate, publish, and fanout flows

## Testing
- /Users/atlas/.hermes/hermes-agent/venv/bin/pytest /Users/atlas/.hermes/hermes-agent/tests/scripts/test_minos_worktree_run.py /Users/atlas/.hermes/hermes-agent/tests/scripts/test_minos_gate.py /Users/atlas/.hermes/hermes-agent/tests/scripts/test_minos_publish.py /Users/atlas/.hermes/hermes-agent/tests/scripts/test_minos_fanout.py -q