### PR TITLE
test(modal_sandbox_fixes): make TestToolResolution hermetic against TERMINAL_* env

### DIFF
--- a/tests/tools/test_modal_sandbox_fixes.py
+++ b/tests/tools/test_modal_sandbox_fixes.py
@@ -33,6 +33,20 @@ except ImportError:
 class TestToolResolution:
     """Verify get_tool_definitions returns all expected tools for eval."""
 
+    @pytest.fixture(autouse=True)
+    def _hermetic_terminal_env(self, monkeypatch):
+        # get_tool_definitions(enabled_toolsets=["terminal", ...]) walks the
+        # real backend-selection path in tools.terminal_tool. If an ambient
+        # TERMINAL_ENV=modal / TERMINAL_MODAL_MODE=direct is present (leaked
+        # from a prior test that set os.environ directly, a CI runner-level
+        # variable, or a stale user shell), backend init tries the Modal
+        # sandbox, fails for lack of credentials, and silently drops the
+        # "terminal" tool — which these tests then report as a regression.
+        # Clearing these here keeps the assertion about tool registration
+        # hermetic regardless of upstream env state.
+        for key in ("TERMINAL_ENV", "TERMINAL_MODAL_MODE", "TERMINAL_CWD"):
+            monkeypatch.delenv(key, raising=False)
+
     def test_terminal_and_file_toolsets_resolve_all_tools(self):
         """enabled_toolsets=['terminal', 'file'] should produce 6 tools."""
         from model_tools import get_tool_definitions


### PR DESCRIPTION
## Summary

`TestToolResolution::test_terminal_tool_present` and
`test_terminal_and_file_toolsets_resolve_all_tools` in
`tests/tools/test_modal_sandbox_fixes.py` call
`get_tool_definitions(enabled_toolsets=["terminal", "file"])`, which walks the
real backend-selection logic in `tools.terminal_tool`. If the process
environment has `TERMINAL_ENV=modal` / `TERMINAL_MODAL_MODE=direct` set
(leaked from a prior test that used `os.environ[...]` directly instead of
`monkeypatch`, a runner-level variable, or a stale user shell), backend init
attempts the Modal sandbox, fails for lack of credentials, and silently
drops the `terminal` tool. The tests then report this as a regression even
though it's an env-isolation leak.

This PR adds a class-scoped autouse fixture that `monkeypatch.delenv`s
`TERMINAL_ENV`, `TERMINAL_MODAL_MODE`, and `TERMINAL_CWD` so these two
assertions describe a hermetic view of tool registration regardless of
ambient terminal env state.

No production code changed; the fixture is scoped to `TestToolResolution`
and leaves the rest of the file unaffected (`TestCwdHandling` etc. continue
to use monkeypatch per-test to set the vars they need).

## How I confirmed the failure mode

Setting `TERMINAL_ENV=modal TERMINAL_MODAL_MODE=direct` locally causes both
tests to fail with `AssertionError: terminal tool missing! Only got:
['process']` — identical to downstream CI failures observed on a fork. The
patch makes both tests pass regardless of whether those vars are set.

## Test plan

- [x] With polluted env (`TERMINAL_ENV=modal TERMINAL_MODAL_MODE=direct`): 2 passed
- [x] With clean env: 2 passed
- [x] Other tests in the file unaffected (fixture is class-scoped, not module-scoped)

Carried patch: patch-fix-test-pr14100