### PR TITLE
fix: show orphaned custom auth pools in interactive remove

### DIFF
--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -38,22 +38,29 @@ _OAUTH_CAPABLE_PROVIDERS = {"anthropic", "nous", "openai-codex", "qwen-oauth", "
 
 def _get_custom_provider_names() -> list:
     """Return list of (display_name, pool_key, provider_key) tuples."""
+    configured: dict[str, tuple[str, str, str]] = {}
     try:
         from hermes_cli.config import get_compatible_custom_providers, load_config
 
         config = load_config()
     except Exception:
-        return []
-    result = []
-    for entry in get_compatible_custom_providers(config):
-        if not isinstance(entry, dict):
+        config = None
+    if config is not None:
+        for entry in get_compatible_custom_providers(config):
+            if not isinstance(entry, dict):
+                continue
+            name = entry.get("name")
+            if not isinstance(name, str) or not name.strip():
+                continue
+            pool_key = f"{CUSTOM_POOL_PREFIX}{_normalize_custom_pool_name(name)}"
+            provider_key = str(entry.get("provider_key", "") or "").strip()
+            configured[pool_key] = (name.strip(), pool_key, provider_key)
+    result = list(configured.values())
+    for pool_key in list_custom_pool_providers():
+        if pool_key in configured:
             continue
-        name = entry.get("name")
-        if not isinstance(name, str) or not name.strip():
-            continue
-        pool_key = f"{CUSTOM_POOL_PREFIX}{_normalize_custom_pool_name(name)}"
-        provider_key = str(entry.get("provider_key", "") or "").strip()
-        result.append((name.strip(), pool_key, provider_key))
+        suffix = pool_key[len(CUSTOM_POOL_PREFIX):] or pool_key
+        result.append((suffix, pool_key, ""))
     return result
 
 

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -611,6 +611,89 @@ def test_auth_list_prefers_explicit_reset_time(monkeypatch, capsys):
     assert "7d 0h left" in out
 
 
+def test_get_custom_provider_names_includes_orphaned_custom_pools(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    (hermes_home / "config.yaml").write_text(
+        "model:\n"
+        "  provider: configured-provider\n"
+        "custom_providers:\n"
+        "  - name: Configured Provider\n"
+        "    provider_key: configured-provider\n"
+        "    base_url: https://configured.example.com/v1\n"
+        "    api_key: sk-configured\n"
+    )
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "custom:configured-provider": [
+                    {
+                        "id": "cfg-1",
+                        "label": "configured",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "config:Configured Provider",
+                        "access_token": "sk-configured",
+                    }
+                ],
+                "custom:orphaned-provider": [
+                    {
+                        "id": "orph-1",
+                        "label": "orphaned",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-orphaned",
+                    }
+                ],
+            },
+        },
+    )
+
+    from hermes_cli.auth_commands import _get_custom_provider_names
+
+    assert _get_custom_provider_names() == [
+        ("Configured Provider", "custom:configured-provider", ""),
+        ("orphaned-provider", "custom:orphaned-provider", ""),
+    ]
+
+
+def test_pick_provider_accepts_orphaned_custom_pool_name(tmp_path, monkeypatch, capsys):
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "custom:orphaned-provider": [
+                    {
+                        "id": "orph-1",
+                        "label": "orphaned",
+                        "auth_type": "api_key",
+                        "priority": 0,
+                        "source": "manual",
+                        "access_token": "sk-orphaned",
+                    }
+                ],
+            },
+        },
+    )
+    monkeypatch.setattr("builtins.input", lambda _prompt: "orphaned-provider")
+
+    from hermes_cli.auth_commands import _pick_provider
+
+    assert _pick_provider("Provider to remove credential from") == "custom:orphaned-provider"
+
+    out = capsys.readouterr().out
+    assert "Custom endpoints: orphaned-provider" in out
+
+
 def test_auth_remove_env_seeded_clears_env_var(tmp_path, monkeypatch):
     """Removing an env-seeded credential should also clear the env var from .env
     so the entry doesn't get re-seeded on the next load_pool() call."""


### PR DESCRIPTION
## Summary
- merge configured custom providers with persisted custom:* auth pools when building interactive provider hints
- keep configured display names when they still exist, and synthesize orphaned entries from auth.json when config.yaml no longer has them
- add regression coverage for orphaned custom pool listing and selection in the interactive picker

## Testing
- python3 -m pytest -o addopts='' tests/hermes_cli/test_auth_commands.py

Fixes #14218