### PR TITLE
fix(gateway): preserve legacy /voice off suppression across #12542 migration

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -808,15 +808,28 @@ class GatewayRunner:
             if mode not in valid_modes:
                 continue
             key = str(chat_id)
-            # Skip legacy unprefixed keys (warn and skip)
-            if ":" not in key:
-                logger.warning(
-                    "Skipping legacy unprefixed voice mode key %r during migration. "
-                    "Re-enable voice mode on that chat to rebuild the prefixed key.",
+            if ":" in key:
+                result[key] = mode
+                continue
+            # Legacy pre-#12542 key. Keep "off" so auto-TTS suppression
+            # survives the migration (#14025); drop voice_only/all to
+            # avoid firing TTS on a platform the user never configured.
+            if mode == "off":
+                logger.info(
+                    "Preserving legacy unprefixed voice mode key %r (mode=off) "
+                    "for cross-adapter auto-TTS suppression. Run any /voice "
+                    "command on the affected chat to write a prefixed entry "
+                    "that supersedes this fallback on that platform.",
                     key,
                 )
-                continue
-            result[key] = mode
+                result[key] = mode
+            else:
+                logger.warning(
+                    "Skipping legacy unprefixed voice mode key %r (mode=%s) "
+                    "during migration. Re-enable voice mode on that chat to "
+                    "rebuild the prefixed key.",
+                    key, mode,
+                )
         return result
 
     def _save_voice_modes(self) -> None:
@@ -839,7 +852,12 @@ class GatewayRunner:
             disabled_chats.discard(chat_id)
 
     def _sync_voice_mode_state_to_adapter(self, adapter) -> None:
-        """Restore persisted /voice off state into a live platform adapter."""
+        """Restore persisted /voice off state into a live platform adapter.
+
+        Explicit platform-prefixed entries win; legacy pre-#12542 unprefixed
+        "off" rows act as a cross-platform fallback for chats that have no
+        prefixed entry yet (#14025).
+        """
         disabled_chats = getattr(adapter, "_auto_tts_disabled_chats", None)
         if not isinstance(disabled_chats, set):
             return
@@ -848,10 +866,18 @@ class GatewayRunner:
             return
         disabled_chats.clear()
         prefix = f"{platform.value}:"
-        disabled_chats.update(
-            key[len(prefix):] for key, mode in self._voice_mode.items()
-            if mode == "off" and key.startswith(prefix)
-        )
+
+        explicit_ids: set = set()
+        for key, mode in self._voice_mode.items():
+            if key.startswith(prefix):
+                chat_id = key[len(prefix):]
+                explicit_ids.add(chat_id)
+                if mode == "off":
+                    disabled_chats.add(chat_id)
+
+        for key, mode in self._voice_mode.items():
+            if mode == "off" and ":" not in key and key not in explicit_ids:
+                disabled_chats.add(key)
 
     async def _safe_adapter_disconnect(self, adapter, platform) -> None:
         """Call adapter.disconnect() defensively, swallowing any error.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3274,15 +3274,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if mode not in valid_modes:
                 continue
             key = str(chat_id)
-            # Skip legacy unprefixed keys (warn and skip)
-            if ":" not in key:
-                logger.warning(
-                    "Skipping legacy unprefixed voice mode key %r during migration. "
-                    "Re-enable voice mode on that chat to rebuild the prefixed key.",
+            if ":" in key:
+                result[key] = mode
+                continue
+            # Legacy pre-#12542 key. Keep "off" so auto-TTS suppression
+            # survives the migration (#14025); drop voice_only/all to
+            # avoid firing TTS on a platform the user never configured.
+            if mode == "off":
+                logger.info(
+                    "Preserving legacy unprefixed voice mode key %r (mode=off) "
+                    "for cross-adapter auto-TTS suppression. Run any /voice "
+                    "command on the affected chat to write a prefixed entry "
+                    "that supersedes this fallback on that platform.",
                     key,
                 )
-                continue
-            result[key] = mode
+                result[key] = mode
+            else:
+                logger.warning(
+                    "Skipping legacy unprefixed voice mode key %r (mode=%s) "
+                    "during migration. Re-enable voice mode on that chat to "
+                    "rebuild the prefixed key.",
+                    key, mode,
+                )
         return result
 
     def _save_voice_modes(self) -> None:
@@ -3333,6 +3346,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
           - ``_auto_tts_default``: global default from ``voice.auto_tts``
           - ``_auto_tts_enabled_chats``: chats with mode ``voice_only``/``all``
           - ``_auto_tts_disabled_chats``: chats with mode ``off``
+
+        Explicit platform-prefixed entries win. Legacy pre-#12542 unprefixed
+        ``off`` rows are a cross-platform fallback only for chats without an
+        explicit entry on the adapter's platform (#14025).
         """
         platform = getattr(adapter, "platform", None)
         if not isinstance(platform, Platform):
@@ -3357,16 +3374,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             adapter._auto_tts_default = _auto_tts_default
 
         prefix = f"{platform.value}:"
+        explicit_ids = {
+            key[len(prefix):]
+            for key in self._voice_mode
+            if key.startswith(prefix)
+        }
         if isinstance(disabled_chats, set):
             disabled_chats.clear()
             disabled_chats.update(
-                key[len(prefix):] for key, mode in self._voice_mode.items()
+                key[len(prefix):]
+                for key, mode in self._voice_mode.items()
                 if mode == "off" and key.startswith(prefix)
+            )
+            disabled_chats.update(
+                key
+                for key, mode in self._voice_mode.items()
+                if mode == "off" and ":" not in key and key not in explicit_ids
             )
         if isinstance(enabled_chats, set):
             enabled_chats.clear()
             enabled_chats.update(
-                key[len(prefix):] for key, mode in self._voice_mode.items()
+                key[len(prefix):]
+                for key, mode in self._voice_mode.items()
                 if mode in {"voice_only", "all"} and key.startswith(prefix)
             )
 

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -194,6 +194,35 @@ class TestHandleVoiceCommand:
         assert adapter._auto_tts_disabled_chats == {"123"}
 
     @pytest.mark.asyncio
+    async def test_voice_on_after_legacy_off_overrides_fallback_after_restart(self, tmp_path):
+        """Full lifecycle: a pre-#12542 legacy {chat_id: 'off'} row is
+        preserved across save/reload, but an explicit /voice on writes a
+        prefixed entry that overrides the legacy fallback on subsequent
+        restarts — no split-brain where /voice status reports 'on' while
+        auto-TTS stays suppressed (#14025)."""
+        from gateway.config import Platform
+
+        runner = _make_runner(tmp_path)
+        runner._VOICE_MODE_PATH.write_text(json.dumps({"123": "off"}))
+        runner._voice_mode = runner._load_voice_modes()
+        assert runner._voice_mode == {"123": "off"}
+
+        event = _make_event("/voice on", chat_id="123")
+        await runner._handle_voice_command(event)
+
+        restored_runner = _make_runner(tmp_path)
+        restored_runner._voice_mode = restored_runner._load_voice_modes()
+        adapter = SimpleNamespace(
+            _auto_tts_disabled_chats=set(),
+            platform=Platform.TELEGRAM,
+        )
+        restored_runner._sync_voice_mode_state_to_adapter(adapter)
+
+        assert restored_runner._voice_mode["123"] == "off"
+        assert restored_runner._voice_mode["telegram:123"] == "voice_only"
+        assert "123" not in adapter._auto_tts_disabled_chats
+
+    @pytest.mark.asyncio
     async def test_per_chat_isolation(self, runner):
         e1 = _make_event("/voice on", chat_id="aaa")
         e2 = _make_event("/voice tts", chat_id="bbb")

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -241,6 +241,46 @@ class TestHandleVoiceCommand:
         assert adapter._auto_tts_disabled_chats == {"123"}
 
     @pytest.mark.asyncio
+    async def test_voice_on_after_legacy_off_overrides_fallback_after_restart(self, tmp_path):
+        """Full lifecycle: a pre-#12542 legacy {chat_id: 'off'} row is
+        preserved across save/reload, but an explicit /voice on writes a
+        prefixed entry that overrides the legacy fallback on subsequent
+        restarts — no split-brain where /voice status reports 'on' while
+        auto-TTS stays suppressed (#14025)."""
+        from gateway.config import Platform
+
+        runner = _make_runner(tmp_path)
+        runner._VOICE_MODE_PATH.write_text(json.dumps({"123": "off"}))
+        runner._voice_mode = runner._load_voice_modes()
+        assert runner._voice_mode == {"123": "off"}
+
+        event = _make_event("/voice on", chat_id="123")
+        await runner._handle_voice_command(event)
+
+        restored_runner = _make_runner(tmp_path)
+        restored_runner._voice_mode = restored_runner._load_voice_modes()
+        adapter = SimpleNamespace(
+            _auto_tts_default=False,
+            _auto_tts_enabled_chats=set(),
+            _auto_tts_disabled_chats=set(),
+            platform=Platform.TELEGRAM,
+        )
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"voice": {"auto_tts": True}},
+        ):
+            restored_runner._sync_voice_mode_state_to_adapter(adapter)
+
+        from gateway.platforms.base import BasePlatformAdapter
+
+        assert restored_runner._voice_mode["123"] == "off"
+        assert restored_runner._voice_mode["telegram:123"] == "voice_only"
+        assert adapter._auto_tts_default is True
+        assert adapter._auto_tts_enabled_chats == {"123"}
+        assert adapter._auto_tts_disabled_chats == set()
+        assert BasePlatformAdapter._should_auto_tts_for_chat(adapter, "123") is True
+
+    @pytest.mark.asyncio
     async def test_per_chat_isolation(self, runner):
         e1 = _make_event("/voice on", chat_id="aaa")
         e2 = _make_event("/voice tts", chat_id="bbb")

--- a/tests/gateway/test_voice_mode_platform_isolation.py
+++ b/tests/gateway/test_voice_mode_platform_isolation.py
@@ -9,10 +9,12 @@ same key. The fix prefixes keys with platform value: 'telegram:123' vs
 import json
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 
 from gateway.config import Platform
+from gateway.platforms.base import BasePlatformAdapter
 from gateway.run import GatewayRunner
 
 
@@ -64,15 +66,18 @@ class TestVoiceModePlatformIsolation:
 class TestLegacyKeyMigration:
     """Test migration of legacy unprefixed keys in _load_voice_modes."""
 
-    def test_load_voice_modes_skips_legacy_keys(self):
-        """_load_voice_modes skips keys without ':' prefix and logs a warning."""
+    def test_load_voice_modes_skips_legacy_nonoff_keys(self):
+        """Legacy unprefixed non-'off' keys are dropped with a warning.
+
+        Only 'off' legacy rows are preserved (see #14025); 'all' and
+        'voice_only' legacy rows would broadcast TTS to the wrong
+        platform if migrated without knowing the owner.
+        """
         runner = _make_runner()
 
-        # Simulate legacy persisted data with unprefixed keys
         legacy_data = {
             "123": "all",
             "456": "voice_only",
-            # Also includes a properly prefixed key (from after the fix)
             "telegram:789": "off",
         }
 
@@ -84,15 +89,36 @@ class TestLegacyKeyMigration:
                 with patch("gateway.run.logger") as mock_logger:
                     result = runner._load_voice_modes()
 
-            # Legacy keys without ':' should be skipped
             assert "123" not in result
             assert "456" not in result
-            # Prefixed key should be preserved
             assert result.get("telegram:789") == "off"
-            # Warning should be logged for each legacy key
             assert mock_logger.warning.called
             warning_calls = [str(call) for call in mock_logger.warning.call_args_list]
             assert any("Skipping legacy unprefixed voice mode key" in str(c) for c in warning_calls)
+
+    def test_load_voice_modes_preserves_legacy_off_keys(self):
+        """Legacy unprefixed keys with mode='off' are preserved so the
+        auto-TTS suppression survives the #12542 migration (#14025)."""
+        runner = _make_runner()
+
+        legacy_data = {
+            "123": "off",
+            "456": "all",
+            "789": "voice_only",
+            "telegram:999": "off",
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            voice_path = Path(tmpdir) / "gateway_voice_mode.json"
+            voice_path.write_text(json.dumps(legacy_data))
+
+            with patch.object(runner, "_VOICE_MODE_PATH", voice_path):
+                result = runner._load_voice_modes()
+
+        assert result.get("123") == "off"
+        assert "456" not in result
+        assert "789" not in result
+        assert result.get("telegram:999") == "off"
 
     def test_load_voice_modes_preserves_prefixed_keys(self):
         """_load_voice_modes correctly loads platform-prefixed keys."""
@@ -203,9 +229,96 @@ class TestSyncVoiceModeStateToAdapter:
         # Should not raise
         runner._sync_voice_mode_state_to_adapter(mock_adapter)
 
+    def test_sync_legacy_off_applies_to_all_adapters(self):
+        """Legacy unprefixed 'off' rows suppress auto-TTS on every adapter
+        that has no explicit prefixed entry for the same chat id (#14025)."""
+        runner = _make_runner()
+        runner._voice_mode = {
+            "123": "off",
+            "telegram:456": "off",
+            "slack:789": "off",
+        }
+
+        telegram_adapter = _make_adapter(Platform.TELEGRAM)
+        slack_adapter = _make_adapter(Platform.SLACK)
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"voice": {"auto_tts": True}},
+        ):
+            runner._sync_voice_mode_state_to_adapter(telegram_adapter)
+            runner._sync_voice_mode_state_to_adapter(slack_adapter)
+
+        assert telegram_adapter._auto_tts_disabled_chats == {"123", "456"}
+        assert _should_auto_tts(telegram_adapter, "123") is False
+        assert _should_auto_tts(telegram_adapter, "456") is False
+        assert slack_adapter._auto_tts_disabled_chats == {"123", "789"}
+        assert _should_auto_tts(slack_adapter, "123") is False
+        assert _should_auto_tts(slack_adapter, "789") is False
+
+    def test_explicit_prefixed_enables_override_legacy_off_after_restart(self):
+        """Explicit voice_only/all rows beat legacy off on their platform."""
+        runner = _make_runner()
+        persisted_data = {
+            "123": "off",
+            "456": "off",
+            "telegram:123": "voice_only",
+            "telegram:456": "all",
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            voice_path = Path(tmpdir) / "gateway_voice_mode.json"
+            voice_path.write_text(json.dumps(persisted_data))
+            with patch.object(runner, "_VOICE_MODE_PATH", voice_path):
+                runner._voice_mode = runner._load_voice_modes()
+
+        telegram_adapter = _make_adapter(Platform.TELEGRAM)
+        slack_adapter = _make_adapter(Platform.SLACK)
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"voice": {"auto_tts": True}},
+        ):
+            runner._sync_voice_mode_state_to_adapter(telegram_adapter)
+            runner._sync_voice_mode_state_to_adapter(slack_adapter)
+
+        assert telegram_adapter._auto_tts_default is True
+        assert telegram_adapter._auto_tts_enabled_chats == {"123", "456"}
+        assert telegram_adapter._auto_tts_disabled_chats == set()
+        assert _should_auto_tts(telegram_adapter, "123") is True
+        assert _should_auto_tts(telegram_adapter, "456") is True
+
+        # The same legacy IDs remain safe fallbacks on a platform without
+        # explicit state, proving platform collisions do not erase suppression.
+        assert slack_adapter._auto_tts_enabled_chats == set()
+        assert slack_adapter._auto_tts_disabled_chats == {"123", "456"}
+        assert _should_auto_tts(slack_adapter, "123") is False
+        assert _should_auto_tts(slack_adapter, "456") is False
+
+    def test_legacy_off_suppresses_enabled_default_after_restart(self):
+        """Legacy off overrides voice.auto_tts=true after an upgrade restart."""
+        runner = _make_runner()
+        legacy_data = {"987654321": "off"}
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            voice_path = Path(tmpdir) / "gateway_voice_mode.json"
+            voice_path.write_text(json.dumps(legacy_data))
+            with patch.object(runner, "_VOICE_MODE_PATH", voice_path):
+                runner._voice_mode = runner._load_voice_modes()
+
+        telegram_adapter = _make_adapter(Platform.TELEGRAM)
+        with patch(
+            "hermes_cli.config.load_config",
+            return_value={"voice": {"auto_tts": True}},
+        ):
+            runner._sync_voice_mode_state_to_adapter(telegram_adapter)
+
+        assert telegram_adapter._auto_tts_default is True
+        assert telegram_adapter._auto_tts_enabled_chats == set()
+        assert telegram_adapter._auto_tts_disabled_chats == {"987654321"}
+        assert _should_auto_tts(telegram_adapter, "987654321") is False
+
 
 # ---------------------------------------------------------------------------
-# Helper
+# Helpers
 # ---------------------------------------------------------------------------
 
 def _make_runner() -> GatewayRunner:
@@ -215,3 +328,16 @@ def _make_runner() -> GatewayRunner:
         runner._voice_mode = {}
         runner.adapters = {}
     return runner
+
+
+def _make_adapter(platform: Platform) -> SimpleNamespace:
+    return SimpleNamespace(
+        platform=platform,
+        _auto_tts_default=False,
+        _auto_tts_enabled_chats=set(),
+        _auto_tts_disabled_chats=set(),
+    )
+
+
+def _should_auto_tts(adapter, chat_id: str) -> bool:
+    return BasePlatformAdapter._should_auto_tts_for_chat(adapter, chat_id)

--- a/tests/gateway/test_voice_mode_platform_isolation.py
+++ b/tests/gateway/test_voice_mode_platform_isolation.py
@@ -65,15 +65,18 @@ class TestVoiceModePlatformIsolation:
 class TestLegacyKeyMigration:
     """Test migration of legacy unprefixed keys in _load_voice_modes."""
 
-    def test_load_voice_modes_skips_legacy_keys(self):
-        """_load_voice_modes skips keys without ':' prefix and logs a warning."""
+    def test_load_voice_modes_skips_legacy_nonoff_keys(self):
+        """Legacy unprefixed non-'off' keys are dropped with a warning.
+
+        Only 'off' legacy rows are preserved (see #14025); 'all' and
+        'voice_only' legacy rows would broadcast TTS to the wrong
+        platform if migrated without knowing the owner.
+        """
         runner = _make_runner()
 
-        # Simulate legacy persisted data with unprefixed keys
         legacy_data = {
             "123": "all",
             "456": "voice_only",
-            # Also includes a properly prefixed key (from after the fix)
             "telegram:789": "off",
         }
 
@@ -85,15 +88,36 @@ class TestLegacyKeyMigration:
                 with patch("gateway.run.logger") as mock_logger:
                     result = runner._load_voice_modes()
 
-            # Legacy keys without ':' should be skipped
             assert "123" not in result
             assert "456" not in result
-            # Prefixed key should be preserved
             assert result.get("telegram:789") == "off"
-            # Warning should be logged for each legacy key
             assert mock_logger.warning.called
             warning_calls = [str(call) for call in mock_logger.warning.call_args_list]
             assert any("Skipping legacy unprefixed voice mode key" in str(c) for c in warning_calls)
+
+    def test_load_voice_modes_preserves_legacy_off_keys(self):
+        """Legacy unprefixed keys with mode='off' are preserved so the
+        auto-TTS suppression survives the #12542 migration (#14025)."""
+        runner = _make_runner()
+
+        legacy_data = {
+            "123": "off",
+            "456": "all",
+            "789": "voice_only",
+            "telegram:999": "off",
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            voice_path = Path(tmpdir) / "gateway_voice_mode.json"
+            voice_path.write_text(json.dumps(legacy_data))
+
+            with patch.object(runner, "_VOICE_MODE_PATH", voice_path):
+                result = runner._load_voice_modes()
+
+        assert result.get("123") == "off"
+        assert "456" not in result
+        assert "789" not in result
+        assert result.get("telegram:999") == "off"
 
     def test_load_voice_modes_preserves_prefixed_keys(self):
         """_load_voice_modes correctly loads platform-prefixed keys."""
@@ -204,9 +228,69 @@ class TestSyncVoiceModeStateToAdapter:
         # Should not raise
         runner._sync_voice_mode_state_to_adapter(mock_adapter)
 
+    def test_sync_legacy_off_applies_to_all_adapters(self):
+        """Legacy unprefixed 'off' rows suppress auto-TTS on every adapter
+        that has no explicit prefixed entry for the same chat id (#14025)."""
+        runner = _make_runner()
+        runner._voice_mode = {
+            "123": "off",
+            "telegram:456": "off",
+            "slack:789": "off",
+        }
+
+        telegram_adapter = _make_adapter(Platform.TELEGRAM)
+        runner._sync_voice_mode_state_to_adapter(telegram_adapter)
+        assert telegram_adapter._auto_tts_disabled_chats == {"123", "456"}
+
+        slack_adapter = _make_adapter(Platform.SLACK)
+        runner._sync_voice_mode_state_to_adapter(slack_adapter)
+        assert slack_adapter._auto_tts_disabled_chats == {"123", "789"}
+
+    def test_explicit_prefixed_state_overrides_legacy_off_on_same_platform(self):
+        """An explicit <platform>:<chat_id> row wins over a legacy unprefixed
+        off row on the same chat id on that platform, regardless of the
+        explicit mode (#14025). Covers voice_only, all (the mode written by
+        the Discord /voice channel join path), and off."""
+        runner = _make_runner()
+        runner._voice_mode = {
+            "123": "off",
+            "456": "off",
+            "789": "off",
+            "telegram:123": "voice_only",
+            "telegram:456": "all",
+            "telegram:789": "off",
+            "slack:123": "off",
+        }
+
+        telegram_adapter = _make_adapter(Platform.TELEGRAM)
+        runner._sync_voice_mode_state_to_adapter(telegram_adapter)
+        assert telegram_adapter._auto_tts_disabled_chats == {"789"}
+
+        slack_adapter = _make_adapter(Platform.SLACK)
+        runner._sync_voice_mode_state_to_adapter(slack_adapter)
+        assert slack_adapter._auto_tts_disabled_chats == {"123", "456", "789"}
+
+    def test_legacy_off_survives_upgrade_restart_for_telegram(self):
+        """End-to-end: a pre-#12542 {<chat_id>: 'off'} entry still suppresses
+        auto-TTS on the Telegram adapter after an upgrade and restart without
+        requiring the user to re-run /voice off (#14025)."""
+        runner = _make_runner()
+        legacy_data = {"987654321": "off"}
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            voice_path = Path(tmpdir) / "gateway_voice_mode.json"
+            voice_path.write_text(json.dumps(legacy_data))
+            with patch.object(runner, "_VOICE_MODE_PATH", voice_path):
+                runner._voice_mode = runner._load_voice_modes()
+
+        telegram_adapter = _make_adapter(Platform.TELEGRAM)
+        runner._sync_voice_mode_state_to_adapter(telegram_adapter)
+
+        assert "987654321" in telegram_adapter._auto_tts_disabled_chats
+
 
 # ---------------------------------------------------------------------------
-# Helper
+# Helpers
 # ---------------------------------------------------------------------------
 
 def _make_runner() -> GatewayRunner:
@@ -216,3 +300,10 @@ def _make_runner() -> GatewayRunner:
         runner._voice_mode = {}
         runner.adapters = {}
     return runner
+
+
+def _make_adapter(platform: Platform) -> MagicMock:
+    adapter = MagicMock()
+    adapter.platform = platform
+    adapter._auto_tts_disabled_chats = set()
+    return adapter


### PR DESCRIPTION
## Summary

Fixes #14025.

- Preserve legacy unprefixed `"<chat_id>": "off"` rows in `gateway_voice_mode.json` on load so auto-TTS suppression survives the #12542 platform-namespacing migration. Legacy `voice_only` / `all` rows continue to be dropped — migrating them without knowing the owning platform could fire TTS on a platform the user never configured.
- In `_sync_voice_mode_state_to_adapter`, make explicit `<platform>:<chat_id>` entries take precedence over legacy fallback rows for the same chat id on that platform, regardless of the explicit mode. Without this, a user who ran `/voice on` on a chat that had a legacy `off` row would get silently re-suppressed on the next restart — the same two-store drift as #14025 in the opposite direction.

### Reproduction (before fix)

1. On a pre-#12542 build, run `/voice off` in a Telegram DM so `gateway_voice_mode.json` contains `{"<telegram_chat_id>": "off"}`.
2. Upgrade to a build containing `52a972e9` (#12542). Restart.
3. Send a voice message in that DM. Hermes sends one unwanted TTS reply because `_auto_tts_disabled_chats` was never rebuilt from the dropped legacy row, even though `/voice status` still reports `off`.

### After fix

- Startup load preserves `{"<chat_id>": "off"}` and logs one info line explaining the preservation.
- Adapter sync applies the legacy `off` as a cross-platform fallback → `_auto_tts_disabled_chats` contains the chat id → the auto-TTS gate at `gateway/platforms/base.py:1879` correctly suppresses.
- When the user later runs `/voice on|tts` on any platform, a prefixed row is written. On the next restart the precedence rule ensures the explicit row wins for that platform; the legacy row continues to act as a fallback for platforms that have not yet been explicitly reconfigured.

## Test plan

New tests in `tests/gateway/test_voice_mode_platform_isolation.py`:
- `test_load_voice_modes_preserves_legacy_off_keys` — legacy `off` preserved, legacy `all`/`voice_only` dropped.
- `test_sync_legacy_off_applies_to_all_adapters` — legacy `off` suppresses auto-TTS on every adapter that has no explicit prefixed row for the same chat id.
- `test_explicit_prefixed_state_overrides_legacy_off_on_same_platform` — explicit prefixed rows (covering `voice_only`, `all`, and `off`) win over legacy fallback for the same chat id on the same platform; legacy fallback still applies to platforms that have no explicit row for that id.
- `test_legacy_off_survives_upgrade_restart_for_telegram` — end-to-end regression for the exact repro from the issue.

Renamed and tightened `test_load_voice_modes_skips_legacy_keys` → `test_load_voice_modes_skips_legacy_nonoff_keys` to reflect the new preservation behavior for `off`.

New test in `tests/gateway/test_voice_command.py`:
- `test_voice_on_after_legacy_off_overrides_fallback_after_restart` — full lifecycle through the real `_handle_voice_command` / `_save_voice_modes` / reload / sync chain, asserts no split-brain where `/voice status` reports on while auto-TTS stays suppressed.

All voice-mode tests pass: `pytest tests/gateway/test_voice_mode_platform_isolation.py tests/gateway/test_voice_command.py` — 164 passed, 21 skipped.