### PR TITLE
fix(cli): normalize saved platform tool entries

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -669,16 +669,27 @@ def _save_platform_tools(config: dict, platform: str, enabled_toolset_keys: Set[
     existing_toolsets = config.get("platform_toolsets", {}).get(platform, [])
     if not isinstance(existing_toolsets, list):
         existing_toolsets = []
+    existing_toolsets = [str(entry) for entry in existing_toolsets]
+    normalized_enabled = {str(entry) for entry in enabled_toolset_keys}
+
+    enabled_mcp_servers = {
+        str(name)
+        for name, server_cfg in (config.get("mcp_servers") or {}).items()
+        if isinstance(server_cfg, dict)
+        and _parse_enabled_flag(server_cfg.get("enabled", True), default=True)
+    }
+    selected_mcp_servers = normalized_enabled & enabled_mcp_servers
 
     # Preserve any entries that are NOT configurable toolsets and NOT platform
     # defaults (i.e. only MCP server names should be preserved)
     preserved_entries = {
         entry for entry in existing_toolsets
+        if not (entry == "no_mcp" and selected_mcp_servers)
         if entry not in configurable_keys and entry not in platform_default_keys
     }
 
     # Merge preserved entries with new enabled toolsets
-    config["platform_toolsets"][platform] = sorted(enabled_toolset_keys | preserved_entries)
+    config["platform_toolsets"][platform] = sorted(normalized_enabled | preserved_entries)
 
     # Track which plugin toolsets are "known" for this platform so we can
     # distinguish "new plugin, default enabled" from "user disabled it".

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -343,6 +343,38 @@ def test_save_platform_tools_still_preserves_mcp_with_platform_default_present()
     assert "terminal" not in saved
 
 
+def test_save_platform_tools_reenabling_mcp_clears_no_mcp_sentinel():
+    """Selecting an MCP server should drop any stale no_mcp sentinel."""
+    config = {
+        "platform_toolsets": {"cli": ["web", "no_mcp"]},
+        "mcp_servers": {"exa": {"url": "https://mcp.exa.ai/mcp"}},
+    }
+
+    with patch("hermes_cli.tools_config.save_config"):
+        _save_platform_tools(config, "cli", {"web", "exa"})
+
+    saved = config["platform_toolsets"]["cli"]
+
+    assert "exa" in saved
+    assert "web" in saved
+    assert "no_mcp" not in saved
+    assert sorted(_get_platform_tools(config, "cli")) == ["exa", "web"]
+
+
+def test_save_platform_tools_normalizes_numeric_entries_before_sorting():
+    """Save path should stringify numeric YAML names before sorting/preserving."""
+    config = {
+        "platform_toolsets": {"cli": ["web", 12306]},
+    }
+
+    with patch("hermes_cli.tools_config.save_config"):
+        _save_platform_tools(config, "cli", {"web"})
+
+    saved = config["platform_toolsets"]["cli"]
+    assert saved == ["12306", "web"]
+    assert all(isinstance(name, str) for name in saved)
+
+
 def test_visible_providers_include_nous_subscription_when_logged_in(monkeypatch):
     monkeypatch.setattr("hermes_cli.tools_config.managed_nous_tools_enabled", lambda: True)
     config = {"model": {"provider": "nous"}}


### PR DESCRIPTION
## Summary
- normalize saved platform tool entries to strings before preserving and sorting them
- drop a stale no_mcp sentinel when the new selection explicitly re-enables MCP server entries
- add regressions for the stale sentinel and numeric YAML-name save paths

## Testing
- pytest -o addopts='' tests/hermes_cli/test_tools_config.py
- issue repro script from #13028

Fixes #13028