### PR TITLE
fix(image_gen/openai): support Codex auth fallback in OpenAI provider

### DIFF
--- a/plugins/image_gen/openai/__init__.py
+++ b/plugins/image_gen/openai/__init__.py
@@ -72,11 +72,99 @@ _MODELS: Dict[str, Dict[str, Any]] = {
 
 DEFAULT_MODEL = "gpt-image-2-medium"
 
+_CODEX_CHAT_MODEL = "gpt-5.4"
+_CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
+_CODEX_INSTRUCTIONS = (
+    "You are an assistant that must fulfill image generation requests by using "
+    "the image_generation tool when provided."
+)
+
 _SIZES = {
     "landscape": "1536x1024",
     "square": "1024x1024",
     "portrait": "1024x1536",
 }
+
+
+def _read_codex_access_token() -> Optional[str]:
+    """Read a usable Codex OAuth token from Hermes auth state."""
+    try:
+        from agent.auxiliary_client import _read_codex_access_token as _reader
+
+        token = _reader()
+        return str(token).strip() if isinstance(token, str) and token.strip() else None
+    except Exception as exc:
+        logger.debug("Could not resolve Codex access token for image generation: %s", exc)
+        return None
+
+
+def _build_codex_client():
+    """Return an OpenAI client pointed at the ChatGPT/Codex backend, or None."""
+    token = _read_codex_access_token()
+    if not token:
+        return None
+    try:
+        import openai
+        from agent.auxiliary_client import _codex_cloudflare_headers
+
+        return openai.OpenAI(
+            api_key=token,
+            base_url=_CODEX_BASE_URL,
+            default_headers=_codex_cloudflare_headers(token),
+        )
+    except Exception as exc:
+        logger.debug("Could not build Codex image client: %s", exc)
+        return None
+
+
+def _collect_codex_image_b64(client: Any, *, prompt: str, size: str, quality: str) -> Optional[str]:
+    """Generate via Codex Responses image tool and return the final base64 image."""
+    image_b64: Optional[str] = None
+    with client.responses.stream(
+        model=_CODEX_CHAT_MODEL,
+        store=False,
+        instructions=_CODEX_INSTRUCTIONS,
+        input=[{
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": prompt}],
+        }],
+        tools=[{
+            "type": "image_generation",
+            "model": API_MODEL,
+            "size": size,
+            "quality": quality,
+            "output_format": "png",
+            "background": "opaque",
+            "partial_images": 1,
+        }],
+        tool_choice={
+            "type": "allowed_tools",
+            "mode": "required",
+            "tools": [{"type": "image_generation"}],
+        },
+    ) as stream:
+        for event in stream:
+            event_type = getattr(event, "type", "")
+            if event_type == "response.output_item.done":
+                item = getattr(event, "item", None)
+                if getattr(item, "type", None) == "image_generation_call":
+                    result = getattr(item, "result", None)
+                    if isinstance(result, str) and result:
+                        image_b64 = result
+            elif event_type == "response.image_generation_call.partial_image":
+                partial = getattr(event, "partial_image_b64", None)
+                if isinstance(partial, str) and partial:
+                    image_b64 = partial
+        final = stream.get_final_response()
+
+    for item in getattr(final, "output", None) or []:
+        if getattr(item, "type", None) == "image_generation_call":
+            result = getattr(item, "result", None)
+            if isinstance(result, str) and result:
+                image_b64 = result
+
+    return image_b64
 
 
 def _load_openai_config() -> Dict[str, Any]:
@@ -133,7 +221,7 @@ class OpenAIImageGenProvider(ImageGenProvider):
         return "OpenAI"
 
     def is_available(self) -> bool:
-        if not os.environ.get("OPENAI_API_KEY"):
+        if not (os.environ.get("OPENAI_API_KEY") or _read_codex_access_token()):
             return False
         try:
             import openai  # noqa: F401
@@ -160,11 +248,11 @@ class OpenAIImageGenProvider(ImageGenProvider):
         return {
             "name": "OpenAI",
             "badge": "paid",
-            "tag": "gpt-image-2 at low/medium/high quality tiers",
+            "tag": "gpt-image-2 at low/medium/high quality tiers (API key or ChatGPT/Codex auth)",
             "env_vars": [
                 {
                     "key": "OPENAI_API_KEY",
-                    "prompt": "OpenAI API key",
+                    "prompt": "OpenAI API key (optional if ChatGPT/Codex auth is already configured)",
                     "url": "https://platform.openai.com/api-keys",
                 },
             ],
@@ -187,12 +275,16 @@ class OpenAIImageGenProvider(ImageGenProvider):
                 aspect_ratio=aspect,
             )
 
-        if not os.environ.get("OPENAI_API_KEY"):
+        api_key_present = bool(os.environ.get("OPENAI_API_KEY"))
+        codex_token = _read_codex_access_token()
+        use_codex = not api_key_present and bool(codex_token)
+
+        if not api_key_present and not codex_token:
             return error_response(
                 error=(
-                    "OPENAI_API_KEY not set. Run `hermes tools` → Image "
-                    "Generation → OpenAI to configure, or `hermes setup` "
-                    "to add the key."
+                    "Neither OPENAI_API_KEY nor ChatGPT/Codex OAuth auth is available. "
+                    "Run `hermes tools` → Image Generation → OpenAI to configure, "
+                    "or authenticate Hermes with OpenAI Codex/ChatGPT first."
                 ),
                 error_type="auth_required",
                 provider="openai",
@@ -222,35 +314,61 @@ class OpenAIImageGenProvider(ImageGenProvider):
             "quality": meta["quality"],
         }
 
-        try:
-            client = openai.OpenAI()
-            response = client.images.generate(**payload)
-        except Exception as exc:
-            logger.debug("OpenAI image generation failed", exc_info=True)
-            return error_response(
-                error=f"OpenAI image generation failed: {exc}",
-                error_type="api_error",
-                provider="openai",
-                model=tier_id,
-                prompt=prompt,
-                aspect_ratio=aspect,
-            )
+        b64 = None
+        url = None
+        revised_prompt = None
 
-        data = getattr(response, "data", None) or []
-        if not data:
-            return error_response(
-                error="OpenAI returned no image data",
-                error_type="empty_response",
-                provider="openai",
-                model=tier_id,
-                prompt=prompt,
-                aspect_ratio=aspect,
-            )
+        if use_codex:
+            try:
+                client = _build_codex_client()
+                if client is None:
+                    raise RuntimeError("Could not initialize Codex image client")
+                b64 = _collect_codex_image_b64(
+                    client,
+                    prompt=prompt,
+                    size=size,
+                    quality=meta["quality"],
+                )
+            except Exception as exc:
+                logger.debug("Codex-backed OpenAI image generation failed", exc_info=True)
+                return error_response(
+                    error=f"OpenAI image generation via Codex auth failed: {exc}",
+                    error_type="api_error",
+                    provider="openai",
+                    model=tier_id,
+                    prompt=prompt,
+                    aspect_ratio=aspect,
+                )
+        else:
+            try:
+                client = openai.OpenAI()
+                response = client.images.generate(**payload)
+            except Exception as exc:
+                logger.debug("OpenAI image generation failed", exc_info=True)
+                return error_response(
+                    error=f"OpenAI image generation failed: {exc}",
+                    error_type="api_error",
+                    provider="openai",
+                    model=tier_id,
+                    prompt=prompt,
+                    aspect_ratio=aspect,
+                )
 
-        first = data[0]
-        b64 = getattr(first, "b64_json", None)
-        url = getattr(first, "url", None)
-        revised_prompt = getattr(first, "revised_prompt", None)
+            data = getattr(response, "data", None) or []
+            if not data:
+                return error_response(
+                    error="OpenAI returned no image data",
+                    error_type="empty_response",
+                    provider="openai",
+                    model=tier_id,
+                    prompt=prompt,
+                    aspect_ratio=aspect,
+                )
+
+            first = data[0]
+            b64 = getattr(first, "b64_json", None)
+            url = getattr(first, "url", None)
+            revised_prompt = getattr(first, "revised_prompt", None)
 
         if b64:
             try:
@@ -279,7 +397,11 @@ class OpenAIImageGenProvider(ImageGenProvider):
                 aspect_ratio=aspect,
             )
 
-        extra: Dict[str, Any] = {"size": size, "quality": meta["quality"]}
+        extra: Dict[str, Any] = {
+            "size": size,
+            "quality": meta["quality"],
+            "auth_source": "codex" if use_codex else "api_key",
+        }
         if revised_prompt:
             extra["revised_prompt"] = revised_prompt
 

--- a/plugins/image_gen/openai/plugin.yaml
+++ b/plugins/image_gen/openai/plugin.yaml
@@ -1,7 +1,5 @@
 name: openai
-version: 1.0.0
-description: "OpenAI image generation backend (gpt-image-2). Saves generated images to $HERMES_HOME/cache/images/."
+version: 1.1.0
+description: "OpenAI image generation backend (gpt-image-2). Supports either OPENAI_API_KEY or ChatGPT/Codex OAuth auth and saves generated images to $HERMES_HOME/cache/images/."
 author: NousResearch
 kind: backend
-requires_env:
-  - OPENAI_API_KEY

--- a/tests/plugins/image_gen/test_openai_provider_codex.py
+++ b/tests/plugins/image_gen/test_openai_provider_codex.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import plugins.image_gen.openai as openai_plugin
+
+
+_PNG_HEX = (
+    "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4"
+    "890000000d49444154789c6300010000000500010d0a2db40000000049454e44"
+    "ae426082"
+)
+
+
+def _b64_png() -> str:
+    import base64
+
+    return base64.b64encode(bytes.fromhex(_PNG_HEX)).decode()
+
+
+class _FakeStream:
+    def __init__(self, events, final_response):
+        self._events = list(events)
+        self._final = final_response
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def __iter__(self):
+        return iter(self._events)
+
+    def get_final_response(self):
+        return self._final
+
+
+@pytest.fixture(autouse=True)
+def _tmp_hermes_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    yield tmp_path
+
+
+@pytest.fixture
+def provider(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    return openai_plugin.OpenAIImageGenProvider()
+
+
+class TestCodexAvailability:
+    def test_codex_token_makes_provider_available_without_openai_api_key(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setattr(openai_plugin, "_read_codex_access_token", lambda: "codex-token")
+        assert openai_plugin.OpenAIImageGenProvider().is_available() is True
+
+
+class TestCodexGenerate:
+    def test_generate_uses_codex_stream_path_without_openai_api_key(self, provider, monkeypatch, tmp_path):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setattr(openai_plugin, "_read_codex_access_token", lambda: "codex-token")
+
+        output_item = SimpleNamespace(
+            type="image_generation_call",
+            status="generating",
+            id="ig_test",
+            result=_b64_png(),
+        )
+        done_event = SimpleNamespace(type="response.output_item.done", item=output_item)
+        final_response = SimpleNamespace(output=[], status="completed", output_text="")
+
+        fake_client = SimpleNamespace(
+            responses=SimpleNamespace(
+                stream=lambda **kwargs: _FakeStream([done_event], final_response)
+            )
+        )
+        monkeypatch.setattr(openai_plugin, "_build_codex_client", lambda: fake_client)
+
+        result = provider.generate("a cat", aspect_ratio="landscape")
+
+        assert result["success"] is True
+        assert result["model"] == "gpt-image-2-medium"
+        assert result["provider"] == "openai"
+        assert result["quality"] == "medium"
+
+        saved = Path(result["image"])
+        assert saved.exists()
+        assert saved.parent == tmp_path / "cache" / "images"
+
+    def test_codex_stream_request_shape(self, provider, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.setattr(openai_plugin, "_read_codex_access_token", lambda: "codex-token")
+
+        captured = {}
+
+        def _stream(**kwargs):
+            captured.update(kwargs)
+            output_item = SimpleNamespace(
+                type="image_generation_call",
+                status="generating",
+                id="ig_test",
+                result=_b64_png(),
+            )
+            done_event = SimpleNamespace(type="response.output_item.done", item=output_item)
+            final_response = SimpleNamespace(output=[], status="completed", output_text="")
+            return _FakeStream([done_event], final_response)
+
+        fake_client = SimpleNamespace(responses=SimpleNamespace(stream=_stream))
+        monkeypatch.setattr(openai_plugin, "_build_codex_client", lambda: fake_client)
+
+        result = provider.generate("a cat", aspect_ratio="portrait")
+
+        assert result["success"] is True
+        assert captured["model"] == "gpt-5.4"
+        assert captured["store"] is False
+        assert captured["input"][0]["type"] == "message"
+        assert captured["input"][0]["role"] == "user"
+        assert captured["input"][0]["content"][0]["type"] == "input_text"
+        assert captured["tool_choice"]["type"] == "allowed_tools"
+        assert captured["tool_choice"]["mode"] == "required"
+        assert captured["tool_choice"]["tools"] == [{"type": "image_generation"}]
+        tool = captured["tools"][0]
+        assert tool["type"] == "image_generation"
+        assert tool["model"] == "gpt-image-2"
+        assert tool["quality"] == "medium"
+        assert tool["size"] == "1024x1536"
+        assert tool["output_format"] == "png"
+        assert tool["background"] == "opaque"
+        assert tool["partial_images"] == 1


### PR DESCRIPTION
## Summary
- allow `plugins/image_gen/openai` to work when reusable ChatGPT/Codex auth exists but `OPENAI_API_KEY` is unset
- keep the existing API-key `images.generate()` path unchanged when `OPENAI_API_KEY` is configured
- add regression coverage for provider availability and the Codex-backed request shape

## Changes
- read existing Codex auth and treat it as a valid availability signal for the OpenAI image provider
- add a Codex Responses image-generation path inside `OpenAIImageGenProvider.generate()` that extracts the returned image and saves it into Hermes' normal image cache
- update the OpenAI image provider setup/manifest text so it no longer implies an API key is mandatory when Codex auth already exists
- add focused tests covering availability, streamed image extraction, and the request shape sent to the Codex image-generation tool

## Validation
- `pytest tests/plugins/image_gen/test_openai_provider_codex.py tests/plugins/image_gen/test_openai_provider.py -q` -> 27 passed
- manual smoke in a Codex-authenticated environment: `OpenAIImageGenProvider.generate(...)` returned a cached image with `model=gpt-image-2-medium` and `auth_source=codex`

## Notes
- when `OPENAI_API_KEY` is present, the existing API-key path remains preferred
- this is scoped to the OpenAI image provider; it does not change FAL defaults

Closes #11195
