### PR TITLE
fix(web): apply search limits to unique sessions

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -736,20 +736,36 @@ async def search_sessions(q: str = "", limit: int = 20):
                 else:
                     terms.append(token + "*")
             prefix_query = " ".join(terms)
-            matches = db.search_messages(query=prefix_query, limit=limit)
-            # Group by session_id — return unique sessions with their best snippet
+            # search_messages() limits raw message hits, but this endpoint
+            # promises up to N unique sessions. Overfetch message hits until
+            # we either collect enough unique session IDs or exhaust results.
             seen: dict = {}
-            for m in matches:
-                sid = m["session_id"]
-                if sid not in seen:
-                    seen[sid] = {
-                        "session_id": sid,
-                        "snippet": m.get("snippet", ""),
-                        "role": m.get("role"),
-                        "source": m.get("source"),
-                        "model": m.get("model"),
-                        "session_started": m.get("session_started"),
-                    }
+            offset = 0
+            fetch_size = max(limit, min(limit * 3, 100))
+            while len(seen) < limit:
+                matches = db.search_messages(
+                    query=prefix_query,
+                    limit=fetch_size,
+                    offset=offset,
+                )
+                if not matches:
+                    break
+                for m in matches:
+                    sid = m["session_id"]
+                    if sid not in seen:
+                        seen[sid] = {
+                            "session_id": sid,
+                            "snippet": m.get("snippet", ""),
+                            "role": m.get("role"),
+                            "source": m.get("source"),
+                            "model": m.get("model"),
+                            "session_started": m.get("session_started"),
+                        }
+                        if len(seen) >= limit:
+                            break
+                if len(matches) < fetch_size:
+                    break
+                offset += len(matches)
             return {"results": list(seen.values())}
         finally:
             db.close()

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -191,6 +191,53 @@ class TestWebServerEndpoints:
         assert resp.json()["gateway_state"] == "startup_failed"
         assert resp.json()["gateway_platforms"] == {}
 
+    def test_session_search_overfetches_until_limit_unique_sessions(self, monkeypatch):
+        import hermes_state
+
+        batches = []
+        for idx in range(6):
+            batches.append(
+                {
+                    "session_id": "session-a",
+                    "snippet": f"needle dup {idx}",
+                    "role": "user" if idx % 2 == 0 else "assistant",
+                    "source": "cli",
+                    "model": "m",
+                    "session_started": 1,
+                }
+            )
+        batches.append(
+            {
+                "session_id": "session-b",
+                "snippet": "needle unique",
+                "role": "user",
+                "source": "telegram",
+                "model": "m2",
+                "session_started": 2,
+            }
+        )
+        calls = []
+
+        class _FakeSessionDB:
+            def search_messages(self, query, limit, offset=0):
+                calls.append({"query": query, "limit": limit, "offset": offset})
+                return batches[offset:offset + limit]
+
+            def close(self):
+                return None
+
+        monkeypatch.setattr(hermes_state, "SessionDB", _FakeSessionDB)
+
+        resp = self.client.get("/api/sessions/search", params={"q": "needle", "limit": 2})
+
+        assert resp.status_code == 200
+        results = resp.json()["results"]
+        assert [row["session_id"] for row in results] == ["session-a", "session-b"]
+        assert len(calls) == 2
+        assert calls[0]["limit"] == 6
+        assert calls[0]["offset"] == 0
+        assert calls[1]["offset"] == 6
+
     def test_get_config_schema(self):
         resp = self.client.get("/api/config/schema")
         assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- make `/api/sessions/search` overfetch message hits until it can return the requested number of unique sessions or exhaust the result set
- keep the first snippet per session while preventing early duplicate hits from shrinking the API response below the requested limit
- add a regression covering the case where the first fetched message hits all belong to the same session

## Testing
- python3 -m pytest -o addopts= tests/hermes_cli/test_web_server.py -k "session_search_overfetches_until_limit_unique_sessions"
- python3 -m pytest -o addopts= tests/hermes_cli/test_web_server.py

Closes #14193
