### PR TITLE
fix: use builtin cd in command wrapper to bypass shell aliases (salvage #9520)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -354,6 +354,7 @@ AUTHOR_MAP = {
     "3580442280@qq.com": "Tianworld",
     "wujianxu91@gmail.com": "wujhsu",
     "zhrh120@gmail.com": "niyoh120",
+    "vrinek@hey.com": "vrinek",
 }
 
 

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -383,7 +383,7 @@ class BaseEnvironment(ABC):
         quoted_cwd = (
             shlex.quote(cwd) if cwd != "~" and not cwd.startswith("~/") else cwd
         )
-        parts.append(f"cd {quoted_cwd} || exit 126")
+        parts.append(f"builtin cd {quoted_cwd} || exit 126")
 
         # Run the actual command
         parts.append(f"eval '{escaped}'")


### PR DESCRIPTION
Salvages #9520 by @vrinek onto current main.

The terminal backend wraps every agent command in a bash script that starts with `cd <cwd>`. If a user has aliased `cd` in their environment (common with zsh-style `cd=z` or similar), that alias gets invoked instead of the real `cd` builtin — which can fail silently or land in the wrong directory, causing `exit 126` from the wrapper. `builtin cd` bypasses aliases and functions, guaranteeing the wrapper uses the real cd.

Verified: `alias cd="echo HIJACKED"; builtin cd /tmp && pwd` → `/tmp` (alias bypassed).

Closes #9520. Author attribution preserved via cherry-pick.