### PR TITLE
fix(agent): isolate plugin context engines per agent

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -390,6 +390,7 @@ class PluginContext:
             )
             return
         self._manager._context_engine = engine
+        self._manager._context_engine_manifest = self.manifest
         logger.info(
             "Plugin '%s' registered context engine: %s",
             self.manifest.name, engine.name,
@@ -502,6 +503,7 @@ class PluginManager:
         self._plugin_tool_names: Set[str] = set()
         self._cli_commands: Dict[str, dict] = {}
         self._context_engine = None  # Set by a plugin via register_context_engine()
+        self._context_engine_manifest: Optional[PluginManifest] = None
         self._plugin_commands: Dict[str, dict] = {}  # Slash commands registered by plugins
         self._discovered: bool = False
         self._cli_ref = None  # Set by CLI after plugin discovery
@@ -1090,8 +1092,35 @@ def _ensure_plugins_discovered() -> PluginManager:
 
 
 def get_plugin_context_engine():
-    """Return the plugin-registered context engine, or None."""
+    """Return the singleton plugin-registered context engine, or None."""
     return _ensure_plugins_discovered()._context_engine
+
+
+def create_plugin_context_engine(expected_name: Optional[str] = None):
+    """Instantiate a fresh plugin context engine for one agent/session.
+
+    The global plugin manager keeps a singleton engine for status surfaces and
+    discovery metadata, but agent runtime must not share that mutable instance
+    across sessions. This helper reloads the owning plugin into a temporary
+    PluginManager and returns the newly-registered engine instance.
+    """
+    manager = _ensure_plugins_discovered()
+    singleton = manager._context_engine
+    manifest = manager._context_engine_manifest
+    if singleton is None or manifest is None:
+        return None
+    if expected_name and getattr(singleton, "name", None) != expected_name:
+        return None
+
+    temp_manager = PluginManager()
+    temp_manager._discovered = True
+    temp_manager._load_plugin(manifest)
+    engine = temp_manager._context_engine
+    if engine is None:
+        return None
+    if expected_name and getattr(engine, "name", None) != expected_name:
+        return None
+    return engine
 
 
 def get_plugin_command_handler(name: str) -> Optional[Callable]:

--- a/run_agent.py
+++ b/run_agent.py
@@ -1666,8 +1666,8 @@ class AIAgent:
             # Try general plugin system as fallback
             if _selected_engine is None:
                 try:
-                    from hermes_cli.plugins import get_plugin_context_engine
-                    _candidate = get_plugin_context_engine()
+                    from hermes_cli.plugins import create_plugin_context_engine
+                    _candidate = create_plugin_context_engine(_engine_name)
                     if _candidate and _candidate.name == _engine_name:
                         _selected_engine = _candidate
                 except Exception:

--- a/tests/run_agent/test_plugin_context_engine_init.py
+++ b/tests/run_agent/test_plugin_context_engine_init.py
@@ -89,3 +89,46 @@ def test_plugin_engine_update_model_args():
     assert "provider" in kw
     # Should NOT pass api_mode — the ABC doesn't accept it
     assert "api_mode" not in kw
+
+
+def test_general_plugin_context_engine_is_isolated_per_agent_instance():
+    """General plugin engines must not be shared mutable singletons across agents."""
+    shared_singleton = _StubEngine()
+    fresh_one = _StubEngine()
+    fresh_two = _StubEngine()
+    cfg = {"context": {"engine": "stub"}, "agent": {}}
+
+    with (
+        patch("hermes_cli.config.load_config", return_value=cfg),
+        patch("plugins.context_engine.load_context_engine", return_value=None),
+        patch("hermes_cli.plugins.get_plugin_context_engine", return_value=shared_singleton),
+        patch(
+            "hermes_cli.plugins.create_plugin_context_engine",
+            side_effect=[fresh_one, fresh_two],
+            create=True,
+        ),
+        patch("agent.model_metadata.get_model_context_length", return_value=131_072),
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        from run_agent import AIAgent
+
+        agent_one = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent_two = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+    assert agent_one.context_compressor is fresh_one
+    assert agent_two.context_compressor is fresh_two
+    assert agent_one.context_compressor is not agent_two.context_compressor


### PR DESCRIPTION
## What changed
- instantiate a fresh general-plugin context engine for each `AIAgent`
- keep the plugin manager singleton only for discovery metadata instead of live per-session runtime state
- add a regression test covering the general-plugin fallback path

## Why
General-plugin context engines are currently reused as mutable singletons across agents. That is wrong for engines that carry session-scoped state such as session ids, cursors, compaction counters, and lifecycle markers.

In practice, that lets context-engine state bleed across sessions. For LCM, this can produce a bad mixed state after a rebind where `compression_count > 0` while the newly bound session still has `store_messages == 0` and `dag_nodes == 0`.

## How to test
### Automated
- `pytest tests/run_agent/test_plugin_context_engine_init.py -q`
- `pytest tests/agent/test_context_engine.py tests/hermes_cli/test_plugins.py -q`
- `pytest tests/ -v`  
  - current result in this Linux/Python 3.14 environment: unrelated existing upstream failures outside the touched files; targeted suites above pass

### Manual
- instantiate two `AIAgent` instances through the general-plugin fallback path
- verify each agent receives a distinct context-engine instance instead of sharing the plugin manager singleton

## Platforms tested
- Linux (Arch)
- Python 3.14.4

## Related context
- clean PR: only `hermes_cli/plugins.py`, `run_agent.py`, and `tests/run_agent/test_plugin_context_engine_init.py`
- replaces #14254, which was cut from a dirty branch and included unrelated changes