### PR TITLE
fix(gateway): add timeout to adapter.disconnect() during shutdown

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2629,14 +2629,25 @@ class GatewayRunner:
 
             self._finalize_shutdown_agents(active_agents)
 
+            # Disconnect adapters with per-adapter timeout to prevent hangs.
+            # A stuck adapter (e.g., Feishu WebSocket thread waiting for network
+            # I/O) should not block the entire shutdown sequence and prevent
+            # PID file cleanup, which would cause "PID file race lost" errors
+            # on restart after systemd SIGKILL's the process.
+            _adapter_disconnect_timeout = 15.0  # seconds per adapter
             for platform, adapter in list(self.adapters.items()):
                 try:
                     await adapter.cancel_background_tasks()
                 except Exception as e:
                     logger.debug("✗ %s background-task cancel error: %s", platform.value, e)
                 try:
-                    await adapter.disconnect()
+                    await asyncio.wait_for(adapter.disconnect(), timeout=_adapter_disconnect_timeout)
                     logger.info("✓ %s disconnected", platform.value)
+                except asyncio.TimeoutError:
+                    logger.warning(
+                        "✗ %s disconnect timed out after %.1fs - forcing continue",
+                        platform.value, _adapter_disconnect_timeout
+                    )
                 except Exception as e:
                     logger.error("✗ %s disconnect error: %s", platform.value, e)
 


### PR DESCRIPTION
## Problem

When restarting the Hermes gateway via , the gateway process sometimes hangs during shutdown and gets SIGKILL'd by systemd after `TimeoutStopSec` (default 60s). This leaves a stale PID file, causing the new gateway instance to fail with "PID file race lost to another gateway instance. Exiting."

## Root Cause

The shutdown sequence in `gateway/run.py` calls `await adapter.disconnect()` for each platform adapter without a timeout. If any adapter's `disconnect()` method blocks (e.g., Feishu adapter's WebSocket thread waiting for network response), the entire shutdown process hangs.

When systemd sends SIGKILL after timeout, Python's `atexit` handlers don't run, so the PID file is never cleaned up. The new instance sees the stale PID file and exits.

## Solution

Add a timeout wrapper (`asyncio.wait_for`) around `adapter.disconnect()` with a 15-second timeout per adapter. On timeout, log a warning and continue with the shutdown sequence instead of hanging indefinitely.

## Changes

- Wrap `adapter.disconnect()` in `asyncio.wait_for()` with 15s timeout
- Add `asyncio.TimeoutError` handler to log warning and continue
- Ensures PID file cleanup always runs even if adapter cleanup fails

## Testing

Manually tested by triggering gateway restart while Feishu WebSocket was active. The gateway now shuts down cleanly within the timeout and restarts successfully without "PID file race lost" errors.

Fixes #14128