### PR TITLE
fix: avoid oversized Discord skill sync payloads

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -10,6 +10,7 @@ Uses discord.py library for:
 """
 
 import asyncio
+import json
 import logging
 import os
 import struct
@@ -23,6 +24,7 @@ from typing import Callable, Dict, Optional, Any
 logger = logging.getLogger(__name__)
 
 VALID_THREAD_AUTO_ARCHIVE_MINUTES = {60, 1440, 4320, 10080}
+DISCORD_APP_COMMAND_MAX_JSON_BYTES = 8000
 
 try:
     import discord
@@ -1877,13 +1879,28 @@ class DiscordAdapter(BasePlatformAdapter):
         # supporting up to 25 categories × 25 skills = 625 skills.
         self._register_skill_group(tree)
 
+    def _estimate_discord_app_command_size(self, command, tree) -> Optional[int]:
+        """Return the minified JSON payload size for a Discord app command.
+
+        Discord rejects oversized app-command payloads with error 50035,
+        e.g. ``Command exceeds maximum size (8000)``.  The generated ``/skill``
+        tree can legitimately fit Discord's structural limits while still
+        exceeding the serialized JSON limit, so we size-check before sync.
+        """
+        try:
+            payload = command.to_dict(tree)
+            return len(json.dumps(payload, separators=(",", ":")))
+        except Exception:
+            return None
+
     def _register_skill_group(self, tree) -> None:
         """Register a ``/skill`` command group with category subcommand groups.
 
         Skills are organized by their directory category under ``SKILLS_DIR``.
         Each category becomes a subcommand group; root-level skills become
         direct subcommands.  Discord supports 25 subcommand groups × 25
-        subcommands each = 625 skills — well beyond the old 100-command cap.
+        subcommands each = 625 skills, but the serialized command payload must
+        also stay under Discord's 8000-byte limit.
         """
         try:
             from hermes_cli.commands import discord_skill_commands_by_category
@@ -1941,9 +1958,26 @@ class DiscordAdapter(BasePlatformAdapter):
                     )
                     cat_group.add_command(cmd)
 
+            total = sum(len(v) for v in categories.values()) + len(uncategorized)
+            payload_size = self._estimate_discord_app_command_size(skill_group, tree)
+            if payload_size is not None and payload_size > DISCORD_APP_COMMAND_MAX_JSON_BYTES:
+                logger.warning(
+                    "[%s] Skipping /skill group: payload=%d bytes exceeds Discord's %d-byte app-command limit. "
+                    "Skills remain available via text slash commands; this suppresses startup sync failures.",
+                    self.name,
+                    payload_size,
+                    DISCORD_APP_COMMAND_MAX_JSON_BYTES,
+                )
+                if hidden:
+                    logger.warning(
+                        "[%s] %d additional skill(s) already exceeded Discord subcommand limits before payload sizing",
+                        self.name,
+                        hidden,
+                    )
+                return
+
             tree.add_command(skill_group)
 
-            total = sum(len(v) for v in categories.values()) + len(uncategorized)
             logger.info(
                 "[%s] Registered /skill group: %d skill(s) across %d categories"
                 " + %d uncategorized",

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -672,3 +672,25 @@ def test_register_skill_group_handler_dispatches_command(adapter):
     # The callback name should reflect the skill
     assert "gif_search" in gif_cmd.callback.__name__
 
+
+def test_register_skill_group_skips_oversized_payload(adapter):
+    """Oversized /skill payloads should be skipped before Discord sync."""
+    mock_categories = {
+        "mlops": [
+            (f"skill-{i}", "x" * 100, f"/skill-{i}")
+            for i in range(60)
+        ],
+    }
+
+    with (
+        patch(
+            "hermes_cli.commands.discord_skill_commands_by_category",
+            return_value=(mock_categories, [], 0),
+        ),
+        patch.object(adapter, "_estimate_discord_app_command_size", return_value=9001),
+    ):
+        adapter._register_slash_commands()
+
+    tree = adapter._client.tree
+    assert "skill" not in tree.commands
+


### PR DESCRIPTION
## Summary
- add a Discord app-command payload size guard before registering the generated /skill tree
- skip the oversized /skill native command instead of letting Discord sync fail with error 50035
- cover the oversized-payload case with a gateway test

## Verification
- `python -m pytest tests/gateway/test_discord_slash_commands.py tests/hermes_cli/test_commands.py -q`
- restarted the canonical `ai.hermes.gateway` launchd service (`python -m hermes_cli.main gateway restart`)
- verified the old `Command exceeds maximum size (8000)` sync failure was replaced by an explicit skip log for `/skill`

## Context
- Paperclip: SUP-1113
- canonical Discord runtime: launchd service `ai.hermes.gateway` running `python -m hermes_cli.main gateway run --replace`