### PR TITLE
fix(models): add maas.aliyuncs.com to provider URL map

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -257,6 +257,7 @@ _URL_TO_PROVIDER: Dict[str, str] = {
     "api.minimax": "minimax",
     "dashscope.aliyuncs.com": "alibaba",
     "dashscope-intl.aliyuncs.com": "alibaba",
+    "maas.aliyuncs.com": "alibaba",
     "portal.qwen.ai": "qwen-oauth",
     "openrouter.ai": "openrouter",
     "generativelanguage.googleapis.com": "gemini",


### PR DESCRIPTION
## Problem

Alibaba Cloud MaaS endpoints (e.g. `token-plan.cn-beijing.maas.aliyuncs.com`) are not recognized as known providers in `_URL_TO_PROVIDER`. This causes `get_model_context_length()` to hit the "unknown custom endpoint" early-return branch at step 2, which falls back to `DEFAULT_FALLBACK_CONTEXT` (128K) without ever reaching the `models.dev` lookup at step 5.

**Impact:** Models served via `*.maas.aliyuncs.com` endpoints are incorrectly reported as having 128K context, regardless of their actual context window. For example, `qwen3.6-plus` (1M context) is detected as 128K.

## Fix

Add `"maas.aliyuncs.com": "alibaba"` to `_URL_TO_PROVIDER`. The existing substring-matching logic (`url_part in host`) ensures this single entry covers all `*.maas.aliyuncs.com` subdomains:

- `token-plan.cn-beijing.maas.aliyuncs.com` ✅
- `privatelink.cn-beijing.maas.aliyuncs.com` ✅
- Any future `*.maas.aliyuncs.com` endpoints ✅

## Verification

```python
from agent.model_metadata import _infer_provider_from_url, _is_known_provider_base_url

url = "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1"
assert _infer_provider_from_url(url) == "alibaba"
assert _is_known_provider_base_url(url) is True
```

After this fix, `get_model_context_length("qwen3.6-plus", base_url="...token-plan...")` correctly returns `1,000,000` via models.dev lookup instead of the 128K fallback.
