### PR TITLE
feat(docker): add docker-cli to Docker image (salvage #10096)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/opt/hermes/.playwright
 # Install system dependencies in one layer, clear APT cache
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        build-essential nodejs npm python3 ripgrep ffmpeg gcc python3-dev libffi-dev procps git openssh-client && \
+        build-essential nodejs npm python3 ripgrep ffmpeg gcc python3-dev libffi-dev procps git openssh-client docker-cli && \
     rm -rf /var/lib/apt/lists/*
 
 # Non-root user for runtime; UID can be overridden via HERMES_UID at runtime

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -357,6 +357,7 @@ AUTHOR_MAP = {
     "vrinek@hey.com": "vrinek",
     "268198004+xandersbell@users.noreply.github.com": "xandersbell",
     "somme4096@gmail.com": "Somme4096",
+    "brian@tiuxo.com": "brianclemens",
 }
 
 


### PR DESCRIPTION
Salvages #10096 by @brianclemens onto current main.

Adds `docker-cli` to the Docker image's apt install line. Lets users who run Hermes inside a container manage Docker from within the agent — `terminal("docker ps")` and similar. Debian 13 (bookworm+) ships this as a standalone apt package (`docker-cli - Linux container runtime -- client`).

Verified the package exists and installs cleanly on the base image.

Closes #10096. Author attribution preserved via cherry-pick.