### PR TITLE
fix(gateway): add hermes-gateway script pattern to PID detection (salvage #10302)

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -136,6 +136,7 @@ def _looks_like_gateway_process(pid: int) -> bool:
         "hermes_cli.main gateway",
         "hermes_cli/main.py gateway",
         "hermes gateway",
+        "hermes-gateway",
         "gateway/run.py",
     )
     return any(pattern in cmdline for pattern in patterns)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -346,6 +346,7 @@ AUTHOR_MAP = {
     "vivien000812@gmail.com": "iamagenius00",
     "89228157+Feranmi10@users.noreply.github.com": "Feranmi10",
     "simon@gtcl.us": "simon-gtcl",
+    "suzukaze.haduki@gmail.com": "houko",
 }
 
 


### PR DESCRIPTION
Salvages #10302 by @houko onto current main.

Adds `hermes-gateway` to the cmdline patterns `_looks_like_gateway_process` checks, so the dashboard correctly identifies gateway processes launched via the installed entry-point script. Without this, users who start the gateway via the `hermes-gateway` wrapper see "not running" in the dashboard even when it is.

Also adds AUTHOR_MAP entry for attribution.

Closes #10302. Author attribution preserved via cherry-pick.