### PR TITLE
fix(web): remove duplicate skill count in dashboard Skills badge (salvage #12469)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -366,6 +366,7 @@ AUTHOR_MAP = {
     "276886827+WuTianyi123@users.noreply.github.com": "WuTianyi123",
     "22549957+li0near@users.noreply.github.com": "li0near",
     "23434080+sicnuyudidi@users.noreply.github.com": "sicnuyudidi",
+    "haimu0x0@proton.me": "haimu0x",
 }
 
 

--- a/web/src/pages/SkillsPage.tsx
+++ b/web/src/pages/SkillsPage.tsx
@@ -378,7 +378,6 @@ export default function SkillsPage() {
                       : t.skills.all}
                   </CardTitle>
                   <Badge variant="secondary" className="text-[10px]">
-                    {activeSkills.length}{" "}
                     {t.skills.skillCount
                       .replace("{count}", String(activeSkills.length))
                       .replace("{s}", activeSkills.length !== 1 ? "s" : "")}


### PR DESCRIPTION
Salvages #12469 by @haimu0x onto current main.

The Skills dashboard badge was rendering `{activeSkills.length} ` followed by `t.skills.skillCount` — but the `skillCount` template already contains `{count}` (`"{count} skill{s}"` in en.ts, `"{count} 个技能"` in zh.ts). Result: the badge displayed `"5 5 skills"` instead of `"5 skills"`.

One-line fix: drop the leading `{activeSkills.length}` since the i18n template handles the count substitution.

Closes #12469. Author attribution preserved via cherry-pick.