### PR TITLE
fix(docker): add openssh-client for SSH terminal backend (salvage #10838)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/opt/hermes/.playwright
 # Install system dependencies in one layer, clear APT cache
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        build-essential nodejs npm python3 ripgrep ffmpeg gcc python3-dev libffi-dev procps git && \
+        build-essential nodejs npm python3 ripgrep ffmpeg gcc python3-dev libffi-dev procps git openssh-client && \
     rm -rf /var/lib/apt/lists/*
 
 # Non-root user for runtime; UID can be overridden via HERMES_UID at runtime

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -356,6 +356,7 @@ AUTHOR_MAP = {
     "zhrh120@gmail.com": "niyoh120",
     "vrinek@hey.com": "vrinek",
     "268198004+xandersbell@users.noreply.github.com": "xandersbell",
+    "somme4096@gmail.com": "Somme4096",
 }
 
 


### PR DESCRIPTION
Salvages #10838 by @Somme4096 onto current main.

The SSH terminal backend (`tools/environments/ssh.py`) shells out to the system `ssh` binary, but the Docker image only installed the server-side deps — no client. Adds `openssh-client` to the apt install line so users who configure SSH terminal execution from inside the Hermes Docker image can actually connect.

Closes #10838. Author attribution preserved via cherry-pick.