### PR TITLE
fix(skills): preserve file modes across atomic writes

### DIFF
--- a/tests/tools/test_atomic_write_permissions.py
+++ b/tests/tools/test_atomic_write_permissions.py
@@ -1,0 +1,54 @@
+import os
+import stat
+from unittest.mock import patch
+
+from tools.skill_manager_tool import _atomic_write_text
+from tools.skills_sync import _write_manifest
+
+
+def _mode(path):
+    return stat.S_IMODE(os.stat(path).st_mode)
+
+
+def test_atomic_write_text_preserves_existing_file_mode(tmp_path, monkeypatch):
+    target = tmp_path / "demo-skill" / "SKILL.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("old content", encoding="utf-8")
+    os.chmod(target, 0o664)
+
+    original_replace = os.replace
+    seen = {}
+
+    def capture_replace(src, dst):
+        seen["temp_mode"] = _mode(src)
+        return original_replace(src, dst)
+
+    monkeypatch.setattr("tools.skill_manager_tool.os.replace", capture_replace)
+
+    _atomic_write_text(target, "new content")
+
+    assert target.read_text(encoding="utf-8") == "new content"
+    assert seen["temp_mode"] == 0o664
+    assert _mode(target) == 0o664
+
+
+def test_write_manifest_preserves_existing_file_mode(tmp_path, monkeypatch):
+    manifest = tmp_path / ".bundled_manifest"
+    manifest.write_text("old:hash\n", encoding="utf-8")
+    os.chmod(manifest, 0o664)
+
+    original_replace = os.replace
+    seen = {}
+
+    def capture_replace(src, dst):
+        seen["temp_mode"] = _mode(src)
+        return original_replace(src, dst)
+
+    monkeypatch.setattr("tools.skills_sync.os.replace", capture_replace)
+
+    with patch("tools.skills_sync.MANIFEST_FILE", manifest):
+        _write_manifest({"skill-a": "abc123"})
+
+    assert manifest.read_text(encoding="utf-8") == "skill-a:abc123\n"
+    assert seen["temp_mode"] == 0o664
+    assert _mode(manifest) == 0o664

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -75,6 +75,8 @@ def _security_scan_skill(skill_dir: Path) -> Optional[str]:
 
 import yaml
 
+from utils import _preserve_file_mode, _restore_file_mode
+
 
 # All skills live in ~/.hermes/skills/ (single source of truth)
 HERMES_HOME = get_hermes_home()
@@ -279,6 +281,7 @@ def _atomic_write_text(file_path: Path, content: str, encoding: str = "utf-8") -
         encoding: Text encoding (default: utf-8)
     """
     file_path.parent.mkdir(parents=True, exist_ok=True)
+    original_mode = _preserve_file_mode(file_path)
     fd, temp_path = tempfile.mkstemp(
         dir=str(file_path.parent),
         prefix=f".{file_path.name}.tmp.",
@@ -287,7 +290,10 @@ def _atomic_write_text(file_path: Path, content: str, encoding: str = "utf-8") -
     try:
         with os.fdopen(fd, "w", encoding=encoding) as f:
             f.write(content)
+        if original_mode is not None:
+            os.chmod(temp_path, original_mode)
         os.replace(temp_path, file_path)
+        _restore_file_mode(file_path, original_mode)
     except Exception:
         # Clean up temp file on error
         try:

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -29,6 +29,8 @@ from pathlib import Path
 from hermes_constants import get_hermes_home
 from typing import Dict, List, Tuple
 
+from utils import _preserve_file_mode, _restore_file_mode
+
 logger = logging.getLogger(__name__)
 
 
@@ -86,6 +88,7 @@ def _write_manifest(entries: Dict[str, str]):
 
     MANIFEST_FILE.parent.mkdir(parents=True, exist_ok=True)
     data = "\n".join(f"{name}:{hash_val}" for name, hash_val in sorted(entries.items())) + "\n"
+    original_mode = _preserve_file_mode(MANIFEST_FILE)
 
     try:
         fd, tmp_path = tempfile.mkstemp(
@@ -98,7 +101,10 @@ def _write_manifest(entries: Dict[str, str]):
                 f.write(data)
                 f.flush()
                 os.fsync(f.fileno())
+            if original_mode is not None:
+                os.chmod(tmp_path, original_mode)
             os.replace(tmp_path, MANIFEST_FILE)
+            _restore_file_mode(MANIFEST_FILE, original_mode)
         except BaseException:
             try:
                 os.unlink(tmp_path)


### PR DESCRIPTION
## Summary

Preserve existing file permissions when skill writes and bundled skill manifest updates replace files atomically.

Before this change, both `tools.skill_manager_tool._atomic_write_text()` and `tools.skills_sync._write_manifest()` rewrote existing files through `mkstemp()` + `os.replace()` without restoring the original mode first. That let `SKILL.md` and `.bundled_manifest` collapse to `0600`, which breaks managed/shared Hermes runtimes that expect group-readable files.

## Root cause

`tempfile.mkstemp()` creates the temp file with owner-only permissions. `os.replace()` then swaps that temp file into place, so the target inherits the temp file mode unless the write path explicitly preserves the old mode.

## Fix

- capture the existing target mode before each atomic write
- apply that mode to the temp file before `os.replace()`
- reapply the mode after replacement as a defensive follow-up

## Regression coverage

Added focused tests that verify both write paths preserve an existing `0664` mode, including the temp file mode at replace time:
- `tools.skill_manager_tool._atomic_write_text()` for `SKILL.md`
- `tools.skills_sync._write_manifest()` for `.bundled_manifest`

## Testing

- `scripts/run_tests.sh tests/tools/test_atomic_write_permissions.py -q`
- `scripts/run_tests.sh tests/tools/test_skill_manager_tool.py -q`
- `scripts/run_tests.sh tests/tools/test_skills_sync.py -q`

Closes #14181
