### PR TITLE
fix: route media files to Feishu send_message pipeline

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -528,6 +528,23 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             last_result = result
         return last_result
 
+    # --- Feishu: native file/image/video/voice attachment support ---
+    if platform == Platform.FEISHU and media_files:
+        last_result = None
+        for i, chunk in enumerate(chunks):
+            is_last = (i == len(chunks) - 1)
+            result = await _send_feishu(
+                pconfig,
+                chat_id,
+                chunk,
+                media_files=media_files if is_last else [],
+                thread_id=thread_id,
+            )
+            if isinstance(result, dict) and result.get("error"):
+                return result
+            last_result = result
+        return last_result
+
     # --- Non-media platforms ---
     if media_files and not message.strip():
         return {


### PR DESCRIPTION
## Summary

Fixes #10136

Route `media_files` to `_send_feishu()` in the send_message tool pipeline. The Feishu adapter already fully supports file sending (`send_document`, `send_image_file`, `send_video`), but the routing layer silently dropped `media_files` for Feishu.

## Changes

- Added Feishu media routing branch in `tools/send_message_tool.py` before the non-media fallback
- Passes `media_files` to `_send_feishu()` so `MEDIA:` tagged files are delivered correctly

## Test

Tested by sending PPT and markdown files via Feishu DM — both delivered successfully.

---

Simple fix addressing the exact issue reported in #10136. The adapter layer (`feishu.py`) was already correct; only the routing layer was missing the Feishu branch.