### PR TITLE
fix(skills): raise system-prompt skill description limit to match runtime tool (#13944)

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -414,15 +414,30 @@ def resolve_skill_config_values(
 
 # ── Description extraction ────────────────────────────────────────────────
 
+# Align with `MAX_DESCRIPTION_LENGTH` in tools/skills_tool.py. The system
+# prompt skill index used to hard-truncate descriptions at 60 chars while
+# the runtime `skills_list()` tool allowed 1024 — which meant the LLM saw
+# a cut-off prefix like "Complete guide to using and extending Hermes
+# Agent — CLI ..." in the system prompt (where the routing decision is
+# actually made) and only got the full description after deciding to call
+# skills_list(). Descriptions under the limit are returned verbatim; over
+# the limit get truncated with a trailing ellipsis. See #13944.
+SKILL_INDEX_MAX_DESCRIPTION_LENGTH = 1024
+
 
 def extract_skill_description(frontmatter: Dict[str, Any]) -> str:
-    """Extract a truncated description from parsed frontmatter."""
+    """Extract a (possibly truncated) description from parsed frontmatter.
+
+    Descriptions under ``SKILL_INDEX_MAX_DESCRIPTION_LENGTH`` are returned
+    verbatim. Longer ones are truncated to ``SKILL_INDEX_MAX_DESCRIPTION_LENGTH``
+    total characters, with a trailing ``"..."`` included in the budget.
+    """
     raw_desc = frontmatter.get("description", "")
     if not raw_desc:
         return ""
     desc = str(raw_desc).strip().strip("'\"")
-    if len(desc) > 60:
-        return desc[:57] + "..."
+    if len(desc) > SKILL_INDEX_MAX_DESCRIPTION_LENGTH:
+        return desc[: SKILL_INDEX_MAX_DESCRIPTION_LENGTH - 3] + "..."
     return desc
 
 

--- a/tests/agent/test_extract_skill_description.py
+++ b/tests/agent/test_extract_skill_description.py
@@ -1,0 +1,65 @@
+"""Regression tests for ``agent/skill_utils.py::extract_skill_description``.
+
+Before #13944, this helper hard-truncated every skill description to 60
+characters, while the runtime ``skills_list()`` tool (``tools/skills_tool.py``)
+allowed 1024. The LLM therefore saw a vague prefix in the system prompt —
+where the routing decision is actually made — and only got the full text
+after deciding to call ``skills_list()``. The fix raises the system-prompt
+limit to match the runtime-tool limit and ensures all three paths
+(short, boundary, long) behave correctly.
+"""
+
+from agent.skill_utils import (
+    extract_skill_description,
+    SKILL_INDEX_MAX_DESCRIPTION_LENGTH,
+)
+
+
+class TestExtractSkillDescription:
+    def test_empty_description_returns_empty_string(self):
+        assert extract_skill_description({}) == ""
+        assert extract_skill_description({"description": ""}) == ""
+
+    def test_short_description_returned_verbatim(self):
+        desc = "Short description"
+        assert extract_skill_description({"description": desc}) == desc
+
+    def test_description_at_60_chars_not_truncated(self):
+        """Regression: old limit was 60; the 61st char used to be '...'."""
+        desc = "x" * 60
+        assert extract_skill_description({"description": desc}) == desc
+
+    def test_description_over_60_not_truncated_under_new_limit(self):
+        """Main regression guard for #13944."""
+        desc = (
+            "Complete guide to using and extending Hermes Agent — CLI "
+            "tooling, skill authoring, and gateway integration"
+        )
+        assert len(desc) > 60
+        result = extract_skill_description({"description": desc})
+        assert result == desc
+        assert not result.endswith("...")
+
+    def test_description_at_exact_new_limit_not_truncated(self):
+        desc = "x" * SKILL_INDEX_MAX_DESCRIPTION_LENGTH
+        result = extract_skill_description({"description": desc})
+        assert result == desc
+        assert len(result) == SKILL_INDEX_MAX_DESCRIPTION_LENGTH
+
+    def test_description_over_new_limit_is_truncated_with_ellipsis(self):
+        desc = "x" * (SKILL_INDEX_MAX_DESCRIPTION_LENGTH + 500)
+        result = extract_skill_description({"description": desc})
+        assert len(result) == SKILL_INDEX_MAX_DESCRIPTION_LENGTH
+        assert result.endswith("...")
+
+    def test_description_strips_surrounding_quotes_and_whitespace(self):
+        """Pre-existing behavior; guarded so the fix keeps the strip()."""
+        assert (
+            extract_skill_description({"description": "  'wrapped'  "})
+            == "wrapped"
+        )
+
+    def test_new_limit_matches_skills_tool_runtime_limit(self):
+        """#13944: the two paths must agree."""
+        from tools.skills_tool import MAX_DESCRIPTION_LENGTH as RUNTIME_LIMIT
+        assert SKILL_INDEX_MAX_DESCRIPTION_LENGTH == RUNTIME_LIMIT


### PR DESCRIPTION
## What does this PR do?

The skill index injected into the system prompt hard-truncated every skill description to 60 characters, while the runtime `skills_list()` tool (`tools/skills_tool.py`) allowed up to 1024. The LLM saw a vague prefix in the system prompt — where the routing decision is actually made — and only got the full description *after* deciding to call `skills_list()`. That's backwards: the trigger criteria need to be visible at system-prompt time so the model can decide *whether* to route to the skill.

Example before vs after:

```
Before:  "Complete guide to using and extending Hermes Agent — CLI ..."
After:   "Complete guide to using and extending Hermes Agent — CLI tooling, skill authoring, and gateway integration"
```

Fix: introduce `SKILL_INDEX_MAX_DESCRIPTION_LENGTH = 1024` in `agent/skill_utils.py` and use it in `extract_skill_description()`. Descriptions under the limit are returned verbatim; over-limit ones are truncated to exactly `SKILL_INDEX_MAX_DESCRIPTION_LENGTH` with a trailing `"..."` included in the budget (same contract the runtime tool uses).

## Related Issue

Fixes #13944

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/skill_utils.py` (+19 / −4): new `SKILL_INDEX_MAX_DESCRIPTION_LENGTH` constant; `extract_skill_description()` uses it instead of the hardcoded 60; docstring updated to describe the contract + issue context.
- `tests/agent/test_extract_skill_description.py` (+68, new file): 8 regression cases covering empty / short / boundary / long-below / at-new-limit / over-new-limit / strip() preservation, plus one that locks in equality with `tools.skills_tool.MAX_DESCRIPTION_LENGTH` so the two paths can't silently drift apart again.

Core diff:

```diff
-def extract_skill_description(frontmatter: Dict[str, Any]) -> str:
-    """Extract a truncated description from parsed frontmatter."""
+SKILL_INDEX_MAX_DESCRIPTION_LENGTH = 1024
+
+
+def extract_skill_description(frontmatter: Dict[str, Any]) -> str:
+    """Extract a (possibly truncated) description from parsed frontmatter.
+
+    Descriptions under ``SKILL_INDEX_MAX_DESCRIPTION_LENGTH`` are returned
+    verbatim. Longer ones are truncated to that length, with a trailing
+    ``"..."`` included in the budget.
+    """
     raw_desc = frontmatter.get("description", "")
     if not raw_desc:
         return ""
     desc = str(raw_desc).strip().strip("'\"")
-    if len(desc) > 60:
-        return desc[:57] + "..."
+    if len(desc) > SKILL_INDEX_MAX_DESCRIPTION_LENGTH:
+        return desc[: SKILL_INDEX_MAX_DESCRIPTION_LENGTH - 3] + "..."
     return desc
```

## How to Test

Before:

```python
from agent.skill_utils import extract_skill_description
desc = "Complete guide to using and extending Hermes Agent — CLI tooling, skill authoring, and gateway integration"
extract_skill_description({"description": desc})
# 'Complete guide to using and extending Hermes Agent — CLI...'   # 60 chars
```

After: returns the full description verbatim (108 chars).

```
pytest tests/agent/test_extract_skill_description.py -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(skills):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/agent/test_extract_skill_description.py -q` and all tests pass
- [x] I've added tests for my changes (8 new regression cases)
- [x] I've tested on my platform: macOS 26.5 (arm64), Python 3.11.14 via uv

### Documentation & Housekeeping

- [x] Documentation updates — N/A (internal constant; docstring updated in-place)
- [x] `cli-config.yaml.example` — N/A (no new config)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — string slicing, no OS-specific paths
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

### Verification

```
$ uv run --with pytest --with pytest-xdist python -m pytest \
    tests/agent/test_extract_skill_description.py -v
........                                                                 [100%]
8 passed in 0.56s
```

## Not in scope

The issue author's long-term suggestion (prompt_builder consuming skills_tool's metadata rather than maintaining a parallel parsing implementation) is out of scope for this PR — that's an architectural refactor that deserves its own proposal and review. This PR implements the reporter's minimum fix and adds a regression guard so the two paths can't silently drift apart again.
