### PR TITLE
fix: honor api_mode for named custom auxiliary providers

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1684,6 +1684,25 @@ def resolve_provider_client(
                 model or _read_main_model() or "gpt-4o-mini",
                 provider,
             )
+            if api_mode == "anthropic_messages":
+                try:
+                    from agent.anthropic_adapter import build_anthropic_client
+                    real_client = build_anthropic_client(custom_key, custom_base)
+                except ImportError:
+                    logger.warning(
+                        "Explicit custom endpoint declares api_mode=anthropic_messages but the "
+                        "anthropic SDK is not installed — falling back to OpenAI-wire."
+                    )
+                else:
+                    client = AnthropicAuxiliaryClient(
+                        real_client,
+                        final_model,
+                        custom_key,
+                        custom_base,
+                        is_oauth=False,
+                    )
+                    return (_to_async_client(client, final_model) if async_mode
+                            else (client, final_model))
             extra = {}
             if base_url_host_matches(custom_base, "api.kimi.com"):
                 extra["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
@@ -1724,13 +1743,27 @@ def resolve_provider_client(
                     model or custom_entry.get("model") or _read_main_model() or "gpt-4o-mini",
                     provider,
                 )
-                client = OpenAI(api_key=custom_key, base_url=custom_base)
-                client = _wrap_if_needed(client, final_model, custom_base)
+                resolved_api_mode = (
+                    str(api_mode or "").strip()
+                    or str(custom_entry.get("api_mode") or "").strip()
+                    or None
+                )
                 logger.debug(
-                    "resolve_provider_client: named custom provider %r (%s)",
-                    provider, final_model)
-                return (_to_async_client(client, final_model) if async_mode
-                        else (client, final_model))
+                    "resolve_provider_client: named custom provider %r (%s, api_mode=%s)",
+                    provider,
+                    final_model,
+                    resolved_api_mode or "chat_completions",
+                )
+                return resolve_provider_client(
+                    "custom",
+                    final_model,
+                    async_mode=async_mode,
+                    raw_codex=raw_codex,
+                    explicit_base_url=custom_base,
+                    explicit_api_key=custom_key,
+                    api_mode=resolved_api_mode,
+                    main_runtime=main_runtime,
+                )
             logger.warning(
                 "resolve_provider_client: named custom provider %r has no base_url",
                 provider)

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -155,6 +155,52 @@ class TestResolveProviderClientNamedCustom:
         assert client is None
 
 
+class TestResolveProviderClientNamedCustomApiMode:
+    """Named custom providers should honor configured api_mode transports."""
+
+    def test_named_custom_provider_wraps_codex_responses(self, tmp_path):
+        _write_config(tmp_path, {
+            "model": {"default": "gpt-5.4"},
+            "custom_providers": [
+                {
+                    "name": "beans",
+                    "base_url": "http://beans.local/v1",
+                    "api_key": "***",
+                    "api_mode": "codex_responses",
+                },
+            ],
+        })
+        with patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_openai.return_value = MagicMock()
+            from agent.auxiliary_client import resolve_provider_client, CodexAuxiliaryClient
+
+            client, model = resolve_provider_client("beans", "gpt-5.4")
+
+        assert isinstance(client, CodexAuxiliaryClient)
+        assert model == "gpt-5.4"
+
+    def test_named_custom_provider_wraps_anthropic_messages(self, tmp_path):
+        _write_config(tmp_path, {
+            "model": {"default": "claude-sonnet-4-6"},
+            "custom_providers": [
+                {
+                    "name": "beans",
+                    "base_url": "https://api.minimax.io/anthropic",
+                    "api_key": "***",
+                    "api_mode": "anthropic_messages",
+                },
+            ],
+        })
+        with patch("agent.anthropic_adapter.build_anthropic_client") as mock_build:
+            mock_build.return_value = MagicMock()
+            from agent.auxiliary_client import resolve_provider_client, AnthropicAuxiliaryClient
+
+            client, model = resolve_provider_client("beans", "claude-sonnet-4-6")
+
+        assert isinstance(client, AnthropicAuxiliaryClient)
+        assert model == "claude-sonnet-4-6"
+
+
 class TestResolveProviderClientModelNormalization:
     """Direct-provider auxiliary routing should normalize models like main runtime."""
 


### PR DESCRIPTION
## Summary
- route named custom providers through the explicit custom endpoint resolver so auxiliary clients inherit the configured `api_mode`
- preserve transport-specific behavior for both `codex_responses` and `anthropic_messages`
- add regression coverage for named custom providers using those two API modes

## Testing
- `pytest tests/agent/test_auxiliary_named_custom_providers.py tests/agent/test_auxiliary_client_anthropic_custom.py tests/agent/test_auxiliary_main_first.py tests/agent/test_auxiliary_config_bridge.py tests/agent/test_auxiliary_client.py -q`
