### PR TITLE
fix(cli): respect terminal.cwd in chat sessions

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -836,6 +836,8 @@ class SlashCommandCompleter(Completer):
     def _path_completions(word: str, limit: int = 30):
         """Yield Completion objects for file paths matching *word*."""
         expanded = os.path.expanduser(word)
+        terminal_cwd = os.getenv("TERMINAL_CWD") or os.getcwd()
+        base_dir = os.path.abspath(os.path.expanduser(terminal_cwd))
         # Split into directory part and prefix to match inside it
         if expanded.endswith("/"):
             search_dir = expanded
@@ -844,8 +846,13 @@ class SlashCommandCompleter(Completer):
             search_dir = os.path.dirname(expanded) or "."
             prefix = os.path.basename(expanded)
 
+        if os.path.isabs(expanded):
+            resolved_search_dir = search_dir
+        else:
+            resolved_search_dir = os.path.join(base_dir, search_dir)
+
         try:
-            entries = os.listdir(search_dir)
+            entries = os.listdir(resolved_search_dir)
         except OSError:
             return
 
@@ -857,7 +864,7 @@ class SlashCommandCompleter(Completer):
             if count >= limit:
                 break
 
-            full_path = os.path.join(search_dir, entry)
+            full_path = os.path.join(resolved_search_dir, entry)
             is_dir = os.path.isdir(full_path)
 
             # Build the completion text (what replaces the typed word)
@@ -866,8 +873,9 @@ class SlashCommandCompleter(Completer):
             elif os.path.isabs(word):
                 display_path = full_path
             else:
-                # Keep relative
-                display_path = os.path.relpath(full_path)
+                # Keep relative to the terminal session cwd rather than the
+                # process cwd so completions match terminal.cwd.
+                display_path = os.path.relpath(full_path, base_dir)
 
             if is_dir:
                 display_path += "/"

--- a/tests/hermes_cli/test_path_completion.py
+++ b/tests/hermes_cli/test_path_completion.py
@@ -125,6 +125,23 @@ class TestPathCompletions:
         names = _display_names(completions)
         assert "README.md" in names
 
+    def test_relative_paths_use_terminal_cwd(self, tmp_path, monkeypatch):
+        launch_dir = tmp_path / "launch"
+        launch_dir.mkdir()
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        (project_dir / "target.py").touch()
+
+        monkeypatch.setenv("TERMINAL_CWD", str(project_dir))
+        old_cwd = os.getcwd()
+        os.chdir(launch_dir)
+        try:
+            completions = list(SlashCommandCompleter._path_completions("./ta"))
+            names = _display_names(completions)
+            assert "target.py" in names
+        finally:
+            os.chdir(old_cwd)
+
 
 class TestIntegration:
     """Test the completer produces path completions via the prompt_toolkit API."""

--- a/tests/tools/test_local_shell_init.py
+++ b/tests/tools/test_local_shell_init.py
@@ -160,3 +160,24 @@ class TestSnapshotEndToEnd:
         output = result.get("output", "")
         assert "PROBE=probe-ok" in output
         assert "/opt/shell-init-probe/bin" in output
+
+    def test_snapshot_preserves_configured_cwd(self, tmp_path):
+        configured_dir = tmp_path / "configured"
+        configured_dir.mkdir()
+        launch_dir = tmp_path / "launch"
+        launch_dir.mkdir()
+
+        old_cwd = os.getcwd()
+        os.chdir(launch_dir)
+        try:
+            env = LocalEnvironment(cwd=str(configured_dir), timeout=15)
+            try:
+                result = env.execute("pwd")
+            finally:
+                env.cleanup()
+        finally:
+            os.chdir(old_cwd)
+
+        expected = str(configured_dir.resolve())
+        assert env.cwd == expected
+        assert expected in result.get("output", "")

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -334,8 +334,15 @@ class BaseEnvironment(ABC):
         ``_snapshot_ready = True`` so subsequent commands source the snapshot
         instead of running with ``bash -l``.
         """
+        configured_cwd = self.cwd
+        bootstrap_cwd = (
+            shlex.quote(configured_cwd)
+            if configured_cwd != "~" and not configured_cwd.startswith("~/")
+            else configured_cwd
+        )
         # Full capture: env vars, functions (filtered), aliases, shell options.
         bootstrap = (
+            f"cd {bootstrap_cwd} 2>/dev/null || true\n"
             f"export -p > {self._snapshot_path}\n"
             f"declare -f | grep -vE '^_[^_]' >> {self._snapshot_path}\n"
             f"alias -p >> {self._snapshot_path}\n"
@@ -760,4 +767,3 @@ class BaseEnvironment(ABC):
         from tools.terminal_tool import _transform_sudo_command
 
         return _transform_sudo_command(command)
-


### PR DESCRIPTION
Fixes #14044.

## Summary
- seed environment snapshots from the configured terminal cwd so chat sessions stop resetting to the launch directory
- resolve relative CLI path completions from TERMINAL_CWD instead of the process cwd
- add regressions covering both the local terminal session cwd and interactive path completion behavior

## Testing
- pytest -o addopts= tests/hermes_cli/test_path_completion.py
- pytest -o addopts= tests/tools/test_local_shell_init.py