### PR TITLE
fix(file-tools): move dedup hints out of content

### DIFF
--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -172,7 +172,8 @@ class TestFileDedup(unittest.TestCase):
         # Second read — should get dedup stub
         r2 = json.loads(read_file_tool(self._tmpfile, task_id="dup"))
         self.assertTrue(r2.get("dedup"), "Second read should return dedup stub")
-        self.assertIn("unchanged", r2.get("content", ""))
+        self.assertNotIn("content", r2)
+        self.assertIn("unchanged", r2.get("error", ""))
 
     @patch("tools.file_tools._get_file_ops")
     def test_modified_file_not_deduped(self, mock_ops):

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -405,10 +405,10 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 500, task_id: str = 
                 current_mtime = os.path.getmtime(resolved_str)
                 if current_mtime == cached_mtime:
                     return json.dumps({
-                        "content": (
-                            "File unchanged since last read. The content from "
-                            "the earlier read_file result in this conversation is "
-                            "still current — refer to that instead of re-reading."
+                        "error": (
+                            "SKIP: File unchanged since last read. You already have "
+                            "this content from the earlier read_file result in this "
+                            "conversation. Refer to that instead of re-reading."
                         ),
                         "path": path,
                         "dedup": True,


### PR DESCRIPTION
## Summary
- stop returning read-file dedup hints in the `content` field
- return the dedup notice as an `error` payload so downstream callers do not treat it as file contents
- lock the contract with a regression test for the dedup stub shape

Closes #13079.

## Testing
- pytest -o addopts= tests/tools/test_file_read_guards.py
