### PR TITLE
fix(run_agent): add model.preserve_dots config flag for Bedrock-style proxies

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1167,6 +1167,10 @@ class AIAgent:
         # When running against an Ollama server, detect the model's max context
         # and pass num_ctx on every chat request so the full window is used.
         # User override: set model.ollama_num_ctx in config.yaml to cap VRAM use.
+        self._preserve_dots_config: bool = bool(
+            isinstance(_model_cfg, dict) and _model_cfg.get("preserve_dots")
+        )
+
         self._ollama_num_ctx: int | None = None
         _ollama_num_ctx_override = None
         if isinstance(_model_cfg, dict):
@@ -5220,7 +5224,11 @@ class AIAgent:
     def _anthropic_preserve_dots(self) -> bool:
         """True when using an anthropic-compatible endpoint that preserves dots in model names.
         Alibaba/DashScope keeps dots (e.g. qwen3.5-plus).
-        OpenCode Go keeps dots (e.g. minimax-m2.7)."""
+        OpenCode Go keeps dots (e.g. minimax-m2.7).
+        Users can also set model.preserve_dots: true in config.yaml for third-party
+        Bedrock-style proxies not covered by the built-in host list."""
+        if getattr(self, "_preserve_dots_config", False):
+            return True
         if (getattr(self, "provider", "") or "").lower() in {"alibaba", "opencode-go"}:
             return True
         base = (getattr(self, "base_url", "") or "").lower()


### PR DESCRIPTION
## Summary

`_anthropic_preserve_dots()` had a hard-coded allowlist (`alibaba`, `opencode-go`, DashScope URLs). Third-party Bedrock-style proxies that also preserve dots in model names had no way to opt in without patching the source.

- Read `model.preserve_dots: true` from `config.yaml` into `self._preserve_dots_config` at `__init__` time
- `_anthropic_preserve_dots()` checks the flag first before falling through to the built-in host list

## Test plan

- [ ] Set `model: {preserve_dots: true}` in `config.yaml` → `_anthropic_preserve_dots()` returns `True`
- [ ] Without flag → built-in Alibaba/DashScope detection unchanged
- [ ] Flag `false` or absent → no change in behaviour

Fixes #13953