### PR TITLE
fix(nix): use stdenv.hostPlatform.system instead of deprecated pkgs.system (salvage #10249)

### DIFF
--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -28,7 +28,7 @@
 
   let
     cfg = config.services.hermes-agent;
-    hermes-agent = inputs.self.packages.${pkgs.system}.default;
+    hermes-agent = inputs.self.packages.${pkgs.stdenv.hostPlatform.system}.default;
 
     # Deep-merge config type (from 0xrsydn/nix-hermes-agent)
     deepConfigType = lib.types.mkOptionType {

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -348,6 +348,7 @@ AUTHOR_MAP = {
     "simon@gtcl.us": "simon-gtcl",
     "suzukaze.haduki@gmail.com": "houko",
     "cliff@cigii.com": "cgarwood82",
+    "anna@oa.ke": "anna-oake",
 }
 
 


### PR DESCRIPTION
Salvages #10249 by @anna-oake onto current main.

Replaces `pkgs.system` with `pkgs.stdenv.hostPlatform.system` in `nix/nixosModules.nix`. `pkgs.system` has been deprecated for a while in nixpkgs and emits a deprecation warning when the module is evaluated.

Closes #10249. Author attribution preserved via cherry-pick.