### PR TITLE
fix(gateway): exit with RestartForceExitStatus code and detect zombie PIDs in --replace

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17,6 +17,7 @@ import asyncio
 import json
 import logging
 import os
+import platform
 import re
 import shlex
 import sys
@@ -10775,6 +10776,25 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
     logger.info("Cron ticker stopped")
 
 
+def _is_zombie(pid: int) -> bool:
+    """Return True if pid is a zombie process (Linux only).
+
+    os.kill(pid, 0) succeeds for zombies because they remain in the process
+    table until their parent calls wait().  A zombie cannot be killed and will
+    never release the PID, so the --replace wait loop must treat it as gone.
+    """
+    if platform.system() != "Linux":
+        return False
+    try:
+        with open(f"/proc/{pid}/status") as f:
+            for line in f:
+                if line.startswith("State:"):
+                    return "Z" in line
+    except (FileNotFoundError, PermissionError, OSError):
+        pass
+    return False
+
+
 async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = False, verbosity: Optional[int] = 0) -> bool:
     """
     Start the gateway and run until interrupted.
@@ -10829,10 +10849,18 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 except Exception:
                     pass
                 return False
-            # Wait up to 10 seconds for the old process to exit
+            # Wait up to 10 seconds for the old process to exit.
+            # Also check for zombie state: os.kill(pid, 0) succeeds for
+            # zombies, but they can't be killed and won't vacate the PID.
             for _ in range(20):
                 try:
                     os.kill(existing_pid, 0)
+                    if _is_zombie(existing_pid):
+                        logger.info(
+                            "Old gateway PID %d is a zombie; treating as gone.",
+                            existing_pid,
+                        )
+                        break
                     time.sleep(0.5)
                 except (ProcessLookupError, PermissionError):
                     break  # Process is gone

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1994,12 +1994,12 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False):
     print("└─────────────────────────────────────────────────────────┘")
     print()
     
-    # Exit with code 1 if gateway fails to connect any platform,
-    # so systemd Restart=on-failure will retry on transient errors
     verbosity = None if quiet else verbose
     success = asyncio.run(start_gateway(replace=replace, verbosity=verbosity))
     if not success:
-        sys.exit(1)
+        # Use RestartForceExitStatus code so systemd bypasses StartLimitBurst
+        # on transient startup failures (e.g. PID file race, platform errors).
+        sys.exit(GATEWAY_SERVICE_RESTART_EXIT_CODE)
 
 
 # =============================================================================

--- a/tests/gateway/test_zombie_detection.py
+++ b/tests/gateway/test_zombie_detection.py
@@ -1,0 +1,45 @@
+"""Tests for _is_zombie() zombie-process detection used in --replace wait loop."""
+
+import os
+import platform
+from unittest.mock import mock_open, patch
+
+import pytest
+
+from gateway.run import _is_zombie
+
+
+class TestIsZombie:
+    def test_returns_false_on_non_linux(self, monkeypatch):
+        monkeypatch.setattr(platform, "system", lambda: "Darwin")
+        assert _is_zombie(12345) is False
+
+    def test_returns_false_on_windows(self, monkeypatch):
+        monkeypatch.setattr(platform, "system", lambda: "Windows")
+        assert _is_zombie(12345) is False
+
+    def test_returns_false_when_proc_status_missing(self, monkeypatch):
+        monkeypatch.setattr(platform, "system", lambda: "Linux")
+        assert _is_zombie(0x7FFFFFFF) is False
+
+    def test_detects_zombie_state_from_proc_status(self, monkeypatch):
+        monkeypatch.setattr(platform, "system", lambda: "Linux")
+        proc_status = "Name:\tpython3\nState:\tZ (zombie)\nPid:\t42\n"
+        with patch("builtins.open", mock_open(read_data=proc_status)):
+            assert _is_zombie(42) is True
+
+    def test_returns_false_for_sleeping_process(self, monkeypatch):
+        monkeypatch.setattr(platform, "system", lambda: "Linux")
+        proc_status = "Name:\tpython3\nState:\tS (sleeping)\nPid:\t42\n"
+        with patch("builtins.open", mock_open(read_data=proc_status)):
+            assert _is_zombie(42) is False
+
+    def test_returns_false_for_running_process(self, monkeypatch):
+        monkeypatch.setattr(platform, "system", lambda: "Linux")
+        proc_status = "Name:\tpython3\nState:\tR (running)\nPid:\t42\n"
+        with patch("builtins.open", mock_open(read_data=proc_status)):
+            assert _is_zombie(42) is False
+
+    @pytest.mark.skipif(platform.system() != "Linux", reason="Linux only")
+    def test_current_process_is_not_zombie(self):
+        assert _is_zombie(os.getpid()) is False

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1730,3 +1730,28 @@ class TestSystemdInstallOffersLegacyRemoval:
 
         assert prompt_called["count"] == 0
         assert remove_called["invoked"] is False
+
+
+class TestRunGatewayExitCode:
+    """run_gateway() must exit with GATEWAY_SERVICE_RESTART_EXIT_CODE on failure.
+
+    This ensures systemd's RestartForceExitStatus=75 bypasses StartLimitBurst
+    for transient startup failures (PID file race, platform connection errors).
+    """
+
+    def test_run_gateway_exits_with_service_restart_code_on_failure(self, monkeypatch, capsys):
+        import pytest
+
+        # Simulate start_gateway returning False (startup failure)
+        monkeypatch.setattr(gateway_cli.asyncio, "run", lambda _coro: False)
+
+        with pytest.raises(SystemExit) as exc_info:
+            gateway_cli.run_gateway()
+
+        assert exc_info.value.code == GATEWAY_SERVICE_RESTART_EXIT_CODE
+
+    def test_run_gateway_does_not_exit_on_success(self, monkeypatch, capsys):
+        monkeypatch.setattr(gateway_cli.asyncio, "run", lambda _coro: True)
+
+        # Should not raise SystemExit
+        gateway_cli.run_gateway()


### PR DESCRIPTION
Fix two bugs that combine to exhaust systemd's `StartLimitBurst=5` on rapid restarts, permanently failing the gateway service.

## What changed and why

**Fix 1 — exit code mismatch (`hermes_cli/gateway.py`)**

`run_gateway()` was exiting with code `1` on startup failure. The systemd service file declares `RestartForceExitStatus=75`, meaning only exit code `75` bypasses `StartLimitBurst`. Exit code `1` was counted against the burst limit, so 5 fast failures (e.g. PID file races) permanently failed the service. Now exits with `GATEWAY_SERVICE_RESTART_EXIT_CODE` (75), which was already imported but unused in this path.

**Fix 2 — zombie process detection (`gateway/run.py`)**

The `--replace` wait loop used `os.kill(pid, 0)` to check if the old gateway was alive. This call succeeds for zombie processes (crashed but not yet reaped by their parent), so a zombie gateway would stall the loop for 10 s, then receive `SIGKILL` — which has no effect on zombies. Both the old zombie and the new instance would then race to write the PID file, causing `FileExistsError` → exit with old code 1 → burst counter hit.

Added `_is_zombie(pid)` that reads `/proc/{pid}/status` on Linux and checks for `State: Z`. The wait loop now breaks immediately when the old PID is a zombie, treating it as already gone before proceeding to force-unlink the PID file.

## How to test

1. Start gateway: `hermes gateway start`
2. Kill it with SIGKILL: `kill -9 <pid>`
3. Verify `systemctl --user status hermes-gateway.service` shows restart attempts, not a permanent `failed` state
4. Run new unit tests: `pytest tests/gateway/test_zombie_detection.py tests/hermes_cli/test_gateway_service.py::TestRunGatewayExitCode -v`

## What platforms tested on

- macOS on darwin-arm64 (local, zombie detection path returns False and is skipped — systemd path tested via unit tests)
- Linux/systemd path covered by unit tests with mocked `/proc/{pid}/status`

Fixes #14051

<!-- autocontrib:worker-id=issue-new-1e8aae21 kind=pr-open -->