### PR TITLE
fix(skill_utils): raise extract_skill_description cap from 60 to 1024 chars

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -415,13 +415,13 @@ def resolve_skill_config_values(
 
 
 def extract_skill_description(frontmatter: Dict[str, Any]) -> str:
-    """Extract a truncated description from parsed frontmatter."""
+    """Extract a description from parsed frontmatter, capped at 1024 characters."""
     raw_desc = frontmatter.get("description", "")
     if not raw_desc:
         return ""
     desc = str(raw_desc).strip().strip("'\"")
-    if len(desc) > 60:
-        return desc[:57] + "..."
+    if len(desc) > 1024:
+        return desc[:1021] + "..."
     return desc
 
 


### PR DESCRIPTION
## Summary

The 60-character truncation in `extract_skill_description` was cutting descriptions too short for the system prompt index to carry enough detail for accurate skill routing.

- Raise the cap from 60 to 1024 characters
- Update docstring accordingly

## Test plan

- [ ] Skills with descriptions between 60 and 1024 chars are no longer truncated
- [ ] Descriptions over 1024 chars are still truncated with `...`
- [ ] Short descriptions unchanged

Fixes #13944