### PR TITLE
fix(ssh): forward skill env vars into SSH snapshots

### DIFF
--- a/tests/tools/test_ssh_env_passthrough.py
+++ b/tests/tools/test_ssh_env_passthrough.py
@@ -1,0 +1,68 @@
+import subprocess
+
+from tools.env_passthrough import clear_env_passthrough, register_env_passthrough
+from tools.environments import ssh as ssh_env
+from tools.environments.ssh import SSHEnvironment
+
+
+def _make_ssh_env(monkeypatch):
+    monkeypatch.setattr(ssh_env.shutil, "which", lambda _name: "/usr/bin/ssh")
+    monkeypatch.setattr(ssh_env.SSHEnvironment, "_establish_connection", lambda self: None)
+    monkeypatch.setattr(ssh_env.SSHEnvironment, "_detect_remote_home", lambda self: "/home/testuser")
+    monkeypatch.setattr(ssh_env.SSHEnvironment, "_ensure_remote_dirs", lambda self: None)
+    monkeypatch.setattr(ssh_env.SSHEnvironment, "init_session", lambda self: None)
+    monkeypatch.setattr(
+        ssh_env,
+        "FileSyncManager",
+        lambda **kw: type(
+            "M",
+            (),
+            {"sync": lambda self, **k: None, "sync_back": lambda self: None},
+        )(),
+    )
+    return SSHEnvironment(host="example.com", user="testuser")
+
+
+def test_login_shell_forwards_registered_passthrough_env_vars(monkeypatch):
+    clear_env_passthrough()
+    monkeypatch.setenv("NEXTCLOUD_URL", "https://next.example.com")
+    monkeypatch.setenv("NEXTCLOUD_USER", "alice")
+    register_env_passthrough(["NEXTCLOUD_URL", "NEXTCLOUD_USER"])
+    env = _make_ssh_env(monkeypatch)
+
+    captured = {}
+
+    def fake_popen(cmd, stdin_data=None, **kwargs):
+        captured["cmd"] = cmd
+        return object()
+
+    monkeypatch.setattr(ssh_env, "_popen_bash", fake_popen)
+
+    env._run_bash("printf test", login=True)
+
+    assert captured["cmd"][:3] == ["ssh", "-o", f"ControlPath={env.control_socket}"]
+    assert "-o" in captured["cmd"]
+    assert "SendEnv=NEXTCLOUD_URL" in captured["cmd"]
+    assert "SendEnv=NEXTCLOUD_USER" in captured["cmd"]
+
+    clear_env_passthrough()
+
+
+def test_login_shell_omits_unregistered_env_vars(monkeypatch):
+    clear_env_passthrough()
+    monkeypatch.setenv("NEXTCLOUD_URL", "https://next.example.com")
+    env = _make_ssh_env(monkeypatch)
+
+    captured = {}
+
+    def fake_popen(cmd, stdin_data=None, **kwargs):
+        captured["cmd"] = cmd
+        return object()
+
+    monkeypatch.setattr(ssh_env, "_popen_bash", fake_popen)
+
+    env._run_bash("printf test", login=True)
+
+    assert "SendEnv=NEXTCLOUD_URL" not in captured["cmd"]
+
+    clear_env_passthrough()

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -76,6 +76,24 @@ class SSHEnvironment(BaseEnvironment):
 
         self.init_session()
 
+    def _build_init_sendenv_args(self) -> list[str]:
+        """Build SendEnv args for skill-registered passthrough variables.
+
+        SSH only needs these during init_session(): the login-shell snapshot
+        captures the forwarded variables, and later commands source that
+        snapshot instead of re-sending env vars on every call.
+        """
+        try:
+            from tools.env_passthrough import get_all_passthrough
+        except Exception:
+            return []
+
+        args: list[str] = []
+        for key in sorted(get_all_passthrough()):
+            if os.getenv(key) is not None:
+                args.extend(["-o", f"SendEnv={key}"])
+        return args
+
     def _build_ssh_command(self, extra_args: list | None = None) -> list:
         cmd = ["ssh"]
         cmd.extend(["-o", f"ControlPath={self.control_socket}"])
@@ -261,7 +279,8 @@ class SSHEnvironment(BaseEnvironment):
                   timeout: int = 120,
                   stdin_data: str | None = None) -> subprocess.Popen:
         """Spawn an SSH process that runs bash on the remote host."""
-        cmd = self._build_ssh_command()
+        extra_args = self._build_init_sendenv_args() if login else None
+        cmd = self._build_ssh_command(extra_args=extra_args)
         if login:
             cmd.extend(["bash", "-l", "-c", shlex.quote(cmd_string)])
         else:


### PR DESCRIPTION
## Summary
- forward skill-registered passthrough vars with `SendEnv` during SSH login-shell bootstrap
- keep forwarding scoped to `init_session()` so later SSH commands reuse the captured snapshot
- add regression tests covering registered vs unregistered env vars

## Root cause
- the SSH backend captured its login-shell snapshot without any `SendEnv` options
- skill passthrough vars existed in the Hermes process, but OpenSSH was never told to forward them into the remote login shell

## Fix
- build `SendEnv` args from the registered passthrough allowlist for env vars that are actually present locally
- attach those args only to login-shell SSH invocations so the snapshot persists them for later `terminal` / `execute_code` calls

## Regression coverage
- added `tests/tools/test_ssh_env_passthrough.py` to assert registered vars are forwarded during login-shell bootstrap
- added a negative test proving unregistered vars are not forwarded

## Testing
- `scripts/run_tests.sh tests/tools/test_ssh_env_passthrough.py`
- `scripts/run_tests.sh tests/tools/test_sync_back_backends.py tests/tools/test_skill_env_passthrough.py`

Closes #14091