### PR TITLE
fix(cli): show full titles in /resume list instead of silently truncating

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4454,14 +4454,24 @@ class HermesCLI:
         else:
             print("  Recent sessions:")
         print()
-        print(f"  {'Title':<32} {'Preview':<40} {'Last Active':<13} {'ID'}")
-        print(f"  {'─' * 32} {'─' * 40} {'─' * 13} {'─' * 24}")
+        # Render each session across two lines so long titles are never
+        # silently truncated — copying the displayed title was previously
+        # producing "Session not found" because the list clipped titles
+        # to 30 chars while `/resume` required an exact match.
+        preview_cap = 100
         for session in sessions:
-            title = (session.get("title") or "—")[:30]
-            preview = (session.get("preview") or "")[:38]
+            title = session.get("title") or "—"
+            preview = (session.get("preview") or "").strip()
+            if len(preview) > preview_cap:
+                preview = preview[: preview_cap - 1] + "…"
             last_active = _relative_time(session.get("last_active"))
-            print(f"  {title:<32} {preview:<40} {last_active:<13} {session['id']}")
-        print()
+            sid = session["id"]
+            print(f"  {title}")
+            meta = f"    id: {sid}  ·  {last_active}"
+            if preview:
+                meta += f"  ·  {preview}"
+            print(meta)
+            print()
         print("  Use /resume <session id or title> to continue where you left off.")
         print()
         return True

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -245,6 +245,34 @@ class TestHistoryDisplay:
         assert "Checking Running Hermes Agent" in output
         assert "Use /resume <session id or title> to continue" in output
 
+    def test_recent_sessions_shows_full_long_title(self, capsys):
+        """Long titles must be printed in full so `/resume <title>` can match.
+
+        Regression test for the bug where the list truncated titles to 30
+        chars, breaking copy-paste into `/resume` (which requires an exact
+        title match).
+        """
+        long_title = "Salvage BytePlus Volcengine PR With Fixes"
+        assert len(long_title) > 30
+        cli = _make_cli()
+        cli.session_id = "current"
+        cli._session_db = MagicMock()
+        cli._session_db.list_sessions_rich.return_value = [
+            {
+                "id": "20260420_120000_abcdef",
+                "title": long_title,
+                "preview": "wiring up the missing unit tests",
+                "last_active": 0,
+            },
+        ]
+
+        cli._handle_resume_command("/resume")
+        output = capsys.readouterr().out
+
+        assert long_title in output
+        assert long_title[:30] + "…" not in output
+        assert "20260420_120000_abcdef" in output
+
 
 class TestRootLevelProviderOverride:
     """Root-level provider/base_url in config.yaml must NOT override model.provider."""


### PR DESCRIPTION
Closes #14082

---

The recent-sessions list that `/resume` (and `/history` with an empty current chat) renders was truncating each title to 30 characters so it fit a fixed-width table column. The helper text under the list tells users to "Use /resume <session id or title>", but the title shown there would never match because `resolve_session_by_title` requires an exact match. So copy-pasting the displayed title resulted in "Session not found".

The fix swaps the fixed-column table for a two-line-per-session layout:

```
  Salvage BytePlus Volcengine PR With Fixes
    id: 20260420_120000_abcdef  ·  2h ago  ·  wiring up the missing unit tests
```

Each session occupies its own block: the full title on the first line, then the session id, relative last-active, and a capped preview on the second. Users can now copy either the title or the id and `/resume` will resolve it. The preview is still bounded (100 chars) so long summaries don't blow up the list.

Covered by a regression test that feeds a >30-char title into `_show_recent_sessions` and asserts the full title (not a truncated variant) appears in the output. The existing tests for the short-title case continue to pass.

_Disclaimer: this contribution was prepared with AI-agent assistance._