### PR TITLE
test(cli): cover underscore strip regressions

### DIFF
--- a/tests/cli/test_cli_markdown_rendering.py
+++ b/tests/cli/test_cli_markdown_rendering.py
@@ -131,6 +131,38 @@ def test_strip_mode_preserves_intraword_underscores_in_snake_case_identifiers():
     assert "file_with_name" in output
 
 
+def test_strip_mode_preserves_matrix_gateway_env_var_names():
+    renderable = _render_final_assistant_content(
+        "MATRIX_HOMESERVER\n"
+        "MATRIX_ACCESS_TOKEN\n"
+        "MATRIX_USER_ID\n"
+        "MATRIX_PASSWORD\n"
+        "\n"
+        "Token auth: MATRIX_ACCESS_TOKEN\n"
+        "Password auth: MATRIX_USER_ID + MATRIX_PASSWORD",
+        mode="strip",
+    )
+
+    output = _render_to_text(renderable)
+    assert "MATRIX_HOMESERVER" in output
+    assert "MATRIX_ACCESS_TOKEN" in output
+    assert "MATRIX_USER_ID" in output
+    assert "MATRIX_PASSWORD" in output
+    assert "MATRIXACCESSTOKEN" not in output
+    assert "MATRIXUSERID" not in output
+
+
+def test_strip_mode_preserves_intraword_triple_underscore_sequences():
+    renderable = _render_final_assistant_content(
+        "pre___triple___post",
+        mode="strip",
+    )
+
+    output = _render_to_text(renderable)
+    assert "pre___triple___post" in output
+    assert "pretriplepost" not in output
+
+
 def test_strip_mode_still_strips_boundary_underscore_emphasis():
     renderable = _render_final_assistant_content(
         "say _hi_ and __bold__ now",


### PR DESCRIPTION
Summary
Add classic CLI strip-mode regression coverage for intraword underscore tokens that were reported as mangled in rendered assistant output.

Problem
Older builds could display assistant text like Matrix env var names incorrectly in classic CLI strip mode, e.g. `MATRIX_ACCESS_TOKEN` -> `MATRIXACCESSTOKEN` and `MATRIX_USER_ID` -> `MATRIXUSERID`.

The runtime strip-mode fix is already present on `main` from the earlier underscore-boundary work, but the current test suite did not directly lock the two user-facing cases reported in the new issue thread:
- Matrix gateway env var names rendered as assistant text
- intraword triple-underscore tokens such as `pre___triple___post`

What Changed
- add regression coverage that strip mode preserves Matrix gateway env var names exactly:
  - `MATRIX_HOMESERVER`
  - `MATRIX_ACCESS_TOKEN`
  - `MATRIX_USER_ID`
  - `MATRIX_PASSWORD`
- add regression coverage that strip mode preserves `pre___triple___post`
- keep the existing boundary-emphasis test (`_hi_`, `__bold__`) so the intended markdown stripping behavior remains covered too

Why
This PR is intentionally test-only.

The current `main` branch already has the runtime word-boundary protection in `cli.py::_strip_markdown_syntax()`. This PR just makes the reported regressions explicit in the test suite so they cannot silently come back.

Testing
`python -m pytest tests/cli/test_cli_markdown_rendering.py -q`

Related
- #13985
- #13616
- runtime fix context: #13652