### PR TITLE
fix(runtime-provider): preserve named custom api modes

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -323,12 +323,16 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                 # Found match by provider key
                 base_url = entry.get("api") or entry.get("url") or entry.get("base_url") or ""
                 if base_url:
-                    return {
+                    result = {
                         "name": entry.get("name", ep_name),
                         "base_url": base_url.strip(),
                         "api_key": resolved_api_key,
                         "model": entry.get("default_model", ""),
                     }
+                    api_mode = _parse_api_mode(entry.get("api_mode"))
+                    if api_mode:
+                        result["api_mode"] = api_mode
+                    return result
             # Also check the 'name' field if present
             display_name = entry.get("name", "")
             if display_name:
@@ -337,12 +341,16 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                     # Found match by display name
                     base_url = entry.get("api") or entry.get("url") or entry.get("base_url") or ""
                     if base_url:
-                        return {
+                        result = {
                             "name": display_name,
                             "base_url": base_url.strip(),
                             "api_key": resolved_api_key,
                             "model": entry.get("default_model", ""),
                         }
+                        api_mode = _parse_api_mode(entry.get("api_mode"))
+                        if api_mode:
+                            result["api_mode"] = api_mode
+                        return result
 
     # Fall back to custom_providers: list (legacy format)
     custom_providers = config.get("custom_providers")

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1324,6 +1324,26 @@ def test_get_named_custom_provider_includes_model(monkeypatch):
     assert result["model"] == "qwen3.6-plus"
 
 
+def test_get_named_custom_provider_new_style_includes_api_mode(monkeypatch):
+    """providers: entries should preserve explicit api_mode overrides."""
+    monkeypatch.setattr(rp, "load_config", lambda: {
+        "providers": {
+            "my-codex-proxy": {
+                "name": "My Codex Proxy",
+                "base_url": "https://example.com/v1",
+                "api_key": "test-key",
+                "default_model": "gpt-test",
+                "api_mode": "codex_responses",
+            }
+        }
+    })
+
+    result = rp._get_named_custom_provider("my-codex-proxy")
+    assert result is not None
+    assert result["api_mode"] == "codex_responses"
+    assert result["model"] == "gpt-test"
+
+
 def test_get_named_custom_provider_excludes_empty_model(monkeypatch):
     """Empty or whitespace-only model field should not appear in result."""
     for model_val in ["", "   ", None]:
@@ -1364,6 +1384,27 @@ def test_named_custom_runtime_propagates_model_direct_path(monkeypatch):
     resolved = rp.resolve_runtime_provider(requested="my-server")
     assert resolved["model"] == "qwen3.6-plus"
     assert resolved["provider"] == "custom"
+
+
+def test_named_custom_runtime_preserves_new_style_api_mode(monkeypatch):
+    """providers: entries should keep explicit api_mode during runtime resolution."""
+    monkeypatch.setattr(rp, "load_config", lambda: {
+        "providers": {
+            "my-codex-proxy": {
+                "name": "My Codex Proxy",
+                "base_url": "https://example.com/v1",
+                "api_key": "test-key",
+                "default_model": "gpt-test",
+                "api_mode": "codex_responses",
+            }
+        }
+    })
+
+    resolved = rp.resolve_runtime_provider(requested="my-codex-proxy")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["api_mode"] == "codex_responses"
+    assert resolved["model"] == "gpt-test"
 
 
 def test_named_custom_runtime_propagates_model_pool_path(monkeypatch):


### PR DESCRIPTION
## Summary
- preserve explicit `api_mode` when resolving named custom providers from the new `providers:` config block
- keep both provider-key and display-name matches aligned with the legacy custom-provider path
- add regression coverage for provider lookup and runtime resolution

Closes #13051.

## Testing
- pytest -o addopts= tests/hermes_cli/test_runtime_provider_resolution.py
