### PR TITLE
fix(agent): detect custom provider context length for auto-mode compression

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1033,6 +1033,15 @@ def get_model_context_length(
     if config_context_length is not None and isinstance(config_context_length, int) and config_context_length > 0:
         return config_context_length
 
+    # 0b. Custom provider context length (for auto mode auxiliary tasks)
+    # When auxiliary.*.model is empty (auto), the resolved model comes from
+    # the main provider, but get_model_context_length doesn't know it's auto.
+    # Check if base_url matches a custom provider with context_length.
+    if base_url:
+        custom_ctx = _get_custom_provider_context_length(model, base_url)
+        if custom_ctx is not None:
+            return custom_ctx
+
     # Normalise provider-prefixed model names (e.g. "local:model-name" →
     # "model-name") so cache lookups and server queries use the bare ID that
     # local servers actually know about.  Ollama "model:tag" colons are preserved.
@@ -1150,6 +1159,61 @@ def get_model_context_length(
 
     # 10. Default fallback — 128K
     return DEFAULT_FALLBACK_CONTEXT
+
+
+def _get_custom_provider_context_length(model: str, base_url: str) -> Optional[int]:
+    """Get context length from custom_providers config for a model+base_url.
+    
+    Used when auxiliary.* tasks use auto mode (empty model) and should inherit
+    the main model's context length from the custom provider config.
+    """
+    try:
+        from hermes_cli.config import get_compatible_custom_providers, load_config
+        config = load_config()
+        providers = get_compatible_custom_providers(config)
+    except ImportError:
+        return None
+    
+    if not isinstance(providers, list):
+        return None
+    
+    # Normalize base_url for comparison (strip /v1 suffix if present)
+    normalized_base_url = base_url.rstrip("/")
+    if normalized_base_url.endswith("/v1"):
+        normalized_base_url = normalized_base_url[:-3]
+    
+    # Normalize model for comparison (case-insensitive)
+    normalized_model = model.lower()
+    
+    for entry in providers:
+        if not isinstance(entry, dict):
+            continue
+        
+        entry_base_url = entry.get("base_url", "").rstrip("/")
+        if entry_base_url.endswith("/v1"):
+            entry_base_url = entry_base_url[:-3]
+        
+        if entry_base_url != normalized_base_url:
+            continue
+        
+        # Found matching base_url, check for context_length at provider level
+        provider_ctx = entry.get("context_length")
+        if isinstance(provider_ctx, int) and provider_ctx > 0:
+            return provider_ctx
+        
+        # Check per-model context_length in models dict
+        models = entry.get("models")
+        if isinstance(models, dict):
+            for model_key, model_entry in models.items():
+                if not isinstance(model_entry, dict):
+                    continue
+                # Check for exact match (case-insensitive) or substring match
+                if model_key.lower() == normalized_model or normalized_model in model_key.lower():
+                    ctx = model_entry.get("context_length")
+                    if isinstance(ctx, int) and ctx > 0:
+                        return ctx
+    
+    return None
 
 
 def estimate_tokens_rough(text: str) -> int:

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -23,6 +23,7 @@ from agent.model_metadata import (
     CONTEXT_PROBE_TIERS,
     DEFAULT_CONTEXT_LENGTHS,
     _strip_provider_prefix,
+    _get_custom_provider_context_length,
     estimate_tokens_rough,
     estimate_messages_tokens_rough,
     get_model_context_length,
@@ -712,3 +713,126 @@ class TestContextLengthCache:
         with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
             save_context_length(model, url, 200000)
             assert get_cached_context_length(model, url) == 200000
+
+
+# =========================================================================
+# _get_custom_provider_context_length — auto mode context length inheritance
+# =========================================================================
+
+class TestGetCustomProviderContextLength:
+    """Tests for _get_custom_provider_context_length() helper function."""
+
+    @patch("hermes_cli.config.get_compatible_custom_providers")
+    @patch("hermes_cli.config.load_config")
+    def test_returns_context_length_from_custom_provider(self, mock_load_config, mock_get_providers):
+        """When base_url matches a custom provider with context_length, return it."""
+        mock_load_config.return_value = {
+            "custom_providers": [
+                {
+                    "name": "Local (oMLX:4328)",
+                    "base_url": "http://127.0.0.1:4328/v1",
+                    "model": "bearzi/Qwen3-Coder-Next-oQ8",
+                    "models": {
+                        "bearzi/Qwen3-Coder-Next-oQ8": {"context_length": 230000},
+                    },
+                }
+            ]
+        }
+        mock_get_providers.return_value = [
+            {
+                "name": "Local (oMLX:4328)",
+                "base_url": "http://127.0.0.1:4328/v1",
+                "model": "bearzi/Qwen3-Coder-Next-oQ8",
+                "models": {
+                    "bearzi/Qwen3-Coder-Next-oQ8": {"context_length": 230000},
+                },
+            }
+        ]
+
+        result = _get_custom_provider_context_length(
+            "bearzi/Qwen3-Coder-Next-oQ8",
+            "http://127.0.0.1:4328/v1"
+        )
+        assert result == 230000
+
+    @patch("hermes_cli.config.get_compatible_custom_providers")
+    @patch("hermes_cli.config.load_config")
+    def test_returns_none_when_base_url_does_not_match(self, mock_load_config, mock_get_providers):
+        """When base_url doesn't match any custom provider, return None."""
+        mock_load_config.return_value = {"custom_providers": [
+            {"name": "Test", "base_url": "http://127.0.0.1:9999/v1", "models": {}}
+        ]}
+        mock_get_providers.return_value = [
+            {"name": "Test", "base_url": "http://127.0.0.1:9999/v1", "models": {}}
+        ]
+
+        result = _get_custom_provider_context_length(
+            "some/model",
+            "http://127.0.0.1:8888/v1"  # Different port
+        )
+        assert result is None
+
+    @patch("hermes_cli.config.get_compatible_custom_providers")
+    @patch("hermes_cli.config.load_config")
+    def test_returns_provider_level_context_length(self, mock_load_config, mock_get_providers):
+        """Context length can be set at provider level (not just per-model)."""
+        mock_load_config.return_value = {"custom_providers": [
+            {
+                "name": "Test Provider",
+                "base_url": "http://localhost:4321/v1",
+                "context_length": 200000,
+                "model": "some/model",
+                "models": {}
+            }
+        ]}
+        mock_get_providers.return_value = [
+            {
+                "name": "Test Provider",
+                "base_url": "http://localhost:4321/v1",
+                "context_length": 200000,
+                "model": "some/model",
+                "models": {}
+            }
+        ]
+
+        result = _get_custom_provider_context_length("some/model", "http://localhost:4321/v1")
+        assert result == 200000
+
+    @patch("hermes_cli.config.get_compatible_custom_providers")
+    @patch("hermes_cli.config.load_config")
+    def test_case_insensitive_model_match(self, mock_load_config, mock_get_providers):
+        """Model matching is case-insensitive."""
+        mock_load_config.return_value = {"custom_providers": [
+            {
+                "name": "Test",
+                "base_url": "http://localhost:4321/v1",
+                "models": {
+                    "BEARZI/QWEN3-CODER-NEXT-OQ8": {"context_length": 230000},
+                },
+            }
+        ]}
+        mock_get_providers.return_value = [
+            {
+                "name": "Test",
+                "base_url": "http://localhost:4321/v1",
+                "models": {
+                    "BEARZI/QWEN3-CODER-NEXT-OQ8": {"context_length": 230000},
+                },
+            }
+        ]
+
+        result = _get_custom_provider_context_length(
+            "bearzi/qwen3-coder-next-oq8",
+            "http://localhost:4321/v1"
+        )
+        assert result == 230000
+
+    @patch("hermes_cli.config.get_compatible_custom_providers")
+    @patch("hermes_cli.config.load_config")
+    def test_returns_none_when_import_fails(self, mock_load_config, mock_get_providers):
+        """When hermes_cli.config is unavailable, return None gracefully."""
+        mock_load_config.side_effect = ImportError("hermes_cli.config not available")
+        mock_get_providers.return_value = []
+
+        result = _get_custom_provider_context_length("some/model", "http://localhost:4321/v1")
+        assert result is None


### PR DESCRIPTION
- Added _get_custom_provider_context_length() helper to query custom_providers config for context length
- Integrated step 0b in get_model_context_length() to consult custom_providers before probe tiers
- Preserves auto flexibility (no hardcoded model names) by matching on base_url