### PR TITLE
fix(skills): reject unsupported tap repositories

### DIFF
--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -838,7 +838,12 @@ def do_tap(action: str, repo: str = "", console: Optional[Console] = None) -> No
         if not repo:
             c.print("[bold red]Error:[/] Repo required. Usage: hermes skills tap add owner/repo\n")
             return
-        if mgr.add(repo):
+        try:
+            added = mgr.add(repo)
+        except ValueError as exc:
+            c.print(f"[bold red]Error:[/] {exc}\n")
+            return
+        if added:
             c.print(f"[bold green]Added tap:[/] {repo}\n")
         else:
             c.print(f"[yellow]Tap already exists:[/] {repo}\n")

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -5,7 +5,7 @@ import pytest
 from rich.console import Console
 
 from cli import ChatConsole
-from hermes_cli.skills_hub import do_check, do_install, do_list, do_update, handle_skills_slash
+from hermes_cli.skills_hub import do_check, do_install, do_list, do_tap, do_update, handle_skills_slash
 
 
 class _DummyLockFile:
@@ -119,6 +119,16 @@ def test_do_list_initializes_hub_dir(monkeypatch, hub_env):
     assert (hub_dir / "lock.json").exists()
     assert (hub_dir / "quarantine").is_dir()
     assert (hub_dir / "index-cache").is_dir()
+
+
+def test_do_tap_add_rejects_unsupported_non_github_repo(hub_env):
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+
+    do_tap("add", repo="git@git.rccchina.com:crawl/spider-skills.git", console=console)
+
+    output = sink.getvalue()
+    assert "GitHub.com repos" in output
 
 
 def test_do_list_distinguishes_hub_builtin_and_local(three_source_env):

--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -886,6 +886,18 @@ class TestTapsManager:
         assert len(taps) == 1
         assert taps[0]["repo"] == "owner/repo"
 
+    def test_add_github_url_tap_normalizes_repo(self, tmp_path):
+        mgr = TapsManager(path=tmp_path / "taps.json")
+        assert mgr.add("git@github.com:owner/repo.git", "skills/") is True
+        taps = mgr.load()
+        assert taps == [{"repo": "owner/repo", "path": "skills/"}]
+
+    def test_add_rejects_unsupported_non_github_repo(self, tmp_path):
+        mgr = TapsManager(path=tmp_path / "taps.json")
+        with pytest.raises(ValueError, match="GitHub.com repos"):
+            mgr.add("git@git.rccchina.com:crawl/spider-skills.git", "skills/")
+        assert mgr.load() == []
+
     def test_add_duplicate_tap(self, tmp_path):
         mgr = TapsManager(path=tmp_path / "taps.json")
         mgr.add("owner/repo")

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -2447,6 +2447,38 @@ class TapsManager:
     def __init__(self, path: Path = TAPS_FILE):
         self.path = path
 
+    @staticmethod
+    def normalize_repo(repo: str) -> str:
+        """Normalize supported GitHub.com tap specs to owner/repo."""
+        repo = repo.strip()
+        if not repo:
+            raise ValueError("Tap repo is required")
+
+        candidates = [repo]
+        if repo.startswith("https://github.com/"):
+            candidates.append(repo[len("https://github.com/"):])
+        if repo.startswith("git@github.com:"):
+            candidates.append(repo[len("git@github.com:"):])
+        if repo.startswith("ssh://git@github.com/"):
+            candidates.append(repo[len("ssh://git@github.com/"):])
+
+        for candidate in candidates:
+            cleaned = candidate.strip().rstrip("/")
+            if cleaned.endswith(".git"):
+                cleaned = cleaned[:-4]
+            parts = cleaned.split("/")
+            if (
+                len(parts) == 2
+                and all(parts)
+                and re.fullmatch(r"[A-Za-z0-9_.-]+", parts[0])
+                and re.fullmatch(r"[A-Za-z0-9_.-]+", parts[1])
+            ):
+                return f"{parts[0]}/{parts[1]}"
+
+        raise ValueError(
+            "Tap repos must be GitHub.com repos in owner/repo form or a github.com URL."
+        )
+
     def load(self) -> List[dict]:
         if not self.path.exists():
             return []
@@ -2462,6 +2494,7 @@ class TapsManager:
 
     def add(self, repo: str, path: str = "skills/") -> bool:
         """Add a tap. Returns False if already exists."""
+        repo = self.normalize_repo(repo)
         taps = self.load()
         if any(t["repo"] == repo for t in taps):
             return False


### PR DESCRIPTION
## Summary
- validate custom tap repos before saving them to taps.json
- normalize supported github.com URL and SSH forms to owner/repo slugs
- reject unsupported non-GitHub repos with a clear CLI error instead of accepting unusable taps

## Testing
- python3 -m pytest -o addopts='' tests/tools/test_skills_hub.py tests/hermes_cli/test_skills_hub.py

Fixes #14290