### PR TITLE
fix: keep macOS gateway launch agent alive after clean exit

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1730,10 +1730,7 @@ def generate_launchd_plist() -> str:
     <true/>
     
     <key>KeepAlive</key>
-    <dict>
-        <key>SuccessfulExit</key>
-        <false/>
-    </dict>
+    <true/>
     
     <key>StandardOutPath</key>
     <string>{log_dir}/gateway.log</string>
@@ -1842,8 +1839,8 @@ def launchd_stop():
     label = get_launchd_label()
     target = f"{_launchd_domain()}/{label}"
     # bootout unloads the service definition so KeepAlive doesn't respawn
-    # the process.  A plain `kill SIGTERM` only signals the process — launchd
-    # immediately restarts it because KeepAlive.SuccessfulExit = false.
+    # the process. A plain `kill SIGTERM` only signals the process — launchd
+    # immediately restarts it because the job is configured with KeepAlive=true.
     # `hermes gateway start` re-bootstraps when it detects the job is unloaded.
     try:
         subprocess.run(["launchctl", "bootout", target], check=True, timeout=90)


### PR DESCRIPTION
## Summary
- change the generated macOS launchd plist to use `KeepAlive=true`
- keep the gateway/API server running after clean exits so Open WebUI does not lose the Hermes model backend on port 8642
- update the launchd stop-path comment to match the new behavior

## Problem
On macOS, the generated launch agent used `KeepAlive = { SuccessfulExit = false; }`. If the Hermes gateway exited cleanly, launchd would not restart it. That left the API server on `127.0.0.1:8642` down, which caused browser frontends like Open WebUI to show no available model / "model not selected" until the user manually restarted the gateway.

## Verification
- regenerated the launchd plist locally and confirmed it now contains `KeepAlive => true`
- verified launchd reports the job with keepalive enabled
- verified the Hermes API server remains available on port 8642 and `/v1/models` returns `hermes-agent`
