### PR TITLE
feat(skills): add configurable agent skills directory (skills.agent_dir)

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -228,8 +228,19 @@ def get_all_skills_dirs() -> List[Path]:
 
     The local dir is always first (and always included even if it doesn't exist
     yet — callers handle that).  External dirs follow in config order.
+
+    When ``skills.agent_dir`` is configured, that directory is included
+    immediately after the local dir so agent-created skills are discovered.
     """
-    dirs = [get_hermes_home() / "skills"]
+    local = get_hermes_home() / "skills"
+    dirs: List[Path] = [local]
+    try:
+        from tools.skills_tool import get_agent_skills_dir
+        agent_dir = get_agent_skills_dir()
+        if agent_dir.resolve() != local.resolve() and agent_dir not in dirs:
+            dirs.append(agent_dir)
+    except Exception:
+        pass
     dirs.extend(get_external_skills_dirs())
     return dirs
 

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -190,10 +190,16 @@ def _validate_content_size(content: str, label: str = "SKILL.md") -> Optional[st
 
 
 def _resolve_skill_dir(name: str, category: str = None) -> Path:
-    """Build the directory path for a new skill, optionally under a category."""
+    """Build the directory path for a new skill, optionally under a category.
+
+    Uses the configured ``skills.agent_dir`` when set so agent-created skills
+    land in a separate directory from bundled ones.
+    """
+    from tools.skills_tool import get_agent_skills_dir
+    target = get_agent_skills_dir()
     if category:
-        return SKILLS_DIR / category / name
-    return SKILLS_DIR / name
+        return target / category / name
+    return target / name
 
 
 def _find_skill(name: str) -> Optional[Dict[str, Any]]:
@@ -318,10 +324,12 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
         shutil.rmtree(skill_dir, ignore_errors=True)
         return {"success": False, "error": scan_error}
 
+    from tools.skills_tool import get_agent_skills_dir
+    _base = get_agent_skills_dir()
     result = {
         "success": True,
         "message": f"Skill '{name}' created.",
-        "path": str(skill_dir.relative_to(SKILLS_DIR)),
+        "path": str(skill_dir.relative_to(_base)),
         "skill_md": str(skill_md),
     }
     if category:

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -87,6 +87,30 @@ logger = logging.getLogger(__name__)
 HERMES_HOME = get_hermes_home()
 SKILLS_DIR = HERMES_HOME / "skills"
 
+
+def get_agent_skills_dir() -> Path:
+    """Return the directory where the agent should write self-created skills.
+
+    Reads ``skills.agent_dir`` from config.yaml.  Falls back to SKILLS_DIR so
+    the default behaviour is unchanged when the option is not set.
+
+    Example config.yaml entry::
+
+        skills:
+          agent_dir: ~/my-agent-skills
+    """
+    try:
+        from hermes_cli.config import load_config as _load_cfg
+        cfg = _load_cfg().get("skills", {})
+        raw = cfg.get("agent_dir", "") if isinstance(cfg, dict) else ""
+        if raw:
+            resolved = Path(raw).expanduser().resolve()
+            resolved.mkdir(parents=True, exist_ok=True)
+            return resolved
+    except Exception:
+        pass
+    return SKILLS_DIR
+
 # Anthropic-recommended limits for progressive disclosure efficiency
 MAX_NAME_LENGTH = 64
 MAX_DESCRIPTION_LENGTH = 1024


### PR DESCRIPTION
## Summary

Agent-created skills and bundled skills were forced into the same directory. There was no way to separate them or configure a dedicated write target.

- Add `get_agent_skills_dir()` in `skills_tool.py` reading `skills.agent_dir` from `config.yaml` (falls back to the default skills dir)
- `skill_manager_tool._resolve_skill_dir()` uses it as the write target
- `get_all_skills_dirs()` in `skill_utils.py` includes `agent_dir` immediately after the local dir so agent-created skills are discovered during routing

## Test plan

- [ ] Set `skills.agent_dir: ~/my-agent-skills` in `config.yaml` → new skills created by the agent go there
- [ ] Skills in `agent_dir` are visible to the skill router
- [ ] Without config entry → behaviour unchanged (falls back to default dir)

Fixes #13963