### PR TITLE
fix(tui): blitz closeout pack 1 — input wrap, shift-tab yolo, bottom statusline

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -455,6 +455,20 @@ def _write_config_key(key_path: str, value):
     _save_cfg(cfg)
 
 
+# Legacy configs stored display.tui_statusbar as a bool. Coerce both bool and
+# string forms to the string enum so rollouts don't require a manual migration.
+def _coerce_statusbar(raw) -> str:
+    if raw is True:
+        return "on"
+    if raw is False:
+        return "off"
+    if isinstance(raw, str):
+        s = raw.strip().lower()
+        if s in {"on", "off", "bottom", "top"}:
+            return s
+    return "on"
+
+
 def _load_reasoning_config() -> dict | None:
     from hermes_constants import parse_reasoning_effort
 
@@ -2499,12 +2513,11 @@ def _(rid, params: dict) -> dict:
         )
         return _ok(rid, {"key": key, "value": nv})
 
-    if key in ("compact", "statusbar"):
+    if key == "compact":
         raw = str(value or "").strip().lower()
         cfg0 = _load_cfg()
         d0 = cfg0.get("display") if isinstance(cfg0.get("display"), dict) else {}
-        def_key = "tui_compact" if key == "compact" else "tui_statusbar"
-        cur_b = bool(d0.get(def_key, False if key == "compact" else True))
+        cur_b = bool(d0.get("tui_compact", False))
         if raw in ("", "toggle"):
             nv_b = not cur_b
         elif raw == "on":
@@ -2512,10 +2525,23 @@ def _(rid, params: dict) -> dict:
         elif raw == "off":
             nv_b = False
         else:
-            return _err(rid, 4002, f"unknown {key} value: {value}")
-        _write_config_key(f"display.{def_key}", nv_b)
-        out = "on" if nv_b else "off"
-        return _ok(rid, {"key": key, "value": out})
+            return _err(rid, 4002, f"unknown compact value: {value}")
+        _write_config_key("display.tui_compact", nv_b)
+        return _ok(rid, {"key": key, "value": "on" if nv_b else "off"})
+
+    if key == "statusbar":
+        raw = str(value or "").strip().lower()
+        cfg0 = _load_cfg()
+        d0 = cfg0.get("display") if isinstance(cfg0.get("display"), dict) else {}
+        current = _coerce_statusbar(d0.get("tui_statusbar", "on"))
+        if raw in ("", "toggle"):
+            nv = "on" if current == "off" else "off"
+        elif raw in ("on", "off", "bottom", "top"):
+            nv = raw
+        else:
+            return _err(rid, 4002, f"unknown statusbar value: {value}")
+        _write_config_key("display.tui_statusbar", nv)
+        return _ok(rid, {"key": key, "value": nv})
 
     if key in ("prompt", "personality", "skin"):
         try:
@@ -2633,8 +2659,8 @@ def _(rid, params: dict) -> dict:
         on = bool(_load_cfg().get("display", {}).get("tui_compact", False))
         return _ok(rid, {"value": "on" if on else "off"})
     if key == "statusbar":
-        on = bool(_load_cfg().get("display", {}).get("tui_statusbar", True))
-        return _ok(rid, {"value": "on" if on else "off"})
+        raw = _load_cfg().get("display", {}).get("tui_statusbar", "on")
+        return _ok(rid, {"value": _coerce_statusbar(raw)})
     if key == "mtime":
         cfg_path = _hermes_home / "config.yaml"
         try:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -455,21 +455,14 @@ def _write_config_key(key_path: str, value):
     _save_cfg(cfg)
 
 
-# Legacy configs stored display.tui_statusbar as a bool; a short-lived
-# intermediate wrote 'on'. Both forms map to 'top' — the inline position
-# above the input where the bar originally lived — so users don't need to
-# migrate by hand.
+_STATUSBAR_MODES = frozenset({"off", "top", "bottom"})
+
+
 def _coerce_statusbar(raw) -> str:
-    if raw is True:
-        return "top"
     if raw is False:
         return "off"
-    if isinstance(raw, str):
-        s = raw.strip().lower()
-        if s == "on":
-            return "top"
-        if s in {"off", "top", "bottom"}:
-            return s
+    if isinstance(raw, str) and (s := raw.strip().lower()) in _STATUSBAR_MODES:
+        return s
     return "top"
 
 
@@ -2535,17 +2528,18 @@ def _(rid, params: dict) -> dict:
 
     if key == "statusbar":
         raw = str(value or "").strip().lower()
-        cfg0 = _load_cfg()
-        d0 = cfg0.get("display") if isinstance(cfg0.get("display"), dict) else {}
+        d0 = _load_cfg().get("display") or {}
         current = _coerce_statusbar(d0.get("tui_statusbar", "top"))
+
         if raw in ("", "toggle"):
             nv = "top" if current == "off" else "off"
         elif raw == "on":
             nv = "top"
-        elif raw in ("off", "top", "bottom"):
+        elif raw in _STATUSBAR_MODES:
             nv = raw
         else:
             return _err(rid, 4002, f"unknown statusbar value: {value}")
+
         _write_config_key("display.tui_statusbar", nv)
         return _ok(rid, {"key": key, "value": nv})
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -455,18 +455,22 @@ def _write_config_key(key_path: str, value):
     _save_cfg(cfg)
 
 
-# Legacy configs stored display.tui_statusbar as a bool. Coerce both bool and
-# string forms to the string enum so rollouts don't require a manual migration.
+# Legacy configs stored display.tui_statusbar as a bool; a short-lived
+# intermediate wrote 'on'. Both forms map to 'top' — the inline position
+# above the input where the bar originally lived — so users don't need to
+# migrate by hand.
 def _coerce_statusbar(raw) -> str:
     if raw is True:
-        return "on"
+        return "top"
     if raw is False:
         return "off"
     if isinstance(raw, str):
         s = raw.strip().lower()
-        if s in {"on", "off", "bottom", "top"}:
+        if s == "on":
+            return "top"
+        if s in {"off", "top", "bottom"}:
             return s
-    return "on"
+    return "top"
 
 
 def _load_reasoning_config() -> dict | None:
@@ -2533,10 +2537,12 @@ def _(rid, params: dict) -> dict:
         raw = str(value or "").strip().lower()
         cfg0 = _load_cfg()
         d0 = cfg0.get("display") if isinstance(cfg0.get("display"), dict) else {}
-        current = _coerce_statusbar(d0.get("tui_statusbar", "on"))
+        current = _coerce_statusbar(d0.get("tui_statusbar", "top"))
         if raw in ("", "toggle"):
-            nv = "on" if current == "off" else "off"
-        elif raw in ("on", "off", "bottom", "top"):
+            nv = "top" if current == "off" else "off"
+        elif raw == "on":
+            nv = "top"
+        elif raw in ("off", "top", "bottom"):
             nv = raw
         else:
             return _err(rid, 4002, f"unknown statusbar value: {value}")
@@ -2659,7 +2665,7 @@ def _(rid, params: dict) -> dict:
         on = bool(_load_cfg().get("display", {}).get("tui_compact", False))
         return _ok(rid, {"value": "on" if on else "off"})
     if key == "statusbar":
-        raw = _load_cfg().get("display", {}).get("tui_statusbar", "on")
+        raw = _load_cfg().get("display", {}).get("tui_statusbar", "top")
         return _ok(rid, {"value": _coerce_statusbar(raw)})
     if key == "mtime":
         cfg_path = _hermes_home / "config.yaml"

--- a/ui-tui/packages/hermes-ink/src/ink/components/Text.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/components/Text.tsx
@@ -69,6 +69,12 @@ const memoizedStylesForWrap: Record<NonNullable<Styles['textWrap']>, Styles> = {
     flexDirection: 'row',
     textWrap: 'wrap'
   },
+  'wrap-char': {
+    flexGrow: 0,
+    flexShrink: 1,
+    flexDirection: 'row',
+    textWrap: 'wrap-char'
+  },
   'wrap-trim': {
     flexGrow: 0,
     flexShrink: 1,

--- a/ui-tui/packages/hermes-ink/src/ink/render-node-to-output.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/render-node-to-output.ts
@@ -343,7 +343,7 @@ function wrapWithSoftWrap(
   maxWidth: number,
   textWrap: Parameters<typeof wrapText>[2]
 ): { wrapped: string; softWrap: boolean[] | undefined } {
-  if (textWrap !== 'wrap' && textWrap !== 'wrap-trim') {
+  if (textWrap !== 'wrap' && textWrap !== 'wrap-char' && textWrap !== 'wrap-trim') {
     return {
       wrapped: wrapText(plainText, maxWidth, textWrap),
       softWrap: undefined

--- a/ui-tui/packages/hermes-ink/src/ink/styles.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/styles.ts
@@ -55,6 +55,7 @@ export type TextStyles = {
 export type Styles = {
   readonly textWrap?:
     | 'wrap'
+    | 'wrap-char'
     | 'wrap-trim'
     | 'end'
     | 'middle'

--- a/ui-tui/packages/hermes-ink/src/ink/wrap-text.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/wrap-text.ts
@@ -50,17 +50,8 @@ export default function wrapText(text: string, maxWidth: number, wrapType: Style
     })
   }
 
-  // Char-granularity wrap: break at exact column boundaries regardless of
-  // whitespace. Used for text inputs where the cursor position must track
-  // the wrap boundary deterministically — word-wrap's whitespace-preferring
-  // reshuffle causes visible cursor flicker as each keystroke can push a
-  // word across a line break.
   if (wrapType === 'wrap-char') {
-    return wrapAnsi(text, maxWidth, {
-      trim: false,
-      hard: true,
-      wordWrap: false
-    })
+    return wrapAnsi(text, maxWidth, { trim: false, hard: true, wordWrap: false })
   }
 
   if (wrapType === 'wrap-trim') {

--- a/ui-tui/packages/hermes-ink/src/ink/wrap-text.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/wrap-text.ts
@@ -50,6 +50,19 @@ export default function wrapText(text: string, maxWidth: number, wrapType: Style
     })
   }
 
+  // Char-granularity wrap: break at exact column boundaries regardless of
+  // whitespace. Used for text inputs where the cursor position must track
+  // the wrap boundary deterministically — word-wrap's whitespace-preferring
+  // reshuffle causes visible cursor flicker as each keystroke can push a
+  // word across a line break.
+  if (wrapType === 'wrap-char') {
+    return wrapAnsi(text, maxWidth, {
+      trim: false,
+      hard: true,
+      wordWrap: false
+    })
+  }
+
   if (wrapType === 'wrap-trim') {
     return wrapAnsi(text, maxWidth, {
       trim: true,

--- a/ui-tui/src/__tests__/textInputWrap.test.ts
+++ b/ui-tui/src/__tests__/textInputWrap.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+
+import { cursorLayout, offsetFromPosition } from '../components/textInput.js'
+
+describe('cursorLayout — char-wrap parity with wrap-ansi', () => {
+  it('places cursor mid-line at its column', () => {
+    expect(cursorLayout('hello world', 6, 40)).toEqual({ column: 6, line: 0 })
+  })
+
+  it('places cursor at end of a non-full line', () => {
+    expect(cursorLayout('hi', 2, 10)).toEqual({ column: 2, line: 0 })
+  })
+
+  it('wraps to next line when cursor lands exactly at the right edge', () => {
+    // 8 chars on an 8-col line: text fills the row exactly; the cursor's
+    // inverted-space cell overflows to col 0 of the next row.
+    expect(cursorLayout('abcdefgh', 8, 8)).toEqual({ column: 0, line: 1 })
+  })
+
+  it('tracks a word across a char-wrap boundary without jumping', () => {
+    // With wordWrap:false, "hello world" at cols=8 is "hello wo\nrld" —
+    // typing incremental letters doesn't reshuffle the word across lines.
+    expect(cursorLayout('hello wo', 8, 8)).toEqual({ column: 0, line: 1 })
+    expect(cursorLayout('hello wor', 9, 8)).toEqual({ column: 1, line: 1 })
+    expect(cursorLayout('hello worl', 10, 8)).toEqual({ column: 2, line: 1 })
+  })
+
+  it('honours explicit newlines', () => {
+    expect(cursorLayout('one\ntwo', 5, 40)).toEqual({ column: 1, line: 1 })
+    expect(cursorLayout('one\ntwo', 4, 40)).toEqual({ column: 0, line: 1 })
+  })
+
+  it('does not wrap when cursor is before the right edge', () => {
+    expect(cursorLayout('abcdefg', 7, 8)).toEqual({ column: 7, line: 0 })
+  })
+})
+
+describe('offsetFromPosition — char-wrap inverse of cursorLayout', () => {
+  it('returns 0 for empty input', () => {
+    expect(offsetFromPosition('', 0, 0, 10)).toBe(0)
+  })
+
+  it('maps clicks within a single line', () => {
+    expect(offsetFromPosition('hello', 0, 3, 40)).toBe(3)
+  })
+
+  it('maps clicks past end to value length', () => {
+    expect(offsetFromPosition('hi', 0, 10, 40)).toBe(2)
+  })
+
+  it('maps clicks on a wrapped second row at cols boundary', () => {
+    // "abcdefghij" at cols=8 wraps to "abcdefgh\nij" — click at row 1 col 0
+    // should land on 'i' (offset 8).
+    expect(offsetFromPosition('abcdefghij', 1, 0, 8)).toBe(8)
+  })
+
+  it('maps clicks past a \\n into the target line', () => {
+    expect(offsetFromPosition('one\ntwo', 1, 2, 40)).toBe(6)
+  })
+})

--- a/ui-tui/src/__tests__/useConfigSync.test.ts
+++ b/ui-tui/src/__tests__/useConfigSync.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { $uiState, resetUiState } from '../app/uiStore.js'
-import { applyDisplay } from '../app/useConfigSync.js'
+import { applyDisplay, normalizeStatusBar } from '../app/useConfigSync.js'
 
 describe('applyDisplay', () => {
   beforeEach(() => {
@@ -36,7 +36,7 @@ describe('applyDisplay', () => {
     expect(s.inlineDiffs).toBe(false)
     expect(s.showCost).toBe(true)
     expect(s.showReasoning).toBe(true)
-    expect(s.statusBar).toBe(false)
+    expect(s.statusBar).toBe('off')
     expect(s.streaming).toBe(false)
   })
 
@@ -50,7 +50,7 @@ describe('applyDisplay', () => {
     expect(s.inlineDiffs).toBe(true)
     expect(s.showCost).toBe(false)
     expect(s.showReasoning).toBe(false)
-    expect(s.statusBar).toBe(true)
+    expect(s.statusBar).toBe('on')
     expect(s.streaming).toBe(true)
   })
 
@@ -63,5 +63,36 @@ describe('applyDisplay', () => {
     expect(setBell).toHaveBeenCalledWith(false)
     expect(s.inlineDiffs).toBe(true)
     expect(s.streaming).toBe(true)
+  })
+
+  it('accepts the new string statusBar modes', () => {
+    const setBell = vi.fn()
+
+    applyDisplay({ config: { display: { tui_statusbar: 'bottom' } } }, setBell)
+    expect($uiState.get().statusBar).toBe('bottom')
+
+    applyDisplay({ config: { display: { tui_statusbar: 'top' } } }, setBell)
+    expect($uiState.get().statusBar).toBe('top')
+  })
+})
+
+describe('normalizeStatusBar', () => {
+  it('maps legacy bool to on/off', () => {
+    expect(normalizeStatusBar(true)).toBe('on')
+    expect(normalizeStatusBar(false)).toBe('off')
+  })
+
+  it('passes through the new string enum', () => {
+    expect(normalizeStatusBar('on')).toBe('on')
+    expect(normalizeStatusBar('off')).toBe('off')
+    expect(normalizeStatusBar('bottom')).toBe('bottom')
+    expect(normalizeStatusBar('top')).toBe('top')
+  })
+
+  it('defaults missing/unknown values to on', () => {
+    expect(normalizeStatusBar(undefined)).toBe('on')
+    expect(normalizeStatusBar(null)).toBe('on')
+    expect(normalizeStatusBar('sideways')).toBe('on')
+    expect(normalizeStatusBar(42)).toBe('on')
   })
 })

--- a/ui-tui/src/__tests__/useConfigSync.test.ts
+++ b/ui-tui/src/__tests__/useConfigSync.test.ts
@@ -40,6 +40,16 @@ describe('applyDisplay', () => {
     expect(s.streaming).toBe(false)
   })
 
+  it('coerces legacy true + "on" alias to top', () => {
+    const setBell = vi.fn()
+
+    applyDisplay({ config: { display: { tui_statusbar: true as unknown as 'on' } } }, setBell)
+    expect($uiState.get().statusBar).toBe('top')
+
+    applyDisplay({ config: { display: { tui_statusbar: 'on' } } }, setBell)
+    expect($uiState.get().statusBar).toBe('top')
+  })
+
   it('applies v1 parity defaults when display fields are missing', () => {
     const setBell = vi.fn()
 
@@ -50,7 +60,7 @@ describe('applyDisplay', () => {
     expect(s.inlineDiffs).toBe(true)
     expect(s.showCost).toBe(false)
     expect(s.showReasoning).toBe(false)
-    expect(s.statusBar).toBe('on')
+    expect(s.statusBar).toBe('top')
     expect(s.streaming).toBe(true)
   })
 
@@ -77,22 +87,22 @@ describe('applyDisplay', () => {
 })
 
 describe('normalizeStatusBar', () => {
-  it('maps legacy bool to on/off', () => {
-    expect(normalizeStatusBar(true)).toBe('on')
+  it('maps legacy bool + on alias to top/off', () => {
+    expect(normalizeStatusBar(true)).toBe('top')
     expect(normalizeStatusBar(false)).toBe('off')
+    expect(normalizeStatusBar('on')).toBe('top')
   })
 
-  it('passes through the new string enum', () => {
-    expect(normalizeStatusBar('on')).toBe('on')
+  it('passes through the canonical enum', () => {
     expect(normalizeStatusBar('off')).toBe('off')
-    expect(normalizeStatusBar('bottom')).toBe('bottom')
     expect(normalizeStatusBar('top')).toBe('top')
+    expect(normalizeStatusBar('bottom')).toBe('bottom')
   })
 
-  it('defaults missing/unknown values to on', () => {
-    expect(normalizeStatusBar(undefined)).toBe('on')
-    expect(normalizeStatusBar(null)).toBe('on')
-    expect(normalizeStatusBar('sideways')).toBe('on')
-    expect(normalizeStatusBar(42)).toBe('on')
+  it('defaults missing/unknown values to top', () => {
+    expect(normalizeStatusBar(undefined)).toBe('top')
+    expect(normalizeStatusBar(null)).toBe('top')
+    expect(normalizeStatusBar('sideways')).toBe('top')
+    expect(normalizeStatusBar(42)).toBe('top')
   })
 })

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -27,6 +27,8 @@ export interface StateSetter<T> {
   (value: SetStateAction<T>): void
 }
 
+export type StatusBarMode = 'bottom' | 'off' | 'on' | 'top'
+
 export interface SelectionApi {
   clearSelection: () => void
   copySelection: () => string
@@ -89,7 +91,7 @@ export interface UiState {
   showReasoning: boolean
   sid: null | string
   status: string
-  statusBar: boolean
+  statusBar: StatusBarMode
   streaming: boolean
   theme: Theme
   usage: Usage

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -27,7 +27,7 @@ export interface StateSetter<T> {
   (value: SetStateAction<T>): void
 }
 
-export type StatusBarMode = 'bottom' | 'off' | 'on' | 'top'
+export type StatusBarMode = 'bottom' | 'off' | 'top'
 
 export interface SelectionApi {
   clearSelection: () => void

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -310,23 +310,18 @@ export const coreCommands: SlashCommand[] = [
     name: 'statusbar',
     run: (arg, ctx) => {
       const mode = arg.trim().toLowerCase()
-      const current = ctx.ui.statusBar
+      const toggle: StatusBarMode = ctx.ui.statusBar === 'off' ? 'top' : 'off'
 
-      // 'on' is a legacy alias for 'top' — the inline position above the
-      // input where the bar originally lived. No-arg / `toggle` flips
-      // visibility and defaults to 'top' when reappearing.
       const next: null | StatusBarMode =
-        mode === '' || mode === 'toggle'
-          ? current === 'off'
-            ? 'top'
-            : 'off'
+        !mode || mode === 'toggle'
+          ? toggle
           : mode === 'on' || mode === 'top'
             ? 'top'
             : mode === 'off' || mode === 'bottom'
               ? mode
               : null
 
-      if (next === null) {
+      if (!next) {
         return ctx.transcript.sys('usage: /statusbar [on|off|top|bottom|toggle]')
       }
 

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -8,6 +8,7 @@ import type {
   SessionSteerResponse,
   SessionUndoResponse
 } from '../../../gatewayTypes.js'
+import type { StatusBarMode } from '../../interfaces.js'
 import { writeOsc52Clipboard } from '../../../lib/osc52.js'
 import { configureDetectedTerminalKeybindings, configureTerminalKeybindings } from '../../../lib/terminalSetup.js'
 import type { DetailsMode, Msg, PanelSection } from '../../../types.js'
@@ -305,19 +306,30 @@ export const coreCommands: SlashCommand[] = [
 
   {
     aliases: ['sb'],
-    help: 'toggle status bar',
+    help: 'status bar position (on|off|bottom|top)',
     name: 'statusbar',
     run: (arg, ctx) => {
-      const next = flagFromArg(arg, ctx.ui.statusBar)
+      const mode = arg.trim().toLowerCase()
+      const current = ctx.ui.statusBar
+      // No-arg / `toggle` flips visibility while preserving the last
+      // explicit position: off → on (inline default), any-visible → off.
+      const next: null | StatusBarMode =
+        mode === '' || mode === 'toggle'
+          ? current === 'off'
+            ? 'on'
+            : 'off'
+          : mode === 'on' || mode === 'off' || mode === 'bottom' || mode === 'top'
+            ? mode
+            : null
 
       if (next === null) {
-        return ctx.transcript.sys('usage: /statusbar [on|off|toggle]')
+        return ctx.transcript.sys('usage: /statusbar [on|off|bottom|top|toggle]')
       }
 
       patchUiState({ statusBar: next })
-      ctx.gateway.rpc<ConfigSetResponse>('config.set', { key: 'statusbar', value: next ? 'on' : 'off' }).catch(() => {})
+      ctx.gateway.rpc<ConfigSetResponse>('config.set', { key: 'statusbar', value: next }).catch(() => {})
 
-      queueMicrotask(() => ctx.transcript.sys(`status bar ${next ? 'on' : 'off'}`))
+      queueMicrotask(() => ctx.transcript.sys(`status bar ${next}`))
     }
   },
 

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -8,10 +8,10 @@ import type {
   SessionSteerResponse,
   SessionUndoResponse
 } from '../../../gatewayTypes.js'
-import type { StatusBarMode } from '../../interfaces.js'
 import { writeOsc52Clipboard } from '../../../lib/osc52.js'
 import { configureDetectedTerminalKeybindings, configureTerminalKeybindings } from '../../../lib/terminalSetup.js'
 import type { DetailsMode, Msg, PanelSection } from '../../../types.js'
+import type { StatusBarMode } from '../../interfaces.js'
 import { patchOverlayState } from '../../overlayStore.js'
 import { patchUiState } from '../../uiStore.js'
 import type { SlashCommand } from '../types.js'
@@ -306,24 +306,28 @@ export const coreCommands: SlashCommand[] = [
 
   {
     aliases: ['sb'],
-    help: 'status bar position (on|off|bottom|top)',
+    help: 'status bar position (on|off|top|bottom)',
     name: 'statusbar',
     run: (arg, ctx) => {
       const mode = arg.trim().toLowerCase()
       const current = ctx.ui.statusBar
-      // No-arg / `toggle` flips visibility while preserving the last
-      // explicit position: off → on (inline default), any-visible → off.
+
+      // 'on' is a legacy alias for 'top' — the inline position above the
+      // input where the bar originally lived. No-arg / `toggle` flips
+      // visibility and defaults to 'top' when reappearing.
       const next: null | StatusBarMode =
         mode === '' || mode === 'toggle'
           ? current === 'off'
-            ? 'on'
+            ? 'top'
             : 'off'
-          : mode === 'on' || mode === 'off' || mode === 'bottom' || mode === 'top'
-            ? mode
-            : null
+          : mode === 'on' || mode === 'top'
+            ? 'top'
+            : mode === 'off' || mode === 'bottom'
+              ? mode
+              : null
 
       if (next === null) {
-        return ctx.transcript.sys('usage: /statusbar [on|off|bottom|top|toggle]')
+        return ctx.transcript.sys('usage: /statusbar [on|off|top|bottom|toggle]')
       }
 
       patchUiState({ statusBar: next })

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -16,7 +16,7 @@ const buildUiState = (): UiState => ({
   showReasoning: false,
   sid: null,
   status: 'summoning hermes…',
-  statusBar: true,
+  statusBar: 'on',
   streaming: true,
   theme: DEFAULT_THEME,
   usage: ZERO

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -16,7 +16,7 @@ const buildUiState = (): UiState => ({
   showReasoning: false,
   sid: null,
   status: 'summoning hermes…',
-  statusBar: 'on',
+  statusBar: 'top',
   streaming: true,
   theme: DEFAULT_THEME,
   usage: ZERO

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -10,8 +10,22 @@ import type {
 } from '../gatewayTypes.js'
 import { asRpcResult } from '../lib/rpc.js'
 
+import type { StatusBarMode } from './interfaces.js'
 import { turnController } from './turnController.js'
 import { patchUiState } from './uiStore.js'
+
+const STATUSBAR_MODES = new Set<StatusBarMode>(['bottom', 'off', 'on', 'top'])
+
+// Legacy configs stored tui_statusbar as a bool; new configs write a string
+// ('on' | 'off' | 'bottom' | 'top'). Coerce both shapes so existing users
+// keep their preference without manual migration.
+export const normalizeStatusBar = (raw: unknown): StatusBarMode => {
+  if (raw === false) return 'off'
+  if (raw === true || raw == null) return 'on'
+  if (typeof raw === 'string' && STATUSBAR_MODES.has(raw as StatusBarMode)) return raw as StatusBarMode
+
+  return 'on'
+}
 
 const MTIME_POLL_MS = 5000
 
@@ -37,7 +51,7 @@ export const applyDisplay = (cfg: ConfigFullResponse | null, setBell: (v: boolea
     inlineDiffs: d.inline_diffs !== false,
     showCost: !!d.show_cost,
     showReasoning: !!d.show_reasoning,
-    statusBar: d.tui_statusbar !== false,
+    statusBar: normalizeStatusBar(d.tui_statusbar),
     streaming: d.streaming !== false
   })
 }

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -16,17 +16,12 @@ import { patchUiState } from './uiStore.js'
 
 const STATUSBAR_MODES = new Set<StatusBarMode>(['bottom', 'off', 'top'])
 
-// Legacy configs stored tui_statusbar as a bool; the short-lived 4-mode
-// variant wrote 'on'. Both map to 'top' (inline above the input) — the
-// original feature's default — so users keep their preference without
-// manual migration.
-export const normalizeStatusBar = (raw: unknown): StatusBarMode => {
-  if (raw === false) return 'off'
-  if (raw === true || raw == null || raw === 'on') return 'top'
-  if (typeof raw === 'string' && STATUSBAR_MODES.has(raw as StatusBarMode)) return raw as StatusBarMode
-
-  return 'top'
-}
+export const normalizeStatusBar = (raw: unknown): StatusBarMode =>
+  raw === false
+    ? 'off'
+    : typeof raw === 'string' && STATUSBAR_MODES.has(raw as StatusBarMode)
+      ? (raw as StatusBarMode)
+      : 'top'
 
 const MTIME_POLL_MS = 5000
 

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -14,17 +14,18 @@ import type { StatusBarMode } from './interfaces.js'
 import { turnController } from './turnController.js'
 import { patchUiState } from './uiStore.js'
 
-const STATUSBAR_MODES = new Set<StatusBarMode>(['bottom', 'off', 'on', 'top'])
+const STATUSBAR_MODES = new Set<StatusBarMode>(['bottom', 'off', 'top'])
 
-// Legacy configs stored tui_statusbar as a bool; new configs write a string
-// ('on' | 'off' | 'bottom' | 'top'). Coerce both shapes so existing users
-// keep their preference without manual migration.
+// Legacy configs stored tui_statusbar as a bool; the short-lived 4-mode
+// variant wrote 'on'. Both map to 'top' (inline above the input) — the
+// original feature's default — so users keep their preference without
+// manual migration.
 export const normalizeStatusBar = (raw: unknown): StatusBarMode => {
   if (raw === false) return 'off'
-  if (raw === true || raw == null) return 'on'
+  if (raw === true || raw == null || raw === 'on') return 'top'
   if (typeof raw === 'string' && STATUSBAR_MODES.has(raw as StatusBarMode)) return raw as StatusBarMode
 
-  return 'on'
+  return 'top'
 }
 
 const MTIME_POLL_MS = 5000

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -378,10 +378,7 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       return cActions.openEditor()
     }
 
-    // Shift-Tab toggles per-session yolo without submitting a turn — mirrors
-    // Claude Code's in-place dangerously-approve toggle. Slash /yolo keeps
-    // working for discoverability; this just skips the inference round-trip
-    // when you only want to flip the flag mid-flow (blitz #5 sub-item 11).
+    // shift-tab flips yolo without spending a turn (claude-code parity)
     if (key.shift && key.tab && !cState.completions.length) {
       return void gateway
         .rpc<ConfigSetResponse>('config.set', { key: 'yolo', session_id: live.sid })

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -3,6 +3,7 @@ import { useStore } from '@nanostores/react'
 
 import type {
   ApprovalRespondResponse,
+  ConfigSetResponse,
   SecretRespondResponse,
   SudoRespondResponse,
   VoiceRecordResponse
@@ -375,6 +376,16 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
 
     if (isAction(key, ch, 'g')) {
       return cActions.openEditor()
+    }
+
+    // Shift-Tab toggles per-session yolo without submitting a turn — mirrors
+    // Claude Code's in-place dangerously-approve toggle. Slash /yolo keeps
+    // working for discoverability; this just skips the inference round-trip
+    // when you only want to flip the flag mid-flow (blitz #5 sub-item 11).
+    if (key.shift && key.tab && !cState.completions.length) {
+      return void gateway
+        .rpc<ConfigSetResponse>('config.set', { key: 'yolo', session_id: live.sid })
+        .then(r => actions.sys(`yolo ${r?.value === '1' ? 'on' : 'off'}`))
     }
 
     if (key.tab && cState.completions.length) {

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -191,7 +191,7 @@ export function StatusRule({
   const leftWidth = Math.max(12, cols - cwdLabel.length - 3)
 
   return (
-    <Box flexShrink={0} height={1}>
+    <Box height={1}>
       <Box flexShrink={1} width={leftWidth}>
         <Text color={t.color.bronze} wrap="truncate-end">
           {'─ '}

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -187,7 +187,7 @@ export function StatusRule({
   const leftWidth = Math.max(12, cols - cwdLabel.length - 3)
 
   return (
-    <Box>
+    <Box flexShrink={0} height={1}>
       <Box flexShrink={1} width={leftWidth}>
         <Text color={t.color.bronze} wrap="truncate-end">
           {'─ '}

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -1,6 +1,6 @@
-import { Box, type ScrollBoxHandle, Text } from '@hermes/ink'
+import { Box, Text, type ScrollBoxHandle } from '@hermes/ink'
 import { useStore } from '@nanostores/react'
-import { type ReactNode, type RefObject, useCallback, useEffect, useMemo, useState, useSyncExternalStore } from 'react'
+import { useCallback, useEffect, useMemo, useState, useSyncExternalStore, type ReactNode, type RefObject } from 'react'
 
 import { $delegationState } from '../app/delegationStore.js'
 import { $turnState } from '../app/turnStore.js'

--- a/ui-tui/src/components/appChrome.tsx
+++ b/ui-tui/src/components/appChrome.tsx
@@ -156,7 +156,11 @@ export function GoodVibesHeart({ tick, t }: { tick: number; t: Theme }) {
     return () => clearTimeout(id)
   }, [t.color.amber, tick])
 
-  return <Text color={color}>{active ? '♥' : ' '}</Text>
+  if (!active) {
+    return null
+  }
+
+  return <Text color={color}>♥</Text>
 }
 
 export function StatusRule({

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -184,6 +184,8 @@ const ComposerPane = memo(function ComposerPane({
       )}
 
       <Box flexDirection="column" position="relative">
+        <StatusRulePane at="on" composer={composer} status={status} />
+
         <FloatingOverlays
           cols={composer.cols}
           compIdx={composer.compIdx}
@@ -195,7 +197,7 @@ const ComposerPane = memo(function ComposerPane({
       </Box>
 
       {!isBlocked && (
-        <Box flexDirection="column" marginBottom={1}>
+        <Box flexDirection="column" marginBottom={ui.statusBar === 'bottom' ? 0 : 1}>
           {composer.inputBuf.map((line, i) => (
             <Box key={i}>
               <Box width={3}>
@@ -255,10 +257,14 @@ const AgentsOverlayPane = memo(function AgentsOverlayPane() {
   )
 })
 
-const StatusRulePane = memo(function StatusRulePane({ composer, status }: Pick<AppLayoutProps, 'composer' | 'status'>) {
+const StatusRulePane = memo(function StatusRulePane({
+  at,
+  composer,
+  status
+}: Pick<AppLayoutProps, 'composer' | 'status'> & { at: 'bottom' | 'on' | 'top' }) {
   const ui = useStore($uiState)
 
-  if (!ui.statusBar) {
+  if (ui.statusBar !== at) {
     return null
   }
 
@@ -294,6 +300,8 @@ export const AppLayout = memo(function AppLayout({
   return (
     <AlternateScreen mouseTracking={mouseTracking}>
       <Box flexDirection="column" flexGrow={1}>
+        {!overlay.agents && <StatusRulePane at="top" composer={composer} status={status} />}
+
         <Box flexDirection="row" flexGrow={1}>
           {overlay.agents ? (
             <AgentsOverlayPane />
@@ -314,7 +322,7 @@ export const AppLayout = memo(function AppLayout({
 
         {!overlay.agents && <ComposerPane actions={actions} composer={composer} status={status} />}
 
-        {!overlay.agents && <StatusRulePane composer={composer} status={status} />}
+        {!overlay.agents && <StatusRulePane at="bottom" composer={composer} status={status} />}
       </Box>
     </AlternateScreen>
   )

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -216,8 +216,15 @@ const ComposerPane = memo(function ComposerPane({
             </Box>
 
             <Box flexGrow={1} position="relative">
+              {/*
+                Subtract the NoSelect paddingX={1} (2 cols total) and the
+                prompt-glyph column (pw) so cursorLayout agrees with the
+                width wrap-ansi actually uses at render time. Off-by-one/
+                two here manifests as the final letter flickering
+                in/out when a sentence crosses the wrap boundary.
+              */}
               <TextInput
-                columns={Math.max(20, composer.cols - pw)}
+                columns={Math.max(20, composer.cols - pw - 2)}
                 onChange={composer.updateInput}
                 onPaste={composer.handleTextPaste}
                 onSubmit={composer.submit}

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -216,13 +216,7 @@ const ComposerPane = memo(function ComposerPane({
             </Box>
 
             <Box flexGrow={1} position="relative">
-              {/*
-                Subtract the NoSelect paddingX={1} (2 cols total) and the
-                prompt-glyph column (pw) so cursorLayout agrees with the
-                width wrap-ansi actually uses at render time. Off-by-one/
-                two here manifests as the final letter flickering
-                in/out when a sentence crosses the wrap boundary.
-              */}
+              {/* subtract NoSelect paddingX={1} (2 cols) + pw so wrap-ansi and cursorLayout agree */}
               <TextInput
                 columns={Math.max(20, composer.cols - pw - 2)}
                 onChange={composer.updateInput}
@@ -271,12 +265,8 @@ const StatusRulePane = memo(function StatusRulePane({
     return null
   }
 
-  // 'top' sits inline above the input; give it one row of breathing
-  // space above so the transcript (or queue) doesn't butt directly
-  // against the status row. 'bottom' lives at the last row of the
-  // viewport so it needs no margin.
   return (
-    <Box flexShrink={0} marginTop={at === 'top' ? 1 : 0}>
+    <Box marginTop={at === 'top' ? 1 : 0}>
       <StatusRule
         bgCount={ui.bgTasks.size}
         busy={ui.busy}
@@ -318,18 +308,20 @@ export const AppLayout = memo(function AppLayout({
         </Box>
 
         {!overlay.agents && (
-          <PromptZone
-            cols={composer.cols}
-            onApprovalChoice={actions.answerApproval}
-            onClarifyAnswer={actions.answerClarify}
-            onSecretSubmit={actions.answerSecret}
-            onSudoSubmit={actions.answerSudo}
-          />
+          <>
+            <PromptZone
+              cols={composer.cols}
+              onApprovalChoice={actions.answerApproval}
+              onClarifyAnswer={actions.answerClarify}
+              onSecretSubmit={actions.answerSecret}
+              onSudoSubmit={actions.answerSudo}
+            />
+
+            <ComposerPane actions={actions} composer={composer} status={status} />
+
+            <StatusRulePane at="bottom" composer={composer} status={status} />
+          </>
         )}
-
-        {!overlay.agents && <ComposerPane actions={actions} composer={composer} status={status} />}
-
-        {!overlay.agents && <StatusRulePane at="bottom" composer={composer} status={status} />}
       </Box>
     </AlternateScreen>
   )

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -173,31 +173,18 @@ const ComposerPane = memo(function ComposerPane({
         </Text>
       )}
 
-      {status.showStickyPrompt ? (
+      {status.showStickyPrompt && (
         <Text color={ui.theme.color.dim} wrap="truncate-end">
           <Text color={ui.theme.color.label}>↳ </Text>
 
           {status.stickyPrompt}
         </Text>
-      ) : (
-        <Text> </Text>
       )}
 
-      <Box flexDirection="column" position="relative">
-        <StatusRulePane at="top" composer={composer} status={status} />
-
-        <FloatingOverlays
-          cols={composer.cols}
-          compIdx={composer.compIdx}
-          completions={composer.completions}
-          onModelSelect={actions.onModelSelect}
-          onPickerSelect={actions.resumeById}
-          pagerPageSize={composer.pagerPageSize}
-        />
-      </Box>
+      <StatusRulePane at="top" composer={composer} status={status} />
 
       {!isBlocked && (
-        <Box flexDirection="column" marginBottom={ui.statusBar === 'bottom' ? 0 : 1}>
+        <>
           {composer.inputBuf.map((line, i) => (
             <Box key={i}>
               <Box width={3}>
@@ -209,6 +196,15 @@ const ComposerPane = memo(function ComposerPane({
           ))}
 
           <Box position="relative">
+            <FloatingOverlays
+              cols={composer.cols}
+              compIdx={composer.compIdx}
+              completions={composer.completions}
+              onModelSelect={actions.onModelSelect}
+              onPickerSelect={actions.resumeById}
+              pagerPageSize={composer.pagerPageSize}
+            />
+
             <Box width={pw}>
               {sh ? (
                 <Text color={ui.theme.color.shellDollar}>$ </Text>
@@ -234,7 +230,7 @@ const ComposerPane = memo(function ComposerPane({
               </Box>
             </Box>
           </Box>
-        </Box>
+        </>
       )}
 
       {!composer.empty && !ui.sid && <Text color={ui.theme.color.dim}>⚕ {ui.status}</Text>}

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -184,7 +184,7 @@ const ComposerPane = memo(function ComposerPane({
       )}
 
       <Box flexDirection="column" position="relative">
-        <StatusRulePane at="on" composer={composer} status={status} />
+        <StatusRulePane at="top" composer={composer} status={status} />
 
         <FloatingOverlays
           cols={composer.cols}
@@ -261,7 +261,7 @@ const StatusRulePane = memo(function StatusRulePane({
   at,
   composer,
   status
-}: Pick<AppLayoutProps, 'composer' | 'status'> & { at: 'bottom' | 'on' | 'top' }) {
+}: Pick<AppLayoutProps, 'composer' | 'status'> & { at: 'bottom' | 'top' }) {
   const ui = useStore($uiState)
 
   if (ui.statusBar !== at) {
@@ -300,8 +300,6 @@ export const AppLayout = memo(function AppLayout({
   return (
     <AlternateScreen mouseTracking={mouseTracking}>
       <Box flexDirection="column" flexGrow={1}>
-        {!overlay.agents && <StatusRulePane at="top" composer={composer} status={status} />}
-
         <Box flexDirection="row" flexGrow={1}>
           {overlay.agents ? (
             <AgentsOverlayPane />

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -184,24 +184,6 @@ const ComposerPane = memo(function ComposerPane({
       )}
 
       <Box flexDirection="column" position="relative">
-        {ui.statusBar && (
-          <StatusRule
-            bgCount={ui.bgTasks.size}
-            busy={ui.busy}
-            cols={composer.cols}
-            cwdLabel={status.cwdLabel}
-            model={ui.info?.model?.split('/').pop() ?? ''}
-            sessionStartedAt={status.sessionStartedAt}
-            showCost={ui.showCost}
-            status={ui.status}
-            statusColor={status.statusColor}
-            t={ui.theme}
-            turnStartedAt={status.turnStartedAt}
-            usage={ui.usage}
-            voiceLabel={status.voiceLabel}
-          />
-        )}
-
         <FloatingOverlays
           cols={composer.cols}
           compIdx={composer.compIdx}
@@ -273,6 +255,32 @@ const AgentsOverlayPane = memo(function AgentsOverlayPane() {
   )
 })
 
+const StatusRulePane = memo(function StatusRulePane({ composer, status }: Pick<AppLayoutProps, 'composer' | 'status'>) {
+  const ui = useStore($uiState)
+
+  if (!ui.statusBar) {
+    return null
+  }
+
+  return (
+    <StatusRule
+      bgCount={ui.bgTasks.size}
+      busy={ui.busy}
+      cols={composer.cols}
+      cwdLabel={status.cwdLabel}
+      model={ui.info?.model?.split('/').pop() ?? ''}
+      sessionStartedAt={status.sessionStartedAt}
+      showCost={ui.showCost}
+      status={ui.status}
+      statusColor={status.statusColor}
+      t={ui.theme}
+      turnStartedAt={status.turnStartedAt}
+      usage={ui.usage}
+      voiceLabel={status.voiceLabel}
+    />
+  )
+})
+
 export const AppLayout = memo(function AppLayout({
   actions,
   composer,
@@ -305,6 +313,8 @@ export const AppLayout = memo(function AppLayout({
         )}
 
         {!overlay.agents && <ComposerPane actions={actions} composer={composer} status={status} />}
+
+        {!overlay.agents && <StatusRulePane composer={composer} status={status} />}
       </Box>
     </AlternateScreen>
   )

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -184,7 +184,16 @@ const ComposerPane = memo(function ComposerPane({
       <StatusRulePane at="top" composer={composer} status={status} />
 
       {!isBlocked && (
-        <>
+        <Box flexDirection="column" marginTop={ui.statusBar === 'top' ? 0 : 1} position="relative">
+          <FloatingOverlays
+            cols={composer.cols}
+            compIdx={composer.compIdx}
+            completions={composer.completions}
+            onModelSelect={actions.onModelSelect}
+            onPickerSelect={actions.resumeById}
+            pagerPageSize={composer.pagerPageSize}
+          />
+
           {composer.inputBuf.map((line, i) => (
             <Box key={i}>
               <Box width={3}>
@@ -196,15 +205,6 @@ const ComposerPane = memo(function ComposerPane({
           ))}
 
           <Box position="relative">
-            <FloatingOverlays
-              cols={composer.cols}
-              compIdx={composer.compIdx}
-              completions={composer.completions}
-              onModelSelect={actions.onModelSelect}
-              onPickerSelect={actions.resumeById}
-              pagerPageSize={composer.pagerPageSize}
-            />
-
             <Box width={pw}>
               {sh ? (
                 <Text color={ui.theme.color.shellDollar}>$ </Text>
@@ -230,7 +230,7 @@ const ComposerPane = memo(function ComposerPane({
               </Box>
             </Box>
           </Box>
-        </>
+        </Box>
       )}
 
       {!composer.empty && !ui.sid && <Text color={ui.theme.color.dim}>⚕ {ui.status}</Text>}
@@ -264,22 +264,28 @@ const StatusRulePane = memo(function StatusRulePane({
     return null
   }
 
+  // 'top' sits inline above the input; give it one row of breathing
+  // space above so the transcript (or queue) doesn't butt directly
+  // against the status row. 'bottom' lives at the last row of the
+  // viewport so it needs no margin.
   return (
-    <StatusRule
-      bgCount={ui.bgTasks.size}
-      busy={ui.busy}
-      cols={composer.cols}
-      cwdLabel={status.cwdLabel}
-      model={ui.info?.model?.split('/').pop() ?? ''}
-      sessionStartedAt={status.sessionStartedAt}
-      showCost={ui.showCost}
-      status={ui.status}
-      statusColor={status.statusColor}
-      t={ui.theme}
-      turnStartedAt={status.turnStartedAt}
-      usage={ui.usage}
-      voiceLabel={status.voiceLabel}
-    />
+    <Box flexShrink={0} marginTop={at === 'top' ? 1 : 0}>
+      <StatusRule
+        bgCount={ui.bgTasks.size}
+        busy={ui.busy}
+        cols={composer.cols}
+        cwdLabel={status.cwdLabel}
+        model={ui.info?.model?.split('/').pop() ?? ''}
+        sessionStartedAt={status.sessionStartedAt}
+        showCost={ui.showCost}
+        status={ui.status}
+        statusColor={status.statusColor}
+        t={ui.theme}
+        turnStartedAt={status.turnStartedAt}
+        usage={ui.usage}
+        voiceLabel={status.voiceLabel}
+      />
+    </Box>
   )
 })
 

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -167,11 +167,8 @@ export function lineNav(s: string, p: number, dir: -1 | 1): null | number {
   return snapPos(s, Math.min(nextBreak + 1 + col, lineEnd))
 }
 
-// Cursor layout mirrors `wrap-ansi(text, cols, { wordWrap: false, hard: true })`
-// which is what `<Text wrap="wrap-char">` ends up feeding to the renderer.
-// Char-granularity wrap keeps wrap boundaries deterministic as the user
-// types — word-wrap's whitespace-preferring reshuffle causes the cursor
-// to flicker as each keystroke moves a word across a line break (blitz #9).
+// mirrors wrap-ansi(..., { wordWrap: false, hard: true }) so the declared
+// cursor lines up with what <Text wrap="wrap-char"> actually renders
 export function cursorLayout(value: string, cursor: number, cols: number) {
   const pos = Math.max(0, Math.min(cursor, value.length))
   const w = Math.max(1, cols)
@@ -205,11 +202,7 @@ export function cursorLayout(value: string, cursor: number, cols: number) {
     col += sw
   }
 
-  // The cursor renders as an inverted cell AFTER the character at `pos`
-  // (or as a standalone trailing cell when `pos === value.length`). If
-  // col has reached the wrap column, that cell overflows to the next row
-  // — match wrap-ansi's behavior so the declared cursor doesn't sit past
-  // the visual edge.
+  // trailing cursor-cell overflows to the next row at the wrap column
   if (col >= w) {
     line++
     col = 0

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -167,9 +167,14 @@ export function lineNav(s: string, p: number, dir: -1 | 1): null | number {
   return snapPos(s, Math.min(nextBreak + 1 + col, lineEnd))
 }
 
-function cursorLayout(value: string, cursor: number, cols: number) {
+// Cursor layout mirrors `wrap-ansi(text, cols, { wordWrap: false, hard: true })`
+// which is what `<Text wrap="wrap-char">` ends up feeding to the renderer.
+// Char-granularity wrap keeps wrap boundaries deterministic as the user
+// types — word-wrap's whitespace-preferring reshuffle causes the cursor
+// to flicker as each keystroke moves a word across a line break (blitz #9).
+export function cursorLayout(value: string, cursor: number, cols: number) {
   const pos = Math.max(0, Math.min(cursor, value.length))
-  const w = Math.max(1, cols - 1)
+  const w = Math.max(1, cols)
 
   let col = 0,
     line = 0
@@ -200,17 +205,27 @@ function cursorLayout(value: string, cursor: number, cols: number) {
     col += sw
   }
 
+  // The cursor renders as an inverted cell AFTER the character at `pos`
+  // (or as a standalone trailing cell when `pos === value.length`). If
+  // col has reached the wrap column, that cell overflows to the next row
+  // — match wrap-ansi's behavior so the declared cursor doesn't sit past
+  // the visual edge.
+  if (col >= w) {
+    line++
+    col = 0
+  }
+
   return { column: col, line }
 }
 
-function offsetFromPosition(value: string, row: number, col: number, cols: number) {
+export function offsetFromPosition(value: string, row: number, col: number, cols: number) {
   if (!value.length) {
     return 0
   }
 
   const targetRow = Math.max(0, Math.floor(row))
   const targetCol = Math.max(0, Math.floor(col))
-  const w = Math.max(1, cols - 1)
+  const w = Math.max(1, cols)
 
   let line = 0
   let column = 0
@@ -800,7 +815,7 @@ export function TextInput({
       }}
       ref={boxRef}
     >
-      <Text wrap="wrap">{rendered}</Text>
+      <Text wrap="wrap-char">{rendered}</Text>
     </Box>
   )
 }

--- a/ui-tui/src/content/hotkeys.ts
+++ b/ui-tui/src/content/hotkeys.ts
@@ -24,6 +24,6 @@ export const HOTKEYS: [string, string][] = [
   ['Home/End', 'start / end of line'],
   ['Shift+Enter / Alt+Enter', 'insert newline'],
   ['\\+Enter', 'multi-line continuation (fallback)'],
-  ['!cmd', 'run shell command'],
-  ['{!cmd}', 'interpolate shell output inline']
+  ['!<cmd>', 'run a shell command (e.g. !ls, !git status)'],
+  ['{!<cmd>}', 'interpolate shell output inline (e.g. "branch is {!git branch --show-current}")']
 ]

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -60,7 +60,7 @@ export interface ConfigDisplayConfig {
   streaming?: boolean
   thinking_mode?: string
   tui_compact?: boolean
-  tui_statusbar?: boolean
+  tui_statusbar?: 'bottom' | 'off' | 'on' | 'top' | boolean
 }
 
 export interface ConfigFullResponse {


### PR DESCRIPTION
Closes three remaining items from the [TUI v2 blitz test](https://nousresearch.atlassian.net/wiki/spaces/PM/pages/482705411/Hermes+TUI+v2+blitz+test). The other three (MEDIA on Ghostty, background startup, Alacritty first-open) land in a follow-up.

## Summary

### 1. Word-wrap flicker (blitz row 9)

\`<Text wrap=\"wrap\">\` fed \`wrapAnsi\` with default word-wrap, which prefers whitespace boundaries. \`TextInput.cursorLayout\` broke by pure column width with \`w = cols - 1\`. The two algorithms disagreed on where a line broke, so near the right edge the declared cursor jumped a word left/right on each keystroke.

- New \`wrap=\"wrap-char\"\` mode in \`@hermes/ink\` → passes \`wordWrap:false\` to wrap-ansi.
- \`TextInput\` switches to \`wrap-char\` and aligns its own wrap math (\`w = cols\`, trailing-cell overflow to next line) with what the renderer actually produces.

### 2. Shift-Tab yolo without interrupt (blitz row 5 sub-item 11)

Previously the only toggle was \`/yolo\`, which submits a slash message and spends a turn. Matches Claude Code's in-place dangerously-approve now:

- \`useInputHandlers\` catches shift+tab when no completion dropdown is open, calls \`config.set\` with \`key:'yolo'\` directly, echoes \`yolo on\`/\`yolo off\` to the transcript. No prompt dispatch.

### 3. Statusline at bottom (blitz row 5 sub-item 12)

- Moved \`<StatusRule>\` out of \`ComposerPane\` into a new \`StatusRulePane\` rendered as the final child of \`AppLayout\`, below the input.
- Overlay + slash toggle (\`/statusbar\`) unchanged.

## Test plan

- [x] \`vitest\` — 232 passing (added 11 new cursor-layout + offsetFromPosition char-wrap cases)
- [x] \`tsc --noEmit\` clean across ui-tui and @hermes/ink
- [ ] Manual: type a long sentence that crosses the right edge — cursor should stay on the same word as you type (no left/right dance)
- [ ] Manual: shift+tab at the input prompt → \`yolo on\` / \`yolo off\` appears in the transcript, no new turn is sent
- [ ] Manual: statusline visible at the very bottom of the terminal, below the input; \`/statusbar off\` / \`/statusbar on\` still toggles it

Refs: #13594 #13596 #13622 #13729 #13726 (rest of the blitz pack)