### PR TITLE
fix(cli): guard fallback_model against non-dict YAML shapes in save_config (salvage #5035)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3169,7 +3169,7 @@ def save_config(config: Dict[str, Any]):
     if not sec or sec.get("redact_secrets") is None:
         parts.append(_SECURITY_COMMENT)
     fb = normalized.get("fallback_model", {})
-    if not fb or not (fb.get("provider") and fb.get("model")):
+    if not fb or not isinstance(fb, dict) or not (fb.get("provider") and fb.get("model")):
         parts.append(_FALLBACK_COMMENT)
 
     atomic_yaml_write(

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -369,6 +369,7 @@ AUTHOR_MAP = {
     "haimu0x0@proton.me": "haimu0x",
     "abdelmajidnidnasser1@gmail.com": "NIDNASSER-Abdelmajid",
     "projectadmin@wit.id": "projectadmin-dev",
+    "mrigankamondal10@gmail.com": "Dev-Mriganka",
 }
 
 


### PR DESCRIPTION
Salvages #5035 by @Dev-Mriganka onto current main.

`save_config` reads `fb = normalized.get("fallback_model", {})` and immediately calls `fb.get("provider")`. If a user's `config.yaml` has a corrupt or unexpected `fallback_model:` shape (e.g. a list or string), `.get()` raises `AttributeError` and the save fails. One-line isinstance guard makes the check robust — if it's not a dict, fall through to the default-comment path just like an empty/missing value.

## Attribution note
Original commit's author email was `mriganka@local.dev` (unlinked git default), so the commit was re-authored to @Dev-Mriganka's public GitHub email so the contribution attributes to their profile. All code is @Dev-Mriganka's.

Closes #5035.