### PR TITLE
fix(disk-cleanup): preserve git internals during empty-dir cleanup

### DIFF
--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -10,7 +10,7 @@ Rules:
   - test files    → delete immediately at task end (age >= 0)
   - temp files    → delete after 7 days
   - cron-output   → delete after 14 days
-  - empty dirs    → always delete (under HERMES_HOME)
+  - empty dirs    → delete when safe under HERMES_HOME (excluding checkpoint state)
   - research      → keep 10 newest, prompt for older (deep only)
   - chrome-profile→ prompt after 14 days (deep only)
   - >500 MB files → prompt always (deep only)
@@ -160,6 +160,26 @@ _EMPTY_DIR_SWEEP_PRUNE_DIRS = frozenset({
 # regardless of what the stored category says.  This is a defense-in-depth
 # guard against stale tracked.json entries from before #34840.
 _PROTECTED_CRON_PATHS: set[str] = set()
+
+
+def _is_checkpoint_state_dir(path: Path, hermes_home: Path) -> bool:
+    """Protect the current store and recognized archived legacy repos."""
+    try:
+        rel_parts = path.relative_to(hermes_home).parts
+    except ValueError:
+        return False
+    if len(rel_parts) == 2:
+        return rel_parts == ("checkpoints", "store")
+    if (
+        len(rel_parts) == 3
+        and rel_parts[0] == "checkpoints"
+        and rel_parts[1].startswith("legacy-")
+    ):
+        return any(
+            (path / marker).exists()
+            for marker in ("HEAD", "config", "HERMES_WORKDIR")
+        )
+    return False
 
 
 def _is_protected_cron_path(p: Path) -> bool:
@@ -402,6 +422,7 @@ def quick() -> Dict[str, Any]:
                     child.is_dir()
                     and not child.is_symlink()
                     and child.name not in _EMPTY_DIR_SWEEP_PRUNE_DIRS
+                    and not _is_checkpoint_state_dir(child, hermes_home)
                 ):
                     sweep_stack.append((child, False))
         except OSError:

--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -10,7 +10,7 @@ Rules:
   - test files    → delete immediately at task end (age >= 0)
   - temp files    → delete after 7 days
   - cron-output   → delete after 14 days
-  - empty dirs    → always delete (under HERMES_HOME)
+  - empty dirs    → delete when safe under HERMES_HOME (excluding checkpoint shadow-repo dirs and git internals)
   - research      → keep 10 newest, prompt for older (deep only)
   - chrome-profile→ prompt after 14 days (deep only)
   - >500 MB files → prompt always (deep only)
@@ -143,6 +143,29 @@ ALLOWED_CATEGORIES = {
     "temp", "test", "research", "download",
     "chrome-profile", "cron-output", "other",
 }
+
+
+def _is_protected_empty_dir(dirpath: Path, hermes_home: Path) -> bool:
+    """Return True when an empty-dir cleanup candidate must be preserved.
+
+    This protects git internals for both Hermes checkpoint shadow repos
+    (stored under ``checkpoints/<id>/...``) and ordinary repos living under
+    ``HERMES_HOME`` (stored under ``.git/...``).
+    """
+    try:
+        rel_parts = dirpath.relative_to(hermes_home).parts
+    except ValueError:
+        return False
+
+    if ".git" in rel_parts and rel_parts[-1] != ".git":
+        return True
+
+    if len(rel_parts) >= 2 and rel_parts[0] == "checkpoints":
+        repo_root = hermes_home / rel_parts[0] / rel_parts[1]
+        if any((repo_root / marker).exists() for marker in ("HEAD", "HERMES_WORKDIR", "config")):
+            return True
+
+    return False
 
 
 def fmt_size(n: float) -> str:
@@ -308,6 +331,8 @@ def quick() -> Dict[str, Any]:
             try:
                 rel_parts = dirpath.relative_to(hermes_home).parts
             except ValueError:
+                continue
+            if _is_protected_empty_dir(dirpath, hermes_home):
                 continue
             # Skip the well-known top-level state dirs themselves.
             if len(rel_parts) == 1 and rel_parts[0] in _PROTECTED_TOP_LEVEL:

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -382,6 +382,46 @@ class TestTrackForgetQuick:
         for d in ("logs", "memories", "sessions", "cron", "cache"):
             assert (_isolate_env / d).exists(), f"{d}/ should be preserved"
 
+    def test_quick_preserves_checkpoint_store_tree(self, _isolate_env):
+        dg = _load_lib()
+        checkpoint_heads = _isolate_env / "checkpoints" / "store" / "refs" / "hermes"
+        checkpoint_info = _isolate_env / "checkpoints" / "store" / "objects" / "info"
+        plain_empty = _isolate_env / "checkpoints" / "scratch" / "empty-dir"
+
+        for p in (checkpoint_heads, checkpoint_info):
+            p.mkdir(parents=True, exist_ok=True)
+        plain_empty.mkdir(parents=True)
+
+        dg.quick()
+
+        assert checkpoint_heads.exists()
+        assert checkpoint_info.exists()
+        assert not plain_empty.exists()
+
+    def test_quick_preserves_legacy_checkpoint_tree(self, _isolate_env):
+        dg = _load_lib()
+        legacy_repo = _isolate_env / "checkpoints" / "legacy-20260712" / "repo"
+        legacy_heads = legacy_repo / "refs" / "heads"
+        legacy_info = legacy_repo / "objects" / "info"
+        plain_empty = (
+            _isolate_env
+            / "checkpoints"
+            / "legacy-20260712"
+            / "ordinary"
+            / "empty-dir"
+        )
+
+        for p in (legacy_heads, legacy_info):
+            p.mkdir(parents=True, exist_ok=True)
+        (legacy_repo / "HEAD").write_text("ref: refs/heads/main\n")
+        plain_empty.mkdir(parents=True)
+
+        dg.quick()
+
+        assert legacy_heads.exists()
+        assert legacy_info.exists()
+        assert not plain_empty.exists()
+
     def test_quick_does_not_descend_into_protected_top_level_dirs(
         self, _isolate_env, monkeypatch
     ):

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -195,6 +195,28 @@ class TestTrackForgetQuick:
         for d in ("logs", "memories", "sessions", "cron", "cache"):
             assert (_isolate_env / d).exists(), f"{d}/ should be preserved"
 
+    def test_quick_preserves_git_internal_dirs_and_removes_normal_empty_dirs(self, _isolate_env):
+        dg = _load_lib()
+        checkpoint_heads = _isolate_env / "checkpoints" / "demo" / "refs" / "heads"
+        checkpoint_info = _isolate_env / "checkpoints" / "demo" / "objects" / "info"
+        repo_heads = _isolate_env / "scratch" / "repo" / ".git" / "refs" / "heads"
+        repo_info = _isolate_env / "scratch" / "repo" / ".git" / "objects" / "info"
+        plain_empty = _isolate_env / "scratch" / "empty-dir"
+
+        for p in (checkpoint_heads, checkpoint_info, repo_heads, repo_info):
+            p.mkdir(parents=True, exist_ok=True)
+        (_isolate_env / "checkpoints" / "demo" / "HERMES_WORKDIR").write_text("/tmp/demo\n")
+        plain_empty.mkdir(parents=True)
+
+        summary = dg.quick()
+
+        assert checkpoint_heads.exists()
+        assert checkpoint_info.exists()
+        assert repo_heads.exists()
+        assert repo_info.exists()
+        assert not plain_empty.exists()
+        assert summary["empty_dirs"] == 1
+
 
 class TestStatus:
     def test_empty_status(self, _isolate_env):


### PR DESCRIPTION
## Summary
- preserve checkpoint shadow-repo directories during empty-dir cleanup
- preserve ordinary `.git` internals during empty-dir cleanup under `HERMES_HOME`
- add a focused regression test covering both protected cases and a normal empty-dir control

## Root cause
`disk_cleanup.quick()` recursively removed empty directories under `HERMES_HOME` without exempting git internals. That allowed cleanup to delete directories like `refs/heads` and `objects/info` inside Hermes checkpoint shadow repos and ordinary `.git` trees.

## Test plan
- `python -m pytest tests/plugins/test_disk_cleanup_plugin.py -q -o 'addopts='`

## Notes
- This intentionally fixes the cleanup corruption bug only.
- It does not change checkpoint retention, target selection, or stale `index.lock` recovery.
