### PR TITLE
fix(compressor): preserve focus_topic on summary-model fallback retry (salvage #10724)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -848,7 +848,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                 )
                 self.summary_model = ""  # empty = use main model
                 self._summary_failure_cooldown_until = 0.0  # no cooldown
-                return self._generate_summary(turns_to_summarize)  # retry immediately
+                return self._generate_summary(turns_to_summarize, focus_topic=focus_topic)  # retry immediately
 
             # Transient errors (timeout, rate limit, network) — shorter cooldown
             _transient_cooldown = 60

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -364,6 +364,7 @@ AUTHOR_MAP = {
     "chenb19870707@gmail.com": "ms-alan",
     "276886827+WuTianyi123@users.noreply.github.com": "WuTianyi123",
     "22549957+li0near@users.noreply.github.com": "li0near",
+    "23434080+sicnuyudidi@users.noreply.github.com": "sicnuyudidi",
 }
 
 


### PR DESCRIPTION
Salvages #10724 by @sicnuyudidi onto current main.

When the configured summary model returns 404/503, `_generate_summary` falls back to the main model and retries. The retry previously dropped the `focus_topic` arg, so users running focus-topic-guided compression silently lost the guidance exactly when the fallback fired. Original PR also fixed the primary arg-name bug (`messages` vs `turns_to_summarize`) which has since been partially fixed on main — this PR completes it by also passing `focus_topic=focus_topic`.

## Attribution note
Original commit's author email was the git default placeholder (`you@example.com`), so the commit was re-authored to @sicnuyudidi's GitHub noreply email so the contribution attributes correctly. All code is @sicnuyudidi's.

Closes #10724.