### PR TITLE
fix(claw): normalize workspace paths with as_posix() for Windows (salvage #8564)

### DIFF
--- a/hermes_cli/claw.py
+++ b/hermes_cli/claw.py
@@ -249,7 +249,7 @@ def _scan_workspace_state(source_dir: Path) -> list[tuple[Path, str]]:
             state_path = child / state_name
             if state_path.exists():
                 kind = "directory" if state_path.is_dir() else "file"
-                rel = state_path.relative_to(source_dir)
+                rel = state_path.relative_to(source_dir).as_posix()
                 findings.append((state_path, f"Workspace {kind}: {rel}"))
 
     return findings

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -367,6 +367,7 @@ AUTHOR_MAP = {
     "22549957+li0near@users.noreply.github.com": "li0near",
     "23434080+sicnuyudidi@users.noreply.github.com": "sicnuyudidi",
     "haimu0x0@proton.me": "haimu0x",
+    "abdelmajidnidnasser1@gmail.com": "NIDNASSER-Abdelmajid",
 }
 
 


### PR DESCRIPTION
Salvages #8564 by @NIDNASSER-Abdelmajid onto current main.

`_scan_workspace_state` in `hermes_cli/claw.py` formats workspace state-path findings via f-string interpolation of `Path.relative_to()`. On Windows this renders with backslashes (`WindowsPath('foo\\bar')`), which is inconsistent with the rest of the code's display strings and breaks log/diagnostic parsing that assumes forward slashes. Appending `.as_posix()` normalizes to forward slashes on all platforms.

Closes #8564. Author attribution preserved via cherry-pick.