### PR TITLE
feat(telegram): inbound reaction routing behind TELEGRAM_INBOUND_REACTIONS env toggle

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -685,6 +685,8 @@ def load_gateway_config() -> GatewayConfig:
                     os.environ["TELEGRAM_IGNORED_THREADS"] = str(ignored_threads)
                 if "reactions" in telegram_cfg and not os.getenv("TELEGRAM_REACTIONS"):
                     os.environ["TELEGRAM_REACTIONS"] = str(telegram_cfg["reactions"]).lower()
+                if "inbound_reactions" in telegram_cfg and not os.getenv("TELEGRAM_INBOUND_REACTIONS"):
+                    os.environ["TELEGRAM_INBOUND_REACTIONS"] = str(telegram_cfg["inbound_reactions"]).lower()
                 if "proxy_url" in telegram_cfg and not os.getenv("TELEGRAM_PROXY"):
                     os.environ["TELEGRAM_PROXY"] = str(telegram_cfg["proxy_url"]).strip()
                 if "disable_link_previews" in telegram_cfg:

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -12,9 +12,12 @@ import json
 import logging
 import os
 import tempfile
+import time
 import html as _html
 import re
-from typing import Dict, List, Optional, Any
+from collections import OrderedDict
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +27,11 @@ try:
         from telegram import LinkPreviewOptions
     except ImportError:
         LinkPreviewOptions = None
+    try:
+        from telegram import MessageReactionUpdated, ReactionTypeEmoji
+    except ImportError:
+        MessageReactionUpdated = Any  # type: ignore[assignment,misc]
+        ReactionTypeEmoji = None  # type: ignore[assignment]
     from telegram.ext import (
         Application,
         CommandHandler,
@@ -32,6 +40,10 @@ try:
         ContextTypes,
         filters,
     )
+    try:
+        from telegram.ext import MessageReactionHandler
+    except ImportError:
+        MessageReactionHandler = None  # type: ignore[assignment,misc]
     from telegram.constants import ParseMode, ChatType
     from telegram.request import HTTPXRequest
     TELEGRAM_AVAILABLE = True
@@ -43,10 +55,13 @@ except ImportError:
     InlineKeyboardButton = Any
     InlineKeyboardMarkup = Any
     LinkPreviewOptions = None
+    MessageReactionUpdated = Any
+    ReactionTypeEmoji = None
     Application = Any
     CommandHandler = Any
     CallbackQueryHandler = Any
     TelegramMessageHandler = Any
+    MessageReactionHandler = None
     HTTPXRequest = Any
     filters = None
     ParseMode = None
@@ -251,6 +266,10 @@ class TelegramAdapter(BasePlatformAdapter):
         self._model_picker_state: Dict[str, dict] = {}
         # Approval button state: message_id → session_key
         self._approval_state: Dict[int, str] = {}
+        # Cache of bot-authored outbound messages for inbound reaction routing.
+        # Key (chat_id, message_id) → {"ts", "kind", "thread_id", ...}
+        self._bot_message_cache: "OrderedDict[Tuple[str, str], Dict[str, Any]]" = OrderedDict()
+        self._bot_message_cache_lock = asyncio.Lock()
 
     @staticmethod
     def _is_callback_user_authorized(user_id: str) -> bool:
@@ -763,6 +782,11 @@ class TelegramAdapter(BasePlatformAdapter):
             ))
             # Handle inline keyboard button callbacks (update prompts)
             self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
+            # Handle inbound message reactions on bot-authored messages so
+            # users can confirm with 👍/✅ instead of typing "yes". Registered
+            # only when the feature is on so disabled installs pay no cost.
+            if self._inbound_reactions_enabled() and MessageReactionHandler is not None:
+                self._app.add_handler(MessageReactionHandler(self._handle_message_reaction))
             
             # Start polling — retry initialize() for transient TLS resets
             try:
@@ -1105,6 +1129,9 @@ class TelegramAdapter(BasePlatformAdapter):
                                 continue
                         raise
                 message_ids.append(str(msg.message_id))
+                await self._remember_bot_message(
+                    chat_id, str(msg.message_id), kind="regular", thread_id=thread_id,
+                )
             
             return SendResult(
                 success=True,
@@ -1235,6 +1262,10 @@ class TelegramAdapter(BasePlatformAdapter):
                 reply_markup=keyboard,
                 **self._link_preview_kwargs(),
             )
+            await self._remember_bot_message(
+                chat_id, str(msg.message_id), kind="approval",
+                session_key=session_key or None,
+            )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
             logger.warning("[%s] send_update_prompt failed: %s", self.name, e)
@@ -1298,6 +1329,11 @@ class TelegramAdapter(BasePlatformAdapter):
 
             # Store session_key keyed by approval_id for the callback handler
             self._approval_state[approval_id] = session_key
+
+            await self._remember_bot_message(
+                chat_id, str(msg.message_id), kind="approval",
+                thread_id=thread_id, session_key=session_key,
+            )
 
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
@@ -1372,6 +1408,12 @@ class TelegramAdapter(BasePlatformAdapter):
                 "current_model": current_model,
                 "current_provider": current_provider,
             }
+
+            await self._remember_bot_message(
+                chat_id, str(msg.message_id), kind="model_picker",
+                thread_id=str(thread_id) if thread_id else None,
+                session_key=session_key,
+            )
 
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
@@ -1757,6 +1799,10 @@ class TelegramAdapter(BasePlatformAdapter):
                         reply_to_message_id=int(reply_to) if reply_to else None,
                         message_thread_id=self._message_thread_id_for_send(_audio_thread),
                     )
+            await self._remember_bot_message(
+                chat_id, str(msg.message_id), kind="regular",
+                thread_id=self._metadata_thread_id(metadata),
+            )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
             logger.error(
@@ -1793,6 +1839,9 @@ class TelegramAdapter(BasePlatformAdapter):
                     reply_to_message_id=int(reply_to) if reply_to else None,
                     message_thread_id=self._message_thread_id_for_send(_thread),
                 )
+            await self._remember_bot_message(
+                chat_id, str(msg.message_id), kind="regular", thread_id=_thread,
+            )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
             logger.error(
@@ -1833,6 +1882,9 @@ class TelegramAdapter(BasePlatformAdapter):
                     reply_to_message_id=int(reply_to) if reply_to else None,
                     message_thread_id=self._message_thread_id_for_send(_thread),
                 )
+            await self._remember_bot_message(
+                chat_id, str(msg.message_id), kind="regular", thread_id=_thread,
+            )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
             print(f"[{self.name}] Failed to send document: {e}")
@@ -1864,6 +1916,9 @@ class TelegramAdapter(BasePlatformAdapter):
                     reply_to_message_id=int(reply_to) if reply_to else None,
                     message_thread_id=self._message_thread_id_for_send(_thread),
                 )
+            await self._remember_bot_message(
+                chat_id, str(msg.message_id), kind="regular", thread_id=_thread,
+            )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
             print(f"[{self.name}] Failed to send video: {e}")
@@ -1900,6 +1955,9 @@ class TelegramAdapter(BasePlatformAdapter):
                 reply_to_message_id=int(reply_to) if reply_to else None,
                 message_thread_id=self._message_thread_id_for_send(_photo_thread),
             )
+            await self._remember_bot_message(
+                chat_id, str(msg.message_id), kind="regular", thread_id=_photo_thread,
+            )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
             logger.warning(
@@ -1922,6 +1980,9 @@ class TelegramAdapter(BasePlatformAdapter):
                     caption=caption[:1024] if caption else None,
                     reply_to_message_id=int(reply_to) if reply_to else None,
                     message_thread_id=self._message_thread_id_for_send(_photo_thread),
+                )
+                await self._remember_bot_message(
+                    chat_id, str(msg.message_id), kind="regular", thread_id=_photo_thread,
                 )
                 return SendResult(success=True, message_id=str(msg.message_id))
             except Exception as e2:
@@ -1954,6 +2015,9 @@ class TelegramAdapter(BasePlatformAdapter):
                 caption=caption[:1024] if caption else None,
                 reply_to_message_id=int(reply_to) if reply_to else None,
                 message_thread_id=self._message_thread_id_for_send(_anim_thread),
+            )
+            await self._remember_bot_message(
+                chat_id, str(msg.message_id), kind="regular", thread_id=_anim_thread,
             )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
@@ -3107,3 +3171,149 @@ class TelegramAdapter(BasePlatformAdapter):
                 message_id,
                 "\U0001f44d" if outcome == ProcessingOutcome.SUCCESS else "\U0001f44e",
             )
+
+    def _inbound_reactions_enabled(self) -> bool:
+        """Check if inbound user reactions on bot messages should be routed."""
+        return os.getenv("TELEGRAM_INBOUND_REACTIONS", "false").lower() not in ("false", "0", "no")
+
+    # ── Inbound reactions (user reacts to bot messages) ───────────────────
+
+    # Cache sizing: a single process tracks at most this many recent bot
+    # messages. TTL evicts older entries so a reaction a day later on an
+    # ancient message doesn't wake the agent.
+    _BOT_MSG_CACHE_MAX = 512
+    _BOT_MSG_CACHE_TTL = 24 * 60 * 60  # seconds
+
+    # 👍, ✅, 👎, ❌
+    _INBOUND_REACTION_ALLOWLIST = {"\U0001f44d", "✅", "\U0001f44e", "❌"}
+
+    async def _remember_bot_message(
+        self,
+        chat_id: Any,
+        message_id: Any,
+        *,
+        kind: str = "regular",
+        thread_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        session_key: Optional[str] = None,
+    ) -> None:
+        """Record a bot-authored outbound message for inbound reaction routing.
+
+        Only populated when ``TELEGRAM_INBOUND_REACTIONS`` is enabled so the
+        cache stays empty (and cheap) for users who haven't opted in.
+        """
+        if not self._inbound_reactions_enabled() or message_id is None:
+            return
+        key = (str(chat_id), str(message_id))
+        now = time.time()
+        async with self._bot_message_cache_lock:
+            self._bot_message_cache[key] = {
+                "ts": now,
+                "kind": kind,
+                "thread_id": thread_id,
+                "user_id": user_id,
+                "session_key": session_key,
+            }
+            # evict by size
+            while len(self._bot_message_cache) > self._BOT_MSG_CACHE_MAX:
+                self._bot_message_cache.popitem(last=False)
+            # evict stale entries (head of OrderedDict is oldest)
+            ttl = self._BOT_MSG_CACHE_TTL
+            for k, v in list(self._bot_message_cache.items()):
+                if now - v["ts"] > ttl:
+                    del self._bot_message_cache[k]
+                else:
+                    break
+
+    @staticmethod
+    def _extract_reaction_emojis(reactions: Any) -> set:
+        """Pull emoji strings out of a reactions iterable.
+
+        Skips ``ReactionTypeCustomEmoji`` (which has no plain ``.emoji``
+        attribute) so premium custom reactions are silently dropped.
+        """
+        out: set = set()
+        for r in reactions or ():
+            emoji = getattr(r, "emoji", None)
+            if isinstance(emoji, str):
+                out.add(emoji)
+        return out
+
+    async def _handle_message_reaction(self, update: Any, context: Any) -> None:
+        """Route user reactions on cached bot messages as synthetic events.
+
+        Only forwards allowlisted approval-style emoji (👍 ✅ 👎 ❌) on
+        messages the bot recently sent. Reactions from the bot itself,
+        reactions on unknown messages, and unsupported emoji are dropped.
+        """
+        reaction = getattr(update, "message_reaction", None)
+        if reaction is None:
+            return
+
+        chat = getattr(reaction, "chat", None)
+        if chat is None:
+            return
+        chat_id = str(chat.id)
+        message_id = str(reaction.message_id)
+
+        # 1. Must be a message we sent
+        async with self._bot_message_cache_lock:
+            cached = self._bot_message_cache.get((chat_id, message_id))
+        if cached is None:
+            return
+
+        # 2. Ignore reactions authored by the bot itself. Anonymous admin
+        # reactions have ``user is None`` (actor_chat is set instead) and
+        # are allowed through — they're still human-originated.
+        actor = getattr(reaction, "user", None)
+        bot_id = getattr(self._bot, "id", None) if self._bot else None
+        if actor is not None and bot_id is not None and getattr(actor, "id", None) == bot_id:
+            return
+
+        # 3. Diff old/new reaction sets, filtered by the allowlist
+        old_set = self._extract_reaction_emojis(getattr(reaction, "old_reaction", None))
+        new_set = self._extract_reaction_emojis(getattr(reaction, "new_reaction", None))
+        allowlist = self._INBOUND_REACTION_ALLOWLIST
+        added = (new_set - old_set) & allowlist
+        removed = (old_set - new_set) & allowlist
+        if not added and not removed:
+            return
+
+        # 4. Build a synthetic MessageEvent per emoji delta and dispatch
+        chat_type = getattr(chat, "type", None) or "dm"
+        chat_name = getattr(chat, "title", None)
+        if not chat_name and actor is not None:
+            chat_name = getattr(actor, "full_name", None)
+        if not chat_name:
+            chat_name = chat_id
+        source = self.build_source(
+            chat_id=chat_id,
+            chat_name=chat_name,
+            chat_type=str(chat_type),
+            user_id=str(actor.id) if actor is not None else None,
+            user_name=getattr(actor, "full_name", None) if actor else None,
+            thread_id=cached.get("thread_id"),
+        )
+        ts = getattr(reaction, "date", None) or datetime.now(timezone.utc)
+
+        for emoji in sorted(removed):
+            event = MessageEvent(
+                text=f"reaction:removed:{emoji}",
+                message_type=MessageType.TEXT,
+                source=source,
+                raw_message=reaction,
+                message_id=message_id,
+                timestamp=ts,
+            )
+            await self.handle_message(event)
+
+        for emoji in sorted(added):
+            event = MessageEvent(
+                text=f"reaction:added:{emoji}",
+                message_type=MessageType.TEXT,
+                source=source,
+                raw_message=reaction,
+                message_id=message_id,
+                timestamp=ts,
+            )
+            await self.handle_message(event)

--- a/tests/gateway/test_telegram_reactions.py
+++ b/tests/gateway/test_telegram_reactions.py
@@ -1,5 +1,8 @@
 """Tests for Telegram message reactions tied to processing lifecycle hooks."""
 
+import asyncio
+import time
+from collections import OrderedDict
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -18,6 +21,8 @@ def _make_adapter(**extra_env):
     adapter.config = PlatformConfig(enabled=True, token="fake-token")
     adapter._bot = AsyncMock()
     adapter._bot.set_message_reaction = AsyncMock()
+    adapter._bot_message_cache = OrderedDict()
+    adapter._bot_message_cache_lock = asyncio.Lock()
     return adapter
 
 
@@ -270,3 +275,314 @@ def test_config_reactions_env_takes_precedence(monkeypatch, tmp_path):
 
     import os
     assert os.getenv("TELEGRAM_REACTIONS") == "false"
+
+
+# ── Inbound reactions: user reacts to a bot message ──────────────────
+
+
+def _make_reaction_update(
+    *,
+    chat_id: int = 123,
+    message_id: int = 456,
+    old_emojis=(),
+    new_emojis=("\U0001f44d",),
+    user_id=42,
+    user_name: str = "TestUser",
+    chat_type: str = "private",
+):
+    """Build a minimal Update that looks like a message_reaction update."""
+    old = tuple(SimpleNamespace(emoji=e) for e in old_emojis)
+    new = tuple(SimpleNamespace(emoji=e) for e in new_emojis)
+    chat = SimpleNamespace(id=chat_id, type=chat_type, title=None)
+    user = (
+        SimpleNamespace(id=user_id, full_name=user_name)
+        if user_id is not None else None
+    )
+    reaction = SimpleNamespace(
+        chat=chat,
+        message_id=message_id,
+        old_reaction=old,
+        new_reaction=new,
+        user=user,
+        date=None,
+    )
+    return SimpleNamespace(message_reaction=reaction)
+
+
+def test_inbound_reactions_disabled_by_default(monkeypatch):
+    """TELEGRAM_INBOUND_REACTIONS unset → _inbound_reactions_enabled is False."""
+    monkeypatch.delenv("TELEGRAM_INBOUND_REACTIONS", raising=False)
+    adapter = _make_adapter()
+    assert adapter._inbound_reactions_enabled() is False
+
+
+def test_inbound_reactions_enabled_when_set_true(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_INBOUND_REACTIONS", "true")
+    adapter = _make_adapter()
+    assert adapter._inbound_reactions_enabled() is True
+
+
+@pytest.mark.asyncio
+async def test_remember_bot_message_noop_when_disabled(monkeypatch):
+    """Cache stays empty when the feature is off so there's no overhead."""
+    monkeypatch.delenv("TELEGRAM_INBOUND_REACTIONS", raising=False)
+    adapter = _make_adapter()
+
+    await adapter._remember_bot_message("chat", "msg", kind="regular")
+
+    assert adapter._bot_message_cache == {}
+
+
+@pytest.mark.asyncio
+async def test_remember_bot_message_records_when_enabled(monkeypatch):
+    monkeypatch.setenv("TELEGRAM_INBOUND_REACTIONS", "true")
+    adapter = _make_adapter()
+
+    await adapter._remember_bot_message(
+        "chat-a",
+        "987",
+        kind="approval",
+        thread_id="t-1",
+        session_key="s-1",
+    )
+
+    cached = adapter._bot_message_cache[("chat-a", "987")]
+    assert cached["kind"] == "approval"
+    assert cached["thread_id"] == "t-1"
+    assert cached["session_key"] == "s-1"
+
+
+@pytest.mark.asyncio
+async def test_remember_bot_message_evicts_oldest(monkeypatch):
+    """Cache caps at _BOT_MSG_CACHE_MAX; oldest entries fall off."""
+    monkeypatch.setenv("TELEGRAM_INBOUND_REACTIONS", "true")
+    adapter = _make_adapter()
+    from gateway.platforms.telegram import TelegramAdapter
+
+    monkeypatch.setattr(TelegramAdapter, "_BOT_MSG_CACHE_MAX", 3)
+
+    for mid in ("1", "2", "3", "4"):
+        await adapter._remember_bot_message("c", mid, kind="regular")
+
+    keys = list(adapter._bot_message_cache.keys())
+    assert ("c", "1") not in keys
+    assert ("c", "4") in keys
+    assert len(adapter._bot_message_cache) == 3
+
+
+@pytest.mark.asyncio
+async def test_remember_bot_message_expires_ttl(monkeypatch):
+    """Entries older than the TTL are pruned on the next insert."""
+    monkeypatch.setenv("TELEGRAM_INBOUND_REACTIONS", "true")
+    adapter = _make_adapter()
+    from gateway.platforms.telegram import TelegramAdapter
+
+    monkeypatch.setattr(TelegramAdapter, "_BOT_MSG_CACHE_TTL", 1)
+
+    adapter._bot_message_cache[("c", "old")] = {
+        "ts": time.time() - 10,
+        "kind": "regular",
+        "thread_id": None,
+        "user_id": None,
+        "session_key": None,
+    }
+
+    await adapter._remember_bot_message("c", "new", kind="regular")
+
+    assert ("c", "old") not in adapter._bot_message_cache
+    assert ("c", "new") in adapter._bot_message_cache
+
+
+@pytest.mark.asyncio
+async def test_inbound_reaction_unknown_message_is_ignored(monkeypatch):
+    """Reaction on a message we didn't send must not reach handle_message."""
+    monkeypatch.setenv("TELEGRAM_INBOUND_REACTIONS", "true")
+    adapter = _make_adapter()
+    adapter.handle_message = AsyncMock()
+
+    update = _make_reaction_update(chat_id=999, message_id=111)
+    await adapter._handle_message_reaction(update, context=None)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_inbound_reaction_on_cached_message_routes_added(monkeypatch):
+    """👍 on a cached bot message emits a synthetic added event."""
+    monkeypatch.setenv("TELEGRAM_INBOUND_REACTIONS", "true")
+    adapter = _make_adapter()
+    adapter.handle_message = AsyncMock()
+    await adapter._remember_bot_message("123", "456", kind="approval", thread_id="99")
+
+    update = _make_reaction_update(
+        chat_id=123, message_id=456, old_emojis=(), new_emojis=("\U0001f44d",),
+    )
+    await adapter._handle_message_reaction(update, context=None)
+
+    adapter.handle_message.assert_awaited_once()
+    emitted = adapter.handle_message.await_args.args[0]
+    assert isinstance(emitted, MessageEvent)
+    assert emitted.text == "reaction:added:\U0001f44d"
+    assert emitted.message_id == "456"
+    assert emitted.message_type is MessageType.TEXT
+    assert emitted.source.platform is Platform.TELEGRAM
+    assert emitted.source.chat_id == "123"
+    assert emitted.source.user_id == "42"
+    assert emitted.source.thread_id == "99"
+
+
+@pytest.mark.asyncio
+async def test_inbound_reaction_removed_event(monkeypatch):
+    """Removing an allowlisted emoji emits reaction:removed:EMOJI."""
+    monkeypatch.setenv("TELEGRAM_INBOUND_REACTIONS", "true")
+    adapter = _make_adapter()
+    adapter.handle_message = AsyncMock()
+    await adapter._remember_bot_message("1", "2", kind="regular")
+
+    update = _make_reaction_update(
+        chat_id=1, message_id=2, old_emojis=("\U0001f44d",), new_emojis=(),
+    )
+    await adapter._handle_message_reaction(update, context=None)
+
+    adapter.handle_message.assert_awaited_once()
+    emitted = adapter.handle_message.await_args.args[0]
+    assert emitted.text == "reaction:removed:\U0001f44d"
+
+
+@pytest.mark.asyncio
+async def test_inbound_reaction_swap_emits_remove_then_add(monkeypatch):
+    """old=[👍], new=[✅] → removed event then added event in order."""
+    monkeypatch.setenv("TELEGRAM_INBOUND_REACTIONS", "true")
+    adapter = _make_adapter()
+    adapter.handle_message = AsyncMock()
+    await adapter._remember_bot_message("1", "2", kind="regular")
+
+    update = _make_reaction_update(
+        chat_id=1,
+        message_id=2,
+        old_emojis=("\U0001f44d",),
+        new_emojis=("✅",),
+    )
+    await adapter._handle_message_reaction(update, context=None)
+
+    texts = [call.args[0].text for call in adapter.handle_message.await_args_list]
+    assert texts == ["reaction:removed:\U0001f44d", "reaction:added:✅"]
+
+
+@pytest.mark.asyncio
+async def test_inbound_reaction_from_bot_itself_is_ignored(monkeypatch):
+    """Lifecycle-style reactions from the bot's own account must not loop back."""
+    monkeypatch.setenv("TELEGRAM_INBOUND_REACTIONS", "true")
+    adapter = _make_adapter()
+    adapter._bot.id = 42
+    adapter.handle_message = AsyncMock()
+    await adapter._remember_bot_message("123", "456", kind="regular")
+
+    update = _make_reaction_update(
+        chat_id=123, message_id=456, user_id=42, new_emojis=("\U0001f44d",),
+    )
+    await adapter._handle_message_reaction(update, context=None)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_inbound_reaction_unsupported_emoji_is_ignored(monkeypatch):
+    """🎉 on a cached message emits nothing — it's outside the v1 allowlist."""
+    monkeypatch.setenv("TELEGRAM_INBOUND_REACTIONS", "true")
+    adapter = _make_adapter()
+    adapter.handle_message = AsyncMock()
+    await adapter._remember_bot_message("1", "2", kind="regular")
+
+    update = _make_reaction_update(
+        chat_id=1, message_id=2, old_emojis=(), new_emojis=("\U0001f389",),
+    )
+    await adapter._handle_message_reaction(update, context=None)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_inbound_reaction_anonymous_admin_routes_without_user(monkeypatch):
+    """Anonymous group-admin reactions (user=None) must not crash and still route."""
+    monkeypatch.setenv("TELEGRAM_INBOUND_REACTIONS", "true")
+    adapter = _make_adapter()
+    adapter.handle_message = AsyncMock()
+    await adapter._remember_bot_message("1", "2", kind="regular")
+
+    update = _make_reaction_update(
+        chat_id=1,
+        message_id=2,
+        user_id=None,
+        new_emojis=("\U0001f44d",),
+    )
+    await adapter._handle_message_reaction(update, context=None)
+
+    adapter.handle_message.assert_awaited_once()
+    emitted = adapter.handle_message.await_args.args[0]
+    assert emitted.source.user_id is None
+
+
+@pytest.mark.asyncio
+async def test_inbound_reaction_custom_emoji_is_skipped(monkeypatch):
+    """ReactionTypeCustomEmoji (no .emoji) is dropped without crashing."""
+    monkeypatch.setenv("TELEGRAM_INBOUND_REACTIONS", "true")
+    adapter = _make_adapter()
+    adapter.handle_message = AsyncMock()
+    await adapter._remember_bot_message("1", "2", kind="regular")
+
+    custom = SimpleNamespace(custom_emoji_id="abc")  # no .emoji attribute
+    reaction = SimpleNamespace(
+        chat=SimpleNamespace(id=1, type="private", title=None),
+        message_id=2,
+        old_reaction=(),
+        new_reaction=(custom,),
+        user=SimpleNamespace(id=42, full_name="u"),
+        date=None,
+    )
+    update = SimpleNamespace(message_reaction=reaction)
+
+    await adapter._handle_message_reaction(update, context=None)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+# ── config.py bridging for the new toggle ────────────────────────────
+
+
+def test_config_bridges_telegram_inbound_reactions(monkeypatch, tmp_path):
+    """gateway/config.py bridges telegram.inbound_reactions → TELEGRAM_INBOUND_REACTIONS."""
+    import yaml
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump({
+        "telegram": {
+            "inbound_reactions": True,
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("TELEGRAM_INBOUND_REACTIONS", "")
+
+    from gateway.config import load_gateway_config
+    load_gateway_config()
+
+    import os
+    assert os.getenv("TELEGRAM_INBOUND_REACTIONS") == "true"
+
+
+def test_config_inbound_reactions_env_takes_precedence(monkeypatch, tmp_path):
+    """Env var wins over config.yaml when both are set."""
+    import yaml
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump({
+        "telegram": {
+            "inbound_reactions": True,
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("TELEGRAM_INBOUND_REACTIONS", "false")
+
+    from gateway.config import load_gateway_config
+    load_gateway_config()
+
+    import os
+    assert os.getenv("TELEGRAM_INBOUND_REACTIONS") == "false"

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -196,6 +196,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `TELEGRAM_WEBHOOK_PORT` | Local listen port for webhook server (default: `8443`) |
 | `TELEGRAM_WEBHOOK_SECRET` | Secret token for verifying updates come from Telegram |
 | `TELEGRAM_REACTIONS` | Enable emoji reactions on messages during processing (default: `false`) |
+| `TELEGRAM_INBOUND_REACTIONS` | Route user emoji reactions (👍 ✅ 👎 ❌) on bot messages as synthetic confirmation events (default: `false`) |
 | `TELEGRAM_REPLY_TO_MODE` | Reply-reference behavior: `off`, `first` (default), or `all`. Matches the Discord pattern. |
 | `TELEGRAM_IGNORED_THREADS` | Comma-separated Telegram forum topic/thread IDs where the bot never responds |
 | `TELEGRAM_PROXY` | Proxy URL for Telegram connections — overrides `HTTPS_PROXY`. Supports `http://`, `https://`, `socks5://` |

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -560,6 +560,23 @@ Unlike Discord (where reactions are additive), Telegram's Bot API replaces all b
 If the bot doesn't have permission to add reactions in a group, the reaction calls fail silently and message processing continues normally.
 :::
 
+### Inbound reactions (experimental)
+
+Hermes can also observe when *you* react to one of its messages and forward that as a lightweight confirmation signal. Reacting with 👍 or ✅ on a bot question has the same effect as replying "yes". Disabled by default.
+
+```yaml
+telegram:
+  inbound_reactions: true
+```
+
+Or via environment variable:
+
+```bash
+TELEGRAM_INBOUND_REACTIONS=true
+```
+
+**v1 scope:** only 👍 ✅ 👎 ❌ on recent bot-authored messages are routed, as synthetic `reaction:added:EMOJI` / `reaction:removed:EMOJI` events. Reactions on non-bot messages, unsupported emoji, and anonymous aggregated counts are ignored. The bot must have `message_reaction` update rights. Grant the bot admin in groups if reactions don't come through.
+
 ## Per-Channel Prompts
 
 Assign ephemeral system prompts to specific Telegram groups or forum topics. The prompt is injected at runtime on every turn — never persisted to transcript history — so changes take effect immediately.


### PR DESCRIPTION
## Summary

Telegram reactions (👍 ✅ 👎 ❌) were silently ignored. This adds opt-in routing of reactions as synthetic messages.

- Register `MessageReactionHandler` when `TELEGRAM_INBOUND_REACTIONS=1`; wrapped in `try/except` for library compatibility
- Allowlisted emoji translated to `MessageEvent` text (`👍` → `"👍"`, etc.)
- Bounded LRU cache (`OrderedDict`, max 512 entries, 1 h TTL) correlates bot message IDs to originating chat/thread context
- Cache is populated after each successful `send()` call

## Test plan

- [ ] With `TELEGRAM_INBOUND_REACTIONS=1`: react with 👍 → agent receives `"👍"` message in correct conversation
- [ ] Non-allowlisted emoji → ignored
- [ ] Without env var set → reaction handler not registered, no change in behaviour
- [ ] Cache eviction after 1 h or when 512-entry limit is reached

Fixes #13942