### PR TITLE
fix(local): respect configured cwd in init_session() (salvage #12983)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -362,6 +362,7 @@ AUTHOR_MAP = {
     "chayton@sina.com": "ycbai",
     "longsizhuo@gmail.com": "longsizhuo",
     "chenb19870707@gmail.com": "ms-alan",
+    "276886827+WuTianyi123@users.noreply.github.com": "WuTianyi123",
 }
 
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -349,6 +349,7 @@ class LocalEnvironment(BaseEnvironment):
             stderr=subprocess.STDOUT,
             stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
             preexec_fn=None if _IS_WINDOWS else os.setsid,
+            cwd=self.cwd,
         )
 
         if stdin_data is not None:


### PR DESCRIPTION
Salvages #12983 by @WuTianyi123 onto current main.

`LocalEnvironment._run_bash` builds a `subprocess.Popen` without passing `cwd`, so every bash invocation — including the initial `init_session` bootstrap — inherits the Python process's current directory instead of the caller-configured `self.cwd`. For regular commands this is masked by the `_wrap_command` prefix (`builtin cd $cwd ...`), but `init_session` bootstrap runs a raw `pwd -P > cwd_file` without a wrapping cd — it records the wrong starting directory.

One-line fix: pass `cwd=self.cwd` to Popen. `self.cwd` is always set (`__init__` defaults to `os.getcwd()` when no value provided), so no regression risk for callers that don't configure an explicit cwd.

## Attribution note
Original commit's author email was an unlinked Gmail address, so the commit was re-authored to @WuTianyi123's GitHub noreply email so the contribution attributes to their profile. All code is @WuTianyi123's.

Closes #12983.