### PR TITLE
fix(gateway): add failure context after visible interim replies

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -432,6 +432,21 @@ def _is_control_interrupt_message(message: Optional[str]) -> bool:
     return normalized in _CONTROL_INTERRUPT_MESSAGES
 
 
+_INTERIM_FAILURE_PREFIX = (
+    "Note: the earlier message was an intermediate update, "
+    "not a completed final answer.\n\n"
+)
+
+
+def _prefix_failure_with_interim_context(
+    response: str, *, failed: bool, interim_visible: bool
+) -> str:
+    if failed and interim_visible and response:
+        if not response.startswith(_INTERIM_FAILURE_PREFIX):
+            return _INTERIM_FAILURE_PREFIX + response
+    return response
+
+
 def _check_unavailable_skill(command_name: str) -> str | None:
     """Check if a command matches a known-but-inactive skill.
 
@@ -4529,6 +4544,15 @@ class GatewayRunner:
                         f"The request failed: {str(error_detail)[:300]}\n"
                         "Try again or use /reset to start a fresh session."
                     )
+
+            # If an interim/streamed reply already reached the user and the
+            # run later failed, prefix the failure so it doesn't read like a
+            # contradiction with the earlier visible message.
+            response = _prefix_failure_with_interim_context(
+                response,
+                failed=bool(agent_result.get("failed")),
+                interim_visible=bool(agent_result.get("already_sent")),
+            )
 
             # If the agent's session_id changed during compression, update
             # session_entry so transcript writes below go to the right session.

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -970,3 +970,61 @@ async def test_verbose_mode_respects_explicit_tool_preview_length(monkeypatch, t
     assert VerboseAgent.LONG_CODE not in all_content
     # But should still contain the truncated portion with "..."
     assert "..." in all_content
+
+
+# ---------------------------------------------------------------------------
+# Interim-visible failure prefixing
+# ---------------------------------------------------------------------------
+
+
+_INTERIM_PREFIX = (
+    "Note: the earlier message was an intermediate update, "
+    "not a completed final answer.\n\n"
+)
+
+
+def test_failure_after_visible_interim_is_prefixed():
+    gateway_run = importlib.import_module("gateway.run")
+    out = gateway_run._prefix_failure_with_interim_context(
+        "The request failed: invalid response.",
+        failed=True,
+        interim_visible=True,
+    )
+    assert out.startswith(_INTERIM_PREFIX)
+    assert "The request failed: invalid response." in out
+
+
+def test_failure_without_interim_is_plain():
+    gateway_run = importlib.import_module("gateway.run")
+    out = gateway_run._prefix_failure_with_interim_context(
+        "The request failed: invalid response.",
+        failed=True,
+        interim_visible=False,
+    )
+    assert out == "The request failed: invalid response."
+
+
+def test_streamed_interim_failure_prefix_is_idempotent():
+    gateway_run = importlib.import_module("gateway.run")
+    once = gateway_run._prefix_failure_with_interim_context(
+        "stream failure",
+        failed=True,
+        interim_visible=True,
+    )
+    twice = gateway_run._prefix_failure_with_interim_context(
+        once,
+        failed=True,
+        interim_visible=True,
+    )
+    assert once.startswith(_INTERIM_PREFIX)
+    assert twice == once
+
+
+def test_non_failure_response_is_unchanged_even_after_interim():
+    gateway_run = importlib.import_module("gateway.run")
+    out = gateway_run._prefix_failure_with_interim_context(
+        "all good",
+        failed=False,
+        interim_visible=True,
+    )
+    assert out == "all good"


### PR DESCRIPTION
## What does this PR do?

Narrow, messaging-only fix for the contradictory UX where the gateway shows a visible interim/streamed assistant message that looks like success, and then the run later fails validation — so the user sees an apparent "success" followed by an invalid-final-response failure with no acknowledgement that the earlier visible message was only intermediate.

When the run's `final_response` is empty and `failed` is true **and** an interim/streamed reply has already reached the user (`already_sent=True`), the final failure text is now prefixed with:

> Note: the earlier message was an intermediate update, not a completed final answer.

The two messages then read coherently as "that was intermediate; here's the real status" instead of "it said it worked, then said it failed." Retry / validation logic is untouched; no adapter changes; no change to when messages are sent.

## Related Issue

Fixes #14154

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: added pure helper `_prefix_failure_with_interim_context(response, *, failed, interim_visible)` and `_INTERIM_FAILURE_PREFIX` constant; called from `_handle_message_with_agent` immediately after the existing block that synthesises a failure string for `failed && empty final_response`. Idempotent (never double-prefixes).
- `tests/gateway/test_run_progress_topics.py`: 4 unit tests on the helper — failure-after-visible-interim is prefixed, failure-without-interim stays plain, prefixing is idempotent, non-failure responses are never prefixed.

## How to Test

```bash
source .venv/bin/activate
scripts/run_tests.sh tests/gateway/test_run_progress_topics.py -q
```

Expected output (just ran locally on macOS): `27 passed, 1 warning in 11.50s`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **only the targeted file `tests/gateway/test_run_progress_topics.py` was run (27 passed); I have not run the full suite**
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin 25.4.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (messaging-only change, helper is self-descriptive)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure string formatting, platform-agnostic
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Targeted test run:

```
▶ running pytest with 4 workers, hermetic env, in /…/hermes-agent
  (TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0; all credential env vars unset)
...........................                                              [100%]
27 passed, 1 warning in 11.50s
```