### PR TITLE
fix(ssh): forward skill passthrough env vars into SSH sessions

### DIFF
--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -39,12 +39,14 @@ class SSHEnvironment(BaseEnvironment):
     """
 
     def __init__(self, host: str, user: str, cwd: str = "~",
-                 timeout: int = 60, port: int = 22, key_path: str = ""):
+                 timeout: int = 60, port: int = 22, key_path: str = "",
+                 env: dict[str, str] | None = None):
         super().__init__(cwd=cwd, timeout=timeout)
         self.host = host
         self.user = user
         self.port = port
         self.key_path = key_path
+        self._injected_env: dict[str, str] = dict(env) if env else {}
 
         self.control_dir = Path(tempfile.gettempdir()) / "hermes-ssh"
         self.control_dir.mkdir(parents=True, exist_ok=True)
@@ -75,6 +77,32 @@ class SSHEnvironment(BaseEnvironment):
         self._sync_manager.sync(force=True)
 
         self.init_session()
+        if self._injected_env and self._snapshot_ready:
+            self._inject_env_into_snapshot()
+
+    def _inject_env_into_snapshot(self) -> None:
+        """Append skill-required passthrough env vars to the remote session snapshot."""
+        appends = []
+        for k, v in self._injected_env.items():
+            line = f"export {k}={shlex.quote(v)}"
+            appends.append(f"echo {shlex.quote(line)} >> {self._snapshot_path}")
+        script = "; ".join(appends)
+        cmd = self._build_ssh_command()
+        cmd.extend(["bash", "-c", shlex.quote(script)])
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+            if result.returncode != 0:
+                logger.warning(
+                    "SSH: failed to inject passthrough env vars into snapshot: %s",
+                    result.stderr.strip(),
+                )
+            else:
+                logger.debug(
+                    "SSH: injected %d passthrough env var(s) into session snapshot",
+                    len(self._injected_env),
+                )
+        except Exception as exc:
+            logger.warning("SSH: passthrough env var injection failed: %s", exc)
 
     def _build_ssh_command(self, extra_args: list | None = None) -> list:
         cmd = ["ssh"]

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -988,6 +988,21 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
     elif env_type == "ssh":
         if not ssh_config or not ssh_config.get("host") or not ssh_config.get("user"):
             raise ValueError("SSH environment requires ssh_host and ssh_user to be configured")
+        ssh_env: dict[str, str] = {}
+        try:
+            from tools.env_passthrough import get_all_passthrough
+            from tools.environments.local import _HERMES_PROVIDER_ENV_BLOCKLIST
+            from tools.environments.docker import _load_hermes_env_vars
+            passthrough_keys = set(get_all_passthrough()) - _HERMES_PROVIDER_ENV_BLOCKLIST
+            hermes_env = _load_hermes_env_vars() if passthrough_keys else {}
+            for key in passthrough_keys:
+                value = os.getenv(key)
+                if value is None:
+                    value = hermes_env.get(key)
+                if value is not None:
+                    ssh_env[key] = value
+        except Exception:
+            pass
         return _SSHEnvironment(
             host=ssh_config["host"],
             user=ssh_config["user"],
@@ -995,6 +1010,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
             key_path=ssh_config.get("key", ""),
             cwd=cwd,
             timeout=timeout,
+            env=ssh_env or None,
         )
 
     else:


### PR DESCRIPTION
Root cause: SSHEnvironment was the only execution backend that received no env vars at creation time. Docker
  injects them via -e KEY=VALUE flags during docker exec at init_session, and local uses os.environ directly. SSH
  just connected and ran export -p to capture the remote machine's environment — host-side passthrough vars
  registered by skills never crossed the wire.

 Changes:

  tools/environments/ssh.py
  - SSHEnvironment.__init__ now accepts an env: dict[str, str] | None parameter
  - After init_session() captures the remote shell snapshot, _inject_env_into_snapshot() appends export KEY=VALUE
  lines to that snapshot file on the remote machine
  - All subsequent commands source the snapshot before running, so they inherit the injected vars

  tools/terminal_tool.py
  - In _create_environment for env_type == "ssh", collects passthrough vars exactly as Docker's _build_init_env_args
   does: get_all_passthrough() minus the Hermes provider credential blocklist, with ~/.hermes/.env as fallback when
  os.getenv returns nothing
  - Passes them as env= to SSHEnvironment

  The approach is consistent with Docker's pattern and safe: Hermes provider credentials are filtered out via
  _HERMES_PROVIDER_ENV_BLOCKLIST (same guard Docker uses), and the injection is wrapped in a broad except Exception
  so a failure never breaks SSH session creation.

Fix:
- SSHEnvironment.__init__ now accepts an `env` dict of vars to inject. After init_session() captures the remote snapshot, _inject_env_into_ snapshot() appends `export KEY=VALUE` lines to that snapshot file on the remote machine. All subsequent commands source the snapshot, so they inherit the injected vars automatically.
- _create_environment() in terminal_tool.py now collects passthrough vars for SSH exactly as DockerEnvironment._build_init_env_args does: get_all_passthrough() minus _HERMES_PROVIDER_ENV_BLOCKLIST, with ~/.hermes/.env as a fallback when os.getenv returns nothing.

Hermes provider credentials remain blocked (same guard Docker uses). Injection failure is caught and logged as a warning so it never breaks SSH session creation.

🐛 Bug fix (non-breaking change that fixes an issue)