### PR TITLE
fix(agent): honor provider context for aux compression

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1575,6 +1575,48 @@ class AIAgent:
                 _aux_context_config = int(_aux_context_config)
             except (TypeError, ValueError):
                 _aux_context_config = None
+        if _aux_context_config is None and isinstance(_aux_cfg, dict):
+            _aux_model = str(_aux_cfg.get("model") or "").strip()
+            _aux_base_url = str(_aux_cfg.get("base_url") or "").strip().rstrip("/")
+            _aux_provider_key = str(_aux_cfg.get("provider") or "").strip().lower()
+            try:
+                from hermes_cli.config import get_compatible_custom_providers
+
+                _aux_custom_providers = get_compatible_custom_providers(_agent_cfg)
+            except Exception:
+                _aux_custom_providers = _agent_cfg.get("custom_providers")
+                if not isinstance(_aux_custom_providers, list):
+                    _aux_custom_providers = []
+            for _cp_entry in _aux_custom_providers:
+                if not isinstance(_cp_entry, dict):
+                    continue
+                _cp_url = str(_cp_entry.get("base_url") or "").strip().rstrip("/")
+                _cp_key = str(_cp_entry.get("provider_key") or "").strip().lower()
+                if _aux_base_url:
+                    if not _cp_url or _cp_url != _aux_base_url:
+                        continue
+                elif _aux_provider_key and _aux_provider_key != "custom":
+                    if not _cp_key or _cp_key != _aux_provider_key:
+                        continue
+                else:
+                    continue
+                _cp_models = _cp_entry.get("models", {})
+                if isinstance(_cp_models, dict):
+                    _cp_model_cfg = _cp_models.get(_aux_model, {})
+                    if isinstance(_cp_model_cfg, dict):
+                        _cp_ctx = _cp_model_cfg.get("context_length")
+                        if _cp_ctx is not None:
+                            try:
+                                _aux_context_config = int(_cp_ctx)
+                            except (TypeError, ValueError):
+                                logger.warning(
+                                    "Invalid context_length for auxiliary compression model %r in "
+                                    "custom_providers: %r — must be a plain integer "
+                                    "(e.g. 256000, not '256K'). Falling back to auto-detection.",
+                                    _aux_model or _cp_entry.get("model") or "?",
+                                    _cp_ctx,
+                                )
+                break
         self._aux_compression_context_length_config = _aux_context_config
 
         # Read explicit context_length override from model config

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -257,6 +257,76 @@ def test_init_feasibility_check_uses_aux_context_override_from_config():
     )
 
 
+def test_init_feasibility_check_uses_aux_provider_model_context_length():
+    """Aux compression should reuse per-model context_length from providers config."""
+
+    class _StubCompressor:
+        def __init__(self, *args, **kwargs):
+            self.context_length = 200_000
+            self.threshold_tokens = 100_000
+            self.threshold_percent = 0.50
+
+        def get_tool_schemas(self):
+            return []
+
+        def on_session_start(self, *args, **kwargs):
+            return None
+
+    cfg = {
+        "providers": {
+            "local-kimi": {
+                "api": "http://127.0.0.1:8080/v1",
+                "models": {
+                    "kimi-code/kimi-code": {
+                        "context_length": 262_141,
+                    }
+                },
+            }
+        },
+        "auxiliary": {
+            "compression": {
+                "provider": "custom",
+                "model": "kimi-code/kimi-code",
+                "base_url": "http://127.0.0.1:8080/v1",
+            },
+        },
+    }
+    mock_client = MagicMock()
+    mock_client.base_url = "http://127.0.0.1:8080/v1"
+    mock_client.api_key = "sk-custom"
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("run_agent.ContextCompressor", new=_StubCompressor),
+        patch(
+            "agent.auxiliary_client.get_text_auxiliary_client",
+            return_value=(mock_client, "kimi-code/kimi-code"),
+        ),
+        patch(
+            "agent.model_metadata.get_model_context_length",
+            return_value=262_141,
+        ) as mock_ctx_len,
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent._aux_compression_context_length_config == 262_141
+    mock_ctx_len.assert_called_once_with(
+        "kimi-code/kimi-code",
+        base_url="http://127.0.0.1:8080/v1",
+        api_key="sk-custom",
+        config_context_length=262_141,
+    )
+
+
 @patch("agent.auxiliary_client.get_text_auxiliary_client")
 def test_warns_when_no_auxiliary_provider(mock_get_client):
     """Warning emitted when no auxiliary provider is configured."""


### PR DESCRIPTION
## Summary
- reuse `providers` / compatible custom-provider model context hints for `auxiliary.compression`
- keep explicit `auxiliary.compression.context_length` overrides taking precedence
- add an init-level regression test covering provider-backed auxiliary context resolution

## Testing
- `pytest -o addopts= tests/run_agent/test_compression_feasibility.py`

Closes #13807