### PR TITLE
fix(terminal): forward docker_forward_env and docker_env to container_config (salvage #10162)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -359,6 +359,7 @@ AUTHOR_MAP = {
     "somme4096@gmail.com": "Somme4096",
     "brian@tiuxo.com": "brianclemens",
     "25944632+yudaiyan@users.noreply.github.com": "yudaiyan",
+    "chayton@sina.com": "ycbai",
 }
 
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1547,6 +1547,8 @@ def terminal_tool(
                                 "modal_mode": config.get("modal_mode", "auto"),
                                 "docker_volumes": config.get("docker_volumes", []),
                                 "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
+                                "docker_forward_env": config.get("docker_forward_env", []),
+                                "docker_env": config.get("docker_env", {}),
                             }
 
                         local_config = None


### PR DESCRIPTION
Salvages #10162 by @ycbai onto current main.

## What was wrong
`tools/terminal_tool.py:1547` builds a `container_config` dict from `config.yaml` for the async terminal path but was missing two keys: `docker_forward_env` (list of env var names to pass through) and `docker_env` (explicit var map). At line 939-954 the same file reads both from container_config and passes them to DockerEnvironment via `forward_env=` / `env=`. Result: users who configured `docker_forward_env: [...]` in config.yaml saw those variables silently dropped — never injected into containers.

Two-line fix: add both keys when the builder assembles container_config.

## Attribution note
Original commit's author email was an unlinked corporate address (`@goldwind.com`), so the commit was re-authored to @ycbai's public GitHub email so the contribution attributes correctly. All code is @ycbai's.

Closes #10162.