### PR TITLE
fix(cli): show full titles in /resume session list

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4457,7 +4457,7 @@ class HermesCLI:
         print(f"  {'Title':<32} {'Preview':<40} {'Last Active':<13} {'ID'}")
         print(f"  {'─' * 32} {'─' * 40} {'─' * 13} {'─' * 24}")
         for session in sessions:
-            title = (session.get("title") or "—")[:30]
+            title = session.get("title") or "—"
             preview = (session.get("preview") or "")[:38]
             last_active = _relative_time(session.get("last_active"))
             print(f"  {title:<32} {preview:<40} {last_active:<13} {session['id']}")

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -245,6 +245,32 @@ class TestHistoryDisplay:
         assert "Checking Running Hermes Agent" in output
         assert "Use /resume <session id or title> to continue" in output
 
+    def test_resume_list_shows_full_long_titles(self, capsys):
+        cli = _make_cli()
+        cli.session_id = "current"
+        cli._session_db = MagicMock()
+        long_title = "Salvage BytePlus Volcengine PR With Fixes"
+        cli._session_db.list_sessions_rich.return_value = [
+            {
+                "id": "current",
+                "title": "Current",
+                "preview": "Current preview",
+                "last_active": 0,
+            },
+            {
+                "id": "20260401_201329_d85961",
+                "title": long_title,
+                "preview": "fix byteplus pr and resume",
+                "last_active": 0,
+            },
+        ]
+
+        cli._handle_resume_command("/resume")
+        output = capsys.readouterr().out
+
+        assert long_title in output
+        assert "20260401_201329_d85961" in output
+
 
 class TestRootLevelProviderOverride:
     """Root-level provider/base_url in config.yaml must NOT override model.provider."""


### PR DESCRIPTION
## Summary
- show full session titles in the inline /resume list instead of truncating them to 30 characters
- keep the existing exact title/session ID lookup unchanged so users can copy either visible value directly
- add CLI regression coverage for long titles in the recent session list

## Testing
- pytest -o addopts='' tests/cli/test_cli_init.py

Fixes #14082