### PR TITLE
fix(scripts): read gateway_voice_mode.json as UTF-8 (salvage #8471)

### DIFF
--- a/scripts/discord-voice-doctor.py
+++ b/scripts/discord-voice-doctor.py
@@ -265,7 +265,7 @@ def check_config(groq_key, eleven_key):
     if voice_mode_path.exists():
         try:
             import json
-            modes = json.loads(voice_mode_path.read_text())
+            modes = json.loads(voice_mode_path.read_text(encoding="utf-8"))
             off_count = sum(1 for v in modes.values() if v == "off")
             all_count = sum(1 for v in modes.values() if v == "all")
             check("Voice mode state", True, f"{all_count} on, {off_count} off, {len(modes)} total")

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -351,6 +351,7 @@ AUTHOR_MAP = {
     "anna@oa.ke": "anna-oake",
     "jaffarkeikei@gmail.com": "jaffarkeikei",
     "hxp@hxp.plus": "hxp-plus",
+    "3580442280@qq.com": "Tianworld",
 }
 
 


### PR DESCRIPTION
Salvages #8471 by @Tianworld onto current main.

`scripts/discord-voice-doctor.py` reads `gateway_voice_mode.json` with `path.read_text()`, which uses the platform's default locale encoding. On Windows systems with non-UTF-8 code pages (e.g. cp936/cp1252) this can fail or misread non-ASCII content. Explicit `encoding="utf-8"` matches how the file is written elsewhere in the codebase.

Closes #8471. Author attribution preserved via cherry-pick.