### PR TITLE
fix(cli): register sms platform toolset

### DIFF
--- a/hermes_cli/platforms.py
+++ b/hermes_cli/platforms.py
@@ -26,6 +26,7 @@ PLATFORMS: OrderedDict[str, PlatformInfo] = OrderedDict([
     ("whatsapp",       PlatformInfo(label="📱 WhatsApp",        default_toolset="hermes-whatsapp")),
     ("signal",         PlatformInfo(label="📡 Signal",          default_toolset="hermes-signal")),
     ("bluebubbles",    PlatformInfo(label="💙 BlueBubbles",     default_toolset="hermes-bluebubbles")),
+    ("sms",            PlatformInfo(label="📱 SMS (Twilio)",    default_toolset="hermes-sms")),
     ("email",          PlatformInfo(label="📧 Email",           default_toolset="hermes-email")),
     ("homeassistant",  PlatformInfo(label="🏠 Home Assistant",  default_toolset="hermes-homeassistant")),
     ("mattermost",     PlatformInfo(label="💬 Mattermost",      default_toolset="hermes-mattermost")),

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -444,6 +444,13 @@ def test_first_install_nous_auto_configures_managed_defaults(monkeypatch):
 class TestPlatformToolsetConsistency:
     """Every platform in tools_config.PLATFORMS must have a matching toolset."""
 
+    def test_sms_platform_is_registered(self):
+        """SMS gateway sessions need a platform registry entry to resolve toolsets."""
+        from hermes_cli.tools_config import PLATFORMS
+
+        assert "sms" in PLATFORMS
+        assert PLATFORMS["sms"]["default_toolset"] == "hermes-sms"
+
     def test_all_platforms_have_toolset_definitions(self):
         """Each platform's default_toolset must exist in TOOLSETS."""
         from hermes_cli.tools_config import PLATFORMS


### PR DESCRIPTION
## Summary
- register the shared `sms` platform entry in `hermes_cli.platforms`
- map it to the existing `hermes-sms` default toolset used by gateway sessions
- add a regression test that asserts the SMS platform is present in the platform/toolset registry

## Why
Fixes #9789. SMS gateway sessions resolve enabled toolsets through the shared platform registry, but `sms` was missing from that registry, causing `KeyError: sms` during inbound message handling.

## Testing
- `pytest -o addopts= tests/hermes_cli/test_tools_config.py -k sms_platform_is_registered
