### PR TITLE
fix(gateway): skip plain-text fallback on send timeouts

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1577,7 +1577,12 @@ class BasePlatformAdapter(ABC):
         if not error:
             return False
         lowered = error.lower()
-        return "timed out" in lowered or "readtimeout" in lowered or "writetimeout" in lowered
+        return (
+            "timed out" in lowered
+            or "readtimeout" in lowered
+            or "writetimeout" in lowered
+            or lowered.startswith("timeout")
+        )
 
     async def _send_with_retry(
         self,

--- a/tests/gateway/test_send_retry.py
+++ b/tests/gateway/test_send_retry.py
@@ -102,6 +102,9 @@ class TestIsTimeoutError:
     def test_write_timeout(self):
         assert _StubAdapter._is_timeout_error("WriteTimeout: send stalled")
 
+    def test_timeout_prefix_is_flagged(self):
+        assert _StubAdapter._is_timeout_error("Timeout sending message to WeCom")
+
     def test_connect_timeout_not_flagged(self):
         """ConnectTimeout is a connection error, not a delivery-ambiguous timeout."""
         assert not _StubAdapter._is_timeout_error("ConnectTimeout: host unreachable")
@@ -176,6 +179,20 @@ class TestSendWithRetryNetworkRetry:
             result = await adapter._send_with_retry("chat1", "hello", max_retries=2, base_delay=0)
         assert result.success
         assert len(adapter._send_calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_timeout_prefix_skips_plaintext_fallback(self):
+        """Timeout-prefixed adapter errors should return immediately so we do
+        not send a second plain-text copy after an ambiguous delivery."""
+        adapter = _StubAdapter()
+        adapter._send_results = [
+            SendResult(success=False, error="Timeout sending message to WeCom"),
+        ]
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await adapter._send_with_retry("chat1", "hello", max_retries=3, base_delay=0)
+        mock_sleep.assert_not_called()
+        assert not result.success
+        assert len(adapter._send_calls) == 1
 
     @pytest.mark.asyncio
     async def test_retryable_flag_respected(self):


### PR DESCRIPTION
## Summary
- treat `Timeout ...` send errors as delivery-ambiguous timeouts
- stop `_send_with_retry()` from sending a second plain-text copy after a timeout-prefixed failure
- add regression coverage for both timeout classification and the no-fallback behavior

## Problem
On current `main`, WeCom returns `Timeout sending message to WeCom` from its adapter. `_is_timeout_error()` does not recognize that prefix, so `_send_with_retry()` falls through to the plain-text fallback and attempts a second send.

Closes #14061.

## Testing
- `pytest -o addopts= tests/gateway/test_send_retry.py`
- manual repro: `_send_with_retry()` with `Timeout sending message to WeCom` now performs 1 send attempt instead of 2
