### PR TITLE
fix(title): bump title_generator max_tokens to 500 for reasoning-model headroom (salvage #9606)

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -38,7 +38,7 @@ def generate_title(user_message: str, assistant_response: str, timeout: float = 
         response = call_llm(
             task="title_generation",
             messages=messages,
-            max_tokens=30,
+            max_tokens=500,
             temperature=0.3,
             timeout=timeout,
         )

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -371,6 +371,7 @@ AUTHOR_MAP = {
     "projectadmin@wit.id": "projectadmin-dev",
     "mrigankamondal10@gmail.com": "Dev-Mriganka",
     "132275809+shushuzn@users.noreply.github.com": "shushuzn",
+    "ibrahimozsarac@gmail.com": "iborazzi",
 }
 
 


### PR DESCRIPTION
Salvages #9606 by @iborazzi onto current main. Closes #9571.

Reasoning-heavy models (GLM 5.1, DeepSeek-R1, etc.) burn their `max_tokens` budget on internal thinking before producing the final title. With the previous 30-token cap they hit `finish_reason: length` inside the reasoning trace and returned an empty completion, leaving sessions with blank titles. Bumping to 500 gives the model comfortable reasoning headroom while its own system-prompt instructions ("3-7 words") keep the final output concise.

Title generation runs on the aux-task model override (typically cheap/fast Gemini Flash), so the cost impact is negligible.

Closes #9606, closes #9571. Author attribution preserved via cherry-pick.