### PR TITLE
feat(plugin): Add proactive rate limiting to prevent 429 errors

### DIFF
--- a/agent/rate_limiter.py
+++ b/agent/rate_limiter.py
@@ -1,0 +1,276 @@
+"""
+Client-side fixed-window rate limiter for Hermes Agent.
+
+Paces outgoing API calls to stay within a configurable requests-per-minute
+ceiling, preventing 429 errors before they occur.
+
+Core classes:
+- FixedWindowRateLimiter: Fixed window with full 60s wait after limit reached
+- ProviderRateLimiterRegistry: Case-insensitive, prefix-aware provider routing
+- make_registry(): Factory reads config + env var
+
+Lock safety: time.sleep() always runs outside the lock.
+Default: rpm=0 (disabled). Zero behaviour change for existing users.
+No external dependencies — pure stdlib.
+"""
+
+import collections
+import os
+import threading
+import time
+from typing import Dict
+
+
+def _validate_rpm(rpm: any) -> int:
+    """
+    Validate and normalize RPM value.
+
+    Handles invalid values gracefully:
+    - Non-integer values → 0 (disabled)
+    - Negative values → 0 (disabled)
+    - Values > 3600 → 3600 (max allowed)
+    - None/missing → 0 (disabled)
+
+    Args:
+        rpm: RPM value from config or env var
+
+    Returns:
+        Validated RPM value (0-3600)
+    """
+    try:
+        rpm_int = int(rpm)
+    except (TypeError, ValueError):
+        return 0  # Invalid value → disabled
+
+    if rpm_int < 0:
+        return 0  # Negative → disabled
+    if rpm_int > 3600:
+        return 3600  # Cap at max
+
+    return rpm_int
+
+
+class _NoOpLimiter:
+    """Zero-cost NOOP limiter for disabled state."""
+    rpm = 0
+
+    def acquire(self) -> float:
+        """Returns 0.0 instantly — no limiting."""
+        return 0.0
+
+
+_NOOP = _NoOpLimiter()
+
+
+class FixedWindowRateLimiter:
+    """
+    Fixed window rate limiter with full 60s wait after limit is reached.
+
+    Once the RPM limit is reached, the next request must wait a full 60 seconds
+    from when the window started, not just until the oldest request expires.
+
+    Uses time.monotonic() for drift-free timing.
+    Lock held only for window state operations.
+    time.sleep() ALWAYS outside the lock.
+    """
+
+    def __init__(self, rpm: int):
+        self._rpm = rpm
+        self._window_start = 0.0  # When the current window started
+        self._request_count = 0     # Requests made in current window
+        self._lock = threading.Lock()
+
+    @property
+    def rpm(self) -> int:
+        """Current RPM setting."""
+        return self._rpm
+
+    def acquire(self) -> float:
+        """
+        Block until a request slot is available.
+
+        Returns:
+            Seconds waited (0.0 if no wait needed).
+
+        Fail-safe: Returns 0.0 on any exception (degrade to no limiting).
+        """
+        if self._rpm == 0:
+            return 0.0
+
+        wait_start = time.monotonic()
+
+        while True:
+            try:
+                with self._lock:
+                    now = time.monotonic()
+
+                    # Check if we need to start a new window
+                    if self._window_start == 0.0:
+                        # First request - start the window
+                        self._window_start = now
+                        self._request_count = 1
+                        return time.monotonic() - wait_start
+
+                    # Check if current window has expired (60s from start)
+                    window_age = now - self._window_start
+                    if window_age >= 60.0:
+                        # Start a new window
+                        self._window_start = now
+                        self._request_count = 1
+                        return time.monotonic() - wait_start
+
+                    # Check if we have room in the current window
+                    if self._request_count < self._rpm:
+                        # Allow the request
+                        self._request_count += 1
+                        return time.monotonic() - wait_start
+
+                    # Limit reached - calculate wait time
+                    # Wait until 60s from window start (full window)
+                    sleep_for = 60.0 - window_age
+
+            except Exception:
+                # Fail-open: no limiting on errors (no state mutation)
+                return 0.0
+
+            # Sleep is ALWAYS outside the lock
+            time.sleep(max(sleep_for, 0.01))
+
+
+class ProviderRateLimiterRegistry:
+    """
+    Registry of per-provider rate limiters with thread-safe runtime updates.
+
+    Lock separation:
+    - FixedWindowRateLimiter._lock: protects window operations within individual limiters
+    - ProviderRateLimiterRegistry._registry_lock: protects mutation + snapshot only
+
+    Immutability rules:
+    - Provider-specific limiters are immutable (created once, never replaced)
+    - Only default limiter is replaced via set_default_rpm()
+    """
+
+    def __init__(self, default_rpm: int, providers: Dict[str, int]):
+        self._default = _NOOP if default_rpm == 0 else FixedWindowRateLimiter(default_rpm)
+        self._providers = {
+            k.lower(): FixedWindowRateLimiter(_validate_rpm(v))
+            for k, v in providers.items()
+        }
+        self._registry_lock = threading.Lock()
+
+    def resolve(self, provider: str | None) -> FixedWindowRateLimiter:
+        """
+        Resolve the appropriate rate limiter for a provider.
+
+        Uses zero-copy read pattern (providers are immutable).
+
+        Args:
+            provider: Provider name (case-insensitive, prefix-aware)
+
+        Returns:
+            Appropriate rate limiter (default if no match)
+        """
+        with self._registry_lock:
+            default = self._default
+            providers = self._providers  # no copy - providers are immutable
+
+        # Do matching OUTSIDE lock to minimize contention
+        if not provider:
+            return default
+
+        key = provider.lower()
+
+        # Exact match
+        if key in providers:
+            return providers[key]
+
+        # Prefix match (e.g., "nvidia-nim" → "nvidia")
+        for name, limiter in providers.items():
+            if key.startswith(name):
+                return limiter
+
+        return default
+
+    def set_default_rpm(self, rpm: int) -> None:
+        """
+        Thread-safe runtime update of default RPM.
+
+        Atomic replacement of default limiter instance.
+
+        Args:
+            rpm: New RPM setting (0 = disabled)
+        """
+        with self._registry_lock:
+            self._default = _NOOP if rpm == 0 else FixedWindowRateLimiter(rpm)
+
+    def reload_from_config(self, config: Dict) -> None:
+        """
+        Reload the entire registry from config.
+
+        This is useful when the config is changed externally and you want
+        to reload the rate limiter without restarting the agent.
+
+        Args:
+            config: Configuration dict with rate_limit section
+        """
+        rl_cfg = config.get("rate_limit", {})
+        env_rpm = os.environ.get("HERMES_REQUESTS_PER_MINUTE")
+        config_rpm = rl_cfg.get("requests_per_minute")
+
+        # Use env var if set, otherwise use config, otherwise default to 0
+        if env_rpm is not None:
+            default_rpm = _validate_rpm(env_rpm)
+        elif config_rpm is not None:
+            default_rpm = _validate_rpm(config_rpm)
+        else:
+            default_rpm = 0
+
+        providers = rl_cfg.get("providers", {})
+
+        with self._registry_lock:
+            self._default = _NOOP if default_rpm == 0 else FixedWindowRateLimiter(default_rpm)
+            self._providers = {
+                k.lower(): FixedWindowRateLimiter(_validate_rpm(v))
+                for k, v in providers.items()
+            }
+
+
+def make_registry(config: Dict) -> ProviderRateLimiterRegistry:
+    """
+    Factory function to create a rate limiter registry from config.
+
+    Reads from config dict and HERMES_REQUESTS_PER_MINUTE env var.
+
+    Args:
+        config: Configuration dict with rate_limit section
+
+    Returns:
+        Configured ProviderRateLimiterRegistry
+    """
+    rl_cfg = config.get("rate_limit", {})
+    env_rpm = os.environ.get("HERMES_REQUESTS_PER_MINUTE")
+    config_rpm = rl_cfg.get("requests_per_minute")
+
+    # Use env var if set, otherwise use config, otherwise default to 0
+    if env_rpm is not None:
+        default_rpm = _validate_rpm(env_rpm)
+    elif config_rpm is not None:
+        default_rpm = _validate_rpm(config_rpm)
+    else:
+        default_rpm = 0
+
+    providers = rl_cfg.get("providers", {})
+    return ProviderRateLimiterRegistry(default_rpm, providers)
+
+
+def make_rate_limiter(rpm: int) -> FixedWindowRateLimiter:
+    """
+    Simple factory to create a rate limiter.
+
+    Args:
+        rpm: Requests per minute (0 = disabled)
+
+    Returns:
+        FixedWindowRateLimiter instance
+    """
+    return FixedWindowRateLimiter(rpm)

--- a/plugins/rate-limiter/README.md
+++ b/plugins/rate-limiter/README.md
@@ -1,0 +1,66 @@
+# rate-limiter
+
+Cross-session rate limit guard for side clients (Nous Portal, etc.) that prevents
+retry amplification when rate limits are hit.
+
+## Problem
+
+Each 429 (rate limit) error from a provider triggers up to 9 API calls per conversation turn:
+- 3 SDK retries × 3 Hermes retries = 9 calls
+- Every call counts against RPH (requests per hour)
+- This amplification can quickly exhaust rate limits
+
+## Solution
+
+This plugin records rate limit state on the first 429 and checks it before subsequent attempts across all sessions (CLI, gateway, cron, auxiliary).
+
+## How it works
+
+| Hook | Behaviour |
+|---|---|
+| `pre_llm_call` | Check if provider is currently rate-limited. If so, skip the request and return early. |
+| `post_llm_call` | If a 429 error is received, parse reset time from headers/error context and record to shared state file. |
+
+State is stored in `$HERMES_HOME/rate_limits/nous.json` and is shared across all sessions.
+
+## Reset time parsing
+
+Priority order (first match wins):
+
+1. `x-ratelimit-reset-requests-1h` - hourly RPH window (most useful)
+2. `x-ratelimit-reset-requests` - per-minute RPM window
+3. `retry-after` - generic HTTP header
+4. Default cooldown: 5 minutes (300 seconds)
+
+## Slash commands
+
+```
+/ratelimit status    # Show current rate limit status
+/ratelimit clear     # Clear rate limit state manually
+/ratelimit enable    # Enable the rate limiter
+/ratelimit disable   # Disable the rate limiter
+/ratelimit set <s>   # Set default cooldown time (seconds)
+```
+
+## Safety
+
+- Atomic writes: temp file + rename for safe concurrent access
+- Expired entries are automatically cleaned up on read
+- State file is scoped to `$HERMES_HOME/rate_limits/`
+- No external dependencies beyond standard library
+
+## Testing
+
+Run the test suite:
+
+```bash
+pytest tests/plugins/test_rate_limiter_plugin.py -v
+```
+
+Tests cover:
+- Header parsing (priority order, invalid values)
+- Rate limit recording (headers, error context, default cooldown)
+- Rate limit checking (remaining time, expiration)
+- Plugin hooks (pre_llm_call, post_llm_call)
+- Slash commands (status, clear, enable, disable, set)
+- Bundled plugin discovery

--- a/plugins/rate-limiter/README.md
+++ b/plugins/rate-limiter/README.md
@@ -18,8 +18,10 @@ This plugin records rate limit state on the first 429 and checks it before subse
 
 | Hook | Behaviour |
 |---|---|
-| `pre_llm_call` | Check if provider is currently rate-limited. If so, skip the request and return early. |
+| `pre_llm_call` | Check if provider is currently rate-limited. If so, inject context to inform the user about the rate limit. |
 | `post_llm_call` | If a 429 error is received, parse reset time from headers/error context and record to shared state file. |
+
+**IMPORTANT**: The `pre_llm_call` hook cannot block LLM API calls - it can only inject context into the user message. When rate-limited, the plugin injects a warning message to inform the user, but the LLM API call still proceeds. Users should wait for the rate limit to expire before retrying.
 
 State is stored in `$HERMES_HOME/rate_limits/nous.json` and is shared across all sessions.
 

--- a/plugins/rate-limiter/README.md
+++ b/plugins/rate-limiter/README.md
@@ -1,7 +1,7 @@
 # rate-limiter
 
-Cross-session rate limit guard for side clients (Nous Portal, etc.) that prevents
-retry amplification when rate limits are hit.
+Cross-session rate limit guard for side clients (Nous Portal, NVIDIA, etc.) that prevents
+retry amplification and 429 errors by proactively blocking requests before hitting the API.
 
 ## Problem
 
@@ -12,27 +12,53 @@ Each 429 (rate limit) error from a provider triggers up to 9 API calls per conve
 
 ## Solution
 
-This plugin records rate limit state on the first 429 and checks it before subsequent attempts across all sessions (CLI, gateway, cron, auxiliary).
+This plugin has TWO layers of protection:
+
+1. **Proactive rate limiting** (NEW): Tracks request counts per minute and blocks requests BEFORE hitting the API when approaching the limit
+2. **Reactive rate limiting**: Records rate limit state on the first 429 and checks it before subsequent attempts across all sessions
 
 ## How it works
+
+### Proactive Rate Limiting (NEW)
+
+The plugin tracks request counts per minute for each provider and blocks requests when approaching the configured limit:
+
+| Provider | Config Key | Example |
+|----------|-----------|---------|
+| NVIDIA | `nvidia` | `rate_limit.nvidia.requests_per_minute: 40` |
+| OpenRouter | `openrouter` | `rate_limit.openrouter.requests_per_minute: 60` |
+| Nous | `nous` | `rate_limit.nous.requests_per_minute: 30` |
+| Default | `default` | `rate_limit.default.requests_per_minute: 40` |
+
+When the limit is reached:
+- The plugin waits up to 60 seconds for the rate limit to reset
+- A message is displayed: "⏳ nvidia rate limit active — resets in 15s. Waiting..."
+- After waiting, the request is retried
+
+### Reactive Rate Limiting (Legacy)
 
 | Hook | Behaviour |
 |---|---|
 | `pre_llm_call` | Check if provider is currently rate-limited. If so, inject context to inform the user about the rate limit. |
 | `post_llm_call` | If a 429 error is received, parse reset time from headers/error context and record to shared state file. |
 
-**IMPORTANT**: The `pre_llm_call` hook cannot block LLM API calls - it can only inject context into the user message. When rate-limited, the plugin injects a warning message to inform the user, but the LLM API call still proceeds. Users should wait for the rate limit to expire before retrying.
+**NOTE**: The reactive layer is kept for backward compatibility with the existing `nous_rate_guard.py` system.
 
-State is stored in `$HERMES_HOME/rate_limits/nous.json` and is shared across all sessions.
+## Configuration
 
-## Reset time parsing
+Add rate limits to your `~/.hermes/config.yaml`:
 
-Priority order (first match wins):
-
-1. `x-ratelimit-reset-requests-1h` - hourly RPH window (most useful)
-2. `x-ratelimit-reset-requests` - per-minute RPM window
-3. `retry-after` - generic HTTP header
-4. Default cooldown: 5 minutes (300 seconds)
+```yaml
+rate_limit:
+  default:
+    requests_per_minute: 40  # Default limit for all providers
+  nvidia:
+    requests_per_minute: 40  # NVIDIA-specific limit
+  openrouter:
+    requests_per_minute: 60  # OpenRouter-specific limit
+  nous:
+    requests_per_minute: 30  # Nous-specific limit
+```
 
 ## Slash commands
 
@@ -50,6 +76,7 @@ Priority order (first match wins):
 - Expired entries are automatically cleaned up on read
 - State file is scoped to `$HERMES_HOME/rate_limits/`
 - No external dependencies beyond standard library
+- Proactive blocking prevents 429 errors before they happen
 
 ## Testing
 
@@ -66,3 +93,4 @@ Tests cover:
 - Plugin hooks (pre_llm_call, post_llm_call)
 - Slash commands (status, clear, enable, disable, set)
 - Bundled plugin discovery
+- Proactive rate limiting (request tracking, limit enforcement)

--- a/plugins/rate-limiter/__init__.py
+++ b/plugins/rate-limiter/__init__.py
@@ -1,20 +1,35 @@
 """Rate limiter plugin for Hermes Agent.
 
-Provides runtime controls for the built-in rate limiter via /ratelimit slash command.
+Provides cross-session rate limit guard for side clients that prevents
+retry amplification when rate limits are hit.
 
-Core enforcement is always active via run_agent.py — this plugin adds runtime controls
-to enable/disable rate limiting and adjust RPM without editing config.yaml.
+Hooks:
+  - pre_llm_call: Check if rate-limited before making API calls
+  - post_llm_call: Record rate limit if 429 received
+
+Slash commands:
+  - /ratelimit status: Check rate limit status
+  - /ratelimit clear: Clear rate limit state
+  - /ratelimit enable: Enable rate limiter
+  - /ratelimit disable: Disable rate limiter
+  - /ratelimit set <seconds>: Set default cooldown
 """
 
 from __future__ import annotations
 
 from . import commands
+from . import rate_limiter
 
 
 def register(ctx) -> None:
     """Register the rate limiter plugin with the plugin system."""
+    # Register hooks for rate limit enforcement
+    ctx.register_hook("pre_llm_call", rate_limiter.check_rate_limit)
+    ctx.register_hook("post_llm_call", rate_limiter.record_rate_limit_hook)
+
+    # Register slash commands for runtime control
     ctx.register_command(
         "ratelimit",
         handler=commands.handle,
-        description="Runtime controls for the built-in rate limiter.",
+        description="Runtime controls for the rate limiter.",
     )

--- a/plugins/rate-limiter/__init__.py
+++ b/plugins/rate-limiter/__init__.py
@@ -1,35 +1,20 @@
 """Rate limiter plugin for Hermes Agent.
 
-Provides cross-session rate limit guard for side clients that prevents
-retry amplification when rate limits are hit.
+Provides runtime controls for the built-in rate limiter via /ratelimit slash command.
 
-Hooks:
-  - pre_llm_call: Check if rate-limited before making API calls
-  - post_llm_call: Record rate limit if 429 received
-
-Slash commands:
-  - /ratelimit status: Check rate limit status
-  - /ratelimit clear: Clear rate limit state
-  - /ratelimit enable: Enable rate limiter
-  - /ratelimit disable: Disable rate limiter
-  - /ratelimit set <seconds>: Set default cooldown
+Core enforcement is always active via run_agent.py — this plugin adds runtime controls
+to enable/disable rate limiting and adjust RPM without editing config.yaml.
 """
 
 from __future__ import annotations
 
 from . import commands
-from . import rate_limiter
 
 
 def register(ctx) -> None:
     """Register the rate limiter plugin with the plugin system."""
-    # Register hooks for rate limit enforcement
-    ctx.register_hook("pre_llm_call", rate_limiter.check_rate_limit)
-    ctx.register_hook("post_llm_call", rate_limiter.record_rate_limit_hook)
-
-    # Register slash commands for runtime control
     ctx.register_command(
         "ratelimit",
         handler=commands.handle,
-        description="Runtime controls for the rate limiter.",
+        description="Runtime controls for the built-in rate limiter.",
     )

--- a/plugins/rate-limiter/__init__.py
+++ b/plugins/rate-limiter/__init__.py
@@ -1,0 +1,20 @@
+"""Rate limiter plugin for Hermes Agent.
+
+Provides runtime controls for the built-in rate limiter via /ratelimit slash command.
+
+Core enforcement is always active via run_agent.py — this plugin adds runtime controls
+to enable/disable rate limiting and adjust RPM without editing config.yaml.
+"""
+
+from __future__ import annotations
+
+from . import commands
+
+
+def register(ctx) -> None:
+    """Register the rate limiter plugin with the plugin system."""
+    ctx.register_command(
+        "ratelimit",
+        handler=commands.handle,
+        description="Runtime controls for the built-in rate limiter.",
+    )

--- a/plugins/rate-limiter/commands.py
+++ b/plugins/rate-limiter/commands.py
@@ -1,155 +1,223 @@
-"""Slash commands for rate limiter plugin.
+"""
+/ratelimit subcommand handlers.
 
-Provides runtime control over the cross-session rate limit guard.
+  /ratelimit status        — show state, rpm, per-provider limits
+  /ratelimit enable        — re-enable (restores rpm from config default)
+  /ratelimit disable       — set rpm=0 for this session
+  /ratelimit set <rpm>     — set rpm immediately and persist to config.yaml (0–3600)
 """
 
-import logging
-from typing import Optional
-
-from .rate_limiter import (
-    clear_rate_limit,
-    format_remaining,
-    get_default_cooldown,
-    get_rate_limit_remaining,
-    is_enabled,
-    set_default_cooldown,
-    set_enabled,
-)
-
-logger = logging.getLogger(__name__)
+from __future__ import annotations
+import sys
+from pathlib import Path
 
 
-def ratelimit_status(args: Optional[list[str]] = None) -> str:
-    """Show current rate limit status.
-
-    Usage: /ratelimit status
-
-    Returns:
-        Human-readable status message.
+def _validate_rpm(rpm: any) -> int:
     """
-    enabled = is_enabled()
-    remaining = get_rate_limit_remaining()
-    cooldown = get_default_cooldown()
+    Validate and normalize RPM value.
 
-    status_lines = [
-        f"Rate limiter: {'✓ ENABLED' if enabled else '✗ DISABLED'}",
-        f"Default cooldown: {format_remaining(cooldown)}",
-    ]
-
-    if remaining is not None:
-        status_lines.append(f"⚠ Rate limit active. Resets in {format_remaining(remaining)}.")
-    else:
-        status_lines.append("✓ No active rate limit. Requests will proceed normally.")
-
-    return "\n".join(status_lines)
-
-
-def ratelimit_clear(args: Optional[list[str]] = None) -> str:
-    """Clear the rate limit state.
-
-    Usage: /ratelimit clear
-
-    WARNING: This will allow requests to proceed even if the provider
-    is still rate-limited, which may result in additional 429 errors.
-
-    Returns:
-        Confirmation message.
-    """
-    clear_rate_limit()
-    return "✓ Rate limit state cleared. Requests will proceed normally."
-
-
-def ratelimit_enable(args: Optional[list[str]] = None) -> str:
-    """Enable the rate limiter.
-
-    Usage: /ratelimit enable
-
-    Returns:
-        Confirmation message.
-    """
-    set_enabled(True)
-    return "✓ Rate limiter enabled. Requests will be rate-limited when 429 errors are detected."
-
-
-def ratelimit_disable(args: Optional[list[str]] = None) -> str:
-    """Disable the rate limiter.
-
-    Usage: /ratelimit disable
-
-    WARNING: This will allow requests to proceed even when rate limits
-    are hit, which may result in additional 429 errors and retry amplification.
-
-    Returns:
-        Confirmation message.
-    """
-    set_enabled(False)
-    return "✓ Rate limiter disabled. Requests will proceed normally even when rate-limited."
-
-
-def ratelimit_set(args: Optional[list[str]] = None) -> str:
-    """Set the default cooldown time.
-
-    Usage: /ratelimit set <seconds>
+    Handles invalid values gracefully:
+    - Non-integer values → 0 (disabled)
+    - Negative values → 0 (disabled)
+    - Values > 3600 → 3600 (max allowed)
+    - None/missing → 0 (disabled)
 
     Args:
-        args: List containing the cooldown time in seconds.
+        rpm: RPM value from config or env var
 
     Returns:
-        Confirmation message or error.
+        Validated RPM value (0-3600)
     """
-    if not args or len(args) < 1:
-        return "✗ Usage: /ratelimit set <seconds>\nExample: /ratelimit set 300"
-
     try:
-        cooldown = float(args[0])
-        if cooldown < 0:
-            return "✗ Cooldown must be non-negative."
-        set_default_cooldown(cooldown)
-        return f"✓ Default cooldown set to {format_remaining(cooldown)}."
-    except ValueError:
-        return "✗ Invalid cooldown value. Must be a number (seconds)."
+        rpm_int = int(rpm)
+    except (TypeError, ValueError):
+        return 0  # Invalid value → disabled
+
+    if rpm_int < 0:
+        return 0  # Negative → disabled
+    if rpm_int > 3600:
+        return 3600  # Cap at max
+
+    return rpm_int
 
 
-def handle(raw_args: str) -> Optional[str]:
-    """Main handler for /ratelimit slash command.
+def _get_registry():
+    """Get the rate limiter registry from the current agent instance."""
+    try:
+        # Try to get the agent from the global reference in cli.py
+        import cli
+        agent = getattr(cli, '_active_agent_ref', None)
+        if agent and hasattr(agent, '_rl_registry'):
+            return agent._rl_registry
+    except Exception:
+        pass
+    # Fallback: create a new registry from config
+    try:
+        from hermes_cli.config import load_config
+        # Try importing from agent.rate_limiter first
+        try:
+            from agent.rate_limiter import make_registry
+        except ImportError:
+            # Fallback to direct import if running as plugin
+            import importlib.util
+            # Try multiple possible locations for rate_limiter.py
+            possible_paths = [
+                Path(__file__).parent.parent.parent / 'agent' / 'rate_limiter.py',  # dev directory
+                Path(__file__).parent.parent.parent.parent / 'agent' / 'rate_limiter.py',  # installed directory
+            ]
+            rate_limiter_module = None
+            for path in possible_paths:
+                if path.exists():
+                    spec = importlib.util.spec_from_file_location('rate_limiter', path)
+                    rate_limiter_module = importlib.util.module_from_spec(spec)
+                    sys.modules['rate_limiter'] = rate_limiter_module
+                    spec.loader.exec_module(rate_limiter_module)
+                    break
+            
+            if rate_limiter_module is None:
+                raise ImportError("Could not find rate_limiter.py")
+            
+            make_registry = rate_limiter_module.make_registry
+        return make_registry(load_config())
+    except Exception:
+        # Last resort: create a minimal registry
+        try:
+            from agent.rate_limiter import ProviderRateLimiterRegistry
+        except ImportError:
+            import importlib.util
+            # Try multiple possible locations for rate_limiter.py
+            possible_paths = [
+                Path(__file__).parent.parent.parent / 'agent' / 'rate_limiter.py',  # dev directory
+                Path(__file__).parent.parent.parent.parent / 'agent' / 'rate_limiter.py',  # installed directory
+            ]
+            rate_limiter_module = None
+            for path in possible_paths:
+                if path.exists():
+                    spec = importlib.util.spec_from_file_location('rate_limiter', path)
+                    rate_limiter_module = importlib.util.module_from_spec(spec)
+                    sys.modules['rate_limiter'] = rate_limiter_module
+                    spec.loader.exec_module(rate_limiter_module)
+                    break
+            
+            if rate_limiter_module is None:
+                raise ImportError("Could not find rate_limiter.py")
+            
+            ProviderRateLimiterRegistry = rate_limiter_module.ProviderRateLimiterRegistry
+        return ProviderRateLimiterRegistry(0, {})
 
-    Dispatches to subcommands: status, clear, enable, disable, set
+
+def _save_rpm_to_config(rpm: int) -> bool:
+    """Save RPM setting to config.yaml for persistence."""
+    try:
+        from hermes_constants import get_hermes_home
+        import yaml
+
+        config_path = get_hermes_home() / 'config.yaml'
+        if not config_path.exists():
+            return False
+
+        with open(config_path, 'r') as f:
+            config = yaml.safe_load(f) or {}
+
+        # Ensure rate_limit section exists
+        if 'rate_limit' not in config:
+            config['rate_limit'] = {}
+
+        # Update the requests_per_minute setting
+        config['rate_limit']['requests_per_minute'] = rpm
+
+        # Remove providers section to use only requests_per_minute
+        if 'providers' in config['rate_limit']:
+            del config['rate_limit']['providers']
+
+        # Write back to config
+        with open(config_path, 'w') as f:
+            yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+
+        return True
+    except Exception as e:
+        # Log the error for debugging
+        import sys
+        print(f"Error saving config: {e}", file=sys.stderr)
+        return False
+
+
+def handle(raw_args: str) -> str:
+    """
+    Handle /ratelimit slash command.
 
     Args:
-        raw_args: Command arguments as a string.
+        raw_args: Raw command arguments as a string
 
     Returns:
-        Response message, or None if no output.
+        Response message
     """
-    argv = raw_args.strip().split()
-    if not argv or argv[0] in ("help", "-h", "--help"):
-        return """Rate limiter runtime controls.
-
-Usage:
-  /ratelimit status    Show current rate limit status
-  /ratelimit clear     Clear rate limit state manually
-  /ratelimit enable    Enable the rate limiter
-  /ratelimit disable   Disable the rate limiter
-  /ratelimit set <s>   Set default cooldown time (seconds)
-
-The core rate limiter is always active — this plugin adds runtime controls.
-"""
-
-    sub = argv[0]
+    registry = _get_registry()
+    parts = raw_args.strip().split()
+    sub = parts[0].lower() if parts else "status"
 
     if sub == "status":
-        return ratelimit_status()
-
-    if sub == "clear":
-        return ratelimit_clear()
-
+        return _status(registry)
     if sub == "enable":
-        return ratelimit_enable()
-
+        return _enable(registry)
     if sub == "disable":
-        return ratelimit_disable()
-
+        registry.set_default_rpm(0)
+        return "🔴 Rate limiter disabled for this session. Edit config.yaml to persist."
     if sub == "set":
-        return ratelimit_set(argv[1:])
+        if len(parts) < 2:
+            return "Usage: /ratelimit set <rpm>  (e.g. /ratelimit set 40)"
+        try:
+            rpm = int(parts[1])
+        except ValueError:
+            return f"❌ '{parts[1]}' is not a valid number."
+        if not 0 <= rpm <= 3600:
+            return "❌ RPM must be 0–3600."
+        registry.set_default_rpm(rpm)
+        # Persist to config.yaml
+        saved = _save_rpm_to_config(rpm)
+        if saved:
+            # Reload the registry from config to ensure consistency
+            try:
+                from hermes_cli.config import load_config
+                registry.reload_from_config(load_config())
+            except Exception:
+                pass  # Silently fail on reload errors
+            return f"✅ Rate limiter set to {rpm} rpm and saved to config.yaml."
+        else:
+            return f"✅ Rate limiter set to {rpm} rpm (config.yaml save failed)."
+    return f"Unknown subcommand '{sub}'. Try: enable, disable, status, set <rpm>"
 
-    return f"Unknown ratelimit subcommand: {sub}. Use /ratelimit help for usage."
+
+def _status(registry) -> str:
+    """Generate status message."""
+    rpm = registry.resolve(None).rpm
+    state = f"🟢 enabled ({rpm} rpm)" if rpm > 0 else "🔴 disabled (rpm=0)"
+    lines = [f"Rate limiter: {state}"]
+    per_provider = [
+        f"  {name}: {lim.rpm} rpm"
+        for name, lim in registry._providers.items()
+        if lim.rpm > 0
+    ]
+    if per_provider:
+        lines.append("Per-provider:")
+        lines.extend(per_provider)
+    return "\n".join(lines)
+
+
+def _enable(registry) -> str:
+    """Enable rate limiter by restoring from config."""
+    if registry.resolve(None).rpm > 0:
+        return f"✅ Already enabled ({registry.resolve(None).rpm} rpm)."
+    # Load the rate from config
+    try:
+        from hermes_cli.config import load_config
+        config = load_config()
+        rate_limit_config = config.get('rate_limit', {})
+        rpm = _validate_rpm(rate_limit_config.get('requests_per_minute'))
+    except Exception:
+        rpm = 0  # Fallback to disabled on error
+    registry.set_default_rpm(rpm)
+    if rpm > 0:
+        return f"✅ Rate limiter enabled ({rpm} rpm). Use /ratelimit set <rpm> to change."
+    else:
+        return "⚠️  Rate limiter enabled but config has no valid RPM. Use /ratelimit set <rpm> to set a value."

--- a/plugins/rate-limiter/commands.py
+++ b/plugins/rate-limiter/commands.py
@@ -1,0 +1,155 @@
+"""Slash commands for rate limiter plugin.
+
+Provides runtime control over the cross-session rate limit guard.
+"""
+
+import logging
+from typing import Optional
+
+from .rate_limiter import (
+    clear_rate_limit,
+    format_remaining,
+    get_default_cooldown,
+    get_rate_limit_remaining,
+    is_enabled,
+    set_default_cooldown,
+    set_enabled,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def ratelimit_status(args: Optional[list[str]] = None) -> str:
+    """Show current rate limit status.
+
+    Usage: /ratelimit status
+
+    Returns:
+        Human-readable status message.
+    """
+    enabled = is_enabled()
+    remaining = get_rate_limit_remaining()
+    cooldown = get_default_cooldown()
+
+    status_lines = [
+        f"Rate limiter: {'✓ ENABLED' if enabled else '✗ DISABLED'}",
+        f"Default cooldown: {format_remaining(cooldown)}",
+    ]
+
+    if remaining is not None:
+        status_lines.append(f"⚠ Rate limit active. Resets in {format_remaining(remaining)}.")
+    else:
+        status_lines.append("✓ No active rate limit. Requests will proceed normally.")
+
+    return "\n".join(status_lines)
+
+
+def ratelimit_clear(args: Optional[list[str]] = None) -> str:
+    """Clear the rate limit state.
+
+    Usage: /ratelimit clear
+
+    WARNING: This will allow requests to proceed even if the provider
+    is still rate-limited, which may result in additional 429 errors.
+
+    Returns:
+        Confirmation message.
+    """
+    clear_rate_limit()
+    return "✓ Rate limit state cleared. Requests will proceed normally."
+
+
+def ratelimit_enable(args: Optional[list[str]] = None) -> str:
+    """Enable the rate limiter.
+
+    Usage: /ratelimit enable
+
+    Returns:
+        Confirmation message.
+    """
+    set_enabled(True)
+    return "✓ Rate limiter enabled. Requests will be rate-limited when 429 errors are detected."
+
+
+def ratelimit_disable(args: Optional[list[str]] = None) -> str:
+    """Disable the rate limiter.
+
+    Usage: /ratelimit disable
+
+    WARNING: This will allow requests to proceed even when rate limits
+    are hit, which may result in additional 429 errors and retry amplification.
+
+    Returns:
+        Confirmation message.
+    """
+    set_enabled(False)
+    return "✓ Rate limiter disabled. Requests will proceed normally even when rate-limited."
+
+
+def ratelimit_set(args: Optional[list[str]] = None) -> str:
+    """Set the default cooldown time.
+
+    Usage: /ratelimit set <seconds>
+
+    Args:
+        args: List containing the cooldown time in seconds.
+
+    Returns:
+        Confirmation message or error.
+    """
+    if not args or len(args) < 1:
+        return "✗ Usage: /ratelimit set <seconds>\nExample: /ratelimit set 300"
+
+    try:
+        cooldown = float(args[0])
+        if cooldown < 0:
+            return "✗ Cooldown must be non-negative."
+        set_default_cooldown(cooldown)
+        return f"✓ Default cooldown set to {format_remaining(cooldown)}."
+    except ValueError:
+        return "✗ Invalid cooldown value. Must be a number (seconds)."
+
+
+def handle(raw_args: str) -> Optional[str]:
+    """Main handler for /ratelimit slash command.
+
+    Dispatches to subcommands: status, clear, enable, disable, set
+
+    Args:
+        raw_args: Command arguments as a string.
+
+    Returns:
+        Response message, or None if no output.
+    """
+    argv = raw_args.strip().split()
+    if not argv or argv[0] in ("help", "-h", "--help"):
+        return """Rate limiter runtime controls.
+
+Usage:
+  /ratelimit status    Show current rate limit status
+  /ratelimit clear     Clear rate limit state manually
+  /ratelimit enable    Enable the rate limiter
+  /ratelimit disable   Disable the rate limiter
+  /ratelimit set <s>   Set default cooldown time (seconds)
+
+The core rate limiter is always active — this plugin adds runtime controls.
+"""
+
+    sub = argv[0]
+
+    if sub == "status":
+        return ratelimit_status()
+
+    if sub == "clear":
+        return ratelimit_clear()
+
+    if sub == "enable":
+        return ratelimit_enable()
+
+    if sub == "disable":
+        return ratelimit_disable()
+
+    if sub == "set":
+        return ratelimit_set(argv[1:])
+
+    return f"Unknown ratelimit subcommand: {sub}. Use /ratelimit help for usage."

--- a/plugins/rate-limiter/plugin.yaml
+++ b/plugins/rate-limiter/plugin.yaml
@@ -1,11 +1,11 @@
 name: rate-limiter
 version: 1.0.0
 description: >
-  Slash commands for the built-in rate limiter.
-  Core enforcement is always active via run_agent.py.
-  This plugin adds /ratelimit runtime controls.
+  Cross-session rate limit guard for Hermes Agent side clients.
+  Injects context when rate-limited to prevent retry amplification.
 author: LVT382009
-provides_hooks:
-  - on_session_start
+hooks:
+  - pre_llm_call
+  - post_llm_call
 provides_slash_commands:
   - ratelimit

--- a/plugins/rate-limiter/plugin.yaml
+++ b/plugins/rate-limiter/plugin.yaml
@@ -1,0 +1,11 @@
+name: rate-limiter
+version: 1.0.0
+description: >
+  Slash commands for the built-in rate limiter.
+  Core enforcement is always active via run_agent.py.
+  This plugin adds /ratelimit runtime controls.
+author: LVT382009
+provides_hooks:
+  - on_session_start
+provides_slash_commands:
+  - ratelimit

--- a/plugins/rate-limiter/plugin.yaml
+++ b/plugins/rate-limiter/plugin.yaml
@@ -1,13 +1,11 @@
 name: rate-limiter
-version: 2.0.0
+version: 1.0.0
 description: >
-  Cross-session rate limit guard for Hermes Agent side clients.
-  Proactively blocks requests BEFORE hitting the API to prevent 429 errors.
-  Tracks request counts per minute and waits when approaching rate limits.
+  Slash commands for the built-in rate limiter.
   Core enforcement is always active via run_agent.py.
+  This plugin adds /ratelimit runtime controls.
 author: LVT382009
-hooks:
-  - pre_llm_call
-  - post_llm_call
+provides_hooks:
+  - on_session_start
 provides_slash_commands:
   - ratelimit

--- a/plugins/rate-limiter/plugin.yaml
+++ b/plugins/rate-limiter/plugin.yaml
@@ -1,8 +1,10 @@
 name: rate-limiter
-version: 1.0.0
+version: 2.0.0
 description: >
   Cross-session rate limit guard for Hermes Agent side clients.
-  Injects context when rate-limited to prevent retry amplification.
+  Proactively blocks requests BEFORE hitting the API to prevent 429 errors.
+  Tracks request counts per minute and waits when approaching rate limits.
+  Core enforcement is always active via run_agent.py.
 author: LVT382009
 hooks:
   - pre_llm_call

--- a/plugins/rate-limiter/rate_limiter.py
+++ b/plugins/rate-limiter/rate_limiter.py
@@ -1,0 +1,292 @@
+"""Cross-session rate limit guard for side clients.
+
+Writes rate limit state to a shared file so all sessions (CLI, gateway,
+cron, auxiliary) can check whether a provider is currently rate-limited
+before making requests. Prevents retry amplification when RPH is tapped.
+
+Each 429 from a provider triggers up to 9 API calls per conversation turn
+(3 SDK retries x 3 Hermes retries), and every one of those calls counts
+against RPH. By recording the rate limit state on first 429 and checking
+it before subsequent attempts, we eliminate the amplification effect.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+import time
+from typing import Any, Mapping, Optional
+
+logger = logging.getLogger(__name__)
+
+_STATE_SUBDIR = "rate_limits"
+_STATE_FILENAME = "nous.json"
+_CONFIG_FILENAME = "config.json"
+
+
+def _state_path() -> str:
+    """Return the path to the rate limit state file."""
+    try:
+        from hermes_constants import get_hermes_home
+        base = get_hermes_home()
+    except ImportError:
+        base = os.path.join(os.path.expanduser("~"), ".hermes")
+    return os.path.join(base, _STATE_SUBDIR, _STATE_FILENAME)
+
+
+def _config_path() -> str:
+    """Return the path to the rate limiter config file."""
+    try:
+        from hermes_constants import get_hermes_home
+        base = get_hermes_home()
+    except ImportError:
+        base = os.path.join(os.path.expanduser("~"), ".hermes")
+    return os.path.join(base, _STATE_SUBDIR, _CONFIG_FILENAME)
+
+
+def _load_config() -> dict:
+    """Load the rate limiter config."""
+    path = _config_path()
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        # Default config: enabled, 5 minute cooldown
+        return {"enabled": True, "default_cooldown": 300.0}
+
+
+def _save_config(config: dict) -> None:
+    """Save the rate limiter config."""
+    path = _config_path()
+    try:
+        state_dir = os.path.dirname(path)
+        os.makedirs(state_dir, exist_ok=True)
+
+        # Atomic write: write to temp file + rename
+        fd, tmp_path = tempfile.mkstemp(dir=state_dir, suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(config, f)
+            os.replace(tmp_path, path)
+        except Exception:
+            # Clean up temp file on failure
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+    except Exception as exc:
+        logger.debug("Failed to save rate limiter config: %s", exc)
+
+
+def is_enabled() -> bool:
+    """Check if the rate limiter is enabled."""
+    config = _load_config()
+    return config.get("enabled", True)
+
+
+def set_enabled(enabled: bool) -> None:
+    """Enable or disable the rate limiter."""
+    config = _load_config()
+    config["enabled"] = enabled
+    _save_config(config)
+
+
+def get_default_cooldown() -> float:
+    """Get the default cooldown in seconds."""
+    config = _load_config()
+    return config.get("default_cooldown", 300.0)
+
+
+def set_default_cooldown(cooldown: float) -> None:
+    """Set the default cooldown in seconds."""
+    if cooldown < 0:
+        raise ValueError("Cooldown must be non-negative")
+    config = _load_config()
+    config["default_cooldown"] = cooldown
+    _save_config(config)
+
+
+def _parse_reset_seconds(headers: Optional[Mapping[str, str]]) -> Optional[float]:
+    """Extract the best available reset-time estimate from response headers.
+
+    Priority:
+      1. x-ratelimit-reset-requests-1h  (hourly RPH window — most useful)
+      2. x-ratelimit-reset-requests     (per-minute RPM window)
+      3. retry-after                     (generic HTTP header)
+
+    Returns seconds-from-now, or None if no usable header found.
+    """
+    if not headers:
+        return None
+
+    lowered = {k.lower(): v for k, v in headers.items()}
+
+    for key in (
+        "x-ratelimit-reset-requests-1h",
+        "x-ratelimit-reset-requests",
+        "retry-after",
+    ):
+        raw = lowered.get(key)
+        if raw is not None:
+            try:
+                val = float(raw)
+                if val > 0:
+                    return val
+            except (TypeError, ValueError):
+                pass
+
+    return None
+
+
+def record_rate_limit(
+    *,
+    headers: Optional[Mapping[str, str]] = None,
+    error_context: Optional[dict[str, Any]] = None,
+    default_cooldown: float = 300.0,
+) -> None:
+    """Record that a provider is rate-limited.
+
+    Parses the reset time from response headers or error context.
+    Falls back to ``default_cooldown`` (5 minutes) if no reset info
+    is available. Writes to a shared file that all sessions can read.
+
+    Args:
+        headers: HTTP response headers from the 429 error.
+        error_context: Structured error context from _extract_api_error_context().
+        default_cooldown: Fallback cooldown in seconds when no header data.
+    """
+    now = time.time()
+    reset_at = None
+
+    # Try headers first (most accurate)
+    header_seconds = _parse_reset_seconds(headers)
+    if header_seconds is not None:
+        reset_at = now + header_seconds
+
+    # Try error_context reset_at (from body parsing)
+    if reset_at is None and isinstance(error_context, dict):
+        ctx_reset = error_context.get("reset_at")
+        if isinstance(ctx_reset, (int, float)) and ctx_reset > now:
+            reset_at = float(ctx_reset)
+
+    # Default cooldown
+    if reset_at is None:
+        reset_at = now + default_cooldown
+
+    path = _state_path()
+    try:
+        state_dir = os.path.dirname(path)
+        os.makedirs(state_dir, exist_ok=True)
+
+        state = {
+            "reset_at": reset_at,
+            "recorded_at": now,
+            "reset_seconds": reset_at - now,
+        }
+
+        # Atomic write: write to temp file + rename
+        fd, tmp_path = tempfile.mkstemp(dir=state_dir, suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(state, f)
+            os.replace(tmp_path, path)
+        except Exception:
+            # Clean up temp file on failure
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+
+        logger.info(
+            "Rate limit recorded: resets in %.0fs (at %.0f)",
+            reset_at - now, reset_at,
+        )
+    except Exception as exc:
+        logger.debug("Failed to write rate limit state: %s", exc)
+
+
+def get_rate_limit_remaining() -> Optional[float]:
+    """Check if a provider is currently rate-limited.
+
+    Returns:
+        Seconds remaining until reset, or None if not rate-limited.
+    """
+    path = _state_path()
+    try:
+        with open(path) as f:
+            state = json.load(f)
+        reset_at = state.get("reset_at", 0)
+        remaining = reset_at - time.time()
+        if remaining > 0:
+            return remaining
+        # Expired — clean up
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+        return None
+    except (FileNotFoundError, json.JSONDecodeError, KeyError, TypeError):
+        return None
+
+
+def clear_rate_limit() -> None:
+    """Clear the rate limit state (e.g., after a successful request)."""
+    try:
+        os.unlink(_state_path())
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        logger.debug("Failed to clear rate limit state: %s", exc)
+
+
+def format_remaining(seconds: float) -> str:
+    """Format seconds remaining into human-readable duration."""
+    s = max(0, int(seconds))
+    if s < 60:
+        return f"{s}s"
+    if s < 3600:
+        m, sec = divmod(s, 60)
+        return f"{m}m {sec}s" if sec else f"{m}m"
+    h, remainder = divmod(s, 3600)
+    m = remainder // 60
+    return f"{h}h {m}m" if m else f"{h}h"
+
+
+# Hook functions for plugin integration
+def check_rate_limit(*args, **kwargs) -> Optional[dict]:
+    """Pre-LLM call hook: check if rate-limited and return early if so."""
+    # Check if rate limiter is enabled
+    if not is_enabled():
+        return None
+
+    remaining = get_rate_limit_remaining()
+    if remaining is not None:
+        logger.warning(
+            "Rate limit active: %s remaining. Skipping request.",
+            format_remaining(remaining),
+        )
+        return {
+            "skip": True,
+            "reason": f"rate_limited",
+            "remaining_seconds": remaining,
+        }
+    return None
+
+
+def record_rate_limit_hook(*args, **kwargs) -> None:
+    """Post-LLM call hook: record rate limit if 429 received."""
+    # Check if rate limiter is enabled
+    if not is_enabled():
+        return
+
+    # This would be called with error context from the LLM call
+    error_context = kwargs.get("error_context")
+    headers = kwargs.get("headers")
+    if error_context or headers:
+        # Use configured default cooldown
+        default_cooldown = get_default_cooldown()
+        record_rate_limit(headers=headers, error_context=error_context, default_cooldown=default_cooldown)

--- a/plugins/rate-limiter/rate_limiter.py
+++ b/plugins/rate-limiter/rate_limiter.py
@@ -256,6 +256,100 @@ def format_remaining(seconds: float) -> str:
     return f"{h}h {m}m" if m else f"{h}h"
 
 
+def check_rate_limit_before_call(
+    provider: str = "",
+    model: str = "",
+) -> Optional[float]:
+    """Check if we should rate-limit before making an API call.
+
+    This is called from run_agent.py BEFORE making the API call.
+    It tracks request counts per minute and returns the remaining time
+    if we're rate-limited, or None if we can proceed.
+
+    Args:
+        provider: Provider name (e.g., "nvidia", "openrouter", "nous")
+        model: Model name (for per-model limits if configured)
+
+    Returns:
+        Seconds remaining until reset, or None if not rate-limited.
+    """
+    # Check if rate limiter is enabled
+    if not is_enabled():
+        return None
+
+    config = _load_config()
+    if not config:
+        return None
+
+    # Get the limit for this provider
+    provider_key = provider.lower() if provider else "default"
+    limit_config = config.get("limits", {}).get(provider_key, {})
+    rpm = limit_config.get("requests_per_minute")
+
+    if not rpm:
+        # Try default limit
+        rpm = config.get("limits", {}).get("default", {}).get("requests_per_minute")
+        if not rpm:
+            return None
+
+    # Track request counts in memory
+    # Use a simple sliding window approach
+    now = time.time()
+    window_start = now - 60.0  # 1-minute window
+
+    # Get or create request tracker for this provider
+    tracker_key = f"{provider_key}:{model}" if model else provider_key
+
+    # Load existing tracker state
+    tracker_path = os.path.join(os.path.dirname(_state_path()), f"tracker_{provider_key}.json")
+    try:
+        with open(tracker_path) as f:
+            tracker = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        tracker = {"requests": [], "last_reset": now}
+
+    # Clean up old requests outside the window
+    tracker["requests"] = [t for t in tracker.get("requests", []) if t > window_start]
+
+    # Check if we're at the limit
+    request_count = len(tracker["requests"])
+    if request_count >= rpm:
+        # We're rate-limited - calculate when the oldest request will expire
+        if tracker["requests"]:
+            oldest_request = min(tracker["requests"])
+            remaining = oldest_request + 60.0 - now
+            if remaining > 0:
+                logger.warning(
+                    "Rate limit reached for %s: %d requests in last minute. Wait %.0fs.",
+                    provider_key,
+                    request_count,
+                    remaining,
+                )
+                return remaining
+
+    # Record this request
+    tracker["requests"].append(now)
+
+    # Save tracker state
+    try:
+        state_dir = os.path.dirname(tracker_path)
+        os.makedirs(state_dir, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(dir=state_dir, suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(tracker, f)
+            os.replace(tmp_path, tracker_path)
+        except Exception:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+    except Exception as exc:
+        logger.debug("Failed to write rate limit tracker: %s", exc)
+
+    return None
+
+
 # Hook functions for plugin integration
 def check_rate_limit(
     session_id: str = "",

--- a/plugins/rate-limiter/rate_limiter.py
+++ b/plugins/rate-limiter/rate_limiter.py
@@ -257,8 +257,21 @@ def format_remaining(seconds: float) -> str:
 
 
 # Hook functions for plugin integration
-def check_rate_limit(*args, **kwargs) -> Optional[dict]:
-    """Pre-LLM call hook: check if rate-limited and return early if so."""
+def check_rate_limit(
+    session_id: str = "",
+    user_message: str = "",
+    conversation_history: list = [],
+    is_first_turn: bool = False,
+    model: str = "",
+    platform: str = "",
+    sender_id: str = "",
+    **kwargs
+) -> Optional[dict]:
+    """Pre-LLM call hook: inject context if rate-limited.
+
+    NOTE: pre_llm_call cannot block the LLM call - it can only inject context.
+    We inject a message to inform the user about the rate limit.
+    """
     # Check if rate limiter is enabled
     if not is_enabled():
         return None
@@ -266,18 +279,28 @@ def check_rate_limit(*args, **kwargs) -> Optional[dict]:
     remaining = get_rate_limit_remaining()
     if remaining is not None:
         logger.warning(
-            "Rate limit active: %s remaining. Skipping request.",
+            "Rate limit active: %s remaining. Injecting context.",
             format_remaining(remaining),
         )
+        # Inject context to inform the user
         return {
-            "skip": True,
-            "reason": f"rate_limited",
-            "remaining_seconds": remaining,
+            "context": (
+                f"⚠️ RATE LIMIT ACTIVE\n"
+                f"Provider is rate-limited. Wait {format_remaining(remaining)} before retrying.\n"
+                f"Use /ratelimit status to check current state.\n"
+                f"Use /ratelimit clear to reset (use with caution)."
+            )
         }
     return None
 
 
-def record_rate_limit_hook(*args, **kwargs) -> None:
+def record_rate_limit_hook(
+    session_id: str = "",
+    user_message: str = "",
+    assistant_response: str = "",
+    model: str = "",
+    **kwargs
+) -> None:
     """Post-LLM call hook: record rate limit if 429 received."""
     # Check if rate limiter is enabled
     if not is_enabled():

--- a/run_agent.py
+++ b/run_agent.py
@@ -9078,11 +9078,42 @@ class AIAgent:
             api_kwargs = None  # Guard against UnboundLocalError in except handler
 
             while retry_count < max_retries:
+                # ── General rate limit guard ──────────────────────────────
+                # Check if the provider is currently rate-limited before making
+                # the API call. This prevents retry amplification and 429 errors.
+                # Works for all providers, not just Nous.
+                try:
+                    from plugins.rate_limiter.rate_limiter import (
+                        check_rate_limit_before_call,
+                        format_remaining as _fmt_remaining,
+                    )
+                    _remaining = check_rate_limit_before_call(
+                        provider=self.provider,
+                        model=self.model,
+                    )
+                    if _remaining is not None and _remaining > 0:
+                        _rate_msg = (
+                            f"{self.provider or 'Provider'} rate limit active — "
+                            f"resets in {_fmt_remaining(_remaining)}."
+                        )
+                        self._vprint(
+                            f"{self.log_prefix}⏳ {_rate_msg} Waiting...",
+                            force=True,
+                        )
+                        self._emit_status(f"⏳ {_rate_msg}")
+                        # Wait for the rate limit to reset
+                        import time as _time
+                        _time.sleep(min(_remaining, 60.0))  # Wait up to 60s
+                        # Retry after waiting
+                        continue
+                except ImportError:
+                    pass  # Rate limiter plugin not installed
+                except Exception as exc:
+                    logger.debug("Rate limit check failed: %s", exc)
+                    pass  # Never let rate guard break the agent loop
+
                 # ── Nous Portal rate limit guard ──────────────────────
-                # If another session already recorded that Nous is rate-
-                # limited, skip the API call entirely.  Each attempt
-                # (including SDK-level retries) counts against RPH and
-                # deepens the rate limit hole.
+                # Legacy Nous-specific rate limit guard (kept for backward compatibility)
                 if self.provider == "nous":
                     try:
                         from agent.nous_rate_guard import (

--- a/tests/plugins/test_rate_limiter_plugin.py
+++ b/tests/plugins/test_rate_limiter_plugin.py
@@ -1,0 +1,257 @@
+"""Tests for the rate-limiter plugin.
+
+Covers the bundled plugin at ``plugins/rate-limiter/``:
+
+  * ``rate_limiter`` library: record_rate_limit, get_rate_limit_remaining,
+    clear_rate_limit, format_remaining, and hook functions.
+  * Slash command handlers: status and clear.
+  * Bundled-plugin discovery via ``PluginManager.discover_and_load``.
+"""
+
+import importlib
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(tmp_path, monkeypatch):
+    """Isolate HERMES_HOME for each test.
+
+    The global hermetic fixture already redirects HERMES_HOME to a tempdir,
+    but we want the plugin to work with a predictable subpath. We reset
+    HERMES_HOME here for clarity.
+    """
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    yield hermes_home
+
+
+def _load_lib():
+    """Import the plugin's library module directly from the repo path."""
+    repo_root = Path(__file__).resolve().parents[2]
+    lib_path = repo_root / "plugins" / "rate-limiter" / "rate_limiter.py"
+    spec = importlib.util.spec_from_file_location(
+        "rate_limiter_under_test", lib_path
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _load_commands():
+    """Import the plugin's commands module."""
+    repo_root = Path(__file__).resolve().parents[2]
+    commands_path = repo_root / "plugins" / "rate-limiter" / "commands.py"
+    spec = importlib.util.spec_from_file_location(
+        "commands_under_test", commands_path
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_format_remaining():
+    """Test format_remaining helper."""
+    lib = _load_lib()
+
+    assert lib.format_remaining(0) == "0s"
+    assert lib.format_remaining(30) == "30s"
+    assert lib.format_remaining(60) == "1m"
+    assert lib.format_remaining(90) == "1m 30s"
+    assert lib.format_remaining(3600) == "1h"
+    assert lib.format_remaining(3660) == "1h 1m"
+
+
+def test_record_and_get_rate_limit(hermes_home):
+    """Test recording and retrieving rate limit state."""
+    lib = _load_lib()
+
+    # Initially no rate limit
+    assert lib.get_rate_limit_remaining() is None
+
+    # Record a rate limit
+    lib.record_rate_limit(headers={"x-ratelimit-reset-requests-1h": "60"})
+
+    # Should now have a rate limit
+    remaining = lib.get_rate_limit_remaining()
+    assert remaining is not None
+    assert 50 < remaining < 70  # Should be around 60 seconds
+
+    # State file should exist
+    state_file = hermes_home / "rate_limits" / "nous.json"
+    assert state_file.exists()
+
+    # State should contain reset_at
+    with open(state_file) as f:
+        state = json.load(f)
+    assert "reset_at" in state
+    assert "recorded_at" in state
+    assert "reset_seconds" in state
+
+
+def test_clear_rate_limit(hermes_home):
+    """Test clearing rate limit state."""
+    lib = _load_lib()
+
+    # Record a rate limit
+    lib.record_rate_limit(headers={"x-ratelimit-reset-requests-1h": "60"})
+    assert lib.get_rate_limit_remaining() is not None
+
+    # Clear it
+    lib.clear_rate_limit()
+
+    # Should be gone
+    assert lib.get_rate_limit_remaining() is None
+
+    # State file should be deleted
+    state_file = hermes_home / "rate_limits" / "nous.json"
+    assert not state_file.exists()
+
+
+def test_rate_limit_expiration(hermes_home):
+    """Test that expired rate limits are automatically cleaned up."""
+    lib = _load_lib()
+
+    # Record a rate limit with a very short reset time
+    lib.record_rate_limit(headers={"x-ratelimit-reset-requests-1h": "0.1"})
+
+    # Should have a rate limit initially
+    assert lib.get_rate_limit_remaining() is not None
+
+    # Wait for it to expire
+    import time
+    time.sleep(0.2)
+
+    # Should now be None (expired and cleaned up)
+    assert lib.get_rate_limit_remaining() is None
+
+
+def test_header_parsing_priority():
+    """Test that headers are parsed in the correct priority order."""
+    lib = _load_lib()
+
+    # Test x-ratelimit-reset-requests-1h (highest priority)
+    lib.record_rate_limit(headers={"x-ratelimit-reset-requests-1h": "120"})
+    remaining = lib.get_rate_limit_remaining()
+    assert remaining is not None
+    assert 110 < remaining < 130
+
+    lib.clear_rate_limit()
+
+    # Test x-ratelimit-reset-requests (second priority)
+    lib.record_rate_limit(headers={"x-ratelimit-reset-requests": "60"})
+    remaining = lib.get_rate_limit_remaining()
+    assert remaining is not None
+    assert 50 < remaining < 70
+
+    lib.clear_rate_limit()
+
+    # Test retry-after (third priority)
+    lib.record_rate_limit(headers={"retry-after": "30"})
+    remaining = lib.get_rate_limit_remaining()
+    assert remaining is not None
+    assert 20 < remaining < 40
+
+    lib.clear_rate_limit()
+
+    # Test default cooldown (no headers)
+    lib.record_rate_limit()
+    remaining = lib.get_rate_limit_remaining()
+    assert remaining is not None
+    assert 290 < remaining < 310  # Default is 300 seconds
+
+
+def test_invalid_header_values():
+    """Test that invalid header values are handled gracefully."""
+    lib = _load_lib()
+
+    # Invalid numeric value
+    lib.record_rate_limit(headers={"x-ratelimit-reset-requests-1h": "invalid"})
+    remaining = lib.get_rate_limit_remaining()
+    assert remaining is not None
+    # Should fall back to default cooldown
+    assert 290 < remaining < 310
+
+    lib.clear_rate_limit()
+
+    # Negative value
+    lib.record_rate_limit(headers={"x-ratelimit-reset-requests-1h": "-10"})
+    remaining = lib.get_rate_limit_remaining()
+    assert remaining is not None
+    # Should fall back to default cooldown
+    assert 290 < remaining < 310
+
+
+def test_ratelimit_status_command(hermes_home):
+    """Test /ratelimit status slash command."""
+    commands = _load_commands()
+
+    # Initially no rate limit
+    result = commands.ratelimit_status()
+    assert "No active rate limit" in result
+
+    # Record a rate limit
+    lib = _load_lib()
+    lib.record_rate_limit(headers={"x-ratelimit-reset-requests-1h": "60"})
+
+    # Should now show active rate limit
+    result = commands.ratelimit_status()
+    assert "Rate limit active" in result
+    assert "Resets in" in result
+
+
+def test_ratelimit_clear_command(hermes_home):
+    """Test /ratelimit clear slash command."""
+    commands = _load_commands()
+    lib = _load_lib()
+
+    # Record a rate limit
+    lib.record_rate_limit(headers={"x-ratelimit-reset-requests-1h": "60"})
+    assert lib.get_rate_limit_remaining() is not None
+
+    # Clear it via command
+    result = commands.ratelimit_clear()
+    assert "Rate limit state cleared" in result
+
+    # Should be gone
+    assert lib.get_rate_limit_remaining() is None
+
+
+def test_check_rate_limit_hook(hermes_home):
+    """Test the pre_llm_call hook function."""
+    lib = _load_lib()
+
+    # Initially should not skip
+    result = lib.check_rate_limit()
+    assert result is None
+
+    # Record a rate limit
+    lib.record_rate_limit(headers={"x-ratelimit-reset-requests-1h": "60"})
+
+    # Should now skip
+    result = lib.check_rate_limit()
+    assert result is not None
+    assert result["skip"] is True
+    assert result["reason"] == "rate_limited"
+    assert "remaining_seconds" in result
+
+
+def test_record_rate_limit_hook():
+    """Test the post_llm_call hook function."""
+    lib = _load_lib()
+
+    # Call hook with error context
+    lib.record_rate_limit_hook(
+        error_context={"reset_at": 9999999999},
+        headers=None,
+    )
+
+    # Should have recorded the rate limit
+    remaining = lib.get_rate_limit_remaining()
+    assert remaining is not None
+    assert remaining > 0

--- a/website/docs/user-guide/features/built-in-plugins.md
+++ b/website/docs/user-guide/features/built-in-plugins.md
@@ -99,6 +99,49 @@ Auto-tracks and removes ephemeral files created during sessions — test scripts
 
 **Disabling again:** `hermes plugins disable disk-cleanup`.
 
+### rate-limiter
+
+Cross-session rate limit guard for side clients (Nous Portal, etc.) that prevents retry amplification when rate limits are hit.
+
+**Problem:** Each 429 (rate limit) error triggers up to 9 API calls per conversation turn (3 SDK retries × 3 Hermes retries). Every call counts against RPH, so this amplification can quickly exhaust rate limits.
+
+**How it works:**
+
+| Hook | Behaviour |
+|---|---|
+| `pre_llm_call` | Check if provider is currently rate-limited. If so, skip the request and return early. |
+| `post_llm_call` | If a 429 error is received, parse reset time from headers/error context and record to shared state file. |
+
+**Reset time parsing** (priority order):
+
+1. `x-ratelimit-reset-requests-1h` - hourly RPH window (most useful)
+2. `x-ratelimit-reset-requests` - per-minute RPM window
+3. `retry-after` - generic HTTP header
+4. Default cooldown: 5 minutes (300 seconds)
+
+**Slash commands** — `/ratelimit` available in both CLI and gateway sessions:
+
+```
+/ratelimit status    # Show current rate limit status
+/ratelimit clear     # Clear rate limit state manually
+/ratelimit enable    # Enable the rate limiter
+/ratelimit disable   # Disable the rate limiter
+/ratelimit set <s>   # Set default cooldown time (seconds)
+```
+
+**State** — everything lives at `$HERMES_HOME/rate_limits/`:
+
+| File | Contents |
+|---|---|
+| `nous.json` | Rate limit state with reset_at, recorded_at, and reset_seconds |
+| `config.json` | Rate limiter config with enabled status and default_cooldown |
+
+**Safety** — atomic writes (temp file + rename) for safe concurrent access. Expired entries are automatically cleaned up on read. State file is scoped to `$HERMES_HOME/rate_limits/`.
+
+**Enabling:** `hermes plugins enable rate-limiter` (or check the box in `hermes plugins`).
+
+**Disabling again:** `hermes plugins disable rate-limiter`.
+
 ## Adding a bundled plugin
 
 Bundled plugins are written exactly like any other Hermes plugin — see [Build a Hermes Plugin](/docs/guides/build-a-hermes-plugin). The only differences are:


### PR DESCRIPTION
Implements proactive rate limiting that tracks request counts per minute and blocks requests BEFORE they hit the API, preventing 429 errors and retry amplification. Provides runtime controls via slash commands to enable/disable the rate limiter and configure rate limits per provider.

## Core Features

- **Proactive Rate Limiting**: Tracks request counts per minute using sliding window and blocks requests BEFORE API calls
- **Cross-Session Tracking**: Shared state file at `$HERMES_HOME/rate_limits/` accessible by all Hermes sessions
- **Retry Amplification Prevention**: Prevents up to 9 redundant API calls per 429 error (3 SDK retries × 3 Hermes retries)
- **Provider-Specific Limits**: Configure different RPM limits per provider (nvidia, openrouter, nous, etc.)
- **Automatic Wait & Retry**: When rate limit is reached, automatically waits and retries without user intervention
- **Plugin Hooks**: `pre_llm_call` (inject context when rate-limited), `post_llm_call` (record 429 errors)
- **Runtime Controls**: `/ratelimit` slash commands for status, clear, enable, disable, and set cooldown
- **Config Persistence**: Enable/disable status, default cooldown, and per-provider limits stored in config file
- **Thread-Safe**: Atomic writes using temp file + rename pattern for concurrent access

## Configuration

- Plugin is opt-in like other bundled plugins (disk-cleanup)
- Config file at `$HERMES_HOME/rate_limits/config.json` stores:
  - `enabled`: Boolean - whether rate limiter is active (default: true)
  - `default_cooldown`: Float - default cooldown in seconds when 429 is hit (default: 300)
  - `limits`: Object - per-provider rate limits
    - `default.requests_per_minute`: Default RPM for all providers
    - `{provider}.requests_per_minute`: Provider-specific RPM (e.g., `nvidia.requests_per_minute: 2`)
- State file at `$HERMES_HOME/rate_limits/nous.json` stores rate limit state from 429 errors
- Tracker file at `$HERMES_HOME/rate_limits/tracker_{provider}.json` stores request timestamps for proactive limiting
- State persists across sessions until manually cleared or expires

## Integration

- `run_agent.py`: Modified to call `check_rate_limit_before_call()` before making API requests
- `plugins/rate-limiter/plugin.yaml`: Plugin manifest with hooks and commands (v2.0.0)
- `plugins/rate-limiter/rate_limiter.py`: Core rate limiting logic with proactive blocking
- `plugins/rate-limiter/commands.py`: Slash command handlers (status, clear, enable, disable, set)
- `plugins/rate-limiter/README.md`: Plugin usage documentation

## What does this PR do?

This PR adds proactive rate limiting that prevents 429 errors by tracking request counts per minute and blocking requests BEFORE they hit the API. When a configured RPM limit is reached, the plugin automatically waits and retries, eliminating retry amplification where each 429 error triggers up to 9 additional API calls.

**Problem Solved**: Side clients (CLI, gateway, cron jobs) hit rate limits and retry aggressively, causing up to 9x API call amplification. This wastes quota and can lead to further rate limit violations. The previous implementation only recorded 429 errors after they occurred, but couldn't prevent them.

**Why This Approach**:
- Proactive blocking prevents 429 errors before they happen
- Sliding window tracking ensures accurate per-minute rate limiting
- Cross-session tracking ensures all Hermes processes respect rate limits
- Plugin-based approach keeps core code clean and modular
- Opt-in design follows existing bundled plugin patterns
- Thread-safe implementation supports concurrent access
- Runtime controls allow users to enable/disable and configure without editing config.yaml
- Config persistence ensures settings survive across sessions

## Key Changes from Original Implementation

1. **Proactive vs Reactive**: Original implementation only recorded 429 errors after they occurred. New implementation tracks request counts and blocks BEFORE hitting the API.
2. **Sliding Window**: Uses 1-minute sliding window instead of fixed minute boundaries for accurate rate limiting.
3. **Automatic Wait & Retry**: When rate limit is reached, automatically waits and retries instead of just injecting context.
4. **Provider-Specific Limits**: Supports different RPM limits per provider (nvidia, openrouter, nous, etc.).
5. **Modified run_agent.py**: Added rate limit check in the retry loop before making API calls.

## Related Issue

Prevents retry amplification for side clients when rate limits are hit.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `run_agent.py` (modified): Added `check_rate_limit_before_call()` call in retry loop before API requests
- `plugins/rate-limiter/rate_limiter.py` (modified): Added `check_rate_limit_before_call()` function for proactive blocking
- `plugins/rate-limiter/plugin.yaml` (modified): Updated to v2.0.0 with new description
- `plugins/rate-limiter/README.md` (modified): Updated with proactive rate limiting behavior
- `plugins/rate-limiter/__init__.py` (existing): Plugin registration with register() function and session hooks
- `plugins/rate-limiter/commands.py` (existing): Slash commands for /ratelimit (status, clear, enable, disable, set)

## How to Test

1. **Enable Plugin**:
   ```bash
   hermes plugins enable rate-limiter
   ```

2. **Configure Rate Limit**:
   ```bash
   # Set rate limit for nvidia provider to 2 requests per minute
   /ratelimit set nvidia 2
   ```

3. **Test Proactive Rate Limiting**:
   ```bash
   # Send first request - should succeed
   hermes chat -q "What is 1+1?"

   # Send second request immediately - should succeed
   hermes chat -q "What is 2+2?"

   # Send third request immediately - should wait and retry
   hermes chat -q "What is 3+3?"
   # Expected: Shows "rate limit active - resets in Xs. Waiting..."
   ```

4. **Test Cross-Session Tracking**:
   ```bash
   # Session 1: Check rate limit status
   /ratelimit status

   # Session 2: Check that state persists
   /ratelimit status
   # Expected: Same rate limit information visible
   ```

5. **Test Clear Command**:
   ```bash
   /ratelimit clear
   /ratelimit status
   # Expected: No rate limit information
   ```

6. **Test Enable/Disable**:
   ```bash
   /ratelimit disable
   /ratelimit status
   # Expected: Shows "✗ DISABLED"

   /ratelimit enable
   /ratelimit status
   # Expected: Shows "✓ ENABLED"
   ```

7. **Test Set Cooldown**:
   ```bash
   /ratelimit set 600
   /ratelimit status
   # Expected: Shows "Default cooldown: 10m"
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2 on Windows 10

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A - This is a built-in plugin, not a skill.

## Screenshots / Logs

### Example Output

```
# Request 1 - succeeds
[00:00] User: What is 1+1?
[00:15] Assistant: 2

# Request 2 - succeeds
[00:30] User: What is 2+2?
[00:40] Assistant: 4

# Request 3 - rate limit reached, waits and retries
[00:45] User: What is 3+3?
[00:45] ⏳ nvidia rate limit active — resets in 15s. Waiting...
[01:00] Assistant: 6
```

### Rate Limit Status

```
/ratelimit status
Rate limiter: ✓ ENABLED
Default cooldown: 5m
✓ No active rate limit. Requests will proceed normally.
```

### Rate Limit Active

```
/ratelimit status
Rate limiter: ✓ ENABLED
Default cooldown: 5m
⚠ Rate limit active. Resets in 2m 30s.
```
