### PR TITLE
[codex] feat(cli): support deleting multiple sessions

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8099,9 +8099,11 @@ Examples:
     sessions_export.add_argument("--session-id", help="Export a specific session")
 
     sessions_delete = sessions_subparsers.add_parser(
-        "delete", help="Delete a specific session"
+        "delete", help="Delete one or more sessions"
     )
-    sessions_delete.add_argument("session_id", help="Session ID to delete")
+    sessions_delete.add_argument(
+        "session_ids", nargs="+", help="Session ID(s) to delete"
+    )
     sessions_delete.add_argument(
         "--yes", "-y", action="store_true", help="Skip confirmation"
     )
@@ -8221,20 +8223,58 @@ Examples:
                     print(f"Exported {len(sessions)} sessions to {args.output}")
 
         elif action == "delete":
-            resolved_session_id = db.resolve_session_id(args.session_id)
-            if not resolved_session_id:
-                print(f"Session '{args.session_id}' not found.")
+            resolved_sessions = []
+            missing_sessions = []
+
+            for requested_session_id in args.session_ids:
+                resolved_session_id = db.resolve_session_id(requested_session_id)
+                if resolved_session_id:
+                    resolved_sessions.append((requested_session_id, resolved_session_id))
+                else:
+                    missing_sessions.append(requested_session_id)
+
+            if not resolved_sessions and missing_sessions:
+                for missing_session_id in missing_sessions:
+                    print(f"Session '{missing_session_id}' not found.")
                 return
+
             if not args.yes:
-                if not _confirm_prompt(
-                    f"Delete session '{resolved_session_id}' and all its messages? [y/N] "
-                ):
+                if len(resolved_sessions) == 1:
+                    _requested_session_id, resolved_session_id = resolved_sessions[0]
+                    confirm_prompt = (
+                        f"Delete session '{resolved_session_id}' and all its messages? [y/N] "
+                    )
+                else:
+                    resolved_list = ", ".join(
+                        f"'{resolved_session_id}'"
+                        for _, resolved_session_id in resolved_sessions
+                    )
+                    confirm_prompt = (
+                        f"Delete {len(resolved_sessions)} sessions ({resolved_list}) and all their messages? [y/N] "
+                    )
+                if not _confirm_prompt(confirm_prompt):
                     print("Cancelled.")
                     return
-            if db.delete_session(resolved_session_id):
-                print(f"Deleted session '{resolved_session_id}'.")
-            else:
-                print(f"Session '{args.session_id}' not found.")
+
+            deleted_count = 0
+            failed_count = 0
+
+            for requested_session_id, resolved_session_id in resolved_sessions:
+                if db.delete_session(resolved_session_id):
+                    print(f"Deleted session '{resolved_session_id}'.")
+                    deleted_count += 1
+                else:
+                    print(f"Session '{requested_session_id}' not found.")
+                    failed_count += 1
+
+            for missing_session_id in missing_sessions:
+                print(f"Session '{missing_session_id}' not found.")
+                failed_count += 1
+
+            if deleted_count:
+                print(f"Deleted {deleted_count} session(s).")
+            if failed_count:
+                print(f"Failed to delete {failed_count} session(s).")
 
         elif action == "prune":
             days = args.older_than

--- a/tests/hermes_cli/test_sessions_delete.py
+++ b/tests/hermes_cli/test_sessions_delete.py
@@ -92,6 +92,107 @@ def test_sessions_delete_handles_eoferror_on_confirm(monkeypatch, capsys):
     assert "Cancelled" in output
 
 
+def test_sessions_delete_accepts_multiple_session_ids(monkeypatch, capsys):
+    import hermes_cli.main as main_mod
+    import hermes_state
+
+    captured = {"resolved_from": [], "deleted": []}
+    resolved = {
+        "20260315_092437_c9a6": "20260315_092437_c9a6ff",
+        "20260316_101500_abcd": "20260316_101500_abcd12",
+    }
+
+    class FakeDB:
+        def resolve_session_id(self, session_id):
+            captured["resolved_from"].append(session_id)
+            return resolved.get(session_id)
+
+        def delete_session(self, session_id):
+            captured["deleted"].append(session_id)
+            return True
+
+        def close(self):
+            captured["closed"] = True
+
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: FakeDB())
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "hermes",
+            "sessions",
+            "delete",
+            "20260315_092437_c9a6",
+            "20260316_101500_abcd",
+            "--yes",
+        ],
+    )
+
+    main_mod.main()
+
+    output = capsys.readouterr().out
+    assert captured == {
+        "resolved_from": ["20260315_092437_c9a6", "20260316_101500_abcd"],
+        "deleted": ["20260315_092437_c9a6ff", "20260316_101500_abcd12"],
+        "closed": True,
+    }
+    assert "Deleted session '20260315_092437_c9a6ff'." in output
+    assert "Deleted session '20260316_101500_abcd12'." in output
+    assert "Deleted 2 session(s)." in output
+
+
+def test_sessions_delete_continues_when_some_session_ids_are_not_found(monkeypatch, capsys):
+    import hermes_cli.main as main_mod
+    import hermes_state
+
+    captured = {"resolved_from": [], "deleted": []}
+
+    class FakeDB:
+        def resolve_session_id(self, session_id):
+            captured["resolved_from"].append(session_id)
+            return {
+                "existing-one": "20260315_092437_c9a6ff",
+                "missing-one": None,
+                "existing-two": "20260316_101500_abcd12",
+            }[session_id]
+
+        def delete_session(self, session_id):
+            captured["deleted"].append(session_id)
+            return True
+
+        def close(self):
+            captured["closed"] = True
+
+    monkeypatch.setattr(hermes_state, "SessionDB", lambda: FakeDB())
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "hermes",
+            "sessions",
+            "delete",
+            "existing-one",
+            "missing-one",
+            "existing-two",
+            "--yes",
+        ],
+    )
+
+    main_mod.main()
+
+    output = capsys.readouterr().out
+    assert captured == {
+        "resolved_from": ["existing-one", "missing-one", "existing-two"],
+        "deleted": ["20260315_092437_c9a6ff", "20260316_101500_abcd12"],
+        "closed": True,
+    }
+    assert "Deleted session '20260315_092437_c9a6ff'." in output
+    assert "Session 'missing-one' not found." in output
+    assert "Deleted session '20260316_101500_abcd12'." in output
+    assert "Deleted 2 session(s)." in output
+    assert "Failed to delete 1 session(s)." in output
+
+
 def test_sessions_prune_handles_eoferror_on_confirm(monkeypatch, capsys):
     """sessions prune should not crash when stdin is closed (non-TTY)."""
     import hermes_cli.main as main_mod


### PR DESCRIPTION
## Summary
- support deleting multiple sessions in a single `hermes sessions delete` invocation
- continue deleting valid sessions when some requested session IDs cannot be resolved
- add tests for multi-session deletion and mixed success/failure cases

## Why
The CLI currently accepts only one session ID per delete command. This makes cleanup cumbersome and inconsistent with bulk maintenance workflows. Extending `sessions delete` to accept multiple IDs fixes that gap while keeping the existing confirmation flow.

## Validation
- `uv run --extra dev python -m pytest tests/hermes_cli/test_sessions_delete.py -q`
