### PR TITLE
fix: isolate plugin context engines per agent

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -360,6 +360,7 @@ class PluginContext:
             )
             return
         self._manager._context_engine = engine
+        self._manager._context_engine_manifest = self.manifest
         logger.info(
             "Plugin '%s' registered context engine: %s",
             self.manifest.name, engine.name,
@@ -445,6 +446,7 @@ class PluginManager:
         self._plugin_tool_names: Set[str] = set()
         self._cli_commands: Dict[str, dict] = {}
         self._context_engine = None  # Set by a plugin via register_context_engine()
+        self._context_engine_manifest: Optional[PluginManifest] = None
         self._plugin_commands: Dict[str, dict] = {}  # Slash commands registered by plugins
         self._discovered: bool = False
         self._cli_ref = None  # Set by CLI after plugin discovery
@@ -881,8 +883,35 @@ def _ensure_plugins_discovered() -> PluginManager:
 
 
 def get_plugin_context_engine():
-    """Return the plugin-registered context engine, or None."""
+    """Return the singleton plugin-registered context engine, or None."""
     return _ensure_plugins_discovered()._context_engine
+
+
+def create_plugin_context_engine(expected_name: Optional[str] = None):
+    """Instantiate a fresh plugin context engine for one agent/session.
+
+    The global plugin manager keeps a singleton engine for status surfaces and
+    discovery metadata, but agent runtime must not share that mutable instance
+    across sessions. This helper reloads the owning plugin into a temporary
+    PluginManager and returns the newly-registered engine instance.
+    """
+    manager = _ensure_plugins_discovered()
+    singleton = manager._context_engine
+    manifest = manager._context_engine_manifest
+    if singleton is None or manifest is None:
+        return None
+    if expected_name and getattr(singleton, "name", None) != expected_name:
+        return None
+
+    temp_manager = PluginManager()
+    temp_manager._discovered = True
+    temp_manager._load_plugin(manifest)
+    engine = temp_manager._context_engine
+    if engine is None:
+        return None
+    if expected_name and getattr(engine, "name", None) != expected_name:
+        return None
+    return engine
 
 
 def get_plugin_command_handler(name: str) -> Optional[Callable]:

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -15,11 +15,13 @@ Config: Uses the existing Honcho config chain:
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import re
 import threading
 import time
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from agent.memory_provider import MemoryProvider
@@ -268,6 +270,75 @@ class HonchoMemoryProvider(MemoryProvider):
         from plugins.memory.honcho.cli import cmd_setup
         cmd_setup(types.SimpleNamespace())
 
+    @staticmethod
+    def _memory_backfill_state_path(hermes_home: Path) -> Path:
+        return hermes_home / "state" / "honcho_memory_backfill.json"
+
+    @staticmethod
+    def _memory_backfill_fingerprint(memory_dir: Path) -> str:
+        hasher = hashlib.sha256()
+        found = False
+        for name in ("USER.md", "MEMORY.md", "SOUL.md"):
+            path = memory_dir / name
+            if not path.exists():
+                continue
+            content = path.read_text(encoding="utf-8").strip()
+            if not content:
+                continue
+            found = True
+            hasher.update(name.encode("utf-8"))
+            hasher.update(b"\0")
+            hasher.update(content.encode("utf-8"))
+            hasher.update(b"\0")
+        return hasher.hexdigest() if found else ""
+
+    def _load_memory_backfill_state(self, hermes_home: Path) -> dict[str, str]:
+        path = self._memory_backfill_state_path(hermes_home)
+        if not path.exists():
+            return {}
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _save_memory_backfill_state(self, hermes_home: Path, state: dict[str, str]) -> None:
+        path = self._memory_backfill_state_path(hermes_home)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(state, indent=2, sort_keys=True), encoding="utf-8")
+
+    def _maybe_backfill_existing_session_memory(self, cfg, session) -> None:
+        if not self._manager or not self._session_key:
+            return
+        if cfg.session_strategy == "per-session":
+            return
+        if not getattr(session, "messages", None):
+            return
+
+        from hermes_constants import get_hermes_home
+
+        hermes_home = Path(get_hermes_home())
+        memory_dir = hermes_home / "memories"
+        fingerprint = self._memory_backfill_fingerprint(memory_dir)
+        if not fingerprint:
+            return
+
+        state = self._load_memory_backfill_state(hermes_home)
+        if state.get(self._session_key) == fingerprint:
+            logger.debug(
+                "Honcho existing-session memory backfill already completed for %s",
+                self._session_key,
+            )
+            return
+
+        if self._manager.migrate_memory_files(self._session_key, str(memory_dir)):
+            state[self._session_key] = fingerprint
+            self._save_memory_backfill_state(hermes_home, state)
+            logger.debug(
+                "Honcho existing-session memory backfill completed for %s",
+                self._session_key,
+            )
+
     def initialize(self, session_id: str, **kwargs) -> None:
         """Initialize Honcho session manager.
 
@@ -392,6 +463,8 @@ class HonchoMemoryProvider(MemoryProvider):
                     "Honcho memory file migration skipped: per-session strategy creates a fresh session per run (%s)",
                     self._session_key,
                 )
+            else:
+                self._maybe_backfill_existing_session_memory(cfg, session)
         except Exception as e:
             logger.debug("Honcho memory file migration skipped: %s", e)
 
@@ -1153,6 +1226,13 @@ class HonchoMemoryProvider(MemoryProvider):
                         return tool_error("Failed to update peer card.")
                     return json.dumps({"result": f"Peer card updated ({len(result)} facts).", "card": result})
                 card = self._manager.get_peer_card(self._session_key, peer=peer)
+                if not card:
+                    session_ctx = self._manager.get_session_context(self._session_key, peer=peer)
+                    raw_card = session_ctx.get("card", "") if session_ctx else ""
+                    if isinstance(raw_card, str):
+                        card = [line.strip() for line in raw_card.splitlines() if line.strip()]
+                    elif isinstance(raw_card, list):
+                        card = [str(line).strip() for line in raw_card if str(line).strip()]
                 if not card:
                     return json.dumps({"result": "No profile facts available yet."})
                 return json.dumps({"result": card})

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -988,10 +988,19 @@ class HonchoSessionManager:
 
         try:
             observer_peer_id, target_peer_id = self._resolve_observer_target(session, peer)
-            return self._fetch_peer_card(observer_peer_id, target=target_peer_id)
+            card = self._fetch_peer_card(observer_peer_id, target=target_peer_id)
+            if card:
+                return card
         except Exception as e:
             logger.debug("Failed to fetch peer card from Honcho: %s", e)
-            return []
+
+        ctx = self.get_session_context(session_key, peer=peer)
+        raw_card = ctx.get("card", "") if ctx else ""
+        if isinstance(raw_card, str):
+            return [line.strip() for line in raw_card.splitlines() if line.strip()]
+        if isinstance(raw_card, list):
+            return [str(line).strip() for line in raw_card if str(line).strip()]
+        return []
 
     def search_context(
         self,

--- a/run_agent.py
+++ b/run_agent.py
@@ -1707,8 +1707,8 @@ class AIAgent:
             # Try general plugin system as fallback
             if _selected_engine is None:
                 try:
-                    from hermes_cli.plugins import get_plugin_context_engine
-                    _candidate = get_plugin_context_engine()
+                    from hermes_cli.plugins import create_plugin_context_engine
+                    _candidate = create_plugin_context_engine(_engine_name)
                     if _candidate and _candidate.name == _engine_name:
                         _selected_engine = _candidate
                 except Exception:

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -212,6 +212,28 @@ class TestPeerLookupHelpers:
         assert mgr.get_peer_card(session.key) == ["Name: Robert"]
         assistant_peer.get_card.assert_called_once_with(target=session.user_peer_id)
 
+    def test_get_peer_card_falls_back_to_session_context_card(self):
+        mgr, session = self._make_cached_manager()
+        assistant_peer = MagicMock()
+        assistant_peer.get_card.return_value = None
+        mgr._get_or_create_peer = MagicMock(return_value=assistant_peer)
+
+        honcho_session = MagicMock()
+        honcho_session.context.return_value = SimpleNamespace(
+            summary=None,
+            peer_representation="",
+            peer_card=["Name: Robert", "Prefers dark mode"],
+            messages=[],
+        )
+        mgr._sessions_cache[session.honcho_session_id] = honcho_session
+
+        assert mgr.get_peer_card(session.key) == ["Name: Robert", "Prefers dark mode"]
+        honcho_session.context.assert_called_once_with(
+            summary=True,
+            peer_target=session.user_peer_id,
+            peer_perspective=session.user_peer_id,
+        )
+
     def test_search_context_uses_assistant_perspective_with_target(self):
         mgr, session = self._make_cached_manager()
         assistant_peer = MagicMock()
@@ -429,6 +451,26 @@ class TestConcludeToolDispatch:
 
         assert "Role: Assistant" in result
         provider._manager.get_peer_card.assert_called_once_with("telegram:123", peer="hermes")
+
+    def test_honcho_profile_falls_back_to_session_context_card(self):
+        provider = HonchoMemoryProvider()
+        provider._session_initialized = True
+        provider._session_key = "telegram:123"
+        provider._manager = MagicMock()
+        provider._manager.get_peer_card.return_value = []
+        provider._manager.get_session_context.return_value = {
+            "card": "Name: Robert\nPrefers dark mode",
+        }
+
+        result = provider.handle_tool_call(
+            "honcho_profile",
+            {"peer": "user"},
+        )
+
+        assert "Name: Robert" in result
+        assert "Prefers dark mode" in result
+        provider._manager.get_peer_card.assert_called_once_with("telegram:123", peer="user")
+        provider._manager.get_session_context.assert_called_once_with("telegram:123", peer="user")
 
     def test_honcho_search_can_target_explicit_peer_id(self):
         provider = HonchoMemoryProvider()
@@ -669,6 +711,47 @@ class TestPerSessionMigrateGuard:
         """per-directory strategy with empty session SHOULD call migrate_memory_files."""
         _, mock_manager = self._make_provider_with_strategy("per-directory")
         mock_manager.migrate_memory_files.assert_called_once()
+
+
+class TestExistingSessionBackfill:
+    def test_existing_session_with_empty_profile_backfills_memory_files_once(self):
+        from pathlib import Path
+        from tempfile import TemporaryDirectory
+        from unittest.mock import patch, MagicMock
+
+        from plugins.memory.honcho.client import HonchoClientConfig
+
+        cfg = HonchoClientConfig(
+            api_key="test-key",
+            enabled=True,
+            recall_mode="hybrid",
+            session_strategy="per-directory",
+        )
+        provider = HonchoMemoryProvider()
+
+        mock_manager = MagicMock()
+        mock_session = MagicMock()
+        mock_session.messages = [{"role": "user", "content": "hi"}]
+        mock_manager.get_or_create.return_value = mock_session
+        mock_manager.get_peer_card.return_value = []
+
+        with TemporaryDirectory() as tmpdir:
+            hermes_home = Path(tmpdir)
+            memories = hermes_home / "memories"
+            memories.mkdir()
+            (memories / "USER.md").write_text("Call Stephen 'Boss.'", encoding="utf-8")
+
+            with patch("plugins.memory.honcho.client.HonchoClientConfig.from_global_config", return_value=cfg), \
+                 patch("plugins.memory.honcho.client.get_honcho_client", return_value=MagicMock()), \
+                 patch("plugins.memory.honcho.session.HonchoSessionManager", return_value=mock_manager), \
+                 patch("hermes_constants.get_hermes_home", return_value=hermes_home):
+                provider.initialize(session_id="test-session-001")
+
+                mock_manager.migrate_memory_files.assert_called_once()
+
+                provider2 = HonchoMemoryProvider()
+                provider2.initialize(session_id="test-session-001")
+                mock_manager.migrate_memory_files.assert_called_once()
 
 
 class TestChunkMessage:

--- a/tests/run_agent/test_plugin_context_engine_init.py
+++ b/tests/run_agent/test_plugin_context_engine_init.py
@@ -89,3 +89,46 @@ def test_plugin_engine_update_model_args():
     assert "provider" in kw
     # Should NOT pass api_mode — the ABC doesn't accept it
     assert "api_mode" not in kw
+
+
+def test_general_plugin_context_engine_is_isolated_per_agent_instance():
+    """General plugin engines must not be shared mutable singletons across agents."""
+    shared_singleton = _StubEngine()
+    fresh_one = _StubEngine()
+    fresh_two = _StubEngine()
+    cfg = {"context": {"engine": "stub"}, "agent": {}}
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("plugins.context_engine.load_context_engine", return_value=None),
+        patch("hermes_cli.plugins.get_plugin_context_engine", return_value=shared_singleton),
+        patch(
+            "hermes_cli.plugins.create_plugin_context_engine",
+            side_effect=[fresh_one, fresh_two],
+            create=True,
+        ),
+        patch("agent.model_metadata.get_model_context_length", return_value=131_072),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent_one = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent_two = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent_one.context_compressor is fresh_one
+    assert agent_two.context_compressor is fresh_two
+    assert agent_one.context_compressor is not agent_two.context_compressor


### PR DESCRIPTION
## Summary
- stop reusing the plugin manager's singleton context engine as the live per-agent runtime engine
- add a helper that reloads the owning context-engine plugin into a temporary plugin manager to produce a fresh engine instance per agent
- add a regression test covering the general-plugin fallback path so two agents do not share mutable context-engine state

## Why
- plugin context engines carry mutable session-scoped state such as session ids, cursors, compaction counters, and lifecycle markers
- reusing the singleton engine across agents lets that state bleed across sessions
- this reproduces the bad LCM status shape where `compression_count > 0` but `store_messages == 0` and `dag_nodes == 0` after the engine is rebound

## Test Plan
- `pytest tests/run_agent/test_plugin_context_engine_init.py -q`
- `pytest tests/agent/test_context_engine.py tests/hermes_cli/test_plugins.py -q`

## Notes
- this keeps the singleton plugin context engine for discovery and status surfaces, but agent runtime now gets a fresh instance
- no unrelated workspace changes included