### PR TITLE
fix(toolsets): use typing.Any in get_distribution return annotation

### DIFF
--- a/toolset_distributions.py
+++ b/toolset_distributions.py
@@ -19,7 +19,7 @@ Usage:
     all_dists = list_distributions()
 """
 
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 import random
 from toolsets import validate_toolset
 
@@ -220,7 +220,7 @@ DISTRIBUTIONS = {
 }
 
 
-def get_distribution(name: str) -> Optional[Dict[str, any]]:
+def get_distribution(name: str) -> Optional[Dict[str, Any]]:
     """
     Get a toolset distribution by name.
     


### PR DESCRIPTION
Fixes #2139.

## Summary
- `toolset_distributions.get_distribution()` was annotated `Optional[Dict[str, any]]` — lowercase `any` is Python's builtin function, not a type.
- Also adds `Any` to the `from typing import …` line (previously missing).

## Test plan
- [x] `python3 -c "import toolset_distributions; print(toolset_distributions.get_distribution.__annotations__)"` now returns `typing.Any` instead of `<class 'builtin_function_or_method'>`.
- Existing tests in `tests/tools/test_toolset_distributions.py` (if any) unchanged.