### PR TITLE
fix(delegate): fail loudly when requested toolsets unavailable to parent

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -459,7 +459,23 @@ class ContextCompressor(ContextEngine):
                 if isinstance(tc, dict):
                     args = tc.get("function", {}).get("arguments", "")
                     if len(args) > 500:
-                        tc = {**tc, "function": {**tc["function"], "arguments": args[:200] + "...[truncated]"}}
+                        # Produce VALID JSON for the truncated arguments.
+                        # The previous implementation emitted
+                        #   args[:200] + "...[truncated]"
+                        # which is malformed JSON the server parser can't
+                        # close. When the compressed history was re-sent
+                        # to the model, the model copied the broken
+                        # pattern and produced identically-truncated
+                        # output, causing the server to reject its
+                        # response with HTTP 500: "missing closing quote".
+                        # The compression signal ("this call happened
+                        # with long args") is preserved via the
+                        # _compressed marker plus the original byte
+                        # count, which is all the model needs to know
+                        # not to re-run the call.
+                        tc = {**tc, "function": {**tc["function"], "arguments": json.dumps(
+                            {"_compressed": f"arguments truncated from {len(args)} bytes for context compression"}
+                        )}}
                         modified = True
                 new_tcs.append(tc)
             if modified:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -517,8 +517,18 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
     script_timeout = _get_script_timeout()
 
     try:
+        # Detect script type and use appropriate interpreter
+        # Check file extension first, then fall back to shebang detection
+        suffix = path.suffix.lower()
+        if suffix in {'.sh', '.bash'}:
+            # Shell script - use bash
+            cmd = ['bash', str(path)]
+        else:
+            # Assume Python script
+            cmd = [sys.executable, str(path)]
+        
         result = subprocess.run(
-            [sys.executable, str(path)],
+            cmd,
             capture_output=True,
             text=True,
             timeout=script_timeout,

--- a/gateway/builtin_hooks/boot_md.py
+++ b/gateway/builtin_hooks/boot_md.py
@@ -46,9 +46,44 @@ def _run_boot_agent(content: str) -> None:
     """Spawn a one-shot agent session to execute the boot instructions."""
     try:
         from run_agent import AIAgent
+        from gateway.run import (
+            _resolve_gateway_model,
+            _resolve_runtime_agent_kwargs,
+        )
+
+        # Without resolving model/provider from config.yaml, AIAgent's
+        # `model` kwarg defaults to "" and the first outbound
+        # chat/completions call fails with HTTP 400: "missing or
+        # invalid 'model' key". Use the same canonical resolvers that
+        # session-scoped agent instances use in _resolve_session_agent_runtime.
+        model = _resolve_gateway_model()
+        runtime_kwargs = _resolve_runtime_agent_kwargs()
+
+        # Mirror the fallback used by _resolve_session_agent_runtime
+        # when the user authenticated a provider but never ran
+        # `hermes model` to set an explicit default. Without this,
+        # users with a valid provider but no configured model hit
+        # the boot-md skip path instead of running the boot hook.
+        if not model and runtime_kwargs.get("provider"):
+            try:
+                from hermes_cli.models import get_default_model_for_provider
+                model = get_default_model_for_provider(runtime_kwargs["provider"])
+            except Exception as e:
+                logger.debug(
+                    "boot-md: provider default model lookup failed: %s", e,
+                )
+
+        if not model or not runtime_kwargs.get("api_key"):
+            logger.warning(
+                "boot-md: skipping — no model resolved (%r) or no api_key",
+                model,
+            )
+            return
 
         prompt = _build_boot_prompt(content)
         agent = AIAgent(
+            **runtime_kwargs,
+            model=model,
             quiet_mode=True,
             skip_context_files=True,
             skip_memory=True,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4085,12 +4085,11 @@ class GatewayRunner:
                         display_reasoning = last_reasoning.strip()
                     response = f"💭 **Reasoning:**\n```\n{display_reasoning}\n```\n\n{response}"
 
-            # Emit agent:end hook
-            await self.hooks.emit("agent:end", {
-                **hook_ctx,
-                "response": (response or "")[:500],
-            })
-            
+            # agent:end hook emission moved below the
+            # compression-exhaustion post-processing (see the block
+            # that may append an auto-reset notice to `response`)
+            # so hooks always see the user-visible text.
+
             # Check for pending process watchers (check_interval on background processes)
             try:
                 from tools.process_registry import process_registry
@@ -4164,6 +4163,47 @@ class GatewayRunner:
                     "maximum context size and could not be compressed further. "
                     "Your next message will start a fresh session."
                 )
+
+            # Emit agent:end hook now — response is finalized.
+            #
+            # The prior truncation to 500 chars silently clipped long
+            # replies before hooks could see them. For hook use-cases
+            # that need the whole reply (TTS narration, dashboards,
+            # cross-session bridges) a 500-char preview was a leaky
+            # default. Hooks that want a preview can trim on their side.
+            #
+            # Tunable via HERMES_HOOK_RESPONSE_MAX_CHARS for callers
+            # who need to cap memory footprint on very long replies.
+            # 0 or missing = no cap.
+            #
+            # Strip transport-only markers (`[[audio_as_voice]]`,
+            # `MEDIA:<path>`) via BasePlatformAdapter.extract_media so
+            # hooks see exactly the user-visible text and paths with
+            # spaces are handled correctly (the prior regex broke on
+            # whitespace in path components).
+            #
+            # Pass session_entry.session_id explicitly — hook_ctx was
+            # built earlier in the turn; if context compression
+            # rotated the session id mid-run, the stale id in hook_ctx
+            # would misreport to consumers.
+            _, hook_response = BasePlatformAdapter.extract_media(response or "")
+            hook_response = hook_response.strip()
+            try:
+                cap = int(os.environ.get("HERMES_HOOK_RESPONSE_MAX_CHARS", "0"))
+                if cap > 0 and len(hook_response) > cap:
+                    hook_response = hook_response[:cap]
+            except (TypeError, ValueError):
+                pass
+            _final_session_id = (
+                getattr(session_entry, "session_id", None)
+                if session_entry is not None
+                else hook_ctx.get("session_id")
+            )
+            await self.hooks.emit("agent:end", {
+                **hook_ctx,
+                "session_id": _final_session_id,
+                "response": hook_response,
+            })
 
             ts = datetime.now().isoformat()
             

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3971,12 +3971,37 @@ class GatewayRunner:
             return
 
         try:
-            # Emit agent:start hook
+            # Emit agent:start hook.
+            #
+            # - Include chat_id, thread_id, and message_event_id so
+            #   hooks that want to construct Matrix m.in_reply_to
+            #   (or per-platform equivalents) can do so without
+            #   having to peer into the source object or event.
+            #   Specifically: the matrix-session-watchdog hook needs
+            #   event_id to let Ryan tap-reply a resumption nudge.
+            # - Drop the [:500] cap on message. The prior truncation
+            #   matched the agent:end cap we already lifted in
+            #   gateway/run.py for hooks that want full context (TTS
+            #   narration, cross-session replay, dashboards). Hooks
+            #   that want a preview trim on their side; this default
+            #   now uses HERMES_HOOK_MESSAGE_MAX_CHARS if set
+            #   (0 or missing = no cap; same convention as
+            #   HERMES_HOOK_RESPONSE_MAX_CHARS).
+            hook_message = message_text or ""
+            try:
+                _cap = int(os.environ.get("HERMES_HOOK_MESSAGE_MAX_CHARS", "0"))
+                if _cap > 0 and len(hook_message) > _cap:
+                    hook_message = hook_message[:_cap]
+            except (TypeError, ValueError):
+                pass
             hook_ctx = {
                 "platform": source.platform.value if source.platform else "",
                 "user_id": source.user_id,
                 "session_id": session_entry.session_id,
-                "message": message_text[:500],
+                "chat_id": getattr(source, "chat_id", "") or "",
+                "thread_id": getattr(source, "thread_id", "") or "",
+                "message_event_id": getattr(event, "message_id", "") or "",
+                "message": hook_message,
             }
             await self.hooks.emit("agent:start", hook_ctx)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8835,13 +8835,39 @@ class GatewayRunner:
                     logger.debug("Could not set up stream consumer: %s", _sc_err)
 
             def _interim_assistant_cb(text: str, *, already_streamed: bool = False) -> None:
+                # Fire a hook event BEFORE downstream routing so
+                # consumers (TTS narration, logging, dashboards) can
+                # see interim replies. Without this, hooks only saw
+                # agent:end — the mid-iteration "here's what I found
+                # so far" posts were invisible to the hook layer even
+                # though they appear as user-visible messages on
+                # Matrix/Telegram/etc. Best-effort: hook failure never
+                # blocks the downstream send below.
+                interim_text = str(text or "").strip()
+                if interim_text:
+                    try:
+                        _interim_ctx = {
+                            "platform": source.platform.value if source.platform else "",
+                            "user_id": getattr(source, "user_id", "") or "",
+                            "session_id": session_id,
+                            "chat_id": getattr(source, "chat_id", "") or "",
+                            "response": interim_text,
+                            "already_streamed": bool(already_streamed),
+                        }
+                        asyncio.run_coroutine_threadsafe(
+                            self.hooks.emit("agent:interim_reply", _interim_ctx),
+                            _loop_for_step,
+                        )
+                    except Exception as _e:
+                        logger.debug("agent:interim_reply hook emit failed: %s", _e)
+
                 if _stream_consumer is not None:
                     if already_streamed:
                         _stream_consumer.on_segment_break()
                     else:
                         _stream_consumer.on_commentary(text)
                     return
-                if already_streamed or not _status_adapter or not str(text or "").strip():
+                if already_streamed or not _status_adapter or not interim_text:
                     return
                 try:
                     asyncio.run_coroutine_threadsafe(

--- a/run_agent.py
+++ b/run_agent.py
@@ -3641,6 +3641,52 @@ class AIAgent:
                 "Pre-call sanitizer: added %d stub tool result(s)",
                 len(missing_results),
             )
+
+        # 3. Repair malformed tool_call arguments.
+        #
+        # The context compressor used to slice mid-string and append
+        # "...[truncated]" which produced invalid JSON like:
+        #   {"old_text": "Self-reflection: Three-layer narrative...[truncated]
+        # Sessions that still contain these pre-fix artifacts cause
+        # the serving backend to reject the request with HTTP 500
+        # "parse error... missing closing quote" because the model
+        # sees the broken pattern in its prompt and copies it.
+        #
+        # Heal on load: any tool_call whose arguments string doesn't
+        # parse as JSON gets replaced with a valid marker object. The
+        # companion fix in agent/context_compressor.py stops NEW
+        # corruption; this sanitizer handles sessions written before
+        # that landed.
+        import json as _json
+        repaired_count = 0
+        for msg in messages:
+            if msg.get("role") != "assistant":
+                continue
+            tcs = msg.get("tool_calls")
+            if not tcs:
+                continue
+            for tc in tcs:
+                if not isinstance(tc, dict):
+                    continue
+                fn = tc.get("function")
+                if not isinstance(fn, dict):
+                    continue
+                args = fn.get("arguments")
+                if not isinstance(args, str) or not args:
+                    continue
+                try:
+                    _json.loads(args)
+                except (_json.JSONDecodeError, ValueError):
+                    fn["arguments"] = _json.dumps({
+                        "_compressed": f"arguments were malformed in session history ({len(args)} bytes); repaired on load",
+                    })
+                    repaired_count += 1
+        if repaired_count:
+            logger.info(
+                "Pre-call sanitizer: repaired %d malformed tool_call arguments",
+                repaired_count,
+            )
+
         return messages
 
     @staticmethod

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -155,6 +155,24 @@ def _strip_blocked_tools(toolsets: List[str]) -> List[str]:
     return [t for t in toolsets if t not in blocked_toolset_names]
 
 
+def _compute_parent_effective_toolsets(parent_agent) -> set:
+    """Resolve the parent's effective toolsets — the set a child can
+    legally inherit. Mirrors the logic in `_build_child_agent` so
+    pre-validation in `delegate_task` sees the same answer the child
+    builder will.
+    """
+    parent_enabled = getattr(parent_agent, "enabled_toolsets", None)
+    if parent_enabled is not None:
+        return set(parent_enabled)
+    if parent_agent and hasattr(parent_agent, "valid_tool_names"):
+        import model_tools
+        return {
+            ts for name in parent_agent.valid_tool_names
+            if (ts := model_tools.get_toolset_for_tool(name)) is not None
+        }
+    return set(DEFAULT_TOOLSETS)
+
+
 def _build_child_progress_callback(task_index: int, parent_agent, task_count: int = 1) -> Optional[callable]:
     """Build a callback that relays child agent tool calls to the parent display.
 
@@ -289,6 +307,24 @@ def _build_child_agent(
         child_toolsets = _strip_blocked_tools(sorted(parent_toolsets))
     else:
         child_toolsets = _strip_blocked_tools(DEFAULT_TOOLSETS)
+
+    # Defense in depth — any path producing an empty child toolset
+    # would send a request with no `tools=[...]` parameter and the
+    # child LLM would hallucinate tool syntax in text output (see
+    # comment in `delegate_task` for the observed failure mode).
+    # `delegate_task` pre-validates requested toolsets, but an empty
+    # set can still happen if the parent somehow has zero tools.
+    # Refuse to build a toolless child; the error propagates back
+    # to the parent so it knows what went wrong.
+    if not child_toolsets:
+        raise ValueError(
+            "Cannot build subagent with empty toolsets. "
+            f"parent_toolsets={sorted(parent_toolsets) if parent_toolsets else []}, "
+            f"requested={sorted(toolsets) if toolsets else []}. "
+            "A toolless child cannot tool-call and will hallucinate "
+            "tool-call text. Adjust the parent's enabled_toolsets or "
+            "the delegate_task `toolsets` argument."
+        )
 
     workspace_hint = _resolve_workspace_hint(parent_agent)
     child_prompt = _build_child_system_prompt(goal, context, workspace_path=workspace_hint)
@@ -691,6 +727,32 @@ def delegate_task(
     for i, task in enumerate(task_list):
         if not task.get("goal", "").strip():
             return tool_error(f"Task {i} is missing a 'goal'.")
+
+    # Validate requested toolsets against parent's effective set.
+    #
+    # Without this, a parent that calls `delegate_task(toolsets=["web"])`
+    # when "web" isn't in its own enabled toolsets silently gets a child
+    # with ZERO tools — `self.tools` is empty, no `tools` key is added
+    # to the OpenAI request, and Magnum/Qwen/etc hallucinate tool-call
+    # syntax in free-text (observed 2026-04-22: `<tool_call>` /
+    # `<function=web_search>` / ```json[{"name":"tavily_search"...}]```
+    # instead of real OpenAI `tool_calls` — result: `tool_trace=[]`,
+    # no side effects, parent falls back to doing the work itself).
+    # Fail loudly so the parent can retry with valid toolsets.
+    parent_effective = _compute_parent_effective_toolsets(parent_agent)
+    for i, task in enumerate(task_list):
+        requested = task.get("toolsets") or toolsets or []
+        if not requested:
+            continue
+        survivors = [t for t in requested if t in parent_effective]
+        if not survivors:
+            return tool_error(
+                f"Task {i}: none of the requested toolsets "
+                f"{sorted(requested)!r} are available to this agent. "
+                f"Available toolsets: {sorted(parent_effective)!r}. "
+                f"Either drop `toolsets` to inherit the parent's set, "
+                f"or pick from the available list."
+            )
 
     overall_start = time.monotonic()
     results = []

--- a/tools/lilly_search_emails.py
+++ b/tools/lilly_search_emails.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""lilly_search_emails — hybrid search over Ryan's email archive.
+
+Thin wrapper around `scripts/email_search.py search` in the homegrown_lilly
+repo. Queries a local SQLite+FTS5+embeddings cache (populated by
+email_sync.py), so retrieval works offline and supports semantic matching
+for paraphrase-heavy queries that keyword-only search would miss.
+
+Earlier implementation wrapped `mu_search.py` (keyword-only via the mu
+binary, now retired). The current implementation hits lilly's own cache
+so the muse can call the tool in all three modes (lexical / semantic /
+hybrid) through the same entry point, with no dependency on an external
+indexer.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from tools.registry import registry, tool_error
+
+
+LILLY_DIR = Path(os.environ.get("LILLY_DIR", "/home/ryan/homegrown_lilly"))
+LILLY_PY = str(LILLY_DIR / ".venv" / "bin" / "python")
+SEARCH_SCRIPT = str(LILLY_DIR / "scripts" / "email_search.py")
+
+
+SEARCH_EMAILS_SCHEMA = {
+    "name": "lilly_search_emails",
+    "description": (
+        "Search Ryan's email archive (local SQLite+FTS5+embeddings) for "
+        "messages matching a query. Use this for source-of-truth retrieval "
+        "of anything email-mediated: job application status, decisions, "
+        "conversations with a specific person, interview scheduling. More "
+        "reliable than the extracted fact graph for recent or outbound "
+        "messages.\n\n"
+        "Three search modes (default 'hybrid'):\n"
+        "  - 'hybrid' — RRF fusion of lexical FTS5 + semantic embeddings; "
+        "best general-purpose\n"
+        "  - 'semantic' — embedding-only, for paraphrase queries "
+        "(\"Ryan turning down offers\" matches \"decided to pass\")\n"
+        "  - 'lexical' — FTS5 only, exact-term queries, supports "
+        "since_days and from_filter\n\n"
+        "Lexical / hybrid query syntax (FTS5):\n"
+        "  - Keywords: \"akasa interview\"\n"
+        "  - Phrase: '\"decided to pass\"'\n"
+        "  - Boolean: \"harry OR sarah\"\n"
+        "  - Column-scoped: \"subject: interview from: akasa\"\n\n"
+        "Semantic mode takes natural language — no special syntax."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Query string."},
+            "mode": {
+                "type": "string",
+                "enum": ["lexical", "semantic", "hybrid"],
+                "description": "Search mode (default hybrid).",
+                "default": "hybrid",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Max results (default 10, capped at 50).",
+                "default": 10,
+            },
+            "since_days": {
+                "type": "integer",
+                "description": "Lexical mode only: restrict to last N days.",
+            },
+            "from_filter": {
+                "type": "string",
+                "description": (
+                    "Lexical mode only: substring match on sender "
+                    "(e.g. 'akasa.com', 'harry')."
+                ),
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+
+def lilly_search_emails(
+    query: str,
+    mode: str = "hybrid",
+    limit: int = 10,
+    since_days: int | None = None,
+    from_filter: str | None = None,
+    task_id=None,
+) -> str:
+    if not query or not query.strip():
+        return tool_error("query is required")
+    if mode not in ("lexical", "semantic", "hybrid"):
+        mode = "hybrid"
+    try:
+        limit = max(1, min(int(limit), 50))
+    except (TypeError, ValueError):
+        limit = 10
+
+    cmd = [LILLY_PY, SEARCH_SCRIPT, "search", query,
+           "--limit", str(limit), "--mode", mode]
+    if mode == "lexical":
+        if since_days:
+            cmd.extend(["--since-days", str(int(since_days))])
+        if from_filter:
+            cmd.extend(["--from", from_filter])
+
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    except subprocess.TimeoutExpired:
+        return tool_error("email search timed out after 30s")
+    except FileNotFoundError:
+        return tool_error(f"email_search.py not available at {SEARCH_SCRIPT}")
+
+    if r.returncode != 0:
+        return tool_error(
+            f"email search failed (exit {r.returncode}): {r.stderr.strip()[:400]}"
+        )
+
+    raw = r.stdout.strip()
+    if not raw:
+        return json.dumps({"query": query, "mode": mode, "count": 0, "results": []})
+
+    try:
+        json.loads(raw)  # validate
+    except json.JSONDecodeError:
+        return json.dumps(
+            {"query": query, "raw_stdout": raw[:4000], "warning": "non-JSON output"}
+        )
+    return raw
+
+
+def check_lilly_search_emails_requirements() -> bool:
+    return Path(SEARCH_SCRIPT).exists() and Path(LILLY_PY).exists()
+
+
+registry.register(
+    name="lilly_search_emails",
+    toolset="lilly",
+    schema=SEARCH_EMAILS_SCHEMA,
+    handler=lambda args, **kw: lilly_search_emails(
+        query=args.get("query", ""),
+        mode=args.get("mode", "hybrid"),
+        limit=args.get("limit", 10),
+        since_days=args.get("since_days"),
+        from_filter=args.get("from_filter"),
+        task_id=kw.get("task_id"),
+    ),
+    check_fn=check_lilly_search_emails_requirements,
+    emoji="📧",
+)

--- a/tools/lilly_search_limitless.py
+++ b/tools/lilly_search_limitless.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""lilly_search_limitless — search Ryan's local Limitless lifelog archive.
+
+Thin wrapper over `scripts/limitless_search.py search` in the homegrown_lilly
+repo. Queries a local SQLite+FTS5 cache of Limitless lifelogs (populated by
+limitless_sync.py), so retrieval works offline and survives the inevitable
+Limitless sunset post-Meta-acquisition.
+
+Same rationale as lilly_search_emails: fact-extraction is lossy; the raw
+transcript is source-of-truth for what Ryan actually said aloud.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from tools.registry import registry, tool_error
+
+
+LILLY_DIR = Path(os.environ.get("LILLY_DIR", "/home/ryan/homegrown_lilly"))
+LILLY_PY = str(LILLY_DIR / ".venv" / "bin" / "python")
+SEARCH_SCRIPT = str(LILLY_DIR / "scripts" / "limitless_search.py")
+
+
+SEARCH_LIMITLESS_SCHEMA = {
+    "name": "lilly_search_limitless",
+    "description": (
+        "Search Ryan's Limitless pendant recordings (local SQLite+FTS5 "
+        "archive) for spoken content. Use this to confirm what Ryan or "
+        "someone in his environment said aloud — family conversations, "
+        "phone calls, meetings, verbal decisions. Returns matching lifelog "
+        "snippets with timestamps and title. More reliable than the "
+        "extracted fact graph for recent conversations or anything the "
+        "fact-extractor may have dropped.\n\n"
+        "Three search modes (default 'hybrid' gives the best quality):\n"
+        "  - 'hybrid' — RRF fusion of lexical FTS5 + semantic embeddings\n"
+        "  - 'semantic' — embedding-only, for paraphrase-heavy queries "
+        "(\"Ryan turning down offers\" matches \"decided to pass\")\n"
+        "  - 'lexical' — FTS5 only, for exact-term queries and when you "
+        "need since_days / starred_only filters\n\n"
+        "Lexical/hybrid query syntax (FTS5):\n"
+        "  - Keywords: \"akasa interview\"\n"
+        "  - Phrase: '\"decided to pass\"'\n"
+        "  - Boolean: \"harry OR sarah\"\n"
+        "  - Proximity: \"recruiter NEAR job\"\n\n"
+        "Semantic mode uses natural language — no special syntax."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "Query string.",
+            },
+            "mode": {
+                "type": "string",
+                "enum": ["lexical", "semantic", "hybrid"],
+                "description": "Search mode (default hybrid).",
+                "default": "hybrid",
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Max results (default 10, capped at 50).",
+                "default": 10,
+            },
+            "since_days": {
+                "type": "integer",
+                "description": (
+                    "Lexical mode only: restrict to lifelogs from last N days."
+                ),
+            },
+            "starred_only": {
+                "type": "boolean",
+                "description": "Lexical mode only: restrict to starred lifelogs.",
+                "default": False,
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+
+def lilly_search_limitless(
+    query: str,
+    mode: str = "hybrid",
+    limit: int = 10,
+    since_days: int | None = None,
+    starred_only: bool = False,
+    task_id=None,
+) -> str:
+    if not query or not query.strip():
+        return tool_error("query is required")
+    if mode not in ("lexical", "semantic", "hybrid"):
+        mode = "hybrid"
+    try:
+        limit = max(1, min(int(limit), 50))
+    except (TypeError, ValueError):
+        limit = 10
+
+    cmd = [LILLY_PY, SEARCH_SCRIPT, "search", query,
+           "--limit", str(limit), "--mode", mode]
+    if since_days and mode == "lexical":
+        cmd.extend(["--since-days", str(int(since_days))])
+    if starred_only and mode == "lexical":
+        cmd.append("--starred")
+
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+    except subprocess.TimeoutExpired:
+        return tool_error("limitless search timed out after 15s")
+    except FileNotFoundError:
+        return tool_error(f"limitless_search.py not available at {SEARCH_SCRIPT}")
+
+    if r.returncode != 0:
+        return tool_error(
+            f"limitless search failed (exit {r.returncode}): {r.stderr.strip()[:400]}"
+        )
+
+    raw = r.stdout.strip()
+    if not raw:
+        return json.dumps({"query": query, "count": 0, "results": []})
+
+    # limitless_search.py already emits a JSON object; pass it through unchanged.
+    try:
+        json.loads(raw)  # validate
+    except json.JSONDecodeError:
+        return json.dumps(
+            {"query": query, "raw_stdout": raw[:4000], "warning": "non-JSON output"}
+        )
+    return raw
+
+
+def check_lilly_search_limitless_requirements() -> bool:
+    """Tool is available iff the search wrapper and its venv exist."""
+    return Path(SEARCH_SCRIPT).exists() and Path(LILLY_PY).exists()
+
+
+registry.register(
+    name="lilly_search_limitless",
+    toolset="lilly",
+    schema=SEARCH_LIMITLESS_SCHEMA,
+    handler=lambda args, **kw: lilly_search_limitless(
+        query=args.get("query", ""),
+        mode=args.get("mode", "hybrid"),
+        limit=args.get("limit", 10),
+        since_days=args.get("since_days"),
+        starred_only=args.get("starred_only", False),
+        task_id=kw.get("task_id"),
+    ),
+    check_fn=check_lilly_search_limitless_requirements,
+    emoji="🎙️",
+)

--- a/tools/lilly_search_linkedin.py
+++ b/tools/lilly_search_linkedin.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""lilly_search_linkedin — hybrid search over Ryan's LinkedIn messages.
+
+Same architecture as lilly_search_emails and lilly_search_limitless: queries
+a local SQLite+FTS5+embeddings cache populated by linkedin_sync.py via the
+Voyager API through CDP Chrome.
+"""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+from tools.registry import registry, tool_error
+
+LILLY_DIR = Path(os.environ.get("LILLY_DIR", "/home/ryan/homegrown_lilly"))
+LILLY_PY = str(LILLY_DIR / ".venv" / "bin" / "python")
+SEARCH_SCRIPT = str(LILLY_DIR / "scripts" / "linkedin_search.py")
+
+SCHEMA = {
+    "name": "lilly_search_linkedin",
+    "description": (
+        "Search Ryan's LinkedIn message archive (local cache with FTS5 + "
+        "embeddings) for recruiter conversations, InMail threads, and "
+        "networking exchanges. Use when you need to confirm what a "
+        "recruiter said, check the status of a LinkedIn conversation, or "
+        "find a specific person's messages.\n\n"
+        "Three modes: 'hybrid' (default, RRF fusion), 'semantic' "
+        "(paraphrase matching), 'lexical' (exact terms)."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Query string."},
+            "mode": {
+                "type": "string",
+                "enum": ["lexical", "semantic", "hybrid"],
+                "default": "hybrid",
+            },
+            "limit": {"type": "integer", "default": 10},
+            "since_days": {"type": "integer",
+                           "description": "Lexical only: restrict to last N days."},
+        },
+        "required": ["query"],
+    },
+}
+
+
+def lilly_search_linkedin(query="", mode="hybrid", limit=10,
+                          since_days=None, task_id=None):
+    if not query or not query.strip():
+        return tool_error("query is required")
+    limit = max(1, min(int(limit or 10), 50))
+    cmd = [LILLY_PY, SEARCH_SCRIPT, "search", query,
+           "--limit", str(limit), "--mode", mode or "hybrid"]
+    if since_days and mode == "lexical":
+        cmd.extend(["--since-days", str(int(since_days))])
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    except subprocess.TimeoutExpired:
+        return tool_error("linkedin search timed out")
+    except FileNotFoundError:
+        return tool_error(f"linkedin_search.py not found at {SEARCH_SCRIPT}")
+    if r.returncode != 0:
+        return tool_error(f"exit {r.returncode}: {r.stderr[:400]}")
+    return r.stdout.strip() or json.dumps({"query": query, "count": 0, "results": []})
+
+
+def check_requirements():
+    return Path(SEARCH_SCRIPT).exists() and Path(LILLY_PY).exists()
+
+
+registry.register(
+    name="lilly_search_linkedin",
+    toolset="lilly",
+    schema=SCHEMA,
+    handler=lambda args, **kw: lilly_search_linkedin(
+        query=args.get("query", ""),
+        mode=args.get("mode", "hybrid"),
+        limit=args.get("limit", 10),
+        since_days=args.get("since_days"),
+        task_id=kw.get("task_id"),
+    ),
+    check_fn=check_requirements,
+    emoji="💼",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -52,6 +52,10 @@ _HERMES_CORE_TOOLS = [
     "session_search",
     # Clarifying questions
     "clarify",
+    # Lilly-specific retrieval (email, Limitless pendant, LinkedIn messages)
+    "lilly_search_emails",
+    "lilly_search_limitless",
+    "lilly_search_linkedin",
     # Code execution + delegation
     "execute_code", "delegate_task",
     # Cronjob management


### PR DESCRIPTION
## Summary

`delegate_task(toolsets=[...])` silently produced a toolless subagent when none of the requested toolsets intersected the parent's enabled toolsets. The child LLM received a request with no `tools=[...]` parameter, hallucinated tool-call syntax in free-text (`<tool_call>`, `<function=web_search>`, ```json[{"name":"tavily_search"...}]```), and returned `tool_trace=[]`. The parent correctly detected the empty artifacts but only after the wasted round trip, and fell back to doing the work itself.

## Root cause

In `_build_child_agent`:
```python
if toolsets:
    child_toolsets = _strip_blocked_tools([t for t in toolsets if t in parent_toolsets])
```
If `toolsets=["web"]` but parent has `{"file","terminal","browser"}`, the intersection is `[]`. Downstream: `self.tools = []`, which is falsy, so `_build_api_kwargs` skips the `tools` key entirely. The OpenAI-compat request reaches llama-swap / Magnum with no tool schema — the model has nothing to tool-call with, so it emits tool-call syntax in text.

## Fix

**Layer 1** — `delegate_task` pre-validates per-task `toolsets` against the parent's effective set before spawning. Returns a clear `tool_error` listing available toolsets so the parent agent can retry with a valid set (or drop the argument to inherit).

**Layer 2** — `_build_child_agent` raises `ValueError` if `child_toolsets` ends up empty for any reason. Defense in depth — pre-validation covers the delegate_task path, but any future path that produces an empty toolset would hit the same silent failure.

## Test plan

`/tmp/delegate_repro.py` exercises four cases:
- [x] Unavailable toolset (`['web']` vs parent `{'file','terminal'}`) → clear error returned to parent
- [x] Partial overlap (`['browser','web']` vs parent with `browser`) → surviving set kept, unavailable silently filtered
- [x] No toolsets specified → child inherits parent's
- [x] Empty parent edge case → `ValueError` raised instead of toolless child

Observed 2026-04-22 in a live Matrix session (rmulligan/lilly_v4, session `20260422_143157_fe9b85`): matrix responder called `delegate_task(toolsets=["web"])` during job-vetting work. After this fix, the same call returns an error listing `{browser, file, terminal, ...}` and Lilly can retry with `toolsets=["browser"]` which actually contains `web_search`.