### PR TITLE
feat(image-gen): add Codex-backed image generation provider

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -283,6 +283,7 @@ class PluginContext:
         name: str,
         handler: Callable,
         description: str = "",
+        args_hint: str = "",
     ) -> None:
         """Register a slash command (e.g. ``/lcm``) available in CLI and gateway sessions.
 
@@ -292,6 +293,13 @@ class PluginContext:
         Unlike ``register_cli_command()`` (which creates ``hermes <subcommand>``
         terminal commands), this registers in-session slash commands that users
         invoke during a conversation.
+
+        ``args_hint`` is an optional short string (e.g. ``"<file>"`` or
+        ``"dias:7 formato:json"``) used by gateway adapters to surface the
+        command with an argument field — for example Discord's native slash
+        command picker. Plugin commands without ``args_hint`` register as
+        parameterless in Discord and still accept trailing text when invoked
+        as free-form chat.
 
         Names conflicting with built-in commands are rejected with a warning.
         """
@@ -320,6 +328,7 @@ class PluginContext:
             "handler": handler,
             "description": description or "Plugin command",
             "plugin": self.manifest.name,
+            "args_hint": (args_hint or "").strip(),
         }
         logger.debug("Plugin %s registered command: /%s", self.manifest.name, clean)
 
@@ -503,10 +512,23 @@ class PluginManager:
     # Public
     # -----------------------------------------------------------------------
 
-    def discover_and_load(self) -> None:
-        """Scan all plugin sources and load each plugin found."""
-        if self._discovered:
+    def discover_and_load(self, force: bool = False) -> None:
+        """Scan all plugin sources and load each plugin found.
+
+        When ``force`` is true, clear cached discovery state first so config
+        changes or newly-added bundled backends become visible in long-lived
+        sessions without requiring a full agent restart.
+        """
+        if self._discovered and not force:
             return
+        if force:
+            self._plugins.clear()
+            self._hooks.clear()
+            self._plugin_tool_names.clear()
+            self._cli_commands.clear()
+            self._plugin_commands.clear()
+            self._plugin_skills.clear()
+            self._context_engine = None
         self._discovered = True
 
         manifests: List[PluginManifest] = []
@@ -1020,9 +1042,13 @@ def get_plugin_manager() -> PluginManager:
     return _plugin_manager
 
 
-def discover_plugins() -> None:
-    """Discover and load all plugins (idempotent)."""
-    get_plugin_manager().discover_and_load()
+def discover_plugins(force: bool = False) -> None:
+    """Discover and load all plugins.
+
+    Default behavior is idempotent. Pass ``force=True`` to rescan plugin
+    manifests and reload state in the current process.
+    """
+    get_plugin_manager().discover_and_load(force=force)
 
 
 def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
@@ -1073,10 +1099,13 @@ def get_pre_tool_call_block_message(
     return None
 
 
-def _ensure_plugins_discovered() -> PluginManager:
-    """Return the global manager after running idempotent plugin discovery."""
+def _ensure_plugins_discovered(force: bool = False) -> PluginManager:
+    """Return the global manager after ensuring plugin discovery has run.
+
+    Pass ``force=True`` to rescan in the current process.
+    """
     manager = get_plugin_manager()
-    manager.discover_and_load()
+    manager.discover_and_load(force=force)
     return manager
 
 

--- a/plugins/image_gen/codex/__init__.py
+++ b/plugins/image_gen/codex/__init__.py
@@ -1,0 +1,345 @@
+"""Codex / ChatGPT-subscription image generation backend.
+
+Uses Hermes's existing ``openai-codex`` OAuth session (stored in
+``~/.hermes/auth.json``) to call the ChatGPT Codex Responses backend with the
+built-in ``image_generation`` tool. No ``OPENAI_API_KEY`` is required.
+
+Selection precedence (first hit wins):
+
+1. ``CODEX_IMAGE_MODEL`` env var
+2. ``image_gen.codex.model`` in ``config.yaml``
+3. ``image_gen.model`` in ``config.yaml`` (when it matches our catalog)
+4. :data:`DEFAULT_MODEL`
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List, Optional, Tuple
+
+from agent.auxiliary_client import _codex_cloudflare_headers
+from agent.image_gen_provider import (
+    DEFAULT_ASPECT_RATIO,
+    ImageGenProvider,
+    error_response,
+    resolve_aspect_ratio,
+    save_b64_image,
+    success_response,
+)
+from hermes_cli.auth import resolve_codex_runtime_credentials
+
+logger = logging.getLogger(__name__)
+
+
+_MODELS: Dict[str, Dict[str, Any]] = {
+    "gpt-5.4-low": {
+        "display": "GPT-5.4 via ChatGPT Subscription (Low)",
+        "speed": "~15s",
+        "strengths": "Fast iteration, lowest cost",
+        "tool_model": "gpt-image-2",
+        "quality": "low",
+        "api_model": "gpt-5.4",
+    },
+    "gpt-5.4-medium": {
+        "display": "GPT-5.4 via ChatGPT Subscription (Medium)",
+        "speed": "~40s",
+        "strengths": "Balanced — default",
+        "tool_model": "gpt-image-2",
+        "quality": "medium",
+        "api_model": "gpt-5.4",
+    },
+    "gpt-5.4-high": {
+        "display": "GPT-5.4 via ChatGPT Subscription (High)",
+        "speed": "~2min",
+        "strengths": "Highest fidelity",
+        "tool_model": "gpt-image-2",
+        "quality": "high",
+        "api_model": "gpt-5.4",
+    },
+}
+
+DEFAULT_MODEL = "gpt-5.4-medium"
+
+
+def _load_codex_config() -> Dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        section = cfg.get("image_gen") if isinstance(cfg, dict) else None
+        return section if isinstance(section, dict) else {}
+    except Exception as exc:
+        logger.debug("Could not load image_gen config: %s", exc)
+        return {}
+
+
+
+def _resolve_model() -> Tuple[str, Dict[str, Any]]:
+    env_override = os.environ.get("CODEX_IMAGE_MODEL")
+    if env_override and env_override in _MODELS:
+        return env_override, _MODELS[env_override]
+
+    cfg = _load_codex_config()
+    codex_cfg = cfg.get("codex") if isinstance(cfg.get("codex"), dict) else {}
+    candidate: Optional[str] = None
+    if isinstance(codex_cfg, dict):
+        value = codex_cfg.get("model")
+        if isinstance(value, str) and value in _MODELS:
+            candidate = value
+    if candidate is None:
+        top = cfg.get("model")
+        if isinstance(top, str) and top in _MODELS:
+            candidate = top
+
+    if candidate is not None:
+        return candidate, _MODELS[candidate]
+    return DEFAULT_MODEL, _MODELS[DEFAULT_MODEL]
+
+
+
+def _extract_output(response: Any) -> List[Any]:
+    if isinstance(response, list):
+        terminal_response = None
+        output_items: List[Any] = []
+        for event in response:
+            etype = _item_get(event, "type")
+            if etype == "response.output_item.done":
+                item = _item_get(event, "item")
+                if item is not None:
+                    output_items.append(item)
+            if etype in {"response.completed", "response.failed", "response.incomplete"}:
+                terminal_response = _item_get(event, "response")
+                break
+        if terminal_response is not None:
+            terminal_output = _extract_output(terminal_response)
+            if terminal_output:
+                return terminal_output
+        return output_items
+    if hasattr(response, "__iter__") and not isinstance(response, (dict, str, bytes)):
+        terminal_response = None
+        output_items: List[Any] = []
+        try:
+            for event in response:
+                etype = _item_get(event, "type")
+                if etype == "response.output_item.done":
+                    item = _item_get(event, "item")
+                    if item is not None:
+                        output_items.append(item)
+                if etype in {"response.completed", "response.failed", "response.incomplete"}:
+                    terminal_response = _item_get(event, "response")
+                    break
+        finally:
+            close_fn = getattr(response, "close", None)
+            if callable(close_fn):
+                try:
+                    close_fn()
+                except Exception:
+                    pass
+        if terminal_response is not None:
+            terminal_output = _extract_output(terminal_response)
+            if terminal_output:
+                return terminal_output
+        return output_items
+    if isinstance(response, dict):
+        output = response.get("output")
+    else:
+        output = getattr(response, "output", None)
+    return output if isinstance(output, list) else []
+
+
+
+def _item_get(item: Any, key: str, default: Any = None) -> Any:
+    if isinstance(item, dict):
+        return item.get(key, default)
+    return getattr(item, key, default)
+
+
+
+def _find_image_generation_item(output: List[Any]) -> Any:
+    for item in output:
+        if _item_get(item, "type") == "image_generation_call":
+            return item
+    return None
+
+
+class CodexImageGenProvider(ImageGenProvider):
+    @property
+    def name(self) -> str:
+        return "codex"
+
+    @property
+    def display_name(self) -> str:
+        return "Codex"
+
+    def is_available(self) -> bool:
+        try:
+            creds = resolve_codex_runtime_credentials(refresh_if_expiring=False)
+            api_key = str(creds.get("api_key", "") or "").strip()
+            if not api_key:
+                return False
+            import openai  # noqa: F401
+        except Exception:
+            return False
+        return True
+
+    def list_models(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "id": model_id,
+                "display": meta["display"],
+                "speed": meta["speed"],
+                "strengths": meta["strengths"],
+                "price": "included with ChatGPT/Codex auth",
+            }
+            for model_id, meta in _MODELS.items()
+        ]
+
+    def default_model(self) -> Optional[str]:
+        return DEFAULT_MODEL
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Codex",
+            "badge": "chatgpt",
+            "tag": "No OpenAI API key required. Uses your Hermes OpenAI Codex / ChatGPT login if available. Please login OpenAI Codex via OAuth using hermes model first before using this.",
+            "env_vars": [],
+        }
+
+    def generate(
+        self,
+        prompt: str,
+        aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        prompt = (prompt or "").strip()
+        aspect = resolve_aspect_ratio(aspect_ratio)
+
+        if not prompt:
+            return error_response(
+                error="Prompt is required and must be a non-empty string",
+                error_type="invalid_argument",
+                provider="codex",
+                aspect_ratio=aspect,
+            )
+
+        try:
+            creds = resolve_codex_runtime_credentials(refresh_if_expiring=True)
+        except Exception as exc:
+            return error_response(
+                error=(
+                    "Codex authentication not available. Run `hermes auth` and log in "
+                    f"to OpenAI Codex / ChatGPT first. ({exc})"
+                ),
+                error_type="auth_required",
+                provider="codex",
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        api_key = str(creds.get("api_key", "") or "").strip()
+        base_url = str(creds.get("base_url", "") or "").strip().rstrip("/")
+        if not api_key or not base_url:
+            return error_response(
+                error="Codex credentials are missing api_key or base_url.",
+                error_type="auth_required",
+                provider="codex",
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        try:
+            import openai
+        except ImportError:
+            return error_response(
+                error="openai Python package not installed (pip install openai)",
+                error_type="missing_dependency",
+                provider="codex",
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        model_id, meta = _resolve_model()
+        payload: Dict[str, Any] = {
+            "model": meta["api_model"],
+            "instructions": "You are a helpful assistant.",
+            "input": [{"role": "user", "content": prompt}],
+            "tools": [{
+                "type": "image_generation",
+                "output_format": "png",
+                "quality": meta["quality"],
+            }],
+            "store": False,
+            "stream": True,
+        }
+
+        try:
+            client = openai.OpenAI(
+                api_key=api_key,
+                base_url=base_url,
+                default_headers=_codex_cloudflare_headers(api_key),
+            )
+            response = client.responses.create(**payload)
+        except Exception as exc:
+            logger.debug("Codex image generation failed", exc_info=True)
+            return error_response(
+                error=f"Codex image generation failed: {exc}",
+                error_type="api_error",
+                provider="codex",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        item = _find_image_generation_item(_extract_output(response))
+        if item is None:
+            return error_response(
+                error="Codex returned no image generation output",
+                error_type="empty_response",
+                provider="codex",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        result_b64 = _item_get(item, "result")
+        revised_prompt = _item_get(item, "revised_prompt")
+        if not isinstance(result_b64, str) or not result_b64.strip():
+            return error_response(
+                error="Codex image generation output was missing base64 result data",
+                error_type="empty_response",
+                provider="codex",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        try:
+            saved_path = save_b64_image(result_b64, prefix=f"codex_{model_id.replace('.', '_')}")
+        except Exception as exc:
+            return error_response(
+                error=f"Could not save image to cache: {exc}",
+                error_type="io_error",
+                provider="codex",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        extra: Dict[str, Any] = {"tool_model": meta["tool_model"]}
+        if revised_prompt:
+            extra["revised_prompt"] = revised_prompt
+
+        return success_response(
+            image=str(saved_path),
+            model=model_id,
+            prompt=prompt,
+            aspect_ratio=aspect,
+            provider="codex",
+            extra=extra,
+        )
+
+
+
+def register(ctx) -> None:
+    ctx.register_image_gen_provider(CodexImageGenProvider())

--- a/plugins/image_gen/codex/plugin.yaml
+++ b/plugins/image_gen/codex/plugin.yaml
@@ -1,0 +1,5 @@
+name: codex
+version: 1.0.0
+description: "Codex / ChatGPT subscription image generation backend. Uses Hermes openai-codex OAuth and saves generated images to $HERMES_HOME/cache/images/."
+author: Agent Hammy
+kind: backend

--- a/tests/hermes_cli/test_plugin_scanner_recursion.py
+++ b/tests/hermes_cli/test_plugin_scanner_recursion.py
@@ -287,6 +287,20 @@ class TestBundledBackendAutoLoad:
         assert loaded.manifest.kind == "backend"
         assert loaded.enabled is True, f"error: {loaded.error}"
 
+    def test_bundled_image_gen_codex_autoloads(self, tmp_path, monkeypatch):
+        """The bundled ``plugins/image_gen/codex/`` plugin also auto-loads."""
+        import os
+        hermes_home = Path(os.environ["HERMES_HOME"])  # set by hermetic conftest fixture
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        assert "image_gen/codex" in mgr._plugins
+        loaded = mgr._plugins["image_gen/codex"]
+        assert loaded.manifest.source == "bundled"
+        assert loaded.manifest.kind == "backend"
+        assert loaded.enabled is True, f"error: {loaded.error}"
+
 
 # ── PluginContext.register_image_gen_provider ───────────────────────────────
 

--- a/tests/plugins/image_gen/test_codex_provider.py
+++ b/tests/plugins/image_gen/test_codex_provider.py
@@ -1,0 +1,256 @@
+"""Tests for the bundled Codex-backed image_gen plugin."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import plugins.image_gen.codex as codex_plugin
+
+
+# 1×1 transparent PNG — valid bytes for save_b64_image()
+_PNG_HEX = (
+    "89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4"
+    "890000000d49444154789c6300010000000500010d0a2db40000000049454e44"
+    "ae426082"
+)
+
+
+def _b64_png() -> str:
+    import base64
+
+    return base64.b64encode(bytes.fromhex(_PNG_HEX)).decode()
+
+
+@pytest.fixture(autouse=True)
+def _tmp_hermes_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    yield tmp_path
+
+
+@pytest.fixture
+def provider():
+    return codex_plugin.CodexImageGenProvider()
+
+
+@pytest.fixture
+def fake_creds():
+    return {
+        "provider": "openai-codex",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+        "api_key": "chatgpt-access-token",
+        "auth_mode": "chatgpt",
+    }
+
+
+def _patched_openai(fake_client: MagicMock):
+    fake_openai = MagicMock()
+    fake_openai.OpenAI.return_value = fake_client
+    return patch.dict("sys.modules", {"openai": fake_openai})
+
+
+def _fake_response(*, result=None, revised_prompt=None, item_type="image_generation_call"):
+    item = SimpleNamespace(type=item_type, result=result, revised_prompt=revised_prompt)
+    return SimpleNamespace(output=[item])
+
+
+class TestMetadata:
+    def test_name(self, provider):
+        assert provider.name == "codex"
+
+    def test_default_model(self, provider):
+        assert provider.default_model() == codex_plugin.DEFAULT_MODEL == "gpt-5.4-medium"
+
+    def test_list_models_three_tiers(self, provider):
+        models = provider.list_models()
+        assert [m["id"] for m in models] == [
+            "gpt-5.4-low",
+            "gpt-5.4-medium",
+            "gpt-5.4-high",
+        ]
+        assert all(m["display"] for m in models)
+
+
+class TestAvailability:
+    def test_unavailable_without_codex_auth(self, monkeypatch):
+        monkeypatch.setattr(
+            codex_plugin,
+            "resolve_codex_runtime_credentials",
+            MagicMock(side_effect=RuntimeError("missing auth")),
+        )
+        assert codex_plugin.CodexImageGenProvider().is_available() is False
+
+    def test_available_with_codex_auth(self, monkeypatch, fake_creds):
+        monkeypatch.setattr(
+            codex_plugin,
+            "resolve_codex_runtime_credentials",
+            MagicMock(return_value=fake_creds),
+        )
+        assert codex_plugin.CodexImageGenProvider().is_available() is True
+
+
+class TestGenerate:
+    def test_empty_prompt_rejected(self, provider):
+        result = provider.generate("", aspect_ratio="square")
+        assert result["success"] is False
+        assert result["error_type"] == "invalid_argument"
+
+    def test_missing_codex_auth(self, monkeypatch, provider):
+        monkeypatch.setattr(
+            codex_plugin,
+            "resolve_codex_runtime_credentials",
+            MagicMock(side_effect=RuntimeError("not logged in")),
+        )
+        result = provider.generate("a cat")
+        assert result["success"] is False
+        assert result["error_type"] == "auth_required"
+        assert "Codex" in result["error"]
+
+    def test_success_saves_b64_result(self, provider, monkeypatch, fake_creds, tmp_path):
+        fake_client = MagicMock()
+        fake_stream = [
+            SimpleNamespace(type="response.output_item.done", item=SimpleNamespace(
+                type="image_generation_call",
+                result=_b64_png(),
+                revised_prompt="A cat lounging in the sun",
+            )),
+            SimpleNamespace(type="response.completed", response=SimpleNamespace(output=[])),
+        ]
+        fake_client.responses.create.return_value = fake_stream
+        monkeypatch.setattr(
+            codex_plugin,
+            "resolve_codex_runtime_credentials",
+            MagicMock(return_value=fake_creds),
+        )
+        monkeypatch.setattr(codex_plugin, "_codex_cloudflare_headers", lambda token: {"originator": "codex_cli_rs"})
+
+        with _patched_openai(fake_client) as patched_modules:
+            result = provider.generate("a cat", aspect_ratio="portrait")
+            fake_openai = patched_modules["openai"]
+
+        assert result["success"] is True
+        assert result["provider"] == "codex"
+        assert result["model"] == codex_plugin.DEFAULT_MODEL == "gpt-5.4-medium"
+        assert result["tool_model"] == "gpt-image-2"
+        assert result["aspect_ratio"] == "portrait"
+        assert result["revised_prompt"] == "A cat lounging in the sun"
+
+        saved = Path(result["image"])
+        assert saved.exists()
+        assert saved.parent == tmp_path / "cache" / "images"
+        assert saved.read_bytes() == bytes.fromhex(_PNG_HEX)
+
+        fake_openai.OpenAI.assert_called_once_with(
+            api_key="chatgpt-access-token",
+            base_url="https://chatgpt.com/backend-api/codex",
+            default_headers={"originator": "codex_cli_rs"},
+        )
+        call_kwargs = fake_client.responses.create.call_args.kwargs
+        assert call_kwargs["model"] == "gpt-5.4"
+        assert call_kwargs["instructions"] == "You are a helpful assistant."
+        assert call_kwargs["input"] == [{"role": "user", "content": "a cat"}]
+        assert call_kwargs["stream"] is True
+        assert call_kwargs["store"] is False
+        assert call_kwargs["tools"] == [{
+            "type": "image_generation",
+            "output_format": "png",
+            "quality": "medium",
+        }]
+
+    def test_dict_output_item_supported(self, provider, monkeypatch, fake_creds):
+        fake_client = MagicMock()
+        fake_client.responses.create.return_value = [
+            SimpleNamespace(type="response.output_item.done", item={
+                "type": "image_generation_call",
+                "result": _b64_png(),
+                "revised_prompt": "A nice cat",
+            }),
+            SimpleNamespace(type="response.completed", response={"output": []}),
+        ]
+        monkeypatch.setattr(
+            codex_plugin,
+            "resolve_codex_runtime_credentials",
+            MagicMock(return_value=fake_creds),
+        )
+        monkeypatch.setattr(codex_plugin, "_codex_cloudflare_headers", lambda token: {})
+
+        with _patched_openai(fake_client):
+            result = provider.generate("a cat")
+
+        assert result["success"] is True
+        assert result["revised_prompt"] == "A nice cat"
+
+    @pytest.mark.parametrize(
+        ("tier", "quality"),
+        [
+            ("gpt-5.4-low", "low"),
+            ("gpt-5.4-medium", "medium"),
+            ("gpt-5.4-high", "high"),
+        ],
+    )
+    def test_tier_maps_to_quality(self, provider, monkeypatch, fake_creds, tier, quality):
+        fake_client = MagicMock()
+        fake_client.responses.create.return_value = [
+            SimpleNamespace(type="response.output_item.done", item=SimpleNamespace(
+                type="image_generation_call",
+                result=_b64_png(),
+                revised_prompt="tiered prompt",
+            )),
+            SimpleNamespace(type="response.completed", response=SimpleNamespace(output=[])),
+        ]
+        monkeypatch.setenv("CODEX_IMAGE_MODEL", tier)
+        monkeypatch.setattr(
+            codex_plugin,
+            "resolve_codex_runtime_credentials",
+            MagicMock(return_value=fake_creds),
+        )
+        monkeypatch.setattr(codex_plugin, "_codex_cloudflare_headers", lambda token: {})
+
+        with _patched_openai(fake_client):
+            result = provider.generate("a cat")
+
+        assert result["success"] is True
+        assert result["model"] == tier
+        assert fake_client.responses.create.call_args.kwargs["tools"] == [{
+            "type": "image_generation",
+            "output_format": "png",
+            "quality": quality,
+        }]
+
+    def test_api_error_returns_error_response(self, provider, monkeypatch, fake_creds):
+        fake_client = MagicMock()
+        fake_client.responses.create.side_effect = RuntimeError("boom")
+        monkeypatch.setattr(
+            codex_plugin,
+            "resolve_codex_runtime_credentials",
+            MagicMock(return_value=fake_creds),
+        )
+        monkeypatch.setattr(codex_plugin, "_codex_cloudflare_headers", lambda token: {})
+
+        with _patched_openai(fake_client):
+            result = provider.generate("a cat")
+
+        assert result["success"] is False
+        assert result["error_type"] == "api_error"
+        assert "boom" in result["error"]
+
+    def test_missing_image_output_returns_empty_response(self, provider, monkeypatch, fake_creds):
+        fake_client = MagicMock()
+        fake_client.responses.create.return_value = [
+            SimpleNamespace(type="response.completed", response=SimpleNamespace(output=[])),
+        ]
+        monkeypatch.setattr(
+            codex_plugin,
+            "resolve_codex_runtime_credentials",
+            MagicMock(return_value=fake_creds),
+        )
+        monkeypatch.setattr(codex_plugin, "_codex_cloudflare_headers", lambda token: {})
+
+        with _patched_openai(fake_client):
+            result = provider.generate("a cat")
+
+        assert result["success"] is False
+        assert result["error_type"] == "empty_response"

--- a/tests/tools/test_image_generation_plugin_dispatch.py
+++ b/tests/tools/test_image_generation_plugin_dispatch.py
@@ -68,3 +68,32 @@ class TestPluginDispatch:
         assert payload["success"] is False
         assert payload["error_type"] == "provider_not_registered"
         assert "image_gen.provider='missing-codex'" in payload["error"]
+
+    def test_dispatch_force_refreshes_plugins_when_provider_initially_missing(self, monkeypatch, tmp_path):
+        from tools import image_generation_tool
+        from hermes_cli import plugins as plugins_module
+        from agent import image_gen_registry as registry_module
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("image_gen:\n  provider: codex\n")
+
+        monkeypatch.setattr(image_generation_tool, "_read_configured_image_provider", lambda: "codex")
+
+        calls = []
+        provider_state = {"provider": None}
+
+        def fake_ensure_plugins_discovered(force=False):
+            calls.append(force)
+            if force:
+                provider_state["provider"] = _FakeCodexProvider()
+
+        monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", fake_ensure_plugins_discovered)
+        monkeypatch.setattr(registry_module, "get_provider", lambda name: provider_state["provider"])
+
+        dispatched = image_generation_tool._dispatch_to_plugin_provider("draw hammy", "portrait")
+        payload = json.loads(dispatched)
+
+        assert calls == [False, True]
+        assert payload["success"] is True
+        assert payload["provider"] == "codex"
+        assert payload["aspect_ratio"] == "portrait"

--- a/tests/tools/test_image_generation_plugin_dispatch.py
+++ b/tests/tools/test_image_generation_plugin_dispatch.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+import pytest
+
+from agent import image_gen_registry
+from agent.image_gen_provider import ImageGenProvider
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    image_gen_registry._reset_for_tests()
+    yield
+    image_gen_registry._reset_for_tests()
+
+
+class _FakeCodexProvider(ImageGenProvider):
+    @property
+    def name(self) -> str:
+        return "codex"
+
+    def generate(self, prompt, aspect_ratio="landscape", **kwargs):
+        return {
+            "success": True,
+            "image": "/tmp/codex-test.png",
+            "model": "gpt-5.2-codex",
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "provider": "codex",
+        }
+
+
+class TestPluginDispatch:
+    def test_dispatch_routes_to_codex_provider(self, monkeypatch, tmp_path):
+        from tools import image_generation_tool
+        from agent import image_gen_registry as registry_module
+        from hermes_cli import plugins as plugins_module
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("image_gen:\n  provider: codex\n")
+        image_gen_registry.register_provider(_FakeCodexProvider())
+
+        monkeypatch.setattr(image_generation_tool, "_read_configured_image_provider", lambda: "codex")
+        monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda: None)
+        monkeypatch.setattr(registry_module, "get_provider", lambda name: _FakeCodexProvider() if name == "codex" else None)
+
+        dispatched = image_generation_tool._dispatch_to_plugin_provider("draw cat", "square")
+        payload = json.loads(dispatched)
+
+        assert payload["success"] is True
+        assert payload["provider"] == "codex"
+        assert payload["image"] == "/tmp/codex-test.png"
+        assert payload["aspect_ratio"] == "square"
+
+    def test_dispatch_reports_missing_registered_provider(self, monkeypatch, tmp_path):
+        from tools import image_generation_tool
+        from hermes_cli import plugins as plugins_module
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("image_gen:\n  provider: missing-codex\n")
+
+        monkeypatch.setattr(image_generation_tool, "_read_configured_image_provider", lambda: "missing-codex")
+        monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda: None)
+
+        dispatched = image_generation_tool._dispatch_to_plugin_provider("draw cat", "landscape")
+        payload = json.loads(dispatched)
+
+        assert payload["success"] is False
+        assert payload["error_type"] == "provider_not_registered"
+        assert "image_gen.provider='missing-codex'" in payload["error"]

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -928,6 +928,16 @@ def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
         return None
 
     if provider is None:
+        try:
+            # Long-lived sessions may have discovered plugins before a bundled
+            # backend was patched in or before config changed. Retry once with
+            # a forced refresh before surfacing a missing-provider error.
+            _ensure_plugins_discovered(force=True)
+            provider = get_provider(configured)
+        except Exception as exc:
+            logger.debug("image_gen plugin force-refresh skipped: %s", exc)
+
+    if provider is None:
         return json.dumps({
             "success": False,
             "image": None,


### PR DESCRIPTION
## Summary
- add a bundled Codex image generation backend under plugins/image_gen/codex
- reuse Hermes OpenAI Codex / ChatGPT OAuth instead of requiring OPENAI_API_KEY
- add targeted tests for provider behavior, plugin dispatch, and registry integration
- clarify setup text that no API key is needed, but Hermes Codex OAuth login must exist first

## Test Plan
- pytest tests/plugins/image_gen/test_codex_provider.py tests/tools/test_image_generation_plugin_dispatch.py tests/hermes_cli/test_plugin_scanner_recursion.py -q

## Notes
- This PR is separate from the existing tools patch / web_search_plus PR.
- There are unrelated local changes left unstaged (toolsets.py, tests/test_toolsets.py, package-lock.json) and they are intentionally excluded from this PR.