### PR TITLE
fix(install): use `npm ci` on update to avoid lockfile churn

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -4471,6 +4471,25 @@ def _gateway_prompt(prompt_text: str, default: str = "", timeout: float = 300.0)
     return default
 
 
+def _npm_deps_install_cmd(
+    npm: str, cwd: Path, extra_args: Optional[list[str]] = None
+) -> list[str]:
+    """Build the npm command for installing dependencies in ``cwd``.
+
+    Uses ``npm ci`` when a ``package-lock.json`` is present so the lockfile is
+    respected byte-for-byte. Falls back to ``npm install`` when no lockfile
+    exists (e.g. a fresh dir or a repo that does not commit its lockfile).
+    ``npm install`` without a matching lockfile can silently rewrite
+    ``package-lock.json`` under certain npm-version / peer-resolution deltas,
+    which then trips ``hermes update``'s autostash on every subsequent run.
+    """
+    subcommand = "ci" if (cwd / "package-lock.json").exists() else "install"
+    cmd = [npm, subcommand]
+    if extra_args:
+        cmd.extend(extra_args)
+    return cmd
+
+
 def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
     """Build the web UI frontend if npm is available.
 
@@ -4491,7 +4510,11 @@ def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
             print("Install Node.js, then run:  cd web && npm install && npm run build")
         return not fatal
     print("→ Building web UI...")
-    r1 = subprocess.run([npm, "install", "--silent"], cwd=web_dir, capture_output=True)
+    r1 = subprocess.run(
+        _npm_deps_install_cmd(npm, web_dir, ["--silent"]),
+        cwd=web_dir,
+        capture_output=True,
+    )
     if r1.returncode != 0:
         print(
             f"  {'✗' if fatal else '⚠'} Web UI npm install failed"
@@ -5203,7 +5226,9 @@ def _update_node_dependencies() -> None:
             continue
 
         result = subprocess.run(
-            [npm, "install", "--silent", "--no-fund", "--no-audit", "--progress=false"],
+            _npm_deps_install_cmd(
+                npm, path, ["--silent", "--no-fund", "--no-audit", "--progress=false"]
+            ),
             cwd=path,
             capture_output=True,
             text=True,


### PR DESCRIPTION
## Summary

- `hermes update` calls `npm install` in `web/`, repo root, and `ui-tui/` on every cycle.
- Under npm version / peer-resolution deltas, `npm install` silently rewrites `package-lock.json` (e.g. strips `\"peer\": true` markers), leaving the repo dirty.
- The next `hermes update` then detects \"local changes\" and autostashes an unrelated lockfile diff the user never authored. Occasionally the stash/reapply round-trips without conflicts; it's still noise, and it can conflict.
- Switch to `npm ci` when a `package-lock.json` is present -- `npm ci` respects the lockfile byte-for-byte. Fall back to `npm install` when no lockfile exists so directories that don't commit one still work.

Scope: `hermes_cli/main.py` only -- `_build_web_ui()` (web UI build path) and `_update_node_dependencies()` (update path for repo root + ui-tui). Both now go through a small `_npm_deps_install_cmd()` helper.

## Repro

On a local checkout pre-dating commit `402d048e`, `web/package-lock.json` contained 22 `\"peer\": true` markers. Running `hermes update` under a locally-installed npm that normalizes those markers away produced this autostash on the next update:

```
Saved working directory and index state On main: hermes-update-autostash-<ts>
web/package-lock.json | 26 ++------------------------
1 file changed, 2 insertions(+), 24 deletions(-)
```

All 24 removed lines were `\"peer\": true` entries. The user had not modified any Hermes source.

## Test plan

- [x] `python3 -c \"import ast; ast.parse(open('hermes_cli/main.py').read())\"` parses clean
- [x] `npm ci --silent --no-fund --no-audit --progress=false` in `web/` (lockfile present) succeeds and leaves `package-lock.json` byte-identical (verified via `shasum -a 256`)
- [x] `_npm_deps_install_cmd()` falls back to `npm install` when `package-lock.json` is absent (unit-tested inline)
- [ ] Maintainer to confirm the same behavior in `ui-tui/` and repo root on CI

## Platforms tested

- macOS (Darwin 25.3.0), Node.js v25.9.0, npm 11.12.1