### PR TITLE
fix(gateway): always unlink stale PID files, even with foreign PID

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -213,14 +213,26 @@ def _read_pid_record(pid_path: Optional[Path] = None) -> Optional[dict]:
 
 
 def _cleanup_invalid_pid_path(pid_path: Path, *, cleanup_stale: bool) -> None:
+    """Remove a verified-stale/invalid PID file.
+
+    The caller in ``get_running_pid`` only reaches this path after it has
+    established that the record is unreadable, names a dead process, or
+    references a PID whose identity no longer looks like a gateway — so
+    the file is ours to delete.
+
+    Must NOT call ``remove_pid_file()`` here: its "only unlink if PID
+    matches os.getpid()" guard protects live --replace atexit handoffs
+    but, at *startup*, wrongly preserves foreign stale records. On
+    macOS + launchd that preserved file caused ``write_pid_file()``'s
+    O_CREAT|O_EXCL to trip forever, producing an infinite respawn
+    crash-loop with the log line "PID file race lost to another gateway
+    instance. Exiting." (see crash report 2026-04-22).
+    """
     if not cleanup_stale:
         return
     try:
-        if pid_path == _get_pid_path():
-            remove_pid_file()
-        else:
-            pid_path.unlink(missing_ok=True)
-    except Exception:
+        pid_path.unlink(missing_ok=True)
+    except OSError:
         pass
 
 

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -51,6 +51,46 @@ class TestGatewayPidState:
         assert status.get_running_pid() is None
         assert not pid_path.exists()
 
+    def test_get_running_pid_cleans_up_stale_foreign_gateway_pid_file(self, tmp_path, monkeypatch):
+        """Regression: a gateway.pid left behind by a crashed process
+        (SIGKILL, power loss, launchd kill -9) must be removed by the
+        next startup's liveness check.
+
+        Before the fix, ``_cleanup_invalid_pid_path`` delegated to
+        ``remove_pid_file()``, whose safety guard ("PID doesn't match
+        our own — leave alone") was designed for --replace atexit
+        handoffs but incorrectly protected foreign *stale* records
+        during startup. The observable symptom on macOS + launchd
+        was an infinite respawn crash-loop emitting
+        ``"PID file race lost to another gateway instance. Exiting."``
+        because ``write_pid_file()``'s O_CREAT|O_EXCL kept tripping on
+        the surviving stale file.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        pid_path = tmp_path / "gateway.pid"
+        dead_pid = 999999  # Forced dead via monkeypatched os.kill below.
+        assert dead_pid != os.getpid()
+        pid_path.write_text(json.dumps({
+            "pid": dead_pid,
+            "kind": "hermes-gateway",
+            "argv": ["/venv/bin/python", "-m", "hermes_cli.main", "gateway", "run"],
+            "start_time": None,  # macOS has no /proc — this is the real on-disk shape.
+        }))
+
+        def _simulate_dead(pid, sig):
+            if pid == dead_pid:
+                raise ProcessLookupError
+            return None
+
+        monkeypatch.setattr(status.os, "kill", _simulate_dead)
+
+        assert status.get_running_pid() is None
+        assert not pid_path.exists(), (
+            "Stale gateway.pid must be removed so the next write_pid_file() "
+            "O_CREAT|O_EXCL call can succeed — otherwise launchd respawn "
+            "crash-loops forever on 'PID file race lost'."
+        )
+
     def test_get_running_pid_accepts_gateway_metadata_when_cmdline_unavailable(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         pid_path = tmp_path / "gateway.pid"


### PR DESCRIPTION
## Summary

`gateway/status.py::_cleanup_invalid_pid_path` was delegating to `remove_pid_file()`, whose "only unlink if PID matches `os.getpid()`" guard is correct for the live `--replace` atexit-handoff case it was written for, but wrongly preserves stale foreign records during startup cleanup. The result: once a gateway exits uncleanly (SIGKILL, power loss, launchd `kill -9`), the next startup's liveness check sees a stale PID file belonging to a dead foreign PID, refuses to delete it, and then `write_pid_file()`'s `O_CREAT|O_EXCL` trips forever. Under launchd's `KeepAlive`, this becomes an infinite respawn crash-loop.

## Observed failure (macOS + launchd, 2026-04-22)

`com.hermes.cutieclawie` respawned ~every 15s for ~12 hours (throttled by `ThrottleInterval`). Each child logged:

```
ERROR gateway.run: PID file race lost to another gateway instance. Exiting.
```

The "other instance" was a long-dead PID whose record was left behind by an earlier SIGKILL, because `_cleanup_invalid_pid_path` → `remove_pid_file()` → identity guard → no-op → file survives → next `O_CREAT|O_EXCL` trips again. Forever.

## Fix

When we reach `_cleanup_invalid_pid_path`, `get_running_pid` has already established the file is unreadable, names a dead process, or references a PID whose identity no longer looks like a gateway — so the identity guard that protected live `--replace` handoffs is actively harmful here. Replaced the delegation with a direct `pid_path.unlink(missing_ok=True)` and let the next `O_CREAT|O_EXCL` serialize any real concurrent-startup race.

`remove_pid_file()` itself is left untouched — its guard is still correct for the atexit path it was written for.

## Repro / regression test

`tests/gateway/test_status.py::test_get_running_pid_cleans_up_stale_foreign_gateway_pid_file` writes a gateway-shaped record with a foreign, provably-dead PID, stubs `os.kill` to raise `ProcessLookupError`, and asserts that `get_running_pid()` (a) returns `None`, and (b) removes the stale file. Before the fix: the assertion that the file is gone fails. After the fix: passes.

## Test plan

- [x] `pytest tests/gateway/test_status.py -v` → 28 passed
- [x] Broader sweep `pytest tests/` → 3619 passed / 3 pre-existing unrelated failures (Matrix upload, WhatsApp bridge phase2, AgentCache idle resume — confirmed by reverting fix and re-running: same 3 fail, unrelated to this change)
- [x] Real-agent verification on live Hermes profile (`hermes -p hub gateway run --foreground` with a stale foreign PID injected): gateway started cleanly, wrote its own pid, `hermes -p hub chat -q "ping"` returned the expected response, atexit removed the pid on shutdown.

## Why this matters

This is the difference between a gateway that recovers from a kill -9 and one that requires manual `rm ~/.hermes/profiles/<name>/gateway.pid` intervention after every unclean exit. Under a supervisor like launchd / systemd, the latter means a service outage that grows the longer nobody notices.