### PR TITLE
feat(slack): add strict_mention mode to prevent agent-to-agent loops

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -1098,6 +1098,13 @@ class SlackAdapter(BasePlatformAdapter):
         if not is_dm and bot_uid:
             if channel_id in self._slack_free_response_channels():
                 pass  # Free-response channel — always process
+            elif self._slack_strict_mention():
+                # Strict mode: only an explicit @mention in *this* message triggers
+                # a response. Thread continuity, bot-started threads, and active
+                # sessions are all ignored. Use this for bots that should never
+                # auto-engage on follow-up messages (prevents agent-to-agent loops).
+                if not is_mentioned:
+                    return
             elif not self._slack_require_mention():
                 pass  # Mention requirement disabled globally for Slack
             elif not is_mentioned:
@@ -1122,8 +1129,9 @@ class SlackAdapter(BasePlatformAdapter):
         if is_mentioned:
             # Strip the bot mention from the text
             text = text.replace(f"<@{bot_uid}>", "").strip()
-            # Register this thread so all future messages auto-trigger the bot
-            if event_thread_ts:
+            # Register this thread so all future messages auto-trigger the bot.
+            # Skip in strict mode — strict bots must be re-mentioned every time.
+            if event_thread_ts and not self._slack_strict_mention():
                 self._mentioned_threads.add(event_thread_ts)
                 if len(self._mentioned_threads) > self._MENTIONED_THREADS_MAX:
                     to_remove = list(self._mentioned_threads)[:self._MENTIONED_THREADS_MAX // 2]
@@ -1731,6 +1739,24 @@ class SlackAdapter(BasePlatformAdapter):
                 return configured.lower() not in ("false", "0", "no", "off")
             return bool(configured)
         return os.getenv("SLACK_REQUIRE_MENTION", "true").lower() not in ("false", "0", "no", "off")
+
+    def _slack_strict_mention(self) -> bool:
+        """Return whether the bot should ONLY reply to direct @mentions.
+
+        Strict mode disables all forms of thread auto-engagement:
+        bot-started threads, previously-mentioned threads, and active
+        sessions are all ignored. The bot only responds when explicitly
+        @-tagged in the current message. Useful for agent-to-agent
+        scenarios where one agent's reply could land in a thread the
+        other agent was once tagged in, causing infinite acknowledgement
+        loops. Default: False (preserves legacy behavior).
+        """
+        configured = self.config.extra.get("strict_mention")
+        if configured is not None:
+            if isinstance(configured, str):
+                return configured.lower() in ("true", "1", "yes", "on")
+            return bool(configured)
+        return os.getenv("SLACK_STRICT_MENTION", "false").lower() in ("true", "1", "yes", "on")
 
     def _slack_free_response_channels(self) -> set:
         """Return channel IDs where no @mention is required."""


### PR DESCRIPTION
## Summary

Adds a new `strict_mention` Slack config flag. When enabled, the bot **only** replies to messages that explicitly `@`-tag it — all forms of thread auto-engagement are disabled.

## Why

Currently, once a bot is `@`-mentioned in a thread, [slack.py:1125-1131](https://github.com/NousResearch/hermes-agent/blob/main/gateway/platforms/slack.py#L1125-L1131) registers the thread in `_mentioned_threads` and the bot replies to **every subsequent message** in that thread (regardless of mention).

When two Hermes agents share a thread (e.g. one agent delegating tasks to another via Slack), this causes infinite acknowledgement loops:

1. Agent A `@`-tags Agent B with a task
2. Agent B completes, replies in thread
3. Agent A sees the reply (its own thread → auto-trigger via `_bot_message_ts`)
4. Agent A acks (`✓`)
5. Agent B sees the ack (its mentioned thread → auto-trigger via `_mentioned_threads`)
6. Agent B acks (`✓`)
7. Loop forever

`require_mention=true` doesn't help because it only gates the *first* mention — the auto-engagement paths bypass it entirely.

## Behavior

| Config | Behavior |
|---|---|
| `strict_mention=false` (default) | Unchanged — current behavior |
| `strict_mention=true` | Only direct `@`-mentions in the current message trigger a reply. Thread continuity, bot-started threads, and active sessions are all ignored. Mentions also do not register the thread in `_mentioned_threads`. |

## Config

```yaml
gateways:
  slack:
    extra:
      strict_mention: true
```

Or via env: `SLACK_STRICT_MENTION=true`.

## Test Plan

- [ ] With `strict_mention=false` (default): existing thread auto-engagement still works (regression check)
- [ ] With `strict_mention=true`: bot replies only to messages containing `<@bot_uid>`
- [ ] With `strict_mention=true`: thread is NOT added to `_mentioned_threads` even after a mention (verified by re-replying without mention → no response)
- [ ] DMs unaffected (gating only applies in channels)
- [ ] `free_response_channels` still take precedence over strict mode

## Related

Discovered via Planepoints agent-to-agent loop where a tester agent (`Ringo`) and the primary Hermes agent ack-looped each other dozens of times in a single thread before manual intervention.
