### PR TITLE
fix: preserve full-log lines at truncation boundaries

### DIFF
--- a/hermes_cli/debug.py
+++ b/hermes_cli/debug.py
@@ -38,6 +38,7 @@ _AUTO_DELETE_SECONDS = 21600
 # Pending-deletion tracking (replaces the old fork-and-sleep subprocess).
 # ---------------------------------------------------------------------------
 
+
 def _pending_file() -> Path:
     """Path to ``~/.hermes/pastes/pending.json``.
 
@@ -59,7 +60,8 @@ def _load_pending() -> list[dict]:
         if isinstance(data, list):
             # Filter to well-formed entries only
             return [
-                e for e in data
+                e
+                for e in data
                 if isinstance(e, dict) and "url" in e and "expire_at" in e
             ]
     except (OSError, ValueError, json.JSONDecodeError):
@@ -180,7 +182,7 @@ def _extract_paste_id(url: str) -> Optional[str]:
     url = url.strip().rstrip("/")
     for prefix in ("https://paste.rs/", "http://paste.rs/"):
         if url.startswith(prefix):
-            return url[len(prefix):]
+            return url[len(prefix) :]
     return None
 
 
@@ -198,7 +200,8 @@ def delete_paste(url: str) -> bool:
 
     target = f"{_PASTE_RS_URL}{paste_id}"
     req = urllib.request.Request(
-        target, method="DELETE",
+        target,
+        method="DELETE",
         headers={"User-Agent": "hermes-agent/debug-share"},
     )
     with urllib.request.urlopen(req, timeout=30) as resp:
@@ -237,7 +240,9 @@ def _upload_paste_rs(content: str) -> str:
     """
     data = content.encode("utf-8")
     req = urllib.request.Request(
-        _PASTE_RS_URL, data=data, method="POST",
+        _PASTE_RS_URL,
+        data=data,
+        method="POST",
         headers={
             "Content-Type": "text/plain; charset=utf-8",
             "User-Agent": "hermes-agent/debug-share",
@@ -273,7 +278,9 @@ def _upload_dpaste_com(content: str, expiry_days: int = 7) -> str:
     ).encode("utf-8")
 
     req = urllib.request.Request(
-        _DPASTE_COM_URL, data=body, method="POST",
+        _DPASTE_COM_URL,
+        data=body,
+        method="POST",
         headers={
             "Content-Type": f"multipart/form-data; boundary={boundary}",
             "User-Agent": "hermes-agent/debug-share",
@@ -313,6 +320,7 @@ def upload_to_pastebin(content: str, expiry_days: int = 7) -> str:
 # ---------------------------------------------------------------------------
 # Log file reading
 # ---------------------------------------------------------------------------
+
 
 def _resolve_log_path(log_name: str) -> Optional[Path]:
     """Find the log file for *log_name*, falling back to the .1 rotation.
@@ -373,9 +381,15 @@ def _read_full_log(log_name: str, max_bytes: int = _MAX_LOG_BYTES) -> Optional[s
 
         # File is larger than max_bytes — read the tail.
         with open(log_path, "rb") as f:
-            f.seek(size - max_bytes)
-            # Skip partial line at the seek point.
-            f.readline()
+            offset = size - max_bytes
+            starts_on_line_boundary = offset == 0
+            if offset > 0:
+                f.seek(offset - 1)
+                starts_on_line_boundary = f.read(1) == b"\n"
+            f.seek(offset)
+            if not starts_on_line_boundary:
+                # Skip a leading partial line when the retained tail starts mid-line.
+                f.readline()
             content = f.read().decode("utf-8", errors="replace")
         return f"[... truncated — showing last ~{max_bytes // 1024}KB ...]\n{content}"
     except Exception:
@@ -385,6 +399,7 @@ def _read_full_log(log_name: str, max_bytes: int = _MAX_LOG_BYTES) -> Optional[s
 # ---------------------------------------------------------------------------
 # Debug report collection
 # ---------------------------------------------------------------------------
+
 
 def _capture_dump() -> str:
     """Run ``hermes dump`` and return its stdout as a string."""
@@ -445,6 +460,7 @@ def collect_debug_report(*, log_lines: int = 200, dump_text: str = "") -> str:
 # ---------------------------------------------------------------------------
 # CLI entry points
 # ---------------------------------------------------------------------------
+
 
 def run_debug_share(args):
     """Collect debug report + full logs, upload each, print URLs."""

--- a/tests/hermes_cli/test_debug.py
+++ b/tests/hermes_cli/test_debug.py
@@ -12,6 +12,7 @@ import pytest
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture
 def hermes_home(tmp_path, monkeypatch):
     """Set up an isolated HERMES_HOME with minimal logs."""
@@ -40,6 +41,7 @@ def hermes_home(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 # Unit tests for upload helpers
 # ---------------------------------------------------------------------------
+
 
 class TestUploadPasteRs:
     """Test paste.rs upload path."""
@@ -103,8 +105,9 @@ class TestUploadToPastebin:
     def test_tries_paste_rs_first(self):
         from hermes_cli.debug import upload_to_pastebin
 
-        with patch("hermes_cli.debug._upload_paste_rs",
-                    return_value="https://paste.rs/test") as prs:
+        with patch(
+            "hermes_cli.debug._upload_paste_rs", return_value="https://paste.rs/test"
+        ) as prs:
             url = upload_to_pastebin("content")
 
         assert url == "https://paste.rs/test"
@@ -113,10 +116,13 @@ class TestUploadToPastebin:
     def test_falls_back_to_dpaste_com(self):
         from hermes_cli.debug import upload_to_pastebin
 
-        with patch("hermes_cli.debug._upload_paste_rs",
-                    side_effect=Exception("down")), \
-             patch("hermes_cli.debug._upload_dpaste_com",
-                    return_value="https://dpaste.com/TEST") as dp:
+        with (
+            patch("hermes_cli.debug._upload_paste_rs", side_effect=Exception("down")),
+            patch(
+                "hermes_cli.debug._upload_dpaste_com",
+                return_value="https://dpaste.com/TEST",
+            ) as dp,
+        ):
             url = upload_to_pastebin("content")
 
         assert url == "https://dpaste.com/TEST"
@@ -125,10 +131,10 @@ class TestUploadToPastebin:
     def test_raises_when_both_fail(self):
         from hermes_cli.debug import upload_to_pastebin
 
-        with patch("hermes_cli.debug._upload_paste_rs",
-                    side_effect=Exception("err1")), \
-             patch("hermes_cli.debug._upload_dpaste_com",
-                    side_effect=Exception("err2")):
+        with (
+            patch("hermes_cli.debug._upload_paste_rs", side_effect=Exception("err1")),
+            patch("hermes_cli.debug._upload_dpaste_com", side_effect=Exception("err2")),
+        ):
             with pytest.raises(RuntimeError, match="Failed to upload"):
                 upload_to_pastebin("content")
 
@@ -136,6 +142,7 @@ class TestUploadToPastebin:
 # ---------------------------------------------------------------------------
 # Log reading
 # ---------------------------------------------------------------------------
+
 
 class TestReadFullLog:
     """Test _read_full_log for standalone log uploads."""
@@ -153,6 +160,7 @@ class TestReadFullLog:
         monkeypatch.setenv("HERMES_HOME", str(home))
 
         from hermes_cli.debug import _read_full_log
+
         assert _read_full_log("agent") is None
 
     def test_returns_none_for_empty(self, hermes_home):
@@ -160,6 +168,7 @@ class TestReadFullLog:
         (hermes_home / "logs" / "agent.log").write_text("")
 
         from hermes_cli.debug import _read_full_log
+
         assert _read_full_log("agent") is None
 
     def test_truncates_large_file(self, hermes_home):
@@ -174,8 +183,31 @@ class TestReadFullLog:
         assert content is not None
         assert "truncated" in content
 
+    def test_keeps_first_line_when_truncation_starts_on_line_boundary(
+        self, hermes_home
+    ):
+        from hermes_cli.debug import _read_full_log
+
+        log_path = hermes_home / "logs" / "agent.log"
+        log_path.write_text("abc\ndef\n")
+
+        content = _read_full_log("agent", max_bytes=4)
+
+        assert content == "[... truncated — showing last ~0KB ...]\ndef\n"
+
+    def test_drops_partial_fragment_when_truncation_starts_mid_line(self, hermes_home):
+        from hermes_cli.debug import _read_full_log
+
+        log_path = hermes_home / "logs" / "agent.log"
+        log_path.write_text("abcd\nefgh\n")
+
+        content = _read_full_log("agent", max_bytes=7)
+
+        assert content == "[... truncated — showing last ~0KB ...]\nefgh\n"
+
     def test_unknown_log_returns_none(self, hermes_home):
         from hermes_cli.debug import _read_full_log
+
         assert _read_full_log("nonexistent") is None
 
     def test_falls_back_to_rotated_file(self, hermes_home):
@@ -221,6 +253,7 @@ class TestReadFullLog:
 # ---------------------------------------------------------------------------
 # Debug report collection
 # ---------------------------------------------------------------------------
+
 
 class TestCollectDebugReport:
     """Test the debug report builder."""
@@ -280,6 +313,7 @@ class TestCollectDebugReport:
 # CLI entry point — run_debug_share
 # ---------------------------------------------------------------------------
 
+
 class TestRunDebugShare:
     """Test the run_debug_share CLI handler."""
 
@@ -311,15 +345,19 @@ class TestRunDebugShare:
 
         call_count = [0]
         uploaded_content = []
+
         def _mock_upload(content, expiry_days=7):
             call_count[0] += 1
             uploaded_content.append(content)
             return f"https://paste.rs/paste{call_count[0]}"
 
-        with patch("hermes_cli.dump.run_dump") as mock_dump, \
-             patch("hermes_cli.debug.upload_to_pastebin",
-                    side_effect=_mock_upload):
-            mock_dump.side_effect = lambda a: print("--- hermes dump ---\nversion: test\n--- end dump ---")
+        with (
+            patch("hermes_cli.dump.run_dump") as mock_dump,
+            patch("hermes_cli.debug.upload_to_pastebin", side_effect=_mock_upload),
+        ):
+            mock_dump.side_effect = lambda a: print(
+                "--- hermes dump ---\nversion: test\n--- end dump ---"
+            )
             run_debug_share(args)
 
         out = capsys.readouterr().out
@@ -354,13 +392,15 @@ class TestRunDebugShare:
         args.local = False
 
         call_count = [0]
+
         def _mock_upload(content, expiry_days=7):
             call_count[0] += 1
             return f"https://paste.rs/paste{call_count[0]}"
 
-        with patch("hermes_cli.dump.run_dump"), \
-             patch("hermes_cli.debug.upload_to_pastebin",
-                    side_effect=_mock_upload):
+        with (
+            patch("hermes_cli.dump.run_dump"),
+            patch("hermes_cli.debug.upload_to_pastebin", side_effect=_mock_upload),
+        ):
             run_debug_share(args)
 
         out = capsys.readouterr().out
@@ -378,15 +418,17 @@ class TestRunDebugShare:
         args.local = False
 
         call_count = [0]
+
         def _mock_upload(content, expiry_days=7):
             call_count[0] += 1
             if call_count[0] > 1:
                 raise RuntimeError("upload failed")
             return "https://paste.rs/report"
 
-        with patch("hermes_cli.dump.run_dump"), \
-             patch("hermes_cli.debug.upload_to_pastebin",
-                    side_effect=_mock_upload):
+        with (
+            patch("hermes_cli.dump.run_dump"),
+            patch("hermes_cli.debug.upload_to_pastebin", side_effect=_mock_upload),
+        ):
             run_debug_share(args)
 
         out = capsys.readouterr().out
@@ -403,9 +445,13 @@ class TestRunDebugShare:
         args.expire = 7
         args.local = False
 
-        with patch("hermes_cli.dump.run_dump"), \
-             patch("hermes_cli.debug.upload_to_pastebin",
-                    side_effect=RuntimeError("all failed")):
+        with (
+            patch("hermes_cli.dump.run_dump"),
+            patch(
+                "hermes_cli.debug.upload_to_pastebin",
+                side_effect=RuntimeError("all failed"),
+            ),
+        ):
             with pytest.raises(SystemExit) as exc_info:
                 run_debug_share(args)
 
@@ -417,6 +463,7 @@ class TestRunDebugShare:
 # ---------------------------------------------------------------------------
 # run_debug router
 # ---------------------------------------------------------------------------
+
 
 class TestRunDebug:
     def test_no_subcommand_shows_usage(self, capsys):
@@ -453,25 +500,31 @@ class TestRunDebug:
 # Delete / auto-delete
 # ---------------------------------------------------------------------------
 
+
 class TestExtractPasteId:
     def test_paste_rs_url(self):
         from hermes_cli.debug import _extract_paste_id
+
         assert _extract_paste_id("https://paste.rs/abc123") == "abc123"
 
     def test_paste_rs_trailing_slash(self):
         from hermes_cli.debug import _extract_paste_id
+
         assert _extract_paste_id("https://paste.rs/abc123/") == "abc123"
 
     def test_http_variant(self):
         from hermes_cli.debug import _extract_paste_id
+
         assert _extract_paste_id("http://paste.rs/xyz") == "xyz"
 
     def test_non_paste_rs_returns_none(self):
         from hermes_cli.debug import _extract_paste_id
+
         assert _extract_paste_id("https://dpaste.com/ABCDEF") is None
 
     def test_empty_returns_none(self):
         from hermes_cli.debug import _extract_paste_id
+
         assert _extract_paste_id("") is None
 
 
@@ -484,8 +537,9 @@ class TestDeletePaste:
         mock_resp.__enter__ = lambda s: s
         mock_resp.__exit__ = MagicMock(return_value=False)
 
-        with patch("hermes_cli.debug.urllib.request.urlopen",
-                    return_value=mock_resp) as mock_open:
+        with patch(
+            "hermes_cli.debug.urllib.request.urlopen", return_value=mock_resp
+        ) as mock_open:
             result = delete_paste("https://paste.rs/abc123")
 
         assert result is True
@@ -551,6 +605,7 @@ class TestScheduleAutoDelete:
         # And verify that calling it doesn't produce any orphaned children
         # (it should just write pending.json synchronously).
         import os as _os
+
         before = set(_os.listdir("/proc")) if _os.path.exists("/proc") else None
         _schedule_auto_delete(
             ["https://paste.rs/abc", "https://paste.rs/def"],
@@ -594,6 +649,7 @@ class TestScheduleAutoDelete:
 
         # expire_at is ~now + delay_seconds
         import time
+
         for e in entries:
             assert e["expire_at"] > time.time()
             assert e["expire_at"] <= time.time() + 15
@@ -649,10 +705,12 @@ class TestSweepExpiredPastes:
         import time
 
         # Seed pending.json with one expired + one future entry
-        _save_pending([
-            {"url": "https://paste.rs/expired", "expire_at": time.time() - 100},
-            {"url": "https://paste.rs/future", "expire_at": time.time() + 3600},
-        ])
+        _save_pending(
+            [
+                {"url": "https://paste.rs/expired", "expire_at": time.time() - 100},
+                {"url": "https://paste.rs/future", "expire_at": time.time() + 3600},
+            ]
+        )
 
         delete_calls = []
 
@@ -675,10 +733,12 @@ class TestSweepExpiredPastes:
         from hermes_cli.debug import _sweep_expired_pastes, _save_pending
         import time
 
-        _save_pending([
-            {"url": "https://paste.rs/future1", "expire_at": time.time() + 3600},
-            {"url": "https://paste.rs/future2", "expire_at": time.time() + 7200},
-        ])
+        _save_pending(
+            [
+                {"url": "https://paste.rs/future1", "expire_at": time.time() + 3600},
+                {"url": "https://paste.rs/future2", "expire_at": time.time() + 7200},
+            ]
+        )
 
         with patch("hermes_cli.debug.delete_paste") as mock_delete:
             deleted, remaining = _sweep_expired_pastes()
@@ -696,9 +756,11 @@ class TestSweepExpiredPastes:
         )
         import time
 
-        _save_pending([
-            {"url": "https://paste.rs/flaky", "expire_at": time.time() - 100},
-        ])
+        _save_pending(
+            [
+                {"url": "https://paste.rs/flaky", "expire_at": time.time() - 100},
+            ]
+        )
 
         with patch(
             "hermes_cli.debug.delete_paste",
@@ -722,9 +784,11 @@ class TestSweepExpiredPastes:
 
         # Expired 25 hours ago → past the 24h grace window
         very_old = time.time() - (25 * 3600)
-        _save_pending([
-            {"url": "https://paste.rs/ancient", "expire_at": very_old},
-        ])
+        _save_pending(
+            [
+                {"url": "https://paste.rs/ancient", "expire_at": very_old},
+            ]
+        )
 
         with patch(
             "hermes_cli.debug.delete_paste",
@@ -789,8 +853,9 @@ class TestRunDebugDelete:
         args = MagicMock()
         args.urls = ["https://paste.rs/abc"]
 
-        with patch("hermes_cli.debug.delete_paste",
-                    side_effect=Exception("network error")):
+        with patch(
+            "hermes_cli.debug.delete_paste", side_effect=Exception("network error")
+        ):
             run_debug_delete(args)
 
         out = capsys.readouterr().out
@@ -819,10 +884,14 @@ class TestShareIncludesAutoDelete:
         args.expire = 7
         args.local = False
 
-        with patch("hermes_cli.dump.run_dump"), \
-             patch("hermes_cli.debug.upload_to_pastebin",
-                    return_value="https://paste.rs/test1"), \
-             patch("hermes_cli.debug._schedule_auto_delete") as mock_sched:
+        with (
+            patch("hermes_cli.dump.run_dump"),
+            patch(
+                "hermes_cli.debug.upload_to_pastebin",
+                return_value="https://paste.rs/test1",
+            ),
+            patch("hermes_cli.debug._schedule_auto_delete") as mock_sched,
+        ):
             run_debug_share(args)
 
         # auto-delete was scheduled with the uploaded URLs
@@ -841,10 +910,14 @@ class TestShareIncludesAutoDelete:
         args.expire = 7
         args.local = False
 
-        with patch("hermes_cli.dump.run_dump"), \
-             patch("hermes_cli.debug.upload_to_pastebin",
-                    return_value="https://paste.rs/test"), \
-             patch("hermes_cli.debug._schedule_auto_delete"):
+        with (
+            patch("hermes_cli.dump.run_dump"),
+            patch(
+                "hermes_cli.debug.upload_to_pastebin",
+                return_value="https://paste.rs/test",
+            ),
+            patch("hermes_cli.debug._schedule_auto_delete"),
+        ):
             run_debug_share(args)
 
         out = capsys.readouterr().out


### PR DESCRIPTION
## Summary
- preserve the first retained line in `_read_full_log()` when truncation starts exactly on a line boundary
- keep dropping only the leading partial fragment when the retained tail starts mid-line
- add regression coverage for both truncation boundary cases in `tests/hermes_cli/test_debug.py`

## Test Plan
- [x] `source venv/bin/activate && scripts/run_tests.sh tests/hermes_cli/test_debug.py -q`

Fixes #13968