### PR TITLE
fix(skills-config): normalize disabled skill entries

### DIFF
--- a/hermes_cli/skills_config.py
+++ b/hermes_cli/skills_config.py
@@ -24,16 +24,31 @@ PLATFORMS = {k: info.label for k, info in _PLATFORMS.items() if k != "api_server
 
 # ─── Config Helpers ───────────────────────────────────────────────────────────
 
+def _normalize_string_set(values) -> Set[str]:
+    if values is None:
+        return set()
+    if isinstance(values, str):
+        values = [values]
+    return {str(v).strip() for v in values if str(v).strip()}
+
+
 def get_disabled_skills(config: dict, platform: Optional[str] = None) -> Set[str]:
     """Return disabled skill names. Platform-specific list falls back to global."""
     skills_cfg = config.get("skills", {})
-    global_disabled = set(skills_cfg.get("disabled", []))
+    if not isinstance(skills_cfg, dict):
+        return set()
+
+    global_disabled = _normalize_string_set(skills_cfg.get("disabled"))
     if platform is None:
         return global_disabled
-    platform_disabled = skills_cfg.get("platform_disabled", {}).get(platform)
+    platform_cfg = skills_cfg.get("platform_disabled")
+    if not isinstance(platform_cfg, dict):
+        return global_disabled
+
+    platform_disabled = platform_cfg.get(platform)
     if platform_disabled is None:
         return global_disabled
-    return set(platform_disabled)
+    return _normalize_string_set(platform_disabled)
 
 
 def save_disabled_skills(config: dict, disabled: Set[str], platform: Optional[str] = None):

--- a/tests/hermes_cli/test_skills_config.py
+++ b/tests/hermes_cli/test_skills_config.py
@@ -39,6 +39,19 @@ class TestGetDisabledSkills:
         from hermes_cli.skills_config import get_disabled_skills
         assert get_disabled_skills({"skills": {"disabled": []}}) == set()
 
+    def test_scalar_disabled_is_normalized_to_single_skill(self):
+        from hermes_cli.skills_config import get_disabled_skills
+        assert get_disabled_skills({"skills": {"disabled": "my-skill"}}) == {"my-skill"}
+
+    def test_null_skills_section_returns_empty(self):
+        from hermes_cli.skills_config import get_disabled_skills
+        assert get_disabled_skills({"skills": None}) == set()
+
+    def test_scalar_platform_disabled_is_normalized(self):
+        from hermes_cli.skills_config import get_disabled_skills
+        config = {"skills": {"platform_disabled": {"telegram": "tg-skill"}}}
+        assert get_disabled_skills(config, platform="telegram") == {"tg-skill"}
+
 
 # ---------------------------------------------------------------------------
 # save_disabled_skills


### PR DESCRIPTION
## Summary
- normalize scalar `skills.disabled` values as a single skill name instead of a set of characters
- treat `skills: null` and malformed `platform_disabled` blocks as empty config instead of crashing
- add regression coverage for null and scalar config shapes

Closes #13026.

## Testing
- pytest -o addopts= tests/hermes_cli/test_skills_config.py
