### PR TITLE
feat: add Claude Code CLI provider

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1829,6 +1829,34 @@ def resolve_provider_client(
     if pconfig.auth_type == "external_process":
         creds = resolve_external_process_provider_credentials(provider)
         final_model = _normalize_resolved_model(model or _read_main_model(), provider)
+        if provider == "claude-cli":
+            api_key = str(creds.get("api_key", "")).strip()
+            base_url = str(creds.get("base_url", "")).strip()
+            command = str(creds.get("command", "")).strip() or None
+            args = list(creds.get("args") or [])
+            if not final_model:
+                logger.warning(
+                    "resolve_provider_client: claude-cli requested but no model "
+                    "was provided or configured"
+                )
+                return None, None
+            if not api_key or not base_url:
+                logger.warning(
+                    "resolve_provider_client: claude-cli requested but external "
+                    "process credentials are incomplete"
+                )
+                return None, None
+            from agent.claude_cli_client import ClaudeCLIClient
+
+            client = ClaudeCLIClient(
+                api_key=api_key,
+                base_url=base_url,
+                command=command,
+                args=args,
+            )
+            logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
+            return (_to_async_client(client, final_model) if async_mode
+                    else (client, final_model))
         if provider == "copilot-acp":
             api_key = str(creds.get("api_key", "")).strip()
             base_url = str(creds.get("base_url", "")).strip()

--- a/agent/claude_cli_client.py
+++ b/agent/claude_cli_client.py
@@ -16,8 +16,10 @@ import select
 import shlex
 import shutil
 import subprocess
+import tempfile
 import time
 import uuid
+from contextlib import contextmanager
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -33,6 +35,7 @@ _TOOL_CALL_JSON_RE = re.compile(
 )
 _STREAM_TOOL_START = "<tool_call>"
 _STREAM_TOOL_END = "</tool_call>"
+_EMPTY_MCP_CONFIG = json.dumps({"mcpServers": {}}, separators=(",", ":"))
 
 
 def _debug_log(message: str) -> None:
@@ -64,6 +67,27 @@ def _resolve_args() -> list[str]:
     return shlex.split(raw)
 
 
+def _resolve_cwd(explicit: str | None = None) -> str:
+    if explicit and explicit.strip():
+        return str(Path(explicit).expanduser().resolve())
+
+    env_cwd = os.getenv("HERMES_CLAUDE_CLI_CWD", "").strip()
+    if env_cwd:
+        return str(Path(env_cwd).expanduser().resolve())
+
+    if os.getenv("HERMES_CLAUDE_CLI_USE_PROCESS_CWD", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }:
+        return str(Path.cwd().resolve())
+
+    neutral = Path.home() / ".hermes" / "claude-cli-runtime"
+    neutral.mkdir(parents=True, exist_ok=True)
+    return str(neutral.resolve())
+
+
 def _normalize_model(model: str | None) -> str | None:
     if not model:
         return None
@@ -77,7 +101,76 @@ def _normalize_model(model: str | None) -> str | None:
 
 def _resume_enabled() -> bool:
     raw = os.getenv("HERMES_CLAUDE_CLI_RESUME", "").strip().lower()
+    if not raw:
+        return True
     return raw in {"1", "true", "yes", "on"}
+
+
+def _normalize_effort(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower()
+    if not normalized or normalized in {"none", "disabled", "off"}:
+        return None
+    return {
+        "minimal": "low",
+        "low": "low",
+        "medium": "medium",
+        "high": "high",
+        "xhigh": "max",
+        "max": "max",
+    }.get(normalized)
+
+
+def _extract_effort(extra_kwargs: dict[str, Any]) -> str | None:
+    reasoning = extra_kwargs.get("reasoning")
+    if isinstance(reasoning, dict):
+        if reasoning.get("enabled") is False:
+            return None
+        normalized = _normalize_effort(reasoning.get("effort"))
+        if normalized:
+            return normalized
+
+    extra_body = extra_kwargs.get("extra_body")
+    if isinstance(extra_body, dict):
+        body_reasoning = extra_body.get("reasoning")
+        if isinstance(body_reasoning, dict):
+            if body_reasoning.get("enabled") is False:
+                return None
+            normalized = _normalize_effort(body_reasoning.get("effort"))
+            if normalized:
+                return normalized
+
+        if extra_body.get("think") is False:
+            return None
+
+    return None
+
+
+def _system_prompt_flag() -> str:
+    mode = os.getenv("HERMES_CLAUDE_CLI_SYSTEM_PROMPT_MODE", "").strip().lower()
+    if mode in {"append", "append-file"}:
+        return "--append-system-prompt-file"
+    return "--system-prompt-file"
+
+
+@contextmanager
+def _system_prompt_file_args(system_prompt: str):
+    text = str(system_prompt or "").strip()
+    if not text:
+        yield []
+        return
+
+    fd, path = tempfile.mkstemp(prefix="hermes-claude-system-", suffix=".txt")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        yield [_system_prompt_flag(), path]
+    finally:
+        try:
+            os.unlink(path)
+        except FileNotFoundError:
+            pass
 
 
 def _render_message_content(content: Any) -> str:
@@ -133,25 +226,34 @@ def _render_assistant_tool_calls(tool_calls: Any) -> str:
     return "\n".join(rendered_calls).strip()
 
 
+def _split_system_prompt(
+    messages: list[dict[str, Any]],
+    ) -> tuple[str, list[dict[str, Any]]]:
+    system_parts: list[str] = []
+    non_system: list[dict[str, Any]] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        role = str(message.get("role") or "").strip().lower()
+        if role == "system":
+            rendered = _render_message_content(message.get("content"))
+            if rendered:
+                system_parts.append(rendered)
+            continue
+        non_system.append(message)
+    return "\n\n".join(part for part in system_parts if part).strip(), non_system
+
+
 def _format_messages_as_prompt(
     messages: list[dict[str, Any]],
-    model: str | None = None,
     tools: list[dict[str, Any]] | None = None,
     tool_choice: Any = None,
 ) -> str:
     sections: list[str] = [
-        "You are the active Claude Code CLI backend for Hermes.",
-        "Claude Code built-in tools are disabled for this call.",
-        "When Hermes tools are needed, emit tool calls using <tool_call>{...}</tool_call> blocks.",
+        "If you need a Hermes tool, emit exactly <tool_call>{...}</tool_call>.",
         "Each tool call JSON must match OpenAI function-call shape exactly: {\"id\":...,\"type\":\"function\",\"function\":{\"name\":...,\"arguments\":\"{...}\"}}.",
-        "Assistant tool request(s) in the transcript show the exact tool calls you already asked Hermes to run.",
-        "Tool result (...) entries are the results Hermes returned for those tool calls.",
-        "After tool results arrive, either issue the next required tool call or give the final answer.",
-        "Do not repeat the same failed probe over and over. If a tool result shows a missing binary/config/path, adapt your next tool call to use the concrete path or environment that was discovered.",
-        "If no tool is needed, answer normally.",
+        "Transcript tool requests and tool results are literal prior Hermes tool traffic.",
     ]
-    if model:
-        sections.append(f"Hermes requested model hint: {model}")
 
     if isinstance(tools, list) and tools:
         tool_specs: list[dict[str, Any]] = []
@@ -174,11 +276,13 @@ def _format_messages_as_prompt(
         if tool_specs:
             sections.append(
                 "Available Hermes tools (OpenAI function schema):\n"
-                + json.dumps(tool_specs, ensure_ascii=False)
+                + json.dumps(tool_specs, ensure_ascii=False, separators=(",", ":"))
             )
 
-    if tool_choice is not None:
-        sections.append(f"Tool choice hint: {json.dumps(tool_choice, ensure_ascii=False)}")
+    if tool_choice not in (None, "auto"):
+        sections.append(
+            f"Tool choice hint: {json.dumps(tool_choice, ensure_ascii=False, separators=(',', ':'))}"
+        )
 
     transcript: list[str] = []
     for message in messages:
@@ -206,7 +310,6 @@ def _format_messages_as_prompt(
             continue
 
         label = {
-            "system": "System",
             "user": "User",
         }.get(role, role.title())
         rendered = _render_message_content(message.get("content"))
@@ -218,6 +321,121 @@ def _format_messages_as_prompt(
 
     sections.append("Continue the conversation from the latest user request.")
     return "\n\n".join(part.strip() for part in sections if part and part.strip())
+
+
+def _build_tool_guidance(
+    *,
+    tools: list[dict[str, Any]] | None,
+    tool_choice: Any = None,
+) -> str:
+    sections: list[str] = [
+        "If you need a Hermes tool, emit exactly <tool_call>{...}</tool_call>.",
+        "Each tool call JSON must match OpenAI function-call shape exactly: {\"id\":...,\"type\":\"function\",\"function\":{\"name\":...,\"arguments\":\"{...}\"}}.",
+        "Tool result messages arrive as plain user messages prefixed with 'Tool result (...)'.",
+    ]
+
+    if isinstance(tools, list) and tools:
+        tool_specs: list[dict[str, Any]] = []
+        for tool in tools:
+            if not isinstance(tool, dict):
+                continue
+            fn = tool.get("function") or {}
+            if not isinstance(fn, dict):
+                continue
+            name = fn.get("name")
+            if not isinstance(name, str) or not name.strip():
+                continue
+            tool_specs.append(
+                {
+                    "name": name.strip(),
+                    "description": fn.get("description", ""),
+                    "parameters": fn.get("parameters", {}),
+                }
+            )
+        if tool_specs:
+            sections.append(
+                "Available Hermes tools (OpenAI function schema):\n"
+                + json.dumps(tool_specs, ensure_ascii=False, separators=(",", ":"))
+            )
+
+    if tool_choice not in (None, "auto"):
+        sections.append(
+            f"Tool choice hint: {json.dumps(tool_choice, ensure_ascii=False, separators=(',', ':'))}"
+        )
+
+    return "\n\n".join(part.strip() for part in sections if part and part.strip())
+
+
+def _combine_system_prompt(system_prompt: str, tool_guidance: str) -> str:
+    parts = [str(system_prompt or "").strip(), str(tool_guidance or "").strip()]
+    return "\n\n".join(part for part in parts if part)
+
+
+def _make_user_event(text: str) -> str | None:
+    cleaned = str(text or "").strip()
+    if not cleaned:
+        return None
+    return json.dumps(
+        {
+            "type": "user",
+            "message": {
+                "role": "user",
+                "content": cleaned,
+            },
+        },
+        ensure_ascii=False,
+    )
+
+
+def _build_resume_delta_payload(messages: list[dict[str, Any]]) -> str | None:
+    if not messages:
+        return None
+
+    last_assistant_idx = None
+    for idx in range(len(messages) - 1, -1, -1):
+        message = messages[idx]
+        if isinstance(message, dict) and str(message.get("role") or "").strip().lower() == "assistant":
+            last_assistant_idx = idx
+            break
+
+    if last_assistant_idx is None:
+        return None
+
+    delta_messages = messages[last_assistant_idx + 1 :]
+    if not delta_messages:
+        return None
+
+    parts: list[str] = []
+    for message in delta_messages:
+        if not isinstance(message, dict):
+            continue
+        role = str(message.get("role") or "").strip().lower()
+        if role == "user":
+            rendered = _render_message_content(message.get("content"))
+            if rendered:
+                parts.append(rendered)
+            continue
+        if role == "tool":
+            rendered = _render_message_content(message.get("content"))
+            if rendered:
+                tool_call_id = str(message.get("tool_call_id") or "").strip()
+                label = f"Tool result ({tool_call_id})" if tool_call_id else "Tool result"
+                parts.append(f"{label}:\n{rendered}")
+            continue
+        return None
+
+    return _make_user_event("\n\n".join(part for part in parts if part))
+
+
+def _build_initial_structured_payload(messages: list[dict[str, Any]]) -> str | None:
+    if len(messages) != 1:
+        return None
+    message = messages[0]
+    if not isinstance(message, dict):
+        return None
+    if str(message.get("role") or "").strip().lower() != "user":
+        return None
+    return _make_user_event(_render_message_content(message.get("content")))
 
 
 def _extract_tool_calls_from_text(text: str) -> tuple[list[SimpleNamespace], str]:
@@ -427,7 +645,7 @@ class ClaudeCLIClient:
         self._default_headers = dict(default_headers or {})
         self._command = claude_command or command or _resolve_command()
         self._args = list(claude_args or args or _resolve_args())
-        self._cwd = str(Path(claude_cwd or os.getcwd()).resolve())
+        self._cwd = _resolve_cwd(claude_cwd)
         self._timeout = (
             float(timeout) if isinstance(timeout, (int, float)) else _DEFAULT_TIMEOUT_SECONDS
         )
@@ -449,13 +667,42 @@ class ClaudeCLIClient:
         tools: list[dict[str, Any]] | None = None,
         tool_choice: Any = None,
         stream: bool = False,
-        **_: Any,
+        **extra_kwargs: Any,
     ) -> Any:
+        system_prompt, prompt_messages = _split_system_prompt(messages or [])
+        tool_guidance = _build_tool_guidance(tools=tools, tool_choice=tool_choice)
         prompt_text = _format_messages_as_prompt(
-            messages or [],
-            model=model,
+            prompt_messages,
             tools=tools,
             tool_choice=tool_choice,
+        )
+        effort = _extract_effort(extra_kwargs)
+        structured_stream_input: str | None = None
+        structured_stream_system_prompt = system_prompt
+
+        if self._last_session_id and _resume_enabled():
+            structured_stream_input = _build_resume_delta_payload(prompt_messages)
+            if structured_stream_input:
+                structured_stream_system_prompt = _combine_system_prompt(
+                    system_prompt,
+                    tool_guidance,
+                )
+        else:
+            structured_stream_input = _build_initial_structured_payload(prompt_messages)
+            if structured_stream_input:
+                structured_stream_system_prompt = _combine_system_prompt(
+                    system_prompt,
+                    tool_guidance,
+                )
+        _debug_log(
+            "create:stream_prep "
+            f"stream={stream} "
+            f"resume_enabled={_resume_enabled()} "
+            f"has_last_session={bool(self._last_session_id)} "
+            f"last_session_id={self._last_session_id or ''} "
+            f"prompt_messages={len(prompt_messages)} "
+            f"roles={[str((m or {}).get('role') or '') for m in prompt_messages if isinstance(m, dict)]} "
+            f"structured_input={bool(structured_stream_input)}"
         )
 
         if timeout is None:
@@ -470,10 +717,29 @@ class ClaudeCLIClient:
             numeric = [float(v) for v in candidates if isinstance(v, (int, float))]
             effective_timeout = max(numeric) if numeric else self._timeout
 
-        result = self._run_prompt(prompt_text, model=model, timeout_seconds=effective_timeout)
+        if stream:
+            return self._stream_completion_live(
+                model=model or "claude-cli",
+                prompt_text=prompt_text,
+                system_prompt=system_prompt,
+                structured_input=structured_stream_input,
+                structured_system_prompt=structured_stream_system_prompt,
+                effort=effort,
+                timeout_seconds=effective_timeout,
+            )
+
+        result = self._run_prompt(
+            prompt_text,
+            system_prompt=system_prompt,
+            model=model,
+            effort=effort,
+            timeout_seconds=effective_timeout,
+        )
         _debug_log(
             "create:prompt_done "
             f"prompt_len={len(prompt_text)} "
+            f"system_prompt_len={len(system_prompt)} "
+            f"effort={effort or ''} "
             f"result_keys={sorted(result.keys())}"
         )
         response_text = str(result.get("result") or "").strip()
@@ -500,13 +766,6 @@ class ClaudeCLIClient:
             prompt_tokens_details=SimpleNamespace(cached_tokens=cached_tokens),
         )
         finish_reason = "tool_calls" if tool_calls else "stop"
-
-        if stream:
-            return self._stream_completion_live(
-                model=model or "claude-cli",
-                prompt_text=prompt_text,
-                timeout_seconds=effective_timeout,
-            )
 
         assistant_message = SimpleNamespace(
             content=cleaned_text,
@@ -562,23 +821,376 @@ class ClaudeCLIClient:
         *,
         model: str,
         prompt_text: str,
+        system_prompt: str,
+        structured_input: str | None,
+        structured_system_prompt: str,
+        effort: str | None,
         timeout_seconds: float,
     ):
         def _generator():
             normalized_model = _normalize_model(model)
+            use_structured_input = bool(structured_input and structured_input.strip())
+            effective_system_prompt = (
+                structured_system_prompt if use_structured_input else system_prompt
+            )
+            stdin_payload = structured_input if use_structured_input else prompt_text
+
+            with _system_prompt_file_args(effective_system_prompt) as system_args:
+                command = [
+                    self._command,
+                    *self._args,
+                    "-p",
+                    "--verbose",
+                    "--input-format",
+                    "stream-json" if use_structured_input else "text",
+                    "--output-format",
+                    "stream-json",
+                    "--include-partial-messages",
+                    "--tools",
+                    "",
+                    "--disable-slash-commands",
+                    "--strict-mcp-config",
+                    "--mcp-config",
+                    _EMPTY_MCP_CONFIG,
+                    "--setting-sources",
+                    "user",
+                    *system_args,
+                ]
+                if normalized_model:
+                    command.extend(["--model", normalized_model])
+                if effort:
+                    command.extend(["--effort", effort])
+                if self._last_session_id and _resume_enabled():
+                    command.extend(["--resume", self._last_session_id])
+
+                resolved = shutil.which(command[0]) if command and command[0] else None
+                if not resolved:
+                    raise RuntimeError(
+                        f"Could not find Claude CLI command '{command[0]}'. Install Claude Code or set "
+                        "HERMES_CLAUDE_CLI_COMMAND/CLAUDE_CLI_PATH."
+                    )
+                command[0] = resolved
+                _debug_log(
+                    "stream_prompt:start "
+                    f"model={normalized_model or ''} "
+                    f"structured={use_structured_input} "
+                    f"effort={effort or ''} "
+                    f"timeout={timeout_seconds:.1f} "
+                    f"cwd={self._cwd} "
+                    f"argv_len={sum(len(part) for part in command)} "
+                    f"stdin_len={len(stdin_payload)} "
+                    f"system_prompt_len={len(effective_system_prompt)}"
+                )
+
+                try:
+                    proc = subprocess.Popen(
+                        command,
+                        stdin=subprocess.PIPE,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        text=True,
+                        cwd=self._cwd,
+                        bufsize=1,
+                    )
+                except Exception as exc:
+                    raise RuntimeError(f"Failed to start Claude CLI: {exc}") from exc
+
+                assert proc.stdin is not None
+                assert proc.stdout is not None
+                assert proc.stderr is not None
+
+                try:
+                    proc.stdin.write(stdin_payload)
+                    proc.stdin.close()
+                except Exception:
+                    proc.kill()
+                    proc.wait()
+                    raise
+
+                block_types: dict[int, str] = {}
+                stderr_lines: list[str] = []
+                raw_text_parts: list[str] = []
+                fallback_assistant_text = ""
+                pending_text = ""
+                tool_buffer = ""
+                inside_tool_block = False
+                emitted_text = ""
+                result_payload: dict[str, Any] | None = None
+                usage = None
+                finish_reason = "stop"
+                start = time.monotonic()
+
+                def _emit_visible(fragment: str, *, final: bool = False):
+                    nonlocal pending_text, tool_buffer, inside_tool_block, emitted_text
+                    if fragment:
+                        pending_text += fragment
+                    emitted_now: list[str] = []
+                    while True:
+                        if inside_tool_block:
+                            end_idx = pending_text.find(_STREAM_TOOL_END)
+                            if end_idx == -1:
+                                tool_buffer += pending_text
+                                pending_text = ""
+                                break
+                            tool_buffer += pending_text[:end_idx]
+                            pending_text = pending_text[end_idx + len(_STREAM_TOOL_END):]
+                            inside_tool_block = False
+                            tool_buffer = ""
+                            continue
+
+                        start_idx = pending_text.find(_STREAM_TOOL_START)
+                        if start_idx != -1:
+                            visible = pending_text[:start_idx]
+                            if visible:
+                                emitted_now.append(visible)
+                                emitted_text += visible
+                            pending_text = pending_text[start_idx + len(_STREAM_TOOL_START):]
+                            inside_tool_block = True
+                            tool_buffer = ""
+                            continue
+
+                        if not pending_text:
+                            break
+                        if final:
+                            visible = pending_text
+                            pending_text = ""
+                        else:
+                            visible, pending_text = _split_partial_marker_tail(
+                                pending_text,
+                                _STREAM_TOOL_START,
+                            )
+                        if visible:
+                            emitted_now.append(visible)
+                            emitted_text += visible
+                        break
+                    return emitted_now
+
+                while True:
+                    elapsed = time.monotonic() - start
+                    remaining = timeout_seconds - elapsed
+                    if remaining <= 0:
+                        proc.kill()
+                        raise TimeoutError(f"Claude CLI timed out after {timeout_seconds:.0f}s")
+
+                    ready, _, _ = select.select([proc.stdout, proc.stderr], [], [], remaining)
+                    if not ready:
+                        proc.kill()
+                        raise TimeoutError(f"Claude CLI timed out after {timeout_seconds:.0f}s")
+
+                    if proc.stderr in ready:
+                        err_line = proc.stderr.readline()
+                        if err_line:
+                            stderr_lines.append(err_line.rstrip("\n"))
+
+                    if proc.stdout in ready:
+                        line = proc.stdout.readline()
+                        if line:
+                            stripped = line.strip()
+                            if stripped:
+                                try:
+                                    payload = json.loads(stripped)
+                                except Exception:
+                                    _debug_log(f"stream_prompt:json_error preview={stripped[:200]!r}")
+                                    continue
+
+                                payload_type = str(payload.get("type") or "").strip().lower()
+                                if payload_type == "system":
+                                    session_id = str(payload.get("session_id") or "").strip()
+                                    if session_id:
+                                        self._last_session_id = session_id
+                                elif payload_type == "stream_event":
+                                    event = payload.get("event") or {}
+                                    if not isinstance(event, dict):
+                                        event = {}
+                                    event_type = str(event.get("type") or "").strip().lower()
+                                    if event_type == "content_block_start":
+                                        idx = int(event.get("index") or 0)
+                                        block = event.get("content_block") or {}
+                                        if not isinstance(block, dict):
+                                            block = {}
+                                        block_types[idx] = str(block.get("type") or "").strip().lower()
+                                    elif event_type == "content_block_delta":
+                                        idx = int(event.get("index") or 0)
+                                        block_type = block_types.get(idx)
+                                        delta = event.get("delta") or {}
+                                        if not isinstance(delta, dict):
+                                            delta = {}
+                                        text_delta = str(delta.get("text") or "")
+                                        if text_delta and (
+                                            block_type == "text"
+                                            or str(delta.get("type") or "").strip().lower() == "text_delta"
+                                        ):
+                                            raw_text_parts.append(text_delta)
+                                            for visible in _emit_visible(text_delta):
+                                                yield _make_stream_chunk(model=model, content=visible)
+                                        reasoning_delta = _coerce_reasoning_delta(block_type, delta)
+                                        if reasoning_delta:
+                                            yield _make_stream_chunk(model=model, reasoning=reasoning_delta)
+                                    elif event_type == "content_block_stop":
+                                        idx = int(event.get("index") or 0)
+                                        block_types.pop(idx, None)
+                                    elif event_type == "message_delta":
+                                        delta = event.get("delta") or {}
+                                        if not isinstance(delta, dict):
+                                            delta = {}
+                                        stop = delta.get("stop_reason")
+                                        if isinstance(stop, str) and stop.strip():
+                                            finish_reason = "tool_calls" if stop == "tool_use" else "stop"
+                                        usage_payload = event.get("usage") or {}
+                                        if isinstance(usage_payload, dict):
+                                            prompt_tokens = int(
+                                                usage_payload.get("input_tokens")
+                                                or usage_payload.get("cache_creation_input_tokens")
+                                                or 0
+                                            )
+                                            completion_tokens = int(usage_payload.get("output_tokens") or 0)
+                                            cached_tokens = int(
+                                                usage_payload.get("cache_read_input_tokens") or 0
+                                            )
+                                            usage = SimpleNamespace(
+                                                prompt_tokens=prompt_tokens,
+                                                completion_tokens=completion_tokens,
+                                                total_tokens=prompt_tokens + completion_tokens,
+                                                prompt_tokens_details=SimpleNamespace(
+                                                    cached_tokens=cached_tokens
+                                                ),
+                                            )
+                                elif payload_type == "assistant" and not raw_text_parts:
+                                    message = payload.get("message") or {}
+                                    if not isinstance(message, dict):
+                                        message = {}
+                                    fallback_assistant_text = _extract_text_from_content_blocks(
+                                        message.get("content")
+                                    )
+                                elif payload_type == "result":
+                                    result_payload = payload
+                                    session_id = str(payload.get("session_id") or "").strip()
+                                    if session_id:
+                                        self._last_session_id = session_id
+                                        _debug_log(
+                                            "stream_prompt:result "
+                                            f"session_id={session_id} "
+                                            f"stop_reason={payload.get('stop_reason') or ''}"
+                                        )
+                                    total_cost = payload.get("total_cost_usd")
+                                    self._last_total_cost_usd = (
+                                        float(total_cost)
+                                        if isinstance(total_cost, (int, float))
+                                        else None
+                                    )
+                                    stop_reason = payload.get("stop_reason")
+                                    self._last_stop_reason = (
+                                        str(stop_reason).strip()
+                                        if isinstance(stop_reason, str)
+                                        else None
+                                    )
+                        elif proc.poll() is not None:
+                            break
+
+                    if proc.poll() is not None:
+                        break
+
+                try:
+                    rc = proc.wait(timeout=1)
+                except Exception:
+                    proc.kill()
+                    rc = proc.wait()
+
+                stderr = "\n".join(part for part in stderr_lines if part).strip()
+                if rc != 0:
+                    raise RuntimeError(
+                        f"Claude CLI returned exit code {rc}: {stderr or 'unknown error'}"
+                    )
+
+                if fallback_assistant_text and not raw_text_parts:
+                    raw_text_parts.append(fallback_assistant_text)
+
+                raw_text = "".join(raw_text_parts).strip()
+                tool_calls, cleaned_text = _extract_tool_calls_from_text(raw_text)
+                for visible in _emit_visible("", final=True):
+                    yield _make_stream_chunk(model=model, content=visible)
+
+                if cleaned_text and len(cleaned_text) > len(emitted_text) and cleaned_text.startswith(
+                    emitted_text
+                ):
+                    tail = cleaned_text[len(emitted_text):]
+                    if tail:
+                        emitted_text += tail
+                        yield _make_stream_chunk(model=model, content=tail)
+
+                if not usage and isinstance(result_payload, dict):
+                    usage_payload = result_payload.get("usage") or {}
+                    if isinstance(usage_payload, dict):
+                        prompt_tokens = int(
+                            usage_payload.get("input_tokens")
+                            or usage_payload.get("cache_creation_input_tokens")
+                            or 0
+                        )
+                        completion_tokens = int(usage_payload.get("output_tokens") or 0)
+                        cached_tokens = int(usage_payload.get("cache_read_input_tokens") or 0)
+                        usage = SimpleNamespace(
+                            prompt_tokens=prompt_tokens,
+                            completion_tokens=completion_tokens,
+                            total_tokens=prompt_tokens + completion_tokens,
+                            prompt_tokens_details=SimpleNamespace(cached_tokens=cached_tokens),
+                        )
+
+                if tool_calls:
+                    finish_reason = "tool_calls"
+                    for index, tool_call in enumerate(tool_calls):
+                        yield _make_stream_chunk(
+                            model=model,
+                            tool_call_delta={
+                                "index": index,
+                                "id": getattr(tool_call, "id", None),
+                                "name": getattr(getattr(tool_call, "function", None), "name", ""),
+                                "arguments": getattr(
+                                    getattr(tool_call, "function", None),
+                                    "arguments",
+                                    "",
+                                ),
+                            },
+                        )
+
+                yield _make_stream_chunk(
+                    model=model,
+                    finish_reason=finish_reason,
+                    usage=usage,
+                )
+
+        return _generator()
+
+    def _run_prompt(
+        self,
+        prompt_text: str,
+        *,
+        system_prompt: str,
+        model: str | None,
+        effort: str | None,
+        timeout_seconds: float,
+    ) -> dict[str, Any]:
+        normalized_model = _normalize_model(model)
+        with _system_prompt_file_args(system_prompt) as system_args:
             command = [
                 self._command,
                 *self._args,
                 "-p",
-                "--verbose",
                 "--output-format",
-                "stream-json",
-                "--include-partial-messages",
+                "json",
                 "--tools",
                 "",
+                "--disable-slash-commands",
+                "--strict-mcp-config",
+                "--mcp-config",
+                _EMPTY_MCP_CONFIG,
+                "--setting-sources",
+                "user",
+                *system_args,
             ]
             if normalized_model:
                 command.extend(["--model", normalized_model])
+            if effort:
+                command.extend(["--effort", effort])
             if self._last_session_id and _resume_enabled():
                 command.extend(["--resume", self._last_session_id])
 
@@ -590,335 +1202,29 @@ class ClaudeCLIClient:
                 )
             command[0] = resolved
             _debug_log(
-                "stream_prompt:start "
+                "run_prompt:start "
                 f"model={normalized_model or ''} "
+                f"effort={effort or ''} "
                 f"timeout={timeout_seconds:.1f} "
                 f"cwd={self._cwd} "
                 f"argv_len={sum(len(part) for part in command)} "
-                f"prompt_len={len(prompt_text)}"
+                f"prompt_len={len(prompt_text)} "
+                f"system_prompt_len={len(system_prompt)}"
             )
 
             try:
-                proc = subprocess.Popen(
+                proc = subprocess.run(
                     command,
-                    stdin=subprocess.PIPE,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
+                    input=prompt_text,
+                    capture_output=True,
                     text=True,
+                    timeout=timeout_seconds,
+                    check=False,
                     cwd=self._cwd,
-                    bufsize=1,
                 )
-            except Exception as exc:
-                raise RuntimeError(f"Failed to start Claude CLI: {exc}") from exc
-
-            assert proc.stdin is not None
-            assert proc.stdout is not None
-            assert proc.stderr is not None
-
-            try:
-                proc.stdin.write(prompt_text)
-                proc.stdin.close()
-            except Exception:
-                proc.kill()
-                proc.wait()
-                raise
-
-            block_types: dict[int, str] = {}
-            stderr_lines: list[str] = []
-            raw_text_parts: list[str] = []
-            fallback_assistant_text = ""
-            pending_text = ""
-            tool_buffer = ""
-            inside_tool_block = False
-            emitted_text = ""
-            reasoning_text = ""
-            result_payload: dict[str, Any] | None = None
-            usage = None
-            finish_reason = "stop"
-            start = time.monotonic()
-
-            def _emit_visible(fragment: str, *, final: bool = False):
-                nonlocal pending_text, tool_buffer, inside_tool_block, emitted_text
-                if fragment:
-                    pending_text += fragment
-                emitted_now: list[str] = []
-                while True:
-                    if inside_tool_block:
-                        end_idx = pending_text.find(_STREAM_TOOL_END)
-                        if end_idx == -1:
-                            tool_buffer += pending_text
-                            pending_text = ""
-                            break
-                        tool_buffer += pending_text[:end_idx]
-                        pending_text = pending_text[end_idx + len(_STREAM_TOOL_END):]
-                        inside_tool_block = False
-                        tool_buffer = ""
-                        continue
-
-                    start_idx = pending_text.find(_STREAM_TOOL_START)
-                    if start_idx != -1:
-                        visible = pending_text[:start_idx]
-                        if visible:
-                            emitted_now.append(visible)
-                            emitted_text += visible
-                        pending_text = pending_text[start_idx + len(_STREAM_TOOL_START):]
-                        inside_tool_block = True
-                        tool_buffer = ""
-                        continue
-
-                    if not pending_text:
-                        break
-                    if final:
-                        visible = pending_text
-                        pending_text = ""
-                    else:
-                        visible, pending_text = _split_partial_marker_tail(
-                            pending_text,
-                            _STREAM_TOOL_START,
-                        )
-                    if visible:
-                        emitted_now.append(visible)
-                        emitted_text += visible
-                    break
-                return emitted_now
-
-            while True:
-                elapsed = time.monotonic() - start
-                remaining = timeout_seconds - elapsed
-                if remaining <= 0:
-                    proc.kill()
-                    raise TimeoutError(f"Claude CLI timed out after {timeout_seconds:.0f}s")
-
-                ready, _, _ = select.select([proc.stdout, proc.stderr], [], [], remaining)
-                if not ready:
-                    proc.kill()
-                    raise TimeoutError(f"Claude CLI timed out after {timeout_seconds:.0f}s")
-
-                if proc.stderr in ready:
-                    err_line = proc.stderr.readline()
-                    if err_line:
-                        stderr_lines.append(err_line.rstrip("\n"))
-
-                if proc.stdout in ready:
-                    line = proc.stdout.readline()
-                    if line:
-                        stripped = line.strip()
-                        if stripped:
-                            try:
-                                payload = json.loads(stripped)
-                            except Exception:
-                                _debug_log(f"stream_prompt:json_error preview={stripped[:200]!r}")
-                                continue
-
-                            payload_type = str(payload.get("type") or "").strip().lower()
-                            if payload_type == "system":
-                                session_id = str(payload.get("session_id") or "").strip()
-                                if session_id:
-                                    self._last_session_id = session_id
-                            elif payload_type == "stream_event":
-                                event = payload.get("event") or {}
-                                if not isinstance(event, dict):
-                                    event = {}
-                                event_type = str(event.get("type") or "").strip().lower()
-                                if event_type == "content_block_start":
-                                    idx = int(event.get("index") or 0)
-                                    block = event.get("content_block") or {}
-                                    if not isinstance(block, dict):
-                                        block = {}
-                                    block_types[idx] = str(block.get("type") or "").strip().lower()
-                                elif event_type == "content_block_delta":
-                                    idx = int(event.get("index") or 0)
-                                    block_type = block_types.get(idx)
-                                    delta = event.get("delta") or {}
-                                    if not isinstance(delta, dict):
-                                        delta = {}
-                                    text_delta = str(delta.get("text") or "")
-                                    if text_delta and (
-                                        block_type == "text"
-                                        or str(delta.get("type") or "").strip().lower() == "text_delta"
-                                    ):
-                                        raw_text_parts.append(text_delta)
-                                        for visible in _emit_visible(text_delta):
-                                            yield _make_stream_chunk(model=model, content=visible)
-                                    reasoning_delta = _coerce_reasoning_delta(block_type, delta)
-                                    if reasoning_delta:
-                                        reasoning_text += reasoning_delta
-                                        yield _make_stream_chunk(
-                                            model=model,
-                                            reasoning=reasoning_delta,
-                                        )
-                                elif event_type == "content_block_stop":
-                                    idx = int(event.get("index") or 0)
-                                    block_types.pop(idx, None)
-                                elif event_type == "message_delta":
-                                    delta = event.get("delta") or {}
-                                    if not isinstance(delta, dict):
-                                        delta = {}
-                                    stop = delta.get("stop_reason")
-                                    if isinstance(stop, str) and stop.strip():
-                                        finish_reason = "tool_calls" if stop == "tool_use" else "stop"
-                                    usage_payload = event.get("usage") or {}
-                                    if isinstance(usage_payload, dict):
-                                        prompt_tokens = int(
-                                            usage_payload.get("input_tokens")
-                                            or usage_payload.get("cache_creation_input_tokens")
-                                            or 0
-                                        )
-                                        completion_tokens = int(usage_payload.get("output_tokens") or 0)
-                                        cached_tokens = int(
-                                            usage_payload.get("cache_read_input_tokens") or 0
-                                        )
-                                        usage = SimpleNamespace(
-                                            prompt_tokens=prompt_tokens,
-                                            completion_tokens=completion_tokens,
-                                            total_tokens=prompt_tokens + completion_tokens,
-                                            prompt_tokens_details=SimpleNamespace(
-                                                cached_tokens=cached_tokens
-                                            ),
-                                        )
-                            elif payload_type == "assistant" and not raw_text_parts:
-                                message = payload.get("message") or {}
-                                if not isinstance(message, dict):
-                                    message = {}
-                                fallback_assistant_text = _extract_text_from_content_blocks(
-                                    message.get("content")
-                                )
-                            elif payload_type == "result":
-                                result_payload = payload
-                                session_id = str(payload.get("session_id") or "").strip()
-                                if session_id:
-                                    self._last_session_id = session_id
-                                total_cost = payload.get("total_cost_usd")
-                                self._last_total_cost_usd = (
-                                    float(total_cost)
-                                    if isinstance(total_cost, (int, float))
-                                    else None
-                                )
-                                stop_reason = payload.get("stop_reason")
-                                self._last_stop_reason = (
-                                    str(stop_reason).strip()
-                                    if isinstance(stop_reason, str)
-                                    else None
-                                )
-                    elif proc.poll() is not None:
-                        break
-
-                if proc.poll() is not None:
-                    break
-
-            try:
-                rc = proc.wait(timeout=1)
-            except Exception:
-                proc.kill()
-                rc = proc.wait()
-
-            stderr = "\n".join(part for part in stderr_lines if part).strip()
-            if rc != 0:
-                raise RuntimeError(
-                    f"Claude CLI returned exit code {rc}: {stderr or 'unknown error'}"
-                )
-
-            if fallback_assistant_text and not raw_text_parts:
-                raw_text_parts.append(fallback_assistant_text)
-
-            raw_text = "".join(raw_text_parts).strip()
-            tool_calls, cleaned_text = _extract_tool_calls_from_text(raw_text)
-            for visible in _emit_visible("", final=True):
-                yield _make_stream_chunk(model=model, content=visible)
-
-            if cleaned_text and len(cleaned_text) > len(emitted_text) and cleaned_text.startswith(
-                emitted_text
-            ):
-                tail = cleaned_text[len(emitted_text):]
-                if tail:
-                    emitted_text += tail
-                    yield _make_stream_chunk(model=model, content=tail)
-
-            if not usage and isinstance(result_payload, dict):
-                usage_payload = result_payload.get("usage") or {}
-                if isinstance(usage_payload, dict):
-                    prompt_tokens = int(
-                        usage_payload.get("input_tokens")
-                        or usage_payload.get("cache_creation_input_tokens")
-                        or 0
-                    )
-                    completion_tokens = int(usage_payload.get("output_tokens") or 0)
-                    cached_tokens = int(usage_payload.get("cache_read_input_tokens") or 0)
-                    usage = SimpleNamespace(
-                        prompt_tokens=prompt_tokens,
-                        completion_tokens=completion_tokens,
-                        total_tokens=prompt_tokens + completion_tokens,
-                        prompt_tokens_details=SimpleNamespace(cached_tokens=cached_tokens),
-                    )
-
-            if tool_calls:
-                finish_reason = "tool_calls"
-                for index, tool_call in enumerate(tool_calls):
-                    yield _make_stream_chunk(
-                        model=model,
-                        tool_call_delta={
-                            "index": index,
-                            "id": getattr(tool_call, "id", None),
-                            "name": getattr(getattr(tool_call, "function", None), "name", ""),
-                            "arguments": getattr(
-                                getattr(tool_call, "function", None),
-                                "arguments",
-                                "",
-                            ),
-                        },
-                    )
-
-            yield _make_stream_chunk(
-                model=model,
-                finish_reason=finish_reason,
-                usage=usage,
-            )
-
-        return _generator()
-
-    def _run_prompt(
-        self,
-        prompt_text: str,
-        *,
-        model: str | None,
-        timeout_seconds: float,
-    ) -> dict[str, Any]:
-        normalized_model = _normalize_model(model)
-        command = [self._command, *self._args, "-p", "--output-format", "json", "--tools", ""]
-        if normalized_model:
-            command.extend(["--model", normalized_model])
-        if self._last_session_id and _resume_enabled():
-            command.extend(["--resume", self._last_session_id])
-
-        resolved = shutil.which(command[0]) if command and command[0] else None
-        if not resolved:
-            raise RuntimeError(
-                f"Could not find Claude CLI command '{command[0]}'. Install Claude Code or set "
-                "HERMES_CLAUDE_CLI_COMMAND/CLAUDE_CLI_PATH."
-            )
-        command[0] = resolved
-        _debug_log(
-            "run_prompt:start "
-            f"model={normalized_model or ''} "
-            f"timeout={timeout_seconds:.1f} "
-            f"cwd={self._cwd} "
-            f"argv_len={sum(len(part) for part in command)} "
-            f"prompt_len={len(prompt_text)}"
-        )
-
-        try:
-            proc = subprocess.run(
-                command,
-                input=prompt_text,
-                capture_output=True,
-                text=True,
-                timeout=timeout_seconds,
-                check=False,
-                cwd=self._cwd,
-            )
-        except subprocess.TimeoutExpired as exc:
-            _debug_log("run_prompt:timeout")
-            raise TimeoutError(f"Claude CLI timed out after {timeout_seconds:.0f}s") from exc
+            except subprocess.TimeoutExpired as exc:
+                _debug_log("run_prompt:timeout")
+                raise TimeoutError(f"Claude CLI timed out after {timeout_seconds:.0f}s") from exc
 
         stdout = proc.stdout.strip()
         stderr = proc.stderr.strip()

--- a/agent/claude_cli_client.py
+++ b/agent/claude_cli_client.py
@@ -9,6 +9,7 @@ turns within the same Hermes session.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
@@ -660,6 +661,32 @@ def _coerce_reasoning_delta(block_type: str | None, delta: dict[str, Any]) -> st
     return ""
 
 
+def _chunk_hydration_text(text: str, max_chars: int = 8000) -> list[str]:
+    cleaned = str(text or "").strip()
+    if not cleaned:
+        return []
+    if len(cleaned) <= max_chars:
+        return [cleaned]
+
+    chunks: list[str] = []
+    remaining = cleaned
+    while remaining:
+        if len(remaining) <= max_chars:
+            chunks.append(remaining.strip())
+            break
+        window = remaining[:max_chars]
+        split_at = window.rfind("\n\n")
+        if split_at < max_chars // 2:
+            split_at = window.rfind("\n")
+        if split_at < max_chars // 2:
+            split_at = max_chars
+        chunk = remaining[:split_at].strip()
+        if chunk:
+            chunks.append(chunk)
+        remaining = remaining[split_at:].lstrip()
+    return [chunk for chunk in chunks if chunk]
+
+
 class _ClaudeCLIChatCompletions:
     def __init__(self, client: "ClaudeCLIClient"):
         self._client = client
@@ -755,11 +782,83 @@ class ClaudeCLIClient:
         self._last_session_id: str | None = None
         self._last_total_cost_usd: float | None = None
         self._last_stop_reason: str | None = None
+        self._hydrated_session_id: str | None = None
+        self._hydrated_prompt_hash: str | None = None
         self.chat = _ClaudeCLIChatNamespace(self)
         self.is_closed = False
 
     def close(self) -> None:
         self.is_closed = True
+
+    def _ensure_bootstrap_hydrated(
+        self,
+        *,
+        model: str | None,
+        full_system_prompt: str,
+        timeout_seconds: float,
+    ) -> None:
+        if not self._strip_runtime:
+            return
+        hydration_source = str(full_system_prompt or "").strip()
+        if not hydration_source:
+            return
+
+        prompt_hash = hashlib.sha1(hydration_source.encode("utf-8")).hexdigest()
+        if not self._last_session_id:
+            _debug_log("hydrate:bootstrap_start")
+            bootstrap = self._run_prompt(
+                "Reply with exactly OK.",
+                system_prompt="",
+                model=model,
+                effort=None,
+                timeout_seconds=min(timeout_seconds, 60.0),
+            )
+            _debug_log(
+                "hydrate:bootstrap_done "
+                f"session_id={self._last_session_id or ''} "
+                f"result={str(bootstrap.get('result') or '')[:24]!r}"
+            )
+
+        if not self._last_session_id:
+            return
+
+        if (
+            self._hydrated_session_id == self._last_session_id
+            and self._hydrated_prompt_hash == prompt_hash
+        ):
+            return
+
+        chunks = _chunk_hydration_text(hydration_source, max_chars=8000)
+        _debug_log(
+            "hydrate:start "
+            f"session_id={self._last_session_id} chunks={len(chunks)} chars={len(hydration_source)}"
+        )
+        for idx, chunk in enumerate(chunks, start=1):
+            hidden_prompt = (
+                f"Internal Hermes context block {idx}/{len(chunks)} for this session. "
+                "Store and follow it for later turns in this session. "
+                "Do not summarize it. Do not call any tools. Reply with exactly OK.\n\n"
+                f"{chunk}"
+            )
+            result = self._run_prompt(
+                hidden_prompt,
+                system_prompt="",
+                model=model,
+                effort=None,
+                timeout_seconds=min(timeout_seconds, 120.0),
+            )
+            _debug_log(
+                "hydrate:chunk_done "
+                f"idx={idx}/{len(chunks)} session_id={self._last_session_id or ''} "
+                f"result={str(result.get('result') or '')[:24]!r}"
+            )
+
+        self._hydrated_session_id = self._last_session_id
+        self._hydrated_prompt_hash = prompt_hash
+        _debug_log(
+            "hydrate:complete "
+            f"session_id={self._last_session_id or ''} hash={prompt_hash[:10]}"
+        )
 
     def _create_chat_completion(
         self,
@@ -773,6 +872,7 @@ class ClaudeCLIClient:
         **extra_kwargs: Any,
     ) -> Any:
         system_prompt, prompt_messages = _split_system_prompt(messages or [])
+        full_system_prompt = system_prompt
         if self._strip_runtime:
             original_system_prompt = system_prompt
             system_prompt = _lean_claude_cli_system_prompt(system_prompt)
@@ -831,6 +931,13 @@ class ClaudeCLIClient:
             ]
             numeric = [float(v) for v in candidates if isinstance(v, (int, float))]
             effective_timeout = max(numeric) if numeric else self._timeout
+
+        if self._strip_runtime and full_system_prompt:
+            self._ensure_bootstrap_hydrated(
+                model=model,
+                full_system_prompt=full_system_prompt,
+                timeout_seconds=effective_timeout,
+            )
 
         if stream:
             return self._stream_completion_live(

--- a/agent/claude_cli_client.py
+++ b/agent/claude_cli_client.py
@@ -185,6 +185,109 @@ def _build_process_env(*, strip_runtime: bool) -> dict[str, str]:
             env.pop(key, None)
     return env
 
+def _slice_between(text: str, start_marker: str, end_marker: str | None = None) -> str:
+    if not text:
+        return ""
+    start = text.find(start_marker)
+    if start < 0:
+        return ""
+    end = len(text)
+    if end_marker:
+        marker_end = text.find(end_marker, start)
+        if marker_end >= 0:
+            end = marker_end
+    return text[start:end].strip()
+
+
+def _lean_claude_cli_system_prompt(system_prompt: str) -> str:
+    text = str(system_prompt or "").strip()
+    if not text:
+        return ""
+
+    parts: list[str] = []
+
+    persistent_memory_marker = "You have persistent memory across sessions."
+    memory_section_marker = "MEMORY (your personal notes)"
+    skills_section_marker = "## Skills (mandatory)"
+
+    prefix_end = text.find(persistent_memory_marker)
+    if prefix_end > 0:
+        prefix = text[:prefix_end].strip()
+        if prefix:
+            parts.append(prefix)
+    else:
+        parts.append(text[:2000].strip())
+
+    memory_and_profile = _slice_between(
+        text,
+        memory_section_marker,
+        skills_section_marker,
+    )
+    if memory_and_profile:
+        parts.append(memory_and_profile)
+
+    parts.append(
+        "Use Hermes tools when relevant. Keep the existing voice and user context, "
+        "but do not self-update skills or persist new memories unless the user asks."
+    )
+
+    lean = "\n\n".join(part for part in parts if part).strip()
+    return lean or text
+
+
+def _summarize_tool_specs(
+    tools: list[dict[str, Any]] | None,
+    *,
+    compact: bool = False,
+) -> list[dict[str, Any]]:
+    tool_specs: list[dict[str, Any]] = []
+    if not isinstance(tools, list):
+        return tool_specs
+
+    for tool in tools:
+        if not isinstance(tool, dict):
+            continue
+        fn = tool.get("function") or {}
+        if not isinstance(fn, dict):
+            continue
+        name = fn.get("name")
+        if not isinstance(name, str) or not name.strip():
+            continue
+        description = str(fn.get("description") or "").strip()
+        parameters = fn.get("parameters", {})
+        if compact:
+            if description:
+                description = description.splitlines()[0].strip()[:160]
+            props: dict[str, Any] = {}
+            required: list[str] = []
+            if isinstance(parameters, dict):
+                raw_props = parameters.get("properties")
+                if isinstance(raw_props, dict):
+                    props = raw_props
+                raw_required = parameters.get("required")
+                if isinstance(raw_required, list):
+                    required = [str(item) for item in raw_required[:10]]
+            tool_specs.append(
+                {
+                    "name": name.strip(),
+                    "description": description,
+                    "args": list(props.keys())[:10],
+                    "required": required,
+                }
+            )
+            continue
+
+        tool_specs.append(
+            {
+                "name": name.strip(),
+                "description": description,
+                "parameters": parameters,
+            }
+        )
+
+    return tool_specs
+
+
 
 @contextmanager
 def _system_prompt_file_args(system_prompt: str):
@@ -280,6 +383,8 @@ def _format_messages_as_prompt(
     messages: list[dict[str, Any]],
     tools: list[dict[str, Any]] | None = None,
     tool_choice: Any = None,
+    *,
+    compact_tools: bool = False,
 ) -> str:
     sections: list[str] = [
         "If you need a Hermes tool, emit exactly <tool_call>{...}</tool_call>.",
@@ -287,33 +392,14 @@ def _format_messages_as_prompt(
         "Transcript tool requests and tool results are literal prior Hermes tool traffic.",
     ]
 
-    if isinstance(tools, list) and tools:
-        tool_specs: list[dict[str, Any]] = []
-        for tool in tools:
-            if not isinstance(tool, dict):
-                continue
-            fn = tool.get("function") or {}
-            if not isinstance(fn, dict):
-                continue
-            name = fn.get("name")
-            if not isinstance(name, str) or not name.strip():
-                continue
-            tool_specs.append(
-                {
-                    "name": name.strip(),
-                    "description": fn.get("description", ""),
-                    "parameters": fn.get("parameters", {}),
-                }
-            )
-        if tool_specs:
-            sections.append(
-                "Available Hermes tools (OpenAI function schema):\n"
-                + json.dumps(tool_specs, ensure_ascii=False, separators=(",", ":"))
-            )
+    tool_specs = _summarize_tool_specs(tools, compact=compact_tools)
+    if tool_specs:
+        label = "Available Hermes tools (compact schema):" if compact_tools else "Available Hermes tools (OpenAI function schema):"
+        sections.append(label + "\n" + json.dumps(tool_specs, ensure_ascii=False, separators=(",", ":")))
 
     if tool_choice not in (None, "auto"):
         sections.append(
-            f"Tool choice hint: {json.dumps(tool_choice, ensure_ascii=False, separators=(',', ':'))}"
+            "Tool choice hint: " + json.dumps(tool_choice, ensure_ascii=False, separators=(",", ":"))
         )
 
     transcript: list[str] = []
@@ -359,6 +445,7 @@ def _build_tool_guidance(
     *,
     tools: list[dict[str, Any]] | None,
     tool_choice: Any = None,
+    compact_tools: bool = False,
 ) -> str:
     sections: list[str] = [
         "If you need a Hermes tool, emit exactly <tool_call>{...}</tool_call>.",
@@ -366,33 +453,14 @@ def _build_tool_guidance(
         "Tool result messages arrive as plain user messages prefixed with 'Tool result (...)'.",
     ]
 
-    if isinstance(tools, list) and tools:
-        tool_specs: list[dict[str, Any]] = []
-        for tool in tools:
-            if not isinstance(tool, dict):
-                continue
-            fn = tool.get("function") or {}
-            if not isinstance(fn, dict):
-                continue
-            name = fn.get("name")
-            if not isinstance(name, str) or not name.strip():
-                continue
-            tool_specs.append(
-                {
-                    "name": name.strip(),
-                    "description": fn.get("description", ""),
-                    "parameters": fn.get("parameters", {}),
-                }
-            )
-        if tool_specs:
-            sections.append(
-                "Available Hermes tools (OpenAI function schema):\n"
-                + json.dumps(tool_specs, ensure_ascii=False, separators=(",", ":"))
-            )
+    tool_specs = _summarize_tool_specs(tools, compact=compact_tools)
+    if tool_specs:
+        label = "Available Hermes tools (compact schema):" if compact_tools else "Available Hermes tools (OpenAI function schema):"
+        sections.append(label + "\n" + json.dumps(tool_specs, ensure_ascii=False, separators=(",", ":")))
 
     if tool_choice not in (None, "auto"):
         sections.append(
-            f"Tool choice hint: {json.dumps(tool_choice, ensure_ascii=False, separators=(',', ':'))}"
+            "Tool choice hint: " + json.dumps(tool_choice, ensure_ascii=False, separators=(",", ":"))
         )
 
     return "\n\n".join(part.strip() for part in sections if part and part.strip())
@@ -705,11 +773,23 @@ class ClaudeCLIClient:
         **extra_kwargs: Any,
     ) -> Any:
         system_prompt, prompt_messages = _split_system_prompt(messages or [])
-        tool_guidance = _build_tool_guidance(tools=tools, tool_choice=tool_choice)
+        if self._strip_runtime:
+            original_system_prompt = system_prompt
+            system_prompt = _lean_claude_cli_system_prompt(system_prompt)
+            _debug_log(
+                "create:lean_system_prompt "
+                f"before={len(original_system_prompt)} after={len(system_prompt)}"
+            )
+        tool_guidance = _build_tool_guidance(
+            tools=tools,
+            tool_choice=tool_choice,
+            compact_tools=self._strip_runtime,
+        )
         prompt_text = _format_messages_as_prompt(
             prompt_messages,
             tools=tools,
             tool_choice=tool_choice,
+            compact_tools=self._strip_runtime,
         )
         effort = _extract_effort(extra_kwargs)
         structured_stream_input: str | None = None

--- a/agent/claude_cli_client.py
+++ b/agent/claude_cli_client.py
@@ -1131,14 +1131,33 @@ class ClaudeCLIClient:
                     proc.kill()
                     rc = proc.wait()
 
+                try:
+                    stderr_tail = proc.stderr.read()
+                except Exception:
+                    stderr_tail = ""
+                if stderr_tail:
+                    stderr_lines.extend(line for line in stderr_tail.splitlines() if line)
+
                 stderr = "\n".join(part for part in stderr_lines if part).strip()
-                if rc != 0:
+                if rc != 0 and not fallback_assistant_text and not raw_text_parts and not isinstance(result_payload, dict):
                     raise RuntimeError(
                         f"Claude CLI returned exit code {rc}: {stderr or 'unknown error'}"
+                    )
+                if rc != 0:
+                    _debug_log(
+                        "stream_prompt:nonzero_with_result "
+                        f"rc={rc} stderr_len={len(stderr)} "
+                        f"has_result={isinstance(result_payload, dict)} "
+                        f"has_fallback={bool(fallback_assistant_text)} "
+                        f"raw_parts={len(raw_text_parts)}"
                     )
 
                 if fallback_assistant_text and not raw_text_parts:
                     raw_text_parts.append(fallback_assistant_text)
+                if not raw_text_parts and isinstance(result_payload, dict):
+                    result_text = str(result_payload.get("result") or "").strip()
+                    if result_text:
+                        raw_text_parts.append(result_text)
 
                 raw_text = "".join(raw_text_parts).strip()
                 tool_calls, cleaned_text = _extract_tool_calls_from_text(raw_text)

--- a/agent/claude_cli_client.py
+++ b/agent/claude_cli_client.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import select
 import shlex
 import shutil
 import subprocess
@@ -30,6 +31,8 @@ _TOOL_CALL_JSON_RE = re.compile(
     r"\{\s*\"id\"\s*:\s*\"[^\"]+\"\s*,\s*\"type\"\s*:\s*\"function\"\s*,\s*\"function\"\s*:\s*\{.*?\}\s*\}",
     re.DOTALL,
 )
+_STREAM_TOOL_START = "<tool_call>"
+_STREAM_TOOL_END = "</tool_call>"
 
 
 def _debug_log(message: str) -> None:
@@ -300,6 +303,45 @@ def _extract_tool_calls_from_text(text: str) -> tuple[list[SimpleNamespace], str
     return extracted, cleaned
 
 
+def _split_partial_marker_tail(text: str, marker: str) -> tuple[str, str]:
+    if not text or not marker:
+        return text, ""
+    max_keep = min(len(text), len(marker) - 1)
+    for size in range(max_keep, 0, -1):
+        if marker.startswith(text[-size:]):
+            return text[:-size], text[-size:]
+    return text, ""
+
+
+def _extract_text_from_content_blocks(content: Any) -> str:
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for item in content:
+        if not isinstance(item, dict):
+            continue
+        if str(item.get("type") or "").strip().lower() != "text":
+            continue
+        text = item.get("text")
+        if isinstance(text, str) and text:
+            parts.append(text)
+    return "".join(parts)
+
+
+def _coerce_reasoning_delta(block_type: str | None, delta: dict[str, Any]) -> str:
+    kind = str(delta.get("type") or "").strip().lower()
+    if block_type in {"thinking", "redacted_thinking"} or "thinking" in kind:
+        for key in ("thinking", "text"):
+            value = delta.get(key)
+            if isinstance(value, str) and value:
+                return value
+    for key in ("reasoning", "reasoning_content"):
+        value = delta.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
 class _ClaudeCLIChatCompletions:
     def __init__(self, client: "ClaudeCLIClient"):
         self._client = client
@@ -460,12 +502,10 @@ class ClaudeCLIClient:
         finish_reason = "tool_calls" if tool_calls else "stop"
 
         if stream:
-            return self._stream_completion(
+            return self._stream_completion_live(
                 model=model or "claude-cli",
-                content=cleaned_text,
-                tool_calls=tool_calls,
-                finish_reason=finish_reason,
-                usage=usage,
+                prompt_text=prompt_text,
+                timeout_seconds=effective_timeout,
             )
 
         assistant_message = SimpleNamespace(
@@ -508,6 +548,325 @@ class ClaudeCLIClient:
                         "arguments": getattr(getattr(tool_call, "function", None), "arguments", ""),
                     },
                 )
+
+            yield _make_stream_chunk(
+                model=model,
+                finish_reason=finish_reason,
+                usage=usage,
+            )
+
+        return _generator()
+
+    def _stream_completion_live(
+        self,
+        *,
+        model: str,
+        prompt_text: str,
+        timeout_seconds: float,
+    ):
+        def _generator():
+            normalized_model = _normalize_model(model)
+            command = [
+                self._command,
+                *self._args,
+                "-p",
+                "--verbose",
+                "--output-format",
+                "stream-json",
+                "--include-partial-messages",
+                "--tools",
+                "",
+            ]
+            if normalized_model:
+                command.extend(["--model", normalized_model])
+            if self._last_session_id and _resume_enabled():
+                command.extend(["--resume", self._last_session_id])
+
+            resolved = shutil.which(command[0]) if command and command[0] else None
+            if not resolved:
+                raise RuntimeError(
+                    f"Could not find Claude CLI command '{command[0]}'. Install Claude Code or set "
+                    "HERMES_CLAUDE_CLI_COMMAND/CLAUDE_CLI_PATH."
+                )
+            command[0] = resolved
+            _debug_log(
+                "stream_prompt:start "
+                f"model={normalized_model or ''} "
+                f"timeout={timeout_seconds:.1f} "
+                f"cwd={self._cwd} "
+                f"argv_len={sum(len(part) for part in command)} "
+                f"prompt_len={len(prompt_text)}"
+            )
+
+            try:
+                proc = subprocess.Popen(
+                    command,
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                    cwd=self._cwd,
+                    bufsize=1,
+                )
+            except Exception as exc:
+                raise RuntimeError(f"Failed to start Claude CLI: {exc}") from exc
+
+            assert proc.stdin is not None
+            assert proc.stdout is not None
+            assert proc.stderr is not None
+
+            try:
+                proc.stdin.write(prompt_text)
+                proc.stdin.close()
+            except Exception:
+                proc.kill()
+                proc.wait()
+                raise
+
+            block_types: dict[int, str] = {}
+            stderr_lines: list[str] = []
+            raw_text_parts: list[str] = []
+            fallback_assistant_text = ""
+            pending_text = ""
+            tool_buffer = ""
+            inside_tool_block = False
+            emitted_text = ""
+            reasoning_text = ""
+            result_payload: dict[str, Any] | None = None
+            usage = None
+            finish_reason = "stop"
+            start = time.monotonic()
+
+            def _emit_visible(fragment: str, *, final: bool = False):
+                nonlocal pending_text, tool_buffer, inside_tool_block, emitted_text
+                if fragment:
+                    pending_text += fragment
+                emitted_now: list[str] = []
+                while True:
+                    if inside_tool_block:
+                        end_idx = pending_text.find(_STREAM_TOOL_END)
+                        if end_idx == -1:
+                            tool_buffer += pending_text
+                            pending_text = ""
+                            break
+                        tool_buffer += pending_text[:end_idx]
+                        pending_text = pending_text[end_idx + len(_STREAM_TOOL_END):]
+                        inside_tool_block = False
+                        tool_buffer = ""
+                        continue
+
+                    start_idx = pending_text.find(_STREAM_TOOL_START)
+                    if start_idx != -1:
+                        visible = pending_text[:start_idx]
+                        if visible:
+                            emitted_now.append(visible)
+                            emitted_text += visible
+                        pending_text = pending_text[start_idx + len(_STREAM_TOOL_START):]
+                        inside_tool_block = True
+                        tool_buffer = ""
+                        continue
+
+                    if not pending_text:
+                        break
+                    if final:
+                        visible = pending_text
+                        pending_text = ""
+                    else:
+                        visible, pending_text = _split_partial_marker_tail(
+                            pending_text,
+                            _STREAM_TOOL_START,
+                        )
+                    if visible:
+                        emitted_now.append(visible)
+                        emitted_text += visible
+                    break
+                return emitted_now
+
+            while True:
+                elapsed = time.monotonic() - start
+                remaining = timeout_seconds - elapsed
+                if remaining <= 0:
+                    proc.kill()
+                    raise TimeoutError(f"Claude CLI timed out after {timeout_seconds:.0f}s")
+
+                ready, _, _ = select.select([proc.stdout, proc.stderr], [], [], remaining)
+                if not ready:
+                    proc.kill()
+                    raise TimeoutError(f"Claude CLI timed out after {timeout_seconds:.0f}s")
+
+                if proc.stderr in ready:
+                    err_line = proc.stderr.readline()
+                    if err_line:
+                        stderr_lines.append(err_line.rstrip("\n"))
+
+                if proc.stdout in ready:
+                    line = proc.stdout.readline()
+                    if line:
+                        stripped = line.strip()
+                        if stripped:
+                            try:
+                                payload = json.loads(stripped)
+                            except Exception:
+                                _debug_log(f"stream_prompt:json_error preview={stripped[:200]!r}")
+                                continue
+
+                            payload_type = str(payload.get("type") or "").strip().lower()
+                            if payload_type == "system":
+                                session_id = str(payload.get("session_id") or "").strip()
+                                if session_id:
+                                    self._last_session_id = session_id
+                            elif payload_type == "stream_event":
+                                event = payload.get("event") or {}
+                                if not isinstance(event, dict):
+                                    event = {}
+                                event_type = str(event.get("type") or "").strip().lower()
+                                if event_type == "content_block_start":
+                                    idx = int(event.get("index") or 0)
+                                    block = event.get("content_block") or {}
+                                    if not isinstance(block, dict):
+                                        block = {}
+                                    block_types[idx] = str(block.get("type") or "").strip().lower()
+                                elif event_type == "content_block_delta":
+                                    idx = int(event.get("index") or 0)
+                                    block_type = block_types.get(idx)
+                                    delta = event.get("delta") or {}
+                                    if not isinstance(delta, dict):
+                                        delta = {}
+                                    text_delta = str(delta.get("text") or "")
+                                    if text_delta and (
+                                        block_type == "text"
+                                        or str(delta.get("type") or "").strip().lower() == "text_delta"
+                                    ):
+                                        raw_text_parts.append(text_delta)
+                                        for visible in _emit_visible(text_delta):
+                                            yield _make_stream_chunk(model=model, content=visible)
+                                    reasoning_delta = _coerce_reasoning_delta(block_type, delta)
+                                    if reasoning_delta:
+                                        reasoning_text += reasoning_delta
+                                        yield _make_stream_chunk(
+                                            model=model,
+                                            reasoning=reasoning_delta,
+                                        )
+                                elif event_type == "content_block_stop":
+                                    idx = int(event.get("index") or 0)
+                                    block_types.pop(idx, None)
+                                elif event_type == "message_delta":
+                                    delta = event.get("delta") or {}
+                                    if not isinstance(delta, dict):
+                                        delta = {}
+                                    stop = delta.get("stop_reason")
+                                    if isinstance(stop, str) and stop.strip():
+                                        finish_reason = "tool_calls" if stop == "tool_use" else "stop"
+                                    usage_payload = event.get("usage") or {}
+                                    if isinstance(usage_payload, dict):
+                                        prompt_tokens = int(
+                                            usage_payload.get("input_tokens")
+                                            or usage_payload.get("cache_creation_input_tokens")
+                                            or 0
+                                        )
+                                        completion_tokens = int(usage_payload.get("output_tokens") or 0)
+                                        cached_tokens = int(
+                                            usage_payload.get("cache_read_input_tokens") or 0
+                                        )
+                                        usage = SimpleNamespace(
+                                            prompt_tokens=prompt_tokens,
+                                            completion_tokens=completion_tokens,
+                                            total_tokens=prompt_tokens + completion_tokens,
+                                            prompt_tokens_details=SimpleNamespace(
+                                                cached_tokens=cached_tokens
+                                            ),
+                                        )
+                            elif payload_type == "assistant" and not raw_text_parts:
+                                message = payload.get("message") or {}
+                                if not isinstance(message, dict):
+                                    message = {}
+                                fallback_assistant_text = _extract_text_from_content_blocks(
+                                    message.get("content")
+                                )
+                            elif payload_type == "result":
+                                result_payload = payload
+                                session_id = str(payload.get("session_id") or "").strip()
+                                if session_id:
+                                    self._last_session_id = session_id
+                                total_cost = payload.get("total_cost_usd")
+                                self._last_total_cost_usd = (
+                                    float(total_cost)
+                                    if isinstance(total_cost, (int, float))
+                                    else None
+                                )
+                                stop_reason = payload.get("stop_reason")
+                                self._last_stop_reason = (
+                                    str(stop_reason).strip()
+                                    if isinstance(stop_reason, str)
+                                    else None
+                                )
+                    elif proc.poll() is not None:
+                        break
+
+                if proc.poll() is not None:
+                    break
+
+            try:
+                rc = proc.wait(timeout=1)
+            except Exception:
+                proc.kill()
+                rc = proc.wait()
+
+            stderr = "\n".join(part for part in stderr_lines if part).strip()
+            if rc != 0:
+                raise RuntimeError(
+                    f"Claude CLI returned exit code {rc}: {stderr or 'unknown error'}"
+                )
+
+            if fallback_assistant_text and not raw_text_parts:
+                raw_text_parts.append(fallback_assistant_text)
+
+            raw_text = "".join(raw_text_parts).strip()
+            tool_calls, cleaned_text = _extract_tool_calls_from_text(raw_text)
+            for visible in _emit_visible("", final=True):
+                yield _make_stream_chunk(model=model, content=visible)
+
+            if cleaned_text and len(cleaned_text) > len(emitted_text) and cleaned_text.startswith(
+                emitted_text
+            ):
+                tail = cleaned_text[len(emitted_text):]
+                if tail:
+                    emitted_text += tail
+                    yield _make_stream_chunk(model=model, content=tail)
+
+            if not usage and isinstance(result_payload, dict):
+                usage_payload = result_payload.get("usage") or {}
+                if isinstance(usage_payload, dict):
+                    prompt_tokens = int(
+                        usage_payload.get("input_tokens")
+                        or usage_payload.get("cache_creation_input_tokens")
+                        or 0
+                    )
+                    completion_tokens = int(usage_payload.get("output_tokens") or 0)
+                    cached_tokens = int(usage_payload.get("cache_read_input_tokens") or 0)
+                    usage = SimpleNamespace(
+                        prompt_tokens=prompt_tokens,
+                        completion_tokens=completion_tokens,
+                        total_tokens=prompt_tokens + completion_tokens,
+                        prompt_tokens_details=SimpleNamespace(cached_tokens=cached_tokens),
+                    )
+
+            if tool_calls:
+                finish_reason = "tool_calls"
+                for index, tool_call in enumerate(tool_calls):
+                    yield _make_stream_chunk(
+                        model=model,
+                        tool_call_delta={
+                            "index": index,
+                            "id": getattr(tool_call, "id", None),
+                            "name": getattr(getattr(tool_call, "function", None), "name", ""),
+                            "arguments": getattr(
+                                getattr(tool_call, "function", None),
+                                "arguments",
+                                "",
+                            ),
+                        },
+                    )
 
             yield _make_stream_chunk(
                 model=model,

--- a/agent/claude_cli_client.py
+++ b/agent/claude_cli_client.py
@@ -1,0 +1,599 @@
+"""OpenAI-compatible facade that routes Hermes requests through Claude Code CLI.
+
+This adapter lets Hermes treat ``claude -p`` as a chat-style backend.
+It disables Claude Code built-in tools and asks the model to emit OpenAI-style
+tool calls inside ``<tool_call>{...}</tool_call>`` blocks when Hermes tools are
+needed. The client remembers the Claude session id and resumes it on later
+turns within the same Hermes session.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import time
+import uuid
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+
+CLAUDE_CLI_MARKER_BASE_URL = "claude-cli://local"
+_DEFAULT_TIMEOUT_SECONDS = 900.0
+
+_TOOL_CALL_BLOCK_RE = re.compile(r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL)
+_TOOL_CALL_JSON_RE = re.compile(
+    r"\{\s*\"id\"\s*:\s*\"[^\"]+\"\s*,\s*\"type\"\s*:\s*\"function\"\s*,\s*\"function\"\s*:\s*\{.*?\}\s*\}",
+    re.DOTALL,
+)
+
+
+def _debug_log(message: str) -> None:
+    path = os.getenv("HERMES_CLAUDE_CLI_DEBUG_LOG", "").strip()
+    if not path:
+        return
+    try:
+        target = Path(path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with target.open("a", encoding="utf-8") as handle:
+            handle.write(f"{time.strftime('%Y-%m-%d %H:%M:%S')} {message}\n")
+    except Exception:
+        pass
+
+
+def _resolve_command() -> str:
+    return (
+        os.getenv("HERMES_CLAUDE_CLI_COMMAND", "").strip()
+        or os.getenv("CLAUDE_CLI_PATH", "").strip()
+        or os.getenv("CLAUDE_CODE_CLI_PATH", "").strip()
+        or "claude"
+    )
+
+
+def _resolve_args() -> list[str]:
+    raw = os.getenv("HERMES_CLAUDE_CLI_ARGS", "").strip()
+    if not raw:
+        return []
+    return shlex.split(raw)
+
+
+def _normalize_model(model: str | None) -> str | None:
+    if not model:
+        return None
+    normalized = model.strip()
+    if normalized.startswith("claude-cli/"):
+        normalized = normalized.split("/", 1)[1]
+    if normalized.startswith("anthropic/"):
+        normalized = normalized.split("/", 1)[1]
+    return normalized or None
+
+
+def _resume_enabled() -> bool:
+    raw = os.getenv("HERMES_CLAUDE_CLI_RESUME", "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def _render_message_content(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, dict):
+        if "text" in content:
+            return str(content.get("text") or "").strip()
+        if "content" in content and isinstance(content.get("content"), str):
+            return str(content.get("content") or "").strip()
+        return json.dumps(content, ensure_ascii=True)
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+                continue
+            if not isinstance(item, dict):
+                continue
+            item_type = str(item.get("type", "")).strip().lower()
+            if item_type in {"text", "input_text"}:
+                text = item.get("text") or item.get("input_text") or ""
+                parts.append(str(text).strip())
+            elif item_type in {"image_url", "input_image"}:
+                parts.append("[image omitted]")
+            elif item_type in {"tool_result", "tool_use", "function"}:
+                parts.append(f"[{item_type} omitted]")
+        return "\n".join(part for part in parts if part).strip()
+    return str(content).strip()
+
+
+def _render_assistant_tool_calls(tool_calls: Any) -> str:
+    if not isinstance(tool_calls, list) or not tool_calls:
+        return ""
+    rendered_calls: list[str] = []
+    for tool_call in tool_calls:
+        if not isinstance(tool_call, dict):
+            continue
+        function = tool_call.get("function") or {}
+        if not isinstance(function, dict):
+            function = {}
+        payload = {
+            "id": tool_call.get("call_id") or tool_call.get("id") or "",
+            "type": tool_call.get("type") or "function",
+            "function": {
+                "name": function.get("name") or "",
+                "arguments": function.get("arguments") or "{}",
+            },
+        }
+        rendered_calls.append(json.dumps(payload, ensure_ascii=False))
+    return "\n".join(rendered_calls).strip()
+
+
+def _format_messages_as_prompt(
+    messages: list[dict[str, Any]],
+    model: str | None = None,
+    tools: list[dict[str, Any]] | None = None,
+    tool_choice: Any = None,
+) -> str:
+    sections: list[str] = [
+        "You are the active Claude Code CLI backend for Hermes.",
+        "Claude Code built-in tools are disabled for this call.",
+        "When Hermes tools are needed, emit tool calls using <tool_call>{...}</tool_call> blocks.",
+        "Each tool call JSON must match OpenAI function-call shape exactly: {\"id\":...,\"type\":\"function\",\"function\":{\"name\":...,\"arguments\":\"{...}\"}}.",
+        "Assistant tool request(s) in the transcript show the exact tool calls you already asked Hermes to run.",
+        "Tool result (...) entries are the results Hermes returned for those tool calls.",
+        "After tool results arrive, either issue the next required tool call or give the final answer.",
+        "Do not repeat the same failed probe over and over. If a tool result shows a missing binary/config/path, adapt your next tool call to use the concrete path or environment that was discovered.",
+        "If no tool is needed, answer normally.",
+    ]
+    if model:
+        sections.append(f"Hermes requested model hint: {model}")
+
+    if isinstance(tools, list) and tools:
+        tool_specs: list[dict[str, Any]] = []
+        for tool in tools:
+            if not isinstance(tool, dict):
+                continue
+            fn = tool.get("function") or {}
+            if not isinstance(fn, dict):
+                continue
+            name = fn.get("name")
+            if not isinstance(name, str) or not name.strip():
+                continue
+            tool_specs.append(
+                {
+                    "name": name.strip(),
+                    "description": fn.get("description", ""),
+                    "parameters": fn.get("parameters", {}),
+                }
+            )
+        if tool_specs:
+            sections.append(
+                "Available Hermes tools (OpenAI function schema):\n"
+                + json.dumps(tool_specs, ensure_ascii=False)
+            )
+
+    if tool_choice is not None:
+        sections.append(f"Tool choice hint: {json.dumps(tool_choice, ensure_ascii=False)}")
+
+    transcript: list[str] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        role = str(message.get("role") or "unknown").strip().lower()
+        if role == "assistant":
+            rendered = _render_message_content(message.get("content"))
+            rendered_tool_calls = _render_assistant_tool_calls(message.get("tool_calls"))
+            if rendered:
+                transcript.append(f"Assistant:\n{rendered}")
+            if rendered_tool_calls:
+                transcript.append(
+                    "Assistant tool request(s):\n"
+                    f"{rendered_tool_calls}"
+                )
+            continue
+
+        if role == "tool":
+            tool_call_id = str(message.get("tool_call_id") or "").strip()
+            rendered = _render_message_content(message.get("content"))
+            if rendered:
+                label = f"Tool result ({tool_call_id})" if tool_call_id else "Tool result"
+                transcript.append(f"{label}:\n{rendered}")
+            continue
+
+        label = {
+            "system": "System",
+            "user": "User",
+        }.get(role, role.title())
+        rendered = _render_message_content(message.get("content"))
+        if rendered:
+            transcript.append(f"{label}:\n{rendered}")
+
+    if transcript:
+        sections.append("Conversation transcript:\n\n" + "\n\n".join(transcript))
+
+    sections.append("Continue the conversation from the latest user request.")
+    return "\n\n".join(part.strip() for part in sections if part and part.strip())
+
+
+def _extract_tool_calls_from_text(text: str) -> tuple[list[SimpleNamespace], str]:
+    _debug_log(
+        "extract:start "
+        f"text_len={len(text) if isinstance(text, str) else -1} "
+        f"has_tag={'<tool_call>' in text if isinstance(text, str) else False}"
+    )
+    if not isinstance(text, str) or not text.strip():
+        _debug_log("extract:empty")
+        return [], ""
+
+    extracted: list[SimpleNamespace] = []
+    consumed_spans: list[tuple[int, int]] = []
+
+    def _try_add_tool_call(raw_json: str) -> None:
+        try:
+            obj = json.loads(raw_json)
+        except Exception:
+            return
+        if not isinstance(obj, dict):
+            return
+        fn = obj.get("function")
+        if not isinstance(fn, dict):
+            return
+        fn_name = fn.get("name")
+        if not isinstance(fn_name, str) or not fn_name.strip():
+            return
+        fn_args = fn.get("arguments", "{}")
+        if not isinstance(fn_args, str):
+            fn_args = json.dumps(fn_args, ensure_ascii=False)
+        call_id = obj.get("id")
+        if not isinstance(call_id, str) or not call_id.strip():
+            call_id = f"claude_cli_call_{len(extracted)+1}"
+
+        extracted.append(
+            SimpleNamespace(
+                id=call_id,
+                call_id=call_id,
+                response_item_id=None,
+                type="function",
+                function=SimpleNamespace(name=fn_name.strip(), arguments=fn_args),
+            )
+        )
+
+    for match in _TOOL_CALL_BLOCK_RE.finditer(text):
+        _try_add_tool_call(match.group(1))
+        consumed_spans.append((match.start(), match.end()))
+
+    if not extracted:
+        for match in _TOOL_CALL_JSON_RE.finditer(text):
+            _try_add_tool_call(match.group(0))
+            consumed_spans.append((match.start(), match.end()))
+
+    if not consumed_spans:
+        cleaned = text.strip()
+        if cleaned in {"</s>", "<|endoftext|>", "<|eot_id|>"}:
+            cleaned = ""
+        _debug_log(f"extract:none cleaned_len={len(cleaned)}")
+        return extracted, cleaned
+
+    consumed_spans.sort()
+    merged: list[tuple[int, int]] = []
+    for start, end in consumed_spans:
+        if not merged or start > merged[-1][1]:
+            merged.append((start, end))
+        else:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+
+    parts: list[str] = []
+    cursor = 0
+    for start, end in merged:
+        if cursor < start:
+            parts.append(text[cursor:start])
+        cursor = max(cursor, end)
+    if cursor < len(text):
+        parts.append(text[cursor:])
+
+    cleaned = "\n".join(part.strip() for part in parts if part and part.strip()).strip()
+    if cleaned in {"</s>", "<|endoftext|>", "<|eot_id|>"}:
+        cleaned = ""
+    _debug_log(f"extract:done tool_calls={len(extracted)} cleaned_len={len(cleaned)}")
+    return extracted, cleaned
+
+
+class _ClaudeCLIChatCompletions:
+    def __init__(self, client: "ClaudeCLIClient"):
+        self._client = client
+
+    def create(self, **kwargs: Any) -> Any:
+        return self._client._create_chat_completion(**kwargs)
+
+
+class _ClaudeCLIChatNamespace:
+    def __init__(self, client: "ClaudeCLIClient"):
+        self.completions = _ClaudeCLIChatCompletions(client)
+
+
+class _ClaudeCLIStreamChunk(SimpleNamespace):
+    """Mimics an OpenAI ChatCompletionChunk with .choices[0].delta."""
+
+
+def _make_stream_chunk(
+    *,
+    model: str,
+    content: str = "",
+    reasoning: str = "",
+    tool_call_delta: dict[str, Any] | None = None,
+    finish_reason: str | None = None,
+    usage: Any = None,
+) -> _ClaudeCLIStreamChunk:
+    delta_kwargs: dict[str, Any] = {
+        "content": None,
+        "tool_calls": None,
+        "reasoning": None,
+        "reasoning_content": None,
+    }
+    if content or tool_call_delta is not None or reasoning:
+        delta_kwargs["role"] = "assistant"
+    if content:
+        delta_kwargs["content"] = content
+    if reasoning:
+        delta_kwargs["reasoning"] = reasoning
+        delta_kwargs["reasoning_content"] = reasoning
+    if tool_call_delta is not None:
+        delta_kwargs["tool_calls"] = [
+            SimpleNamespace(
+                index=tool_call_delta.get("index", 0),
+                id=tool_call_delta.get("id") or f"call_{uuid.uuid4().hex[:12]}",
+                type="function",
+                function=SimpleNamespace(
+                    name=tool_call_delta.get("name") or "",
+                    arguments=tool_call_delta.get("arguments") or "",
+                ),
+            )
+        ]
+    delta = SimpleNamespace(**delta_kwargs)
+    choice = SimpleNamespace(index=0, delta=delta, finish_reason=finish_reason)
+    return _ClaudeCLIStreamChunk(
+        id=f"chatcmpl-{uuid.uuid4().hex[:12]}",
+        object="chat.completion.chunk",
+        created=int(time.time()),
+        model=model,
+        choices=[choice],
+        usage=usage,
+    )
+
+
+class ClaudeCLIClient:
+    """Minimal OpenAI-client-compatible facade for Claude Code CLI."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        default_headers: dict[str, str] | None = None,
+        command: str | None = None,
+        args: list[str] | None = None,
+        claude_command: str | None = None,
+        claude_args: list[str] | None = None,
+        claude_cwd: str | None = None,
+        timeout: float | None = None,
+        **_: Any,
+    ):
+        self.api_key = api_key or "claude-cli"
+        self.base_url = base_url or CLAUDE_CLI_MARKER_BASE_URL
+        self._default_headers = dict(default_headers or {})
+        self._command = claude_command or command or _resolve_command()
+        self._args = list(claude_args or args or _resolve_args())
+        self._cwd = str(Path(claude_cwd or os.getcwd()).resolve())
+        self._timeout = (
+            float(timeout) if isinstance(timeout, (int, float)) else _DEFAULT_TIMEOUT_SECONDS
+        )
+        self._last_session_id: str | None = None
+        self._last_total_cost_usd: float | None = None
+        self._last_stop_reason: str | None = None
+        self.chat = _ClaudeCLIChatNamespace(self)
+        self.is_closed = False
+
+    def close(self) -> None:
+        self.is_closed = True
+
+    def _create_chat_completion(
+        self,
+        *,
+        model: str | None = None,
+        messages: list[dict[str, Any]] | None = None,
+        timeout: float | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: Any = None,
+        stream: bool = False,
+        **_: Any,
+    ) -> Any:
+        prompt_text = _format_messages_as_prompt(
+            messages or [],
+            model=model,
+            tools=tools,
+            tool_choice=tool_choice,
+        )
+
+        if timeout is None:
+            effective_timeout = self._timeout
+        elif isinstance(timeout, (int, float)):
+            effective_timeout = float(timeout)
+        else:
+            candidates = [
+                getattr(timeout, attr, None)
+                for attr in ("read", "write", "connect", "pool", "timeout")
+            ]
+            numeric = [float(v) for v in candidates if isinstance(v, (int, float))]
+            effective_timeout = max(numeric) if numeric else self._timeout
+
+        result = self._run_prompt(prompt_text, model=model, timeout_seconds=effective_timeout)
+        _debug_log(
+            "create:prompt_done "
+            f"prompt_len={len(prompt_text)} "
+            f"result_keys={sorted(result.keys())}"
+        )
+        response_text = str(result.get("result") or "").strip()
+        _debug_log(f"create:result_text result_len={len(response_text)}")
+        tool_calls, cleaned_text = _extract_tool_calls_from_text(response_text)
+        _debug_log(
+            "create:extract_done "
+            f"tool_calls={len(tool_calls)} cleaned_len={len(cleaned_text)}"
+        )
+        usage_payload = result.get("usage") or {}
+
+        prompt_tokens = int(
+            usage_payload.get("input_tokens")
+            or usage_payload.get("cache_creation_input_tokens")
+            or 0
+        )
+        completion_tokens = int(usage_payload.get("output_tokens") or 0)
+        cached_tokens = int(usage_payload.get("cache_read_input_tokens") or 0)
+
+        usage = SimpleNamespace(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=prompt_tokens + completion_tokens,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=cached_tokens),
+        )
+        finish_reason = "tool_calls" if tool_calls else "stop"
+
+        if stream:
+            return self._stream_completion(
+                model=model or "claude-cli",
+                content=cleaned_text,
+                tool_calls=tool_calls,
+                finish_reason=finish_reason,
+                usage=usage,
+            )
+
+        assistant_message = SimpleNamespace(
+            content=cleaned_text,
+            tool_calls=tool_calls,
+            reasoning=None,
+            reasoning_content=None,
+            reasoning_details=None,
+        )
+        choice = SimpleNamespace(message=assistant_message, finish_reason=finish_reason)
+        return SimpleNamespace(
+            choices=[choice],
+            usage=usage,
+            model=model or "claude-cli",
+            claude_session_id=self._last_session_id,
+            claude_total_cost_usd=self._last_total_cost_usd,
+            claude_stop_reason=self._last_stop_reason,
+        )
+
+    def _stream_completion(
+        self,
+        *,
+        model: str,
+        content: str,
+        tool_calls: list[SimpleNamespace],
+        finish_reason: str,
+        usage: Any,
+    ):
+        def _generator():
+            if content:
+                yield _make_stream_chunk(model=model, content=content)
+
+            for index, tool_call in enumerate(tool_calls):
+                yield _make_stream_chunk(
+                    model=model,
+                    tool_call_delta={
+                        "index": index,
+                        "id": getattr(tool_call, "id", None),
+                        "name": getattr(getattr(tool_call, "function", None), "name", ""),
+                        "arguments": getattr(getattr(tool_call, "function", None), "arguments", ""),
+                    },
+                )
+
+            yield _make_stream_chunk(
+                model=model,
+                finish_reason=finish_reason,
+                usage=usage,
+            )
+
+        return _generator()
+
+    def _run_prompt(
+        self,
+        prompt_text: str,
+        *,
+        model: str | None,
+        timeout_seconds: float,
+    ) -> dict[str, Any]:
+        normalized_model = _normalize_model(model)
+        command = [self._command, *self._args, "-p", "--output-format", "json", "--tools", ""]
+        if normalized_model:
+            command.extend(["--model", normalized_model])
+        if self._last_session_id and _resume_enabled():
+            command.extend(["--resume", self._last_session_id])
+
+        resolved = shutil.which(command[0]) if command and command[0] else None
+        if not resolved:
+            raise RuntimeError(
+                f"Could not find Claude CLI command '{command[0]}'. Install Claude Code or set "
+                "HERMES_CLAUDE_CLI_COMMAND/CLAUDE_CLI_PATH."
+            )
+        command[0] = resolved
+        _debug_log(
+            "run_prompt:start "
+            f"model={normalized_model or ''} "
+            f"timeout={timeout_seconds:.1f} "
+            f"cwd={self._cwd} "
+            f"argv_len={sum(len(part) for part in command)} "
+            f"prompt_len={len(prompt_text)}"
+        )
+
+        try:
+            proc = subprocess.run(
+                command,
+                input=prompt_text,
+                capture_output=True,
+                text=True,
+                timeout=timeout_seconds,
+                check=False,
+                cwd=self._cwd,
+            )
+        except subprocess.TimeoutExpired as exc:
+            _debug_log("run_prompt:timeout")
+            raise TimeoutError(f"Claude CLI timed out after {timeout_seconds:.0f}s") from exc
+
+        stdout = proc.stdout.strip()
+        stderr = proc.stderr.strip()
+        _debug_log(
+            "run_prompt:done "
+            f"rc={proc.returncode} stdout_len={len(stdout)} stderr_len={len(stderr)}"
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"Claude CLI returned exit code {proc.returncode}: {stderr or stdout or 'unknown error'}"
+            )
+
+        try:
+            payload = json.loads(stdout)
+        except Exception as exc:
+            _debug_log(f"run_prompt:json_error preview={stdout[:200]!r}")
+            raise RuntimeError(f"Claude CLI did not return JSON: {stdout[:500]}") from exc
+
+        if not isinstance(payload, dict):
+            raise RuntimeError("Claude CLI returned unexpected payload shape")
+
+        session_id = str(payload.get("session_id") or "").strip()
+        if session_id:
+            self._last_session_id = session_id
+
+        total_cost = payload.get("total_cost_usd")
+        self._last_total_cost_usd = (
+            float(total_cost) if isinstance(total_cost, (int, float)) else None
+        )
+        stop_reason = payload.get("stop_reason")
+        self._last_stop_reason = str(stop_reason).strip() if isinstance(stop_reason, str) else None
+        _debug_log(
+            "run_prompt:parsed "
+            f"session_id={self._last_session_id or ''} "
+            f"stop_reason={self._last_stop_reason or ''}"
+        )
+        return payload

--- a/agent/claude_cli_client.py
+++ b/agent/claude_cli_client.py
@@ -161,18 +161,29 @@ def _system_prompt_flag() -> str:
     return "--system-prompt-file"
 
 
-def _strip_runtime_enabled() -> bool:
+def _truthy(value: Any) -> bool:
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _strip_runtime_enabled(explicit: Any = None) -> bool:
+    if isinstance(explicit, bool):
+        return explicit
+    if isinstance(explicit, str) and explicit.strip():
+        return _truthy(explicit)
     raw = os.getenv("HERMES_CLAUDE_CLI_STRIP_RUNTIME", "").strip().lower()
     if not raw:
         return True
-    return raw in {"1", "true", "yes", "on"}
+    return _truthy(raw)
 
 
-def _apply_runtime_env_defaults() -> None:
-    if not _strip_runtime_enabled():
-        return
-    for key, value in _DEFAULT_STRIPPED_RUNTIME_ENV.items():
-        os.environ.setdefault(key, value)
+def _build_process_env(*, strip_runtime: bool) -> dict[str, str]:
+    env = dict(os.environ)
+    if strip_runtime:
+        env.update(_DEFAULT_STRIPPED_RUNTIME_ENV)
+    else:
+        for key in _DEFAULT_STRIPPED_RUNTIME_ENV:
+            env.pop(key, None)
+    return env
 
 
 @contextmanager
@@ -658,16 +669,18 @@ class ClaudeCLIClient:
         claude_command: str | None = None,
         claude_args: list[str] | None = None,
         claude_cwd: str | None = None,
+        strip_runtime: bool | None = None,
         timeout: float | None = None,
         **_: Any,
     ):
-        _apply_runtime_env_defaults()
         self.api_key = api_key or "claude-cli"
         self.base_url = base_url or CLAUDE_CLI_MARKER_BASE_URL
         self._default_headers = dict(default_headers or {})
         self._command = claude_command or command or _resolve_command()
         self._args = list(claude_args or args or _resolve_args())
         self._cwd = _resolve_cwd(claude_cwd)
+        self._strip_runtime = _strip_runtime_enabled(strip_runtime)
+        self._process_env = _build_process_env(strip_runtime=self._strip_runtime)
         self._timeout = (
             float(timeout) if isinstance(timeout, (int, float)) else _DEFAULT_TIMEOUT_SECONDS
         )
@@ -911,6 +924,7 @@ class ClaudeCLIClient:
                         stderr=subprocess.PIPE,
                         text=True,
                         cwd=self._cwd,
+                        env=self._process_env,
                         bufsize=1,
                     )
                 except Exception as exc:
@@ -1241,6 +1255,7 @@ class ClaudeCLIClient:
                     timeout=timeout_seconds,
                     check=False,
                     cwd=self._cwd,
+                    env=self._process_env,
                 )
             except subprocess.TimeoutExpired as exc:
                 _debug_log("run_prompt:timeout")

--- a/agent/claude_cli_client.py
+++ b/agent/claude_cli_client.py
@@ -36,6 +36,13 @@ _TOOL_CALL_JSON_RE = re.compile(
 _STREAM_TOOL_START = "<tool_call>"
 _STREAM_TOOL_END = "</tool_call>"
 _EMPTY_MCP_CONFIG = json.dumps({"mcpServers": {}}, separators=(",", ":"))
+_DEFAULT_STRIPPED_RUNTIME_ENV = {
+    "CLAUDE_CODE_SIMPLE_SYSTEM_PROMPT": "1",
+    "CLAUDE_CODE_DISABLE_CLAUDE_MDS": "1",
+    "CLAUDE_CODE_DISABLE_AUTO_MEMORY": "1",
+    "CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS": "1",
+    "ENABLE_CLAUDEAI_MCP_SERVERS": "false",
+}
 
 
 def _debug_log(message: str) -> None:
@@ -152,6 +159,20 @@ def _system_prompt_flag() -> str:
     if mode in {"append", "append-file"}:
         return "--append-system-prompt-file"
     return "--system-prompt-file"
+
+
+def _strip_runtime_enabled() -> bool:
+    raw = os.getenv("HERMES_CLAUDE_CLI_STRIP_RUNTIME", "").strip().lower()
+    if not raw:
+        return True
+    return raw in {"1", "true", "yes", "on"}
+
+
+def _apply_runtime_env_defaults() -> None:
+    if not _strip_runtime_enabled():
+        return
+    for key, value in _DEFAULT_STRIPPED_RUNTIME_ENV.items():
+        os.environ.setdefault(key, value)
 
 
 @contextmanager
@@ -640,6 +661,7 @@ class ClaudeCLIClient:
         timeout: float | None = None,
         **_: Any,
     ):
+        _apply_runtime_env_defaults()
         self.api_key = api_key or "claude-cli"
         self.base_url = base_url or CLAUDE_CLI_MARKER_BASE_URL
         self._default_headers = dict(default_headers or {})
@@ -881,7 +903,6 @@ class ClaudeCLIClient:
                     f"stdin_len={len(stdin_payload)} "
                     f"system_prompt_len={len(effective_system_prompt)}"
                 )
-
                 try:
                     proc = subprocess.Popen(
                         command,
@@ -1211,7 +1232,6 @@ class ClaudeCLIClient:
                 f"prompt_len={len(prompt_text)} "
                 f"system_prompt_len={len(system_prompt)}"
             )
-
             try:
                 proc = subprocess.run(
                     command,

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1045,11 +1045,12 @@ def get_model_context_length(
             return cached
 
     # 2. Active endpoint metadata for truly custom/unknown endpoints.
-    # Known providers (Copilot, OpenAI, Anthropic, etc.) skip this — their
-    # /models endpoint may report a provider-imposed limit (e.g. Copilot
-    # returns 128k) instead of the model's full context (400k).  models.dev
-    # has the correct per-provider values and is checked at step 5+.
-    if _is_custom_endpoint(base_url) and not _is_known_provider_base_url(base_url):
+    # Known providers (Copilot, OpenAI, Anthropic, Claude CLI, etc.) skip this —
+    # their /models endpoint may report a transport-imposed limit or may not be
+    # queryable at all. models.dev has the correct per-provider values and is
+    # checked at step 5+.
+    skip_custom_endpoint_probe = bool(provider) and provider not in ("openrouter", "custom")
+    if _is_custom_endpoint(base_url) and not _is_known_provider_base_url(base_url) and not skip_custom_endpoint_probe:
         endpoint_metadata = fetch_endpoint_model_metadata(base_url, api_key=api_key)
         matched = endpoint_metadata.get(model)
         if not matched:

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -142,6 +142,7 @@ class ProviderInfo:
 PROVIDER_TO_MODELS_DEV: Dict[str, str] = {
     "openrouter": "openrouter",
     "anthropic": "anthropic",
+    "claude-cli": "anthropic",
     "openai": "openai",
     "openai-codex": "openai",
     "zai": "zai",

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -92,6 +92,28 @@ def auto_title_session(
         logger.debug("Failed to set auto-generated title: %s", e)
 
 
+def _session_uses_claude_cli(session_db, session_id: str) -> bool:
+    """Return True when the session is using the Claude CLI transport.
+
+    We only special-case auto-titling for the claude-cli workaround path.
+    Other providers keep the existing first-exchange behavior.
+    """
+    try:
+        session = session_db.get_session(session_id)
+    except Exception:
+        return False
+
+    if not isinstance(session, dict):
+        return False
+
+    billing_provider = str(session.get("billing_provider") or "").strip().lower()
+    if billing_provider == "claude-cli":
+        return True
+
+    billing_base_url = str(session.get("billing_base_url") or "").strip().lower()
+    return billing_base_url.startswith("claude-cli://")
+
+
 def maybe_auto_title(
     session_db,
     session_id: str,
@@ -101,19 +123,23 @@ def maybe_auto_title(
 ) -> None:
     """Fire-and-forget title generation after the first exchange.
 
-    Only generates a title when:
-    - This appears to be the first user→assistant exchange
-    - No title is already set
+    Only generates a title during the first two visible user turns.
+    For claude-cli sessions, we intentionally delay auto-titling until the
+    second visible turn because the first turn is often a lightweight warm-up
+    that produces low-value session titles.
     """
     if not session_db or not session_id or not user_message or not assistant_response:
         return
 
-    # Count user messages in history to detect first exchange.
-    # conversation_history includes the exchange that just happened,
-    # so for a first exchange we expect exactly 1 user message
-    # (or 2 counting system). Be generous: generate on first 2 exchanges.
     user_msg_count = sum(1 for m in (conversation_history or []) if m.get("role") == "user")
     if user_msg_count > 2:
+        return
+
+    if _session_uses_claude_cli(session_db, session_id) and user_msg_count < 2:
+        logger.debug(
+            "Delaying auto-title for claude-cli session %s until the second visible turn",
+            session_id,
+        )
         return
 
     thread = threading.Thread(

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -135,6 +135,12 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         auth_type="oauth_external",
         inference_base_url=DEFAULT_GEMINI_CLOUDCODE_BASE_URL,
     ),
+    "claude-cli": ProviderConfig(
+        id="claude-cli",
+        name="Claude Code CLI",
+        auth_type="external_process",
+        inference_base_url="claude-cli://local",
+    ),
     "copilot": ProviderConfig(
         id="copilot",
         name="GitHub Copilot",
@@ -1011,7 +1017,7 @@ def resolve_provider(
         "github-copilot-acp": "copilot-acp", "copilot-acp-agent": "copilot-acp",
         "aigateway": "ai-gateway", "vercel": "ai-gateway", "vercel-ai-gateway": "ai-gateway",
         "opencode": "opencode-zen", "zen": "opencode-zen",
-        "qwen-portal": "qwen-oauth", "qwen-cli": "qwen-oauth", "qwen-oauth": "qwen-oauth", "google-gemini-cli": "google-gemini-cli", "gemini-cli": "google-gemini-cli", "gemini-oauth": "google-gemini-cli",
+        "qwen-portal": "qwen-oauth", "qwen-cli": "qwen-oauth", "qwen-oauth": "qwen-oauth", "google-gemini-cli": "google-gemini-cli", "gemini-cli": "google-gemini-cli", "gemini-oauth": "google-gemini-cli", "claude-cli": "claude-cli", "claude-code-cli": "claude-cli",
         "hf": "huggingface", "hugging-face": "huggingface", "huggingface-hub": "huggingface",
         "mimo": "xiaomi", "xiaomi-mimo": "xiaomi",
         "aws": "bedrock", "aws-bedrock": "bedrock", "amazon-bedrock": "bedrock", "amazon": "bedrock",
@@ -2578,28 +2584,58 @@ def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
     if not pconfig or pconfig.auth_type != "external_process":
         return {"configured": False}
 
-    command = (
-        os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
-        or os.getenv("COPILOT_CLI_PATH", "").strip()
-        or "copilot"
-    )
-    raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
-    args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
+    if provider_id == "claude-cli":
+        command = (
+            os.getenv("HERMES_CLAUDE_CLI_COMMAND", "").strip()
+            or os.getenv("CLAUDE_CLI_PATH", "").strip()
+            or os.getenv("CLAUDE_CODE_CLI_PATH", "").strip()
+            or "claude"
+        )
+        raw_args = os.getenv("HERMES_CLAUDE_CLI_ARGS", "").strip()
+        args = shlex.split(raw_args) if raw_args else []
+    else:
+        command = (
+            os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
+            or os.getenv("COPILOT_CLI_PATH", "").strip()
+            or "copilot"
+        )
+        raw_args = os.getenv("HERMES_COPILOT_ACP_ARGS", "").strip()
+        args = shlex.split(raw_args) if raw_args else ["--acp", "--stdio"]
     base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
     if not base_url:
         base_url = pconfig.inference_base_url
 
     resolved_command = shutil.which(command) if command else None
-    return {
-        "configured": bool(resolved_command or base_url.startswith("acp+tcp://")),
+    status = {
+        "configured": bool(resolved_command or base_url.startswith("acp+tcp://") or provider_id == "claude-cli"),
         "provider": provider_id,
         "name": pconfig.name,
         "command": command,
         "args": args,
         "resolved_command": resolved_command,
         "base_url": base_url,
-        "logged_in": bool(resolved_command or base_url.startswith("acp+tcp://")),
+        "logged_in": bool(resolved_command or base_url.startswith("acp+tcp://") or provider_id == "claude-cli"),
     }
+    if provider_id == "claude-cli" and resolved_command:
+        try:
+            proc = subprocess.run(
+                [resolved_command, "auth", "status", "--json"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+            if proc.returncode == 0 and proc.stdout.strip():
+                payload = json.loads(proc.stdout)
+                if isinstance(payload, dict):
+                    status["logged_in"] = bool(payload.get("loggedIn"))
+                    status["configured"] = bool(payload.get("loggedIn"))
+                    status["auth_method"] = payload.get("authMethod")
+                    status["subscription_type"] = payload.get("subscriptionType")
+                    status["email_address"] = payload.get("emailAddress")
+        except Exception:
+            pass
+    return status
 
 
 def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
@@ -2613,6 +2649,8 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
         return get_qwen_auth_status()
     if target == "google-gemini-cli":
         return get_gemini_oauth_auth_status()
+    if target == "claude-cli":
+        return get_external_process_provider_status(target)
     if target == "copilot-acp":
         return get_external_process_provider_status(target)
     # API-key providers
@@ -2680,6 +2718,33 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
     base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
     if not base_url:
         base_url = pconfig.inference_base_url
+
+    if provider_id == "claude-cli":
+        command = (
+            os.getenv("HERMES_CLAUDE_CLI_COMMAND", "").strip()
+            or os.getenv("CLAUDE_CLI_PATH", "").strip()
+            or os.getenv("CLAUDE_CODE_CLI_PATH", "").strip()
+            or "claude"
+        )
+        raw_args = os.getenv("HERMES_CLAUDE_CLI_ARGS", "").strip()
+        args = shlex.split(raw_args) if raw_args else []
+        resolved_command = shutil.which(command) if command else None
+        if not resolved_command:
+            raise AuthError(
+                f"Could not find the Claude CLI command '{command}'. Install Claude Code or set "
+                "HERMES_CLAUDE_CLI_COMMAND/CLAUDE_CLI_PATH.",
+                provider=provider_id,
+                code="missing_claude_cli",
+            )
+
+        return {
+            "provider": provider_id,
+            "api_key": "claude-cli",
+            "base_url": base_url.rstrip("/"),
+            "command": resolved_command,
+            "args": args,
+            "source": "process",
+        }
 
     command = (
         os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3426,7 +3426,8 @@ def _model_flow_claude_cli(config, current_model=""):
 
     if not status.get("resolved_command"):
         print("  ⚠ Claude CLI was not found on PATH.")
-        print("  Set HERMES_CLAUDE_CLI_COMMAND or CLAUDE_CLI_PATH if it is installed elsewhere.")
+        print("  Install Claude Code: https://docs.claude.com/en/docs/claude-code/overview")
+        print("  Or set HERMES_CLAUDE_CLI_COMMAND / CLAUDE_CLI_PATH if installed elsewhere.")
         return
     if not status.get("logged_in"):
         print("  ⚠ Claude CLI is not logged in. Run `claude auth login` or `claude /login` first.")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1542,6 +1542,8 @@ def select_provider_and_model(args=None):
         _model_flow_qwen_oauth(config, current_model)
     elif selected_provider == "google-gemini-cli":
         _model_flow_google_gemini_cli(config, current_model)
+    elif selected_provider == "claude-cli":
+        _model_flow_claude_cli(config, current_model)
     elif selected_provider == "copilot-acp":
         _model_flow_copilot_acp(config, current_model)
     elif selected_provider == "copilot":
@@ -3349,6 +3351,65 @@ def _model_flow_copilot_acp(config, current_model=""):
     model["api_mode"] = "chat_completions"
     save_config(cfg)
     deactivate_provider()
+
+
+def _model_flow_claude_cli(config, current_model=""):
+    """Claude Code CLI flow using the local claude command."""
+    from hermes_cli.auth import (
+        PROVIDER_REGISTRY,
+        _prompt_model_selection,
+        get_external_process_provider_status,
+    )
+    from hermes_cli.config import load_config, save_config
+    from hermes_cli.models import _PROVIDER_MODELS
+
+    del config
+
+    provider_id = "claude-cli"
+    pconfig = PROVIDER_REGISTRY[provider_id]
+    status = get_external_process_provider_status(provider_id)
+    resolved_command = status.get("resolved_command") or status.get("command") or "claude"
+    effective_base = status.get("base_url") or pconfig.inference_base_url
+
+    print("  Claude Code CLI delegates Hermes turns to `claude -p`.")
+    print("  Hermes disables Claude built-in tools and reuses Hermes tool calls.")
+    print(f"  Command: {resolved_command}")
+    if status.get("subscription_type"):
+        print(f"  Subscription: {status.get('subscription_type')}")
+    if status.get("email_address"):
+        print(f"  Account: {status.get('email_address')}")
+    print(f"  Backend marker: {effective_base}")
+    print()
+
+    if not status.get("resolved_command"):
+        print("  ⚠ Claude CLI was not found on PATH.")
+        print("  Set HERMES_CLAUDE_CLI_COMMAND or CLAUDE_CLI_PATH if it is installed elsewhere.")
+        return
+    if not status.get("logged_in"):
+        print("  ⚠ Claude CLI is not logged in. Run `claude auth login` or `claude /login` first.")
+        return
+
+    model_list = list(_PROVIDER_MODELS.get(provider_id) or [])
+    selected = _prompt_model_selection(
+        model_list,
+        current_model=current_model or (model_list[0] if model_list else "claude-opus-4-7"),
+    )
+    if not selected:
+        print("No change.")
+        return
+
+    cfg = load_config()
+    model_cfg = cfg.get("model")
+    if not isinstance(model_cfg, dict):
+        model_cfg = {"default": model_cfg} if model_cfg else {}
+        cfg["model"] = model_cfg
+    model_cfg["provider"] = provider_id
+    model_cfg["base_url"] = effective_base
+    model_cfg["api_mode"] = "chat_completions"
+    model_cfg["api_key"] = "claude-cli"
+    model_cfg["default"] = selected
+    save_config(cfg)
+    print(f"  Config updated: provider={provider_id}, model={selected}")
 
     print(f"Default model set to: {selected} (via {pconfig.name})")
 
@@ -6656,6 +6717,7 @@ For more help on a command:
             "openrouter",
             "nous",
             "openai-codex",
+            "claude-cli",
             "copilot-acp",
             "copilot",
             "anthropic",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1956,25 +1956,23 @@ def _aux_flow_custom_endpoint(task: str, task_cfg: dict) -> None:
     print(f"{display_name}: custom ({short_url})" + (f" · {model}" if model else ""))
 
 
-def _prompt_provider_choice(choices, *, default=0):
-    """Show provider selection menu with curses arrow-key navigation.
+def _prompt_provider_choice(choices, *, default=0, title="Select provider:"):
+    """Show a curses-backed single-choice menu.
 
-    Falls back to a numbered list when curses is unavailable (e.g. piped
-    stdin, non-TTY environments).  Returns the selected index, or None
-    if the user cancels.
+    Falls back to a numbered list when curses is unavailable. Returns the
+    selected index, or None if the user cancels.
     """
     try:
         from hermes_cli.setup import _curses_prompt_choice
 
-        idx = _curses_prompt_choice("Select provider:", choices, default)
+        idx = _curses_prompt_choice(title, choices, default)
         if idx >= 0:
             print()
             return idx
     except Exception:
         pass
 
-    # Fallback: numbered list
-    print("Select provider:")
+    print(title)
     for i, c in enumerate(choices, 1):
         marker = "→" if i - 1 == default else " "
         print(f"  {marker} {i}. {c}")
@@ -3353,6 +3351,49 @@ def _model_flow_copilot_acp(config, current_model=""):
     deactivate_provider()
 
 
+def _current_claude_cli_runtime_mode(config) -> str:
+    model_cfg = config.get("model") if isinstance(config, dict) else {}
+    if not isinstance(model_cfg, dict):
+        return "stripped"
+    raw = str(model_cfg.get("claude_cli_runtime") or "").strip().lower()
+    if raw in {"standard", "full", "default"}:
+        return "standard"
+    if raw in {"stripped", "minimal", "hermes"}:
+        return "stripped"
+    legacy = model_cfg.get("claude_cli_strip_runtime")
+    if isinstance(legacy, bool):
+        return "stripped" if legacy else "standard"
+    if isinstance(legacy, str) and legacy.strip():
+        return "stripped" if legacy.strip().lower() in {"1", "true", "yes", "on"} else "standard"
+    return "stripped"
+
+
+def _prompt_claude_cli_runtime_mode(current_mode: str) -> str | None:
+    options = [
+        (
+            "stripped",
+            "Stripped runtime (recommended for Hermes — disables Claude MDS, auto-memory, git instructions, and Claude.ai MCP)",
+        ),
+        (
+            "standard",
+            "Standard Claude Code runtime (closer to stock Claude Code; may inject extra context)",
+        ),
+        ("cancel", "Cancel"),
+    ]
+    default_idx = 0 if current_mode != "standard" else 1
+    idx = _prompt_provider_choice(
+        [label for _, label in options],
+        default=default_idx,
+        title="Select Claude Code runtime mode:",
+    )
+    if idx is None:
+        return None
+    mode = options[idx][0]
+    if mode == "cancel":
+        return None
+    return mode
+
+
 def _model_flow_claude_cli(config, current_model=""):
     """Claude Code CLI flow using the local claude command."""
     from hermes_cli.auth import (
@@ -3370,9 +3411,11 @@ def _model_flow_claude_cli(config, current_model=""):
     status = get_external_process_provider_status(provider_id)
     resolved_command = status.get("resolved_command") or status.get("command") or "claude"
     effective_base = status.get("base_url") or pconfig.inference_base_url
+    current_runtime = _current_claude_cli_runtime_mode(load_config())
 
     print("  Claude Code CLI delegates Hermes turns to `claude -p`.")
     print("  Hermes disables Claude built-in tools and reuses Hermes tool calls.")
+    print(f"  Runtime mode: {current_runtime}")
     print(f"  Command: {resolved_command}")
     if status.get("subscription_type"):
         print(f"  Subscription: {status.get('subscription_type')}")
@@ -3387,6 +3430,11 @@ def _model_flow_claude_cli(config, current_model=""):
         return
     if not status.get("logged_in"):
         print("  ⚠ Claude CLI is not logged in. Run `claude auth login` or `claude /login` first.")
+        return
+
+    selected_runtime = _prompt_claude_cli_runtime_mode(current_runtime)
+    if not selected_runtime:
+        print("No change.")
         return
 
     model_list = list(_PROVIDER_MODELS.get(provider_id) or [])
@@ -3408,10 +3456,14 @@ def _model_flow_claude_cli(config, current_model=""):
     model_cfg["api_mode"] = "chat_completions"
     model_cfg["api_key"] = "claude-cli"
     model_cfg["default"] = selected
+    model_cfg["claude_cli_runtime"] = selected_runtime
+    model_cfg.pop("claude_cli_strip_runtime", None)
     save_config(cfg)
-    print(f"  Config updated: provider={provider_id}, model={selected}")
+    print(
+        f"  Config updated: provider={provider_id}, model={selected}, runtime={selected_runtime}"
+    )
 
-    print(f"Default model set to: {selected} (via {pconfig.name})")
+    print(f"Default model set to: {selected} (via {pconfig.name}, {selected_runtime} runtime)")
 
 
 def _model_flow_kimi(config, current_model=""):

--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -75,6 +75,7 @@ _DOT_TO_HYPHEN_PROVIDERS: frozenset[str] = frozenset({
 _STRIP_VENDOR_ONLY_PROVIDERS: frozenset[str] = frozenset({
     "copilot",
     "copilot-acp",
+    "claude-cli",
     "openai-codex",
 })
 
@@ -380,7 +381,7 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
     #     and live-catalog lookups.  Without this, vendor-prefixed or
     #     dash-notation Claude IDs survive to the Copilot API and hit
     #     HTTP 400 "model_not_supported".  See issue #6879.
-    if provider in {"copilot", "copilot-acp"}:
+    if provider in {"copilot", "copilot-acp", "claude-cli"}:
         try:
             from hermes_cli.models import normalize_copilot_model_id
 
@@ -423,4 +424,3 @@ def normalize_model_for_provider(model_input: str, target_provider: str) -> str:
 # ---------------------------------------------------------------------------
 # Batch / convenience helpers
 # ---------------------------------------------------------------------------
-

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -137,6 +137,11 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "openai/gpt-5.4-nano",
     ],
     "openai-codex": _codex_curated_models(),
+    "claude-cli": [
+        "claude-opus-4-7",
+        "claude-opus-4-6",
+        "claude-sonnet-4-6",
+    ],
     "copilot-acp": [
         "copilot-acp",
     ],
@@ -690,6 +695,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("ai-gateway",     "Vercel AI Gateway",        "Vercel AI Gateway (200+ models, $5 free credit, no markup)"),
     ProviderEntry("anthropic",      "Anthropic",                "Anthropic (Claude models — API key or Claude Code)"),
     ProviderEntry("openai-codex",   "OpenAI Codex",             "OpenAI Codex"),
+    ProviderEntry("claude-cli",     "Claude Code CLI",          "Claude Code CLI (spawns `claude -p` using your local Claude subscription login)"),
     ProviderEntry("xiaomi",         "Xiaomi MiMo",              "Xiaomi MiMo (MiMo-V2 models — pro, omni, flash)"),
     ProviderEntry("nvidia",         "NVIDIA NIM",               "NVIDIA NIM (Nemotron models — build.nvidia.com or local NIM)"),
     ProviderEntry("qwen-oauth",     "Qwen OAuth (Portal)",      "Qwen OAuth (reuses local Qwen CLI login)"),
@@ -731,6 +737,8 @@ _PROVIDER_ALIASES = {
     "github-model": "copilot",
     "github-copilot-acp": "copilot-acp",
     "copilot-acp-agent": "copilot-acp",
+    "claude-cli": "claude-cli",
+    "claude-code-cli": "claude-cli",
     "google": "gemini",
     "google-gemini": "gemini",
     "google-ai-studio": "gemini",
@@ -1600,14 +1608,14 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
         from hermes_cli.codex_models import get_codex_model_ids
 
         return get_codex_model_ids()
-    if normalized in {"copilot", "copilot-acp"}:
+    if normalized in {"copilot", "copilot-acp", "claude-cli"}:
         try:
             live = _fetch_github_models(_resolve_copilot_catalog_api_key())
             if live:
                 return live
         except Exception:
             pass
-        if normalized == "copilot-acp":
+        if normalized in {"copilot-acp", "claude-cli"}:
             return list(_PROVIDER_MODELS.get("copilot", []))
     if normalized == "nous":
         # Try live Nous Portal /models endpoint

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -71,6 +71,11 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         auth_type="oauth_external",
         base_url_override="cloudcode-pa://google",
     ),
+    "claude-cli": HermesOverlay(
+        transport="openai_chat",
+        auth_type="external_process",
+        base_url_override="claude-cli://local",
+    ),
     "copilot-acp": HermesOverlay(
         transport="codex_responses",
         auth_type="external_process",
@@ -227,6 +232,8 @@ ALIASES: Dict[str, str] = {
     # anthropic
     "claude": "anthropic",
     "claude-code": "anthropic",
+    "claude-cli": "claude-cli",
+    "claude-code-cli": "claude-cli",
 
     # github-copilot (models.dev ID)
     "copilot": "github-copilot",
@@ -304,6 +311,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "nous": "Nous Portal",
     "openai-codex": "OpenAI Codex",
     "copilot-acp": "GitHub Copilot ACP",
+    "claude-cli": "Claude Code CLI",
     "stepfun": "StepFun Step Plan",
     "xiaomi": "Xiaomi MiMo",
     "local": "Local endpoint",

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -855,6 +855,19 @@ def resolve_runtime_provider(
             logger.info("Google Gemini OAuth credentials failed; "
                         "falling through to next provider.")
 
+    if provider == "claude-cli":
+        creds = resolve_external_process_provider_credentials(provider)
+        return {
+            "provider": "claude-cli",
+            "api_mode": "chat_completions",
+            "base_url": creds.get("base_url", "").rstrip("/"),
+            "api_key": creds.get("api_key", ""),
+            "command": creds.get("command", ""),
+            "args": list(creds.get("args") or []),
+            "source": creds.get("source", "process"),
+            "requested_provider": requested_provider,
+        }
+
     if provider == "copilot-acp":
         creds = resolve_external_process_provider_credentials(provider)
         return {

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -153,6 +153,23 @@ def _parse_api_mode(raw: Any) -> Optional[str]:
     return None
 
 
+def _claude_cli_runtime_mode(model_cfg: Optional[Dict[str, Any]] = None) -> str:
+    cfg = model_cfg or _get_model_config()
+    raw = str(cfg.get("claude_cli_runtime") or "").strip().lower()
+    if raw in {"standard", "full", "default"}:
+        return "standard"
+    if raw in {"stripped", "minimal", "hermes"}:
+        return "stripped"
+
+    legacy = cfg.get("claude_cli_strip_runtime")
+    if isinstance(legacy, bool):
+        return "stripped" if legacy else "standard"
+    if isinstance(legacy, str) and legacy.strip():
+        return "stripped" if legacy.strip().lower() in {"1", "true", "yes", "on"} else "standard"
+
+    return "stripped"
+
+
 def _resolve_runtime_from_pool_entry(
     *,
     provider: str,
@@ -857,6 +874,7 @@ def resolve_runtime_provider(
 
     if provider == "claude-cli":
         creds = resolve_external_process_provider_credentials(provider)
+        runtime_mode = _claude_cli_runtime_mode(model_cfg)
         return {
             "provider": "claude-cli",
             "api_mode": "chat_completions",
@@ -864,6 +882,8 @@ def resolve_runtime_provider(
             "api_key": creds.get("api_key", ""),
             "command": creds.get("command", ""),
             "args": list(creds.get("args") or []),
+            "strip_runtime": runtime_mode == "stripped",
+            "claude_cli_runtime": runtime_mode,
             "source": creds.get("source", "process"),
             "requested_provider": requested_provider,
         }

--- a/run_agent.py
+++ b/run_agent.py
@@ -2171,15 +2171,19 @@ class AIAgent:
         if not self.compression_enabled:
             return
         try:
-            from agent.auxiliary_client import get_text_auxiliary_client
+            from agent.auxiliary_client import (
+                _resolve_task_provider_model,
+                get_text_auxiliary_client,
+            )
             from agent.model_metadata import (
                 MINIMUM_CONTEXT_LENGTH,
                 get_model_context_length,
             )
 
+            main_runtime = self._current_main_runtime()
             client, aux_model = get_text_auxiliary_client(
                 "compression",
-                main_runtime=self._current_main_runtime(),
+                main_runtime=main_runtime,
             )
             if client is None or not aux_model:
                 msg = (
@@ -2197,12 +2201,16 @@ class AIAgent:
 
             aux_base_url = str(getattr(client, "base_url", ""))
             aux_api_key = str(getattr(client, "api_key", ""))
+            aux_provider, _, _, _, _ = _resolve_task_provider_model("compression")
+            if aux_provider == "auto":
+                aux_provider = str((main_runtime or {}).get("provider") or "").strip() or aux_provider
 
             aux_context = get_model_context_length(
                 aux_model,
                 base_url=aux_base_url,
                 api_key=aux_api_key,
                 config_context_length=getattr(self, "_aux_compression_context_length_config", None),
+                provider=aux_provider,
             )
 
             # Hard floor: the auxiliary compression model must have at least

--- a/run_agent.py
+++ b/run_agent.py
@@ -1169,7 +1169,7 @@ class AIAgent:
                 client_kwargs = {"api_key": api_key, "base_url": base_url}
                 if _provider_timeout is not None:
                     client_kwargs["timeout"] = _provider_timeout
-                if self.provider == "copilot-acp":
+                if self.provider in {"copilot-acp", "claude-cli"}:
                     client_kwargs["command"] = self.acp_command
                     client_kwargs["args"] = self.acp_args
                 effective_base = base_url
@@ -4445,6 +4445,17 @@ class AIAgent:
             client = CopilotACPClient(**client_kwargs)
             logger.info(
                 "Copilot ACP client created (%s, shared=%s) %s",
+                reason,
+                shared,
+                self._client_log_context(),
+            )
+            return client
+        if self.provider == "claude-cli" or str(client_kwargs.get("base_url", "")).startswith("claude-cli://"):
+            from agent.claude_cli_client import ClaudeCLIClient
+
+            client = ClaudeCLIClient(**client_kwargs)
+            logger.info(
+                "Claude CLI client created (%s, shared=%s) %s",
                 reason,
                 shared,
                 self._client_log_context(),

--- a/run_agent.py
+++ b/run_agent.py
@@ -4720,11 +4720,18 @@ class AIAgent:
         primary_client = self._ensure_primary_openai_client(reason=reason)
         if isinstance(primary_client, Mock):
             return primary_client
+        if self.provider == "claude-cli" or str(getattr(self, "base_url", "")).startswith("claude-cli://"):
+            # Claude CLI is a stateful local subprocess transport, not a pooled
+            # HTTP client. Reuse the shared primary client so Claude session ids
+            # survive across tool turns and cron-style multi-step runs.
+            return primary_client
         with self._openai_client_lock():
             request_kwargs = dict(self._client_kwargs)
         return self._create_openai_client(request_kwargs, reason=reason, shared=False)
 
     def _close_request_openai_client(self, client: Any, *, reason: str) -> None:
+        if client is getattr(self, "client", None):
+            return
         self._close_openai_client(client, reason=reason, shared=False)
 
     def _run_codex_stream(self, api_kwargs: dict, client: Any = None, on_first_delta: callable = None):

--- a/tests/agent/test_claude_cli_client.py
+++ b/tests/agent/test_claude_cli_client.py
@@ -1,0 +1,83 @@
+import json
+from unittest.mock import patch
+
+import pytest
+
+from agent.claude_cli_client import ClaudeCLIClient, _extract_tool_calls_from_text
+
+
+def test_extract_tool_calls_from_text_parses_blocks_and_preserves_visible_text():
+    text = (
+        "Checking repo state now.\n"
+        "<tool_call>{\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"terminal\",\"arguments\":\"{\\\"command\\\":\\\"git status --short\\\"}\"}}</tool_call>\n"
+        "I will summarize after that."
+    )
+
+    tool_calls, visible_text = _extract_tool_calls_from_text(text)
+
+    assert len(tool_calls) == 1
+    assert tool_calls[0].function.name == "terminal"
+    assert json.loads(tool_calls[0].function.arguments) == {"command": "git status --short"}
+    assert "<tool_call>" not in visible_text
+    assert "Checking repo state now." in visible_text
+    assert "I will summarize after that." in visible_text
+
+
+def test_run_prompt_raises_helpful_error_when_claude_cli_missing():
+    client = ClaudeCLIClient(command="definitely-missing-claude")
+
+    with patch("agent.claude_cli_client.shutil.which", return_value=None):
+        with pytest.raises(RuntimeError, match="Could not find Claude CLI command 'definitely-missing-claude'"):
+            client._run_prompt(
+                "Reply with OK.",
+                system_prompt="",
+                model="claude-opus-4-7",
+                effort=None,
+                timeout_seconds=5.0,
+            )
+
+
+def test_bootstrap_hydration_runs_once_per_session_and_prompt_hash():
+    client = ClaudeCLIClient(command="claude", strip_runtime=True)
+    calls = []
+
+    def fake_run_prompt(prompt_text, *, system_prompt, model, effort, timeout_seconds):
+        calls.append(
+            {
+                "prompt_text": prompt_text,
+                "system_prompt": system_prompt,
+                "model": model,
+                "effort": effort,
+                "timeout_seconds": timeout_seconds,
+            }
+        )
+        if prompt_text == "Reply with exactly OK.":
+            client._last_session_id = "sess-123"
+        return {"result": "OK"}
+
+    client._run_prompt = fake_run_prompt
+
+    with patch("agent.claude_cli_client._chunk_hydration_text", return_value=["chunk one", "chunk two"]):
+        client._ensure_bootstrap_hydrated(
+            model="claude-opus-4-7",
+            full_system_prompt="System block",
+            timeout_seconds=90.0,
+        )
+        assert len(calls) == 3
+        assert calls[0]["prompt_text"] == "Reply with exactly OK."
+        assert client._hydrated_session_id == "sess-123"
+
+        client._ensure_bootstrap_hydrated(
+            model="claude-opus-4-7",
+            full_system_prompt="System block",
+            timeout_seconds=90.0,
+        )
+        assert len(calls) == 3
+
+        client._ensure_bootstrap_hydrated(
+            model="claude-opus-4-7",
+            full_system_prompt="Different system block",
+            timeout_seconds=90.0,
+        )
+        assert len(calls) == 5
+        assert calls[-1]["prompt_text"].startswith("Internal Hermes context block 2/2")

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -217,6 +217,20 @@ class TestGetModelContextLength:
         mock_fetch.return_value = {}
         assert get_model_context_length("anthropic/claude-sonnet-4") == 200000
 
+    @patch("agent.models_dev.lookup_models_dev_context")
+    @patch("agent.model_metadata.fetch_model_metadata")
+    @patch("agent.model_metadata.fetch_endpoint_model_metadata")
+    def test_known_provider_skips_custom_endpoint_fallback(self, mock_endpoint, mock_fetch, mock_lookup):
+        mock_fetch.return_value = {}
+        mock_endpoint.return_value = {}
+        mock_lookup.return_value = 654321
+        assert get_model_context_length(
+            "provider-only-test-model",
+            base_url="claude-cli://local",
+            provider="claude-cli",
+        ) == 654321
+        mock_lookup.assert_called_once_with("claude-cli", "provider-only-test-model")
+
     @patch("agent.model_metadata.fetch_model_metadata")
     def test_unknown_model_returns_first_probe_tier(self, mock_fetch):
         mock_fetch.return_value = {}

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -81,6 +81,7 @@ class TestProviderMapping:
 
     def test_known_providers_mapped(self):
         assert PROVIDER_TO_MODELS_DEV["anthropic"] == "anthropic"
+        assert PROVIDER_TO_MODELS_DEV["claude-cli"] == "anthropic"
         assert PROVIDER_TO_MODELS_DEV["copilot"] == "github-copilot"
         assert PROVIDER_TO_MODELS_DEV["stepfun"] == "stepfun"
         assert PROVIDER_TO_MODELS_DEV["kilocode"] == "kilo"
@@ -143,6 +144,12 @@ class TestLookupModelsDevContext:
         assert lookup_models_dev_context("anthropic", "claude-opus-4-6") == 1000000
         # GitHub Copilot: only 128K for same model
         assert lookup_models_dev_context("copilot", "claude-opus-4.6") == 128000
+
+    @patch("agent.models_dev.fetch_models_dev")
+    def test_claude_cli_uses_anthropic_metadata(self, mock_fetch):
+        """claude-cli should inherit Anthropic model context lengths."""
+        mock_fetch.return_value = SAMPLE_REGISTRY
+        assert lookup_models_dev_context("claude-cli", "claude-opus-4-6") == 1000000
 
     @patch("agent.models_dev.fetch_models_dev")
     def test_zero_context_filtered(self, mock_fetch):

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -140,6 +140,7 @@ class TestMaybeAutoTitle:
         """Should fire a background thread for the first exchange."""
         db = MagicMock()
         db.get_session_title.return_value = None
+        db.get_session.return_value = {"billing_provider": "anthropic"}
         history = [
             {"role": "user", "content": "hello"},
             {"role": "assistant", "content": "hi there"},
@@ -151,6 +152,41 @@ class TestMaybeAutoTitle:
             import time
             time.sleep(0.3)
             mock_auto.assert_called_once_with(db, "sess-1", "hello", "hi there")
+
+    def test_delays_first_exchange_for_claude_cli(self):
+        """claude-cli should wait one visible turn before auto-titling."""
+        db = MagicMock()
+        db.get_session.return_value = {
+            "billing_provider": "claude-cli",
+            "billing_base_url": "claude-cli://local",
+        }
+        history = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi there"},
+        ]
+
+        with patch("agent.title_generator.auto_title_session") as mock_auto:
+            maybe_auto_title(db, "sess-1", "hello", "hi there", history)
+            import time
+            time.sleep(0.1)
+            mock_auto.assert_not_called()
+
+    def test_fires_on_second_exchange_for_claude_cli(self):
+        """claude-cli should title from the second visible exchange."""
+        db = MagicMock()
+        db.get_session.return_value = {"billing_provider": "claude-cli"}
+        history = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi there"},
+            {"role": "user", "content": "who are you?"},
+            {"role": "assistant", "content": "Hermes."},
+        ]
+
+        with patch("agent.title_generator.auto_title_session") as mock_auto:
+            maybe_auto_title(db, "sess-1", "who are you?", "Hermes.", history)
+            import time
+            time.sleep(0.3)
+            mock_auto.assert_called_once_with(db, "sess-1", "who are you?", "Hermes.")
 
     def test_skips_if_no_response(self):
         db = MagicMock()

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -180,6 +180,7 @@ def test_feasibility_check_passes_config_context_length(mock_get_client, mock_ct
         base_url="http://custom-endpoint:8080/v1",
         api_key="sk-custom",
         config_context_length=1_000_000,
+        provider="openrouter",
     )
 
 
@@ -202,6 +203,7 @@ def test_feasibility_check_ignores_invalid_context_length(mock_get_client, mock_
         base_url="http://custom:8080/v1",
         api_key="sk-test",
         config_context_length=None,
+        provider="openrouter",
     )
 
 
@@ -254,6 +256,37 @@ def test_init_feasibility_check_uses_aux_context_override_from_config():
         base_url="http://custom-endpoint:8080/v1",
         api_key="sk-custom",
         config_context_length=1_000_000,
+        provider="auto",
+    )
+
+
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=1_000_000)
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_feasibility_check_passes_main_provider_for_auto_aux(mock_get_client, mock_ctx_len):
+    """Auto auxiliary compression should reuse the live main provider for context lookup."""
+    agent = _make_agent(main_context=1_000_000, threshold_percent=0.75)
+    agent.model = "claude-opus-4-7"
+    agent.provider = "claude-cli"
+    agent.base_url = "claude-cli://local"
+    agent.api_key = "claude-cli"
+    agent.api_mode = "chat_completions"
+
+    mock_client = MagicMock()
+    mock_client.base_url = "claude-cli://local"
+    mock_client.api_key = "claude-cli"
+    mock_get_client.return_value = (mock_client, "claude-opus-4-7")
+
+    agent._emit_status = lambda msg: None
+    agent._check_compression_model_feasibility()
+
+    mock_ctx_len.assert_called_once_with(
+        "claude-opus-4-7",
+        base_url="claude-cli://local",
+        api_key="claude-cli",
+        config_context_length=None,
+        provider="claude-cli",
     )
 
 

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -238,6 +238,28 @@ model:
 | `HERMES_COPILOT_ACP_COMMAND` | Override the Copilot CLI binary path (default: `copilot`) |
 | `HERMES_COPILOT_ACP_ARGS` | Override ACP args (default: `--acp --stdio`) |
 
+**`claude-cli` — Claude Code CLI subprocess backend**. Runs the local `claude` binary as an external process while keeping Hermes orchestration, tools, MCP, and session storage:
+
+```bash
+hermes chat --provider claude-cli --model claude-opus-4-7
+# Requires the Claude Code CLI in PATH and an existing `claude auth login` session
+```
+
+**Runtime modes:**
+- `standard` keeps Claude Code's default runtime behavior.
+- `stripped` disables extra Claude Code runtime helpers where possible and bootstraps the Hermes system prompt into the Claude session before the first real turn.
+
+Use `hermes model` to choose the runtime mode, or set it directly:
+
+```yaml
+model:
+  provider: "claude-cli"
+  default: "claude-opus-4-7"
+  claude_cli_runtime: "stripped"   # or "standard"
+```
+
+Hermes tool calls are marshalled through Claude's text output, so this provider is best treated like an external-process transport rather than a native API.
+
 ### First-Class Chinese AI Providers
 
 These providers have built-in support with dedicated provider IDs. Set the API key and use `--provider` to select:
@@ -1159,7 +1181,7 @@ fallback_model:
 
 When activated, the fallback swaps the model and provider mid-session without losing your conversation. It fires **at most once** per session.
 
-Supported providers: `openrouter`, `nous`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `gemini`, `google-gemini-cli`, `qwen-oauth`, `huggingface`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `deepseek`, `nvidia`, `xai`, `ollama-cloud`, `bedrock`, `ai-gateway`, `opencode-zen`, `opencode-go`, `kilocode`, `xiaomi`, `arcee`, `alibaba`, `custom`.
+Supported providers: `openrouter`, `nous`, `openai-codex`, `claude-cli`, `copilot`, `copilot-acp`, `anthropic`, `gemini`, `google-gemini-cli`, `qwen-oauth`, `huggingface`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `deepseek`, `nvidia`, `xai`, `ollama-cloud`, `bedrock`, `ai-gateway`, `opencode-zen`, `opencode-go`, `kilocode`, `xiaomi`, `arcee`, `alibaba`, `custom`.
 
 :::tip
 Fallback is configured exclusively through `config.yaml` — there are no environment variables for it. For full details on when it triggers, supported providers, and how it interacts with auxiliary tasks and delegation, see [Fallback Providers](/docs/user-guide/features/fallback-providers).

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -86,7 +86,7 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 
 | Variable | Description |
 |----------|-------------|
-| `HERMES_INFERENCE_PROVIDER` | Override provider selection: `auto`, `openrouter`, `nous`, `openai-codex`, `copilot`, `copilot-acp`, `anthropic`, `huggingface`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `kilocode`, `xiaomi`, `arcee`, `alibaba`, `deepseek`, `nvidia`, `ollama-cloud`, `xai` (alias `grok`), `google-gemini-cli`, `qwen-oauth`, `bedrock`, `opencode-zen`, `opencode-go`, `ai-gateway` (default: `auto`) |
+| `HERMES_INFERENCE_PROVIDER` | Override provider selection: `auto`, `openrouter`, `nous`, `openai-codex`, `claude-cli`, `copilot`, `copilot-acp`, `anthropic`, `huggingface`, `zai`, `kimi-coding`, `kimi-coding-cn`, `minimax`, `minimax-cn`, `kilocode`, `xiaomi`, `arcee`, `alibaba`, `deepseek`, `nvidia`, `ollama-cloud`, `xai` (alias `grok`), `google-gemini-cli`, `qwen-oauth`, `bedrock`, `opencode-zen`, `opencode-go`, `ai-gateway` (default: `auto`) |
 | `HERMES_PORTAL_BASE_URL` | Override Nous Portal URL (for development/testing) |
 | `NOUS_INFERENCE_BASE_URL` | Override Nous inference API URL |
 | `HERMES_NOUS_MIN_KEY_TTL_SECONDS` | Min agent key TTL before re-mint (default: 1800 = 30min) |
@@ -94,6 +94,13 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 | `HERMES_DUMP_REQUESTS` | Dump API request payloads to log files (`true`/`false`) |
 | `HERMES_PREFILL_MESSAGES_FILE` | Path to a JSON file of ephemeral prefill messages injected at API-call time |
 | `HERMES_TIMEZONE` | IANA timezone override (for example `America/New_York`) |
+| `HERMES_CLAUDE_CLI_COMMAND` | Override the Claude Code CLI binary used by `claude-cli` (default: `claude`) |
+| `HERMES_CLAUDE_CLI_ARGS` | Extra arguments prepended to every `claude-cli` invocation |
+| `HERMES_CLAUDE_CLI_CWD` | Working directory for Claude Code subprocess calls (default: neutral runtime dir) |
+| `HERMES_CLAUDE_CLI_RESUME` | Enable or disable Claude session reuse for `claude-cli` (`true`/`false`, default: `true`) |
+| `HERMES_CLAUDE_CLI_STRIP_RUNTIME` | Force stripped runtime behavior for `claude-cli` (`true`/`false`) |
+| `HERMES_CLAUDE_CLI_USE_PROCESS_CWD` | Use the current process cwd instead of Hermes' neutral Claude runtime dir |
+| `HERMES_CLAUDE_CLI_DEBUG_LOG` | Write verbose Claude CLI transport logs to the given file path |
 
 ## Tool APIs
 


### PR DESCRIPTION
## Summary

Adds a new `claude-cli` provider that routes Hermes turns through the locally-installed `claude` CLI, letting users with an existing Claude Code login drive Hermes with their Claude subscription — no API key required.

Hermes keeps orchestration, tools, MCP, session storage, compression, and multi-step reasoning. Claude Code is treated as a local external-process transport behind an OpenAI-compatible facade.

## How it works

- `agent/claude_cli_client.py` — OpenAI-style `chat.completions` facade around `claude -p`. Manages session id hydration/resume, streams responses live, and marshals Hermes tool calls through `<tool_call>{...}</tool_call>` blocks in Claude's text output.
- Wired into the provider registry, overlay map, auth resolver, auxiliary client, runtime provider, and model-normalizer.
- `hermes model` adds a dedicated Claude Code CLI flow that detects `claude auth status`, picks a model, and sets a runtime mode.

## Runtime modes

- `standard` — keeps Claude Code's default runtime behavior.
- `stripped` — disables Claude Code's MDS loader, auto-memory, git instructions, and Claude.ai MCP servers where possible, then bootstraps the Hermes system prompt into the Claude session before the first real turn. Recommended for Hermes.

```yaml
model:
  provider: "claude-cli"
  default: "claude-opus-4-7"
  claude_cli_runtime: "stripped"   # or "standard"
```

## Usage

```bash
hermes chat --provider claude-cli --model claude-opus-4-7
```

Requires:
- Claude Code CLI on `PATH` (or `HERMES_CLAUDE_CLI_COMMAND` / `CLAUDE_CLI_PATH`)
- An active `claude auth login` session

## New env vars

| Variable | Description |
|---|---|
| `HERMES_CLAUDE_CLI_COMMAND` | Override the Claude CLI binary (default: `claude`) |
| `HERMES_CLAUDE_CLI_ARGS` | Extra arguments prepended to every invocation |
| `HERMES_CLAUDE_CLI_CWD` | Working directory for Claude Code subprocess calls |
| `HERMES_CLAUDE_CLI_RESUME` | Enable/disable Claude session reuse (default: `true`) |
| `HERMES_CLAUDE_CLI_STRIP_RUNTIME` | Force stripped runtime behavior |
| `HERMES_CLAUDE_CLI_USE_PROCESS_CWD` | Use current process cwd instead of Hermes' neutral dir |
| `HERMES_CLAUDE_CLI_DEBUG_LOG` | Write verbose transport logs to file |

Also added to the `HERMES_INFERENCE_PROVIDER` and fallback-provider allow-lists.

## Tests

- `tests/agent/test_claude_cli_client.py` — tool-call parsing, missing-binary error, session hydration reuse
- `tests/agent/test_model_metadata.py`, `test_models_dev.py` — context-window resolution for `claude-cli`
- `tests/agent/test_title_generator.py` — delayed auto-title for Claude CLI sessions (avoids the bootstrap turn)
- `tests/run_agent/test_compression_feasibility.py` — compression threshold handling for the external-process backend

All 141 tests in the affected suite pass locally.

## Docs

- `website/docs/integrations/providers.md` — new provider section with runtime-mode guidance
- `website/docs/reference/environment-variables.md` — all seven new env vars

## Notes for reviewers

- Because Claude Code CLI is a stateful local subprocess rather than a pooled HTTP client, the primary OpenAI client is shared across tool turns so Claude session ids survive.
- Tool calls are marshalled through Claude's text output. This is best thought of as an external-process transport, not a native chat API.
- The stripped runtime relies on Claude Code environment toggles (`CLAUDE_CODE_DISABLE_*`, `ENABLE_CLAUDEAI_MCP_SERVERS`). If Anthropic renames them, stripped mode will silently degrade to standard.
