### PR TITLE
fix(skills): drop non-shipped agentic-research-ideas from llm-wiki related_skills (salvage #11391)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -372,6 +372,7 @@ AUTHOR_MAP = {
     "mrigankamondal10@gmail.com": "Dev-Mriganka",
     "132275809+shushuzn@users.noreply.github.com": "shushuzn",
     "ibrahimozsarac@gmail.com": "iborazzi",
+    "130149563+A-afflatus@users.noreply.github.com": "A-afflatus",
 }
 
 

--- a/skills/research/llm-wiki/SKILL.md
+++ b/skills/research/llm-wiki/SKILL.md
@@ -8,7 +8,7 @@ metadata:
   hermes:
     tags: [wiki, knowledge-base, research, notes, markdown, rag-alternative]
     category: research
-    related_skills: [obsidian, arxiv, agentic-research-ideas]
+    related_skills: [obsidian, arxiv]
 ---
 
 # Karpathy's LLM Wiki


### PR DESCRIPTION
Salvages #11391 by @A-afflatus onto current main.

`skills/research/llm-wiki/SKILL.md` listed `agentic-research-ideas` under `metadata.hermes.related_skills`, but that skill doesn't ship in the repo — it only exists in some users' private `~/.hermes/skills/research/` trees. The `related_skills` hint is meant for repo-shipped siblings the agent can reliably load. One-line fix: trim the list to skills that actually exist in the repo (`obsidian`, `arxiv`).

## Attribution note
Original commit's author email was `wangjing921@jd.com` (unlinked corporate JD address), re-authored to @A-afflatus's GitHub noreply email so the contribution attributes to their profile.

Closes #11391.