### PR TITLE
Documentation: Update Docker guide with terminal command

### DIFF
--- a/website/docs/user-guide/docker.md
+++ b/website/docs/user-guide/docker.md
@@ -78,6 +78,12 @@ docker run -it --rm \
   nousresearch/hermes-agent
 ```
 
+Or if you have already opened a terminal in your running container (via Docker Desktop for instance), just run:
+
+```sh
+/opt/hermes/.venv/bin/hermes
+```
+
 ## Persistent volumes
 
 The `/opt/data` volume is the single source of truth for all Hermes state. It maps to your host's `~/.hermes/` directory and contains:


### PR DESCRIPTION
In `/website/docs/user-guide/docker.md` 
add 2 lines of alternative instructions for opening an interactive Hermes cli chat session in a running Docker container.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->
Clarifies how to start a Hermes cli chat session in an already running container.

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Small addition to docs.

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Look at the diff.
2. Try the command that was documented.

## Checklist
<!-- Complete these before requesting review. -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ✓ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ N/A ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ N/A ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ N/A ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ N/A ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A


