### PR TITLE
fix(cli): validate Gemini models against curated catalog instead of probing /models

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2314,6 +2314,69 @@ def validate_requested_model(
                 ),
             }
 
+    # Gemini native AI Studio / Google Gemini CLI (OAuth Code Assist) do not
+    # expose an OpenAI-compatible ``/models`` endpoint: the native AI Studio
+    # REST surface uses ``generateContent`` / ``streamGenerateContent``, and
+    # the OAuth path uses ``cloudcode-pa.googleapis.com``.  Probing either
+    # URL returns HTTP 404, which historically caused ``validate_requested_model``
+    # to reject every ``/model`` switch for Gemini providers (regression
+    # introduced when gemini was migrated off the OpenAI translation layer —
+    # commit 3dea497b).  Validate against the curated catalog instead, mirroring
+    # the OpenAI Codex / MiniMax path.
+    if normalized in ("gemini", "google-gemini-cli"):
+        try:
+            gemini_models = provider_model_ids(normalized)
+        except Exception:
+            gemini_models = []
+        if gemini_models:
+            # Case-insensitive lookup: Gemini model names are already lowercase,
+            # but users sometimes paste "Gemini-3.1-Pro-Preview".
+            catalog_lower = {m.lower(): m for m in gemini_models}
+            if requested_for_lookup.lower() in catalog_lower:
+                return {
+                    "accepted": True,
+                    "persist": True,
+                    "recognized": True,
+                    "message": None,
+                }
+            catalog_lower_list = list(catalog_lower.keys())
+            auto = get_close_matches(
+                requested_for_lookup.lower(), catalog_lower_list, n=1, cutoff=0.9
+            )
+            if auto:
+                corrected = catalog_lower[auto[0]]
+                return {
+                    "accepted": True,
+                    "persist": True,
+                    "recognized": True,
+                    "corrected_model": corrected,
+                    "message": f"Auto-corrected `{requested}` → `{corrected}`",
+                }
+            suggestions = get_close_matches(
+                requested_for_lookup.lower(), catalog_lower_list, n=3, cutoff=0.5
+            )
+            suggestion_text = ""
+            if suggestions:
+                suggestion_text = (
+                    "\n  Similar models: "
+                    + ", ".join(f"`{catalog_lower[s]}`" for s in suggestions)
+                )
+            # Accept unknown Gemini names (preview releases land in the AI
+            # Studio catalog ahead of Hermes' static list) but flag them so
+            # typos are not silently persisted.
+            return {
+                "accepted": True,
+                "persist": True,
+                "recognized": False,
+                "message": (
+                    f"Note: `{requested}` was not found in Hermes' Gemini catalog."
+                    f"{suggestion_text}"
+                    "\n  Google AI Studio and Gemini OAuth do not expose an OpenAI-compatible "
+                    "`/models` endpoint, so Hermes cannot probe for the live model list."
+                    "\n  The model may still work if it exists upstream."
+                ),
+            }
+
     # Probe the live API to check if the model actually exists
     api_models = fetch_api_models(api_key, base_url)
 

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -542,6 +542,108 @@ class TestValidateCodexAutoCorrection:
         assert "not found" in result["message"]
 
 
+# -- validate — Gemini native / OAuth (no /models probe) -----------------------
+
+class TestValidateGeminiCuratedCatalog:
+    """Regression test for #13186: /model switches to Gemini native / OAuth
+    Code Assist must validate against Hermes' curated catalog, not probe a
+    non-existent OpenAI-compatible /models endpoint.
+
+    Background: commit 3dea497b migrated the ``gemini`` provider off the
+    OpenAI translation layer onto the native AI Studio API.  The CLI's
+    ``validate_requested_model`` kept probing ``/v1/models`` for existence,
+    which returns HTTP 404 on both AI Studio (``generativelanguage.googleapis.com``)
+    and OAuth Code Assist (``cloudcode-pa.googleapis.com``), so every
+    ``/model gemini-3.1-pro-preview`` style switch was rejected with
+    ``accepted=False`` and ``"Could not reach the Google AI Studio API to
+    validate..."``.
+    """
+
+    GEMINI_CATALOG = [
+        "gemini-3.1-pro-preview",
+        "gemini-3-pro-preview",
+        "gemini-3-flash-preview",
+        "gemini-3.1-flash-lite-preview",
+    ]
+
+    GEMINI_CLI_CATALOG = [
+        "gemini-3.1-pro-preview",
+        "gemini-3-pro-preview",
+        "gemini-3-flash-preview",
+    ]
+
+    def test_gemini_native_exact_match_accepted(self):
+        """Exact match against the curated Gemini catalog is accepted without probing."""
+        with patch("hermes_cli.models.provider_model_ids", return_value=self.GEMINI_CATALOG), \
+             patch("hermes_cli.models.fetch_api_models") as mock_fetch:
+            result = validate_requested_model("gemini-3.1-pro-preview", "gemini")
+        assert result["accepted"] is True
+        assert result["recognized"] is True
+        assert result["persist"] is True
+        assert result["message"] is None
+        # Critical: must NOT probe the AI Studio endpoint — that is the
+        # bug that caused #13186.
+        mock_fetch.assert_not_called()
+
+    def test_google_gemini_cli_oauth_exact_match_accepted(self):
+        """OAuth Code Assist path (google-gemini-cli) validates against its own catalog."""
+        with patch("hermes_cli.models.provider_model_ids", return_value=self.GEMINI_CLI_CATALOG), \
+             patch("hermes_cli.models.fetch_api_models") as mock_fetch:
+            result = validate_requested_model("gemini-3-flash-preview", "google-gemini-cli")
+        assert result["accepted"] is True
+        assert result["recognized"] is True
+        mock_fetch.assert_not_called()
+
+    def test_gemini_provider_alias_resolves(self):
+        """``google`` / ``google-ai-studio`` aliases route to the gemini catalog."""
+        with patch("hermes_cli.models.provider_model_ids", return_value=self.GEMINI_CATALOG):
+            for alias in ("google", "google-ai-studio", "google-gemini"):
+                result = validate_requested_model("gemini-3.1-pro-preview", alias)
+                assert result["accepted"] is True, f"alias {alias!r} should resolve"
+                assert result["recognized"] is True
+
+    def test_gemini_case_insensitive_match(self):
+        """Pasted names like ``Gemini-3.1-Pro-Preview`` are accepted."""
+        with patch("hermes_cli.models.provider_model_ids", return_value=self.GEMINI_CATALOG):
+            result = validate_requested_model("Gemini-3.1-Pro-Preview", "gemini")
+        assert result["accepted"] is True
+        assert result["recognized"] is True
+
+    def test_gemini_typo_auto_corrects(self):
+        """``gemini-3.1-pro-previw`` (missing ``e``) auto-corrects."""
+        with patch("hermes_cli.models.provider_model_ids", return_value=self.GEMINI_CATALOG):
+            result = validate_requested_model("gemini-3.1-pro-previw", "gemini")
+        assert result["accepted"] is True
+        assert result["recognized"] is True
+        assert result["corrected_model"] == "gemini-3.1-pro-preview"
+        assert "Auto-corrected" in result["message"]
+
+    def test_gemini_unknown_model_accepted_with_warning(self):
+        """Unknown Gemini names (preview releases not yet in the static catalog)
+        are accepted with a warning — rejecting them would leave users stuck
+        when Google ships a new preview model."""
+        with patch("hermes_cli.models.provider_model_ids", return_value=self.GEMINI_CATALOG):
+            result = validate_requested_model("gemini-5-ultra-preview", "gemini")
+        assert result["accepted"] is True
+        assert result["recognized"] is False
+        assert result["persist"] is True
+        assert "not found" in result["message"]
+        # Must mention the probe limitation so the user understands why.
+        assert "/models" in result["message"]
+
+    def test_gemini_does_not_probe_openai_models_endpoint(self):
+        """Regression guard: validate_requested_model MUST NOT call
+        ``fetch_api_models`` for any Gemini provider — that's what caused
+        #13186 in the first place."""
+        with patch("hermes_cli.models.provider_model_ids", return_value=self.GEMINI_CATALOG), \
+             patch("hermes_cli.models.fetch_api_models") as mock_fetch:
+            # Try both: a known model and an unknown one.
+            validate_requested_model("gemini-3-flash-preview", "gemini")
+            validate_requested_model("gemini-99-unreleased", "gemini")
+            validate_requested_model("gemini-3.1-pro-preview", "google-gemini-cli")
+        assert mock_fetch.call_count == 0
+
+
 # -- probe_api_models — Cloudflare UA mitigation --------------------------------
 
 class TestProbeApiModelsUserAgent:


### PR DESCRIPTION
## Summary

Fixes #13186 — `/model <gemini-name>` silently rejected after the native Gemini adapter migration.

Commit 3dea497b migrated the built-in `gemini` provider off the OpenAI translation layer onto the native AI Studio API (`generateContent` / `streamGenerateContent`). The OAuth variant `google-gemini-cli` targets `cloudcode-pa.googleapis.com`. **Neither endpoint exposes an OpenAI-compatible `/v1/models` listing.**

However, `validate_requested_model` in `hermes_cli/models.py` still calls `fetch_api_models` for every provider that doesn't opt out explicitly (openrouter, custom, openai-codex, minimax, bedrock already have bespoke paths). For both Gemini variants the probe returns HTTP 404, so the function falls through to the terminal branch and returns:

```python
{
    "accepted": False,
    "persist": False,
    "message": "Could not reach the Google AI Studio API to validate `gemini-3.1-pro-preview`. ...",
}
```

Net effect: `/model gemini-3.1-pro-preview` and every other Gemini switch silently fails in the CLI and gateway. Reproduced locally against `upstream/main` (see below).

## Fix

Add a `gemini` / `google-gemini-cli` branch mirroring the existing `openai-codex` / `minimax` treatment — validate against Hermes' curated catalog (`_PROVIDER_MODELS["gemini"]` / `_PROVIDER_MODELS["google-gemini-cli"]`) with:

- exact match (case-insensitive — users paste `Gemini-3.1-Pro-Preview` too)
- `difflib.get_close_matches` auto-correction (cutoff 0.9) for typos
- **soft-accept** fallback for unknown Gemini names: preview releases regularly land in AI Studio ahead of Hermes' static catalog, so we mark them `recognized=False` but still `accepted=True, persist=True` with a warning explaining why we can't verify. Rejecting would leave users stuck whenever Google ships a new preview.
- **never probes `/models`** — that's the bug.

The branch is placed immediately after `minimax` and before the generic `fetch_api_models(...)` call, so the `normalize_provider` aliases (`google`, `google-ai-studio`, `google-gemini`) that already resolve to `gemini` flow through correctly.

## Reproduction

Before the fix, against `upstream/main`:

```python
>>> from hermes_cli.models import validate_requested_model
>>> validate_requested_model("gemini-3.1-pro-preview", provider="gemini")
{'accepted': False, 'persist': False, 'recognized': False,
 'message': "Could not reach the Google AI Studio API to validate "
            "`gemini-3.1-pro-preview`. If the service isn't down, this model may not be valid."}
```

After the fix:

```python
>>> validate_requested_model("gemini-3.1-pro-preview", provider="gemini")
{'accepted': True, 'persist': True, 'recognized': True, 'message': None}

>>> validate_requested_model("gemini-3.1-pro-preview", provider="google-gemini-cli")
{'accepted': True, 'persist': True, 'recognized': True, 'message': None}

>>> validate_requested_model("Gemini-3.1-Pro-Preview", provider="gemini")
{'accepted': True, 'persist': True, 'recognized': True, 'message': None}

>>> validate_requested_model("gemini-3.1-pro-previw", provider="gemini")
{'accepted': True, 'persist': True, 'recognized': True,
 'corrected_model': 'gemini-3.1-pro-preview',
 'message': 'Auto-corrected `gemini-3.1-pro-previw` → `gemini-3.1-pro-preview`'}

>>> validate_requested_model("gemini-5-ultra-preview", provider="gemini")  # soft-accept
{'accepted': True, 'persist': True, 'recognized': False,
 'message': "Note: `gemini-5-ultra-preview` was not found in Hermes' Gemini catalog.\n  "
            "Google AI Studio and Gemini OAuth do not expose an OpenAI-compatible "
            "`/models` endpoint, so Hermes cannot probe for the live model list.\n  "
            "The model may still work if it exists upstream."}
```

## Tests

New test class `TestValidateGeminiCuratedCatalog` in `tests/hermes_cli/test_model_validation.py`, 7 cases:

| Test | Asserts |
|---|---|
| `test_gemini_native_exact_match_accepted` | Exact match + `fetch_api_models` is **not** called |
| `test_google_gemini_cli_oauth_exact_match_accepted` | OAuth path validates against its own catalog |
| `test_gemini_provider_alias_resolves` | `google` / `google-ai-studio` / `google-gemini` all work |
| `test_gemini_case_insensitive_match` | Mixed-case input accepted |
| `test_gemini_typo_auto_corrects` | Typo triggers `corrected_model` |
| `test_gemini_unknown_model_accepted_with_warning` | Unknown names soft-accept with guidance |
| `test_gemini_does_not_probe_openai_models_endpoint` | Regression guard — `fetch_api_models.call_count == 0` for any Gemini call |

```
$ pytest tests/hermes_cli/test_model_validation.py -o addopts=''
======================== 63 passed, 1 warning in 0.44s =========================
```

Broader model-validation regression:

```
$ pytest tests/hermes_cli/test_model_validation.py \
         tests/hermes_cli/test_models.py \
         tests/hermes_cli/test_overlay_slug_resolution.py \
         tests/hermes_cli/test_user_providers_model_switch.py \
         tests/hermes_cli/test_model_normalize.py \
         tests/hermes_cli/test_model_switch_variant_tags.py \
         tests/hermes_cli/test_model_switch_custom_providers.py \
         tests/hermes_cli/test_model_provider_persistence.py -o addopts=''
======================== 214 passed, 1 warning in 3.00s =========================
```

## Scope

- `hermes_cli/models.py` — +63 / -0 (new branch in `validate_requested_model`, no changes to any existing code path)
- `tests/hermes_cli/test_model_validation.py` — +102 / -0 (new test class)

Total **+165 / -0**, no behavioural change for non-Gemini providers.

## Related

- #13186 — the bug report this fixes
- #13260 / #13392 — Gemini Code Assist HTTP 404 on API call (different code path: adapter, not `/model` validation); does **not** overlap with this fix
- #13360 — Gemini OAuth model switching: improves curated catalog *content* for the `/model` picker; complementary to this fix which targets `/model`'s validation gate
- Commit 3dea497b — original regression source
