### PR TITLE
Close out holographic memory understanding

### DIFF
--- a/docs/holographic-memory-understanding.md
+++ b/docs/holographic-memory-understanding.md
@@ -1,0 +1,246 @@
+# Holographic Memory Understanding
+
+This document describes the productionized Phase 1 "memory understanding"
+layer for the local `holographic` memory provider.
+
+## Scope
+
+The upgrade is additive. It does not replace built-in `MEMORY.md` / `USER.md`,
+does not change launchd or gateway wiring, and does not require cloud memory.
+
+The understanding layer now adds:
+
+- hybrid retrieval scoring across semantic, keyword, recency, salience, and confidence
+- structured enrichment on write / ingest
+- bounded deferred understanding ingestion for turn and session extraction
+- related-memory links for repeated people / project / topic mentions
+- canonical keys / lightweight clustering for people, projects, and topics
+- explain/debug retrieval output
+- operator commands for status, reindex, inspect, and query debugging
+
+## Architecture
+
+Primary modules:
+
+- `plugins/memory/holographic/store.py`
+  Stores facts plus derived metadata, vectors, and links.
+- `plugins/memory/holographic/enrichment.py`
+  Local heuristics for extracting entities, people, projects, topics,
+  dates/times, locations, intent/type, source channel, salience, and confidence.
+- `plugins/memory/holographic/embeddings.py`
+  Optional embedding-provider abstraction. Current providers: `none`, `openai`.
+- `plugins/memory/holographic/ingestion.py`
+  Durable deferred-ingest payload shaping, bounded queue draining, and
+  heuristic turn/session extraction.
+- `plugins/memory/holographic/retrieval.py`
+  Hybrid candidate generation, ranking, and explain/debug scoring.
+- `plugins/memory/holographic/cli.py`
+  Operator commands.
+
+Storage model:
+
+- `facts`
+  Source text plus trust, salience, source confidence, intent, source channel,
+  metadata JSON, canonical keys, HRR vector, and optional embedding vector.
+- `fact_entities`
+  Normalized entity links.
+- `fact_links`
+  Lightweight related-memory edges.
+- `memory_banks`
+  Existing HRR banks kept intact.
+- `understanding_ingest_queue`
+  Durable deferred-ingest ledger for turn/session understanding work.
+- `understanding_state`
+  Last-success, failure, queue-reject, and reindex state for operators.
+
+Write paths:
+
+- synchronous:
+  - explicit `fact_store(action="add")`
+  - built-in memory mirroring via `memory` tool writes
+- deferred:
+  - `sync_turn()` queues bounded turn understanding
+  - `on_session_end()` queues bounded session extraction when `auto_extract` is enabled
+  - deferred work drains opportunistically on `queue_prefetch`, `prefetch`, session end, shutdown, and `hermes holographic reindex`
+
+The deferred path is intentionally small:
+
+- no always-on worker
+- durable queue in the existing SQLite DB
+- bounded pending queue with reject counting
+- retry with backoff on failures
+- safe restart recovery for interrupted in-flight items
+
+## Retrieval Model
+
+Search now merges two candidate paths:
+
+1. keyword candidates from SQLite FTS5
+2. semantic candidates from HRR vectors and optional embeddings
+
+Each candidate gets a configurable weighted score across:
+
+- semantic relevance
+- keyword relevance
+- recency
+- salience / priority
+- source confidence
+
+If semantic signals are unavailable, weights are renormalized and retrieval
+continues instead of failing.
+
+## Enrichment Model
+
+Every write or ingest path that stores a fact now enriches it with:
+
+- entities
+- people
+- projects
+- topics
+- dates
+- times
+- locations
+- intent/type
+- source channel
+- salience score
+- source confidence
+- canonical `entity_keys`, `person_keys`, `project_keys`, `topic_keys`
+- lightweight `cluster_keys`
+
+The extraction is intentionally heuristic and local. It is deterministic,
+fast, and testable, not LLM-dependent.
+
+## Operator Commands
+
+With `memory.provider: holographic` active:
+
+```bash
+hermes holographic status
+hermes holographic reindex
+hermes holographic inspect <fact_id>
+hermes holographic query-debug "Hermes deploy checklist"
+```
+
+Command mapping to the Phase 1 operator asks:
+
+- `status` -> index status / coverage
+- `reindex` -> drain pending deferred ingest, then rebuild derived state
+- `inspect` -> memory inspect
+- `query-debug` -> memory query debug
+- `hermes doctor` -> concise global health summary when `memory.provider: holographic` is active
+
+`hermes holographic status` now exposes:
+
+- pending / failed / processing deferred-ingest counts
+- oldest pending item timestamp
+- last successful ingest time
+- last ingest error summary
+- queue reject count
+- reindex state (`idle`, `running`, `completed`, `failed`)
+
+Global doctor behavior:
+
+- `hermes doctor` shows a single holographic summary line only when the
+  holographic provider is active.
+- Healthy state is `OK` with compact counts.
+- Degraded state is `WARN`, not `FAIL`, for:
+  - failed deferred-ingest items
+  - stale pending/processing backlog
+  - reindex running
+  - reindex failed
+- Use holographic-specific commands for full detail and recovery.
+
+## Config And Env
+
+Config path:
+
+- `$HERMES_HOME/config.yaml`
+- section: `plugins.hermes-memory-store`
+
+Key knobs:
+
+- `db_path`
+- `auto_extract`
+- `deferred_ingest`
+- `turn_understanding`
+- `ingest_batch_size`
+- `ingest_max_pending`
+- `ingest_retry_delay_seconds`
+- `session_ingest_message_limit`
+- `default_trust`
+- `hrr_dim`
+- `link_threshold`
+- `temporal_decay_half_life`
+- `semantic_provider`
+- `semantic_model`
+- `semantic_dimensions`
+- `semantic_base_url`
+- `rank_semantic_weight`
+- `rank_keyword_weight`
+- `rank_recency_weight`
+- `rank_salience_weight`
+- `rank_confidence_weight`
+
+Optional env:
+
+- `HOLOGRAPHIC_OPENAI_API_KEY`
+- `OPENAI_API_KEY`
+- `HOLOGRAPHIC_OPENAI_BASE_URL`
+- `OPENAI_BASE_URL`
+
+## Failure Modes
+
+- Missing embedding credentials:
+  Semantic embedding path is skipped. HRR and keyword retrieval remain active.
+- Missing NumPy:
+  HRR path is skipped. Keyword and metadata ranking remain active.
+- Deferred ingest failure:
+  The queue item is retained, marked failed, and retried later with backoff.
+  Normal agent operation continues.
+- Deferred ingest queue full:
+  New understanding items are skipped rather than blocking the agent. Status
+  shows the reject count and last error summary.
+- Interrupted process during ingest:
+  `processing` items are recovered to `failed` on next startup and retried.
+- Reindex on an existing store:
+  Facts are preserved. Derived metadata, vectors, links, and canonical keys
+  are rebuilt. Pending deferred-ingest items can be drained first.
+- Stale links:
+  Run `hermes holographic reindex`.
+
+Recommended operator flow:
+
+1. `hermes doctor`
+2. If holographic shows `WARN`, run `hermes holographic status`
+3. Use `hermes holographic inspect <fact_id>` or `query-debug` for diagnosis
+4. Run `hermes holographic reindex` to recover derived state / drain backlog
+
+## Inspecting What Hermes Knows
+
+For a single fact:
+
+```bash
+hermes holographic inspect 42
+```
+
+For explainable recall:
+
+```bash
+hermes holographic query-debug "Alice Johnson deployment preferences"
+```
+
+The debug output includes:
+
+- why a fact matched
+- score breakdown
+- matched entities/topics/terms
+- matched canonical clusters
+- recency contribution
+- related memory IDs
+
+`hermes holographic inspect <fact_id>` shows:
+
+- raw entities / people / projects / topics
+- canonical keys used for alias grouping
+- cluster keys
+- related-memory links with reasons

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -9,6 +9,8 @@ import sys
 import subprocess
 import shutil
 from pathlib import Path
+import sqlite3
+from datetime import datetime, timezone
 
 from hermes_cli.config import get_project_root, get_hermes_home, get_env_path
 from hermes_constants import display_hermes_home
@@ -98,6 +100,140 @@ def _honcho_is_configured_for_doctor() -> bool:
         return bool(cfg.enabled and (cfg.api_key or cfg.base_url))
     except Exception:
         return False
+
+
+def _parse_holographic_timestamp(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        text = str(value).strip().replace("Z", "+00:00")
+        if "T" not in text and "+" not in text:
+            text = text.replace(" ", "T")
+        parsed = datetime.fromisoformat(text)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed
+    except Exception:
+        return None
+
+
+def _load_doctor_raw_config() -> dict:
+    config_path = HERMES_HOME / "config.yaml"
+    if not config_path.exists():
+        return {}
+    try:
+        import yaml
+        with open(config_path, encoding="utf-8") as handle:
+            return yaml.safe_load(handle) or {}
+    except Exception:
+        return {}
+
+
+def _resolve_holographic_db_path(raw_config: dict) -> str:
+    plugin_cfg = (raw_config.get("plugins") or {}).get("hermes-memory-store", {}) or {}
+    db_path = plugin_cfg.get("db_path", str(HERMES_HOME / "memory_store.db"))
+    if isinstance(db_path, str):
+        hermes_home = str(HERMES_HOME)
+        db_path = db_path.replace("$HERMES_HOME", hermes_home)
+        db_path = db_path.replace("${HERMES_HOME}", hermes_home)
+    return str(db_path)
+
+
+def _read_holographic_doctor_status(raw_config: dict) -> dict:
+    db_path = _resolve_holographic_db_path(raw_config)
+    status = {
+        "db_path": db_path,
+        "db_exists": False,
+        "db_initialized": False,
+        "facts": 0,
+        "pending_ingest_items": 0,
+        "failed_ingest_items": 0,
+        "processing_ingest_items": 0,
+        "oldest_pending_ingest": None,
+        "oldest_pending_age_minutes": None,
+        "last_ingest_success": None,
+        "last_ingest_error": None,
+        "reindex_status": "idle",
+        "reindex_started_at": None,
+        "reindex_completed_at": None,
+        "reindex_error": None,
+        "error": None,
+    }
+
+    if not os.path.exists(db_path):
+        return status
+
+    status["db_exists"] = True
+    uri = f"file:{db_path}?mode=ro"
+    try:
+        conn = sqlite3.connect(uri, uri=True, timeout=2.0)
+        conn.row_factory = sqlite3.Row
+    except Exception as exc:
+        status["error"] = str(exc)
+        return status
+
+    try:
+        tables = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            ).fetchall()
+        }
+        if "facts" not in tables:
+            return status
+
+        status["db_initialized"] = True
+        status["facts"] = int(conn.execute("SELECT COUNT(*) FROM facts").fetchone()[0])
+
+        if "understanding_ingest_queue" in tables:
+            status["pending_ingest_items"] = int(
+                conn.execute(
+                    "SELECT COUNT(*) FROM understanding_ingest_queue WHERE status = 'pending'"
+                ).fetchone()[0]
+            )
+            status["failed_ingest_items"] = int(
+                conn.execute(
+                    "SELECT COUNT(*) FROM understanding_ingest_queue WHERE status = 'failed'"
+                ).fetchone()[0]
+            )
+            status["processing_ingest_items"] = int(
+                conn.execute(
+                    "SELECT COUNT(*) FROM understanding_ingest_queue WHERE status = 'processing'"
+                ).fetchone()[0]
+            )
+            oldest_pending = conn.execute(
+                """
+                SELECT MIN(created_at)
+                FROM understanding_ingest_queue
+                WHERE status IN ('pending', 'failed', 'processing')
+                """
+            ).fetchone()[0]
+            status["oldest_pending_ingest"] = oldest_pending
+            parsed_oldest = _parse_holographic_timestamp(oldest_pending)
+            if parsed_oldest is not None:
+                age_minutes = max(
+                    0,
+                    int((datetime.now(timezone.utc) - parsed_oldest).total_seconds() // 60),
+                )
+                status["oldest_pending_age_minutes"] = age_minutes
+
+        if "understanding_state" in tables:
+            rows = conn.execute(
+                "SELECT state_key, state_value FROM understanding_state"
+            ).fetchall()
+            state_map = {str(row["state_key"]): row["state_value"] for row in rows}
+            status["last_ingest_success"] = state_map.get("last_ingest_success_at") or None
+            status["last_ingest_error"] = state_map.get("last_ingest_error_summary") or None
+            status["reindex_status"] = state_map.get("reindex_status") or "idle"
+            status["reindex_started_at"] = state_map.get("reindex_started_at") or None
+            status["reindex_completed_at"] = state_map.get("reindex_completed_at") or None
+            status["reindex_error"] = state_map.get("reindex_error") or None
+    except Exception as exc:
+        status["error"] = str(exc)
+    finally:
+        conn.close()
+
+    return status
 
 
 def _apply_doctor_tool_availability_overrides(available: list[str], unavailable: list[dict]) -> tuple[list[str], list[dict]]:
@@ -1094,13 +1230,10 @@ def run_doctor(args):
     print(color("◆ Memory Provider", Colors.CYAN, Colors.BOLD))
 
     _active_memory_provider = ""
+    _raw_cfg = {}
     try:
-        import yaml as _yaml
-        _mem_cfg_path = HERMES_HOME / "config.yaml"
-        if _mem_cfg_path.exists():
-            with open(_mem_cfg_path) as _f:
-                _raw_cfg = _yaml.safe_load(_f) or {}
-            _active_memory_provider = (_raw_cfg.get("memory") or {}).get("provider", "")
+        _raw_cfg = _load_doctor_raw_config()
+        _active_memory_provider = (_raw_cfg.get("memory") or {}).get("provider", "")
     except Exception:
         pass
 
@@ -1152,6 +1285,70 @@ def run_doctor(args):
             issues.append("Mem0 is set as memory provider but mem0ai is not installed")
         except Exception as _e:
             check_warn("Mem0 check failed", str(_e))
+    elif _active_memory_provider == "holographic":
+        try:
+            hstatus = _read_holographic_doctor_status(_raw_cfg)
+            if hstatus.get("error"):
+                check_warn("holographic status check failed", f"({hstatus['error']})")
+                issues.append("Inspect holographic provider state: hermes holographic status")
+            elif not hstatus["db_exists"]:
+                check_ok("holographic provider active", "(index not initialized yet)")
+            elif not hstatus["db_initialized"]:
+                check_warn("holographic index unreadable", f"(db={hstatus['db_path']})")
+                issues.append("Rebuild or inspect holographic memory DB: hermes holographic reindex")
+            else:
+                pending = hstatus["pending_ingest_items"]
+                failed = hstatus["failed_ingest_items"]
+                processing = hstatus["processing_ingest_items"]
+                oldest_age = hstatus["oldest_pending_age_minutes"]
+                reindex_status = hstatus["reindex_status"] or "idle"
+                degraded = False
+                reasons = [f"facts={hstatus['facts']}"]
+
+                if failed > 0:
+                    degraded = True
+                    reasons.append(f"failed={failed}")
+                if reindex_status == "failed":
+                    degraded = True
+                    reasons.append("reindex=failed")
+                elif reindex_status == "running":
+                    degraded = True
+                    reasons.append("reindex=running")
+                else:
+                    reasons.append(f"reindex={reindex_status}")
+
+                if pending > 0:
+                    reasons.append(f"pending={pending}")
+                    if oldest_age is not None and oldest_age >= 15:
+                        degraded = True
+                        reasons.append(f"oldest={oldest_age}m")
+                if processing > 0:
+                    reasons.append(f"processing={processing}")
+                    if oldest_age is None or oldest_age >= 15:
+                        degraded = True
+
+                detail = "(" + " ".join(reasons) + ")"
+                if degraded:
+                    check_warn("holographic provider active", detail)
+                    if hstatus.get("last_ingest_error"):
+                        check_info(f"last ingest error: {hstatus['last_ingest_error']}")
+                    elif hstatus.get("last_ingest_success"):
+                        check_info(f"last ingest success: {hstatus['last_ingest_success']}")
+                    issues.append("Inspect holographic memory backlog: hermes holographic status")
+                    if failed > 0 or reindex_status == "failed":
+                        issues.append("Recover holographic understanding state: hermes holographic reindex")
+                else:
+                    check_ok("holographic provider active", detail)
+                    if pending > 0 or processing > 0:
+                        age_text = f", oldest {oldest_age}m" if oldest_age is not None else ""
+                        check_info(
+                            f"background ingest pending={pending} processing={processing}{age_text}"
+                        )
+                    elif hstatus.get("last_ingest_success"):
+                        check_info(f"last ingest success: {hstatus['last_ingest_success']}")
+        except Exception as _e:
+            check_warn("holographic check failed", str(_e))
+            issues.append("Inspect holographic provider state: hermes holographic status")
     else:
         # Generic check for other memory providers (openviking, hindsight, etc.)
         try:

--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -33,14 +33,26 @@ logger = logging.getLogger(__name__)
 _MEMORY_PLUGINS_DIR = Path(__file__).parent
 
 
-# ---------------------------------------------------------------------------
-# Directory helpers
-# ---------------------------------------------------------------------------
+def __getattr__(name: str):
+    """Lazily expose memory plugin packages as attributes.
+
+    This keeps normal discovery lightweight while still allowing dotted imports
+    like ``plugins.memory.honcho.client`` to resolve reliably in diagnostics
+    code and tests.
+    """
+    candidate = _MEMORY_PLUGINS_DIR / name
+    if candidate.is_dir() and (candidate / "__init__.py").exists():
+        module = importlib.import_module(f"{__name__}.{name}")
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 def _get_user_plugins_dir() -> Optional[Path]:
     """Return ``$HERMES_HOME/plugins/`` or None if unavailable."""
     try:
         from hermes_constants import get_hermes_home
+
         d = get_hermes_home() / "plugins"
         return d if d.is_dir() else None
     except Exception:
@@ -48,11 +60,7 @@ def _get_user_plugins_dir() -> Optional[Path]:
 
 
 def _is_memory_provider_dir(path: Path) -> bool:
-    """Heuristic: does *path* look like a memory provider plugin?
-
-    Checks for ``register_memory_provider`` or ``MemoryProvider`` in the
-    ``__init__.py`` source.  Cheap text scan — no import needed.
-    """
+    """Heuristic: does *path* look like a memory provider plugin?"""
     init_file = path / "__init__.py"
     if not init_file.exists():
         return False
@@ -64,15 +72,10 @@ def _is_memory_provider_dir(path: Path) -> bool:
 
 
 def _iter_provider_dirs() -> List[Tuple[str, Path]]:
-    """Yield ``(name, path)`` for all discovered provider directories.
-
-    Scans bundled first, then user-installed.  Bundled takes precedence
-    on name collisions (first-seen wins via ``seen`` set).
-    """
+    """Yield ``(name, path)`` for all discovered provider directories."""
     seen: set = set()
     dirs: List[Tuple[str, Path]] = []
 
-    # 1. Bundled providers (plugins/memory/<name>/)
     if _MEMORY_PLUGINS_DIR.is_dir():
         for child in sorted(_MEMORY_PLUGINS_DIR.iterdir()):
             if not child.is_dir() or child.name.startswith(("_", ".")):
@@ -82,42 +85,34 @@ def _iter_provider_dirs() -> List[Tuple[str, Path]]:
             seen.add(child.name)
             dirs.append((child.name, child))
 
-    # 2. User-installed providers ($HERMES_HOME/plugins/<name>/)
     user_dir = _get_user_plugins_dir()
     if user_dir:
         for child in sorted(user_dir.iterdir()):
             if not child.is_dir() or child.name.startswith(("_", ".")):
                 continue
             if child.name in seen:
-                continue  # bundled takes precedence
+                continue
             if not _is_memory_provider_dir(child):
-                continue  # skip non-memory plugins
+                continue
             dirs.append((child.name, child))
 
     return dirs
 
 
 def find_provider_dir(name: str) -> Optional[Path]:
-    """Resolve a provider name to its directory.
-
-    Checks bundled first, then user-installed.
-    """
-    # Bundled
+    """Resolve a provider name to its directory."""
     bundled = _MEMORY_PLUGINS_DIR / name
     if bundled.is_dir() and (bundled / "__init__.py").exists():
         return bundled
-    # User-installed
+
     user_dir = _get_user_plugins_dir()
     if user_dir:
         user = user_dir / name
         if user.is_dir() and _is_memory_provider_dir(user):
             return user
+
     return None
 
-
-# ---------------------------------------------------------------------------
-# Public API
-# ---------------------------------------------------------------------------
 
 def discover_memory_providers() -> List[Tuple[str, str, bool]]:
     """Scan bundled and user-installed directories for available providers.

--- a/plugins/memory/holographic/README.md
+++ b/plugins/memory/holographic/README.md
@@ -1,10 +1,24 @@
 # Holographic Memory Provider
 
-Local SQLite fact store with FTS5 search, trust scoring, entity resolution, and HRR-based compositional retrieval.
+Local SQLite understanding-oriented memory store with:
+
+- hybrid recall: keyword + semantic + recency + salience + confidence
+- structured enrichment: entities, people, projects, topics, dates/times, locations, intent, source channel
+- bounded deferred turn/session understanding ingestion with retryable queue status
+- canonical keys / lightweight clustering for people, projects, and topics
+- related-memory linking across repeated mentions
+- explain/debug retrieval output
+- optional OpenAI-compatible embeddings with graceful fallback
 
 ## Requirements
 
-None — uses SQLite (always available). NumPy optional for HRR algebra.
+None for the base path — uses SQLite (always available). NumPy is optional for HRR algebra.
+
+Optional semantic embeddings:
+
+- `semantic_provider: openai`
+- `HOLOGRAPHIC_OPENAI_API_KEY` or `OPENAI_API_KEY`
+- optional `semantic_base_url` for OpenAI-compatible endpoints
 
 ## Setup
 
@@ -25,8 +39,25 @@ Config in `config.yaml` under `plugins.hermes-memory-store`:
 |-----|---------|-------------|
 | `db_path` | `$HERMES_HOME/memory_store.db` | SQLite database path |
 | `auto_extract` | `false` | Auto-extract facts at session end |
+| `deferred_ingest` | `true` | Enable durable deferred understanding ingestion |
+| `turn_understanding` | `true` | Extract understanding from user turns |
+| `ingest_batch_size` | `2` | Number of deferred items drained per bounded pass |
+| `ingest_max_pending` | `200` | Max deferred-ingest queue depth before new items are rejected |
+| `ingest_retry_delay_seconds` | `60` | Base retry delay for failed deferred-ingest items |
+| `session_ingest_message_limit` | `80` | Max session messages captured for deferred session ingestion |
 | `default_trust` | `0.5` | Default trust score for new facts |
 | `hrr_dim` | `1024` | HRR vector dimensions |
+| `link_threshold` | `0.36` | Minimum score for related-memory links |
+| `temporal_decay_half_life` | `45` | Recency half-life in days |
+| `semantic_provider` | `none` | `none` or `openai` |
+| `semantic_model` | `text-embedding-3-small` | Embedding model when `semantic_provider=openai` |
+| `semantic_dimensions` | `1536` | Optional embedding dimension override |
+| `semantic_base_url` | `` | Optional OpenAI-compatible base URL |
+| `rank_semantic_weight` | `0.35` | Retrieval weight: semantic relevance |
+| `rank_keyword_weight` | `0.25` | Retrieval weight: keyword relevance |
+| `rank_recency_weight` | `0.15` | Retrieval weight: recency |
+| `rank_salience_weight` | `0.15` | Retrieval weight: salience |
+| `rank_confidence_weight` | `0.10` | Retrieval weight: source confidence / trust |
 
 ## Tools
 
@@ -34,3 +65,78 @@ Config in `config.yaml` under `plugins.hermes-memory-store`:
 |------|-------------|
 | `fact_store` | 9 actions: add, search, probe, related, reason, contradict, update, remove, list |
 | `fact_feedback` | Rate facts as helpful/unhelpful (trains trust scores) |
+
+`fact_store(action="search", debug=true)` returns explain/debug scoring details.
+
+## Operator Commands
+
+When `holographic` is the active memory provider:
+
+```bash
+hermes holographic status
+hermes holographic reindex
+hermes holographic inspect <fact_id>
+hermes holographic query-debug "your query"
+```
+
+These cover the Phase 1 operator flows:
+
+- index status / coverage
+- full reindex of enrichment, vectors, optional embeddings, and links
+- inspection of a single stored memory and its related memories
+- explainable recall with score breakdowns
+
+`status` now includes:
+
+- pending / failed / processing deferred-ingest counts
+- last successful ingest time
+- last ingest error summary
+- queue reject count
+- reindex status and timestamps
+
+Global visibility:
+
+- `hermes doctor` shows a concise holographic summary only when
+  `memory.provider: holographic` is active.
+- Healthy holographic state is reported as `OK`.
+- Degraded holographic state is reported conservatively as `WARN` for backlog,
+  failed ingest items, or reindex issues.
+- Use `hermes holographic status` for full operator detail and recovery state.
+
+`inspect` now includes canonical keys / cluster keys so operators can see how
+alias grouping is working.
+
+`reindex` drains pending deferred-ingest items by default before rebuilding
+derived understanding state.
+
+## Runtime Model
+
+- synchronous writes:
+  - explicit `fact_store(action=\"add\")`
+  - built-in memory mirroring from `memory` tool writes
+- deferred writes:
+  - turn understanding queued from `sync_turn()`
+  - session extraction queued from `on_session_end()` when `auto_extract=true`
+
+Deferred ingestion is durable but intentionally lightweight:
+
+- queue stored in the same SQLite DB
+- no separate always-on worker
+- bounded queue with reject counting
+- retry with backoff
+- interrupted `processing` items are recovered on next startup
+
+## Failure Modes
+
+- If embeddings are not configured or fail, retrieval falls back to keyword + HRR + metadata scoring.
+- If NumPy is unavailable, HRR-based semantic features are skipped and retrieval falls back to keyword + metadata scoring.
+- If deferred ingest fails, the item stays queued with failure state and retries later; normal agent operation continues.
+- If the deferred queue fills, new understanding items are skipped rather than blocking the agent; see `hermes holographic status`.
+- Reindexing never deletes facts; it only rebuilds derived enrichment, vectors, and links.
+
+## Operator Workflow
+
+1. Run `hermes doctor` for the concise global summary.
+2. If holographic is warned, run `hermes holographic status`.
+3. Use `inspect` or `query-debug` to inspect specific memories / matches.
+4. Run `hermes holographic reindex` to drain backlog and rebuild derived state.

--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -1,7 +1,8 @@
 """hermes-memory-store — holographic memory plugin using MemoryProvider interface.
 
 Registers as a MemoryProvider plugin, giving the agent structured fact storage
-with entity resolution, trust scoring, and HRR-based compositional retrieval.
+with entity resolution, semantic retrieval, explainable ranking, and
+related-memory linking.
 
 Original plugin by dusterbloom (PR #2351), adapted to the MemoryProvider ABC.
 
@@ -12,18 +13,24 @@ Config in $HERMES_HOME/config.yaml (profile-scoped):
       auto_extract: false
       default_trust: 0.5
       min_trust_threshold: 0.3
-      temporal_decay_half_life: 0
+      temporal_decay_half_life: 45
 """
 
 from __future__ import annotations
 
 import json
 import logging
-import re
 from typing import Any, Dict, List
 
 from agent.memory_provider import MemoryProvider
 from tools.registry import tool_error
+from .embeddings import build_embedding_provider
+from .ingestion import (
+    drain_understanding_ingest,
+    ingest_settings,
+    queue_session_ingest,
+    queue_turn_ingest,
+)
 from .store import MemoryStore
 from .retrieval import FactRetriever
 
@@ -31,7 +38,7 @@ logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
-# Tool schemas (unchanged from original PR)
+# Tool schemas
 # ---------------------------------------------------------------------------
 
 FACT_STORE_SCHEMA = {
@@ -42,7 +49,7 @@ FACT_STORE_SCHEMA = {
         "fact_store for deep recall and compositional queries.\n\n"
         "ACTIONS (simple → powerful):\n"
         "• add — Store a fact the user would expect you to remember.\n"
-        "• search — Keyword lookup ('editor config', 'deploy process').\n"
+        "• search — Hybrid recall across keyword, semantic, recency, salience, and confidence.\n"
         "• probe — Entity recall: ALL facts about a person/thing.\n"
         "• related — What connects to an entity? Structural adjacency.\n"
         "• reason — Compositional: facts connected to MULTIPLE entities simultaneously.\n"
@@ -67,6 +74,11 @@ FACT_STORE_SCHEMA = {
             "trust_delta": {"type": "number", "description": "Trust adjustment for 'update'."},
             "min_trust": {"type": "number", "description": "Minimum trust filter (default: 0.3)."},
             "limit": {"type": "integer", "description": "Max results (default: 10)."},
+            "debug": {"type": "boolean", "description": "Return explain/debug scoring details for search."},
+            "source_channel": {"type": "string", "description": "Optional source channel label for add/update."},
+            "source_confidence": {"type": "number", "description": "Optional source confidence override for add/update."},
+            "intent_type": {"type": "string", "description": "Optional intent/type override for add/update."},
+            "salience_score": {"type": "number", "description": "Optional salience override for add/update."},
         },
         "required": ["action"],
     },
@@ -112,13 +124,16 @@ def _load_plugin_config() -> dict:
 # ---------------------------------------------------------------------------
 
 class HolographicMemoryProvider(MemoryProvider):
-    """Holographic memory with structured facts, entity resolution, and HRR retrieval."""
+    """Holographic memory with structured enrichment and explainable retrieval."""
 
     def __init__(self, config: dict | None = None):
         self._config = config or _load_plugin_config()
         self._store = None
         self._retriever = None
         self._min_trust = float(self._config.get("min_trust_threshold", 0.3))
+        self._ingest_settings = ingest_settings(self._config)
+        self._session_id = ""
+        self._write_enabled = True
 
     @property
     def name(self) -> str:
@@ -150,8 +165,26 @@ class HolographicMemoryProvider(MemoryProvider):
         return [
             {"key": "db_path", "description": "SQLite database path", "default": _default_db},
             {"key": "auto_extract", "description": "Auto-extract facts at session end", "default": "false", "choices": ["true", "false"]},
+            {"key": "deferred_ingest", "description": "Enable bounded deferred understanding ingestion", "default": "true", "choices": ["true", "false"]},
+            {"key": "turn_understanding", "description": "Extract understanding from user turns", "default": "true", "choices": ["true", "false"]},
+            {"key": "ingest_batch_size", "description": "Deferred ingest batch size", "default": "2"},
+            {"key": "ingest_max_pending", "description": "Max queued deferred ingest items", "default": "200"},
+            {"key": "ingest_retry_delay_seconds", "description": "Base retry delay for failed ingest", "default": "60"},
+            {"key": "session_ingest_message_limit", "description": "Max session messages captured for deferred session ingest", "default": "80"},
             {"key": "default_trust", "description": "Default trust score for new facts", "default": "0.5"},
             {"key": "hrr_dim", "description": "HRR vector dimensions", "default": "1024"},
+            {"key": "link_threshold", "description": "Related-memory link threshold", "default": "0.36"},
+            {"key": "temporal_decay_half_life", "description": "Recency half-life in days", "default": "45"},
+            {"key": "semantic_provider", "description": "Semantic embedding provider", "default": "none", "choices": ["none", "openai"]},
+            {"key": "semantic_model", "description": "Embedding model", "default": "text-embedding-3-small", "when": {"semantic_provider": "openai"}},
+            {"key": "semantic_dimensions", "description": "Embedding dimensions (optional)", "default": "1536", "when": {"semantic_provider": "openai"}},
+            {"key": "semantic_base_url", "description": "OpenAI-compatible base URL (optional)", "default": "", "when": {"semantic_provider": "openai"}},
+            {"key": "semantic_api_key", "description": "Embedding API key", "secret": True, "env_var": "HOLOGRAPHIC_OPENAI_API_KEY", "when": {"semantic_provider": "openai"}},
+            {"key": "rank_semantic_weight", "description": "Ranking weight: semantic", "default": "0.35"},
+            {"key": "rank_keyword_weight", "description": "Ranking weight: keyword", "default": "0.25"},
+            {"key": "rank_recency_weight", "description": "Ranking weight: recency", "default": "0.15"},
+            {"key": "rank_salience_weight", "description": "Ranking weight: salience", "default": "0.15"},
+            {"key": "rank_confidence_weight", "description": "Ranking weight: confidence", "default": "0.10"},
         ]
 
     def initialize(self, session_id: str, **kwargs) -> None:
@@ -167,17 +200,31 @@ class HolographicMemoryProvider(MemoryProvider):
             db_path = db_path.replace("${HERMES_HOME}", _hermes_home)
         default_trust = float(self._config.get("default_trust", 0.5))
         hrr_dim = int(self._config.get("hrr_dim", 1024))
-        hrr_weight = float(self._config.get("hrr_weight", 0.3))
-        temporal_decay = int(self._config.get("temporal_decay_half_life", 0))
+        temporal_decay = int(self._config.get("temporal_decay_half_life", 45))
+        embedder = build_embedding_provider(self._config)
 
-        self._store = MemoryStore(db_path=db_path, default_trust=default_trust, hrr_dim=hrr_dim)
+        self._store = MemoryStore(
+            db_path=db_path,
+            default_trust=default_trust,
+            hrr_dim=hrr_dim,
+            embedding_provider=embedder,
+            link_threshold=float(self._config.get("link_threshold", 0.36)),
+        )
         self._retriever = FactRetriever(
             store=self._store,
             temporal_decay_half_life=temporal_decay,
-            hrr_weight=hrr_weight,
             hrr_dim=hrr_dim,
+            semantic_weight=float(self._config.get("rank_semantic_weight", 0.35)),
+            keyword_weight=float(self._config.get("rank_keyword_weight", 0.25)),
+            recency_weight=float(self._config.get("rank_recency_weight", 0.15)),
+            salience_weight=float(self._config.get("rank_salience_weight", 0.15)),
+            confidence_weight=float(self._config.get("rank_confidence_weight", 0.10)),
         )
+        self._ingest_settings = ingest_settings(self._config)
         self._session_id = session_id
+        agent_context = kwargs.get("agent_context", "")
+        platform = kwargs.get("platform", "")
+        self._write_enabled = agent_context not in ("cron", "flush", "subagent") and platform != "cron"
 
     def system_prompt_block(self) -> str:
         if not self._store:
@@ -191,13 +238,14 @@ class HolographicMemoryProvider(MemoryProvider):
         if total == 0:
             return (
                 "# Holographic Memory\n"
-                "Active. Empty fact store — proactively add facts the user would expect you to remember.\n"
-                "Use fact_store(action='add') to store durable structured facts about people, projects, preferences, decisions.\n"
+                "Active. Empty understanding index.\n"
+                "Use fact_store(action='add') to store durable facts about people, projects, preferences, decisions, and incidents.\n"
+                "Use fact_store(action='search', debug=true) for explainable recall diagnostics.\n"
                 "Use fact_feedback to rate facts after using them (trains trust scores)."
             )
         return (
             f"# Holographic Memory\n"
-            f"Active. {total} facts stored with entity resolution and trust scoring.\n"
+            f"Active. {total} facts stored with structured enrichment, semantic retrieval, and trust scoring.\n"
             f"Use fact_store to search, probe entities, reason across entities, or add facts.\n"
             f"Use fact_feedback to rate facts after using them (trains trust scores)."
         )
@@ -206,22 +254,57 @@ class HolographicMemoryProvider(MemoryProvider):
         if not self._retriever or not query:
             return ""
         try:
+            if self._store and self._ingest_settings.get("deferred_ingest"):
+                drain_understanding_ingest(
+                    self._store,
+                    self._config,
+                    limit=1,
+                    reason="prefetch",
+                )
             results = self._retriever.search(query, min_trust=self._min_trust, limit=5)
             if not results:
                 return ""
             lines = []
             for r in results:
-                trust = r.get("trust_score", r.get("trust", 0))
-                lines.append(f"- [{trust:.1f}] {r.get('content', '')}")
+                score = r.get("score", 0.0)
+                topics = ", ".join(r.get("metadata", {}).get("topics", [])[:3])
+                suffix = f" ({topics})" if topics else ""
+                lines.append(f"- [{score:.2f}] {r.get('content', '')}{suffix}")
             return "## Holographic Memory\n" + "\n".join(lines)
         except Exception as e:
             logger.debug("Holographic prefetch failed: %s", e)
             return ""
 
     def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
-        # Holographic memory stores explicit facts via tools, not auto-sync.
-        # The on_session_end hook handles auto-extraction if configured.
-        pass
+        if not self._store or not self._write_enabled:
+            return
+        try:
+            result = queue_turn_ingest(
+                self._store,
+                self._config,
+                session_id=session_id or self._session_id,
+                user_content=user_content,
+                assistant_content=assistant_content,
+            )
+            if result.get("reason") == "queue_full":
+                logger.warning(
+                    "Holographic deferred ingest queue full for session %s",
+                    session_id or self._session_id,
+                )
+        except Exception as exc:
+            logger.debug("Holographic sync_turn enqueue failed: %s", exc)
+
+    def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
+        if not self._store or not self._ingest_settings.get("deferred_ingest"):
+            return
+        try:
+            drain_understanding_ingest(
+                self._store,
+                self._config,
+                reason="queue_prefetch",
+            )
+        except Exception as exc:
+            logger.debug("Holographic deferred ingest drain failed: %s", exc)
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
         return [FACT_STORE_SCHEMA, FACT_FEEDBACK_SCHEMA]
@@ -234,22 +317,57 @@ class HolographicMemoryProvider(MemoryProvider):
         return tool_error(f"Unknown tool: {tool_name}")
 
     def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
-        if not self._config.get("auto_extract", False):
+        if not self._store or not self._write_enabled:
             return
-        if not self._store or not messages:
+        if self._config.get("auto_extract", False) and messages:
+            try:
+                queue_session_ingest(
+                    self._store,
+                    self._config,
+                    session_id=self._session_id,
+                    messages=messages,
+                )
+            except Exception as exc:
+                logger.debug("Holographic session ingest enqueue failed: %s", exc)
+
+        if not self._ingest_settings.get("deferred_ingest"):
             return
-        self._auto_extract_facts(messages)
+        try:
+            drain_understanding_ingest(
+                self._store,
+                self._config,
+                limit=max(self._ingest_settings.get("ingest_batch_size", 2), 4),
+                reason="session_end",
+            )
+        except Exception as exc:
+            logger.debug("Holographic session-end drain failed: %s", exc)
 
     def on_memory_write(self, action: str, target: str, content: str) -> None:
         """Mirror built-in memory writes as facts."""
-        if action == "add" and self._store and content:
+        if action == "add" and self._store and self._write_enabled and content:
             try:
                 category = "user_pref" if target == "user" else "general"
-                self._store.add_fact(content, category=category)
+                self._store.add_fact(
+                    content,
+                    category=category,
+                    source_channel=f"builtin:{target}",
+                )
             except Exception as e:
                 logger.debug("Holographic memory_write mirror failed: %s", e)
 
     def shutdown(self) -> None:
+        if self._store:
+            try:
+                if self._ingest_settings.get("deferred_ingest"):
+                    drain_understanding_ingest(
+                        self._store,
+                        self._config,
+                        limit=max(self._ingest_settings.get("ingest_batch_size", 2), 4),
+                        reason="shutdown",
+                    )
+                self._store.close()
+            except Exception:
+                pass
         self._store = None
         self._retriever = None
 
@@ -266,6 +384,10 @@ class HolographicMemoryProvider(MemoryProvider):
                     args["content"],
                     category=args.get("category", "general"),
                     tags=args.get("tags", ""),
+                    source_channel=args.get("source_channel", "tool:fact_store"),
+                    source_confidence=float(args["source_confidence"]) if "source_confidence" in args else None,
+                    intent_type=args.get("intent_type"),
+                    salience_score=float(args["salience_score"]) if "salience_score" in args else None,
                 )
                 return json.dumps({"fact_id": fact_id, "status": "added"})
 
@@ -275,6 +397,7 @@ class HolographicMemoryProvider(MemoryProvider):
                     category=args.get("category"),
                     min_trust=float(args.get("min_trust", self._min_trust)),
                     limit=int(args.get("limit", 10)),
+                    debug=bool(args.get("debug", False)),
                 )
                 return json.dumps({"results": results, "count": len(results)})
 
@@ -319,6 +442,10 @@ class HolographicMemoryProvider(MemoryProvider):
                     trust_delta=float(args["trust_delta"]) if "trust_delta" in args else None,
                     tags=args.get("tags"),
                     category=args.get("category"),
+                    source_channel=args.get("source_channel"),
+                    source_confidence=float(args["source_confidence"]) if "source_confidence" in args else None,
+                    intent_type=args.get("intent_type"),
+                    salience_score=float(args["salience_score"]) if "salience_score" in args else None,
                 )
                 return json.dumps({"updated": updated})
 
@@ -352,49 +479,6 @@ class HolographicMemoryProvider(MemoryProvider):
             return tool_error(f"Missing required argument: {exc}")
         except Exception as exc:
             return tool_error(str(exc))
-
-    # -- Auto-extraction (on_session_end) ------------------------------------
-
-    def _auto_extract_facts(self, messages: list) -> None:
-        _PREF_PATTERNS = [
-            re.compile(r'\bI\s+(?:prefer|like|love|use|want|need)\s+(.+)', re.IGNORECASE),
-            re.compile(r'\bmy\s+(?:favorite|preferred|default)\s+\w+\s+is\s+(.+)', re.IGNORECASE),
-            re.compile(r'\bI\s+(?:always|never|usually)\s+(.+)', re.IGNORECASE),
-        ]
-        _DECISION_PATTERNS = [
-            re.compile(r'\bwe\s+(?:decided|agreed|chose)\s+(?:to\s+)?(.+)', re.IGNORECASE),
-            re.compile(r'\bthe\s+project\s+(?:uses|needs|requires)\s+(.+)', re.IGNORECASE),
-        ]
-
-        extracted = 0
-        for msg in messages:
-            if msg.get("role") != "user":
-                continue
-            content = msg.get("content", "")
-            if not isinstance(content, str) or len(content) < 10:
-                continue
-
-            for pattern in _PREF_PATTERNS:
-                if pattern.search(content):
-                    try:
-                        self._store.add_fact(content[:400], category="user_pref")
-                        extracted += 1
-                    except Exception:
-                        pass
-                    break
-
-            for pattern in _DECISION_PATTERNS:
-                if pattern.search(content):
-                    try:
-                        self._store.add_fact(content[:400], category="project")
-                        extracted += 1
-                    except Exception:
-                        pass
-                    break
-
-        if extracted:
-            logger.info("Auto-extracted %d facts from conversation", extracted)
-
 
 # ---------------------------------------------------------------------------
 # Plugin entry point

--- a/plugins/memory/holographic/cli.py
+++ b/plugins/memory/holographic/cli.py
@@ -1,0 +1,269 @@
+"""CLI commands for the holographic memory provider.
+
+Exposes:
+  hermes holographic status
+  hermes holographic reindex
+  hermes holographic inspect <fact_id>
+  hermes holographic query-debug <query>
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from hermes_constants import get_hermes_home
+
+from .embeddings import build_embedding_provider
+from .ingestion import drain_understanding_ingest, ingest_settings
+from .retrieval import FactRetriever
+from .store import MemoryStore
+
+
+def _load_plugin_config() -> dict:
+    config_path = get_hermes_home() / "config.yaml"
+    if not config_path.exists():
+        return {}
+    try:
+        import yaml
+
+        with open(config_path, encoding="utf-8") as handle:
+            payload = yaml.safe_load(handle) or {}
+        return payload.get("plugins", {}).get("hermes-memory-store", {}) or {}
+    except Exception:
+        return {}
+
+
+def _open_store() -> MemoryStore:
+    cfg = _load_plugin_config()
+    hermes_home = str(get_hermes_home())
+    db_path = cfg.get("db_path", hermes_home + "/memory_store.db")
+    if isinstance(db_path, str):
+        db_path = db_path.replace("$HERMES_HOME", hermes_home)
+        db_path = db_path.replace("${HERMES_HOME}", hermes_home)
+
+    return MemoryStore(
+        db_path=Path(db_path).expanduser(),
+        default_trust=float(cfg.get("default_trust", 0.5)),
+        hrr_dim=int(cfg.get("hrr_dim", 1024)),
+        embedding_provider=build_embedding_provider(cfg),
+        link_threshold=float(cfg.get("link_threshold", 0.36)),
+    )
+
+
+def cmd_status(_args) -> None:
+    cfg = _load_plugin_config()
+    settings = ingest_settings(cfg)
+    store = _open_store()
+    try:
+        status = store.index_status()
+    finally:
+        store.close()
+
+    print("\nHolographic memory index status\n" + "-" * 40)
+    print(f"  Database:            {status['db_path']}")
+    print(f"  Facts:               {status['facts']}")
+    print(f"  Enriched facts:      {status['enriched_facts']}")
+    print(f"  HRR-ready facts:     {status['hrr_ready_facts']}")
+    print(f"  Embedded facts:      {status['embedded_facts']}")
+    print(f"  Related links:       {status['links']}")
+    print(f"  Embedding provider:  {status['embedding_provider'] or 'none'}")
+    print(f"  Embedding available: {'yes' if status['embedding_available'] else 'no'}")
+    print(f"  Embedding model:     {status['embedding_model'] or '-'}")
+    print(f"  Link threshold:      {status['link_threshold']}")
+    print(f"  Latest update:       {status['latest_update'] or '-'}")
+    print(f"  Deferred ingest:     {'on' if settings['deferred_ingest'] else 'off'}")
+    print(f"  Turn understanding:  {'on' if settings['turn_understanding'] else 'off'}")
+    print(f"  Ingest batch size:   {settings['ingest_batch_size']}")
+    print(f"  Max pending queue:   {settings['ingest_max_pending']}")
+    print(f"  Pending ingest:      {status['pending_ingest_items']}")
+    print(f"  Failed ingest:       {status['failed_ingest_items']}")
+    print(f"  Processing ingest:   {status['processing_ingest_items']}")
+    print(f"  Oldest pending:      {status['oldest_pending_ingest'] or '-'}")
+    print(f"  Last ingest success: {status['last_ingest_success'] or '-'}")
+    print(f"  Last ingest error:   {status['last_ingest_error'] or '-'}")
+    print(f"  Queue rejects:       {status['ingest_enqueue_rejected']}")
+    print(f"  Reindex status:      {status['reindex_status']}")
+    print(f"  Reindex started:     {status['reindex_started_at'] or '-'}")
+    print(f"  Reindex completed:   {status['reindex_completed_at'] or '-'}")
+    print(f"  Reindex error:       {status['reindex_error'] or '-'}")
+    print()
+
+
+def cmd_reindex(args) -> None:
+    cfg = _load_plugin_config()
+    store = _open_store()
+    try:
+        if args.drain_pending:
+            settings = ingest_settings(cfg)
+            drain_understanding_ingest(
+                store,
+                cfg,
+                limit=settings["ingest_max_pending"],
+                reason="cli_reindex",
+            )
+        result = store.rebuild_understanding_index(
+            include_embeddings=bool(args.include_embeddings),
+            refresh_links=bool(args.refresh_links),
+        )
+        status = store.index_status()
+    finally:
+        store.close()
+
+    print("\nHolographic memory reindex\n" + "-" * 40)
+    print(f"  Facts reindexed:   {result['facts_reindexed']}")
+    print(f"  Embedded facts:    {result['embedded_facts']}")
+    print(f"  Links rebuilt:     {'yes' if result['links_rebuilt'] else 'no'}")
+    print(f"  Embedding provider:{' '}{result['embedding_provider'] or 'none'}")
+    print(f"  Started at:        {result['reindex_started_at']}")
+    print(f"  Completed at:      {result['reindex_completed_at']}")
+    print(f"  Pending ingest:    {status['pending_ingest_items']}")
+    print(f"  Failed ingest:     {status['failed_ingest_items']}")
+    print()
+
+
+def cmd_inspect(args) -> None:
+    store = _open_store()
+    try:
+        fact = store.get_fact(int(args.fact_id))
+    finally:
+        store.close()
+
+    if not fact:
+        print(f"\nFact {args.fact_id} not found.\n")
+        return
+
+    metadata = fact.get("metadata", {})
+    print(f"\nHolographic memory inspect: {fact['fact_id']}\n" + "-" * 52)
+    print(f"  Content:            {fact['content']}")
+    print(f"  Category:           {fact.get('category', '-')}")
+    print(f"  Intent:             {fact.get('intent_type', '-')}")
+    print(f"  Source channel:     {fact.get('source_channel', '-')}")
+    print(f"  Trust:              {fact.get('trust_score', 0.0):.2f}")
+    print(f"  Salience:           {fact.get('salience_score', 0.0):.2f}")
+    print(f"  Source confidence:  {fact.get('source_confidence', 0.0):.2f}")
+    print(f"  Updated at:         {fact.get('updated_at', '-')}")
+    print(f"  Entities:           {', '.join(metadata.get('entities', [])) or '-'}")
+    print(f"  Entity keys:        {', '.join(metadata.get('entity_keys', [])) or '-'}")
+    print(f"  People:             {', '.join(metadata.get('people', [])) or '-'}")
+    print(f"  Person keys:        {', '.join(metadata.get('person_keys', [])) or '-'}")
+    print(f"  Projects:           {', '.join(metadata.get('projects', [])) or '-'}")
+    print(f"  Project keys:       {', '.join(metadata.get('project_keys', [])) or '-'}")
+    print(f"  Topics:             {', '.join(metadata.get('topics', [])) or '-'}")
+    print(f"  Topic keys:         {', '.join(metadata.get('topic_keys', [])) or '-'}")
+    print(f"  Cluster keys:       {', '.join(metadata.get('cluster_keys', [])) or '-'}")
+    print(f"  Dates:              {', '.join(metadata.get('dates', [])) or '-'}")
+    print(f"  Times:              {', '.join(metadata.get('times', [])) or '-'}")
+    print(f"  Locations:          {', '.join(metadata.get('locations', [])) or '-'}")
+
+    links = fact.get("links", [])
+    print("  Related memories:")
+    if not links:
+        print("    - none")
+    else:
+        for link in links[:10]:
+            print(
+                f"    - #{link['linked_fact_id']} [{link['link_type']}] "
+                f"{link['strength']:.2f} :: {link['reason']}"
+            )
+    print()
+
+
+def cmd_query_debug(args) -> None:
+    cfg = _load_plugin_config()
+    store = _open_store()
+    retriever = FactRetriever(
+        store=store,
+        temporal_decay_half_life=int(cfg.get("temporal_decay_half_life", 45)),
+        hrr_dim=int(cfg.get("hrr_dim", 1024)),
+        semantic_weight=float(cfg.get("rank_semantic_weight", 0.35)),
+        keyword_weight=float(cfg.get("rank_keyword_weight", 0.25)),
+        recency_weight=float(cfg.get("rank_recency_weight", 0.15)),
+        salience_weight=float(cfg.get("rank_salience_weight", 0.15)),
+        confidence_weight=float(cfg.get("rank_confidence_weight", 0.10)),
+    )
+    try:
+        results = retriever.search(
+            args.query,
+            category=args.category,
+            min_trust=float(args.min_trust),
+            limit=int(args.limit),
+            debug=True,
+        )
+    finally:
+        store.close()
+
+    print("\nHolographic memory query debug\n" + "-" * 40)
+    print(f"  Query: {args.query}")
+    print(f"  Results: {len(results)}\n")
+    print(json.dumps(results, indent=2, ensure_ascii=False))
+    print()
+
+
+def register_cli(parser) -> None:
+    sub = parser.add_subparsers(dest="holographic_action")
+
+    sub.add_parser("status", help="Show understanding-index status")
+
+    reindex = sub.add_parser("reindex", help="Rebuild enrichment, vectors, embeddings, and links")
+    reindex.add_argument(
+        "--include-embeddings",
+        action="store_true",
+        default=True,
+        help="Recompute embeddings when an embedding provider is configured (default: on)",
+    )
+    reindex.add_argument(
+        "--no-embeddings",
+        dest="include_embeddings",
+        action="store_false",
+        help="Skip embedding recomputation",
+    )
+    reindex.add_argument(
+        "--refresh-links",
+        action="store_true",
+        default=True,
+        help="Rebuild related-memory links (default: on)",
+    )
+    reindex.add_argument(
+        "--no-links",
+        dest="refresh_links",
+        action="store_false",
+        help="Skip link rebuilding",
+    )
+    reindex.add_argument(
+        "--drain-pending",
+        action="store_true",
+        default=True,
+        help="Process pending deferred-ingest items before reindexing (default: on)",
+    )
+    reindex.add_argument(
+        "--no-drain-pending",
+        dest="drain_pending",
+        action="store_false",
+        help="Skip draining deferred-ingest backlog before reindexing",
+    )
+
+    inspect_parser = sub.add_parser("inspect", help="Inspect one stored memory by fact ID")
+    inspect_parser.add_argument("fact_id", help="Fact ID to inspect")
+
+    query_parser = sub.add_parser("query-debug", help="Run explainable retrieval and print JSON debug output")
+    query_parser.add_argument("query", help="Search query")
+    query_parser.add_argument("--category", help="Optional category filter")
+    query_parser.add_argument("--min-trust", type=float, default=0.3, help="Minimum trust threshold")
+    query_parser.add_argument("--limit", type=int, default=5, help="Number of results to return")
+
+    parser.set_defaults(func=holographic_command)
+
+
+def holographic_command(args) -> None:
+    action = getattr(args, "holographic_action", None) or "status"
+    if action == "status":
+        cmd_status(args)
+    elif action == "reindex":
+        cmd_reindex(args)
+    elif action == "inspect":
+        cmd_inspect(args)
+    elif action == "query-debug":
+        cmd_query_debug(args)
+    else:
+        cmd_status(args)

--- a/plugins/memory/holographic/embeddings.py
+++ b/plugins/memory/holographic/embeddings.py
@@ -1,0 +1,147 @@
+"""Optional embedding providers for holographic memory understanding."""
+
+from __future__ import annotations
+
+from array import array
+import logging
+import math
+import os
+from typing import Iterable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def vector_to_bytes(values: Iterable[float]) -> bytes:
+    payload = array("f", [float(value) for value in values])
+    return payload.tobytes()
+
+
+def bytes_to_vector(data: bytes | None) -> list[float]:
+    if not data:
+        return []
+    payload = array("f")
+    payload.frombytes(data)
+    return list(payload)
+
+
+def cosine_similarity(left: Iterable[float], right: Iterable[float]) -> float:
+    left_values = list(left)
+    right_values = list(right)
+    if not left_values or not right_values or len(left_values) != len(right_values):
+        return 0.0
+
+    dot = 0.0
+    left_norm = 0.0
+    right_norm = 0.0
+    for left_value, right_value in zip(left_values, right_values):
+        dot += left_value * right_value
+        left_norm += left_value * left_value
+        right_norm += right_value * right_value
+
+    if left_norm <= 0.0 or right_norm <= 0.0:
+        return 0.0
+
+    return dot / (math.sqrt(left_norm) * math.sqrt(right_norm))
+
+
+class EmbeddingProvider:
+    name = "none"
+
+    def is_available(self) -> bool:
+        return False
+
+    def embed_many(self, texts: list[str]) -> list[Optional[list[float]]]:
+        return [None for _ in texts]
+
+    def embed_one(self, text: str) -> Optional[list[float]]:
+        return self.embed_many([text])[0]
+
+
+class NoopEmbeddingProvider(EmbeddingProvider):
+    name = "none"
+
+
+class OpenAIEmbeddingProvider(EmbeddingProvider):
+    name = "openai"
+
+    def __init__(
+        self,
+        *,
+        model: str = "text-embedding-3-small",
+        api_key: str = "",
+        base_url: str = "",
+        dimensions: int | None = None,
+        timeout: float = 8.0,
+    ) -> None:
+        self.model = model
+        self.api_key = (
+            api_key
+            or os.environ.get("HOLOGRAPHIC_OPENAI_API_KEY", "")
+            or os.environ.get("OPENAI_API_KEY", "")
+        )
+        self.base_url = (
+            base_url
+            or os.environ.get("HOLOGRAPHIC_OPENAI_BASE_URL", "")
+            or os.environ.get("OPENAI_BASE_URL", "")
+        )
+        self.dimensions = dimensions
+        self.timeout = timeout
+        self._client = None
+
+    def is_available(self) -> bool:
+        if not self.model:
+            return False
+        if not (self.api_key or self.base_url):
+            return False
+        try:
+            from openai import OpenAI  # noqa: F401
+        except Exception:
+            return False
+        return True
+
+    def _get_client(self):
+        if self._client is not None:
+            return self._client
+
+        from openai import OpenAI
+
+        kwargs = {"timeout": self.timeout}
+        if self.api_key:
+            kwargs["api_key"] = self.api_key
+        if self.base_url:
+            kwargs["base_url"] = self.base_url
+        self._client = OpenAI(**kwargs)
+        return self._client
+
+    def embed_many(self, texts: list[str]) -> list[Optional[list[float]]]:
+        if not texts or not self.is_available():
+            return [None for _ in texts]
+
+        try:
+            client = self._get_client()
+            kwargs = {
+                "model": self.model,
+                "input": texts,
+            }
+            if self.dimensions and self.model.startswith("text-embedding-3"):
+                kwargs["dimensions"] = self.dimensions
+            response = client.embeddings.create(**kwargs)
+            return [list(item.embedding) for item in response.data]
+        except Exception as exc:
+            logger.debug("OpenAI embedding request failed: %s", exc)
+            return [None for _ in texts]
+
+
+def build_embedding_provider(config: dict | None = None) -> EmbeddingProvider:
+    cfg = config or {}
+    provider_name = (cfg.get("semantic_provider") or cfg.get("embedding_provider") or "none").strip().lower()
+    if provider_name == "openai":
+        dimensions = cfg.get("semantic_dimensions")
+        return OpenAIEmbeddingProvider(
+            model=str(cfg.get("semantic_model") or "text-embedding-3-small"),
+            api_key=str(cfg.get("semantic_api_key") or ""),
+            base_url=str(cfg.get("semantic_base_url") or ""),
+            dimensions=int(dimensions) if dimensions not in (None, "", "0") else None,
+            timeout=float(cfg.get("semantic_timeout_seconds", 8.0)),
+        )
+    return NoopEmbeddingProvider()

--- a/plugins/memory/holographic/enrichment.py
+++ b/plugins/memory/holographic/enrichment.py
@@ -1,0 +1,388 @@
+"""Lightweight enrichment helpers for the holographic memory provider.
+
+The goal is not perfect NLP. We want deterministic, local, testable signal
+extraction that improves retrieval quality without introducing hard runtime
+dependencies or network calls.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import re
+from typing import Iterable
+
+
+_RE_CAPITALIZED_MULTI = re.compile(r"\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)\b")
+_RE_DOUBLE_QUOTE = re.compile(r'"([^"]+)"')
+_RE_SINGLE_QUOTE = re.compile(r"'([^']+)'")
+_RE_AKA = re.compile(
+    r"(\w+(?:\s+\w+)*)\s+(?:aka|also known as)\s+(\w+(?:\s+\w+)*)",
+    re.IGNORECASE,
+)
+_RE_MENTION = re.compile(r"@([A-Za-z0-9_][A-Za-z0-9_.-]{1,31})")
+_RE_HASHTAG = re.compile(r"#([A-Za-z0-9_-]{2,32})")
+_RE_ISO_DATE = re.compile(r"\b\d{4}-\d{2}-\d{2}\b")
+_RE_SLASH_DATE = re.compile(r"\b\d{1,2}/\d{1,2}/\d{2,4}\b")
+_RE_MONTH_DATE = re.compile(
+    r"\b(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Sept|Oct|Nov|Dec|"
+    r"January|February|March|April|June|July|August|September|October|November|December)"
+    r"\s+\d{1,2}(?:,\s*\d{4})?\b",
+    re.IGNORECASE,
+)
+_RE_TIME = re.compile(r"\b\d{1,2}(?::\d{2})?\s?(?:am|pm)\b", re.IGNORECASE)
+_RE_24H_TIME = re.compile(r"\b(?:[01]?\d|2[0-3]):[0-5]\d\b")
+_RE_LOCATION = re.compile(
+    r"\b(?:in|at|from|near|around|to)\s+([A-Z][A-Za-z]+(?:\s+[A-Z][A-Za-z]+){0,2})\b"
+)
+_RE_PROJECT = re.compile(
+    r"\b(?:project|repo|repository|service|app|application|workspace|module|plugin|pipeline|job|bot|agent)\s+"
+    r"([A-Za-z0-9._/-]+(?:\s+[A-Za-z0-9._/-]+){0,2})",
+    re.IGNORECASE,
+)
+_RE_PREFIX_PROJECT = re.compile(
+    r"\b([A-Za-z0-9._/-]+(?:\s+[A-Za-z0-9._/-]+){0,2})\s+"
+    r"(?:project|repo|repository|service|app|application|workspace|module|plugin|pipeline|job|bot|agent)\b",
+    re.IGNORECASE,
+)
+_TOKEN_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:/-]{1,}")
+
+_STOPWORDS = {
+    "a", "an", "and", "are", "as", "at", "be", "been", "being", "but", "by",
+    "can", "could", "did", "do", "does", "for", "from", "had", "has", "have",
+    "he", "her", "hers", "him", "his", "i", "if", "in", "into", "is", "it",
+    "its", "me", "my", "of", "on", "or", "our", "ours", "she", "should", "so",
+    "that", "the", "their", "them", "they", "this", "to", "up", "use", "using",
+    "was", "we", "were", "what", "when", "where", "which", "who", "why", "with",
+    "you", "your", "yours",
+}
+
+_PROJECT_HINTS = {
+    "project", "repo", "repository", "service", "app", "application",
+    "workspace", "module", "plugin", "pipeline", "job", "bot", "agent",
+}
+_PROJECT_LEADING_ARTICLES = {"a", "an", "the"}
+_PROJECT_REJECT_HEADS = {"needs", "uses", "requires", "with", "for", "to"}
+_CANONICAL_SEPARATORS = re.compile(r"[_./:-]+")
+_CANONICAL_STRIP = re.compile(r"[^a-z0-9\s]")
+
+_INTENT_PATTERNS = [
+    ("preference", re.compile(r"\b(?:i prefer|i like|i love|my preferred|my favorite)\b", re.IGNORECASE)),
+    ("decision", re.compile(r"\b(?:we decided|we chose|decision:|decided to|agreed to)\b", re.IGNORECASE)),
+    ("goal", re.compile(r"\b(?:i want|i need|goal:|trying to|plan to)\b", re.IGNORECASE)),
+    ("task", re.compile(r"\b(?:todo|task|follow up|next step|remember to)\b", re.IGNORECASE)),
+    ("issue", re.compile(r"\b(?:bug|broken|error|incident|failure|regression)\b", re.IGNORECASE)),
+    ("event", re.compile(r"\b(?:met|meeting|call with|appointment|trip|travel)\b", re.IGNORECASE)),
+]
+
+_HIGH_SALIENCE_TERMS = {
+    "always", "never", "must", "important", "critical", "urgent", "blocker",
+    "production", "incident", "regression", "decision",
+}
+
+
+def _ordered_unique(values: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    output: list[str] = []
+    for value in values:
+        cleaned = value.strip()
+        key = cleaned.lower()
+        if cleaned and key not in seen:
+            seen.add(key)
+            output.append(cleaned)
+    return output
+
+
+def _normalize_topic_token(token: str) -> str:
+    cleaned = token.strip(".,;:!?\"'()[]{}")
+    cleaned = cleaned.lstrip("#@").lower()
+    return cleaned
+
+
+def canonicalize_key(value: str, *, drop_project_hints: bool = False) -> str:
+    cleaned = (value or "").strip().lower()
+    if not cleaned:
+        return ""
+
+    cleaned = cleaned.lstrip("#@")
+    cleaned = _CANONICAL_SEPARATORS.sub(" ", cleaned)
+    cleaned = _CANONICAL_STRIP.sub(" ", cleaned)
+    tokens = [token for token in cleaned.split() if token]
+    if drop_project_hints:
+        tokens = [token for token in tokens if token not in _PROJECT_HINTS]
+    if not tokens:
+        return ""
+    return " ".join(tokens)
+
+
+def _clean_project_candidate(value: str) -> str:
+    cleaned = (value or "").strip(" \t\r\n,.;:!?\"'()[]{}")
+    if not cleaned:
+        return ""
+
+    tokens = cleaned.split()
+    while tokens and tokens[0].lower() in _PROJECT_LEADING_ARTICLES:
+        tokens.pop(0)
+    if not tokens or tokens[0].lower() in _PROJECT_REJECT_HEADS:
+        return ""
+    return " ".join(tokens)
+
+
+def _extract_topic_tokens(text: str, tags: str = "", limit: int = 12) -> list[str]:
+    candidates = []
+    for source in (text, tags):
+        for raw in _TOKEN_RE.findall(source or ""):
+            token = _normalize_topic_token(raw)
+            if len(token) < 3 or token in _STOPWORDS or token.isdigit():
+                continue
+            candidates.append(token)
+    return _ordered_unique(candidates)[:limit]
+
+
+@dataclass
+class EnrichedFact:
+    entities: list[str]
+    people: list[str]
+    projects: list[str]
+    topics: list[str]
+    entity_keys: list[str]
+    person_keys: list[str]
+    project_keys: list[str]
+    topic_keys: list[str]
+    cluster_keys: list[str]
+    dates: list[str]
+    times: list[str]
+    locations: list[str]
+    intent_type: str
+    source_channel: str
+    salience_score: float
+    source_confidence: float
+    keywords: list[str]
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def build_cluster_keys(
+    entities: Iterable[str],
+    people: Iterable[str],
+    projects: Iterable[str],
+    topics: Iterable[str],
+) -> tuple[list[str], list[str], list[str], list[str], list[str]]:
+    entity_keys = _ordered_unique(canonicalize_key(entity) for entity in entities)
+    person_keys = _ordered_unique(canonicalize_key(person) for person in people)
+    project_keys = _ordered_unique(
+        canonicalize_key(project, drop_project_hints=True) for project in projects
+    )
+    topic_keys = _ordered_unique(canonicalize_key(topic) for topic in topics)
+    cluster_keys = _ordered_unique(
+        [f"entity:{value}" for value in entity_keys]
+        + [f"person:{value}" for value in person_keys]
+        + [f"project:{value}" for value in project_keys]
+        + [f"topic:{value}" for value in topic_keys]
+    )
+    return entity_keys, person_keys, project_keys, topic_keys, cluster_keys
+
+
+def extract_entities(text: str, tags: str = "") -> list[str]:
+    candidates: list[str] = []
+    for match in _RE_CAPITALIZED_MULTI.finditer(text):
+        candidates.append(match.group(1))
+    for match in _RE_DOUBLE_QUOTE.finditer(text):
+        candidates.append(match.group(1))
+    for match in _RE_SINGLE_QUOTE.finditer(text):
+        candidates.append(match.group(1))
+    for match in _RE_AKA.finditer(text):
+        candidates.extend([match.group(1), match.group(2)])
+    for match in _RE_MENTION.finditer(text):
+        candidates.append(match.group(1))
+    for match in _RE_HASHTAG.finditer(text):
+        candidates.append(match.group(1))
+    for tag in (tags or "").split(","):
+        tag = tag.strip()
+        if tag:
+            candidates.append(tag)
+    return _ordered_unique(candidates)
+
+
+def extract_people(entities: Iterable[str]) -> list[str]:
+    people = []
+    for entity in entities:
+        if " " in entity and entity[:1].isupper():
+            people.append(entity)
+        elif entity.startswith("@"):
+            people.append(entity.lstrip("@"))
+    return _ordered_unique(people)
+
+
+def extract_projects(text: str, entities: Iterable[str], tags: str = "") -> list[str]:
+    projects: list[str] = []
+    for match in _RE_PROJECT.finditer(text):
+        cleaned = _clean_project_candidate(match.group(1))
+        if cleaned:
+            projects.append(cleaned)
+    for match in _RE_PREFIX_PROJECT.finditer(text):
+        cleaned = _clean_project_candidate(match.group(1))
+        if cleaned:
+            projects.append(cleaned)
+
+    topic_tokens = set(_extract_topic_tokens(text, tags))
+    for entity in entities:
+        lowered = entity.lower()
+        if any(hint in lowered for hint in _PROJECT_HINTS):
+            projects.append(entity)
+            continue
+        if lowered in topic_tokens and any(marker in lowered for marker in ("hermes", "neo", "repo", "service", "bot")):
+            projects.append(entity)
+
+    for tag in (tags or "").split(","):
+        cleaned = tag.strip()
+        if cleaned.lower().startswith("project:"):
+            project_value = _clean_project_candidate(cleaned.split(":", 1)[1].strip())
+            if project_value:
+                projects.append(project_value)
+
+    return _ordered_unique(projects)
+
+
+def extract_dates(text: str) -> list[str]:
+    matches: list[str] = []
+    for pattern in (_RE_ISO_DATE, _RE_SLASH_DATE, _RE_MONTH_DATE):
+        matches.extend(match.group(0) for match in pattern.finditer(text))
+    return _ordered_unique(matches)
+
+
+def extract_times(text: str) -> list[str]:
+    matches: list[str] = []
+    for pattern in (_RE_TIME, _RE_24H_TIME):
+        matches.extend(match.group(0) for match in pattern.finditer(text))
+    return _ordered_unique(matches)
+
+
+def extract_locations(text: str) -> list[str]:
+    return _ordered_unique(match.group(1) for match in _RE_LOCATION.finditer(text))
+
+
+def infer_intent_type(text: str, category: str = "general") -> str:
+    lowered = (category or "").lower()
+    if lowered == "user_pref":
+        return "preference"
+    if lowered == "project":
+        return "decision"
+    for label, pattern in _INTENT_PATTERNS:
+        if pattern.search(text or ""):
+            return label
+    return "general"
+
+
+def estimate_salience(
+    text: str,
+    *,
+    category: str = "general",
+    tags: str = "",
+    intent_type: str = "general",
+    override: float | None = None,
+) -> float:
+    if override is not None:
+        return max(0.0, min(1.0, float(override)))
+
+    score = 0.45
+    lowered = (text or "").lower()
+    if category in {"user_pref", "project"}:
+        score += 0.08
+    if intent_type in {"decision", "goal", "issue", "task"}:
+        score += 0.12
+    if any(term in lowered for term in _HIGH_SALIENCE_TERMS):
+        score += 0.1
+    if len(text or "") > 160:
+        score += 0.05
+    if tags:
+        score += 0.03
+    return max(0.15, min(1.0, score))
+
+
+def estimate_source_confidence(
+    source_channel: str,
+    *,
+    intent_type: str = "general",
+    override: float | None = None,
+) -> float:
+    if override is not None:
+        return max(0.0, min(1.0, float(override)))
+
+    source = (source_channel or "").lower()
+    if source.startswith("builtin:user"):
+        base = 0.9
+    elif source.startswith("tool:") or source.startswith("explicit:"):
+        base = 0.88
+    elif source.startswith("builtin:memory"):
+        base = 0.82
+    elif source.startswith("session_auto_extract"):
+        base = 0.62
+    elif source.startswith("telegram") or source.startswith("discord") or source.startswith("slack"):
+        base = 0.76
+    elif source:
+        base = 0.72
+    else:
+        base = 0.68
+
+    if intent_type in {"decision", "preference"}:
+        base += 0.04
+
+    return max(0.1, min(1.0, base))
+
+
+def enrich_fact(
+    text: str,
+    *,
+    category: str = "general",
+    tags: str = "",
+    source_channel: str = "",
+    intent_type: str | None = None,
+    salience_score: float | None = None,
+    source_confidence: float | None = None,
+) -> EnrichedFact:
+    entities = extract_entities(text, tags=tags)
+    people = extract_people(entities)
+    projects = extract_projects(text, entities, tags=tags)
+    topics = _extract_topic_tokens(text, tags=tags)
+    entity_keys, person_keys, project_keys, topic_keys, cluster_keys = build_cluster_keys(
+        entities,
+        people,
+        projects,
+        topics,
+    )
+    dates = extract_dates(text)
+    times = extract_times(text)
+    locations = extract_locations(text)
+    inferred_intent = intent_type or infer_intent_type(text, category=category)
+    effective_source = source_channel or "unknown"
+
+    return EnrichedFact(
+        entities=entities,
+        people=people,
+        projects=projects,
+        topics=topics,
+        entity_keys=entity_keys,
+        person_keys=person_keys,
+        project_keys=project_keys,
+        topic_keys=topic_keys,
+        cluster_keys=cluster_keys,
+        dates=dates,
+        times=times,
+        locations=locations,
+        intent_type=inferred_intent,
+        source_channel=effective_source,
+        salience_score=estimate_salience(
+            text,
+            category=category,
+            tags=tags,
+            intent_type=inferred_intent,
+            override=salience_score,
+        ),
+        source_confidence=estimate_source_confidence(
+            effective_source,
+            intent_type=inferred_intent,
+            override=source_confidence,
+        ),
+        keywords=topics[:8],
+    )

--- a/plugins/memory/holographic/ingestion.py
+++ b/plugins/memory/holographic/ingestion.py
@@ -1,0 +1,262 @@
+"""Durable deferred understanding ingestion for the holographic provider."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+from typing import Any
+
+from .enrichment import enrich_fact
+
+logger = logging.getLogger(__name__)
+
+_PREF_PATTERNS = [
+    re.compile(r"\bI\s+(?:prefer|like|love|use|want|need)\s+(.+)", re.IGNORECASE),
+    re.compile(r"\bmy\s+(?:favorite|preferred|default)\s+\w+\s+is\s+(.+)", re.IGNORECASE),
+    re.compile(r"\bI\s+(?:always|never|usually)\s+(.+)", re.IGNORECASE),
+]
+_DECISION_PATTERNS = [
+    re.compile(r"\bwe\s+(?:decided|agreed|chose)\s+(?:to\s+)?(.+)", re.IGNORECASE),
+    re.compile(r"\bthe\s+project\s+(?:uses|needs|requires)\s+(.+)", re.IGNORECASE),
+]
+
+_MAX_FACT_LENGTH = 480
+_MAX_TURN_CONTENT = 1200
+_MAX_MESSAGE_CONTENT = 900
+
+
+def _as_bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() not in {"0", "false", "no", "off", ""}
+
+
+def _as_int(value: Any, default: int, *, minimum: int = 1, maximum: int | None = None) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        parsed = default
+    parsed = max(minimum, parsed)
+    if maximum is not None:
+        parsed = min(maximum, parsed)
+    return parsed
+
+
+def ingest_settings(config: dict | None) -> dict:
+    config = config or {}
+    return {
+        "deferred_ingest": _as_bool(config.get("deferred_ingest"), True),
+        "turn_understanding": _as_bool(config.get("turn_understanding"), True),
+        "ingest_batch_size": _as_int(config.get("ingest_batch_size"), 2, minimum=1, maximum=16),
+        "ingest_max_pending": _as_int(config.get("ingest_max_pending"), 200, minimum=10, maximum=5000),
+        "ingest_retry_delay_seconds": _as_int(config.get("ingest_retry_delay_seconds"), 60, minimum=5, maximum=1800),
+        "session_ingest_message_limit": _as_int(config.get("session_ingest_message_limit"), 80, minimum=10, maximum=400),
+    }
+
+
+def queue_turn_ingest(store, config: dict | None, *, session_id: str, user_content: str, assistant_content: str) -> dict:
+    settings = ingest_settings(config)
+    if not settings["deferred_ingest"] or not settings["turn_understanding"]:
+        return {"enqueued": False, "reason": "disabled"}
+
+    payload = {
+        "session_id": session_id or "",
+        "user_content": (user_content or "").strip()[:_MAX_TURN_CONTENT],
+        "assistant_content": (assistant_content or "").strip()[:_MAX_TURN_CONTENT],
+    }
+    if not payload["user_content"]:
+        return {"enqueued": False, "reason": "empty"}
+
+    dedupe_key = _dedupe_key("turn", payload)
+    return store.enqueue_ingest(
+        "turn",
+        payload,
+        dedupe_key=dedupe_key,
+        source_channel="turn_understanding",
+        session_id=session_id or "",
+        max_pending=settings["ingest_max_pending"],
+    )
+
+
+def queue_session_ingest(store, config: dict | None, *, session_id: str, messages: list[dict]) -> dict:
+    settings = ingest_settings(config)
+    if not settings["deferred_ingest"]:
+        return {"enqueued": False, "reason": "disabled"}
+
+    sanitized = _sanitize_messages(messages, limit=settings["session_ingest_message_limit"])
+    if not sanitized:
+        return {"enqueued": False, "reason": "empty"}
+
+    payload = {
+        "session_id": session_id or "",
+        "messages": sanitized,
+    }
+    dedupe_key = _dedupe_key("session", payload)
+    return store.enqueue_ingest(
+        "session",
+        payload,
+        dedupe_key=dedupe_key,
+        source_channel="session_auto_extract",
+        session_id=session_id or "",
+        max_pending=settings["ingest_max_pending"],
+    )
+
+
+def drain_understanding_ingest(
+    store,
+    config: dict | None,
+    *,
+    limit: int | None = None,
+    reason: str = "runtime",
+) -> dict:
+    settings = ingest_settings(config)
+    if not settings["deferred_ingest"]:
+        return {"claimed": 0, "processed": 0, "failed": 0, "facts_written": 0, "reason": "disabled"}
+
+    batch_limit = limit if limit is not None else settings["ingest_batch_size"]
+    claimed = store.claim_ingest_batch(limit=batch_limit)
+    if not claimed:
+        return {"claimed": 0, "processed": 0, "failed": 0, "facts_written": 0, "reason": reason}
+
+    processed = 0
+    failed = 0
+    facts_written = 0
+    for item in claimed:
+        ingest_id = int(item["ingest_id"])
+        try:
+            written = _process_ingest_item(store, item)
+            store.complete_ingest(ingest_id, facts_written=written)
+            processed += 1
+            facts_written += written
+        except Exception as exc:
+            failed += 1
+            store.fail_ingest(
+                ingest_id,
+                str(exc),
+                retry_delay_seconds=settings["ingest_retry_delay_seconds"],
+            )
+            logger.warning("Holographic ingest failed during %s: %s", reason, exc)
+
+    return {
+        "claimed": len(claimed),
+        "processed": processed,
+        "failed": failed,
+        "facts_written": facts_written,
+        "reason": reason,
+    }
+
+
+def _process_ingest_item(store, item: dict) -> int:
+    payload = json.loads(item["payload_json"])
+    ingest_type = item.get("ingest_type", "")
+
+    if ingest_type == "turn":
+        candidates = _extract_candidates_from_text(
+            payload.get("user_content", ""),
+            source_prefix="turn_understanding",
+        )
+    elif ingest_type == "session":
+        candidates = []
+        for message in payload.get("messages", []):
+            if message.get("role") != "user":
+                continue
+            candidates.extend(
+                _extract_candidates_from_text(
+                    message.get("content", ""),
+                    source_prefix="session_auto_extract",
+                )
+            )
+    else:
+        raise ValueError(f"unknown ingest type: {ingest_type}")
+
+    written = 0
+    for candidate in candidates:
+        store.add_fact(
+            candidate["content"],
+            category=candidate["category"],
+            source_channel=candidate["source_channel"],
+            source_confidence=candidate["source_confidence"],
+            intent_type=candidate["intent_type"],
+            salience_score=candidate["salience_score"],
+        )
+        written += 1
+    return written
+
+
+def _extract_candidates_from_text(text: str, *, source_prefix: str) -> list[dict]:
+    normalized = (text or "").strip()
+    if len(normalized) < 10:
+        return []
+
+    enrichment = enrich_fact(normalized, source_channel=source_prefix)
+    direct_pref = any(pattern.search(normalized) for pattern in _PREF_PATTERNS)
+    direct_decision = any(pattern.search(normalized) for pattern in _DECISION_PATTERNS)
+    has_structure = any(
+        enrichment.to_dict().get(key)
+        for key in ("entities", "projects", "topics", "dates", "times", "locations")
+    )
+
+    if direct_pref:
+        category = "user_pref"
+    elif direct_decision or enrichment.intent_type in {"decision", "goal", "task", "issue"} or enrichment.projects:
+        category = "project"
+    elif enrichment.intent_type in {"event"} and has_structure:
+        category = "general"
+    else:
+        category = "general"
+
+    should_capture = direct_pref or direct_decision
+    if not should_capture:
+        if enrichment.intent_type in {"goal", "task", "issue", "event"} and has_structure:
+            should_capture = True
+        elif enrichment.salience_score >= 0.72 and has_structure:
+            should_capture = True
+
+    if not should_capture:
+        return []
+
+    source_confidence = 0.66 if source_prefix.startswith("turn_") else 0.62
+    if category == "user_pref":
+        source_suffix = "user_pref"
+    elif category == "project":
+        source_suffix = "project"
+    else:
+        source_suffix = "general"
+
+    return [{
+        "content": normalized[:_MAX_FACT_LENGTH],
+        "category": category,
+        "source_channel": f"{source_prefix}:{source_suffix}",
+        "source_confidence": source_confidence,
+        "intent_type": enrichment.intent_type,
+        "salience_score": enrichment.salience_score,
+    }]
+
+
+def _sanitize_messages(messages: list[dict], *, limit: int) -> list[dict]:
+    sanitized: list[dict] = []
+    for message in messages[-limit:]:
+        role = str(message.get("role", "") or "")
+        content = message.get("content", "")
+        if role not in {"user", "assistant"} or not isinstance(content, str):
+            continue
+        compact = content.strip()
+        if not compact:
+            continue
+        sanitized.append({
+            "role": role,
+            "content": compact[:_MAX_MESSAGE_CONTENT],
+        })
+    return sanitized
+
+
+def _dedupe_key(ingest_type: str, payload: dict) -> str:
+    digest = hashlib.sha256(
+        json.dumps(payload, ensure_ascii=False, sort_keys=True).encode("utf-8")
+    ).hexdigest()
+    session_id = str(payload.get("session_id", "") or "")
+    return f"{ingest_type}:{session_id}:{digest}"

--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -1,14 +1,14 @@
-"""Hybrid keyword/BM25 retrieval for the memory store.
-
-Ported from KIK memory_agent.py — combines FTS5 full-text search with
-Jaccard similarity reranking and trust-weighted scoring.
-"""
+"""Hybrid retrieval and ranking for the holographic memory store."""
 
 from __future__ import annotations
 
 import math
 from datetime import datetime, timezone
+import json
 from typing import TYPE_CHECKING
+
+from .embeddings import bytes_to_vector, cosine_similarity
+from .enrichment import enrich_fact
 
 if TYPE_CHECKING:
     from .store import MemoryStore
@@ -18,32 +18,45 @@ try:
 except ImportError:
     import holographic as hrr  # type: ignore[no-redef]
 
+_MAX_SEMANTIC_SCAN = 1000
+
 
 class FactRetriever:
-    """Multi-strategy fact retrieval with trust-weighted scoring."""
+    """Hybrid retrieval with explainable score breakdowns."""
 
     def __init__(
         self,
         store: MemoryStore,
-        temporal_decay_half_life: int = 0,  # days, 0 = disabled
-        fts_weight: float = 0.4,
-        jaccard_weight: float = 0.3,
-        hrr_weight: float = 0.3,
+        temporal_decay_half_life: int = 45,
+        fts_weight: float = 0.6,
+        jaccard_weight: float = 0.4,
+        hrr_weight: float = 0.45,
         hrr_dim: int = 1024,
+        embedding_weight: float = 0.55,
+        semantic_weight: float = 0.35,
+        keyword_weight: float = 0.25,
+        recency_weight: float = 0.15,
+        salience_weight: float = 0.15,
+        confidence_weight: float = 0.10,
     ):
         self.store = store
         self.half_life = temporal_decay_half_life
         self.hrr_dim = hrr_dim
 
-        # Auto-redistribute weights if numpy unavailable
         if hrr_weight > 0 and not hrr._HAS_NUMPY:
-            fts_weight = 0.6
-            jaccard_weight = 0.4
             hrr_weight = 0.0
 
         self.fts_weight = fts_weight
         self.jaccard_weight = jaccard_weight
         self.hrr_weight = hrr_weight
+        self.embedding_weight = embedding_weight
+        self.rank_weights = {
+            "semantic": semantic_weight,
+            "keyword": keyword_weight,
+            "recency": recency_weight,
+            "salience": salience_weight,
+            "confidence": confidence_weight,
+        }
 
     def search(
         self,
@@ -51,64 +64,59 @@ class FactRetriever:
         category: str | None = None,
         min_trust: float = 0.3,
         limit: int = 10,
+        debug: bool = False,
     ) -> list[dict]:
-        """Hybrid search: FTS5 candidates → Jaccard rerank → trust weighting.
-
-        Pipeline:
-        1. FTS5 search: Get limit*3 candidates from SQLite full-text search
-        2. Jaccard boost: Token overlap between query and fact content
-        3. Trust weighting: final_score = relevance * trust_score
-        4. Temporal decay (optional): decay = 0.5^(age_days / half_life)
-
-        Returns list of dicts with fact data + 'score' field, sorted by score desc.
-        """
-        # Stage 1: Get FTS5 candidates (more than limit for reranking headroom)
-        candidates = self._fts_candidates(query, category, min_trust, limit * 3)
-
-        if not candidates:
+        """Hybrid retrieval with semantic and keyword candidate generation."""
+        query = (query or "").strip()
+        if not query:
             return []
 
-        # Stage 2: Rerank with Jaccard + trust + optional decay
         query_tokens = self._tokenize(query)
-        scored = []
+        query_meta = enrich_fact(query, category=category or "general", source_channel="query")
+        query_embedding = self.store._embedding_provider.embed_one(query)
+        query_hrr = hrr.encode_text(query, self.hrr_dim) if hrr._HAS_NUMPY else None
 
-        for fact in candidates:
-            content_tokens = self._tokenize(fact["content"])
-            tag_tokens = self._tokenize(fact.get("tags", ""))
-            all_tokens = content_tokens | tag_tokens
+        candidate_map: dict[int, dict] = {}
+        for candidate in self._fts_candidates(query, category, min_trust, max(limit * 4, 20)):
+            candidate_map[candidate["fact_id"]] = candidate
 
-            jaccard = self._jaccard_similarity(query_tokens, all_tokens)
-            fts_score = fact.get("fts_rank", 0.0)
-
-            # HRR similarity
-            if self.hrr_weight > 0 and fact.get("hrr_vector"):
-                fact_vec = hrr.bytes_to_phases(fact["hrr_vector"])
-                query_vec = hrr.encode_text(query, self.hrr_dim)
-                hrr_sim = (hrr.similarity(query_vec, fact_vec) + 1.0) / 2.0  # shift to [0,1]
+        for candidate in self._semantic_candidates(
+            category=category,
+            min_trust=min_trust,
+            limit=max(limit * 6, 24),
+            query_embedding=query_embedding,
+            query_hrr=query_hrr,
+        ):
+            existing = candidate_map.get(candidate["fact_id"])
+            if existing:
+                existing.update({k: v for k, v in candidate.items() if k not in existing or v})
             else:
-                hrr_sim = 0.5  # neutral
+                candidate_map[candidate["fact_id"]] = candidate
 
-            # Combine FTS5 + Jaccard + HRR
-            relevance = (self.fts_weight * fts_score
-                        + self.jaccard_weight * jaccard
-                        + self.hrr_weight * hrr_sim)
+        scored: list[dict] = []
+        for candidate in candidate_map.values():
+            breakdown = self._score_fact(
+                candidate,
+                query=query,
+                query_tokens=query_tokens,
+                query_meta=query_meta.to_dict(),
+                query_embedding=query_embedding,
+                query_hrr=query_hrr,
+            )
+            normalized = self._normalize_fact(candidate)
+            normalized["score"] = breakdown["final_score"]
+            if debug:
+                normalized["debug"] = self._build_debug_payload(
+                    normalized,
+                    breakdown,
+                    query_tokens=query_tokens,
+                    query_meta=query_meta.to_dict(),
+                )
+            scored.append(normalized)
 
-            # Trust weighting
-            score = relevance * fact["trust_score"]
-
-            # Optional temporal decay
-            if self.half_life > 0:
-                score *= self._temporal_decay(fact.get("updated_at") or fact.get("created_at"))
-
-            fact["score"] = score
-            scored.append(fact)
-
-        # Sort by score descending, return top limit
-        scored.sort(key=lambda x: x["score"], reverse=True)
+        scored.sort(key=lambda fact: fact["score"], reverse=True)
         results = scored[:limit]
-        # Strip raw HRR bytes — callers expect JSON-serializable dicts
-        for fact in results:
-            fact.pop("hrr_vector", None)
+        self._mark_retrieved(results)
         return results
 
     def probe(
@@ -117,41 +125,14 @@ class FactRetriever:
         category: str | None = None,
         limit: int = 10,
     ) -> list[dict]:
-        """Compositional entity query using HRR algebra.
-
-        Unbinds entity from memory bank to extract associated content.
-        This is NOT keyword search — it uses algebraic structure to find facts
-        where the entity plays a structural role.
-
-        Falls back to FTS5 search if numpy unavailable.
-        """
         if not hrr._HAS_NUMPY:
-            # Fallback to keyword search on entity name
             return self.search(entity, category=category, limit=limit)
 
         conn = self.store._conn
-
-        # Encode entity as role-bound vector
         role_entity = hrr.encode_atom("__hrr_role_entity__", self.hrr_dim)
         entity_vec = hrr.encode_atom(entity.lower(), self.hrr_dim)
         probe_key = hrr.bind(entity_vec, role_entity)
 
-        # Try category-specific bank first, then all facts
-        if category:
-            bank_name = f"cat:{category}"
-            bank_row = conn.execute(
-                "SELECT vector FROM memory_banks WHERE bank_name = ?",
-                (bank_name,),
-            ).fetchone()
-            if bank_row:
-                bank_vec = hrr.bytes_to_phases(bank_row["vector"])
-                extracted = hrr.unbind(bank_vec, probe_key)
-                # Use extracted signal to score individual facts
-                return self._score_facts_by_vector(
-                    extracted, category=category, limit=limit
-                )
-
-        # Score against individual fact vectors directly
         where = "WHERE hrr_vector IS NOT NULL"
         params: list = []
         if category:
@@ -160,33 +141,27 @@ class FactRetriever:
 
         rows = conn.execute(
             f"""
-            SELECT fact_id, content, category, tags, trust_score,
-                   retrieval_count, helpful_count, created_at, updated_at,
-                   hrr_vector
-            FROM facts
+            SELECT * FROM facts
             {where}
             """,
             params,
         ).fetchall()
-
         if not rows:
-            # Final fallback: keyword search
             return self.search(entity, category=category, limit=limit)
 
+        role_content = hrr.encode_atom("__hrr_role_content__", self.hrr_dim)
         scored = []
         for row in rows:
             fact = dict(row)
             fact_vec = hrr.bytes_to_phases(fact.pop("hrr_vector"))
-            # Unbind probe key from fact to see if entity is structurally present
             residual = hrr.unbind(fact_vec, probe_key)
-            # Compare residual against content signal
-            role_content = hrr.encode_atom("__hrr_role_content__", self.hrr_dim)
             content_vec = hrr.bind(hrr.encode_text(fact["content"], self.hrr_dim), role_content)
             sim = hrr.similarity(residual, content_vec)
-            fact["score"] = (sim + 1.0) / 2.0 * fact["trust_score"]
-            scored.append(fact)
+            normalized = self._normalize_fact(fact)
+            normalized["score"] = ((sim + 1.0) / 2.0) * normalized["trust_score"]
+            scored.append(normalized)
 
-        scored.sort(key=lambda x: x["score"], reverse=True)
+        scored.sort(key=lambda fact: fact["score"], reverse=True)
         return scored[:limit]
 
     def related(
@@ -195,23 +170,12 @@ class FactRetriever:
         category: str | None = None,
         limit: int = 10,
     ) -> list[dict]:
-        """Discover facts that share structural connections with an entity.
-
-        Unlike probe (which finds facts *about* an entity), related finds
-        facts that are connected through shared context — e.g., other entities
-        mentioned alongside this one, or content that overlaps structurally.
-
-        Falls back to FTS5 search if numpy unavailable.
-        """
         if not hrr._HAS_NUMPY:
             return self.search(entity, category=category, limit=limit)
 
         conn = self.store._conn
-
-        # Encode entity as a bare atom (not role-bound — we want ANY structural match)
         entity_vec = hrr.encode_atom(entity.lower(), self.hrr_dim)
 
-        # Get all facts with vectors
         where = "WHERE hrr_vector IS NOT NULL"
         params: list = []
         if category:
@@ -220,41 +184,30 @@ class FactRetriever:
 
         rows = conn.execute(
             f"""
-            SELECT fact_id, content, category, tags, trust_score,
-                   retrieval_count, helpful_count, created_at, updated_at,
-                   hrr_vector
-            FROM facts
+            SELECT * FROM facts
             {where}
             """,
             params,
         ).fetchall()
-
         if not rows:
             return self.search(entity, category=category, limit=limit)
 
-        # Score each fact by how much the entity's atom appears in its vector
-        # This catches both role-bound entity matches AND content word matches
         scored = []
         for row in rows:
             fact = dict(row)
             fact_vec = hrr.bytes_to_phases(fact.pop("hrr_vector"))
-
-            # Check structural similarity: unbind entity from fact
             residual = hrr.unbind(fact_vec, entity_vec)
-            # A high-similarity residual to ANY known role vector means this entity
-            # plays a structural role in the fact
             role_entity = hrr.encode_atom("__hrr_role_entity__", self.hrr_dim)
             role_content = hrr.encode_atom("__hrr_role_content__", self.hrr_dim)
+            best_sim = max(
+                hrr.similarity(residual, role_entity),
+                hrr.similarity(residual, role_content),
+            )
+            normalized = self._normalize_fact(fact)
+            normalized["score"] = ((best_sim + 1.0) / 2.0) * normalized["trust_score"]
+            scored.append(normalized)
 
-            entity_role_sim = hrr.similarity(residual, role_entity)
-            content_role_sim = hrr.similarity(residual, role_content)
-            # Take the max — entity could appear in either role
-            best_sim = max(entity_role_sim, content_role_sim)
-
-            fact["score"] = (best_sim + 1.0) / 2.0 * fact["trust_score"]
-            scored.append(fact)
-
-        scored.sort(key=lambda x: x["score"], reverse=True)
+        scored.sort(key=lambda fact: fact["score"], reverse=True)
         return scored[:limit]
 
     def reason(
@@ -263,34 +216,16 @@ class FactRetriever:
         category: str | None = None,
         limit: int = 10,
     ) -> list[dict]:
-        """Multi-entity compositional query — vector-space JOIN.
-
-        Given multiple entities, algebraically intersects their structural
-        connections to find facts related to ALL of them simultaneously.
-        This is compositional reasoning that no embedding DB can do.
-
-        Example: reason(["peppi", "backend"]) finds facts where peppi AND
-        backend both play structural roles — without keyword matching.
-
-        Falls back to FTS5 search if numpy unavailable.
-        """
         if not hrr._HAS_NUMPY or not entities:
-            # Fallback: search with all entities as keywords
-            query = " ".join(entities)
-            return self.search(query, category=category, limit=limit)
+            return self.search(" ".join(entities), category=category, limit=limit)
 
         conn = self.store._conn
         role_entity = hrr.encode_atom("__hrr_role_entity__", self.hrr_dim)
-
-        # For each entity, compute what the bank "remembers" about it
-        # by unbinding entity+role from each fact vector
-        entity_residuals = []
+        probe_keys = []
         for entity in entities:
             entity_vec = hrr.encode_atom(entity.lower(), self.hrr_dim)
-            probe_key = hrr.bind(entity_vec, role_entity)
-            entity_residuals.append(probe_key)
+            probe_keys.append(hrr.bind(entity_vec, role_entity))
 
-        # Get all facts with vectors
         where = "WHERE hrr_vector IS NOT NULL"
         params: list = []
         if category:
@@ -299,40 +234,28 @@ class FactRetriever:
 
         rows = conn.execute(
             f"""
-            SELECT fact_id, content, category, tags, trust_score,
-                   retrieval_count, helpful_count, created_at, updated_at,
-                   hrr_vector
-            FROM facts
+            SELECT * FROM facts
             {where}
             """,
             params,
         ).fetchall()
-
         if not rows:
-            query = " ".join(entities)
-            return self.search(query, category=category, limit=limit)
+            return self.search(" ".join(entities), category=category, limit=limit)
 
-        # Score each fact by how much EACH entity is structurally present.
-        # A fact scores high only if ALL entities have structural presence
-        # (AND semantics via min, vs OR which would use mean/max).
         role_content = hrr.encode_atom("__hrr_role_content__", self.hrr_dim)
-
         scored = []
         for row in rows:
             fact = dict(row)
             fact_vec = hrr.bytes_to_phases(fact.pop("hrr_vector"))
-
             entity_scores = []
-            for probe_key in entity_residuals:
+            for probe_key in probe_keys:
                 residual = hrr.unbind(fact_vec, probe_key)
-                sim = hrr.similarity(residual, role_content)
-                entity_scores.append(sim)
+                entity_scores.append(hrr.similarity(residual, role_content))
+            normalized = self._normalize_fact(fact)
+            normalized["score"] = ((min(entity_scores) + 1.0) / 2.0) * normalized["trust_score"]
+            scored.append(normalized)
 
-            min_sim = min(entity_scores)
-            fact["score"] = (min_sim + 1.0) / 2.0 * fact["trust_score"]
-            scored.append(fact)
-
-        scored.sort(key=lambda x: x["score"], reverse=True)
+        scored.sort(key=lambda fact: fact["score"], reverse=True)
         return scored[:limit]
 
     def contradict(
@@ -341,115 +264,10 @@ class FactRetriever:
         threshold: float = 0.3,
         limit: int = 10,
     ) -> list[dict]:
-        """Find potentially contradictory facts via entity overlap + content divergence.
-
-        Two facts contradict when they share entities (same subject) but have
-        low content-vector similarity (different claims). This is automated
-        memory hygiene — no other memory system does this.
-
-        Returns pairs of facts with a contradiction score.
-        Falls back to empty list if numpy unavailable.
-        """
         if not hrr._HAS_NUMPY:
             return []
 
         conn = self.store._conn
-
-        # Get all facts with vectors and their linked entities
-        where = "WHERE f.hrr_vector IS NOT NULL"
-        params: list = []
-        if category:
-            where += " AND f.category = ?"
-            params.append(category)
-
-        rows = conn.execute(
-            f"""
-            SELECT f.fact_id, f.content, f.category, f.tags, f.trust_score,
-                   f.created_at, f.updated_at, f.hrr_vector
-            FROM facts f
-            {where}
-            """,
-            params,
-        ).fetchall()
-
-        if len(rows) < 2:
-            return []
-
-        # Guard against O(n²) explosion on large fact stores.
-        # At 500 facts, that's ~125K comparisons — acceptable.
-        # Above that, only check the most recently updated facts.
-        _MAX_CONTRADICT_FACTS = 500
-        if len(rows) > _MAX_CONTRADICT_FACTS:
-            rows = sorted(rows, key=lambda r: r["updated_at"] or r["created_at"], reverse=True)
-            rows = rows[:_MAX_CONTRADICT_FACTS]
-
-        # Build entity sets per fact
-        fact_entities: dict[int, set[str]] = {}
-        for row in rows:
-            fid = row["fact_id"]
-            entity_rows = conn.execute(
-                """
-                SELECT e.name FROM entities e
-                JOIN fact_entities fe ON fe.entity_id = e.entity_id
-                WHERE fe.fact_id = ?
-                """,
-                (fid,),
-            ).fetchall()
-            fact_entities[fid] = {r["name"].lower() for r in entity_rows}
-
-        # Compare all pairs: high entity overlap + low content similarity = contradiction
-        facts = [dict(r) for r in rows]
-        contradictions = []
-
-        for i in range(len(facts)):
-            for j in range(i + 1, len(facts)):
-                f1, f2 = facts[i], facts[j]
-                ents1 = fact_entities.get(f1["fact_id"], set())
-                ents2 = fact_entities.get(f2["fact_id"], set())
-
-                if not ents1 or not ents2:
-                    continue
-
-                # Entity overlap (Jaccard)
-                entity_overlap = len(ents1 & ents2) / len(ents1 | ents2) if (ents1 | ents2) else 0.0
-
-                if entity_overlap < 0.3:
-                    continue  # Not enough entity overlap to be contradictory
-
-                # Content similarity via HRR vectors
-                v1 = hrr.bytes_to_phases(f1["hrr_vector"])
-                v2 = hrr.bytes_to_phases(f2["hrr_vector"])
-                content_sim = hrr.similarity(v1, v2)
-
-                # High entity overlap + low content similarity = potential contradiction
-                # contradiction_score: higher = more contradictory
-                contradiction_score = entity_overlap * (1.0 - (content_sim + 1.0) / 2.0)
-
-                if contradiction_score >= threshold:
-                    # Strip hrr_vector from output (not JSON serializable)
-                    f1_clean = {k: v for k, v in f1.items() if k != "hrr_vector"}
-                    f2_clean = {k: v for k, v in f2.items() if k != "hrr_vector"}
-                    contradictions.append({
-                        "fact_a": f1_clean,
-                        "fact_b": f2_clean,
-                        "entity_overlap": round(entity_overlap, 3),
-                        "content_similarity": round(content_sim, 3),
-                        "contradiction_score": round(contradiction_score, 3),
-                        "shared_entities": sorted(ents1 & ents2),
-                    })
-
-        contradictions.sort(key=lambda x: x["contradiction_score"], reverse=True)
-        return contradictions[:limit]
-
-    def _score_facts_by_vector(
-        self,
-        target_vec: "np.ndarray",
-        category: str | None = None,
-        limit: int = 10,
-    ) -> list[dict]:
-        """Score facts by similarity to a target vector."""
-        conn = self.store._conn
-
         where = "WHERE hrr_vector IS NOT NULL"
         params: list = []
         if category:
@@ -458,25 +276,309 @@ class FactRetriever:
 
         rows = conn.execute(
             f"""
-            SELECT fact_id, content, category, tags, trust_score,
-                   retrieval_count, helpful_count, created_at, updated_at,
-                   hrr_vector
-            FROM facts
+            SELECT * FROM facts
             {where}
             """,
             params,
         ).fetchall()
+        if len(rows) < 2:
+            return []
+
+        if len(rows) > 500:
+            rows = sorted(rows, key=lambda row: row["updated_at"] or row["created_at"], reverse=True)[:500]
+
+        fact_entities: dict[int, set[str]] = {}
+        for row in rows:
+            metadata = self._parse_metadata(row["metadata_json"])
+            fact_entities[row["fact_id"]] = {
+                value.lower()
+                for value in metadata.get("entity_keys", metadata.get("entities", []))
+            }
+
+        contradictions = []
+        facts = [dict(row) for row in rows]
+        for index, left in enumerate(facts):
+            for right in facts[index + 1:]:
+                left_entities = fact_entities.get(left["fact_id"], set())
+                right_entities = fact_entities.get(right["fact_id"], set())
+                if not left_entities or not right_entities:
+                    continue
+
+                entity_overlap = len(left_entities & right_entities) / len(left_entities | right_entities)
+                if entity_overlap < 0.3:
+                    continue
+
+                left_vec = hrr.bytes_to_phases(left["hrr_vector"])
+                right_vec = hrr.bytes_to_phases(right["hrr_vector"])
+                content_similarity = hrr.similarity(left_vec, right_vec)
+                contradiction_score = entity_overlap * (1.0 - ((content_similarity + 1.0) / 2.0))
+                if contradiction_score >= threshold:
+                    left_clean = self._normalize_fact(left)
+                    right_clean = self._normalize_fact(right)
+                    contradictions.append({
+                        "fact_a": left_clean,
+                        "fact_b": right_clean,
+                        "entity_overlap": round(entity_overlap, 3),
+                        "content_similarity": round(content_similarity, 3),
+                        "contradiction_score": round(contradiction_score, 3),
+                        "shared_entities": sorted(left_entities & right_entities),
+                    })
+
+        contradictions.sort(key=lambda item: item["contradiction_score"], reverse=True)
+        return contradictions[:limit]
+
+    # ------------------------------------------------------------------
+    # Candidate generation and scoring
+    # ------------------------------------------------------------------
+
+    def _semantic_candidates(
+        self,
+        *,
+        category: str | None,
+        min_trust: float,
+        limit: int,
+        query_embedding: list[float] | None,
+        query_hrr,
+    ) -> list[dict]:
+        if not query_embedding and query_hrr is None:
+            return []
+
+        conn = self.store._conn
+        params: list = [min_trust]
+        where_clauses = ["trust_score >= ?"]
+        if category:
+            where_clauses.append("category = ?")
+            params.append(category)
+        where_clauses.append("(hrr_vector IS NOT NULL OR embedding_vector IS NOT NULL)")
+        where_sql = " AND ".join(where_clauses)
+
+        rows = conn.execute(
+            f"""
+            SELECT * FROM facts
+            WHERE {where_sql}
+            ORDER BY salience_score DESC, updated_at DESC
+            LIMIT ?
+            """,
+            params + [_MAX_SEMANTIC_SCAN],
+        ).fetchall()
 
         scored = []
         for row in rows:
-            fact = dict(row)
-            fact_vec = hrr.bytes_to_phases(fact.pop("hrr_vector"))
-            sim = hrr.similarity(target_vec, fact_vec)
-            fact["score"] = (sim + 1.0) / 2.0 * fact["trust_score"]
-            scored.append(fact)
+            candidate = dict(row)
+            semantic_hrr = 0.0
+            semantic_embedding = 0.0
 
-        scored.sort(key=lambda x: x["score"], reverse=True)
+            if query_hrr is not None and candidate.get("hrr_vector"):
+                fact_hrr = hrr.bytes_to_phases(candidate["hrr_vector"])
+                semantic_hrr = (hrr.similarity(query_hrr, fact_hrr) + 1.0) / 2.0
+
+            if query_embedding and candidate.get("embedding_vector"):
+                fact_embedding = bytes_to_vector(candidate["embedding_vector"])
+                if fact_embedding and len(fact_embedding) == len(query_embedding):
+                    semantic_embedding = (cosine_similarity(query_embedding, fact_embedding) + 1.0) / 2.0
+
+            semantic_score = self._combine_semantic(semantic_hrr, semantic_embedding)
+            if semantic_score <= 0.0:
+                continue
+
+            candidate["semantic_hrr"] = semantic_hrr
+            candidate["semantic_embedding"] = semantic_embedding
+            candidate["semantic_score"] = semantic_score
+            scored.append(candidate)
+
+        scored.sort(key=lambda item: item.get("semantic_score", 0.0), reverse=True)
         return scored[:limit]
+
+    def _score_fact(
+        self,
+        fact: dict,
+        *,
+        query: str,
+        query_tokens: set[str],
+        query_meta: dict,
+        query_embedding: list[float] | None,
+        query_hrr,
+    ) -> dict:
+        keyword_jaccard = self._jaccard_similarity(query_tokens, self._tokenize(fact["content"] + " " + fact.get("tags", "")))
+        fts_score = float(fact.get("fts_score", 0.0))
+        keyword_score = self._combine_keyword(fts_score, keyword_jaccard)
+
+        semantic_hrr = float(fact.get("semantic_hrr", 0.0))
+        semantic_embedding = float(fact.get("semantic_embedding", 0.0))
+
+        if semantic_hrr <= 0.0 and query_hrr is not None and fact.get("hrr_vector"):
+            fact_hrr = hrr.bytes_to_phases(fact["hrr_vector"])
+            semantic_hrr = (hrr.similarity(query_hrr, fact_hrr) + 1.0) / 2.0
+
+        if semantic_embedding <= 0.0 and query_embedding and fact.get("embedding_vector"):
+            fact_embedding = bytes_to_vector(fact["embedding_vector"])
+            if fact_embedding and len(fact_embedding) == len(query_embedding):
+                semantic_embedding = (cosine_similarity(query_embedding, fact_embedding) + 1.0) / 2.0
+
+        semantic_score = self._combine_semantic(semantic_hrr, semantic_embedding)
+        recency_score = self._recency_score(fact.get("updated_at") or fact.get("created_at"))
+        confidence_score = _mean((fact.get("source_confidence", 0.5), fact.get("trust_score", 0.5)))
+        salience_score = float(fact.get("salience_score", 0.5))
+
+        component_scores = {
+            "semantic": semantic_score,
+            "keyword": keyword_score,
+            "recency": recency_score,
+            "salience": salience_score,
+            "confidence": confidence_score,
+        }
+
+        active_weights = {}
+        for component, weight in self.rank_weights.items():
+            if weight <= 0:
+                continue
+            if component == "semantic" and semantic_score <= 0.0:
+                continue
+            active_weights[component] = weight
+
+        if not active_weights:
+            final_score = max(keyword_score, salience_score, confidence_score)
+        else:
+            total_weight = sum(active_weights.values())
+            weighted_sum = sum(component_scores[name] * weight for name, weight in active_weights.items())
+            final_score = weighted_sum / total_weight if total_weight > 0 else 0.0
+
+        return {
+            "final_score": final_score,
+            "semantic_score": semantic_score,
+            "semantic_hrr": semantic_hrr,
+            "semantic_embedding": semantic_embedding,
+            "keyword_score": keyword_score,
+            "fts_score": fts_score,
+            "keyword_jaccard": keyword_jaccard,
+            "recency_score": recency_score,
+            "salience_score": salience_score,
+            "confidence_score": confidence_score,
+            "active_weights": active_weights,
+            "query": query,
+            "query_meta": query_meta,
+        }
+
+    def _build_debug_payload(
+        self,
+        fact: dict,
+        breakdown: dict,
+        *,
+        query_tokens: set[str],
+        query_meta: dict,
+    ) -> dict:
+        metadata = fact.get("metadata", {})
+        matched_entities = sorted(
+            set(query_meta.get("entities", [])) & set(metadata.get("entities", []))
+        )
+        if not matched_entities:
+            matched_entities = sorted(
+                set(query_meta.get("entity_keys", [])) & set(metadata.get("entity_keys", []))
+            )
+
+        matched_topics = sorted(set(query_meta.get("topics", [])) & set(metadata.get("topics", [])))
+        if not matched_topics:
+            matched_topics = sorted(
+                set(query_meta.get("topic_keys", [])) & set(metadata.get("topic_keys", []))
+            )
+
+        matched_clusters = sorted(
+            set(query_meta.get("cluster_keys", [])) & set(metadata.get("cluster_keys", []))
+        )
+        matched_terms = sorted(query_tokens & self._tokenize(fact["content"] + " " + fact.get("tags", "")))
+        links = self.store.get_fact_links(fact["fact_id"], limit=5)
+
+        why: list[str] = []
+        if breakdown["semantic_score"] > 0.6:
+            semantic_parts = []
+            if breakdown["semantic_embedding"] > 0.0:
+                semantic_parts.append(f"embedding {breakdown['semantic_embedding']:.2f}")
+            if breakdown["semantic_hrr"] > 0.0:
+                semantic_parts.append(f"hrr {breakdown['semantic_hrr']:.2f}")
+            why.append("semantic match via " + ", ".join(semantic_parts))
+        if breakdown["keyword_score"] > 0.15:
+            why.append(
+                f"keyword overlap fts={breakdown['fts_score']:.2f}, jaccard={breakdown['keyword_jaccard']:.2f}"
+            )
+        if matched_entities:
+            why.append("matched entities: " + ", ".join(matched_entities[:4]))
+        if matched_topics:
+            why.append("matched topics: " + ", ".join(matched_topics[:4]))
+        if matched_clusters:
+            why.append("matched clusters: " + ", ".join(matched_clusters[:4]))
+        if links:
+            why.append("linked memories: " + ", ".join(str(link["linked_fact_id"]) for link in links[:3]))
+
+        return {
+            "why": why,
+            "score_breakdown": {
+                "semantic": round(breakdown["semantic_score"], 4),
+                "keyword": round(breakdown["keyword_score"], 4),
+                "recency": round(breakdown["recency_score"], 4),
+                "salience": round(breakdown["salience_score"], 4),
+                "confidence": round(breakdown["confidence_score"], 4),
+                "weighted": {
+                    name: round(weight, 4)
+                    for name, weight in breakdown["active_weights"].items()
+                },
+            },
+            "matched_entities": matched_entities,
+            "matched_topics": matched_topics,
+            "matched_clusters": matched_clusters,
+            "matched_terms": matched_terms,
+            "source_channel": fact.get("source_channel", ""),
+            "recency_contribution": round(
+                breakdown["recency_score"] * breakdown["active_weights"].get("recency", 0.0),
+                4,
+            ),
+            "related_memory_ids": [link["linked_fact_id"] for link in links],
+        }
+
+    def _mark_retrieved(self, facts: list[dict]) -> None:
+        if not facts:
+            return
+        ids = [fact["fact_id"] for fact in facts]
+        placeholders = ",".join("?" * len(ids))
+        self.store._conn.execute(
+            f"UPDATE facts SET retrieval_count = retrieval_count + 1 WHERE fact_id IN ({placeholders})",
+            ids,
+        )
+        self.store._conn.commit()
+
+    def _normalize_fact(self, row: dict) -> dict:
+        fact = dict(row)
+        fact["metadata"] = self._parse_metadata(fact.get("metadata_json"))
+        fact.pop("metadata_json", None)
+        fact.pop("hrr_vector", None)
+        fact.pop("embedding_vector", None)
+        return fact
+
+    @staticmethod
+    def _parse_metadata(raw: str | None) -> dict:
+        if not raw:
+            return {}
+        try:
+            parsed = json.loads(raw)
+            return parsed if isinstance(parsed, dict) else {}
+        except Exception:
+            return {}
+
+    def _combine_keyword(self, fts_score: float, jaccard_score: float) -> float:
+        weight_total = self.fts_weight + self.jaccard_weight
+        if weight_total <= 0:
+            return 0.0
+        return ((fts_score * self.fts_weight) + (jaccard_score * self.jaccard_weight)) / weight_total
+
+    def _combine_semantic(self, hrr_score: float, embedding_score: float) -> float:
+        weights = []
+        if hrr_score > 0.0 and self.hrr_weight > 0:
+            weights.append((hrr_score, self.hrr_weight))
+        if embedding_score > 0.0 and self.embedding_weight > 0:
+            weights.append((embedding_score, self.embedding_weight))
+        if not weights:
+            return 0.0
+        total = sum(weight for _, weight in weights)
+        return sum(score * weight for score, weight in weights) / total
 
     def _fts_candidates(
         self,
@@ -485,71 +587,50 @@ class FactRetriever:
         min_trust: float,
         limit: int,
     ) -> list[dict]:
-        """Get raw FTS5 candidates from the store.
-
-        Uses the store's database connection directly for FTS5 MATCH
-        with rank scoring. Normalizes FTS5 rank to [0, 1] range.
-        """
         conn = self.store._conn
-
-        # Build query - FTS5 rank is negative (lower = better match)
-        # We need to join facts_fts with facts to get all columns
-        params: list = []
+        params: list = [query]
         where_clauses = ["facts_fts MATCH ?"]
-        params.append(query)
-
         if category:
             where_clauses.append("f.category = ?")
             params.append(category)
-
         where_clauses.append("f.trust_score >= ?")
         params.append(min_trust)
-
         where_sql = " AND ".join(where_clauses)
 
-        sql = f"""
-            SELECT f.*, facts_fts.rank as fts_rank_raw
-            FROM facts_fts
-            JOIN facts f ON f.fact_id = facts_fts.rowid
-            WHERE {where_sql}
-            ORDER BY facts_fts.rank
-            LIMIT ?
-        """
-        params.append(limit)
-
         try:
-            rows = conn.execute(sql, params).fetchall()
+            rows = conn.execute(
+                f"""
+                SELECT f.*, facts_fts.rank AS fts_rank_raw
+                FROM facts_fts
+                JOIN facts f ON f.fact_id = facts_fts.rowid
+                WHERE {where_sql}
+                ORDER BY facts_fts.rank
+                LIMIT ?
+                """,
+                params + [limit],
+            ).fetchall()
         except Exception:
-            # FTS5 MATCH can fail on malformed queries — fall back to empty
             return []
 
         if not rows:
             return []
 
-        # Normalize FTS5 rank: rank is negative, lower = better
-        # Convert to positive score in [0, 1] range
         raw_ranks = [abs(row["fts_rank_raw"]) for row in rows]
         max_rank = max(raw_ranks) if raw_ranks else 1.0
-        max_rank = max(max_rank, 1e-6)  # avoid div by zero
+        max_rank = max(max_rank, 1e-6)
 
         results = []
         for row, raw_rank in zip(rows, raw_ranks):
             fact = dict(row)
             fact.pop("fts_rank_raw", None)
-            fact["fts_rank"] = raw_rank / max_rank  # normalize to [0, 1]
+            fact["fts_score"] = max(0.0, 1.0 - (raw_rank / max_rank))
             results.append(fact)
-
         return results
 
     @staticmethod
     def _tokenize(text: str) -> set[str]:
-        """Simple whitespace tokenization with lowercasing.
-
-        Strips common punctuation. No stemming/lemmatization (Phase 1).
-        """
         if not text:
             return set()
-        # Split on whitespace, lowercase, strip punctuation
         tokens = set()
         for word in text.lower().split():
             cleaned = word.strip(".,;:!?\"'()[]{}#@<>")
@@ -559,35 +640,29 @@ class FactRetriever:
 
     @staticmethod
     def _jaccard_similarity(set_a: set, set_b: set) -> float:
-        """Jaccard similarity coefficient: |A ∩ B| / |A ∪ B|."""
         if not set_a or not set_b:
             return 0.0
         intersection = len(set_a & set_b)
         union = len(set_a | set_b)
         return intersection / union if union > 0 else 0.0
 
-    def _temporal_decay(self, timestamp_str: str | None) -> float:
-        """Exponential decay: 0.5^(age_days / half_life_days).
-
-        Returns 1.0 if decay is disabled or timestamp is missing.
-        """
+    def _recency_score(self, timestamp_str: str | None) -> float:
         if not self.half_life or not timestamp_str:
-            return 1.0
+            return 0.0
 
         try:
-            if isinstance(timestamp_str, str):
-                # Parse ISO format timestamp from SQLite
-                ts = datetime.fromisoformat(timestamp_str.replace("Z", "+00:00"))
-            else:
-                ts = timestamp_str
-
-            if ts.tzinfo is None:
-                ts = ts.replace(tzinfo=timezone.utc)
-
-            age_days = (datetime.now(timezone.utc) - ts).total_seconds() / 86400
+            timestamp = datetime.fromisoformat(str(timestamp_str).replace("Z", "+00:00"))
+            if timestamp.tzinfo is None:
+                timestamp = timestamp.replace(tzinfo=timezone.utc)
+            age_days = (datetime.now(timezone.utc) - timestamp).total_seconds() / 86400
             if age_days < 0:
                 return 1.0
-
             return math.pow(0.5, age_days / self.half_life)
         except (ValueError, TypeError):
-            return 1.0
+            return 0.0
+
+
+def _mean(values: tuple[float, ...]) -> float:
+    if not values:
+        return 0.0
+    return sum(values) / len(values)

--- a/plugins/memory/holographic/store.py
+++ b/plugins/memory/holographic/store.py
@@ -1,12 +1,21 @@
-"""
-SQLite-backed fact store with entity resolution and trust scoring.
-Single-user Hermes memory store plugin.
-"""
+"""SQLite-backed fact store with enrichment, linking, and trust scoring."""
 
-import re
+from __future__ import annotations
+
+import json
 import sqlite3
 import threading
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
+
+from .embeddings import (
+    EmbeddingProvider,
+    NoopEmbeddingProvider,
+    bytes_to_vector,
+    cosine_similarity,
+    vector_to_bytes,
+)
+from .enrichment import canonicalize_key, enrich_fact, extract_entities
 
 try:
     from . import holographic as hrr
@@ -15,22 +24,32 @@ except ImportError:
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS facts (
-    fact_id         INTEGER PRIMARY KEY AUTOINCREMENT,
-    content         TEXT NOT NULL UNIQUE,
-    category        TEXT DEFAULT 'general',
-    tags            TEXT DEFAULT '',
-    trust_score     REAL DEFAULT 0.5,
-    retrieval_count INTEGER DEFAULT 0,
-    helpful_count   INTEGER DEFAULT 0,
-    created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    hrr_vector      BLOB
+    fact_id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    content            TEXT NOT NULL UNIQUE,
+    category           TEXT DEFAULT 'general',
+    tags               TEXT DEFAULT '',
+    trust_score        REAL DEFAULT 0.5,
+    retrieval_count    INTEGER DEFAULT 0,
+    helpful_count      INTEGER DEFAULT 0,
+    created_at         TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at         TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    hrr_vector         BLOB,
+    metadata_json      TEXT DEFAULT '{}',
+    salience_score     REAL DEFAULT 0.5,
+    source_confidence  REAL DEFAULT 0.5,
+    source_channel     TEXT DEFAULT '',
+    intent_type        TEXT DEFAULT 'general',
+    embedding_vector   BLOB,
+    embedding_dim      INTEGER DEFAULT 0,
+    embedding_provider TEXT DEFAULT '',
+    embedding_model    TEXT DEFAULT ''
 );
 
 CREATE TABLE IF NOT EXISTS entities (
     entity_id   INTEGER PRIMARY KEY AUTOINCREMENT,
     name        TEXT NOT NULL,
     entity_type TEXT DEFAULT 'unknown',
+    canonical_key TEXT DEFAULT '',
     aliases     TEXT DEFAULT '',
     created_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
@@ -41,9 +60,26 @@ CREATE TABLE IF NOT EXISTS fact_entities (
     PRIMARY KEY (fact_id, entity_id)
 );
 
-CREATE INDEX IF NOT EXISTS idx_facts_trust    ON facts(trust_score DESC);
-CREATE INDEX IF NOT EXISTS idx_facts_category ON facts(category);
-CREATE INDEX IF NOT EXISTS idx_entities_name  ON entities(name);
+CREATE TABLE IF NOT EXISTS fact_links (
+    fact_id          INTEGER NOT NULL REFERENCES facts(fact_id),
+    related_fact_id  INTEGER NOT NULL REFERENCES facts(fact_id),
+    link_type        TEXT NOT NULL DEFAULT 'related',
+    strength         REAL NOT NULL DEFAULT 0.0,
+    reason           TEXT NOT NULL DEFAULT '',
+    created_at       TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at       TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (fact_id, related_fact_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_facts_trust      ON facts(trust_score DESC);
+CREATE INDEX IF NOT EXISTS idx_facts_category   ON facts(category);
+CREATE INDEX IF NOT EXISTS idx_facts_salience   ON facts(salience_score DESC);
+CREATE INDEX IF NOT EXISTS idx_facts_source     ON facts(source_channel);
+CREATE INDEX IF NOT EXISTS idx_facts_intent     ON facts(intent_type);
+CREATE INDEX IF NOT EXISTS idx_entities_name    ON entities(name);
+CREATE INDEX IF NOT EXISTS idx_fact_links_right ON fact_links(related_fact_id);
+CREATE INDEX IF NOT EXISTS idx_fact_links_type  ON fact_links(link_type);
+CREATE INDEX IF NOT EXISTS idx_entities_canonical ON entities(canonical_key);
 
 CREATE VIRTUAL TABLE IF NOT EXISTS facts_fts
     USING fts5(content, tags, content=facts, content_rowid=fact_id);
@@ -73,45 +109,75 @@ CREATE TABLE IF NOT EXISTS memory_banks (
     fact_count INTEGER DEFAULT 0,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE TABLE IF NOT EXISTS understanding_ingest_queue (
+    ingest_id       INTEGER PRIMARY KEY AUTOINCREMENT,
+    ingest_type     TEXT NOT NULL,
+    session_id      TEXT DEFAULT '',
+    dedupe_key      TEXT NOT NULL UNIQUE,
+    payload_json    TEXT NOT NULL,
+    source_channel  TEXT DEFAULT '',
+    status          TEXT NOT NULL DEFAULT 'pending',
+    attempt_count   INTEGER NOT NULL DEFAULT 0,
+    created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    available_at    TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    started_at      TIMESTAMP,
+    last_error      TEXT DEFAULT ''
+);
+
+CREATE INDEX IF NOT EXISTS idx_ingest_queue_status
+    ON understanding_ingest_queue(status, available_at, ingest_id);
+
+CREATE TABLE IF NOT EXISTS understanding_state (
+    state_key   TEXT PRIMARY KEY,
+    state_value TEXT NOT NULL DEFAULT '',
+    updated_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
 """
 
-# Trust adjustment constants
-_HELPFUL_DELTA   =  0.05
+_HELPFUL_DELTA = 0.05
 _UNHELPFUL_DELTA = -0.10
-_TRUST_MIN       =  0.0
-_TRUST_MAX       =  1.0
+_TRUST_MIN = 0.0
+_TRUST_MAX = 1.0
+_MAX_LINK_SCAN = 500
+_MAX_BACKOFF_SECONDS = 1800
 
-# Entity extraction patterns
-_RE_CAPITALIZED  = re.compile(r'\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)\b')
-_RE_DOUBLE_QUOTE = re.compile(r'"([^"]+)"')
-_RE_SINGLE_QUOTE = re.compile(r"'([^']+)'")
-_RE_AKA          = re.compile(
-    r'(\w+(?:\s+\w+)*)\s+(?:aka|also known as)\s+(\w+(?:\s+\w+)*)',
-    re.IGNORECASE,
-)
+
+def _utc_now_sql() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
 
 
 def _clamp_trust(value: float) -> float:
     return max(_TRUST_MIN, min(_TRUST_MAX, value))
 
 
+def _clamp_unit(value: float) -> float:
+    return max(0.0, min(1.0, float(value)))
+
+
 class MemoryStore:
-    """SQLite-backed fact store with entity resolution and trust scoring."""
+    """SQLite-backed fact store with enrichment, trust scoring, and links."""
 
     def __init__(
         self,
         db_path: "str | Path | None" = None,
         default_trust: float = 0.5,
         hrr_dim: int = 1024,
+        embedding_provider: EmbeddingProvider | None = None,
+        link_threshold: float = 0.36,
     ) -> None:
         if db_path is None:
             from hermes_constants import get_hermes_home
+
             db_path = str(get_hermes_home() / "memory_store.db")
         self.db_path = Path(db_path).expanduser()
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         self.default_trust = _clamp_trust(default_trust)
         self.hrr_dim = hrr_dim
         self._hrr_available = hrr._HAS_NUMPY
+        self._embedding_provider = embedding_provider or NoopEmbeddingProvider()
+        self._link_threshold = _clamp_unit(link_threshold)
         self._conn: sqlite3.Connection = sqlite3.connect(
             str(self.db_path),
             check_same_thread=False,
@@ -126,14 +192,32 @@ class MemoryStore:
     # ------------------------------------------------------------------
 
     def _init_db(self) -> None:
-        """Create tables, indexes, and triggers if they do not exist. Enable WAL mode."""
         self._conn.execute("PRAGMA journal_mode=WAL")
         self._conn.executescript(_SCHEMA)
-        # Migrate: add hrr_vector column if missing (safe for existing databases)
-        columns = {row[1] for row in self._conn.execute("PRAGMA table_info(facts)").fetchall()}
-        if "hrr_vector" not in columns:
-            self._conn.execute("ALTER TABLE facts ADD COLUMN hrr_vector BLOB")
+        self._ensure_fact_column("hrr_vector", "BLOB")
+        self._ensure_fact_column("metadata_json", "TEXT DEFAULT '{}'")
+        self._ensure_fact_column("salience_score", "REAL DEFAULT 0.5")
+        self._ensure_fact_column("source_confidence", "REAL DEFAULT 0.5")
+        self._ensure_fact_column("source_channel", "TEXT DEFAULT ''")
+        self._ensure_fact_column("intent_type", "TEXT DEFAULT 'general'")
+        self._ensure_fact_column("embedding_vector", "BLOB")
+        self._ensure_fact_column("embedding_dim", "INTEGER DEFAULT 0")
+        self._ensure_fact_column("embedding_provider", "TEXT DEFAULT ''")
+        self._ensure_fact_column("embedding_model", "TEXT DEFAULT ''")
+        self._ensure_entity_column("canonical_key", "TEXT DEFAULT ''")
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_entities_canonical ON entities(canonical_key)")
+        self._recover_processing_ingest()
         self._conn.commit()
+
+    def _ensure_fact_column(self, name: str, definition: str) -> None:
+        columns = {row[1] for row in self._conn.execute("PRAGMA table_info(facts)").fetchall()}
+        if name not in columns:
+            self._conn.execute(f"ALTER TABLE facts ADD COLUMN {name} {definition}")
+
+    def _ensure_entity_column(self, name: str, definition: str) -> None:
+        columns = {row[1] for row in self._conn.execute("PRAGMA table_info(entities)").fetchall()}
+        if name not in columns:
+            self._conn.execute(f"ALTER TABLE entities ADD COLUMN {name} {definition}")
 
     # ------------------------------------------------------------------
     # Public API
@@ -144,44 +228,67 @@ class MemoryStore:
         content: str,
         category: str = "general",
         tags: str = "",
+        source_channel: str = "tool:fact_store",
+        source_confidence: float | None = None,
+        intent_type: str | None = None,
+        salience_score: float | None = None,
     ) -> int:
-        """Insert a fact and return its fact_id.
+        """Insert a fact and return its fact_id."""
+        normalized = content.strip()
+        if not normalized:
+            raise ValueError("content must not be empty")
 
-        Deduplicates by content (UNIQUE constraint). On duplicate, returns
-        the existing fact_id without modifying the row. Extracts entities from
-        the content and links them to the fact.
-        """
+        enrichment = enrich_fact(
+            normalized,
+            category=category,
+            tags=tags,
+            source_channel=source_channel,
+            intent_type=intent_type,
+            salience_score=salience_score,
+            source_confidence=source_confidence,
+        )
+        embedding_payload = self._build_embedding_payload(normalized)
+
         with self._lock:
-            content = content.strip()
-            if not content:
-                raise ValueError("content must not be empty")
-
             try:
                 cur = self._conn.execute(
                     """
-                    INSERT INTO facts (content, category, tags, trust_score)
-                    VALUES (?, ?, ?, ?)
+                    INSERT INTO facts (
+                        content, category, tags, trust_score,
+                        metadata_json, salience_score, source_confidence,
+                        source_channel, intent_type, embedding_vector,
+                        embedding_dim, embedding_provider, embedding_model
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
-                    (content, category, tags, self.default_trust),
+                    (
+                        normalized,
+                        category,
+                        tags,
+                        self.default_trust,
+                        json.dumps(enrichment.to_dict(), ensure_ascii=False),
+                        enrichment.salience_score,
+                        enrichment.source_confidence,
+                        enrichment.source_channel,
+                        enrichment.intent_type,
+                        embedding_payload["vector"],
+                        embedding_payload["dim"],
+                        embedding_payload["provider"],
+                        embedding_payload["model"],
+                    ),
                 )
-                self._conn.commit()
                 fact_id: int = cur.lastrowid  # type: ignore[assignment]
             except sqlite3.IntegrityError:
-                # Duplicate content — return existing id
                 row = self._conn.execute(
-                    "SELECT fact_id FROM facts WHERE content = ?", (content,)
+                    "SELECT fact_id FROM facts WHERE content = ?", (normalized,)
                 ).fetchone()
                 return int(row["fact_id"])
 
-            # Entity extraction and linking
-            for name in self._extract_entities(content):
-                entity_id = self._resolve_entity(name)
-                self._link_fact_entity(fact_id, entity_id)
-
-            # Compute HRR vector after entity linking
-            self._compute_hrr_vector(fact_id, content)
-            self._rebuild_bank(category)
-
+            self._refresh_fact_entities(fact_id, enrichment.entities)
+            self._compute_hrr_vector(fact_id, normalized, commit=False)
+            self._rebuild_bank(category, commit=False)
+            self._refresh_links_for_fact(fact_id, commit=False)
+            self._conn.commit()
             return fact_id
 
     def search_facts(
@@ -191,11 +298,7 @@ class MemoryStore:
         min_trust: float = 0.3,
         limit: int = 10,
     ) -> list[dict]:
-        """Full-text search over facts using FTS5.
-
-        Returns a list of fact dicts ordered by FTS5 rank, then trust_score
-        descending. Also increments retrieval_count for matched facts.
-        """
+        """Full-text search over facts using FTS5."""
         with self._lock:
             query = query.strip()
             if not query:
@@ -211,7 +314,9 @@ class MemoryStore:
             sql = f"""
                 SELECT f.fact_id, f.content, f.category, f.tags,
                        f.trust_score, f.retrieval_count, f.helpful_count,
-                       f.created_at, f.updated_at
+                       f.created_at, f.updated_at, f.metadata_json,
+                       f.salience_score, f.source_confidence, f.source_channel,
+                       f.intent_type, f.embedding_provider, f.embedding_model
                 FROM facts f
                 JOIN facts_fts fts ON fts.rowid = f.fact_id
                 WHERE facts_fts MATCH ?
@@ -222,10 +327,10 @@ class MemoryStore:
             """
 
             rows = self._conn.execute(sql, params).fetchall()
-            results = [self._row_to_dict(r) for r in rows]
+            results = [self._row_to_dict(row) for row in rows]
 
             if results:
-                ids = [r["fact_id"] for r in results]
+                ids = [result["fact_id"] for result in results]
                 placeholders = ",".join("?" * len(ids))
                 self._conn.execute(
                     f"UPDATE facts SET retrieval_count = retrieval_count + 1 WHERE fact_id IN ({placeholders})",
@@ -242,65 +347,87 @@ class MemoryStore:
         trust_delta: float | None = None,
         tags: str | None = None,
         category: str | None = None,
+        source_channel: str | None = None,
+        source_confidence: float | None = None,
+        intent_type: str | None = None,
+        salience_score: float | None = None,
     ) -> bool:
-        """Partially update a fact. Trust is clamped to [0, 1].
-
-        Returns True if the row existed, False otherwise.
-        """
+        """Partially update a fact. Trust is clamped to [0, 1]."""
         with self._lock:
-            row = self._conn.execute(
-                "SELECT fact_id, trust_score FROM facts WHERE fact_id = ?", (fact_id,)
-            ).fetchone()
+            row = self._conn.execute("SELECT * FROM facts WHERE fact_id = ?", (fact_id,)).fetchone()
             if row is None:
                 return False
 
-            assignments: list[str] = ["updated_at = CURRENT_TIMESTAMP"]
-            params: list = []
-
-            if content is not None:
-                assignments.append("content = ?")
-                params.append(content.strip())
-            if tags is not None:
-                assignments.append("tags = ?")
-                params.append(tags)
-            if category is not None:
-                assignments.append("category = ?")
-                params.append(category)
+            new_content = content.strip() if content is not None else row["content"]
+            new_tags = tags if tags is not None else row["tags"]
+            new_category = category if category is not None else row["category"]
+            new_source = source_channel if source_channel is not None else row["source_channel"]
+            new_intent = intent_type if intent_type is not None else row["intent_type"]
+            effective_salience = salience_score if salience_score is not None else row["salience_score"]
+            effective_confidence = source_confidence if source_confidence is not None else row["source_confidence"]
+            new_trust = row["trust_score"]
             if trust_delta is not None:
-                new_trust = _clamp_trust(row["trust_score"] + trust_delta)
-                assignments.append("trust_score = ?")
-                params.append(new_trust)
+                new_trust = _clamp_trust(new_trust + trust_delta)
 
-            params.append(fact_id)
-            self._conn.execute(
-                f"UPDATE facts SET {', '.join(assignments)} WHERE fact_id = ?",
-                params,
+            enrichment = enrich_fact(
+                new_content,
+                category=new_category,
+                tags=new_tags,
+                source_channel=new_source,
+                intent_type=new_intent,
+                salience_score=effective_salience,
+                source_confidence=effective_confidence,
             )
+            embedding_payload = self._build_embedding_payload(new_content)
+
+            self._conn.execute(
+                """
+                UPDATE facts
+                SET content = ?,
+                    category = ?,
+                    tags = ?,
+                    trust_score = ?,
+                    updated_at = CURRENT_TIMESTAMP,
+                    metadata_json = ?,
+                    salience_score = ?,
+                    source_confidence = ?,
+                    source_channel = ?,
+                    intent_type = ?,
+                    embedding_vector = ?,
+                    embedding_dim = ?,
+                    embedding_provider = ?,
+                    embedding_model = ?
+                WHERE fact_id = ?
+                """,
+                (
+                    new_content,
+                    new_category,
+                    new_tags,
+                    new_trust,
+                    json.dumps(enrichment.to_dict(), ensure_ascii=False),
+                    enrichment.salience_score,
+                    enrichment.source_confidence,
+                    enrichment.source_channel,
+                    enrichment.intent_type,
+                    embedding_payload["vector"],
+                    embedding_payload["dim"],
+                    embedding_payload["provider"],
+                    embedding_payload["model"],
+                    fact_id,
+                ),
+            )
+
+            self._refresh_fact_entities(fact_id, enrichment.entities)
+            self._compute_hrr_vector(fact_id, new_content, commit=False)
+            old_category = row["category"]
+            self._rebuild_bank(old_category, commit=False)
+            if new_category != old_category:
+                self._rebuild_bank(new_category, commit=False)
+            self._refresh_links_for_fact(fact_id, commit=False)
             self._conn.commit()
-
-            # If content changed, re-extract entities
-            if content is not None:
-                self._conn.execute(
-                    "DELETE FROM fact_entities WHERE fact_id = ?", (fact_id,)
-                )
-                for name in self._extract_entities(content):
-                    entity_id = self._resolve_entity(name)
-                    self._link_fact_entity(fact_id, entity_id)
-                self._conn.commit()
-
-            # Recompute HRR vector if content changed
-            if content is not None:
-                self._compute_hrr_vector(fact_id, content)
-            # Rebuild bank for relevant category
-            cat = category or self._conn.execute(
-                "SELECT category FROM facts WHERE fact_id = ?", (fact_id,)
-            ).fetchone()["category"]
-            self._rebuild_bank(cat)
-
             return True
 
     def remove_fact(self, fact_id: int) -> bool:
-        """Delete a fact and its entity links. Returns True if the row existed."""
         with self._lock:
             row = self._conn.execute(
                 "SELECT fact_id, category FROM facts WHERE fact_id = ?", (fact_id,)
@@ -308,12 +435,14 @@ class MemoryStore:
             if row is None:
                 return False
 
+            self._conn.execute("DELETE FROM fact_entities WHERE fact_id = ?", (fact_id,))
             self._conn.execute(
-                "DELETE FROM fact_entities WHERE fact_id = ?", (fact_id,)
+                "DELETE FROM fact_links WHERE fact_id = ? OR related_fact_id = ?",
+                (fact_id, fact_id),
             )
             self._conn.execute("DELETE FROM facts WHERE fact_id = ?", (fact_id,))
+            self._rebuild_bank(row["category"], commit=False)
             self._conn.commit()
-            self._rebuild_bank(row["category"])
             return True
 
     def list_facts(
@@ -322,10 +451,6 @@ class MemoryStore:
         min_trust: float = 0.0,
         limit: int = 50,
     ) -> list[dict]:
-        """Browse facts ordered by trust_score descending.
-
-        Optionally filter by category and minimum trust score.
-        """
         with self._lock:
             params: list = [min_trust]
             category_clause = ""
@@ -336,25 +461,432 @@ class MemoryStore:
 
             sql = f"""
                 SELECT fact_id, content, category, tags, trust_score,
-                       retrieval_count, helpful_count, created_at, updated_at
+                       retrieval_count, helpful_count, created_at, updated_at,
+                       metadata_json, salience_score, source_confidence,
+                       source_channel, intent_type, embedding_provider,
+                       embedding_model
                 FROM facts
                 WHERE trust_score >= ?
                   {category_clause}
-                ORDER BY trust_score DESC
+                ORDER BY trust_score DESC, salience_score DESC
                 LIMIT ?
             """
             rows = self._conn.execute(sql, params).fetchall()
-            return [self._row_to_dict(r) for r in rows]
+            return [self._row_to_dict(row) for row in rows]
+
+    def get_fact(self, fact_id: int) -> dict | None:
+        with self._lock:
+            row = self._conn.execute("SELECT * FROM facts WHERE fact_id = ?", (fact_id,)).fetchone()
+            if row is None:
+                return None
+            result = self._row_to_dict(row)
+            result["links"] = self.get_fact_links(fact_id)
+            return result
+
+    def get_fact_links(self, fact_id: int, limit: int = 20) -> list[dict]:
+        with self._lock:
+            rows = self._conn.execute(
+                """
+                SELECT
+                    CASE WHEN fl.fact_id = ? THEN fl.related_fact_id ELSE fl.fact_id END AS linked_fact_id,
+                    fl.link_type,
+                    fl.strength,
+                    fl.reason,
+                    f.content,
+                    f.category,
+                    f.updated_at
+                FROM fact_links fl
+                JOIN facts f
+                  ON f.fact_id = CASE WHEN fl.fact_id = ? THEN fl.related_fact_id ELSE fl.fact_id END
+                WHERE fl.fact_id = ? OR fl.related_fact_id = ?
+                ORDER BY fl.strength DESC, f.updated_at DESC
+                LIMIT ?
+                """,
+                (fact_id, fact_id, fact_id, fact_id, limit),
+            ).fetchall()
+            return [dict(row) for row in rows]
+
+    def enqueue_ingest(
+        self,
+        ingest_type: str,
+        payload: dict,
+        *,
+        dedupe_key: str,
+        source_channel: str = "",
+        session_id: str = "",
+        max_pending: int = 200,
+    ) -> dict:
+        payload_json = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+        with self._lock:
+            existing = self._conn.execute(
+                """
+                SELECT ingest_id, status
+                FROM understanding_ingest_queue
+                WHERE dedupe_key = ?
+                """,
+                (dedupe_key,),
+            ).fetchone()
+            if existing is not None:
+                return {
+                    "enqueued": False,
+                    "duplicate": True,
+                    "ingest_id": int(existing["ingest_id"]),
+                    "status": existing["status"],
+                }
+
+            pending_count = self._conn.execute(
+                """
+                SELECT COUNT(*)
+                FROM understanding_ingest_queue
+                WHERE status IN ('pending', 'failed', 'processing')
+                """
+            ).fetchone()[0]
+            if pending_count >= max_pending:
+                rejected = int(self._get_state("ingest_enqueue_rejected_count") or "0") + 1
+                self._set_state("ingest_enqueue_rejected_count", str(rejected))
+                self._set_state(
+                    "last_ingest_error_summary",
+                    f"understanding ingest queue full ({pending_count} items)",
+                )
+                self._conn.commit()
+                return {
+                    "enqueued": False,
+                    "duplicate": False,
+                    "reason": "queue_full",
+                    "pending_items": int(pending_count),
+                }
+
+            now = _utc_now_sql()
+            cur = self._conn.execute(
+                """
+                INSERT INTO understanding_ingest_queue (
+                    ingest_type, session_id, dedupe_key, payload_json,
+                    source_channel, status, created_at, updated_at,
+                    available_at
+                )
+                VALUES (?, ?, ?, ?, ?, 'pending', ?, ?, ?)
+                """,
+                (
+                    ingest_type,
+                    session_id,
+                    dedupe_key,
+                    payload_json,
+                    source_channel,
+                    now,
+                    now,
+                    now,
+                ),
+            )
+            self._conn.commit()
+            return {
+                "enqueued": True,
+                "duplicate": False,
+                "ingest_id": int(cur.lastrowid),
+            }
+
+    def claim_ingest_batch(self, *, limit: int = 1) -> list[dict]:
+        with self._lock:
+            rows = self._conn.execute(
+                """
+                SELECT ingest_id
+                FROM understanding_ingest_queue
+                WHERE status IN ('pending', 'failed')
+                  AND available_at <= CURRENT_TIMESTAMP
+                ORDER BY ingest_id ASC
+                LIMIT ?
+                """,
+                (max(1, int(limit)),),
+            ).fetchall()
+            if not rows:
+                return []
+
+            claimed: list[dict] = []
+            now = _utc_now_sql()
+            for row in rows:
+                ingest_id = int(row["ingest_id"])
+                cur = self._conn.execute(
+                    """
+                    UPDATE understanding_ingest_queue
+                    SET status = 'processing',
+                        attempt_count = attempt_count + 1,
+                        started_at = ?,
+                        updated_at = ?
+                    WHERE ingest_id = ?
+                      AND status IN ('pending', 'failed')
+                    """,
+                    (now, now, ingest_id),
+                )
+                if cur.rowcount != 1:
+                    continue
+                claimed_row = self._conn.execute(
+                    "SELECT * FROM understanding_ingest_queue WHERE ingest_id = ?",
+                    (ingest_id,),
+                ).fetchone()
+                if claimed_row is not None:
+                    claimed.append(dict(claimed_row))
+            self._conn.commit()
+            return claimed
+
+    def complete_ingest(self, ingest_id: int, *, facts_written: int = 0) -> None:
+        with self._lock:
+            now = _utc_now_sql()
+            processed_count = int(self._get_state("ingest_processed_count") or "0") + 1
+            self._conn.execute(
+                "DELETE FROM understanding_ingest_queue WHERE ingest_id = ?",
+                (ingest_id,),
+            )
+            self._set_state("last_ingest_success_at", now)
+            self._set_state("last_ingest_error_summary", "")
+            self._set_state("ingest_processed_count", str(processed_count))
+            self._set_state("last_ingest_facts_written", str(max(0, int(facts_written))))
+            self._conn.commit()
+
+    def fail_ingest(self, ingest_id: int, error: str, *, retry_delay_seconds: int = 60) -> None:
+        with self._lock:
+            row = self._conn.execute(
+                """
+                SELECT attempt_count
+                FROM understanding_ingest_queue
+                WHERE ingest_id = ?
+                """,
+                (ingest_id,),
+            ).fetchone()
+            if row is None:
+                return
+
+            attempts = max(1, int(row["attempt_count"]))
+            next_delay = min(
+                max(1, int(retry_delay_seconds)) * (2 ** max(0, attempts - 1)),
+                _MAX_BACKOFF_SECONDS,
+            )
+            next_at = datetime.now(timezone.utc) + timedelta(seconds=next_delay)
+            next_at_sql = next_at.strftime("%Y-%m-%d %H:%M:%S")
+            summary = (error or "unknown ingest failure").strip()[:240]
+            now = _utc_now_sql()
+            self._conn.execute(
+                """
+                UPDATE understanding_ingest_queue
+                SET status = 'failed',
+                    updated_at = ?,
+                    available_at = ?,
+                    last_error = ?
+                WHERE ingest_id = ?
+                """,
+                (now, next_at_sql, summary, ingest_id),
+            )
+            self._set_state("last_ingest_error_summary", summary)
+            self._conn.commit()
+
+    def _recover_processing_ingest(self) -> None:
+        now = _utc_now_sql()
+        cutoff = (datetime.now(timezone.utc) - timedelta(minutes=15)).strftime("%Y-%m-%d %H:%M:%S")
+        cur = self._conn.execute(
+            """
+            UPDATE understanding_ingest_queue
+            SET status = 'failed',
+                updated_at = ?,
+                available_at = ?,
+                last_error = CASE
+                    WHEN trim(coalesce(last_error, '')) = ''
+                    THEN 'Recovered interrupted ingest attempt'
+                    ELSE last_error
+                END
+            WHERE status = 'processing'
+              AND (started_at IS NULL OR started_at < ?)
+            """,
+            (now, now, cutoff),
+        )
+        if cur.rowcount:
+            self._set_state(
+                "last_ingest_error_summary",
+                "Recovered interrupted ingest attempt",
+            )
+
+    def _get_state(self, key: str) -> str:
+        row = self._conn.execute(
+            "SELECT state_value FROM understanding_state WHERE state_key = ?",
+            (key,),
+        ).fetchone()
+        if row is None:
+            return ""
+        return str(row["state_value"] or "")
+
+    def _set_state(self, key: str, value: str) -> None:
+        self._conn.execute(
+            """
+            INSERT INTO understanding_state (state_key, state_value, updated_at)
+            VALUES (?, ?, ?)
+            ON CONFLICT(state_key) DO UPDATE SET
+                state_value = excluded.state_value,
+                updated_at = excluded.updated_at
+            """,
+            (key, value, _utc_now_sql()),
+        )
+
+    def index_status(self) -> dict:
+        with self._lock:
+            total = self._conn.execute("SELECT COUNT(*) FROM facts").fetchone()[0]
+            enriched = self._conn.execute(
+                "SELECT COUNT(*) FROM facts WHERE metadata_json IS NOT NULL AND metadata_json != '' AND metadata_json != '{}'"
+            ).fetchone()[0]
+            embedded = self._conn.execute(
+                "SELECT COUNT(*) FROM facts WHERE embedding_vector IS NOT NULL"
+            ).fetchone()[0]
+            hrr_ready = self._conn.execute(
+                "SELECT COUNT(*) FROM facts WHERE hrr_vector IS NOT NULL"
+            ).fetchone()[0]
+            linked = self._conn.execute("SELECT COUNT(*) FROM fact_links").fetchone()[0]
+            latest = self._conn.execute("SELECT MAX(updated_at) FROM facts").fetchone()[0]
+            pending = self._conn.execute(
+                "SELECT COUNT(*) FROM understanding_ingest_queue WHERE status = 'pending'"
+            ).fetchone()[0]
+            failed = self._conn.execute(
+                "SELECT COUNT(*) FROM understanding_ingest_queue WHERE status = 'failed'"
+            ).fetchone()[0]
+            processing = self._conn.execute(
+                "SELECT COUNT(*) FROM understanding_ingest_queue WHERE status = 'processing'"
+            ).fetchone()[0]
+            oldest_pending = self._conn.execute(
+                """
+                SELECT MIN(created_at)
+                FROM understanding_ingest_queue
+                WHERE status IN ('pending', 'failed', 'processing')
+                """
+            ).fetchone()[0]
+
+        return {
+            "db_path": str(self.db_path),
+            "facts": int(total),
+            "enriched_facts": int(enriched),
+            "embedded_facts": int(embedded),
+            "hrr_ready_facts": int(hrr_ready),
+            "links": int(linked),
+            "embedding_provider": getattr(self._embedding_provider, "name", "none"),
+            "embedding_available": bool(self._embedding_provider.is_available()),
+            "embedding_model": getattr(self._embedding_provider, "model", ""),
+            "latest_update": latest,
+            "link_threshold": self._link_threshold,
+            "pending_ingest_items": int(pending),
+            "failed_ingest_items": int(failed),
+            "processing_ingest_items": int(processing),
+            "oldest_pending_ingest": oldest_pending,
+            "last_ingest_success": self._get_state("last_ingest_success_at") or None,
+            "last_ingest_error": self._get_state("last_ingest_error_summary") or None,
+            "ingest_enqueue_rejected": int(self._get_state("ingest_enqueue_rejected_count") or "0"),
+            "reindex_status": self._get_state("reindex_status") or "idle",
+            "reindex_started_at": self._get_state("reindex_started_at") or None,
+            "reindex_completed_at": self._get_state("reindex_completed_at") or None,
+            "reindex_error": self._get_state("reindex_error") or None,
+        }
+
+    def rebuild_understanding_index(
+        self,
+        *,
+        include_embeddings: bool = True,
+        refresh_links: bool = True,
+    ) -> dict:
+        with self._lock:
+            started_at = _utc_now_sql()
+            self._set_state("reindex_status", "running")
+            self._set_state("reindex_started_at", started_at)
+            self._set_state("reindex_error", "")
+            self._conn.commit()
+
+            try:
+                rows = self._conn.execute(
+                    """
+                    SELECT fact_id, content, category, tags, source_channel,
+                           source_confidence, intent_type, salience_score
+                    FROM facts
+                    ORDER BY fact_id
+                    """
+                ).fetchall()
+
+                categories: set[str] = set()
+                updated = 0
+                embedded = 0
+
+                if refresh_links:
+                    self._conn.execute("DELETE FROM fact_links")
+
+                for row in rows:
+                    categories.add(row["category"])
+                    enrichment = enrich_fact(
+                        row["content"],
+                        category=row["category"],
+                        tags=row["tags"] or "",
+                        source_channel=row["source_channel"] or "unknown",
+                        intent_type=row["intent_type"] or None,
+                        salience_score=row["salience_score"],
+                        source_confidence=row["source_confidence"],
+                    )
+                    embedding_payload = {"vector": None, "dim": 0, "provider": "", "model": ""}
+                    if include_embeddings:
+                        embedding_payload = self._build_embedding_payload(row["content"])
+                        if embedding_payload["vector"] is not None:
+                            embedded += 1
+
+                    self._conn.execute(
+                        """
+                        UPDATE facts
+                        SET metadata_json = ?,
+                            salience_score = ?,
+                            source_confidence = ?,
+                            source_channel = ?,
+                            intent_type = ?,
+                            embedding_vector = COALESCE(?, embedding_vector),
+                            embedding_dim = CASE WHEN ? > 0 THEN ? ELSE embedding_dim END,
+                            embedding_provider = CASE WHEN ? != '' THEN ? ELSE embedding_provider END,
+                            embedding_model = CASE WHEN ? != '' THEN ? ELSE embedding_model END
+                        WHERE fact_id = ?
+                        """,
+                        (
+                            json.dumps(enrichment.to_dict(), ensure_ascii=False),
+                            enrichment.salience_score,
+                            enrichment.source_confidence,
+                            enrichment.source_channel,
+                            enrichment.intent_type,
+                            embedding_payload["vector"],
+                            embedding_payload["dim"],
+                            embedding_payload["dim"],
+                            embedding_payload["provider"],
+                            embedding_payload["provider"],
+                            embedding_payload["model"],
+                            embedding_payload["model"],
+                            row["fact_id"],
+                        ),
+                    )
+                    self._refresh_fact_entities(row["fact_id"], enrichment.entities)
+                    self._compute_hrr_vector(row["fact_id"], row["content"], commit=False)
+                    updated += 1
+
+                for category in categories:
+                    self._rebuild_bank(category, commit=False)
+
+                if refresh_links:
+                    for row in rows:
+                        self._refresh_links_for_fact(row["fact_id"], commit=False)
+
+                completed_at = _utc_now_sql()
+                self._set_state("reindex_status", "completed")
+                self._set_state("reindex_completed_at", completed_at)
+                self._conn.commit()
+            except Exception as exc:
+                self._set_state("reindex_status", "failed")
+                self._set_state("reindex_error", str(exc)[:240])
+                self._conn.commit()
+                raise
+
+        return {
+            "facts_reindexed": updated,
+            "embedded_facts": embedded,
+            "links_rebuilt": refresh_links,
+            "embedding_provider": getattr(self._embedding_provider, "name", "none"),
+            "reindex_started_at": started_at,
+            "reindex_completed_at": completed_at,
+        }
 
     def record_feedback(self, fact_id: int, helpful: bool) -> dict:
-        """Record user feedback and adjust trust asymmetrically.
-
-        helpful=True  -> trust += 0.05, helpful_count += 1
-        helpful=False -> trust -= 0.10
-
-        Returns a dict with fact_id, old_trust, new_trust, helpful_count.
-        Raises KeyError if fact_id does not exist.
-        """
         with self._lock:
             row = self._conn.execute(
                 "SELECT fact_id, trust_score, helpful_count FROM facts WHERE fact_id = ?",
@@ -366,14 +898,14 @@ class MemoryStore:
             old_trust: float = row["trust_score"]
             delta = _HELPFUL_DELTA if helpful else _UNHELPFUL_DELTA
             new_trust = _clamp_trust(old_trust + delta)
-
             helpful_increment = 1 if helpful else 0
+
             self._conn.execute(
                 """
                 UPDATE facts
-                SET trust_score    = ?,
-                    helpful_count  = helpful_count + ?,
-                    updated_at     = CURRENT_TIMESTAMP
+                SET trust_score = ?,
+                    helpful_count = helpful_count + ?,
+                    updated_at = CURRENT_TIMESTAMP
                 WHERE fact_id = ?
                 """,
                 (new_trust, helpful_increment, fact_id),
@@ -381,9 +913,9 @@ class MemoryStore:
             self._conn.commit()
 
             return {
-                "fact_id":      fact_id,
-                "old_trust":    old_trust,
-                "new_trust":    new_trust,
+                "fact_id": fact_id,
+                "old_trust": old_trust,
+                "new_trust": new_trust,
                 "helpful_count": row["helpful_count"] + helpful_increment,
             }
 
@@ -392,148 +924,169 @@ class MemoryStore:
     # ------------------------------------------------------------------
 
     def _extract_entities(self, text: str) -> list[str]:
-        """Extract entity candidates from text using simple regex rules.
+        return extract_entities(text)
 
-        Rules applied (in order):
-        1. Capitalized multi-word phrases  e.g. "John Doe"
-        2. Double-quoted terms             e.g. "Python"
-        3. Single-quoted terms             e.g. 'pytest'
-        4. AKA patterns                    e.g. "Guido aka BDFL" -> two entities
+    @staticmethod
+    def _merge_aliases(raw_aliases: str, value: str) -> str:
+        aliases = [alias.strip() for alias in (raw_aliases or "").split(",") if alias.strip()]
+        lower_aliases = {alias.lower() for alias in aliases}
+        candidate = value.strip()
+        if candidate and candidate.lower() not in lower_aliases:
+            aliases.append(candidate)
+        return ",".join(aliases)
 
-        Returns a deduplicated list preserving first-seen order.
-        """
-        seen: set[str] = set()
-        candidates: list[str] = []
+    def _resolve_entity(self, name: str, *, commit: bool = True) -> int:
+        canonical_key = canonicalize_key(name)
+        if canonical_key:
+            row = self._conn.execute(
+                """
+                SELECT entity_id, name, aliases, canonical_key
+                FROM entities
+                WHERE canonical_key = ?
+                """,
+                (canonical_key,),
+            ).fetchone()
+            if row is not None:
+                updated_aliases = self._merge_aliases(row["aliases"], name)
+                if updated_aliases != (row["aliases"] or ""):
+                    self._conn.execute(
+                        "UPDATE entities SET aliases = ? WHERE entity_id = ?",
+                        (updated_aliases, row["entity_id"]),
+                    )
+                    if commit:
+                        self._conn.commit()
+                return int(row["entity_id"])
 
-        def _add(name: str) -> None:
-            stripped = name.strip()
-            if stripped and stripped.lower() not in seen:
-                seen.add(stripped.lower())
-                candidates.append(stripped)
-
-        for m in _RE_CAPITALIZED.finditer(text):
-            _add(m.group(1))
-
-        for m in _RE_DOUBLE_QUOTE.finditer(text):
-            _add(m.group(1))
-
-        for m in _RE_SINGLE_QUOTE.finditer(text):
-            _add(m.group(1))
-
-        for m in _RE_AKA.finditer(text):
-            _add(m.group(1))
-            _add(m.group(2))
-
-        return candidates
-
-    def _resolve_entity(self, name: str) -> int:
-        """Find an existing entity by name or alias (case-insensitive) or create one.
-
-        Returns the entity_id.
-        """
-        # Exact name match
         row = self._conn.execute(
-            "SELECT entity_id FROM entities WHERE name LIKE ?", (name,)
+            "SELECT entity_id, canonical_key FROM entities WHERE lower(name) = lower(?)",
+            (name,),
         ).fetchone()
         if row is not None:
+            if canonical_key and not row["canonical_key"]:
+                self._conn.execute(
+                    "UPDATE entities SET canonical_key = ? WHERE entity_id = ?",
+                    (canonical_key, row["entity_id"]),
+                )
+                if commit:
+                    self._conn.commit()
             return int(row["entity_id"])
 
-        # Search aliases — aliases stored as comma-separated; use LIKE with % boundaries
         alias_row = self._conn.execute(
             """
-            SELECT entity_id FROM entities
-            WHERE ',' || aliases || ',' LIKE '%,' || ? || ',%'
+            SELECT entity_id, canonical_key FROM entities
+            WHERE ',' || lower(aliases) || ',' LIKE '%,' || lower(?) || ',%'
             """,
             (name,),
         ).fetchone()
         if alias_row is not None:
+            if canonical_key and not alias_row["canonical_key"]:
+                self._conn.execute(
+                    "UPDATE entities SET canonical_key = ? WHERE entity_id = ?",
+                    (canonical_key, alias_row["entity_id"]),
+                )
+                if commit:
+                    self._conn.commit()
             return int(alias_row["entity_id"])
 
-        # Create new entity
         cur = self._conn.execute(
-            "INSERT INTO entities (name) VALUES (?)", (name,)
+            "INSERT INTO entities (name, canonical_key) VALUES (?, ?)",
+            (name, canonical_key),
         )
-        self._conn.commit()
+        if commit:
+            self._conn.commit()
         return int(cur.lastrowid)  # type: ignore[return-value]
 
-    def _link_fact_entity(self, fact_id: int, entity_id: int) -> None:
-        """Insert into fact_entities, silently ignore if the link already exists."""
-        self._conn.execute(
-            """
-            INSERT OR IGNORE INTO fact_entities (fact_id, entity_id)
-            VALUES (?, ?)
-            """,
-            (fact_id, entity_id),
-        )
-        self._conn.commit()
-
-    def _compute_hrr_vector(self, fact_id: int, content: str) -> None:
-        """Compute and store HRR vector for a fact. No-op if numpy unavailable."""
-        with self._lock:
-            if not self._hrr_available:
-                return
-
-            # Get entities linked to this fact
-            rows = self._conn.execute(
-                """
-                SELECT e.name FROM entities e
-                JOIN fact_entities fe ON fe.entity_id = e.entity_id
-                WHERE fe.fact_id = ?
-                """,
-                (fact_id,),
-            ).fetchall()
-            entities = [row["name"] for row in rows]
-
-            vector = hrr.encode_fact(content, entities, self.hrr_dim)
+    def _refresh_fact_entities(self, fact_id: int, entities: list[str]) -> None:
+        self._conn.execute("DELETE FROM fact_entities WHERE fact_id = ?", (fact_id,))
+        for name in entities:
+            entity_id = self._resolve_entity(name, commit=False)
             self._conn.execute(
-                "UPDATE facts SET hrr_vector = ? WHERE fact_id = ?",
-                (hrr.phases_to_bytes(vector), fact_id),
+                """
+                INSERT OR IGNORE INTO fact_entities (fact_id, entity_id)
+                VALUES (?, ?)
+                """,
+                (fact_id, entity_id),
             )
+
+    # ------------------------------------------------------------------
+    # Vectors and linking
+    # ------------------------------------------------------------------
+
+    def _build_embedding_payload(self, content: str) -> dict:
+        provider = self._embedding_provider
+        if not provider or not provider.is_available():
+            return {"vector": None, "dim": 0, "provider": "", "model": ""}
+
+        vector = provider.embed_one(content)
+        if not vector:
+            return {"vector": None, "dim": 0, "provider": "", "model": ""}
+
+        return {
+            "vector": vector_to_bytes(vector),
+            "dim": len(vector),
+            "provider": getattr(provider, "name", ""),
+            "model": getattr(provider, "model", ""),
+        }
+
+    def _compute_hrr_vector(self, fact_id: int, content: str, *, commit: bool = True) -> None:
+        if not self._hrr_available:
+            return
+
+        rows = self._conn.execute(
+            """
+            SELECT e.name FROM entities e
+            JOIN fact_entities fe ON fe.entity_id = e.entity_id
+            WHERE fe.fact_id = ?
+            """,
+            (fact_id,),
+        ).fetchall()
+        entities = [row["name"] for row in rows]
+
+        vector = hrr.encode_fact(content, entities, self.hrr_dim)
+        self._conn.execute(
+            "UPDATE facts SET hrr_vector = ? WHERE fact_id = ?",
+            (hrr.phases_to_bytes(vector), fact_id),
+        )
+        if commit:
             self._conn.commit()
 
-    def _rebuild_bank(self, category: str) -> None:
-        """Full rebuild of a category's memory bank from all its fact vectors."""
-        with self._lock:
-            if not self._hrr_available:
-                return
+    def _rebuild_bank(self, category: str, *, commit: bool = True) -> None:
+        if not self._hrr_available:
+            return
 
-            bank_name = f"cat:{category}"
-            rows = self._conn.execute(
-                "SELECT hrr_vector FROM facts WHERE category = ? AND hrr_vector IS NOT NULL",
-                (category,),
-            ).fetchall()
+        bank_name = f"cat:{category}"
+        rows = self._conn.execute(
+            "SELECT hrr_vector FROM facts WHERE category = ? AND hrr_vector IS NOT NULL",
+            (category,),
+        ).fetchall()
 
-            if not rows:
-                self._conn.execute("DELETE FROM memory_banks WHERE bank_name = ?", (bank_name,))
+        if not rows:
+            self._conn.execute("DELETE FROM memory_banks WHERE bank_name = ?", (bank_name,))
+            if commit:
                 self._conn.commit()
-                return
+            return
 
-            vectors = [hrr.bytes_to_phases(row["hrr_vector"]) for row in rows]
-            bank_vector = hrr.bundle(*vectors)
-            fact_count = len(vectors)
+        vectors = [hrr.bytes_to_phases(row["hrr_vector"]) for row in rows]
+        bank_vector = hrr.bundle(*vectors)
+        fact_count = len(vectors)
+        hrr.snr_estimate(self.hrr_dim, fact_count)
 
-            # Check SNR
-            hrr.snr_estimate(self.hrr_dim, fact_count)
-
-            self._conn.execute(
-                """
-                INSERT INTO memory_banks (bank_name, vector, dim, fact_count, updated_at)
-                VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
-                ON CONFLICT(bank_name) DO UPDATE SET
-                    vector = excluded.vector,
-                    dim = excluded.dim,
-                    fact_count = excluded.fact_count,
-                    updated_at = excluded.updated_at
-                """,
-                (bank_name, hrr.phases_to_bytes(bank_vector), self.hrr_dim, fact_count),
-            )
+        self._conn.execute(
+            """
+            INSERT INTO memory_banks (bank_name, vector, dim, fact_count, updated_at)
+            VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
+            ON CONFLICT(bank_name) DO UPDATE SET
+                vector = excluded.vector,
+                dim = excluded.dim,
+                fact_count = excluded.fact_count,
+                updated_at = excluded.updated_at
+            """,
+            (bank_name, hrr.phases_to_bytes(bank_vector), self.hrr_dim, fact_count),
+        )
+        if commit:
             self._conn.commit()
 
     def rebuild_all_vectors(self, dim: int | None = None) -> int:
-        """Recompute all HRR vectors + banks from text. For recovery/migration.
-
-        Returns the number of facts processed.
-        """
         with self._lock:
             if not self._hrr_available:
                 return 0
@@ -544,27 +1097,138 @@ class MemoryStore:
             rows = self._conn.execute(
                 "SELECT fact_id, content, category FROM facts"
             ).fetchall()
-
             categories: set[str] = set()
             for row in rows:
-                self._compute_hrr_vector(row["fact_id"], row["content"])
+                self._compute_hrr_vector(row["fact_id"], row["content"], commit=False)
                 categories.add(row["category"])
-
             for category in categories:
-                self._rebuild_bank(category)
-
+                self._rebuild_bank(category, commit=False)
+            self._conn.commit()
             return len(rows)
+
+    def _refresh_links_for_fact(self, fact_id: int, *, commit: bool = True) -> None:
+        row = self._conn.execute("SELECT * FROM facts WHERE fact_id = ?", (fact_id,)).fetchone()
+        if row is None:
+            return
+
+        base_fact = dict(row)
+        self._conn.execute(
+            "DELETE FROM fact_links WHERE fact_id = ? OR related_fact_id = ?",
+            (fact_id, fact_id),
+        )
+
+        candidates = self._conn.execute(
+            """
+            SELECT * FROM facts
+            WHERE fact_id != ?
+            ORDER BY updated_at DESC, salience_score DESC
+            LIMIT ?
+            """,
+            (fact_id, _MAX_LINK_SCAN),
+        ).fetchall()
+
+        for candidate in candidates:
+            score, link_type, reason = self._link_score(base_fact, dict(candidate))
+            if score < self._link_threshold:
+                continue
+            left_id, right_id = sorted((fact_id, candidate["fact_id"]))
+            self._conn.execute(
+                """
+                INSERT OR REPLACE INTO fact_links (
+                    fact_id, related_fact_id, link_type, strength, reason,
+                    created_at, updated_at
+                )
+                VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                """,
+                (left_id, right_id, link_type, score, reason),
+            )
+
+        if commit:
+            self._conn.commit()
+
+    def _link_score(self, left: dict, right: dict) -> tuple[float, str, str]:
+        left_meta = self._parse_metadata(left.get("metadata_json"))
+        right_meta = self._parse_metadata(right.get("metadata_json"))
+
+        left_entities = set(left_meta.get("entity_keys", left_meta.get("entities", [])))
+        right_entities = set(right_meta.get("entity_keys", right_meta.get("entities", [])))
+        left_projects = set(left_meta.get("project_keys", left_meta.get("projects", [])))
+        right_projects = set(right_meta.get("project_keys", right_meta.get("projects", [])))
+        left_topics = set(left_meta.get("topic_keys", left_meta.get("topics", [])))
+        right_topics = set(right_meta.get("topic_keys", right_meta.get("topics", [])))
+
+        shared_entities = sorted(left_entities & right_entities)
+        shared_projects = sorted(left_projects & right_projects)
+        shared_topics = sorted(left_topics & right_topics)
+
+        score = 0.0
+        reasons: list[str] = []
+        link_type = "related"
+
+        if shared_entities:
+            score += min(0.45, 0.22 + (0.14 * len(shared_entities)))
+            link_type = "entity"
+            reasons.append(f"shared entities: {', '.join(shared_entities[:3])}")
+
+        if shared_projects:
+            score += min(0.5, 0.24 + (0.14 * len(shared_projects)))
+            link_type = "project"
+            reasons.append(f"shared projects: {', '.join(shared_projects[:3])}")
+
+        if shared_topics:
+            score += min(0.2, 0.05 * len(shared_topics))
+            if link_type == "related":
+                link_type = "topic"
+            reasons.append(f"shared topics: {', '.join(shared_topics[:4])}")
+
+        semantic_similarity = self._semantic_similarity(left, right)
+        if semantic_similarity >= 0.72:
+            score += 0.25 * semantic_similarity
+            if link_type == "related":
+                link_type = "semantic"
+            reasons.append(f"semantic similarity {semantic_similarity:.2f}")
+
+        return min(1.0, score), link_type, "; ".join(reasons)
+
+    def _semantic_similarity(self, left: dict, right: dict) -> float:
+        scores: list[float] = []
+
+        if self._hrr_available and left.get("hrr_vector") and right.get("hrr_vector"):
+            left_vec = hrr.bytes_to_phases(left["hrr_vector"])
+            right_vec = hrr.bytes_to_phases(right["hrr_vector"])
+            scores.append((hrr.similarity(left_vec, right_vec) + 1.0) / 2.0)
+
+        left_emb = bytes_to_vector(left.get("embedding_vector"))
+        right_emb = bytes_to_vector(right.get("embedding_vector"))
+        if left_emb and right_emb and len(left_emb) == len(right_emb):
+            scores.append((cosine_similarity(left_emb, right_emb) + 1.0) / 2.0)
+
+        if not scores:
+            return 0.0
+        return sum(scores) / len(scores)
 
     # ------------------------------------------------------------------
     # Utilities
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _parse_metadata(raw: str | None) -> dict:
+        if not raw:
+            return {}
+        try:
+            parsed = json.loads(raw)
+            return parsed if isinstance(parsed, dict) else {}
+        except Exception:
+            return {}
+
     def _row_to_dict(self, row: sqlite3.Row) -> dict:
-        """Convert a sqlite3.Row to a plain dict."""
-        return dict(row)
+        result = dict(row)
+        result["metadata"] = self._parse_metadata(result.pop("metadata_json", None))
+        result.pop("hrr_vector", None)
+        result.pop("embedding_vector", None)
+        return result
 
     def close(self) -> None:
-        """Close the database connection."""
         self._conn.close()
 
     def __enter__(self) -> "MemoryStore":

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -15,6 +15,7 @@ Config: Uses the existing Honcho config chain:
 
 from __future__ import annotations
 
+import importlib
 import json
 import logging
 import re
@@ -26,6 +27,14 @@ from agent.memory_provider import MemoryProvider
 from tools.registry import tool_error
 
 logger = logging.getLogger(__name__)
+
+
+def __getattr__(name: str):
+    if name in {"client", "session", "cli"}:
+        module = importlib.import_module(f"{__name__}.{name}")
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -12,6 +12,8 @@ import hermes_cli.doctor as doctor
 import hermes_cli.gateway as gateway_cli
 from hermes_cli import doctor as doctor_mod
 from hermes_cli.doctor import _has_provider_env_config
+from plugins.memory.holographic.ingestion import queue_turn_ingest
+from plugins.memory.holographic.store import MemoryStore
 
 
 class TestDoctorPlatformHints:
@@ -169,9 +171,11 @@ class TestDoctorMemoryProviderSection:
         """Create a minimal HERMES_HOME with config.yaml."""
         home = tmp_path / ".hermes"
         home.mkdir(parents=True, exist_ok=True)
-        import yaml
-        config = {"memory": {"provider": provider}} if provider else {"memory": {}}
-        (home / "config.yaml").write_text(yaml.dump(config))
+        config_path = home / "config.yaml"
+        if not config_path.exists():
+            import yaml
+            config = {"memory": {"provider": provider}} if provider else {"memory": {}}
+            config_path.write_text(yaml.dump(config))
         return home
 
     def _run_doctor_and_capture(self, monkeypatch, tmp_path, provider=""):
@@ -228,6 +232,59 @@ class TestDoctorMemoryProviderSection:
         assert "Memory Provider" in out
         assert "Built-in memory active" not in out
 
+    def test_holographic_provider_reports_clean_global_status(self, monkeypatch, tmp_path):
+        home = self._make_hermes_home(tmp_path, provider="holographic")
+        db_path = home / "memory_store.db"
+
+        config = {"memory": {"provider": "holographic"}, "plugins": {"hermes-memory-store": {"db_path": str(db_path)}}}
+        import yaml
+        (home / "config.yaml").write_text(yaml.dump(config))
+
+        store = MemoryStore(db_path=db_path)
+        try:
+            store.add_fact(
+                "Alice Johnson prefers the Hermes deploy checklist in Shanghai.",
+                category="user_pref",
+                source_channel="builtin:user",
+            )
+        finally:
+            store.close()
+
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+        out = self._run_doctor_and_capture(monkeypatch, tmp_path, provider="holographic")
+        assert "holographic provider active" in out
+        assert "facts=1" in out
+        assert "reindex=idle" in out
+
+    def test_holographic_provider_warns_on_failed_ingest(self, monkeypatch, tmp_path):
+        home = self._make_hermes_home(tmp_path, provider="holographic")
+        db_path = home / "memory_store.db"
+
+        config = {"memory": {"provider": "holographic"}, "plugins": {"hermes-memory-store": {"db_path": str(db_path)}}}
+        import yaml
+        (home / "config.yaml").write_text(yaml.dump(config))
+
+        store = MemoryStore(db_path=db_path)
+        try:
+            queue_turn_ingest(
+                store,
+                {"deferred_ingest": True, "turn_understanding": True},
+                session_id="sess-doctor",
+                user_content="We decided the Hermes project needs a rollout checklist.",
+                assistant_content="",
+            )
+            claimed = store.claim_ingest_batch(limit=1)
+            assert claimed
+            store.fail_ingest(int(claimed[0]["ingest_id"]), "synthetic doctor failure", retry_delay_seconds=1)
+        finally:
+            store.close()
+
+        monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+        out = self._run_doctor_and_capture(monkeypatch, tmp_path, provider="holographic")
+        assert "holographic provider active" in out
+        assert "failed=1" in out
+        assert "last ingest error: synthetic doctor failure" in out
+
 
 def test_run_doctor_termux_treats_docker_and_browser_warnings_as_expected(monkeypatch, tmp_path):
     helper = TestDoctorMemoryProviderSection()
@@ -267,10 +324,17 @@ def test_run_doctor_termux_does_not_mark_browser_available_without_agent_browser
     monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
     monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
     monkeypatch.setattr(doctor_mod, "_DHH", str(home))
-    monkeypatch.setattr(doctor_mod.shutil, "which", lambda cmd: "/data/data/com.termux/files/usr/bin/node" if cmd in {"node", "npm"} else None)
+    monkeypatch.setattr(
+        doctor_mod.shutil,
+        "which",
+        lambda cmd: "/data/data/com.termux/files/usr/bin/node" if cmd in {"node", "npm"} else None,
+    )
 
     fake_model_tools = types.SimpleNamespace(
-        check_tool_availability=lambda *a, **kw: (["terminal"], [{"name": "browser", "env_vars": [], "tools": ["browser_navigate"]}]),
+        check_tool_availability=lambda *a, **kw: (
+            ["terminal"],
+            [{"name": "browser", "env_vars": [], "tools": ["browser_navigate"]}],
+        ),
         TOOLSET_REQUIREMENTS={
             "terminal": {"name": "terminal"},
             "browser": {"name": "browser"},
@@ -280,12 +344,14 @@ def test_run_doctor_termux_does_not_mark_browser_available_without_agent_browser
 
     try:
         from hermes_cli import auth as _auth_mod
+
         monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
         monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
     except Exception:
         pass
 
     import io, contextlib
+
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):
         doctor_mod.run_doctor(Namespace(fix=False))
@@ -319,6 +385,7 @@ def test_run_doctor_kimi_cn_env_is_detected_and_probe_is_null_safe(monkeypatch, 
 
     try:
         from hermes_cli import auth as _auth_mod
+
         monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
         monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
     except Exception:
@@ -331,9 +398,11 @@ def test_run_doctor_kimi_cn_env_is_detected_and_probe_is_null_safe(monkeypatch, 
         return types.SimpleNamespace(status_code=200)
 
     import httpx
+
     monkeypatch.setattr(httpx, "get", fake_get)
 
     import io, contextlib
+
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):
         doctor_mod.run_doctor(Namespace(fix=False))
@@ -371,6 +440,7 @@ def test_run_doctor_opencode_go_skips_invalid_models_probe(monkeypatch, tmp_path
 
     try:
         from hermes_cli import auth as _auth_mod
+
         monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
         monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
     except ImportError:
@@ -383,9 +453,11 @@ def test_run_doctor_opencode_go_skips_invalid_models_probe(monkeypatch, tmp_path
         return types.SimpleNamespace(status_code=200)
 
     import httpx
+
     monkeypatch.setattr(httpx, "get", fake_get)
 
     import io, contextlib
+
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):
         doctor_mod.run_doctor(Namespace(fix=False))

--- a/tests/plugins/memory/test_holographic_understanding.py
+++ b/tests/plugins/memory/test_holographic_understanding.py
@@ -1,0 +1,441 @@
+"""Focused tests for the holographic understanding layer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import yaml
+
+from plugins.memory.holographic import HolographicMemoryProvider
+from plugins.memory.holographic.cli import cmd_inspect, cmd_query_debug, cmd_reindex, cmd_status
+from plugins.memory.holographic.ingestion import drain_understanding_ingest, queue_turn_ingest
+from plugins.memory.holographic.retrieval import FactRetriever
+from plugins.memory.holographic.store import MemoryStore
+
+
+class UnavailableEmbeddingProvider:
+    name = "openai"
+    model = "text-embedding-3-small"
+
+    def is_available(self) -> bool:
+        return False
+
+    def embed_one(self, _text: str):
+        return None
+
+
+def _make_store(tmp_path: Path, *, embedding_provider=None) -> MemoryStore:
+    return MemoryStore(
+        db_path=tmp_path / "memory_store.db",
+        embedding_provider=embedding_provider,
+    )
+
+
+def test_search_falls_back_when_embeddings_unavailable(tmp_path):
+    store = _make_store(tmp_path, embedding_provider=UnavailableEmbeddingProvider())
+    try:
+        store.add_fact(
+            "Deployment rollback procedure uses feature flags and canary checks.",
+            category="project",
+            source_channel="tool:fact_store",
+        )
+        retriever = FactRetriever(store=store, semantic_weight=0.6, keyword_weight=0.2)
+
+        results = retriever.search("deployment rollback", debug=True, limit=3)
+
+        assert results
+        assert results[0]["content"].startswith("Deployment rollback procedure")
+        assert "debug" in results[0]
+        assert results[0]["debug"]["score_breakdown"]["keyword"] > 0
+    finally:
+        store.close()
+
+
+def test_add_fact_enriches_metadata_and_links(tmp_path):
+    store = _make_store(tmp_path)
+    try:
+        first_id = store.add_fact(
+            "Alice Johnson scheduled the Hermes project review in Shanghai on 2026-04-23 at 3pm.",
+            category="project",
+            tags="release,review",
+            source_channel="telegram:ops",
+        )
+        second_id = store.add_fact(
+            "Hermes project status with Alice Johnson is blocked by the release checklist in Shanghai.",
+            category="project",
+            source_channel="tool:fact_store",
+        )
+
+        fact = store.get_fact(first_id)
+        assert fact is not None
+        metadata = fact["metadata"]
+        assert "Alice Johnson" in metadata["entities"]
+        assert "Alice Johnson" in metadata["people"]
+        assert any("hermes" in project.lower() for project in metadata["projects"])
+        assert "Shanghai" in metadata["locations"]
+        assert "2026-04-23" in metadata["dates"]
+        assert any("3pm" in value.lower() for value in metadata["times"])
+
+        linked_ids = {link["linked_fact_id"] for link in fact["links"]}
+        assert second_id in linked_ids
+    finally:
+        store.close()
+
+
+def test_ranking_uses_recency_salience_and_confidence(tmp_path):
+    store = _make_store(tmp_path)
+    try:
+        older_id = store.add_fact(
+            "Hermes migration checklist for memory understanding rollout.",
+            category="project",
+            source_channel="tool:fact_store",
+            source_confidence=0.4,
+            salience_score=0.3,
+        )
+        newer_id = store.add_fact(
+            "Hermes migration checklist for memory understanding rollout with production blockers.",
+            category="project",
+            source_channel="builtin:user",
+            source_confidence=0.95,
+            salience_score=0.95,
+        )
+
+        store._conn.execute(
+            "UPDATE facts SET updated_at = '2024-01-01 00:00:00' WHERE fact_id = ?",
+            (older_id,),
+        )
+        store._conn.commit()
+
+        retriever = FactRetriever(store=store, temporal_decay_half_life=30)
+        results = retriever.search("Hermes migration checklist", debug=True, limit=5)
+
+        assert results[0]["fact_id"] == newer_id
+        assert results[0]["debug"]["score_breakdown"]["salience"] > results[1]["debug"]["score_breakdown"]["salience"]
+        assert results[0]["debug"]["score_breakdown"]["confidence"] > results[1]["debug"]["score_breakdown"]["confidence"]
+    finally:
+        store.close()
+
+
+def test_search_debug_output_contains_explanations(tmp_path):
+    store = _make_store(tmp_path)
+    try:
+        store.add_fact(
+            "Alice Johnson prefers the Hermes release checklist before every production deploy.",
+            category="user_pref",
+            source_channel="builtin:user",
+        )
+        retriever = FactRetriever(store=store)
+
+        results = retriever.search("What does Alice Johnson prefer for Hermes deploys?", debug=True, limit=3)
+
+        assert results
+        debug = results[0]["debug"]
+        assert debug["why"]
+        assert set(debug["score_breakdown"]) == {"semantic", "keyword", "recency", "salience", "confidence", "weighted"}
+        assert "Alice Johnson" in debug["matched_entities"]
+        assert any("alice johnson" in cluster for cluster in debug["matched_clusters"])
+        assert isinstance(debug["related_memory_ids"], list)
+        assert "recency_contribution" in debug
+    finally:
+        store.close()
+
+
+def test_rebuild_understanding_index_restores_metadata_and_links(tmp_path):
+    store = _make_store(tmp_path)
+    try:
+        first_id = store.add_fact(
+            "Hermes project launch review with Alice Johnson in Shanghai.",
+            category="project",
+            source_channel="telegram:ops",
+        )
+        second_id = store.add_fact(
+            "Alice Johnson asked for the Hermes launch review checklist.",
+            category="project",
+            source_channel="tool:fact_store",
+        )
+
+        store._conn.execute("UPDATE facts SET metadata_json = '{}', hrr_vector = NULL")
+        store._conn.execute("DELETE FROM fact_links")
+        store._conn.commit()
+
+        result = store.rebuild_understanding_index(include_embeddings=False, refresh_links=True)
+
+        assert result["facts_reindexed"] == 2
+        fact = store.get_fact(first_id)
+        assert fact is not None
+        assert fact["metadata"]["entities"]
+        linked_ids = {link["linked_fact_id"] for link in fact["links"]}
+        assert second_id in linked_ids
+    finally:
+        store.close()
+
+
+def test_operator_cli_commands_work(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "memory": {"provider": "holographic"},
+                "plugins": {
+                    "hermes-memory-store": {
+                        "db_path": str(tmp_path / "memory_store.db"),
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    store = _make_store(tmp_path)
+    try:
+        fact_id = store.add_fact(
+            "Alice Johnson prefers the Hermes deploy checklist in Shanghai.",
+            category="user_pref",
+            source_channel="builtin:user",
+        )
+    finally:
+        store.close()
+
+    cmd_status(SimpleNamespace())
+    status_out = capsys.readouterr().out
+    assert "Holographic memory index status" in status_out
+    assert "Pending ingest" in status_out
+
+    cmd_inspect(SimpleNamespace(fact_id=str(fact_id)))
+    inspect_out = capsys.readouterr().out
+    assert "Alice Johnson prefers the Hermes deploy checklist" in inspect_out
+    assert "Cluster keys" in inspect_out
+
+    cmd_query_debug(
+        SimpleNamespace(
+            query="Alice Johnson deploy checklist",
+            category=None,
+            min_trust=0.0,
+            limit=2,
+        )
+    )
+    debug_out = capsys.readouterr().out
+    assert '"matched_entities"' in debug_out
+    assert '"matched_clusters"' in debug_out
+
+
+def test_deferred_turn_ingest_updates_status_and_facts(tmp_path):
+    provider = HolographicMemoryProvider(
+        config={
+            "db_path": str(tmp_path / "memory_store.db"),
+            "deferred_ingest": True,
+            "turn_understanding": True,
+            "ingest_batch_size": 2,
+        }
+    )
+    provider.initialize(session_id="sess-turn", platform="cli")
+    try:
+        provider.sync_turn(
+            "I prefer the Hermes deploy checklist in Shanghai before every release.",
+            "Noted.",
+            session_id="sess-turn",
+        )
+        status = provider._store.index_status()
+        assert status["pending_ingest_items"] == 1
+        assert status["last_ingest_success"] is None
+
+        provider.queue_prefetch("Hermes deploy checklist", session_id="sess-turn")
+        status = provider._store.index_status()
+        assert status["pending_ingest_items"] == 0
+        assert status["failed_ingest_items"] == 0
+        assert status["last_ingest_success"] is not None
+
+        facts = provider._store.list_facts(limit=10)
+        assert any(fact["source_channel"].startswith("turn_understanding:user_pref") for fact in facts)
+    finally:
+        provider.shutdown()
+
+
+def test_deferred_ingest_failure_is_visible_and_retryable(tmp_path, monkeypatch):
+    store = _make_store(tmp_path)
+    try:
+        cfg = {
+            "deferred_ingest": True,
+            "turn_understanding": True,
+            "ingest_retry_delay_seconds": 1,
+        }
+        queue_turn_ingest(
+            store,
+            cfg,
+            session_id="sess-fail",
+            user_content="We decided the Hermes project needs a rollout checklist.",
+            assistant_content="",
+        )
+
+        original_add_fact = store.add_fact
+        state = {"calls": 0}
+
+        def flaky_add_fact(*args, **kwargs):
+            state["calls"] += 1
+            if state["calls"] == 1:
+                raise RuntimeError("synthetic ingest failure")
+            return original_add_fact(*args, **kwargs)
+
+        monkeypatch.setattr(store, "add_fact", flaky_add_fact)
+
+        first = drain_understanding_ingest(store, cfg, reason="test_failure")
+        assert first["failed"] == 1
+
+        status = store.index_status()
+        assert status["failed_ingest_items"] == 1
+        assert "synthetic ingest failure" in status["last_ingest_error"]
+
+        store._conn.execute("UPDATE understanding_ingest_queue SET available_at = CURRENT_TIMESTAMP")
+        store._conn.commit()
+
+        second = drain_understanding_ingest(store, cfg, reason="test_retry")
+        assert second["processed"] == 1
+
+        status = store.index_status()
+        assert status["failed_ingest_items"] == 0
+        assert status["pending_ingest_items"] == 0
+        assert status["last_ingest_success"] is not None
+    finally:
+        store.close()
+
+
+def test_stale_processing_ingest_is_recovered_on_startup(tmp_path):
+    store = _make_store(tmp_path)
+    try:
+        queue_turn_ingest(
+            store,
+            {"deferred_ingest": True, "turn_understanding": True},
+            session_id="sess-stale",
+            user_content="We decided the Hermes project needs a rollout checklist.",
+            assistant_content="",
+        )
+        claimed = store.claim_ingest_batch(limit=1)
+        assert claimed
+        ingest_id = int(claimed[0]["ingest_id"])
+        store._conn.execute(
+            """
+            UPDATE understanding_ingest_queue
+            SET started_at = '2000-01-01 00:00:00'
+            WHERE ingest_id = ?
+            """,
+            (ingest_id,),
+        )
+        store._conn.commit()
+    finally:
+        store.close()
+
+    recovered = _make_store(tmp_path)
+    try:
+        status = recovered.index_status()
+        assert status["failed_ingest_items"] == 1
+        assert status["last_ingest_error"] == "Recovered interrupted ingest attempt"
+    finally:
+        recovered.close()
+
+
+def test_session_auto_extract_uses_deferred_ingest(tmp_path):
+    provider = HolographicMemoryProvider(
+        config={
+            "db_path": str(tmp_path / "memory_store.db"),
+            "auto_extract": True,
+            "deferred_ingest": True,
+            "ingest_batch_size": 4,
+        }
+    )
+    provider.initialize(session_id="sess-end", platform="cli")
+    try:
+        provider.on_session_end(
+            [
+                {
+                    "role": "user",
+                    "content": "We decided the Hermes project uses canary checks in Shanghai.",
+                }
+            ]
+        )
+
+        status = provider._store.index_status()
+        assert status["pending_ingest_items"] == 0
+        assert status["last_ingest_success"] is not None
+
+        facts = provider._store.list_facts(limit=10)
+        assert any(fact["source_channel"].startswith("session_auto_extract:project") for fact in facts)
+    finally:
+        provider.shutdown()
+
+
+def test_canonicalization_clusters_project_aliases(tmp_path):
+    store = _make_store(tmp_path)
+    try:
+        first_id = store.add_fact(
+            "Hermes project rollout is blocked by the release checklist.",
+            category="project",
+            source_channel="tool:fact_store",
+        )
+        second_id = store.add_fact(
+            "The hermes-project repo needs Alice Johnson for the rollout.",
+            category="project",
+            source_channel="tool:fact_store",
+        )
+
+        first = store.get_fact(first_id)
+        second = store.get_fact(second_id)
+        assert first is not None
+        assert second is not None
+        assert "hermes" in first["metadata"]["project_keys"]
+        assert "hermes" in second["metadata"]["project_keys"]
+
+        linked_ids = {link["linked_fact_id"] for link in first["links"]}
+        assert second_id in linked_ids
+    finally:
+        store.close()
+
+
+def test_reindex_drains_pending_ingest(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "memory": {"provider": "holographic"},
+                "plugins": {
+                    "hermes-memory-store": {
+                        "db_path": str(tmp_path / "memory_store.db"),
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    store = _make_store(tmp_path)
+    try:
+        queue_turn_ingest(
+            store,
+            {"deferred_ingest": True, "turn_understanding": True},
+            session_id="sess-reindex",
+            user_content="I prefer the Hermes deploy checklist before each release.",
+            assistant_content="",
+        )
+    finally:
+        store.close()
+
+    cmd_reindex(
+        SimpleNamespace(
+            include_embeddings=False,
+            refresh_links=True,
+            drain_pending=True,
+        )
+    )
+    reindex_out = capsys.readouterr().out
+    assert "Pending ingest:" in reindex_out
+
+    store = _make_store(tmp_path)
+    try:
+        status = store.index_status()
+        facts = store.list_facts(limit=10)
+        assert status["pending_ingest_items"] == 0
+        assert any(fact["source_channel"].startswith("turn_understanding:user_pref") for fact in facts)
+    finally:
+        store.close()

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -372,16 +372,20 @@ See [plugin README](https://github.com/NousResearch/hermes-agent/blob/main/plugi
 
 ### Holographic
 
-Local SQLite fact store with FTS5 full-text search, trust scoring, and HRR (Holographic Reduced Representations) for compositional algebraic queries.
+Local SQLite understanding-oriented memory with hybrid retrieval, structured
+enrichment, deferred turn/session understanding ingestion, related-memory
+linking, and explainable recall debugging.
 
 | | |
 |---|---|
-| **Best for** | Local-only memory with advanced retrieval, no external dependencies |
-| **Requires** | Nothing (SQLite is always available). NumPy optional for HRR algebra. |
+| **Best for** | Local-first memory with semantic fallback, metadata-rich recall, and operator inspection |
+| **Requires** | Nothing for the base path. NumPy optional for HRR; OpenAI-compatible embeddings optional. |
 | **Data storage** | Local SQLite |
 | **Cost** | Free |
 
 **Tools:** `fact_store` (9 actions: add, search, probe, related, reason, contradict, update, remove, list), `fact_feedback` (helpful/unhelpful rating that trains trust scores)
+
+`fact_store(action="search", debug=true)` returns explain/debug scoring details.
 
 **Setup:**
 ```bash
@@ -396,13 +400,61 @@ hermes config set memory.provider holographic
 |-----|---------|-------------|
 | `db_path` | `$HERMES_HOME/memory_store.db` | SQLite database path |
 | `auto_extract` | `false` | Auto-extract facts at session end |
+| `deferred_ingest` | `true` | Enable durable deferred understanding ingestion |
+| `turn_understanding` | `true` | Extract understanding from user turns |
+| `ingest_batch_size` | `2` | Number of deferred items drained per bounded pass |
+| `ingest_max_pending` | `200` | Max deferred-ingest queue depth before new items are rejected |
+| `ingest_retry_delay_seconds` | `60` | Base retry delay for failed deferred-ingest items |
+| `session_ingest_message_limit` | `80` | Max session messages captured for deferred session ingestion |
 | `default_trust` | `0.5` | Default trust score (0.0–1.0) |
+| `hrr_dim` | `1024` | HRR vector dimensions |
+| `link_threshold` | `0.36` | Minimum score for related-memory links |
+| `temporal_decay_half_life` | `45` | Recency half-life in days |
+| `semantic_provider` | `none` | `none` or `openai` |
+| `semantic_model` | `text-embedding-3-small` | Embedding model when using OpenAI-compatible embeddings |
+| `rank_semantic_weight` | `0.35` | Retrieval weight: semantic relevance |
+| `rank_keyword_weight` | `0.25` | Retrieval weight: keyword relevance |
+| `rank_recency_weight` | `0.15` | Retrieval weight: recency |
+| `rank_salience_weight` | `0.15` | Retrieval weight: salience |
+| `rank_confidence_weight` | `0.10` | Retrieval weight: source confidence / trust |
 
 **Unique capabilities:**
+- Structured enrichment on write: entities, people, projects, topics, dates/times, locations, intent, source channel
+- Canonical keys / lightweight clustering for repeated people, projects, and topics
+- Hybrid ranking across semantic, keyword, recency, salience, and confidence
+- Bounded deferred understanding ingestion with retryable queue state
 - `probe` — entity-specific algebraic recall (all facts about a person/thing)
 - `reason` — compositional AND queries across multiple entities
 - `contradict` — automated detection of conflicting facts
+- `query-debug` / `debug=true` search path with score breakdowns and match explanations
 - Trust scoring with asymmetric feedback (+0.05 helpful / -0.10 unhelpful)
+
+**Operator commands** (when `holographic` is the active memory provider):
+
+```bash
+hermes holographic status
+hermes holographic reindex
+hermes holographic inspect <fact_id>
+hermes holographic query-debug "Alice Johnson deploy preferences"
+```
+
+`status` exposes pending / failed deferred-ingest counts, last ingest success,
+last ingest error, queue rejects, and reindex state. `inspect` shows canonical
+keys / cluster keys, and `reindex` drains pending deferred-ingest work by
+default before rebuilding derived understanding state.
+
+When `holographic` is the active provider, `hermes doctor` also shows a
+concise global summary. Hermes reports degraded holographic state as `WARN`
+rather than `FAIL` for backlog, ingest failures, or reindex issues; use the
+holographic-specific commands for detail and recovery.
+
+**Failure behavior:**
+
+- If embeddings are not configured or fail, recall falls back to keyword + HRR + metadata scoring.
+- If NumPy is unavailable, HRR features are skipped and keyword + metadata scoring still works.
+- If deferred ingest fails, the item stays queued and retries later with backoff while normal agent operation continues.
+- If the deferred queue fills, new understanding items are skipped rather than blocking the agent; operators can see this in `hermes holographic status`.
+- Reindexing rebuilds derived metadata, vectors, and links without deleting stored facts.
 
 ---
 


### PR DESCRIPTION
## Summary

This PR closes out the SQLite-backed `holographic` memory-understanding path on top of the latest `origin/main`.

It carries the production-safe holographic slice forward as an isolated 15-file diff:
- hybrid retrieval across FTS, HRR, and optional embeddings with graceful fallback
- write-time enrichment and explainable ranking/debug output
- lightweight related-memory linking and canonical clustering
- bounded deferred understanding ingest for turn/session understanding
- operator-facing `holographic` commands plus global `hermes doctor` visibility
- focused docs and tests for the understanding layer

## Operator impact

When `memory.provider: holographic` is active:
- `hermes doctor` now shows a concise holographic summary with conservative `WARN` behavior for backlog, failed ingest, or reindex activity/failure
- `hermes holographic status` shows queue/reindex visibility
- `hermes holographic reindex` safely drains pending ingest by default before rebuilding derived state
- `hermes holographic inspect <fact_id>` shows canonical/cluster metadata
- `hermes holographic query-debug "<query>"` exposes explainable retrieval details

This is additive and keeps the current provider contract, built-in memory flow, and SQLite runtime path intact.

## Schema / config / command changes

Additive holographic schema only:
- `entities.canonical_key`
- `understanding_ingest_queue`
- `understanding_state`
- enriched canonical/cluster metadata in `facts.metadata_json`

Config/env surface:
- deferred ingest knobs for bounded turn/session understanding
- ranking weight knobs
- optional embedding config for `none` / `openai`

Commands:
- `hermes holographic status`
- `hermes holographic reindex`
- `hermes holographic inspect <fact_id>`
- `hermes holographic query-debug "<query>"`
- global `hermes doctor` summary when `memory.provider: holographic` is active

## Verification

Merge-relevant batch on the clean feature branch:

```bash
pytest tests/plugins/memory/test_holographic_understanding.py \
  tests/agent/test_memory_provider.py \
  tests/agent/test_memory_user_id.py \
  tests/hermes_cli/test_plugin_cli_registration.py \
  tests/hermes_cli/test_doctor.py \
  tests/tools/test_memory_tool.py \
  tests/run_agent/test_memory_provider_init.py \
  tests/run_agent/test_run_agent.py \
  -n 0 -q -k 'memory or doctor'
```

Result:
- `157 passed, 278 deselected, 1 warning`

Live smoke on the clean feature branch with `memory.provider: holographic`:
- top-level CLI help included `holographic`
- `hermes doctor` reported `✓ holographic provider active (facts=1 reindex=idle)`
- `hermes holographic status` showed pending `0`, failed `0`, processing `0`, reindex `idle`
- `hermes holographic query-debug 'Hermes deploy checklist'` returned the ingested fact with score/debug breakdown

## Baseline failure comparison

Comparison set:

```bash
pytest tests/cli/test_quick_commands.py \
  tests/gateway/test_approve_deny_commands.py \
  tests/hermes_cli/test_api_key_providers.py \
  tests/hermes_cli/test_update_gateway_restart.py \
  tests/agent/test_auxiliary_named_custom_providers.py \
  tests/tools/test_docker_environment.py \
  tests/tools/test_transcription.py \
  tests/tools/test_transcription_tools.py \
  tests/tools/test_vision_tools.py \
  -n 0 -q
```

Results:
- clean `origin/main`: `4 failed, 407 passed, 6 skipped`
- clean feature branch: `2 failed, 409 passed, 6 skipped`

The two failures that reproduce on both clean `origin/main` and this branch are baseline transcription failures:
- `tests/tools/test_transcription.py::TestGetProvider::test_explicit_local_no_cloud_fallback`
- `tests/tools/test_transcription.py::TestGetProvider::test_local_nothing_available`

Exact failure behavior on both branches:
- `_get_provider({"provider": "local"})` returns `local_command`
- the tests expect `none`

Gateway approval note:
- the two gateway approval tests that failed once in an earlier broader baseline batch were rerun in isolation on both clean `origin/main` and this branch
- they passed on both sides in isolated reruns, so there is no evidence that this PR introduces a gateway regression
- current signal points to baseline flake/environment sensitivity rather than branch-specific breakage

## Notes

- `package-lock.json` was intentionally excluded from this PR
- the original dirty local `main` worktree was preserved untouched; this PR was rebased into a fresh worktree from the latest `origin/main`
