### PR TITLE
docs: add Windows to installation description

### DIFF
--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 2
 title: "Installation"
-description: "Install Hermes Agent on Linux, macOS, WSL2, or Android via Termux"
+description: "Install Hermes Agent on Linux, macOS, Windows (via WSL2), or Android via Termux"
 ---
 
 # Installation


### PR DESCRIPTION
## What does this PR do?
Added "Windows (via WSL2)" to the page description metadata so Windows users can find this installation page more easily when searching the docs. Previously the description only mentioned Linux, macOS, WSL2, and Android — but not Windows explicitly.

## Related Issue
No related issue — this is a small docs improvement spotted while reading the installation guide as a first-time Windows user.

## Type of Change
- [x] Documentation update
