### PR TITLE
feat(web): support TAVILY_BASE_URL env var for custom proxy endpoints (salvage #9072)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -353,6 +353,7 @@ AUTHOR_MAP = {
     "hxp@hxp.plus": "hxp-plus",
     "3580442280@qq.com": "Tianworld",
     "wujianxu91@gmail.com": "wujhsu",
+    "zhrh120@gmail.com": "niyoh120",
 }
 
 

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -282,7 +282,7 @@ def _get_async_parallel_client():
 
 # ─── Tavily Client ───────────────────────────────────────────────────────────
 
-_TAVILY_BASE_URL = "https://api.tavily.com"
+_TAVILY_BASE_URL = os.getenv("TAVILY_BASE_URL", "https://api.tavily.com")
 
 
 def _tavily_request(endpoint: str, payload: dict) -> dict:


### PR DESCRIPTION
Salvages #9072 by @niyoh120 onto current main.

Allows overriding the Tavily API endpoint via `TAVILY_BASE_URL` — useful for users behind corporate proxies or using compatible self-hosted search backends. Follows the existing pattern used by `GROQ_BASE_URL`, `BROWSERBASE_BASE_URL`, and `STT_OPENAI_BASE_URL`. Default unchanged.

Closes #9072. Author attribution preserved via cherry-pick.