### PR TITLE
fix(cli): refuse to overwrite corrupt webhook subscriptions

### DIFF
--- a/hermes_cli/webhook.py
+++ b/hermes_cli/webhook.py
@@ -37,11 +37,23 @@ def _load_subscriptions() -> Dict[str, dict]:
     path = _subscriptions_path()
     if not path.exists():
         return {}
+
     try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-        return data if isinstance(data, dict) else {}
-    except Exception:
-        return {}
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ValueError(f"Failed to read webhook subscriptions file {path}: {exc}") from exc
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid webhook subscriptions file {path}: {exc.msg}") from exc
+
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"Invalid webhook subscriptions file {path}: expected a JSON object at the top level"
+        )
+
+    return data
 
 
 def _save_subscriptions(subs: Dict[str, dict]) -> None:
@@ -124,13 +136,20 @@ def webhook_command(args):
         return
 
     if sub in ("subscribe", "add"):
-        _cmd_subscribe(args)
+        handler = _cmd_subscribe
     elif sub in ("list", "ls"):
-        _cmd_list(args)
+        handler = _cmd_list
     elif sub in ("remove", "rm"):
-        _cmd_remove(args)
+        handler = _cmd_remove
     elif sub == "test":
-        _cmd_test(args)
+        handler = _cmd_test
+    else:
+        return
+
+    try:
+        handler(args)
+    except ValueError as exc:
+        print(f"Error: {exc}")
 
 
 def _cmd_subscribe(args):

--- a/tests/hermes_cli/test_webhook_cli.py
+++ b/tests/hermes_cli/test_webhook_cli.py
@@ -91,6 +91,19 @@ class TestSubscribe:
         assert "Error" in out or "Invalid" in out
         assert _load_subscriptions() == {}
 
+    def test_subscribe_refuses_to_overwrite_corrupt_file(self, capsys):
+        path = _subscriptions_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        original = "broken{{{"
+        path.write_text(original)
+
+        webhook_command(_make_args(webhook_action="subscribe", name="demo", events="ping"))
+
+        out = capsys.readouterr().out
+        assert "Error" in out
+        assert "webhook subscriptions file" in out
+        assert path.read_text() == original
+
 
 class TestList:
     def test_empty(self, capsys):
@@ -143,7 +156,9 @@ class TestPersistence:
         path = _subscriptions_path()
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text("broken{{{")
-        assert _load_subscriptions() == {}
+
+        with pytest.raises(ValueError, match="webhook subscriptions file"):
+            _load_subscriptions()
 
 
 class TestWebhookEnabledGate:


### PR DESCRIPTION
## Summary
- surface invalid `webhook_subscriptions.json` contents instead of treating them as empty state
- block `hermes webhook` commands from mutating a corrupted subscriptions file
- add regression coverage for both the parse error and the subscribe no-overwrite path

## Root cause
`_load_subscriptions()` swallowed every read/parse failure and returned `{}` for both a missing file and a corrupted one. `hermes webhook subscribe` then treated that empty dict as real state and overwrote the corrupted file.

## Fix
- make `_load_subscriptions()` raise a `ValueError` for unreadable, invalid-JSON, or non-object subscription files
- catch that error in `webhook_command()` and print a user-facing error instead of continuing with the mutation path

## Regression coverage
- assert `_load_subscriptions()` raises on a corrupted subscriptions file
- assert `hermes webhook subscribe` reports the error and leaves the corrupted file unchanged

## Testing
- `scripts/run_tests.sh tests/hermes_cli/test_webhook_cli.py`
- `scripts/run_tests.sh tests/hermes_cli` *(existing unrelated failures on current main: ZAI provider URL expectations, gateway WSL systemd checks, and one oversized tip string)*

Closes #14194
