### PR TITLE
fix(providers): add moonshotai provider, disambiguate from kimi-for-coding

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -144,11 +144,21 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
     ),
     "kimi-coding": ProviderConfig(
         id="kimi-coding",
-        name="Kimi / Moonshot",
+        name="Kimi Code (api.kimi.com — needs sk-kimi-* key)",
         auth_type="api_key",
         inference_base_url="https://api.moonshot.ai/v1",
         api_key_env_vars=("KIMI_API_KEY",),
         base_url_env_var="KIMI_BASE_URL",
+    ),
+    # Moonshot AI Global (platform.moonshot.ai) — distinct from kimi-coding.
+    # Keys from platform.moonshot.ai use api.moonshot.ai/v1, not api.kimi.com.
+    "moonshotai": ProviderConfig(
+        id="moonshotai",
+        name="Moonshot AI (platform.moonshot.ai)",
+        auth_type="api_key",
+        inference_base_url="https://api.moonshot.ai/v1",
+        api_key_env_vars=("MOONSHOT_API_KEY", "KIMI_API_KEY"),
+        base_url_env_var="MOONSHOT_BASE_URL",
     ),
     "minimax": ProviderConfig(
         id="minimax",

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -81,6 +81,10 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         transport="openai_chat",
         base_url_env_var="KIMI_BASE_URL",
     ),
+    "moonshotai": HermesOverlay(
+        transport="openai_chat",
+        base_url_env_var="MOONSHOT_BASE_URL",
+    ),
     "minimax": HermesOverlay(
         transport="openai_chat",
         base_url_env_var="MINIMAX_BASE_URL",
@@ -161,10 +165,11 @@ ALIASES: Dict[str, str] = {
     "z.ai": "zai",
     "zhipu": "zai",
 
-    # kimi-for-coding (models.dev ID)
+    # kimi-for-coding (models.dev ID) — api.kimi.com/coding, needs sk-kimi-* key
     "kimi": "kimi-for-coding",
     "kimi-coding": "kimi-for-coding",
-    "moonshot": "kimi-for-coding",
+    # moonshot → moonshotai (platform.moonshot.ai); distinct from kimi-for-coding
+    "moonshot": "moonshotai",
 
     # minimax-cn
     "minimax-china": "minimax-cn",
@@ -355,7 +360,8 @@ LABELS: Dict[str, str] = {
     "github-copilot": "GitHub Copilot",
     "anthropic": "Anthropic",
     "zai": "Z.AI / GLM",
-    "kimi-for-coding": "Kimi / Moonshot",
+    "kimi-for-coding": "Kimi Code (api.kimi.com)",
+    "moonshotai": "Moonshot AI (platform.moonshot.ai)",
     "minimax": "MiniMax",
     "minimax-cn": "MiniMax (China)",
     "deepseek": "DeepSeek",
@@ -371,7 +377,8 @@ LABELS: Dict[str, str] = {
     "ai-gateway": "Vercel AI Gateway",
     "kilocode": "Kilo Gateway",
     "copilot": "GitHub Copilot",
-    "kimi-coding": "Kimi / Moonshot",
+    "kimi-coding": "Kimi Code (api.kimi.com)",
+    "moonshot": "Moonshot AI (platform.moonshot.ai)",
     "opencode-zen": "OpenCode Zen",
 }
 


### PR DESCRIPTION
## Summary

`kimi-for-coding` targets `api.kimi.com/coding` (a coding-optimised endpoint requiring `sk-kimi-*` keys). The general Moonshot AI platform at `api.moonshot.ai/v1` (accepting `MOONSHOT_API_KEY`) had no separate entry and shared the `moonshot` alias with the coding endpoint.

- Add `moonshotai` provider pointing to `api.moonshot.ai/v1`, env vars `MOONSHOT_API_KEY` / `KIMI_API_KEY`
- Reroute the `moonshot` alias to `moonshotai`
- Update `kimi-coding` / `kimi-for-coding` display name to clarify it expects an `sk-kimi-*` key
- Add `moonshotai` overlay in `providers.py`

## Test plan

- [ ] `--provider moonshot` resolves to `moonshotai`, base URL `api.moonshot.ai/v1`
- [ ] `--provider kimi-for-coding` still resolves to `api.kimi.com` endpoint
- [ ] `hermes auth add moonshotai` prompts for `MOONSHOT_API_KEY`

Fixes #13935