### PR TITLE
fix CLI approval callback propagation

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -696,7 +696,11 @@ from cron import get_job
 
 # Resource cleanup imports for safe shutdown (terminal VMs, browser sessions)
 from tools.terminal_tool import cleanup_all_environments as _cleanup_all_terminals
-from tools.terminal_tool import set_sudo_password_callback, set_approval_callback
+from tools.terminal_tool import (
+    bind_interactive_callbacks,
+    set_sudo_password_callback,
+    set_approval_callback,
+)
 from tools.skills_tool import set_secret_capture_callback
 from hermes_cli.callbacks import prompt_for_secret
 from tools.browser_tool import _emergency_cleanup_all_sessions as _cleanup_all_browsers
@@ -6310,6 +6314,13 @@ class HermesCLI:
 
         def run_background():
             try:
+                from tools.terminal_tool import (
+                    _get_approval_callback,
+                    _get_sudo_password_callback,
+                )
+
+                approval_callback = _get_approval_callback()
+                sudo_password_callback = _get_sudo_password_callback()
                 bg_agent = AIAgent(
                     model=turn_route["model"],
                     api_key=turn_route["runtime"].get("api_key"),
@@ -6348,10 +6359,14 @@ class HermesCLI:
 
                 bg_agent.thinking_callback = _bg_thinking
 
-                result = bg_agent.run_conversation(
-                    user_message=prompt,
-                    task_id=task_id,
-                )
+                with bind_interactive_callbacks(
+                    approval_callback=approval_callback,
+                    sudo_password_callback=sudo_password_callback,
+                ):
+                    result = bg_agent.run_conversation(
+                        user_message=prompt,
+                        task_id=task_id,
+                    )
 
                 response = result.get("final_response", "") if result else ""
                 if not response and result and result.get("error"):
@@ -8437,26 +8452,28 @@ class HermesCLI:
                 # registration (run() line ~9046) is invisible here because
                 # _callback_tls is threading.local().  Matches the pattern used
                 # by acp_adapter/server.py for ACP sessions.
-                set_sudo_password_callback(self._sudo_password_callback)
-                set_approval_callback(self._approval_callback)
                 try:
-                    set_secret_capture_callback(self._secret_capture_callback)
-                except Exception:
-                    pass
-                agent_message = _voice_prefix + message if _voice_prefix else message
-                # Prepend pending model switch note so the model knows about the switch
-                _msn = getattr(self, '_pending_model_switch_note', None)
-                if _msn:
-                    agent_message = _msn + "\n\n" + agent_message
-                    self._pending_model_switch_note = None
-                try:
-                    result = self.agent.run_conversation(
-                        user_message=agent_message,
-                        conversation_history=self.conversation_history[:-1],  # Exclude the message we just added
-                        stream_callback=stream_callback,
-                        task_id=self.session_id,
-                        persist_user_message=message if _voice_prefix else None,
-                    )
+                    with bind_interactive_callbacks(
+                        approval_callback=self._approval_callback,
+                        sudo_password_callback=self._sudo_password_callback,
+                    ):
+                        try:
+                            set_secret_capture_callback(self._secret_capture_callback)
+                        except Exception:
+                            pass
+                        agent_message = _voice_prefix + message if _voice_prefix else message
+                        # Prepend pending model switch note so the model knows about the switch
+                        _msn = getattr(self, '_pending_model_switch_note', None)
+                        if _msn:
+                            agent_message = _msn + "\n\n" + agent_message
+                            self._pending_model_switch_note = None
+                        result = self.agent.run_conversation(
+                            user_message=agent_message,
+                            conversation_history=self.conversation_history[:-1],  # Exclude the message we just added
+                            stream_callback=stream_callback,
+                            task_id=self.session_id,
+                            persist_user_message=message if _voice_prefix else None,
+                        )
                 except Exception as exc:
                     logging.error("run_conversation raised: %s", exc, exc_info=True)
                     _summary = getattr(self.agent, '_summarize_api_error', lambda e: str(e)[:300])(exc)
@@ -8472,8 +8489,6 @@ class HermesCLI:
                     # Clear thread-local callbacks so a reused thread doesn't
                     # hold stale references to a disposed CLI instance.
                     try:
-                        set_sudo_password_callback(None)
-                        set_approval_callback(None)
                         set_secret_capture_callback(None)
                     except Exception:
                         pass

--- a/run_agent.py
+++ b/run_agent.py
@@ -7889,6 +7889,19 @@ class AIAgent:
         # Each slot holds (function_name, function_args, function_result, duration, error_flag)
         results = [None] * num_tools
 
+        try:
+            from tools.terminal_tool import (
+                _get_approval_callback as _get_terminal_approval_callback,
+                _get_sudo_password_callback as _get_terminal_sudo_callback,
+                bind_interactive_callbacks as _bind_terminal_callbacks,
+            )
+            _worker_approval_callback = _get_terminal_approval_callback()
+            _worker_sudo_callback = _get_terminal_sudo_callback()
+        except Exception:
+            _bind_terminal_callbacks = None
+            _worker_approval_callback = None
+            _worker_sudo_callback = None
+
         # Touch activity before launching workers so the gateway knows
         # we're executing tools (not stuck).
         self._current_tool = tool_names_str
@@ -7922,7 +7935,26 @@ class AIAgent:
                 pass
             start = time.time()
             try:
-                result = self._invoke_tool(function_name, function_args, effective_task_id, tool_call.id, messages=messages)
+                if _bind_terminal_callbacks is not None:
+                    with _bind_terminal_callbacks(
+                        approval_callback=_worker_approval_callback,
+                        sudo_password_callback=_worker_sudo_callback,
+                    ):
+                        result = self._invoke_tool(
+                            function_name,
+                            function_args,
+                            effective_task_id,
+                            tool_call.id,
+                            messages=messages,
+                        )
+                else:
+                    result = self._invoke_tool(
+                        function_name,
+                        function_args,
+                        effective_task_id,
+                        tool_call.id,
+                        messages=messages,
+                    )
             except Exception as tool_error:
                 result = f"Error executing tool '{function_name}': {tool_error}"
                 logger.error("_invoke_tool raised for %s: %s", function_name, tool_error, exc_info=True)

--- a/tests/cli/test_cli_approval_ui.py
+++ b/tests/cli/test_cli_approval_ui.py
@@ -1,6 +1,7 @@
 import queue
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -339,3 +340,121 @@ class TestApprovalCallbackThreadLocalWiring:
         # would hold a stale reference to a disposed CLI instance.
         assert seen["approval_after"] is None
         assert seen["sudo_after"] is None
+
+
+class TestApprovalCallbackThreadPropagation:
+    def test_bind_interactive_callbacks_propagates_to_executor_worker(self):
+        from tools.terminal_tool import (
+            _get_approval_callback,
+            _get_sudo_password_callback,
+            bind_interactive_callbacks,
+            set_approval_callback,
+            set_sudo_password_callback,
+        )
+
+        def approval_cb(_cmd, _desc):
+            return "once"
+
+        def sudo_cb():
+            return "hunter2"
+
+        set_approval_callback(approval_cb)
+        set_sudo_password_callback(sudo_cb)
+        try:
+            seen = {}
+
+            def worker():
+                seen["before"] = _get_approval_callback()
+                seen["before_sudo"] = _get_sudo_password_callback()
+                with bind_interactive_callbacks(
+                    approval_callback=approval_cb,
+                    sudo_password_callback=sudo_cb,
+                ):
+                    seen["inside"] = _get_approval_callback()
+                    seen["inside_sudo"] = _get_sudo_password_callback()
+                seen["after"] = _get_approval_callback()
+                seen["after_sudo"] = _get_sudo_password_callback()
+
+            with ThreadPoolExecutor(max_workers=1) as pool:
+                pool.submit(worker).result(timeout=2)
+
+            assert seen["before"] is None
+            assert seen["before_sudo"] is None
+            assert seen["inside"] is approval_cb
+            assert seen["inside_sudo"] is sudo_cb
+            assert seen["after"] is None
+            assert seen["after_sudo"] is None
+        finally:
+            set_approval_callback(None)
+            set_sudo_password_callback(None)
+
+    def test_background_thread_pattern_can_rebind_cli_callbacks(self):
+        from tools.terminal_tool import (
+            _get_approval_callback,
+            _get_sudo_password_callback,
+            bind_interactive_callbacks,
+            set_approval_callback,
+            set_sudo_password_callback,
+        )
+
+        cli = _make_cli_stub()
+        set_approval_callback(cli._approval_callback)
+        set_sudo_password_callback(cli._sudo_password_callback)
+        try:
+            captured_approval = _get_approval_callback()
+            captured_sudo = _get_sudo_password_callback()
+            seen = {}
+
+            def background_worker():
+                seen["before"] = _get_approval_callback()
+                with bind_interactive_callbacks(
+                    approval_callback=captured_approval,
+                    sudo_password_callback=captured_sudo,
+                ):
+                    seen["inside"] = _get_approval_callback()
+                    seen["inside_sudo"] = _get_sudo_password_callback()
+                seen["after"] = _get_approval_callback()
+
+            thread = threading.Thread(target=background_worker, daemon=True)
+            thread.start()
+            thread.join(timeout=2)
+
+            assert seen["before"] is None
+            assert seen["inside"] == cli._approval_callback
+            assert seen["inside_sudo"] == cli._sudo_password_callback
+            assert seen["after"] is None
+        finally:
+            set_approval_callback(None)
+            set_sudo_password_callback(None)
+
+    def test_delegate_executor_pattern_rebinds_callbacks_and_cleans_up(self):
+        from tools.terminal_tool import (
+            _get_approval_callback,
+            bind_interactive_callbacks,
+            set_approval_callback,
+        )
+
+        def approval_cb(_cmd, _desc):
+            return "once"
+
+        set_approval_callback(approval_cb)
+        try:
+            parent_callback = _get_approval_callback()
+            seen = {}
+
+            def child_run():
+                seen["before"] = _get_approval_callback()
+                with bind_interactive_callbacks(approval_callback=parent_callback):
+                    seen["inside"] = _get_approval_callback()
+                seen["after"] = _get_approval_callback()
+                return {"final_response": "ok"}
+
+            with ThreadPoolExecutor(max_workers=1) as pool:
+                result = pool.submit(child_run).result(timeout=2)
+
+            assert result["final_response"] == "ok"
+            assert seen["before"] is None
+            assert seen["inside"] is approval_cb
+            assert seen["after"] is None
+        finally:
+            set_approval_callback(None)

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1,6 +1,7 @@
 """Tests for the dangerous command approval module."""
 
 import ast
+import logging
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch as mock_patch
@@ -519,6 +520,18 @@ class TestFullCommandAlwaysShown:
             result = prompt_dangerous_approval(short_cmd, "recursive delete")
         assert result == "deny"
 
+    def test_interactive_missing_callback_logs_warning_before_stdin_fallback(self, caplog):
+        with mock_patch.dict("os.environ", {"HERMES_INTERACTIVE": "1"}, clear=False):
+            with mock_patch("builtins.input", return_value="d"):
+                with caplog.at_level(logging.WARNING, logger="tools.approval"):
+                    result = prompt_dangerous_approval("rm -rf /tmp", "recursive delete")
+
+        assert result == "deny"
+        assert any(
+            "Interactive approval missing callback" in record.message
+            for record in caplog.records
+        )
+
 
 class TestForkBombDetection:
     """The fork bomb regex must match the classic :(){ :|:& };: pattern."""
@@ -836,4 +849,3 @@ class TestChmodExecuteCombo:
         cmd = "chmod +x script.sh"
         dangerous, _, _ = detect_dangerous_command(cmd)
         assert dangerous is False
-

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -434,6 +434,13 @@ def prompt_dangerous_approval(command: str, description: str,
             logger.error("Approval callback failed: %s", e, exc_info=True)
             return "deny"
 
+    if os.getenv("HERMES_INTERACTIVE"):
+        logger.warning(
+            "Interactive approval missing callback; falling back to stdin input. "
+            "This usually means the current worker thread did not bind the CLI "
+            "approval callback before executing a terminal command."
+        )
+
     os.environ["HERMES_SPINNER_PAUSE"] = "1"
     try:
         while True:

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -33,6 +33,11 @@ from typing import Any, Dict, List, Optional
 
 from toolsets import TOOLSETS
 from tools import file_state
+from tools.terminal_tool import (
+    _get_approval_callback,
+    _get_sudo_password_callback,
+    bind_interactive_callbacks,
+)
 from utils import base_url_hostname, is_truthy_value
 
 
@@ -1153,6 +1158,8 @@ def _run_single_child(
 
         child_task_id = _subagent_id or f"subagent-{task_index}-{_uuid.uuid4().hex[:8]}"
         parent_task_id = getattr(parent_agent, "_current_task_id", None)
+        parent_approval_callback = _get_approval_callback()
+        parent_sudo_callback = _get_sudo_password_callback()
         wall_start = time.time()
         parent_reads_snapshot = (
             list(file_state.known_reads(parent_task_id)) if parent_task_id else []
@@ -1162,11 +1169,17 @@ def _run_single_child(
         # when the child's API call or tool-level HTTP request hangs.
         child_timeout = _get_child_timeout()
         _timeout_executor = ThreadPoolExecutor(max_workers=1)
-        _child_future = _timeout_executor.submit(
-            child.run_conversation,
-            user_message=goal,
-            task_id=child_task_id,
-        )
+        def _run_child():
+            with bind_interactive_callbacks(
+                approval_callback=parent_approval_callback,
+                sudo_password_callback=parent_sudo_callback,
+            ):
+                return child.run_conversation(
+                    user_message=goal,
+                    task_id=child_task_id,
+                )
+
+        _child_future = _timeout_executor.submit(_run_child)
         try:
             result = _child_future.result(timeout=child_timeout)
         except Exception as _timeout_exc:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -41,6 +41,7 @@ import threading
 import atexit
 import shutil
 import subprocess
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Optional, Dict, Any, List
 
@@ -189,6 +190,26 @@ def set_approval_callback(cb):
     GHSA-qg5c-hvr5-hjgr.
     """
     _callback_tls.approval = cb
+
+
+@contextmanager
+def bind_interactive_callbacks(*, approval_callback=None, sudo_password_callback=None):
+    """Bind interactive callbacks for the current thread only.
+
+    Dangerous-command approval and sudo prompts are stored in thread-local
+    state. Any worker/background thread that may execute terminal commands
+    must re-register the callbacks inside that thread or approvals fall back
+    to raw stdin input(), which deadlocks against prompt_toolkit in the CLI.
+    """
+    previous_approval = _get_approval_callback()
+    previous_sudo = _get_sudo_password_callback()
+    set_approval_callback(approval_callback)
+    set_sudo_password_callback(sudo_password_callback)
+    try:
+        yield
+    finally:
+        set_approval_callback(previous_approval)
+        set_sudo_password_callback(previous_sudo)
 
 # =============================================================================
 # Dangerous Command Approval System


### PR DESCRIPTION
## What does this PR do?

Fixes a CLI bug where dangerous-command approval prompts could freeze instead of rendering the normal interactive approval UI.

The issue was caused by approval/sudo callbacks being stored in thread-local state while some CLI execution paths ran terminal
commands from different worker threads. In those cases Hermes could fall back to raw `stdin` input, which deadlocked against
`prompt_toolkit`.

This PR rebinds the interactive callbacks in the affected worker/background/delegate threads so approval prompts stay inside the
CLI UI.

## Related Issue

Fixes #<issue-number>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Added a shared thread-local callback binding helper in `tools/terminal_tool.py`
- Rebound approval/sudo callbacks in concurrent tool worker threads in `run_agent.py`
- Rebound approval/sudo callbacks for `/background` execution in `cli.py`
- Rebound approval/sudo callbacks for delegated child-agent execution in `tools/delegate_tool.py`
- Added an interactive fallback warning in `tools/approval.py`
- Added regression tests for executor/background/delegate callback propagation and cleanup
- Added a test for the interactive stdin-fallback warning

## How to Test

1. Trigger a dangerous terminal command from the interactive CLI.
2. Verify the normal approval UI appears and remains selectable.
3. Run:
    - `python -m pytest tests/cli/test_cli_approval_ui.py -q -n 4`
    - `python -m pytest tests/tools/test_approval.py -q -n 4`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu / WSL

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-
  agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `python -m pytest tests/cli/test_cli_approval_ui.py -q -n 4` → `13 passed`
- `python -m pytest tests/tools/test_approval.py -q -n 4` → `121 passed`