### PR TITLE
fix(agent): accept empty content with stop_reason=end_turn as valid anthropic response

### DIFF
--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -87,14 +87,20 @@ class AnthropicTransport(ProviderTransport):
         return normalize_anthropic_response_v2(response, strip_tool_prefix=strip_tool_prefix)
 
     def validate_response(self, response: Any) -> bool:
-        """Check Anthropic response structure is valid."""
+        """Check Anthropic response structure is valid.
+
+        An empty content list is legitimate when ``stop_reason == "end_turn"``
+        — the model's canonical way of signalling "nothing more to add" after
+        a tool turn that already delivered the user-facing text. Treating it
+        as invalid falsely retries a completed response.
+        """
         if response is None:
             return False
         content_blocks = getattr(response, "content", None)
         if not isinstance(content_blocks, list):
             return False
         if not content_blocks:
-            return False
+            return getattr(response, "stop_reason", None) == "end_turn"
         return True
 
     def extract_cache_stats(self, response: Any) -> Optional[Dict[str, int]]:

--- a/tests/agent/transports/test_transport.py
+++ b/tests/agent/transports/test_transport.py
@@ -114,6 +114,14 @@ class TestAnthropicTransport:
         r = SimpleNamespace(content=[])
         assert transport.validate_response(r) is False
 
+    def test_validate_response_empty_content_with_end_turn_is_valid(self, transport):
+        r = SimpleNamespace(content=[], stop_reason="end_turn")
+        assert transport.validate_response(r) is True
+
+    def test_validate_response_empty_content_with_tool_use_is_invalid(self, transport):
+        r = SimpleNamespace(content=[], stop_reason="tool_use")
+        assert transport.validate_response(r) is False
+
     def test_validate_response_valid(self, transport):
         r = SimpleNamespace(content=[SimpleNamespace(type="text", text="hello")])
         assert transport.validate_response(r) is True


### PR DESCRIPTION
## What does this PR do?

Fixes a false positive in `AnthropicTransport.validate_response` that rejects `content=[]` with `stop_reason="end_turn"` — a legitimate Anthropic API response meaning "I have nothing more to add." When this shape is rejected, the invalid-response retry path fires 3× and the run fails with `"Invalid API response after 3 retries"` even though the user-facing work was already completed on the prior turn.

The fix is one conditional: when `content_blocks` is empty, accept iff `stop_reason == "end_turn"`. Empty content with any other stop_reason (`tool_use`, `max_tokens`, `refusal`, missing) is still rejected — the existing behaviour for those cases is preserved.

No downstream changes are required. `normalize_anthropic_response` already iterates `response.content` (empty loop is a no-op: `content=None`, `tool_calls=None`) and `stop_reason_map` already maps `end_turn → "stop"`.

## Related Issue

Fixes #14158

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/transports/anthropic.py`: `validate_response` now returns `True` when `content_blocks` is empty **and** `stop_reason == "end_turn"`; all other empty-content cases still return `False`.
- `tests/agent/transports/test_transport.py`: two new unit tests — `test_validate_response_empty_content_with_end_turn_is_valid` (the fix) and `test_validate_response_empty_content_with_tool_use_is_invalid` (regression guard). The existing `test_validate_response_empty_content` (no `stop_reason`) continues to pass, confirming the default-invalid path is preserved.

## How to Test

```bash
source .venv/bin/activate
scripts/run_tests.sh tests/agent/transports/test_transport.py -q
```

Expected: `22 passed`. I also ran the related Anthropic-adjacent suites as a regression check:

```bash
scripts/run_tests.sh tests/agent/test_anthropic_adapter.py tests/agent/test_anthropic_normalize_v2.py tests/run_agent/test_anthropic_error_handling.py -q
```

Expected: `158 passed`.

## Scope note vs. #14155

Complementary to (not replacing) [#14155](https://github.com/NousResearch/hermes-agent/pull/14155). #14155 handles the gateway-level UX seam so that genuine failures — ones that actually should surface — read coherently after a visible interim reply. This PR removes the most common *false* trigger of that seam by preventing the validator from marking valid `end_turn` responses as invalid in the first place. Both are worth merging.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **only targeted suites were run (see "How to Test"); the full suite was not run**
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin 25.4.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; docstring on `validate_response` explains the new branch
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure attribute inspection, platform-agnostic
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
▶ running pytest with 4 workers, hermetic env, in /…/hermes-agent
  (TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0; all credential env vars unset)
......................                                                   [100%]
22 passed, 4 warnings in 0.68s
```

Broader regression suites:

```
........................................................................ [ 45%]
........................................................................ [ 91%]
..............                                                           [100%]
158 passed, 4 warnings in 4.40s
```