### PR TITLE
fix: address 11 open issues — auth, skills, providers, CLI, Telegram

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -255,6 +255,18 @@ def is_local_endpoint(base_url: str) -> bool:
     return False
 
 
+def is_ollama_endpoint(base_url: str) -> bool:
+    """Return True only for endpoints that are explicitly Ollama.
+
+    Matches the default Ollama port (11434) or "ollama" in the URL.
+    Unlike is_local_endpoint(), this does NOT match arbitrary local proxies,
+    preventing false positives when a local gateway forwards to a remote API
+    (e.g. a GLM/ZAI proxy at localhost:8000).
+    """
+    normalized = (_normalize_base_url(base_url) or "").lower()
+    return ":11434" in normalized or "ollama" in normalized
+
+
 def detect_local_server_type(base_url: str) -> Optional[str]:
     """Detect which local server is running at base_url by probing known endpoints.
 

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -228,8 +228,19 @@ def get_all_skills_dirs() -> List[Path]:
 
     The local dir is always first (and always included even if it doesn't exist
     yet — callers handle that).  External dirs follow in config order.
+
+    When ``skills.agent_dir`` is configured, that directory is included
+    immediately after the local dir so agent-created skills are discovered.
     """
-    dirs = [get_hermes_home() / "skills"]
+    local = get_hermes_home() / "skills"
+    dirs: List[Path] = [local]
+    try:
+        from tools.skills_tool import get_agent_skills_dir
+        agent_dir = get_agent_skills_dir()
+        if agent_dir.resolve() != local.resolve() and agent_dir not in dirs:
+            dirs.append(agent_dir)
+    except Exception:
+        pass
     dirs.extend(get_external_skills_dirs())
     return dirs
 
@@ -415,13 +426,13 @@ def resolve_skill_config_values(
 
 
 def extract_skill_description(frontmatter: Dict[str, Any]) -> str:
-    """Extract a truncated description from parsed frontmatter."""
+    """Extract a description from parsed frontmatter, capped at 1024 characters."""
     raw_desc = frontmatter.get("description", "")
     if not raw_desc:
         return ""
     desc = str(raw_desc).strip().strip("'\"")
-    if len(desc) > 60:
-        return desc[:57] + "..."
+    if len(desc) > 1024:
+        return desc[:1021] + "..."
     return desc
 
 

--- a/cli.py
+++ b/cli.py
@@ -997,13 +997,25 @@ def _rich_text_from_ansi(text: str) -> _RichText:
     return _RichText.from_ansi(text or "")
 
 
+# Set when a dangerous-command approval prompt is active.  Background threads
+# that produce streaming output must wait for this event to be set before
+# printing, so they don't flood the terminal and make the prompt unresponsive.
+_approval_output_gate = threading.Event()
+_approval_output_gate.set()  # cleared while prompt is shown, set when done
+
+
 def _cprint(text: str):
     """Print ANSI-colored text through prompt_toolkit's native renderer.
 
     Raw ANSI escapes written via print() are swallowed by patch_stdout's
     StdoutProxy.  Routing through print_formatted_text(ANSI(...)) lets
     prompt_toolkit parse the escapes and render real colors.
+
+    When a dangerous-command approval prompt is active the gate is cleared,
+    blocking background output until the user responds so the prompt stays
+    readable.
     """
+    _approval_output_gate.wait(timeout=120)
     _pt_print(_PT_ANSI(text))
 
 
@@ -6265,24 +6277,31 @@ class HermesCLI:
             }
             self._approval_deadline = _time.monotonic() + timeout
 
+            # Block background output so streaming model tokens / command logs
+            # don't flood over the prompt and make it unresponsive.
+            _approval_output_gate.clear()
             self._invalidate()
 
             _last_countdown_refresh = _time.monotonic()
-            while True:
-                try:
-                    result = response_queue.get(timeout=1)
-                    self._approval_state = None
-                    self._approval_deadline = 0
-                    self._invalidate()
-                    return result
-                except queue.Empty:
-                    remaining = self._approval_deadline - _time.monotonic()
-                    if remaining <= 0:
-                        break
-                    now = _time.monotonic()
-                    if now - _last_countdown_refresh >= 5.0:
-                        _last_countdown_refresh = now
+            try:
+                while True:
+                    try:
+                        result = response_queue.get(timeout=1)
+                        self._approval_state = None
+                        self._approval_deadline = 0
                         self._invalidate()
+                        return result
+                    except queue.Empty:
+                        remaining = self._approval_deadline - _time.monotonic()
+                        if remaining <= 0:
+                            break
+                        now = _time.monotonic()
+                        if now - _last_countdown_refresh >= 5.0:
+                            _last_countdown_refresh = now
+                            self._invalidate()
+            finally:
+                # Always re-open the gate so background threads unblock.
+                _approval_output_gate.set()
 
             self._approval_state = None
             self._approval_deadline = 0

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -8,10 +8,12 @@ Uses python-telegram-bot library for:
 """
 
 import asyncio
+import collections
 import json
 import logging
 import os
 import re
+import time
 from typing import Dict, List, Optional, Any
 
 logger = logging.getLogger(__name__)
@@ -155,6 +157,11 @@ class TelegramAdapter(BasePlatformAdapter):
         self._model_picker_state: Dict[str, dict] = {}
         # Approval button state: message_id → session_key
         self._approval_state: Dict[int, str] = {}
+        # Inbound reaction routing: LRU cache of bot-sent message_id → (event, timestamp)
+        # Used to correlate incoming reaction updates with the originating conversation.
+        # Bounded to _REACTION_CACHE_SIZE entries; entries expire after _REACTION_TTL_S.
+        self._reaction_cache: collections.OrderedDict = collections.OrderedDict()
+        self._reaction_cache_lock = asyncio.Lock()
 
     def _fallback_ips(self) -> list[str]:
         """Return validated fallback IPs from config (populated by _apply_env_overrides)."""
@@ -553,6 +560,12 @@ class TelegramAdapter(BasePlatformAdapter):
             ))
             # Handle inline keyboard button callbacks (update prompts)
             self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
+            # Inbound emoji reaction routing (opt-in via TELEGRAM_INBOUND_REACTIONS=true)
+            try:
+                from telegram.ext import MessageReactionHandler
+                self._app.add_handler(MessageReactionHandler(self._handle_message_reaction))
+            except ImportError:
+                logger.debug("[%s] MessageReactionHandler not available in this python-telegram-bot version", self.name)
             
             # Start polling — retry initialize() for transient TLS resets
             try:
@@ -883,11 +896,22 @@ class TelegramAdapter(BasePlatformAdapter):
                         raise
                 message_ids.append(str(msg.message_id))
             
-            return SendResult(
+            result = SendResult(
                 success=True,
                 message_id=message_ids[0] if message_ids else None,
                 raw_response={"message_ids": message_ids}
             )
+            # Cache last sent message so inbound reactions can be correlated.
+            if message_ids and self._inbound_reactions_enabled() and metadata:
+                _src_event = metadata.get("_source_event")
+                if _src_event is not None:
+                    try:
+                        asyncio.ensure_future(
+                            self._cache_bot_message(int(message_ids[-1]), _src_event)
+                        )
+                    except Exception:
+                        pass
+            return result
             
         except Exception as e:
             logger.error("[%s] Failed to send Telegram message: %s", self.name, e, exc_info=True)
@@ -2716,3 +2740,103 @@ class TelegramAdapter(BasePlatformAdapter):
         message_id = getattr(event, "message_id", None)
         if chat_id and message_id:
             await self._set_reaction(chat_id, message_id, "\u2705" if success else "\u274c")
+
+    # ── Inbound reaction routing ──────────────────────────────────────────────
+
+    # Emoji reactions that are routed as synthetic confirmation signals.
+    _INBOUND_REACTION_ALLOW = frozenset({"\U0001f44d", "\u2705", "\U0001f44e", "\u274c"})
+    # Max cached bot-sent messages and TTL seconds for cache entries.
+    _REACTION_CACHE_SIZE = 500
+    _REACTION_CACHE_TTL = 3600.0
+
+    def _inbound_reactions_enabled(self) -> bool:
+        return os.getenv("TELEGRAM_INBOUND_REACTIONS", "false").lower() not in ("false", "0", "no")
+
+    async def _cache_bot_message(self, message_id: int, source_event: MessageEvent) -> None:
+        """Record a bot-sent message so inbound reactions can reference its context."""
+        if not self._inbound_reactions_enabled():
+            return
+        now = time.monotonic()
+        async with self._reaction_cache_lock:
+            self._reaction_cache[message_id] = (source_event, now)
+            self._reaction_cache.move_to_end(message_id)
+            # Evict stale entries from the front (oldest first).
+            cutoff = now - self._REACTION_CACHE_TTL
+            while self._reaction_cache:
+                oldest_id, (_, oldest_ts) = next(iter(self._reaction_cache.items()))
+                if oldest_ts < cutoff or len(self._reaction_cache) > self._REACTION_CACHE_SIZE:
+                    self._reaction_cache.popitem(last=False)
+                else:
+                    break
+
+    async def _handle_message_reaction(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Route an inbound emoji reaction as a synthetic MessageEvent.
+
+        Only fires when TELEGRAM_INBOUND_REACTIONS=true.  Allowlisted emoji
+        (👍 ✅ 👎 ❌) are emitted as [reaction: <emoji>] text events so the
+        agent can treat them as lightweight confirmation signals.
+
+        Bot's own reactions are ignored to prevent feedback loops.
+        """
+        if not self._inbound_reactions_enabled():
+            return
+
+        reaction_update = getattr(update, "message_reaction", None)
+        if reaction_update is None:
+            return
+
+        # Ignore reactions added by the bot itself.
+        actor = getattr(reaction_update, "actor_chat", None) or getattr(reaction_update, "user", None)
+        if actor and self._bot:
+            actor_id = getattr(actor, "id", None)
+            try:
+                bot_id = self._bot.id
+            except Exception:
+                bot_id = None
+            if bot_id and actor_id == bot_id:
+                return
+
+        new_reactions = getattr(reaction_update, "new_reaction", []) or []
+        emoji_set = set()
+        for r in new_reactions:
+            emoji = getattr(r, "emoji", None)
+            if emoji and emoji in self._INBOUND_REACTION_ALLOW:
+                emoji_set.add(emoji)
+
+        if not emoji_set:
+            return
+
+        msg_id = getattr(reaction_update, "message_id", None)
+        if msg_id is None:
+            return
+
+        # Find the originating event for this message.
+        async with self._reaction_cache_lock:
+            cached = self._reaction_cache.get(msg_id)
+
+        origin_event: Optional[MessageEvent] = cached[0] if cached else None
+
+        for emoji in sorted(emoji_set):
+            if origin_event is not None:
+                source = origin_event.source
+            else:
+                # Best-effort: build a minimal source from the reaction update.
+                chat = getattr(reaction_update, "chat", None)
+                chat_id = str(chat.id) if chat else "unknown"
+                user_id = str(getattr(actor, "id", "unknown")) if actor else None
+                user_name = getattr(actor, "full_name", None) if actor else None
+                source = self.build_source(
+                    chat_id=chat_id,
+                    chat_type="dm",
+                    user_id=user_id,
+                    user_name=user_name,
+                )
+
+            event = MessageEvent(
+                text=f"[reaction: {emoji}]",
+                message_type=MessageType.TEXT,
+                source=source,
+                raw_message=reaction_update,
+                message_id=str(msg_id),
+            )
+            await self.handle_message(event)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2921,6 +2921,22 @@ class GatewayRunner:
 
             response = agent_result.get("final_response") or ""
             agent_messages = agent_result.get("messages", [])
+
+            # Strip compaction handoff echoes — if the model parrots the
+            # [CONTEXT COMPACTION] summary stored in its context, remove
+            # it so the user gets a clean greeting instead of a raw
+            # internal handoff blob (#6212).
+            if response and "[CONTEXT COMPACTION]" in response:
+                import re as _re_compact
+                response = _re_compact.sub(
+                    r'\[CONTEXT COMPACTION\].*?(?:avoid repeating work:)',
+                    '',
+                    response,
+                    flags=_re_compact.DOTALL,
+                ).strip()
+                if not response:
+                    response = ""
+
             _response_time = time.time() - _msg_start_time
             _api_calls = agent_result.get("api_calls", 0)
             _resp_len = len(response)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -144,11 +144,21 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
     ),
     "kimi-coding": ProviderConfig(
         id="kimi-coding",
-        name="Kimi / Moonshot",
+        name="Kimi Code (api.kimi.com — needs sk-kimi-* key)",
         auth_type="api_key",
         inference_base_url="https://api.moonshot.ai/v1",
         api_key_env_vars=("KIMI_API_KEY",),
         base_url_env_var="KIMI_BASE_URL",
+    ),
+    # Moonshot AI Global (platform.moonshot.ai) — distinct from kimi-coding.
+    # Keys from platform.moonshot.ai use api.moonshot.ai/v1, not api.kimi.com.
+    "moonshotai": ProviderConfig(
+        id="moonshotai",
+        name="Moonshot AI (platform.moonshot.ai)",
+        auth_type="api_key",
+        inference_base_url="https://api.moonshot.ai/v1",
+        api_key_env_vars=("MOONSHOT_API_KEY", "KIMI_API_KEY"),
+        base_url_env_var="MOONSHOT_BASE_URL",
     ),
     "minimax": ProviderConfig(
         id="minimax",

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -307,7 +307,12 @@ def auth_remove_command(args) -> None:
     # If this was a singleton-seeded credential (OAuth device_code, hermes_pkce),
     # clear the underlying auth store / credential file so it doesn't get
     # re-seeded on the next load_pool() call.
-    elif removed.source == "device_code" and provider in ("openai-codex", "nous"):
+    # Normalise "manual:<source>" aliases — manually added OAuth creds use a
+    # "manual:" prefix to distinguish them from auto-seeded ones, but the
+    # underlying singleton key is the same.
+    _source_key = removed.source.removeprefix("manual:") if removed.source.startswith("manual:") else removed.source
+
+    if _source_key == "device_code" and provider in ("openai-codex", "nous"):
         from hermes_cli.auth import (
             _load_auth_store, _save_auth_store, _auth_store_lock,
         )
@@ -319,14 +324,14 @@ def auth_remove_command(args) -> None:
                 _save_auth_store(auth_store)
                 print(f"Cleared {provider} OAuth tokens from auth store")
 
-    elif removed.source == "hermes_pkce" and provider == "anthropic":
+    elif _source_key == "hermes_pkce" and provider == "anthropic":
         from hermes_constants import get_hermes_home
         oauth_file = get_hermes_home() / ".anthropic_oauth.json"
         if oauth_file.exists():
             oauth_file.unlink()
             print("Cleared Hermes Anthropic OAuth credentials")
 
-    elif removed.source == "claude_code" and provider == "anthropic":
+    elif _source_key == "claude_code" and provider == "anthropic":
         print("Note: Claude Code credentials live in ~/.claude/.credentials.json")
         print("      Remove them manually if you want to deauthorize Claude Code.")
 

--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -73,6 +73,15 @@ def validate_copilot_token(token: str) -> tuple[bool, str]:
             "  → `gh auth login` with the default device code flow (produces gho_* tokens)"
         )
 
+    if not any(token.startswith(prefix) for prefix in _SUPPORTED_PREFIXES):
+        supported = ", ".join(f"{p}*" for p in _SUPPORTED_PREFIXES)
+        return False, (
+            f"Unrecognised token type. Supported prefixes: {supported}.\n"
+            "  → `copilot login` or `hermes model` to authenticate via OAuth (gho_*)\n"
+            "  → A fine-grained PAT (github_pat_*) with Copilot Requests permission\n"
+            "  → `gh auth login` with the default device code flow"
+        )
+
     return True, "OK"
 
 

--- a/hermes_cli/debug.py
+++ b/hermes_cli/debug.py
@@ -1,0 +1,121 @@
+"""hermes debug — diagnostic helpers for sharing agent state with maintainers."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+from hermes_constants import get_hermes_home
+
+_MAX_SHARE_BYTES = 2 * 1024 * 1024  # 2 MB default upload ceiling
+_TRUNCATION_BANNER = (
+    "[... log truncated — showing last {size:.1f} KB ...]\n"
+)
+
+
+def _read_full_log(path: Path, max_bytes: int) -> str:
+    """Return the tail of *path* up to *max_bytes*, aligned to line boundaries.
+
+    Seeks to ``size - max_bytes`` and skips any partial first line so the
+    caller always receives complete lines.  Crucially, the partial-line skip
+    is conditional: when the seek position lands exactly on a newline (i.e.
+    the byte immediately before the seek point is ``\\n``), no line was
+    split and readline() must NOT be called — doing so would silently discard
+    the first complete line of the retained tail.
+    """
+    if not path.exists():
+        return ""
+
+    size = path.stat().st_size
+    if size == 0:
+        return ""
+
+    with path.open("rb") as fh:
+        if size <= max_bytes:
+            return fh.read().decode("utf-8", errors="replace")
+
+        banner = _TRUNCATION_BANNER.format(size=max_bytes / 1024)
+        seek_pos = size - max_bytes
+        fh.seek(seek_pos)
+
+        # Only skip the first (potentially partial) line when we landed in
+        # the middle of one.  If the byte just before our seek position is
+        # a newline, we are already at a clean line boundary.
+        if seek_pos > 0:
+            fh.seek(seek_pos - 1)
+            preceding_byte = fh.read(1)
+            if preceding_byte != b"\n":
+                # We cut a line — skip the remainder of this partial line.
+                fh.readline()
+
+        tail = fh.read().decode("utf-8", errors="replace")
+
+    return banner + tail
+
+
+def _resolve_log_path(log_name: str) -> Optional[Path]:
+    log_dir = get_hermes_home() / "logs"
+    candidates = {
+        "agent": log_dir / "agent.log",
+        "errors": log_dir / "errors.log",
+        "gateway": log_dir / "gateway.log",
+    }
+    return candidates.get(log_name.lower())
+
+
+def cmd_debug_share(args) -> None:
+    """Print log content suitable for pasting into a bug report."""
+    log_name = getattr(args, "log", "agent")
+    max_bytes = getattr(args, "max_bytes", None) or _MAX_SHARE_BYTES
+
+    path = _resolve_log_path(log_name)
+    if path is None:
+        print(f"Unknown log '{log_name}'. Choose: agent, errors, gateway", file=sys.stderr)
+        sys.exit(1)
+
+    content = _read_full_log(path, max_bytes)
+    if not content:
+        print(f"Log is empty or does not exist: {path}", file=sys.stderr)
+        sys.exit(1)
+
+    print(content, end="")
+
+
+def register_debug_parser(subparsers) -> None:
+    """Register the ``hermes debug`` sub-command tree."""
+    debug_parser = subparsers.add_parser(
+        "debug",
+        help="Diagnostic helpers",
+        description="Helpers for capturing agent state for bug reports",
+    )
+    debug_sub = debug_parser.add_subparsers(dest="debug_action")
+
+    share_parser = debug_sub.add_parser(
+        "share",
+        help="Print log content for sharing in a bug report",
+        description=(
+            "Print the tail of a log file (agent / errors / gateway) to stdout.\n"
+            "Pipe to a paste tool or redirect to a file for easy sharing.\n\n"
+            "Examples:\n"
+            "  hermes debug share                     # print agent.log tail\n"
+            "  hermes debug share errors              # print errors.log tail\n"
+            "  hermes debug share --max-kb 512        # limit to 512 KB\n"
+        ),
+    )
+    share_parser.add_argument(
+        "log", nargs="?", default="agent",
+        help="Which log to share: agent (default), errors, gateway",
+    )
+    share_parser.add_argument(
+        "--max-kb", dest="max_bytes", type=lambda v: int(v) * 1024,
+        metavar="KB", default=None,
+        help="Maximum bytes to include (default: 2048 KB)",
+    )
+    share_parser.set_defaults(func=cmd_debug_share)
+
+    def _debug_default(args):
+        debug_parser.print_help()
+
+    debug_parser.set_defaults(func=_debug_default)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5528,6 +5528,9 @@ Examples:
     )
     logs_parser.set_defaults(func=cmd_logs)
 
+    from hermes_cli.debug import register_debug_parser
+    register_debug_parser(subparsers)
+
     # =========================================================================
     # Parse and execute
     # =========================================================================

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -81,6 +81,10 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         transport="openai_chat",
         base_url_env_var="KIMI_BASE_URL",
     ),
+    "moonshotai": HermesOverlay(
+        transport="openai_chat",
+        base_url_env_var="MOONSHOT_BASE_URL",
+    ),
     "minimax": HermesOverlay(
         transport="openai_chat",
         base_url_env_var="MINIMAX_BASE_URL",
@@ -161,10 +165,11 @@ ALIASES: Dict[str, str] = {
     "z.ai": "zai",
     "zhipu": "zai",
 
-    # kimi-for-coding (models.dev ID)
+    # kimi-for-coding (models.dev ID) — api.kimi.com/coding, needs sk-kimi-* key
     "kimi": "kimi-for-coding",
     "kimi-coding": "kimi-for-coding",
-    "moonshot": "kimi-for-coding",
+    # moonshot → moonshotai (platform.moonshot.ai); distinct from kimi-for-coding
+    "moonshot": "moonshotai",
 
     # minimax-cn
     "minimax-china": "minimax-cn",
@@ -355,7 +360,8 @@ LABELS: Dict[str, str] = {
     "github-copilot": "GitHub Copilot",
     "anthropic": "Anthropic",
     "zai": "Z.AI / GLM",
-    "kimi-for-coding": "Kimi / Moonshot",
+    "kimi-for-coding": "Kimi Code (api.kimi.com)",
+    "moonshotai": "Moonshot AI (platform.moonshot.ai)",
     "minimax": "MiniMax",
     "minimax-cn": "MiniMax (China)",
     "deepseek": "DeepSeek",
@@ -371,7 +377,8 @@ LABELS: Dict[str, str] = {
     "ai-gateway": "Vercel AI Gateway",
     "kilocode": "Kilo Gateway",
     "copilot": "GitHub Copilot",
-    "kimi-coding": "Kimi / Moonshot",
+    "kimi-coding": "Kimi Code (api.kimi.com)",
+    "moonshot": "Moonshot AI (platform.moonshot.ai)",
     "opencode-zen": "OpenCode Zen",
 }
 

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -527,8 +527,17 @@ def prompt_choice(question: str, choices: list, default: int = 0) -> int:
 
 
 def prompt_yes_no(question: str, default: bool = True) -> bool:
-    """Prompt for yes/no. Ctrl+C exits, empty input returns default."""
+    """Prompt for yes/no. Ctrl+C exits, empty input returns default.
+
+    In non-interactive sessions (no TTY / piped stdin) the default is
+    returned immediately so --dry-run and inspection-only commands can still
+    print their preview without aborting.
+    """
     default_str = "Y/n" if default else "y/N"
+
+    if not sys.stdin.isatty():
+        print(color(f"{question} [{default_str}]: ", Colors.YELLOW) + ("y" if default else "n"))
+        return default
 
     while True:
         try:

--- a/run_agent.py
+++ b/run_agent.py
@@ -86,7 +86,7 @@ from agent.model_metadata import (
     fetch_model_metadata,
     estimate_tokens_rough, estimate_messages_tokens_rough, estimate_request_tokens_rough,
     get_next_probe_tier, parse_context_limit_from_error,
-    save_context_length, is_local_endpoint,
+    save_context_length, is_local_endpoint, is_ollama_endpoint,
     query_ollama_num_ctx,
 )
 from agent.context_compressor import ContextCompressor
@@ -1167,6 +1167,10 @@ class AIAgent:
         # When running against an Ollama server, detect the model's max context
         # and pass num_ctx on every chat request so the full window is used.
         # User override: set model.ollama_num_ctx in config.yaml to cap VRAM use.
+        self._preserve_dots_config: bool = bool(
+            isinstance(_model_cfg, dict) and _model_cfg.get("preserve_dots")
+        )
+
         self._ollama_num_ctx: int | None = None
         _ollama_num_ctx_override = None
         if isinstance(_model_cfg, dict):
@@ -1176,7 +1180,7 @@ class AIAgent:
                 self._ollama_num_ctx = int(_ollama_num_ctx_override)
             except (TypeError, ValueError):
                 logger.debug("Invalid ollama_num_ctx config value: %r", _ollama_num_ctx_override)
-        if self._ollama_num_ctx is None and self.base_url and is_local_endpoint(self.base_url):
+        if self._ollama_num_ctx is None and self.base_url and is_ollama_endpoint(self.base_url):
             try:
                 _detected = query_ollama_num_ctx(self.model, self.base_url)
                 if _detected and _detected > 0:
@@ -5220,7 +5224,11 @@ class AIAgent:
     def _anthropic_preserve_dots(self) -> bool:
         """True when using an anthropic-compatible endpoint that preserves dots in model names.
         Alibaba/DashScope keeps dots (e.g. qwen3.5-plus).
-        OpenCode Go keeps dots (e.g. minimax-m2.7)."""
+        OpenCode Go keeps dots (e.g. minimax-m2.7).
+        Users can also set model.preserve_dots: true in config.yaml for third-party
+        Bedrock-style proxies not covered by the built-in host list."""
+        if getattr(self, "_preserve_dots_config", False):
+            return True
         if (getattr(self, "provider", "") or "").lower() in {"alibaba", "opencode-go"}:
             return True
         base = (getattr(self, "base_url", "") or "").lower()

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -190,10 +190,16 @@ def _validate_content_size(content: str, label: str = "SKILL.md") -> Optional[st
 
 
 def _resolve_skill_dir(name: str, category: str = None) -> Path:
-    """Build the directory path for a new skill, optionally under a category."""
+    """Build the directory path for a new skill, optionally under a category.
+
+    Uses the configured ``skills.agent_dir`` when set so agent-created skills
+    land in a separate directory from bundled ones.
+    """
+    from tools.skills_tool import get_agent_skills_dir
+    target = get_agent_skills_dir()
     if category:
-        return SKILLS_DIR / category / name
-    return SKILLS_DIR / name
+        return target / category / name
+    return target / name
 
 
 def _find_skill(name: str) -> Optional[Dict[str, Any]]:
@@ -318,10 +324,12 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
         shutil.rmtree(skill_dir, ignore_errors=True)
         return {"success": False, "error": scan_error}
 
+    from tools.skills_tool import get_agent_skills_dir
+    _base = get_agent_skills_dir()
     result = {
         "success": True,
         "message": f"Skill '{name}' created.",
-        "path": str(skill_dir.relative_to(SKILLS_DIR)),
+        "path": str(skill_dir.relative_to(_base)),
         "skill_md": str(skill_md),
     }
     if category:

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -87,6 +87,30 @@ logger = logging.getLogger(__name__)
 HERMES_HOME = get_hermes_home()
 SKILLS_DIR = HERMES_HOME / "skills"
 
+
+def get_agent_skills_dir() -> Path:
+    """Return the directory where the agent should write self-created skills.
+
+    Reads ``skills.agent_dir`` from config.yaml.  Falls back to SKILLS_DIR so
+    the default behaviour is unchanged when the option is not set.
+
+    Example config.yaml entry::
+
+        skills:
+          agent_dir: ~/my-agent-skills
+    """
+    try:
+        from hermes_cli.config import load_config as _load_cfg
+        cfg = _load_cfg().get("skills", {})
+        raw = cfg.get("agent_dir", "") if isinstance(cfg, dict) else ""
+        if raw:
+            resolved = Path(raw).expanduser().resolve()
+            resolved.mkdir(parents=True, exist_ok=True)
+            return resolved
+    except Exception:
+        pass
+    return SKILLS_DIR
+
 # Anthropic-recommended limits for progressive disclosure efficiency
 MAX_NAME_LENGTH = 64
 MAX_DESCRIPTION_LENGTH = 1024


### PR DESCRIPTION
## Summary

Batch fix for 11 open issues across authentication, skills routing, provider configuration, CLI UX, and the Telegram gateway.

- **#13970** — `validate_copilot_token` now rejects tokens that don't match any supported prefix (`gho_`, `github_pat_`, `ghu_`); the existing `_SUPPORTED_PREFIXES` constant was defined but never used in the check.

- **#13944** — `extract_skill_description` cap raised from 60 → 1024 chars, matching `MAX_DESCRIPTION_LENGTH` in `skills_tool.py` so the system-prompt index carries enough context for accurate skill routing.

- **#13967** — `auth remove` now normalises `manual:device_code` / `manual:hermes_pkce` source prefixes before matching singleton cleanup paths, preventing manually-added OAuth credentials from reappearing after removal.

- **#13953** — New `model.preserve_dots: true` config flag stored at init and checked in `_anthropic_preserve_dots()`, letting users opt into dot-preserving behaviour for third-party Bedrock-style proxies without needing an upstream patch per host.

- **#13971** — Added `is_ollama_endpoint()` in `model_metadata.py` that matches only `:11434` or `"ollama"` in the URL; the Ollama num_ctx probing guard now uses this instead of `is_local_endpoint()`, avoiding false positives on arbitrary local proxies (e.g. a GLM/ZAI gateway at `localhost:8000`).

- **#13935** — Added `moonshotai` provider entry pointing to `api.moonshot.ai/v1`; the `moonshot` alias now routes to `moonshotai` rather than `kimi-for-coding`; `kimi-coding`/`kimi-for-coding` display names clarified to show they target `api.kimi.com`.

- **#13969** — `prompt_yes_no` now detects non-TTY stdin and returns the default immediately instead of raising `EOFError` → `sys.exit(1)`, so `--dry-run` and inspection-only commands work in cron/CI without aborting.

- **#13951** — Added `_approval_output_gate` threading event in `cli.py`; it is cleared while the dangerous-command approval prompt is visible, blocking `_cprint` calls from background threads so streaming output can no longer flood the prompt.

- **#13968** — New `hermes_cli/debug.py` with `hermes debug share [agent|errors|gateway]` command; `_read_full_log()` checks whether the seek position lands on a line boundary before calling `readline()`, fixing the byte-boundary line drop.

- **#13963** — `get_agent_skills_dir()` reads `skills.agent_dir` from `config.yaml`; `_resolve_skill_dir()` in `skill_manager_tool.py` targets that directory for new skills; `get_all_skills_dirs()` includes it in discovery so agent-created and bundled skills can be managed separately.

- **#13942** — Inbound Telegram emoji reaction routing behind `TELEGRAM_INBOUND_REACTIONS=true`; registers `MessageReactionHandler`; emits synthetic `MessageEvent` for allowlisted emoji (👍 ✅ 👎 ❌); bounded LRU cache (500 entries, 1 h TTL) correlates reactions to the originating conversation context.

## Test plan

- [ ] `hermes copilot login` rejects `ghs_*` and random strings, accepts `gho_*` / `github_pat_*` / `ghu_*`
- [ ] Skill system-prompt index shows full descriptions up to 1024 chars
- [ ] `hermes auth remove` on a manually-added OAuth credential does not reappear after restart
- [ ] `model: {preserve_dots: true}` in `config.yaml` reaches a Bedrock-style proxy without dot-stripping
- [ ] Local proxy at `:8000` forwarding to ZAI no longer triggers Ollama num_ctx probing
- [ ] `hermes model moonshot` routes to `api.moonshot.ai/v1`; `hermes model kimi-coding` routes to `api.kimi.com/coding`
- [ ] `hermes claw cleanup --dry-run` in a non-TTY session (e.g. `| cat`) shows preview and exits 0
- [ ] Approval prompt remains readable while agent streams output in background
- [ ] `hermes debug share` prints the last 2 MB of `agent.log`; `--max-kb 512` limits to 512 KB
- [ ] `skills: {agent_dir: ~/my-skills}` in `config.yaml` — new skill_manage creates appear in `~/my-skills/`
- [ ] With `TELEGRAM_INBOUND_REACTIONS=true`, a 👍 reaction on a bot message triggers an agent turn