### PR TITLE
fix(delegate): preset toolset expansion + stdio-safe progress printing for ACP subagents

### DIFF
--- a/tests/tools/test_delegate_toolset_scope.py
+++ b/tests/tools/test_delegate_toolset_scope.py
@@ -9,7 +9,7 @@ arbitrary toolsets.
 from unittest.mock import MagicMock, patch
 from types import SimpleNamespace
 
-from tools.delegate_tool import _strip_blocked_tools, _expand_parent_enabled_toolsets
+from tools.delegate_tool import _strip_blocked_tools, _expand_parent_enabled_toolsets, _emit_parent_console
 
 
 class TestToolsetIntersection:
@@ -109,3 +109,44 @@ class TestExpandParentEnabledToolsets:
         requested = ["browser", "terminal", "web"]
         scoped = _strip_blocked_tools([t for t in requested if t in parent_toolsets])
         assert sorted(scoped) == ["browser", "terminal", "web"]
+
+
+class TestEmitParentConsole:
+    """Progress lines (e.g. ``✓ [N/M] …``) must route through the parent's
+    configured ``_safe_print`` in headless stdio hosts (ACP, gateway) so
+    they don't land on stdout and corrupt JSON-RPC frames. Regression for a
+    bug where delegate_task completion lines pushed to stdout caused
+    ``Failed to parse JSON message: ✓ [3/3] …`` errors in the ACP adapter."""
+
+    def test_routes_through_parent_safe_print_when_available(self, capsys):
+        captured_lines = []
+        parent = SimpleNamespace(_safe_print=lambda line: captured_lines.append(line))
+
+        _emit_parent_console(parent, "  ✓ [1/3] Research done  (11.55s)")
+
+        assert captured_lines == ["  ✓ [1/3] Research done  (11.55s)"]
+        stdout_stderr = capsys.readouterr()
+        assert stdout_stderr.out == ""
+        assert stdout_stderr.err == ""
+
+    def test_falls_back_to_stdout_when_no_safe_print(self, capsys):
+        parent = SimpleNamespace()
+        _emit_parent_console(parent, "  ✓ [1/3] fallback path")
+        captured = capsys.readouterr()
+        assert "fallback path" in captured.out
+
+    def test_falls_back_to_stdout_when_safe_print_raises(self, capsys):
+        def raiser(_line):
+            raise RuntimeError("boom")
+
+        parent = SimpleNamespace(_safe_print=raiser)
+        _emit_parent_console(parent, "  ✓ [2/3] fallback on exception")
+        captured = capsys.readouterr()
+        assert "fallback on exception" in captured.out
+
+    def test_non_callable_safe_print_is_ignored(self, capsys):
+        """Defensive: if _safe_print is set but not callable, fall back."""
+        parent = SimpleNamespace(_safe_print="not-a-function")
+        _emit_parent_console(parent, "  ✓ [3/3] non-callable guard")
+        captured = capsys.readouterr()
+        assert "non-callable guard" in captured.out

--- a/tests/tools/test_delegate_toolset_scope.py
+++ b/tests/tools/test_delegate_toolset_scope.py
@@ -9,7 +9,7 @@ arbitrary toolsets.
 from unittest.mock import MagicMock, patch
 from types import SimpleNamespace
 
-from tools.delegate_tool import _strip_blocked_tools
+from tools.delegate_tool import _strip_blocked_tools, _expand_parent_enabled_toolsets
 
 
 class TestToolsetIntersection:
@@ -64,3 +64,48 @@ class TestToolsetIntersection:
         scoped = [t for t in requested if t in parent_toolsets]
 
         assert scoped == []
+
+
+class TestExpandParentEnabledToolsets:
+    """Preset names (e.g. ``hermes-acp``) must expand to individual toolsets
+    before subagent intersection. Without this, an ACP-hosted parent would
+    always pass an empty toolset to children — a regression that stripped
+    every tool from subagents spawned via ``delegate_task``."""
+
+    def test_preset_expands_to_individual_toolsets(self):
+        """Preset bundle expands to its underlying individual toolsets."""
+        expanded = _expand_parent_enabled_toolsets(["hermes-acp"])
+        # hermes-acp bundles web, browser, terminal, file, skills, vision,
+        # session_search, todo, memory, code_execution, delegation — exact
+        # membership depends on toolsets.py, so only assert the key ones
+        # the delegate-scoping test cares about.
+        assert "web" in expanded
+        assert "browser" in expanded
+        assert "file" in expanded
+        assert "terminal" in expanded
+
+    def test_individual_toolset_is_idempotent(self):
+        """Passing an already-individual toolset name returns itself."""
+        expanded = _expand_parent_enabled_toolsets(["web", "terminal"])
+        assert expanded == {"web", "terminal"}
+
+    def test_mixed_preset_and_individual_toolsets(self):
+        """Mix of preset + individual names all expand correctly."""
+        expanded = _expand_parent_enabled_toolsets(["hermes-acp", "rl"])
+        assert "browser" in expanded  # from hermes-acp
+        assert "rl" in expanded       # individual passthrough
+
+    def test_unknown_name_kept_literal(self):
+        """Unknown/legacy names are preserved so downstream code sees them."""
+        expanded = _expand_parent_enabled_toolsets(["definitely-not-a-real-toolset"])
+        assert expanded == {"definitely-not-a-real-toolset"}
+
+    def test_preset_parent_intersects_with_llm_requested(self):
+        """End-to-end: preset parent + LLM-requested individual toolsets
+        must produce the correct intersection. Regression for the bug where
+        ``parent_toolsets = {"hermes-acp"}`` trivially rejected every request.
+        """
+        parent_toolsets = _expand_parent_enabled_toolsets(["hermes-acp"])
+        requested = ["browser", "terminal", "web"]
+        scoped = _strip_blocked_tools([t for t in requested if t in parent_toolsets])
+        assert sorted(scoped) == ["browser", "terminal", "web"]

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -155,6 +155,38 @@ def _strip_blocked_tools(toolsets: List[str]) -> List[str]:
     return [t for t in toolsets if t not in blocked_toolset_names]
 
 
+def _expand_parent_enabled_toolsets(parent_enabled: List[str]) -> set:
+    """Expand any preset names in parent_enabled to individual toolsets.
+
+    `enabled_toolsets` on AIAgent may contain either individual toolset names
+    (``["web", "browser"]``) or a preset bundle name (``["hermes-acp"]``).
+    The subagent intersect-check uses set membership against individual
+    toolset names supplied by the LLM (e.g. ``["web", "browser", "file"]``),
+    so any preset in parent_enabled must be expanded first — otherwise no
+    LLM-requested toolset would ever match and the subagent would receive
+    an empty toolset.
+
+    For individual toolset names this function is idempotent: expanding
+    ``"web"`` walks its tools, resolves each tool's owning toolset, and
+    collects ``{"web"}`` back.
+    """
+    import model_tools
+    from toolsets import resolve_toolset, validate_toolset
+
+    expanded: set = set()
+    for name in parent_enabled:
+        if validate_toolset(name):
+            for tool_name in resolve_toolset(name):
+                ts = model_tools.get_toolset_for_tool(tool_name)
+                if ts is not None:
+                    expanded.add(ts)
+        else:
+            # Unknown / legacy name — keep literal so downstream logic
+            # can still see it (e.g. _LEGACY_TOOLSET_MAP handling).
+            expanded.add(name)
+    return expanded
+
+
 def _build_child_progress_callback(task_index: int, goal: str, parent_agent, task_count: int = 1) -> Optional[callable]:
     """Build a callback that relays child agent tool calls to the parent display.
 
@@ -297,7 +329,12 @@ def _build_child_agent(
     # so we must derive effective toolsets from the parent's loaded tools.
     parent_enabled = getattr(parent_agent, "enabled_toolsets", None)
     if parent_enabled is not None:
-        parent_toolsets = set(parent_enabled)
+        # Expand any preset names (e.g. "hermes-acp") into their individual
+        # toolsets so set-intersect against child-requested individual names
+        # (like "web","browser","file") works. Without this expansion a
+        # parent running under a preset would reject every model-supplied
+        # toolset as "not in parent" and the child would get zero tools.
+        parent_toolsets = _expand_parent_enabled_toolsets(parent_enabled)
     elif parent_agent and hasattr(parent_agent, "valid_tool_names"):
         # enabled_toolsets is None (all tools) — derive from loaded tool names
         import model_tools

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -187,6 +187,24 @@ def _expand_parent_enabled_toolsets(parent_enabled: List[str]) -> set:
     return expanded
 
 
+def _emit_parent_console(parent_agent, line: str) -> None:
+    """Emit a human-readable progress line to the parent's console.
+
+    Routes through ``parent_agent._safe_print`` when available so headless
+    stdio hosts (ACP, gateway API) can redirect non-protocol output to
+    stderr via their configured ``_print_fn``. A bare ``print()`` would
+    otherwise land on stdout and corrupt JSON-RPC framing.
+    """
+    printer = getattr(parent_agent, "_safe_print", None)
+    if callable(printer):
+        try:
+            printer(line)
+            return
+        except Exception:
+            pass
+    print(line)
+
+
 def _build_child_progress_callback(task_index: int, goal: str, parent_agent, task_count: int = 1) -> Optional[callable]:
     """Build a callback that relays child agent tool calls to the parent display.
 
@@ -912,9 +930,9 @@ def delegate_task(
                         try:
                             spinner_ref.print_above(completion_line)
                         except Exception:
-                            print(f"  {completion_line}")
+                            _emit_parent_console(parent_agent, f"  {completion_line}")
                     else:
-                        print(f"  {completion_line}")
+                        _emit_parent_console(parent_agent, f"  {completion_line}")
 
                     # Update spinner text to show remaining count
                     if spinner_ref and remaining > 0:


### PR DESCRIPTION
Two closely-related fixes for `delegate_task` when the parent runs under the ACP stdio transport. Each fix targets a distinct symptom that together rendered subagent delegation unusable in practice.

---

## Fix 1 — Preset toolset expansion (commit 39ca6e97)

### Problem

When a parent agent's `enabled_toolsets` contains a preset bundle name (e.g. `hermes-acp` set by `acp_adapter/session.py`), `_build_child_agent` in `tools/delegate_tool.py` builds `parent_toolsets` as `set(enabled_toolsets)` — so it becomes `{"hermes-acp"}`. The downstream intersect against LLM-supplied individual toolset names trivially rejects every request:

```python
parent_toolsets = {"hermes-acp"}
scoped = [t for t in ["web","browser","file"] if t in parent_toolsets]
# => []
```

The subagent then spawns with `enabled_toolsets=[]` and zero tools. Every tool call the subagent attempts raises `Unknown tool …`, usually exhausting all 3 self-correction retries before quitting. The parent sees `delegate_task` return `completed` in seconds and falls back to doing the work itself — wasting tokens, degrading research quality, and breaking any skill that expects `delegate_task` to actually work.

### Reproduction

Real-world trace from an ACP session where the LLM requested three parallel research subagents:

```json
{"name":"delegate task","arguments":{"tasks":[
  {"goal":"Research Paid GEO Platforms…","toolsets":["browser","terminal","web"]},
  {"goal":"Research Open Source GEO Tools…","toolsets":["terminal","web"]},
  {"goal":"Research Academic Foundation…","toolsets":["terminal","web"]}
]}}
```

All three subagents returned `status=completed` within 18 seconds of spawn — because each received `enabled_toolsets=[]`, every tool call raised `Unknown tool browser_navigate`, and after 3 self-correction retries each subagent quit with no meaningful output.

### Fix

Expand any preset name in `parent_enabled` to its individual toolsets before building `parent_toolsets`, via `toolsets.resolve_toolset` + `model_tools.get_toolset_for_tool`. The expansion is idempotent: expanding `"web"` walks its tools, resolves each tool's owning toolset, and collects `{"web"}` back — so non-preset callers are unaffected.

Extracted into `_expand_parent_enabled_toolsets(parent_enabled)` for unit testability.

---

## Fix 2 — stdio-safe progress printing (commit d35b3621)

### Problem

`delegate_task`'s per-task completion display built lines like `✓ [1/3] Research Paid GEO Platforms  (17.92s)` and, when no CLI spinner was attached, emitted them via a bare `print()`. Under ACP (and any other headless JSON-RPC stdio host where the AIAgent has a custom `_print_fn` routing human output to stderr), this landed on **stdout** and corrupted the protocol frame stream.

The AiX ACP adapter client surfaced this as repeated errors:

```
Failed to parse JSON message: ✓ [3/3] Research Academic Foundation and Contrad  (11.55s) SyntaxError
Failed to parse JSON message: ✓ [2/3] Research Open Source GEO Tools and Stand  (12.36s) SyntaxError
Failed to parse JSON message: ✓ [1/3] Research Paid GEO Platforms. Find and do  (17.92s) SyntaxError
```

Any stream chunks that happened to arrive in the same read window were dropped by the client parser, producing silent gaps in the UI.

### Fix

Added helper `_emit_parent_console(parent_agent, line)` that prefers `parent_agent._safe_print` — the same hook `run_agent.AIAgent` uses for every other user-facing print — and falls back to `print()` only when no router is wired up (or the router itself raises). CLI behavior is unchanged: with no `_print_fn` set, the helper reaches `print()` immediately.

---

## Test plan

- [x] `pytest tests/tools/test_delegate_toolset_scope.py` — **14/14 pass** (5 preset expansion + 5 intersection + 4 stdout routing)
- [x] `pytest tests/ -k delegate` — **105 passed, 4 skipped**
- [x] Manual reproduction with real ACP event-log inputs (`parent_enabled=["hermes-acp"]`, LLM `toolsets=["browser","terminal","web"]`) now yields correct non-empty `child_toolsets`
- [x] Verified progress lines route to `_safe_print` when set; stdout stays clean for JSON-RPC frames

### Commits

- `39ca6e97` — preset toolset expansion + regression tests
- `d35b3621` — `_emit_parent_console` routing + regression tests