### PR TITLE
fix(tools): restrict RPC socket permissions to owner-only (salvage #6231)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -349,6 +349,7 @@ AUTHOR_MAP = {
     "suzukaze.haduki@gmail.com": "houko",
     "cliff@cigii.com": "cgarwood82",
     "anna@oa.ke": "anna-oake",
+    "jaffarkeikei@gmail.com": "jaffarkeikei",
 }
 
 

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -979,6 +979,7 @@ def execute_code(
         # --- Start UDS server ---
         server_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         server_sock.bind(sock_path)
+        os.chmod(sock_path, 0o600)
         server_sock.listen(1)
 
         rpc_thread = threading.Thread(


### PR DESCRIPTION
Salvages #6231 by @jaffarkeikei onto current main.

Defense-in-depth: calls `os.chmod(sock_path, 0o600)` immediately after `server_sock.bind(sock_path)` in execute_code's UDS server setup. The socket path already uses a uuid-randomized name in /tmp, but on multi-user systems with loose umasks another user could race to connect before the agent's child attaches. Tightening to owner-only closes the window.

Closes #6231. Also closes #6302 (duplicate by @duan78). Credit to both contributors — @jaffarkeikei's PR was submitted first.

Author attribution preserved via cherry-pick.