### PR TITLE
fix(delegate): inherit parent MCP toolsets in narrowed subagents (salvage #14211)

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -776,7 +776,7 @@ delegation:
   # max_concurrent_children: 3                # Max parallel child agents (default: 3)
   # max_spawn_depth: 1                        # Tree depth cap (1-3, default: 1 = flat). Raise to 2 or 3 to allow orchestrator children to spawn their own workers.
   # orchestrator_enabled: true                # Kill switch for role="orchestrator" children (default: true).
-  # inherit_mcp_toolsets: true                # When explicit child toolsets are narrowed, also keep the parent's MCP toolsets (default: false).
+  # inherit_mcp_toolsets: true                # When explicit child toolsets are narrowed, also keep the parent's MCP toolsets (default: true). Set false for strict intersection.
   # model: "google/gemini-3-flash-preview"    # Override model for subagents (empty = inherit parent)
   # provider: "openrouter"                    # Override provider for subagents (empty = inherit parent)
   #                                           # Resolves full credentials (base_url, api_key) automatically.

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -776,6 +776,7 @@ delegation:
   # max_concurrent_children: 3                # Max parallel child agents (default: 3)
   # max_spawn_depth: 1                        # Tree depth cap (1-3, default: 1 = flat). Raise to 2 or 3 to allow orchestrator children to spawn their own workers.
   # orchestrator_enabled: true                # Kill switch for role="orchestrator" children (default: true).
+  # inherit_mcp_toolsets: true                # When explicit child toolsets are narrowed, also keep the parent's MCP toolsets (default: false).
   # model: "google/gemini-3-flash-preview"    # Override model for subagents (empty = inherit parent)
   # provider: "openrouter"                    # Override provider for subagents (empty = inherit parent)
   #                                           # Resolves full credentials (base_url, api_key) automatically.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -713,9 +713,11 @@ DEFAULT_CONFIG = {
         "base_url": "",    # direct OpenAI-compatible endpoint for subagents
         "api_key": "",     # API key for delegation.base_url (falls back to OPENAI_API_KEY)
         # When delegate_task narrows child toolsets explicitly, preserve any
-        # MCP toolsets the parent already has enabled. Off by default so
-        # narrowed child toolsets stay strict unless the operator opts in.
-        "inherit_mcp_toolsets": False,
+        # MCP toolsets the parent already has enabled. On by default so
+        # narrowing (e.g. toolsets=["web","browser"]) expresses "I want these
+        # extras" without silently stripping MCP tools the parent already has.
+        # Set to false for strict intersection.
+        "inherit_mcp_toolsets": True,
         "max_iterations": 50,  # per-subagent iteration cap (each subagent gets its own budget,
                                # independent of the parent's max_iterations)
         "reasoning_effort": "",  # reasoning effort for subagents: "xhigh", "high", "medium",
@@ -927,7 +929,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 23,
+    "_config_version": 22,
 }
 
 # =============================================================================

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -712,6 +712,10 @@ DEFAULT_CONFIG = {
         "provider": "",    # e.g. "openrouter" (empty = inherit parent provider + credentials)
         "base_url": "",    # direct OpenAI-compatible endpoint for subagents
         "api_key": "",     # API key for delegation.base_url (falls back to OPENAI_API_KEY)
+        # When delegate_task narrows child toolsets explicitly, preserve any
+        # MCP toolsets the parent already has enabled. Off by default so
+        # narrowed child toolsets stay strict unless the operator opts in.
+        "inherit_mcp_toolsets": False,
         "max_iterations": 50,  # per-subagent iteration cap (each subagent gets its own budget,
                                # independent of the parent's max_iterations)
         "reasoning_effort": "",  # reasoning effort for subagents: "xhigh", "high", "medium",
@@ -923,7 +927,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 22,
+    "_config_version": 23,
 }
 
 # =============================================================================

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1059,35 +1059,7 @@ class TestChildCredentialPoolResolution(unittest.TestCase):
             self.assertEqual(mock_child._credential_pool, mock_pool)
 
     @patch("tools.delegate_tool._load_config", return_value={})
-    def test_build_child_agent_does_not_preserve_mcp_toolsets_by_default(self, mock_cfg):
-        parent = _make_mock_parent()
-        parent.enabled_toolsets = ["web", "browser", "mcp-MiniMax"]
-
-        with patch("run_agent.AIAgent") as MockAgent:
-            mock_child = MagicMock()
-            MockAgent.return_value = mock_child
-
-            _build_child_agent(
-                task_index=0,
-                goal="Test narrowed toolsets",
-                context=None,
-                toolsets=["web", "browser"],
-                model=None,
-                max_iterations=10,
-                parent_agent=parent,
-                task_count=1,
-            )
-
-        self.assertEqual(
-            MockAgent.call_args[1]["enabled_toolsets"],
-            ["web", "browser"],
-        )
-
-    @patch(
-        "tools.delegate_tool._load_config",
-        return_value={"inherit_mcp_toolsets": True},
-    )
-    def test_build_child_agent_can_preserve_parent_mcp_toolsets(self, mock_cfg):
+    def test_build_child_agent_preserves_mcp_toolsets_by_default(self, mock_cfg):
         parent = _make_mock_parent()
         parent.enabled_toolsets = ["web", "browser", "mcp-MiniMax"]
 
@@ -1109,6 +1081,34 @@ class TestChildCredentialPoolResolution(unittest.TestCase):
         self.assertEqual(
             MockAgent.call_args[1]["enabled_toolsets"],
             ["web", "browser", "mcp-MiniMax"],
+        )
+
+    @patch(
+        "tools.delegate_tool._load_config",
+        return_value={"inherit_mcp_toolsets": False},
+    )
+    def test_build_child_agent_strict_intersection_when_opted_out(self, mock_cfg):
+        parent = _make_mock_parent()
+        parent.enabled_toolsets = ["web", "browser", "mcp-MiniMax"]
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+
+            _build_child_agent(
+                task_index=0,
+                goal="Test narrowed toolsets",
+                context=None,
+                toolsets=["web", "browser"],
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        self.assertEqual(
+            MockAgent.call_args[1]["enabled_toolsets"],
+            ["web", "browser"],
         )
 
 

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1058,6 +1058,59 @@ class TestChildCredentialPoolResolution(unittest.TestCase):
 
             self.assertEqual(mock_child._credential_pool, mock_pool)
 
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_build_child_agent_does_not_preserve_mcp_toolsets_by_default(self, mock_cfg):
+        parent = _make_mock_parent()
+        parent.enabled_toolsets = ["web", "browser", "mcp-MiniMax"]
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+
+            _build_child_agent(
+                task_index=0,
+                goal="Test narrowed toolsets",
+                context=None,
+                toolsets=["web", "browser"],
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        self.assertEqual(
+            MockAgent.call_args[1]["enabled_toolsets"],
+            ["web", "browser"],
+        )
+
+    @patch(
+        "tools.delegate_tool._load_config",
+        return_value={"inherit_mcp_toolsets": True},
+    )
+    def test_build_child_agent_can_preserve_parent_mcp_toolsets(self, mock_cfg):
+        parent = _make_mock_parent()
+        parent.enabled_toolsets = ["web", "browser", "mcp-MiniMax"]
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+
+            _build_child_agent(
+                task_index=0,
+                goal="Test narrowed toolsets",
+                context=None,
+                toolsets=["web", "browser"],
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        self.assertEqual(
+            MockAgent.call_args[1]["enabled_toolsets"],
+            ["web", "browser", "mcp-MiniMax"],
+        )
+
 
 class TestChildCredentialLeasing(unittest.TestCase):
     def test_run_single_child_acquires_and_releases_lease(self):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -379,7 +379,7 @@ def _get_orchestrator_enabled() -> bool:
 def _get_inherit_mcp_toolsets() -> bool:
     """Whether narrowed child toolsets should keep the parent's MCP toolsets."""
     cfg = _load_config()
-    return is_truthy_value(cfg.get("inherit_mcp_toolsets"), default=False)
+    return is_truthy_value(cfg.get("inherit_mcp_toolsets"), default=True)
 
 
 def _is_mcp_toolset_name(name: str) -> bool:

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -33,7 +33,7 @@ from typing import Any, Dict, List, Optional
 
 from toolsets import TOOLSETS
 from tools import file_state
-from utils import base_url_hostname
+from utils import base_url_hostname, is_truthy_value
 
 
 # Tools that children must never have access to
@@ -374,6 +374,38 @@ def _get_orchestrator_enabled() -> bool:
     if isinstance(val, str):
         return val.strip().lower() in ("true", "1", "yes", "on")
     return True
+
+
+def _get_inherit_mcp_toolsets() -> bool:
+    """Whether narrowed child toolsets should keep the parent's MCP toolsets."""
+    cfg = _load_config()
+    return is_truthy_value(cfg.get("inherit_mcp_toolsets"), default=False)
+
+
+def _is_mcp_toolset_name(name: str) -> bool:
+    """Return True for canonical MCP toolsets and their registered aliases."""
+    if not name:
+        return False
+    if str(name).startswith("mcp-"):
+        return True
+    try:
+        from tools.registry import registry
+
+        target = registry.get_toolset_alias_target(str(name))
+    except Exception:
+        target = None
+    return bool(target and str(target).startswith("mcp-"))
+
+
+def _preserve_parent_mcp_toolsets(
+    child_toolsets: List[str], parent_toolsets: set[str]
+) -> List[str]:
+    """Append any parent MCP toolsets that are missing from a narrowed child."""
+    preserved = list(child_toolsets)
+    for toolset_name in sorted(parent_toolsets):
+        if _is_mcp_toolset_name(toolset_name) and toolset_name not in preserved:
+            preserved.append(toolset_name)
+    return preserved
 
 
 DEFAULT_MAX_ITERATIONS = 50
@@ -782,6 +814,8 @@ def _build_child_agent(
     parent_subagent_id = getattr(parent_agent, "_subagent_id", None)
     tui_depth = max(0, child_depth - 1)  # 0 = first-level child for the UI
 
+    delegation_cfg = _load_config()
+
     # When no explicit toolsets given, inherit from parent's enabled toolsets
     # so disabled tools (e.g. web) don't leak to subagents.
     # Note: enabled_toolsets=None means "all tools enabled" (the default),
@@ -803,9 +837,12 @@ def _build_child_agent(
 
     if toolsets:
         # Intersect with parent — subagent must not gain tools the parent lacks
-        child_toolsets = _strip_blocked_tools(
-            [t for t in toolsets if t in parent_toolsets]
-        )
+        child_toolsets = [t for t in toolsets if t in parent_toolsets]
+        if _get_inherit_mcp_toolsets():
+            child_toolsets = _preserve_parent_mcp_toolsets(
+                child_toolsets, parent_toolsets
+            )
+        child_toolsets = _strip_blocked_tools(child_toolsets)
     elif parent_agent and parent_enabled is not None:
         child_toolsets = _strip_blocked_tools(parent_enabled)
     elif parent_toolsets:
@@ -889,7 +926,6 @@ def _build_child_agent(
     parent_reasoning = getattr(parent_agent, "reasoning_config", None)
     child_reasoning = parent_reasoning
     try:
-        delegation_cfg = _load_config()
         delegation_effort = str(delegation_cfg.get("reasoning_effort") or "").strip()
         if delegation_effort:
             from hermes_constants import parse_reasoning_effort


### PR DESCRIPTION
Salvages @helix4u's #14211 with two tweaks.

## Summary
Narrowing delegate_task toolsets (e.g. `toolsets=['web','browser']`) no longer silently strips parent MCP toolsets. Discord report: MiniMax MCP tools (`mcp_MiniMax_web_search`) worked in the parent gateway session but disappeared from subagents because the explicit toolsets intersection in `tools/delegate_tool.py` dropped `mcp-MiniMax`.

## Changes vs #14211
- **Default flipped to `true`.** Narrowing a toolset list expresses "I want these extras," not "silently drop MCP that I explicitly configured." Users who hit this bug are exactly the ones who wouldn't know an opt-in flag exists. Set `delegation.inherit_mcp_toolsets: false` for the old strict-intersection behavior.
- **Dropped `_config_version` bump (22 → 23).** Additive nested key under `delegation.*`; `_deep_merge()` handles it, no migration needed.
- Tests updated to match new default (preserve on by default, strict when opted out).

## Validation
- `scripts/run_tests.sh tests/tools/test_delegate.py tests/hermes_cli/test_config.py tests/hermes_cli/test_config_drift.py -n 4` → 157/157 green
- helix4u's substantive commit preserved via cherry-pick (author attribution intact)

Closes #14211.