### PR TITLE
feat: add ctx_size to context length keys for Lemonade server (salvage #8536)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -203,6 +203,7 @@ _CONTEXT_LENGTH_KEYS = (
     "max_seq_len",
     "n_ctx_train",
     "n_ctx",
+    "ctx_size",
 )
 
 _MAX_COMPLETION_KEYS = (

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -347,6 +347,7 @@ AUTHOR_MAP = {
     "89228157+Feranmi10@users.noreply.github.com": "Feranmi10",
     "simon@gtcl.us": "simon-gtcl",
     "suzukaze.haduki@gmail.com": "houko",
+    "cliff@cigii.com": "cgarwood82",
 }
 
 


### PR DESCRIPTION
Salvages #8536 by @cgarwood82 onto current main.

Adds `ctx_size` to the `_CONTEXT_LENGTH_KEYS` tuple in `agent/model_metadata.py`. Lemonade-server-hosted custom LLMs report context length under the `ctx_size` field instead of the standard `max_seq_len`/`n_ctx` keys — without this entry, Hermes can't read the context window and falls back to a conservative default.

Closes #8536. Author attribution preserved via cherry-pick.