### PR TITLE
docs: fix broken env var example in CONTRIBUTING.md (salvage #14067)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,7 @@ cp cli-config.yaml.example ~/.hermes/config.yaml
 touch ~/.hermes/.env
 
 # Add at minimum an LLM provider key:
-echo 'OPENROUTER_API_KEY=sk-or-v1-your-key' >> ~/.hermes/.env
+echo "OPENROUTER_API_KEY=***" >> ~/.hermes/.env
 ```
 
 ### Run

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -345,6 +345,7 @@ AUTHOR_MAP = {
     "105142614+VTRiot@users.noreply.github.com": "VTRiot",
     "vivien000812@gmail.com": "iamagenius00",
     "89228157+Feranmi10@users.noreply.github.com": "Feranmi10",
+    "simon@gtcl.us": "simon-gtcl",
 }
 
 


### PR DESCRIPTION
Salvages #14067 by @simon-gtcl onto current main.

Fixes a shell-quoting typo in the CONTRIBUTING.md quickstart — the example `echo 'OPENROUTER_API_KEY=***` was missing a closing quote. Now uses double quotes consistently.

Also adds `simon@gtcl.us` → `simon-gtcl` to AUTHOR_MAP in scripts/release.py so release-notes CI attributes the commit correctly.

Closes #14067. Author attribution preserved via cherry-pick.