### PR TITLE
fix(model_switch): include all models from custom_providers models dict

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1083,6 +1083,18 @@ def list_authenticated_providers(
             default_model = (entry.get("model") or "").strip()
             if default_model and default_model not in groups[slug]["models"]:
                 groups[slug]["models"].append(default_model)
+            # Also include models from the "models" dict (model_name -> metadata)
+            # or list format in the entry.
+            entry_models = entry.get("models")
+            if isinstance(entry_models, dict):
+                for m_name in entry_models:
+                    if m_name and m_name not in groups[slug]["models"]:
+                        groups[slug]["models"].append(m_name)
+            elif isinstance(entry_models, list):
+                for m in entry_models:
+                    m_str = (m if isinstance(m, str) else str(m)).strip()
+                    if m_str and m_str not in groups[slug]["models"]:
+                        groups[slug]["models"].append(m_str)
 
         for slug, grp in groups.items():
             if slug.lower() in seen_slugs:


### PR DESCRIPTION
## Bug Description

`list_authenticated_providers()` Section 4 (custom_providers handling) only reads the `model` field (default model), ignoring the `models` dict/list that contains all available models for that provider.

This causes `/model` command to show only 1 model per custom_provider even when multiple models are configured in `config.yaml`.

## Example

**config.yaml:**
```yaml
custom_providers:
- name: Ark.cn-beijing.volces.com
  base_url: https://ark.cn-beijing.volces.com/api/coding/v3
  api_key: xxx
  model: glm-5.1
  models:
    glm-5.1:
      context_length: 200000
    glm-4-7-251222:
      context_length: 200000
    kimi-k2-6:
      context_length: 200000
    minimax-m2-7:
      context_length: 200000
```

**Before fix:** `/model` shows only `['glm-5.1']`

**After fix:** `/model` shows `['glm-5.1', 'glm-4-7-251222', 'kimi-k2-6', 'minimax-m2-7']`

## Root Cause

In `model_switch.py` lines 1083-1085:

```python
default_model = (entry.get("model") or "").strip()
if default_model and default_model not in groups[slug]["models"]:
    groups[slug]["models"].append(default_model)
# entry["models"] dict is completely ignored
```

Section 3 (`user_providers`) correctly iterates over `ep_cfg.get("models", [])`, but Section 4 (`custom_providers`) missed this.

## Fix

Iterate over `entry["models"]` (dict keys or list items) and add all model names to the group's models list, matching Section 3 logic.

```python
entry_models = entry.get("models")
if isinstance(entry_models, dict):
    for m_name in entry_models:
        if m_name and m_name not in groups[slug]["models"]:
            groups[slug]["models"].append(m_name)
elif isinstance(entry_models, list):
    for m in entry_models:
        m_str = (m if isinstance(m, str) else str(m)).strip()
        if m_str and m_str not in groups[slug]["models"]:
            groups[slug]["models"].append(m_str)
```

## Testing

Verified with Python script:
```python
from hermes_cli.model_switch import list_authenticated_providers
providers = list_authenticated_providers(custom_providers=cfg.get("custom_providers", []))
# Ark provider now shows 4 models instead of 1
```