### PR TITLE
fix(claw): preserve dry-run preview in non-interactive cleanup

### DIFF
--- a/hermes_cli/claw.py
+++ b/hermes_cli/claw.py
@@ -541,7 +541,7 @@ def _cmd_cleanup(args):
         )
         print_info("Stop OpenClaw first: systemctl --user stop openclaw-gateway.service")
         print()
-        if not auto_yes:
+        if not auto_yes and not dry_run:
             if not sys.stdin.isatty():
                 print_info("Non-interactive session — aborting. Stop OpenClaw and re-run.")
                 return

--- a/tests/hermes_cli/test_claw.py
+++ b/tests/hermes_cli/test_claw.py
@@ -583,6 +583,33 @@ class TestCmdCleanup:
         assert not openclaw.exists()
         assert not clawdbot.exists()
 
+    def test_dry_run_still_shows_preview_when_running_in_non_interactive_session(self, tmp_path, capsys):
+        openclaw = tmp_path / ".openclaw"
+        openclaw.mkdir()
+        ws = openclaw / "workspace"
+        ws.mkdir()
+        (ws / "todo.json").write_text("{}")
+
+        args = Namespace(source=None, dry_run=True, yes=False)
+        fake_stdin = MagicMock()
+        fake_stdin.isatty.return_value = False
+
+        with (
+            patch.object(claw_mod, "_find_openclaw_dirs", return_value=[openclaw]),
+            patch.object(
+                claw_mod,
+                "_detect_openclaw_processes",
+                return_value=["openclaw process(es) (PIDs: 1234)"],
+            ),
+            patch("sys.stdin", fake_stdin),
+        ):
+            claw_mod._cmd_cleanup(args)
+
+        captured = capsys.readouterr()
+        assert "OpenClaw appears to be still running" in captured.out
+        assert "Non-interactive session — aborting" not in captured.out
+        assert "Would archive" in captured.out
+
 
 # ---------------------------------------------------------------------------
 # _print_migration_report


### PR DESCRIPTION
## Summary
- keep the existing OpenClaw-running warning for `hermes claw cleanup`
- preserve `--dry-run` preview behavior in non-interactive sessions instead of aborting early
- add regression coverage for the running-process + non-TTY + dry-run combination

## Problem
`hermes claw cleanup --dry-run` is meant to be inspection-only, but the command checked the running-process safety gate before the dry-run preview path.

That meant a non-interactive caller could see the warning, but never the actual preview:
- `OpenClaw appears to be still running`
- `Non-interactive session — aborting. Stop OpenClaw and re-run.`
- no `Would archive: ...` output

So automation and cron-style callers could not use `--dry-run` for its main purpose: previewing what would be archived.

## Fix
The cleanup command still warns when OpenClaw appears to be running, but it no longer routes `dry_run=True` through the non-interactive abort / confirmation path.

Behavior after this patch:
- real archive execution is still protected by the same non-TTY / confirmation checks
- `--dry-run` remains preview-only and always shows `Would archive: ...`

## Tests
- `pytest -o addopts="" tests/hermes_cli/test_claw.py`

## Manual verification
Reproduced with:
- running-process detection mocked truthy
- `sys.stdin.isatty() == False`
- `args = Namespace(source=None, dry_run=True, yes=False)`

The command now prints the safety warning and the archive preview instead of aborting before the preview.

Closes #13969
