### PR TITLE
feat: support document/archive extensions in MEDIA: tag extraction (salvage #8255)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1343,7 +1343,7 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|pdf)(?=[\s`"',;:)\]}]|$)|\S+)[`"']?'''
+            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$)|\S+)[`"']?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -373,6 +373,7 @@ AUTHOR_MAP = {
     "132275809+shushuzn@users.noreply.github.com": "shushuzn",
     "ibrahimozsarac@gmail.com": "iborazzi",
     "130149563+A-afflatus@users.noreply.github.com": "A-afflatus",
+    "huangkwell@163.com": "huangke19",
 }
 
 


### PR DESCRIPTION
Salvages #8255 by @huangke19 onto current main.

Adds epub/zip/rar/7z/docx/xlsx/pptx/txt/csv/apk/ipa to the MEDIA: regex in `extract_media()`. These extensions were previously hitting the generic `\S+` fallback branch in the alternation, which is greedy and can fail silently on adjacent punctuation or formatting. Listing them explicitly makes matching deterministic.

Per `gateway-media-extraction-audit` skill guidance: this touches ONLY the MEDIA: regex (safe, explicit opt-in), NOT `_LOCAL_MEDIA_EXTS` (unsafe bare-path expansion). Document files the agent merely mentions in prose ("saved to /tmp/thoughts.pdf") are NOT auto-sent — only explicit `MEDIA:` tags trigger delivery. The existing `send_document` fallback in base.py:1971 handles routing.

## E2E verification
Positive cases (MEDIA: with new extensions extract correctly): pdf, epub, zip, docx, xlsx, apk, pptx ✓
Negative cases (bare paths don't auto-send): .pdf ✓, .zip ✓
Existing extensions unchanged: .png, .ogg ✓

Closes #8255. Author attribution preserved via cherry-pick.