### PR TITLE
fix(debug): preserve exact-boundary tail lines in full-log uploads

### DIFF
--- a/hermes_cli/debug.py
+++ b/hermes_cli/debug.py
@@ -373,9 +373,16 @@ def _read_full_log(log_name: str, max_bytes: int = _MAX_LOG_BYTES) -> Optional[s
 
         # File is larger than max_bytes — read the tail.
         with open(log_path, "rb") as f:
-            f.seek(size - max_bytes)
-            # Skip partial line at the seek point.
-            f.readline()
+            start = size - max_bytes
+            f.seek(start)
+            # Skip the first line only when the seek landed mid-line.
+            if start > 0:
+                f.seek(start - 1)
+                if f.read(1) != b"\n":
+                    f.seek(start)
+                    f.readline()
+                else:
+                    f.seek(start)
             content = f.read().decode("utf-8", errors="replace")
         return f"[... truncated — showing last ~{max_bytes // 1024}KB ...]\n{content}"
     except Exception:

--- a/tests/hermes_cli/test_debug.py
+++ b/tests/hermes_cli/test_debug.py
@@ -174,6 +174,16 @@ class TestReadFullLog:
         assert content is not None
         assert "truncated" in content
 
+    def test_preserves_line_when_tail_starts_on_exact_boundary(self, hermes_home):
+        from hermes_cli.debug import _read_full_log
+
+        (hermes_home / "logs" / "agent.log").write_bytes(b"abc\ndef\n")
+
+        content = _read_full_log("agent", max_bytes=4)
+
+        assert content is not None
+        assert content == "[... truncated — showing last ~0KB ...]\ndef\n"
+
     def test_unknown_log_returns_none(self, hermes_home):
         from hermes_cli.debug import _read_full_log
         assert _read_full_log("nonexistent") is None


### PR DESCRIPTION
## Summary

Fix `_read_full_log()` so `hermes debug share` preserves the first retained line when the tail truncation boundary lands exactly at the start of a line.

Before this change, the implementation always called `readline()` after seeking to `size - max_bytes`, which correctly skipped a partial line when the seek landed mid-line, but incorrectly discarded a complete line when the seek landed exactly on a newline boundary.

## Fix

- compute the tail start offset once
- inspect the byte immediately before the truncation boundary
- only skip the first line when the boundary is inside a line
- preserve the first retained line when the boundary already starts at a line boundary

## Regression coverage

Added a focused test for the exact-boundary case:

- input: `abc\ndef\n`
- `max_bytes=4`
- expected retained tail: `def\n`

## Testing

- `scripts/run_tests.sh tests/hermes_cli/test_debug.py::TestReadFullLog::test_preserves_line_when_tail_starts_on_exact_boundary -v`
- `scripts/run_tests.sh tests/hermes_cli/test_debug.py -v`

Closes #13968
