### PR TITLE
fix(tools): dedupe plugin-configurable toolsets

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -82,10 +82,16 @@ def _get_effective_configurable_toolsets():
     built-in toolsets in the TUI checklist.
     """
     result = list(CONFIGURABLE_TOOLSETS)
+    seen = {ts_key for ts_key, _, _ in result}
     try:
         from hermes_cli.plugins import discover_plugins, get_plugin_toolsets
         discover_plugins()  # idempotent — ensures plugins are loaded
-        result.extend(get_plugin_toolsets())
+        for toolset in get_plugin_toolsets():
+            ts_key = toolset[0]
+            if ts_key in seen:
+                continue
+            result.append(toolset)
+            seen.add(ts_key)
     except Exception:
         pass
     return result

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -6,6 +6,7 @@ from hermes_cli.tools_config import (
     _DEFAULT_OFF_TOOLSETS,
     _apply_toolset_change,
     _configure_provider,
+    _get_effective_configurable_toolsets,
     _get_platform_tools,
     _platform_toolset_summary,
     _save_platform_tools,
@@ -28,6 +29,34 @@ def test_get_platform_tools_uses_default_when_platform_not_configured():
 
 def test_configurable_toolsets_include_messaging():
     assert any(ts_key == "messaging" for ts_key, _, _ in CONFIGURABLE_TOOLSETS)
+
+
+def test_effective_configurable_toolsets_dedupes_plugin_rows_for_builtin_keys():
+    with patch("hermes_cli.plugins.discover_plugins"), patch(
+        "hermes_cli.plugins.get_plugin_toolsets",
+        return_value=[
+            ("web", "🔌 Web", "plugin extends built-in web"),
+            ("browser", "🔌 Browser", "plugin extends built-in browser"),
+        ],
+    ):
+        effective = _get_effective_configurable_toolsets()
+
+    keys = [ts_key for ts_key, _, _ in effective]
+    assert keys.count("web") == 1
+    assert keys.count("browser") == 1
+
+
+def test_effective_configurable_toolsets_keeps_plugin_only_rows():
+    with patch("hermes_cli.plugins.discover_plugins"), patch(
+        "hermes_cli.plugins.get_plugin_toolsets",
+        return_value=[
+            ("web_search_plus", "🔌 Web Search Plus", "plugin-only toolset"),
+        ],
+    ):
+        effective = _get_effective_configurable_toolsets()
+
+    assert ("web_search_plus", "🔌 Web Search Plus", "plugin-only toolset") in effective
+
 
 def test_get_platform_tools_default_telegram_includes_messaging():
     enabled = _get_platform_tools({}, "telegram")


### PR DESCRIPTION
## Summary
- keep built-in configurable toolsets authoritative when plugins register tools onto an existing toolset key
- dedupe plugin-discovered toolset rows by key so `hermes tools` only shows one logical row per toolset
- add regressions covering both built-in-key dedupe and plugin-only toolset preservation

## Testing
- pytest -o addopts='' tests/hermes_cli/test_tools_config.py
- pytest -o addopts='' tests/hermes_cli/test_web_server.py -k toolsets_list

Closes #13640