### PR TITLE
fix(ssh): pass through skill env vars to remote shells

### DIFF
--- a/tests/tools/test_ssh_environment.py
+++ b/tests/tools/test_ssh_environment.py
@@ -9,6 +9,7 @@ import pytest
 
 from tools.environments.ssh import SSHEnvironment
 from tools.environments import ssh as ssh_env
+from tools.env_passthrough import clear_env_passthrough, register_env_passthrough
 
 _SSH_HOST = os.getenv("TERMINAL_SSH_HOST", "")
 _SSH_USER = os.getenv("TERMINAL_SSH_USER", "")
@@ -65,6 +66,36 @@ class TestBuildSSHCommand:
     def test_user_host_suffix(self):
         env = SSHEnvironment(host="h", user="u")
         assert env._build_ssh_command()[-1] == "u@h"
+
+    def test_passthrough_env_vars_are_exported_from_process_env(self, monkeypatch):
+        clear_env_passthrough()
+        register_env_passthrough(["TENOR_API_KEY"])
+        monkeypatch.setenv("TENOR_API_KEY", "tenor-secret")
+
+        env = SSHEnvironment(host="h", user="u")
+
+        exports = env._build_passthrough_exports()
+
+        assert "export TENOR_API_KEY=" in exports
+        assert "tenor-secret" in exports
+        clear_env_passthrough()
+
+    def test_passthrough_env_vars_fall_back_to_hermes_env_file(self, monkeypatch):
+        clear_env_passthrough()
+        register_env_passthrough(["TENOR_API_KEY"])
+        monkeypatch.delenv("TENOR_API_KEY", raising=False)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_env",
+            lambda: {"TENOR_API_KEY": "persisted-secret"},
+        )
+
+        env = SSHEnvironment(host="h", user="u")
+
+        exports = env._build_passthrough_exports()
+
+        assert "export TENOR_API_KEY=" in exports
+        assert "persisted-secret" in exports
+        clear_env_passthrough()
 
 
 class TestControlSocketPath:

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -3,6 +3,7 @@
 import hashlib
 import logging
 import os
+import re
 import shlex
 import shutil
 import subprocess
@@ -10,6 +11,7 @@ import tempfile
 from pathlib import Path
 
 from tools.environments.base import BaseEnvironment, _popen_bash
+from tools.environments.local import _HERMES_PROVIDER_ENV_BLOCKLIST
 from tools.environments.file_sync import (
     FileSyncManager,
     iter_sync_files,
@@ -19,6 +21,7 @@ from tools.environments.file_sync import (
 )
 
 logger = logging.getLogger(__name__)
+_ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 def _ensure_ssh_available() -> None:
@@ -92,6 +95,39 @@ class SSHEnvironment(BaseEnvironment):
             cmd.extend(extra_args)
         cmd.append(f"{self.user}@{self.host}")
         return cmd
+
+    def _build_passthrough_exports(self) -> str:
+        """Build export statements for skill/config allowlisted env vars."""
+        try:
+            from tools.env_passthrough import get_all_passthrough
+            passthrough_keys = set(get_all_passthrough())
+        except Exception:
+            passthrough_keys = set()
+
+        if not passthrough_keys:
+            return ""
+
+        try:
+            from hermes_cli.config import load_env
+            hermes_env = load_env() or {}
+        except Exception:
+            hermes_env = {}
+
+        exports: list[str] = []
+        for key in sorted(passthrough_keys - _HERMES_PROVIDER_ENV_BLOCKLIST):
+            if not isinstance(key, str):
+                continue
+            key = key.strip()
+            if not _ENV_VAR_NAME_RE.match(key):
+                continue
+            value = os.getenv(key)
+            if value is None:
+                value = hermes_env.get(key)
+            if value is None:
+                continue
+            exports.append(f"export {key}={shlex.quote(value)}")
+
+        return "\n".join(exports)
 
     def _establish_connection(self):
         cmd = self._build_ssh_command()
@@ -262,6 +298,9 @@ class SSHEnvironment(BaseEnvironment):
                   stdin_data: str | None = None) -> subprocess.Popen:
         """Spawn an SSH process that runs bash on the remote host."""
         cmd = self._build_ssh_command()
+        passthrough_exports = self._build_passthrough_exports()
+        if passthrough_exports:
+            cmd_string = f"{passthrough_exports}\n{cmd_string}"
         if login:
             cmd.extend(["bash", "-l", "-c", shlex.quote(cmd_string)])
         else:


### PR DESCRIPTION
## Summary
- inject allowlisted env passthrough variables into SSH-backed shell sessions before the remote bash command runs
- load passthrough values from the live process env first, then fall back to ~/.hermes/.env for persisted skill secrets
- keep Hermes-managed provider credentials blocked so SSH passthrough matches the existing sandbox safety rules

## Testing
- pytest -o addopts= tests/tools/test_ssh_environment.py -k "passthrough_env_vars or test_base_flags or test_user_host_suffix"
- pytest -o addopts= tests/tools/test_ssh_environment.py

Closes #14091
