### PR TITLE
docs(agent-loop): rename _api_call_with_interrupt to _interruptible_api_call

### DIFF
--- a/website/docs/developer-guide/adding-providers.md
+++ b/website/docs/developer-guide/adding-providers.md
@@ -253,7 +253,7 @@ Search for `api_mode` and audit every switch point. At minimum, verify:
 - `__init__` chooses the new `api_mode`
 - client construction works for the provider
 - `_build_api_kwargs()` knows how to format requests
-- `_api_call_with_interrupt()` dispatches to the right client call
+- `_interruptible_api_call()` dispatches to the right client call
 - interrupt / client rebuild paths work
 - response validation accepts the provider's shape
 - finish-reason extraction is correct

--- a/website/docs/developer-guide/agent-loop.md
+++ b/website/docs/developer-guide/agent-loop.md
@@ -72,7 +72,7 @@ run_conversation()
      - anthropic_messages: convert via anthropic_adapter.py
   6. Inject ephemeral prompt layers (budget warnings, context pressure)
   7. Apply prompt caching markers if on Anthropic
-  8. Make interruptible API call (_api_call_with_interrupt)
+  8. Make interruptible API call (_interruptible_api_call)
   9. Parse response:
      - If tool_calls: execute them, append results, loop back to step 5
      - If text response: persist session, flush memory if needed, return
@@ -105,7 +105,7 @@ Providers validate these sequences and will reject malformed histories.
 
 ## Interruptible API Calls
 
-API requests are wrapped in `_api_call_with_interrupt()` which runs the actual HTTP call in a background thread while monitoring an interrupt event:
+API requests are wrapped in `_interruptible_api_call()` which runs the actual HTTP call in a background thread while monitoring an interrupt event:
 
 ```text
 ┌────────────────────────────────────────────────────┐


### PR DESCRIPTION
## What does this PR do?

The developer-guide docs reference a function name (`_api_call_with_interrupt`) that does not exist in `run_agent.py`. The actual function is `_interruptible_api_call` (defined at `run_agent.py:5172`). This PR aligns the three doc references with the real symbol so readers grepping the codebase from the docs can find it.

## Related Issue

N/A — purely a docs/code-name drift fix found while reading the developer guide.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `website/docs/developer-guide/agent-loop.md` (line 75): step list reference updated to `_interruptible_api_call`.
- `website/docs/developer-guide/agent-loop.md` (line 108): "Interruptible API Calls" section opener updated to `` `_interruptible_api_call()` ``.
- `website/docs/developer-guide/adding-providers.md` (line 256): provider-audit checklist item updated to `` `_interruptible_api_call()` ``.

Diff: 2 files changed, 3 insertions(+), 3 deletions(-).

## How to Test

1. `grep -rn "_api_call_with_interrupt" website/` — should return zero hits.
2. `grep -rn "_interruptible_api_call" website/docs/developer-guide/` — should return three hits (one in `adding-providers.md`, two in `agent-loop.md`).
3. `grep -n "_interruptible_api_call" run_agent.py` — confirms the symbol exists at line 5172 (the source of truth the docs now match).
4. Optional Docusaurus sanity check: `cd website && npm ci && npm run build` (mirrors the `Docs Site Checks` CI job).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`docs(agent-loop): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A, docs-only change
- [x] I've added tests for my changes — N/A, docs-only change
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (this PR _is_ the documentation update)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A, docs-only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)