### PR TITLE
feat(terminal): add nsjail backend for lightweight local sandboxing

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1305,6 +1305,14 @@ DEFAULT_CONFIG = {
         # Env scrubbing (strips *_API_KEY, *_TOKEN, *_SECRET, ...) and the
         # tool whitelist apply identically in both modes.
         "mode": "project",
+        # Backend override for execute_code. Defaults to empty, which means
+        # ``execute_code`` shares ``terminal.backend`` (historical behavior).
+        # Set to one of local / nsjail / docker / singularity / modal /
+        # daytona / ssh to isolate LLM-authored scripts even when the
+        # terminal tool runs on the host directly — useful when you want the
+        # agent to edit your files freely (terminal=local) but confine
+        # throwaway code it generates (code_execution=nsjail).
+        "backend": "",
     },
 
     # Logging — controls file logging to ~/.hermes/logs/.
@@ -4823,6 +4831,7 @@ def set_config_value(key: str, value: str):
         "terminal.container_persistent": "TERMINAL_CONTAINER_PERSISTENT",
         "terminal.nsjail_config": "TERMINAL_NSJAIL_CONFIG",
         "terminal.nsjail_allow_net": "TERMINAL_NSJAIL_ALLOW_NET",
+        "code_execution.backend": "CODE_EXECUTION_ENV",
     }
     if key in _config_to_env_sync:
         save_env_value(_config_to_env_sync[key], str(value))

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -552,6 +552,21 @@ DEFAULT_CONFIG = {
         # Enabled by default for non-local backends (SSH); local is always opt-in
         # via TERMINAL_LOCAL_PERSISTENT env var.
         "persistent_shell": True,
+        # Nsjail backend — lightweight Linux-only namespace sandbox. No daemon,
+        # no image pull, ~20 ms per exec. Safer than local but much cheaper
+        # than Docker for short-lived code runs.
+        # Optional path to a user-supplied nsjail.cfg (protobuf text-format).
+        # When set, Hermes delegates all sandbox policy to that file and only
+        # injects the time limit. Leave empty to use Hermes's built-in defaults
+        # (rootfs read-only, writable cwd, tmpfs /tmp, no network).
+        "nsjail_config": "",
+        # Allow outbound network access from inside the jail. Off by default —
+        # nsjail puts the process in a fresh network namespace with no routes.
+        "nsjail_allow_net": False,
+        # Env var names to forward from the host into the jail (beyond PATH /
+        # HOME / LANG / locale defaults). Provider API keys are still filtered
+        # out by the shared subprocess-env blocklist.
+        "nsjail_forward_env": [],
     },
 
     "web": {
@@ -4806,6 +4821,8 @@ def set_config_value(key: str, value: str):
         "terminal.container_memory": "TERMINAL_CONTAINER_MEMORY",
         "terminal.container_disk": "TERMINAL_CONTAINER_DISK",
         "terminal.container_persistent": "TERMINAL_CONTAINER_PERSISTENT",
+        "terminal.nsjail_config": "TERMINAL_NSJAIL_CONFIG",
+        "terminal.nsjail_allow_net": "TERMINAL_NSJAIL_ALLOW_NET",
     }
     if key in _config_to_env_sync:
         save_env_value(_config_to_env_sync[key], str(value))

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2010,7 +2010,8 @@ TERMINAL_CONFIG_ENV_MAP = {
             "docker_volumes", "docker_env", "docker_mount_cwd_to_workspace", "docker_network",
             "docker_extra_args", "docker_shm_size", "docker_run_as_host_user", "docker_snap_compat",
             "docker_persist_across_processes", "docker_shared_container_key",
-            "docker_orphan_reaper", "sandbox_dir", "persistent_shell")}}
+            "docker_orphan_reaper", "sandbox_dir", "persistent_shell", "nsjail_config",
+            "nsjail_allow_net", "nsjail_forward_env")}}
 
 
 def _terminal_env_value(value: Any) -> str:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -344,6 +344,11 @@ DEFAULT_CONFIG = {
         # Keep a long-lived bash shell across execute() calls so cwd/env/shell variables survive.
         # Applies to non-local backends (SSH); local is opt-in via TERMINAL_LOCAL_PERSISTENT env.
         "persistent_shell": True,
+        # Linux-only lightweight namespace sandbox. Empty uses Hermes defaults;
+        # set a protobuf-text nsjail.cfg to supply a custom policy.
+        "nsjail_config": "",
+        "nsjail_allow_net": False,
+        "nsjail_forward_env": [],
     },
 
     "web": {
@@ -1785,6 +1790,9 @@ DEFAULT_CONFIG = {
         # rebound per cell — that runtime boundary is the cross-cell enforcement.
         "kernel_idle_timeout": 1800,
         "max_session_kernels": 4,
+        # Optional backend override for execute_code. Empty inherits terminal.backend.
+        # This permits terminal=local while routing generated Python through nsjail.
+        "backend": "",
     },
     # Tool Search: deferrable (MCP / non-core plugin) tools are replaced in the model-facing array
     # by tool_search / tool_describe / tool_call bridges and surfaced on demand. Core Hermes tools

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -1320,6 +1320,11 @@ def setup_terminal_backend(config: dict):
         backend_to_idx["singularity"] = next_idx
         next_idx += 1
 
+        terminal_choices.append("Nsjail - lightweight namespace sandbox (fast, no daemon)")
+        idx_to_backend[next_idx] = "nsjail"
+        backend_to_idx["nsjail"] = next_idx
+        next_idx += 1
+
     # Add keep current option
     keep_current_idx = next_idx
     terminal_choices.append(f"Keep current ({current_backend})")
@@ -1401,6 +1406,45 @@ def setup_terminal_backend(config: dict):
         image = prompt("  Container image", current_image)
         config["terminal"]["singularity_image"] = image
         save_env_value("TERMINAL_SINGULARITY_IMAGE", image)
+
+        _prompt_container_resources(config)
+
+    elif selected_backend == "nsjail":
+        print_success("Terminal backend: Nsjail")
+        print_info(
+            "Lightweight Linux namespace sandbox. No daemon, no container image, "
+            "~20 ms per command."
+        )
+
+        # Preflight: locate the binary so the user gets an install hint if missing.
+        from tools.environments.nsjail import find_nsjail as _find_nsjail
+        nsjail_bin = _find_nsjail()
+        if not nsjail_bin:
+            print_warning("nsjail not found in PATH!")
+            print_info(
+                "Install from source: https://github.com/google/nsjail "
+                "(or set HERMES_NSJAIL_BINARY to the absolute path)."
+            )
+        else:
+            print_info(f"nsjail found: {nsjail_bin}")
+
+        current_config_path = config.get("terminal", {}).get("nsjail_config", "")
+        cfg_prompt_hint = (
+            "  nsjail.cfg path (optional, empty for Hermes defaults)"
+        )
+        config_path = prompt(cfg_prompt_hint, current_config_path)
+        config["terminal"]["nsjail_config"] = config_path or ""
+        save_env_value("TERMINAL_NSJAIL_CONFIG", config_path or "")
+
+        current_allow_net = bool(
+            config.get("terminal", {}).get("nsjail_allow_net", False)
+        )
+        allow_net = prompt_yes_no(
+            "Allow network access from inside the jail? (default: deny)",
+            current_allow_net,
+        )
+        config["terminal"]["nsjail_allow_net"] = allow_net
+        save_env_value("TERMINAL_NSJAIL_ALLOW_NET", "true" if allow_net else "false")
 
         _prompt_container_resources(config)
 

--- a/hermes_cli/web_server_profiles.py
+++ b/hermes_cli/web_server_profiles.py
@@ -258,6 +258,7 @@ def _config_profile_scope(profile: Optional[str]):
 _TERMINAL_BACKENDS: List[Dict[str, str]] = [
     dict(zip(("name", "label", "description"), row)) for row in (
         ("local", "Local", "Run commands directly on this machine. No isolation."),
+        ("nsjail", "Nsjail", "Run commands in a lightweight Linux namespace sandbox without a daemon."),
         ("docker", "Docker",
          "Run commands in an isolated Docker container with a persistent workspace."),
         ("singularity", "Singularity / Apptainer",

--- a/tests/tools/test_code_execution_backend.py
+++ b/tests/tools/test_code_execution_backend.py
@@ -1,0 +1,125 @@
+"""Tests for execute_code backend resolution.
+
+The key contract: ``code_execution.backend`` (synced to the
+``CODE_EXECUTION_ENV`` environment variable) overrides ``terminal.backend``
+for the ``execute_code`` tool only. When unset, execute_code inherits the
+terminal backend.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from tools import code_execution_tool as ce
+
+
+@pytest.fixture(autouse=True)
+def _clear_env():
+    """Ensure no test inherits a stray CODE_EXECUTION_ENV / TERMINAL_ENV."""
+    saved = {k: os.environ.get(k) for k in ("CODE_EXECUTION_ENV", "TERMINAL_ENV")}
+    for k in ("CODE_EXECUTION_ENV", "TERMINAL_ENV"):
+        os.environ.pop(k, None)
+    yield
+    for k, v in saved.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+
+
+class TestBackendResolution:
+    def test_defaults_to_terminal_backend_when_override_unset(self):
+        """Historical behavior: execute_code inherits TERMINAL_ENV."""
+        with patch(
+            "tools.terminal_tool._get_env_config",
+            return_value={"env_type": "docker"},
+        ):
+            assert ce._resolve_code_execution_env_type() == "docker"
+
+    def test_override_wins_over_terminal_backend(self):
+        """Setting CODE_EXECUTION_ENV isolates execute_code from terminal."""
+        os.environ["CODE_EXECUTION_ENV"] = "nsjail"
+        with patch(
+            "tools.terminal_tool._get_env_config",
+            return_value={"env_type": "local"},
+        ):
+            assert ce._resolve_code_execution_env_type() == "nsjail"
+
+    def test_empty_override_is_ignored(self):
+        """An empty CODE_EXECUTION_ENV must not shadow the terminal value."""
+        os.environ["CODE_EXECUTION_ENV"] = ""
+        with patch(
+            "tools.terminal_tool._get_env_config",
+            return_value={"env_type": "singularity"},
+        ):
+            assert ce._resolve_code_execution_env_type() == "singularity"
+
+    def test_whitespace_override_is_ignored(self):
+        """Whitespace-only values (stray spaces in .env) don't count."""
+        os.environ["CODE_EXECUTION_ENV"] = "   "
+        with patch(
+            "tools.terminal_tool._get_env_config",
+            return_value={"env_type": "local"},
+        ):
+            assert ce._resolve_code_execution_env_type() == "local"
+
+    def test_falls_back_to_local_when_everything_missing(self):
+        """Safe default when neither terminal nor code_execution is set."""
+        with patch(
+            "tools.terminal_tool._get_env_config",
+            return_value={"env_type": None},
+        ):
+            assert ce._resolve_code_execution_env_type() == "local"
+
+
+class TestCacheNamespacing:
+    def test_separate_cache_key_when_backends_differ(self):
+        """When execute_code uses a different backend than terminal, the
+        cache must use a namespaced task_id so the two tools never reuse
+        each other's live environment."""
+        os.environ["CODE_EXECUTION_ENV"] = "nsjail"
+
+        # Patch the terminal_tool module-level state so _get_or_create_env
+        # hits our fake caches and environment factory.
+        active = {}
+        fake_config = {
+            "env_type": "local",
+            "docker_image": "", "singularity_image": "", "modal_image": "",
+            "daytona_image": "", "container_cpu": 1, "container_memory": 256,
+            "container_disk": 64, "container_persistent": True,
+            "docker_volumes": [], "nsjail_config": "", "nsjail_allow_net": False,
+            "nsjail_forward_env": [], "cwd": "/tmp", "timeout": 30,
+            "host_cwd": None,
+        }
+
+        captured_task_ids = []
+
+        def _fake_create_environment(env_type, image, cwd, timeout, **kwargs):
+            captured_task_ids.append((env_type, kwargs.get("task_id")))
+
+            class _StubEnv:
+                def cleanup(self):
+                    pass
+            return _StubEnv()
+
+        import threading as _threading
+        with patch("tools.terminal_tool._active_environments", active), \
+             patch("tools.terminal_tool._env_lock", _threading.RLock()), \
+             patch("tools.terminal_tool._create_environment", _fake_create_environment), \
+             patch("tools.terminal_tool._get_env_config", return_value=fake_config), \
+             patch("tools.terminal_tool._last_activity", {}), \
+             patch("tools.terminal_tool._start_cleanup_thread", lambda: None), \
+             patch("tools.terminal_tool._creation_locks", {}), \
+             patch("tools.terminal_tool._creation_locks_lock", _threading.RLock()), \
+             patch("tools.terminal_tool._task_env_overrides", {}):
+            env, env_type = ce._get_or_create_env("session-42")
+
+        assert env_type == "nsjail"
+        assert len(captured_task_ids) == 1
+        captured_env_type, captured_id = captured_task_ids[0]
+        assert captured_env_type == "nsjail"
+        # The cache key must be namespaced so it can't collide with a
+        # terminal-owned entry for the same raw task id.
+        assert captured_id.startswith("_code_exec/nsjail/")
+        assert "session-42" in captured_id

--- a/tests/tools/test_code_execution_backend.py
+++ b/tests/tools/test_code_execution_backend.py
@@ -1,0 +1,97 @@
+"""Tests for execute_code backend resolution.
+
+The key contract: ``code_execution.backend`` overrides ``terminal.backend``
+for the ``execute_code`` tool only. When unset, execute_code inherits the
+terminal backend.
+"""
+
+from unittest.mock import patch
+
+from tools import code_execution_tool as ce
+
+
+class TestBackendResolution:
+    def test_defaults_to_terminal_backend_when_override_unset(self):
+        """Historical behavior: execute_code inherits terminal.backend."""
+        with patch.object(ce, "_load_config", return_value={}), patch(
+            "tools.terminal_tool._get_env_config",
+            return_value={"env_type": "docker"},
+        ):
+            assert ce._resolve_code_execution_env_type() == "docker"
+
+    def test_override_wins_over_terminal_backend(self):
+        """Setting code_execution.backend isolates execute_code from terminal."""
+        with patch.object(ce, "_load_config", return_value={"backend": "nsjail"}), patch(
+            "tools.terminal_tool._get_env_config",
+            return_value={"env_type": "local"},
+        ):
+            assert ce._resolve_code_execution_env_type() == "nsjail"
+
+    def test_empty_override_is_ignored(self):
+        """An empty backend must not shadow the terminal value."""
+        with patch.object(ce, "_load_config", return_value={"backend": ""}), patch(
+            "tools.terminal_tool._get_env_config",
+            return_value={"env_type": "singularity"},
+        ):
+            assert ce._resolve_code_execution_env_type() == "singularity"
+
+    def test_whitespace_override_is_ignored(self):
+        """Whitespace-only values don't count."""
+        with patch.object(ce, "_load_config", return_value={"backend": "   "}), patch(
+            "tools.terminal_tool._get_env_config",
+            return_value={"env_type": "local"},
+        ):
+            assert ce._resolve_code_execution_env_type() == "local"
+
+    def test_falls_back_to_local_when_everything_missing(self):
+        """Safe default when neither terminal nor code_execution is set."""
+        with patch.object(ce, "_load_config", return_value={}), patch(
+            "tools.terminal_tool._get_env_config",
+            return_value={"env_type": None},
+        ):
+            assert ce._resolve_code_execution_env_type() == "local"
+
+
+class TestCacheNamespacing:
+    def test_separate_cache_key_when_backends_differ(self):
+        """A distinct backend gets a namespaced task id and separate env."""
+        active = {}
+        fake_config = {
+            "env_type": "local",
+            "docker_image": "", "singularity_image": "", "modal_image": "",
+            "daytona_image": "", "container_cpu": 1, "container_memory": 256,
+            "container_disk": 64, "container_persistent": True,
+            "docker_volumes": [], "nsjail_config": "", "nsjail_allow_net": False,
+            "nsjail_forward_env": [], "cwd": "/tmp", "timeout": 30,
+            "host_cwd": None,
+        }
+        captured_task_ids = []
+
+        def _fake_create_environment(env_type, image, cwd, timeout, **kwargs):
+            captured_task_ids.append((env_type, kwargs.get("task_id")))
+
+            class _StubEnv:
+                def cleanup(self):
+                    pass
+
+            return _StubEnv()
+
+        import threading as _threading
+        with patch.object(ce, "_load_config", return_value={"backend": "nsjail"}), \
+             patch("tools.terminal_tool._active_environments", active), \
+             patch("tools.terminal_tool._env_lock", _threading.RLock()), \
+             patch("tools.terminal_tool_backends._create_environment", _fake_create_environment), \
+             patch("tools.terminal_tool._get_env_config", return_value=fake_config), \
+             patch("tools.terminal_tool._last_activity", {}), \
+             patch("tools.terminal_tool._start_cleanup_thread", lambda: None), \
+             patch("tools.terminal_tool._creation_locks", {}), \
+             patch("tools.terminal_tool._creation_locks_lock", _threading.RLock()), \
+             patch("tools.terminal_tool.resolve_task_overrides", return_value={}):
+            env, env_type = ce._get_or_create_env("session-42")
+
+        assert env_type == "nsjail"
+        assert len(captured_task_ids) == 1
+        captured_env_type, captured_id = captured_task_ids[0]
+        assert captured_env_type == "nsjail"
+        assert captured_id.startswith("_code_exec/nsjail/")
+        assert "session-42" in captured_id

--- a/tests/tools/test_nsjail_environment.py
+++ b/tests/tools/test_nsjail_environment.py
@@ -16,8 +16,9 @@ from tools.environments import nsjail as nsjail_mod
 
 
 @pytest.fixture(autouse=True)
-def _reset_cache():
+def _reset_cache(monkeypatch):
     nsjail_mod._nsjail_executable = None
+    monkeypatch.delenv("HERMES_NSJAIL_BINARY", raising=False)
     yield
     nsjail_mod._nsjail_executable = None
 

--- a/tests/tools/test_nsjail_environment.py
+++ b/tests/tools/test_nsjail_environment.py
@@ -1,0 +1,170 @@
+"""Tests for NsjailEnvironment CLI-arg construction and preflight.
+
+These tests stub out the real nsjail binary and sandbox process spawn — they
+verify the Python-side contract (which flags Hermes asks nsjail for, what the
+backend does when nsjail is missing/broken, how config_file mode behaves)
+without actually entering a Linux namespace, so they run on any OS.
+"""
+
+import os
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.environments import nsjail as nsjail_mod
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache(monkeypatch):
+    nsjail_mod._nsjail_executable = None
+    monkeypatch.delenv("HERMES_NSJAIL_BINARY", raising=False)
+    yield
+    nsjail_mod._nsjail_executable = None
+
+
+@pytest.fixture
+def _fake_nsjail_preflight():
+    """Pretend nsjail exists on PATH and responds to --help successfully."""
+    fake_help = subprocess.CompletedProcess(
+        args=["/usr/bin/nsjail", "--help"],
+        returncode=0,
+        stdout="Usage: nsjail [options] -- cmd\n",
+        stderr="",
+    )
+    with patch("tools.environments.nsjail.shutil.which", return_value="/usr/bin/nsjail"), \
+         patch("tools.environments.nsjail._IS_LINUX", True), \
+         patch("tools.environments.nsjail.subprocess.run", return_value=fake_help):
+        yield
+
+
+def _make_env(tmp_path, **kwargs):
+    """Construct an NsjailEnvironment with init_session() stubbed out.
+
+    init_session() would call _run_bash() which spawns the real nsjail;
+    we skip it so the test stays hermetic.
+    """
+    with patch.object(nsjail_mod.NsjailEnvironment, "init_session", lambda self: None):
+        return nsjail_mod.NsjailEnvironment(
+            cwd=str(tmp_path), timeout=30, **kwargs
+        )
+
+
+class TestPreflight:
+    def test_missing_binary_raises(self):
+        with patch("tools.environments.nsjail.shutil.which", return_value=None), \
+             patch("tools.environments.nsjail._IS_LINUX", True):
+            os.environ.pop("HERMES_NSJAIL_BINARY", None)
+            with pytest.raises(RuntimeError, match="nsjail binary not found"):
+                nsjail_mod._ensure_nsjail_available()
+
+    def test_non_linux_raises(self):
+        with patch("tools.environments.nsjail._IS_LINUX", False):
+            with pytest.raises(RuntimeError, match="only supported on Linux"):
+                nsjail_mod._ensure_nsjail_available()
+
+    def test_help_timeout_raises(self):
+        with patch("tools.environments.nsjail.shutil.which", return_value="/usr/bin/nsjail"), \
+             patch("tools.environments.nsjail._IS_LINUX", True), \
+             patch(
+                 "tools.environments.nsjail.subprocess.run",
+                 side_effect=subprocess.TimeoutExpired(cmd="nsjail", timeout=5),
+             ):
+            with pytest.raises(RuntimeError, match="timed out"):
+                nsjail_mod._ensure_nsjail_available()
+
+
+class TestNsjailArgs:
+    def test_defaults_include_rootfs_ro_and_cwd_rw(self, tmp_path, _fake_nsjail_preflight):
+        env = _make_env(tmp_path)
+        args = env._build_nsjail_args(timeout=30)
+
+        assert args[0] == "/usr/bin/nsjail"
+        assert "-Mo" in args
+        assert "--quiet" in args
+        assert "--bindmount_ro" in args and "/" in args
+        # cwd bindmount uses the host path verbatim (rw inside the jail).
+        assert f"--bindmount" in args
+        assert str(tmp_path) in args
+        # time_limit is timeout + cushion (5s).
+        tl_idx = args.index("--time_limit")
+        assert int(args[tl_idx + 1]) >= 30
+
+    def test_network_off_by_default(self, tmp_path, _fake_nsjail_preflight):
+        env = _make_env(tmp_path)
+        args = env._build_nsjail_args(timeout=30)
+        assert "--disable_clone_newnet" not in args
+
+    def test_allow_net_true_disables_new_netns(self, tmp_path, _fake_nsjail_preflight):
+        env = _make_env(tmp_path, allow_net=True)
+        args = env._build_nsjail_args(timeout=30)
+        assert "--disable_clone_newnet" in args
+
+    def test_memory_limit_passed_as_rlimit_as(self, tmp_path, _fake_nsjail_preflight):
+        env = _make_env(tmp_path, memory=777)
+        args = env._build_nsjail_args(timeout=30)
+        i = args.index("--rlimit_as")
+        assert args[i + 1] == "777"
+
+    def test_disk_limit_passed_as_rlimit_fsize(self, tmp_path, _fake_nsjail_preflight):
+        env = _make_env(tmp_path, disk=555)
+        args = env._build_nsjail_args(timeout=30)
+        i = args.index("--rlimit_fsize")
+        assert args[i + 1] == "555"
+
+    def test_provider_keys_stripped_from_env(self, tmp_path, _fake_nsjail_preflight):
+        with patch.dict(os.environ, {
+            "OPENAI_API_KEY": "sk-should-be-stripped",
+            "PATH": "/usr/bin",
+        }, clear=False):
+            env = _make_env(tmp_path)
+            args = env._build_nsjail_args(timeout=30)
+
+        env_flags = [args[i + 1] for i, a in enumerate(args) if a == "--env"]
+        assert not any("OPENAI_API_KEY" in v for v in env_flags)
+        assert any(v.startswith("PATH=") for v in env_flags)
+
+    def test_forward_env_includes_named_var(self, tmp_path, _fake_nsjail_preflight):
+        with patch.dict(os.environ, {"CUSTOM_RESEARCH_TOKEN": "xyz"}, clear=False):
+            env = _make_env(tmp_path, forward_env=["CUSTOM_RESEARCH_TOKEN"])
+            args = env._build_nsjail_args(timeout=30)
+        env_flags = [args[i + 1] for i, a in enumerate(args) if a == "--env"]
+        assert any(v == "CUSTOM_RESEARCH_TOKEN=xyz" for v in env_flags)
+
+
+class TestConfigFileMode:
+    def test_config_file_overrides_default_args(self, tmp_path, _fake_nsjail_preflight):
+        cfg = tmp_path / "jail.cfg"
+        cfg.write_text("# nsjail text-format config\n")
+
+        env = _make_env(tmp_path, config_file=str(cfg))
+        args = env._build_nsjail_args(timeout=30)
+
+        # Config mode: only executable, --config <path>, --time_limit.
+        assert "--config" in args
+        assert str(cfg) in args
+        assert "--bindmount_ro" not in args
+        assert "--tmpfsmount" not in args
+
+    def test_missing_config_file_raises(self, tmp_path, _fake_nsjail_preflight):
+        with pytest.raises(RuntimeError, match="non-existent file"):
+            _make_env(tmp_path, config_file=str(tmp_path / "nope.cfg"))
+
+
+class TestInitialCwdPin:
+    def test_cwd_change_does_not_change_rw_bindmount(self, tmp_path, _fake_nsjail_preflight):
+        """If the user cd's elsewhere mid-session, the new location must stay
+        read-only. Only ``--cwd`` updates; ``--bindmount`` keeps the original."""
+        env = _make_env(tmp_path)
+        env.cwd = "/etc"
+        args = env._build_nsjail_args(timeout=30)
+
+        def _values_after(flag: str) -> list[str]:
+            return [args[i + 1] for i, a in enumerate(args) if a == flag]
+
+        rw_bindmounts = [b for b in _values_after("--bindmount") if ":" not in b]
+        start_cwds = _values_after("--cwd")
+
+        assert str(tmp_path) in rw_bindmounts  # initial cwd still rw-mounted
+        assert "/etc" not in rw_bindmounts      # new cwd NOT bindmounted rw
+        assert start_cwds == ["/etc"]           # but process starts in /etc

--- a/tests/tools/test_nsjail_environment.py
+++ b/tests/tools/test_nsjail_environment.py
@@ -1,0 +1,169 @@
+"""Tests for NsjailEnvironment CLI-arg construction and preflight.
+
+These tests stub out the real nsjail binary and sandbox process spawn — they
+verify the Python-side contract (which flags Hermes asks nsjail for, what the
+backend does when nsjail is missing/broken, how config_file mode behaves)
+without actually entering a Linux namespace, so they run on any OS.
+"""
+
+import os
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.environments import nsjail as nsjail_mod
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    nsjail_mod._nsjail_executable = None
+    yield
+    nsjail_mod._nsjail_executable = None
+
+
+@pytest.fixture
+def _fake_nsjail_preflight():
+    """Pretend nsjail exists on PATH and responds to --help successfully."""
+    fake_help = subprocess.CompletedProcess(
+        args=["/usr/bin/nsjail", "--help"],
+        returncode=0,
+        stdout="Usage: nsjail [options] -- cmd\n",
+        stderr="",
+    )
+    with patch("tools.environments.nsjail.shutil.which", return_value="/usr/bin/nsjail"), \
+         patch("tools.environments.nsjail._IS_LINUX", True), \
+         patch("tools.environments.nsjail.subprocess.run", return_value=fake_help):
+        yield
+
+
+def _make_env(tmp_path, **kwargs):
+    """Construct an NsjailEnvironment with init_session() stubbed out.
+
+    init_session() would call _run_bash() which spawns the real nsjail;
+    we skip it so the test stays hermetic.
+    """
+    with patch.object(nsjail_mod.NsjailEnvironment, "init_session", lambda self: None):
+        return nsjail_mod.NsjailEnvironment(
+            cwd=str(tmp_path), timeout=30, **kwargs
+        )
+
+
+class TestPreflight:
+    def test_missing_binary_raises(self):
+        with patch("tools.environments.nsjail.shutil.which", return_value=None), \
+             patch("tools.environments.nsjail._IS_LINUX", True):
+            os.environ.pop("HERMES_NSJAIL_BINARY", None)
+            with pytest.raises(RuntimeError, match="nsjail binary not found"):
+                nsjail_mod._ensure_nsjail_available()
+
+    def test_non_linux_raises(self):
+        with patch("tools.environments.nsjail._IS_LINUX", False):
+            with pytest.raises(RuntimeError, match="only supported on Linux"):
+                nsjail_mod._ensure_nsjail_available()
+
+    def test_help_timeout_raises(self):
+        with patch("tools.environments.nsjail.shutil.which", return_value="/usr/bin/nsjail"), \
+             patch("tools.environments.nsjail._IS_LINUX", True), \
+             patch(
+                 "tools.environments.nsjail.subprocess.run",
+                 side_effect=subprocess.TimeoutExpired(cmd="nsjail", timeout=5),
+             ):
+            with pytest.raises(RuntimeError, match="timed out"):
+                nsjail_mod._ensure_nsjail_available()
+
+
+class TestNsjailArgs:
+    def test_defaults_include_rootfs_ro_and_cwd_rw(self, tmp_path, _fake_nsjail_preflight):
+        env = _make_env(tmp_path)
+        args = env._build_nsjail_args(timeout=30)
+
+        assert args[0] == "/usr/bin/nsjail"
+        assert "-Mo" in args
+        assert "--quiet" in args
+        assert "--bindmount_ro" in args and "/" in args
+        # cwd bindmount uses the host path verbatim (rw inside the jail).
+        assert f"--bindmount" in args
+        assert str(tmp_path) in args
+        # time_limit is timeout + cushion (5s).
+        tl_idx = args.index("--time_limit")
+        assert int(args[tl_idx + 1]) >= 30
+
+    def test_network_off_by_default(self, tmp_path, _fake_nsjail_preflight):
+        env = _make_env(tmp_path)
+        args = env._build_nsjail_args(timeout=30)
+        assert "--disable_clone_newnet" not in args
+
+    def test_allow_net_true_disables_new_netns(self, tmp_path, _fake_nsjail_preflight):
+        env = _make_env(tmp_path, allow_net=True)
+        args = env._build_nsjail_args(timeout=30)
+        assert "--disable_clone_newnet" in args
+
+    def test_memory_limit_passed_as_rlimit_as(self, tmp_path, _fake_nsjail_preflight):
+        env = _make_env(tmp_path, memory=777)
+        args = env._build_nsjail_args(timeout=30)
+        i = args.index("--rlimit_as")
+        assert args[i + 1] == "777"
+
+    def test_disk_limit_passed_as_rlimit_fsize(self, tmp_path, _fake_nsjail_preflight):
+        env = _make_env(tmp_path, disk=555)
+        args = env._build_nsjail_args(timeout=30)
+        i = args.index("--rlimit_fsize")
+        assert args[i + 1] == "555"
+
+    def test_provider_keys_stripped_from_env(self, tmp_path, _fake_nsjail_preflight):
+        with patch.dict(os.environ, {
+            "OPENAI_API_KEY": "sk-should-be-stripped",
+            "PATH": "/usr/bin",
+        }, clear=False):
+            env = _make_env(tmp_path)
+            args = env._build_nsjail_args(timeout=30)
+
+        env_flags = [args[i + 1] for i, a in enumerate(args) if a == "--env"]
+        assert not any("OPENAI_API_KEY" in v for v in env_flags)
+        assert any(v.startswith("PATH=") for v in env_flags)
+
+    def test_forward_env_includes_named_var(self, tmp_path, _fake_nsjail_preflight):
+        with patch.dict(os.environ, {"CUSTOM_RESEARCH_TOKEN": "xyz"}, clear=False):
+            env = _make_env(tmp_path, forward_env=["CUSTOM_RESEARCH_TOKEN"])
+            args = env._build_nsjail_args(timeout=30)
+        env_flags = [args[i + 1] for i, a in enumerate(args) if a == "--env"]
+        assert any(v == "CUSTOM_RESEARCH_TOKEN=xyz" for v in env_flags)
+
+
+class TestConfigFileMode:
+    def test_config_file_overrides_default_args(self, tmp_path, _fake_nsjail_preflight):
+        cfg = tmp_path / "jail.cfg"
+        cfg.write_text("# nsjail text-format config\n")
+
+        env = _make_env(tmp_path, config_file=str(cfg))
+        args = env._build_nsjail_args(timeout=30)
+
+        # Config mode: only executable, --config <path>, --time_limit.
+        assert "--config" in args
+        assert str(cfg) in args
+        assert "--bindmount_ro" not in args
+        assert "--tmpfsmount" not in args
+
+    def test_missing_config_file_raises(self, tmp_path, _fake_nsjail_preflight):
+        with pytest.raises(RuntimeError, match="non-existent file"):
+            _make_env(tmp_path, config_file=str(tmp_path / "nope.cfg"))
+
+
+class TestInitialCwdPin:
+    def test_cwd_change_does_not_change_rw_bindmount(self, tmp_path, _fake_nsjail_preflight):
+        """If the user cd's elsewhere mid-session, the new location must stay
+        read-only. Only ``--cwd`` updates; ``--bindmount`` keeps the original."""
+        env = _make_env(tmp_path)
+        env.cwd = "/etc"
+        args = env._build_nsjail_args(timeout=30)
+
+        def _values_after(flag: str) -> list[str]:
+            return [args[i + 1] for i, a in enumerate(args) if a == flag]
+
+        rw_bindmounts = [b for b in _values_after("--bindmount") if ":" not in b]
+        start_cwds = _values_after("--cwd")
+
+        assert str(tmp_path) in rw_bindmounts  # initial cwd still rw-mounted
+        assert "/etc" not in rw_bindmounts      # new cwd NOT bindmounted rw
+        assert start_cwds == ["/etc"]           # but process starts in /etc

--- a/tests/tools/test_nsjail_find.py
+++ b/tests/tools/test_nsjail_find.py
@@ -1,0 +1,67 @@
+"""Tests for tools.environments.nsjail.find_nsjail — nsjail CLI discovery."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from tools.environments import nsjail as nsjail_mod
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    """Clear the module-level nsjail executable cache between tests."""
+    nsjail_mod._nsjail_executable = None
+    yield
+    nsjail_mod._nsjail_executable = None
+
+
+class TestFindNsjail:
+    def test_found_via_shutil_which(self):
+        with patch("tools.environments.nsjail.shutil.which", return_value="/usr/local/bin/nsjail"):
+            result = nsjail_mod.find_nsjail()
+        assert result == "/usr/local/bin/nsjail"
+
+    def test_returns_none_when_not_found(self):
+        with patch("tools.environments.nsjail.shutil.which", return_value=None), \
+             patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("HERMES_NSJAIL_BINARY", None)
+            result = nsjail_mod.find_nsjail()
+        assert result is None
+
+    def test_caches_result(self):
+        with patch("tools.environments.nsjail.shutil.which", return_value="/usr/bin/nsjail"):
+            first = nsjail_mod.find_nsjail()
+        # Second call should use cache, not call shutil.which again.
+        with patch("tools.environments.nsjail.shutil.which", return_value=None):
+            second = nsjail_mod.find_nsjail()
+        assert first == second == "/usr/bin/nsjail"
+
+    def test_env_var_override_takes_precedence(self, tmp_path):
+        """HERMES_NSJAIL_BINARY overrides PATH discovery."""
+        fake_binary = tmp_path / "nsjail"
+        fake_binary.write_text("#!/bin/sh\n")
+        fake_binary.chmod(0o755)
+
+        with patch.dict(os.environ, {"HERMES_NSJAIL_BINARY": str(fake_binary)}), \
+             patch("tools.environments.nsjail.shutil.which", return_value="/usr/bin/nsjail"):
+            result = nsjail_mod.find_nsjail()
+        assert result == str(fake_binary)
+
+    def test_env_var_override_ignored_when_nonexistent(self):
+        """A dangling HERMES_NSJAIL_BINARY must not preempt PATH lookup."""
+        with patch.dict(os.environ, {"HERMES_NSJAIL_BINARY": "/does/not/exist/nsjail"}), \
+             patch("tools.environments.nsjail.shutil.which", return_value="/usr/bin/nsjail"):
+            result = nsjail_mod.find_nsjail()
+        assert result == "/usr/bin/nsjail"
+
+    def test_env_var_override_ignored_when_not_executable(self, tmp_path):
+        """A non-executable file at HERMES_NSJAIL_BINARY must not be accepted."""
+        non_exec = tmp_path / "nsjail"
+        non_exec.write_text("#!/bin/sh\n")
+        non_exec.chmod(0o644)
+
+        with patch.dict(os.environ, {"HERMES_NSJAIL_BINARY": str(non_exec)}), \
+             patch("tools.environments.nsjail.shutil.which", return_value="/usr/bin/nsjail"):
+            result = nsjail_mod.find_nsjail()
+        assert result == "/usr/bin/nsjail"

--- a/tests/tools/test_nsjail_find.py
+++ b/tests/tools/test_nsjail_find.py
@@ -9,9 +9,11 @@ from tools.environments import nsjail as nsjail_mod
 
 
 @pytest.fixture(autouse=True)
-def _reset_cache():
-    """Clear the module-level nsjail executable cache between tests."""
+def _reset_cache(monkeypatch):
+    """Clear the module-level cache and any inherited HERMES_NSJAIL_BINARY
+    env var so tests see only what they explicitly set."""
     nsjail_mod._nsjail_executable = None
+    monkeypatch.delenv("HERMES_NSJAIL_BINARY", raising=False)
     yield
     nsjail_mod._nsjail_executable = None
 

--- a/tests/tools/test_nsjail_find.py
+++ b/tests/tools/test_nsjail_find.py
@@ -1,0 +1,69 @@
+"""Tests for tools.environments.nsjail.find_nsjail — nsjail CLI discovery."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from tools.environments import nsjail as nsjail_mod
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache(monkeypatch):
+    """Clear the module-level cache and any inherited HERMES_NSJAIL_BINARY
+    env var so tests see only what they explicitly set."""
+    nsjail_mod._nsjail_executable = None
+    monkeypatch.delenv("HERMES_NSJAIL_BINARY", raising=False)
+    yield
+    nsjail_mod._nsjail_executable = None
+
+
+class TestFindNsjail:
+    def test_found_via_shutil_which(self):
+        with patch("tools.environments.nsjail.shutil.which", return_value="/usr/local/bin/nsjail"):
+            result = nsjail_mod.find_nsjail()
+        assert result == "/usr/local/bin/nsjail"
+
+    def test_returns_none_when_not_found(self):
+        with patch("tools.environments.nsjail.shutil.which", return_value=None), \
+             patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("HERMES_NSJAIL_BINARY", None)
+            result = nsjail_mod.find_nsjail()
+        assert result is None
+
+    def test_caches_result(self):
+        with patch("tools.environments.nsjail.shutil.which", return_value="/usr/bin/nsjail"):
+            first = nsjail_mod.find_nsjail()
+        # Second call should use cache, not call shutil.which again.
+        with patch("tools.environments.nsjail.shutil.which", return_value=None):
+            second = nsjail_mod.find_nsjail()
+        assert first == second == "/usr/bin/nsjail"
+
+    def test_env_var_override_takes_precedence(self, tmp_path):
+        """HERMES_NSJAIL_BINARY overrides PATH discovery."""
+        fake_binary = tmp_path / "nsjail"
+        fake_binary.write_text("#!/bin/sh\n")
+        fake_binary.chmod(0o755)
+
+        with patch.dict(os.environ, {"HERMES_NSJAIL_BINARY": str(fake_binary)}), \
+             patch("tools.environments.nsjail.shutil.which", return_value="/usr/bin/nsjail"):
+            result = nsjail_mod.find_nsjail()
+        assert result == str(fake_binary)
+
+    def test_env_var_override_ignored_when_nonexistent(self):
+        """A dangling HERMES_NSJAIL_BINARY must not preempt PATH lookup."""
+        with patch.dict(os.environ, {"HERMES_NSJAIL_BINARY": "/does/not/exist/nsjail"}), \
+             patch("tools.environments.nsjail.shutil.which", return_value="/usr/bin/nsjail"):
+            result = nsjail_mod.find_nsjail()
+        assert result == "/usr/bin/nsjail"
+
+    def test_env_var_override_ignored_when_not_executable(self, tmp_path):
+        """A non-executable file at HERMES_NSJAIL_BINARY must not be accepted."""
+        non_exec = tmp_path / "nsjail"
+        non_exec.write_text("#!/bin/sh\n")
+        non_exec.chmod(0o644)
+
+        with patch.dict(os.environ, {"HERMES_NSJAIL_BINARY": str(non_exec)}), \
+             patch("tools.environments.nsjail.shutil.which", return_value="/usr/bin/nsjail"):
+            result = nsjail_mod.find_nsjail()
+        assert result == "/usr/bin/nsjail"

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -833,7 +833,7 @@ def check_dangerous_command(command: str, env_type: str,
     Returns:
         {"approved": True/False, "message": str or None, ...}
     """
-    if env_type in ("docker", "singularity", "modal", "daytona", "vercel_sandbox"):
+    if env_type in ("nsjail", "docker", "singularity", "modal", "daytona", "vercel_sandbox"):
         return {"approved": True, "message": None}
 
     # Hardline floor: commands with no recovery path (rm -rf /, mkfs, dd
@@ -958,7 +958,7 @@ def check_all_command_guards(command: str, env_type: str,
     other was shown to the user.
     """
     # Skip containers for both checks
-    if env_type in ("docker", "singularity", "modal", "daytona", "vercel_sandbox"):
+    if env_type in ("nsjail", "docker", "singularity", "modal", "daytona", "vercel_sandbox"):
         return {"approved": True, "message": None}
 
     # Hardline floor: unconditional block for catastrophic commands

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -870,7 +870,9 @@ def _should_skip_container_guards(env_type: str, has_host_access: bool = False) 
     exception once host paths are bind-mounted: ``rm -rf /workspace`` then reaches host files."""
     if env_type == "docker":
         return not has_host_access
-    return env_type in ("singularity", "modal", "daytona", "vercel_sandbox")
+    if env_type in ("nsjail", "singularity", "modal", "daytona", "vercel_sandbox"):
+        return True
+    return False
 
 
 def _user_deny_block(command: str) -> dict | None:

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -458,27 +458,58 @@ def _rpc_server_loop(
 # Remote execution support (file-based RPC via terminal backend)
 # ---------------------------------------------------------------------------
 
-def _get_or_create_env(task_id: str):
-    """Get or create the terminal environment for *task_id*.
+def _resolve_code_execution_env_type() -> str:
+    """Resolve the effective backend for ``execute_code``.
 
-    Reuses the same environment (container/sandbox/SSH session) that the
-    terminal and file tools use, creating one if it doesn't exist yet.
+    Precedence:
+    1. ``CODE_EXECUTION_ENV`` (synced from ``code_execution.backend`` in
+       ``config.yaml``). When set, lets ``execute_code`` use a stricter
+       sandbox independently of the terminal backend — e.g. keep
+       ``terminal.backend=local`` so the agent can edit host files
+       directly, while routing LLM-authored scripts through ``nsjail``.
+    2. ``TERMINAL_ENV`` / ``terminal.backend`` fallback — preserves the
+       historical behavior where both tools shared a single backend.
+    """
+    from tools.terminal_tool import _get_env_config
+    override = os.getenv("CODE_EXECUTION_ENV", "").strip()
+    if override:
+        return override
+    return _get_env_config().get("env_type") or "local"
+
+
+def _get_or_create_env(task_id: str):
+    """Get or create the ``execute_code`` environment for *task_id*.
+
+    When ``code_execution.backend`` matches ``terminal.backend``, shares the
+    same live environment the terminal and file tools use (backward-compat
+    default). When it differs, uses a namespaced cache key so the two tools
+    keep separate sandboxes — so e.g. terminal-on-local never accidentally
+    reuses a previously-created nsjail environment owned by execute_code.
     Returns ``(env, env_type)`` tuple.
     """
     from tools.terminal_tool import (
         _active_environments, _env_lock, _create_environment,
         _get_env_config, _last_activity, _start_cleanup_thread,
         _creation_locks, _creation_locks_lock, _task_env_overrides,
-        _resolve_container_task_id,
     )
 
-    effective_task_id = _resolve_container_task_id(task_id)
+    # Resolve the effective backend once per call. Everything below threads
+    # this through so we never mix up terminal's env_type with our own.
+    base_config = _get_env_config()
+    terminal_env_type = base_config["env_type"]
+    env_type = _resolve_code_execution_env_type()
+
+    raw_task_id = task_id or "default"
+    if env_type != terminal_env_type:
+        effective_task_id = f"_code_exec/{env_type}/{raw_task_id}"
+    else:
+        effective_task_id = raw_task_id
 
     # Fast path: environment already exists
     with _env_lock:
         if effective_task_id in _active_environments:
             _last_activity[effective_task_id] = time.time()
-            return _active_environments[effective_task_id], _get_env_config()["env_type"]
+            return _active_environments[effective_task_id], env_type
 
     # Slow path: create environment (same pattern as file_tools._get_file_ops)
     with _creation_locks_lock:
@@ -490,10 +521,9 @@ def _get_or_create_env(task_id: str):
         with _env_lock:
             if effective_task_id in _active_environments:
                 _last_activity[effective_task_id] = time.time()
-                return _active_environments[effective_task_id], _get_env_config()["env_type"]
+                return _active_environments[effective_task_id], env_type
 
-        config = _get_env_config()
-        env_type = config["env_type"]
+        config = base_config
         overrides = _task_env_overrides.get(effective_task_id, {})
 
         if env_type == "docker":
@@ -963,9 +993,10 @@ def execute_code(
     if not code or not code.strip():
         return tool_error("No code provided.")
 
-    # Dispatch: remote backends use file-based RPC, local uses UDS
-    from tools.terminal_tool import _get_env_config
-    env_type = _get_env_config()["env_type"]
+    # Dispatch: remote backends use file-based RPC, local uses UDS.
+    # Resolve the code_execution backend independently of terminal.backend
+    # so users can keep terminal on local while sandboxing execute_code.
+    env_type = _resolve_code_execution_env_type()
     if env_type != "local":
         return _execute_remote(code, task_id, enabled_tools)
 

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -510,7 +510,7 @@ def _get_or_create_env(task_id: str):
         cwd = overrides.get("cwd") or config["cwd"]
 
         container_config = None
-        if env_type in ("docker", "singularity", "modal", "daytona", "vercel_sandbox"):
+        if env_type in ("docker", "singularity", "modal", "daytona", "vercel_sandbox", "nsjail"):
             container_config = {
                 "container_cpu": config.get("container_cpu", 1),
                 "container_memory": config.get("container_memory", 5120),
@@ -519,6 +519,9 @@ def _get_or_create_env(task_id: str):
                 "vercel_runtime": config.get("vercel_runtime", ""),
                 "docker_volumes": config.get("docker_volumes", []),
                 "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
+                "nsjail_config": config.get("nsjail_config", ""),
+                "nsjail_allow_net": config.get("nsjail_allow_net", False),
+                "nsjail_forward_env": config.get("nsjail_forward_env", []),
             }
 
         ssh_config = None

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -100,18 +100,36 @@ def _spill_full_stdout(stdout_text: str) -> Optional[str]:
         return None
 
 
+def _resolve_code_execution_env_type() -> str:
+    """Resolve the execute_code backend: explicit code_execution.backend first,
+    then the terminal backend for backward compatibility."""
+    override = str(_load_config().get("backend", "") or "").strip().lower()
+    if override:
+        return override
+    try:
+        from tools.terminal_tool import _get_env_config
+        return str(_get_env_config().get("env_type") or "local").strip().lower()
+    except Exception:
+        return "local"
+
+
 def check_sandbox_requirements() -> bool:
-    """check_fn: available unless the vercel_sandbox backend fails its own checks."""
+    """check_fn: validate the effective execute_code backend when it has one."""
     if not SANDBOX_AVAILABLE:
         return False
     try:
         from tools.terminal_tool import _get_env_config
-        from tools.terminal_tool_backends import _check_vercel_sandbox_requirements
+        from tools.terminal_tool_backends import _check_nsjail, _check_vercel
         config = _get_env_config()
     except Exception:
         logger.debug("Could not resolve terminal config for execute_code availability", exc_info=True)
         return False
-    return config.get("env_type") != "vercel_sandbox" or _check_vercel_sandbox_requirements(config)
+    env_type = _resolve_code_execution_env_type()
+    if env_type == "vercel_sandbox":
+        return _check_vercel(config)
+    if env_type == "nsjail":
+        return _check_nsjail(config)
+    return True
 
 
 # ---- hermes_tools.py code generator ----
@@ -398,54 +416,82 @@ def _call(tool_name, args):
 # ---- Remote execution support (file-based RPC via terminal backend) ----
 
 def _get_or_create_env(task_id: str):
-    """``(env, env_type)`` — the environment the terminal/file tools share for *task_id*, created on
-    first use (same double-checked per-task lock pattern as file_tools._get_file_ops)."""
-    from tools.terminal_tool_backends import _container_config_from_config, _create_environment, _ssh_config_from_config
+    """Return the execute_code environment, optionally separate from terminal.backend.
+
+    An explicit ``code_execution.backend`` gets a namespaced cache key so it cannot
+    reuse the terminal tool's environment for the same task. Empty inherits the
+    terminal backend for backward compatibility.
+    """
+    from tools.terminal_tool_backends import (
+        _container_config_from_config, _create_environment, _ssh_config_from_config,
+    )
     from tools.terminal_tool import (
         _active_environments, _env_lock, _get_env_config, _last_activity,
-        _start_cleanup_thread, _creation_locks, _creation_locks_lock, _task_env_overrides,
-        _resolve_container_task_id, _resolve_task_host_cwd, _is_container_backend, _select_image,
+        _start_cleanup_thread, _creation_locks, _creation_locks_lock,
+        _resolve_container_task_id, _resolve_task_host_cwd, _is_container_backend,
+        _select_image, resolve_task_overrides,
     )
-    effective_task_id = _resolve_container_task_id(task_id)
+
+    base_config = dict(_get_env_config())
+    terminal_env_type = str(base_config.get("env_type") or "local").strip().lower()
+    env_type = _resolve_code_execution_env_type()
+    raw_task_id = task_id or "default"
+    effective_task_id = (
+        f"_code_exec/{env_type}/{raw_task_id}"
+        if env_type != terminal_env_type
+        else _resolve_container_task_id(raw_task_id)
+    )
+
     def _cached():
         with _env_lock:
             env = _active_environments.get(effective_task_id)
             if env is not None:
                 _last_activity[effective_task_id] = time.time()
         return env
+
     env = _cached()
     if env is not None:
-        return env, _get_env_config()["env_type"]
+        return env, env_type
     with _creation_locks_lock:
         task_lock = _creation_locks.setdefault(effective_task_id, threading.Lock())
     with task_lock:
         env = _cached()
         if env is not None:
-            return env, _get_env_config()["env_type"]
-        config = _get_env_config()
-        env_type = config["env_type"]
-        overrides = _task_env_overrides.get(effective_task_id, {})
-        container_config = None
-        if _is_container_backend(env_type):
-            # Shared shaper: execute_code's own key subset dropped docker_extra_args / docker_forward_env /
-            # docker_env, so a sandbox created from this path lost the operator's configured settings.
-            container_config = _container_config_from_config(config)
+            return env, env_type
+
+        config = base_config
+        overrides = resolve_task_overrides(raw_task_id)
+        # When terminal remains local but execute_code selects nsjail, terminal.*
+        # values may not have been parsed into the env config. Read explicit
+        # nsjail policy from config.yaml for this independent backend.
+        if env_type == "nsjail":
+            try:
+                from hermes_cli.config import read_raw_config
+                terminal_cfg = read_raw_config().get("terminal", {})
+                if isinstance(terminal_cfg, dict):
+                    for key in ("nsjail_config", "nsjail_allow_net", "nsjail_forward_env"):
+                        if key in terminal_cfg:
+                            config[key] = terminal_cfg[key]
+            except Exception:
+                logger.debug("Could not load nsjail config overrides", exc_info=True)
+
+        container_config = _container_config_from_config(config) if _is_container_backend(env_type) else None
         logger.info("Creating new %s environment for execute_code task %s...",
-                     env_type, effective_task_id[:8])
+                    env_type, effective_task_id[:8])
         env = _create_environment(
             env_type=env_type, image=_select_image(env_type, overrides, config),
             cwd=overrides.get("cwd") or config["cwd"], timeout=config["timeout"],
             ssh_config=_ssh_config_from_config(config) if env_type == "ssh" else None,
             container_config=container_config,
             local_config={"persistent": config.get("local_persistent", False)} if env_type == "local" else None,
-            task_id=effective_task_id, host_cwd=_resolve_task_host_cwd(config, task_id),
+            task_id=effective_task_id, host_cwd=_resolve_task_host_cwd(config, raw_task_id),
         )
         with _env_lock:
             _active_environments[effective_task_id] = env
             _last_activity[effective_task_id] = time.time()
         _start_cleanup_thread()
         logger.info("%s environment ready for execute_code task %s",
-                     env_type, effective_task_id[:8])
+                    env_type, effective_task_id[:8])
         return env, env_type
 
 
@@ -702,13 +748,14 @@ def execute_code(
             )
     from tools.terminal_tool import _get_env_config, _docker_has_host_access
     _env_config = _get_env_config()
-    env_type = _env_config["env_type"]
+    env_type = _resolve_code_execution_env_type()
     # Arbitrary Python never passes through terminal()/DANGEROUS_PATTERNS, so guard the whole
     # script before either dispatch path spawns it — in this (tool-executor) thread, which holds
     # the session context. A Docker sandbox with host bind mounts gets no container fast-path.
     # See #30882.
     from tools.approval import check_execute_code_guard
-    _guard = check_execute_code_guard(code, env_type, has_host_access=_docker_has_host_access(_env_config))
+    has_host_access = _docker_has_host_access(_env_config) if env_type == "docker" else False
+    _guard = check_execute_code_guard(code, env_type, has_host_access=has_host_access)
     if not _guard.get("approved", False):
         return _error_result(_guard.get("message") or "execute_code blocked by approval guard.")
     # Clear a stale interrupt bit that landed during the blocking approval-wait so it can't

--- a/tools/environments/__init__.py
+++ b/tools/environments/__init__.py
@@ -1,7 +1,7 @@
 """Hermes execution environment backends.
 
 Each backend provides the same interface (BaseEnvironment ABC) for running
-shell commands in a specific execution context: local, Docker, SSH,
+shell commands in a specific execution context: local, Nsjail, Docker, SSH,
 Singularity, Modal, Daytona, or Vercel Sandbox. (Modal additionally has
 direct and Nous-managed modes, selected via terminal.modal_mode.)
 

--- a/tools/environments/__init__.py
+++ b/tools/environments/__init__.py
@@ -1,5 +1,5 @@
 """Hermes execution environment backends: one BaseEnvironment ABC for running shell commands
-in a specific context (local, Docker, SSH, Singularity, Modal direct/Nous-managed, Daytona,
+in a specific context (local, Nsjail, Docker, SSH, Singularity, Modal direct/Nous-managed, Daytona,
 Vercel Sandbox). ``terminal_tool._create_environment`` selects the backend from TERMINAL_ENV."""
 
 from tools.environments.base import BaseEnvironment

--- a/tools/environments/nsjail.py
+++ b/tools/environments/nsjail.py
@@ -134,7 +134,7 @@ class NsjailEnvironment(BaseEnvironment):
         self,
         cwd: str = "",
         timeout: int = 60,
-        env: dict = None,
+        env: dict | None = None,
         *,
         cpu: int = 1,
         memory: int = 5120,

--- a/tools/environments/nsjail.py
+++ b/tools/environments/nsjail.py
@@ -1,0 +1,319 @@
+"""Nsjail execution environment — lightweight namespace sandbox (Linux-only).
+
+Wraps each command with ``nsjail -Mo`` (once mode) to execute inside a fresh
+Linux user/mount/(net/pid) namespace set. No daemon, no container image, no
+root required: spawn latency is ~20 ms on a Pi-class device.
+
+Threat model: commands see a read-only view of the host filesystem with a
+single rw bindmount for the working directory, a tmpfs-backed session dir for
+snapshot state, and (by default) no network. Suitable for running untrusted
+short-lived code — the LLM equivalent of a CTF judge jail — without the boot
+overhead of Docker.
+
+Escape hatch: set ``terminal.nsjail_config`` to the path of a user-supplied
+``nsjail.cfg`` (protobuf text-format) and Hermes will delegate all policy to
+that file, only injecting the working directory and timeout.
+"""
+
+import logging
+import os
+import platform
+import shutil
+import subprocess
+from typing import Optional
+
+from tools.environments.base import (
+    BaseEnvironment,
+    _pipe_stdin,
+    get_sandbox_dir,
+)
+from tools.environments.local import _SANE_PATH, _sanitize_subprocess_env
+
+logger = logging.getLogger(__name__)
+
+_IS_LINUX = platform.system() == "Linux"
+
+
+_nsjail_executable: Optional[str] = None  # resolved once, cached
+
+
+def find_nsjail() -> Optional[str]:
+    """Locate the nsjail CLI binary.
+
+    Resolution order:
+    1. ``HERMES_NSJAIL_BINARY`` env var — explicit override
+    2. ``nsjail`` on PATH via ``shutil.which``
+
+    Returns the absolute path, or ``None`` if nsjail cannot be found.
+    """
+    global _nsjail_executable
+    if _nsjail_executable is not None:
+        return _nsjail_executable
+
+    override = os.getenv("HERMES_NSJAIL_BINARY")
+    if override and os.path.isfile(override) and os.access(override, os.X_OK):
+        _nsjail_executable = override
+        logger.info("Using HERMES_NSJAIL_BINARY override: %s", override)
+        return override
+
+    found = shutil.which("nsjail")
+    if found:
+        _nsjail_executable = found
+        return found
+
+    return None
+
+
+def _ensure_nsjail_available() -> str:
+    """Best-effort preflight that nsjail is usable before the first exec."""
+    if not _IS_LINUX:
+        raise RuntimeError(
+            "Nsjail backend is only supported on Linux. "
+            "Set terminal.backend to 'local', 'docker', or 'singularity'."
+        )
+
+    exe = find_nsjail()
+    if not exe:
+        raise RuntimeError(
+            "nsjail binary not found. Install nsjail "
+            "(https://github.com/google/nsjail) and ensure it is on PATH, "
+            "or set HERMES_NSJAIL_BINARY to its absolute path."
+        )
+
+    try:
+        result = subprocess.run(
+            [exe, "--help"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            f"Resolved nsjail binary {exe!r} could not be executed: {exc}"
+        ) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+            f"'{exe} --help' timed out after 5s; the binary appears unresponsive."
+        ) from exc
+
+    # nsjail prints help to stderr and exits non-zero; both are fine as long
+    # as we can tell the binary responds at all.
+    if result.returncode not in (0, 1) and "Usage:" not in (result.stderr + result.stdout):
+        raise RuntimeError(
+            f"'{exe} --help' returned an unexpected error "
+            f"(rc={result.returncode}): {result.stderr.strip() or result.stdout.strip()}"
+        )
+
+    return exe
+
+
+# Environment variables every sandboxed bash session needs to behave normally.
+# Forwarded from the sanitized host env when present so locale/paths work.
+_ALWAYS_FORWARD_ENV = (
+    "HOME",
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    "TERM",
+    "USER",
+    "LOGNAME",
+    "SHELL",
+)
+
+
+class NsjailEnvironment(BaseEnvironment):
+    """Spawn-per-call execution inside an nsjail user-namespace jail.
+
+    The host filesystem is bindmounted read-only; the working directory is
+    bindmounted read-write at the same path; a host-side session directory is
+    bindmounted at ``/tmp`` so the env-snapshot file written by
+    :class:`BaseEnvironment` persists across invocations.
+    """
+
+    def __init__(
+        self,
+        cwd: str = "",
+        timeout: int = 60,
+        env: dict = None,
+        *,
+        cpu: int = 1,
+        memory: int = 5120,
+        disk: int = 51200,
+        task_id: str = "default",
+        config_file: str | None = None,
+        allow_net: bool = False,
+        forward_env: list[str] | None = None,
+    ):
+        resolved_cwd = os.path.abspath(os.path.expanduser(cwd or os.getcwd()))
+        super().__init__(cwd=resolved_cwd, timeout=timeout, env=env)
+
+        # Pin the read-write bindmount to the cwd captured at init. If the
+        # user cd's elsewhere mid-session, that new location stays read-only
+        # (the /-level bindmount_ro still covers it for reads). Without this
+        # pin, a ``cd /etc`` followed by another exec would re-bindmount /etc
+        # as rw and silently weaken the sandbox.
+        self._initial_cwd = resolved_cwd
+
+        self.executable = _ensure_nsjail_available()
+
+        self._config_file = (
+            os.path.abspath(os.path.expanduser(config_file))
+            if config_file
+            else None
+        )
+        if self._config_file and not os.path.isfile(self._config_file):
+            raise RuntimeError(
+                f"terminal.nsjail_config points to a non-existent file: "
+                f"{self._config_file}"
+            )
+
+        self._allow_net = bool(allow_net)
+        self._cpu = max(int(cpu), 0)
+        self._memory = max(int(memory), 0)
+        self._disk = max(int(disk), 0)
+        self._forward_env = list(forward_env or [])
+        self._task_id = str(task_id)
+
+        # Host-side session dir bindmounted into the jail as /tmp, so the env
+        # snapshot + cwd marker file persist across spawn-per-call invocations.
+        # Spawn-per-call otherwise wipes a tmpfs /tmp between each command.
+        self._session_dir = (
+            get_sandbox_dir() / "nsjail" / f"{self._task_id}-{self._session_id}"
+        )
+        self._session_dir.mkdir(parents=True, exist_ok=True)
+
+        self.init_session()
+
+    def get_temp_dir(self) -> str:
+        # Paths in base.BaseEnvironment are computed against this. We bindmount
+        # self._session_dir → /tmp inside the jail, so these paths are writable
+        # from inside and readable from the host.
+        return "/tmp"
+
+    # ------------------------------------------------------------------
+    # nsjail CLI construction
+    # ------------------------------------------------------------------
+
+    def _build_nsjail_args(self, timeout: int) -> list[str]:
+        """Assemble the nsjail invocation flags for a single command run."""
+        # Deadline passed to nsjail is given in whole seconds; give it a small
+        # cushion over our own timeout so our Python-side poll wins the race
+        # and we get a clean stdout drain instead of a kernel SIGKILL.
+        nsjail_time_limit = max(int(timeout) + 5, 5)
+
+        if self._config_file:
+            # User-supplied config owns all policy. We still inject the
+            # time limit so runaway commands can't outlive the tool call.
+            return [
+                self.executable,
+                "--config", self._config_file,
+                "--time_limit", str(nsjail_time_limit),
+            ]
+
+        rw_cwd = (
+            self._initial_cwd if os.path.isdir(self._initial_cwd) else "/"
+        )
+        start_cwd = self.cwd if os.path.isdir(self.cwd) else rw_cwd
+
+        args: list[str] = [
+            self.executable,
+            "-Mo",                    # once mode: single exec, no listener
+            "--quiet",                # suppress nsjail's [I] chatter
+            "--bindmount_ro", "/",
+            "--bindmount", f"{self._session_dir}:/tmp",
+            "--bindmount", rw_cwd,
+            "--cwd", start_cwd,
+            "--time_limit", str(nsjail_time_limit),
+        ]
+
+        if self._allow_net:
+            args.append("--disable_clone_newnet")
+
+        if self._memory > 0:
+            args += ["--rlimit_as", str(self._memory)]
+        if self._disk > 0:
+            args += ["--rlimit_fsize", str(self._disk)]
+        args += ["--rlimit_nofile", "1024"]
+
+        # Build a sanitized env and forward the explicit subset into the jail.
+        # Provider API keys and messaging-platform tokens are stripped by
+        # _sanitize_subprocess_env before we even construct the --env flags.
+        host_env = dict(os.environ)
+        sanitized = _sanitize_subprocess_env(host_env, self.env)
+        ensured_path = sanitized.get("PATH") or _SANE_PATH
+
+        keep: dict[str, str] = {"PATH": ensured_path}
+        for name in _ALWAYS_FORWARD_ENV:
+            value = sanitized.get(name)
+            if value is not None:
+                keep[name] = value
+        for name in self._forward_env:
+            value = sanitized.get(name)
+            if value is not None:
+                keep[name] = value
+
+        for key, value in keep.items():
+            args += ["--env", f"{key}={value}"]
+
+        return args
+
+    # ------------------------------------------------------------------
+    # Bash wrapper entrypoint
+    # ------------------------------------------------------------------
+
+    def _run_bash(
+        self,
+        cmd_string: str,
+        *,
+        login: bool = False,
+        timeout: int = 120,
+        stdin_data: str | None = None,
+    ) -> subprocess.Popen:
+        nsjail_args = self._build_nsjail_args(timeout)
+        bash_argv = ["/bin/bash"]
+        if login:
+            bash_argv.append("-l")
+        bash_argv += ["-c", cmd_string]
+
+        full_args = nsjail_args + ["--"] + bash_argv
+
+        proc = subprocess.Popen(
+            full_args,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
+        )
+        if stdin_data is not None:
+            _pipe_stdin(proc, stdin_data)
+        return proc
+
+    # ------------------------------------------------------------------
+    # CWD extraction — the cwd marker file lives in the host-side session
+    # dir thanks to the /tmp bindmount, so we can read it without a round
+    # trip through the sandbox.
+    # ------------------------------------------------------------------
+
+    def _update_cwd(self, result: dict):
+        host_cwd_file = self._session_dir / os.path.basename(self._cwd_file)
+        try:
+            cwd_path = host_cwd_file.read_text().strip()
+            if cwd_path:
+                self.cwd = cwd_path
+        except (OSError, FileNotFoundError):
+            pass
+        self._extract_cwd_from_output(result)
+
+    # ------------------------------------------------------------------
+    # Cleanup
+    # ------------------------------------------------------------------
+
+    def cleanup(self):
+        session_dir = getattr(self, "_session_dir", None)
+        if session_dir is not None:
+            try:
+                shutil.rmtree(session_dir, ignore_errors=True)
+            except OSError:
+                pass

--- a/tools/environments/nsjail.py
+++ b/tools/environments/nsjail.py
@@ -1,0 +1,320 @@
+"""Nsjail execution environment — lightweight namespace sandbox (Linux-only).
+
+Wraps each command with ``nsjail -Mo`` (once mode) to execute inside a fresh
+Linux user/mount/(net/pid) namespace set. No daemon, no container image, no
+root required: spawn latency is ~20 ms on a Pi-class device.
+
+Threat model: commands see a read-only view of the host filesystem with a
+single rw bindmount for the working directory, a tmpfs-backed session dir for
+snapshot state, and (by default) no network. Suitable for running untrusted
+short-lived code — the LLM equivalent of a CTF judge jail — without the boot
+overhead of Docker.
+
+Escape hatch: set ``terminal.nsjail_config`` to the path of a user-supplied
+``nsjail.cfg`` (protobuf text-format) and Hermes will delegate all policy to
+that file, only injecting the working directory and timeout.
+"""
+
+import logging
+import os
+import platform
+import shutil
+import subprocess
+from typing import Optional
+
+from tools.environments.base import (
+    BaseEnvironment,
+    get_sandbox_dir,
+)
+from tools.environments.base_output import _pipe_stdin
+from tools.environments.local import _SANE_PATH, _sanitize_subprocess_env
+
+logger = logging.getLogger(__name__)
+
+_IS_LINUX = platform.system() == "Linux"
+
+
+_nsjail_executable: Optional[str] = None  # resolved once, cached
+
+
+def find_nsjail() -> Optional[str]:
+    """Locate the nsjail CLI binary.
+
+    Resolution order:
+    1. ``HERMES_NSJAIL_BINARY`` env var — explicit override
+    2. ``nsjail`` on PATH via ``shutil.which``
+
+    Returns the absolute path, or ``None`` if nsjail cannot be found.
+    """
+    global _nsjail_executable
+    if _nsjail_executable is not None:
+        return _nsjail_executable
+
+    override = os.getenv("HERMES_NSJAIL_BINARY")
+    if override and os.path.isfile(override) and os.access(override, os.X_OK):
+        _nsjail_executable = override
+        logger.info("Using HERMES_NSJAIL_BINARY override: %s", override)
+        return override
+
+    found = shutil.which("nsjail")
+    if found:
+        _nsjail_executable = found
+        return found
+
+    return None
+
+
+def _ensure_nsjail_available() -> str:
+    """Best-effort preflight that nsjail is usable before the first exec."""
+    if not _IS_LINUX:
+        raise RuntimeError(
+            "Nsjail backend is only supported on Linux. "
+            "Set terminal.backend to 'local', 'docker', or 'singularity'."
+        )
+
+    exe = find_nsjail()
+    if not exe:
+        raise RuntimeError(
+            "nsjail binary not found. Install nsjail "
+            "(https://github.com/google/nsjail) and ensure it is on PATH, "
+            "or set HERMES_NSJAIL_BINARY to its absolute path."
+        )
+
+    try:
+        result = subprocess.run(
+            [exe, "--help"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError(
+            f"Resolved nsjail binary {exe!r} could not be executed: {exc}"
+        ) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+            f"'{exe} --help' timed out after 5s; the binary appears unresponsive."
+        ) from exc
+
+    # nsjail prints help to stderr and exits non-zero; both are fine as long
+    # as we can tell the binary responds at all.
+    if result.returncode not in (0, 1) and "Usage:" not in (result.stderr + result.stdout):
+        raise RuntimeError(
+            f"'{exe} --help' returned an unexpected error "
+            f"(rc={result.returncode}): {result.stderr.strip() or result.stdout.strip()}"
+        )
+
+    return exe
+
+
+# Environment variables every sandboxed bash session needs to behave normally.
+# Forwarded from the sanitized host env when present so locale/paths work.
+_ALWAYS_FORWARD_ENV = (
+    "HOME",
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    "TERM",
+    "USER",
+    "LOGNAME",
+    "SHELL",
+)
+
+
+class NsjailEnvironment(BaseEnvironment):
+    """Spawn-per-call execution inside an nsjail user-namespace jail.
+
+    The host filesystem is bindmounted read-only; the working directory is
+    bindmounted read-write at the same path; a host-side session directory is
+    bindmounted at ``/tmp`` so the env-snapshot file written by
+    :class:`BaseEnvironment` persists across invocations.
+    """
+
+    def __init__(
+        self,
+        cwd: str = "",
+        timeout: int = 60,
+        env: dict | None = None,
+        *,
+        cpu: int = 1,
+        memory: int = 5120,
+        disk: int = 51200,
+        task_id: str = "default",
+        config_file: str | None = None,
+        allow_net: bool = False,
+        forward_env: list[str] | None = None,
+    ):
+        resolved_cwd = os.path.abspath(os.path.expanduser(cwd or os.getcwd()))
+        super().__init__(cwd=resolved_cwd, timeout=timeout, env=env)
+
+        # Pin the read-write bindmount to the cwd captured at init. If the
+        # user cd's elsewhere mid-session, that new location stays read-only
+        # (the /-level bindmount_ro still covers it for reads). Without this
+        # pin, a ``cd /etc`` followed by another exec would re-bindmount /etc
+        # as rw and silently weaken the sandbox.
+        self._initial_cwd = resolved_cwd
+
+        self.executable = _ensure_nsjail_available()
+
+        self._config_file = (
+            os.path.abspath(os.path.expanduser(config_file))
+            if config_file
+            else None
+        )
+        if self._config_file and not os.path.isfile(self._config_file):
+            raise RuntimeError(
+                f"terminal.nsjail_config points to a non-existent file: "
+                f"{self._config_file}"
+            )
+
+        self._allow_net = bool(allow_net)
+        self._cpu = max(int(cpu), 0)
+        self._memory = max(int(memory), 0)
+        self._disk = max(int(disk), 0)
+        self._forward_env = list(forward_env or [])
+        self._task_id = str(task_id)
+        self._persistent = True
+
+        # Host-side session dir bindmounted into the jail as /tmp, so the env
+        # snapshot + cwd marker file persist across spawn-per-call invocations.
+        # Spawn-per-call otherwise wipes a tmpfs /tmp between each command.
+        self._session_dir = (
+            get_sandbox_dir() / "nsjail" / f"{self._task_id}-{self._session_id}"
+        )
+        self._session_dir.mkdir(parents=True, exist_ok=True)
+
+        self.init_session()
+
+    def get_temp_dir(self) -> str:
+        # Paths in base.BaseEnvironment are computed against this. We bindmount
+        # self._session_dir → /tmp inside the jail, so these paths are writable
+        # from inside and readable from the host.
+        return "/tmp"
+
+    # ------------------------------------------------------------------
+    # nsjail CLI construction
+    # ------------------------------------------------------------------
+
+    def _build_nsjail_args(self, timeout: int) -> list[str]:
+        """Assemble the nsjail invocation flags for a single command run."""
+        # Deadline passed to nsjail is given in whole seconds; give it a small
+        # cushion over our own timeout so our Python-side poll wins the race
+        # and we get a clean stdout drain instead of a kernel SIGKILL.
+        nsjail_time_limit = max(int(timeout) + 5, 5)
+
+        if self._config_file:
+            # User-supplied config owns all policy. We still inject the
+            # time limit so runaway commands can't outlive the tool call.
+            return [
+                self.executable,
+                "--config", self._config_file,
+                "--time_limit", str(nsjail_time_limit),
+            ]
+
+        rw_cwd = (
+            self._initial_cwd if os.path.isdir(self._initial_cwd) else "/"
+        )
+        start_cwd = self.cwd if os.path.isdir(self.cwd) else rw_cwd
+
+        args: list[str] = [
+            self.executable,
+            "-Mo",                    # once mode: single exec, no listener
+            "--quiet",                # suppress nsjail's [I] chatter
+            "--bindmount_ro", "/",
+            "--bindmount", f"{self._session_dir}:/tmp",
+            "--bindmount", rw_cwd,
+            "--cwd", start_cwd,
+            "--time_limit", str(nsjail_time_limit),
+        ]
+
+        if self._allow_net:
+            args.append("--disable_clone_newnet")
+
+        if self._memory > 0:
+            args += ["--rlimit_as", str(self._memory)]
+        if self._disk > 0:
+            args += ["--rlimit_fsize", str(self._disk)]
+        args += ["--rlimit_nofile", "1024"]
+
+        # Build a sanitized env and forward the explicit subset into the jail.
+        # Provider API keys and messaging-platform tokens are stripped by
+        # _sanitize_subprocess_env before we even construct the --env flags.
+        host_env = dict(os.environ)
+        sanitized = _sanitize_subprocess_env(host_env, self.env)
+        ensured_path = sanitized.get("PATH") or _SANE_PATH
+
+        keep: dict[str, str] = {"PATH": ensured_path}
+        for name in _ALWAYS_FORWARD_ENV:
+            value = sanitized.get(name)
+            if value is not None:
+                keep[name] = value
+        for name in self._forward_env:
+            value = sanitized.get(name)
+            if value is not None:
+                keep[name] = value
+
+        for key, value in keep.items():
+            args += ["--env", f"{key}={value}"]
+
+        return args
+
+    # ------------------------------------------------------------------
+    # Bash wrapper entrypoint
+    # ------------------------------------------------------------------
+
+    def _run_bash(
+        self,
+        cmd_string: str,
+        *,
+        login: bool = False,
+        timeout: int = 120,
+        stdin_data: str | None = None,
+    ) -> subprocess.Popen:
+        nsjail_args = self._build_nsjail_args(timeout)
+        bash_argv = ["/bin/bash"]
+        if login:
+            bash_argv.append("-l")
+        bash_argv += ["-c", cmd_string]
+
+        full_args = nsjail_args + ["--"] + bash_argv
+
+        proc = subprocess.Popen(
+            full_args,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
+        )
+        if stdin_data is not None:
+            _pipe_stdin(proc, stdin_data)
+        return proc
+
+    # ------------------------------------------------------------------
+    # CWD extraction — the cwd marker file lives in the host-side session
+    # dir thanks to the /tmp bindmount, so we can read it without a round
+    # trip through the sandbox.
+    # ------------------------------------------------------------------
+
+    def _update_cwd(self, result: dict):
+        host_cwd_file = self._session_dir / os.path.basename(self._cwd_file)
+        try:
+            cwd_path = host_cwd_file.read_text().strip()
+            if cwd_path:
+                self.cwd = cwd_path
+        except (OSError, FileNotFoundError):
+            pass
+        self._extract_cwd_from_output(result)
+
+    # ------------------------------------------------------------------
+    # Cleanup
+    # ------------------------------------------------------------------
+
+    def cleanup(self):
+        session_dir = getattr(self, "_session_dir", None)
+        if session_dir is not None:
+            try:
+                shutil.rmtree(session_dir, ignore_errors=True)
+            except OSError:
+                pass

--- a/tools/file_tools_paths.py
+++ b/tools/file_tools_paths.py
@@ -14,9 +14,9 @@ from pathlib import Path, PurePosixPath
 # ``TERMINAL_CWD`` values that mean "not configured" ("." from a stale config;
 # "auto"/"cwd" are wizard placeholders). gateway/run.py sanitizes the same set.
 _TERMINAL_CWD_SENTINELS = frozenset({"", ".", "./", "auto", "cwd"})
-_CONTAINER_PATH_BACKENDS_FALLBACK = frozenset({"docker", "singularity", "modal", "daytona", "vercel_sandbox"})
+_CONTAINER_PATH_BACKENDS_FALLBACK = frozenset({"docker", "nsjail", "singularity", "modal", "daytona", "vercel_sandbox"})
 # Backend name inferred from the live environment's class name (first match wins).
-_ENV_CLASS_NAME_HINTS = ("local", "ssh", "docker", "singularity", "modal", "daytona")
+_ENV_CLASS_NAME_HINTS = ("local", "ssh", "docker", "nsjail", "singularity", "modal", "daytona")
 
 
 def _expand_tilde(path: str) -> str:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -882,6 +882,7 @@ def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None
 
 # Environment classes now live in tools/environments/
 from tools.environments.local import LocalEnvironment as _LocalEnvironment
+from tools.environments.nsjail import NsjailEnvironment as _NsjailEnvironment
 from tools.environments.singularity import SingularityEnvironment as _SingularityEnvironment
 from tools.environments.ssh import SSHEnvironment as _SSHEnvironment
 from tools.environments.docker import DockerEnvironment as _DockerEnvironment
@@ -1086,6 +1087,10 @@ def _get_env_config() -> Dict[str, Any]:
         "container_persistent": os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in ("true", "1", "yes"),
         "docker_volumes": _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON"),
         "docker_run_as_host_user": os.getenv("TERMINAL_DOCKER_RUN_AS_HOST_USER", "false").lower() in ("true", "1", "yes"),
+        # Nsjail-specific config (ignored for non-nsjail backends)
+        "nsjail_config": os.getenv("TERMINAL_NSJAIL_CONFIG", ""),
+        "nsjail_allow_net": os.getenv("TERMINAL_NSJAIL_ALLOW_NET", "false").lower() in ("true", "1", "yes"),
+        "nsjail_forward_env": _parse_env_var("TERMINAL_NSJAIL_FORWARD_ENV", "[]", json.loads, "valid JSON"),
     }
 
 
@@ -1131,7 +1136,17 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
 
     if env_type == "local":
         return _LocalEnvironment(cwd=cwd, timeout=timeout)
-    
+
+    elif env_type == "nsjail":
+        return _NsjailEnvironment(
+            cwd=cwd, timeout=timeout,
+            cpu=cpu, memory=memory, disk=disk,
+            task_id=task_id,
+            config_file=cc.get("nsjail_config") or None,
+            allow_net=bool(cc.get("nsjail_allow_net", False)),
+            forward_env=cc.get("nsjail_forward_env", []) or [],
+        )
+
     elif env_type == "docker":
         return _DockerEnvironment(
             image=image, cwd=cwd, timeout=timeout,
@@ -1242,7 +1257,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
 
     else:
         raise ValueError(
-            f"Unknown environment type: {env_type}. Use 'local', 'docker', "
+            f"Unknown environment type: {env_type}. Use 'local', 'nsjail', 'docker', "
             f"'singularity', 'modal', 'daytona', 'vercel_sandbox', or 'ssh'"
         )
 
@@ -1778,7 +1793,7 @@ def terminal_tool(
                             }
 
                         container_config = None
-                        if env_type in ("docker", "singularity", "modal", "daytona", "vercel_sandbox"):
+                        if env_type in ("docker", "singularity", "modal", "daytona", "vercel_sandbox", "nsjail"):
                             container_config = {
                                 "container_cpu": config.get("container_cpu", 1),
                                 "container_memory": config.get("container_memory", 5120),
@@ -1791,6 +1806,9 @@ def terminal_tool(
                                 "docker_forward_env": config.get("docker_forward_env", []),
                                 "docker_env": config.get("docker_env", {}),
                                 "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
+                                "nsjail_config": config.get("nsjail_config", ""),
+                                "nsjail_allow_net": config.get("nsjail_allow_net", False),
+                                "nsjail_forward_env": config.get("nsjail_forward_env", []),
                             }
 
                         local_config = None

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1012,10 +1012,11 @@ def _get_env_config() -> Dict[str, Any]:
     
     mount_docker_cwd = os.getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in ("true", "1", "yes")
 
-    # Default cwd: local uses the host's current directory, ssh uses the
-    # remote home, Vercel uses its documented workspace root, and everything
-    # else starts in the backend's default root-like cwd.
-    if env_type == "local":
+    # Default cwd: local + nsjail both run as the host user against the host
+    # filesystem (nsjail just bindmounts it into the jail), so host paths
+    # work. ssh uses the remote home, Vercel uses its documented workspace
+    # root, and everything else starts in the backend's default root-like cwd.
+    if env_type in ("local", "nsjail"):
         default_cwd = os.getcwd()
     elif env_type == "ssh":
         default_cwd = "~"
@@ -2140,6 +2141,21 @@ def check_terminal_requirements() -> bool:
         if env_type == "local":
             return True
 
+        elif env_type == "nsjail":
+            from tools.environments.nsjail import find_nsjail
+            nsjail_bin = find_nsjail()
+            if not nsjail_bin:
+                logger.error(
+                    "nsjail binary not found in PATH and HERMES_NSJAIL_BINARY is unset. "
+                    "Install nsjail (https://github.com/google/nsjail) or switch "
+                    "TERMINAL_ENV to 'local' / 'docker'."
+                )
+                return False
+            result = subprocess.run([nsjail_bin, "--help"], capture_output=True, timeout=5)
+            # nsjail prints help then exits non-zero; as long as the binary is
+            # executable and responds, it's usable.
+            return b"Usage:" in (result.stdout + result.stderr)
+
         elif env_type == "docker":
             from tools.environments.docker import find_docker
             docker = find_docker()
@@ -2229,8 +2245,8 @@ def check_terminal_requirements() -> bool:
 
         else:
             logger.error(
-                "Unknown TERMINAL_ENV '%s'. Use one of: local, docker, singularity, "
-                "modal, daytona, vercel_sandbox, ssh.",
+                "Unknown TERMINAL_ENV '%s'. Use one of: local, nsjail, docker, "
+                "singularity, modal, daytona, vercel_sandbox, ssh.",
                 env_type,
             )
             return False

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Terminal tool: run shell commands in the configured backend.
 
-Backends (``TERMINAL_ENV``): local (default), docker, singularity, modal
+Backends (``TERMINAL_ENV``): local (default), nsjail, docker, singularity, modal
 (direct or managed gateway), daytona, vercel_sandbox, ssh, plus
 plugin-registered backends. Handles background processes, sandbox lifecycle
 (per-task cache, idle reaper, atexit teardown) and sudo password plumbing.
@@ -585,7 +585,7 @@ def _resolve_config_cwd(env_type: str, mount_docker_cwd: bool) -> tuple:
     path is remapped to /workspace and tracked as host_cwd; otherwise host paths
     are discarded in favor of the backend default.
     """
-    default_cwd = _safe_getcwd() if env_type == "local" else _DEFAULT_CWD_BY_BACKEND.get(env_type, "/root")
+    default_cwd = _safe_getcwd() if env_type in ("local", "nsjail") else _DEFAULT_CWD_BY_BACKEND.get(env_type, "/root")
     cwd = _tenv("TERMINAL_CWD", default_cwd)
     from hermes_cli.config import _is_ssh_remote_tilde_cwd
     if cwd and not _is_ssh_remote_tilde_cwd(env_type, cwd):
@@ -599,7 +599,7 @@ def _resolve_config_cwd(env_type: str, mount_docker_cwd: bool) -> tuple:
         ):
             host_cwd = candidate
             cwd = "/workspace"
-    elif _is_container_backend(env_type) and cwd and _is_unusable_container_cwd(cwd) and cwd != default_cwd:
+    elif env_type != "nsjail" and _is_container_backend(env_type) and cwd and _is_unusable_container_cwd(cwd) and cwd != default_cwd:
         logger.info("Ignoring TERMINAL_CWD=%r for %s backend "
                     "(host/relative path won't work in sandbox). Using %r instead.",
                     cwd, env_type, default_cwd)
@@ -630,8 +630,15 @@ def _get_env_config() -> Dict[str, Any]:
         docker_env = _parse_env_var("TERMINAL_DOCKER_ENV", "{}", json.loads, "valid JSON")
         docker_extra_args = _parse_env_var("TERMINAL_DOCKER_EXTRA_ARGS", "[]", json.loads, "valid JSON")
         docker_shm_size = _tenv("TERMINAL_DOCKER_SHM_SIZE", "1g")
+        nsjail_config, nsjail_allow_net, nsjail_forward_env = "", False, []
+    elif env_type == "nsjail":
+        docker_forward_env, docker_volumes, docker_env, docker_extra_args, docker_shm_size = [], [], {}, [], "1g"
+        nsjail_config = _tenv("TERMINAL_NSJAIL_CONFIG", "")
+        nsjail_allow_net = _tenv_bool("TERMINAL_NSJAIL_ALLOW_NET", "false")
+        nsjail_forward_env = _parse_env_var("TERMINAL_NSJAIL_FORWARD_ENV", "[]", json.loads, "valid JSON")
     else:
         docker_forward_env, docker_volumes, docker_env, docker_extra_args, docker_shm_size = [], [], {}, [], "1g"
+        nsjail_config, nsjail_allow_net, nsjail_forward_env = "", False, []
 
     cwd, host_cwd = _resolve_config_cwd(env_type, mount_docker_cwd)
 
@@ -677,6 +684,9 @@ def _get_env_config() -> Dict[str, Any]:
         "docker_persist_across_processes": _tenv_bool("TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES", "true"),
         "docker_shared_container_key": _tenv("TERMINAL_DOCKER_SHARED_CONTAINER_KEY", "").strip(),
         "docker_orphan_reaper": _tenv_bool("TERMINAL_DOCKER_ORPHAN_REAPER", "true"),
+        "nsjail_config": nsjail_config,
+        "nsjail_allow_net": nsjail_allow_net,
+        "nsjail_forward_env": nsjail_forward_env,
     }
 
 

--- a/tools/terminal_tool_backends.py
+++ b/tools/terminal_tool_backends.py
@@ -6,6 +6,7 @@ import functools
 import importlib.util
 import inspect
 import logging
+import platform
 import shutil
 import subprocess
 from typing import Any, Dict, Optional
@@ -14,6 +15,7 @@ from tools.environments.docker import DockerEnvironment as _DockerEnvironment
 from tools.environments.local import LocalEnvironment as _LocalEnvironment
 from tools.environments.managed_modal import ManagedModalEnvironment as _ManagedModalEnvironment
 from tools.environments.modal import ModalEnvironment as _ModalEnvironment
+from tools.environments.nsjail import NsjailEnvironment as _NsjailEnvironment
 from tools.environments.singularity import SingularityEnvironment as _SingularityEnvironment
 from tools.environments.ssh import SSHEnvironment as _SSHEnvironment
 from tools.managed_tool_gateway import is_managed_tool_gateway_ready
@@ -26,7 +28,7 @@ logger = logging.getLogger("tools.terminal_tool")
 
 _VERCEL_SANDBOX_DEFAULT_CWD = "/vercel/sandbox"
 _SUPPORTED_VERCEL_RUNTIMES = ("node24", "node22", "python3.13")
-_BUILTIN_BACKENDS = "local, docker, singularity, modal, daytona, vercel_sandbox, ssh"
+_BUILTIN_BACKENDS = "local, nsjail, docker, singularity, modal, daytona, vercel_sandbox, ssh"
 
 # Config -> kwargs shapers, driven by (out_key, config_key, default) tables. The container table's
 # (key, default) literal is intentionally greppable; tools/terminal_tool.py keeps its own for the AST test.
@@ -41,6 +43,7 @@ _CONTAINER_KEYS = (
     ("docker_env", {}), ("docker_run_as_host_user", False), ("docker_extra_args", []),
     ("docker_shm_size", "1g"), ("docker_network", True), ("docker_persist_across_processes", True),
     ("docker_shared_container_key", ""), ("docker_orphan_reaper", True), ("docker_snap_compat", False),
+    ("nsjail_config", ""), ("nsjail_allow_net", False), ("nsjail_forward_env", []),
 )
 _DOCKER_KWARGS = (
     ("volumes", "docker_volumes", []), ("auto_mount_cwd", "docker_mount_cwd_to_workspace", False),
@@ -102,6 +105,21 @@ def _modal_unavailable_reason(modal_state: Dict[str, Any]) -> tuple[str, str]:
 # --- Environment builders. Signature: (*, env_type, image, cwd, timeout, cc, task_id, ssh_config, host_cwd)
 def _build_local_env(*, cwd, timeout, **_):
     return _LocalEnvironment(cwd=cwd, timeout=timeout)
+
+
+def _build_nsjail_env(*, cwd, timeout, cc, task_id, **_):
+    res = _resources(cc)
+    return _NsjailEnvironment(
+        cwd=cwd,
+        timeout=timeout,
+        cpu=res["cpu"],
+        memory=res["memory"],
+        disk=res["disk"],
+        task_id=task_id,
+        config_file=cc.get("nsjail_config") or None,
+        allow_net=bool(cc.get("nsjail_allow_net", False)),
+        forward_env=cc.get("nsjail_forward_env", []) or [],
+    )
 
 
 def _build_docker_env(*, image, cwd, timeout, cc, task_id, host_cwd, **_):
@@ -202,7 +220,7 @@ def _build_plugin_env(*, env_type, image, cwd, timeout, cc, task_id, **_):
 
 
 # Built-in backend -> builder. Anything else is looked up in the plugin registry.
-_ENV_BUILDERS = {"local": _build_local_env, "docker": _build_docker_env, "singularity": _build_singularity_env,
+_ENV_BUILDERS = {"local": _build_local_env, "nsjail": _build_nsjail_env, "docker": _build_docker_env, "singularity": _build_singularity_env,
                  "modal": _build_modal_env, "daytona": _build_daytona_env, "vercel_sandbox": _build_vercel_env,
                  "ssh": _build_ssh_env}
 
@@ -263,6 +281,26 @@ def _modal_pre(config: Dict[str, Any]) -> Optional[bool]:
     return None
 
 
+def _check_nsjail(config: Dict[str, Any]) -> bool:
+    if platform.system() != "Linux":
+        logger.error("The nsjail terminal backend is supported only on Linux")
+        return False
+    from tools.environments.nsjail import find_nsjail
+    executable = find_nsjail()
+    if not executable:
+        logger.error("nsjail binary not found in PATH and HERMES_NSJAIL_BINARY is unset")
+        return False
+    try:
+        probe = subprocess.run(
+            [executable, "--help"], capture_output=True, text=True,
+            timeout=5, stdin=subprocess.DEVNULL,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        logger.error("nsjail preflight failed: %s", exc)
+        return False
+    return bool("Usage:" in (probe.stdout + probe.stderr) or probe.returncode in (0, 1))
+
+
 def _ssh_pre(config: Dict[str, Any]) -> bool:
     if config.get("ssh_host") and config.get("ssh_user"):
         return True
@@ -279,6 +317,7 @@ def _daytona_post(config: Dict[str, Any]) -> bool:
 
 _BACKEND_SPECS: Dict[str, Dict[str, Any]] = {
     "local": {},
+    "nsjail": {"pre": _check_nsjail},
     "docker": {"binary": (lambda: importlib.import_module("tools.environments.docker").find_docker(), "version",
                           "Docker executable not found in PATH or common install locations")},
     "singularity": {"binary": (lambda: shutil.which("apptainer") or shutil.which("singularity"), "--version", None)},

--- a/tools/terminal_tool_config.py
+++ b/tools/terminal_tool_config.py
@@ -61,7 +61,7 @@ _WINDOWS_DRIVE_RE = re.compile(r"^[A-Za-z]:[\\/]")
 def _is_host_cwd(path: str) -> bool:
     return path.startswith(_HOST_CWD_PREFIXES) or bool(_WINDOWS_DRIVE_RE.match(path))
 
-_CONTAINER_BACKENDS = frozenset({"docker", "singularity", "modal", "daytona", "vercel_sandbox"})
+_CONTAINER_BACKENDS = frozenset({"docker", "nsjail", "singularity", "modal", "daytona", "vercel_sandbox"})
 _BUILTIN_BACKENDS = _CONTAINER_BACKENDS | {"local", "ssh", "managed_modal"}
 
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -195,6 +195,8 @@ terminal:
 
 **What it won't sandbox:** Commands that rely on privileged syscalls (`ptrace`, raw sockets, `unshare` under some kernel configs) may behave differently or fail. For those, use Docker.
 
+**Fork bombs:** The default profile does not set `rlimit_nproc` because that flag is enforced host-wide per real uid, which would interfere with the user's other processes outside the jail. Wall-clock `--time_limit` is the containment. If you need a per-jail process cap, supply an `nsjail.cfg` that uses cgroup v2 `pids.max` instead.
+
 ### SSH Backend
 
 Runs commands on a remote server over SSH. Uses ControlMaster for connection reuse (5-minute idle keepalive). Persistent shell is enabled by default — state (cwd, env vars) survives across commands.

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -83,11 +83,11 @@ Leaving these unset keeps the legacy defaults (`HERMES_API_TIMEOUT=1800`s, `HERM
 
 ## Terminal Backend Configuration
 
-Hermes supports seven terminal backends. Each determines where the agent's shell commands actually execute — your local machine, a Docker container, a remote server via SSH, a Modal cloud sandbox (direct or via the Nous-managed gateway), a Daytona workspace, a Vercel Sandbox, or a Singularity/Apptainer container.
+Hermes supports eight terminal backends. Each determines where the agent's shell commands actually execute — your local machine, an Nsjail namespace sandbox, a Docker container, a remote server via SSH, a Modal cloud sandbox (direct or via the Nous-managed gateway), a Daytona workspace, a Vercel Sandbox, or a Singularity/Apptainer container.
 
 ```yaml
 terminal:
-  backend: local    # local | docker | ssh | modal | daytona | vercel_sandbox | singularity
+  backend: local    # local | nsjail | docker | ssh | modal | daytona | vercel_sandbox | singularity
   cwd: "."          # Gateway/cron working directory (CLI always uses launch dir)
   timeout: 180      # Per-command timeout in seconds
   env_passthrough: []  # Env var names to forward to sandboxed execution (terminal + execute_code)
@@ -103,6 +103,7 @@ For cloud sandboxes such as Modal, Daytona, and Vercel Sandbox, `container_persi
 | Backend | Where commands run | Isolation | Best for |
 |---------|-------------------|-----------|----------|
 | **local** | Your machine directly | None | Development, personal use |
+| **nsjail** | Local namespace sandbox | User/mount/net namespaces, rlimits | Fast sandboxing of short-lived untrusted code (Linux only) |
 | **docker** | Single persistent Docker container (shared across session, `/new`, subagents) | Full (namespaces, cap-drop) | Safe sandboxing, CI/CD |
 | **ssh** | Remote server via SSH | Network boundary | Remote dev, powerful hardware |
 | **modal** | Modal cloud sandbox | Full (cloud VM) | Ephemeral cloud compute, evals |
@@ -161,6 +162,38 @@ Parallel subagents spawned via `delegate_task(tasks=[...])` share this one conta
 - Size-limited tmpfs for `/tmp` (512MB), `/var/tmp` (256MB), `/run` (64MB)
 
 **Credential forwarding:** Env vars listed in `docker_forward_env` are resolved from your shell environment first, then `~/.hermes/.env`. Skills can also declare `required_environment_variables` which are merged automatically.
+
+### Nsjail Backend
+
+Runs commands inside a fresh [nsjail](https://github.com/google/nsjail) user-namespace sandbox. No daemon, no container image, no root required. Spawn latency is ~20 ms on a Pi-class device — a good fit for deep-research workflows that run many short-lived code snippets and don't want Docker's per-call overhead.
+
+```yaml
+terminal:
+  backend: nsjail
+  nsjail_config: ""        # Optional: path to a user-supplied nsjail.cfg
+  nsjail_allow_net: false  # Grant network access from inside the jail
+  nsjail_forward_env: []   # Env var names to forward into the jail
+
+  # Resource limits (shared with the container backends)
+  container_memory: 5120   # MB → --rlimit_as
+  container_disk: 51200    # MB → --rlimit_fsize
+```
+
+**Requirements:** Linux with user namespaces enabled (the default on most distributions). The `nsjail` binary on `$PATH`, or `HERMES_NSJAIL_BINARY` pointing at the absolute path. Install from source: `https://github.com/google/nsjail`.
+
+**Default policy (when `nsjail_config` is empty):**
+- Host root filesystem bindmounted read-only
+- The launch working directory bindmounted read-write at the same path
+- A private host-side session directory bindmounted at `/tmp` so env/cwd snapshots persist across commands
+- Network namespace: new and empty (no outbound access) unless `nsjail_allow_net: true`
+- `rlimit_as` (address space) from `container_memory`, `rlimit_fsize` from `container_disk`, `rlimit_nofile` 1024
+- Wall-clock `--time_limit` tracks the Hermes per-command timeout (with a few-second cushion)
+
+**Custom policy:** Set `nsjail_config` to the path of a protobuf text-format `nsjail.cfg` and Hermes delegates all sandbox policy to that file (only the time limit is re-injected). Use this when you need seccomp filters, finer mount control, or PID/UTS namespace tuning.
+
+**Initial-cwd pin:** Only the cwd captured at session init is bindmounted read-write. If the agent `cd`s elsewhere mid-session, the new location stays readable but read-only — preventing a stray `cd /etc` from silently widening the write surface.
+
+**What it won't sandbox:** Commands that rely on privileged syscalls (`ptrace`, raw sockets, `unshare` under some kernel configs) may behave differently or fail. For those, use Docker.
 
 ### SSH Backend
 
@@ -296,6 +329,7 @@ terminal:
 If terminal commands fail immediately or the terminal tool is reported as disabled:
 
 - **Local** — No special requirements. The safest default when getting started.
+- **Nsjail** — Run `nsjail --help` to confirm the binary is reachable. Needs Linux with user namespaces enabled (default on mainstream distros; check `sysctl kernel.unprivileged_userns_clone` on older Debian/Ubuntu kernels).
 - **Docker** — Run `docker version` to verify Docker is working. If it fails, fix Docker or `hermes config set terminal.backend local`.
 - **SSH** — Both `TERMINAL_SSH_HOST` and `TERMINAL_SSH_USER` must be set. Hermes logs a clear error if either is missing.
 - **Modal** — Needs `MODAL_TOKEN_ID` env var or `~/.modal.toml`. Run `hermes doctor` to check.

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -197,6 +197,24 @@ terminal:
 
 **Fork bombs:** The default profile does not set `rlimit_nproc` because that flag is enforced host-wide per real uid, which would interfere with the user's other processes outside the jail. Wall-clock `--time_limit` is the containment. If you need a per-jail process cap, supply an `nsjail.cfg` that uses cgroup v2 `pids.max` instead.
 
+#### Isolating execute_code only
+
+Setting `terminal.backend` affects **every** file- and shell-touching tool (`terminal`, `read_file`, `write_file`, `patch`, `search_files`, `process`). That's usually too restrictive for a coding agent — you want it to freely edit your repo, run `pip install`, commit to git, etc. — and only sandbox the *experimental* scripts the LLM writes on the fly.
+
+For that, set a separate `code_execution.backend` and leave `terminal.backend` on `local`:
+
+```yaml
+terminal:
+  backend: local           # normal agent work — file edits, git, installs
+
+code_execution:
+  backend: nsjail          # LLM-authored scripts run isolated
+```
+
+When `code_execution.backend` is empty (the default), `execute_code` inherits `terminal.backend` — so existing single-backend configs keep working unchanged. When it's set, only the `execute_code` tool uses that backend; everything else runs via `terminal.backend`.
+
+The nsjail-specific settings (`nsjail_config`, `nsjail_allow_net`, `nsjail_forward_env`) live under `terminal:` and apply to whichever tool routes through the nsjail backend.
+
 ### SSH Backend
 
 Runs commands on a remote server over SSH. Uses ControlMaster for connection reuse (5-minute idle keepalive). Persistent shell is enabled by default — state (cwd, env vars) survives across commands.

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -201,11 +201,11 @@ Before that stash step, Hermes also restores tracked `package-lock.json` diffs l
 
 ## Terminal Backend Configuration
 
-Hermes supports seven terminal backends. Each determines where the agent's shell commands actually execute — your local machine, a Docker container, a remote server via SSH, a Modal cloud sandbox (direct or via the Nous-managed gateway), a Daytona workspace, a Vercel Sandbox, or a Singularity/Apptainer container.
+Hermes supports eight terminal backends. Each determines where the agent's shell commands actually execute — your local machine, an Nsjail namespace sandbox, a Docker container, a remote server via SSH, a Modal cloud sandbox (direct or via the Nous-managed gateway), a Daytona workspace, a Vercel Sandbox, or a Singularity/Apptainer container.
 
 ```yaml
 terminal:
-  backend: local    # local | docker | ssh | modal | daytona | vercel_sandbox | singularity
+  backend: local    # local | nsjail | docker | ssh | modal | daytona | vercel_sandbox | singularity
   cwd: "."          # Gateway/cron working directory (CLI always uses launch dir)
   temp_dir: ""      # Session temp root; empty = TMPDIR, else ~/.hermes/cache/terminal
   font_family: ""   # Desktop terminal font; e.g. "MesloLGS NF"
@@ -238,6 +238,7 @@ For cloud sandboxes such as Modal, Daytona, and Vercel Sandbox, `container_persi
 | Backend | Where commands run | Isolation | Best for |
 |---------|-------------------|-----------|----------|
 | **local** | Your machine directly | None | Development, personal use |
+| **nsjail** | Local Linux namespace sandbox | User/mount/net namespaces, rlimits | Fast local sandboxing of short-lived untrusted code |
 | **docker** | Single persistent Docker container (shared across session, `/new`, subagents) | Full (namespaces, cap-drop) | Safe sandboxing, CI/CD |
 | **ssh** | Remote server via SSH | Network boundary | Remote dev, powerful hardware |
 | **modal** | Modal cloud sandbox | Full (cloud VM) | Ephemeral cloud compute, evals |
@@ -305,6 +306,31 @@ real_home = Path(os.environ.get("HERMES_REAL_HOME", os.environ["HOME"]))
 :::warning
 The agent has the same filesystem access as your user account. Use `hermes tools` to disable tools you don't want, or switch to Docker for sandboxing.
 :::
+
+### Nsjail Backend
+
+Runs commands inside a fresh [nsjail](https://github.com/google/nsjail) Linux user/mount/network-namespace sandbox. It needs no daemon or container image and is intended for fast local isolation of short-lived untrusted commands.
+
+```yaml
+terminal:
+  backend: nsjail
+  nsjail_config: ""        # Optional protobuf-text nsjail.cfg
+  nsjail_allow_net: false  # Deny outbound network by default
+  nsjail_forward_env: []    # Explicit additional environment names
+  container_memory: 5120   # Address-space limit
+  container_disk: 51200    # File-size limit
+```
+
+The default policy bind-mounts the host root read-only, bind-mounts the initial working directory read-write, uses a private session directory at `/tmp`, denies network access, and applies the configured resource/time limits. Only the initial cwd is writable; changing to another directory during the session does not widen the write surface. Set `HERMES_NSJAIL_BINARY` when `nsjail` is not on `PATH`.
+
+When `terminal.backend` remains `local`, an independent code sandbox can be selected with:
+
+```yaml
+code_execution:
+  backend: nsjail
+```
+
+An empty `code_execution.backend` inherits `terminal.backend`; when set, only `execute_code` uses the selected backend. For custom seccomp, mounts, or cgroup policy, point `nsjail_config` at your own configuration file. Use Docker when a stronger, image-based boundary or broader process isolation is required.
 
 ### Docker Backend
 

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -137,7 +137,7 @@ The following patterns trigger approval prompts (defined in `tools/approval.py`)
 | `gateway run` with `&`/`disown`/`nohup`/`setsid` | Prevents starting gateway outside service manager |
 
 :::info
-**Container bypass**: When running in `docker`, `singularity`, `modal`, `daytona`, or `vercel_sandbox` backends, dangerous command checks are **skipped** because the container itself is the security boundary. Destructive commands inside a container can't harm the host.
+**Container bypass**: When running in `nsjail`, `docker`, `singularity`, `modal`, `daytona`, or `vercel_sandbox` backends, dangerous command checks are **skipped** because the sandbox itself is the security boundary. Destructive commands inside the jail can't harm the host.
 :::
 
 ### Approval Flow (CLI)
@@ -345,6 +345,7 @@ If you add names to `terminal.docker_forward_env`, those variables are intention
 | Backend | Isolation | Dangerous Cmd Check | Best For |
 |---------|-----------|-------------------|----------|
 | **local** | None — runs on host | ✅ Yes | Development, trusted users |
+| **nsjail** | User/mount/net namespaces (Linux) | ❌ Skipped | Fast local sandboxing of short-lived code |
 | **ssh** | Remote machine | ✅ Yes | Running on a separate server |
 | **docker** | Container | ❌ Skipped (container is boundary) | Production gateway |
 | **singularity** | Container | ❌ Skipped | HPC environments |

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -220,7 +220,7 @@ The following patterns trigger approval prompts (defined in `tools/approval.py`)
 | `podman --remote`/`-r`/`--url`/`--connection`/`--identity`, `CONTAINER_HOST=` | Podman remote daemon redirect |
 
 :::info
-**Container bypass**: When running in `docker`, `singularity`, `modal`, `daytona`, or `vercel_sandbox` backends, dangerous command checks are **skipped** because the container itself is the security boundary. Destructive commands inside a container can't harm the host.
+**Container bypass**: When running in `nsjail`, `docker`, `singularity`, `modal`, `daytona`, or `vercel_sandbox` backends, dangerous command checks are **skipped** because the sandbox itself is the security boundary. Destructive commands inside the sandbox are not expected to reach the host outside its writable workspace.
 :::
 
 ### Approval Flow (CLI)


### PR DESCRIPTION
## Summary

Adds a seventh terminal backend — **nsjail** — that runs each command inside a fresh Linux user-namespace jail. No daemon, no container image, no root required: spawn latency is ~20 ms on a Pi-class device, which makes it a much better fit than Docker for workflows that run many short-lived code snippets (deep research, tool-calling code execution, etc.) where Docker's per-call overhead dominates.

It sits cleanly between the existing options:

| | Local | **Nsjail** | Docker |
|---|---|---|---|
| Isolation | None | User/mount/net namespaces, rlimits | Full (cap-drop, no-new-privs, tmpfs) |
| Cold start | ~10 ms | ~20 ms | ~1–2 s + image pull |
| Requires root / daemon | No | No | Docker daemon (often root) |
| Platform | Linux/macOS/Windows | Linux only | Linux/macOS/Windows |

## Default policy

When `terminal.nsjail_config` is empty, Hermes builds the jail with:

- Host rootfs bindmounted **read-only** (`--bindmount_ro /`)
- The launch cwd bindmounted **read-write** at the same path
- The rw cwd is **pinned to the initial cwd** — if the agent `cd`'s to `/etc` mid-session, writes there stay blocked. Otherwise a stray `cd` would silently widen the write surface.
- A private host-side session directory bindmounted at `/tmp` so the env-snapshot + cwd-marker files written by `BaseEnvironment` survive spawn-per-call
- Fresh network namespace with no routes (toggle via `terminal.nsjail_allow_net`)
- `rlimit_as` from `container_memory`, `rlimit_fsize` from `container_disk`, `rlimit_nofile` 1024
- Wall-clock `--time_limit` tracking the Hermes per-command timeout (+5 s cushion so the Python-side poll wins the race and we get a clean stdout drain instead of a kernel SIGKILL)
- Host env stripped through the existing provider-secret blocklist (`_sanitize_subprocess_env`), then `PATH`/`HOME`/locale vars + user-declared `nsjail_forward_env` entries forwarded via `--env KEY=VALUE`

## Escape hatch

Users who need seccomp filters, PID/UTS namespace tuning, or bespoke mounts can set `terminal.nsjail_config` to the path of a protobuf text-format `nsjail.cfg`. Hermes then delegates **all** sandbox policy to that file and only re-injects `--time_limit` so runaway commands can't outlive the tool call.

## What's wired

- `tools/environments/nsjail.py` — new `NsjailEnvironment` subclass of `BaseEnvironment`, plus `find_nsjail()` with the same `HERMES_NSJAIL_BINARY` override pattern as Docker
- `tools/terminal_tool.py` — factory branch, backend-config reads (`TERMINAL_NSJAIL_CONFIG`, `TERMINAL_NSJAIL_ALLOW_NET`, `TERMINAL_NSJAIL_FORWARD_ENV`), inclusion in the container-backend group for the restart path
- `tools/approval.py` — added `nsjail` to the dangerous-command skip list (the jail is the security boundary)
- `hermes_cli/config.py` — `nsjail_config` / `nsjail_allow_net` / `nsjail_forward_env` defaults + config→env sync entries
- `hermes_cli/setup.py` — Linux-only wizard option with preflight check
- `tools/environments/__init__.py` — docstring updated
- `website/docs/user-guide/configuration.md` — new "Nsjail Backend" section, updated backend overview table + troubleshooting list
- `website/docs/user-guide/security.md` — updated sandbox-bypass note + backend security comparison table

## Tests

Two new test files, mirroring the Docker pattern (all hermetic — no real nsjail binary needed, so they run on non-Linux CI too):

- `tests/tools/test_nsjail_find.py` — 6 tests for binary discovery (PATH, env-var override, cache, missing-file handling, non-executable handling)
- `tests/tools/test_nsjail_environment.py` — 13 tests for CLI-arg construction, preflight errors, `config_file` mode, env filtering, initial-cwd pin

Verified locally on Debian bookworm / aarch64:

- \`19 passed in 5.31s\` for the new tests
- \`53 passed\` for the combined docker/singularity/nsjail backend tests
- \`120 passed\` for the approval test suite
- E2E through \`terminal_tool(command=...)\`: nsjail spawns, inherits sanitized env, writes to the bindmounted cwd, fails writes to read-only paths, blocks network by default

## Test plan

- [ ] CI green on existing test suite (no existing tests changed behavior)
- [ ] Manual check: \`hermes setup terminal\` shows the new option on Linux and preflights the binary
- [ ] Manual check: with \`backend: nsjail\`, a simple terminal command runs; \`curl\` fails by default; setting \`nsjail_allow_net: true\` re-enables it
- [ ] Manual check: provider API keys in the host env don't appear inside the jail (\`env | grep OPENAI\` returns nothing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)