### PR TITLE
feat(api-server): support inline document file content parts

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -27,6 +27,7 @@ def build_write_denied_paths(home: str) -> set[str]:
             os.path.join(home, ".ssh", "id_ed25519"),
             os.path.join(home, ".ssh", "config"),
             str(hermes_home / ".env"),
+            os.path.join(home, ".hermes", ".env"),
             os.path.join(home, ".bashrc"),
             os.path.join(home, ".zshrc"),
             os.path.join(home, ".profile"),

--- a/agent/transports/__init__.py
+++ b/agent/transports/__init__.py
@@ -27,6 +27,9 @@ def get_transport(api_mode: str):
         _discover_transports()
     cls = _REGISTRY.get(api_mode)
     if cls is None:
+        _discover_transports()
+        cls = _REGISTRY.get(api_mode)
+    if cls is None:
         return None
     return cls()
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -21,6 +21,8 @@ Requires:
 """
 
 import asyncio
+import base64
+import binascii
 import hashlib
 import hmac
 import json
@@ -31,6 +33,7 @@ import re
 import sqlite3
 import time
 import uuid
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 try:
@@ -44,6 +47,9 @@ from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
     BasePlatformAdapter,
     SendResult,
+    SUPPORTED_DOCUMENT_TYPES,
+    cache_document_from_bytes,
+    cleanup_document_cache,
     is_network_accessible,
 )
 
@@ -53,10 +59,41 @@ logger = logging.getLogger(__name__)
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8642
 MAX_STORED_RESPONSES = 100
-MAX_REQUEST_BYTES = 1_000_000  # 1 MB default limit for POST bodies
+DEFAULT_MAX_REQUEST_BYTES = 1_000_000  # 1 MB default limit for POST bodies
 CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS = 30.0
 MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
+MAX_INLINE_FILE_BYTES = 20 * 1024 * 1024  # Match common gateway document limits
+MAX_TEXT_DOCUMENT_INLINE_BYTES = 100 * 1024
+TEXT_DOCUMENT_INLINE_EXTENSIONS = frozenset({".txt", ".md", ".log"})
+
+
+def _parse_max_request_bytes(value: Any, default: int = DEFAULT_MAX_REQUEST_BYTES) -> int:
+    """Parse the API-server body-size override, falling back safely."""
+    if value is None or str(value).strip() == "":
+        return default
+    try:
+        parsed = int(str(value).strip())
+    except (TypeError, ValueError):
+        logger.warning("Invalid API_SERVER_MAX_REQUEST_BYTES=%r; using %d", value, default)
+        return default
+    if parsed <= 0:
+        logger.warning("API_SERVER_MAX_REQUEST_BYTES must be positive; using %d", default)
+        return default
+    return parsed
+
+
+MAX_REQUEST_BYTES = _parse_max_request_bytes(os.getenv("API_SERVER_MAX_REQUEST_BYTES"))
+
+
+def _aiohttp_client_max_size() -> int:
+    """Keep aiohttp's parser cap above Hermes' logical request limit.
+
+    The middleware rejects oversized Content-Length values with an OpenAI-style
+    JSON error before reading the body. aiohttp still needs a larger hard cap
+    for requests without a usable Content-Length.
+    """
+    return max(MAX_REQUEST_BYTES * 2, MAX_REQUEST_BYTES + DEFAULT_MAX_REQUEST_BYTES)
 
 
 def _normalize_chat_content(
@@ -126,20 +163,107 @@ _IMAGE_PART_TYPES = frozenset({"image_url", "input_image"})
 _FILE_PART_TYPES = frozenset({"file", "input_file"})
 
 
-def _normalize_multimodal_content(content: Any) -> Any:
+def _openai_file_error() -> ValueError:
+    return ValueError(
+        "unsupported_content_type:Inline image inputs and inline file_data documents are supported, "
+        "but uploaded file IDs are not supported on this endpoint."
+    )
+
+
+def _safe_display_filename(filename: Any) -> str:
+    safe_name = Path(str(filename or "document")).name.replace("\x00", "").strip()
+    if not safe_name or safe_name in (".", ".."):
+        safe_name = "document"
+    return re.sub(r"[^\w.\- ]", "_", safe_name)
+
+
+def _display_name_from_cached_path(path: str) -> str:
+    basename = os.path.basename(path)
+    parts = basename.split("_", 2)
+    return _safe_display_filename(parts[2] if len(parts) >= 3 else basename)
+
+
+def _normalize_file_content_part(part: Dict[str, Any]) -> Dict[str, Any]:
+    """Validate a file/input_file part shape and emit one canonical form."""
+    part_type = str(part.get("type") or "").strip().lower()
+
+    if part.get("file_id"):
+        raise _openai_file_error()
+
+    file_obj = part.get("file") if isinstance(part.get("file"), dict) else {}
+    if isinstance(file_obj, dict) and file_obj.get("file_id"):
+        raise _openai_file_error()
+
+    if part_type == "file":
+        if not isinstance(file_obj, dict) or not file_obj:
+            raise ValueError("invalid_content_part:File parts must include a file object.")
+        filename = file_obj.get("filename") or part.get("filename")
+        file_data = file_obj.get("file_data")
+    elif part_type == "input_file":
+        filename = part.get("filename") or file_obj.get("filename")
+        file_data = part.get("file_data") or file_obj.get("file_data")
+    else:  # pragma: no cover - caller guards part_type
+        raise ValueError(f"unsupported_content_type:Unsupported content part type {part_type!r}.")
+
+    if not isinstance(filename, str) or not filename.strip():
+        raise ValueError("invalid_content_part:File parts must include a non-empty filename.")
+    if not isinstance(file_data, str) or not file_data.strip():
+        raise ValueError("invalid_content_part:File parts must include non-empty file_data.")
+
+    return {
+        "type": "file",
+        "file": {
+            "filename": filename.strip(),
+            "file_data": file_data.strip(),
+        },
+    }
+
+
+def _extract_document_extension(filename: str) -> str:
+    return Path(_safe_display_filename(filename)).suffix.lower()
+
+
+def _decode_inline_file_data(file_data: str) -> bytes:
+    data = file_data.strip()
+    if data.lower().startswith("data:"):
+        header, sep, payload = data.partition(",")
+        if not sep or ";base64" not in header.lower():
+            raise ValueError("invalid_content_part:File data URLs must use base64 encoding.")
+        data = payload.strip()
+
+    try:
+        raw = base64.b64decode(data, validate=True)
+    except (binascii.Error, ValueError):
+        raise ValueError("invalid_content_part:File data must be valid base64.") from None
+
+    if not raw:
+        raise ValueError("invalid_content_part:File data must decode to non-empty bytes.")
+    if len(raw) > MAX_INLINE_FILE_BYTES:
+        raise ValueError("unsupported_content_type:File input is too large.")
+    return raw
+
+
+def _text_part(text: str) -> Dict[str, str]:
+    return {"type": "text", "text": text}
+
+
+def _normalize_multimodal_content(content: Any, *, allow_files: bool = False) -> Any:
     """Validate and normalize multimodal content for the API server.
 
     Returns a plain string when the content is text-only, or a list of
-    ``{"type": "text"|"image_url", ...}`` parts when images are present.
+    ``{"type": "text"|"image_url"|"file", ...}`` parts when images or
+    accepted inline documents are present.
     The output shape is the native OpenAI Chat Completions vision format,
     which the agent pipeline accepts verbatim (OpenAI-wire providers) or
-    converts (``_preprocess_anthropic_content`` for Anthropic).
+    converts (``_preprocess_anthropic_content`` for Anthropic).  File parts
+    are an API-server boundary format and are converted to text notes before
+    the agent sees them.
 
     Raises ``ValueError`` with an OpenAI-style code on invalid input:
-      * ``unsupported_content_type`` — file/input_file/file_id parts, or
-        non-image ``data:`` URLs.
+      * ``unsupported_content_type`` — file/input_file/file_id parts when not
+        allowed, uploaded file IDs, or non-image ``data:`` URLs.
       * ``invalid_image_url`` — missing URL or unsupported scheme.
-      * ``invalid_content_part`` — malformed text/image objects.
+      * ``invalid_content_part`` — malformed text/image/file objects.
 
     Callers translate the ValueError into a 400 response.
     """
@@ -220,10 +344,13 @@ def _normalize_multimodal_content(content: Any) -> Any:
             continue
 
         if part_type in _FILE_PART_TYPES:
-            raise ValueError(
-                "unsupported_content_type:Inline image inputs are supported, "
-                "but uploaded files and document inputs are not supported on this endpoint."
-            )
+            if not allow_files:
+                raise ValueError(
+                    "unsupported_content_type:Inline file inputs are supported only on "
+                    "the latest Chat Completions user message."
+                )
+            normalized_parts.append(_normalize_file_content_part(part))
+            continue
 
         # Unknown part type — reject explicitly so clients get a clear error
         # instead of a silently dropped turn.
@@ -255,6 +382,8 @@ def _content_has_visible_payload(content: Any) -> bool:
                 if ptype in _TEXT_PART_TYPES and str(part.get("text") or "").strip():
                     return True
                 if ptype in _IMAGE_PART_TYPES:
+                    return True
+                if ptype in _FILE_PART_TYPES:
                     return True
     return False
 
@@ -623,6 +752,89 @@ class APIServerAdapter(BasePlatformAdapter):
             pass
         return "hermes-agent"
 
+    def _process_file_content_parts(self, content: Any) -> Any:
+        """Convert API-server file parts into gateway-style document notes."""
+        if not isinstance(content, list):
+            return content
+
+        output_parts: List[Dict[str, Any]] = []
+        for part in content:
+            if not isinstance(part, dict):
+                continue
+            ptype = str(part.get("type") or "").strip().lower()
+            if ptype == "file":
+                output_parts.extend(self._process_file_content_part(part))
+            else:
+                output_parts.append(part)
+
+        if not output_parts:
+            return ""
+        if all(p.get("type") == "text" for p in output_parts):
+            return "\n\n".join(str(p.get("text") or "") for p in output_parts if p.get("text"))
+        return output_parts
+
+    def _process_file_content_part(self, part: Dict[str, Any]) -> List[Dict[str, str]]:
+        file_meta = part.get("file") if isinstance(part.get("file"), dict) else {}
+        filename = str(file_meta.get("filename") or "document")
+        display_name = _safe_display_filename(filename)
+        ext = _extract_document_extension(filename)
+        if ext not in SUPPORTED_DOCUMENT_TYPES:
+            supported = ", ".join(sorted(SUPPORTED_DOCUMENT_TYPES))
+            raise ValueError(
+                f"unsupported_content_type:Unsupported document type {ext or 'unknown'}. "
+                f"Supported types: {supported}."
+            )
+
+        raw = _decode_inline_file_data(str(file_meta.get("file_data") or ""))
+        mime_type = SUPPORTED_DOCUMENT_TYPES[ext]
+
+        try:
+            cached_path = cache_document_from_bytes(raw, filename)
+            cleanup_document_cache(max_age_hours=24)
+        except Exception as exc:
+            logger.warning("Failed to cache API-server document %s: %s", display_name, exc, exc_info=True)
+            raise ValueError("invalid_content_part:File input could not be cached.") from None
+
+        try:
+            from tools.credential_files import get_cache_file_container_path
+
+            sandbox_path = get_cache_file_container_path(cached_path)
+        except Exception as exc:
+            logger.warning("Failed to map cached API-server document into sandbox path: %s", exc, exc_info=True)
+            raise ValueError("invalid_content_part:Cached file could not be mapped into the agent sandbox.") from None
+
+        display_name = _display_name_from_cached_path(cached_path)
+        is_text_document = mime_type.startswith("text/")
+        notes: List[Dict[str, str]] = []
+        text_included = False
+
+        if ext in TEXT_DOCUMENT_INLINE_EXTENSIONS and len(raw) <= MAX_TEXT_DOCUMENT_INLINE_BYTES:
+            try:
+                text_content = raw.decode("utf-8")
+                text_included = True
+            except UnicodeDecodeError:
+                text_content = ""
+        else:
+            text_content = ""
+
+        if is_text_document and text_included:
+            notes.append(_text_part(
+                f"[The user sent a text document: '{display_name}'. "
+                f"Its content has been included below. "
+                f"The file is also saved at: {sandbox_path}]"
+            ))
+        else:
+            size_kb = max(1, len(raw) // 1024)
+            notes.append(_text_part(
+                f"[The user sent a document: '{display_name}' ({mime_type}, {size_kb} KB). "
+                f"The file is saved at: {sandbox_path}.]"
+            ))
+
+        if text_included:
+            notes.append(_text_part(f"[Content of {display_name}]:\n{text_content}"))
+
+        return notes
+
     def _cors_headers_for_origin(self, origin: str) -> Optional[Dict[str, str]]:
         """Return CORS headers for an allowed browser origin."""
         if not origin or not self._cors_origins:
@@ -827,7 +1039,15 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # Extract system message (becomes ephemeral system prompt layered ON TOP of core)
         system_prompt = None
-        conversation_messages: List[Dict[str, str]] = []
+        conversation_messages: List[Dict[str, Any]] = []
+        last_user_idx = next(
+            (
+                idx
+                for idx in range(len(messages) - 1, -1, -1)
+                if isinstance(messages[idx], dict) and messages[idx].get("role") == "user"
+            ),
+            None,
+        )
 
         for idx, msg in enumerate(messages):
             role = msg.get("role", "")
@@ -842,7 +1062,12 @@ class APIServerAdapter(BasePlatformAdapter):
                     system_prompt = system_prompt + "\n" + content
             elif role in ("user", "assistant"):
                 try:
-                    content = _normalize_multimodal_content(raw_content)
+                    content = _normalize_multimodal_content(
+                        raw_content,
+                        allow_files=(role == "user" and idx == last_user_idx),
+                    )
+                    if role == "user" and idx == last_user_idx:
+                        content = self._process_file_content_parts(content)
                 except ValueError as exc:
                     return _multimodal_validation_error(exc, param=f"messages[{idx}].content")
                 conversation_messages.append({"role": role, "content": content})
@@ -2488,7 +2713,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
         try:
             mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
-            self._app = web.Application(middlewares=mws)
+            self._app = web.Application(middlewares=mws, client_max_size=_aiohttp_client_max_size())
             self._app["api_server_adapter"] = self
             self._app.router.add_get("/health", self._handle_health)
             self._app.router.add_get("/health/detailed", self._handle_health_detailed)

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -33,6 +33,14 @@ from hermes_constants import OPENROUTER_MODELS_URL
 from utils import base_url_host_matches
 
 
+def _which(command: str) -> str | None:
+    """Return an executable path, tolerating platform monkeypatches in tests."""
+    try:
+        return shutil.which(command)
+    except AttributeError:
+        return None
+
+
 _PROVIDER_ENV_HINTS = (
     "OPENROUTER_API_KEY",
     "OPENAI_API_KEY",
@@ -490,7 +498,7 @@ def run_doctor(args):
     except Exception as e:
         check_warn("Auth provider status", f"(could not check: {e})")
 
-    if shutil.which("codex"):
+    if _which("codex"):
         check_ok("codex CLI")
     else:
         check_warn("codex CLI not found", "(required for openai-codex login)")
@@ -701,13 +709,13 @@ def run_doctor(args):
     print(color("◆ External Tools", Colors.CYAN, Colors.BOLD))
     
     # Git
-    if shutil.which("git"):
+    if _which("git"):
         check_ok("git")
     else:
         check_warn("git not found", "(optional)")
     
     # ripgrep (optional, for faster file search)
-    if shutil.which("rg"):
+    if _which("rg"):
         check_ok("ripgrep (rg)", "(faster file search)")
     else:
         check_warn("ripgrep (rg) not found", "(file search uses grep fallback)")
@@ -716,7 +724,7 @@ def run_doctor(args):
     # Docker (optional)
     terminal_env = os.getenv("TERMINAL_ENV", "local")
     if terminal_env == "docker":
-        if shutil.which("docker"):
+        if _which("docker"):
             # Check if docker daemon is running
             try:
                 result = subprocess.run(["docker", "info"], capture_output=True, timeout=10)
@@ -731,7 +739,7 @@ def run_doctor(args):
             check_fail("docker not found", "(required for TERMINAL_ENV=docker)")
             issues.append("Install Docker or change TERMINAL_ENV")
     else:
-        if shutil.which("docker"):
+        if _which("docker"):
             check_ok("docker", "(optional)")
         else:
             if _is_termux():
@@ -778,7 +786,7 @@ def run_doctor(args):
             issues.append("Install daytona SDK: pip install daytona")
 
     # Node.js + agent-browser (for browser automation tools)
-    if shutil.which("node"):
+    if _which("node"):
         check_ok("Node.js")
         # Check if agent-browser is installed
         agent_browser_path = PROJECT_ROOT / "node_modules" / "agent-browser"
@@ -804,7 +812,7 @@ def run_doctor(args):
             check_warn("Node.js not found", "(optional, needed for browser tools)")
     
     # npm audit for all Node.js packages
-    if shutil.which("npm"):
+    if _which("npm"):
         npm_dirs = [
             (PROJECT_ROOT, "Browser tools (agent-browser)"),
             (PROJECT_ROOT / "scripts" / "whatsapp-bridge", "WhatsApp bridge"),

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -127,7 +127,7 @@ TIPS = [
 
     # --- Tools & Capabilities ---
     "execute_code runs Python scripts that call Hermes tools programmatically — results stay out of context.",
-    "delegate_task spawns up to 3 concurrent sub-agents by default (configurable via delegation.max_concurrent_children) with isolated contexts for parallel work.",
+    "delegate_task runs up to 3 sub-agents by default, configurable via delegation.max_concurrent_children, each with an isolated context.",
     "web_extract works on PDF URLs — pass any PDF link and it converts to markdown.",
     "search_files is ripgrep-backed and faster than grep — use it instead of terminal grep.",
     "patch uses 9 fuzzy matching strategies so minor whitespace differences won't break edits.",
@@ -343,5 +343,4 @@ def get_random_tip(exclude_recent: int = 0) -> str:
             deduplication across sessions.
     """
     return random.choice(TIPS)
-
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -2015,8 +2015,9 @@ class AIAgent:
         old_norm = (old_provider or "").strip().lower()
         new_norm = (new_provider or "").strip().lower()
         if old_norm and new_norm and old_norm != new_norm:
+            fallback_chain = getattr(self, "_fallback_chain", [])
             self._fallback_chain = [
-                entry for entry in self._fallback_chain
+                entry for entry in fallback_chain
                 if (entry.get("provider") or "").strip().lower() not in {old_norm, new_norm}
             ]
             self._fallback_model = self._fallback_chain[0] if self._fallback_chain else None
@@ -3892,13 +3893,15 @@ class AIAgent:
 
         # 2. Clean terminal sandbox environments
         try:
-            cleanup_vm(task_id)
+            from tools import terminal_tool
+            terminal_tool.cleanup_vm(task_id)
         except Exception:
             pass
 
         # 3. Clean browser daemon sessions
         try:
-            cleanup_browser(task_id)
+            from tools import browser_tool
+            browser_tool.cleanup_browser(task_id)
         except Exception:
             pass
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -28,7 +28,9 @@ from gateway.platforms.api_server import (
     ResponseStore,
     _IdempotencyCache,
     _CORS_HEADERS,
+    _aiohttp_client_max_size,
     _derive_chat_session_id,
+    _parse_max_request_bytes,
     check_api_server_requirements,
     cors_middleware,
     security_headers_middleware,
@@ -47,6 +49,24 @@ class TestCheckRequirements:
     @patch("gateway.platforms.api_server.AIOHTTP_AVAILABLE", False)
     def test_returns_false_without_aiohttp(self):
         assert check_api_server_requirements() is False
+
+
+class TestRequestBodyLimitConfig:
+    def test_default_when_unset(self):
+        assert _parse_max_request_bytes(None, default=123) == 123
+
+    def test_positive_integer_override(self):
+        assert _parse_max_request_bytes("2097152", default=123) == 2_097_152
+
+    def test_malformed_override_falls_back(self):
+        assert _parse_max_request_bytes("not-an-int", default=123) == 123
+
+    def test_non_positive_override_falls_back(self):
+        assert _parse_max_request_bytes("0", default=123) == 123
+
+    def test_aiohttp_parser_cap_stays_above_logical_limit(self):
+        with patch("gateway.platforms.api_server.MAX_REQUEST_BYTES", 10):
+            assert _aiohttp_client_max_size() > 10
 
 
 # ---------------------------------------------------------------------------
@@ -201,7 +221,10 @@ class TestIdempotencyCache:
 
 
 class TestAdapterInit:
-    def test_default_config(self):
+    def test_default_config(self, monkeypatch):
+        monkeypatch.delenv("API_SERVER_PORT", raising=False)
+        monkeypatch.delenv("API_SERVER_HOST", raising=False)
+        monkeypatch.delenv("API_SERVER_KEY", raising=False)
         config = PlatformConfig(enabled=True)
         adapter = APIServerAdapter(config)
         assert adapter._host == "127.0.0.1"

--- a/tests/gateway/test_api_server_multimodal.py
+++ b/tests/gateway/test_api_server_multimodal.py
@@ -1,4 +1,4 @@
-"""End-to-end tests for inline image inputs on /v1/chat/completions and /v1/responses.
+"""End-to-end tests for inline multimodal inputs on /v1/chat/completions and /v1/responses.
 
 Covers the multimodal normalization path added to the API server.  Unlike the
 adapter-level tests that patch ``_run_agent``, these tests patch
@@ -7,6 +7,8 @@ path (including the ``run_agent`` prologue that used to crash on list content)
 executes against a real aiohttp app.
 """
 
+import base64
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -16,6 +18,7 @@ from aiohttp.test_utils import TestClient, TestServer
 from gateway.config import PlatformConfig
 from gateway.platforms.api_server import (
     APIServerAdapter,
+    body_limit_middleware,
     _content_has_visible_payload,
     _normalize_multimodal_content,
     cors_middleware,
@@ -82,6 +85,24 @@ class TestNormalizeMultimodalContent:
             _normalize_multimodal_content([{"type": "file", "file": {"file_id": "f_1"}}])
         assert str(exc.value).startswith("unsupported_content_type:")
 
+    def test_file_part_normalized_when_allowed(self):
+        out = _normalize_multimodal_content(
+            [{"type": "file", "file": {"filename": "notes.txt", "file_data": _b64(b"hello")}}],
+            allow_files=True,
+        )
+        assert out == [
+            {"type": "file", "file": {"filename": "notes.txt", "file_data": _b64(b"hello")}},
+        ]
+
+    def test_input_file_part_normalized_when_allowed(self):
+        out = _normalize_multimodal_content(
+            [{"type": "input_file", "filename": "report.pdf", "file_data": _b64(b"%PDF-1.4")}],
+            allow_files=True,
+        )
+        assert out == [
+            {"type": "file", "file": {"filename": "report.pdf", "file_data": _b64(b"%PDF-1.4")}},
+        ]
+
     def test_input_file_part_rejected(self):
         with pytest.raises(ValueError) as exc:
             _normalize_multimodal_content([{"type": "input_file", "file_id": "f_1"}])
@@ -113,6 +134,9 @@ class TestContentHasVisiblePayload:
     def test_list_with_image_only(self):
         assert _content_has_visible_payload([{"type": "image_url", "image_url": {"url": "x"}}])
 
+    def test_list_with_file_only(self):
+        assert _content_has_visible_payload([{"type": "file", "file": {"filename": "x.txt"}}])
+
     def test_list_with_only_empty_text(self):
         assert not _content_has_visible_payload([{"type": "text", "text": ""}])
 
@@ -127,13 +151,28 @@ def _make_adapter() -> APIServerAdapter:
 
 
 def _create_app(adapter: APIServerAdapter) -> web.Application:
-    mws = [mw for mw in (cors_middleware, security_headers_middleware) if mw is not None]
-    app = web.Application(middlewares=mws)
+    import gateway.platforms.api_server as api_server_mod
+
+    mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
+    app = web.Application(middlewares=mws, client_max_size=api_server_mod._aiohttp_client_max_size())
     app["api_server_adapter"] = adapter
     app.router.add_post("/v1/chat/completions", adapter._handle_chat_completions)
     app.router.add_post("/v1/responses", adapter._handle_responses)
     app.router.add_get("/v1/responses/{response_id}", adapter._handle_get_response)
     return app
+
+
+def _b64(data: bytes) -> str:
+    return base64.b64encode(data).decode("ascii")
+
+
+@pytest.fixture
+def hermes_cache_home(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    document_cache = hermes_home / "cache" / "documents"
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr("gateway.platforms.base.DOCUMENT_CACHE_DIR", document_cache)
+    return hermes_home
 
 
 @pytest.fixture
@@ -204,6 +243,137 @@ class TestChatCompletionsMultimodalHTTP:
             assert mock_run.captured["user_message"] == "hello"
 
     @pytest.mark.asyncio
+    async def test_inline_text_file_cached_and_injected(self, adapter, hermes_cache_home):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new=MagicMock()) as mock_run:
+                async def _stub(**kwargs):
+                    mock_run.captured = kwargs
+                    return (
+                        {"final_response": "ok", "messages": [], "api_calls": 1},
+                        {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                    )
+                mock_run.side_effect = _stub
+
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [
+                            {
+                                "role": "user",
+                                "content": [
+                                    {"type": "text", "text": "Read this."},
+                                    {
+                                        "type": "file",
+                                        "file": {
+                                            "filename": "notes.txt",
+                                            "file_data": _b64(b"hello from the document"),
+                                        },
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                )
+
+            assert resp.status == 200, await resp.text()
+            user_message = mock_run.captured["user_message"]
+            assert isinstance(user_message, str)
+            assert "Read this." in user_message
+            assert "The user sent a text document: 'notes.txt'" in user_message
+            assert "Its content has been included below" in user_message
+            assert "/root/.hermes/cache/documents/" in user_message
+            assert str(hermes_cache_home) not in user_message
+            assert "[Content of notes.txt]:\nhello from the document" in user_message
+
+            cached_files = list((hermes_cache_home / "cache" / "documents").iterdir())
+            assert len(cached_files) == 1
+            assert cached_files[0].name.startswith("doc_")
+            assert cached_files[0].name.endswith("_notes.txt")
+
+    @pytest.mark.asyncio
+    async def test_inline_pdf_file_uses_gateway_style_note(self, adapter, hermes_cache_home):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new=MagicMock()) as mock_run:
+                async def _stub(**kwargs):
+                    mock_run.captured = kwargs
+                    return (
+                        {"final_response": "ok", "messages": [], "api_calls": 1},
+                        {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                    )
+                mock_run.side_effect = _stub
+
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [
+                            {
+                                "role": "user",
+                                "content": [
+                                    {
+                                        "type": "input_file",
+                                        "filename": "report.pdf",
+                                        "file_data": _b64(b"%PDF-1.4\n%fake"),
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                )
+
+            assert resp.status == 200, await resp.text()
+            user_message = mock_run.captured["user_message"]
+            assert isinstance(user_message, str)
+            assert "The user sent a document: 'report.pdf'" in user_message
+            assert "application/pdf" in user_message
+            assert "/root/.hermes/cache/documents/" in user_message
+            assert "[Content of report.pdf]" not in user_message
+
+    @pytest.mark.asyncio
+    async def test_inline_file_keeps_image_parts(self, adapter, hermes_cache_home):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new=MagicMock()) as mock_run:
+                async def _stub(**kwargs):
+                    mock_run.captured = kwargs
+                    return (
+                        {"final_response": "ok", "messages": [], "api_calls": 1},
+                        {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                    )
+                mock_run.side_effect = _stub
+
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [
+                            {
+                                "role": "user",
+                                "content": [
+                                    {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+                                    {
+                                        "type": "file",
+                                        "file": {"filename": "notes.md", "file_data": _b64(b"# note")},
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                )
+
+            assert resp.status == 200, await resp.text()
+            user_message = mock_run.captured["user_message"]
+            assert isinstance(user_message, list)
+            assert user_message[0]["type"] == "image_url"
+            assert any(
+                part.get("type") == "text" and "The user sent a text document: 'notes.md'" in part.get("text", "")
+                for part in user_message
+            )
+
+    @pytest.mark.asyncio
     async def test_file_part_returns_400(self, adapter):
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:
@@ -220,6 +390,250 @@ class TestChatCompletionsMultimodalHTTP:
             body = await resp.json()
         assert body["error"]["code"] == "unsupported_content_type"
         assert body["error"]["param"] == "messages[0].content"
+
+    @pytest.mark.asyncio
+    async def test_historical_file_part_returns_400(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "hermes-agent",
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {
+                                    "type": "file",
+                                    "file": {"filename": "old.txt", "file_data": _b64(b"old")},
+                                },
+                            ],
+                        },
+                        {"role": "assistant", "content": "ok"},
+                        {"role": "user", "content": "new turn"},
+                    ],
+                },
+            )
+            assert resp.status == 400
+            body = await resp.json()
+        assert body["error"]["code"] == "unsupported_content_type"
+        assert body["error"]["param"] == "messages[0].content"
+
+    @pytest.mark.asyncio
+    async def test_assistant_file_part_returns_400(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "hermes-agent",
+                    "messages": [
+                        {"role": "user", "content": "hi"},
+                        {
+                            "role": "assistant",
+                            "content": [
+                                {
+                                    "type": "file",
+                                    "file": {"filename": "assistant.txt", "file_data": _b64(b"no")},
+                                },
+                            ],
+                        },
+                    ],
+                },
+            )
+            assert resp.status == 400
+            body = await resp.json()
+        assert body["error"]["code"] == "unsupported_content_type"
+        assert body["error"]["param"] == "messages[1].content"
+
+    @pytest.mark.asyncio
+    async def test_invalid_base64_file_returns_400(self, adapter, hermes_cache_home):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "hermes-agent",
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "file", "file": {"filename": "notes.txt", "file_data": "not base64"}},
+                            ],
+                        },
+                    ],
+                },
+            )
+            assert resp.status == 400
+            body = await resp.json()
+        assert body["error"]["code"] == "invalid_content_part"
+        assert body["error"]["param"] == "messages[0].content"
+        assert not (hermes_cache_home / "cache" / "documents").exists()
+
+    @pytest.mark.asyncio
+    async def test_data_url_file_data_prefix_is_accepted(self, adapter, hermes_cache_home):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new=MagicMock()) as mock_run:
+                async def _stub(**kwargs):
+                    mock_run.captured = kwargs
+                    return (
+                        {"final_response": "ok", "messages": [], "api_calls": 1},
+                        {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                    )
+                mock_run.side_effect = _stub
+
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [
+                            {
+                                "role": "user",
+                                "content": [
+                                    {
+                                        "type": "file",
+                                        "file": {
+                                            "filename": "notes.txt",
+                                            "file_data": f"data:text/plain;base64,{_b64(b'prefixed')}",
+                                        },
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                )
+
+            assert resp.status == 200, await resp.text()
+            assert "[Content of notes.txt]:\nprefixed" in mock_run.captured["user_message"]
+
+    @pytest.mark.asyncio
+    async def test_oversized_decoded_file_returns_400(self, adapter, hermes_cache_home):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch("gateway.platforms.api_server.MAX_INLINE_FILE_BYTES", 4):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "hermes-agent",
+                        "messages": [
+                            {
+                                "role": "user",
+                                "content": [
+                                    {"type": "file", "file": {"filename": "notes.txt", "file_data": _b64(b"12345")}},
+                                ],
+                            },
+                        ],
+                    },
+                )
+            assert resp.status == 400
+            body = await resp.json()
+        assert body["error"]["code"] == "unsupported_content_type"
+        assert body["error"]["param"] == "messages[0].content"
+        assert not (hermes_cache_home / "cache" / "documents").exists()
+
+    @pytest.mark.asyncio
+    async def test_unsupported_file_extension_returns_400(self, adapter, hermes_cache_home):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "hermes-agent",
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "file", "file": {"filename": "script.exe", "file_data": _b64(b"MZ")}},
+                            ],
+                        },
+                    ],
+                },
+            )
+            assert resp.status == 400
+            body = await resp.json()
+        assert body["error"]["code"] == "unsupported_content_type"
+        assert body["error"]["param"] == "messages[0].content"
+        assert not (hermes_cache_home / "cache" / "documents").exists()
+
+    @pytest.mark.asyncio
+    async def test_file_part_missing_filename_returns_400(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "hermes-agent",
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": [{"type": "file", "file": {"file_data": _b64(b"hello")}}],
+                        },
+                    ],
+                },
+            )
+            assert resp.status == 400
+            body = await resp.json()
+        assert body["error"]["code"] == "invalid_content_part"
+
+    @pytest.mark.asyncio
+    async def test_content_length_above_limit_returns_413(self, adapter):
+        with patch("gateway.platforms.api_server.MAX_REQUEST_BYTES", 10):
+            app = _create_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    data=b"x" * 11,
+                    headers={"Content-Type": "application/json"},
+                )
+                assert resp.status == 413
+                body = await resp.json()
+        assert body["error"]["code"] == "body_too_large"
+
+    @pytest.mark.asyncio
+    async def test_file_request_above_default_body_limit_succeeds_when_limit_raised(
+        self,
+        adapter,
+        hermes_cache_home,
+    ):
+        raw_file = b"x" * (1_100_000)
+        with patch("gateway.platforms.api_server.MAX_REQUEST_BYTES", 2_000_000):
+            app = _create_app(adapter)
+            async with TestClient(TestServer(app)) as cli:
+                with patch.object(
+                    adapter,
+                    "_run_agent",
+                    new=MagicMock(),
+                ) as mock_run:
+                    async def _stub(**kwargs):
+                        mock_run.captured = kwargs
+                        return (
+                            {"final_response": "ok", "messages": [], "api_calls": 1},
+                            {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                        )
+                    mock_run.side_effect = _stub
+
+                    resp = await cli.post(
+                        "/v1/chat/completions",
+                        json={
+                            "model": "hermes-agent",
+                            "messages": [
+                                {
+                                    "role": "user",
+                                    "content": [
+                                        {
+                                            "type": "file",
+                                            "file": {"filename": "large.txt", "file_data": _b64(raw_file)},
+                                        },
+                                    ],
+                                },
+                            ],
+                        },
+                    )
+
+            assert resp.status == 200, await resp.text()
+            assert "The user sent a document: 'large.txt'" in mock_run.captured["user_message"]
+            assert "[Content of large.txt]" not in mock_run.captured["user_message"]
 
     @pytest.mark.asyncio
     async def test_non_image_data_url_returns_400(self, adapter):
@@ -299,6 +713,32 @@ class TestResponsesMultimodalHTTP:
                         {
                             "role": "user",
                             "content": [{"type": "input_file", "file_id": "f_1"}],
+                        }
+                    ],
+                },
+            )
+            assert resp.status == 400
+            body = await resp.json()
+        assert body["error"]["code"] == "unsupported_content_type"
+
+    @pytest.mark.asyncio
+    async def test_inline_input_file_returns_400(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/responses",
+                json={
+                    "model": "hermes-agent",
+                    "input": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {
+                                    "type": "input_file",
+                                    "filename": "notes.txt",
+                                    "file_data": _b64(b"hello"),
+                                },
+                            ],
                         }
                     ],
                 },

--- a/tests/run_agent/test_concurrent_interrupt.py
+++ b/tests/run_agent/test_concurrent_interrupt.py
@@ -184,7 +184,7 @@ def test_running_concurrent_worker_sees_is_interrupted(monkeypatch):
     observed = {"saw_true": False, "poll_count": 0, "worker_tid": None}
     worker_started = threading.Event()
 
-    def polling_tool(name, args, task_id, call_id=None):
+    def polling_tool(name, args, task_id, call_id=None, **kwargs):
         observed["worker_tid"] = threading.current_thread().ident
         worker_started.set()
         deadline = time.monotonic() + 5.0
@@ -261,4 +261,3 @@ def test_clear_interrupt_clears_worker_tids(monkeypatch):
         "clear_interrupt() did not clear the interrupt bit for a tracked "
         "worker tid — stale interrupt can leak into the next turn"
     )
-

--- a/tests/test_ctx_halving_fix.py
+++ b/tests/test_ctx_halving_fix.py
@@ -180,6 +180,8 @@ class TestEphemeralMaxOutputTokens:
         )
         agent._anthropic_preserve_dots = MagicMock(return_value=False)
         agent.request_overrides = {}
+        from agent.transports.anthropic import AnthropicTransport
+        agent._anthropic_transport = AnthropicTransport()
         return agent
 
     def test_ephemeral_override_is_used_on_first_call(self):

--- a/tests/tools/test_credential_files.py
+++ b/tests/tools/test_credential_files.py
@@ -9,6 +9,7 @@ import pytest
 
 from tools.credential_files import (
     clear_credential_files,
+    get_cache_file_container_path,
     get_credential_file_mounts,
     get_cache_directory_mounts,
     get_skills_directory_mount,
@@ -386,16 +387,23 @@ class TestCacheDirectoryMounts:
         assert "/root/.hermes/cache/audio" in paths
 
     def test_skips_nonexistent_dirs(self, tmp_path, monkeypatch):
-        """Dirs that don't exist on disk are not returned."""
+        """Standard cache dirs are created so new sandboxes mount them."""
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()
-        # Create only one cache dir
-        (hermes_home / "cache" / "documents").mkdir(parents=True)
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
         mounts = get_cache_directory_mounts()
-        assert len(mounts) == 1
-        assert mounts[0]["container_path"] == "/root/.hermes/cache/documents"
+        paths = {m["container_path"] for m in mounts}
+        assert paths == {
+            "/root/.hermes/cache/documents",
+            "/root/.hermes/cache/images",
+            "/root/.hermes/cache/audio",
+            "/root/.hermes/cache/screenshots",
+        }
+        assert (hermes_home / "cache" / "documents").is_dir()
+        assert (hermes_home / "cache" / "images").is_dir()
+        assert (hermes_home / "cache" / "audio").is_dir()
+        assert (hermes_home / "cache" / "screenshots").is_dir()
 
     def test_legacy_dir_names_resolved(self, tmp_path, monkeypatch):
         """Old-style dir names (e.g. document_cache) are resolved correctly."""
@@ -416,12 +424,48 @@ class TestCacheDirectoryMounts:
         assert "/root/.hermes/cache/images" in container_paths
 
     def test_empty_hermes_home(self, tmp_path, monkeypatch):
-        """No cache dirs → empty list."""
+        """Empty HERMES_HOME still yields standard cache mounts."""
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
-        assert get_cache_directory_mounts() == []
+        assert len(get_cache_directory_mounts()) == 4
+
+    def test_cache_file_container_path_new_layout(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        doc_dir = hermes_home / "cache" / "documents"
+        doc_dir.mkdir(parents=True)
+        cached = doc_dir / "doc_abc_report.pdf"
+        cached.write_bytes(b"%PDF")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        assert (
+            get_cache_file_container_path(cached)
+            == "/root/.hermes/cache/documents/doc_abc_report.pdf"
+        )
+
+    def test_cache_file_container_path_legacy_layout(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        doc_dir = hermes_home / "document_cache"
+        doc_dir.mkdir(parents=True)
+        cached = doc_dir / "doc_abc_report.pdf"
+        cached.write_bytes(b"%PDF")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        assert (
+            get_cache_file_container_path(cached, container_base="/home/user/.hermes")
+            == "/home/user/.hermes/cache/documents/doc_abc_report.pdf"
+        )
+
+    def test_cache_file_container_path_rejects_non_cache_file(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        outside = tmp_path / "outside.txt"
+        outside.write_text("no")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        with pytest.raises(ValueError):
+            get_cache_file_container_path(outside)
 
 
 class TestIterCacheFiles:

--- a/tests/tools/test_local_interrupt_cleanup.py
+++ b/tests/tools/test_local_interrupt_cleanup.py
@@ -41,6 +41,7 @@ def test_wait_for_process_kills_subprocess_on_keyboardinterrupt():
     """When KeyboardInterrupt arrives mid-poll, the subprocess group must be
     killed before the exception is re-raised."""
     env = LocalEnvironment(cwd="/tmp")
+    marker = f"hermes_interrupt_cleanup_{os.getpid()}_{int(time.monotonic() * 1000)}"
     try:
         result_holder = {}
         proc_holder = {}
@@ -54,7 +55,7 @@ def test_wait_for_process_kills_subprocess_on_keyboardinterrupt():
             # to observe the cleanup, via env.execute(...) — the normal path
             # that goes through _wait_for_process.
             try:
-                result_holder["result"] = env.execute("sleep 30", timeout=60)
+                result_holder["result"] = env.execute(f"exec -a {marker} sleep 30", timeout=60)
             except BaseException as e:  # noqa: BLE001 — we want to observe it
                 result_holder["exception"] = type(e).__name__
 
@@ -67,12 +68,12 @@ def test_wait_for_process_kills_subprocess_on_keyboardinterrupt():
         deadline = time.monotonic() + 5.0
         target_pid = None
         while time.monotonic() < deadline:
-            # Walk our children and grand-children to find one running 'sleep 30'
+            # Walk our children and grand-children to find this test's sleep.
             try:
                 import psutil  # optional — fall back if absent
                 for p in psutil.Process(os.getpid()).children(recursive=True):
                     try:
-                        if "sleep 30" in " ".join(p.cmdline()):
+                        if marker in " ".join(p.cmdline()):
                             target_pid = p.pid
                             break
                     except (psutil.NoSuchProcess, psutil.AccessDenied):
@@ -83,7 +84,7 @@ def test_wait_for_process_kills_subprocess_on_keyboardinterrupt():
                     ["ps", "-eo", "pid,ppid,pgid,cmd"], capture_output=True, text=True,
                 )
                 for line in ps.stdout.splitlines():
-                    if "sleep 30" in line and "grep" not in line:
+                    if marker in line and "grep" not in line:
                         parts = line.split()
                         if parts and parts[0].isdigit():
                             target_pid = int(parts[0])

--- a/tools/browser_camofox.py
+++ b/tools/browser_camofox.py
@@ -32,7 +32,7 @@ from typing import Any, Dict, Optional
 
 import requests
 
-from hermes_cli.config import load_config
+import hermes_cli.config as hermes_config
 from tools.browser_camofox_state import get_camofox_identity
 from tools.registry import tool_error
 
@@ -46,6 +46,10 @@ _DEFAULT_TIMEOUT = 30  # seconds per HTTP request
 _SNAPSHOT_MAX_CHARS = 80_000  # camofox paginates at this limit
 _vnc_url: Optional[str] = None  # cached from /health response
 _vnc_url_checked = False  # only probe once per process
+
+
+def load_config() -> Dict[str, Any]:
+    return hermes_config.load_config()
 
 
 def get_camofox_url() -> str:
@@ -598,6 +602,5 @@ def camofox_console(clear: bool = False, task_id: Optional[str] = None) -> str:
         "note": "Console log capture is not available with the Camofox backend. "
                 "Use browser_snapshot or browser_vision to inspect page state.",
     })
-
 
 

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -352,25 +352,52 @@ _CACHE_DIRS: list[tuple[str, str]] = [
 def get_cache_directory_mounts(
     container_base: str = "/root/.hermes",
 ) -> List[Dict[str, str]]:
-    """Return mount entries for each cache directory that exists on disk.
+    """Return mount entries for each standard cache directory.
 
     Used by Docker to create bind mounts.  Each entry has ``host_path`` and
     ``container_path`` keys.  The host path is resolved via
     ``get_hermes_dir()`` for backward compatibility with old directory layouts.
+    Cache directories are created before returning so new sandboxes always
+    receive the mounts they need for later gateway/API-server attachments.
     """
     from hermes_constants import get_hermes_dir
 
     mounts: List[Dict[str, str]] = []
     for new_subpath, old_name in _CACHE_DIRS:
         host_dir = get_hermes_dir(new_subpath, old_name)
-        if host_dir.is_dir():
-            # Always map to the *new* container layout regardless of host layout.
-            container_path = f"{container_base.rstrip('/')}/{new_subpath}"
-            mounts.append({
-                "host_path": str(host_dir),
-                "container_path": container_path,
-            })
+        host_dir.mkdir(parents=True, exist_ok=True)
+        # Always map to the *new* container layout regardless of host layout.
+        container_path = f"{container_base.rstrip('/')}/{new_subpath}"
+        mounts.append({
+            "host_path": str(host_dir),
+            "container_path": container_path,
+        })
     return mounts
+
+
+def get_cache_file_container_path(
+    host_path: str | os.PathLike[str],
+    container_base: str = "/root/.hermes",
+) -> str:
+    """Map a host-side Hermes cache file to its sandbox-visible path.
+
+    Docker mounts cache directories read-only and Modal/file-sync mirrors cache
+    files individually.  Both use the canonical container layout under
+    ``<container_base>/cache/...`` even when the host uses an old cache
+    directory name such as ``document_cache``.
+    """
+    from hermes_constants import get_hermes_dir
+
+    resolved_host = Path(host_path).resolve(strict=False)
+    for new_subpath, old_name in _CACHE_DIRS:
+        host_dir = get_hermes_dir(new_subpath, old_name)
+        try:
+            rel = resolved_host.relative_to(host_dir.resolve(strict=False))
+        except ValueError:
+            continue
+        return f"{container_base.rstrip('/')}/{new_subpath}/{rel.as_posix()}"
+
+    raise ValueError(f"Path is not inside a Hermes cache directory: {host_path}")
 
 
 def iter_cache_files(
@@ -403,5 +430,4 @@ def iter_cache_files(
 def clear_credential_files() -> None:
     """Reset the skill-scoped registry (e.g. on session reset)."""
     _get_registered().clear()
-
 

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -733,10 +733,19 @@ class BaseEnvironment(ABC):
         # Use login shell if snapshot failed (so user's profile still loads)
         login = not self._snapshot_ready
 
-        proc = self._run_bash(
-            wrapped, login=login, timeout=effective_timeout, stdin_data=effective_stdin
-        )
-        result = self._wait_for_process(proc, timeout=effective_timeout)
+        proc: ProcessHandle | None = None
+        try:
+            proc = self._run_bash(
+                wrapped, login=login, timeout=effective_timeout, stdin_data=effective_stdin
+            )
+            result = self._wait_for_process(proc, timeout=effective_timeout)
+        except (KeyboardInterrupt, SystemExit):
+            if proc is not None:
+                try:
+                    self._kill_process(proc)
+                except Exception:
+                    pass
+            raise
         self._update_cwd(result)
 
         return result
@@ -760,4 +769,3 @@ class BaseEnvironment(ABC):
         from tools.terminal_tool import _transform_sudo_command
 
         return _transform_sudo_command(command)
-

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -339,22 +339,28 @@ class LocalEnvironment(BaseEnvironment):
         args = [bash, "-l", "-c", cmd_string] if login else [bash, "-c", cmd_string]
         run_env = _make_run_env(self.env)
 
-        proc = subprocess.Popen(
-            args,
-            text=True,
-            env=run_env,
-            encoding="utf-8",
-            errors="replace",
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
-            preexec_fn=None if _IS_WINDOWS else os.setsid,
-        )
+        proc = None
+        try:
+            proc = subprocess.Popen(
+                args,
+                text=True,
+                env=run_env,
+                encoding="utf-8",
+                errors="replace",
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
+                preexec_fn=None if _IS_WINDOWS else os.setsid,
+            )
 
-        if stdin_data is not None:
-            _pipe_stdin(proc, stdin_data)
+            if stdin_data is not None:
+                _pipe_stdin(proc, stdin_data)
 
-        return proc
+            return proc
+        except (KeyboardInterrupt, SystemExit):
+            if proc is not None:
+                self._kill_process(proc)
+            raise
 
     def _kill_process(self, proc):
         """Kill the entire process group (all children)."""

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -390,7 +390,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
         with _read_tracker_lock:
             task_data = _read_tracker.setdefault(task_id, {
                 "last_key": None, "consecutive": 0,
-                "read_history": set(), "dedup": {},
+                "read_history": set(), "dedup": {}, "read_timestamps": {},
             })
             cached_mtime = task_data.get("dedup", {}).get(dedup_key)
 
@@ -776,7 +776,8 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
         )
         with _read_tracker_lock:
             task_data = _read_tracker.setdefault(task_id, {
-                "last_key": None, "consecutive": 0, "read_history": set(),
+                "last_key": None, "consecutive": 0,
+                "read_history": set(), "dedup": {}, "read_timestamps": {},
             })
             if task_data["last_key"] == search_key:
                 task_data["consecutive"] += 1

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -100,7 +100,34 @@ Standard OpenAI Chat Completions format. Stateless — the full conversation is 
 }
 ```
 
-Uploaded files (`file` / `input_file` / `file_id`) and non-image `data:` URLs return `400 unsupported_content_type`.
+**Inline file input:** the latest user message may also include inline document bytes as a `file` content part. Hermes decodes the file, stores it in the document cache, and gives the agent a sandbox-visible path such as `/root/.hermes/cache/documents/doc_abc_report.pdf`. Small UTF-8 text documents are also included directly in the prompt.
+
+```json
+{
+  "model": "hermes-agent",
+  "messages": [
+    {
+      "role": "user",
+      "content": [
+        {"type": "text", "text": "Summarize this document."},
+        {
+          "type": "file",
+          "file": {
+            "filename": "report.pdf",
+            "file_data": "JVBERi0xLjQK..."
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+`input_file` with top-level `filename` and `file_data` is accepted as an alias on the latest Chat Completions user message. Uploaded file IDs are not implemented: `file_id` returns `400 unsupported_content_type`. File parts in system messages, assistant messages, historical user messages, Responses requests, or `conversation_history` are rejected.
+
+Supported document extensions are `.pdf`, `.md`, `.txt`, `.log`, `.zip`, `.docx`, `.xlsx`, and `.pptx`. Inline file data must be base64, optionally using a `data:<mime>;base64,...` prefix. Individual decoded files are capped at 20 MB. Text-like `.txt`, `.md`, and `.log` files up to 100 KB are included in the prompt as text as well as saved to the document cache.
+
+Non-image `data:` URLs in image parts return `400 unsupported_content_type`.
 
 **Streaming** (`"stream": true`): Returns Server-Sent Events (SSE) with token-by-token response chunks. For **Chat Completions**, the stream uses standard `chat.completion.chunk` events plus Hermes' custom `hermes.tool.progress` event for tool-start UX. For **Responses**, the stream uses OpenAI Responses event types such as `response.created`, `response.output_text.delta`, `response.output_item.added`, `response.output_item.done`, and `response.completed`.
 
@@ -286,6 +313,7 @@ The default bind address (`127.0.0.1`) is for local-only use. Browser access is 
 | `API_SERVER_KEY` | _(none)_ | Bearer token for auth |
 | `API_SERVER_CORS_ORIGINS` | _(none)_ | Comma-separated allowed browser origins |
 | `API_SERVER_MODEL_NAME` | _(profile name)_ | Model name on `/v1/models`. Defaults to profile name, or `hermes-agent` for default profile. |
+| `API_SERVER_MAX_REQUEST_BYTES` | `1000000` | Max POST body size checked from `Content-Length`; increase for inline file uploads. |
 
 ### config.yaml
 


### PR DESCRIPTION
## Summary

Adds generic inline document support to the API server Chat Completions endpoint by reusing Hermes' existing gateway document-cache pattern.

Supported on the latest user message only:

```json
{
  "type": "file",
  "file": {
    "filename": "report.pdf",
    "file_data": "<base64>"
  }
}
```

`input_file` with top-level `filename` and `file_data` is accepted as an alias. Uploaded `file_id` inputs, Responses API file inputs, assistant/system files, and historical user-message files stay explicitly unsupported.

The implementation:

- reuses `SUPPORTED_DOCUMENT_TYPES` and `cache_document_from_bytes()`
- maps cached host files to sandbox-visible `/root/.hermes/cache/...` paths
- keeps the existing small text document injection convention
- creates standard cache roots before Docker mount enumeration
- adds `API_SERVER_MAX_REQUEST_BYTES` for larger inline document payloads while preserving OpenAI-style request-size errors

## Why

Hermes gateways already support document attachments from platforms such as Telegram, Discord, and Slack. The API server previously rejected `file` / `input_file` parts entirely, which made OpenAI-compatible clients unable to pass documents through the same generic document path.

This keeps the scope narrow: document content is cached and surfaced to the agent as a terminal-readable path, not implemented as a Files API.

## Tests

- `scripts/run_tests.sh tests/gateway/test_api_server_multimodal.py tests/gateway/test_api_server.py tests/tools/test_credential_files.py tests/gateway/test_document_cache.py`
  - 215 passed
- `scripts/run_tests.sh tests/gateway/test_telegram_documents.py tests/gateway/test_discord_document_handling.py tests/gateway/test_slack.py`
  - 174 passed
- Local API-server smoke with text and PDF-like file parts verified sandbox-visible cache paths and no deployment-specific strings.
