### PR TITLE
feat(personality): mark current personality in /personality popup

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -802,6 +802,11 @@ display:
   # Use compact banner mode
   compact: false
 
+  # Currently-active personality name (from agent.personalities above).
+  # Set at runtime with /personality <name>; "" or "none" means no overlay.
+  # The resolved prompt text is stored separately in agent.system_prompt.
+  personality: ""
+
   # Tool progress display level (CLI and gateway)
   #   off:     Silent — no tool activity shown, just the final response
   #   new:     Show a tool indicator only when the tool changes (skip repeats)

--- a/cli.py
+++ b/cli.py
@@ -5482,6 +5482,7 @@ class HermesCLI:
             if personality_name in ("none", "default", "neutral"):
                 self.system_prompt = ""
                 self.agent = None  # Force re-init
+                save_config_value("display.personality", "")
                 if save_config_value("agent.system_prompt", ""):
                     print("(^_^)b Personality cleared (saved to config)")
                 else:
@@ -5490,6 +5491,7 @@ class HermesCLI:
             elif personality_name in self.personalities:
                 self.system_prompt = self._resolve_personality_prompt(self.personalities[personality_name])
                 self.agent = None  # Force re-init
+                save_config_value("display.personality", personality_name)
                 if save_config_value("agent.system_prompt", self.system_prompt):
                     print(f"(^_^)b Personality set to '{personality_name}' (saved to config)")
                 else:
@@ -5499,19 +5501,36 @@ class HermesCLI:
                 print(f"(._.) Unknown personality: {personality_name}")
                 print(f"  Available: none, {', '.join(self.personalities.keys())}")
         else:
+            # Determine currently-active personality by matching resolved prompts
+            current_prompt = (self.system_prompt or "").strip()
+            if not current_prompt:
+                current_name = "none"
+            else:
+                current_name = "custom"
+                for name, prompt in self.personalities.items():
+                    if self._resolve_personality_prompt(prompt).strip() == current_prompt:
+                        current_name = name
+                        break
+
+            def _mark(name: str) -> str:
+                return "* " if name == current_name else "  "
+
             # Show available personalities
             print()
             print("+" + "-" * 50 + "+")
             print("|" + " " * 12 + "(^o^)/ Personalities" + " " * 15 + "|")
             print("+" + "-" * 50 + "+")
             print()
-            print(f"  {'none':<12} - (no personality overlay)")
+            print(f"{_mark('none')}{'none':<12} - (no personality overlay)")
             for name, prompt in self.personalities.items():
                 if isinstance(prompt, dict):
                     preview = prompt.get("description") or prompt.get("system_prompt", "")[:50]
                 else:
                     preview = str(prompt)[:50]
-                print(f"  {name:<12} - {preview}")
+                print(f"{_mark(name)}{name:<12} - {preview}")
+            if current_name == "custom":
+                print()
+                print("  (active prompt doesn't match any named personality)")
             print()
             print("  Usage: /personality <name>")
             print()

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -1134,12 +1134,18 @@ class SlashCommandCompleter(Completer):
         """Yield completions for /personality from configured personalities."""
         try:
             from hermes_cli.config import load_config
-            personalities = load_config().get("agent", {}).get("personalities", {})
+            cfg = load_config()
+            personalities = cfg.get("agent", {}).get("personalities", {})
+            current_name = (cfg.get("display", {}).get("personality", "") or "").strip().lower() or "none"
+
+            def _display(name: str) -> str:
+                return f"● {name}" if name == current_name else f"  {name}"
+
             if "none".startswith(sub_lower) and "none" != sub_lower:
                 yield Completion(
                     "none",
                     start_position=-len(sub_text),
-                    display="none",
+                    display=_display("none"),
                     display_meta="clear personality overlay",
                 )
             for name, prompt in personalities.items():
@@ -1151,7 +1157,7 @@ class SlashCommandCompleter(Completer):
                     yield Completion(
                         name,
                         start_position=-len(sub_text),
-                        display=name,
+                        display=_display(name),
                         display_meta=meta,
                     )
         except Exception:


### PR DESCRIPTION
## What does this PR do?

Adds a visible marker next to the currently-active personality when browsing
the `/personality` menu, so it's obvious which one is in effect.

- In the non-TUI listing (`/personality` with no args): prefix the active entry
  with `* `.
- In the TUI slash-command completion popup: prefix the active entry with `● `.

Also persists the active personality name to `display.personality` in the config
from the CLI side. The TUI gateway already used this key; the CLI was only
writing `agent.system_prompt`, so the two sides are now consistent and the
completer can read `display.personality` as a single source of truth.

## Related Issue

None

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cli.py`: when `/personality` is called with no args, compute the active
  personality (by matching the resolved system prompt against configured
  entries) and prefix it with `* ` in the listing. If the live prompt doesn't
  match any named personality, the listing shows a `(active prompt doesn't
  match any named personality)` note.
- `cli.py`: `/personality <name>` now also writes `display.personality` to the
  config (cleared when set to `none`/`default`/`neutral`), matching what the
  TUI gateway already does.
- `hermes_cli/commands.py`: `SlashCommandCompleter` reads
  `display.personality` and renders a `● ` marker next to the matching entry
  in the completion popup.
- `cli-config.yaml.example`: documented the `display.personality` key (it was
  already used in code but never listed in the example config).

## How to Test

1. Run `/personality` — the currently-active entry is
   prefixed with `* `. Switch with `/personality <name>` and run `/personality`
   again; the marker moves.
3. `/personality none` → the `none` row is the one marked.
4. When in `hermes --tui`, type `/personality ` and open the completion popup, the
   active entry is prefixed with `● `. Pick another one; reopen the popup;
   the marker moves.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` — added the `display.personality` key
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<img width="568" height="399" alt="image" src="https://github.com/user-attachments/assets/754800dd-75f5-45ff-8969-90fc773b7353" />

<img width="601" height="381" alt="image" src="https://github.com/user-attachments/assets/47d8c499-b150-4fe9-b476-de8ee29cb5a9" />

