### PR TITLE
fix(skills): follow symlinks in iter_skill_index_files (salvage #11847)

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -435,7 +435,7 @@ def iter_skill_index_files(skills_dir: Path, filename: str):
     Excludes ``.git``, ``.github``, ``.hub`` directories.
     """
     matches = []
-    for root, dirs, files in os.walk(skills_dir):
+    for root, dirs, files in os.walk(skills_dir, followlinks=True):
         dirs[:] = [d for d in dirs if d not in EXCLUDED_SKILL_DIRS]
         if filename in files:
             matches.append(Path(root) / filename)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -355,6 +355,7 @@ AUTHOR_MAP = {
     "wujianxu91@gmail.com": "wujhsu",
     "zhrh120@gmail.com": "niyoh120",
     "vrinek@hey.com": "vrinek",
+    "268198004+xandersbell@users.noreply.github.com": "xandersbell",
 }
 
 


### PR DESCRIPTION
Salvages #11847 by @xandersbell onto current main (substantive commit 6d5d2e93; the PR's other commits were stale-branch merge commits).

Passes `followlinks=True` to `os.walk()` in `iter_skill_index_files`. Users who symlink their `~/.hermes/skills/` directory to a dotfiles repo or shared location previously had their skills invisible to discovery — `os.walk` skips symlinked directories by default. This matches how skill discovery already walks into the user's skills dir as a regular traversal.

Closes #11847. Author attribution preserved via cherry-pick.