### PR TITLE
fix(agent): classify 'overloaded' messages as server overload, not rate_limit

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -773,6 +773,14 @@ def _classify_by_message(
             should_fallback=True,
         )
 
+    # Overloaded / server-busy patterns — must come BEFORE rate_limit check
+    # so that "overloaded" messages don't incorrectly trigger credential rotation.
+    if any(p in error_msg for p in ("overloaded", "temporarily overloaded", "service is temporarily overloaded")):
+        return result_fn(
+            FailoverReason.overloaded,
+            retryable=True,
+        )
+
     # Billing patterns
     if any(p in error_msg for p in _BILLING_PATTERNS):
         return result_fn(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11163,7 +11163,7 @@ def main():
     # so systemd Restart=on-failure will retry on transient errors (e.g. DNS)
     success = asyncio.run(start_gateway(config))
     if not success:
-        sys.exit(1)
+        sys.exit(GATEWAY_SERVICE_RESTART_EXIT_CODE)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #14038