### PR TITLE
fix: preserve configured context lengths across runtime paths

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -656,13 +656,39 @@ def _load_context_cache() -> Dict[str, int]:
         return {}
 
 
+def _normalize_context_cache_base_url(base_url: str) -> str:
+    """Normalize base_url for persistent context cache keys.
+
+    Treat trailing-slash variants (``/v1`` vs ``/v1/``) as the same endpoint so
+    different runtime call sites don't silently miss the same cached value.
+    """
+    return (base_url or "").rstrip("/")
+
+
+def _context_cache_lookup_keys(model: str, base_url: str) -> list[str]:
+    """Return cache-key candidates for a model/base_url lookup.
+
+    New writes use the normalized no-trailing-slash form, but reads also probe
+    legacy slash variants so existing cache files continue to work.
+    """
+    raw = base_url or ""
+    normalized = _normalize_context_cache_base_url(raw)
+    candidates: list[str] = []
+    for url in (normalized, raw, f"{normalized}/" if normalized else ""):
+        if url:
+            key = f"{model}@{url}"
+            if key not in candidates:
+                candidates.append(key)
+    return candidates
+
+
 def save_context_length(model: str, base_url: str, length: int) -> None:
     """Persist a discovered context length for a model+provider combo.
 
     Cache key is ``model@base_url`` so the same model name served from
     different providers can have different limits.
     """
-    key = f"{model}@{base_url}"
+    key = f"{model}@{_normalize_context_cache_base_url(base_url)}"
     cache = _load_context_cache()
     if cache.get(key) == length:
         return  # already stored
@@ -679,9 +705,11 @@ def save_context_length(model: str, base_url: str, length: int) -> None:
 
 def get_cached_context_length(model: str, base_url: str) -> Optional[int]:
     """Look up a previously discovered context length for model+provider."""
-    key = f"{model}@{base_url}"
     cache = _load_context_cache()
-    return cache.get(key)
+    for key in _context_cache_lookup_keys(model, base_url):
+        if key in cache:
+            return cache[key]
+    return None
 
 
 def get_next_probe_tier(current_length: int) -> Optional[int]:

--- a/run_agent.py
+++ b/run_agent.py
@@ -705,6 +705,45 @@ class AIAgent:
         self._base_url_lower = value.lower() if value else ""
         self._base_url_hostname = base_url_hostname(value)
 
+    def _resolve_config_context_length(self, model: str | None = None, base_url: str | None = None) -> int | None:
+        """Resolve the configured context override for a specific runtime target.
+
+        Global ``model.context_length`` applies to all runtime targets. Per-model
+        ``custom_providers[*].models[*].context_length`` overrides only apply when
+        both model name and provider base_url match the current runtime target.
+        """
+        global_override = getattr(self, "_model_context_length_override", None)
+        if global_override is not None:
+            return global_override
+
+        model = model if model is not None else getattr(self, "model", None)
+        base_url = (base_url if base_url is not None else getattr(self, "base_url", "")) or ""
+        normalized_base_url = base_url.rstrip("/")
+
+        custom_providers = getattr(self, "_custom_provider_context_configs", None)
+        if isinstance(custom_providers, list):
+            for cp_entry in custom_providers:
+                if not isinstance(cp_entry, dict):
+                    continue
+                cp_base_url = (cp_entry.get("base_url") or "").rstrip("/")
+                if cp_base_url and cp_base_url != normalized_base_url:
+                    continue
+                cp_models = cp_entry.get("models", {})
+                if not isinstance(cp_models, dict):
+                    continue
+                cp_model_cfg = cp_models.get(model, {})
+                if not isinstance(cp_model_cfg, dict):
+                    continue
+                cp_ctx = cp_model_cfg.get("context_length")
+                if cp_ctx is None:
+                    return None
+                try:
+                    return int(cp_ctx)
+                except (TypeError, ValueError):
+                    return None
+
+        return getattr(self, "_config_context_length", None)
+
     def __init__(
         self,
         base_url: str = None,
@@ -1601,7 +1640,8 @@ class AIAgent:
                 )
                 _config_context_length = None
 
-        # Store for reuse in switch_model (so config override persists across model switches)
+        self._model_context_length_override = _config_context_length
+        self._custom_provider_context_configs = []
         self._config_context_length = _config_context_length
 
         # Check custom_providers per-model context_length
@@ -1613,6 +1653,9 @@ class AIAgent:
                 _custom_providers = _agent_cfg.get("custom_providers")
                 if not isinstance(_custom_providers, list):
                     _custom_providers = []
+            if not isinstance(_custom_providers, list):
+                _custom_providers = []
+            self._custom_provider_context_configs = list(_custom_providers)
             for _cp_entry in _custom_providers:
                 if not isinstance(_cp_entry, dict):
                     continue
@@ -1641,6 +1684,8 @@ class AIAgent:
                                         file=sys.stderr,
                                     )
                     break
+
+        self._config_context_length = _config_context_length
         
         # Select context engine: config-driven (like memory providers).
         # 1. Check config.yaml context.engine setting
@@ -1977,12 +2022,16 @@ class AIAgent:
         # ── Update context compressor ──
         if hasattr(self, "context_compressor") and self.context_compressor:
             from agent.model_metadata import get_model_context_length
+            _resolved_config_context_length = self._resolve_config_context_length(
+                model=self.model,
+                base_url=self.base_url,
+            )
             new_context_length = get_model_context_length(
                 self.model,
                 base_url=self.base_url,
                 api_key=self.api_key,
                 provider=self.provider,
-                config_context_length=getattr(self, "_config_context_length", None),
+                config_context_length=_resolved_config_context_length,
             )
             self.context_compressor.update_model(
                 model=self.model,
@@ -6265,9 +6314,16 @@ class AIAgent:
             # causing oversized sessions to overflow the fallback.
             if hasattr(self, 'context_compressor') and self.context_compressor:
                 from agent.model_metadata import get_model_context_length
+                _resolved_config_context_length = self._resolve_config_context_length(
+                    model=self.model,
+                    base_url=self.base_url,
+                )
                 fb_context_length = get_model_context_length(
-                    self.model, base_url=self.base_url,
-                    api_key=self.api_key, provider=self.provider,
+                    self.model,
+                    base_url=self.base_url,
+                    api_key=self.api_key,
+                    provider=self.provider,
+                    config_context_length=_resolved_config_context_length,
                 )
                 self.context_compressor.update_model(
                     model=self.model,

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -644,6 +644,14 @@ class TestContextLengthCache:
             save_context_length("test/model", "http://localhost:8080/v1", 32768)
             assert get_cached_context_length("test/model", "http://localhost:8080/v1") == 32768
 
+    def test_trailing_slash_lookup_uses_same_cache_key(self, tmp_path):
+        """/v1 and /v1/ should hit the same persistent cache entry."""
+        cache_file = tmp_path / "cache.yaml"
+        with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
+            save_context_length("test/model", "https://example.com/v1", 500000)
+            assert get_cached_context_length("test/model", "https://example.com/v1/") == 500000
+            assert get_cached_context_length("test/model", "https://example.com/v1") == 500000
+
     def test_missing_cache_returns_none(self, tmp_path):
         cache_file = tmp_path / "nonexistent.yaml"
         with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):

--- a/tests/run_agent/test_fallback_model.py
+++ b/tests/run_agent/test_fallback_model.py
@@ -176,6 +176,77 @@ class TestTryActivateFallback:
             assert agent.provider == "minimax"
             assert agent.client is mock_client
 
+    def test_fallback_preserves_config_context_length(self):
+        """Fallback compressor refresh should reuse the configured context override."""
+        agent = _make_agent(
+            fallback_model={"provider": "custom", "model": "gpt-5.4", "base_url": "https://example.com/v1"},
+        )
+        agent._config_context_length = 500_000
+        agent._model_context_length_override = 500_000
+        agent._custom_provider_context_configs = []
+        agent.context_compressor = MagicMock()
+
+        mock_client = _mock_resolve(
+            api_key="***",
+            base_url="https://example.com/v1",
+        )
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, "gpt-5.4"),
+        ), patch(
+            "agent.model_metadata.get_model_context_length",
+            return_value=500_000,
+        ) as mock_ctx_len:
+            assert agent._try_activate_fallback() is True
+
+        mock_ctx_len.assert_called_once_with(
+            "gpt-5.4",
+            base_url="https://example.com/v1",
+            api_key="***",
+            provider="custom",
+            config_context_length=500_000,
+        )
+
+    def test_fallback_does_not_reuse_primary_custom_provider_override_for_different_model(self):
+        """Per-model custom_providers overrides must not bleed into a different fallback model."""
+        agent = _make_agent(
+            fallback_model={"provider": "custom", "model": "fallback-model", "base_url": "https://example.com/v1"},
+        )
+        agent._config_context_length = 500_000
+        agent._model_context_length_override = None
+        agent._custom_provider_context_configs = [
+            {
+                "base_url": "https://example.com/v1",
+                "models": {
+                    "primary-model": {"context_length": 500_000},
+                },
+            }
+        ]
+        agent.context_compressor = MagicMock()
+
+        mock_client = _mock_resolve(
+            api_key="***",
+            base_url="https://example.com/v1",
+        )
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, "fallback-model"),
+        ), patch(
+            "agent.model_metadata.get_model_context_length",
+            return_value=128_000,
+        ) as mock_ctx_len:
+            assert agent._try_activate_fallback() is True
+
+        mock_ctx_len.assert_called_once_with(
+            "fallback-model",
+            base_url="https://example.com/v1",
+            api_key="***",
+            provider="custom",
+            config_context_length=None,
+        )
+
     def test_only_fires_once(self):
         agent = _make_agent(
             fallback_model={"provider": "openrouter", "model": "anthropic/claude-sonnet-4"},

--- a/tests/run_agent/test_invalid_context_length_warning.py
+++ b/tests/run_agent/test_invalid_context_length_warning.py
@@ -110,5 +110,6 @@ def test_custom_providers_valid_context_length():
             custom_providers=custom_providers,
             model="gpt5.4",
         )
+    assert agent._config_context_length == 256000
     for c in mock_logger.warning.call_args_list:
         assert "Invalid" not in str(c)

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -19,8 +19,10 @@ def _make_agent_with_compressor(config_context_length=None) -> AIAgent:
     agent.client = MagicMock()
     agent.quiet_mode = True
 
-    # Store config_context_length for later use in switch_model
+    # Store config_context_length source state for later use in switch_model
     agent._config_context_length = config_context_length
+    agent._model_context_length_override = config_context_length
+    agent._custom_provider_context_configs = []
 
     # Context compressor with primary model values
     compressor = ContextCompressor(
@@ -72,3 +74,25 @@ def test_switch_model_without_config_context_length():
         mock_ctx_len.assert_called_once()
         call_kwargs = mock_ctx_len.call_args.kwargs
         assert call_kwargs.get("config_context_length") is None
+
+
+def test_switch_model_does_not_reuse_primary_custom_provider_override_for_different_model():
+    """Per-model custom_providers overrides must not bleed into a different target model."""
+    agent = _make_agent_with_compressor(config_context_length=None)
+    agent._config_context_length = 500_000
+    agent._model_context_length_override = None
+    agent._custom_provider_context_configs = [
+        {
+            "base_url": "https://openrouter.ai/api/v1",
+            "models": {
+                "primary-model": {"context_length": 500_000},
+            },
+        }
+    ]
+
+    with patch("agent.model_metadata.get_model_context_length", return_value=128_000) as mock_ctx_len:
+        agent.switch_model("different-model", "openrouter", api_key="sk-new", base_url="https://openrouter.ai/api/v1")
+
+    mock_ctx_len.assert_called_once()
+    call_kwargs = mock_ctx_len.call_args.kwargs
+    assert call_kwargs.get("config_context_length") is None


### PR DESCRIPTION
## Summary

This PR fixes a set of context length inconsistencies that still affect custom-provider runtimes across different execution paths.

### What it fixes

- Normalize persistent context-length cache keys so `/v1` and `/v1/` resolve to the same provider endpoint
- Preserve configured context-length overrides when switching models
- Preserve configured context-length overrides when activating fallback models
- Avoid incorrectly reusing a per-model `custom_providers` context override for a different target model
- Add regression tests for cache normalization, switch-model handling, fallback handling, and configured override persistence

## Root cause

There were two separate issues:

1. Persistent context-length cache lookups treated `.../v1` and `.../v1/` as different keys, which caused cache misses for the same custom provider endpoint in different runtime paths.
2. Runtime context refresh paths (`switch_model()` / fallback activation) did not consistently resolve the configured context-length override for the active target model and endpoint.

As a result, custom providers that were correctly configured in `config.yaml` could still fall back to an incorrect detected context length in some paths.

## Implementation details

- Added base URL normalization for persistent context-length cache writes
- Made cache reads backward-compatible with legacy slash variants
- Added runtime-target-aware context-length resolution in `AIAgent`
- Reused that runtime-target-aware resolution when refreshing model metadata during model switch and fallback activation

## Tests

Verified with:

- `tests/agent/test_model_metadata.py`
- `tests/run_agent/test_switch_model_context.py`
- `tests/run_agent/test_fallback_model.py`
- `tests/run_agent/test_provider_fallback.py`
- `tests/run_agent/test_invalid_context_length_warning.py`
- `tests/run_agent/test_compression_feasibility.py`

Local result:

- `147 passed`

## Notes

This PR is intentionally scoped to the runtime-path inconsistency and cache-key normalization issue. It does not introduce broader changes to provider metadata discovery beyond what is needed to make configured context lengths behave consistently.
