### PR TITLE
feat(gateway): Add plugin gateway command extension points

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -2131,10 +2131,41 @@ class DiscordAdapter(BasePlatformAdapter):
         # This ensures new commands added to COMMAND_REGISTRY in
         # hermes_cli/commands.py automatically appear as Discord slash
         # commands without needing a manual entry here.
+        def _build_auto_slash_command(_name: str, _description: str, _args_hint: str = ""):
+            discord_name = _name.lower()[:32]
+            desc = (_description or f"Run /{_name}")[:100]
+            has_args = bool(_args_hint)
+
+            if has_args:
+                def _make_args_handler(__name: str, __hint: str):
+                    @discord.app_commands.describe(args=f"Arguments: {__hint}"[:100])
+                    async def _handler(interaction: discord.Interaction, args: str = ""):
+                        await self._run_simple_slash(
+                            interaction, f"/{__name} {args}".strip()
+                        )
+                    _handler.__name__ = f"auto_slash_{__name.replace('-', '_')}"
+                    return _handler
+
+                handler = _make_args_handler(_name, _args_hint)
+            else:
+                def _make_simple_handler(__name: str):
+                    async def _handler(interaction: discord.Interaction):
+                        await self._run_simple_slash(interaction, f"/{__name}")
+                    _handler.__name__ = f"auto_slash_{__name.replace('-', '_')}"
+                    return _handler
+
+                handler = _make_simple_handler(_name)
+
+            return discord.app_commands.Command(
+                name=discord_name,
+                description=desc,
+                callback=handler,
+            )
+
+        already_registered = set()
         try:
             from hermes_cli.commands import COMMAND_REGISTRY, _is_gateway_available, _resolve_config_gates
 
-            already_registered = set()
             try:
                 already_registered = {cmd.name for cmd in tree.get_commands()}
             except Exception:
@@ -2149,38 +2180,10 @@ class DiscordAdapter(BasePlatformAdapter):
                 discord_name = cmd_def.name.lower()[:32]
                 if discord_name in already_registered:
                     continue
-                # Skip aliases that overlap with already-registered names
-                # (aliases for explicitly registered commands are handled above).
-                desc = (cmd_def.description or f"Run /{cmd_def.name}")[:100]
-                has_args = bool(cmd_def.args_hint)
-
-                if has_args:
-                    # Command takes optional arguments — create handler with
-                    # an optional ``args`` string parameter.
-                    def _make_args_handler(_name: str, _hint: str):
-                        @discord.app_commands.describe(args=f"Arguments: {_hint}"[:100])
-                        async def _handler(interaction: discord.Interaction, args: str = ""):
-                            await self._run_simple_slash(
-                                interaction, f"/{_name} {args}".strip()
-                            )
-                        _handler.__name__ = f"auto_slash_{_name.replace('-', '_')}"
-                        return _handler
-
-                    handler = _make_args_handler(cmd_def.name, cmd_def.args_hint)
-                else:
-                    # Parameterless command.
-                    def _make_simple_handler(_name: str):
-                        async def _handler(interaction: discord.Interaction):
-                            await self._run_simple_slash(interaction, f"/{_name}")
-                        _handler.__name__ = f"auto_slash_{_name.replace('-', '_')}"
-                        return _handler
-
-                    handler = _make_simple_handler(cmd_def.name)
-
-                auto_cmd = discord.app_commands.Command(
-                    name=discord_name,
-                    description=desc,
-                    callback=handler,
+                auto_cmd = _build_auto_slash_command(
+                    cmd_def.name,
+                    cmd_def.description,
+                    cmd_def.args_hint,
                 )
                 try:
                     tree.add_command(auto_cmd)
@@ -2196,6 +2199,32 @@ class DiscordAdapter(BasePlatformAdapter):
             )
         except Exception as e:
             logger.warning("Discord auto-register from COMMAND_REGISTRY failed: %s", e)
+
+        # Plugin-registered gateway commands for Discord.
+        try:
+            from hermes_cli.plugins import get_plugin_gateway_commands
+
+            for command_name, cmd_meta in get_plugin_gateway_commands("discord").items():
+                discord_name = command_name.lower()[:32]
+                if discord_name in already_registered:
+                    continue
+
+                auto_cmd = _build_auto_slash_command(
+                    command_name,
+                    cmd_meta.get("description") or f"Run /{command_name}",
+                    cmd_meta.get("args_hint") or "",
+                )
+                try:
+                    tree.add_command(auto_cmd)
+                    already_registered.add(discord_name)
+                except Exception:
+                    # Silently skip commands that fail registration (e.g.
+                    # name conflict with a subcommand group).
+                    pass
+        except Exception as e:
+            logger.warning(
+                "Discord auto-register from plugin gateway commands failed: %s", e
+            )
 
         # Register skills under a single /skill command group with category
         # subcommand groups.  This uses 1 top-level slot instead of N,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3434,22 +3434,74 @@ class GatewayRunner:
 
         # Check for commands
         command = event.get_command()
-        
+
+        from hermes_cli.commands import GATEWAY_KNOWN_COMMANDS, resolve_command as _resolve_cmd
+        _cmd_def = _resolve_cmd(command) if command else None
+        canonical = _cmd_def.name if _cmd_def else command
+
+        # Let plugins intercept gateway slash commands before Hermes handles
+        # them. This supports policy/ACL plugins that need allow, deny,
+        # rewrite, or fully-handle behavior at the gateway boundary.
+        if command:
+            try:
+                from hermes_cli.plugins import invoke_hook as _invoke_hook
+
+                raw_args = event.get_command_args().strip()
+                hook_results = _invoke_hook(
+                    "pre_gateway_command",
+                    platform=source.platform.value if source.platform else "",
+                    command_name=command.replace("_", "-"),
+                    canonical_command=(
+                        canonical.replace("_", "-")
+                        if isinstance(canonical, str) and canonical
+                        else command.replace("_", "-")
+                    ),
+                    raw_command=command,
+                    raw_args=raw_args,
+                    event=event,
+                    source=source,
+                    runner=self,
+                )
+
+                for hook_result in hook_results:
+                    if not isinstance(hook_result, dict):
+                        continue
+                    decision = str(hook_result.get("decision", "")).strip().lower()
+                    if not decision or decision == "allow":
+                        continue
+                    if decision == "deny":
+                        message = hook_result.get("message")
+                        if isinstance(message, str) and message:
+                            return message
+                        return f"Command `/{command}` was blocked by a plugin."
+                    if decision == "handled":
+                        message = hook_result.get("message")
+                        return message if isinstance(message, str) and message else None
+                    if decision == "rewrite":
+                        new_command = str(
+                            hook_result.get("command_name", "")
+                        ).strip().lstrip("/")
+                        if not new_command:
+                            continue
+                        new_args = str(hook_result.get("raw_args", "")).strip()
+                        event.text = f"/{new_command} {new_args}".strip()
+                        command = event.get_command()
+                        _cmd_def = _resolve_cmd(command) if command else None
+                        canonical = _cmd_def.name if _cmd_def else command
+                        break
+            except Exception as e:
+                logger.debug("pre_gateway_command hook dispatch failed (non-fatal): %s", e)
+
         # Emit command:* hook for any recognized slash command.
         # GATEWAY_KNOWN_COMMANDS is derived from the central COMMAND_REGISTRY
         # in hermes_cli/commands.py — no hardcoded set to maintain here.
-        from hermes_cli.commands import GATEWAY_KNOWN_COMMANDS, resolve_command as _resolve_cmd
-        if command and command in GATEWAY_KNOWN_COMMANDS:
-            await self.hooks.emit(f"command:{command}", {
+        if canonical and canonical in GATEWAY_KNOWN_COMMANDS:
+            await self.hooks.emit(f"command:{canonical}", {
                 "platform": source.platform.value if source.platform else "",
                 "user_id": source.user_id,
-                "command": command,
+                "command": canonical,
                 "args": event.get_command_args().strip(),
             })
-
-        # Resolve aliases to canonical name so dispatch only checks canonicals.
-        _cmd_def = _resolve_cmd(command) if command else None
-        canonical = _cmd_def.name if _cmd_def else command
 
         if canonical == "new":
             return await self._handle_reset_command(event)

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -60,6 +60,7 @@ logger = logging.getLogger(__name__)
 VALID_HOOKS: Set[str] = {
     "pre_tool_call",
     "post_tool_call",
+    "pre_gateway_command",
     "transform_terminal_output",
     "transform_tool_result",
     "pre_llm_call",
@@ -302,6 +303,53 @@ class PluginContext:
         }
         logger.debug("Plugin %s registered command: /%s", self.manifest.name, clean)
 
+    def register_gateway_command(
+        self,
+        platform: str,
+        name: str,
+        handler: Callable,
+        description: str = "",
+        args_hint: str = "",
+    ) -> None:
+        """Register a plugin slash command for a specific gateway platform.
+
+        This builds on ``register_command()`` so the command remains available
+        through Hermes' normal in-session slash command dispatch while also
+        exposing metadata the gateway adapter can use for native UI
+        registration (for example, Discord app commands).
+        """
+        clean_platform = platform.lower().strip()
+        if not clean_platform:
+            logger.warning(
+                "Plugin '%s' tried to register a gateway command with an empty platform.",
+                self.manifest.name,
+            )
+            return
+
+        clean = name.lower().strip().lstrip("/").replace(" ", "-")
+        self.register_command(clean, handler, description=description)
+
+        entry = self._manager._plugin_commands.get(clean)
+        if not entry or entry.get("handler") is not handler:
+            return
+
+        platform_registry = self._manager._plugin_gateway_commands.setdefault(
+            clean_platform, {}
+        )
+        platform_registry[clean] = {
+            "handler": handler,
+            "description": entry.get("description") or "Plugin command",
+            "plugin": self.manifest.name,
+            "platform": clean_platform,
+            "args_hint": (args_hint or "").strip(),
+        }
+        logger.debug(
+            "Plugin %s registered gateway command for %s: /%s",
+            self.manifest.name,
+            clean_platform,
+            clean,
+        )
+
     # -- tool dispatch -------------------------------------------------------
 
     def dispatch_tool(self, tool_name: str, args: dict, **kwargs) -> str:
@@ -446,6 +494,7 @@ class PluginManager:
         self._cli_commands: Dict[str, dict] = {}
         self._context_engine = None  # Set by a plugin via register_context_engine()
         self._plugin_commands: Dict[str, dict] = {}  # Slash commands registered by plugins
+        self._plugin_gateway_commands: Dict[str, Dict[str, dict]] = {}
         self._discovered: bool = False
         self._cli_ref = None  # Set by CLI after plugin discovery
         # Plugin skill registry: qualified name → metadata dict.
@@ -898,6 +947,16 @@ def get_plugin_commands() -> Dict[str, dict]:
     before any explicit discover_plugins() call.
     """
     return _ensure_plugins_discovered()._plugin_commands
+
+
+def get_plugin_gateway_commands(platform: str) -> Dict[str, dict]:
+    """Return plugin gateway command metadata for a specific platform."""
+    clean_platform = platform.lower().strip()
+    if not clean_platform:
+        return {}
+    return _ensure_plugins_discovered()._plugin_gateway_commands.get(
+        clean_platform, {}
+    )
 
 
 def get_plugin_toolsets() -> List[tuple]:

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -199,6 +199,61 @@ async def test_auto_registered_command_with_args(adapter):
     )
 
 
+@pytest.mark.asyncio
+async def test_auto_registers_plugin_gateway_commands_for_discord(adapter):
+    """Plugin gateway commands should appear as native Discord slash commands."""
+    adapter._run_simple_slash = AsyncMock()
+
+    with patch(
+        "hermes_cli.plugins.get_plugin_gateway_commands",
+        return_value={
+            "metricas": {
+                "description": "Metrics dashboard",
+                "args_hint": "dias:7 formato:json",
+                "plugin": "metrics-plugin",
+            }
+        },
+    ):
+        adapter._register_slash_commands()
+
+    tree_names = set(adapter._client.tree.commands.keys())
+    assert "metricas" in tree_names
+
+    metricas_cmd = adapter._client.tree.commands["metricas"]
+    interaction = SimpleNamespace()
+    await metricas_cmd.callback(interaction, args="dias:7 formato:json")
+    adapter._run_simple_slash.assert_awaited_once_with(
+        interaction, "/metricas dias:7 formato:json"
+    )
+
+
+@pytest.mark.asyncio
+async def test_plugin_gateway_command_skips_existing_name_conflict(adapter):
+    """Plugin gateway commands must not override an existing tree command."""
+    adapter._run_simple_slash = AsyncMock()
+
+    with patch(
+        "hermes_cli.plugins.get_plugin_gateway_commands",
+        return_value={
+            "restart": {
+                "description": "Plugin restart",
+                "args_hint": "",
+                "plugin": "conflict-plugin",
+            }
+        },
+    ):
+        adapter._register_slash_commands()
+
+    restart_cmd = adapter._client.tree.commands["restart"]
+    interaction = SimpleNamespace()
+    await restart_cmd(interaction)
+    adapter._run_simple_slash.assert_awaited_once_with(
+        interaction,
+        "/restart",
+        "Restart requested~",
+    )
+
+
 # ------------------------------------------------------------------
 # _handle_thread_create_slash — success, session dispatch, failure
 # ------------------------------------------------------------------
@@ -882,4 +937,3 @@ def test_register_skill_command_autocomplete_filters_by_name_and_description(ada
     # (covered in other tests). The autocomplete filter itself is exercised
     # via direct function call in the real-discord integration path.
     assert skill_cmd.callback is not None
-

--- a/tests/gateway/test_unknown_command.py
+++ b/tests/gateway/test_unknown_command.py
@@ -7,7 +7,7 @@ delegate_task call instead of telling the user the command doesn't exist).
 
 from datetime import datetime
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -164,3 +164,78 @@ async def test_underscored_alias_for_hyphenated_builtin_not_flagged(monkeypatch)
     # Whatever /reload_mcp returns, it must not be the unknown-command guard.
     if result is not None:
         assert "Unknown command" not in result
+
+
+@pytest.mark.asyncio
+async def test_pre_gateway_command_can_deny_before_dispatch(monkeypatch):
+    """A plugin pre_gateway_command hook can block a slash command early."""
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    runner._run_agent = AsyncMock(
+        side_effect=AssertionError("denied slash command leaked to the agent")
+    )
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    with patch(
+        "hermes_cli.plugins.invoke_hook",
+        return_value=[{"decision": "deny", "message": "Blocked by ACL"}],
+    ):
+        result = await runner._handle_message(_make_event("/status"))
+
+    assert result == "Blocked by ACL"
+    runner._run_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_pre_gateway_command_can_rewrite_to_plugin_command(monkeypatch):
+    """Rewrite directives should update dispatch before plugin command lookup."""
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    runner._run_agent = AsyncMock(
+        side_effect=AssertionError("rewritten slash command leaked to the agent")
+    )
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    with patch(
+        "hermes_cli.plugins.invoke_hook",
+        return_value=[{"decision": "rewrite", "command_name": "metricas", "raw_args": "dias:7"}],
+    ), patch(
+        "hermes_cli.plugins.get_plugin_command_handler",
+        return_value=lambda args: f"metrics {args}",
+    ):
+        result = await runner._handle_message(_make_event("/legacy-metricas"))
+
+    assert result == "metrics dias:7"
+    runner._run_agent.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_pre_gateway_command_can_mark_command_as_handled(monkeypatch):
+    """Handled directives should short-circuit normal dispatch cleanly."""
+    import gateway.run as gateway_run
+
+    runner = _make_runner()
+    runner._run_agent = AsyncMock(
+        side_effect=AssertionError("handled slash command leaked to the agent")
+    )
+
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    with patch(
+        "hermes_cli.plugins.invoke_hook",
+        return_value=[{"decision": "handled", "message": "Already handled upstream"}],
+    ):
+        result = await runner._handle_message(_make_event("/status"))
+
+    assert result == "Already handled upstream"
+    runner._run_agent.assert_not_called()

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -20,6 +20,7 @@ from hermes_cli.plugins import (
     get_plugin_manager,
     get_plugin_command_handler,
     get_plugin_commands,
+    get_plugin_gateway_commands,
     get_pre_tool_call_block_message,
     discover_plugins,
     invoke_hook,
@@ -260,6 +261,7 @@ class TestPluginHooks:
     def test_valid_hooks_include_request_scoped_api_hooks(self):
         assert "pre_api_request" in VALID_HOOKS
         assert "post_api_request" in VALID_HOOKS
+        assert "pre_gateway_command" in VALID_HOOKS
         assert "transform_terminal_output" in VALID_HOOKS
         assert "transform_tool_result" in VALID_HOOKS
 
@@ -762,6 +764,41 @@ class TestPluginCommands:
         ctx.register_command("status-cmd", lambda a: a)
         assert mgr._plugin_commands["status-cmd"]["description"] == "Plugin command"
 
+    def test_register_gateway_command_registers_generic_and_platform_metadata(self):
+        """register_gateway_command() should expose both dispatch and UI metadata."""
+        mgr = PluginManager()
+        manifest = PluginManifest(name="test-plugin", source="user")
+        ctx = PluginContext(manifest, mgr)
+
+        handler = lambda args: f"gateway:{args}"
+        ctx.register_gateway_command(
+            "discord",
+            "metricas",
+            handler,
+            description="Metrics dashboard",
+            args_hint="dias:7 formato:json",
+        )
+
+        assert "metricas" in mgr._plugin_commands
+        assert "metricas" in mgr._plugin_gateway_commands["discord"]
+        entry = mgr._plugin_gateway_commands["discord"]["metricas"]
+        assert entry["handler"] is handler
+        assert entry["description"] == "Metrics dashboard"
+        assert entry["args_hint"] == "dias:7 formato:json"
+        assert entry["plugin"] == "test-plugin"
+
+    def test_register_gateway_command_empty_platform_rejected(self, caplog):
+        """Empty platform names are rejected with a warning."""
+        mgr = PluginManager()
+        manifest = PluginManifest(name="test-plugin", source="user")
+        ctx = PluginContext(manifest, mgr)
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
+            ctx.register_gateway_command("", "metricas", lambda a: a)
+
+        assert mgr._plugin_gateway_commands == {}
+        assert "empty platform" in caplog.text
+
     def test_get_plugin_command_handler_found(self):
         """get_plugin_command_handler() returns the handler for a registered command."""
         mgr = PluginManager()
@@ -794,6 +831,43 @@ class TestPluginCommands:
             assert "cmd-a" in cmds
             assert "cmd-b" in cmds
             assert cmds["cmd-a"]["description"] == "A"
+
+    def test_get_plugin_gateway_commands_returns_platform_slice(self):
+        """get_plugin_gateway_commands() should return only the requested platform."""
+        mgr = PluginManager()
+        manifest = PluginManifest(name="test-plugin", source="user")
+        ctx = PluginContext(manifest, mgr)
+        ctx.register_gateway_command("discord", "metricas", lambda a: a, description="Metrics")
+        ctx.register_gateway_command("telegram", "metricas", lambda a: a, description="Metrics")
+
+        with patch("hermes_cli.plugins._plugin_manager", mgr):
+            discord_cmds = get_plugin_gateway_commands("discord")
+            telegram_cmds = get_plugin_gateway_commands("telegram")
+
+        assert "metricas" in discord_cmds
+        assert discord_cmds["metricas"]["platform"] == "discord"
+        assert "metricas" in telegram_cmds
+        assert telegram_cmds["metricas"]["platform"] == "telegram"
+
+    def test_get_plugin_gateway_commands_discovers_plugins_lazily(self, tmp_path, monkeypatch):
+        """Gateway command lookup should trigger plugin discovery on first access."""
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        _make_plugin_dir(
+            plugins_dir,
+            "gateway-plugin",
+            register_body=(
+                'ctx.register_gateway_command("discord", "metricas", lambda a: a, '
+                'description="Metrics", args_hint="dias:7")'
+            ),
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        import hermes_cli.plugins as plugins_mod
+
+        with patch.object(plugins_mod, "_plugin_manager", None):
+            cmds = get_plugin_gateway_commands("discord")
+            assert "metricas" in cmds
+            assert cmds["metricas"]["args_hint"] == "dias:7"
 
     def test_get_plugin_command_handler_discovers_plugins_lazily(self, tmp_path, monkeypatch):
         """Handler lookup should work before any explicit discover_plugins() call."""


### PR DESCRIPTION
## What changed

This PR adds minimal gateway-facing plugin extension points so Hermes plugins can participate in Discord slash command registration and gateway command interception without patching Hermes core.

Specifically:

- adds `pre_gateway_command` to the plugin hook surface
- adds `PluginContext.register_gateway_command(platform, name, handler, description="", args_hint="")`
- stores plugin gateway-command metadata in the plugin manager
- teaches the Discord adapter to auto-register plugin-provided Discord app commands onto the command tree
- invokes `pre_gateway_command` before normal gateway slash-command dispatch so plugins can allow, deny, rewrite, or fully handle commands

## Why this changed

Today, plugins can register generic Hermes slash commands with `ctx.register_command(...)`, but there is no built-in plugin path for:

- publishing those commands as native Discord app commands
- intercepting gateway slash commands before core dispatch for ACL/governance style behavior

That gap forces downstream Discord plugin authors into fragile compatibility bridges or direct core patching, which makes Hermes upgrades harder than they should be.

This PR provides a small, backward-compatible upstream seam so Discord-facing plugins can stay on supported plugin interfaces instead of carrying local injections.

## Impact

Plugin authors can now:

- register Discord-native slash commands from plugin code through Hermes' plugin system
- keep using the normal plugin command handler for execution
- enforce gateway-time policy via `pre_gateway_command` hooks

Existing plugins and built-in commands continue to work as before.

## Summary
It gives plugins earlier + deeper access to the agent pipeline (before auth and during runtime) instead of only late, limited hooks.
Before: plugins only saw events after session/agent start and got limited context (IDs, not the agent itself).
Now: plugins can
intercept raw inbound messages (even unauthorized ones)
access live agent state during execution
optionally modify behavior or stop handling early
Net effect for plugin builders:
from “observe late, limited control” → “hook early + full control / introspection”

## Validation

Ran:

```bash
uv run --extra dev python -m pytest -q \
  tests/hermes_cli/test_plugins.py \
  tests/gateway/test_discord_slash_commands.py \
  tests/gateway/test_unknown_command.py
```

Result:

- `95 passed in 4.80s`
