### PR TITLE
fix(plugins): treat non-mapping plugin.yaml as invalid instead of crashing

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -719,6 +719,13 @@ class PluginManager:
                 logger.warning("PyYAML not installed – cannot load %s", manifest_file)
                 return None
             data = yaml.safe_load(manifest_file.read_text()) or {}
+            if not isinstance(data, dict):
+                logger.warning(
+                    "%s is not a mapping (got %s); skipping plugin.",
+                    manifest_file,
+                    type(data).__name__,
+                )
+                return None
 
             name = data.get("name", plugin_dir.name)
             key = f"{prefix}/{plugin_dir.name}" if prefix else name

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -122,10 +122,18 @@ def _read_manifest(plugin_dir: Path) -> dict:
         import yaml
 
         with open(manifest_file) as f:
-            return yaml.safe_load(f) or {}
+            data = yaml.safe_load(f) or {}
     except Exception as e:
         logger.warning("Failed to read plugin.yaml in %s: %s", plugin_dir, e)
         return {}
+    if not isinstance(data, dict):
+        logger.warning(
+            "plugin.yaml in %s is not a mapping (got %s); ignoring manifest.",
+            plugin_dir,
+            type(data).__name__,
+        )
+        return {}
+    return data
 
 
 def _copy_example_files(plugin_dir: Path, console) -> None:
@@ -681,6 +689,8 @@ def _discover_all_plugins() -> list:
                 try:
                     with open(manifest_file) as f:
                         manifest = yaml.safe_load(f) or {}
+                    if not isinstance(manifest, dict):
+                        manifest = {}
                     name = manifest.get("name", d.name)
                     version = manifest.get("version", "")
                     description = manifest.get("description", "")

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -161,6 +161,29 @@ class TestPluginDiscovery:
         }
         assert len(non_bundled) == 0
 
+    def test_discover_skips_non_mapping_manifest(self, tmp_path, monkeypatch, caplog):
+        """plugin.yaml that parses to a list/scalar is valid YAML but not a
+        manifest. It must be skipped with a warning instead of crashing the
+        discovery loop with ``AttributeError: 'list' object has no attribute 'get'``.
+        """
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        bad = plugins_dir / "bad_manifest"
+        bad.mkdir(parents=True)
+        (bad / "plugin.yaml").write_text("- not\n- a\n- mapping\n")
+        (bad / "__init__.py").write_text("def register(ctx):\n    pass\n")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        mgr = PluginManager()
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
+            mgr.discover_and_load()
+
+        non_bundled = {
+            n: p for n, p in mgr._plugins.items()
+            if p.manifest.source != "bundled"
+        }
+        assert len(non_bundled) == 0
+        assert any("not a mapping" in r.message for r in caplog.records)
+
     def test_entry_points_scanned(self, tmp_path, monkeypatch):
         """Entry-point based plugins are discovered (mocked)."""
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -155,6 +155,22 @@ class TestReadManifest:
         result = _read_manifest(tmp_path)
         assert result == {}
 
+    def test_non_mapping_yaml_returns_empty_and_logs(self, tmp_path, caplog):
+        """A plugin.yaml that parses to a list/scalar is valid YAML but not a
+        manifest. Callers use ``manifest.get(...)``, so the safe behavior is to
+        coerce to an empty dict rather than crash.
+        """
+        (tmp_path / "plugin.yaml").write_text("- not\n- a\n- mapping\n")
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins_cmd"):
+            result = _read_manifest(tmp_path)
+        assert result == {}
+        assert any("not a mapping" in r.message for r in caplog.records)
+
+    def test_scalar_yaml_returns_empty(self, tmp_path):
+        (tmp_path / "plugin.yaml").write_text("just-a-string\n")
+        result = _read_manifest(tmp_path)
+        assert result == {}
+
 
 # ── cmd_install tests ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
Closes #14066

`hermes plugins install` (and plugin discovery at runtime) crashed with `AttributeError: 'list' object has no attribute 'get'` whenever a plugin's `plugin.yaml` was syntactically valid YAML but parsed to something other than a mapping — for example a top-level list. The three manifest-reading sites all did `yaml.safe_load(...) or {}` and then reached for `.get(...)` straight away, so existing exception handling (which only catches parse errors) didn't protect them.

## What changed
Each site now checks `isinstance(..., dict)` before indexing:

- `_read_manifest` (plugins_cmd.py) — coerce non-mapping YAML to `{}` and log a warning.
- `_discover_all_plugins` (plugins_cmd.py) — same coercion on its inline `yaml.safe_load` path.
- `PluginRegistry._parse_manifest` (plugins.py) — return `None` (skip the plugin) instead of calling `.get()` on a list/scalar.

The coercion/skip choice mirrors how each caller already handles missing or malformed manifests.

## Test plan
- [x] New `TestReadManifest::test_non_mapping_yaml_returns_empty_and_logs` and `test_scalar_yaml_returns_empty`.
- [x] New `TestPluginDiscovery::test_discover_skips_non_mapping_manifest` — reproduces the crash scenario in the runtime discovery path.
- [x] Existing manifest/discovery tests still pass (`tests/hermes_cli/test_plugins_cmd.py::TestReadManifest`, `tests/hermes_cli/test_plugins.py::TestPluginDiscovery`).

_AI-assisted contribution._