### PR TITLE
fix(gateway): use managed restart exit code on startup failure

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1994,12 +1994,13 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False):
     print("└─────────────────────────────────────────────────────────┘")
     print()
     
-    # Exit with code 1 if gateway fails to connect any platform,
-    # so systemd Restart=on-failure will retry on transient errors
+    # Exit with the managed service restart code so systemd / launchd
+    # treat startup failures as supervised restart conditions instead of
+    # consuming the generic on-failure burst budget.
     verbosity = None if quiet else verbose
     success = asyncio.run(start_gateway(replace=replace, verbosity=verbosity))
     if not success:
-        sys.exit(1)
+        sys.exit(GATEWAY_SERVICE_RESTART_EXIT_CODE)
 
 
 # =============================================================================

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -5,6 +5,8 @@ import pwd
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 import hermes_cli.gateway as gateway_cli
 from gateway.restart import (
     DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT,
@@ -109,6 +111,19 @@ class TestGeneratedSystemdUnits:
         assert f"RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}" in unit
         assert "TimeoutStopSec=60" in unit
         assert "WantedBy=multi-user.target" in unit
+
+
+class TestRunGatewayExitCode:
+    def test_run_gateway_uses_service_restart_exit_code_on_startup_failure(self, monkeypatch):
+        async def fake_start_gateway(*args, **kwargs):
+            return False
+
+        monkeypatch.setattr("gateway.run.start_gateway", fake_start_gateway)
+
+        with pytest.raises(SystemExit) as exc:
+            gateway_cli.run_gateway(verbose=0, quiet=True, replace=False)
+
+        assert exc.value.code == GATEWAY_SERVICE_RESTART_EXIT_CODE
 
 
 class TestGatewayStopCleanup:


### PR DESCRIPTION
## Summary
- make `hermes gateway run` exit with the managed gateway restart code on startup failure
- align foreground gateway failures with the generated systemd/launchd service units
- add a regression test that proves `run_gateway()` now exits `75` instead of `1`

## Problem
On current `main`, `run_gateway()` exits with `1` when startup fails, even though the generated service units set `RestartForceExitStatus=75`. A minimal repro with `start_gateway()` returning `False` currently raises `SystemExit(1)`, which means rapid failures count against `StartLimitBurst` instead of being treated as managed restarts.

Closes #14051.

## Testing
- `pytest -o addopts= tests/hermes_cli/test_gateway_service.py`
- manual repro: monkeypatched `start_gateway(...)=False` now exits `75` instead of `1`
