### PR TITLE
fix: surface dashboard auth load failures

### DIFF
--- a/web/src/pages/ConfigPage.tsx
+++ b/web/src/pages/ConfigPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useMemo } from "react";
+import { useCallback, useEffect, useRef, useState, useMemo } from "react";
 import {
   Code,
   Download,
@@ -75,6 +75,8 @@ export default function ConfigPage() {
   const [schema, setSchema] = useState<Record<string, Record<string, unknown>> | null>(null);
   const [categoryOrder, setCategoryOrder] = useState<string[]>([]);
   const [defaults, setDefaults] = useState<Record<string, unknown> | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [yamlMode, setYamlMode] = useState(false);
@@ -92,17 +94,28 @@ export default function ConfigPage() {
     return cat.charAt(0).toUpperCase() + cat.slice(1);
   }
 
-  useEffect(() => {
-    api.getConfig().then(setConfig).catch(() => {});
-    api
-      .getSchema()
-      .then((resp) => {
-        setSchema(resp.fields as Record<string, Record<string, unknown>>);
-        setCategoryOrder(resp.category_order ?? []);
+  const loadPage = useCallback(() => {
+    setLoading(true);
+    setError(null);
+
+    Promise.all([
+      api.getConfig(),
+      api.getSchema(),
+      api.getDefaults(),
+    ])
+      .then(([nextConfig, nextSchema, nextDefaults]) => {
+        setConfig(nextConfig);
+        setSchema(nextSchema.fields as Record<string, Record<string, unknown>>);
+        setCategoryOrder(nextSchema.category_order ?? []);
+        setDefaults(nextDefaults);
       })
-      .catch(() => {});
-    api.getDefaults().then(setDefaults).catch(() => {});
+      .catch((err) => setError(String(err)))
+      .finally(() => setLoading(false));
   }, []);
+
+  useEffect(() => {
+    loadPage();
+  }, [loadPage]);
 
   // Set active category when categories load
   useEffect(() => {
@@ -228,12 +241,29 @@ export default function ConfigPage() {
   };
 
   /* ---- Loading ---- */
-  if (!config || !schema) {
+  if (loading) {
     return (
       <div className="flex items-center justify-center py-24">
         <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
       </div>
     );
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <CardContent className="flex flex-col items-center gap-3 py-8 text-center">
+          <p className="text-sm text-destructive">{error}</p>
+          <Button size="sm" variant="outline" onClick={loadPage}>
+            {t.common.retry}
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!config || !schema) {
+    return null;
   }
 
   /* ---- Render field list (shared between search & normal) ---- */

--- a/web/src/pages/EnvPage.tsx
+++ b/web/src/pages/EnvPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from "react";
+import { useCallback, useEffect, useState, useMemo } from "react";
 import {
   Eye,
   EyeOff,
@@ -358,13 +358,25 @@ export default function EnvPage() {
   const [edits, setEdits] = useState<Record<string, string>>({});
   const [revealed, setRevealed] = useState<Record<string, string>>({});
   const [saving, setSaving] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [showAdvanced, setShowAdvanced] = useState(true); // Show all providers by default
   const { toast, showToast } = useToast();
   const { t } = useI18n();
 
-  useEffect(() => {
-    api.getEnvVars().then(setVars).catch(() => {});
+  const loadVars = useCallback(() => {
+    setLoading(true);
+    setError(null);
+    api
+      .getEnvVars()
+      .then(setVars)
+      .catch((err) => setError(String(err)))
+      .finally(() => setLoading(false));
   }, []);
+
+  useEffect(() => {
+    loadVars();
+  }, [loadVars]);
 
   const handleSave = async (key: string) => {
     const value = edits[key];
@@ -477,12 +489,29 @@ export default function EnvPage() {
     return { providerGroups: groups, nonProviderGrouped: nonProvider };
   }, [vars, showAdvanced, t]);
 
-  if (!vars) {
+  if (loading) {
     return (
       <div className="flex items-center justify-center py-24">
         <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
       </div>
     );
+  }
+
+  if (error) {
+    return (
+      <Card>
+        <CardContent className="flex flex-col items-center gap-3 py-8 text-center">
+          <p className="text-sm text-destructive">{error}</p>
+          <Button size="sm" variant="outline" onClick={loadVars}>
+            {t.common.retry}
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!vars) {
+    return null;
   }
 
   const totalProviders = providerGroups.length;


### PR DESCRIPTION
## Summary
- stop Config and Keys pages from hanging forever when protected dashboard API calls fail
- surface the auth/loading failure as an inline error card with a retry action
- keep the existing success path unchanged for authenticated dashboard sessions

## Reproduction
1. Run the dashboard backend and the Vite web UI in dev mode
2. Open `/config` or `/env` without an injected dashboard session token
3. Observe the page spinning forever instead of explaining the auth failure

## Test Plan
- [x] `npm run build`
- [x] Verified `/config` now shows `Error: 401: {"detail":"Unauthorized"}` with a Retry button
- [x] Verified `/env` now shows `Error: 401: {"detail":"Unauthorized"}` with a Retry button
