### PR TITLE
feat(image-gen): add Codex CLI backend for image generation

### DIFF
--- a/plugins/image_gen/codex_cli/__init__.py
+++ b/plugins/image_gen/codex_cli/__init__.py
@@ -1,0 +1,305 @@
+"""Codex CLI image generation backend.
+
+Uses Codex CLI's built-in image generation capability under the user's ChatGPT /
+Codex login rather than the public OpenAI Images API.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from agent.image_gen_provider import (
+    DEFAULT_ASPECT_RATIO,
+    ImageGenProvider,
+    error_response,
+    resolve_aspect_ratio,
+    success_response,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL = "codex-cli-default"
+_MODELS = [
+    {
+        "id": DEFAULT_MODEL,
+        "display": "Codex CLI Built-in Image Generation",
+        "speed": "varies",
+        "strengths": "Uses ChatGPT/Codex built-in image tool",
+        "price": "included with Codex auth",
+    }
+]
+_ASPECT_GUIDANCE = {
+    "landscape": "Use a landscape orientation.",
+    "square": "Use a square composition.",
+    "portrait": "Use a portrait orientation.",
+}
+
+
+def _load_config() -> Dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        section = cfg.get("image_gen") if isinstance(cfg, dict) else None
+        return section if isinstance(section, dict) else {}
+    except Exception as exc:
+        logger.debug("Could not load image_gen config: %s", exc)
+        return {}
+
+
+def _plugin_config() -> Dict[str, Any]:
+    cfg = _load_config()
+    for key in ("codex_cli", "codex-cli"):
+        value = cfg.get(key)
+        if isinstance(value, dict):
+            return value
+    return {}
+
+
+def _codex_home() -> Path:
+    env = os.environ.get("CODEX_HOME")
+    if env:
+        return Path(env).expanduser()
+    cfg_home = _plugin_config().get("codex_home")
+    if isinstance(cfg_home, str) and cfg_home.strip():
+        return Path(cfg_home).expanduser()
+    raw = Path.home() / ".codex"
+    return raw
+
+
+def _generated_images_dir() -> Path:
+    return _codex_home() / "generated_images"
+
+
+def _subprocess_env() -> Dict[str, str]:
+    env = dict(os.environ)
+    env["CODEX_HOME"] = str(_codex_home())
+    return env
+
+
+def _codex_binary() -> Optional[str]:
+    configured = _plugin_config().get("command")
+    if isinstance(configured, str) and configured.strip():
+        binary = configured.strip().split()[0]
+        found = shutil.which(binary)
+        return found or configured.strip()
+    return shutil.which("codex")
+
+
+def _run_login_status(codex_bin: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [codex_bin, "login", "status"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env=_subprocess_env(),
+    )
+
+
+def _snapshot_generated_images() -> set[Path]:
+    root = _generated_images_dir()
+    if not root.exists():
+        return set()
+    return {p for p in root.rglob("*") if p.is_file()}
+
+
+def _parse_json_lines(stdout: str) -> Iterable[dict]:
+    for line in (stdout or "").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except Exception:
+            continue
+        if isinstance(obj, dict):
+            yield obj
+
+
+def _extract_thread_id(stdout: str) -> Optional[str]:
+    for obj in _parse_json_lines(stdout):
+        if obj.get("type") == "thread.started":
+            thread_id = obj.get("thread_id")
+            if isinstance(thread_id, str) and thread_id.strip():
+                return thread_id.strip()
+    return None
+
+
+def _newest_file(paths: Iterable[Path]) -> Optional[Path]:
+    files = [p for p in paths if p.is_file()]
+    if not files:
+        return None
+    return max(files, key=lambda p: p.stat().st_mtime)
+
+
+def _find_generated_image(thread_id: Optional[str], before: set[Path]) -> Optional[Path]:
+    root = _generated_images_dir()
+    if thread_id:
+        thread_dir = root / thread_id
+        if thread_dir.exists():
+            found = _newest_file(thread_dir.rglob("*"))
+            if found is not None:
+                return found
+    after = _snapshot_generated_images()
+    new_files = sorted((after - before), key=lambda p: p.stat().st_mtime, reverse=True)
+    return new_files[0] if new_files else None
+
+
+def _build_prompt(prompt: str, aspect_ratio: str) -> str:
+    guidance = _ASPECT_GUIDANCE.get(aspect_ratio, _ASPECT_GUIDANCE[DEFAULT_ASPECT_RATIO])
+    return (
+        f"Generate an image for this request: {prompt}\n"
+        f"{guidance}\n"
+        "Use Codex built-in image generation if available."
+    )
+
+
+def _run_codex_image_generation(codex_bin: str, prompt: str, aspect_ratio: str) -> Tuple[subprocess.CompletedProcess, Optional[str], Optional[Path]]:
+    before = _snapshot_generated_images()
+    built_prompt = _build_prompt(prompt, aspect_ratio)
+    with tempfile.TemporaryDirectory(prefix="codex-imagegen-") as tmp:
+        tmp_path = Path(tmp)
+        subprocess.run(["git", "init", "-q"], cwd=tmp_path, capture_output=True, text=True, timeout=30, env=_subprocess_env())
+        cmd = [
+            codex_bin,
+            "exec",
+            "--json",
+            "--full-auto",
+            "--enable",
+            "image_generation",
+            built_prompt,
+        ]
+        result = subprocess.run(
+            cmd,
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            timeout=300,
+            env=_subprocess_env(),
+        )
+    thread_id = _extract_thread_id(result.stdout)
+    image_path = _find_generated_image(thread_id, before)
+    return result, thread_id, image_path
+
+
+class CodexCLIImageGenProvider(ImageGenProvider):
+    @property
+    def name(self) -> str:
+        return "codex-cli"
+
+    @property
+    def display_name(self) -> str:
+        return "Codex CLI"
+
+    def is_available(self) -> bool:
+        codex_bin = _codex_binary()
+        if not codex_bin:
+            return False
+        try:
+            result = _run_login_status(codex_bin)
+        except Exception:
+            return False
+        return result.returncode == 0 and "logged in" in (result.stdout or "").lower()
+
+    def list_models(self) -> List[Dict[str, Any]]:
+        return list(_MODELS)
+
+    def default_model(self) -> Optional[str]:
+        return DEFAULT_MODEL
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Codex CLI",
+            "badge": "chatgpt",
+            "tag": "Built-in image generation via local Codex CLI login",
+            "env_vars": [],
+        }
+
+    def generate(self, prompt: str, aspect_ratio: str = DEFAULT_ASPECT_RATIO, **kwargs: Any) -> Dict[str, Any]:
+        prompt = (prompt or "").strip()
+        aspect = resolve_aspect_ratio(aspect_ratio)
+        if not prompt:
+            return error_response(
+                error="Prompt is required and must be a non-empty string",
+                error_type="invalid_argument",
+                provider=self.name,
+                aspect_ratio=aspect,
+            )
+
+        codex_bin = _codex_binary()
+        if not codex_bin:
+            return error_response(
+                error="codex CLI not installed or not on PATH",
+                error_type="missing_dependency",
+                provider=self.name,
+                model=DEFAULT_MODEL,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        try:
+            result, thread_id, image_path = _run_codex_image_generation(codex_bin, prompt, aspect)
+        except subprocess.TimeoutExpired:
+            return error_response(
+                error="Codex CLI image generation timed out",
+                error_type="timeout",
+                provider=self.name,
+                model=DEFAULT_MODEL,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+        except Exception as exc:
+            logger.debug("Codex CLI image generation failed", exc_info=True)
+            return error_response(
+                error=f"Codex CLI image generation failed: {exc}",
+                error_type="provider_error",
+                provider=self.name,
+                model=DEFAULT_MODEL,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        if result.returncode != 0:
+            detail = (result.stderr or result.stdout or "unknown error").strip()
+            return error_response(
+                error=f"Codex CLI image generation failed: {detail}",
+                error_type="api_error",
+                provider=self.name,
+                model=DEFAULT_MODEL,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        if image_path is None:
+            return error_response(
+                error="Codex CLI completed but no generated image file was found",
+                error_type="empty_response",
+                provider=self.name,
+                model=DEFAULT_MODEL,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        extra: Dict[str, Any] = {}
+        if thread_id:
+            extra["thread_id"] = thread_id
+
+        return success_response(
+            image=str(image_path),
+            model=DEFAULT_MODEL,
+            prompt=prompt,
+            aspect_ratio=aspect,
+            provider=self.name,
+            extra=extra,
+        )
+
+
+def register(ctx) -> None:
+    ctx.register_image_gen_provider(CodexCLIImageGenProvider())

--- a/plugins/image_gen/codex_cli/plugin.yaml
+++ b/plugins/image_gen/codex_cli/plugin.yaml
@@ -1,0 +1,5 @@
+name: codex_cli
+version: 1.0.0
+description: "Codex CLI image generation backend using Codex's built-in image_gen tool. Saves generated images under $CODEX_HOME/generated_images/."
+author: NousResearch
+kind: backend

--- a/tests/plugins/image_gen/test_codex_cli_provider.py
+++ b/tests/plugins/image_gen/test_codex_cli_provider.py
@@ -1,0 +1,225 @@
+"""Tests for the bundled Codex CLI image_gen plugin."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from subprocess import CompletedProcess
+
+import pytest
+
+import plugins.image_gen.codex_cli as codex_cli_plugin
+
+
+_PNG_HEX = (
+    "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4"
+    "890000000d49444154789c6300010000000500010d0a2db40000000049454e44"
+    "ae426082"
+)
+
+
+@pytest.fixture(autouse=True)
+def _tmp_hermes_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    yield tmp_path
+
+
+@pytest.fixture
+def provider():
+    return codex_cli_plugin.CodexCLIImageGenProvider()
+
+
+def _write_png(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(bytes.fromhex(_PNG_HEX))
+
+
+def _jsonl(*payloads: dict) -> str:
+    return "\n".join(json.dumps(p) for p in payloads)
+
+
+class TestMetadata:
+    def test_name(self, provider):
+        assert provider.name == "codex-cli"
+
+    def test_default_model(self, provider):
+        assert provider.default_model() == "codex-cli-default"
+
+    def test_list_models(self, provider):
+        assert provider.list_models() == [
+            {
+                "id": "codex-cli-default",
+                "display": "Codex CLI Built-in Image Generation",
+                "speed": "varies",
+                "strengths": "Uses ChatGPT/Codex built-in image tool",
+                "price": "included with Codex auth",
+            }
+        ]
+
+
+class TestAvailability:
+    def test_unavailable_without_codex_binary(self, monkeypatch):
+        monkeypatch.setattr(codex_cli_plugin.shutil, "which", lambda _: None)
+        assert codex_cli_plugin.CodexCLIImageGenProvider().is_available() is False
+
+    def test_unavailable_when_login_status_fails(self, monkeypatch):
+        monkeypatch.setattr(codex_cli_plugin.shutil, "which", lambda _: "/usr/bin/codex")
+        monkeypatch.setattr(
+            codex_cli_plugin.subprocess,
+            "run",
+            lambda *a, **k: CompletedProcess(a[0], 1, stdout="", stderr="not logged in"),
+        )
+        assert codex_cli_plugin.CodexCLIImageGenProvider().is_available() is False
+
+    def test_available_when_codex_logged_in(self, monkeypatch):
+        monkeypatch.setattr(codex_cli_plugin.shutil, "which", lambda _: "/usr/bin/codex")
+        monkeypatch.setattr(
+            codex_cli_plugin.subprocess,
+            "run",
+            lambda *a, **k: CompletedProcess(a[0], 0, stdout="Logged in using ChatGPT\n", stderr=""),
+        )
+        assert codex_cli_plugin.CodexCLIImageGenProvider().is_available() is True
+
+
+class TestConfig:
+    def test_codex_home_from_env(self, monkeypatch):
+        monkeypatch.setenv("CODEX_HOME", "~/special-codex-home")
+        assert codex_cli_plugin._codex_home() == (Path.home() / "special-codex-home")
+
+    def test_codex_home_from_plugin_config(self, tmp_path):
+        (tmp_path / "config.yaml").write_text(
+            "image_gen:\n  codex_cli:\n    codex_home: ~/.codex-hermes\n"
+        )
+        assert codex_cli_plugin._codex_home() == (Path.home() / ".codex-hermes")
+
+
+class TestGenerate:
+    def test_empty_prompt_rejected(self, provider):
+        result = provider.generate("", aspect_ratio="square")
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_argument"
+
+    def test_missing_codex_binary(self, monkeypatch, provider):
+        monkeypatch.setattr(codex_cli_plugin.shutil, "which", lambda _: None)
+        result = provider.generate("a cat")
+        assert result["success"] is False
+        assert result["error_type"] == "missing_dependency"
+
+    def test_missing_generated_image_returns_error(self, monkeypatch, provider):
+        monkeypatch.setattr(codex_cli_plugin.shutil, "which", lambda _: "/usr/bin/codex")
+
+        def fake_run(cmd, **kwargs):
+            return CompletedProcess(
+                cmd,
+                0,
+                stdout=_jsonl({"type": "thread.started", "thread_id": "thread-123"}),
+                stderr="",
+            )
+
+        monkeypatch.setattr(codex_cli_plugin.subprocess, "run", fake_run)
+        result = provider.generate("a cat")
+        assert result["success"] is False
+        assert result["error_type"] == "empty_response"
+
+    def test_success_uses_thread_dir_file(self, monkeypatch, provider, tmp_path):
+        monkeypatch.setattr(codex_cli_plugin.shutil, "which", lambda _: "/usr/bin/codex")
+        out = _jsonl(
+            {"type": "thread.started", "thread_id": "thread-123"},
+            {
+                "type": "item.completed",
+                "item": {"id": "item_0", "type": "agent_message", "text": "done"},
+            },
+        )
+
+        def fake_run(cmd, **kwargs):
+            image_path = tmp_path / ".codex" / "generated_images" / "thread-123" / "image.png"
+            _write_png(image_path)
+            return CompletedProcess(cmd, 0, stdout=out, stderr="")
+
+        monkeypatch.setattr(codex_cli_plugin.subprocess, "run", fake_run)
+        result = provider.generate("a cat", aspect_ratio="landscape")
+        assert result["success"] is True
+        assert result["provider"] == "codex-cli"
+        assert result["model"] == "codex-cli-default"
+        assert result["aspect_ratio"] == "landscape"
+        assert Path(result["image"]).exists()
+        assert result["thread_id"] == "thread-123"
+
+    def test_fallback_to_new_file_diff_when_no_thread_id(self, monkeypatch, provider, tmp_path):
+        monkeypatch.setattr(codex_cli_plugin.shutil, "which", lambda _: "/usr/bin/codex")
+
+        def fake_run(cmd, **kwargs):
+            image_path = tmp_path / ".codex" / "generated_images" / "other-thread" / "image.png"
+            _write_png(image_path)
+            return CompletedProcess(cmd, 0, stdout=_jsonl({"type": "turn.completed"}), stderr="")
+
+        monkeypatch.setattr(codex_cli_plugin.subprocess, "run", fake_run)
+        result = provider.generate("a cat")
+        assert result["success"] is True
+        assert Path(result["image"]).name == "image.png"
+
+    def test_nonzero_exit_returns_error_response(self, monkeypatch, provider):
+        monkeypatch.setattr(codex_cli_plugin.shutil, "which", lambda _: "/usr/bin/codex")
+        monkeypatch.setattr(
+            codex_cli_plugin.subprocess,
+            "run",
+            lambda cmd, **kwargs: CompletedProcess(cmd, 1, stdout='oops', stderr='boom'),
+        )
+        result = provider.generate("a cat")
+        assert result["success"] is False
+        assert result["error_type"] == "api_error"
+        assert "boom" in result["error"]
+
+    @pytest.mark.parametrize(
+        ("aspect_ratio", "expected"),
+        [
+            ("landscape", "landscape orientation"),
+            ("square", "square composition"),
+            ("portrait", "portrait orientation"),
+        ],
+    )
+    def test_prompt_includes_aspect_ratio_guidance(self, monkeypatch, provider, aspect_ratio, expected, tmp_path):
+        monkeypatch.setattr(codex_cli_plugin.shutil, "which", lambda _: "/usr/bin/codex")
+        seen = {}
+
+        def fake_run(cmd, **kwargs):
+            seen["cmd"] = cmd
+            seen["env"] = kwargs.get("env", {})
+            image_path = tmp_path / ".codex" / "generated_images" / "thread-xyz" / "image.png"
+            _write_png(image_path)
+            return CompletedProcess(cmd, 0, stdout=_jsonl({"type": "thread.started", "thread_id": "thread-xyz"}), stderr="")
+
+        monkeypatch.setattr(codex_cli_plugin.subprocess, "run", fake_run)
+        provider.generate("a cat", aspect_ratio=aspect_ratio)
+        prompt = seen["cmd"][-1]
+        assert expected in prompt
+        assert "--enable" in seen["cmd"]
+        assert "image_generation" in seen["cmd"]
+        assert seen["env"]["CODEX_HOME"].endswith(".codex")
+
+    def test_respects_codex_home_in_subprocess_env(self, monkeypatch, provider, tmp_path):
+        monkeypatch.setattr(codex_cli_plugin.shutil, "which", lambda _: "/usr/bin/codex")
+        monkeypatch.setenv("CODEX_HOME", str(tmp_path / ".codex-hermes"))
+        seen = {}
+
+        def fake_run(cmd, **kwargs):
+            seen.setdefault("envs", []).append(kwargs.get("env", {}))
+            image_path = tmp_path / ".codex-hermes" / "generated_images" / "thread-xyz" / "image.png"
+            _write_png(image_path)
+            return CompletedProcess(cmd, 0, stdout=_jsonl({"type": "thread.started", "thread_id": "thread-xyz"}), stderr="")
+
+        monkeypatch.setattr(codex_cli_plugin.subprocess, "run", fake_run)
+        result = provider.generate("a cat")
+        assert result["success"] is True
+        assert all(env["CODEX_HOME"] == str(tmp_path / ".codex-hermes") for env in seen["envs"])
+
+    def test_register_wires_provider(self):
+        registered = {}
+
+        class Ctx:
+            def register_image_gen_provider(self, provider):
+                registered["provider"] = provider
+
+        codex_cli_plugin.register(Ctx())
+        assert isinstance(registered["provider"], codex_cli_plugin.CodexCLIImageGenProvider)


### PR DESCRIPTION
## Summary
Add a bundled `codex-cli` image generation backend so Hermes can use Codex CLI's built-in image generation through the user's local Codex/ChatGPT login.

## What this changes
- add `plugins/image_gen/codex_cli` backend
- detect availability via `codex login status`
- resolve `CODEX_HOME` from env, config, or default `~/.codex`
- run generation through `codex exec --json --full-auto --enable image_generation`
- discover generated image files from thread output or newly created files
- add focused provider tests for success/error paths and config/env handling

## Sample config
```yaml
image_gen:
  provider: codex-cli
  model: codex-cli-default
  codex_cli:
    codex_home: ~/.codex-hermes
```

## Files touched
- `plugins/image_gen/codex_cli/__init__.py`
- `plugins/image_gen/codex_cli/plugin.yaml`
- `tests/plugins/image_gen/test_codex_cli_provider.py`

## Validation
- `pytest -q tests/plugins/image_gen tests/agent/test_image_gen_registry.py tests/hermes_cli/test_plugin_scanner_recursion.py tests/tools/test_image_generation.py tests/tools/test_image_generation_env.py`
- `126 passed`
