### PR TITLE
fix(honcho): bound gateway session ids

### DIFF
--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 import json
 import os
 import logging
+import hashlib
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -29,6 +31,7 @@ logger = logging.getLogger(__name__)
 
 GLOBAL_CONFIG_PATH = Path.home() / ".honcho" / "config.json"
 HOST = "hermes"
+HONCHO_SESSION_ID_MAX_LENGTH = 100
 
 
 def resolve_active_host() -> str:
@@ -73,6 +76,23 @@ def resolve_config_path() -> Path:
         return default_path
 
     return GLOBAL_CONFIG_PATH
+
+
+def _sanitize_honcho_session_id(value: str, *, max_length: int = HONCHO_SESSION_ID_MAX_LENGTH) -> str:
+    """Return a Honcho-safe session id, truncating long values deterministically."""
+    sanitized = re.sub(r'[^a-zA-Z0-9_-]+', '-', value).strip('-')
+    if len(sanitized) <= max_length:
+        return sanitized
+
+    digest = hashlib.sha256(sanitized.encode("utf-8")).hexdigest()[:12]
+    prefix_len = max_length - len(digest) - 1
+    if prefix_len <= 0:
+        return digest[:max_length]
+
+    prefix = sanitized[:prefix_len].rstrip("-")
+    if not prefix:
+        return digest[:max_length]
+    return f"{prefix}-{digest}"
 
 
 _RECALL_MODE_ALIASES = {"auto": "hybrid"}
@@ -540,8 +560,6 @@ class HonchoClientConfig:
           6. per-directory strategy — directory basename
           7. global strategy — workspace name
         """
-        import re
-
         if not cwd:
             cwd = os.getcwd()
 
@@ -564,7 +582,7 @@ class HonchoClientConfig:
         # based resolution because gateway platforms need per-chat isolation that
         # cwd-based strategies cannot provide.
         if gateway_session_key:
-            sanitized = re.sub(r'[^a-zA-Z0-9_-]+', '-', gateway_session_key).strip('-')
+            sanitized = _sanitize_honcho_session_id(gateway_session_key)
             if sanitized:
                 return sanitized
 

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -9,6 +9,7 @@ from unittest.mock import patch, MagicMock
 import pytest
 
 from plugins.memory.honcho.client import (
+    HONCHO_SESSION_ID_MAX_LENGTH,
     HonchoClientConfig,
     get_honcho_client,
     reset_honcho_client,
@@ -654,6 +655,23 @@ class TestResolveSessionNameGatewayKey:
         )
         assert result == "agent-main-telegram-dm-8439114563"
         assert ":" not in result
+
+    def test_gateway_key_truncates_to_honcho_limit_deterministically(self):
+        """Long gateway keys should stay stable while respecting Honcho's 100-char cap."""
+        config = HonchoClientConfig()
+        gateway_key = (
+            "agent:main:matrix:group:!"
+            + ("r" * 18)
+            + ":very-long-homeserver-name.example.ts.net:"
+            + ("e" * 43)
+        )
+
+        first = config.resolve_session_name(gateway_session_key=gateway_key)
+        second = config.resolve_session_name(gateway_session_key=gateway_key)
+
+        assert first == second
+        assert len(first) <= HONCHO_SESSION_ID_MAX_LENGTH
+        assert first.startswith("agent-main-matrix-group")
 
 
 class TestResetHonchoClient:


### PR DESCRIPTION
## Summary
- sanitize long `gateway_session_key` values through a deterministic Honcho session-id helper
- keep per-chat session IDs under Honcho's 100-character limit while preserving stable prefixes and uniqueness
- add a regression test covering long Matrix-style gateway keys

## Testing
- pytest -o addopts='' tests/honcho_plugin/test_client.py

Closes #13868