### PR TITLE
fix(agent): preserve nested error bodies during classification

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -786,19 +786,25 @@ def _extract_status_code(error: Exception) -> Optional[int]:
 
 
 def _extract_error_body(error: Exception) -> dict:
-    """Extract the structured error body from an SDK exception."""
-    body = getattr(error, "body", None)
-    if isinstance(body, dict):
-        return body
-    # Some errors have .response.json()
-    response = getattr(error, "response", None)
-    if response is not None:
-        try:
-            json_body = response.json()
-            if isinstance(json_body, dict):
-                return json_body
-        except Exception:
-            pass
+    """Walk the error and its cause chain to find a structured error body."""
+    current = error
+    for _ in range(5):  # Max depth to prevent infinite loops
+        body = getattr(current, "body", None)
+        if isinstance(body, dict):
+            return body
+        # Some errors have .response.json()
+        response = getattr(current, "response", None)
+        if response is not None:
+            try:
+                json_body = response.json()
+                if isinstance(json_body, dict):
+                    return json_body
+            except Exception:
+                pass
+        cause = getattr(current, "__cause__", None) or getattr(current, "__context__", None)
+        if cause is None or cause is current:
+            break
+        current = cause
     return {}
 
 

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -120,6 +120,17 @@ class TestExtractErrorBody:
         e = MockAPIError("fail", body={"error": {"message": "bad"}})
         assert _extract_error_body(e) == {"error": {"message": "bad"}}
 
+    def test_from_cause_chain(self):
+        inner = MockAPIError(
+            "inner",
+            body={"error": {"message": "Usage limit reached, try again in 5 minutes"}},
+        )
+        outer = Exception("outer")
+        outer.__cause__ = inner
+        assert _extract_error_body(outer) == {
+            "error": {"message": "Usage limit reached, try again in 5 minutes"}
+        }
+
     def test_empty_when_no_body(self):
         assert _extract_error_body(Exception("generic")) == {}
 
@@ -238,6 +249,20 @@ class TestClassifyApiError:
     def test_402_transient_usage_limit(self):
         e = MockAPIError("usage limit exceeded, try again later", status_code=402)
         result = classify_api_error(e)
+        assert result.reason == FailoverReason.rate_limit
+        assert result.retryable is True
+
+    def test_wrapped_402_uses_nested_body_message(self):
+        inner = MockAPIError(
+            "inner",
+            status_code=402,
+            body={"error": {"message": "Usage limit reached, try again in 5 minutes"}},
+        )
+        outer = Exception("outer")
+        outer.__cause__ = inner
+
+        result = classify_api_error(outer)
+
         assert result.reason == FailoverReason.rate_limit
         assert result.retryable is True
 


### PR DESCRIPTION
## Summary
- walk wrapped exceptions when extracting structured API error bodies
- keep nested provider messages available for message-aware classification
- add regression coverage for wrapped 402 rate-limit bodies

## Root cause
- `classify_api_error()` already walks `__cause__` / `__context__` for status codes
- `_extract_error_body()` only inspected the top-level exception
- wrapped SDK errors therefore kept `status_code=402` but lost the nested body message that says the condition is transient

## Fix
- make `_extract_error_body()` traverse the same cause/context chain as `_extract_status_code()`
- stop at the first structured `body` or `response.json()` payload found

## Regression coverage
- add a helper-level test proving `_extract_error_body()` reads the nested body from `__cause__`
- add an end-to-end classifier test proving a wrapped 402 with "try again" now classifies as `rate_limit`

## Testing
- `scripts/run_tests.sh tests/agent/test_error_classifier.py::TestExtractErrorBody::test_from_cause_chain tests/agent/test_error_classifier.py::TestClassifyApiError::test_wrapped_402_uses_nested_body_message`
- `scripts/run_tests.sh tests/agent/test_error_classifier.py`
- `scripts/run_tests.sh tests/agent/test_gemini_cloudcode.py::TestGeminiHttpErrorParsing::test_status_code_flows_through_error_classifier`

Closes #14195