### PR TITLE
fix(discord): stabilize /sethome for thread homes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,8 @@ mini-swe-agent/
 .nix-stamps/
 result
 website/static/api/skills-index.json
+
+# Beads / Dolt files (added by bd init)
+.dolt/
+*.db
+.beads-credential-key

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5841,6 +5841,32 @@ class GatewayRunner:
         platform_name = source.platform.value if source.platform else "unknown"
         chat_id = source.chat_id
         chat_name = source.chat_name or chat_id
+        reroute_note = None
+
+        # In Discord text-channel threads, the stable home destination should be the
+        # parent channel rather than the specific thread. Forum posts keep their own
+        # thread ID because deliveries without metadata.thread_id target chat_id
+        # directly, and a forum parent is not a normal send destination.
+        if platform_name == "discord" and getattr(source, "chat_type", None) == "thread":
+            raw = getattr(event, "raw_message", None)
+            channel = getattr(raw, "channel", None)
+            parent = getattr(channel, "parent", None)
+            parent_id = getattr(parent, "id", None) or getattr(channel, "parent_id", None)
+            parent_type = getattr(parent, "type", None)
+            parent_type_value = getattr(parent_type, "value", parent_type)
+            is_forum_parent = parent_type_value == 15 or getattr(parent.__class__, "__name__", "") == "ForumChannel"
+            if parent is not None and parent_id is not None and not is_forum_parent:
+                chat_id = str(parent_id)
+                parent_name = getattr(parent, "name", None)
+                guild = getattr(parent, "guild", None) or getattr(channel, "guild", None)
+                guild_name = getattr(guild, "name", None)
+                if parent_name and guild_name:
+                    chat_name = f"{guild_name} / #{parent_name}"
+                elif parent_name:
+                    chat_name = parent_name
+                else:
+                    chat_name = chat_id
+                reroute_note = "Using the parent channel for stable Discord home delivery; explicit thread deliveries still use thread metadata."
         
         env_key = f"{platform_name.upper()}_HOME_CHANNEL"
         
@@ -5859,10 +5885,13 @@ class GatewayRunner:
         except Exception as e:
             return f"Failed to save home channel: {e}"
         
-        return (
+        response = (
             f"✅ Home channel set to **{chat_name}** (ID: {chat_id}).\n"
             f"Cron jobs and cross-platform messages will be delivered here."
         )
+        if reroute_note:
+            response += f"\n{reroute_note}"
+        return response
     
     @staticmethod
     def _get_guild_id(event: MessageEvent) -> Optional[int]:

--- a/tests/gateway/test_set_home_command.py
+++ b/tests/gateway/test_set_home_command.py
@@ -1,0 +1,185 @@
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+class ForumChannel:
+    pass
+
+
+@pytest.mark.asyncio
+async def test_sethome_uses_parent_channel_for_discord_thread(monkeypatch, tmp_path):
+    import gateway.run as gateway_run
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("DISCORD_HOME_CHANNEL", raising=False)
+
+    guild = SimpleNamespace(name="GSV")
+    parent = SimpleNamespace(id=987654321, name="agent-ops", guild=guild)
+    channel = SimpleNamespace(parent=parent, parent_id=parent.id, guild=guild)
+    raw_message = SimpleNamespace(channel=channel)
+
+    event = MessageEvent(
+        text="/sethome",
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="1496043680090558464",
+            chat_name="hermes-apl",
+            chat_type="thread",
+            thread_id="1496043680090558464",
+            user_id="u1",
+            user_name="tester",
+        ),
+        raw_message=raw_message,
+        message_id="m1",
+    )
+
+    result = await runner._handle_set_home_command(event)
+
+    assert "GSV / #agent-ops" in result
+    assert "987654321" in result
+    assert "stable Discord home delivery" in result
+    assert (tmp_path / "config.yaml").exists()
+    config = yaml.safe_load((tmp_path / "config.yaml").read_text())
+    assert config["DISCORD_HOME_CHANNEL"] == "987654321"
+    assert gateway_run.os.environ["DISCORD_HOME_CHANNEL"] == "987654321"
+
+
+@pytest.mark.asyncio
+async def test_sethome_keeps_forum_thread_as_home_target(monkeypatch, tmp_path):
+    import gateway.run as gateway_run
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("DISCORD_HOME_CHANNEL", raising=False)
+
+    guild = SimpleNamespace(name="GSV")
+    parent = ForumChannel()
+    parent.id = 222
+    parent.name = "ideas"
+    parent.guild = guild
+    parent.type = 15
+    channel = SimpleNamespace(parent=parent, parent_id=parent.id, guild=guild)
+    raw_message = SimpleNamespace(channel=channel)
+
+    event = MessageEvent(
+        text="/sethome",
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="333",
+            chat_name="GSV / ideas / post-1",
+            chat_type="thread",
+            thread_id="333",
+            user_id="u1",
+            user_name="tester",
+        ),
+        raw_message=raw_message,
+        message_id="m-forum",
+    )
+
+    result = await runner._handle_set_home_command(event)
+
+    assert "GSV / ideas / post-1" in result
+    assert "(ID: 333)" in result
+    assert "stable Discord home delivery" not in result
+    config = yaml.safe_load((tmp_path / "config.yaml").read_text())
+    assert config["DISCORD_HOME_CHANNEL"] == "333"
+
+
+@pytest.mark.asyncio
+async def test_sethome_keeps_thread_when_parent_object_is_missing(monkeypatch, tmp_path):
+    import gateway.run as gateway_run
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("DISCORD_HOME_CHANNEL", raising=False)
+
+    channel = SimpleNamespace(parent=None, parent_id=987654321, guild=SimpleNamespace(name="GSV"))
+    raw_message = SimpleNamespace(channel=channel)
+
+    event = MessageEvent(
+        text="/sethome",
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="1496043680090558464",
+            chat_name="GSV / #agent-ops / hermes-apl",
+            chat_type="thread",
+            thread_id="1496043680090558464",
+            user_id="u1",
+            user_name="tester",
+        ),
+        raw_message=raw_message,
+        message_id="m-missing-parent",
+    )
+
+    result = await runner._handle_set_home_command(event)
+
+    assert "(ID: 1496043680090558464)" in result
+    assert "stable Discord home delivery" not in result
+    config = yaml.safe_load((tmp_path / "config.yaml").read_text())
+    assert config["DISCORD_HOME_CHANNEL"] == "1496043680090558464"
+
+
+@pytest.mark.asyncio
+async def test_sethome_keeps_current_chat_for_non_thread_discord(monkeypatch, tmp_path):
+    import gateway.run as gateway_run
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("DISCORD_HOME_CHANNEL", raising=False)
+
+    event = MessageEvent(
+        text="/sethome",
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="444",
+            chat_name="GSV / #agent-ops",
+            chat_type="group",
+            user_id="u1",
+            user_name="tester",
+        ),
+        message_id="m3",
+    )
+
+    result = await runner._handle_set_home_command(event)
+
+    assert "GSV / #agent-ops" in result
+    assert "(ID: 444)" in result
+    config = yaml.safe_load((tmp_path / "config.yaml").read_text())
+    assert config["DISCORD_HOME_CHANNEL"] == "444"
+
+
+@pytest.mark.asyncio
+async def test_sethome_keeps_current_chat_for_non_thread_sources(monkeypatch, tmp_path):
+    import gateway.run as gateway_run
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.delenv("TELEGRAM_HOME_CHANNEL", raising=False)
+
+    event = MessageEvent(
+        text="/sethome",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            chat_name="Primary DM",
+            chat_type="dm",
+            user_id="u1",
+            user_name="tester",
+        ),
+        message_id="m2",
+    )
+
+    result = await runner._handle_set_home_command(event)
+
+    assert "Primary DM" in result
+    assert "12345" in result
+    config = yaml.safe_load((tmp_path / "config.yaml").read_text())
+    assert config["TELEGRAM_HOME_CHANNEL"] == "12345"
+    assert gateway_run.os.environ["TELEGRAM_HOME_CHANNEL"] == "12345"


### PR DESCRIPTION
## Summary
- keep Discord text-channel threads on the parent channel when /sethome is run from a thread
- preserve forum-post threads as their own home target because forum parents are not a normal send destination
- add focused gateway tests for text threads, forum threads, missing-parent fallback, and non-thread cases
- ignore Beads/Dolt runtime files created by local bd init

## Test Plan
- uv run --extra dev python -m pytest tests/gateway/test_set_home_command.py -q

## Notes
- direct push to NousResearch/hermes-agent was denied, so this PR comes from the fork branch mistakeknot:fix/discord-sethome-thread-parent