### PR TITLE
fix(plugins): reject non-mapping plugin manifests

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -122,7 +122,15 @@ def _read_manifest(plugin_dir: Path) -> dict:
         import yaml
 
         with open(manifest_file) as f:
-            return yaml.safe_load(f) or {}
+            manifest = yaml.safe_load(f) or {}
+        if not isinstance(manifest, dict):
+            logger.warning(
+                "Expected plugin.yaml in %s to contain a mapping, got %s",
+                plugin_dir,
+                type(manifest).__name__,
+            )
+            return {}
+        return manifest
     except Exception as e:
         logger.warning("Failed to read plugin.yaml in %s: %s", plugin_dir, e)
         return {}

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -155,6 +155,13 @@ class TestReadManifest:
         result = _read_manifest(tmp_path)
         assert result == {}
 
+    def test_valid_yaml_with_non_mapping_root_returns_empty_and_logs(self, tmp_path, caplog):
+        (tmp_path / "plugin.yaml").write_text("- not\n- a\n- mapping\n")
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins_cmd"):
+            result = _read_manifest(tmp_path)
+        assert result == {}
+        assert any("Expected plugin.yaml in" in r.message for r in caplog.records)
+
 
 # ── cmd_install tests ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- validate that `plugin.yaml` parses to a mapping before returning it from `_read_manifest()`
- fall back to `{}` for valid-but-non-mapping YAML so install continues down the repo-name path instead of crashing
- add a regression test covering list-style manifests

## Root cause
`_read_manifest()` returned `yaml.safe_load(...)` verbatim. When `plugin.yaml` was valid YAML with a non-dict top-level value, later install code called `.get(...)` on a list/string/number and raised `AttributeError`.

## Fix
Coerce `_read_manifest()` back to its documented contract: return a dict or `{}`. Non-mapping manifests now log a warning and are treated as invalid metadata.

## Regression coverage
- adds `TestReadManifest::test_valid_yaml_with_non_mapping_root_returns_empty_and_logs`
- locks the valid-YAML/non-mapping path that previously leaked a list out of `_read_manifest()`

## Testing
- `scripts/run_tests.sh tests/hermes_cli/test_plugins_cmd.py::TestReadManifest::test_valid_yaml_with_non_mapping_root_returns_empty_and_logs`
- `scripts/run_tests.sh tests/hermes_cli/test_plugins_cmd.py`

Closes #14066
