### PR TITLE
fix(agent): include model in auxiliary client cache key

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2117,7 +2117,7 @@ def auxiliary_max_tokens_param(value: int) -> dict:
 # Every auxiliary LLM consumer should use these instead of manually
 # constructing clients and calling .chat.completions.create().
 
-# Client cache: (provider, async_mode, base_url, api_key, api_mode, runtime_key) -> (client, default_model, loop)
+# Client cache: (provider, model, async_mode, base_url, api_key, api_mode, runtime_key) -> (client, default_model, loop)
 # NOTE: loop identity is NOT part of the key.  On async cache hits we check
 # whether the cached loop is the *current* loop; if not, the stale entry is
 # replaced in-place.  This bounds cache growth to one entry per unique
@@ -2131,6 +2131,7 @@ _CLIENT_CACHE_MAX_SIZE = 64  # safety belt — evict oldest when exceeded
 def _client_cache_key(
     provider: str,
     *,
+    model: Optional[str] = None,
     async_mode: bool,
     base_url: Optional[str] = None,
     api_key: Optional[str] = None,
@@ -2139,7 +2140,7 @@ def _client_cache_key(
 ) -> tuple:
     runtime = _normalize_main_runtime(main_runtime)
     runtime_key = tuple(runtime.get(field, "") for field in _MAIN_RUNTIME_FIELDS) if provider == "auto" else ()
-    return (provider, async_mode, base_url or "", api_key or "", api_mode or "", runtime_key)
+    return (provider, model or "", async_mode, base_url or "", api_key or "", api_mode or "", runtime_key)
 
 
 def _store_cached_client(cache_key: tuple, client: Any, default_model: Optional[str], *, bound_loop: Any = None) -> None:
@@ -2188,6 +2189,7 @@ def _refresh_nous_auxiliary_client(
 
     cache_key = _client_cache_key(
         cache_provider,
+        model=model,
         async_mode=async_mode,
         base_url=base_url,
         api_key=api_key,
@@ -2353,6 +2355,7 @@ def _get_cached_client(
     runtime = _normalize_main_runtime(main_runtime)
     cache_key = _client_cache_key(
         provider,
+        model=model,
         async_mode=async_mode,
         base_url=base_url,
         api_key=api_key,


### PR DESCRIPTION
## Summary

Fixes a bug where `_client_cache_key` only used `provider` as the cache key, causing different model parameters to return the same cached client and leading to wrong models being used for vision requests.

## Root Cause

`_client_cache_key()` generated cache keys as `(provider, async_mode, base_url, api_key, api_mode, runtime_key)`, omitting `model`. When the first call with `provider="openrouter"` cached a client for `google/gemini-3-flash-preview`, subsequent calls with `openai/gpt-4o` hit the same cache entry because the key did not differentiate by model. The cached client then sent requests with the wrong model, causing OpenRouter to reject them with `invalid params, unknown model 'openai/gpt-4o' (2013)`.

## Changes

- Added `model: Optional[str] = None` parameter to `_client_cache_key()`
- Included `model` in the returned cache key tuple
- Updated `_refresh_nous_auxiliary_client()` and `_get_cached_client()` to pass `model` through
- Updated the cache key comment to reflect the new structure

## Testing

- Python syntax check passed (`py_compile`)
- Ran related test suite:
  - `tests/agent/test_auxiliary_client.py` ✅
  - `tests/agent/test_crossloop_client_cache.py` ✅
  - `tests/agent/test_vision_resolved_args.py` ✅
  - 87 passed, 1 failed (failure is an unrelated environment proxy issue: `socks://proxyhk.zte.com.cn:80`)

## Related Issue

Fixes #14085
