### PR TITLE
fix(gateway/slack): align reaction lifecycle with Discord/Telegram pattern

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -38,6 +38,7 @@ from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
     MessageType,
+    ProcessingOutcome,
     SendResult,
     SUPPORTED_DOCUMENT_TYPES,
     safe_url_for_log,
@@ -113,6 +114,11 @@ class SlackAdapter(BasePlatformAdapter):
         # Cache for _fetch_thread_context results: cache_key → _ThreadContextCache
         self._thread_context_cache: Dict[str, _ThreadContextCache] = {}
         self._THREAD_CACHE_TTL = 60.0
+        # Track message IDs that should get reaction lifecycle (DMs / @mentions).
+        self._reacting_message_ids: set = set()
+        # Track active assistant thread status indicators so stop_typing can
+        # clear them (chat_id → thread_ts).
+        self._active_status_threads: Dict[str, str] = {}
 
     async def connect(self) -> bool:
         """Connect to Slack via Socket Mode."""
@@ -362,6 +368,7 @@ class SlackAdapter(BasePlatformAdapter):
         if not thread_ts:
             return  # Can only set status in a thread context
 
+        self._active_status_threads[chat_id] = thread_ts
         try:
             await self._get_client(chat_id).assistant_threads_setStatus(
                 channel_id=chat_id,
@@ -372,6 +379,22 @@ class SlackAdapter(BasePlatformAdapter):
             # Silently ignore — may lack assistant:write scope or not be
             # in an assistant-enabled context. Falls back to reactions.
             logger.debug("[Slack] assistant.threads.setStatus failed: %s", e)
+
+    async def stop_typing(self, chat_id: str) -> None:
+        """Clear the assistant thread status indicator."""
+        if not self._app:
+            return
+        thread_ts = self._active_status_threads.pop(chat_id, None)
+        if not thread_ts:
+            return
+        try:
+            await self._get_client(chat_id).assistant_threads_setStatus(
+                channel_id=chat_id,
+                thread_ts=thread_ts,
+                status="",
+            )
+        except Exception as e:
+            logger.debug("[Slack] assistant.threads.setStatus clear failed: %s", e)
 
     def _dm_top_level_threads_as_sessions(self) -> bool:
         """Whether top-level Slack DMs get per-message session threads.
@@ -583,6 +606,30 @@ class SlackAdapter(BasePlatformAdapter):
         except Exception as e:
             logger.debug("[Slack] reactions.remove failed (%s): %s", emoji, e)
             return False
+
+    async def on_processing_start(self, event: MessageEvent) -> None:
+        """Add an in-progress reaction when message processing begins."""
+        ts = getattr(event, "message_id", None)
+        if not ts or ts not in self._reacting_message_ids:
+            return
+        channel_id = getattr(event.source, "chat_id", None)
+        if channel_id:
+            await self._add_reaction(channel_id, ts, "eyes")
+
+    async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
+        """Swap the in-progress reaction for a final success/failure reaction."""
+        ts = getattr(event, "message_id", None)
+        if not ts or ts not in self._reacting_message_ids:
+            return
+        self._reacting_message_ids.discard(ts)
+        channel_id = getattr(event.source, "chat_id", None)
+        if not channel_id:
+            return
+        await self._remove_reaction(channel_id, ts, "eyes")
+        if outcome == ProcessingOutcome.SUCCESS:
+            await self._add_reaction(channel_id, ts, "white_check_mark")
+        elif outcome == ProcessingOutcome.FAILURE:
+            await self._add_reaction(channel_id, ts, "x")
 
     # ----- User identity resolution -----
 
@@ -1214,15 +1261,10 @@ class SlackAdapter(BasePlatformAdapter):
         # In listen-all channels (require_mention=false), reacting to every
         # casual message would be noisy.
         _should_react = is_dm or is_mentioned
-
         if _should_react:
-            await self._add_reaction(channel_id, ts, "eyes")
+            self._reacting_message_ids.add(ts)
 
         await self.handle_message(msg_event)
-
-        if _should_react:
-            await self._remove_reaction(channel_id, ts, "eyes")
-            await self._add_reaction(channel_id, ts, "white_check_mark")
 
     # ----- Approval button support (Block Kit) -----
 

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1031,7 +1031,7 @@ class TestReactions:
 
     @pytest.mark.asyncio
     async def test_reactions_in_message_flow(self, adapter):
-        """Reactions should be added on receipt and swapped on completion."""
+        """Reactions should be bracketed around actual processing via hooks."""
         adapter._app.client.reactions_add = AsyncMock()
         adapter._app.client.reactions_remove = AsyncMock()
         adapter._app.client.users_info = AsyncMock(return_value={
@@ -1047,14 +1047,96 @@ class TestReactions:
         }
         await adapter._handle_slack_message(event)
 
-        # Should have added 👀, then removed 👀, then added ✅
+        # _handle_slack_message should register the message for reactions
+        assert "1234567890.000001" in adapter._reacting_message_ids
+
+        # Simulate the base class calling on_processing_start
+        from gateway.platforms.base import MessageEvent, MessageType, SessionSource
+        from gateway.config import Platform
+        source = SessionSource(
+            platform=Platform.SLACK,
+            chat_id="C123",
+            chat_type="dm",
+            user_id="U_USER",
+        )
+        msg_event = MessageEvent(
+            text="hello",
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id="1234567890.000001",
+        )
+        await adapter.on_processing_start(msg_event)
+
+        add_calls = adapter._app.client.reactions_add.call_args_list
+        assert len(add_calls) == 1
+        assert add_calls[0].kwargs["name"] == "eyes"
+
+        # Simulate the base class calling on_processing_complete
+        from gateway.platforms.base import ProcessingOutcome
+        await adapter.on_processing_complete(msg_event, ProcessingOutcome.SUCCESS)
+
         add_calls = adapter._app.client.reactions_add.call_args_list
         remove_calls = adapter._app.client.reactions_remove.call_args_list
         assert len(add_calls) == 2
-        assert add_calls[0].kwargs["name"] == "eyes"
         assert add_calls[1].kwargs["name"] == "white_check_mark"
         assert len(remove_calls) == 1
         assert remove_calls[0].kwargs["name"] == "eyes"
+
+        # Message ID should be cleaned up
+        assert "1234567890.000001" not in adapter._reacting_message_ids
+
+    @pytest.mark.asyncio
+    async def test_reactions_failure_outcome(self, adapter):
+        """Failed processing should add :x: instead of :white_check_mark:."""
+        adapter._app.client.reactions_add = AsyncMock()
+        adapter._app.client.reactions_remove = AsyncMock()
+
+        from gateway.platforms.base import MessageEvent, MessageType, SessionSource, ProcessingOutcome
+        from gateway.config import Platform
+        source = SessionSource(
+            platform=Platform.SLACK,
+            chat_id="C123",
+            chat_type="dm",
+            user_id="U_USER",
+        )
+        adapter._reacting_message_ids.add("1234567890.000002")
+        msg_event = MessageEvent(
+            text="hello",
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id="1234567890.000002",
+        )
+        await adapter.on_processing_complete(msg_event, ProcessingOutcome.FAILURE)
+
+        add_calls = adapter._app.client.reactions_add.call_args_list
+        remove_calls = adapter._app.client.reactions_remove.call_args_list
+        assert len(add_calls) == 1
+        assert add_calls[0].kwargs["name"] == "x"
+        assert len(remove_calls) == 1
+        assert remove_calls[0].kwargs["name"] == "eyes"
+
+    @pytest.mark.asyncio
+    async def test_reactions_skipped_for_non_dm_non_mention(self, adapter):
+        """Non-DM, non-mention messages should not get reactions."""
+        adapter._app.client.reactions_add = AsyncMock()
+        adapter._app.client.reactions_remove = AsyncMock()
+        adapter._app.client.users_info = AsyncMock(return_value={
+            "user": {"profile": {"display_name": "Tyler"}}
+        })
+
+        event = {
+            "text": "hello",
+            "user": "U_USER",
+            "channel": "C123",
+            "channel_type": "channel",
+            "ts": "1234567890.000003",
+        }
+        await adapter._handle_slack_message(event)
+
+        # Should NOT register for reactions when not mentioned in a channel
+        assert "1234567890.000003" not in adapter._reacting_message_ids
+        adapter._app.client.reactions_add.assert_not_called()
+        adapter._app.client.reactions_remove.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes Slack's message reaction lifecycle so it behaves consistently with Discord and Telegram.

On Discord, when a user sends a message, Hermes:
1. Adds :eyes: when processing starts
2. Completes the actual work (agent loop, tool calls, etc.)
3. Removes :eyes: and adds :white_check_mark: when done

On Slack, the same sequence was broken. The reactions were placed around `await self.handle_message(msg_event)`, but `handle_message()` returns **immediately** after spawning a background task (`asyncio.create_task`). This caused the :eyes: → :white_check_mark: swap to happen **before any real work began**, giving users the impression the bot finished instantly while it was actually still running.

Additionally, Slack's "is thinking..." status indicator (set via `assistant.threads.setStatus`) was never cleared because `stop_typing()` was not implemented. The base class's `_keep_typing` loop got cancelled in `finally`, but the last "is thinking..." state remained stuck in Slack's UI.

This PR fixes both issues by:
- Implementing `on_processing_start` / `on_processing_complete` callbacks (matching Discord/Telegram)
- Adding `stop_typing()` to explicitly clear the assistant thread status

## Related Issue

No existing issue — discovered during routine Slack behavior audit.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/slack.py`:
  - Import `ProcessingOutcome` (needed for `on_processing_complete` signature)
  - Add `_reacting_message_ids: set` to track which Slack message timestamps should get reaction lifecycle (preserves existing DM/@mention-only behavior)
  - Add `_active_status_threads: Dict[str, str]` to track which threads have an active "is thinking..." status so `stop_typing` can clear them
  - Replace inline reaction logic in `_handle_slack_message` with a simple `self._reacting_message_ids.add(ts)` before calling `handle_message()`
  - Add `on_processing_start()` — adds :eyes: reaction if the message is in `_reacting_message_ids`
  - Add `on_processing_complete()` — removes :eyes:, then adds :white_check_mark: on success or :x: on failure, and discards the message ID from the set
  - Add `stop_typing()` — looks up the stored `thread_ts` for a `chat_id`, calls `assistant_threads_setStatus` with `status=""` to clear it, and removes the entry
  - Update `send_typing()` to store `thread_ts` in `_active_status_threads` before calling the API

## How to Test

1. Start the gateway with Slack enabled: `hermes gateway run`
2. Send a DM to Hermes on Slack, or @mention it in a channel
3. Observe the reaction lifecycle on your message:
   - :eyes: should appear when processing starts
   - Should remain while the agent is working (tool calls, etc.)
   - Should flip to :white_check_mark: when the response is sent
4. Observe the "is thinking..." indicator next to Hermes's name in the thread:
   - Should appear while processing
   - Should disappear after the response is delivered
5. (Optional) Send a message that triggers a tool failure — verify :x: appears instead of :white_check_mark:

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(gateway/slack): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass *(68 pre-existing failures unrelated to this change; all 129 Slack-specific tests pass)*
- [x] I've added tests for my changes *(updated `test_reactions_in_message_flow` for new callback pattern + added `test_reactions_failure_outcome` and `test_reactions_skipped_for_non_dm_non_mention`)*
- [x] I've tested on my platform: macOS 15, Slack Socket Mode

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A (behavioral fix, no new user-facing config)
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A (Slack-only)
- [x] I've updated tool descriptions/schemas — N/A

## Why this approach?

Discord and Telegram already use the `on_processing_start` / `on_processing_complete` hook pattern. The base class's `_process_message_background()` calls these hooks at the actual start and end of the `_message_handler` call. By making Slack follow the same pattern instead of trying to bracket `handle_message()` directly, we get correct timing for free and eliminate a platform-specific footgun that will break again if anyone copies the old Slack pattern for a new adapter.
