### PR TITLE
fix(gateway): ignore invoking CLI ancestor during PID scan

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -280,6 +280,8 @@ def _scan_gateway_pids(exclude_pids: set[int], all_profiles: bool = False) -> li
                 if any(pattern in command for pattern in patterns) and (
                     all_profiles or _matches_current_profile(command)
                 ):
+                    if _is_pid_ancestor_of_current_process(pid):
+                        continue
                     _append_unique_pid(pids, pid, exclude_pids)
     except (OSError, subprocess.TimeoutExpired):
         return []

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -819,6 +819,31 @@ class TestFindGatewayPidsExclude:
 
         assert pids == [100]
 
+    def test_excludes_ancestor_process_tree(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "is_windows", lambda: False)
+        monkeypatch.setattr(gateway_cli, "_get_service_pids", lambda: set())
+
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(
+                cmd, 0,
+                stdout=(
+                    "300 /usr/bin/python -m hermes_cli.main gateway run --replace\n"
+                    "200 /usr/bin/python /repo/gateway/run.py\n"
+                ),
+                stderr="",
+            )
+
+        parent_map = {500: 400, 400: 300, 300: 1}
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        monkeypatch.setattr("os.getpid", lambda: 500)
+        monkeypatch.setattr(gateway_cli, "_get_parent_pid", lambda pid: parent_map.get(pid))
+
+        pids = gateway_cli.find_gateway_pids()
+
+        assert 300 not in pids
+        assert pids == [200]
+
 
 # ---------------------------------------------------------------------------
 # Gateway mode writes exit code before restart (#8300)


### PR DESCRIPTION
## Summary
- skip ancestor PIDs while scanning the process table for running gateways
- keep PID-file and service-managed discovery unchanged
- add a regression test covering an interactive CLI parent plus a real gateway child

## Root cause
`find_gateway_pids()` scans process-table matches broadly enough to see the foreground CLI process that launched `hermes gateway run --replace`. Because the scan only excluded the current PID, an ancestor in the same process tree could still be reported as an already-running gateway.

## Fix
Restrict the ancestor filter to `_scan_gateway_pids()` so only process-table matches are skipped when they belong to the current process tree. This preserves the existing PID-file fallback and service PID discovery paths.

## Regression coverage
- added `TestFindGatewayPidsExclude::test_excludes_ancestor_process_tree`
- verifies a matching CLI ancestor is ignored while a real `gateway/run.py` process is still returned

## Testing
- `scripts/run_tests.sh tests/hermes_cli/test_update_gateway_restart.py::TestFindGatewayPidsExclude::test_excludes_ancestor_process_tree`
- `scripts/run_tests.sh tests/hermes_cli/test_update_gateway_restart.py`
- `scripts/run_tests.sh tests/hermes_cli/test_gateway.py`

Closes #13242