### PR TITLE
fix: add base_url_env_var to Anthropic ProviderConfig (salvage #12870)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -214,6 +214,7 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         auth_type="api_key",
         inference_base_url="https://api.anthropic.com",
         api_key_env_vars=("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"),
+        base_url_env_var="ANTHROPIC_BASE_URL",
     ),
     "alibaba": ProviderConfig(
         id="alibaba",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -363,6 +363,7 @@ AUTHOR_MAP = {
     "longsizhuo@gmail.com": "longsizhuo",
     "chenb19870707@gmail.com": "ms-alan",
     "276886827+WuTianyi123@users.noreply.github.com": "WuTianyi123",
+    "22549957+li0near@users.noreply.github.com": "li0near",
 }
 
 


### PR DESCRIPTION
Salvages #12870 by @li0near onto current main.

Every other provider in `PROVIDER_REGISTRY` sets `base_url_env_var` (copilot, gemini, glm, kimi, stepfun, arcee, minimax, etc.), but the `anthropic` entry didn't. That meant `ANTHROPIC_BASE_URL` — already a recognized env var elsewhere in the codebase (`tools/environments/local.py:50`, `tests/conftest.py:149`) — wasn't being read as a base URL override for the Anthropic provider through the standard config-resolution path. Users hitting an Anthropic-compatible proxy had to work around it.

One-line fix: wire `base_url_env_var="ANTHROPIC_BASE_URL"` into the anthropic `ProviderConfig`.

## Attribution note
Original commit's author email was `hermes@nousresearch.com` (unlinked), so the commit was re-authored to @li0near's GitHub noreply email so the contribution attributes to their profile. All code is @li0near's.

Closes #12870.