### PR TITLE
fix(model_metadata): add is_ollama_endpoint(), avoid false positives on local proxies

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -255,6 +255,17 @@ def is_local_endpoint(base_url: str) -> bool:
     return False
 
 
+def is_ollama_endpoint(base_url: str) -> bool:
+    """Return True only when base_url is an Ollama server.
+
+    Matches on port :11434 (Ollama's default) or the literal string "ollama"
+    in the URL, avoiding false positives on other local proxies such as GLM/ZAI
+    gateways that listen on localhost:8000.
+    """
+    normalized = (_normalize_base_url(base_url) or "").lower()
+    return ":11434" in normalized or "ollama" in normalized
+
+
 def detect_local_server_type(base_url: str) -> Optional[str]:
     """Detect which local server is running at base_url by probing known endpoints.
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -86,7 +86,7 @@ from agent.model_metadata import (
     fetch_model_metadata,
     estimate_tokens_rough, estimate_messages_tokens_rough, estimate_request_tokens_rough,
     get_next_probe_tier, parse_context_limit_from_error,
-    save_context_length, is_local_endpoint,
+    save_context_length, is_local_endpoint, is_ollama_endpoint,
     query_ollama_num_ctx,
 )
 from agent.context_compressor import ContextCompressor
@@ -1176,7 +1176,7 @@ class AIAgent:
                 self._ollama_num_ctx = int(_ollama_num_ctx_override)
             except (TypeError, ValueError):
                 logger.debug("Invalid ollama_num_ctx config value: %r", _ollama_num_ctx_override)
-        if self._ollama_num_ctx is None and self.base_url and is_local_endpoint(self.base_url):
+        if self._ollama_num_ctx is None and self.base_url and is_ollama_endpoint(self.base_url):
             try:
                 _detected = query_ollama_num_ctx(self.model, self.base_url)
                 if _detected and _detected > 0:


### PR DESCRIPTION
## What this actually fixes

The issue reports `_is_ollama_glm_backend()` causing false positives in truncation-continuation logic — that method does not exist in the current codebase. The relevant code with the same root problem is the Ollama `num_ctx` auto-detect guard in `run_agent.py`:

```python
# before
if self._ollama_num_ctx is None and self.base_url and is_local_endpoint(self.base_url):
    _detected = query_ollama_num_ctx(self.model, self.base_url)
```

`is_local_endpoint()` matches any `localhost` / RFC-1918 address, so it fires for local proxies like a GLM/ZAI gateway at `localhost:8000`. This causes a spurious `query_ollama_num_ctx` API call that:
- hits a non-Ollama endpoint expecting `/api/show`
- produces noisy log output
- can set an incorrect `_ollama_num_ctx` value if the endpoint happens to return a matching JSON shape

## Changes

- Add `is_ollama_endpoint(base_url)` to `agent/model_metadata.py` — matches only `:11434` (Ollama's default port) or the literal string `"ollama"` in the URL
- Replace the `is_local_endpoint` guard in the `num_ctx` detection path with `is_ollama_endpoint`

## What this does not fix

The truncation-continuation false positive path described in the issue (`_is_ollama_glm_backend` → `_should_treat_stop_as_truncated`) is not present in the current codebase and is not addressed here.

## Test plan

- [ ] `localhost:11434` → `is_ollama_endpoint` returns `True`, num_ctx probe runs
- [ ] `http://ollama.internal/v1` → `True`
- [ ] `localhost:8000` (GLM/ZAI proxy) → `False`, no probe attempted
- [ ] `localhost:1234` (LM Studio) → `False`, no probe attempted
- [ ] `192.168.1.10:8080` (arbitrary LAN proxy) → `False`

Addresses #13971