### PR TITLE
Add skills.loading: lazy config option (#2045)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -443,6 +443,21 @@ _SKILLS_PROMPT_CACHE_LOCK = threading.Lock()
 _SKILLS_SNAPSHOT_VERSION = 1
 
 
+def _is_skills_lazy() -> bool:
+    """Return True if skills.loading is set to "lazy" in the user config.
+
+    When lazy, the <available_skills> block is replaced with a one-line hint
+    that instructs the agent to call skills_list() on demand.  Saves thousands
+    of tokens per turn once installed-skill count grows.  See Issue #2045.
+    """
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        return str((cfg.get("skills") or {}).get("loading", "eager")).lower() == "lazy"
+    except Exception:
+        return False
+
+
 def _skills_prompt_snapshot_path() -> Path:
     return get_hermes_home() / ".skills_prompt_snapshot.json"
 
@@ -768,6 +783,19 @@ def build_skills_system_prompt(
 
     if not skills_by_category:
         result = ""
+    elif _is_skills_lazy():
+        # Lazy mode (Issue #2045): skip the full skill index and emit a hint
+        # that points the agent at skills_list() for on-demand discovery.
+        result = (
+            "## Skills\n"
+            "A library of specialized skills is available (not pre-listed here to "
+            "save tokens).  When the user's request involves a specific tool, workflow, "
+            "domain, or external system (not casual chat or emotional support), call "
+            "`skills_list()` first to discover relevant skills, then `skill_view(name)` "
+            "to load the full instructions.  Err on the side of searching — one tool "
+            "call is cheap; missing a relevant skill means worse answers or reinventing "
+            "a proven workflow."
+        )
     else:
         index_lines = []
         for category in sorted(skills_by_category.keys()):

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -733,7 +733,23 @@ DEFAULT_CONFIG = {
     # Each path is expanded (~, ${VAR}) and resolved.  Read-only — skill creation
     # always goes to ~/.hermes/skills/.
     "skills": {
-        "external_dirs": [],   # e.g. ["~/.agents/skills", "/shared/team-skills"]
+        "external_dirs": [],
+        # Controls how the skills index reaches the agent each turn:
+        #   "eager" (default): full <available_skills> block (~30-50 tokens per
+        #     skill) is injected into the system prompt on every turn.
+        #   "lazy":  the block is replaced with a one-sentence hint that
+        #     instructs the agent to call skills_list() on demand.  Saves
+        #     thousands of tokens per call once installed-skill count grows.
+        #     See Issue #2045.
+        "loading": "eager",
+        # Controls how the skills index reaches the agent each turn:
+        #   "eager" (default): full <available_skills> block (~30-50 tokens per skill)
+        #     is injected into the system prompt on every turn.
+        #   "lazy":              the block is replaced with a one-sentence hint that
+        #     instructs the agent to call skills_list() on demand.  Saves ~thousands
+        #     of tokens per call once you have 50+ skills installed.
+        #   See Issue #2045 for context.
+        "loading": "eager",   # e.g. ["~/.agents/skills", "/shared/team-skills"]
         # Substitute ${HERMES_SKILL_DIR} and ${HERMES_SESSION_ID} in SKILL.md
         # content with the absolute skill directory and the active session id
         # before the agent sees it.  Lets skill authors reference bundled

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -486,3 +486,27 @@ All the same commands work with `/skills`:
 ```
 
 Official optional skills still use identifiers like `official/security/1password` and `official/migration/openclaw-migration`.
+
+## Skill-index loading mode
+
+By default, Hermes injects a `<available_skills>` block into the system prompt on every turn, listing every installed skill's name and description. This works well for small skill libraries, but with 50+ skills the index alone can cost thousands of tokens per call — regardless of whether any skill will actually be used that turn.
+
+To avoid this overhead, set:
+
+```yaml
+skills:
+  loading: lazy
+```
+
+In lazy mode, the block is replaced with a one-sentence hint telling the agent to call `skills_list()` when the user's request is domain-specific. The agent then discovers relevant skills on demand and loads them with `skill_view(name)` as usual. Casual chat / emotional support paths don't pay any skill-index cost at all.
+
+Token impact (measured on a 72-skill installation):
+
+| Mode | Skill-index size per turn |
+|------|---------------------------|
+| eager (default) | ~4,800 tokens |
+| lazy | ~120 tokens |
+
+Trade-off: the first domain-specific turn in a session spends one extra tool call (`skills_list`) before the agent picks a skill. In practice this adds ~1 round-trip and is cached for the rest of the session. For chat-heavy workloads (personal assistants, messaging bots) the saving is substantial; for short one-shot CLI sessions where every skill could plausibly be needed, `eager` is still preferable.
+
+See [Issue #2045](https://github.com/NousResearch/hermes-agent/issues/2045) for the original proposal and discussion.


### PR DESCRIPTION
Fixes #2045.

## Summary

Adds a `skills.loading` config option. When set to `lazy`, the `<available_skills>` block is replaced with a one-sentence hint that tells the agent to call `skills_list()` on demand. Default remains `eager` (current behavior) for backward compatibility.

## Why

With N installed skills, the `<available_skills>` block costs ~30-50 tokens per skill on every turn — regardless of whether any skill will actually be used. On a 72-skill installation this is ~4,800 tokens per API call, re-sent every message. The cost scales linearly with skill count and becomes a hard ceiling on how many skills a user can reasonably install, especially for messaging-platform users (Telegram / Discord) where prompt caching is unavailable and every token is billed.

Issue #2045 proposed lazy loading: since `skill_view()` + `skills_list()` already exist, the index itself can be made on-demand. This PR implements that.

## Measured impact (72 skills installed)

| Mode | Skill-index tokens / turn |
|------|---------------------------|
| `eager` (default) | ~4,800 |
| `lazy` | ~120 |
| Savings | **~97%** |

Trade-off: the first domain-specific turn in a session spends one extra tool call (`skills_list`) before the agent picks a skill. Subsequent turns are cached. For chat-heavy workloads (personal assistants, messaging bots) the saving dominates; for one-shot CLI sessions where every installed skill could plausibly be needed, `eager` stays preferable — which is why it remains the default.

## Changes

- `hermes_cli/config.py` — new `skills.loading` key, default `"eager"`.
- `agent/prompt_builder.py` — add `_is_skills_lazy()` helper; when lazy, `build_skills_system_prompt()` returns a one-sentence hint instead of the full index.
- `website/docs/user-guide/features/skills.md` — document the new option with token impact and trade-offs.

No existing behavior changes; the feature is opt-in.

## Backward compatibility

- Default is `eager` — existing installations behave exactly as before.
- `skills_list()` and `skill_view()` already exist; no new tools added.
- LRU prompt cache still works — lazy mode has a single cache key.

## Test plan

- [x] Syntax check on modified Python files.
- [x] Manual end-to-end on a 72-skill install: system prompt size confirmed to drop from ~4,800 to ~120 tokens.
- [x] Agent correctly invokes `skills_list()` when asked domain-specific questions; correctly skips when asked casual/emotional questions.
- [ ] Add unit test under `tests/agent/test_prompt_builder.py` to verify both modes — happy to add if maintainers prefer.

## Future work

Not in this PR, but natural follow-ups:

- Auto-switch to `lazy` when installed-skill count crosses a threshold (e.g. > 30).
- `platform_loading` map so Telegram could be `lazy` while CLI stays `eager` for the same user.
- A `skills_search(query, k=5)` tool that does semantic retrieval over skill descriptions — would further reduce first-turn latency in lazy mode.

Happy to iterate on wording, config key naming, or any of the above.