### PR TITLE
fix(cli): clear stale no_mcp when saving platform toolsets

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -654,6 +654,7 @@ def _save_platform_tools(config: dict, platform: str, enabled_toolset_keys: Set[
     that were already in the config for this platform.
     """
     config.setdefault("platform_toolsets", {})
+    enabled_toolset_keys = {str(entry) for entry in enabled_toolset_keys}
 
     # Get the set of all configurable toolset keys (built-in + plugin)
     configurable_keys = {ts_key for ts_key, _, _ in CONFIGURABLE_TOOLSETS}
@@ -669,12 +670,17 @@ def _save_platform_tools(config: dict, platform: str, enabled_toolset_keys: Set[
     existing_toolsets = config.get("platform_toolsets", {}).get(platform, [])
     if not isinstance(existing_toolsets, list):
         existing_toolsets = []
+    existing_toolsets = [str(entry) for entry in existing_toolsets]
+
+    mcp_server_names = {str(name) for name in (config.get("mcp_servers") or {})}
+    explicit_mcp_selection = enabled_toolset_keys & mcp_server_names
 
     # Preserve any entries that are NOT configurable toolsets and NOT platform
     # defaults (i.e. only MCP server names should be preserved)
     preserved_entries = {
         entry for entry in existing_toolsets
         if entry not in configurable_keys and entry not in platform_default_keys
+        and (entry != "no_mcp" or not explicit_mcp_selection)
     }
 
     # Merge preserved entries with new enabled toolsets

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -212,6 +212,26 @@ def test_save_platform_tools_preserves_mcp_server_names():
     assert "terminal" not in saved_toolsets
 
 
+def test_save_platform_tools_explicit_mcp_selection_clears_stale_no_mcp():
+    """Selecting a concrete MCP server should clear a stale no_mcp sentinel."""
+    config = {
+        "platform_toolsets": {
+            "cli": ["web", "no_mcp"]
+        },
+        "mcp_servers": {
+            "exa": {"url": "https://mcp.exa.ai/mcp"}
+        },
+    }
+
+    with patch("hermes_cli.tools_config.save_config"):
+        _save_platform_tools(config, "cli", {"web", "exa"})
+
+    saved_toolsets = config["platform_toolsets"]["cli"]
+    assert "exa" in saved_toolsets
+    assert "no_mcp" not in saved_toolsets
+    assert sorted(_get_platform_tools(config, "cli")) == ["exa", "web"]
+
+
 def test_save_platform_tools_handles_empty_existing_config():
     """Saving platform tools works when no existing config exists."""
     config = {}
@@ -514,6 +534,23 @@ def test_numeric_mcp_server_name_does_not_crash_sorted():
 
     # sorted() must not raise TypeError
     sorted(enabled)
+
+
+def test_save_platform_tools_normalizes_numeric_entries_before_sort():
+    """Saving must stringify numeric passthrough entries before sorting."""
+    config = {
+        "platform_toolsets": {"cli": ["web", 12306]},
+        "mcp_servers": {
+            12306: {"url": "https://example.com/mcp"},
+        },
+    }
+
+    with patch("hermes_cli.tools_config.save_config"):
+        _save_platform_tools(config, "cli", {"web"})
+
+    saved_toolsets = config["platform_toolsets"]["cli"]
+    assert saved_toolsets == ["12306", "web"]
+    assert all(isinstance(name, str) for name in saved_toolsets)
 
 
 # ─── Imagegen Backend Picker Wiring ────────────────────────────────────────


### PR DESCRIPTION
## Summary
- normalize saved platform toolset entries to strings before preserve and sort logic runs
- stop carrying forward a stale `no_mcp` sentinel once the new selection explicitly enables MCP servers
- add regressions for the stale `no_mcp` case and numeric passthrough entries on save

## Testing
- python3 -m pytest -o addopts= tests/hermes_cli/test_tools_config.py -k "explicit_mcp_selection_clears_stale_no_mcp or normalizes_numeric_entries_before_sort or numeric_mcp_server_name_does_not_crash_sorted"
- python3 -m pytest -o addopts= tests/hermes_cli/test_tools_config.py

Closes #13028
