### PR TITLE
fix(tui): preserve config on save, surface orphaned auth credentials

### DIFF
--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -37,13 +37,17 @@ _OAUTH_CAPABLE_PROVIDERS = {"anthropic", "nous", "openai-codex", "qwen-oauth", "
 
 
 def _get_custom_provider_names() -> list:
-    """Return list of (display_name, pool_key, provider_key) tuples."""
+    """Return (display_name, pool_key, provider_key) tuples for custom providers.
+
+    Includes both live entries from config.yaml and orphaned credentials
+    in auth.json so users can still remove them from the interactive menu.
+    """
     try:
         from hermes_cli.config import get_compatible_custom_providers, load_config
 
         config = load_config()
     except Exception:
-        return []
+        config = {}
     result = []
     for entry in get_compatible_custom_providers(config):
         if not isinstance(entry, dict):
@@ -54,6 +58,20 @@ def _get_custom_provider_names() -> list:
         pool_key = f"{CUSTOM_POOL_PREFIX}{_normalize_custom_pool_name(name)}"
         provider_key = str(entry.get("provider_key", "") or "").strip()
         result.append((name.strip(), pool_key, provider_key))
+
+    # Scan auth.json for orphaned custom provider pool keys that no
+    # longer have a matching config.yaml entry.  Without this, hermes auth
+    # list shows them but the interactive remove menu silently hides them.
+    try:
+        known_pool_keys = {r[1] for r in result}
+        for orphan_key in list_custom_pool_providers():
+            if orphan_key not in known_pool_keys:
+                # Derive display name from pool key: "custom:yunwu.ai" -> "yunwu.ai"
+                display = orphan_key[len(CUSTOM_POOL_PREFIX):]
+                result.append((display, orphan_key, ""))
+    except Exception:
+        pass
+
     return result
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -340,15 +340,25 @@ def _load_cfg() -> dict:
 
 def _save_cfg(cfg: dict):
     global _cfg_cache, _cfg_mtime
-    import yaml
+    from hermes_cli.config import save_config
 
-    path = _hermes_home / "config.yaml"
-    with open(path, "w") as f:
-        yaml.safe_dump(cfg, f)
+    # Ensure save_config writes to the same directory as _hermes_home.
+    # In production they match; in tests, _hermes_home may be monkeypatched
+    # to a tmpdir while HERMES_HOME still points to ~/.hermes.
+    prev_home = os.environ.get("HERMES_HOME")
+    try:
+        os.environ["HERMES_HOME"] = str(_hermes_home)
+        save_config(cfg)
+    finally:
+        if prev_home is None:
+            os.environ.pop("HERMES_HOME", None)
+        else:
+            os.environ["HERMES_HOME"] = prev_home
+
     with _cfg_lock:
         _cfg_cache = copy.deepcopy(cfg)
         try:
-            _cfg_mtime = path.stat().st_mtime
+            _cfg_mtime = (_hermes_home / "config.yaml").stat().st_mtime
         except Exception:
             _cfg_mtime = None
 


### PR DESCRIPTION
### Body

The TUI gateway writes config back to disk with raw `yaml.safe_dump()`, which strips comments and env-var templates like `${GLM_API_KEY}`. Every time the TUI sets a display preference it silently destroys those parts of the user's config. This switches `_save_cfg()` to delegate to `save_config()` — the same atomic write path the CLI uses — so env-var templates, comments, and structure survive round-trips.

The second fix addresses orphaned credentials. When a custom provider is removed from config.yaml, its entries stay in auth.json. `hermes auth list` shows them (reads auth.json) but the interactive remove menu doesn't (reads config.yaml only). `_get_custom_provider_names()` now also scans auth.json for orphaned `custom:*` pool keys so they appear in the remove menu. Closes #14218.

### Changes

- `tui_gateway/server.py`: `_save_cfg()` delegates to `save_config()` with HERMES_HOME env var sync
- `hermes_cli/auth_commands.py`: `_get_custom_provider_names()` merges orphaned auth.json entries

### Testing

89 tests pass (TUI gateway server + auth commands). Config round-trip verified byte-identical on a 331-line config with custom_providers, mcp_servers, matrix config, and env-var templates.