### PR TITLE
fix(model_metadata): add gemma-4 / gemma4 context-length entries

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -133,6 +133,8 @@ DEFAULT_CONTEXT_LENGTHS = {
     # Google
     "gemini": 1048576,
     # Gemma (open models served via AI Studio)
+    "gemma-4": 256000,  # Gemma 4 family
+    "gemma4": 256000,  # Ollama-style naming (e.g. gemma4:31b-cloud)
     "gemma-4-31b": 256000,
     "gemma-3": 131072,
     "gemma": 8192,  # fallback for older gemma models

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -343,6 +343,7 @@ AUTHOR_MAP = {
     "shalompmc0505@naver.com": "pinion05",
     "105142614+VTRiot@users.noreply.github.com": "VTRiot",
     "vivien000812@gmail.com": "iamagenius00",
+    "89228157+Feranmi10@users.noreply.github.com": "Feranmi10",
 }
 
 


### PR DESCRIPTION
Salvages #14174 onto current main.

## Summary
Bare `gemma-4` and Ollama-style `gemma4:...` model IDs resolve to 256K instead of being caught by the `"gemma": 8192` fallback. Closes #12976.

## Changes
- `agent/model_metadata.py`: add `gemma-4: 256000` and `gemma4: 256000` entries before the generic fallback. Matches existing `gemma-4-31b: 256000`; diverges from original PR which used 262144.
- `scripts/release.py`: AUTHOR_MAP entry for Feranmi10.

## Validation
| input | before | after |
|---|---|---|
| `gemma4:31b-cloud` | 8,192 | 256,000 |
| `gemma-4` | 8,192 | 256,000 |
| `gemma-4:31b` | 8,192 | 256,000 |
| `gemma-3-27b` | 131,072 | 131,072 |
| `gemma-2b` | 8,192 | 8,192 |

`tests/agent/test_model_metadata*.py`: 102/102 pass.

## Notes
Original #14174 was branched before the Tailscale CGNAT block landed on main, so its diff appeared to delete 25 unrelated lines. Cherry-picked the 2-line substantive change onto current main, preserved @Feranmi10's authorship, and closed the original.

Local Ollama users with memory-constrained `num_ctx` overrides are not affected: `_query_local_context_length` hits `/api/show` and caches the Modelfile value before the static table is consulted.

Credit: @Feranmi10 (#14174).