### PR TITLE
fix(gateway): remove stale default pid file on startup

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -216,10 +216,7 @@ def _cleanup_invalid_pid_path(pid_path: Path, *, cleanup_stale: bool) -> None:
     if not cleanup_stale:
         return
     try:
-        if pid_path == _get_pid_path():
-            remove_pid_file()
-        else:
-            pid_path.unlink(missing_ok=True)
+        pid_path.unlink(missing_ok=True)
     except Exception:
         pass
 

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -105,6 +105,24 @@ class TestGatewayPidState:
         assert status.get_running_pid(pid_path, cleanup_stale=False) == os.getpid()
         assert pid_path.exists()
 
+    def test_get_running_pid_removes_stale_default_pid_file(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        pid_path = tmp_path / "gateway.pid"
+        pid_path.write_text(json.dumps({
+            "pid": 99999,
+            "kind": "hermes-gateway",
+            "argv": ["python", "-m", "hermes_cli.main", "gateway", "run", "--replace"],
+            "start_time": 123,
+        }))
+
+        def fake_kill(pid, sig):
+            raise ProcessLookupError
+
+        monkeypatch.setattr(status.os, "kill", fake_kill)
+
+        assert status.get_running_pid() is None
+        assert not pid_path.exists()
+
 
 class TestGatewayRuntimeStatus:
     def test_write_runtime_status_overwrites_stale_pid_on_restart(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- remove stale default `gateway.pid` files directly when startup detects an invalid/dead PID
- add a regression test covering the self-restart/systemd restart path where the default pid file points at a dead process

## Problem
When a gateway self-restart or `--replace` handoff leaves behind a stale default `gateway.pid`, `get_running_pid()` correctly detects that the PID is dead but `_cleanup_invalid_pid_path()` routes cleanup through `remove_pid_file()`. That helper only removes pid files owned by the current process, so the stale pid file survives and subsequent startups keep failing with `PID file race lost to another gateway instance`.

## Testing
- `/root/.hermes/hermes-agent/venv/bin/pytest tests/gateway/test_status.py -q`
