### PR TITLE
fix(checkpoints): prune build/VCS subtrees in _dir_file_count

### DIFF
--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -445,6 +445,85 @@ class TestDirFileCount:
         count = _dir_file_count(str(tmp_path / "nonexistent"))
         assert count == 0
 
+    def test_prunes_excluded_dirs(self, tmp_path):
+        """Huge build/VCS trees (.venv/, .git/, .lake/, etc.) must be skipped.
+
+        Regression guard: ``_dir_file_count`` used to do an unbounded
+        ``Path.rglob("*")`` that walked every file — on a mathlib workspace
+        this was ~140k files and ~1s of wall time on every checkpoint
+        attempt, even though the count would exceed ``_MAX_FILES`` and the
+        snapshot would be skipped anyway.  After the fix, pruned dirs are
+        never entered.
+        """
+        project = tmp_path / "project"
+        project.mkdir()
+        # Two real files at the top level
+        (project / "main.py").write_text("print('hi')\n")
+        (project / "README.md").write_text("# hi\n")
+
+        # Build trees we expect to be pruned — each gets many files so the
+        # assertion is meaningful if pruning regresses.
+        for subdir in (".venv", ".git", ".lake", "node_modules", "__pycache__",
+                       "target", ".mypy_cache"):
+            d = project / subdir
+            d.mkdir()
+            for i in range(20):
+                (d / f"junk_{i}.bin").write_text("x")
+
+        count = _dir_file_count(str(project))
+        # Should only see main.py + README.md (= 2).  With the pre-fix
+        # implementation this would return 142 (2 + 7*20).
+        assert count == 2, (
+            f"Expected only top-level files to be counted, got {count}. "
+            f"Did DEFAULT_EXCLUDES / _PRUNE_DIR_NAMES change?"
+        )
+
+    def test_prune_list_derived_from_default_excludes(self):
+        """``_PRUNE_DIR_NAMES`` must include every simple dir-style exclude."""
+        from tools.checkpoint_manager import _PRUNE_DIR_NAMES
+        # Spot-check the entries we rely on most
+        for expected in (".venv", "venv", "__pycache__", "node_modules",
+                         ".git", ".lake", "target", ".pytest_cache"):
+            assert expected in _PRUNE_DIR_NAMES, (
+                f"{expected!r} missing from _PRUNE_DIR_NAMES — did "
+                f"DEFAULT_EXCLUDES drop the directory form?"
+            )
+
+    def test_respects_max_files_ceiling(self, tmp_path, monkeypatch):
+        """Sanity: non-pruned content still trips the early-exit guard."""
+        # Lower the cap so the test is fast.
+        monkeypatch.setattr("tools.checkpoint_manager._MAX_FILES", 10)
+        project = tmp_path / "huge"
+        project.mkdir()
+        # 25 files directly in the project root — not pruned, so the walker
+        # must see them and bail early.
+        for i in range(25):
+            (project / f"f_{i}.txt").write_text("x")
+        count = _dir_file_count(str(project))
+        assert count > 10
+
+    def test_does_not_follow_symlink_cycles(self, tmp_path):
+        """Symlink cycles must not hang or inflate the count.
+
+        Regression guard for the os.walk(followlinks=False) contract.  A
+        symlink loop would cause an infinite walk if followlinks were true.
+        """
+        project = tmp_path / "proj"
+        project.mkdir()
+        (project / "top.txt").write_text("x")
+        inner = project / "inner"
+        inner.mkdir()
+        (inner / "leaf.txt").write_text("x")
+        # Point inner/loop -> project (cycle)
+        try:
+            (inner / "loop").symlink_to(project)
+        except (OSError, NotImplementedError):
+            pytest.skip("symlinks not supported on this platform/FS")
+        count = _dir_file_count(str(project))
+        # Exactly 2 files; if we were following the symlink, we'd blow past
+        # any finite number.
+        assert count == 2
+
 
 # =========================================================================
 # Error resilience

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -271,12 +271,54 @@ def _init_shadow_repo(shadow_repo: Path, working_dir: str) -> Optional[str]:
     return None
 
 
+# Directory names to prune when counting files.  These correspond to the
+# directory-style entries in DEFAULT_EXCLUDES (anything ending in "/") and
+# match common build/VCS/cache trees that can easily contain hundreds of
+# thousands of files.  Kept as a module-level constant so _dir_file_count
+# doesn't rebuild it on every call.  Glob-containing entries (e.g. ".env.*")
+# and file-style entries (e.g. "*.pyc") are filtered out — those are only
+# meaningful at git-add time, not while walking directories.
+def _build_prune_dir_names() -> frozenset:
+    names = set()
+    for entry in DEFAULT_EXCLUDES:
+        if not entry.endswith("/"):
+            continue
+        stripped = entry.rstrip("/")
+        # Skip nested paths ("a/b/") and globs ("*.cache/") — only bare dir
+        # names can be matched against os.walk's ``dirnames`` list.
+        if "/" in stripped or "*" in stripped:
+            continue
+        names.add(stripped)
+    return frozenset(names)
+
+
+_PRUNE_DIR_NAMES: frozenset[str] = _build_prune_dir_names()
+
+
 def _dir_file_count(path: str) -> int:
-    """Quick file count estimate (stops early if over _MAX_FILES)."""
+    """Quick file count estimate (stops early if over _MAX_FILES).
+
+    Uses ``os.walk`` with in-place ``dirs`` pruning so that massive build
+    subtrees (``node_modules/``, ``.venv/``, ``.git/``, ``.lake/``, ``target/``,
+    etc.) don't blow up the count or the walk time.  Without pruning, this
+    function previously walked every file under a project via
+    ``Path.rglob("*")``, which on a mathlib/Lake workspace (~140k compiled
+    artifacts) took ~1s of main-thread time on every checkpoint attempt —
+    even though the resulting count would exceed ``_MAX_FILES`` and the
+    snapshot was immediately skipped.
+
+    Note: only regular files are counted; the previous ``rglob("*")`` variant
+    also counted directories.  The current behaviour better matches the
+    function name and the downstream ``_MAX_FILES`` ceiling semantics.
+    Symlinks are not followed, preventing cycle-induced hangs.
+    """
     count = 0
     try:
-        for _ in Path(path).rglob("*"):
-            count += 1
+        for _root, dirnames, filenames in os.walk(path, followlinks=False):
+            # Prune expensive subtrees in-place.  os.walk honours mutations to
+            # ``dirnames`` only when invoked in top-down mode (the default).
+            dirnames[:] = [d for d in dirnames if d not in _PRUNE_DIR_NAMES]
+            count += len(filenames)
             if count > _MAX_FILES:
                 return count
     except (PermissionError, OSError):

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -37,26 +37,42 @@ logger = logging.getLogger(__name__)
 CHECKPOINT_BASE = get_hermes_home() / "checkpoints"
 
 DEFAULT_EXCLUDES = [
+    # Language/package manager artifacts
     "node_modules/",
     "dist/",
     "build/",
+    "target/",              # Rust / JVM (sbt, Gradle) build output
+    # Secrets — never checkpointed
     ".env",
     ".env.*",
     ".env.local",
     ".env.*.local",
+    # Python
     "__pycache__/",
     "*.pyc",
     "*.pyo",
+    ".venv/",
+    "venv/",
+    ".mypy_cache/",
+    ".ruff_cache/",
+    ".pytest_cache/",
+    ".tox/",
+    # OS / editor noise
     ".DS_Store",
     "*.log",
     ".cache/",
+    # JS meta-frameworks
     ".next/",
     ".nuxt/",
     "coverage/",
-    ".pytest_cache/",
-    ".venv/",
-    "venv/",
+    # VCS
     ".git/",
+    # Lean / Lake (mathlib compiles to 100k+ .olean files)
+    ".lake/",
+    "*.olean",
+    # Misc heavy compiled trees
+    ".gradle/",
+    ".idea/",
 ]
 
 # Git subprocess timeout (seconds).


### PR DESCRIPTION
## Summary

The `CheckpointManager` guard `_dir_file_count()` used `Path.rglob("*")` which walks every file under the project root — including `.git/`, `.venv/`, `node_modules/`, and on Lean/mathlib projects `lean/.lake/` with its ~117k compiled `.olean` files. On a real mathlib workspace this added ~0.87s of blocking main-thread time to every checkpoint attempt, even though the result exceeded `_MAX_FILES` and the snapshot was then skipped anyway.

Since `ensure_checkpoint()` runs before every file-mutating tool call, the cumulative lag made the CLI feel frozen when using Hermes inside large repos: prompt_toolkit input events queued up behind the blocking walks and typed characters weren't echoed until each walk finished.

## Changes

1. `fix(checkpoints):` `_dir_file_count` now uses `os.walk(followlinks=False)` and prunes `dirnames` in-place against a precomputed frozenset of simple dir names from `DEFAULT_EXCLUDES`. `followlinks=False` also eliminates symlink-cycle hangs.
2. `chore(checkpoints):` expand `DEFAULT_EXCLUDES` with `.lake/`, `target/`, `.mypy_cache/`, `.ruff_cache/`, `.tox/`, `.gradle/`, `.idea/`, and `*.olean`.
3. `test(checkpoints):` four new tests covering pruning, the `DEFAULT_EXCLUDES → _PRUNE_DIR_NAMES` contract, the `_MAX_FILES` ceiling, and symlink-cycle safety.

## Verify

Measured on a Lean-augmented research workspace (141k files):

```
before: count=50001 in 869.4ms   # tripped _MAX_FILES, checkpoint skipped
after:  count=260   in 3.0ms     # checkpoint runs normally
```

On this repo (2,285 files): 36ms → 30ms (no regression).

Tests:

```
tests/tools/test_checkpoint_manager.py .........................................................  [100%]
57 passed in 2.45s
```

## Risk

Low. Behaviour change is scoped to `_dir_file_count`:

- Only regular files are counted now; the previous `rglob("*")` also counted directories. This better matches the function name and the `_MAX_FILES` semantics. No caller depends on the old count (only the `> _MAX_FILES` comparison).
- Symlinks are no longer followed. Previously they were, which could cause infinite walks on cycles.
- `_PRUNE_DIR_NAMES` is derived from `DEFAULT_EXCLUDES` via `_build_prune_dir_names()` — adding a new dir-style exclude automatically prunes it during file counting.
