### PR TITLE
fix(tui): degrade gracefully when state.db init fails

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1183,6 +1183,75 @@ def test_session_create_no_race_keeps_worker_alive(monkeypatch):
     server._sessions.pop(sid, None)
 
 
+def test_get_db_degrades_cleanly_when_sessiondb_init_fails(monkeypatch):
+    fake_mod = types.ModuleType("hermes_state")
+
+    class _BrokenSessionDB:
+        def __init__(self):
+            raise RuntimeError("locking protocol")
+
+    fake_mod.SessionDB = _BrokenSessionDB
+    monkeypatch.setitem(sys.modules, "hermes_state", fake_mod)
+    monkeypatch.setattr(server, "_db", None)
+    monkeypatch.setattr(server, "_db_error", None)
+
+    assert server._get_db() is None
+    assert server._db_error == "locking protocol"
+
+
+def test_session_create_continues_when_state_db_is_unavailable(monkeypatch):
+    class _FakeWorker:
+        def __init__(self, key, model):
+            self.key = key
+
+        def close(self):
+            return None
+
+    class _FakeAgent:
+        def __init__(self):
+            self.model = "x"
+            self.provider = "openrouter"
+            self.base_url = ""
+            self.api_key = ""
+
+    emits = []
+
+    monkeypatch.setattr(server, "_make_agent", lambda sid, key: _FakeAgent())
+    monkeypatch.setattr(server, "_SlashWorker", _FakeWorker)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_session_info", lambda _a: {"model": "x"})
+    monkeypatch.setattr(server, "_probe_credentials", lambda _a: None)
+    monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
+    monkeypatch.setattr(server, "_emit", lambda *a, **kw: emits.append(a))
+
+    import tools.approval as _approval
+    monkeypatch.setattr(_approval, "register_gateway_notify", lambda key, cb: None)
+    monkeypatch.setattr(_approval, "load_permanent_allowlist", lambda: None)
+
+    resp = server.handle_request(
+        {"id": "1", "method": "session.create", "params": {"cols": 80}}
+    )
+    sid = resp["result"]["session_id"]
+    session = server._sessions[sid]
+    session["agent_ready"].wait(timeout=2.0)
+
+    assert session["agent_error"] is None
+    assert session["agent"] is not None
+    assert not any(args and args[0] == "error" for args in emits)
+
+    server._sessions.pop(sid, None)
+
+
+def test_session_list_returns_clean_error_when_state_db_is_unavailable(monkeypatch):
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_db_error", "locking protocol")
+
+    resp = server.handle_request({"id": "1", "method": "session.list", "params": {}})
+
+    assert "error" in resp
+    assert "state.db unavailable: locking protocol" in resp["error"]["message"]
+
+
 # --------------------------------------------------------------------------
 # model.options — curated-list parity with `hermes model` and classic /model
 # --------------------------------------------------------------------------

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2,6 +2,7 @@ import atexit
 import concurrent.futures
 import copy
 import json
+import logging
 import os
 import queue
 import subprocess
@@ -14,6 +15,8 @@ from pathlib import Path
 
 from hermes_constants import get_hermes_home
 from hermes_cli.env_loader import load_hermes_dotenv
+
+logger = logging.getLogger(__name__)
 
 _hermes_home = get_hermes_home()
 load_hermes_dotenv(
@@ -34,6 +37,7 @@ _methods: dict[str, callable] = {}
 _pending: dict[str, tuple[str, threading.Event]] = {}
 _answers: dict[str, str] = {}
 _db = None
+_db_error: str | None = None
 _stdout_lock = threading.Lock()
 _cfg_lock = threading.Lock()
 _cfg_cache: dict | None = None
@@ -170,12 +174,26 @@ atexit.register(
 
 
 def _get_db():
-    global _db
+    global _db, _db_error
     if _db is None:
         from hermes_state import SessionDB
 
-        _db = SessionDB()
+        try:
+            _db = SessionDB()
+            _db_error = None
+        except Exception as exc:
+            _db_error = str(exc)
+            logger.warning(
+                "TUI session store unavailable — continuing without state.db features: %s",
+                exc,
+            )
+            return None
     return _db
+
+
+def _db_unavailable_error(rid, *, code: int):
+    detail = _db_error or "state.db unavailable"
+    return _err(rid, code, f"state.db unavailable: {detail}")
 
 
 def write_json(obj: dict) -> bool:
@@ -1318,7 +1336,9 @@ def _(rid, params: dict) -> dict:
             finally:
                 _clear_session_context(tokens)
 
-            _get_db().create_session(key, source="tui", model=_resolve_model())
+            db = _get_db()
+            if db is not None:
+                db.create_session(key, source="tui", model=_resolve_model())
             session["agent"] = agent
 
             try:
@@ -1390,6 +1410,9 @@ def _(rid, params: dict) -> dict:
 
 @method("session.list")
 def _(rid, params: dict) -> dict:
+    db = _get_db()
+    if db is None:
+        return _db_unavailable_error(rid, code=5006)
     try:
         # Resume picker should include human conversation surfaces beyond
         # tui/cli (notably telegram from blitz row #7), but avoid internal
@@ -1416,7 +1439,7 @@ def _(rid, params: dict) -> dict:
         fetch_limit = max(limit * 5, 100)
         rows = [
             s
-            for s in _get_db().list_sessions_rich(source=None, limit=fetch_limit)
+            for s in db.list_sessions_rich(source=None, limit=fetch_limit)
             if (s.get("source") or "").strip().lower() in allow
         ][:limit]
         return _ok(
@@ -1445,6 +1468,8 @@ def _(rid, params: dict) -> dict:
     if not target:
         return _err(rid, 4006, "session_id required")
     db = _get_db()
+    if db is None:
+        return _db_unavailable_error(rid, code=5000)
     found = db.get_session(target)
     if not found:
         found = db.get_session_by_title(target)
@@ -1483,13 +1508,16 @@ def _(rid, params: dict) -> dict:
     session, err = _sess(params, rid)
     if err:
         return err
+    db = _get_db()
+    if db is None:
+        return _db_unavailable_error(rid, code=5007)
     title, key = params.get("title", ""), session["session_key"]
     if not title:
         return _ok(
-            rid, {"title": _get_db().get_session_title(key) or "", "session_key": key}
+            rid, {"title": db.get_session_title(key) or "", "session_key": key}
         )
     try:
-        _get_db().set_session_title(key, title)
+        db.set_session_title(key, title)
         return _ok(rid, {"title": title})
     except Exception as e:
         return _err(rid, 5007, str(e))
@@ -1625,6 +1653,8 @@ def _(rid, params: dict) -> dict:
     if err:
         return err
     db = _get_db()
+    if db is None:
+        return _db_unavailable_error(rid, code=5008)
     old_key = session["session_key"]
     with session["history_lock"]:
         history = [dict(msg) for msg in session.get("history", [])]
@@ -3453,11 +3483,14 @@ def _(rid, params: dict) -> dict:
 @method("insights.get")
 def _(rid, params: dict) -> dict:
     days = params.get("days", 30)
+    db = _get_db()
+    if db is None:
+        return _db_unavailable_error(rid, code=5017)
     try:
         cutoff = time.time() - days * 86400
         rows = [
             s
-            for s in _get_db().list_sessions_rich(limit=500)
+            for s in db.list_sessions_rich(limit=500)
             if (s.get("started_at") or 0) >= cutoff
         ]
         return _ok(


### PR DESCRIPTION
## What does this PR do?

Prevents `hermes --tui` from hard-failing when `state.db` cannot be opened during TUI startup. The TUI gateway was the odd path out: classic CLI and gateway already treat `SessionDB()` init failure as non-fatal, but TUI let the exception bubble out of `_get_db()` and surface as `agent init failed: locking protocol`.

This change makes the TUI gateway degrade gracefully when `SessionDB()` init fails, lets chat continue without state-backed session indexing, and returns explicit `state.db unavailable` RPC errors only for TUI features that actually require the database.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- make `tui_gateway.server._get_db()` catch `SessionDB()` init failures and return `None` instead of aborting TUI startup
- skip `create_session(...)` during TUI session bootstrap when `state.db` is unavailable
- return clear `state.db unavailable: ...` RPC errors for DB-backed TUI methods like session list, resume, title, branch, and insights
- add regression tests covering broken `SessionDB()` init, successful `session.create` without `state.db`, and clean TUI errors for DB-backed commands

## How to Test

1. Reproduce a failing `SessionDB()` init in the TUI path so `_get_db()` cannot open `state.db`.
2. Run `hermes --tui` and confirm the session still comes up instead of showing `agent init failed: locking protocol`.
3. Confirm DB-backed TUI features like `/resume` or session listing now fail with a clear `state.db unavailable: ...` message instead of killing the TUI session.
4. Run `scripts/run_tests.sh tests/test_tui_gateway_server.py tests/tui_gateway/test_protocol.py -n 4`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu / WSL2-style TUI path analysis

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

TUI currently surfaced raw startup failures like:

`agent init failed: locking protocol`

after `SessionDB()` initialization failed in `tui_gateway/server.py`.

Targeted coverage for this change passed:

`source venv/bin/activate && scripts/run_tests.sh tests/test_tui_gateway_server.py tests/tui_gateway/test_protocol.py -n 4`

Repo-wide hermetic coverage was also run:

`source venv/bin/activate && scripts/run_tests.sh -n 4`

That full run is currently red on this checkout with 55 failing tests and 14443 passing tests. The failures observed in that run were spread across unrelated areas including gateway approval flows, DingTalk, Discord bot filtering, MiniMax, Anthropic/Codex response paths, backup, browser/camofox, Tirith, write-deny, and zombie cleanup.
