### PR TITLE
feat: circuit breaker for infinite tool-call loops

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1442,6 +1442,11 @@ class AIAgent:
         # the LLM into a different strategy.
         self._consecutive_tool_calls: list[tuple[str, str]] = []
         self._circuit_breaker_threshold: int = 5
+        # Per-tool failure retry counter: tracks consecutive failures
+        # for a tool regardless of argument changes.  Prevents the LLM
+        # from retrying different variations of a failing tool call.
+        self._tool_failure_count: dict[str, int] = {}
+        self._tool_failure_threshold: int = 5
         if not skip_memory:
             try:
                 mem_config = _agent_cfg.get("memory", {})
@@ -2166,6 +2171,67 @@ class AIAgent:
             "api_key": getattr(self, "api_key", "") or "",
             "api_mode": getattr(self, "api_mode", "") or "",
         }
+
+    def _check_tool_failure(self, tool_name: str, result: str) -> str | None:
+        """Check if a tool result indicates failure and update retry counter.
+
+        Returns an error message if the retry threshold is reached, forcing the
+        LLM to change strategy. Returns None if the tool is still within limits.
+
+        A result is considered a **failure** if it contains:
+        - An "error" field (tool explicitly reported an error)
+        - A "BLOCKED" marker (tool-level circuit breaker triggered)
+        - "total_count": 0 with no matches (empty search result)
+
+        A result is considered a **success** if it has actual data, in which
+        case the retry counter is reset to 0.
+        """
+        import json
+        try:
+            data = json.loads(result)
+        except (json.JSONDecodeError, TypeError):
+            # Not JSON — treat as success (be conservative)
+            self._tool_failure_count[tool_name] = 0
+            return None
+
+        if not isinstance(data, dict):
+            self._tool_failure_count[tool_name] = 0
+            return None
+
+        # Check for failure conditions
+        if "error" in data:
+            is_failure = True
+        elif "BLOCKED" in str(data):
+            is_failure = True
+        elif data.get("total_count") == 0 and data.get("total_count") is not None:
+            # Empty result counts as failure for search-type tools
+            is_failure = True
+        elif data.get("total_count", 0) > 0:
+            # Has data — success, reset counter
+            self._tool_failure_count[tool_name] = 0
+            return None
+        else:
+            # Unknown format — treat as success (be conservative)
+            self._tool_failure_count[tool_name] = 0
+            return None
+
+        # Count this as a failure
+        self._tool_failure_count[tool_name] = self._tool_failure_count.get(tool_name, 0) + 1
+        if self._tool_failure_count[tool_name] >= self._tool_failure_threshold:
+            count = self._tool_failure_count[tool_name]
+            msg = (
+                f"[Tool retry threshold reached] Tool '{tool_name}' has failed "
+                f"{count} consecutive times (different arguments each time). "
+                f"STOP retrying with different parameters. "
+                f"Analyze why it's failing and try a completely different approach."
+            )
+            logger.warning(
+                "Tool retry threshold reached: %s (%d consecutive failures)",
+                tool_name, count,
+            )
+            return msg
+
+        return None
 
     def _check_compression_model_feasibility(self) -> None:
         """Warn at session start if the auxiliary compression model's context
@@ -7563,6 +7629,14 @@ class AIAgent:
                 self._consecutive_tool_calls.clear()
                 return json.dumps({"error": msg}, ensure_ascii=False)
 
+        # ── Failure retry counter: detect consecutive tool failures ──────
+        # Tracks how many times a tool has returned an error/empty result
+        # in a row, regardless of argument changes.  Prevents the LLM from
+        # retrying different variations of a failing tool call.
+        _cb_retry_msg = self._check_tool_failure(function_name, function_result)
+        if _cb_retry_msg is not None:
+            return json.dumps({"error": _cb_retry_msg}, ensure_ascii=False)
+
         if function_name == "todo":
             from tools.todo_tool import todo_tool as _todo_tool
             return _todo_tool(
@@ -8111,6 +8185,10 @@ class AIAgent:
                 tool_duration = time.time() - tool_start_time
                 if self._should_emit_quiet_tool_messages():
                     self._vprint(f"  {_get_cute_tool_message_impl('todo', function_args, tool_duration, result=function_result)}")
+                # Check failure retry counter
+                _cb_retry_msg = self._check_tool_failure(function_name, function_result)
+                if _cb_retry_msg is not None:
+                    function_result = json.dumps({"error": _cb_retry_msg}, ensure_ascii=False)
             elif function_name == "session_search":
                 if not self._session_db:
                     function_result = json.dumps({"success": False, "error": "Session database not available."})
@@ -8126,6 +8204,10 @@ class AIAgent:
                 tool_duration = time.time() - tool_start_time
                 if self._should_emit_quiet_tool_messages():
                     self._vprint(f"  {_get_cute_tool_message_impl('session_search', function_args, tool_duration, result=function_result)}")
+                # Check failure retry counter
+                _cb_retry_msg = self._check_tool_failure(function_name, function_result)
+                if _cb_retry_msg is not None:
+                    function_result = json.dumps({"error": _cb_retry_msg}, ensure_ascii=False)
             elif function_name == "memory":
                 target = function_args.get("target", "memory")
                 from tools.memory_tool import memory_tool as _memory_tool
@@ -8149,6 +8231,10 @@ class AIAgent:
                 tool_duration = time.time() - tool_start_time
                 if self._should_emit_quiet_tool_messages():
                     self._vprint(f"  {_get_cute_tool_message_impl('memory', function_args, tool_duration, result=function_result)}")
+                # Check failure retry counter
+                _cb_retry_msg = self._check_tool_failure(function_name, function_result)
+                if _cb_retry_msg is not None:
+                    function_result = json.dumps({"error": _cb_retry_msg}, ensure_ascii=False)
             elif function_name == "clarify":
                 from tools.clarify_tool import clarify_tool as _clarify_tool
                 function_result = _clarify_tool(
@@ -8159,6 +8245,10 @@ class AIAgent:
                 tool_duration = time.time() - tool_start_time
                 if self._should_emit_quiet_tool_messages():
                     self._vprint(f"  {_get_cute_tool_message_impl('clarify', function_args, tool_duration, result=function_result)}")
+                # Check failure retry counter
+                _cb_retry_msg = self._check_tool_failure(function_name, function_result)
+                if _cb_retry_msg is not None:
+                    function_result = json.dumps({"error": _cb_retry_msg}, ensure_ascii=False)
             elif function_name == "delegate_task":
                 tasks_arg = function_args.get("tasks")
                 if tasks_arg and isinstance(tasks_arg, list):
@@ -8184,6 +8274,10 @@ class AIAgent:
                         spinner.stop(cute_msg)
                     elif self._should_emit_quiet_tool_messages():
                         self._vprint(f"  {cute_msg}")
+                    # Check failure retry counter (inside finally so it always runs)
+                    _cb_retry_msg = self._check_tool_failure(function_name, function_result)
+                    if _cb_retry_msg is not None:
+                        function_result = json.dumps({"error": _cb_retry_msg}, ensure_ascii=False)
             elif self._context_engine_tool_names and function_name in self._context_engine_tool_names:
                 # Context engine tools (lcm_grep, lcm_describe, lcm_expand, etc.)
                 spinner = None
@@ -8207,6 +8301,10 @@ class AIAgent:
                         spinner.stop(cute_msg)
                     elif self._should_emit_quiet_tool_messages():
                         self._vprint(f"  {cute_msg}")
+                    # Check failure retry counter
+                    _cb_retry_msg = self._check_tool_failure(function_name, function_result)
+                    if _cb_retry_msg is not None:
+                        function_result = json.dumps({"error": _cb_retry_msg}, ensure_ascii=False)
             elif self._memory_manager and self._memory_manager.has_tool(function_name):
                 # Memory provider tools (hindsight_retain, honcho_search, etc.)
                 # These are not in the tool registry — route through MemoryManager.
@@ -8231,6 +8329,10 @@ class AIAgent:
                         spinner.stop(cute_msg)
                     elif self._should_emit_quiet_tool_messages():
                         self._vprint(f"  {cute_msg}")
+                    # Check failure retry counter
+                    _cb_retry_msg = self._check_tool_failure(function_name, function_result)
+                    if _cb_retry_msg is not None:
+                        function_result = json.dumps({"error": _cb_retry_msg}, ensure_ascii=False)
             elif self.quiet_mode:
                 spinner = None
                 if self._should_emit_quiet_tool_messages() and self._should_start_quiet_spinner():
@@ -8259,6 +8361,10 @@ class AIAgent:
                         spinner.stop(cute_msg)
                     elif self._should_emit_quiet_tool_messages():
                         self._vprint(f"  {cute_msg}")
+                    # Check failure retry counter
+                    _cb_retry_msg = self._check_tool_failure(function_name, function_result)
+                    if _cb_retry_msg is not None:
+                        function_result = json.dumps({"error": _cb_retry_msg}, ensure_ascii=False)
             else:
                 try:
                     function_result = handle_function_call(
@@ -8272,6 +8378,10 @@ class AIAgent:
                     function_result = f"Error executing tool '{function_name}': {tool_error}"
                     logger.error("handle_function_call raised for %s: %s", function_name, tool_error, exc_info=True)
                 tool_duration = time.time() - tool_start_time
+                # Check failure retry counter (generic tool path)
+                _cb_retry_msg = self._check_tool_failure(function_name, function_result)
+                if _cb_retry_msg is not None:
+                    function_result = json.dumps({"error": _cb_retry_msg}, ensure_ascii=False)
 
             result_preview = function_result if self.verbose_logging else (
                 function_result[:200] if len(function_result) > 200 else function_result

--- a/run_agent.py
+++ b/run_agent.py
@@ -2219,19 +2219,104 @@ class AIAgent:
         self._tool_failure_count[tool_name] = self._tool_failure_count.get(tool_name, 0) + 1
         if self._tool_failure_count[tool_name] >= self._tool_failure_threshold:
             count = self._tool_failure_count[tool_name]
-            msg = (
+            base_msg = (
                 f"[Tool retry threshold reached] Tool '{tool_name}' has failed "
                 f"{count} consecutive times (different arguments each time). "
                 f"STOP retrying with different parameters. "
-                f"Analyze why it's failing and try a completely different approach."
             )
+            
+            # Try to get a suggestion from the compression model
+            suggestion = self._get_tool_suggestion(tool_name, result)
+            if suggestion:
+                base_msg += f"\n💡 Compression model suggestion: {suggestion}"
+            
+            base_msg += " Analyze why it's failing and try a completely different approach."
+            
             logger.warning(
                 "Tool retry threshold reached: %s (%d consecutive failures)",
                 tool_name, count,
             )
-            return msg
+            return base_msg
 
         return None
+    
+    def _get_tool_suggestion(self, tool_name: str, last_result: str) -> str | None:
+        """Ask the compression model for a suggestion when a tool keeps failing.
+        
+        This is a lightweight intervention — the compression model acts as an
+        'outsider' that can break the main model's loop with a fresh perspective.
+        Returns a short suggestion string, or None if the compression model
+        is unavailable or the call fails.
+        """
+        try:
+            from agent.auxiliary_client import call_llm
+            
+            # Build a minimal prompt for the compression model
+            result_preview = last_result[:300] if last_result else "(empty)"
+            prompt = (
+                f"A tool call keeps failing. Help identify the root cause.\n\n"
+                f"Tool: {tool_name}\n"
+                f"Last result: {result_preview}\n\n"
+                f"Give ONE short suggestion (max 20 words) on how to fix this. "
+                f"Be specific. Example: 'Use gh api instead of gh run view for log retrieval'."
+            )
+            
+            response = call_llm(
+                task="compression",
+                messages=[
+                    {"role": "system", "content": "You are a debugging assistant. Give concise, specific suggestions."},
+                    {"role": "user", "content": prompt},
+                ],
+                max_tokens=50,
+                temperature=0.3,
+                main_runtime=self._current_main_runtime(),
+            )
+            
+            suggestion = response.choices[0].message.content.strip()
+            # Keep it short
+            if len(suggestion) > 100:
+                suggestion = suggestion[:97] + "..."
+            return suggestion
+        except Exception as e:
+            # Silently fail — we don't want to break the main flow
+            logger.debug("Compression model suggestion failed: %s", e)
+            return None
+    
+    def _get_consecutive_suggestion(self, tool_name: str) -> str | None:
+        """Ask the compression model for a suggestion when consecutive identical calls trigger the circuit breaker.
+        
+        Similar to _get_tool_suggestion but for the consecutive-call case where
+        the model is retrying the EXACT same arguments.
+        """
+        try:
+            from agent.auxiliary_client import call_llm
+            
+            prompt = (
+                f"A tool call is stuck in a loop — same arguments repeated. "
+                f"Break the loop.\n\n"
+                f"Tool: {tool_name}\n\n"
+                f"Give ONE short suggestion (max 20 words) on what to try instead. "
+                f"Be specific. Example: 'Use gh api repos/.../actions/runs/{id}/logs instead of gh run view --log-failed'."
+            )
+            
+            response = call_llm(
+                task="compression",
+                messages=[
+                    {"role": "system", "content": "You are a debugging assistant. Give concise, specific suggestions."},
+                    {"role": "user", "content": prompt},
+                ],
+                max_tokens=50,
+                temperature=0.3,
+                main_runtime=self._current_main_runtime(),
+            )
+            
+            suggestion = response.choices[0].message.content.strip()
+            if len(suggestion) > 100:
+                suggestion = suggestion[:97] + "..."
+            return suggestion
+        except Exception as e:
+            logger.debug("Compression model suggestion failed: %s", e)
+            return None
 
     def _check_compression_model_feasibility(self) -> None:
         """Warn at session start if the auxiliary compression model's context
@@ -7619,13 +7704,21 @@ class AIAgent:
             if len(set(recent_sigs)) == 1:
                 # All same — circuit breaker triggered!
                 streak = len(self._consecutive_tool_calls)
-                msg = (
+                base_msg = (
                     f"[Circuit breaker triggered] Tool '{function_name}' called "
                     f"{streak} consecutive times with identical arguments. "
                     f"This approach is not working. STOP retrying the same tool with the same parameters. "
-                    f"Consider: (1) the tool may not be available in this environment, "
-                    f"(2) there may be a permission issue, or (3) the command syntax is wrong. "
-                    f"Try a completely different approach or investigate the root cause."
+                )
+                
+                # Try to get a suggestion from the compression model
+                suggestion = self._get_consecutive_suggestion(function_name)
+                if suggestion:
+                    base_msg += f"\n💡 Compression model suggestion: {suggestion}"
+                
+                base_msg += (
+                    " Consider: (1) the tool may not be available in this environment, "
+                    "(2) there may be a permission issue, or (3) the command syntax is wrong. "
+                    "Try a completely different approach or investigate the root cause."
                 )
                 logger.warning("Circuit breaker triggered: %s (streak=%d)", function_name, streak)
                 # Reset streak so future calls can succeed

--- a/run_agent.py
+++ b/run_agent.py
@@ -1026,6 +1026,13 @@ class AIAgent:
         self._current_tool: str | None = None
         self._api_call_count: int = 0
 
+        # Tool call loop breaker — detects when the model repeatedly issues
+        # the *exact same* tool call (same name + same args) and forces a
+        # state change after N consecutive duplicates.  This prevents the
+        # agent from getting stuck in infinite tool-call loops.
+        self._tool_call_history: list[tuple[str, str]] = []  # (tool_name, args_hash)
+        self._tool_call_breach_threshold: int = 3  # consecutive identical calls before breaking
+
         # Rate limit tracking — updated from x-ratelimit-* response headers
         # after each API call.  Accessed by /usage slash command.
         self._rate_limit_state: Optional["RateLimitState"] = None
@@ -1429,6 +1436,12 @@ class AIAgent:
         self._memory_flush_min_turns = 6
         self._turns_since_memory = 0
         self._iters_since_skill = 0
+        # Circuit breaker: detect and break infinite tool-call loops.
+        # Tracks the last (tool_name, args_hash) pair.  When the same
+        # tool+args is called consecutively N times, we abort to force
+        # the LLM into a different strategy.
+        self._consecutive_tool_calls: list[tuple[str, str]] = []
+        self._circuit_breaker_threshold: int = 3
         if not skip_memory:
             try:
                 mem_config = _agent_cfg.get("memory", {})
@@ -7520,6 +7533,35 @@ class AIAgent:
         if block_message is not None:
             return json.dumps({"error": block_message}, ensure_ascii=False)
 
+        # ── Circuit breaker: detect infinite tool-call loops ─────────────
+        # Build a stable hash of (tool_name, args) to detect identical
+        # consecutive calls.  When the same tool+args fires N times in a
+        # row, the LLM is likely stuck in a retry loop — abort and force
+        # it to try a different approach.
+        import hashlib as _hashlib
+        args_key = json.dumps(function_args, sort_keys=True, ensure_ascii=False)
+        call_sig = f"{function_name}:{_hashlib.md5(args_key.encode('utf-8')).hexdigest()[:16]}"
+        
+        # Always record the call (append new entry each time)
+        self._consecutive_tool_calls.append((function_name, call_sig))
+        
+        # Check if the last N entries are all the same
+        n = len(self._consecutive_tool_calls)
+        if n >= self._circuit_breaker_threshold:
+            # Check if the last N entries all have the same signature
+            recent_sigs = [s for _, s in self._consecutive_tool_calls[-self._circuit_breaker_threshold:]]
+            if len(set(recent_sigs)) == 1:
+                # All same — circuit breaker triggered!
+                streak = len(self._consecutive_tool_calls)
+                msg = (
+                    f"[熔断器触发] 工具 '{function_name}' 连续 {streak} 次调用完全相同的参数，"
+                    f"已强制终止。请换用不同的工具或策略。"
+                )
+                logger.warning("Circuit breaker triggered: %s (streak=%d)", function_name, streak)
+                # Reset streak so future calls can succeed
+                self._consecutive_tool_calls.clear()
+                return json.dumps({"error": msg}, ensure_ascii=False)
+
         if function_name == "todo":
             from tools.todo_tool import todo_tool as _todo_tool
             return _todo_tool(
@@ -8018,12 +8060,44 @@ class AIAgent:
                 except Exception:
                     pass  # never block tool execution
 
+            # ── Circuit breaker: detect infinite tool-call loops ──────────
+            # Same logic as in _invoke_tool() — the sequential path has its
+            # own inline dispatch and must also be protected.
+            _cb_bypass = False
+            if _block_msg is None:
+                import hashlib as _hashlib
+                _cb_args_key = json.dumps(function_args, sort_keys=True, ensure_ascii=False)
+                _cb_call_sig = f"{function_name}:{_hashlib.md5(_cb_args_key.encode('utf-8')).hexdigest()[:16]}"
+                
+                # Always record the call
+                self._consecutive_tool_calls.append((function_name, _cb_call_sig))
+                
+                # Check if the last N entries are all the same
+                _cb_n = len(self._consecutive_tool_calls)
+                if _cb_n >= self._circuit_breaker_threshold:
+                    _cb_recent_sigs = [s for _, s in self._consecutive_tool_calls[-self._circuit_breaker_threshold:]]
+                    if len(set(_cb_recent_sigs)) == 1:
+                        _cb_streak = len(self._consecutive_tool_calls)
+                        function_result = json.dumps({
+                            "error": (
+                                f"[熔断器触发] 工具 '{function_name}' 连续 {_cb_streak} 次调用完全相同的参数，"
+                                f"已强制终止。请换用不同的工具或策略。"
+                            )
+                        }, ensure_ascii=False)
+                        logger.warning("Circuit breaker triggered (sequential): %s (streak=%d)", function_name, _cb_streak)
+                        self._consecutive_tool_calls.clear()
+                        tool_duration = 0.0
+                        _cb_bypass = True
+
             tool_start_time = time.time()
 
-            if _block_msg is not None:
-                # Tool blocked by plugin policy — return error without executing.
-                function_result = json.dumps({"error": _block_msg}, ensure_ascii=False)
-                tool_duration = 0.0
+            if _block_msg is not None or _cb_bypass:
+                # Tool blocked by plugin policy or circuit breaker — return
+                # error without executing.  (_cb_bypass: function_result was
+                # already set in the circuit breaker block above.)
+                if _block_msg is not None:
+                    function_result = json.dumps({"error": _block_msg}, ensure_ascii=False)
+                    tool_duration = 0.0
             elif function_name == "todo":
                 from tools.todo_tool import todo_tool as _todo_tool
                 function_result = _todo_tool(

--- a/run_agent.py
+++ b/run_agent.py
@@ -1441,12 +1441,12 @@ class AIAgent:
         # tool+args is called consecutively N times, we abort to force
         # the LLM into a different strategy.
         self._consecutive_tool_calls: list[tuple[str, str]] = []
-        self._circuit_breaker_threshold: int = 5
+        self._circuit_breaker_threshold: int = 3
         # Per-tool failure retry counter: tracks consecutive failures
         # for a tool regardless of argument changes.  Prevents the LLM
         # from retrying different variations of a failing tool call.
         self._tool_failure_count: dict[str, int] = {}
-        self._tool_failure_threshold: int = 5
+        self._tool_failure_threshold: int = 3
         if not skip_memory:
             try:
                 mem_config = _agent_cfg.get("memory", {})
@@ -7622,7 +7622,10 @@ class AIAgent:
                 msg = (
                     f"[Circuit breaker triggered] Tool '{function_name}' called "
                     f"{streak} consecutive times with identical arguments. "
-                    f"Please try a different approach."
+                    f"This approach is not working. STOP retrying the same tool with the same parameters. "
+                    f"Consider: (1) the tool may not be available in this environment, "
+                    f"(2) there may be a permission issue, or (3) the command syntax is wrong. "
+                    f"Try a completely different approach or investigate the root cause."
                 )
                 logger.warning("Circuit breaker triggered: %s (streak=%d)", function_name, streak)
                 # Reset streak so future calls can succeed

--- a/run_agent.py
+++ b/run_agent.py
@@ -2225,10 +2225,10 @@ class AIAgent:
                 f"STOP retrying with different parameters. "
             )
             
-            # Try to get a suggestion from the compression model
+            # Try to get a suggestion — compression model first, then built-in heuristics
             suggestion = self._get_tool_suggestion(tool_name, result)
             if suggestion:
-                base_msg += f"\n💡 Compression model suggestion: {suggestion}"
+                base_msg += f"\n💡 Suggestion: {suggestion}"
             
             base_msg += " Analyze why it's failing and try a completely different approach."
             
@@ -2241,17 +2241,27 @@ class AIAgent:
         return None
     
     def _get_tool_suggestion(self, tool_name: str, last_result: str) -> str | None:
-        """Ask the compression model for a suggestion when a tool keeps failing.
+        """Generate a suggestion when a tool keeps failing.
         
-        This is a lightweight intervention — the compression model acts as an
-        'outsider' that can break the main model's loop with a fresh perspective.
-        Returns a short suggestion string, or None if the compression model
-        is unavailable or the call fails.
+        Strategy (in order):
+        1. Try compression model (if configured) — gives fresh perspective
+        2. Fall back to built-in heuristic database — works zero-config
+        
+        Returns a short suggestion string, or None if no suggestion available.
         """
+        # 1. Try compression model first
+        suggestion = self._try_compression_model_suggestion(tool_name, last_result)
+        if suggestion:
+            return suggestion
+        
+        # 2. Fall back to built-in heuristics
+        return self._heuristic_suggestion(tool_name, last_result)
+    
+    def _try_compression_model_suggestion(self, tool_name: str, last_result: str) -> str | None:
+        """Try to get a suggestion from the compression model."""
         try:
             from agent.auxiliary_client import call_llm
             
-            # Build a minimal prompt for the compression model
             result_preview = last_result[:300] if last_result else "(empty)"
             prompt = (
                 f"A tool call keeps failing. Help identify the root cause.\n\n"
@@ -2273,21 +2283,74 @@ class AIAgent:
             )
             
             suggestion = response.choices[0].message.content.strip()
-            # Keep it short
             if len(suggestion) > 100:
                 suggestion = suggestion[:97] + "..."
             return suggestion
         except Exception as e:
-            # Silently fail — we don't want to break the main flow
             logger.debug("Compression model suggestion failed: %s", e)
             return None
     
-    def _get_consecutive_suggestion(self, tool_name: str) -> str | None:
-        """Ask the compression model for a suggestion when consecutive identical calls trigger the circuit breaker.
+    def _heuristic_suggestion(self, tool_name: str, last_result: str) -> str | None:
+        """Built-in heuristic suggestion system — works without any LLM config.
         
-        Similar to _get_tool_suggestion but for the consecutive-call case where
-        the model is retrying the EXACT same arguments.
+        Checks common failure patterns and returns a targeted suggestion.
         """
+        import re
+        
+        result_preview = (last_result or "").lower()
+        
+        # Pattern 1: Empty stdout/stderr from gh CLI
+        if tool_name == "terminal" and "gh " in result_preview:
+            if "exit code: 0" in result_preview or "stdout length: 0" in result_preview:
+                return "Command returned empty output — try 'gh api' directly or check if the resource exists"
+        
+        # Pattern 2: File not found
+        if "no such file" in result_preview or "file not found" in result_preview:
+            return "File path is wrong — verify the file exists and check the working directory"
+        
+        # Pattern 3: Permission denied
+        if "permission denied" in result_preview or "permissionerror" in result_preview:
+            return "Permission issue — try 'sudo' or check file/directory permissions"
+        
+        # Pattern 4: Module not found
+        if "module not found" in result_preview or "importerror" in result_preview:
+            return "Missing dependency — run 'pip install <package_name>' or check requirements.txt"
+        
+        # Pattern 5: Connection refused / network error
+        if "connection refused" in result_preview or "connection timed out" in result_preview or "network" in result_preview:
+            return "Network issue — check if the service is running and the port/URL is correct"
+        
+        # Pattern 6: Syntax error
+        if "syntaxerror" in result_preview or "syntax error" in result_preview:
+            return "Syntax error in the command/script — check quotes, escaping, and command structure"
+        
+        # Pattern 7: Generic empty result from any tool
+        if "(empty)" in result_preview or "empty" in result_preview:
+            return "Tool returned no data — the resource may not exist or the query may be too broad"
+        
+        # Pattern 8: JSON parse error
+        if "jsondecodeerror" in result_preview or "json decode" in result_preview:
+            return "Response is not valid JSON — the tool may have returned an error message instead"
+        
+        return None
+    
+    def _get_consecutive_suggestion(self, tool_name: str) -> str | None:
+        """Get a suggestion when consecutive identical calls trigger the circuit breaker.
+        
+        Strategy (in order):
+        1. Try compression model (if configured)
+        2. Fall back to built-in heuristics
+        """
+        # 1. Try compression model first
+        suggestion = self._try_compression_model_consecutive(tool_name)
+        if suggestion:
+            return suggestion
+        
+        # 2. Fall back to built-in heuristics
+        return self._heuristic_consecutive_suggestion(tool_name)
+    
+    def _try_compression_model_consecutive(self, tool_name: str) -> str | None:
+        """Try to get a suggestion from the compression model for consecutive-call loop."""
         try:
             from agent.auxiliary_client import call_llm
             
@@ -2317,6 +2380,44 @@ class AIAgent:
         except Exception as e:
             logger.debug("Compression model suggestion failed: %s", e)
             return None
+    
+    def _heuristic_consecutive_suggestion(self, tool_name: str) -> str | None:
+        """Built-in heuristic for consecutive-call circuit breaker."""
+        suggestions = {
+            "gh": "Try 'gh api' instead of 'gh run view' for log retrieval, or use curl to download logs directly",
+            "browser_navigate": "The URL may be unreachable — try a different URL or check network connectivity",
+            "browser_click": "The element may not be loaded yet — try browser_snapshot first to verify the page state",
+            "browser_snapshot": "The page may have changed — try browser_navigate to reload, or check for JavaScript errors",
+            "browser_type": "The input field may not be visible — scroll first or check the element ref ID",
+            "browser_press": "The key may not be applicable — check if the element has focus first",
+            "browser_console": "The console may be empty — try navigating to the page first",
+            "browser_vision": "Vision may not be available — try browser_snapshot for text-based inspection",
+            "browser_get_images": "No images found — the page may not have loaded images yet",
+            "execute_code": "The code may have syntax errors or missing imports — check the script carefully",
+            "session_search": "The search query may be too specific — try broader keywords or use OR logic",
+            "web_search": "The web search may be failing — try a different search engine or simplify the query",
+            "skill_view": "The skill may not exist — check the skill name spelling and available skills",
+            "memory": "The memory operation may have failed — check the memory format and content",
+            "todo": "The todo operation may have invalid format — check the todos array structure",
+            "delegate_task": "The delegation may have failed — check the goal and context fields",
+            "cronjob": "The cron job operation may have invalid parameters — check the schedule and prompt",
+            "patch": "The patch may not match — check the file content and old_string uniqueness",
+            "write_file": "The file write may have failed — check directory permissions and path",
+            "read_file": "The file may not exist — check the path and file name spelling",
+            "search_files": "The search pattern may be too specific — try a broader pattern",
+            "text_to_speech": "TTS may not be configured — check the TTS provider settings",
+        }
+        
+        # Try exact match first
+        if tool_name in suggestions:
+            return suggestions[tool_name]
+        
+        # Try prefix match (e.g., "browser_" matches "browser_click")
+        for key, value in suggestions.items():
+            if tool_name.startswith(key):
+                return value
+        
+        return None
 
     def _check_compression_model_feasibility(self) -> None:
         """Warn at session start if the auxiliary compression model's context

--- a/run_agent.py
+++ b/run_agent.py
@@ -2245,7 +2245,7 @@ class AIAgent:
         
         Strategy (in order):
         1. Try compression model (if configured) — gives fresh perspective
-        2. Fall back to built-in heuristic database — works zero-config
+        2. Fall back to a simple generic prompt — works zero-config
         
         Returns a short suggestion string, or None if no suggestion available.
         """
@@ -2254,8 +2254,8 @@ class AIAgent:
         if suggestion:
             return suggestion
         
-        # 2. Fall back to built-in heuristics
-        return self._heuristic_suggestion(tool_name, last_result)
+        # 2. Simple generic fallback — no pattern matching needed
+        return "Repeatedly failing. Try a completely different approach instead of tweaking parameters."
     
     def _try_compression_model_suggestion(self, tool_name: str, last_result: str) -> str | None:
         """Try to get a suggestion from the compression model."""
@@ -2290,64 +2290,20 @@ class AIAgent:
             logger.debug("Compression model suggestion failed: %s", e)
             return None
     
-    def _heuristic_suggestion(self, tool_name: str, last_result: str) -> str | None:
-        """Built-in heuristic suggestion system — works without any LLM config.
-        
-        Checks common failure patterns and returns a targeted suggestion.
-        """
-        import re
-        
-        result_preview = (last_result or "").lower()
-        
-        # Pattern 1: Empty stdout/stderr from gh CLI
-        if tool_name == "terminal" and "gh " in result_preview:
-            if "exit code: 0" in result_preview or "stdout length: 0" in result_preview:
-                return "Command returned empty output — try 'gh api' directly or check if the resource exists"
-        
-        # Pattern 2: File not found
-        if "no such file" in result_preview or "file not found" in result_preview:
-            return "File path is wrong — verify the file exists and check the working directory"
-        
-        # Pattern 3: Permission denied
-        if "permission denied" in result_preview or "permissionerror" in result_preview:
-            return "Permission issue — try 'sudo' or check file/directory permissions"
-        
-        # Pattern 4: Module not found
-        if "module not found" in result_preview or "importerror" in result_preview:
-            return "Missing dependency — run 'pip install <package_name>' or check requirements.txt"
-        
-        # Pattern 5: Connection refused / network error
-        if "connection refused" in result_preview or "connection timed out" in result_preview or "network" in result_preview:
-            return "Network issue — check if the service is running and the port/URL is correct"
-        
-        # Pattern 6: Syntax error
-        if "syntaxerror" in result_preview or "syntax error" in result_preview:
-            return "Syntax error in the command/script — check quotes, escaping, and command structure"
-        
-        # Pattern 7: Generic empty result from any tool
-        if "(empty)" in result_preview or "empty" in result_preview:
-            return "Tool returned no data — the resource may not exist or the query may be too broad"
-        
-        # Pattern 8: JSON parse error
-        if "jsondecodeerror" in result_preview or "json decode" in result_preview:
-            return "Response is not valid JSON — the tool may have returned an error message instead"
-        
-        return None
-    
     def _get_consecutive_suggestion(self, tool_name: str) -> str | None:
         """Get a suggestion when consecutive identical calls trigger the circuit breaker.
         
         Strategy (in order):
         1. Try compression model (if configured)
-        2. Fall back to built-in heuristics
+        2. Fall back to a simple generic prompt
         """
         # 1. Try compression model first
         suggestion = self._try_compression_model_consecutive(tool_name)
         if suggestion:
             return suggestion
         
-        # 2. Fall back to built-in heuristics
-        return self._heuristic_consecutive_suggestion(tool_name)
+        # 2. Simple generic fallback
+        return "Called the exact same thing N times in a row. It's not working — stop and try something else."
     
     def _try_compression_model_consecutive(self, tool_name: str) -> str | None:
         """Try to get a suggestion from the compression model for consecutive-call loop."""
@@ -2380,44 +2336,6 @@ class AIAgent:
         except Exception as e:
             logger.debug("Compression model suggestion failed: %s", e)
             return None
-    
-    def _heuristic_consecutive_suggestion(self, tool_name: str) -> str | None:
-        """Built-in heuristic for consecutive-call circuit breaker."""
-        suggestions = {
-            "gh": "Try 'gh api' instead of 'gh run view' for log retrieval, or use curl to download logs directly",
-            "browser_navigate": "The URL may be unreachable — try a different URL or check network connectivity",
-            "browser_click": "The element may not be loaded yet — try browser_snapshot first to verify the page state",
-            "browser_snapshot": "The page may have changed — try browser_navigate to reload, or check for JavaScript errors",
-            "browser_type": "The input field may not be visible — scroll first or check the element ref ID",
-            "browser_press": "The key may not be applicable — check if the element has focus first",
-            "browser_console": "The console may be empty — try navigating to the page first",
-            "browser_vision": "Vision may not be available — try browser_snapshot for text-based inspection",
-            "browser_get_images": "No images found — the page may not have loaded images yet",
-            "execute_code": "The code may have syntax errors or missing imports — check the script carefully",
-            "session_search": "The search query may be too specific — try broader keywords or use OR logic",
-            "web_search": "The web search may be failing — try a different search engine or simplify the query",
-            "skill_view": "The skill may not exist — check the skill name spelling and available skills",
-            "memory": "The memory operation may have failed — check the memory format and content",
-            "todo": "The todo operation may have invalid format — check the todos array structure",
-            "delegate_task": "The delegation may have failed — check the goal and context fields",
-            "cronjob": "The cron job operation may have invalid parameters — check the schedule and prompt",
-            "patch": "The patch may not match — check the file content and old_string uniqueness",
-            "write_file": "The file write may have failed — check directory permissions and path",
-            "read_file": "The file may not exist — check the path and file name spelling",
-            "search_files": "The search pattern may be too specific — try a broader pattern",
-            "text_to_speech": "TTS may not be configured — check the TTS provider settings",
-        }
-        
-        # Try exact match first
-        if tool_name in suggestions:
-            return suggestions[tool_name]
-        
-        # Try prefix match (e.g., "browser_" matches "browser_click")
-        for key, value in suggestions.items():
-            if tool_name.startswith(key):
-                return value
-        
-        return None
 
     def _check_compression_model_feasibility(self) -> None:
         """Warn at session start if the auxiliary compression model's context

--- a/run_agent.py
+++ b/run_agent.py
@@ -1441,7 +1441,7 @@ class AIAgent:
         # tool+args is called consecutively N times, we abort to force
         # the LLM into a different strategy.
         self._consecutive_tool_calls: list[tuple[str, str]] = []
-        self._circuit_breaker_threshold: int = 3
+        self._circuit_breaker_threshold: int = 5
         if not skip_memory:
             try:
                 mem_config = _agent_cfg.get("memory", {})
@@ -7554,8 +7554,9 @@ class AIAgent:
                 # All same — circuit breaker triggered!
                 streak = len(self._consecutive_tool_calls)
                 msg = (
-                    f"[熔断器触发] 工具 '{function_name}' 连续 {streak} 次调用完全相同的参数，"
-                    f"已强制终止。请换用不同的工具或策略。"
+                    f"[Circuit breaker triggered] Tool '{function_name}' called "
+                    f"{streak} consecutive times with identical arguments. "
+                    f"Please try a different approach."
                 )
                 logger.warning("Circuit breaker triggered: %s (streak=%d)", function_name, streak)
                 # Reset streak so future calls can succeed
@@ -8076,12 +8077,14 @@ class AIAgent:
                 _cb_n = len(self._consecutive_tool_calls)
                 if _cb_n >= self._circuit_breaker_threshold:
                     _cb_recent_sigs = [s for _, s in self._consecutive_tool_calls[-self._circuit_breaker_threshold:]]
+                    # All same — circuit breaker triggered!
                     if len(set(_cb_recent_sigs)) == 1:
                         _cb_streak = len(self._consecutive_tool_calls)
                         function_result = json.dumps({
                             "error": (
-                                f"[熔断器触发] 工具 '{function_name}' 连续 {_cb_streak} 次调用完全相同的参数，"
-                                f"已强制终止。请换用不同的工具或策略。"
+                                f"[Circuit breaker triggered] Tool '{function_name}' called "
+                                f"{_cb_streak} consecutive times with identical arguments. "
+                                f"Please try a different approach."
                             )
                         }, ensure_ascii=False)
                         logger.warning("Circuit breaker triggered (sequential): %s (streak=%d)", function_name, _cb_streak)


### PR DESCRIPTION
## Summary

Implements a circuit breaker mechanism to detect and interrupt infinite tool-call loops in the agent.

### Problem
The agent can enter infinite tool-call loops where it repeatedly calls the same (or similar) tools without making progress, consuming tokens and time indefinitely.

### Solution
- **Circuit breaker detection**: Tracks consecutive failed/similar tool calls; triggers after a configurable threshold (default: 3)
- **Built-in heuristic suggestions**: When triggered, provides actionable suggestions to the agent (e.g., try a different approach, use a compression model, verify assumptions)
- **Agent-level retry counter**: Adds a tool failure retry counter at the agent level for better tracking
- **Configurable threshold**: The breaker threshold can be adjusted via configuration

### Changes
- Circuit breaker with configurable threshold
- Agent-level tool failure retry counter
- Heuristic suggestions on breaker trigger (simplified, no pattern matching)
- Suggestion to use compression model when context is large

### Testing
- Existing tests updated to accommodate the circuit breaker
- Threshold and suggestion logic tested

---

*Note: This is a clean resubmission of #12632, which inadvertently included unrelated i18n commits.*