### PR TITLE
fix(gateway): remove stale foreign pid file during cleanup

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -216,10 +216,11 @@ def _cleanup_invalid_pid_path(pid_path: Path, *, cleanup_stale: bool) -> None:
     if not cleanup_stale:
         return
     try:
-        if pid_path == _get_pid_path():
-            remove_pid_file()
-        else:
-            pid_path.unlink(missing_ok=True)
+        # Invalid/stale PID records must be removed unconditionally.
+        # Do NOT call remove_pid_file() here: that helper intentionally keeps
+        # PID files that belong to a different process during graceful
+        # handoffs, which is the opposite of what stale cleanup needs.
+        pid_path.unlink(missing_ok=True)
     except Exception:
         pass
 

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -51,6 +51,26 @@ class TestGatewayPidState:
         assert status.get_running_pid() is None
         assert not pid_path.exists()
 
+    def test_get_running_pid_removes_stale_pid_from_different_process(self, tmp_path, monkeypatch):
+        """Regression: stale PID file owned by a dead *different* PID must be removed.
+
+        Previously, stale cleanup called remove_pid_file() for the default PID path,
+        but that helper intentionally refuses to delete files that don't belong to
+        the current process. Result: a dead foreign PID could leave gateway.pid
+        behind forever and block startup with a PID-file race.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        pid_path = tmp_path / "gateway.pid"
+        pid_path.write_text(json.dumps({"pid": 99999}))
+
+        def _dead_pid(pid, sig):
+            raise ProcessLookupError
+
+        monkeypatch.setattr(status.os, "kill", _dead_pid)
+
+        assert status.get_running_pid() is None
+        assert not pid_path.exists()
+
     def test_get_running_pid_accepts_gateway_metadata_when_cmdline_unavailable(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         pid_path = tmp_path / "gateway.pid"


### PR DESCRIPTION
## Summary
- Fix stale PID cleanup for `~/.hermes/gateway.pid` by unlinking invalid/stale PID files directly.
- Avoid calling `remove_pid_file()` in the stale-cleanup path, because that helper intentionally preserves PID files owned by other processes.
- Add a regression test to ensure stale foreign PID records are removed.

## Root cause
`get_running_pid()` delegates invalid/stale PID cleanup to `_cleanup_invalid_pid_path()`. For the default PID path, cleanup previously called `remove_pid_file()`, which refuses to delete files not owned by the current process. A stale foreign PID record could therefore persist and repeatedly block startup with:

`PID file race lost to another gateway instance.`

## Validation
- `python -m pytest tests/gateway/test_status.py -q`
- Result: `28 passed`

## Files changed
- `gateway/status.py`
- `tests/gateway/test_status.py`

## Impact
Prevents restart/startup flap loops caused by stale foreign PID records after unexpected shutdowns or interrupted replacements.