### PR TITLE
fix(error_classifier): don't treat generic 404 as model_not_found

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -470,11 +470,16 @@ def _classify_by_status(
                 retryable=False,
                 should_fallback=True,
             )
-        # Generic 404 — could be model or endpoint
+        # Generic 404 with no "model not found" signal — could be a wrong
+        # endpoint path (common with local llama.cpp / Ollama / vLLM when
+        # the URL is slightly misconfigured), a proxy routing glitch, or
+        # a transient backend issue.  Classifying these as model_not_found
+        # silently falls back to a different provider and tells the model
+        # the model is missing, which is wrong and wastes a turn.  Treat
+        # as unknown so the retry loop surfaces the real error instead.
         return result_fn(
-            FailoverReason.model_not_found,
-            retryable=False,
-            should_fallback=True,
+            FailoverReason.unknown,
+            retryable=True,
         )
 
     if status_code == 413:

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -298,9 +298,15 @@ class TestClassifyApiError:
         assert result.retryable is False
 
     def test_404_generic(self):
+        # Generic 404 with no "model not found" signal — common for local
+        # llama.cpp/Ollama/vLLM endpoints with slightly wrong paths.  Treat
+        # as unknown (retryable) so the real error surfaces, rather than
+        # claiming the model is missing and silently falling back.
         e = MockAPIError("Not Found", status_code=404)
         result = classify_api_error(e)
-        assert result.reason == FailoverReason.model_not_found
+        assert result.reason == FailoverReason.unknown
+        assert result.retryable is True
+        assert result.should_fallback is False
 
     # ── Payload too large ──
 


### PR DESCRIPTION
## Summary
Generic HTTP 404s with no "model not found" message text now classify as `unknown` (retryable) instead of `model_not_found` (silent fallback). Fixes wasted turns on local endpoints where 404 usually means a wrong URL path, not a missing model.

## Root cause
`_classify_by_status` lines 466-478 had dead code — the `_MODEL_NOT_FOUND_PATTERNS` check and the generic fallback returned identical classifications, so every 404 → `model_not_found` + `should_fallback=True` regardless of message content.

## Why it matters for local users
llama.cpp / Ollama / vLLM return 404 for wrong endpoint paths (`/v1/chat` vs `/v1/chat/completions`), proxy routing glitches, and transient backend issues. Classifying these as `model_not_found`:
- Tells the next turn the model is missing (bad context for the model)
- Triggers silent cloud fallback when the real problem is a URL typo the user should see

## Changes
- `agent/error_classifier.py`: generic 404 (no model-not-found signal) → `FailoverReason.unknown`, retryable
- `tests/agent/test_error_classifier.py`: `test_404_generic` updated to assert new behavior

## Validation
| | Before | After |
|---|---|---|
| `404 'model not found'` | model_not_found, fallback | model_not_found, fallback (unchanged) |
| `404 'Not Found'` (generic) | model_not_found, fallback | unknown, retryable |

`scripts/run_tests.sh tests/agent/test_error_classifier.py` → 103 passed.

## Credit
Reported by @waefrebeorn on X.