### PR TITLE
fix(agent): propagate custom provider context to compression checks

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1420,6 +1420,14 @@ class AIAgent:
         # needed later by the startup feasibility check.  Avoid exposing a
         # broad pseudo-public config object on the agent instance.
         self._aux_compression_context_length_config = None
+        try:
+            from hermes_cli.config import get_compatible_custom_providers
+            self._custom_providers = get_compatible_custom_providers(_agent_cfg)
+        except Exception:
+            self._custom_providers = _agent_cfg.get("custom_providers")
+            if not isinstance(self._custom_providers, list):
+                self._custom_providers = []
+        self._invalid_custom_provider_context_warnings = set()
 
         # Persistent memory (MEMORY.md + USER.md) -- loaded from disk
         self._memory_store = None
@@ -1601,46 +1609,14 @@ class AIAgent:
                 )
                 _config_context_length = None
 
-        # Store for reuse in switch_model (so config override persists across model switches)
-        self._config_context_length = _config_context_length
-
-        # Check custom_providers per-model context_length
         if _config_context_length is None:
-            try:
-                from hermes_cli.config import get_compatible_custom_providers
-                _custom_providers = get_compatible_custom_providers(_agent_cfg)
-            except Exception:
-                _custom_providers = _agent_cfg.get("custom_providers")
-                if not isinstance(_custom_providers, list):
-                    _custom_providers = []
-            for _cp_entry in _custom_providers:
-                if not isinstance(_cp_entry, dict):
-                    continue
-                _cp_url = (_cp_entry.get("base_url") or "").rstrip("/")
-                if _cp_url and _cp_url == self.base_url.rstrip("/"):
-                    _cp_models = _cp_entry.get("models", {})
-                    if isinstance(_cp_models, dict):
-                        _cp_model_cfg = _cp_models.get(self.model, {})
-                        if isinstance(_cp_model_cfg, dict):
-                            _cp_ctx = _cp_model_cfg.get("context_length")
-                            if _cp_ctx is not None:
-                                try:
-                                    _config_context_length = int(_cp_ctx)
-                                except (TypeError, ValueError):
-                                    logger.warning(
-                                        "Invalid context_length for model %r in "
-                                        "custom_providers: %r — must be a plain "
-                                        "integer (e.g. 256000, not '256K'). "
-                                        "Falling back to auto-detection.",
-                                        self.model, _cp_ctx,
-                                    )
-                                    print(
-                                        f"\n⚠ Invalid context_length for model {self.model!r} in custom_providers: {_cp_ctx!r}\n"
-                                        f"  Must be a plain integer (e.g. 256000, not '256K').\n"
-                                        f"  Falling back to auto-detected context window.\n",
-                                        file=sys.stderr,
-                                    )
-                    break
+            _config_context_length = self._resolve_custom_provider_context_length(
+                self.model,
+                self.base_url,
+            )
+
+        # Store for reuse in switch_model and compression feasibility checks.
+        self._config_context_length = _config_context_length
         
         # Select context engine: config-driven (like memory providers).
         # 1. Check config.yaml context.engine setting
@@ -2091,6 +2067,57 @@ class AIAgent:
             return
         self._safe_print(*args, **kwargs)
 
+    def _resolve_custom_provider_context_length(self, model_name: str, base_url: str):
+        """Return a custom_providers.models context_length override, if any."""
+        normalized_base_url = (base_url or "").rstrip("/")
+        for custom_provider in getattr(self, "_custom_providers", []):
+            if not isinstance(custom_provider, dict):
+                continue
+            provider_base_url = (custom_provider.get("base_url") or "").rstrip("/")
+            if not provider_base_url or provider_base_url != normalized_base_url:
+                continue
+
+            provider_models = custom_provider.get("models", {})
+            if not isinstance(provider_models, dict):
+                break
+
+            model_cfg = provider_models.get(model_name, {})
+            if not isinstance(model_cfg, dict):
+                break
+
+            context_length = model_cfg.get("context_length")
+            if context_length is None:
+                break
+
+            try:
+                return int(context_length)
+            except (TypeError, ValueError):
+                warning_key = (normalized_base_url, model_name, str(context_length))
+                warned = getattr(
+                    self,
+                    "_invalid_custom_provider_context_warnings",
+                    set(),
+                )
+                if warning_key not in warned:
+                    warned.add(warning_key)
+                    self._invalid_custom_provider_context_warnings = warned
+                    logger.warning(
+                        "Invalid context_length for model %r in custom_providers: %r — "
+                        "must be a plain integer (e.g. 256000, not '256K'). "
+                        "Falling back to auto-detection.",
+                        model_name,
+                        context_length,
+                    )
+                    print(
+                        f"\n⚠ Invalid context_length for model {model_name!r} in custom_providers: {context_length!r}\n"
+                        f"  Must be a plain integer (e.g. 256000, not '256K').\n"
+                        f"  Falling back to auto-detected context window.\n",
+                        file=sys.stderr,
+                    )
+                break
+
+        return None
+
     def _should_start_quiet_spinner(self) -> bool:
         """Return True when quiet-mode spinner output has a safe sink.
 
@@ -2197,12 +2224,22 @@ class AIAgent:
 
             aux_base_url = str(getattr(client, "base_url", ""))
             aux_api_key = str(getattr(client, "api_key", ""))
+            aux_config_context_length = getattr(
+                self,
+                "_aux_compression_context_length_config",
+                None,
+            )
+            if aux_config_context_length is None:
+                aux_config_context_length = self._resolve_custom_provider_context_length(
+                    aux_model,
+                    aux_base_url,
+                )
 
             aux_context = get_model_context_length(
                 aux_model,
                 base_url=aux_base_url,
                 api_key=aux_api_key,
-                config_context_length=getattr(self, "_aux_compression_context_length_config", None),
+                config_context_length=aux_config_context_length,
             )
 
             # Hard floor: the auxiliary compression model must have at least

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -183,6 +183,45 @@ def test_feasibility_check_passes_config_context_length(mock_get_client, mock_ct
     )
 
 
+@patch("agent.model_metadata.get_model_context_length")
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_feasibility_check_uses_custom_provider_context_length(mock_get_client, mock_ctx_len):
+    """Fallback compression model should reuse custom_providers model overrides."""
+    agent = _make_agent(main_context=200_000, threshold_percent=0.65)
+    agent.model = "glm-5.1"
+    agent.base_url = "http://localhost:8317/v1"
+    agent._custom_providers = [
+        {
+            "name": "Local (localhost:8317)",
+            "base_url": "http://localhost:8317/v1",
+            "models": {
+                "glm-5.1": {"context_length": 200_000},
+            },
+        }
+    ]
+    mock_client = MagicMock()
+    mock_client.base_url = "http://localhost:8317/v1"
+    mock_client.api_key = "sk-custom"
+    mock_get_client.return_value = (mock_client, "glm-5.1")
+    mock_ctx_len.side_effect = (
+        lambda _model, *, config_context_length=None, **_kwargs:
+        config_context_length or 128_000
+    )
+
+    messages = []
+    agent._emit_status = lambda msg: messages.append(msg)
+    agent._check_compression_model_feasibility()
+
+    mock_ctx_len.assert_called_once_with(
+        "glm-5.1",
+        base_url="http://localhost:8317/v1",
+        api_key="sk-custom",
+        config_context_length=200_000,
+    )
+    assert messages == []
+    assert agent.context_compressor.threshold_tokens == 130_000
+
+
 @patch("agent.model_metadata.get_model_context_length", return_value=128_000)
 @patch("agent.auxiliary_client.get_text_auxiliary_client")
 def test_feasibility_check_ignores_invalid_context_length(mock_get_client, mock_ctx_len):


### PR DESCRIPTION
## Summary
- reuse the same custom provider context_length resolution for both main-model startup and auxiliary compression feasibility checks
- pass custom_providers.models.<model>.context_length through when compression falls back to the main custom provider model
- avoid duplicate invalid-context warnings when the same bad custom provider entry is touched by both startup paths
- add a regression covering the auxiliary fallback case

## Testing
- python3 -m pytest -o addopts= tests/run_agent/test_compression_feasibility.py -k "custom_provider_context_length or passes_config_context_length or ignores_invalid_context_length"
- python3 -m pytest -o addopts= tests/run_agent/test_compression_feasibility.py
- python3 -m pytest -o addopts= tests/run_agent/test_invalid_context_length_warning.py

Closes #12977
