### PR TITLE
fix(runtime): keep named custom provider keys isolated

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -410,20 +410,38 @@ def _resolve_named_custom_runtime(
     if not base_url:
         return None
 
-    # Check if a credential pool exists for this custom endpoint
-    pool_result = _try_resolve_from_custom_pool(base_url, "custom", custom_provider.get("api_mode"))
-    if pool_result:
-        # Propagate the model name even when using pooled credentials —
-        # the pool doesn't know about the custom_providers model field.
-        model_name = custom_provider.get("model")
-        if model_name:
-            pool_result["model"] = model_name
-        return pool_result
+    expected_pool_key = ""
+    custom_name = str(custom_provider.get("name", "") or "").strip()
+    if custom_name:
+        expected_pool_key = f"custom:{_normalize_custom_provider_name(custom_name)}"
+    shared_pool_key = get_custom_provider_pool_key(base_url) or ""
 
-    api_key_candidates = [
+    direct_api_key_candidates = [
         (explicit_api_key or "").strip(),
         str(custom_provider.get("api_key", "") or "").strip(),
         os.getenv(str(custom_provider.get("key_env", "") or "").strip(), "").strip(),
+    ]
+    direct_api_key = next(
+        (candidate for candidate in direct_api_key_candidates if has_usable_secret(candidate)),
+        "",
+    )
+
+    if not shared_pool_key or shared_pool_key == expected_pool_key:
+        # Fall back to the shared base_url pool only when this named provider
+        # is the one that owns that pool key. Multiple named custom providers
+        # can legitimately share a gateway URL while using different API keys,
+        # so a mismatched pool key must not override the requested provider.
+        pool_result = _try_resolve_from_custom_pool(base_url, "custom", custom_provider.get("api_mode"))
+        if pool_result:
+            # Propagate the model name even when using pooled credentials —
+            # the pool doesn't know about the custom_providers model field.
+            model_name = custom_provider.get("model")
+            if model_name:
+                pool_result["model"] = model_name
+            return pool_result
+
+    api_key_candidates = [
+        direct_api_key,
         os.getenv("OPENAI_API_KEY", "").strip(),
         os.getenv("OPENROUTER_API_KEY", "").strip(),
     ]

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -653,6 +653,59 @@ def test_named_custom_provider_uses_key_env_from_providers_dict(monkeypatch):
     assert resolved["model"] == "acme-large"
 
 
+def test_named_custom_provider_uses_own_api_key_before_shared_pool(monkeypatch):
+    """Named custom providers sharing a base_url must not inherit another provider's pooled key."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.setattr(
+        rp,
+        "load_config",
+        lambda: {
+            "custom_providers": [
+                {
+                    "name": "Gateway Alpha",
+                    "base_url": "https://gateway.example.com/v1",
+                    "api_key": "alpha-key",
+                },
+                {
+                    "name": "Gateway Beta",
+                    "base_url": "https://gateway.example.com/v1",
+                    "api_key": "beta-key",
+                },
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        rp,
+        "get_custom_provider_pool_key",
+        lambda _base_url: "custom:gateway-alpha",
+    )
+    monkeypatch.setattr(
+        rp,
+        "_try_resolve_from_custom_pool",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError("shared pool should not override a named provider's own key")
+        ),
+    )
+    monkeypatch.setattr(
+        rp,
+        "resolve_provider",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError(
+                "resolve_provider should not be called for named custom providers"
+            )
+        ),
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="gateway-beta")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["base_url"] == "https://gateway.example.com/v1"
+    assert resolved["api_key"] == "beta-key"
+    assert resolved["requested_provider"] == "gateway-beta"
+    assert resolved["source"] == "custom_provider:Gateway Beta"
+
+
 def test_named_custom_provider_falls_back_to_openai_api_key(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "env-openai-key")
     monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)


### PR DESCRIPTION
## Summary
- avoid reusing a shared custom-endpoint credential pool when its pool key maps to a different named provider
- keep the existing pool path for the named provider that actually owns the pool key
- add a regression test for two named custom providers sharing the same base URL

## Testing
- pytest -o addopts="" tests/hermes_cli/test_runtime_provider_resolution.py -k "uses_own_api_key_before_shared_pool or propagates_model_pool_path"
- pytest -o addopts="" tests/hermes_cli/test_runtime_provider_resolution.py

Fixes #14141