### PR TITLE
fix: use utf-8 encoding when reading .env file in load_env() (salvage #9639)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -370,6 +370,7 @@ AUTHOR_MAP = {
     "abdelmajidnidnasser1@gmail.com": "NIDNASSER-Abdelmajid",
     "projectadmin@wit.id": "projectadmin-dev",
     "mrigankamondal10@gmail.com": "Dev-Mriganka",
+    "132275809+shushuzn@users.noreply.github.com": "shushuzn",
 }
 
 

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -111,7 +111,7 @@ def load_env() -> Dict[str, str]:
     if not env_path.exists():
         return env_vars
 
-    with env_path.open() as f:
+    with env_path.open(encoding="utf-8") as f:
         for line in f:
             line = line.strip()
             if line and not line.startswith("#") and "=" in line:


### PR DESCRIPTION
Salvages #9639 by @shushuzn onto current main.

`tools/skills_tool.py` `load_env()` opens `.env` without specifying an encoding, so on Windows with non-UTF-8 code pages (cp1252/cp936) a `.env` containing non-ASCII bytes in any value — secrets from APIs with emoji names, non-Latin hostnames, locale-specific paths — will either crash or be misread. One-line fix: pass `encoding="utf-8"` to match how we read every other config file in the codebase.

## Attribution note
Original commit's author was `claude@newsHub.com` (not linked to any GitHub account), so the commit was re-authored to @shushuzn's GitHub noreply email so the contribution attributes to their profile. All code is @shushuzn's.

Closes #9639.