### PR TITLE
fix(security): protect Hermes control-plane files from prompt injection #14072

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -11,6 +11,7 @@ def _hermes_home_path() -> Path:
     """Resolve the active HERMES_HOME (profile-aware) without circular imports."""
     try:
         from hermes_constants import get_hermes_home  # local import to avoid cycles
+
         return get_hermes_home()
     except Exception:
         return Path(os.path.expanduser("~/.hermes"))
@@ -83,8 +84,33 @@ def is_write_denied(path: str) -> bool:
         if resolved.startswith(prefix):
             return True
 
+    # New: Check for Hermes control files and mcp-tokens directory
+    hermes_home = _hermes_home_path()
+    hermes_home_real = os.path.realpath(hermes_home)
+
+    # Check for exact control files
+    hermes_control_files = [
+        os.path.join(hermes_home_real, "auth.json"),
+        os.path.join(hermes_home_real, "config.yaml"),
+        os.path.join(hermes_home_real, "webhook_subscriptions.json"),
+    ]
+    for control_file in hermes_control_files:
+        if resolved == os.path.realpath(control_file):
+            return True
+
+    # Check for anything inside mcp-tokens directory
+    mcp_tokens_dir = os.path.join(hermes_home_real, "mcp-tokens")
+    try:
+        mcp_tokens_dir_real = os.path.realpath(mcp_tokens_dir)
+        if resolved.startswith(mcp_tokens_dir_real + os.sep):
+            return True
+    except Exception:
+        pass
+
     safe_root = get_safe_write_root()
-    if safe_root and not (resolved == safe_root or resolved.startswith(safe_root + os.sep)):
+    if safe_root and not (
+        resolved == safe_root or resolved.startswith(safe_root + os.sep)
+    ):
         return True
 
     return False

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -28,6 +28,7 @@ from tools.file_operations import (
 # Write deny list
 # =========================================================================
 
+
 class TestIsWriteDenied:
     def test_ssh_authorized_keys_denied(self):
         path = os.path.join(str(Path.home()), ".ssh", "authorized_keys")
@@ -59,17 +60,63 @@ class TestIsWriteDenied:
     def test_tilde_expansion(self):
         assert _is_write_denied("~/.ssh/authorized_keys") is True
 
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "auth.json",
+            "config.yaml",
+            "webhook_subscriptions.json",
+            "mcp-tokens/token1.json",
+            "mcp-tokens/subdir/token2.json",
+        ],
+    )
+    def test_hermes_control_files_and_mcp_tokens_denied(self, path):
+        """Test that Hermes control files and mcp-tokens directory are denied."""
+        from hermes_constants import get_hermes_home
+
+        hermes_home = get_hermes_home()
+        full_path = str(hermes_home / path)
+        assert _is_write_denied(full_path) is True
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "dummy/../config.yaml",
+            "./auth.json",
+            "mcp-tokens/../config.yaml",
+        ],
+    )
+    def test_hermes_control_files_traversal_denied(self, path):
+        """Test that traversal attempts to Hermes control files are denied."""
+        from hermes_constants import get_hermes_home
+
+        hermes_home = get_hermes_home()
+        full_path = str(hermes_home / path)
+        assert _is_write_denied(full_path) is True
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/tmp/standard_file.txt",
+            "~/projects/myapp/main.py",
+            "/var/log/app.log",
+        ],
+    )
+    def test_standard_paths_allowed(self, path):
+        """Test that standard paths are allowed."""
+        assert _is_write_denied(path) is False
 
 
 # =========================================================================
 # Result dataclasses
 # =========================================================================
 
+
 class TestReadResult:
     def test_to_dict_omits_defaults(self):
         r = ReadResult()
         d = r.to_dict()
-        assert "error" not in d    # None omitted
+        assert "error" not in d  # None omitted
         assert "similar_files" not in d  # empty list omitted
 
     def test_to_dict_preserves_empty_content(self):
@@ -179,6 +226,7 @@ class TestLintResult:
 # ShellFileOperations helpers
 # =========================================================================
 
+
 @pytest.fixture()
 def mock_env():
     """Create a mock terminal environment."""
@@ -277,12 +325,14 @@ class TestSearchPathValidation:
 
     def test_search_nonexistent_path_returns_error(self, mock_env):
         """search() should return an error when the path doesn't exist."""
+
         def side_effect(command, **kwargs):
             if "test -e" in command:
                 return {"output": "not_found", "returncode": 1}
             if "command -v" in command:
                 return {"output": "yes", "returncode": 0}
             return {"output": "", "returncode": 0}
+
         mock_env.execute.side_effect = side_effect
         ops = ShellFileOperations(mock_env)
         result = ops.search("pattern", path="/nonexistent/path")
@@ -291,12 +341,14 @@ class TestSearchPathValidation:
 
     def test_search_nonexistent_path_files_mode(self, mock_env):
         """search(target='files') should also return error for bad paths."""
+
         def side_effect(command, **kwargs):
             if "test -e" in command:
                 return {"output": "not_found", "returncode": 1}
             if "command -v" in command:
                 return {"output": "yes", "returncode": 0}
             return {"output": "", "returncode": 0}
+
         mock_env.execute.side_effect = side_effect
         ops = ShellFileOperations(mock_env)
         result = ops.search("*.py", path="/nonexistent/path", target="files")
@@ -305,6 +357,7 @@ class TestSearchPathValidation:
 
     def test_search_existing_path_proceeds(self, mock_env):
         """search() should proceed normally when the path exists."""
+
         def side_effect(command, **kwargs):
             if "test -e" in command:
                 return {"output": "exists", "returncode": 0}
@@ -312,6 +365,7 @@ class TestSearchPathValidation:
                 return {"output": "yes", "returncode": 0}
             # rg returns exit 1 (no matches) with empty output
             return {"output": "", "returncode": 1}
+
         mock_env.execute.side_effect = side_effect
         ops = ShellFileOperations(mock_env)
         result = ops.search("pattern", path="/existing/path")
@@ -321,6 +375,7 @@ class TestSearchPathValidation:
     def test_search_rg_error_exit_code(self, mock_env):
         """search() should report error when rg returns exit code 2."""
         call_count = {"n": 0}
+
         def side_effect(command, **kwargs):
             call_count["n"] += 1
             if "test -e" in command:
@@ -329,6 +384,7 @@ class TestSearchPathValidation:
                 return {"output": "yes", "returncode": 0}
             # rg returns exit 2 (error) with empty output
             return {"output": "", "returncode": 2}
+
         mock_env.execute.side_effect = side_effect
         ops = ShellFileOperations(mock_env)
         result = ops.search("pattern", path="/some/path")
@@ -363,7 +419,10 @@ class TestShellFileOpsWriteDenied:
         assert "denied" in result.error.lower()
 
     def test_move_file_failure_path(self, mock_env):
-        mock_env.execute.return_value = {"output": "No such file or directory", "returncode": 1}
+        mock_env.execute.return_value = {
+            "output": "No such file or directory",
+            "returncode": 1,
+        }
         ops = ShellFileOperations(mock_env)
         result = ops.move_file("/tmp/nonexistent.txt", "/tmp/dest.txt")
         assert result.error is not None
@@ -398,7 +457,10 @@ class TestPatchReplacePostWriteVerification:
             if command.startswith("wc -c"):
                 for path in file_contents:
                     if path in command:
-                        return {"output": str(len(file_contents[path].encode())), "returncode": 0}
+                        return {
+                            "output": str(len(file_contents[path].encode())),
+                            "returncode": 0,
+                        }
                 return {"output": "0", "returncode": 0}
             # Everything else (including the write itself) pretends to succeed
             # but DOESN'T update file_contents — simulates silent failure
@@ -437,7 +499,9 @@ class TestPatchReplacePostWriteVerification:
         result = ops.patch_replace("/tmp/test/a.py", "hello", "hi")
         assert result.error is None, f"Unexpected error: {result.error}"
         assert result.success is True
-        assert state["content"] == "hi world\n", f"File not actually updated: {state['content']!r}"
+        assert state["content"] == "hi world\n", (
+            f"File not actually updated: {state['content']!r}"
+        )
 
     def test_patch_replace_fails_when_verify_read_errors(self, mock_env):
         """If the verify-read step itself fails (exit code != 0), return an error."""


### PR DESCRIPTION
## What does this PR do?

This PR resolves a P0 vulnerability where prompt-injected models could bypass terminal approval and use `write_file` or `patch` tools to persistently overwrite Hermes control-plane files.

It hardens the `is_write_denied()` logic to dynamically resolve the active `HERMES_HOME` and strictly block modifications to `auth.json`, `config.yaml`, `webhook_subscriptions.json`, and the `mcp-tokens/` directory.

## Related Issue

Fixes #14072

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/file_safety.py`: Updated `is_write_denied()` to enforce strict protection over `HERMES_HOME` control files. Implemented `os.path.realpath` resolution to categorically prevent directory traversal (e.g., `../`) and symlink bypasses.
- `tests/tools/test_file_operations.py`: Added comprehensive parameterized `pytest` coverage validating direct paths, traversal attempts, `mcp-tokens/` subdirectories, and standard benign paths.

## How to Test

1. Run `pytest tests/tools/test_file_operations.py::TestIsWriteDenied -v` and verify all parameterized test cases pass.
2. Launch an agent session and explicitly instruct it to use the `write_file` tool to overwrite `~/.hermes/config.yaml` or `~/.hermes/dummy/../auth.json`. 
3. Verify the tool handler rejects the operation with a write-denied error.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

**Test Execution Output:**
```text
$ ./venv/bin/pytest tests/tools/ -k "file" --tb=short
================= 463 passed, 4 skipped, 19 warnings in 20.76s =================