### PR TITLE
fix(mcp): don't cancel registration on stale per-thread interrupt flag

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -324,6 +324,72 @@ class TestRunOnMCPLoopInterrupts:
             mcp_mod._mcp_loop = old_loop
             mcp_mod._mcp_thread = old_thread
 
+    def test_respect_interrupt_false_ignores_stale_flag(self):
+        """Registration paths must not be cancelled by a stale per-thread
+        interrupt flag left behind on a recycled executor worker (#14113)."""
+        import tools.mcp_tool as mcp_mod
+        from tools.interrupt import set_interrupt
+
+        loop = asyncio.new_event_loop()
+        thread = threading.Thread(target=loop.run_forever, daemon=True)
+        thread.start()
+
+        async def _quick_call():
+            return "registered"
+
+        old_loop = mcp_mod._mcp_loop
+        old_thread = mcp_mod._mcp_thread
+        mcp_mod._mcp_loop = loop
+        mcp_mod._mcp_thread = thread
+
+        waiter_tid = threading.current_thread().ident
+        set_interrupt(True, waiter_tid)  # simulate stale flag from a prior turn
+
+        try:
+            result = mcp_mod._run_on_mcp_loop(
+                _quick_call(), timeout=2, respect_interrupt=False,
+            )
+            assert result == "registered"
+        finally:
+            set_interrupt(False, waiter_tid)
+            loop.call_soon_threadsafe(loop.stop)
+            thread.join(timeout=2)
+            loop.close()
+            mcp_mod._mcp_loop = old_loop
+            mcp_mod._mcp_thread = old_thread
+
+    def test_respect_interrupt_default_still_cancels(self):
+        """Default (tool-call) path still honors user interrupts."""
+        import tools.mcp_tool as mcp_mod
+        from tools.interrupt import set_interrupt
+
+        loop = asyncio.new_event_loop()
+        thread = threading.Thread(target=loop.run_forever, daemon=True)
+        thread.start()
+
+        async def _slow_call():
+            await asyncio.sleep(5)
+            return "done"
+
+        old_loop = mcp_mod._mcp_loop
+        old_thread = mcp_mod._mcp_thread
+        mcp_mod._mcp_loop = loop
+        mcp_mod._mcp_thread = thread
+
+        waiter_tid = threading.current_thread().ident
+        set_interrupt(True, waiter_tid)
+
+        try:
+            with pytest.raises(InterruptedError, match="User sent a new message"):
+                mcp_mod._run_on_mcp_loop(_slow_call(), timeout=2)
+        finally:
+            set_interrupt(False, waiter_tid)
+            loop.call_soon_threadsafe(loop.stop)
+            thread.join(timeout=2)
+            loop.close()
+            mcp_mod._mcp_loop = old_loop
+            mcp_mod._mcp_thread = old_thread
+
 
 # ---------------------------------------------------------------------------
 # Tool registration (discovery + register)
@@ -986,6 +1052,42 @@ class TestSanitizeError:
         assert "sk-" not in result
         assert "token=" not in result
         assert result.count("[REDACTED]") == 3
+
+
+class TestFormatConnectError:
+    """Tests for _format_connect_error() actionable-message rendering."""
+
+    def test_naked_cancelled_error_has_actionable_message(self):
+        from tools.mcp_tool import _format_connect_error
+        result = _format_connect_error(asyncio.CancelledError())
+        assert "cancelled before the handshake" in result
+        assert "external cancel" in result
+        assert "#14113" in result
+        # Must not degrade to the bare class name it used to emit.
+        assert result != "CancelledError"
+
+    def test_cancelled_error_with_cause_falls_through(self):
+        """A CancelledError chained to a real cause should render the cause,
+        not the generic cancellation hint."""
+        from tools.mcp_tool import _format_connect_error
+        try:
+            try:
+                raise ConnectionRefusedError("connection refused")
+            except ConnectionRefusedError as real_cause:
+                raise asyncio.CancelledError() from real_cause
+        except asyncio.CancelledError as exc:
+            result = _format_connect_error(exc)
+        assert "connection refused" in result
+        assert "#14113" not in result
+
+    def test_missing_node_executable_unchanged(self):
+        """Regression guard: the existing FileNotFoundError → 'missing executable'
+        path is not affected by the new CancelledError branch."""
+        from tools.mcp_tool import _format_connect_error
+        exc = FileNotFoundError(2, "No such file or directory", "node")
+        result = _format_connect_error(exc)
+        assert "missing executable 'node'" in result
+        assert "PATH" in result
 
 
 # ---------------------------------------------------------------------------

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -374,6 +374,18 @@ def _format_connect_error(exc: BaseException) -> str:
             )
         return _sanitize_error(message)
 
+    if (
+        isinstance(exc, asyncio.CancelledError)
+        and not getattr(exc, "__cause__", None)
+        and not getattr(exc, "__context__", None)
+    ):
+        return _sanitize_error(
+            "connection was cancelled before the handshake completed "
+            "(external cancel, not a timeout). If this reproduces under "
+            "launchd/systemd, attach gateway.log around the timestamp to "
+            "issue #14113."
+        )
+
     deduped: List[str] = []
     for item in _flatten_messages(exc):
         if item not in deduped:
@@ -1541,11 +1553,16 @@ def _ensure_mcp_loop():
         _mcp_thread.start()
 
 
-def _run_on_mcp_loop(coro, timeout: float = 30):
+def _run_on_mcp_loop(coro, timeout: float = 30, *, respect_interrupt: bool = True):
     """Schedule a coroutine on the MCP event loop and block until done.
 
     Poll in short intervals so the calling agent thread can honor user
     interrupts while the MCP work is still running on the background loop.
+
+    ``respect_interrupt`` defaults to True (the right semantics for in-flight
+    tool calls). Discovery/registration/probe call sites pass False so they
+    cannot be cancelled by a stale per-thread interrupt flag left behind on
+    a recycled executor worker after a prior turn was abandoned (#14113).
     """
     from tools.interrupt import is_interrupted
 
@@ -1557,7 +1574,7 @@ def _run_on_mcp_loop(coro, timeout: float = 30):
     deadline = None if timeout is None else time.monotonic() + timeout
 
     while True:
-        if is_interrupted():
+        if respect_interrupt and is_interrupted():
             future.cancel()
             raise InterruptedError("User sent a new message")
 
@@ -2400,7 +2417,10 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
 
     # Per-server timeouts are handled inside _discover_and_register_server.
     # The outer timeout is generous: 120s total for parallel discovery.
-    _run_on_mcp_loop(_discover_all(), timeout=120)
+    # respect_interrupt=False so a stale per-thread interrupt flag on a
+    # recycled executor worker cannot cancel registration before the
+    # stdio handshake completes (#14113).
+    _run_on_mcp_loop(_discover_all(), timeout=120, respect_interrupt=False)
 
     # Log a summary so ACP callers get visibility into what was registered.
     with _lock:
@@ -2565,7 +2585,8 @@ def probe_mcp_server_tools() -> Dict[str, List[tuple]]:
         )
 
     try:
-        _run_on_mcp_loop(_probe_all(), timeout=120)
+        # respect_interrupt=False — see register_mcp_servers (#14113).
+        _run_on_mcp_loop(_probe_all(), timeout=120, respect_interrupt=False)
     except Exception as exc:
         logger.debug("MCP probe failed: %s", exc)
     finally:


### PR DESCRIPTION
## What does this PR do?

Narrow fix for #14113 where stdio MCP servers silently fail to register in the launchd-managed gateway with a bare `CancelledError`, while the same config works via `hermes mcp test`, `hermes chat -q`, and the gateway's HTTP transport.

### What's happening

`_run_on_mcp_loop()` ([tools/mcp_tool.py:1544](https://github.com/NousResearch/hermes-agent/blob/main/tools/mcp_tool.py#L1544)) polls `is_interrupted()` in a 0.1s loop and calls `future.cancel()` on the submitted coroutine if the calling thread's tid is in `_interrupted_threads`. That cancellation channel exists so a *new user message* aborts a long-running *tool call* mid-flight — exactly the right semantics for `_make_tool_handler`.

The same plumbing was also being used for **registration / discovery / probe** — call paths that run during gateway startup and `/reload-mcp`, scheduled onto the default executor's worker pool. `run_agent.py`'s own `clear_interrupt()` ([line 3619–3623](https://github.com/NousResearch/hermes-agent/blob/main/run_agent.py#L3619)) already warns that stale per-tid flags can survive a turn boundary and fire on unrelated work scheduled onto the recycled worker:

> "guarantees no stale interrupt can survive a turn boundary and fire on a subsequent, unrelated tool call that happens to get scheduled onto the same recycled worker tid."

When a prior agent turn's cleanup was missed (crash, abandoned task, whatever), the executor worker's tid stays in `_interrupted_threads`. The next thing to run on that worker — `discover_mcp_tools()` at gateway boot or `/reload-mcp` — gets its stdio handshake cancelled before it finishes. `asyncio.gather(..., return_exceptions=True)` collects the bare `CancelledError` and the warning in the report is emitted.

### The fix

One kwarg on `_run_on_mcp_loop`:

```python
def _run_on_mcp_loop(coro, timeout: float = 30, *, respect_interrupt: bool = True):
    ...
    if respect_interrupt and is_interrupted():
        future.cancel()
        raise InterruptedError("User sent a new message")
```

- **Default `True`** — tool-call callers (`_make_tool_handler._call_once` and its five variants) keep the existing interrupt behavior; user interrupts still abort in-flight tool calls.
- **Explicit `False`** from `register_mcp_servers()` and `probe_mcp_server_tools()` — registration / probe cannot be cancelled by a stale flag on a recycled worker.

Also: `_format_connect_error()` now recognises a naked `asyncio.CancelledError` (no `__cause__`, no `__context__`) and emits a short actionable message instead of the bare class name. A chained `CancelledError` with a real cause still falls through to the existing flattening path so the underlying reason is preserved.

### Scope limits

- Does **not** touch `gateway/run.py`, `run_agent.py`, or `model_tools.py`. The fix lives where the bug lives.
- Does **not** change tool-call interrupt semantics.
- Does **not** empirically confirm the stale-flag hypothesis against a live launchd environment — I don't have one. The fix is defensible on its own terms (registration shouldn't be cancellable by a stale user-interrupt flag), and removes the most plausible trigger for the reported symptom. If the reporter sees residual cancellations after this lands, the improved `_format_connect_error` message will point them to the next datapoint (parent-task cancel vs. some other source).

## Related Issue

Fixes #14113

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/mcp_tool.py`:
  - `_run_on_mcp_loop`: new `respect_interrupt` kwarg (keyword-only, default `True`)
  - `register_mcp_servers` and `probe_mcp_server_tools`: pass `respect_interrupt=False`
  - `_format_connect_error`: recognize naked `CancelledError` and emit an actionable hint
- `tests/tools/test_mcp_tool.py`:
  - `TestRunOnMCPLoopInterrupts.test_respect_interrupt_false_ignores_stale_flag` — simulates stale flag, asserts registration proceeds
  - `TestRunOnMCPLoopInterrupts.test_respect_interrupt_default_still_cancels` — regression guard, tool-call path still raises `InterruptedError`
  - `TestFormatConnectError.test_naked_cancelled_error_has_actionable_message` — new CancelledError branch
  - `TestFormatConnectError.test_cancelled_error_with_cause_falls_through` — chained cause still rendered
  - `TestFormatConnectError.test_missing_node_executable_unchanged` — existing FileNotFoundError path unaffected

## How to Test

```bash
source .venv/bin/activate
scripts/run_tests.sh tests/tools/test_mcp_tool.py -q
```

Expected: `171 passed`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **only `tests/tools/test_mcp_tool.py` was run (171 passed); the full suite was not run**
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Darwin 25.4.0). **No live launchd repro** — I don't have the reporter's environment.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — added explanatory docstrings on the new `respect_interrupt` kwarg
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — pure Python, no platform-specific code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
▶ running pytest with 4 workers, hermetic env, in /…/hermes-agent
  (TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0; all credential env vars unset)
........................................................................ [ 42%]
........................................................................ [ 84%]
...........................                                              [100%]
171 passed, 5 warnings in 8.01s
```