### PR TITLE
docs: add repo-centric and gateway MCP guidance

### DIFF
--- a/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -322,6 +322,25 @@ $HERMES_HOME/skills/        Installed skills
 
 Profiles use `~/.hermes/profiles/<name>/` with the same layout.
 
+### Repo-centric shared setup
+
+Hermes can keep its writable state in `~/.hermes/` while loading git-tracked repo skills from `.claude/skills/` or another shared directory via `skills.external_dirs`.
+
+```yaml
+# ~/.hermes/config.yaml
+skills:
+  external_dirs:
+    - ~/src/acme/.claude/skills
+    - /mnt/c/Users/alice/src/acme/.claude/skills   # WSL path to a Windows checkout
+```
+
+- `~/.hermes/skills` stays the local read-write layer.
+- External dirs are discovery-only; Hermes writes new or edited skills locally.
+- `CLAUDE.md` / `AGENTS.md` are shared repo instructions, while `.claude/memory/` is repo documentation — not Hermes built-in `MEMORY.md` / `USER.md`.
+- In WSL, use `/mnt/c/...` paths in config, not raw `C:\...` Windows paths.
+
+Full guide: https://hermes-agent.nousresearch.com/docs/user-guide/repo-centric-setup
+
 ### Config Sections
 
 Edit with `hermes config edit` or `hermes config set section.key value`.

--- a/tests/gateway/test_reload_mcp_command.py
+++ b/tests/gateway/test_reload_mcp_command.py
@@ -1,0 +1,113 @@
+"""Focused tests for the gateway /reload-mcp command."""
+
+from __future__ import annotations
+
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+def _make_source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        user_id="u1",
+        chat_id="c1",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _make_event(text: str = "/reload-mcp") -> MessageEvent:
+    return MessageEvent(text=text, source=_make_source(), message_id="m1")
+
+
+def _make_runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.session_store = MagicMock()
+    session_entry = MagicMock(session_id="sess-1")
+    runner.session_store.get_or_create_session.return_value = session_entry
+    runner.session_store.append_to_transcript = MagicMock()
+    return runner, session_entry
+
+
+@pytest.mark.asyncio
+async def test_reload_mcp_command_reports_success_summary(monkeypatch):
+    import tools.mcp_tool as mcp_mod
+
+    runner, session_entry = _make_runner()
+    servers = {"alpha": object(), "gone": object()}
+    lock = threading.RLock()
+
+    monkeypatch.setattr(mcp_mod, "_servers", servers)
+    monkeypatch.setattr(mcp_mod, "_lock", lock)
+
+    def fake_shutdown():
+        with lock:
+            servers.clear()
+
+    def fake_discover():
+        with lock:
+            servers["alpha"] = object()
+            servers["beta"] = object()
+        return ["mcp_alpha_ping", "mcp_beta_ping"]
+
+    monkeypatch.setattr(mcp_mod, "shutdown_mcp_servers", fake_shutdown)
+    monkeypatch.setattr(mcp_mod, "discover_mcp_tools", fake_discover)
+
+    result = await runner._handle_reload_mcp_command(_make_event())
+
+    assert "🔄 **MCP Servers Reloaded**" in result
+    assert "♻️ Reconnected: alpha" in result
+    assert "➕ Added: beta" in result
+    assert "➖ Removed: gone" in result
+    assert "🔧 2 tool(s) available from 2 server(s)" in result
+
+    runner.session_store.get_or_create_session.assert_called_once()
+    runner.session_store.append_to_transcript.assert_called_once()
+    session_id, reload_msg = runner.session_store.append_to_transcript.call_args.args
+    assert session_id == session_entry.session_id
+    assert reload_msg["role"] == "user"
+    assert "Added servers: beta" in reload_msg["content"]
+    assert "Removed servers: gone" in reload_msg["content"]
+    assert "Reconnected servers: alpha" in reload_msg["content"]
+    assert "2 MCP tool(s) now available" in reload_msg["content"]
+
+
+@pytest.mark.asyncio
+async def test_reload_mcp_command_reports_empty_summary(monkeypatch):
+    import tools.mcp_tool as mcp_mod
+
+    runner, session_entry = _make_runner()
+    servers: dict[str, object] = {}
+    lock = threading.RLock()
+
+    monkeypatch.setattr(mcp_mod, "_servers", servers)
+    monkeypatch.setattr(mcp_mod, "_lock", lock)
+
+    def fake_shutdown():
+        with lock:
+            servers.clear()
+
+    def fake_discover():
+        return []
+
+    monkeypatch.setattr(mcp_mod, "shutdown_mcp_servers", fake_shutdown)
+    monkeypatch.setattr(mcp_mod, "discover_mcp_tools", fake_discover)
+
+    result = await runner._handle_reload_mcp_command(_make_event())
+
+    assert "🔄 **MCP Servers Reloaded**" in result
+    assert "No MCP servers connected." in result
+    assert "tool(s) available" not in result
+
+    runner.session_store.append_to_transcript.assert_called_once()
+    session_id, reload_msg = runner.session_store.append_to_transcript.call_args.args
+    assert session_id == session_entry.session_id
+    assert "No MCP tools available" in reload_msg["content"]

--- a/website/docs/getting-started/quickstart.md
+++ b/website/docs/getting-started/quickstart.md
@@ -68,13 +68,18 @@ Good defaults:
 
 | Situation | Recommended path |
 |---|---|
-| Least friction | Nous Portal or OpenRouter |
+| Least-friction managed stack | Nous Portal + Tool Gateway |
+| Easy inference default | OpenRouter |
 | You already have Claude or Codex auth | Anthropic or OpenAI Codex |
 | You want local/private inference | Ollama or any custom OpenAI-compatible endpoint |
 | You want multi-provider routing | OpenRouter |
 | You have a custom GPU server | vLLM, SGLang, LiteLLM, or any OpenAI-compatible endpoint |
 
 For most first-time users: choose a provider, accept the defaults unless you know why you're changing them. The full provider catalog with env vars and setup steps lives on the [Providers](../integrations/providers.md) page.
+
+:::tip Picking the lowest-friction stack
+If you want the simplest fully managed Hermes setup, use **paid Nous Portal + Tool Gateway**: one login for inference plus managed web, image, TTS, and browser tools. If you mainly want quick model access and plan to manage tool providers separately, **OpenRouter** remains the easiest inference default.
+:::
 
 :::caution Minimum context: 64K tokens
 Hermes Agent requires a model with at least **64,000 tokens** of context. Models with smaller windows cannot maintain enough working memory for multi-step tool-calling workflows and will be rejected at startup. Most hosted models (Claude, GPT, Gemini, Qwen, DeepSeek) meet this easily. If you're running a local model, set its context size to at least 64K (e.g. `--ctx-size 65536` for llama.cpp or `-c 65536` for Ollama).

--- a/website/docs/guides/use-mcp-with-hermes.md
+++ b/website/docs/guides/use-mcp-with-hermes.md
@@ -35,6 +35,22 @@ Think of MCP as an adapter layer:
 
 That last part matters. Good MCP usage is not just “connect everything.” It is “connect the right thing, with the smallest useful surface.”
 
+## Choose transport based on where Hermes runs
+
+If the MCP server will be used from a shared Hermes gateway, a bot, or another always-on deployment, prefer **HTTP/StreamableHTTP via `url:` first** when the server offers it.
+
+Use `command:` stdio first when:
+
+- Hermes CLI and the MCP server live on the same machine
+- the integration depends on local filesystem or local OS access
+- you are prototyping quickly before deciding whether the server belongs in a shared gateway rollout
+
+| Deployment shape | Best default | Why |
+|---|---|---|
+| Local CLI on your laptop | `command` / stdio | Lowest setup friction for machine-local tools |
+| Shared Hermes gateway | `url` / HTTP/StreamableHTTP | Better long-lived reliability, clearer auth boundary, easier reloads and operations |
+| Remote/shared service | `url` / HTTP/StreamableHTTP | Reusable across multiple Hermes processes without spawning local helper CLIs |
+
 ## Step 1: install MCP support
 
 If you installed Hermes with the standard install script, MCP support is already included (the installer runs `uv pip install -e ".[all]"`).
@@ -362,6 +378,22 @@ Do this after changing:
 - enabled flags
 - resources/prompts toggles
 - auth headers / env
+
+## Gateway vs CLI rollout checklist
+
+Use this checklist when moving an MCP integration from a local experiment to something users will hit through the Hermes gateway.
+
+- [ ] **Run `hermes mcp test <name>` first** to prove the server connects outside the gateway.
+- [ ] **Run one read-only CLI smoke prompt** so you know the tools actually load in a normal Hermes session.
+- [ ] **Switch to `url:` HTTP/StreamableHTTP** for gateway-facing use if the MCP server supports it.
+- [ ] **Start with `tools.include`** for anything shared, sensitive, or destructive.
+- [ ] **Move auth out of interactive local state** and into stable `headers`, server config, or managed secrets.
+- [ ] **Set `connect_timeout` and `timeout`** to values that make sense for a long-lived bot.
+- [ ] **Restart or reload the gateway, then run `/reload-mcp`** and read the summary before testing with users.
+- [ ] **Confirm `/reload-mcp` shows connected servers and tool counts**. If it says `No MCP servers connected.`, treat that as a gateway/runtime failure even if CLI worked.
+- [ ] **Treat `hermes tools list --platform ...` as config exposure, not a live connectivity check**.
+- [ ] **Test a read-only prompt from the gateway surface first** before enabling write actions.
+- [ ] **Only expose destructive tools intentionally** after the read-only path is stable.
 
 ## Troubleshooting by symptom
 

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -38,6 +38,11 @@ You need at least one way to connect to an LLM. Use `hermes model` to switch pro
 | **Google Gemini (OAuth)** | `hermes model` → "Google Gemini (OAuth)" (provider: `google-gemini-cli`, free tier supported, browser PKCE login) |
 | **Custom Endpoint** | `hermes model` → choose "Custom endpoint" (saved in `config.yaml`) |
 
+:::tip Choosing between Nous Portal and OpenRouter
+- **Least-friction managed stack:** paid **Nous Portal + Tool Gateway**. One setup flow gives you managed inference plus web, image generation, TTS, and browser tools through your subscription.
+- **Easy inference default:** **OpenRouter**. It is still the quickest general-purpose inference setup when you want broad model access and are comfortable managing tool providers separately.
+:::
+
 :::tip Model key alias
 In the `model:` config section, you can use either `default:` or `model:` as the key name for your model ID. Both `model: { default: my-model }` and `model: { model: my-model }` work identically.
 :::
@@ -137,7 +142,7 @@ Even when using Nous Portal, Codex, or a custom endpoint, some tools (vision, we
 :::
 
 :::tip Nous Tool Gateway
-Paid Nous Portal subscribers also get access to the **[Tool Gateway](/docs/user-guide/features/tool-gateway)** — web search, image generation, TTS, and browser automation routed through your subscription. No extra API keys needed. It's offered automatically during `hermes model` setup, or enable it later with `hermes tools`.
+Paid Nous Portal subscribers also get access to the **[Tool Gateway](/docs/user-guide/features/tool-gateway)** — web search, image generation, TTS, and browser automation routed through your subscription. No extra API keys needed. Combined with Nous Portal inference, it is the lowest-friction managed Hermes stack. It's offered automatically during `hermes model` setup, or enable it later with `hermes tools`.
 :::
 
 ### Two Commands for Model Management
@@ -1076,7 +1081,7 @@ You can also select named custom providers from the interactive `hermes model` m
 
 | Use Case | Recommended |
 |----------|-------------|
-| **Just want it to work** | OpenRouter (default) or Nous Portal |
+| **Just want it to work** | OpenRouter (easy inference default) or paid Nous Portal + Tool Gateway (lowest-friction managed stack) |
 | **Local models, easy setup** | Ollama |
 | **Production GPU serving** | vLLM or SGLang |
 | **Mac / no GPU** | Ollama or llama.cpp |

--- a/website/docs/reference/mcp-config-reference.md
+++ b/website/docs/reference/mcp-config-reference.md
@@ -22,7 +22,7 @@ mcp_servers:
     env: {}
 
     # OR
-    url: "..."          # HTTP servers
+    url: "..."          # HTTP/StreamableHTTP servers (preferred for gateway/shared use)
     headers: {}
 
     enabled: true
@@ -42,7 +42,7 @@ mcp_servers:
 | `command` | string | stdio | Executable to launch |
 | `args` | list | stdio | Arguments for the subprocess |
 | `env` | mapping | stdio | Environment passed to the subprocess |
-| `url` | string | HTTP | Remote MCP endpoint |
+| `url` | string | HTTP | Remote MCP endpoint (HTTP/StreamableHTTP; preferred for gateway-facing deployments) |
 | `headers` | mapping | HTTP | Headers for remote server requests |
 | `enabled` | bool | both | Skip the server entirely when false |
 | `timeout` | number | both | Tool call timeout |
@@ -50,6 +50,14 @@ mcp_servers:
 | `tools` | mapping | both | Filtering and utility-tool policy |
 | `auth` | string | HTTP | Authentication method. Set to `oauth` to enable OAuth 2.1 with PKCE |
 | `sampling` | mapping | both | Server-initiated LLM request policy (see MCP guide) |
+
+## Transport choice
+
+- **`command` + `args` (stdio)**: best for local CLI-only integrations, especially when the server needs direct local machine access.
+- **`url` (HTTP/StreamableHTTP)**: preferred for gateway-facing, shared, or always-on deployments.
+- **If both `command` and `url` are present**, Hermes prefers `url` and treats the server as HTTP/StreamableHTTP.
+
+Practical rule: test locally however you like, but if the MCP server will back a shared Hermes gateway and it offers HTTP/StreamableHTTP, move to `url:` before rollout.
 
 ## `tools` policy keys
 
@@ -196,6 +204,14 @@ After changing MCP config, reload servers with:
 ```text
 /reload-mcp
 ```
+
+## Compact rollout checklist
+
+- Test the server in a local CLI session first.
+- Prefer `url:` for shared gateway deployments when the server supports HTTP/StreamableHTTP.
+- Start with `tools.include` for shared or destructive systems.
+- Verify auth, `connect_timeout`, and `timeout` before exposing it to users.
+- Use `/reload-mcp` and confirm the gateway summary after config changes.
 
 ## Tool naming
 

--- a/website/docs/user-guide/features/context-files.md
+++ b/website/docs/user-guide/features/context-files.md
@@ -14,7 +14,7 @@ Hermes Agent automatically discovers and loads context files that shape how it b
 |------|---------|-----------| 
 | **.hermes.md** / **HERMES.md** | Project instructions (highest priority) | Walks to git root |
 | **AGENTS.md** | Project instructions, conventions, architecture | CWD at startup + subdirectories progressively |
-| **CLAUDE.md** | Claude Code context files (also detected) | CWD at startup + subdirectories progressively |
+| **CLAUDE.md** | Claude Code context files, often used as a shared repo contract | CWD at startup + subdirectories progressively |
 | **SOUL.md** | Global personality and tone customization for this Hermes instance | `HERMES_HOME/SOUL.md` only |
 | **.cursorrules** | Cursor IDE coding conventions | CWD only |
 | **.cursor/rules/*.mdc** | Cursor IDE rule modules | CWD only |
@@ -76,6 +76,26 @@ This is a Next.js 14 web application with a Python FastAPI backend.
 - The `.env.local` file has real API keys, don't commit it
 - Frontend port is 3000, backend is 8000, DB is 5432
 ```
+
+## CLAUDE.md
+
+`CLAUDE.md` is useful when you want a **repo-centric coordination file** that works across Hermes, Claude Code, and other agent tools.
+
+Common pattern:
+
+- keep stable repo instructions in `CLAUDE.md`
+- keep shared skills in `.claude/skills/`
+- keep shared notes, architecture docs, or handoff material in `.claude/memory/`
+- keep Hermes's own built-in memory in `~/.hermes/memories/MEMORY.md` and `USER.md`
+
+Two important distinctions:
+
+1. Hermes still follows its normal priority order: `.hermes.md` → `AGENTS.md` → `CLAUDE.md` → `.cursorrules`.
+2. `.claude/memory/` is **repo content**, not Hermes's built-in memory store.
+
+That means `.claude/memory/` is great for git-tracked, team-shared context like ADRs, runbooks, and decision logs, but it is **not** automatically merged into Hermes `MEMORY.md` or `USER.md`. If a rule must appear every session, keep it in `CLAUDE.md` or `AGENTS.md`, or have Hermes read the specific file when needed.
+
+For the full repo-centric pattern — shared skills, precedence, WSL paths, multi-agent coordination, and git workflow — see [Repo-Centric Shared Setup](/docs/user-guide/repo-centric-setup).
 
 ## SOUL.md
 

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -13,7 +13,7 @@ If you have ever wanted Hermes to use a tool that already exists somewhere else,
 ## What MCP gives you
 
 - Access to external tool ecosystems without writing a native Hermes tool first
-- Local stdio servers and remote HTTP MCP servers in the same config
+- Local stdio servers and remote HTTP/StreamableHTTP MCP servers in the same config
 - Automatic tool discovery and registration at startup
 - Utility wrappers for MCP resources and prompts when supported by the server
 - Per-server filtering so you can expose only the MCP tools you actually want Hermes to see
@@ -72,9 +72,9 @@ Use stdio servers when:
 - you want low-latency access to local resources
 - you are following MCP server docs that show `command`, `args`, and `env`
 
-### HTTP servers
+### HTTP / StreamableHTTP servers
 
-HTTP MCP servers are remote endpoints Hermes connects to directly.
+HTTP/StreamableHTTP MCP servers are remote endpoints Hermes connects to directly.
 
 ```yaml
 mcp_servers:
@@ -89,6 +89,18 @@ Use HTTP servers when:
 - your organization exposes internal MCP endpoints
 - you do not want Hermes spawning a local subprocess for that integration
 
+:::tip Gateway-facing recommendation
+If the MCP server will back an always-on Hermes gateway, a shared bot, or another multi-user deployment, prefer **`url:` HTTP/StreamableHTTP transport first** when the server offers it. Use stdio first mainly for local CLI workflows and machine-local resources.
+:::
+
+## Transport choice: CLI vs gateway
+
+| Where Hermes will use the MCP server | Prefer | Why |
+|---|---|---|
+| Personal CLI session on the same machine | `command` / stdio or local HTTP | Fastest to prototype, easiest for local files and local runtimes |
+| Shared gateway or always-on bot | `url` / HTTP/StreamableHTTP | Cleaner separation, easier auth management, easier reloads, fewer local runtime dependencies |
+| Team service or remote worker | `url` / HTTP/StreamableHTTP | Better operational boundary and easier reuse across multiple Hermes instances |
+
 ## Basic configuration reference
 
 Hermes reads MCP config from `~/.hermes/config.yaml` under `mcp_servers`.
@@ -100,7 +112,7 @@ Hermes reads MCP config from `~/.hermes/config.yaml` under `mcp_servers`.
 | `command` | string | Executable for a stdio MCP server |
 | `args` | list | Arguments for the stdio server |
 | `env` | mapping | Environment variables passed to the stdio server |
-| `url` | string | HTTP MCP endpoint |
+| `url` | string | HTTP/StreamableHTTP MCP endpoint |
 | `headers` | mapping | HTTP headers for remote servers |
 | `timeout` | number | Tool call timeout |
 | `connect_timeout` | number | Initial connection timeout |

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -8,9 +8,13 @@ description: "On-demand knowledge documents — progressive disclosure, agent-ma
 
 Skills are on-demand knowledge documents the agent can load when needed. They follow a **progressive disclosure** pattern to minimize token usage and are compatible with the [agentskills.io](https://agentskills.io/specification) open standard.
 
-All skills live in **`~/.hermes/skills/`** — the primary directory and source of truth. On fresh install, bundled skills are copied from the repo. Hub-installed and agent-created skills also go here. The agent can modify or delete any skill.
+Every Hermes profile has a **local writable skills home** at **`~/.hermes/skills/`** (or `$HERMES_HOME/skills/`). On fresh install, bundled skills are copied there. Hub-installed and agent-created skills also go there by default.
 
-You can also point Hermes at **external skill directories** — additional folders scanned alongside the local one. See [External Skill Directories](#external-skill-directories) below.
+Hermes can also scan **external skill directories** alongside the local one — for example, repo-owned folders like `.claude/skills/` or a shared team skills repo. See [External Skill Directories](#external-skill-directories) below.
+
+:::tip Repo-centric teams
+If you keep shared agent workflows inside the repository, see [Repo-Centric Shared Setup](/docs/user-guide/repo-centric-setup). Hermes can keep its writable state under `~/.hermes/` while loading git-tracked skills from `.claude/skills/`.
+:::
 
 See also:
 
@@ -168,7 +172,7 @@ See [Skill Settings](/docs/user-guide/configuration#skill-settings) and [Creatin
 ## Skill Directory Structure
 
 ```text
-~/.hermes/skills/                  # Single source of truth
+~/.hermes/skills/                  # Local read-write skills home
 ├── mlops/                         # Category directory
 │   ├── axolotl/
 │   │   ├── SKILL.md               # Main instructions (required)
@@ -199,16 +203,21 @@ Add `external_dirs` under the `skills` section in `~/.hermes/config.yaml`:
 skills:
   external_dirs:
     - ~/.agents/skills
-    - /home/shared/team-skills
+    - ~/src/acme-platform/.claude/skills
+    - /mnt/c/Users/alice/src/acme-platform/.claude/skills  # WSL path to a Windows checkout
     - ${SKILLS_REPO}/skills
 ```
 
 Paths support `~` expansion and `${VAR}` environment variable substitution.
 
+:::info
+If Hermes is running inside WSL, use Linux mount paths like `/mnt/c/Users/<you>/...` in `config.yaml`, not raw Windows paths like `C:\Users\<you>\...`.
+:::
+
 ### How it works
 
 - **Read-only**: External dirs are only scanned for skill discovery. When the agent creates or edits a skill, it always writes to `~/.hermes/skills/`.
-- **Local precedence**: If the same skill name exists in both the local dir and an external dir, the local version wins.
+- **Precedence**: If the same skill name exists in both the local dir and an external dir, the local version wins. If multiple external dirs contain the same skill name, Hermes resolves them in the order listed in `skills.external_dirs`.
 - **Full integration**: External skills appear in the system prompt index, `skills_list`, `skill_view`, and as `/skill-name` slash commands — no different from local skills.
 - **Non-existent paths are silently skipped**: If a configured directory doesn't exist, Hermes ignores it without errors. Useful for optional shared directories that may not be present on every machine.
 

--- a/website/docs/user-guide/repo-centric-setup.mdx
+++ b/website/docs/user-guide/repo-centric-setup.mdx
@@ -1,0 +1,212 @@
+---
+title: "Repo-Centric Shared Setup"
+description: "Keep shared agent instructions, skills, and repo memory in git while Hermes keeps personal state in ~/.hermes"
+sidebar_position: 4
+---
+
+# Repo-Centric Shared Setup
+
+A good team setup splits agent state into two layers:
+
+- **Git-tracked repo context** for instructions, workflows, and coordination that every agent should share.
+- **Hermes home state** for writable skills, built-in memory, sessions, auth, and personal preferences.
+
+That gives you a repo that works well with Hermes, Claude Code, Codex, and other agents without forcing all mutable state into git.
+
+## Why use a repo-centric setup?
+
+Use this pattern when you want to:
+
+- keep project instructions next to the code they describe
+- share the same agent contract across multiple tools
+- review prompt and workflow changes in pull requests
+- let Hermes keep its own writable memory and sessions outside the repo
+- coordinate multiple agents on the same codebase without losing a shared source of truth
+
+## Architecture
+
+```mermaid
+flowchart LR
+    subgraph Repo["Git repository"]
+        A["CLAUDE.md / AGENTS.md"]
+        B[".claude/skills/"]
+        C[".claude/memory/"]
+        D["docs/, runbooks, ADRs"]
+    end
+
+    subgraph HermesHome["~/.hermes or profile home"]
+        E["config.yaml"]
+        F["skills/ (local read-write)"]
+        G["memories/MEMORY.md + USER.md"]
+        H["sessions / auth / logs"]
+    end
+
+    subgraph Agents["Agents"]
+        I["Hermes CLI / TUI / Gateway"]
+        J["Claude Code / other agents"]
+    end
+
+    E -->|skills.external_dirs| B
+    I -->|startup context| A
+    I -->|external skill discovery| B
+    I -. shared docs when referenced .-> C
+    I -->|local writable state| F
+    I -->|built-in memory| G
+    J -->|shared context| A
+    J -->|shared skills| B
+    J -. shared docs .-> C
+    Repo -. shared, reviewed, git-tracked .-> J
+    HermesHome -. personal, writable state .-> I
+```
+
+## Recommended repo layout
+
+```text
+my-repo/
+├── CLAUDE.md                  # Shared project contract across agent tools
+├── AGENTS.md                  # Optional Hermes-first file if you want one
+├── .claude/
+│   ├── skills/
+│   │   └── release-checklist/
+│   │       └── SKILL.md
+│   └── memory/
+│       ├── architecture.md
+│       └── decisions.md
+├── docs/
+└── .gitignore
+```
+
+A practical rule:
+
+- Put **stable repo-wide instructions** in `CLAUDE.md` or `AGENTS.md`.
+- Put **reusable project workflows** in `.claude/skills/`.
+- Put **shared notes, ADRs, incident writeups, and handoff docs** in `.claude/memory/` or `docs/`.
+- Let Hermes keep **sessions, auth, built-in memory, and local skill edits** in `~/.hermes/`.
+
+## Configure `skills.external_dirs`
+
+Hermes always keeps a local writable skills directory under `~/.hermes/skills/` (or the active profile's `HERMES_HOME`). To load repo-owned skills too, point Hermes at the repo directory with `skills.external_dirs`.
+
+### Linux / macOS
+
+```yaml
+# ~/.hermes/config.yaml
+skills:
+  external_dirs:
+    - ~/src/acme-platform/.claude/skills
+    - ~/src/shared-agent-skills
+    - ${ACME_REPO}/.claude/skills
+```
+
+### WSL using a Windows checkout
+
+```yaml
+# ~/.hermes/config.yaml inside WSL
+skills:
+  external_dirs:
+    - /mnt/c/Users/alice/src/acme-platform/.claude/skills
+    - /mnt/c/Users/alice/src/shared-agent-skills
+```
+
+:::tip WSL path rule
+When Hermes runs inside WSL, use Linux mount paths like `/mnt/c/Users/<you>/...` in `config.yaml`, not raw Windows paths like `C:\Users\<you>\...`.
+:::
+
+Paths support `~` expansion and `${VAR}` environment variable substitution.
+
+## Precedence rules
+
+Hermes already has clear precedence. The important repo-centric rules are:
+
+| Area | Precedence |
+|---|---|
+| Project context files | `.hermes.md` / `HERMES.md` → `AGENTS.md` → `CLAUDE.md` → `.cursorrules` |
+| Skill lookup | `~/.hermes/skills/` first, then each `skills.external_dirs` entry in config order |
+| Skill writes | New or edited skills are written to `~/.hermes/skills/`, not back into repo-owned external dirs |
+| Repo memory vs Hermes memory | Repo files stay repo files; Hermes built-in memory stays in `~/.hermes/memories/` |
+
+If you keep both `AGENTS.md` and `CLAUDE.md`, remember that **Hermes prefers `AGENTS.md`**. If you want one canonical shared file for all tools, either:
+
+- keep only `CLAUDE.md`, or
+- keep `AGENTS.md` very small and have it mirror or reference the shared rules.
+
+## Shared repo memory vs Hermes built-in memory
+
+These layers solve different problems:
+
+| Store | Lives where | Git-tracked? | Loaded automatically? | Best for |
+|---|---|---:|---:|---|
+| `CLAUDE.md` / `AGENTS.md` | repo root | yes | yes | stable project rules and coordination contract |
+| `.claude/memory/` | repo | yes | no | shared notes, ADRs, architecture docs, handoffs |
+| `MEMORY.md` | `~/.hermes/memories/` | no | yes | Hermes's own learned environment notes |
+| `USER.md` | `~/.hermes/memories/` | no | yes | personal preferences and communication style |
+
+Important distinction:
+
+- **`.claude/memory/` is repo content**, not a special Hermes memory backend.
+- **Hermes built-in memory** is `MEMORY.md` and `USER.md`, stored outside the repo and managed by Hermes.
+
+So if something must show up for Hermes every session, put it in `CLAUDE.md` or `AGENTS.md`. If something should be shared in git but only read when relevant, keep it in `.claude/memory/` or `docs/`.
+
+See also:
+
+- [Context Files](/docs/user-guide/features/context-files)
+- [Persistent Memory](/docs/user-guide/features/memory)
+
+## Multi-agent coordination
+
+Repo-centric setup works best when each layer has a clear job:
+
+1. **Repo contract** — `CLAUDE.md` or `AGENTS.md`
+   - coding conventions
+   - architecture boundaries
+   - deployment rules
+   - review expectations
+
+2. **Repo skills** — `.claude/skills/`
+   - reusable workflows every agent should share
+   - release checklists
+   - migration playbooks
+   - internal runbooks
+
+3. **Hermes personal state** — `~/.hermes/`
+   - session history
+   - auth and provider config
+   - Hermes built-in memory
+   - local skill overrides and agent-created skills
+
+For parallel work, give each agent its own branch or worktree and let the repo-centric files stay shared:
+
+- `hermes -w` for disposable isolated worktrees
+- `git worktree add ...` for named long-lived worktrees
+- separate Hermes profiles if you want isolated providers, memory, or auth
+
+See [Git Worktrees](/docs/user-guide/git-worktrees) for the isolation pattern.
+
+## Git workflow
+
+Treat repo-centric agent files like code:
+
+- commit `CLAUDE.md`, `AGENTS.md`, `.claude/skills/`, and shared repo notes intentionally
+- review those changes in PRs, because they change agent behavior
+- keep personal Hermes state out of git (`~/.hermes/` is not a project artifact)
+- use one branch/worktree per agent when running multiple agents in parallel
+- decide explicitly whether repo-local outputs like `.hermes/plans/` should be committed or gitignored
+
+A simple default is:
+
+- **commit** shared instructions and shared skills
+- **gitignore** local scratch output and personal agent state
+- **merge via PR** once the workflow or instruction change is reviewed
+
+## Recommended operating pattern
+
+If you want a concrete default:
+
+1. Put the shared project contract in `CLAUDE.md`.
+2. Add reusable repo workflows under `.claude/skills/`.
+3. Point Hermes at that directory with `skills.external_dirs`.
+4. Keep Hermes built-in memory in `~/.hermes/memories/`.
+5. Run each substantial agent task in its own branch or worktree.
+
+That gives you shared repo knowledge without giving up Hermes's own memory, sessions, and writable local skills.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -23,6 +23,7 @@ const sidebars: SidebarsConfig = {
         'user-guide/cli',
         'user-guide/tui',
         'user-guide/configuration',
+        'user-guide/repo-centric-setup',
         'user-guide/sessions',
         'user-guide/profiles',
         'user-guide/git-worktrees',


### PR DESCRIPTION
## Summary
- add a repo-centric shared setup doc covering `.claude/skills`, `.claude/memory`, precedence, WSL paths, and git workflow
- update skills and context-file docs to point at the repo-centric pattern
- document HTTP/StreamableHTTP-first guidance for gateway-facing MCP rollouts
- reposition paid Nous Portal + Tool Gateway as the lowest-friction managed stack while keeping OpenRouter as the easy inference default
- add focused gateway `/reload-mcp` tests

## Validation
- `scripts/run_tests.sh tests/gateway/test_reload_mcp_command.py tests/gateway/test_unknown_command.py tests/gateway/test_reasoning_command.py`
- `20 passed`

## Notes
- Website build is still blocked by pre-existing unrelated site issues:
  - unresolved `./api-server.md` link in `website/docs/user-guide/docker.md`
  - missing `website/src/pages/skills` import for `../../data/skills.json`
