### PR TITLE
fix(telegram): replace terminal previews with results

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9251,14 +9251,53 @@ class GatewayRunner:
         last_tool = [None]  # Mutable container for tracking in closure
         last_progress_msg = [None]  # Track last message for dedup
         repeat_count = [0]  # How many times the same message repeated
+
+        def _build_terminal_result_progress(preview_result: Any) -> str | None:
+            """Return a short terminal stdout preview suitable for progress replacement."""
+            if not isinstance(preview_result, str) or not preview_result:
+                return None
+            try:
+                data = json.loads(preview_result)
+            except Exception:
+                return None
+            if not isinstance(data, dict):
+                return None
+            if data.get("exit_code") not in (0, None):
+                return None
+            output = data.get("output")
+            if not isinstance(output, str):
+                return None
+            preview_text = " ".join(output.split())
+            if not preview_text:
+                return None
+            from agent.display import get_tool_preview_max_len
+            _pl = get_tool_preview_max_len()
+            _cap = _pl if _pl > 0 else 40
+            if len(preview_text) > _cap:
+                return None
+            return preview_text
         
         def progress_callback(event_type: str, tool_name: str = None, preview: str = None, args: dict = None, **kwargs):
             """Callback invoked by agent on tool lifecycle events."""
             if not progress_queue or not _run_still_current():
                 return
 
-            # Only act on tool.started events (ignore tool.completed, reasoning.available, etc.)
-            if event_type not in ("tool.started",):
+            if event_type == "tool.completed":
+                if progress_mode == "verbose" or tool_name != "terminal" or kwargs.get("is_error"):
+                    return
+                result_preview = _build_terminal_result_progress(kwargs.get("function_result"))
+                if not result_preview or tool_name != last_tool[0]:
+                    return
+                from agent.display import get_tool_emoji
+                emoji = get_tool_emoji(tool_name, default="⚙️")
+                msg = f"{emoji} {tool_name}: \"{result_preview}\""
+                last_progress_msg[0] = msg
+                repeat_count[0] = 0
+                progress_queue.put(("__replace_last__", msg))
+                return
+
+            # Only act on tool.started events beyond the completion upgrade path.
+            if event_type != "tool.started":
                 return
 
             # "new" mode: only report when tool changes
@@ -9373,6 +9412,13 @@ class GatewayRunner:
                         if progress_lines:
                             progress_lines[-1] = f"{base_msg} (×{count + 1})"
                         msg = progress_lines[-1] if progress_lines else base_msg
+                    elif isinstance(raw, tuple) and len(raw) == 2 and raw[0] == "__replace_last__":
+                        _, replacement = raw
+                        if progress_lines:
+                            progress_lines[-1] = replacement
+                        else:
+                            progress_lines.append(replacement)
+                        msg = progress_lines[-1]
                     else:
                         msg = raw
                         progress_lines.append(msg)
@@ -9442,6 +9488,12 @@ class GatewayRunner:
                                 _, base_msg, count = raw
                                 if progress_lines:
                                     progress_lines[-1] = f"{base_msg} (×{count + 1})"
+                            elif isinstance(raw, tuple) and len(raw) == 2 and raw[0] == "__replace_last__":
+                                _, replacement = raw
+                                if progress_lines:
+                                    progress_lines[-1] = replacement
+                                else:
+                                    progress_lines.append(replacement)
                             else:
                                 progress_lines.append(raw)
                         except Exception:

--- a/run_agent.py
+++ b/run_agent.py
@@ -7841,7 +7841,9 @@ class AIAgent:
                     try:
                         self.tool_progress_callback(
                             "tool.completed", function_name, None, None,
-                            duration=tool_duration, is_error=is_error,
+                            duration=tool_duration,
+                            is_error=is_error,
+                            function_result=function_result,
                         )
                     except Exception as cb_err:
                         logging.debug(f"Tool progress callback error: {cb_err}")
@@ -8212,7 +8214,9 @@ class AIAgent:
                 try:
                     self.tool_progress_callback(
                         "tool.completed", function_name, None, None,
-                        duration=tool_duration, is_error=_is_error_result,
+                        duration=tool_duration,
+                        is_error=_is_error_result,
+                        function_result=function_result,
                     )
                 except Exception as cb_err:
                     logging.debug(f"Tool progress callback error: {cb_err}")

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -110,6 +110,30 @@ class DelayedProgressAgent:
         }
 
 
+class TerminalCompletionPreviewAgent:
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        self.tool_progress_callback("tool.started", "terminal", "date -u +%Y-%m-%dT%H:%M:%SZ", {})
+        time.sleep(0.35)
+        self.tool_progress_callback(
+            "tool.completed",
+            "terminal",
+            None,
+            None,
+            function_result='{"output":"2026-04-21T14:36:21Z\\n","exit_code":0}',
+            is_error=False,
+        )
+        time.sleep(0.1)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
 class DelayedInterimAgent:
     def __init__(self, **kwargs):
         self.interim_assistant_callback = kwargs.get("interim_assistant_callback")
@@ -379,6 +403,54 @@ def test_all_mode_no_truncation_when_preview_fits(monkeypatch, tmp_path):
     content = adapter.sent[0]["content"]
     # With a 200-char cap, the 165-char command should NOT be truncated
     assert "..." not in content, f"Preview was truncated when it shouldn't be: {content}"
+
+
+@pytest.mark.asyncio
+async def test_run_agent_progress_replaces_short_terminal_preview_with_result(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", "all")
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = TerminalCompletionPreviewAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    import tools.terminal_tool  # noqa: F401 - register terminal emoji for this fake-agent test
+
+    adapter = ProgressCaptureAdapter(platform=Platform.TELEGRAM)
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        thread_id=None,
+    )
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-terminal-preview",
+        session_key="agent:main:telegram:dm:12345",
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.sent == [
+        {
+            "chat_id": "12345",
+            "content": '💻 terminal: "date -u +%Y-%m-%dT%H:%M:%SZ"',
+            "reply_to": None,
+            "metadata": None,
+        }
+    ]
+    assert adapter.edits
+    assert adapter.edits[-1]["content"] == '💻 terminal: "2026-04-21T14:36:21Z"'
 
 
 class CommentaryAgent:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1403,6 +1403,24 @@ class TestExecuteToolCalls:
         assert len(messages) == 1
         assert messages[0]["role"] == "tool"
 
+    def test_tool_completed_progress_callback_includes_function_result(self, agent):
+        tc = _mock_tool_call(name="terminal", arguments='{"command":"date -u"}', call_id="c1")
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        messages = []
+        result = '{"output":"2026-04-21T14:36:21Z\\n","exit_code":0}'
+        agent.tool_progress_callback = MagicMock()
+
+        with patch("run_agent.handle_function_call", return_value=result):
+            agent._execute_tool_calls(mock_msg, messages, "task-1")
+
+        completed_calls = [
+            call for call in agent.tool_progress_callback.call_args_list
+            if call.args and call.args[0] == "tool.completed"
+        ]
+        assert completed_calls
+        assert completed_calls[-1].kwargs["function_result"] == result
+        assert completed_calls[-1].kwargs["is_error"] is False
+
     def test_quiet_tool_output_prints_without_progress_callback(self, agent):
         tc = _mock_tool_call(name="web_search", arguments='{"q":"test"}', call_id="c1")
         mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])


### PR DESCRIPTION
## Summary\n- pass terminal tool completion results through the tool progress callback\n- replace the last Telegram terminal progress line with short successful stdout instead of leaving the raw command preview\n- add regression coverage for both the callback payload and the Telegram progress replacement path\n\n## Testing\n- pytest -o addopts='' tests/run_agent/test_run_agent.py -k 'tool_completed_progress_callback_includes_function_result'\n- pytest -o addopts='' tests/gateway/test_run_progress_topics.py\n\nCloses #13584