### PR TITLE
docs: remove Discussions link from README (salvage #4227)

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,6 @@ python -m pytest tests/ -q
 - 💬 [Discord](https://discord.gg/NousResearch)
 - 📚 [Skills Hub](https://agentskills.io)
 - 🐛 [Issues](https://github.com/NousResearch/hermes-agent/issues)
-- 💡 [Discussions](https://github.com/NousResearch/hermes-agent/discussions)
 - 🔌 [HermesClaw](https://github.com/AaronWong1999/hermesclaw) — Community WeChat bridge: Run Hermes Agent and OpenClaw on the same WeChat account.
 
 ---

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -360,6 +360,7 @@ AUTHOR_MAP = {
     "brian@tiuxo.com": "brianclemens",
     "25944632+yudaiyan@users.noreply.github.com": "yudaiyan",
     "chayton@sina.com": "ycbai",
+    "longsizhuo@gmail.com": "longsizhuo",
 }
 
 


### PR DESCRIPTION
Salvages #4227 by @longsizhuo onto current main.

Removes the dead `https://github.com/NousResearch/hermes-agent/discussions` link from the Community section of README.md. Discussions is disabled on the repo (`repo.has_discussions: false`), so the link 404s.

Closes #4227. Author attribution preserved via cherry-pick.