### PR TITLE
fix(discord): enable thread origin context by default

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -578,6 +578,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["mention_patterns"] = platform_cfg["mention_patterns"]
                 if plat == Platform.DISCORD and "channel_skill_bindings" in platform_cfg:
                     bridged["channel_skill_bindings"] = platform_cfg["channel_skill_bindings"]
+                if plat == Platform.DISCORD and "thread_origin_context_history_limit" in platform_cfg:
+                    bridged["thread_origin_context_history_limit"] = platform_cfg["thread_origin_context_history_limit"]
                 if "channel_prompts" in platform_cfg:
                     channel_prompts = platform_cfg["channel_prompts"]
                     if isinstance(channel_prompts, dict):
@@ -623,6 +625,8 @@ def load_gateway_config() -> GatewayConfig:
                     os.environ["DISCORD_AUTO_THREAD"] = str(discord_cfg["auto_thread"]).lower()
                 if "reactions" in discord_cfg and not os.getenv("DISCORD_REACTIONS"):
                     os.environ["DISCORD_REACTIONS"] = str(discord_cfg["reactions"]).lower()
+                if "thread_origin_context_history_limit" in discord_cfg and not os.getenv("DISCORD_THREAD_ORIGIN_CONTEXT_LIMIT"):
+                    os.environ["DISCORD_THREAD_ORIGIN_CONTEXT_LIMIT"] = str(discord_cfg["thread_origin_context_history_limit"])
                 # ignored_channels: channels where bot never responds (even when mentioned)
                 ic = discord_cfg.get("ignored_channels")
                 if ic is not None and not os.getenv("DISCORD_IGNORED_CHANNELS"):

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -826,6 +826,22 @@ class DiscordAdapter(BasePlatformAdapter):
         """Check if message reactions are enabled via config/env."""
         return os.getenv("DISCORD_REACTIONS", "true").lower() not in ("false", "0", "no")
 
+    def _origin_context_history_limit(self) -> int:
+        """Return how many source-channel messages to inject into new threads.
+
+        Default is disabled (0) so deployments must opt in explicitly via
+        config.extra.thread_origin_context_history_limit or the
+        DISCORD_THREAD_ORIGIN_CONTEXT_LIMIT environment variable.
+        """
+        configured = self.config.extra.get("thread_origin_context_history_limit")
+        if configured is None:
+            configured = os.getenv("DISCORD_THREAD_ORIGIN_CONTEXT_LIMIT", "0")
+        try:
+            limit = int(configured)
+        except (TypeError, ValueError):
+            return 0
+        return max(0, min(limit, 100))
+
     async def on_processing_start(self, event: MessageEvent) -> None:
         """Add an in-progress reaction for normal Discord message events."""
         if not self._reactions_enabled():
@@ -2370,10 +2386,91 @@ class DiscordAdapter(BasePlatformAdapter):
         if thread_id:
             self._threads.mark(thread_id)
 
-        # If a message was provided, kick off a new Hermes session in the thread
+        # If a message was provided, kick off a new Hermes session in the thread.
+        # When the slash command was invoked from inside an existing Discord
+        # thread, prepend the originating thread's recent history so the new
+        # session starts with the source context that motivated the new thread.
         starter = (message or "").strip()
+        origin_limit = self._origin_context_history_limit()
         if starter and thread_id:
-            await self._dispatch_thread_session(interaction, thread_id, thread_name, starter)
+            origin_context = ""
+            if origin_limit > 0:
+                origin_context = await self._build_origin_thread_context(interaction, limit=origin_limit)
+            session_starter = f"{origin_context}\n\n{starter}" if origin_context else starter
+            await self._dispatch_thread_session(interaction, thread_id, thread_name, session_starter)
+
+    async def _build_origin_thread_context(
+        self,
+        origin: Any,
+        limit: int = 100,
+        *,
+        exclude_message_id: Optional[str] = None,
+    ) -> str:
+        """Return formatted recent history for the channel/thread that spawned a new thread.
+
+        This is used anywhere Hermes creates a Discord thread so the new
+        session inherits recent context from the originating channel or thread,
+        not just the immediate starter prompt.
+        """
+        if hasattr(origin, "channel") or hasattr(origin, "channel_id"):
+            channel = await self._resolve_interaction_channel(origin)
+        else:
+            channel = origin
+        if channel is None:
+            return ""
+
+        history_method = getattr(channel, "history", None)
+        if history_method is None:
+            return ""
+
+        try:
+            collected = []
+            async for msg in history_method(limit=limit):
+                collected.append(msg)
+        except Exception as exc:
+            logger.warning("[%s] Failed to collect origin thread history for %s: %s", self.name, getattr(channel, "id", "?"), exc)
+            return ""
+
+        if not collected:
+            return ""
+
+        collected.reverse()  # Discord returns newest-first by default.
+        lines: list[str] = []
+        for msg in collected:
+            msg_id = getattr(msg, "id", None)
+            if exclude_message_id is not None and str(msg_id) == str(exclude_message_id):
+                continue
+
+            author = getattr(getattr(msg, "author", None), "display_name", None)
+            if not author:
+                author = getattr(getattr(msg, "author", None), "name", None) or "Unknown"
+
+            content = (getattr(msg, "clean_content", None) or getattr(msg, "content", None) or "").strip()
+            attachments = getattr(msg, "attachments", None) or []
+            if attachments:
+                attachment_names = [getattr(att, "filename", None) or "attachment" for att in attachments]
+                attachment_note = f"[Attachments: {', '.join(attachment_names)}]"
+                content = f"{content}\n{attachment_note}" if content else attachment_note
+
+            if not content:
+                continue
+
+            lines.append(f"[{author}] {content}")
+
+        if not lines:
+            return ""
+
+        origin_name = getattr(channel, "name", None) or "source thread"
+        origin_kind = "thread" if isinstance(channel, discord.Thread) else "channel"
+        return (
+            "Use the following recent conversation from the originating Discord "
+            f"{origin_kind} "
+            f'"{origin_name}" as background context for this new thread. '
+            f"This is the last {len(lines)} messages, ordered oldest to newest:\n"
+            "---\n"
+            + "\n".join(lines)
+            + "\n---"
+        )
 
     async def _dispatch_thread_session(
         self,
@@ -3138,6 +3235,18 @@ class DiscordAdapter(BasePlatformAdapter):
         event_text = message.content
         if pending_text_injection:
             event_text = f"{pending_text_injection}\n\n{event_text}" if event_text else pending_text_injection
+
+        if auto_threaded_channel is not None:
+            origin_limit = self._origin_context_history_limit()
+            origin_context = ""
+            if origin_limit > 0:
+                origin_context = await self._build_origin_thread_context(
+                    message.channel,
+                    limit=origin_limit,
+                    exclude_message_id=str(getattr(message, "id", "") or ""),
+                )
+            if origin_context:
+                event_text = f"{origin_context}\n\n{event_text}" if event_text else origin_context
 
         # Defense-in-depth: prevent empty user messages from entering session
         # (can happen when user sends @mention-only with no other text)

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -829,17 +829,18 @@ class DiscordAdapter(BasePlatformAdapter):
     def _origin_context_history_limit(self) -> int:
         """Return how many source-channel messages to inject into new threads.
 
-        Default is disabled (0) so deployments must opt in explicitly via
-        config.extra.thread_origin_context_history_limit or the
-        DISCORD_THREAD_ORIGIN_CONTEXT_LIMIT environment variable.
+        Default is 100 so new Discord threads inherit the most recent context
+        from the originating channel/thread unless the deployment explicitly
+        overrides or disables it via config.extra.thread_origin_context_history_limit
+        or the DISCORD_THREAD_ORIGIN_CONTEXT_LIMIT environment variable.
         """
         configured = self.config.extra.get("thread_origin_context_history_limit")
         if configured is None:
-            configured = os.getenv("DISCORD_THREAD_ORIGIN_CONTEXT_LIMIT", "0")
+            configured = os.getenv("DISCORD_THREAD_ORIGIN_CONTEXT_LIMIT", "100")
         try:
             limit = int(configured)
         except (TypeError, ValueError):
-            return 0
+            return 100
         return max(0, min(limit, 100))
 
     async def on_processing_start(self, event: MessageEvent) -> None:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -802,7 +802,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 19,
+    "_config_version": 20,
 }
 
 # =============================================================================
@@ -818,6 +818,10 @@ ENV_VARS_BY_VERSION: Dict[int, List[str]] = {
         "SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "SLACK_ALLOWED_USERS"],
     10: ["TAVILY_API_KEY"],
     11: ["TERMINAL_MODAL_MODE"],
+    20: [
+        "TRACKERMANE_POSTGRES_URL", "TRACKERMANE_CLICKHOUSE_URL",
+        "SIDESHIFT_API_KEY", "SIDESHIFT_API_BASE_URL",
+    ],
 }
 
 # Required environment variables with metadata for migration prompts.
@@ -1234,6 +1238,41 @@ OPTIONAL_ENV_VARS = {
         "tools": ["web_search", "web_extract", "web_crawl"],
         "password": True,
         "category": "tool",
+    },
+    "TRACKERMANE_POSTGRES_URL": {
+        "description": "TrackerMane Postgres URL for canonical DealSeek UGC metadata",
+        "prompt": "TrackerMane Postgres URL",
+        "url": None,
+        "tools": ["tracker_get_overview", "tracker_search_videos", "tracker_search_accounts", "tracker_get_video_details"],
+        "password": True,
+        "category": "tool",
+        "advanced": True,
+    },
+    "TRACKERMANE_CLICKHOUSE_URL": {
+        "description": "TrackerMane ClickHouse URL for historical/latest DealSeek UGC analytics snapshots",
+        "prompt": "TrackerMane ClickHouse URL",
+        "url": None,
+        "tools": ["tracker_get_overview", "tracker_search_videos", "tracker_search_accounts", "tracker_get_video_details"],
+        "password": True,
+        "category": "tool",
+        "advanced": True,
+    },
+    "SIDESHIFT_API_KEY": {
+        "description": "SideShift API key for UGC program-specific analytics and post data",
+        "prompt": "SideShift API key",
+        "url": "https://app.sideshift.app/",
+        "tools": ["sideshift_get_overview", "sideshift_get_creators", "sideshift_get_posts", "sideshift_get_post"],
+        "password": True,
+        "category": "tool",
+    },
+    "SIDESHIFT_API_BASE_URL": {
+        "description": "SideShift API base URL override",
+        "prompt": "SideShift API base URL",
+        "url": "https://app.sideshift.app/docs",
+        "tools": ["sideshift_get_overview", "sideshift_get_creators", "sideshift_get_posts", "sideshift_get_post"],
+        "password": False,
+        "category": "tool",
+        "advanced": True,
     },
     "BROWSERBASE_API_KEY": {
         "description": "Browserbase API key for cloud browser (optional — local browser works without this)",
@@ -3355,6 +3394,9 @@ def show_config():
         ("PARALLEL_API_KEY", "Parallel"),
         ("FIRECRAWL_API_KEY", "Firecrawl"),
         ("TAVILY_API_KEY", "Tavily"),
+        ("TRACKERMANE_POSTGRES_URL", "TrackerMane PG"),
+        ("TRACKERMANE_CLICKHOUSE_URL", "TrackerMane CH"),
+        ("SIDESHIFT_API_KEY", "SideShift"),
         ("BROWSERBASE_API_KEY", "Browserbase"),
         ("BROWSER_USE_API_KEY", "Browser Use"),
         ("FAL_KEY", "FAL"),
@@ -3533,6 +3575,8 @@ def set_config_value(key: str, value: str):
         'EXA_API_KEY', 'PARALLEL_API_KEY', 'FIRECRAWL_API_KEY', 'FIRECRAWL_API_URL',
         'FIRECRAWL_GATEWAY_URL', 'TOOL_GATEWAY_DOMAIN', 'TOOL_GATEWAY_SCHEME',
         'TOOL_GATEWAY_USER_TOKEN', 'TAVILY_API_KEY',
+        'TRACKERMANE_POSTGRES_URL', 'TRACKERMANE_CLICKHOUSE_URL',
+        'SIDESHIFT_API_KEY', 'SIDESHIFT_API_BASE_URL',
         'BROWSERBASE_API_KEY', 'BROWSERBASE_PROJECT_ID', 'BROWSER_USE_API_KEY',
         'FAL_KEY', 'TELEGRAM_BOT_TOKEN', 'DISCORD_BOT_TOKEN',
         'TERMINAL_SSH_HOST', 'TERMINAL_SSH_USER', 'TERMINAL_SSH_KEY',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
   "requests>=2.33.0,<3",  # CVE-2026-25645
   "jinja2>=3.1.5,<4",
   "pydantic>=2.12.5,<3",
+  "psycopg[binary]>=3.2,<4",
   # Interactive CLI (prompt_toolkit is used directly by cli.py)
   "prompt_toolkit>=3.0.52,<4",
   # Tools

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -259,6 +259,24 @@ class TestLoadGatewayConfig:
             "456": "Therapist mode",
         }
 
+    def test_bridges_discord_thread_origin_context_limit_from_config_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "discord:\n"
+            "  thread_origin_context_history_limit: 100\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("DISCORD_THREAD_ORIGIN_CONTEXT_LIMIT", raising=False)
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.DISCORD].extra["thread_origin_context_history_limit"] == 100
+        assert os.environ["DISCORD_THREAD_ORIGIN_CONTEXT_LIMIT"] == "100"
+
     def test_bridges_telegram_channel_prompts_from_config_yaml(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -110,6 +110,13 @@ def adapter():
     return adapter
 
 
+def test_origin_context_history_limit_defaults_to_100(adapter, monkeypatch):
+    monkeypatch.delenv("DISCORD_THREAD_ORIGIN_CONTEXT_LIMIT", raising=False)
+    adapter.config.extra.pop("thread_origin_context_history_limit", None)
+
+    assert adapter._origin_context_history_limit() == 100
+
+
 # ------------------------------------------------------------------
 # /thread slash command registration
 # ------------------------------------------------------------------

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -246,11 +246,40 @@ async def test_handle_thread_create_slash_dispatches_session_when_message_provid
     )
 
     adapter._dispatch_thread_session = AsyncMock()
+    adapter._build_origin_thread_context = AsyncMock(return_value="")
+    adapter._origin_context_history_limit = MagicMock(return_value=100)
 
     await adapter._handle_thread_create_slash(interaction, "Planning", "Hello Hermes", 1440)
 
     adapter._dispatch_thread_session.assert_awaited_once_with(
         interaction, "555", "Planning", "Hello Hermes",
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_thread_create_slash_includes_origin_thread_context(adapter):
+    created_thread = SimpleNamespace(id=555, name="Planning", send=AsyncMock())
+    origin_thread = _FakeThreadChannel(channel_id=200, name="source-thread")
+    origin_thread.parent.create_thread = AsyncMock(return_value=created_thread)
+    interaction = SimpleNamespace(
+        channel=origin_thread,
+        channel_id=200,
+        user=SimpleNamespace(display_name="Jezza", id=42),
+        guild=SimpleNamespace(name="TestGuild"),
+        followup=SimpleNamespace(send=AsyncMock()),
+    )
+
+    adapter._dispatch_thread_session = AsyncMock()
+    adapter._build_origin_thread_context = AsyncMock(return_value="origin context block")
+    adapter._origin_context_history_limit = MagicMock(return_value=100)
+
+    await adapter._handle_thread_create_slash(interaction, "Planning", "Hello Hermes", 1440)
+
+    adapter._dispatch_thread_session.assert_awaited_once_with(
+        interaction,
+        "555",
+        "Planning",
+        "origin context block\n\nHello Hermes",
     )
 
 
@@ -352,6 +381,52 @@ async def test_dispatch_thread_session_builds_thread_event(adapter):
     assert event.source.chat_type == "thread"
     assert event.source.thread_id == "555"
     assert "TestGuild" in event.source.chat_name
+
+
+@pytest.mark.asyncio
+async def test_build_origin_thread_context_formats_last_messages_oldest_first(adapter):
+    channel = _FakeThreadChannel(channel_id=200, name="source-thread")
+    newest = _fake_history_message(content="latest reply", display_name="Bob")
+    oldest = _fake_history_message(content="first message", display_name="Alice")
+    attachment_only = _fake_history_message(content="", display_name="Carol", attachments=[SimpleNamespace(filename="spec.pdf")])
+    channel.history = MagicMock(return_value=_AsyncHistory([newest, attachment_only, oldest]))
+
+    interaction = SimpleNamespace(channel=channel, channel_id=200)
+
+    context = await adapter._build_origin_thread_context(interaction)
+
+    channel.history.assert_called_once_with(limit=100)
+    assert 'originating Discord thread "source-thread"' in context
+    assert "[Alice] first message" in context
+    assert "[Carol] [Attachments: spec.pdf]" in context
+    assert "[Bob] latest reply" in context
+    assert context.index("[Alice] first message") < context.index("[Carol] [Attachments: spec.pdf]") < context.index("[Bob] latest reply")
+
+
+@pytest.mark.asyncio
+async def test_build_origin_thread_context_formats_last_channel_messages(adapter):
+    channel = _FakeTextChannel(channel_id=123, name="general")
+    newest = _fake_history_message(content="latest reply", display_name="Bob")
+    oldest = _fake_history_message(content="first message", display_name="Alice")
+    channel.history = MagicMock(return_value=_AsyncHistory([newest, oldest]))
+
+    interaction = SimpleNamespace(channel=channel, channel_id=123)
+
+    context = await adapter._build_origin_thread_context(interaction)
+
+    channel.history.assert_called_once_with(limit=100)
+    assert 'originating Discord channel "general"' in context
+    assert "[Alice] first message" in context
+    assert "[Bob] latest reply" in context
+
+
+@pytest.mark.asyncio
+async def test_build_origin_thread_context_returns_empty_without_history(adapter):
+    interaction = SimpleNamespace(channel=SimpleNamespace(id=123, name="general"), channel_id=123)
+
+    context = await adapter._build_origin_thread_context(interaction)
+
+    assert context == ""
 
 
 # ------------------------------------------------------------------
@@ -539,6 +614,34 @@ class _FakeThreadChannel(_discord_mod.Thread):
         self.parent = SimpleNamespace(id=parent_id, name="general", guild=SimpleNamespace(name=guild_name, id=1))
 
 
+class _AsyncHistory:
+    def __init__(self, items):
+        self._items = list(items)
+        self._iter = None
+
+    def __aiter__(self):
+        self._iter = iter(self._items)
+        return self
+
+    async def __anext__(self):
+        if self._iter is None:
+            self._iter = iter(self._items)
+        try:
+            return next(self._iter)
+        except StopIteration:
+            raise StopAsyncIteration
+
+
+
+def _fake_history_message(*, content="Hello", display_name="Jezza", attachments=None):
+    return SimpleNamespace(
+        author=SimpleNamespace(display_name=display_name, name=display_name, bot=False),
+        content=content,
+        clean_content=content,
+        attachments=attachments or [],
+    )
+
+
 def _fake_message(channel, *, content="Hello", author_id=42, display_name="Jezza"):
     return SimpleNamespace(
         author=SimpleNamespace(id=author_id, display_name=display_name, bot=False),
@@ -578,6 +681,42 @@ async def test_auto_thread_creates_thread_and_redirects(adapter, monkeypatch):
     assert event.source.chat_id == "999"  # redirected to thread
     assert event.source.chat_type == "thread"
     assert event.source.thread_id == "999"
+
+
+@pytest.mark.asyncio
+async def test_auto_thread_prepends_origin_channel_context(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "true")
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_THREAD_ORIGIN_CONTEXT_LIMIT", "100")
+
+    thread = SimpleNamespace(id=999, name="Hello")
+    adapter._auto_create_thread = AsyncMock(return_value=thread)
+
+    captured_events = []
+
+    async def capture_handle(event):
+        captured_events.append(event)
+
+    adapter.handle_message = capture_handle
+
+    channel = _FakeTextChannel()
+    current = _fake_history_message(content="Hello world", display_name="Jezza")
+    current.id = 12345
+    previous = _fake_history_message(content="Prior context", display_name="Alice")
+    previous.id = 12344
+    channel.history = MagicMock(return_value=_AsyncHistory([current, previous]))
+
+    msg = _fake_message(channel, content="Hello world")
+
+    await adapter._handle_message(msg)
+
+    assert len(captured_events) == 1
+    event = captured_events[0]
+    channel.history.assert_called_once_with(limit=100)
+    assert 'originating Discord channel "general"' in event.text
+    assert "[Alice] Prior context" in event.text
+    assert "[Jezza] Hello world" not in event.text
+    assert event.text.endswith("Hello world")
 
 
 @pytest.mark.asyncio

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -393,6 +393,35 @@ class TestOptionalEnvVarsRegistry:
             all_vars.extend(vars_list)
         assert "TAVILY_API_KEY" in all_vars
 
+    def test_ugc_analytics_env_vars_registered(self):
+        """TrackerMane + SideShift env vars are exposed in OPTIONAL_ENV_VARS."""
+        from hermes_cli.config import OPTIONAL_ENV_VARS
+
+        for key in (
+            "TRACKERMANE_POSTGRES_URL",
+            "TRACKERMANE_CLICKHOUSE_URL",
+            "SIDESHIFT_API_KEY",
+            "SIDESHIFT_API_BASE_URL",
+        ):
+            assert key in OPTIONAL_ENV_VARS
+            assert OPTIONAL_ENV_VARS[key]["category"] == "tool"
+
+    def test_ugc_analytics_env_vars_in_env_vars_by_version(self):
+        """TrackerMane + SideShift env vars participate in config migration prompts."""
+        from hermes_cli.config import ENV_VARS_BY_VERSION
+
+        all_vars = []
+        for vars_list in ENV_VARS_BY_VERSION.values():
+            all_vars.extend(vars_list)
+
+        for key in (
+            "TRACKERMANE_POSTGRES_URL",
+            "TRACKERMANE_CLICKHOUSE_URL",
+            "SIDESHIFT_API_KEY",
+            "SIDESHIFT_API_BASE_URL",
+        ):
+            assert key in all_vars
+
 
 class TestAnthropicTokenMigration:
     """Test that config version 8→9 clears ANTHROPIC_TOKEN."""
@@ -459,7 +488,7 @@ class TestCustomProviderCompatibility:
             migrate_config(interactive=False, quiet=True)
             raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
 
-        assert raw["_config_version"] == 19
+        assert raw["_config_version"] == 20
         assert raw["providers"]["openai-direct"] == {
             "api": "https://api.openai.com/v1",
             "api_key": "test-key",
@@ -606,7 +635,7 @@ class TestInterimAssistantMessageConfig:
             migrate_config(interactive=False, quiet=True)
             raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
 
-        assert raw["_config_version"] == 19
+        assert raw["_config_version"] == 20
         assert raw["display"]["tool_progress"] == "off"
         assert raw["display"]["interim_assistant_messages"] is True
 
@@ -626,6 +655,6 @@ class TestDiscordChannelPromptsConfig:
             migrate_config(interactive=False, quiet=True)
             raw = yaml.safe_load(config_path.read_text(encoding="utf-8"))
 
-        assert raw["_config_version"] == 19
+        assert raw["_config_version"] == 20
         assert raw["discord"]["auto_thread"] is True
         assert raw["discord"]["channel_prompts"] == {}

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -100,6 +100,13 @@ class TestResolveMultipleToolsets:
         # No duplicates
         assert len(tools) == len(set(tools))
 
+    def test_ugc_analytics_bundle(self):
+        tools = resolve_multiple_toolsets(["ugc_analytics"])
+        assert "tracker_get_overview" in tools
+        assert "tracker_get_video_details" in tools
+        assert "sideshift_get_overview" in tools
+        assert "sideshift_get_post" in tools
+
     def test_empty_list(self):
         assert resolve_multiple_toolsets([]) == []
 

--- a/tests/tools/test_ugc_analytics_tool.py
+++ b/tests/tools/test_ugc_analytics_tool.py
@@ -1,0 +1,151 @@
+"""Tests for Hermes DealSeek UGC analytics tools."""
+
+from __future__ import annotations
+
+import json
+
+from tools.ugc_analytics_tool import (
+    DEFAULT_SIDESHIFT_API_BASE_URL,
+    _build_playback_url,
+    _check_sideshift_available,
+    _check_trackermane_available,
+    _get_sideshift_base_url,
+    _handle_sideshift_get_overview,
+    _handle_tracker_get_video_details,
+    _map_account,
+    _map_video,
+    _parse_json_each_row,
+    get_sideshift_post,
+    search_trackermane_accounts,
+    search_trackermane_videos,
+)
+
+
+class TestAvailabilityChecks:
+    def test_trackermane_check_accepts_explicit_env_vars(self, monkeypatch):
+        monkeypatch.setenv("TRACKERMANE_POSTGRES_URL", "postgres://example")
+        monkeypatch.setenv("TRACKERMANE_CLICKHOUSE_URL", "https://clickhouse")
+        assert _check_trackermane_available() is True
+
+    def test_trackermane_check_accepts_fallback_aliases(self, monkeypatch):
+        monkeypatch.delenv("TRACKERMANE_POSTGRES_URL", raising=False)
+        monkeypatch.delenv("TRACKERMANE_CLICKHOUSE_URL", raising=False)
+        monkeypatch.setenv("POSTGRES_URL", "postgres://example")
+        monkeypatch.setenv("CLICKHOUSE_URL", "https://clickhouse")
+        assert _check_trackermane_available() is True
+
+    def test_sideshift_check_requires_api_key(self, monkeypatch):
+        monkeypatch.delenv("SIDESHIFT_API_KEY", raising=False)
+        assert _check_sideshift_available() is False
+        monkeypatch.setenv("SIDESHIFT_API_KEY", "secret")
+        assert _check_sideshift_available() is True
+
+
+class TestHelpers:
+    def test_parse_json_each_row(self):
+        rows = _parse_json_each_row('{"a":1}\n{"b":2}\n')
+        assert rows == [{"a": 1}, {"b": 2}]
+
+    def test_build_playback_url(self):
+        assert _build_playback_url("uid-1", "customer.example.com") == "https://customer.example.com/uid-1/iframe"
+        assert _build_playback_url("uid-1", None) == "https://iframe.videodelivery.net/uid-1"
+        assert _build_playback_url(None, "customer.example.com") is None
+
+    def test_get_sideshift_base_url_default_and_override(self, monkeypatch):
+        monkeypatch.delenv("SIDESHIFT_API_BASE_URL", raising=False)
+        assert _get_sideshift_base_url() == DEFAULT_SIDESHIFT_API_BASE_URL
+        monkeypatch.setenv("SIDESHIFT_API_BASE_URL", "https://custom.example/api/")
+        assert _get_sideshift_base_url() == "https://custom.example/api"
+
+
+class TestTrackerSearches:
+    def test_search_videos_query_path_sorts_in_python(self, monkeypatch):
+        monkeypatch.setattr(
+            "tools.ugc_analytics_tool._search_content_metadata_candidates",
+            lambda query, platform, published_within_days: [
+                {"id": "video-a", "title": "A", "platform": "tiktok"},
+                {"id": "video-b", "title": "B", "platform": "tiktok"},
+            ],
+        )
+        monkeypatch.setattr(
+            "tools.ugc_analytics_tool._fetch_latest_video_metrics_by_ids",
+            lambda ids: [
+                {"content_id": "video-a", "view_count": 10, "latest_snapshot_at": "2026-01-01T00:00:00+00:00"},
+                {"content_id": "video-b", "view_count": 100, "latest_snapshot_at": "2026-01-02T00:00:00+00:00"},
+            ],
+        )
+
+        result = search_trackermane_videos({"query": "test", "sortBy": "view_count", "limit": 1})
+
+        assert result["results"][0]["contentId"] == "video-b"
+        assert result["filters"]["query"] == "test"
+
+    def test_search_accounts_query_path_sorts_in_python(self, monkeypatch):
+        monkeypatch.setattr(
+            "tools.ugc_analytics_tool._search_account_metadata_candidates",
+            lambda query, platform, limit: [
+                {"id": "acct-a", "handle": "a"},
+                {"id": "acct-b", "handle": "b"},
+            ],
+        )
+        monkeypatch.setattr(
+            "tools.ugc_analytics_tool._fetch_latest_account_metrics_by_ids",
+            lambda ids: [
+                {"account_id": "acct-a", "total_views": 10, "latest_snapshot_at": "2026-01-01T00:00:00+00:00"},
+                {"account_id": "acct-b", "total_views": 999, "latest_snapshot_at": "2026-01-02T00:00:00+00:00"},
+            ],
+        )
+
+        result = search_trackermane_accounts({"query": "acct", "sortBy": "total_views", "limit": 1})
+
+        assert result["results"][0]["accountId"] == "acct-b"
+        assert result["filters"]["query"] == "acct"
+
+    def test_tracker_video_details_requires_lookup_value(self):
+        payload = json.loads(_handle_tracker_get_video_details({}))
+        assert "error" in payload
+        assert "contentId" in payload["error"]
+
+
+class TestMapping:
+    def test_map_video_prefers_metadata_and_derives_playback_url(self):
+        mapped = _map_video(
+            {"content_id": "video-1", "platform": "tiktok", "view_count": 77, "latest_snapshot_at": "2026-01-01T00:00:00+00:00"},
+            {
+                "title": "Hello",
+                "platform": "instagram",
+                "platform_content_id": "ig-1",
+                "stream_uid": "stream-1",
+                "stream_customer_subdomain": "stream.example.com",
+            },
+        )
+        assert mapped["platform"] == "instagram"
+        assert mapped["title"] == "Hello"
+        assert mapped["playbackUrl"] == "https://stream.example.com/stream-1/iframe"
+
+    def test_map_account_prefers_metadata(self):
+        mapped = _map_account(
+            {"account_id": "acct-1", "platform": "tiktok", "total_views": 123},
+            {"handle": "creator", "platform": "instagram"},
+        )
+        assert mapped["platform"] == "instagram"
+        assert mapped["handle"] == "creator"
+        assert mapped["totalViews"] == 123
+
+
+class TestSideShiftHandlers:
+    def test_sideshift_handler_requires_program_id(self):
+        payload = json.loads(_handle_sideshift_get_overview({}))
+        assert payload == {"error": "programId is required."}
+
+    def test_get_sideshift_post_unwraps_data(self, monkeypatch):
+        monkeypatch.setattr(
+            "tools.ugc_analytics_tool._call_sideshift",
+            lambda path, params=None: {"data": {"id": "post-1", "views": 55}},
+        )
+        result = get_sideshift_post("post-1")
+        assert result == {
+            "source": "SideShift",
+            "postId": "post-1",
+            "data": {"id": "post-1", "views": 55},
+        }

--- a/tools/ugc_analytics_tool.py
+++ b/tools/ugc_analytics_tool.py
@@ -1,0 +1,1118 @@
+#!/usr/bin/env python3
+"""Hermes-native DealSeek UGC analytics tools.
+
+TrackerMane is the primary analytics source:
+- Postgres for canonical content/account metadata
+- ClickHouse for latest + historical snapshot metrics
+
+SideShift is the secondary/fallback source for UGC-program-specific data.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import decimal
+import json
+import os
+import uuid
+from typing import Any, Iterable
+from urllib.parse import urljoin
+
+import requests
+
+from tools.registry import registry, tool_error, tool_result
+
+DEFAULT_SIDESHIFT_API_BASE_URL = "https://app.sideshift.app/api/v1"
+CLICKHOUSE_TIMEOUT = (10, 20)
+SIDESHIFT_TIMEOUT = (10, 20)
+POSTGRES_STATEMENT_TIMEOUT_MS = 20_000
+DEFAULT_TOP_VIDEO_LIMIT = 10
+DEFAULT_TOP_ACCOUNT_LIMIT = 10
+DEFAULT_RESULT_LIMIT = 15
+MAX_RESULT_LIMIT = 25
+MAX_HISTORY_LIMIT = 50
+MAX_COMMENT_LIMIT = 25
+SEARCH_CANDIDATE_LIMIT = 75
+TRACKER_VIDEO_SORT_FIELDS = {
+    "latest_snapshot_at",
+    "published_at",
+    "view_count",
+    "like_count",
+    "comment_count",
+    "share_count",
+    "save_count",
+    "play_count",
+    "engagement_count",
+}
+TRACKER_ACCOUNT_SORT_FIELDS = {
+    "latest_snapshot_at",
+    "followers_count",
+    "following_count",
+    "video_count",
+    "total_views",
+    "total_likes",
+}
+
+
+def _get_trackermane_postgres_url() -> str | None:
+    return os.getenv("TRACKERMANE_POSTGRES_URL") or os.getenv("POSTGRES_URL")
+
+
+def _get_trackermane_clickhouse_url() -> str | None:
+    return os.getenv("TRACKERMANE_CLICKHOUSE_URL") or os.getenv("CLICKHOUSE_URL")
+
+
+def _get_sideshift_api_key() -> str | None:
+    return os.getenv("SIDESHIFT_API_KEY")
+
+
+def _get_sideshift_base_url() -> str:
+    return (os.getenv("SIDESHIFT_API_BASE_URL") or DEFAULT_SIDESHIFT_API_BASE_URL).rstrip("/")
+
+
+def _check_trackermane_available() -> bool:
+    return bool(_get_trackermane_postgres_url() and _get_trackermane_clickhouse_url())
+
+
+def _check_sideshift_available() -> bool:
+    return bool(_get_sideshift_api_key())
+
+
+def _clamp(value: Any, fallback: int, maximum: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        parsed = fallback
+    return max(1, min(parsed, maximum))
+
+
+def _clamp_days(value: Any) -> int | None:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    if parsed <= 0:
+        return None
+    return min(parsed, 3650)
+
+
+def _normalize_sort_order(value: Any) -> str:
+    return "asc" if str(value).lower() == "asc" else "desc"
+
+
+def _json_ready(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {str(k): _json_ready(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_ready(v) for v in value]
+    if isinstance(value, (dt.datetime, dt.date, dt.time)):
+        return value.isoformat()
+    if isinstance(value, uuid.UUID):
+        return str(value)
+    if isinstance(value, decimal.Decimal):
+        if value == value.to_integral_value():
+            return int(value)
+        return float(value)
+    return value
+
+
+def _get_sortable_value(value: Any) -> float:
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return dt.datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+        except ValueError:
+            try:
+                return float(value)
+            except ValueError:
+                return 0.0
+    return 0.0
+
+
+def _escape_clickhouse_string(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("'", "\\'")
+
+
+def _to_clickhouse_array(values: Iterable[str]) -> str:
+    return ", ".join(f"'{_escape_clickhouse_string(value)}'" for value in values)
+
+
+def _parse_json_each_row(raw_text: str) -> list[dict[str, Any]]:
+    text = (raw_text or "").strip()
+    if not text:
+        return []
+    return [json.loads(line) for line in text.splitlines() if line.strip()]
+
+
+def _build_playback_url(stream_uid: str | None, stream_customer_subdomain: str | None) -> str | None:
+    if not stream_uid:
+        return None
+    if stream_customer_subdomain:
+        return f"https://{stream_customer_subdomain}/{stream_uid}/iframe"
+    return f"https://iframe.videodelivery.net/{stream_uid}"
+
+
+def _get_pg_connection():
+    postgres_url = _get_trackermane_postgres_url()
+    if not postgres_url:
+        raise RuntimeError(
+            "TrackerMane Postgres is not configured. Set TRACKERMANE_POSTGRES_URL or POSTGRES_URL."
+        )
+    try:
+        import psycopg
+        from psycopg.rows import dict_row
+    except ImportError as exc:  # pragma: no cover - protected by dependency + runtime message
+        raise RuntimeError(
+            "TrackerMane tools require psycopg. Install hermes-agent with psycopg support."
+        ) from exc
+
+    conn = psycopg.connect(postgres_url, autocommit=True, row_factory=dict_row)
+    conn.execute(f"SET statement_timeout = '{POSTGRES_STATEMENT_TIMEOUT_MS}ms'")
+    return conn
+
+
+def _run_postgres_query(sql: str, params: Iterable[Any] | None = None) -> list[dict[str, Any]]:
+    with _get_pg_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(sql, tuple(params or ()))
+            return [_json_ready(row) for row in cur.fetchall()]
+
+
+def _run_clickhouse_query(sql: str) -> list[dict[str, Any]]:
+    clickhouse_url = _get_trackermane_clickhouse_url()
+    if not clickhouse_url:
+        raise RuntimeError(
+            "TrackerMane ClickHouse is not configured. Set TRACKERMANE_CLICKHOUSE_URL or CLICKHOUSE_URL."
+        )
+    response = requests.post(
+        clickhouse_url,
+        data=sql.encode("utf-8"),
+        headers={"Content-Type": "text/plain; charset=utf-8"},
+        timeout=CLICKHOUSE_TIMEOUT,
+    )
+    response.raise_for_status()
+    return _parse_json_each_row(response.text)
+
+
+def _fetch_content_metadata_by_ids(ids: list[str]) -> dict[str, dict[str, Any]]:
+    if not ids:
+        return {}
+    rows = _run_postgres_query(
+        """
+        SELECT
+          ci.id,
+          ci.platform,
+          ci.platform_content_id,
+          ci.account_id,
+          ci.canonical_url,
+          ci.content_kind,
+          ci.title,
+          ci.description,
+          ci.published_at,
+          ci.duration_seconds,
+          ci.thumbnail_url,
+          ci.platform_permalink,
+          ci.first_seen_at,
+          ci.latest_ingested_at,
+          ci.latest_comment_sync_at,
+          ci.comments_supported,
+          ci.comments_capture_mode,
+          ci.stream_uid,
+          ci.stream_customer_subdomain,
+          ca.handle AS account_handle,
+          ca.display_name AS account_display_name,
+          ca.canonical_url AS account_canonical_url
+        FROM content_items ci
+        LEFT JOIN content_accounts ca ON ca.id = ci.account_id
+        WHERE ci.id = ANY(%s::uuid[])
+        """,
+        [ids],
+    )
+    return {row["id"]: row for row in rows}
+
+
+def _fetch_account_metadata_by_ids(ids: list[str]) -> dict[str, dict[str, Any]]:
+    if not ids:
+        return {}
+    rows = _run_postgres_query(
+        """
+        SELECT
+          id,
+          platform,
+          platform_account_id,
+          handle,
+          display_name,
+          canonical_url,
+          is_verified,
+          created_at,
+          updated_at,
+          profile_image_url
+        FROM content_accounts
+        WHERE id = ANY(%s::uuid[])
+        """,
+        [ids],
+    )
+    return {row["id"]: row for row in rows}
+
+
+def _search_content_metadata_candidates(
+    query: str,
+    platform: str | None,
+    published_within_days: int | None,
+) -> list[dict[str, Any]]:
+    search_term = f"%{query}%"
+    params: list[Any] = [search_term]
+    clauses = [
+        """
+        (
+          ci.title ILIKE %s OR
+          ci.description ILIKE %s OR
+          ci.platform_content_id ILIKE %s OR
+          ci.canonical_url ILIKE %s OR
+          ci.platform_permalink ILIKE %s OR
+          ca.handle ILIKE %s OR
+          ca.display_name ILIKE %s
+        )
+        """.strip()
+    ]
+    params.extend([search_term] * 6)
+    if platform:
+        clauses.append("ci.platform = %s")
+        params.append(platform)
+    if published_within_days:
+        clauses.append("ci.published_at >= NOW() - (%s::text || ' days')::interval")
+        params.append(published_within_days)
+    params.append(SEARCH_CANDIDATE_LIMIT)
+    return _run_postgres_query(
+        f"""
+        SELECT
+          ci.id,
+          ci.platform,
+          ci.platform_content_id,
+          ci.account_id,
+          ci.canonical_url,
+          ci.content_kind,
+          ci.title,
+          ci.description,
+          ci.published_at,
+          ci.duration_seconds,
+          ci.thumbnail_url,
+          ci.platform_permalink,
+          ci.first_seen_at,
+          ci.latest_ingested_at,
+          ci.latest_comment_sync_at,
+          ci.comments_supported,
+          ci.comments_capture_mode,
+          ci.stream_uid,
+          ci.stream_customer_subdomain,
+          ca.handle AS account_handle,
+          ca.display_name AS account_display_name,
+          ca.canonical_url AS account_canonical_url
+        FROM content_items ci
+        LEFT JOIN content_accounts ca ON ca.id = ci.account_id
+        WHERE {' AND '.join(clauses)}
+        ORDER BY COALESCE(ci.published_at, ci.latest_ingested_at, ci.first_seen_at) DESC, ci.id DESC
+        LIMIT %s
+        """,
+        params,
+    )
+
+
+def _search_account_metadata_candidates(query: str, platform: str | None, limit: int) -> list[dict[str, Any]]:
+    search_term = f"%{query}%"
+    params: list[Any] = [search_term, search_term, search_term, search_term]
+    clauses = [
+        """
+        (
+          handle ILIKE %s OR
+          display_name ILIKE %s OR
+          platform_account_id ILIKE %s OR
+          canonical_url ILIKE %s
+        )
+        """.strip()
+    ]
+    if platform:
+        clauses.append("platform = %s")
+        params.append(platform)
+    params.append(limit)
+    return _run_postgres_query(
+        f"""
+        SELECT
+          id,
+          platform,
+          platform_account_id,
+          handle,
+          display_name,
+          canonical_url,
+          is_verified,
+          created_at,
+          updated_at,
+          profile_image_url
+        FROM content_accounts
+        WHERE {' AND '.join(clauses)}
+        ORDER BY updated_at DESC, id DESC
+        LIMIT %s
+        """,
+        params,
+    )
+
+
+def _fetch_latest_video_metrics_by_ids(ids: list[str]) -> list[dict[str, Any]]:
+    if not ids:
+        return []
+    return _run_clickhouse_query(
+        f"""
+        SELECT
+          content_id,
+          max(snapshot_at) AS latest_snapshot_at,
+          argMax(platform, snapshot_at) AS platform,
+          argMax(platform_content_id, snapshot_at) AS platform_content_id,
+          argMax(view_count, snapshot_at) AS view_count,
+          argMax(like_count, snapshot_at) AS like_count,
+          argMax(comment_count, snapshot_at) AS comment_count,
+          argMax(share_count, snapshot_at) AS share_count,
+          argMax(save_count, snapshot_at) AS save_count,
+          argMax(play_count, snapshot_at) AS play_count,
+          argMax(engagement_count, snapshot_at) AS engagement_count,
+          argMax(published_at, snapshot_at) AS published_at
+        FROM video_stat_snapshots
+        WHERE content_id IN ({_to_clickhouse_array(ids)})
+        GROUP BY content_id
+        FORMAT JSONEachRow
+        """
+    )
+
+
+def _fetch_top_latest_video_metrics(
+    *,
+    platform: str | None,
+    published_within_days: int | None,
+    sort_by: str,
+    sort_order: str,
+    limit: int,
+) -> list[dict[str, Any]]:
+    filters: list[str] = []
+    if platform:
+        filters.append(f"platform = '{_escape_clickhouse_string(platform)}'")
+    if published_within_days:
+        filters.append(f"published_at >= now() - INTERVAL {published_within_days} DAY")
+    where_clause = f"WHERE {' AND '.join(filters)}" if filters else ""
+    return _run_clickhouse_query(
+        f"""
+        SELECT *
+        FROM (
+          SELECT
+            content_id,
+            max(snapshot_at) AS latest_snapshot_at,
+            argMax(platform, snapshot_at) AS platform,
+            argMax(platform_content_id, snapshot_at) AS platform_content_id,
+            argMax(view_count, snapshot_at) AS view_count,
+            argMax(like_count, snapshot_at) AS like_count,
+            argMax(comment_count, snapshot_at) AS comment_count,
+            argMax(share_count, snapshot_at) AS share_count,
+            argMax(save_count, snapshot_at) AS save_count,
+            argMax(play_count, snapshot_at) AS play_count,
+            argMax(engagement_count, snapshot_at) AS engagement_count,
+            argMax(published_at, snapshot_at) AS published_at
+          FROM video_stat_snapshots
+          GROUP BY content_id
+        )
+        {where_clause}
+        ORDER BY {sort_by} {sort_order}, latest_snapshot_at DESC
+        LIMIT {limit}
+        FORMAT JSONEachRow
+        """
+    )
+
+
+def _fetch_latest_account_metrics_by_ids(ids: list[str]) -> list[dict[str, Any]]:
+    if not ids:
+        return []
+    return _run_clickhouse_query(
+        f"""
+        SELECT
+          account_id,
+          max(snapshot_at) AS latest_snapshot_at,
+          argMax(platform, snapshot_at) AS platform,
+          argMax(platform_account_id, snapshot_at) AS platform_account_id,
+          argMax(followers_count, snapshot_at) AS followers_count,
+          argMax(following_count, snapshot_at) AS following_count,
+          argMax(video_count, snapshot_at) AS video_count,
+          argMax(total_views, snapshot_at) AS total_views,
+          argMax(total_likes, snapshot_at) AS total_likes
+        FROM account_stat_snapshots
+        WHERE account_id IN ({_to_clickhouse_array(ids)})
+        GROUP BY account_id
+        FORMAT JSONEachRow
+        """
+    )
+
+
+def _fetch_top_latest_account_metrics(
+    *, platform: str | None, sort_by: str, sort_order: str, limit: int
+) -> list[dict[str, Any]]:
+    where_clause = (
+        f"WHERE platform = '{_escape_clickhouse_string(platform)}'" if platform else ""
+    )
+    return _run_clickhouse_query(
+        f"""
+        SELECT *
+        FROM (
+          SELECT
+            account_id,
+            max(snapshot_at) AS latest_snapshot_at,
+            argMax(platform, snapshot_at) AS platform,
+            argMax(platform_account_id, snapshot_at) AS platform_account_id,
+            argMax(followers_count, snapshot_at) AS followers_count,
+            argMax(following_count, snapshot_at) AS following_count,
+            argMax(video_count, snapshot_at) AS video_count,
+            argMax(total_views, snapshot_at) AS total_views,
+            argMax(total_likes, snapshot_at) AS total_likes
+          FROM account_stat_snapshots
+          GROUP BY account_id
+        )
+        {where_clause}
+        ORDER BY {sort_by} {sort_order}, latest_snapshot_at DESC
+        LIMIT {limit}
+        FORMAT JSONEachRow
+        """
+    )
+
+
+def _map_video(metric: dict[str, Any], metadata: dict[str, Any] | None) -> dict[str, Any]:
+    metadata = metadata or {}
+    return {
+        "contentId": metric.get("content_id"),
+        "platform": metadata.get("platform") or metric.get("platform"),
+        "platformContentId": metadata.get("platform_content_id") or metric.get("platform_content_id"),
+        "title": metadata.get("title"),
+        "description": metadata.get("description"),
+        "contentKind": metadata.get("content_kind"),
+        "canonicalUrl": metadata.get("canonical_url"),
+        "platformPermalink": metadata.get("platform_permalink"),
+        "thumbnailUrl": metadata.get("thumbnail_url"),
+        "publishedAt": metadata.get("published_at") or metric.get("published_at"),
+        "durationSeconds": metadata.get("duration_seconds"),
+        "accountId": metadata.get("account_id"),
+        "accountHandle": metadata.get("account_handle"),
+        "accountDisplayName": metadata.get("account_display_name"),
+        "accountCanonicalUrl": metadata.get("account_canonical_url"),
+        "latestSnapshotAt": metric.get("latest_snapshot_at"),
+        "viewCount": metric.get("view_count"),
+        "likeCount": metric.get("like_count"),
+        "commentCount": metric.get("comment_count"),
+        "shareCount": metric.get("share_count"),
+        "saveCount": metric.get("save_count"),
+        "playCount": metric.get("play_count"),
+        "engagementCount": metric.get("engagement_count"),
+        "playbackUrl": _build_playback_url(
+            metadata.get("stream_uid"), metadata.get("stream_customer_subdomain")
+        ),
+        "latestCommentSyncAt": metadata.get("latest_comment_sync_at"),
+        "latestIngestedAt": metadata.get("latest_ingested_at"),
+    }
+
+
+def _map_account(metric: dict[str, Any], metadata: dict[str, Any] | None) -> dict[str, Any]:
+    metadata = metadata or {}
+    return {
+        "accountId": metric.get("account_id"),
+        "platform": metadata.get("platform") or metric.get("platform"),
+        "platformAccountId": metadata.get("platform_account_id") or metric.get("platform_account_id"),
+        "handle": metadata.get("handle"),
+        "displayName": metadata.get("display_name"),
+        "canonicalUrl": metadata.get("canonical_url"),
+        "isVerified": metadata.get("is_verified"),
+        "profileImageUrl": metadata.get("profile_image_url"),
+        "latestSnapshotAt": metric.get("latest_snapshot_at"),
+        "followersCount": metric.get("followers_count"),
+        "followingCount": metric.get("following_count"),
+        "videoCount": metric.get("video_count"),
+        "totalViews": metric.get("total_views"),
+        "totalLikes": metric.get("total_likes"),
+    }
+
+
+def get_trackermane_overview(options: dict[str, Any] | None = None) -> dict[str, Any]:
+    options = options or {}
+    platform = (options.get("platform") or "").strip() or None
+    published_within_days = _clamp_days(options.get("publishedWithinDays"))
+    top_video_limit = _clamp(options.get("topVideoLimit"), DEFAULT_TOP_VIDEO_LIMIT, MAX_RESULT_LIMIT)
+    top_account_limit = _clamp(options.get("topAccountLimit"), DEFAULT_TOP_ACCOUNT_LIMIT, MAX_RESULT_LIMIT)
+
+    filters: list[str] = []
+    if platform:
+        filters.append(f"platform = '{_escape_clickhouse_string(platform)}'")
+    if published_within_days:
+        filters.append(f"published_at >= now() - INTERVAL {published_within_days} DAY")
+    where_clause = f"WHERE {' AND '.join(filters)}" if filters else ""
+
+    summary_rows = _run_clickhouse_query(
+        f"""
+        SELECT
+          count() AS video_count,
+          sum(view_count) AS total_views,
+          sum(like_count) AS total_likes,
+          sum(comment_count) AS total_comments,
+          sum(share_count) AS total_shares,
+          sum(save_count) AS total_saves,
+          sum(play_count) AS total_plays,
+          sum(engagement_count) AS total_engagements,
+          round(avg(view_count), 2) AS avg_views,
+          quantileExact(0.5)(view_count) AS median_views,
+          countIf(view_count >= 10000) AS videos_over_10k,
+          countIf(view_count >= 100000) AS videos_over_100k
+        FROM (
+          SELECT
+            content_id,
+            argMax(view_count, snapshot_at) AS view_count,
+            argMax(like_count, snapshot_at) AS like_count,
+            argMax(comment_count, snapshot_at) AS comment_count,
+            argMax(share_count, snapshot_at) AS share_count,
+            argMax(save_count, snapshot_at) AS save_count,
+            argMax(play_count, snapshot_at) AS play_count,
+            argMax(engagement_count, snapshot_at) AS engagement_count,
+            argMax(published_at, snapshot_at) AS published_at,
+            argMax(platform, snapshot_at) AS platform
+          FROM video_stat_snapshots
+          GROUP BY content_id
+        )
+        {where_clause}
+        FORMAT JSONEachRow
+        """
+    )
+    top_video_metrics = _fetch_top_latest_video_metrics(
+        platform=platform,
+        published_within_days=published_within_days,
+        sort_by="view_count",
+        sort_order="desc",
+        limit=top_video_limit,
+    )
+    top_account_metrics = _fetch_top_latest_account_metrics(
+        platform=platform,
+        sort_by="total_views",
+        sort_order="desc",
+        limit=top_account_limit,
+    )
+    video_metadata = _fetch_content_metadata_by_ids([row["content_id"] for row in top_video_metrics])
+    account_metadata = _fetch_account_metadata_by_ids([row["account_id"] for row in top_account_metrics])
+
+    return {
+        "source": "TrackerMane",
+        "filters": {"platform": platform, "publishedWithinDays": published_within_days},
+        "notes": (
+            [
+                "Date filters apply to the video summary and top videos. Top accounts are filtered by platform only because account snapshots do not carry upload-date semantics."
+            ]
+            if published_within_days
+            else []
+        ),
+        "summary": summary_rows[0] if summary_rows else None,
+        "topVideos": [_map_video(row, video_metadata.get(row["content_id"])) for row in top_video_metrics],
+        "topAccounts": [_map_account(row, account_metadata.get(row["account_id"])) for row in top_account_metrics],
+    }
+
+
+def search_trackermane_videos(options: dict[str, Any] | None = None) -> dict[str, Any]:
+    options = options or {}
+    query = (options.get("query") or "").strip()
+    platform = (options.get("platform") or "").strip() or None
+    published_within_days = _clamp_days(options.get("publishedWithinDays"))
+    sort_by = options.get("sortBy") or "view_count"
+    if sort_by not in TRACKER_VIDEO_SORT_FIELDS:
+        raise ValueError(f"Invalid sortBy '{sort_by}'.")
+    sort_order = _normalize_sort_order(options.get("sortOrder"))
+    limit = _clamp(options.get("limit"), DEFAULT_RESULT_LIMIT, MAX_RESULT_LIMIT)
+
+    if query:
+        metadata_rows = _search_content_metadata_candidates(query, platform, published_within_days)
+        metadata_map = {row["id"]: row for row in metadata_rows}
+        metrics = _fetch_latest_video_metrics_by_ids([row["id"] for row in metadata_rows])
+        reverse = sort_order == "desc"
+        metrics = sorted(
+            metrics,
+            key=lambda row: (
+                _get_sortable_value(row.get(sort_by)),
+                _get_sortable_value(row.get("latest_snapshot_at")),
+            ),
+            reverse=reverse,
+        )[:limit]
+    else:
+        metrics = _fetch_top_latest_video_metrics(
+            platform=platform,
+            published_within_days=published_within_days,
+            sort_by=sort_by,
+            sort_order=sort_order,
+            limit=limit,
+        )
+        metadata_map = _fetch_content_metadata_by_ids([row["content_id"] for row in metrics])
+
+    return {
+        "source": "TrackerMane",
+        "filters": {
+            "query": query or None,
+            "platform": platform,
+            "publishedWithinDays": published_within_days,
+            "sortBy": sort_by,
+            "sortOrder": sort_order,
+            "limit": limit,
+        },
+        "results": [_map_video(row, metadata_map.get(row["content_id"])) for row in metrics],
+    }
+
+
+def search_trackermane_accounts(options: dict[str, Any] | None = None) -> dict[str, Any]:
+    options = options or {}
+    query = (options.get("query") or "").strip()
+    platform = (options.get("platform") or "").strip() or None
+    sort_by = options.get("sortBy") or "total_views"
+    if sort_by not in TRACKER_ACCOUNT_SORT_FIELDS:
+        raise ValueError(f"Invalid sortBy '{sort_by}'.")
+    sort_order = _normalize_sort_order(options.get("sortOrder"))
+    limit = _clamp(options.get("limit"), DEFAULT_RESULT_LIMIT, MAX_RESULT_LIMIT)
+
+    if query:
+        metadata_rows = _search_account_metadata_candidates(query, platform, SEARCH_CANDIDATE_LIMIT)
+        metadata_map = {row["id"]: row for row in metadata_rows}
+        metrics = _fetch_latest_account_metrics_by_ids([row["id"] for row in metadata_rows])
+        reverse = sort_order == "desc"
+        metrics = sorted(
+            metrics,
+            key=lambda row: (
+                _get_sortable_value(row.get(sort_by)),
+                _get_sortable_value(row.get("latest_snapshot_at")),
+            ),
+            reverse=reverse,
+        )[:limit]
+    else:
+        metrics = _fetch_top_latest_account_metrics(
+            platform=platform,
+            sort_by=sort_by,
+            sort_order=sort_order,
+            limit=limit,
+        )
+        metadata_map = _fetch_account_metadata_by_ids([row["account_id"] for row in metrics])
+
+    return {
+        "source": "TrackerMane",
+        "filters": {
+            "query": query or None,
+            "platform": platform,
+            "sortBy": sort_by,
+            "sortOrder": sort_order,
+            "limit": limit,
+        },
+        "results": [_map_account(row, metadata_map.get(row["account_id"])) for row in metrics],
+    }
+
+
+def get_trackermane_video_details(options: dict[str, Any]) -> dict[str, Any]:
+    history_limit = _clamp(options.get("historyLimit"), 12, MAX_HISTORY_LIMIT)
+    comment_limit = _clamp(options.get("commentLimit"), 10, MAX_COMMENT_LIMIT)
+    content_id = (options.get("contentId") or "").strip() or None
+    platform_content_id = (options.get("platformContentId") or "").strip() or None
+    url = (options.get("url") or "").strip() or None
+
+    if not any([content_id, platform_content_id, url]):
+        raise ValueError("Provide at least one of contentId, platformContentId, or url.")
+
+    rows = _run_postgres_query(
+        """
+        SELECT
+          ci.id,
+          ci.platform,
+          ci.platform_content_id,
+          ci.account_id,
+          ci.canonical_url,
+          ci.content_kind,
+          ci.title,
+          ci.description,
+          ci.published_at,
+          ci.duration_seconds,
+          ci.thumbnail_url,
+          ci.platform_permalink,
+          ci.first_seen_at,
+          ci.latest_ingested_at,
+          ci.latest_comment_sync_at,
+          ci.comments_supported,
+          ci.comments_capture_mode,
+          ci.stream_uid,
+          ci.stream_customer_subdomain,
+          ca.handle AS account_handle,
+          ca.display_name AS account_display_name,
+          ca.canonical_url AS account_canonical_url
+        FROM content_items ci
+        LEFT JOIN content_accounts ca ON ca.id = ci.account_id
+        WHERE (%s::text IS NOT NULL AND ci.id::text = %s::text)
+           OR (%s::text IS NOT NULL AND ci.platform_content_id = %s)
+           OR (
+             %s::text IS NOT NULL AND (
+               ci.canonical_url = %s OR
+               ci.platform_permalink = %s
+             )
+           )
+        ORDER BY COALESCE(ci.published_at, ci.latest_ingested_at, ci.first_seen_at) DESC
+        LIMIT 1
+        """,
+        [content_id, content_id, platform_content_id, platform_content_id, url, url, url],
+    )
+    metadata = rows[0] if rows else None
+    if not metadata:
+        return {"source": "TrackerMane", "video": None, "history": [], "recentComments": []}
+
+    content_uuid = metadata["id"]
+    metrics = _fetch_latest_video_metrics_by_ids([content_uuid])
+    video = _map_video(metrics[0], metadata) if metrics else None
+    history = _run_clickhouse_query(
+        f"""
+        SELECT
+          snapshot_at,
+          view_count,
+          like_count,
+          comment_count,
+          share_count,
+          save_count,
+          play_count,
+          engagement_count
+        FROM video_stat_snapshots
+        WHERE content_id = '{_escape_clickhouse_string(content_uuid)}'
+        ORDER BY snapshot_at DESC
+        LIMIT {history_limit}
+        FORMAT JSONEachRow
+        """
+    )
+    recent_comments = _run_clickhouse_query(
+        f"""
+        SELECT
+          snapshot_at,
+          platform_comment_id,
+          comment_posted_at,
+          author_handle,
+          author_profile_url,
+          comment_text,
+          like_count,
+          reply_count
+        FROM comment_snapshots
+        WHERE content_id = '{_escape_clickhouse_string(content_uuid)}'
+        ORDER BY snapshot_at DESC, comment_posted_at DESC
+        LIMIT {comment_limit}
+        FORMAT JSONEachRow
+        """
+    )
+    return {
+        "source": "TrackerMane",
+        "video": video,
+        "history": list(reversed(history)),
+        "recentComments": recent_comments,
+    }
+
+
+def _call_sideshift(path: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+    api_key = _get_sideshift_api_key()
+    if not api_key:
+        raise RuntimeError("SideShift is not configured. Set SIDESHIFT_API_KEY.")
+    response = requests.get(
+        urljoin(f"{_get_sideshift_base_url()}/", path.lstrip("/")),
+        params={k: v for k, v in (params or {}).items() if v is not None and v != ""},
+        headers={"x-api-key": api_key},
+        timeout=SIDESHIFT_TIMEOUT,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    if isinstance(payload, dict):
+        return payload
+    return {"data": payload}
+
+
+def get_sideshift_overview(program_id: str) -> dict[str, Any]:
+    payload = _call_sideshift("analytics/overview", {"programId": program_id})
+    return {
+        "source": "SideShift",
+        "programId": program_id,
+        "data": payload.get("data", payload),
+    }
+
+
+def get_sideshift_creators(program_id: str) -> dict[str, Any]:
+    payload = _call_sideshift("analytics/accounts", {"programId": program_id})
+    data = payload.get("data", payload)
+    return {
+        "source": "SideShift",
+        "programId": program_id,
+        "count": len(data) if isinstance(data, list) else None,
+        "data": data,
+    }
+
+
+def get_sideshift_posts(program_id: str, creator_id: str | None = None) -> dict[str, Any]:
+    params = {"program": program_id}
+    if creator_id:
+        params["creator"] = creator_id
+    payload = _call_sideshift("posts", params)
+    data = payload.get("data", payload)
+    return {
+        "source": "SideShift",
+        "programId": program_id,
+        "creatorId": creator_id,
+        "count": len(data) if isinstance(data, list) else None,
+        "data": data,
+    }
+
+
+def get_sideshift_post(post_id: str) -> dict[str, Any]:
+    payload = _call_sideshift(f"posts/{post_id}")
+    return {"source": "SideShift", "postId": post_id, "data": payload.get("data", payload)}
+
+
+def _handle_tracker_get_overview(args: dict[str, Any], **_: Any) -> str:
+    try:
+        return tool_result(get_trackermane_overview(args))
+    except Exception as exc:
+        return tool_error(str(exc))
+
+
+def _handle_tracker_search_videos(args: dict[str, Any], **_: Any) -> str:
+    try:
+        return tool_result(search_trackermane_videos(args))
+    except Exception as exc:
+        return tool_error(str(exc))
+
+
+def _handle_tracker_search_accounts(args: dict[str, Any], **_: Any) -> str:
+    try:
+        return tool_result(search_trackermane_accounts(args))
+    except Exception as exc:
+        return tool_error(str(exc))
+
+
+def _handle_tracker_get_video_details(args: dict[str, Any], **_: Any) -> str:
+    try:
+        return tool_result(get_trackermane_video_details(args))
+    except Exception as exc:
+        return tool_error(str(exc))
+
+
+def _handle_sideshift_get_overview(args: dict[str, Any], **_: Any) -> str:
+    program_id = (args.get("programId") or "").strip()
+    if not program_id:
+        return tool_error("programId is required.")
+    try:
+        return tool_result(get_sideshift_overview(program_id))
+    except Exception as exc:
+        return tool_error(str(exc))
+
+
+def _handle_sideshift_get_creators(args: dict[str, Any], **_: Any) -> str:
+    program_id = (args.get("programId") or "").strip()
+    if not program_id:
+        return tool_error("programId is required.")
+    try:
+        return tool_result(get_sideshift_creators(program_id))
+    except Exception as exc:
+        return tool_error(str(exc))
+
+
+def _handle_sideshift_get_posts(args: dict[str, Any], **_: Any) -> str:
+    program_id = (args.get("programId") or "").strip()
+    if not program_id:
+        return tool_error("programId is required.")
+    creator_id = (args.get("creatorId") or "").strip() or None
+    try:
+        return tool_result(get_sideshift_posts(program_id, creator_id))
+    except Exception as exc:
+        return tool_error(str(exc))
+
+
+def _handle_sideshift_get_post(args: dict[str, Any], **_: Any) -> str:
+    post_id = (args.get("postId") or "").strip()
+    if not post_id:
+        return tool_error("postId is required.")
+    try:
+        return tool_result(get_sideshift_post(post_id))
+    except Exception as exc:
+        return tool_error(str(exc))
+
+
+TRACKER_GET_OVERVIEW_SCHEMA = {
+    "name": "tracker_get_overview",
+    "description": "TrackerMane primary overview for broad analytics: total video stats, threshold counts, top videos, and top accounts.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "platform": {"type": "string", "description": "Optional platform filter like tiktok, instagram, or youtube."},
+            "publishedWithinDays": {"type": "integer", "description": "Optional upload recency filter in days for summary and top videos."},
+            "topVideoLimit": {"type": "integer", "description": "Number of top videos to return (max 25)."},
+            "topAccountLimit": {"type": "integer", "description": "Number of top accounts to return (max 25)."},
+        },
+    },
+}
+
+TRACKER_SEARCH_VIDEOS_SCHEMA = {
+    "name": "tracker_search_videos",
+    "description": "TrackerMane primary video search and ranking tool. Search by title, description, URL, platform content ID, or creator handle; or list top videos by metric.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Optional text query for title, description, handle, permalink, or platform content ID."},
+            "platform": {"type": "string", "description": "Optional platform filter like tiktok, instagram, or youtube."},
+            "publishedWithinDays": {"type": "integer", "description": "Optional upload recency filter in days."},
+            "sortBy": {"type": "string", "enum": sorted(TRACKER_VIDEO_SORT_FIELDS)},
+            "sortOrder": {"type": "string", "enum": ["asc", "desc"]},
+            "limit": {"type": "integer", "description": "Maximum number of videos to return (max 25)."},
+        },
+    },
+}
+
+TRACKER_SEARCH_ACCOUNTS_SCHEMA = {
+    "name": "tracker_search_accounts",
+    "description": "TrackerMane primary account search and ranking tool for creator stats, follower counts, total views, and top accounts.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Optional text query for handle, display name, URL, or platform account ID."},
+            "platform": {"type": "string", "description": "Optional platform filter like tiktok, instagram, or youtube."},
+            "sortBy": {"type": "string", "enum": sorted(TRACKER_ACCOUNT_SORT_FIELDS)},
+            "sortOrder": {"type": "string", "enum": ["asc", "desc"]},
+            "limit": {"type": "integer", "description": "Maximum number of accounts to return (max 25)."},
+        },
+    },
+}
+
+TRACKER_GET_VIDEO_DETAILS_SCHEMA = {
+    "name": "tracker_get_video_details",
+    "description": "TrackerMane primary detailed video lookup. Returns one video with metadata, latest stats, recent history, and recent comments when available.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "contentId": {"type": "string", "description": "TrackerMane content_items.id UUID if known."},
+            "platformContentId": {"type": "string", "description": "Platform-specific content ID if known."},
+            "url": {"type": "string", "description": "Canonical or platform permalink URL if known."},
+            "historyLimit": {"type": "integer", "description": "Number of history points to return (max 50)."},
+            "commentLimit": {"type": "integer", "description": "Number of recent comments to return (max 25)."},
+        },
+    },
+}
+
+SIDESHIFT_GET_OVERVIEW_SCHEMA = {
+    "name": "sideshift_get_overview",
+    "description": "SideShift fallback: get UGC program overview with top posts and top creators.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "programId": {"type": "string", "description": "The SideShift UGC program ID."},
+        },
+        "required": ["programId"],
+    },
+}
+
+SIDESHIFT_GET_CREATORS_SCHEMA = {
+    "name": "sideshift_get_creators",
+    "description": "SideShift fallback: get all creators in a program with aggregated stats and contractor/program info.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "programId": {"type": "string", "description": "The SideShift UGC program ID."},
+        },
+        "required": ["programId"],
+    },
+}
+
+SIDESHIFT_GET_POSTS_SCHEMA = {
+    "name": "sideshift_get_posts",
+    "description": "SideShift fallback: list posts for a program, optionally filtered to a specific creator.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "programId": {"type": "string", "description": "The SideShift UGC program ID."},
+            "creatorId": {"type": "string", "description": "Optional SideShift contractor/creator ID."},
+        },
+        "required": ["programId"],
+    },
+}
+
+SIDESHIFT_GET_POST_SCHEMA = {
+    "name": "sideshift_get_post",
+    "description": "SideShift fallback: fetch one SideShift post by its post ID.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "postId": {"type": "string", "description": "The SideShift post ID."},
+        },
+        "required": ["postId"],
+    },
+}
+
+
+registry.register(
+    name="tracker_get_overview",
+    toolset="trackermane",
+    schema=TRACKER_GET_OVERVIEW_SCHEMA,
+    handler=_handle_tracker_get_overview,
+    check_fn=_check_trackermane_available,
+    emoji="📈",
+    max_result_size_chars=100_000,
+)
+registry.register(
+    name="tracker_search_videos",
+    toolset="trackermane",
+    schema=TRACKER_SEARCH_VIDEOS_SCHEMA,
+    handler=_handle_tracker_search_videos,
+    check_fn=_check_trackermane_available,
+    emoji="🎬",
+    max_result_size_chars=100_000,
+)
+registry.register(
+    name="tracker_search_accounts",
+    toolset="trackermane",
+    schema=TRACKER_SEARCH_ACCOUNTS_SCHEMA,
+    handler=_handle_tracker_search_accounts,
+    check_fn=_check_trackermane_available,
+    emoji="👤",
+    max_result_size_chars=100_000,
+)
+registry.register(
+    name="tracker_get_video_details",
+    toolset="trackermane",
+    schema=TRACKER_GET_VIDEO_DETAILS_SCHEMA,
+    handler=_handle_tracker_get_video_details,
+    check_fn=_check_trackermane_available,
+    emoji="📹",
+    max_result_size_chars=100_000,
+)
+registry.register(
+    name="sideshift_get_overview",
+    toolset="sideshift",
+    schema=SIDESHIFT_GET_OVERVIEW_SCHEMA,
+    handler=_handle_sideshift_get_overview,
+    check_fn=_check_sideshift_available,
+    emoji="↔️",
+    max_result_size_chars=100_000,
+)
+registry.register(
+    name="sideshift_get_creators",
+    toolset="sideshift",
+    schema=SIDESHIFT_GET_CREATORS_SCHEMA,
+    handler=_handle_sideshift_get_creators,
+    check_fn=_check_sideshift_available,
+    emoji="↔️",
+    max_result_size_chars=100_000,
+)
+registry.register(
+    name="sideshift_get_posts",
+    toolset="sideshift",
+    schema=SIDESHIFT_GET_POSTS_SCHEMA,
+    handler=_handle_sideshift_get_posts,
+    check_fn=_check_sideshift_available,
+    emoji="↔️",
+    max_result_size_chars=100_000,
+)
+registry.register(
+    name="sideshift_get_post",
+    toolset="sideshift",
+    schema=SIDESHIFT_GET_POST_SCHEMA,
+    handler=_handle_sideshift_get_post,
+    check_fn=_check_sideshift_available,
+    emoji="↔️",
+    max_result_size_chars=100_000,
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -78,6 +78,30 @@ TOOLSETS = {
         "tools": ["web_search"],
         "includes": []
     },
+
+    "trackermane": {
+        "description": "Primary DealSeek UGC analytics from TrackerMane metadata + historical snapshots",
+        "tools": [
+            "tracker_get_overview", "tracker_search_videos",
+            "tracker_search_accounts", "tracker_get_video_details",
+        ],
+        "includes": []
+    },
+
+    "sideshift": {
+        "description": "Secondary DealSeek UGC program analytics from SideShift",
+        "tools": [
+            "sideshift_get_overview", "sideshift_get_creators",
+            "sideshift_get_posts", "sideshift_get_post",
+        ],
+        "includes": []
+    },
+
+    "ugc_analytics": {
+        "description": "DealSeek UGC analytics bundle: TrackerMane primary plus SideShift fallback",
+        "tools": [],
+        "includes": ["trackermane", "sideshift"]
+    },
     
     "vision": {
         "description": "Image analysis and vision tools",

--- a/uv.lock
+++ b/uv.lock
@@ -426,7 +426,7 @@ wheels = [
 [[package]]
 name = "atroposlib"
 version = "0.4.0"
-source = { git = "https://github.com/NousResearch/atropos.git#c421582b6f7ce8a32f751aab3117d3824ac8f709" }
+source = { git = "https://github.com/NousResearch/atropos.git?rev=c20c85256e5a45ad31edf8b7276e9c5ee1995a30#c20c85256e5a45ad31edf8b7276e9c5ee1995a30" }
 dependencies = [
     { name = "aiofiles" },
     { name = "aiohttp" },
@@ -556,6 +556,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.42.91"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/c0/98b8cec7ca22dde776df48c58940ae1abc425593959b7226e270760d726f/boto3-1.42.91.tar.gz", hash = "sha256:03d70532b17f7f84df37ca7e8c21553280454dea53ae12b15d1cfef9b16fcb8a", size = 113181, upload-time = "2026-04-17T19:31:06.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/29/faba6521257c34085cc9b439ef98235b581772580f417fa3629728007270/boto3-1.42.91-py3-none-any.whl", hash = "sha256:04e72071cde022951ce7f81bd9933c90095ab8923e8ced61c8dacfe9edac0f5c", size = 140553, upload-time = "2026-04-17T19:31:02.57Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.42.91"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/bc/a4b7c46471c2e789ad8c4c7acfd7f302fdb481d93ff870f441249b924ae6/botocore-1.42.91.tar.gz", hash = "sha256:d252e27bc454afdbf5ed3dc617aa423f2c855c081e98b7963093399483ecc698", size = 15213010, upload-time = "2026-04-17T19:30:50.793Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/fc/24cc0a47c824f13933e210e9ad034b4fba22f7185b8d904c0fbf5a3b2be8/botocore-1.42.91-py3-none-any.whl", hash = "sha256:7a28c3cc6bfab5724ad18899d52402b776a0de7d87fa20c3c5270bcaaf199ce8", size = 14897344, upload-time = "2026-04-17T19:30:44.245Z" },
 ]
 
 [[package]]
@@ -1838,7 +1866,7 @@ wheels = [
 
 [[package]]
 name = "hermes-agent"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
@@ -1852,6 +1880,7 @@ dependencies = [
     { name = "openai" },
     { name = "parallel-web" },
     { name = "prompt-toolkit" },
+    { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-dotenv" },
@@ -1871,6 +1900,7 @@ all = [
     { name = "aiosqlite", marker = "sys_platform == 'linux'" },
     { name = "alibabacloud-dingtalk" },
     { name = "asyncpg", marker = "sys_platform == 'linux'" },
+    { name = "boto3" },
     { name = "croniter" },
     { name = "daytona" },
     { name = "debugpy" },
@@ -1893,11 +1923,15 @@ all = [
     { name = "pytest-xdist" },
     { name = "python-telegram-bot", extra = ["webhooks"] },
     { name = "pywinpty", marker = "sys_platform == 'win32'" },
+    { name = "qrcode" },
     { name = "simple-term-menu" },
     { name = "slack-bolt" },
     { name = "slack-sdk" },
     { name = "sounddevice" },
     { name = "uvicorn", extra = ["standard"] },
+]
+bedrock = [
+    { name = "boto3" },
 ]
 cli = [
     { name = "simple-term-menu" },
@@ -1918,9 +1952,11 @@ dev = [
 dingtalk = [
     { name = "alibabacloud-dingtalk" },
     { name = "dingtalk-stream" },
+    { name = "qrcode" },
 ]
 feishu = [
     { name = "lark-oapi" },
+    { name = "qrcode" },
 ]
 homeassistant = [
     { name = "aiohttp" },
@@ -1941,6 +1977,7 @@ messaging = [
     { name = "aiohttp" },
     { name = "discord-py", extra = ["voice"] },
     { name = "python-telegram-bot", extra = ["webhooks"] },
+    { name = "qrcode" },
     { name = "slack-bolt" },
     { name = "slack-sdk" },
 ]
@@ -1974,6 +2011,7 @@ termux = [
     { name = "honcho-ai" },
     { name = "mcp" },
     { name = "ptyprocess", marker = "sys_platform != 'win32'" },
+    { name = "python-telegram-bot", extra = ["webhooks"] },
     { name = "pywinpty", marker = "sys_platform == 'win32'" },
     { name = "simple-term-menu" },
 ]
@@ -2003,7 +2041,8 @@ requires-dist = [
     { name = "alibabacloud-dingtalk", marker = "extra == 'dingtalk'", specifier = ">=2.0.0" },
     { name = "anthropic", specifier = ">=0.39.0,<1" },
     { name = "asyncpg", marker = "extra == 'matrix'", specifier = ">=0.29" },
-    { name = "atroposlib", marker = "extra == 'rl'", git = "https://github.com/NousResearch/atropos.git" },
+    { name = "atroposlib", marker = "extra == 'rl'", git = "https://github.com/NousResearch/atropos.git?rev=c20c85256e5a45ad31edf8b7276e9c5ee1995a30" },
+    { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.35.0,<2" },
     { name = "croniter", marker = "extra == 'cron'", specifier = ">=6.0.0,<7" },
     { name = "daytona", marker = "extra == 'daytona'", specifier = ">=0.148.0,<1" },
     { name = "debugpy", marker = "extra == 'dev'", specifier = ">=1.8.0,<2" },
@@ -2020,6 +2059,7 @@ requires-dist = [
     { name = "firecrawl-py", specifier = ">=4.16.0,<5" },
     { name = "hermes-agent", extras = ["acp"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["acp"], marker = "extra == 'termux'" },
+    { name = "hermes-agent", extras = ["bedrock"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["cli"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["cli"], marker = "extra == 'termux'" },
     { name = "hermes-agent", extras = ["cron"], marker = "extra == 'all'" },
@@ -2058,6 +2098,7 @@ requires-dist = [
     { name = "openai", specifier = ">=2.21.0,<3" },
     { name = "parallel-web", specifier = ">=0.4.2,<1" },
     { name = "prompt-toolkit", specifier = ">=3.0.52,<4" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.2,<4" },
     { name = "ptyprocess", marker = "sys_platform != 'win32' and extra == 'pty'", specifier = ">=0.7.0,<1" },
     { name = "pydantic", specifier = ">=2.12.5,<3" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.12.0,<3" },
@@ -2066,8 +2107,12 @@ requires-dist = [
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.0,<4" },
     { name = "python-dotenv", specifier = ">=1.2.1,<2" },
     { name = "python-telegram-bot", extras = ["webhooks"], marker = "extra == 'messaging'", specifier = ">=22.6,<23" },
+    { name = "python-telegram-bot", extras = ["webhooks"], marker = "extra == 'termux'", specifier = ">=22.6,<23" },
     { name = "pywinpty", marker = "sys_platform == 'win32' and extra == 'pty'", specifier = ">=2.0.0,<3" },
     { name = "pyyaml", specifier = ">=6.0.2,<7" },
+    { name = "qrcode", marker = "extra == 'dingtalk'", specifier = ">=7.0,<8" },
+    { name = "qrcode", marker = "extra == 'feishu'", specifier = ">=7.0,<8" },
+    { name = "qrcode", marker = "extra == 'messaging'", specifier = ">=7.0,<8" },
     { name = "requests", specifier = ">=2.33.0,<3" },
     { name = "rich", specifier = ">=14.3.3,<15" },
     { name = "simple-term-menu", marker = "extra == 'cli'", specifier = ">=1.0,<2" },
@@ -2077,13 +2122,13 @@ requires-dist = [
     { name = "slack-sdk", marker = "extra == 'slack'", specifier = ">=3.27.0,<4" },
     { name = "sounddevice", marker = "extra == 'voice'", specifier = ">=0.4.6,<1" },
     { name = "tenacity", specifier = ">=9.1.4,<10" },
-    { name = "tinker", marker = "extra == 'rl'", git = "https://github.com/thinking-machines-lab/tinker.git" },
+    { name = "tinker", marker = "extra == 'rl'", git = "https://github.com/thinking-machines-lab/tinker.git?rev=30517b667f18a3dfb7ef33fb56cf686d5820ba2b" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'rl'", specifier = ">=0.24.0,<1" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'web'", specifier = ">=0.24.0,<1" },
     { name = "wandb", marker = "extra == 'rl'", specifier = ">=0.15.0,<1" },
-    { name = "yc-bench", marker = "python_full_version >= '3.12' and extra == 'yc-bench'", git = "https://github.com/collinear-ai/yc-bench.git" },
+    { name = "yc-bench", marker = "python_full_version >= '3.12' and extra == 'yc-bench'", git = "https://github.com/collinear-ai/yc-bench.git?rev=bfb0c88062450f46341bd9a5298903fc2e952a5c" },
 ]
-provides-extras = ["modal", "daytona", "dev", "messaging", "cron", "slack", "matrix", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "acp", "mistral", "termux", "dingtalk", "feishu", "web", "rl", "yc-bench", "all"]
+provides-extras = ["modal", "daytona", "dev", "messaging", "cron", "slack", "matrix", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "acp", "mistral", "bedrock", "termux", "dingtalk", "feishu", "web", "rl", "yc-bench", "all"]
 
 [[package]]
 name = "hf-transfer"
@@ -2408,6 +2453,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/73/a009f41c5eed71c49bec53036c4b33555afcdee70682a18c6f66e396c039/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:ff732bd0a0e778f43d5009840f20b935e79087b4dc65bd36f1cd0f9b04b8ff7f", size = 303808, upload-time = "2026-02-02T12:37:52.092Z" },
     { url = "https://files.pythonhosted.org/packages/c4/10/528b439290763bff3d939268085d03382471b442f212dca4ff5f12802d43/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab44b178f7981fcaea7e0a5df20e773c663d06ffda0198f1a524e91b2fde7e59", size = 337384, upload-time = "2026-02-02T12:37:53.582Z" },
     { url = "https://files.pythonhosted.org/packages/67/8a/a342b2f0251f3dac4ca17618265d93bf244a2a4d089126e81e4c1056ac50/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bb00b6d26db67a05fe3e12c76edc75f32077fb51deed13822dc648fa373bc19", size = 343768, upload-time = "2026-02-02T12:37:55.055Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -3809,6 +3863,75 @@ wheels = [
 ]
 
 [[package]]
+name = "psycopg"
+version = "3.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/b6/379d0a960f8f435ec78720462fd94c4863e7a31237cf81bf76d0af5883bf/psycopg-3.3.3.tar.gz", hash = "sha256:5e9a47458b3c1583326513b2556a2a9473a1001a56c9efe9e587245b43148dd9", size = 165624, upload-time = "2026-02-18T16:52:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/5b/181e2e3becb7672b502f0ed7f16ed7352aca7c109cfb94cf3878a9186db9/psycopg-3.3.3-py3-none-any.whl", hash = "sha256:f96525a72bcfade6584ab17e89de415ff360748c766f0106959144dcbb38c698", size = 212768, upload-time = "2026-02-18T16:46:27.365Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/c0/b389119dd754483d316805260f3e73cdcad97925839107cc7a296f6132b1/psycopg_binary-3.3.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a89bb9ee11177b2995d87186b1d9fa892d8ea725e85eab28c6525e4cc14ee048", size = 4609740, upload-time = "2026-02-18T16:47:51.093Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e3/9976eef20f61840285174d360da4c820a311ab39d6b82fa09fbb545be825/psycopg_binary-3.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9f7d0cf072c6fbac3795b08c98ef9ea013f11db609659dcfc6b1f6cc31f9e181", size = 4676837, upload-time = "2026-02-18T16:47:55.523Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/f2/d28ba2f7404fd7f68d41e8a11df86313bd646258244cb12a8dd83b868a97/psycopg_binary-3.3.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:90eecd93073922f085967f3ed3a98ba8c325cbbc8c1a204e300282abd2369e13", size = 5497070, upload-time = "2026-02-18T16:47:59.929Z" },
+    { url = "https://files.pythonhosted.org/packages/de/2f/6c5c54b815edeb30a281cfcea96dc93b3bb6be939aea022f00cab7aa1420/psycopg_binary-3.3.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:dac7ee2f88b4d7bb12837989ca354c38d400eeb21bce3b73dac02622f0a3c8d6", size = 5172410, upload-time = "2026-02-18T16:48:05.665Z" },
+    { url = "https://files.pythonhosted.org/packages/51/75/8206c7008b57de03c1ada46bd3110cc3743f3fd9ed52031c4601401d766d/psycopg_binary-3.3.3-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b62cf8784eb6d35beaee1056d54caf94ec6ecf2b7552395e305518ab61eb8fd2", size = 6763408, upload-time = "2026-02-18T16:48:13.541Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/5a/ea1641a1e6c8c8b3454b0fcb43c3045133a8b703e6e824fae134088e63bd/psycopg_binary-3.3.3-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a39f34c9b18e8f6794cca17bfbcd64572ca2482318db644268049f8c738f35a6", size = 5006255, upload-time = "2026-02-18T16:48:22.176Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/fb/538df099bf55ae1637d52d7ccb6b9620b535a40f4c733897ac2b7bb9e14c/psycopg_binary-3.3.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:883d68d48ca9ff3cb3d10c5fdebea02c79b48eecacdddbf7cce6e7cdbdc216b8", size = 4532694, upload-time = "2026-02-18T16:48:27.338Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/d1/00780c0e187ea3c13dfc53bd7060654b2232cd30df562aac91a5f1c545ac/psycopg_binary-3.3.3-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:cab7bc3d288d37a80aa8c0820033250c95e40b1c2b5c57cf59827b19c2a8b69d", size = 4222833, upload-time = "2026-02-18T16:48:31.221Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/34/a07f1ff713c51d64dc9f19f2c32be80299a2055d5d109d5853662b922cb4/psycopg_binary-3.3.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:56c767007ca959ca32f796b42379fc7e1ae2ed085d29f20b05b3fc394f3715cc", size = 3952818, upload-time = "2026-02-18T16:48:35.869Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/67/d33f268a7759b4445f3c9b5a181039b01af8c8263c865c1be7a6444d4749/psycopg_binary-3.3.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:da2f331a01af232259a21573a01338530c6016dcfad74626c01330535bcd8628", size = 4258061, upload-time = "2026-02-18T16:48:41.365Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/3b/0d8d2c5e8e29ccc07d28c8af38445d9d9abcd238d590186cac82ee71fc84/psycopg_binary-3.3.3-cp311-cp311-win_amd64.whl", hash = "sha256:19f93235ece6dbfc4036b5e4f6d8b13f0b8f2b3eeb8b0bd2936d406991bcdd40", size = 3558915, upload-time = "2026-02-18T16:48:46.679Z" },
+    { url = "https://files.pythonhosted.org/packages/90/15/021be5c0cbc5b7c1ab46e91cc3434eb42569f79a0592e67b8d25e66d844d/psycopg_binary-3.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6698dbab5bcef8fdb570fc9d35fd9ac52041771bfcfe6fd0fc5f5c4e36f1e99d", size = 4591170, upload-time = "2026-02-18T16:48:55.594Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/54/a60211c346c9a2f8c6b272b5f2bbe21f6e11800ce7f61e99ba75cf8b63e1/psycopg_binary-3.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:329ff393441e75f10b673ae99ab45276887993d49e65f141da20d915c05aafd8", size = 4670009, upload-time = "2026-02-18T16:49:03.608Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/53/ac7c18671347c553362aadbf65f92786eef9540676ca24114cc02f5be405/psycopg_binary-3.3.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:eb072949b8ebf4082ae24289a2b0fd724da9adc8f22743409d6fd718ddb379df", size = 5469735, upload-time = "2026-02-18T16:49:10.128Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c3/4f4e040902b82a344eff1c736cde2f2720f127fe939c7e7565706f96dd44/psycopg_binary-3.3.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:263a24f39f26e19ed7fc982d7859a36f17841b05bebad3eb47bb9cd2dd785351", size = 5152919, upload-time = "2026-02-18T16:49:16.335Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e7/d929679c6a5c212bcf738806c7c89f5b3d0919f2e1685a0e08d6ff877945/psycopg_binary-3.3.3-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5152d50798c2fa5bd9b68ec68eb68a1b71b95126c1d70adaa1a08cd5eefdc23d", size = 6738785, upload-time = "2026-02-18T16:49:22.687Z" },
+    { url = "https://files.pythonhosted.org/packages/69/b0/09703aeb69a9443d232d7b5318d58742e8ca51ff79f90ffe6b88f1db45e7/psycopg_binary-3.3.3-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9d6a1e56dd267848edb824dbeb08cf5bac649e02ee0b03ba883ba3f4f0bd54f2", size = 4979008, upload-time = "2026-02-18T16:49:27.313Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/a6/e662558b793c6e13a7473b970fee327d635270e41eded3090ef14045a6a5/psycopg_binary-3.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73eaaf4bb04709f545606c1db2f65f4000e8a04cdbf3e00d165a23004692093e", size = 4508255, upload-time = "2026-02-18T16:49:31.575Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/7f/0f8b2e1d5e0093921b6f324a948a5c740c1447fbb45e97acaf50241d0f39/psycopg_binary-3.3.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:162e5675efb4704192411eaf8e00d07f7960b679cd3306e7efb120bb8d9456cc", size = 4189166, upload-time = "2026-02-18T16:49:35.801Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ec/ce2e91c33bc8d10b00c87e2f6b0fb570641a6a60042d6a9ae35658a3a797/psycopg_binary-3.3.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:fab6b5e37715885c69f5d091f6ff229be71e235f272ebaa35158d5a46fd548a0", size = 3924544, upload-time = "2026-02-18T16:49:41.129Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/2f/7718141485f73a924205af60041c392938852aa447a94c8cbd222ff389a1/psycopg_binary-3.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a4aab31bd6d1057f287c96c0effca3a25584eb9cc702f282ecb96ded7814e830", size = 4235297, upload-time = "2026-02-18T16:49:46.726Z" },
+    { url = "https://files.pythonhosted.org/packages/57/f9/1add717e2643a003bbde31b1b220172e64fbc0cb09f06429820c9173f7fc/psycopg_binary-3.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:59aa31fe11a0e1d1bcc2ce37ed35fe2ac84cd65bb9036d049b1a1c39064d0f14", size = 3547659, upload-time = "2026-02-18T16:49:52.999Z" },
+    { url = "https://files.pythonhosted.org/packages/03/0a/cac9fdf1df16a269ba0e5f0f06cac61f826c94cadb39df028cdfe19d3a33/psycopg_binary-3.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:05f32239aec25c5fb15f7948cffdc2dc0dac098e48b80a140e4ba32b572a2e7d", size = 4590414, upload-time = "2026-02-18T16:50:01.441Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/c0/d8f8508fbf440edbc0099b1abff33003cd80c9e66eb3a1e78834e3fb4fb9/psycopg_binary-3.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7c84f9d214f2d1de2fafebc17fa68ac3f6561a59e291553dfc45ad299f4898c1", size = 4669021, upload-time = "2026-02-18T16:50:08.803Z" },
+    { url = "https://files.pythonhosted.org/packages/04/05/097016b77e343b4568feddf12c72171fc513acef9a4214d21b9478569068/psycopg_binary-3.3.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e77957d2ba17cada11be09a5066d93026cdb61ada7c8893101d7fe1c6e1f3925", size = 5467453, upload-time = "2026-02-18T16:50:14.985Z" },
+    { url = "https://files.pythonhosted.org/packages/91/23/73244e5feb55b5ca109cede6e97f32ef45189f0fdac4c80d75c99862729d/psycopg_binary-3.3.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:42961609ac07c232a427da7c87a468d3c82fee6762c220f38e37cfdacb2b178d", size = 5151135, upload-time = "2026-02-18T16:50:24.82Z" },
+    { url = "https://files.pythonhosted.org/packages/11/49/5309473b9803b207682095201d8708bbc7842ddf3f192488a69204e36455/psycopg_binary-3.3.3-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ae07a3114313dd91fce686cab2f4c44af094398519af0e0f854bc707e1aeedf1", size = 6737315, upload-time = "2026-02-18T16:50:35.106Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/5d/03abe74ef34d460b33c4d9662bf6ec1dd38888324323c1a1752133c10377/psycopg_binary-3.3.3-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d257c58d7b36a621dcce1d01476ad8b60f12d80eb1406aee4cf796f88b2ae482", size = 4979783, upload-time = "2026-02-18T16:50:42.067Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/6c/3fbf8e604e15f2f3752900434046c00c90bb8764305a1b81112bff30ba24/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:07c7211f9327d522c9c47560cae00a4ecf6687f4e02d779d035dd3177b41cb12", size = 4509023, upload-time = "2026-02-18T16:50:50.116Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6b/1a06b43b7c7af756c80b67eac8bfaa51d77e68635a8a8d246e4f0bb7604a/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:8e7e9eca9b363dbedeceeadd8be97149d2499081f3c52d141d7cd1f395a91f83", size = 4185874, upload-time = "2026-02-18T16:50:55.97Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/d3/bf49e3dcaadba510170c8d111e5e69e5ae3f981c1554c5bb71c75ce354bb/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:cb85b1d5702877c16f28d7b92ba030c1f49ebcc9b87d03d8c10bf45a2f1c7508", size = 3925668, upload-time = "2026-02-18T16:51:03.299Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/92/0aac830ed6a944fe334404e1687a074e4215630725753f0e3e9a9a595b62/psycopg_binary-3.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4d4606c84d04b80f9138d72f1e28c6c02dc5ae0c7b8f3f8aaf89c681ce1cd1b1", size = 4234973, upload-time = "2026-02-18T16:51:09.097Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/96/102244653ee5a143ece5afe33f00f52fe64e389dfce8dbc87580c6d70d3d/psycopg_binary-3.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:74eae563166ebf74e8d950ff359be037b85723d99ca83f57d9b244a871d6c13b", size = 3551342, upload-time = "2026-02-18T16:51:13.892Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/71/7a57e5b12275fe7e7d84d54113f0226080423a869118419c9106c083a21c/psycopg_binary-3.3.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:497852c5eaf1f0c2d88ab74a64a8097c099deac0c71de1cbcf18659a8a04a4b2", size = 4607368, upload-time = "2026-02-18T16:51:19.295Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/04/cb834f120f2b2c10d4003515ef9ca9d688115b9431735e3936ae48549af8/psycopg_binary-3.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:258d1ea53464d29768bf25930f43291949f4c7becc706f6e220c515a63a24edd", size = 4687047, upload-time = "2026-02-18T16:51:23.84Z" },
+    { url = "https://files.pythonhosted.org/packages/40/e9/47a69692d3da9704468041aa5ed3ad6fc7f6bb1a5ae788d261a26bbca6c7/psycopg_binary-3.3.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:111c59897a452196116db12e7f608da472fbff000693a21040e35fc978b23430", size = 5487096, upload-time = "2026-02-18T16:51:29.645Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b6/0e0dd6a2f802864a4ae3dbadf4ec620f05e3904c7842b326aafc43e5f464/psycopg_binary-3.3.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:17bb6600e2455993946385249a3c3d0af52cd70c1c1cdbf712e9d696d0b0bf1b", size = 5168720, upload-time = "2026-02-18T16:51:36.499Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/0d/977af38ac19a6b55d22dff508bd743fd7c1901e1b73657e7937c7cccb0a3/psycopg_binary-3.3.3-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:642050398583d61c9856210568eb09a8e4f2fe8224bf3be21b67a370e677eead", size = 6762076, upload-time = "2026-02-18T16:51:43.167Z" },
+    { url = "https://files.pythonhosted.org/packages/34/40/912a39d48322cf86895c0eaf2d5b95cb899402443faefd4b09abbba6b6e1/psycopg_binary-3.3.3-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:533efe6dc3a7cba5e2a84e38970786bb966306863e45f3db152007e9f48638a6", size = 4997623, upload-time = "2026-02-18T16:51:47.707Z" },
+    { url = "https://files.pythonhosted.org/packages/98/0c/c14d0e259c65dc7be854d926993f151077887391d5a081118907a9d89603/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:5958dbf28b77ce2033482f6cb9ef04d43f5d8f4b7636e6963d5626f000efb23e", size = 4532096, upload-time = "2026-02-18T16:51:51.421Z" },
+    { url = "https://files.pythonhosted.org/packages/39/21/8b7c50a194cfca6ea0fd4d1f276158307785775426e90700ab2eba5cd623/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:a6af77b6626ce92b5817bf294b4d45ec1a6161dba80fc2d82cdffdd6814fd023", size = 4208884, upload-time = "2026-02-18T16:51:57.336Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/2c/a4981bf42cf30ebba0424971d7ce70a222ae9b82594c42fc3f2105d7b525/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:47f06fcbe8542b4d96d7392c476a74ada521c5aebdb41c3c0155f6595fc14c8d", size = 3944542, upload-time = "2026-02-18T16:52:04.266Z" },
+    { url = "https://files.pythonhosted.org/packages/60/e9/b7c29b56aa0b85a4e0c4d89db691c1ceef08f46a356369144430c155a2f5/psycopg_binary-3.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e7800e6c6b5dc4b0ca7cc7370f770f53ac83886b76afda0848065a674231e856", size = 4254339, upload-time = "2026-02-18T16:52:10.444Z" },
+    { url = "https://files.pythonhosted.org/packages/98/5a/291d89f44d3820fffb7a04ebc8f3ef5dda4f542f44a5daea0c55a84abf45/psycopg_binary-3.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:165f22ab5a9513a3d7425ffb7fcc7955ed8ccaeef6d37e369d6cc1dff1582383", size = 3652796, upload-time = "2026-02-18T16:52:14.02Z" },
+]
+
+[[package]]
 name = "ptyprocess"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4110,6 +4233,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pypng"
+version = "0.20220715.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/cd/112f092ec27cca83e0516de0a3368dbd9128c187fb6b52aaaa7cde39c96d/pypng-0.20220715.0.tar.gz", hash = "sha256:739c433ba96f078315de54c0db975aee537cbc3e1d0ae4ed9aab0ca1e427e2c1", size = 128992, upload-time = "2022-07-15T14:11:05.301Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/b9/3766cc361d93edb2ce81e2e1f87dd98f314d7d513877a342d31b30741680/pypng-0.20220715.0-py3-none-any.whl", hash = "sha256:4a43e969b8f5aaafb2a415536c1a8ec7e341cd6a3f957fd5b5f32a4cfeed902c", size = 58057, upload-time = "2022-07-15T14:11:03.713Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -4309,6 +4441,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "qrcode"
+version = "7.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "pypng" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/35/ad6d4c5a547fe9a5baf85a9edbafff93fc6394b014fab30595877305fa59/qrcode-7.4.2.tar.gz", hash = "sha256:9dd969454827e127dbd93696b20747239e6d540e082937c90f14ac95b30f5845", size = 535974, upload-time = "2023-02-05T22:11:46.548Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/79/aaf0c1c7214f2632badb2771d770b1500d3d7cbdf2590ae62e721ec50584/qrcode-7.4.2-py3-none-any.whl", hash = "sha256:581dca7a029bcb2deef5d01068e39093e80ef00b4a61098a2182eac59d01643a", size = 46197, upload-time = "2023-02-05T22:11:43.4Z" },
 ]
 
 [[package]]
@@ -4575,6 +4721,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981, upload-time = "2025-11-30T20:24:32.934Z" },
     { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782, upload-time = "2025-11-30T20:24:35.169Z" },
     { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191, upload-time = "2025-11-30T20:24:36.853Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/04/74127fc843314818edfa81b5540e26dd537353b123a4edc563109d8f17dd/s3transfer-0.16.0.tar.gz", hash = "sha256:8e990f13268025792229cd52fa10cb7163744bf56e719e0b9cb925ab79abf920", size = 153827, upload-time = "2025-12-01T02:30:59.114Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/51/727abb13f44c1fcf6d145979e1535a35794db0f6e450a0cb46aa24732fe2/s3transfer-0.16.0-py3-none-any.whl", hash = "sha256:18e25d66fed509e3868dc1572b3f427ff947dd2c56f844a5bf09481ad3f3b2fe", size = 86830, upload-time = "2025-12-01T02:30:57.729Z" },
 ]
 
 [[package]]
@@ -4927,8 +5085,8 @@ wheels = [
 
 [[package]]
 name = "tinker"
-version = "0.16.1"
-source = { git = "https://github.com/thinking-machines-lab/tinker.git#07bd3c2dd3cd4398ac1c26f0ec0deccbf3c1f913" }
+version = "0.18.0"
+source = { git = "https://github.com/thinking-machines-lab/tinker.git?rev=30517b667f18a3dfb7ef33fb56cf686d5820ba2b#30517b667f18a3dfb7ef33fb56cf686d5820ba2b" }
 dependencies = [
     { name = "anyio" },
     { name = "click" },
@@ -5653,7 +5811,7 @@ wheels = [
 [[package]]
 name = "yc-bench"
 version = "0.1.0"
-source = { git = "https://github.com/collinear-ai/yc-bench.git#0c53c98f01a431db2e391482bc46013045854ab2" }
+source = { git = "https://github.com/collinear-ai/yc-bench.git?rev=bfb0c88062450f46341bd9a5298903fc2e952a5c#bfb0c88062450f46341bd9a5298903fc2e952a5c" }
 dependencies = [
     { name = "litellm", marker = "python_full_version >= '3.12'" },
     { name = "matplotlib", marker = "python_full_version >= '3.12'" },


### PR DESCRIPTION
## Summary\n- make Discord thread origin-context propagation default to the last 100 messages\n- keep explicit overrides intact, including setting the limit to 0 to disable it\n- add a regression test for the default history limit\n\n## Verification\n- pytest tests/gateway/test_discord_slash_commands.py -q\n- independent review: passed (no security or logic issues found)\n\n## Context\nThe propagation code path already existed, but the default history limit was 0, which silently disabled it unless deployments opted in via config or env. This change makes the feature work out of the box while preserving explicit disable/override behavior.