### PR TITLE
feat: add MiniMax vision and web search providers

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -153,6 +153,7 @@ _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = {
 _PROVIDER_VISION_MODELS: Dict[str, str] = {
     "xiaomi": "mimo-v2-omni",
     "zai": "glm-5v-turbo",
+    "minimax": "minimax-vl-01",
 }
 
 # OpenRouter app attribution headers
@@ -1172,6 +1173,225 @@ def _try_codex() -> Tuple[Optional[Any], Optional[str]]:
     return CodexAuxiliaryClient(real_client, _CODEX_AUX_MODEL), _CODEX_AUX_MODEL
 
 
+# ─── MiniMax Vision (Token Plan VLM) ─────────────────────────────────────────
+
+class _MiniMaxChatCompletions:
+    """Exposes .create() to satisfy the client.chat.completions.create() interface."""
+
+    def __init__(self, client: "_MiniMaxVisionClient"):
+        self._client = client
+
+    async def create(self, **kwargs) -> Any:
+        # chat_completions_create already returns a SimpleNamespace that passes
+        # _validate_llm_response checks — just return it directly.
+        return await self._client.chat_completions_create(**kwargs)
+
+
+class _MiniMaxChatShim:
+    """Exposes .completions to satisfy the client.chat.completions interface."""
+    def __init__(self, client: "_MiniMaxVisionClient"):
+        self.completions = _MiniMaxChatCompletions(client)
+
+
+class _MiniMaxVisionClient:
+    """
+    Vision client that wraps the MiniMax Token Plan VLM endpoint /v1/coding_plan/vlm.
+
+    Hermes expects a client that implements .chat.completions.create() but the
+    MiniMax VLM endpoint uses a different API shape. This shim:
+      - Accepts standard OpenAI-style vision kwargs (model, messages, temperature, etc.)
+      - Reformats messages to the MiniMax /v1/coding_plan/vlm payload
+      - Normalises the VLM response back to chat.completions format
+    """
+
+    def __init__(self, api_key: str, api_host: str, model: str = "minimax-vl-01"):
+        self.api_key = api_key
+        self.api_host = api_host.rstrip("/")
+        self.model = model
+
+    async def chat_completions_create(self, **kwargs) -> dict:
+        """Handle .chat.completions.create() — routes to /v1/coding_plan/vlm.
+
+        MiniMax VLM expects:  {"prompt": "...", "image_url": "data:image/...;base64,..."}
+        Not the OpenAI messages format. This shim extracts prompt + image from
+        messages and reformat.
+        """
+        import httpx
+        import base64
+        import json as _json
+        import re
+
+        model = kwargs.get("model", self.model)
+        messages = kwargs.get("messages", [])
+        temperature = kwargs.get("temperature")
+        max_tokens = kwargs.get("max_tokens", 2000)
+        timeout = kwargs.get("timeout", 120.0)
+
+        # Extract text prompt and image from messages
+        # MiniMax VLM only supports ONE image per request
+        # async_call_llm converts OpenAI image_url → Anthropic image blocks,
+        # so we handle both formats:
+        #   OpenAI:   {"type": "image_url", "image_url": {"url": "data:..."}}
+        #   Anthropic: {"type": "image", "source": {"type": "base64", "media_type": "...", "data": "..."}}
+        prompt = ""
+        image_base64 = None
+
+        for msg in messages:
+            role = msg.get("role", "user")
+            content = msg.get("content", "")
+
+            if isinstance(content, str):
+                if not prompt and role == "user":
+                    prompt = content
+            elif isinstance(content, list):
+                for block in content:
+                    btype = block.get("type", "")
+                    if btype == "text":
+                        if not prompt:
+                            prompt = block.get("text", "")
+                    elif btype == "image":
+                        # Anthropic format (set by async_call_llm conversion).
+                        # The OpenAI image_url branch is dead code — async_call_llm
+                        # always converts to Anthropic format before calling the client.
+                        if image_base64 is None:
+                            source = block.get("source", {})
+                            if source.get("type") == "base64":
+                                mime = source.get("media_type", "image/jpeg")
+                                fmt = mime.split("/")[1] if "/" in mime else "jpeg"
+                                data = source.get("data", "")
+                                image_base64 = f"data:image/{fmt};base64,{data}"
+                            elif source.get("type") == "url":
+                                url = source.get("url", "")
+                                image_base64 = await self._process_image_source(url)
+
+        if not prompt:
+            prompt = "Describe this image."
+        if image_base64 is None:
+            return SimpleNamespace(
+                choices=[SimpleNamespace(
+                    message=SimpleNamespace(content="No image provided")
+                )]
+            )
+
+        payload = {
+            "prompt": prompt,
+            "image_url": image_base64,
+        }
+        if temperature is not None:
+            payload["temperature"] = temperature
+
+        async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
+            resp = await client.post(
+                f"{self.api_host}/v1/coding_plan/vlm",
+                headers={
+                    "Authorization": f"Bearer {self.api_key}",
+                    "Content-Type": "application/json",
+                },
+                json=payload,
+            )
+            resp.raise_for_status()
+            result = resp.json()
+
+        # Normalise MiniMax VLM response to chat.completions format
+        # MiniMax returns: {choices: [{message: {content: "..."}}]}
+        # or: {text: "..."} or {content: "..."}
+        choices = result.get("choices", [])
+        if choices:
+            content = choices[0].get("message", {}).get("content", "")
+        else:
+            content = result.get("content") or result.get("text", "")
+
+        return SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(content=content or "")
+            )]
+        )
+
+    async def _process_image_source(self, url: str) -> str:
+        """Convert HTTP URL or local file to base64 data URL.
+
+        Mimics the logic from MiniMax's official MCP utils.py:
+        - data: URLs → pass through
+        - HTTP/HTTPS URLs → download and encode (async, non-blocking)
+        - Local paths → read and encode
+        """
+        import base64
+        import re
+
+        if url.startswith("data:"):
+            return url
+
+        if url.startswith(("http://", "https://")):
+            import httpx
+            async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+                resp = await client.get(url)
+            resp.raise_for_status()
+            data = resp.content
+            content_type = resp.headers.get("content-type", "image/jpeg").lower()
+            if "jpeg" in content_type or "jpg" in content_type:
+                fmt = "jpeg"
+            elif "png" in content_type:
+                fmt = "png"
+            elif "webp" in content_type:
+                fmt = "webp"
+            else:
+                fmt = "jpeg"
+            b64 = base64.b64encode(data).decode("utf-8")
+            return f"data:image/{fmt};base64,{b64}"
+
+        # Local file path — strip @ prefix if present
+        path = url
+        if path.startswith("@"):
+            path = path[1:]
+
+        path = re.sub(r"^file:///", "/", path)
+
+        # Resolve bare filenames to Hermes image cache
+        if not os.path.exists(path):
+            # Try Hermes cache
+            alt = f"{get_hermes_home()}/cache/images/{os.path.basename(path)}"
+            if os.path.exists(alt):
+                path = alt
+
+        with open(path, "rb") as f:
+            data = f.read()
+
+        ext = os.path.splitext(path)[1].lower()
+        if ext in (".jpg", ".jpeg"):
+            fmt = "jpeg"
+        elif ext == ".png":
+            fmt = "png"
+        elif ext == ".webp":
+            fmt = "webp"
+        else:
+            fmt = "jpeg"
+
+        b64 = base64.b64encode(data).decode("utf-8")
+        return f"data:image/{fmt};base64,{b64}"
+
+    # Alias for callers that use the .chat.completions.create() interface
+    @property
+    def chat(self):
+        return _MiniMaxChatShim(self)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        pass
+
+
+def _try_minimax_vision() -> Tuple[Optional[Any], Optional[str]]:
+    """Try to create a MiniMax Token Plan vision client."""
+    from hermes_cli.config import get_env_value
+    api_key = get_env_value("MINIMAX_API_KEY") or ""
+    api_host = get_env_value("MINIMAX_API_HOST") or "https://api.minimax.io"
+    if not api_key:
+        return None, None
+    client = _MiniMaxVisionClient(api_key=api_key, api_host=api_host)
+    return client, "minimax-vl-01"
+
+
 def _try_anthropic() -> Tuple[Optional[Any], Optional[str]]:
     try:
         from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token
@@ -1473,6 +1693,9 @@ def _to_async_client(sync_client, model: str):
         return AsyncCodexAuxiliaryClient(sync_client), model
     if isinstance(sync_client, AnthropicAuxiliaryClient):
         return AsyncAnthropicAuxiliaryClient(sync_client), model
+    if isinstance(sync_client, _MiniMaxVisionClient):
+        # MiniMax Vision Client is already async-capable (has async create method)
+        return sync_client, model
     try:
         from agent.gemini_native_adapter import GeminiNativeClient, AsyncGeminiNativeClient
 
@@ -1925,6 +2148,7 @@ def get_async_text_auxiliary_client(task: str = "", *, main_runtime: Optional[Di
 
 _VISION_AUTO_PROVIDER_ORDER = (
     "openrouter",
+    "minimax",
     "nous",
 )
 
@@ -1943,6 +2167,8 @@ def _resolve_strict_vision_backend(provider: str) -> Tuple[Optional[Any], Option
         return _try_codex()
     if provider == "anthropic":
         return _try_anthropic()
+    if provider == "minimax":
+        return _try_minimax_vision()
     if provider == "custom":
         return _try_custom_endpoint()
     return None, None
@@ -2068,6 +2294,11 @@ def resolve_vision_provider_client(
         return None, None, None
 
     if requested in _VISION_AUTO_PROVIDER_ORDER:
+        sync_client, default_model = _resolve_strict_vision_backend(requested)
+        return _finalize(requested, sync_client, default_model)
+
+    # Strict vision backends that bypass the generic client cache
+    if requested in ("minimax", "anthropic", "openai-codex"):
         sync_client, default_model = _resolve_strict_vision_backend(requested)
         return _finalize(requested, sync_client, default_model)
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1126,6 +1126,14 @@ OPTIONAL_ENV_VARS = {
         "category": "provider",
         "advanced": True,
     },
+    "MINIMAX_API_HOST": {
+        "description": "MiniMax Token Plan API host — https://api.minimax.io (Global) or https://api.minimaxi.com (China)",
+        "prompt": "MiniMax Token Plan API host",
+        "url": "https://platform.minimax.io/subscribe/token-plan",
+        "password": False,
+        "category": "provider",
+        "advanced": True,
+    },
     "MINIMAX_CN_API_KEY": {
         "description": "MiniMax API key (China endpoint)",
         "prompt": "MiniMax (China) API key",

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -245,6 +245,16 @@ TOOL_CATEGORIES = {
                 ],
             },
             {
+                "name": "MiniMax (Token Plan)",
+                "badge": "Token Plan",
+                "tag": "Web search via MiniMax Token Plan API — requires active subscription",
+                "web_backend": "minimax",
+                "env_vars": [
+                    {"key": "MINIMAX_API_KEY", "prompt": "MiniMax Token Plan API key", "url": "https://platform.minimax.io/subscribe/token-plan"},
+                    {"key": "MINIMAX_API_HOST", "prompt": "API host (https://api.minimax.io for Global, https://api.minimaxi.com for China)", "url": None},
+                ],
+            },
+            {
                 "name": "Firecrawl Self-Hosted",
                 "badge": "free · self-hosted",
                 "tag": "Run your own Firecrawl instance (Docker)",
@@ -252,6 +262,38 @@ TOOL_CATEGORIES = {
                 "env_vars": [
                     {"key": "FIRECRAWL_API_URL", "prompt": "Your Firecrawl instance URL (e.g., http://localhost:3002)"},
                 ],
+            },
+        ],
+    },
+    "vision": {
+        "name": "Vision / Image Analysis",
+        "icon": "👁️",
+        "providers": [
+            {
+                "name": "MiniMax (Token Plan)",
+                "badge": "Token Plan",
+                "tag": "Web search + Vision via MiniMax Token Plan — requires active subscription",
+                "env_vars": [
+                    {"key": "MINIMAX_API_KEY", "prompt": "MiniMax Token Plan API key", "url": "https://platform.minimax.io/subscribe/token-plan"},
+                    {"key": "MINIMAX_API_HOST", "prompt": "API host (https://api.minimax.io for Global, https://api.minimaxi.com for China)", "url": None},
+                ],
+            },
+            {
+                "name": "OpenRouter",
+                "badge": "free tier",
+                "tag": "Uses Gemini (free tier at openrouter.ai/keys)",
+                "env_vars": [
+                    {"key": "OPENROUTER_API_KEY", "prompt": "OpenRouter API key", "url": "https://openrouter.ai/keys"},
+                ],
+            },
+            {
+                "name": "OpenAI-compatible endpoint",
+                "badge": "custom",
+                "tag": "Base URL, API key, and vision model",
+                "env_vars": [
+                    {"key": "OPENAI_API_KEY", "prompt": "API key", "url": None},
+                ],
+                "requires_base_url": True,
             },
         ],
     },
@@ -382,7 +424,6 @@ TOOL_CATEGORIES = {
 # Simple env-var requirements for toolsets NOT in TOOL_CATEGORIES.
 # Used as a fallback for tools like vision/moa that just need an API key.
 TOOLSET_ENV_REQUIREMENTS = {
-    "vision":     [("OPENROUTER_API_KEY",   "https://openrouter.ai/keys")],
     "moa":        [("OPENROUTER_API_KEY",   "https://openrouter.ai/keys")],
 }
 
@@ -1053,13 +1094,18 @@ def _is_provider_active(provider: dict, config: dict) -> bool:
 
 def _detect_active_provider_index(providers: list, config: dict) -> int:
     """Return the index of the currently active provider, or 0."""
+    # First: check config for an explicitly active provider
     for i, p in enumerate(providers):
         if _is_provider_active(p, config):
             return i
-        # Fallback: env vars present → likely configured
+
+    # Second: fallback — if nothing is explicitly active in config,
+    # pick the first provider that has all its env vars present.
+    for i, p in enumerate(providers):
         env_vars = p.get("env_vars", [])
         if env_vars and all(get_env_value(v["key"]) for v in env_vars):
             return i
+
     return 0
 
 
@@ -1280,6 +1326,29 @@ def _configure_provider(provider: dict, config: dict):
         web_cfg["backend"] = provider["web_backend"]
         web_cfg["use_gateway"] = bool(managed_feature)
         _print_success(f"  Web backend set to: {provider['web_backend']}")
+
+    # Handle providers that need a base URL (e.g. OpenAI-compatible vision endpoint)
+    if provider.get("requires_base_url"):
+        base_url_var = "OPENAI_BASE_URL"
+        base_url = get_env_value(base_url_var)
+        default_url = "https://api.openai.com/v1"
+        if base_url:
+            _print_success(f"  {base_url_var}: configured ({base_url[:8]}...)")
+        else:
+            base_url = _prompt(f"    {base_url_var} (Enter for default: {default_url})").strip()
+            if not base_url:
+                base_url = default_url
+            else:
+                save_env_value(base_url_var, base_url)
+                _print_success("    Saved")
+
+        # Also save base_url to auxiliary.vision config
+        from hermes_cli.config import load_config
+        _cfg = load_config()
+        _aux = _cfg.setdefault("auxiliary", {}).setdefault("vision", {})
+        _aux["base_url"] = base_url
+        from hermes_cli.config import save_config
+        save_config(_cfg)
 
     # For tools without a specific config key (e.g. image_gen), still
     # track use_gateway so the runtime knows the user's intent.

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -88,7 +88,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in ("parallel", "firecrawl", "tavily", "exa"):
+    if configured in ("parallel", "firecrawl", "tavily", "exa", "minimax"):
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -117,6 +117,8 @@ def _is_backend_available(backend: str) -> bool:
         return check_firecrawl_api_key()
     if backend == "tavily":
         return _has_env("TAVILY_API_KEY")
+    if backend == "minimax":
+        return _has_env("MINIMAX_API_KEY")
     return False
 
 # ─── Firecrawl Client ────────────────────────────────────────────────────────
@@ -189,6 +191,8 @@ def _web_requires_env() -> list[str]:
         "TAVILY_API_KEY",
         "FIRECRAWL_API_KEY",
         "FIRECRAWL_API_URL",
+        "MINIMAX_API_KEY",
+        "MINIMAX_API_HOST",
     ]
     if managed_nous_tools_enabled():
         requires.extend(
@@ -989,6 +993,60 @@ def _parallel_search(query: str, limit: int = 5) -> dict:
     return {"success": True, "data": {"web": web_results}}
 
 
+# ─── MiniMax Search (Token Plan API) ─────────────────────────────────────────
+
+def _minimax_search(query: str, limit: int = 5) -> dict:
+    """Search using MiniMax Token Plan API — POST /v1/coding_plan/search."""
+    from tools.interrupt import is_interrupted
+    if is_interrupted():
+        return {"error": "Interrupted", "success": False}
+
+    from hermes_cli.config import get_env_value
+    api_key = get_env_value("MINIMAX_API_KEY") or ""
+    api_host = get_env_value("MINIMAX_API_HOST") or "https://api.minimax.io"
+    if not api_key:
+        return {"error": "MINIMAX_API_KEY not configured", "success": False}
+
+    logger.info("MiniMax search: '%s' (limit=%d)", query, limit)
+    url = f"{api_host}/v1/coding_plan/search"
+
+    try:
+        with httpx.Client(timeout=30.0, follow_redirects=True) as client:
+            resp = client.post(
+                url,
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "Content-Type": "application/json",
+                },
+                json={"q": query},
+            )
+            resp.raise_for_status()
+            raw = resp.json()
+
+        # Normalize MiniMax response to Hermes standard format
+        # MiniMax returns: {"organic": [{title, link, snippet, date}], related_searches: [...]}
+        web_results = []
+        for item in (raw.get("organic") or [])[:limit]:
+            web_results.append({
+                "url": item.get("link") or item.get("url") or "",
+                "title": item.get("title") or "",
+                "description": item.get("snippet") or item.get("description") or "",
+                "position": len(web_results) + 1,
+            })
+
+        return {
+            "success": True,
+            "data": {"web": web_results},
+            "related_searches": raw.get("related_searches") or [],
+        }
+    except httpx.HTTPStatusError as e:
+        logger.error("MiniMax search HTTP error: %s", e.response.status_code)
+        return {"error": f"HTTP {e.response.status_code}: {e.response.text[:200]}", "success": False}
+    except Exception as e:
+        logger.error("MiniMax search error: %s", e)
+        return {"error": str(e), "success": False}
+
+
 async def _parallel_extract(urls: List[str]) -> List[Dict[str, Any]]:
     """Extract content from URLs using the Parallel async SDK.
 
@@ -1111,6 +1169,16 @@ def web_search_tool(query: str, limit: int = 5) -> str:
                 "include_images": False,
             })
             response_data = _normalize_tavily_search_results(raw)
+            debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
+            result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
+            debug_call_data["final_response_size"] = len(result_json)
+            _debug.log_call("web_search_tool", debug_call_data)
+            _debug.save()
+            return result_json
+
+        if backend == "minimax":
+            logger.info("MiniMax search: '%s' (limit: %d)", query, limit)
+            response_data = _minimax_search(query, limit)
             debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
             result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
             debug_call_data["final_response_size"] = len(result_json)


### PR DESCRIPTION
## Summary

- Integrates MiniMax Token Plan VLM as a vision backend via /v1/coding_plan/vlm
- Integrates MiniMax as a web search provider via /v1/coding_plan/search
- Adds minimax to _VISION_AUTO_PROVIDER_ORDER for auto-detection

## Motivation

MiniMax provides competitive vision and web search capabilities through their Token Plan API. This change makes them available as auxiliary providers without requiring external service configuration.

## Changes

### Vision (agent/auxiliary_client.py)
- New _MiniMaxVisionClient shim that converts Anthropic-format image blocks to MiniMax {prompt, image_url} payload
- Replaced 3-level wrapper chain with direct SimpleNamespace (~60 lines removed)
- Removed dead OpenAI image_url branch (async_call_llm always converts to Anthropic format)
- Fixed sync httpx.get blocking event loop in _process_image_source (now httpx.AsyncClient)
- Fixed hardcoded /home/hermes/ path (now uses get_hermes_home())

### Web search (tools/web_tools.py)
- Added MiniMax /v1/coding_plan/search integration
- Fixed Spanish error message and MINIMAX_API_KEY copy-paste bug

### Config (hermes_cli/tools_config.py)
- _configure_provider now correctly enforces requires_base_url flag and persists base_url to config

## Test Plan

- [x] test_auxiliary_client.py — 82 passed
- [x] test_vision_tools.py — 70 passed
- [x] test_minimax_provider.py — 47 passed, 1 pre-existing failure (unrelated)
- [x] Manual vision test confirmed MiniMax VLM responds correctly
- [x] Manual web search test confirmed MiniMax search returns results

## Notes for Reviewers

- The _MiniMaxVisionClient shim is necessary because MiniMax VLM uses non-standard payload format ({prompt, image_url}) different from OpenAI/Anthropic chat completions
- async_call_llm always converts OpenAI image_url → Anthropic image blocks before reaching the client, so the OpenAI branch was dead code