### PR TITLE
fix: separate browser_cdp into its own toolset (salvage #13289)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -358,6 +358,7 @@ AUTHOR_MAP = {
     "268198004+xandersbell@users.noreply.github.com": "xandersbell",
     "somme4096@gmail.com": "Somme4096",
     "brian@tiuxo.com": "brianclemens",
+    "25944632+yudaiyan@users.noreply.github.com": "yudaiyan",
 }
 
 

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -402,7 +402,7 @@ def _browser_cdp_check() -> bool:
 
 registry.register(
     name="browser_cdp",
-    toolset="browser",
+    toolset="browser-cdp",
     schema=BROWSER_CDP_SCHEMA,
     handler=lambda args, **kw: browser_cdp(
         method=args.get("method", ""),


### PR DESCRIPTION
Salvages #13289 by @yudaiyan onto current main.

## What was wrong
`tools/registry.py` stores the first `check_fn` encountered per toolset. Because `browser_cdp_tool.py` sorts before `browser_tool.py` alphabetically, its CDP-specific `_browser_cdp_check` (which requires `BROWSER_CDP_URL`) became the availability gate for the entire `browser` toolset. Users with `agent-browser` correctly installed saw:

```
External Tools:
  ✓ agent-browser (Node.js) (browser automation)
Tool Availability:
  ⚠ browser (system dependency not met)    ← wrong
```

## The fix
One-line change: register `browser_cdp` under its own `"browser-cdp"` toolset. The tool still loads with the main browser toolset via the existing `toolsets.py` grouping (that's an independent system), but its availability check now scopes to itself. Doctor output becomes accurate: `browser` ✓, `browser-cdp` ⚠ (only when you actually don't have CDP).

## Attribution note
Original commit's author email was an unlinked QQ address, so the commit was re-authored to @yudaiyan's GitHub noreply email (`25944632+yudaiyan@users.noreply.github.com`) so the contribution attributes correctly on GitHub. All code is @yudaiyan's.

Closes #13289.