### PR TITLE
fix(hindsight): always write HINDSIGHT_LLM_API_KEY to .env, even when empty

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -434,8 +434,10 @@ class HindsightMemoryProvider(MemoryProvider):
             sys.stdout.write("  LLM API key: ")
             sys.stdout.flush()
             llm_key = getpass.getpass(prompt="") if sys.stdin.isatty() else sys.stdin.readline().strip()
-            if llm_key:
-                env_writes["HINDSIGHT_LLM_API_KEY"] = llm_key
+            # Always write explicitly (including empty) so the provider sees ""
+            # rather than a missing variable.  The daemon reads from .env at
+            # startup and fails when HINDSIGHT_LLM_API_KEY is unset.
+            env_writes["HINDSIGHT_LLM_API_KEY"] = llm_key
 
         # Step 4: Save everything
         provider_config["bank_id"] = "hermes"


### PR DESCRIPTION
When a user runs `hermes memory setup` for Hindsight and leaves the API key blank, the old code checked `if llm_key:` before writing it to `.env`. Since an empty string is falsy, the variable was omitted entirely from `.env`, causing the local embedded mode's `uvx` daemon to fail at startup.

Removed the guard so HINDSIGHT_LLM_API_KEY is always written — either with a value or as an empty string. 