### PR TITLE
chore(whatsapp): sync package-lock.json baileys pin with package.json SHA (salvage #11854)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -368,6 +368,7 @@ AUTHOR_MAP = {
     "23434080+sicnuyudidi@users.noreply.github.com": "sicnuyudidi",
     "haimu0x0@proton.me": "haimu0x",
     "abdelmajidnidnasser1@gmail.com": "NIDNASSER-Abdelmajid",
+    "projectadmin@wit.id": "projectadmin-dev",
 }
 
 

--- a/scripts/whatsapp-bridge/package-lock.json
+++ b/scripts/whatsapp-bridge/package-lock.json
@@ -8,7 +8,7 @@
       "name": "hermes-whatsapp-bridge",
       "version": "1.0.0",
       "dependencies": {
-        "@whiskeysockets/baileys": "WhiskeySockets/Baileys#fix/abprops-abt-fetch",
+        "@whiskeysockets/baileys": "WhiskeySockets/Baileys#01047debd81beb20da7b7779b08edcb06aa03770",
         "express": "^4.21.0",
         "pino": "^9.0.0",
         "qrcode-terminal": "^0.12.0"


### PR DESCRIPTION
Salvages #11854 by @projectadmin-dev onto current main.

`scripts/whatsapp-bridge/package.json` already pins `@whiskeysockets/baileys` to commit SHA `01047debd8` (`fix(chats): update abprops query to fix bad-request error`, 2026-04-09), but `package-lock.json` still referenced the upstream branch name `fix/abprops-abt-fetch`. That's a supply-chain foot-gun: the branch can be force-pushed, and an `npm ci` against this lockfile can resolve to different bytes on different days.

This PR updates the lockfile to match package.json's SHA pin so both files reference the same immutable commit. Verified the SHA is the HEAD of that branch at the pinning time.

Closes #11854. Author attribution preserved via cherry-pick.