### PR TITLE
fix(docker): unbreak sandbox backend — gosu caps + entrypoint passthrough

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -68,4 +68,19 @@ if [ -d "$INSTALL_DIR/skills" ]; then
     python3 "$INSTALL_DIR/tools/skills_sync.py"
 fi
 
+# Final exec: two supported invocation patterns.
+#
+#   docker run <image>                 -> exec `hermes` with no args (legacy default)
+#   docker run <image> chat -q "..."   -> exec `hermes chat -q "..."` (legacy wrap)
+#   docker run <image> sleep infinity  -> exec `sleep infinity` directly
+#   docker run <image> bash            -> exec `bash` directly
+#
+# If the first positional arg resolves to an executable on PATH, we assume the
+# caller wants to run it directly (needed by the launcher which runs long-lived
+# `sleep infinity` sandbox containers — see tools/environments/docker.py).
+# Otherwise we treat the args as a hermes subcommand and wrap with `hermes`,
+# preserving the documented `docker run <image> <subcommand>` behavior.
+if [ $# -gt 0 ] && command -v "$1" >/dev/null 2>&1; then
+    exec "$@"
+fi
 exec hermes "$@"

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -141,6 +141,7 @@ AUTHOR_MAP = {
     "331214+counterposition@users.noreply.github.com": "counterposition",
     "blspear@gmail.com": "BrennerSpear",
     "akhater@gmail.com": "akhater",
+    "Cos_Admin@PTG-COS.lodluvup4uaudnm3ycd14giyug.xx.internal.cloudapp.net": "akhater",
     "239876380+handsdiff@users.noreply.github.com": "handsdiff",
     "hesapacicam112@gmail.com": "etherman-os",
     "mark.ramsell@rivermounts.com": "mark-ramsell",

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -382,3 +382,31 @@ def test_normalize_env_dict_rejects_complex_values():
         "BAD_DICT": {"nested": True},
     })
     assert result == {"GOOD": "string"}
+
+
+def test_security_args_include_setuid_setgid_for_gosu_drop():
+    """_SECURITY_ARGS must include SETUID and SETGID so the image entrypoint
+    can drop from root to the non-root `hermes` user via gosu.
+
+    Without these caps gosu exits with
+    ``error: failed switching to 'hermes': operation not permitted``
+    and the container exits immediately (exit 1) before running any work.
+
+    `no-new-privileges` is kept, so gosu still cannot escalate back to root
+    after the drop — the drop is a one-way transition performed before the
+    `no_new_privs` bit is enforced on the exec boundary.
+    """
+    args = docker_env._SECURITY_ARGS
+
+    # Flatten to set of added caps for clarity.
+    added = {
+        args[i + 1]
+        for i, flag in enumerate(args[:-1])
+        if flag == "--cap-add"
+    }
+    assert "SETUID" in added, "SETUID cap missing — gosu drop in entrypoint will fail"
+    assert "SETGID" in added, "SETGID cap missing — gosu drop in entrypoint will fail"
+
+    # Sanity: the hardening posture is still in place.
+    assert "--cap-drop" in args and "ALL" in args
+    assert "--security-opt" in args and "no-new-privileges" in args

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -148,6 +148,10 @@ def find_docker() -> Optional[str]:
 # We drop all capabilities then add back the minimum needed:
 #   DAC_OVERRIDE - root can write to bind-mounted dirs owned by host user
 #   CHOWN/FOWNER - package managers (pip, npm, apt) need to set file ownership
+#   SETUID/SETGID - the image entrypoint drops from root to the 'hermes'
+#       user via `gosu`, which requires these caps. Combined with
+#       `no-new-privileges`, gosu still cannot escalate back to root after
+#       the drop, so the security posture is preserved.
 # Block privilege escalation and limit PIDs.
 # /tmp is size-limited and nosuid but allows exec (needed by pip/npm builds).
 _SECURITY_ARGS = [
@@ -155,6 +159,8 @@ _SECURITY_ARGS = [
     "--cap-add", "DAC_OVERRIDE",
     "--cap-add", "CHOWN",
     "--cap-add", "FOWNER",
+    "--cap-add", "SETUID",
+    "--cap-add", "SETGID",
     "--security-opt", "no-new-privileges",
     "--pids-limit", "256",
     "--tmpfs", "/tmp:rw,nosuid,size=512m",


### PR DESCRIPTION
Salvages #13346 and #13349 onto current main. Both Docker-backend regressions compound — a fresh install with `terminal.backend: docker` cannot launch any sandbox container without both fixes.

## Changes

**#13346 — cap(SETUID, SETGID)** (`tools/environments/docker.py`, +6 lines + 28-line test)
`_SECURITY_ARGS` drops ALL caps then re-adds DAC_OVERRIDE/CHOWN/FOWNER. Since commit fee0e0d3, the image entrypoint calls `gosu hermes` to drop root, which the kernel refuses without SETUID/SETGID. Container exits with `error: failed switching to 'hermes': operation not permitted` before any work runs. `no-new-privileges` still prevents escalating back.

**#13349 — entrypoint passthrough** (`docker/entrypoint.sh`, +15 lines)
Since commit 8254b820 the launcher runs containers with `sleep infinity` for idle-reaper lifetime. But the entrypoint unconditionally did `exec hermes "$@"`, turning the command into `hermes sleep infinity` — argparse rejects `sleep` as a subcommand, container exits code 2. Fix: if $1 resolves to a PATH executable, exec it directly; otherwise keep legacy `hermes <subcommand>` wrap.

**AUTHOR_MAP** — map @akhater's Azure VM hostname commit email so check-attribution passes and release notes credit correctly.

## Credit

Both fixes by @akhater in #13346 / #13349. Cherry-picked onto current main with authorship preserved; check-attribution failure in the original PRs was just the missing AUTHOR_MAP entry (commits were authored as the Azure VM default `Cos_Admin@PTG-COS...` identity).

## Validation

**Unit tests:** `pytest tests/tools/test_docker_environment.py` → 19 passed (includes the new `test_security_args_include_setuid_setgid_for_gosu_drop`).

**E2E on rebuilt image** (`DOCKER_BUILDKIT=1 docker build .` → Ubuntu 25.04 / Docker 28.2.2 / kernel 6.14):

| Scenario | Before | After |
|---|---|---|
| `docker run … sleep 20` (PID 1 cmdline) | `hermes: error: invalid choice: 'sleep'` → exit 2 | `sleep 20` running as uid=10000(hermes) |
| `docker run … --cap-drop ALL --cap-add {DAC_OVERRIDE,CHOWN,FOWNER,SETUID,SETGID} … id` | N/A (Tony reports `operation not permitted` on Azure) | `uid=10000(hermes) gid=10000(hermes)` |
| `docker run … --version` (legacy wrap) | works | still works |
| `docker run … bash -c 'whoami'` (new passthrough) | would exec `hermes bash -c …` → error | `hermes` |

Closes #13346 and #13349.