### PR TITLE
fix(environments): byte-exact stdin piping on Windows + EOL-tolerant patch verification

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -453,3 +453,96 @@ class TestPatchReplacePostWriteVerification:
         result = ops.patch_replace("/tmp/test/a.py", "hello", "hi")
         assert result.error is not None
         assert "could not re-read" in result.error.lower()
+
+
+class TestPatchReplaceEolNormalization:
+    """Verification must compare line-ending-normalized content.
+
+    On Windows the underlying terminal backend can persist a string written as
+    pure LF as CRLF (or even CRCRLF if a second pipe layer re-translates).
+    The bytes on disk are functionally identical to what the patch intended;
+    refusing to acknowledge that produces false ``patch did not persist``
+    errors and an infinite retry loop in agent flows.
+    """
+
+    def test_verification_passes_when_disk_is_crlf_input_was_lf(self, mock_env):
+        """Patch wrote ``\\n`` lines; backend persisted ``\\r\\n``. Must succeed."""
+        # Initial content uses LF; "after write" content uses CRLF on disk
+        # (simulating Windows shell pipe translation).
+        initial = "hello world\n"
+        on_disk_after_write = "hi world\r\n"  # Same data, CRLF instead of LF
+        state = {"content": initial}
+
+        def side_effect(command, stdin_data=None, **kwargs):
+            if command.startswith("cat >"):  # write
+                if stdin_data is not None:
+                    # Simulate Windows pipe translating LF -> CRLF on the way to disk
+                    state["content"] = stdin_data.replace("\n", "\r\n")
+                return {"output": "", "returncode": 0}
+            if command.startswith("cat "):  # read
+                return {"output": state["content"], "returncode": 0}
+            if command.startswith("mkdir "):
+                return {"output": "", "returncode": 0}
+            if command.startswith("wc -c"):
+                return {"output": str(len(state["content"].encode())), "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        result = ops.patch_replace("/tmp/test/a.py", "hello", "hi")
+        assert result.error is None, (
+            f"CRLF persistence of LF input must not trigger verification "
+            f"failure, got: {result.error!r}"
+        )
+        assert result.success is True
+        assert state["content"] == on_disk_after_write
+
+    def test_verification_passes_when_disk_is_crcrlf(self, mock_env):
+        """Even pathological CRCRLF (\\r\\r\\n) must not be flagged as mismatch."""
+        state = {"content": "hello world\n"}
+
+        def side_effect(command, stdin_data=None, **kwargs):
+            if command.startswith("cat >"):
+                if stdin_data is not None:
+                    # Pathological double-translation
+                    state["content"] = stdin_data.replace("\n", "\r\r\n")
+                return {"output": "", "returncode": 0}
+            if command.startswith("cat "):
+                return {"output": state["content"], "returncode": 0}
+            if command.startswith("mkdir "):
+                return {"output": "", "returncode": 0}
+            if command.startswith("wc -c"):
+                return {"output": str(len(state["content"].encode())), "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        result = ops.patch_replace("/tmp/test/a.py", "hello", "hi")
+        assert result.error is None, (
+            f"CRCRLF persistence must not trigger verification failure, "
+            f"got: {result.error!r}"
+        )
+        assert result.success is True
+
+    def test_verification_still_catches_real_content_mismatch(self, mock_env):
+        """EOL-tolerant comparison must not mask actual content corruption."""
+        state = {"content": "hello world\n"}
+
+        def side_effect(command, stdin_data=None, **kwargs):
+            if command.startswith("cat >"):
+                # Write goes to /dev/null — content never updates
+                return {"output": "", "returncode": 0}
+            if command.startswith("cat "):
+                return {"output": state["content"], "returncode": 0}
+            if command.startswith("mkdir "):
+                return {"output": "", "returncode": 0}
+            if command.startswith("wc -c"):
+                return {"output": str(len(state["content"].encode())), "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        result = ops.patch_replace("/tmp/test/a.py", "hello", "hi")
+        # Genuine mismatch (file unchanged) must still be flagged
+        assert result.error is not None
+        assert "verification failed" in result.error.lower()

--- a/tests/tools/test_pipe_stdin_no_newline_translation.py
+++ b/tests/tools/test_pipe_stdin_no_newline_translation.py
@@ -1,0 +1,115 @@
+"""Regression tests for byte-exact stdin piping (no LF -> CRLF translation).
+
+On Windows, ``subprocess.Popen(text=True)`` enables universal-newlines on the
+stdin pipe, which silently rewrites every ``"\n"`` to ``"\r\n"`` before the
+child reads it. For ``cat > file`` writers this corrupts on-disk content (LF
+input lands as CRLF; downstream pipes can layer a second ``\r`` to produce
+CRCRLF).
+
+These tests pin the contract: data written via ``_pipe_stdin`` must reach the
+child's stdin byte-for-byte identical to the input string (after UTF-8
+encoding), regardless of host OS.
+"""
+
+import subprocess
+import sys
+
+import pytest
+
+from tools.environments.base import _pipe_stdin, _popen_bash
+
+
+def _read_child_stdin(data: str) -> bytes:
+    """Pipe *data* into a passthrough child and capture the raw bytes it saw on stdin."""
+    proc = subprocess.Popen(
+        [sys.executable, "-c", "import sys; sys.stdout.buffer.write(sys.stdin.buffer.read())"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        # Binary stdout so we don't lose bytes to universal-newlines on the
+        # capture side. _pipe_stdin must still cope with text-mode stdin
+        # (which is what the production code path uses).
+        text=True,
+    )
+    _pipe_stdin(proc, data)
+    proc.wait(timeout=10)
+    # Read stdout as raw bytes via the underlying buffer to preserve the
+    # exact byte sequence the child wrote.
+    return proc.stdout.buffer.read() if hasattr(proc.stdout, "buffer") else proc.stdout.read().encode("utf-8")
+
+
+class TestPipeStdinByteExact:
+    """``_pipe_stdin`` must deliver UTF-8 bytes without newline translation."""
+
+    def test_lf_only_preserved(self):
+        # Three LFs in must arrive as three LFs -- never CRLF, never CRCRLF.
+        captured = _read_child_stdin("a\nb\nc\n")
+        # The Python helper reads via ``sys.stdin.buffer`` (no decoding) and
+        # writes the raw bytes back to stdout.buffer. We then read that back
+        # in text mode (text=True), which on Windows applies universal-
+        # newlines to *stdout*, but not stdin -- so any CRLF that arrived
+        # would be visible as a stripped \r in stdout. Use binary length
+        # checks instead of equality to be robust to that wrinkle.
+        assert b"\r\n" not in captured
+        assert b"\r\r\n" not in captured
+        # Three logical lines plus terminator
+        assert captured.count(b"\n") == 3
+
+    def test_existing_crlf_not_doubled(self):
+        # If user writes Windows-style ``\r\n``, it must not become ``\r\r\n``.
+        captured = _read_child_stdin("a\r\nb\r\n")
+        assert b"\r\r\n" not in captured
+
+    def test_unicode_payload_utf8_encoded(self):
+        captured = _read_child_stdin("日本語\n")
+        assert captured == "日本語\n".encode("utf-8")
+
+    def test_empty_payload(self):
+        captured = _read_child_stdin("")
+        assert captured == b""
+
+    def test_no_trailing_newline_added(self):
+        captured = _read_child_stdin("nofinal")
+        assert captured == b"nofinal"
+
+
+class TestPopenBashStdinByteExact:
+    """End-to-end: full ``_popen_bash`` + ``cat > file`` pipeline."""
+
+    def test_cat_to_file_preserves_lf(self, tmp_path):
+        target = tmp_path / "out.txt"
+        # Use POSIX-style path that works under both Linux bash and git-bash.
+        # tmp_path on Windows looks like C:\Users\... -- bash will accept the
+        # forward-slashed form via /c/Users/...
+        target_str = str(target).replace("\\", "/")
+        # On Windows git-bash, drive letter prefix needs translation.
+        if sys.platform == "win32" and len(target_str) >= 2 and target_str[1] == ":":
+            target_str = "/" + target_str[0].lower() + target_str[2:]
+        proc = _popen_bash(
+            ["bash", "-lc", f"cat > {target_str}"],
+            stdin_data="alpha\nbeta\ngamma\n",
+        )
+        proc.wait(timeout=10)
+        assert proc.returncode == 0
+        raw = target.read_bytes()
+        assert raw == b"alpha\nbeta\ngamma\n", (
+            f"Expected pure LF, got {raw!r}. This indicates the stdin pipe "
+            f"applied newline translation -- the very bug this test guards."
+        )
+
+    def test_cat_to_file_no_crcrlf(self, tmp_path):
+        """Specifically guard the CRCRLF (``\\r\\r\\n``) corruption pattern."""
+        target = tmp_path / "out.txt"
+        target_str = str(target).replace("\\", "/")
+        if sys.platform == "win32" and len(target_str) >= 2 and target_str[1] == ":":
+            target_str = "/" + target_str[0].lower() + target_str[2:]
+        proc = _popen_bash(
+            ["bash", "-lc", f"cat > {target_str}"],
+            stdin_data="x\ny\nz\n",
+        )
+        proc.wait(timeout=10)
+        raw = target.read_bytes()
+        assert b"\r\r\n" not in raw, (
+            f"CRCRLF detected on disk: {raw!r}. The Windows pipe layer "
+            f"double-translated newlines."
+        )

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -99,11 +99,29 @@ def get_sandbox_dir() -> Path:
 
 
 def _pipe_stdin(proc: subprocess.Popen, data: str) -> None:
-    """Write *data* to proc.stdin on a daemon thread to avoid pipe-buffer deadlocks."""
+    """Write *data* to proc.stdin on a daemon thread to avoid pipe-buffer deadlocks.
+
+    On Windows, Popen with ``text=True`` enables universal-newlines on the
+    stdin pipe, which silently rewrites every ``"\\n"`` in *data* to ``"\\r\\n"``
+    before it reaches the child's stdin. For ``cat > file`` writers this
+    corrupts the on-disk content (LF input lands as CRLF, and downstream
+    pipes can layer a second ``\\r`` to produce CRCRLF). To stay byte-exact
+    across platforms, we write through the underlying binary buffer when
+    available and encode str payloads as UTF-8 ourselves.
+    """
 
     def _write():
         try:
-            proc.stdin.write(data)
+            buffer = getattr(proc.stdin, "buffer", None)
+            if buffer is not None:
+                payload = data.encode("utf-8") if isinstance(data, str) else data
+                buffer.write(payload)
+            else:
+                # Pure binary stdin (no text wrapper) — write bytes directly,
+                # encoding str if needed.
+                proc.stdin.write(
+                    data.encode("utf-8") if isinstance(data, str) else data
+                )
             proc.stdin.close()
         except (BrokenPipeError, OSError):
             pass

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -756,15 +756,32 @@ class ShellFileOperations(FileOperations):
         # failures (backend FS oddities, race with another task, truncated
         # pipe, etc.) that would otherwise return success-with-diff while the
         # file is unchanged on disk.
+        #
+        # We normalize line endings (CRLF/CR -> LF) on both sides before
+        # comparing, because the underlying terminal backend may inject CRLF
+        # on Windows or platforms where the shell pipe layer rewrites
+        # newlines. The on-disk bytes can legitimately differ from the
+        # intended string in EOL representation while still being functionally
+        # identical — refusing to acknowledge that produces false "patch did
+        # not persist" errors.
         verify_cmd = f"cat {self._escape_shell_arg(path)} 2>/dev/null"
         verify_result = self._exec(verify_cmd)
         if verify_result.exit_code != 0:
             return PatchResult(error=f"Post-write verification failed: could not re-read {path}")
-        if verify_result.stdout != new_content:
+        def _normalize_eol(s: str) -> str:
+            # Collapse any run of CR(s) before LF into a single LF, then map
+            # any remaining lone CR to LF. Handles LF, CRLF, and pathological
+            # CRCRLF (and longer ``\r+\n`` runs) introduced by stacked pipe
+            # newline-translation layers on Windows.
+            return re.sub(r"\r+\n", "\n", s).replace("\r", "\n")
+        actual = _normalize_eol(verify_result.stdout)
+        expected = _normalize_eol(new_content)
+        if actual != expected:
             return PatchResult(error=(
                 f"Post-write verification failed for {path}: on-disk content "
                 f"differs from intended write "
-                f"(wrote {len(new_content)} chars, read back {len(verify_result.stdout)}). "
+                f"(wrote {len(expected)} chars after EOL normalization, "
+                f"read back {len(actual)}). "
                 "The patch did not persist. Re-read the file and try again."
             ))
 


### PR DESCRIPTION
## What does this PR do?

Fixes a Windows-only data corruption bug in `write_file` and `patch_replace`: every `\n` written through the file tools silently turns into `\r\n` (or `\r\r\n` after repeated edits) on disk. The patch verifier then rejects the "corrupted" write as a persistence failure even though the bytes did land, sending agents into an infinite retry loop.

**Root cause.** `_popen_bash` constructs the subprocess with `text=True`. On Windows that enables Python's universal-newlines layer on the **stdin** pipe, which rewrites every `"\n"` we hand to `proc.stdin.write(data)` into `"\r\n"` before the child reads it. `ShellFileOperations.write_file` pipes content through `cat > path` over stdin, so `cat` sees CRLF where the caller passed LF and writes CRLF to disk. On Windows the git-bash pipe layer can apply a second translation, producing `\r\r\n` on disk. `patch_replace`'s post-write verifier then compares `verify_result.stdout != new_content` byte-for-byte and reports "Post-write verification failed... wrote N chars, read back N+k".

The bug was introduced 2026-02-19 in `d49af633` ("feat: enhance command execution with stdin support"), which legitimately optimized large-file writes by switching from heredoc to stdin pipe — but didn't notice that the existing `text=True` (used to decode stdout) silently took over the new stdin pipe too. Pre-`d49af633` the heredoc path bypassed `proc.stdin` entirely, so the same `text=True` was harmless. Linux/macOS were never affected because universal-newlines is a no-op on platforms where `os.linesep == "\n"`.

**Approach.** Two commits, one per logical fix:

1. **Remove the corruption source** — `_pipe_stdin` writes through `proc.stdin.buffer` (the underlying binary stream) when available, encoding `str` payloads as UTF-8 ourselves. Bytes reach the child exactly as the caller provided them.
2. **Defense-in-depth in the verifier** — `patch_replace`'s post-write check normalizes CR(s)+LF and lone CR to LF on both sides before comparing, so any other backend whose shell layer imposes its own EOL policy (containerized terminals, remote SSH on a Windows host, etc.) won't trigger the same false-positive loop.

## Related Issue

No existing issue — discovered while debugging an infinite "patch did not persist" retry loop on Windows 11. Happy to file one retroactively if preferred.

Fixes # (none)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/environments/base.py` — `_pipe_stdin` now writes via `proc.stdin.buffer` (binary), bypassing `text=True`'s LF→CRLF translation on Windows. Falls back to direct write when no buffer attribute is present. Adds a docstring explaining the platform-specific failure mode.
- `tools/file_operations.py` — `patch_replace`'s post-write verification normalizes line endings (collapses any `\r+\n` run and lone `\r` to `\n`) on both sides before comparing. Genuine content drift is still flagged; only EOL representation is allowed to vary. Error message updated to mention "after EOL normalization".
- `tests/tools/test_pipe_stdin_no_newline_translation.py` (new, +112 lines, 7 tests) — pins byte-exact stdin piping for LF-only, existing-CRLF, UTF-8, empty, no-trailing-newline, and end-to-end `cat > file` scenarios.
- `tests/tools/test_file_operations.py` (+93 lines, 3 tests) — new `TestPatchReplaceEolNormalization` class covering LF-input/CRLF-on-disk, LF-input/CRCRLF-on-disk, and the negative case (genuine content drift still rejected).

## How to Test

**Reproduce the bug** (on `main`, Windows host):

```bash
hermes -q 'use write_file to write "a\nb\nc\n" to /tmp/x.txt'
xxd /tmp/x.txt
# 00000000: 610d 0d0a 620d 0d0a 630d 0d0a       a...b...c...
#                                               ^^^ CRCRLF — expected pure LF (0a)
```

**Verify the fix** (on this branch, same host):

```bash
hermes -q 'use write_file to write "a\nb\nc\n" to /tmp/x.txt'
xxd /tmp/x.txt
# 00000000: 610a 620a 630a                       a.b.c.
#           ^^ clean LF
```

**Run the regression tests:**

```bash
pytest tests/tools/test_pipe_stdin_no_newline_translation.py -v
# 7 passed

pytest tests/tools/test_file_operations.py -v -k "Verification or EolNormalization"
# 6 passed
```

**Confirm no regressions in adjacent test files:**

```bash
pytest tests/tools/test_file_operations.py tests/tools/test_base_environment.py \
       tests/tools/test_file_tools.py tests/tools/test_file_write_safety.py \
       tests/tools/test_pipe_stdin_no_newline_translation.py -q
# 105 passed, 5 pre-existing macOS-only failures in TestCheckSensitivePathMacOSBypass
# (those reproduce on main without this PR — unrelated)
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(environments):`, `fix(file_ops):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the relevant test modules and all my tests pass (the 5 pre-existing macOS-only failures noted above are not caused by this PR)
- [x] I've added tests for my changes (10 new tests across 2 files)
- [x] I've tested on my platform: Windows 11 + Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no public API changes; both `_pipe_stdin` and the verifier are internal helpers; updated docstrings in place)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config changes)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A (bug fix, no architecture change)
- [x] I've considered cross-platform impact — see table below
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (behavior is now correct; schema unchanged)

### Platform impact

| Platform | Before this PR | After this PR |
|----------|----------------|---------------|
| Linux    | works (universal-newlines is a no-op outside Windows) | works (binary write is also a no-op transformation) |
| macOS    | works (same reason) | works (same reason) |
| Windows  | **broken** (LF → CRLF / CRCRLF on disk; patch verifier loops) | works (byte-exact persistence) |

Linux and macOS are unaffected because Python's universal-newlines layer only translates on platforms where `os.linesep != "\n"`. Writing through `proc.stdin.buffer` is identical to the prior behavior on those hosts — it just bypasses a layer that was never doing anything anyway. The new `_pipe_stdin` regression tests are platform-agnostic and pass on any host that can spawn a Python subprocess.

## Screenshots / Logs

**Before (Windows, on `main`)** — repeated `patch` on the same file:

```
Post-write verification failed for /tmp/x.txt: on-disk content differs from
intended write (wrote 28 chars, read back 31). The patch did not persist.
Re-read the file and try again.
```

Inspecting the file shows the bytes did persist, just with `\r\r\n` line endings:

```
$ xxd /tmp/x.txt
00000000: 6c69 6e65 310d 0d0a 6865 6c6c 6f0d 0d0a  line1...hello...
                    ^^^^^^                ^^^^^^   <-- CRCRLF
```

**After this PR** — same operation, same host:

```
$ xxd /tmp/x.txt
00000000: 6c69 6e65 310a 6865 6c6c 6f0a            line1.hello.
                    ^^                ^^           <-- clean LF
```

**Test run:**

```
$ pytest tests/tools/test_pipe_stdin_no_newline_translation.py -v
============================== 7 passed in 5.53s ==============================

$ pytest tests/tools/test_file_operations.py -v -k "Verification or EolNormalization"
============================== 6 passed in 4.60s ==============================
```
