### PR TITLE
fix(ssh): avoid remote tar metadata failures during file sync

### DIFF
--- a/tests/tools/test_ssh_bulk_upload.py
+++ b/tests/tools/test_ssh_bulk_upload.py
@@ -162,15 +162,66 @@ class TestSSHBulkUpload:
 
         # tar: create, dereference symlinks, to stdout
         assert tar_cmd[0] == "tar"
+        assert "--no-xattrs" in tar_cmd
         assert "-chf" in tar_cmd
         assert "-" in tar_cmd  # stdout
         assert "-C" in tar_cmd
+        assert "-T" in tar_cmd
+        assert "." not in tar_cmd
 
         # ssh: extract from stdin at /
         ssh_str = " ".join(ssh_cmd)
         assert "ssh" in ssh_str
         assert "tar xf - -C /" in ssh_str
         assert "testuser@example.com" in ssh_str
+
+    def test_tar_pipe_uses_manifest_and_disables_macos_metadata(self, mock_env, tmp_path):
+        """Archive only file entries and suppress macOS xattr/copyfile metadata."""
+        f1 = tmp_path / "x.txt"
+        f1.write_text("x")
+        f2 = tmp_path / "y.txt"
+        f2.write_text("y")
+
+        files = [
+            (str(f1), "/home/testuser/.hermes/cache/x.txt"),
+            (str(f2), "/home/testuser/.hermes/skills/y.txt"),
+        ]
+
+        tar_calls = []
+
+        def capture_popen(cmd, **kwargs):
+            if cmd[0] == "tar":
+                manifest_path = cmd[cmd.index("-T") + 1]
+                tar_calls.append(
+                    {
+                        "cmd": cmd,
+                        "env": kwargs.get("env", {}),
+                        "manifest": Path(manifest_path).read_text(),
+                    }
+                )
+            mock = MagicMock()
+            mock.stdout = MagicMock()
+            mock.returncode = 0
+            mock.poll.return_value = 0
+            mock.communicate.return_value = (b"", b"")
+            mock.stderr = MagicMock()
+            mock.stderr.read.return_value = b""
+            return mock
+
+        with patch.object(subprocess, "run",
+                          return_value=subprocess.CompletedProcess([], 0)), \
+             patch.object(subprocess, "Popen", side_effect=capture_popen):
+            mock_env._ssh_bulk_upload(files)
+
+        assert len(tar_calls) == 1
+        assert tar_calls[0]["env"]["COPYFILE_DISABLE"] == "1"
+        assert "--no-xattrs" in tar_calls[0]["cmd"]
+        assert "-T" in tar_calls[0]["cmd"]
+        assert "." not in tar_calls[0]["cmd"]
+        assert tar_calls[0]["manifest"].splitlines() == [
+            "home/testuser/.hermes/cache/x.txt",
+            "home/testuser/.hermes/skills/y.txt",
+        ]
 
     def test_mkdir_failure_raises(self, mock_env, tmp_path):
         """mkdir failure should raise RuntimeError before tar pipe."""
@@ -441,7 +492,7 @@ class TestSSHBulkUploadWiring:
 
         monkeypatch.setattr(ssh_env, "FileSyncManager", FakeSyncManager)
 
-        env = SSHEnvironment(host="h", user="u")
+        SSHEnvironment(host="h", user="u")
 
         assert "bulk_upload_fn" in captured_kwargs
         assert captured_kwargs["bulk_upload_fn"] is not None

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -175,17 +175,27 @@ class SSHEnvironment(BaseEnvironment):
 
         # Symlink staging avoids fragile GNU tar --transform rules.
         with tempfile.TemporaryDirectory(prefix="hermes-ssh-bulk-") as staging:
+            tar_entries: list[str] = []
             for host_path, remote_path in files:
-                staged = os.path.join(staging, remote_path.lstrip("/"))
+                tar_entry = remote_path.lstrip("/")
+                staged = os.path.join(staging, tar_entry)
                 os.makedirs(os.path.dirname(staged), exist_ok=True)
                 os.symlink(os.path.abspath(host_path), staged)
+                tar_entries.append(tar_entry)
 
-            tar_cmd = ["tar", "-chf", "-", "-C", staging, "."]
+            manifest_path = os.path.join(staging, ".hermes-tar-entries")
+            with open(manifest_path, "w", encoding="utf-8") as manifest:
+                manifest.write("\n".join(tar_entries))
+                manifest.write("\n")
+
+            tar_cmd = ["tar", "--no-xattrs", "-chf", "-", "-C", staging, "-T", manifest_path]
             ssh_cmd = self._build_ssh_command()
             ssh_cmd.append("tar xf - -C /")
 
+            tar_env = os.environ.copy()
+            tar_env["COPYFILE_DISABLE"] = "1"
             tar_proc = subprocess.Popen(
-                tar_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+                tar_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=tar_env
             )
             try:
                 ssh_proc = subprocess.Popen(


### PR DESCRIPTION
## Summary

Fix SSH bulk file sync so tar extraction does not fail when remote tar tries to restore metadata for parent directories such as `/`, `/home`, or `.`.

The previous bulk upload archived the whole staging root with `tar ... -C <staging> .` and extracted it at `/` on the remote host. On macOS, bsdtar can also emit libarchive xattr metadata. In SSH profiles this produced warnings/errors like:

```
file_sync: sync failed, rolled back state: tar extract over SSH failed
tar: ./home: cannot utime: Operation not permitted
tar: .: cannot utime: Operation not permitted
tar: Ignoring unknown extended header keyword LIBARCHIVE.xattr...
```

## Changes

- Archive only the explicit file entries using a tar manifest instead of archiving the staging root.
- Keep the existing symlink staging approach for preserving remote paths.
- Disable macOS archive metadata with `--no-xattrs` and `COPYFILE_DISABLE=1`.
- Add regression coverage for manifest-based SSH bulk upload.

## Related

Related to #10205. That PR scopes extraction to `.hermes`; this change additionally avoids archiving parent directory entries and suppresses macOS xattr metadata that can break remote extraction.

## Testing

- `source venv/bin/activate && scripts/run_tests.sh tests/tools/test_ssh_bulk_upload.py tests/tools/test_file_sync.py`
- `source venv/bin/activate && uv run --active ruff check tools/environments/ssh.py tests/tools/test_ssh_bulk_upload.py`
- Manual SSH verification against a remote profile: `terminal_tool("pwd")` returned `/home/ubuntu/workspace` with no `file_sync: sync failed` tar/utime warning.
