### PR TITLE
fix(packaging): include agent.* sub-packages in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajector
 hermes_cli = ["web_dist/**/*"]
 
 [tool.setuptools.packages.find]
-include = ["agent", "tools", "tools.*", "hermes_cli", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "acp_adapter", "plugins", "plugins.*"]
+include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "acp_adapter", "plugins", "plugins.*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary

The transport refactor (PRs landing April 20-21) added `agent/transports/` as a sub-package and wired it into the core API call path — every `_build_api_kwargs()` call now hits a transport. However, `pyproject.toml`'s setuptools package include list only had `"agent"` (top-level module), not `"agent.*"` (sub-packages).

This means `pip install` and Nix builds ship `run_agent.py` (which imports `from agent.transports import get_transport`) but **omit the `agent/transports/` directory entirely**, causing:

```
API call failed after 3 retries. No module named 'agent.transports' | provider=copilot model=gpt-5.3-codex
```

on every LLM call for packaged installs. Git-clone users are unaffected because Python resolves from the source tree directly.

## Fix

Add `"agent.*"` to the include list, matching the existing pattern for `tools`, `gateway`, `tui_gateway`, and `plugins`:

```diff
- include = ["agent", "tools", "tools.*", ...]
+ include = ["agent", "agent.*", "tools", "tools.*", ...]
```

## Verification

- `setuptools.find_packages()` with new pattern finds `agent.transports`; old pattern did not
- All 117 transport tests pass
- No other sub-packages are missing (audited `hermes_cli`, `cron`, `acp_adapter` — none have sub-packages)