### PR TITLE
fix(model-picker): dedupe built-in compatibility providers

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1159,7 +1159,12 @@ def list_authenticated_providers(
                         groups[slug]["models"].append(m)
 
         for slug, grp in groups.items():
-            if slug.lower() in seen_slugs:
+            # ``get_compatible_custom_providers()`` turns ``providers:``
+            # entries into ``custom:<name>`` compatibility rows. If a
+            # built-in/provider-key row already emitted ``deepseek``,
+            # the compatibility row should not add ``custom:deepseek``.
+            base_slug = slug[7:] if slug.startswith("custom:") else slug
+            if slug.lower() in seen_slugs or base_slug.lower() in seen_slugs:
                 continue
             # Skip if section 3 already emitted this endpoint under its
             # ``providers:`` dict key — matches on (display_name, base_url),

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -6,6 +6,8 @@ are exposed in the model picker.
 """
 
 import pytest
+
+from hermes_cli.config import get_compatible_custom_providers
 from hermes_cli.model_switch import list_authenticated_providers, switch_model
 from hermes_cli import runtime_provider as rp
 
@@ -350,6 +352,41 @@ def test_list_authenticated_providers_no_duplicate_labels_across_schemas(monkeyp
     assert len(labels) == len(set(labels)), (
         f"Duplicate labels across picker rows: {labels}"
     )
+
+
+def test_list_authenticated_providers_skips_builtin_compat_duplicates(monkeypatch):
+    """Compatibility rows from ``providers:`` must not re-add built-ins as
+    ``custom:*`` entries.
+
+    Regression: a built-in provider such as ``deepseek`` could already be
+    emitted from the curated provider list, then section 4 added the
+    compatibility-generated ``custom:deepseek`` row because it only checked the
+    full custom slug against ``seen_slugs``.
+    """
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {"deepseek": {}})
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key")
+
+    cfg = {
+        "providers": {
+            "deepseek": {
+                "base_url": "https://api.deepseek.com",
+                "models": {
+                    "deepseek-chat": {},
+                    "deepseek-reasoner": {},
+                },
+            }
+        }
+    }
+
+    providers = list_authenticated_providers(
+        current_provider="deepseek",
+        user_providers=cfg["providers"],
+        custom_providers=get_compatible_custom_providers(cfg),
+        max_models=50,
+    )
+
+    deepseek_rows = [p for p in providers if "deepseek" in p["slug"].lower()]
+    assert [(p["slug"], p["source"]) for p in deepseek_rows] == [("deepseek", "built-in")]
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- stop section 4 from re-adding built-in providers as `custom:*` compatibility rows
- keep `/model` provider lists stable when `providers:` entries mirror built-in providers like `deepseek`
- add a regression test that exercises the real `providers -> get_compatible_custom_providers() -> list_authenticated_providers()` path

## Problem
When a built-in provider also exists in `providers:`, the compatibility layer can still emit a duplicate `custom:*` row. On current `main`, a config-backed `deepseek` entry produced both `deepseek` and `custom:deepseek` in the picker.

Closes #14057.

## Testing
- `pytest -o addopts= tests/hermes_cli/test_user_providers_model_switch.py`
- `pytest -o addopts= tests/hermes_cli/test_model_switch_custom_providers.py -k "includes_custom_providers or groups_same_name_custom_providers_into_one_row or dedupes_dict_model_matching_singular_default"`
- manual repro: built-in `deepseek` + compatibility-merged config entry now yields only one `deepseek` row
