### PR TITLE
fix(docker): add /opt/data/.local/bin to PATH in Docker image (salvage #13778)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,5 +50,6 @@ RUN uv venv && \
 # ---------- Runtime ----------
 ENV HERMES_WEB_DIST=/opt/hermes/hermes_cli/web_dist
 ENV HERMES_HOME=/opt/data
+ENV PATH="/opt/data/.local/bin:${PATH}"
 VOLUME [ "/opt/data" ]
 ENTRYPOINT [ "/opt/hermes/docker/entrypoint.sh" ]

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -361,6 +361,7 @@ AUTHOR_MAP = {
     "25944632+yudaiyan@users.noreply.github.com": "yudaiyan",
     "chayton@sina.com": "ycbai",
     "longsizhuo@gmail.com": "longsizhuo",
+    "chenb19870707@gmail.com": "ms-alan",
 }
 
 


### PR DESCRIPTION
Salvages #13778 by @ms-alan onto current main. Closes #13739.

`HERMES_HOME` is set to `/opt/data` in the Docker image, and tools installed inside the container with `pip install --user` or similar land in `/opt/data/.local/bin`. Without this directory on `PATH`, such binaries are invisible to the agent's terminal tool.

## Attribution note
Original commit had an empty author email and no linked GitHub account (commit author recorded as `pander <>`), so the commit was re-authored to @ms-alan's public GitHub email (`chenb19870707@gmail.com`) so the contribution attributes to their profile. All code is @ms-alan's.

Closes #13778, closes #13739.