### PR TITLE
fix(plugins): ignore non-mapping manifests

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -719,6 +719,12 @@ class PluginManager:
                 logger.warning("PyYAML not installed – cannot load %s", manifest_file)
                 return None
             data = yaml.safe_load(manifest_file.read_text()) or {}
+            if not isinstance(data, dict):
+                logger.warning(
+                    "Skipping %s: plugin.yaml must contain a mapping",
+                    manifest_file,
+                )
+                return None
 
             name = data.get("name", plugin_dir.name)
             key = f"{prefix}/{plugin_dir.name}" if prefix else name

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -122,7 +122,14 @@ def _read_manifest(plugin_dir: Path) -> dict:
         import yaml
 
         with open(manifest_file) as f:
-            return yaml.safe_load(f) or {}
+            manifest = yaml.safe_load(f) or {}
+        if not isinstance(manifest, dict):
+            logger.warning(
+                "Ignoring non-mapping plugin manifest in %s",
+                manifest_file,
+            )
+            return {}
+        return manifest
     except Exception as e:
         logger.warning("Failed to read plugin.yaml in %s: %s", plugin_dir, e)
         return {}
@@ -339,6 +346,8 @@ def cmd_install(
 
         # Read manifest
         manifest = _read_manifest(tmp_target)
+        if not isinstance(manifest, dict):
+            manifest = {}
         plugin_name = manifest.get("name") or _repo_name_from_url(git_url)
 
         # Sanitize plugin name against path traversal
@@ -394,6 +403,8 @@ def cmd_install(
 
     # Re-read manifest from installed location (for env var prompting)
     installed_manifest = _read_manifest(target)
+    if not isinstance(installed_manifest, dict):
+        installed_manifest = {}
 
     # Prompt for required environment variables before showing after-install docs
     _prompt_plugin_env_vars(installed_manifest, console)
@@ -627,6 +638,8 @@ def _plugin_exists(name: str) -> bool:
             if not child.is_dir():
                 continue
             manifest = _read_manifest(child)
+            if not isinstance(manifest, dict):
+                manifest = {}
             if manifest.get("name") == name:
                 return True
     # Bundled: <repo>/plugins/<name>/
@@ -681,6 +694,8 @@ def _discover_all_plugins() -> list:
                 try:
                     with open(manifest_file) as f:
                         manifest = yaml.safe_load(f) or {}
+                    if not isinstance(manifest, dict):
+                        manifest = {}
                     name = manifest.get("name", d.name)
                     version = manifest.get("version", "")
                     description = manifest.get("description", "")

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -161,6 +161,22 @@ class TestPluginDiscovery:
         }
         assert len(non_bundled) == 0
 
+    def test_discover_skips_non_mapping_manifest(self, tmp_path, monkeypatch, caplog):
+        """Valid YAML with the wrong top-level type should be skipped, not crash discovery."""
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        plugin_dir = plugins_dir / "bad_manifest"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "plugin.yaml").write_text("- not\n- a\n- mapping\n", encoding="utf-8")
+        (plugin_dir / "__init__.py").write_text("def register(ctx):\n    pass\n", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
+            mgr = PluginManager()
+            mgr.discover_and_load()
+
+        assert "bad_manifest" not in mgr._plugins
+        assert any("must contain a mapping" in record.message for record in caplog.records)
+
     def test_entry_points_scanned(self, tmp_path, monkeypatch):
         """Entry-point based plugins are discovered (mocked)."""
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -211,6 +211,38 @@ class TestCmdInstall:
         mock_move.assert_not_called()
         mock_display_after_install.assert_not_called()
 
+    @patch("hermes_cli.plugins_cmd._display_after_install")
+    @patch("hermes_cli.plugins_cmd.shutil.move")
+    @patch("hermes_cli.plugins_cmd._plugins_dir")
+    @patch("hermes_cli.plugins_cmd.subprocess.run")
+    def test_install_non_mapping_manifest_falls_back_to_repo_name(
+        self,
+        mock_run,
+        mock_plugins_dir,
+        mock_move,
+        mock_display_after_install,
+        tmp_path,
+    ):
+        from hermes_cli.plugins_cmd import cmd_install
+
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+        mock_plugins_dir.return_value = plugins_dir
+
+        def _fake_clone(cmd, capture_output, text, timeout):
+            target = Path(cmd[-1])
+            target.mkdir(parents=True, exist_ok=True)
+            (target / "plugin.yaml").write_text("- not\n- a\n- mapping\n", encoding="utf-8")
+            (target / "__init__.py").write_text("def register(ctx):\n    pass\n", encoding="utf-8")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        mock_run.side_effect = _fake_clone
+
+        cmd_install("owner/repo", enable=False)
+
+        assert Path(mock_move.call_args.args[1]).name == "repo"
+        mock_display_after_install.assert_called_once()
+
 
 # ── cmd_update tests ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- treat valid YAML manifests with a non-mapping top level as invalid plugin manifests instead of crashing on 
- harden both plugin install/list helpers and PluginManager directory scanning against non-dict manifest payloads
- add focused regressions for install fallback and discovery skipping

## Testing
- pytest -o addopts="" tests/hermes_cli/test_plugins_cmd.py -k "non_mapping_manifest_falls_back_to_repo_name"
- pytest -o addopts="" tests/hermes_cli/test_plugins.py -k "skips_non_mapping_manifest"
- pytest -o addopts="" tests/hermes_cli/test_plugins_cmd.py
- pytest -o addopts="" tests/hermes_cli/test_plugins.py

Fixes #14066