### PR TITLE
fix(provider): recognize open.bigmodel.cn as Zhipu/ZAI provider (salvage #7790)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -247,6 +247,7 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "chatgpt.com": "openai",
     "api.anthropic.com": "anthropic",
     "api.z.ai": "zai",
+    "open.bigmodel.cn": "zai",
     "api.moonshot.ai": "kimi-coding",
     "api.moonshot.cn": "kimi-coding-cn",
     "api.kimi.com": "kimi-coding",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -352,6 +352,7 @@ AUTHOR_MAP = {
     "jaffarkeikei@gmail.com": "jaffarkeikei",
     "hxp@hxp.plus": "hxp-plus",
     "3580442280@qq.com": "Tianworld",
+    "wujianxu91@gmail.com": "wujhsu",
 }
 
 


### PR DESCRIPTION
Salvages #7790 by @wujhsu onto current main.

Adds `open.bigmodel.cn` → `zai` to the `_URL_TO_PROVIDER` map in `agent/model_metadata.py`. Zhipu/Z.ai's OpenAI-compatible endpoint is accessible at both `api.z.ai` and `open.bigmodel.cn`; only the former was mapped, so users configured against the mainland-China endpoint didn't get provider auto-detection (context length lookup, model metadata resolution).

Closes #7790. Also closes #8142 (duplicate by @winniesi, submitted ~12h later). Both contributors credited. Author attribution preserved via cherry-pick.