### PR TITLE
fix(acp): honor first-page read_text_file slices

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -560,7 +560,7 @@ class CopilotACPClient:
                 content = path.read_text() if path.exists() else ""
                 line = params.get("line")
                 limit = params.get("limit")
-                if isinstance(line, int) and line > 1:
+                if isinstance(line, int) and line >= 1:
                     lines = content.splitlines(keepends=True)
                     start = line - 1
                     end = start + limit if isinstance(limit, int) and limit > 0 else None

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -94,6 +94,29 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
         self.assertNotIn("abc123def456", content)
         self.assertIn("OPENAI_API_KEY=", content)
 
+    def test_read_text_file_honors_first_page_pagination(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            text_file = root / "notes.txt"
+            text_file.write_text("one\ntwo\nthree\n")
+
+            response = self._dispatch(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 6,
+                    "method": "fs/read_text_file",
+                    "params": {
+                        "path": str(text_file),
+                        "line": 1,
+                        "limit": 1,
+                    },
+                },
+                cwd=str(root),
+            )
+
+        content = ((response.get("result") or {}).get("content") or "")
+        self.assertEqual(content, "one\n")
+
     def test_write_text_file_reuses_write_denylist(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             home = Path(tmpdir) / "home"


### PR DESCRIPTION
## Summary
- honor `fs/read_text_file` pagination when ACP requests start at `line=1`
- keep the existing slice behavior for later pages while applying the same path to the first page
- add a regression test covering `line=1, limit=1`

## Why
Fixes #13451. The ACP shim only sliced file content when `line > 1`, so first-page paginated reads returned the whole file instead of the requested bounded slice.

## Testing
- `pytest -o addopts= tests/agent/test_copilot_acp_client.py`
