### PR TITLE
fix(cli): block corrupt webhook subscription rewrites

### DIFF
--- a/hermes_cli/webhook.py
+++ b/hermes_cli/webhook.py
@@ -24,6 +24,10 @@ from hermes_constants import display_hermes_home
 _SUBSCRIPTIONS_FILENAME = "webhook_subscriptions.json"
 
 
+class SubscriptionStoreError(RuntimeError):
+    """Raised when the webhook subscriptions store cannot be read safely."""
+
+
 def _hermes_home() -> Path:
     from hermes_constants import get_hermes_home
     return get_hermes_home()
@@ -38,10 +42,27 @@ def _load_subscriptions() -> Dict[str, dict]:
     if not path.exists():
         return {}
     try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-        return data if isinstance(data, dict) else {}
-    except Exception:
+        raw_data = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
         return {}
+    except OSError as exc:
+        raise SubscriptionStoreError(
+            f"Could not read webhook subscriptions from {path}: {exc}"
+        ) from exc
+
+    try:
+        data = json.loads(raw_data)
+    except json.JSONDecodeError as exc:
+        raise SubscriptionStoreError(
+            f"Corrupt webhook subscriptions file at {path}; repair or remove it before modifying subscriptions."
+        ) from exc
+
+    if not isinstance(data, dict):
+        raise SubscriptionStoreError(
+            f"Invalid webhook subscriptions file at {path}; expected a JSON object."
+        )
+
+    return data
 
 
 def _save_subscriptions(subs: Dict[str, dict]) -> None:
@@ -123,14 +144,17 @@ def webhook_command(args):
     if not _require_webhook_enabled():
         return
 
-    if sub in ("subscribe", "add"):
-        _cmd_subscribe(args)
-    elif sub in ("list", "ls"):
-        _cmd_list(args)
-    elif sub in ("remove", "rm"):
-        _cmd_remove(args)
-    elif sub == "test":
-        _cmd_test(args)
+    try:
+        if sub in ("subscribe", "add"):
+            _cmd_subscribe(args)
+        elif sub in ("list", "ls"):
+            _cmd_list(args)
+        elif sub in ("remove", "rm"):
+            _cmd_remove(args)
+        elif sub == "test":
+            _cmd_test(args)
+    except SubscriptionStoreError as exc:
+        print(f"Error: {exc}")
 
 
 def _cmd_subscribe(args):

--- a/tests/hermes_cli/test_webhook_cli.py
+++ b/tests/hermes_cli/test_webhook_cli.py
@@ -12,6 +12,7 @@ from hermes_cli.webhook import (
     _save_subscriptions,
     _subscriptions_path,
     _is_webhook_enabled,
+    SubscriptionStoreError,
 )
 
 
@@ -139,11 +140,23 @@ class TestPersistence:
         data = json.loads(path.read_text())
         assert "persist" in data
 
-    def test_corrupted_file(self):
+    def test_corrupted_file_raises_store_error(self):
         path = _subscriptions_path()
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text("broken{{{")
-        assert _load_subscriptions() == {}
+        with pytest.raises(SubscriptionStoreError, match="Corrupt webhook subscriptions file"):
+            _load_subscriptions()
+
+    def test_subscribe_does_not_overwrite_corrupted_file(self, capsys):
+        path = _subscriptions_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("broken{{{", encoding="utf-8")
+
+        webhook_command(_make_args(webhook_action="subscribe", name="persist"))
+
+        out = capsys.readouterr().out
+        assert "Corrupt webhook subscriptions file" in out
+        assert path.read_text(encoding="utf-8") == "broken{{{"
 
 
 class TestWebhookEnabledGate:


### PR DESCRIPTION
## Summary
- treat missing webhook subscription stores as empty, but raise a dedicated error for unreadable, corrupt, or non-object JSON files
- surface that store error through the CLI instead of silently replacing the corrupted file during subscribe/remove/list/test flows
- add regressions proving corrupt JSON is reported and left untouched during subscribe

## Testing
- python3 -m pytest -o addopts= tests/hermes_cli/test_webhook_cli.py -k "corrupted_file or overwrite_corrupted"
- python3 -m pytest -o addopts= tests/hermes_cli/test_webhook_cli.py

Closes #14194
