### PR TITLE
fix(copilot_auth): reject tokens that don't match supported prefixes

### DIFF
--- a/hermes_cli/copilot_auth.py
+++ b/hermes_cli/copilot_auth.py
@@ -73,6 +73,15 @@ def validate_copilot_token(token: str) -> tuple[bool, str]:
             "  → `gh auth login` with the default device code flow (produces gho_* tokens)"
         )
 
+    if not any(token.startswith(prefix) for prefix in _SUPPORTED_PREFIXES):
+        supported = ", ".join(f"{p}*" for p in _SUPPORTED_PREFIXES)
+        return False, (
+            f"Unrecognised token type. Supported prefixes: {supported}.\n"
+            "  → `copilot login` or `hermes model` to authenticate via OAuth (gho_*)\n"
+            "  → A fine-grained PAT (github_pat_*) with Copilot Requests permission\n"
+            "  → `gh auth login` with the default device code flow"
+        )
+
     return True, "OK"
 
 


### PR DESCRIPTION
## Summary

`validate_copilot_token` had `_SUPPORTED_PREFIXES` defined but never checked — any non-empty string that wasn't a classic PAT (`ghp_*`) silently passed validation.

- After the classic-PAT rejection, add a check against `_SUPPORTED_PREFIXES` (`gho_`, `github_pat_`, `ghu_`)
- Return an informative error listing supported prefixes for unrecognised token types

## Test plan

- [ ] Pass a `gho_` token → passes validation
- [ ] Pass a `github_pat_` token → passes validation
- [ ] Pass an arbitrary string (e.g. `abc123`) → rejected with supported-prefix message
- [ ] Pass a `ghp_` token → still rejected with classic-PAT message (existing behaviour)

Fixes #13970