### PR TITLE
fix(error_classifier): classify 'overloaded' message as FailoverReason.overloaded

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -590,6 +590,16 @@ def _classify_400(
 
     # Some providers return rate limit / billing errors as 400 instead of 429/402.
     # Check these patterns before falling through to format_error.
+
+    # Overloaded patterns — server-side overload, NOT a credential/billing issue.
+    # Must come before rate_limit check to avoid rotating credentials unnecessarily.
+    if "overloaded" in error_msg or "temporarily overloaded" in error_msg:
+        return result_fn(
+            FailoverReason.overloaded,
+            retryable=True,
+            should_fallback=True,
+        )
+
     if any(p in error_msg for p in _RATE_LIMIT_PATTERNS):
         return result_fn(
             FailoverReason.rate_limit,
@@ -723,7 +733,14 @@ def _classify_by_message(
             should_fallback=True,
         )
 
-    # Rate limit patterns
+    # Rate limit patterns — but overloaded must come first to avoid credential rotation.
+    if "overloaded" in error_msg or "temporarily overloaded" in error_msg:
+        return result_fn(
+            FailoverReason.overloaded,
+            retryable=True,
+            should_fallback=True,
+        )
+
     if any(p in error_msg for p in _RATE_LIMIT_PATTERNS):
         return result_fn(
             FailoverReason.rate_limit,


### PR DESCRIPTION
Closes #14038

## Summary

When a provider (e.g. Z.AI) returns a 'temporarily overloaded' error (HTTP 200 with code 1305, or HTTP 400), it was being classified as  with . After 2 failures, the single API key was marked exhausted, causing all further retries to fail immediately.

The fix adds an 'overloaded' / 'temporarily overloaded' pattern check **before** the rate_limit check in both  and . Overloaded errors now get  (retryable, should_fallback) instead of , preventing unnecessary credential rotation.

## Changes

- : Added overloaded pattern check before rate_limit in  (~line 594) and  (~line 736)

## Root cause

 contains , but 'overloaded' error messages from providers like Z.AI were matching as generic rate limits. The  flag caused the credential pool to mark the API key as exhausted after just 2 transient errors.