### PR TITLE
fix(kimi): preserve reasoning_content in Anthropic adapter for /coding endpoint (salvage #13897)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1085,11 +1085,29 @@ def convert_messages_to_anthropic(
                 })
             # Kimi's /coding endpoint (Anthropic protocol) requires assistant
             # tool-call messages to carry reasoning_content when thinking is
-            # enabled.  Preserve it as a thinking block so Kimi can validate
-            # the message history.  See hermes-agent#13848.
+            # enabled server-side.  Preserve it as a thinking block so Kimi
+            # can validate the message history.  See hermes-agent#13848.
+            #
+            # Accept empty string "" — _copy_reasoning_content_for_api()
+            # injects "" as a tier-3 fallback for Kimi tool-call messages
+            # that had no reasoning.  Kimi requires the field to exist, even
+            # if empty.
+            #
+            # Prepend (not append): Anthropic protocol requires thinking
+            # blocks before text and tool_use blocks.
+            #
+            # Guard: only add when reasoning_details didn't already contribute
+            # thinking blocks.  On native Anthropic, reasoning_details produces
+            # signed thinking blocks — adding another unsigned one from
+            # reasoning_content would create a duplicate (same text) that gets
+            # downgraded to a spurious text block on the last assistant message.
             reasoning_content = m.get("reasoning_content")
-            if reasoning_content and isinstance(reasoning_content, str):
-                blocks.append({"type": "thinking", "thinking": reasoning_content})
+            _already_has_thinking = any(
+                isinstance(b, dict) and b.get("type") in ("thinking", "redacted_thinking")
+                for b in blocks
+            )
+            if isinstance(reasoning_content, str) and not _already_has_thinking:
+                blocks.insert(0, {"type": "thinking", "thinking": reasoning_content})
             # Anthropic rejects empty assistant content
             effective = blocks or content
             if not effective or effective == "":
@@ -1245,6 +1263,7 @@ def convert_messages_to_anthropic(
     #    cache markers can interfere with signature validation.
     _THINKING_TYPES = frozenset(("thinking", "redacted_thinking"))
     _is_third_party = _is_third_party_anthropic_endpoint(base_url)
+    _is_kimi = _is_kimi_coding_endpoint(base_url)
 
     last_assistant_idx = None
     for i in range(len(result) - 1, -1, -1):
@@ -1256,7 +1275,25 @@ def convert_messages_to_anthropic(
         if m.get("role") != "assistant" or not isinstance(m.get("content"), list):
             continue
 
-        if _is_third_party or idx != last_assistant_idx:
+        if _is_kimi:
+            # Kimi's /coding endpoint enables thinking server-side and
+            # requires unsigned thinking blocks on replayed assistant
+            # tool-call messages.  Strip signed Anthropic blocks (Kimi
+            # can't validate signatures) but preserve the unsigned ones
+            # we synthesised from reasoning_content above.
+            new_content = []
+            for b in m["content"]:
+                if not isinstance(b, dict) or b.get("type") not in _THINKING_TYPES:
+                    new_content.append(b)
+                    continue
+                if b.get("signature") or b.get("data"):
+                    # Anthropic-signed block — Kimi can't validate, strip
+                    continue
+                # Unsigned thinking (synthesised from reasoning_content) —
+                # keep it: Kimi needs it for message-history validation.
+                new_content.append(b)
+            m["content"] = new_content or [{"type": "text", "text": "(empty)"}]
+        elif _is_third_party or idx != last_assistant_idx:
             # Third-party endpoint: strip ALL thinking blocks from every
             # assistant message — signatures are Anthropic-proprietary.
             # Direct Anthropic: strip from non-latest assistant messages only.

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1083,6 +1083,13 @@ def convert_messages_to_anthropic(
                     "name": fn.get("name", ""),
                     "input": parsed_args,
                 })
+            # Kimi's /coding endpoint (Anthropic protocol) requires assistant
+            # tool-call messages to carry reasoning_content when thinking is
+            # enabled.  Preserve it as a thinking block so Kimi can validate
+            # the message history.  See hermes-agent#13848.
+            reasoning_content = m.get("reasoning_content")
+            if reasoning_content and isinstance(reasoning_content, str):
+                blocks.append({"type": "thinking", "thinking": reasoning_content})
             # Anthropic rejects empty assistant content
             effective = blocks or content
             if not effective or effective == "":

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -96,6 +96,7 @@ AUTHOR_MAP = {
     "nocoo@users.noreply.github.com": "nocoo",
     "30841158+n-WN@users.noreply.github.com": "n-WN",
     "tsuijinglei@gmail.com": "hiddenpuppy",
+    "jerome@clawwork.ai": "HiddenPuppy",
     "leoyuan0099@gmail.com": "keyuyuan",
     "bxzt2006@163.com": "Only-Code-A",
     "i@troy-y.org": "TroyMitchell911",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -95,6 +95,7 @@ AUTHOR_MAP = {
     "135070653+sgaofen@users.noreply.github.com": "sgaofen",
     "nocoo@users.noreply.github.com": "nocoo",
     "30841158+n-WN@users.noreply.github.com": "n-WN",
+    "tsuijinglei@gmail.com": "hiddenpuppy",
     "leoyuan0099@gmail.com": "keyuyuan",
     "bxzt2006@163.com": "Only-Code-A",
     "i@troy-y.org": "TroyMitchell911",


### PR DESCRIPTION
Salvages #13897 by @HiddenPuppy onto current main, with critical follow-up fixes.

## Problem

Kimi's `/coding` endpoint speaks Anthropic Messages protocol but enables thinking **server-side**. When replaying conversation history, it requires every assistant tool-call message to carry a thinking block — even when we don't send `thinking.enabled` in the request kwargs (PR #13826 correctly suppressed that). Without this, sessions break after tool calls with:

```
HTTP 400: thinking is enabled but reasoning_content is missing in assistant tool call message at index N
```

PR #13975 fixed the `chat_completions` path in `run_agent.py` (`_copy_reasoning_content_for_api`), but the `anthropic_messages` path (`convert_messages_to_anthropic` in `anthropic_adapter.py`) was still missing the reasoning_content → thinking block conversion.

**Issue confirmed real:** Brand-new gateway sessions (e.g. `20260422_011800_eea181`) fail at message index 2 — the very first replay after an initial tool call. Not stale-session artifacts.

## Cherry-picked from #13897

- `convert_messages_to_anthropic()`: When an assistant message has `reasoning_content`, convert it to a `{"type": "thinking", "thinking": ...}` block in the Anthropic message format.

## Follow-up fixes (found during self-review)

1. **Thinking block stripped by signature management (CRITICAL)**: The thinking block synthesised from `reasoning_content` was immediately stripped by the third-party signature-stripping code — Kimi is classified as `_is_third_party_anthropic_endpoint`. Added a Kimi-specific carve-out: preserve unsigned thinking blocks (which we synthesised from reasoning_content) while stripping Anthropic-signed blocks Kimi can't validate.

2. **Empty-string reasoning_content silently dropped**: The truthiness check (`if reasoning_content and ...`) evaluates to False for `""`. But `_copy_reasoning_content_for_api()` deliberately injects `""` as a tier-3 fallback for Kimi tool-call messages with no reasoning. Changed to `isinstance(reasoning_content, str)` so empty-string reasoning still produces a thinking block.

3. **Wrong block ordering**: Thinking block was appended AFTER tool_use blocks. Anthropic protocol requires thinking → text → tool_use ordering. Changed to `blocks.insert(0, ...)`.

4. **Duplicate thinking content on native Anthropic (CRITICAL)**: The reasoning_content → thinking block insertion ran for ALL endpoints, not just Kimi. On native Anthropic where `reasoning_details` already contributes signed thinking blocks, this created a second unsigned thinking block with the same text. The unsigned block would be downgraded to a spurious text block on the last assistant message — inflating context and potentially confusing the model. Added a guard: only insert the reasoning_content thinking block when no thinking blocks already exist from `reasoning_details`.

## Scope verification

- `_is_kimi_coding_endpoint()` is confirmed a strict subset of `_is_third_party_anthropic_endpoint()` — the if/elif ordering is correct
- Non-Kimi third-party endpoints (MiniMax, etc.): reasoning_content thinking block gets inserted then stripped → **zero behavior change**
- Native Anthropic with reasoning_details: duplicate guard prevents insertion → **zero behavior change**
- Native Anthropic without reasoning_details (edge case — provider switch mid-session): unsigned thinking block inserted → downgraded to text on last assistant. Acceptable.

## Files changed

- `agent/anthropic_adapter.py` — reasoning_content → thinking block conversion + Kimi carve-out in signature stripping + duplicate guard
- `scripts/release.py` — AUTHOR_MAP entries for @HiddenPuppy

## Validation

- 8/8 existing kimi thinking tests pass
- 8/8 kimi build_api_kwargs tests pass
- 23/23 total reasoning-related tests pass
- 8 E2E validations: non-empty, empty-string, signed stripping, unsigned survival, non-Kimi third-party, no-reasoning_content, native Anthropic no-duplication, native Anthropic no-details edge case

Closes #13848. Closes #13897.
