### PR TITLE
feat(cli): add temporary /side conversations

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2089,6 +2089,8 @@ class HermesCLI:
         # Background task tracking: {task_id: threading.Thread}
         self._background_tasks: Dict[str, threading.Thread] = {}
         self._background_task_counter = 0
+        self._side_state: Optional[Dict[str, Any]] = None
+        self._side_queue: list[tuple[str, list[Path]]] = []
 
     def _invalidate(self, min_interval: float = 0.25) -> None:
         """Throttled UI repaint — prevents terminal blinking on slow/SSH connections."""
@@ -2346,12 +2348,13 @@ class HermesCLI:
             percent = snapshot["context_percent"]
             percent_label = f"{percent}%" if percent is not None else "--"
             duration_label = snapshot["duration"]
+            side_prefix = "[SIDE] " if self._side_state else ""
 
             if width < 52:
-                text = f"⚕ {snapshot['model_short']} · {duration_label}"
+                text = f"{side_prefix}⚕ {snapshot['model_short']} · {duration_label}"
                 return self._trim_status_bar_text(text, width)
             if width < 76:
-                parts = [f"⚕ {snapshot['model_short']}", percent_label]
+                parts = [f"{side_prefix}⚕ {snapshot['model_short']}", percent_label]
                 parts.append(duration_label)
                 return self._trim_status_bar_text(" · ".join(parts), width)
 
@@ -2362,30 +2365,33 @@ class HermesCLI:
             else:
                 context_label = "ctx --"
 
-            parts = [f"⚕ {snapshot['model_short']}", context_label, percent_label]
+            parts = [f"{side_prefix}⚕ {snapshot['model_short']}", context_label, percent_label]
             parts.append(duration_label)
             prompt_elapsed = snapshot.get("prompt_elapsed")
             if prompt_elapsed:
                 parts.append(prompt_elapsed)
             return self._trim_status_bar_text(" │ ".join(parts), width)
         except Exception:
-            return f"⚕ {self.model if getattr(self, 'model', None) else 'Hermes'}"
+            prefix = "[SIDE] " if self._side_state else ""
+            return f"{prefix}⚕ {self.model if getattr(self, 'model', None) else 'Hermes'}"
 
     def _get_status_bar_fragments(self):
         if not self._status_bar_visible or getattr(self, '_model_picker_state', None):
             return []
         try:
             snapshot = self._get_status_bar_snapshot()
-            # Use prompt_toolkit's own terminal width when running inside the
-            # TUI — shutil.get_terminal_size() can return stale or fallback
-            # values (especially on SSH) that differ from what prompt_toolkit
-            # actually renders, causing the fragments to overflow to a second
-            # line and produce duplicated status bar rows over long sessions.
             width = self._get_tui_terminal_width()
             duration_label = snapshot["duration"]
+            side_prefix = []
+            if self._side_state:
+                parent_status = self._current_side_parent_status_label()
+                side_prefix = [
+                    ("class:status-bar-strong", " SIDE "),
+                    ("class:status-bar-dim", f"{parent_status} · Esc returns · "),
+                ]
 
             if width < 52:
-                frags = [
+                frags = side_prefix + [
                     ("class:status-bar", " ⚕ "),
                     ("class:status-bar-strong", snapshot["model_short"]),
                     ("class:status-bar-dim", " · "),
@@ -2396,7 +2402,7 @@ class HermesCLI:
                 percent = snapshot["context_percent"]
                 percent_label = f"{percent}%" if percent is not None else "--"
                 if width < 76:
-                    frags = [
+                    frags = side_prefix + [
                         ("class:status-bar", " ⚕ "),
                         ("class:status-bar-strong", snapshot["model_short"]),
                         ("class:status-bar-dim", " · "),
@@ -2414,7 +2420,7 @@ class HermesCLI:
                         context_label = "ctx --"
 
                     bar_style = self._status_bar_context_style(percent)
-                    frags = [
+                    frags = side_prefix + [
                         ("class:status-bar", " ⚕ "),
                         ("class:status-bar-strong", snapshot["model_short"]),
                         ("class:status-bar-dim", " │ "),
@@ -4581,6 +4587,9 @@ class HermesCLI:
 
     def new_session(self, silent=False):
         """Start a fresh session with a new session ID and cleared agent state."""
+        if self._side_state:
+            self._side_state = None
+            self._side_queue = []
         if self.agent and self.conversation_history:
             try:
                 self.agent.flush_memories(self.conversation_history)
@@ -4643,6 +4652,9 @@ class HermesCLI:
 
     def _handle_resume_command(self, cmd_original: str) -> None:
         """Handle /resume <session_id_or_title> — switch to a previous session mid-conversation."""
+        if self._side_state:
+            self._side_state = None
+            self._side_queue = []
         parts = cmd_original.split(None, 1)
         target = parts[1].strip() if len(parts) > 1 else ""
 
@@ -4727,6 +4739,9 @@ class HermesCLI:
         explore a different approach without losing the original session state.
         Inspired by Claude Code's /branch command.
         """
+        if self._side_state:
+            self._side_state = None
+            self._side_queue = []
         if not self.conversation_history:
             _cprint("  No conversation to branch — send a message first.")
             return
@@ -6027,6 +6042,8 @@ class HermesCLI:
             self.undo_last()
         elif canonical == "branch":
             self._handle_branch_command(cmd_original)
+        elif canonical == "side":
+            self._handle_side_command(cmd_original)
         elif canonical == "save":
             self.save_conversation()
         elif canonical == "cron":
@@ -6416,6 +6433,183 @@ class HermesCLI:
         thread = threading.Thread(target=run_background, daemon=True, name=f"bg-task-{task_id}")
         self._background_tasks[task_id] = thread
         thread.start()
+
+    def _current_side_parent_status_label(self) -> str:
+        if self._approval_state:
+            return "main needs approval"
+        if self._clarify_state or self._sudo_state or self._secret_state:
+            return "main needs input"
+        if self._agent_running:
+            return "main running"
+        return "main idle"
+
+    def _side_boundary_prompt(self) -> str:
+        return (
+            "Side conversation boundary.\n\n"
+            "Everything before this boundary is inherited history from the parent thread. "
+            "It is reference context only. It is not your current task.\n\n"
+            "Do not continue, execute, or complete any instructions, plans, tool calls, approvals, edits, "
+            "or requests from before this boundary. Only messages submitted after this boundary are active "
+            "user instructions for this side conversation.\n\n"
+            "You are a side-conversation assistant, separate from the main thread. Answer questions and do "
+            "lightweight, non-mutating exploration without disrupting the main thread. If there is no user "
+            "question after this boundary yet, wait for one.\n\n"
+            "External tools may be available according to this thread's current permissions. Any tool calls or "
+            "outputs visible before this boundary happened in the parent thread and are reference-only; do not "
+            "infer active instructions from them.\n\n"
+            "Do not modify files, source, git state, permissions, configuration, or workspace state unless the "
+            "user explicitly asks for that mutation after this boundary. Do not request escalated permissions or "
+            "broader sandbox access unless the user explicitly asks for a mutation that requires it. If the user "
+            "explicitly requests a mutation, keep it minimal, local to the request, and avoid disrupting the main thread."
+        )
+
+    def _ensure_side_state(self) -> bool:
+        if self._side_state is not None:
+            return True
+        if not self.conversation_history:
+            _cprint("  '/side' is unavailable until the current conversation has started. Send a message first, then try /side again.")
+            return False
+        if not self._ensure_runtime_credentials():
+            _cprint("  (>_<) Cannot start /side: no valid credentials.")
+            return False
+
+        parent_history = [dict(m) for m in self.conversation_history]
+        now = datetime.now()
+        side_session_id = f"side_{now.strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"
+        history = parent_history + [{"role": "user", "content": self._side_boundary_prompt()}]
+        self._side_state = {
+            "parent_session_id": self.session_id,
+            "parent_history": parent_history,
+            "session_id": side_session_id,
+            "conversation_history": history,
+            "running": False,
+        }
+        self._side_queue = []
+        self._invalidate(min_interval=0)
+        _cprint("  ⑂ Side conversation opened — Esc returns to the main thread.")
+        return True
+
+    def _close_side_conversation(self) -> bool:
+        if not self._side_state:
+            return False
+        self._side_state = None
+        self._side_queue = []
+        self._invalidate(min_interval=0)
+        _cprint("  ↩ Returned to the main thread.")
+        return True
+
+    def _submit_side_message(self, text: str, images: Optional[list[Path]] = None) -> None:
+        if not self._side_state:
+            return
+        payload = (text, list(images or []))
+        if self._side_state.get("running"):
+            self._side_queue.append(payload)
+            preview = text[:80] + ("..." if len(text) > 80 else "")
+            _cprint(f"  Queued for side thread: {preview}")
+            self._invalidate(min_interval=0)
+            return
+        self._run_side_turn(payload)
+
+    def _run_side_turn(self, payload: tuple[str, list[Path]]) -> None:
+        if not self._side_state:
+            return
+        question, images = payload
+        side_state = self._side_state
+        side_state["running"] = True
+        self._invalidate(min_interval=0)
+        preview = question[:60] + ("..." if len(question) > 60 else "")
+        _cprint(f'  ⑂ /side: "{preview}"')
+
+        def run_side():
+            try:
+                turn_route = self._resolve_turn_agent_config(question)
+                side_agent = AIAgent(
+                    model=turn_route["model"],
+                    api_key=turn_route["runtime"].get("api_key"),
+                    base_url=turn_route["runtime"].get("base_url"),
+                    provider=turn_route["runtime"].get("provider"),
+                    api_mode=turn_route["runtime"].get("api_mode"),
+                    acp_command=turn_route["runtime"].get("command"),
+                    acp_args=turn_route["runtime"].get("args"),
+                    max_iterations=self.max_turns,
+                    enabled_toolsets=list(self.enabled_toolsets or []),
+                    quiet_mode=True,
+                    verbose_logging=False,
+                    session_id=side_state["session_id"],
+                    platform="cli",
+                    reasoning_config=self.reasoning_config,
+                    service_tier=self.service_tier,
+                    request_overrides=turn_route.get("request_overrides"),
+                    providers_allowed=self._providers_only,
+                    providers_ignored=self._providers_ignore,
+                    providers_order=self._providers_order,
+                    provider_sort=self._provider_sort,
+                    provider_require_parameters=self._provider_require_params,
+                    provider_data_collection=self._provider_data_collection,
+                    fallback_model=self._fallback_model,
+                    session_db=None,
+                    skip_memory=True,
+                    skip_context_files=True,
+                    persist_session=False,
+                )
+                user_message = question
+                if images:
+                    user_message = (question + "\n\n" if question else "") + f"[User attached {len(images)} image{'s' if len(images) != 1 else ''} in this side conversation.]"
+                result = side_agent.run_conversation(
+                    user_message=user_message,
+                    conversation_history=list(side_state["conversation_history"]),
+                    task_id=side_state["session_id"],
+                )
+                response = (result.get("final_response") or "") if result else ""
+                if not response and result and result.get("error"):
+                    response = f"Error: {result['error']}"
+                side_state["conversation_history"] = result.get("messages", side_state["conversation_history"]) if result else side_state["conversation_history"]
+                if self._app:
+                    self._app.invalidate()
+                    time.sleep(0.05)
+                print()
+                if response:
+                    try:
+                        from hermes_cli.skin_engine import get_active_skin
+                        _skin = get_active_skin()
+                        _resp_color = _skin.get_color("response_border", "#4F6D4A")
+                    except Exception:
+                        _resp_color = "#4F6D4A"
+                    ChatConsole().print(Panel(
+                        _rich_text_from_ansi(response),
+                        title=f"[{_resp_color} bold]⚕ /side[/]",
+                        title_align="left",
+                        border_style=_resp_color,
+                        box=rich_box.HORIZONTALS,
+                        padding=(1, 4),
+                    ))
+                else:
+                    _cprint("  ⑂ /side: (no response)")
+            except Exception as e:
+                if self._app:
+                    self._app.invalidate()
+                    time.sleep(0.05)
+                print()
+                _cprint(f"  ❌ /side failed: {e}")
+            finally:
+                if self._side_state is side_state:
+                    side_state["running"] = False
+                    if self._side_queue:
+                        next_payload = self._side_queue.pop(0)
+                        self._run_side_turn(next_payload)
+                    self._invalidate(min_interval=0)
+
+        threading.Thread(target=run_side, daemon=True, name=f"side-{side_state['session_id']}").start()
+
+    def _handle_side_command(self, cmd: str):
+        if self._side_state is not None:
+            _cprint("  '/side' is unavailable in side conversations. Press Esc to return to the main thread first.")
+            return
+        if not self._ensure_side_state():
+            return
+        parts = cmd.strip().split(maxsplit=1)
+        if len(parts) > 1 and parts[1].strip():
+            self._submit_side_message(parts[1].strip())
 
     def _handle_btw_command(self, cmd: str):
         """Handle /btw <question> — ephemeral side question using session context.
@@ -9218,13 +9412,23 @@ class HermesCLI:
             text = event.app.current_buffer.text.strip()
             has_images = bool(self._attached_images)
             if text or has_images:
-                # Handle /model directly on the UI thread so interactive pickers
-                # can safely use prompt_toolkit terminal handoff helpers.
-                if self._should_handle_model_command_inline(text, has_images=has_images):
-                    if not self.process_command(text):
-                        self._should_exit = True
-                        if event.app.is_running:
-                            event.app.exit()
+                # Handle /model and /side directly on the UI thread so interactive
+                # TUI state changes happen immediately even while the parent thread runs.
+                if text and _looks_like_slash_command(text):
+                    _inline_base = text.strip().split()[0].lower()
+                    if _inline_base in {"/model", "/side"}:
+                        if not self.process_command(text):
+                            self._should_exit = True
+                            if event.app.is_running:
+                                event.app.exit()
+                        event.app.current_buffer.reset(append_to_history=True)
+                        return
+
+                if self._side_state and text and not _looks_like_slash_command(text):
+                    images = list(self._attached_images)
+                    self._attached_images.clear()
+                    event.app.invalidate()
+                    self._submit_side_message(text, images=images)
                     event.app.current_buffer.reset(append_to_history=True)
                     return
 
@@ -9546,6 +9750,32 @@ class HermesCLI:
                 self._sudo_state = None
                 event.app.invalidate()
                 return
+
+        @kb.add('escape', filter=Condition(lambda: bool(self._side_state) and not self._clarify_state and not self._approval_state and not self._secret_state and not self._sudo_state), eager=True)
+        def handle_escape_side(event):
+            """ESC exits the active side conversation and returns to the parent thread."""
+            if event.app.current_buffer.text:
+                event.app.current_buffer.reset()
+            self._close_side_conversation()
+            event.app.invalidate()
+
+        @kb.add('escape', filter=Condition(lambda: bool(self._clarify_state)), eager=True)
+        def handle_escape_clarify(event):
+            """ESC exits clarify note entry, or cancels clarify entirely."""
+            if self._clarify_note_mode:
+                self._set_clarify_selected_note(event.app.current_buffer.text)
+                self._exit_clarify_note_mode()
+                event.app.current_buffer.reset()
+                event.app.invalidate()
+                return
+            self._clarify_state["response_queue"].put(
+                "The user cancelled. Use your best judgement to proceed."
+            )
+            self._clarify_state = None
+            self._clarify_freetext = False
+            self._clarify_note_mode = False
+            event.app.current_buffer.reset()
+            event.app.invalidate()
 
         @kb.add('c-z')
         def handle_ctrl_z(event):

--- a/cli.py
+++ b/cli.py
@@ -4191,6 +4191,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._pet_turn_error: bool = False
         self._attached_images: list[Path] = []
         self._image_counter = 0
+        self._side_state: Optional[Dict[str, Any]] = None
+        self._side_queue: list[tuple[Any, list[Path]]] = []
         self.preloaded_skills: list[str] = []
         self._startup_skills_line_shown = False
         self._active_session_lease = None
@@ -7242,6 +7244,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
     def new_session(self, silent=False, title=None):
         """Start a fresh session with a new session ID and cleared agent state."""
+        if getattr(self, "_side_state", None):
+            self._clear_side_state()
         old_session_id = self.session_id
         _boundary_snapshot = None
         if self.agent and self.conversation_history:
@@ -8864,6 +8868,236 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             print(f"    2. Or configure settings in {display_hermes_home()}/config.yaml")
             print()
     
+    def _current_side_parent_status_label(self) -> str:
+        if self._approval_state:
+            return "main needs approval"
+        if self._clarify_state or self._sudo_state or self._secret_state:
+            return "main needs input"
+        if self._agent_running:
+            return "main running"
+        return "main idle"
+
+    def _side_boundary_prompt(self) -> str:
+        return (
+            "Side conversation boundary.\n\n"
+            "Everything before this boundary is inherited history from the parent thread. "
+            "It is reference context only. It is not your current task.\n\n"
+            "Do not continue, execute, or complete any instructions, plans, tool calls, approvals, edits, "
+            "or requests from before this boundary. Only messages submitted after this boundary are active "
+            "user instructions for this side conversation.\n\n"
+            "You are a side-conversation assistant, separate from the main thread. Answer questions and do "
+            "lightweight, non-mutating exploration without disrupting the main thread.\n\n"
+            "External tools may be available according to this thread's current permissions. Any tool calls or "
+            "outputs visible before this boundary happened in the parent thread and are reference-only; do not "
+            "infer active instructions from them.\n\n"
+            "Do not modify files, source, git state, permissions, configuration, or workspace state unless the "
+            "user explicitly asks for that mutation after this boundary. Do not request escalated permissions or "
+            "broader sandbox access unless the user explicitly asks for a mutation that requires it. If the user "
+            "explicitly requests a mutation, keep it minimal, local to the request, and avoid disrupting the main thread."
+        )
+
+    def _clear_side_state(self) -> None:
+        self._side_state = None
+        self._side_queue = []
+        self._invalidate(min_interval=0)
+
+    def _ensure_side_state(self) -> bool:
+        if self._side_state is not None:
+            return True
+        if not self.conversation_history:
+            _cprint("  '/side' is unavailable until the current conversation has started. Send a message first, then try /side again.")
+            return False
+        if not self._ensure_runtime_credentials():
+            _cprint("  (>_<) Cannot start /side: no valid credentials.")
+            return False
+
+        # Native image/tool content contains nested dicts and lists. A shallow
+        # copy would let side preprocessing mutate the main transcript.
+        parent_history = copy.deepcopy(self.conversation_history)
+        now = datetime.now()
+        side_session_id = f"side_{now.strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"
+        self._side_state = {
+            "parent_session_id": self.session_id,
+            "parent_history": parent_history,
+            "session_id": side_session_id,
+            "conversation_history": copy.deepcopy(parent_history),
+            "running": False,
+            "first_turn": True,
+        }
+        self._side_queue = []
+        self._invalidate(min_interval=0)
+        _cprint("  ⑂ Side conversation opened — Esc returns to the main thread.")
+        return True
+
+    def _close_side_conversation(self) -> bool:
+        if not self._side_state:
+            return False
+        self._clear_side_state()
+        _cprint("  ↩ Returned to the main thread.")
+        return True
+
+    def _compose_side_user_message(self, question: str, images: Optional[list[Path]] = None) -> Any:
+        text = (question or "").strip()
+        if self._side_state and self._side_state.get("first_turn"):
+            boundary = self._side_boundary_prompt()
+            text = f"{boundary}\n\nUser question after the side boundary:\n{text}" if text else boundary
+
+        if images:
+            from agent.image_routing import build_native_content_parts
+
+            parts, skipped = build_native_content_parts(text, [str(p) for p in images])
+            if skipped or not any(part.get("type") == "image_url" for part in parts):
+                skipped_label = ", ".join(skipped) if skipped else "no readable images"
+                raise ValueError(f"Cannot submit /side image attachment: {skipped_label}")
+            return parts
+
+        return text
+
+    def _submit_side_message(self, text: str, images: Optional[list[Path]] = None) -> bool:
+        if not self._side_state and not self._ensure_side_state():
+            return False
+        if not self._side_state:
+            return False
+
+        try:
+            user_message = self._compose_side_user_message(text, images)
+        except Exception as exc:
+            _cprint(f"  {_DIM}{exc}{_RST}")
+            self._invalidate(min_interval=0)
+            return False
+
+        payload = (user_message, list(images or []))
+        if self._side_state.get("running"):
+            self._side_queue.append(payload)
+            preview = (text or "[image]").strip()
+            preview = preview[:80] + ("..." if len(preview) > 80 else "")
+            _cprint(f"  Queued for side thread: {preview}")
+            self._invalidate(min_interval=0)
+            return True
+
+        self._run_side_turn(payload)
+        return True
+
+    def _start_side_thread(self, target, *, name: str) -> None:
+        """Start one side turn; split out so queue behavior is testable."""
+        threading.Thread(target=target, daemon=True, name=name).start()
+
+    def _run_side_turn(self, payload: tuple[Any, list[Path]]) -> None:
+        if not self._side_state:
+            return
+        user_message, _images = payload
+        side_state = self._side_state
+        side_state["running"] = True
+        if side_state.get("first_turn"):
+            side_state["first_turn"] = False
+        self._invalidate(min_interval=0)
+
+        def run_side():
+            try:
+                text_preview = user_message
+                if isinstance(user_message, list):
+                    text_preview = next(
+                        (part.get("text", "") for part in user_message if part.get("type") == "text"),
+                        "[image]",
+                    )
+                preview_text = str(text_preview)
+                preview = preview_text[:60] + ("..." if len(preview_text) > 60 else "")
+                _cprint(f'  ⑂ /side: "{preview}"')
+                turn_route = self._resolve_turn_agent_config(preview_text)
+                side_agent = AIAgent(
+                    model=turn_route["model"],
+                    api_key=turn_route["runtime"].get("api_key"),
+                    base_url=turn_route["runtime"].get("base_url"),
+                    provider=turn_route["runtime"].get("provider"),
+                    api_mode=turn_route["runtime"].get("api_mode"),
+                    acp_command=turn_route["runtime"].get("command"),
+                    acp_args=turn_route["runtime"].get("args"),
+                    max_iterations=self.max_turns,
+                    enabled_toolsets=list(self.enabled_toolsets or []),
+                    disabled_toolsets=list(self.disabled_toolsets or []),
+                    quiet_mode=True,
+                    verbose_logging=False,
+                    session_id=side_state["session_id"],
+                    platform="cli",
+                    reasoning_config=self.reasoning_config,
+                    service_tier=self.service_tier,
+                    request_overrides=turn_route.get("request_overrides"),
+                    providers_allowed=self._providers_only,
+                    providers_ignored=self._providers_ignore,
+                    providers_order=self._providers_order,
+                    provider_sort=self._provider_sort,
+                    provider_require_parameters=self._provider_require_params,
+                    provider_data_collection=self._provider_data_collection,
+                    fallback_model=self._fallback_model,
+                    session_db=None,
+                    skip_memory=True,
+                    skip_context_files=True,
+                    parent_session_id=side_state.get("parent_session_id"),
+                    requested_provider=self.requested_provider,
+                )
+                # This fork is ephemeral: never create a state.db row or JSON
+                # transcript, including through lazy session-store fallback.
+                setattr(side_agent, "_persist_disabled", True)
+                setattr(side_agent, "_session_db", None)
+                setattr(side_agent, "_session_json_enabled", False)
+                result = side_agent.run_conversation(
+                    user_message=user_message,
+                    conversation_history=copy.deepcopy(side_state["conversation_history"]),
+                    task_id=side_state["session_id"],
+                )
+                if self._side_state is not side_state:
+                    return
+                response = (result.get("final_response") or "") if result else ""
+                if not response and result and result.get("error"):
+                    response = f"Error: {result['error']}"
+                if result and result.get("messages"):
+                    side_state["conversation_history"] = result["messages"]
+                if self._app:
+                    self._app.invalidate()
+                    time.sleep(0.05)
+                print()
+                if response:
+                    try:
+                        from hermes_cli.skin_engine import get_active_skin
+                        _resp_color = get_active_skin().get_color("response_border", "#4F6D4A")
+                    except Exception:
+                        _resp_color = "#4F6D4A"
+                    ChatConsole().print(Panel(
+                        _rich_text_from_ansi(response),
+                        title=f"[{_resp_color} bold]⚕ /side[/]",
+                        title_align="left",
+                        border_style=_resp_color,
+                        box=rich_box.HORIZONTALS,
+                        padding=(1, 4),
+                    ))
+                else:
+                    _cprint("  ⑂ /side: (no response)")
+            except Exception as exc:
+                if self._app:
+                    self._app.invalidate()
+                    time.sleep(0.05)
+                print()
+                _cprint(f"  ❌ /side failed: {exc}")
+            finally:
+                if self._side_state is side_state:
+                    side_state["running"] = False
+                    if self._side_queue:
+                        next_payload = self._side_queue.pop(0)
+                        self._run_side_turn(next_payload)
+                    self._invalidate(min_interval=0)
+
+        self._start_side_thread(run_side, name=f"side-{side_state['session_id']}")
+
+    def _handle_side_command(self, cmd: str):
+        if self._side_state is not None:
+            _cprint("  '/side' is unavailable in side conversations. Press Esc to return to the main thread first.")
+            return
+        if not self._ensure_side_state():
+            return
+        parts = cmd.strip().split(maxsplit=1)
+        if len(parts) > 1 and parts[1].strip():
+            self._submit_side_message(parts[1].strip())
+
     def process_command(self, command: str) -> bool:
         """
         Process a slash command.
@@ -9114,6 +9348,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             self.undo_last(_undo_n)
         elif canonical == "branch":
             self._handle_branch_command(cmd_original)
+        elif canonical == "side":
+            self._handle_side_command(cmd_original)
         elif canonical == "save":
             self.save_conversation()
         elif canonical == "cron":
@@ -13445,6 +13681,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # Clipboard image attachments (paste images into the CLI)
         self._attached_images: list[Path] = []
         self._image_counter = 0
+        self._side_state = None
+        self._side_queue = []
 
         # Voice mode state (protected by _voice_lock for cross-thread access)
         self._voice_lock = threading.Lock()
@@ -13578,6 +13816,42 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             text = event.app.current_buffer.text.strip()
             has_images = bool(self._attached_images)
             if text or has_images:
+                if text and _looks_like_slash_command(text):
+                    _inline_base = text.strip().split()[0].lower()
+                    if _inline_base == "/side":
+                        images = list(self._attached_images)
+                        parts = text.strip().split(maxsplit=1)
+                        question = parts[1].strip() if len(parts) > 1 else ""
+                        if images:
+                            if not self._side_state and not self._ensure_side_state():
+                                event.app.invalidate()
+                                return
+                            if question:
+                                accepted = self._submit_side_message(question, images=images)
+                                if accepted:
+                                    self._attached_images.clear()
+                                    event.app.current_buffer.reset(append_to_history=True)
+                            else:
+                                _cprint(f"  {_DIM}Attach text with /side before submitting images.{_RST}")
+                            event.app.invalidate()
+                            return
+                        if not self.process_command(text):
+                            self._should_exit = True
+                            if event.app.is_running:
+                                event.app.exit()
+                        event.app.current_buffer.reset(append_to_history=True)
+                        event.app.invalidate()
+                        return
+
+                if self._side_state and not (text and _looks_like_slash_command(text)):
+                    images = list(self._attached_images)
+                    accepted = self._submit_side_message(text, images=images)
+                    if accepted:
+                        self._attached_images.clear()
+                        event.app.current_buffer.reset(append_to_history=True)
+                    event.app.invalidate()
+                    return
+
                 # Handle /model directly on the UI thread so interactive pickers
                 # can safely use prompt_toolkit terminal handoff helpers.
                 if self._should_handle_model_command_inline(text, has_images=has_images):
@@ -14155,6 +14429,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 event.app.current_buffer.reset()
                 event.app.invalidate()
                 return
+
+        @kb.add('escape', filter=Condition(lambda: bool(self._side_state) and not self._clarify_state and not self._approval_state and not self._secret_state and not self._sudo_state and not self._slash_confirm_state), eager=True)
+        def handle_escape_side(event):
+            """ESC exits the active side conversation and returns to the parent thread."""
+            if event.app.current_buffer.text:
+                event.app.current_buffer.reset()
+            self._close_side_conversation()
+            event.app.invalidate()
 
         @kb.add('c-z')
         def handle_ctrl_z(event):

--- a/contributors/emails/mwnickerson@icloud.com
+++ b/contributors/emails/mwnickerson@icloud.com
@@ -1,0 +1,2 @@
+mwnickerson
+# PR #14294 contributor attribution

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -842,6 +842,8 @@ class CLICommandsMixin:
         # relative-path resolution keep operating in the wrong repo. Idempotent
         # and a no-op when the session recorded no cwd. See #38562.
         self._restore_session_cwd(session_meta)
+        if getattr(self, "_side_state", None):
+            self._clear_side_state()
 
     def _handle_sessions_command(self, cmd_original: str) -> None:
         """Handle /sessions [list|<id_or_title>] — browse or resume previous sessions.
@@ -1026,6 +1028,8 @@ class CLICommandsMixin:
         )
         _cprint(f"  Original session: {parent_session_id}")
         _cprint(f"  Branch session:   {new_session_id}")
+        if getattr(self, "_side_state", None):
+            self._clear_side_state()
 
     def _handle_personality_command(self, cmd: str):
         """Handle the /personality command to set predefined personalities."""

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -72,6 +72,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                args_hint="[name]"),
     CommandDef("branch", "Branch the current session (explore a different path)", "Session",
                aliases=("fork",), args_hint="[name]"),
+    CommandDef("side", "Open a temporary side conversation fork", "Session",
+               args_hint="[question]", cli_only=True),
     CommandDef("compress", "Manually compress conversation context", "Session",
                args_hint="[focus topic]"),
     CommandDef("rollback", "List or restore filesystem checkpoints", "Session",

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -88,6 +88,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                args_hint="<platform>", cli_only=True),
     CommandDef("branch", "Branch the current session (explore a different path)", "Session",
                aliases=("fork",), args_hint="[name]"),
+    CommandDef("side", "Open a temporary side conversation fork", "Session",
+               args_hint="[question]", cli_only=True),
     CommandDef("compress", "Compress conversation context (add 'here [N]' to keep recent N turns; --preview shows what would happen)", "Session",
                aliases=("compact",), args_hint="[here [N] | focus topic | --preview|--dry-run]"),
     CommandDef("rollback", "List or restore filesystem checkpoints", "Session",

--- a/tests/cli/test_cli_side_command.py
+++ b/tests/cli/test_cli_side_command.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from tests.cli.test_cli_new_session import _make_cli
+
+
+class _ImmediateThread:
+    def __init__(self, target=None, args=(), kwargs=None, daemon=None, name=None):
+        self._target = target
+        self._args = args
+        self._kwargs = kwargs or {}
+
+    def start(self):
+        if self._target:
+            self._target(*self._args, **self._kwargs)
+
+
+class _FakeSideAgent:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+    def run_conversation(self, user_message, conversation_history=None, task_id=None, **kwargs):
+        messages = list(conversation_history or []) + [
+            {"role": "user", "content": user_message},
+            {"role": "assistant", "content": "side answer"},
+        ]
+        return {
+            "final_response": "side answer",
+            "messages": messages,
+        }
+
+
+def _prepare_cli():
+    cli = _make_cli()
+    cli.console = MagicMock()
+    cli.conversation_history = [
+        {"role": "user", "content": "main question"},
+        {"role": "assistant", "content": "main answer"},
+    ]
+    cli._invalidate = MagicMock()
+    return cli
+
+
+def test_side_command_unavailable_before_session_starts(monkeypatch):
+    cli = _make_cli()
+    cli.console = MagicMock()
+    monkeypatch.setattr("cli._cprint", lambda *args, **kwargs: None)
+
+    result = cli.process_command("/side")
+
+    assert result is True
+    assert cli._side_state is None
+
+
+def test_side_command_opens_ephemeral_side_state(monkeypatch):
+    cli = _prepare_cli()
+    monkeypatch.setattr("cli._cprint", lambda *args, **kwargs: None)
+    cli._ensure_runtime_credentials = MagicMock(return_value=True)
+
+    assert cli.process_command("/side") is True
+
+    assert cli._side_state is not None
+    assert cli._side_state["parent_session_id"] == cli.session_id
+    assert cli._side_state["conversation_history"][-1]["content"].startswith("Side conversation boundary.")
+
+
+def test_side_command_rejects_nested_side(monkeypatch):
+    cli = _prepare_cli()
+    cli._side_state = {"session_id": "side_123", "conversation_history": [], "running": False}
+    printed = []
+    monkeypatch.setattr("cli._cprint", lambda msg, *args, **kwargs: printed.append(msg))
+
+    cli.process_command("/side another question")
+
+    assert any("unavailable in side conversations" in msg for msg in printed)
+
+
+def test_side_command_with_question_runs_in_side_thread(monkeypatch):
+    cli = _prepare_cli()
+    monkeypatch.setattr("cli._cprint", lambda *args, **kwargs: None)
+    monkeypatch.setattr("cli.AIAgent", _FakeSideAgent)
+    monkeypatch.setattr("cli.threading.Thread", _ImmediateThread)
+    monkeypatch.setattr("cli.ChatConsole", lambda: MagicMock(print=MagicMock()))
+    cli._ensure_runtime_credentials = MagicMock(return_value=True)
+    cli._resolve_turn_agent_config = MagicMock(
+        return_value={
+            "model": "gpt-5.4",
+            "runtime": {
+                "api_key": "token",
+                "base_url": "https://chatgpt.com/backend-api/codex",
+                "provider": "openai-codex",
+                "api_mode": None,
+                "command": None,
+                "args": [],
+            },
+            "request_overrides": None,
+        }
+    )
+
+    cli.process_command("/side explain the parser")
+
+    assert cli._side_state is not None
+    assert cli._side_state["running"] is False
+    history = cli._side_state["conversation_history"]
+    assert history[-2]["content"] == "explain the parser"
+    assert history[-1]["content"] == "side answer"
+
+
+def test_close_side_conversation_clears_state(monkeypatch):
+    cli = _prepare_cli()
+    monkeypatch.setattr("cli._cprint", lambda *args, **kwargs: None)
+    cli._side_state = {"session_id": "side_123", "conversation_history": [], "running": False}
+    cli._side_queue = [("queued", [])]
+
+    closed = cli._close_side_conversation()
+
+    assert closed is True
+    assert cli._side_state is None
+    assert cli._side_queue == []

--- a/tests/cli/test_cli_side_command.py
+++ b/tests/cli/test_cli_side_command.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from hermes_cli.commands import COMMAND_REGISTRY, resolve_command
+from tests.cli.test_cli_new_session import _make_cli
+
+
+class _ManualFirstStarter:
+    def __init__(self):
+        self.started = []
+        self.auto_after_first = False
+
+    def __call__(self, target, *, name):
+        self.started.append((target, name))
+        if self.auto_after_first:
+            target()
+
+    def run_first(self):
+        self.auto_after_first = True
+        self.started[0][0]()
+
+
+class _RecordingSideAgent:
+    calls: list[dict] = []
+    instances: list[_RecordingSideAgent] = []
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self._persist_disabled = False
+        self._session_db = object()
+        self._session_json_enabled = True
+        type(self).instances.append(self)
+
+    def run_conversation(self, user_message, conversation_history=None, task_id=None, **kwargs):
+        call = {
+            "user_message": user_message,
+            "conversation_history": list(conversation_history or []),
+            "task_id": task_id,
+            "kwargs": kwargs,
+            "agent_kwargs": self.kwargs,
+        }
+        type(self).calls.append(call)
+        messages = list(conversation_history or []) + [
+            {"role": "user", "content": user_message},
+            {"role": "assistant", "content": f"side answer {len(type(self).calls)}"},
+        ]
+        return {"final_response": messages[-1]["content"], "messages": messages}
+
+
+def _reset_recording_agent():
+    _RecordingSideAgent.calls = []
+    _RecordingSideAgent.instances = []
+
+
+def _prepare_cli():
+    cli = _make_cli()
+    cli.console = MagicMock()
+    cli._invalidate = MagicMock()
+    cli._ensure_runtime_credentials = MagicMock(return_value=True)
+    cli._resolve_turn_agent_config = MagicMock(
+        return_value={
+            "model": "gpt-5.4",
+            "runtime": {
+                "api_key": "token",
+                "base_url": "https://example.test/v1",
+                "provider": "openai",
+                "api_mode": None,
+                "command": None,
+                "args": [],
+            },
+            "request_overrides": None,
+        }
+    )
+    cli.conversation_history = [
+        {"role": "user", "content": "main question"},
+        {"role": "assistant", "content": "main answer"},
+    ]
+    return cli
+
+
+def _roles(history):
+    return [m.get("role") for m in history]
+
+
+def test_side_is_registered_cli_only():
+    side = resolve_command("side")
+
+    assert side is not None
+    assert side.name == "side"
+    assert side.cli_only is True
+    assert any(cmd.name == "side" for cmd in COMMAND_REGISTRY)
+
+
+def test_first_side_question_combines_boundary_and_question_in_one_user_turn(monkeypatch):
+    _reset_recording_agent()
+    cli = _prepare_cli()
+    parent_history = [dict(m) for m in cli.conversation_history]
+    monkeypatch.setattr("cli._cprint", lambda *args, **kwargs: None)
+    monkeypatch.setitem(cli._run_side_turn.__func__.__globals__, "AIAgent", _RecordingSideAgent)
+    cli._start_side_thread = lambda target, **_kwargs: target()
+    monkeypatch.setattr("cli.ChatConsole", lambda: MagicMock(print=MagicMock()))
+
+    assert cli.process_command("/side explain the parser") is True
+
+    assert len(_RecordingSideAgent.calls) == 1
+    call = _RecordingSideAgent.calls[0]
+    assert call["conversation_history"] == parent_history
+    assert _roles(call["conversation_history"]) == ["user", "assistant"]
+    assert isinstance(call["user_message"], str)
+    assert call["user_message"].startswith("Side conversation boundary.")
+    assert "explain the parser" in call["user_message"]
+    assert cli.conversation_history == parent_history
+
+
+def test_repeated_side_turns_use_side_history_without_mutating_parent(monkeypatch):
+    _reset_recording_agent()
+    cli = _prepare_cli()
+    parent_history = [dict(m) for m in cli.conversation_history]
+    monkeypatch.setattr("cli._cprint", lambda *args, **kwargs: None)
+    monkeypatch.setitem(cli._run_side_turn.__func__.__globals__, "AIAgent", _RecordingSideAgent)
+    cli._start_side_thread = lambda target, **_kwargs: target()
+    monkeypatch.setattr("cli.ChatConsole", lambda: MagicMock(print=MagicMock()))
+
+    cli.process_command("/side first")
+    cli._submit_side_message("second")
+
+    assert len(_RecordingSideAgent.calls) == 2
+    second = _RecordingSideAgent.calls[1]
+    assert second["conversation_history"][:2] == parent_history
+    assert _roles(second["conversation_history"]) == [
+        "user",
+        "assistant",
+        "user",
+        "assistant",
+    ]
+    assert second["user_message"] == "second"
+    assert cli.conversation_history == parent_history
+
+
+def test_busy_side_queue_drains_fifo(monkeypatch):
+    _reset_recording_agent()
+    starter = _ManualFirstStarter()
+    cli = _prepare_cli()
+    monkeypatch.setattr("cli._cprint", lambda *args, **kwargs: None)
+    monkeypatch.setitem(cli._run_side_turn.__func__.__globals__, "AIAgent", _RecordingSideAgent)
+    cli._start_side_thread = starter
+    monkeypatch.setattr("cli.ChatConsole", lambda: MagicMock(print=MagicMock()))
+
+    cli.process_command("/side first")
+    cli._submit_side_message("second")
+    cli._submit_side_message("third")
+
+    assert [item[0] for item in cli._side_queue] == ["second", "third"]
+    starter.run_first()
+
+    assert _RecordingSideAgent.calls[0]["user_message"].startswith("Side conversation boundary.")
+    assert [call["user_message"] for call in _RecordingSideAgent.calls[1:]] == [
+        "second",
+        "third",
+    ]
+    assert cli._side_queue == []
+
+
+def test_side_cancel_clears_ephemeral_state_and_queue(monkeypatch):
+    cli = _prepare_cli()
+    monkeypatch.setattr("cli._cprint", lambda *args, **kwargs: None)
+
+    cli._side_state = {"session_id": "side_123", "conversation_history": [], "running": True}
+    cli._side_queue = [("queued", [])]
+
+    assert cli._close_side_conversation() is True
+    assert cli._side_state is None
+    assert cli._side_queue == []
+
+
+def test_side_images_use_native_content_parts_and_are_not_count_markers(monkeypatch, tmp_path):
+    _reset_recording_agent()
+    cli = _prepare_cli()
+    image_path = tmp_path / "one.png"
+    image_path.write_bytes(
+        b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR"
+        b"\x00\x00\x00\x01\x00\x00\x00\x01\x08\x02\x00\x00\x00"
+        b"\x90wS\xde\x00\x00\x00\x00IEND\xaeB`\x82"
+    )
+    monkeypatch.setattr("cli._cprint", lambda *args, **kwargs: None)
+    monkeypatch.setitem(cli._run_side_turn.__func__.__globals__, "AIAgent", _RecordingSideAgent)
+    cli._start_side_thread = lambda target, **_kwargs: target()
+    monkeypatch.setattr("cli.ChatConsole", lambda: MagicMock(print=MagicMock()))
+
+    cli.process_command("/side")
+    accepted = cli._submit_side_message("what is here?", images=[image_path])
+
+    assert accepted is True
+    user_message = _RecordingSideAgent.calls[0]["user_message"]
+    assert isinstance(user_message, list)
+    assert any(part.get("type") == "image_url" for part in user_message)
+    text_parts = [part.get("text", "") for part in user_message if part.get("type") == "text"]
+    assert "what is here?" in "\n".join(text_parts)
+    assert "User attached 1 image" not in "\n".join(text_parts)
+
+
+def test_side_rejects_unreadable_images_before_clearing_composer(monkeypatch, tmp_path):
+    _reset_recording_agent()
+    cli = _prepare_cli()
+    missing = tmp_path / "missing.png"
+    monkeypatch.setattr("cli._cprint", lambda *args, **kwargs: None)
+    monkeypatch.setitem(cli._run_side_turn.__func__.__globals__, "AIAgent", _RecordingSideAgent)
+    cli._start_side_thread = lambda target, **_kwargs: target()
+
+    cli.process_command("/side")
+    accepted = cli._submit_side_message("look", images=[missing])
+
+    assert accepted is False
+    assert _RecordingSideAgent.calls == []
+
+
+def test_side_agent_is_ephemeral_and_isolated(monkeypatch):
+    _reset_recording_agent()
+    cli = _prepare_cli()
+    cli.session_id = "main_session"
+    monkeypatch.setattr("cli._cprint", lambda *args, **kwargs: None)
+    monkeypatch.setitem(cli._run_side_turn.__func__.__globals__, "AIAgent", _RecordingSideAgent)
+    cli._start_side_thread = lambda target, **_kwargs: target()
+    monkeypatch.setattr("cli.ChatConsole", lambda: MagicMock(print=MagicMock()))
+
+    cli.process_command("/side isolated")
+
+    kwargs = _RecordingSideAgent.calls[0]["agent_kwargs"]
+    assert kwargs["session_id"].startswith("side_")
+    assert kwargs["session_id"] != cli.session_id
+    assert kwargs["session_db"] is None
+    assert kwargs["skip_memory"] is True
+    assert kwargs["skip_context_files"] is True
+    side_agent = _RecordingSideAgent.instances[0]
+    assert side_agent._persist_disabled is True
+    assert side_agent._session_db is None
+    assert side_agent._session_json_enabled is False
+    assert cli.session_id == "main_session"
+
+
+def test_side_history_deep_copy_cannot_mutate_parent_nested_content(monkeypatch):
+    cli = _prepare_cli()
+    cli.conversation_history[0]["content"] = [
+        {"type": "text", "text": "main nested content"}
+    ]
+    monkeypatch.setattr("cli._cprint", lambda *args, **kwargs: None)
+
+    assert cli.process_command("/side") is True
+    cli._side_state["conversation_history"][0]["content"][0]["text"] = "side mutation"
+
+    assert cli.conversation_history[0]["content"][0]["text"] == "main nested content"


### PR DESCRIPTION
## Summary
- add a prompt_toolkit CLI `/side` command for temporary side conversations
- keep inherited parent history as reference-only via a side-conversation boundary prompt
- allow returning to the parent thread with `Esc`
- show side-context information in the CLI status area

## Behavior
- `/side` opens an ephemeral side fork in the classic Hermes CLI/TUI
- `/side <question>` opens the fork and immediately submits the question there
- nested side conversations are rejected until the active side conversation is closed
- side conversations are intentionally separate from the main thread and should not continue the parent task implicitly

## Notes
- This PR targets the existing prompt_toolkit CLI/TUI (`cli.py`), not the newer Ink `ui-tui` path.
- The behavior is intentionally modeled after Codex `/side`, but scoped to the classic CLI surface.

## Test Plan
- `python -m py_compile cli.py hermes_cli/commands.py tests/cli/test_cli_side_command.py`
- `pytest tests/cli/test_cli_side_command.py tests/cli/test_branch_command.py -q -n0`
