### PR TITLE
fix(cli): keep queued prompts near the status bar

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2089,6 +2089,9 @@ class HermesCLI:
         # Background task tracking: {task_id: threading.Thread}
         self._background_tasks: Dict[str, threading.Thread] = {}
         self._background_task_counter = 0
+        self._queued_turn_preview: str = ""
+        self._side_state: Optional[Dict[str, Any]] = None
+        self._side_queue: list[tuple[str, list[Path]]] = []
 
     def _invalidate(self, min_interval: float = 0.25) -> None:
         """Throttled UI repaint — prevents terminal blinking on slow/SSH connections."""
@@ -6116,7 +6119,8 @@ class HermesCLI:
             else:
                 self._pending_input.put(payload)
                 if self._agent_running:
-                    _cprint(f"  Queued for the next turn: {payload[:80]}{'...' if len(payload) > 80 else ''}")
+                    self._queued_turn_preview = payload[:80] + ('...' if len(payload) > 80 else '')
+                    self._invalidate(min_interval=0)
                 else:
                     _cprint(f"  Queued: {payload[:80]}{'...' if len(payload) > 80 else ''}")
         elif canonical == "steer":
@@ -8950,7 +8954,15 @@ class HermesCLI:
         overlay menu) into the layout without overriding ``run()``.  Widgets
         are inserted between the spacer and the status bar.
         """
-        return []
+        widgets = []
+        if self._queued_turn_preview:
+            widgets.append(
+                Window(
+                    content=FormattedTextControl(lambda: [("class:hint", f"  queued → {self._queued_turn_preview}")]),
+                    height=1,
+                )
+            )
+        return widgets
 
     def _register_extra_tui_keybindings(self, kb, *, input_area) -> None:
         """Register extra keybindings on the TUI ``KeyBindings`` object.
@@ -9250,7 +9262,8 @@ class HermesCLI:
                         # Queue for the next turn instead of interrupting
                         self._pending_input.put(payload)
                         preview = text if text else f"[{len(images)} image{'s' if len(images) != 1 else ''} attached]"
-                        _cprint(f"  Queued for the next turn: {preview[:80]}{'...' if len(preview) > 80 else ''}")
+                        self._queued_turn_preview = preview[:80] + ('...' if len(preview) > 80 else '')
+                        self._invalidate(min_interval=0)
                     else:
                         self._interrupt_queue.put(payload)
                         # Debug: log to file when message enters interrupt queue
@@ -10531,6 +10544,10 @@ class HermesCLI:
                     
                     if not user_input:
                         continue
+
+                    self._queued_turn_preview = ""
+                    if self._app:
+                        self._invalidate(min_interval=0)
 
                     # Unpack image payload: (text, [Path, ...]) or plain str
                     submit_images = []

--- a/cli.py
+++ b/cli.py
@@ -2090,8 +2090,6 @@ class HermesCLI:
         self._background_tasks: Dict[str, threading.Thread] = {}
         self._background_task_counter = 0
         self._queued_turn_preview: str = ""
-        self._side_state: Optional[Dict[str, Any]] = None
-        self._side_queue: list[tuple[str, list[Path]]] = []
 
     def _invalidate(self, min_interval: float = 0.25) -> None:
         """Throttled UI repaint — prevents terminal blinking on slow/SSH connections."""

--- a/tests/cli/test_cli_queued_status.py
+++ b/tests/cli/test_cli_queued_status.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from tests.cli.test_cli_new_session import _make_cli
+
+
+def test_queue_command_sets_status_area_preview_when_agent_running():
+    cli = _make_cli()
+    cli.console = MagicMock()
+    cli._invalidate = MagicMock()
+    cli._agent_running = True
+
+    cli.process_command("/queue investigate parser state")
+
+    assert cli._queued_turn_preview == "investigate parser state"
+    cli._invalidate.assert_called()
+
+
+def test_extra_tui_widgets_show_queued_preview():
+    cli = _make_cli()
+    cli._queued_turn_preview = "queued prompt"
+
+    widgets = cli._get_extra_tui_widgets()
+
+    assert len(widgets) == 1


### PR DESCRIPTION
## Summary
- keep queued prompts in prompt_toolkit CLI chrome instead of printing them into conversation scrollback
- surface the queued prompt preview just above the status bar
- clear the preview automatically once the queued prompt is consumed

## Behavior
- when the agent is busy and input is queued, the queued prompt stays near the status bar
- the main conversation transcript stays cleaner because queue notices no longer scroll upward with normal output

## Notes
- This PR targets the existing prompt_toolkit CLI/TUI (`cli.py`), not the newer Ink `ui-tui` path.
- It is intentionally scoped to queued-input UX only.

## Test Plan
- `python -m py_compile cli.py tests/cli/test_cli_queued_status.py`
- `pytest tests/cli/test_cli_queued_status.py -q -n0`
