### PR TITLE
fix(wecom): cache inbound media_id attachments

### DIFF
--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -734,6 +734,28 @@ class WeComAdapter(BasePlatformAdapter):
             filename = str(media.get("filename") or media.get("name") or "wecom_file")
             return cache_document_from_bytes(raw, filename), mimetypes.guess_type(filename)[0] or "application/octet-stream"
 
+        media_id = str(media.get("media_id") or "").strip()
+        if media_id:
+            try:
+                raw, headers = await self._download_media_by_id(media_id)
+            except Exception as exc:
+                logger.debug("[%s] Failed to download %s media_id %s: %s", self.name, kind, media_id, exc)
+                return None
+
+            content_type = str(headers.get("content-type") or "").split(";", 1)[0].strip() or "application/octet-stream"
+            if kind == "image":
+                ext = mimetypes.guess_extension(content_type) or self._detect_image_ext(raw)
+                try:
+                    return cache_image_from_bytes(raw, ext), content_type or self._mime_for_ext(ext, fallback="image/jpeg")
+                except ValueError as exc:
+                    logger.warning("[%s] Rejected non-image bytes for media_id %s: %s", self.name, media_id, exc)
+                    return None
+
+            filename = str(media.get("filename") or media.get("name") or media_id).strip() or "wecom_file"
+            if "." not in filename:
+                filename = f"{filename}{mimetypes.guess_extension(content_type) or '.bin'}"
+            return cache_document_from_bytes(raw, filename), content_type
+
         url = str(media.get("url") or "").strip()
         if not url:
             return None
@@ -763,6 +785,50 @@ class WeComAdapter(BasePlatformAdapter):
 
         filename = self._guess_filename(url, headers.get("content-disposition"), content_type)
         return cache_document_from_bytes(raw, filename), content_type
+
+    async def _download_media_by_id(
+        self,
+        media_id: str,
+    ) -> Tuple[bytes, Dict[str, str]]:
+        """Download inbound media referenced by WeCom ``media_id``."""
+        if not media_id:
+            raise ValueError("media_id is required")
+        if not HTTPX_AVAILABLE:
+            raise RuntimeError("httpx is required for WeCom media download")
+        if not self._bot_id or not self._secret:
+            raise RuntimeError("WECOM_BOT_ID and WECOM_SECRET are required for media download")
+
+        client = self._http_client or httpx.AsyncClient(timeout=30.0, follow_redirects=True)
+        created_client = client is not self._http_client
+        try:
+            response = await client.post(
+                "https://qyapi.weixin.qq.com/cgi-bin/aibot/media/get",
+                json={
+                    "robot_id": self._bot_id,
+                    "secret": self._secret,
+                    "media_id": media_id,
+                },
+                headers={
+                    "User-Agent": "HermesAgent/1.0",
+                    "Accept": "*/*",
+                },
+                timeout=REQUEST_TIMEOUT_SECONDS,
+            )
+            response.raise_for_status()
+            headers = {key.lower(): value for key, value in response.headers.items()}
+            content_type = str(headers.get("content-type") or "").split(";", 1)[0].strip().lower()
+            if content_type in {"application/json", "text/plain"}:
+                raise ValueError(
+                    f"WeCom media_id download returned non-binary content-type {content_type or 'unknown'}"
+                )
+            if len(response.content) > ABSOLUTE_MAX_BYTES:
+                raise ValueError(
+                    f"Remote media exceeds WeCom limit while downloading: {len(response.content)} bytes > {ABSOLUTE_MAX_BYTES} bytes"
+                )
+            return response.content, headers
+        finally:
+            if created_client:
+                await client.aclose()
 
     @staticmethod
     def _decode_base64(data: str) -> bytes:

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -422,6 +422,52 @@ class TestMediaUpload:
         assert Path(cached_path).read_bytes() == plaintext
         assert content_type == "application/octet-stream"
 
+    @pytest.mark.asyncio
+    async def test_cache_media_downloads_image_by_media_id(self):
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(
+            PlatformConfig(enabled=True, extra={"bot_id": "bot-1", "secret": "secret-1"})
+        )
+        png_bytes = base64.b64decode(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+aB9sAAAAASUVORK5CYII="
+        )
+        adapter._download_media_by_id = AsyncMock(
+            return_value=(png_bytes, {"content-type": "image/png"})
+        )
+
+        cached = await adapter._cache_media("image", {"media_id": "media-image-1"})
+
+        assert cached is not None
+        cached_path, content_type = cached
+        assert Path(cached_path).read_bytes() == png_bytes
+        assert content_type == "image/png"
+
+    @pytest.mark.asyncio
+    async def test_cache_media_downloads_file_by_media_id(self):
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(
+            PlatformConfig(enabled=True, extra={"bot_id": "bot-1", "secret": "secret-1"})
+        )
+        adapter._download_media_by_id = AsyncMock(
+            return_value=(
+                b"invoice-bytes",
+                {"content-type": "application/pdf"},
+            )
+        )
+
+        cached = await adapter._cache_media(
+            "file",
+            {"media_id": "media-file-1", "filename": "invoice.pdf"},
+        )
+
+        assert cached is not None
+        cached_path, content_type = cached
+        assert Path(cached_path).read_bytes() == b"invoice-bytes"
+        assert Path(cached_path).name.endswith(".pdf")
+        assert content_type == "application/pdf"
+
 
 class TestSend:
     @pytest.mark.asyncio
@@ -783,4 +829,3 @@ class TestWeComZombieSessionFix:
         adapter._send_request.assert_awaited_once()
         cmd = adapter._send_request.await_args.args[0]
         assert cmd == APP_CMD_SEND
-


### PR DESCRIPTION
## Summary
- add a WeCom `media_id` download path for inbound attachments
- teach `_cache_media()` to persist image/file callbacks that only carry `media_id`
- add regression coverage for both image and file media-id payloads

## Problem
On current `main`, inbound WeCom attachments that arrive as `media_id` references are silently dropped because `_cache_media()` only handles `base64` and `url` payloads. A minimal repro with `_cache_media("image", {"media_id": "media-123"})` returned `None`.

Closes #14062.

## Testing
- `pytest -o addopts= tests/gateway/test_wecom.py`
- manual repro: `_cache_media("image", {"media_id": "media-123"})` now returns a cached local image path instead of `None`
