### PR TITLE
feat(models): add xiaomi/mimo-v2.5-pro + mimo-v2.5 to openrouter + nous

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -185,6 +185,8 @@ DEFAULT_CONTEXT_LENGTHS = {
     "mimo-v2-pro": 1000000,
     "mimo-v2-omni": 256000,
     "mimo-v2-flash": 256000,
+    "mimo-v2.5-pro": 1000000,
+    "mimo-v2.5": 1000000,
     "zai-org/GLM-5": 202752,
 }
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -42,7 +42,8 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("openrouter/elephant-alpha",       "free"),
     ("openai/gpt-5.4",                  ""),
     ("openai/gpt-5.4-mini",             ""),
-    ("xiaomi/mimo-v2-pro",               ""),
+    ("xiaomi/mimo-v2.5-pro",             ""),
+    ("xiaomi/mimo-v2.5",                 ""),
     ("openai/gpt-5.3-codex",            ""),
     ("google/gemini-3-pro-image-preview", ""),
     ("google/gemini-3-flash-preview",   ""),
@@ -108,7 +109,8 @@ def _codex_curated_models() -> list[str]:
 _PROVIDER_MODELS: dict[str, list[str]] = {
     "nous": [
         "moonshotai/kimi-k2.6",
-        "xiaomi/mimo-v2-pro",
+        "xiaomi/mimo-v2.5-pro",
+        "xiaomi/mimo-v2.5",
         "anthropic/claude-opus-4.7",
         "anthropic/claude-opus-4.6",
         "anthropic/claude-sonnet-4.6",


### PR DESCRIPTION
Swaps xiaomi/mimo-v2-pro for xiaomi/mimo-v2.5-pro and xiaomi/mimo-v2.5 in the OpenRouter fallback catalog and the nous provider model list, with matching DEFAULT_CONTEXT_LENGTHS entries.

## Changes
- hermes_cli/models.py: OPENROUTER_MODELS + _PROVIDER_MODELS['nous']
- agent/model_metadata.py: DEFAULT_CONTEXT_LENGTHS (1M each)

## Validation
- tests/hermes_cli/test_models.py, test_xiaomi_provider.py, tests/agent/test_model_metadata.py: 173/173 passed