### PR TITLE
fix(email): accept **kwargs in send_document to handle metadata (salvage #12171)

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -545,6 +545,7 @@ class EmailAdapter(BasePlatformAdapter):
         caption: Optional[str] = None,
         file_name: Optional[str] = None,
         reply_to: Optional[str] = None,
+        **kwargs,
     ) -> SendResult:
         """Send a file as an email attachment."""
         try:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -350,6 +350,7 @@ AUTHOR_MAP = {
     "cliff@cigii.com": "cgarwood82",
     "anna@oa.ke": "anna-oake",
     "jaffarkeikei@gmail.com": "jaffarkeikei",
+    "hxp@hxp.plus": "hxp-plus",
 }
 
 


### PR DESCRIPTION
Salvages #12171 by @hxp-plus onto current main.

The base adapter's `send_document` takes `**kwargs` (gateway/platforms/base.py:1288), and call sites at base.py:1985 and :2015 always pass `metadata=_thread_metadata`. Every other adapter (whatsapp, bluebubbles, signal, telegram) accepts `**kwargs` in its override — email was the only one that didn't, so any file attachment over email raised `TypeError: send_document() got an unexpected keyword argument 'metadata'`.

One-line fix: add `**kwargs` to the email adapter's signature to match the base class.

Closes #12171. Author attribution preserved via cherry-pick.