### PR TITLE
fix(auxiliary): inherit live session model for provider=main compression

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1893,7 +1893,10 @@ def get_text_auxiliary_client(
     Callers may override the returned model via config.yaml
     (e.g. auxiliary.compression.model, auxiliary.web_extract.model).
     """
-    provider, model, base_url, api_key, api_mode = _resolve_task_provider_model(task or None)
+    provider, model, base_url, api_key, api_mode = _resolve_task_provider_model(
+        task or None,
+        main_runtime=main_runtime,
+    )
     return resolve_provider_client(
         provider,
         model=model,
@@ -1911,7 +1914,10 @@ def get_async_text_auxiliary_client(task: str = "", *, main_runtime: Optional[Di
     (AsyncCodexAuxiliaryClient, model) which wraps the Responses API.
     Returns (None, None) when no provider is available.
     """
-    provider, model, base_url, api_key, api_mode = _resolve_task_provider_model(task or None)
+    provider, model, base_url, api_key, api_mode = _resolve_task_provider_model(
+        task or None,
+        main_runtime=main_runtime,
+    )
     return resolve_provider_client(
         provider,
         model=model,
@@ -2414,6 +2420,7 @@ def _resolve_task_provider_model(
     model: str = None,
     base_url: str = None,
     api_key: str = None,
+    main_runtime: Optional[Dict[str, Any]] = None,
 ) -> Tuple[str, Optional[str], Optional[str], Optional[str], Optional[str]]:
     """Determine provider + model for a call.
 
@@ -2441,7 +2448,12 @@ def _resolve_task_provider_model(
         cfg_api_key = str(task_config.get("api_key", "")).strip() or None
         cfg_api_mode = str(task_config.get("api_mode", "")).strip() or None
 
+    runtime = _normalize_main_runtime(main_runtime)
+    runtime_model = runtime.get("model")
     resolved_model = model or cfg_model
+    requested_provider = str(provider or cfg_provider or "").strip().lower()
+    if not resolved_model and runtime_model and requested_provider == "main":
+        resolved_model = runtime_model
     resolved_api_mode = cfg_api_mode
 
     if base_url:
@@ -2702,7 +2714,7 @@ def call_llm(
         RuntimeError: If no provider is configured.
     """
     resolved_provider, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
-        task, provider, model, base_url, api_key)
+        task, provider, model, base_url, api_key, main_runtime=main_runtime)
     effective_extra_body = _get_task_extra_body(task)
     effective_extra_body.update(extra_body or {})
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -21,6 +21,7 @@ from agent.auxiliary_client import (
     _is_payment_error,
     _try_payment_fallback,
     _resolve_auto,
+    _resolve_task_provider_model,
 )
 
 
@@ -449,6 +450,78 @@ class TestExplicitProviderRouting:
 
 class TestGetTextAuxiliaryClient:
     """Test the full resolution chain for get_text_auxiliary_client."""
+
+    def test_resolve_task_provider_model_uses_live_main_model_for_main_provider(self):
+        with patch("hermes_cli.config.load_config", return_value={
+            "auxiliary": {"compression": {"provider": "main", "model": ""}}
+        }):
+            provider, model, base_url, api_key, api_mode = _resolve_task_provider_model(
+                "compression",
+                main_runtime={"provider": "openai-codex", "model": "gpt-5.4"},
+            )
+
+        assert provider == "main"
+        assert model == "gpt-5.4"
+        assert base_url is None
+        assert api_key is None
+        assert api_mode is None
+
+    def test_resolve_task_provider_model_prefers_explicit_task_model_override(self):
+        with patch("hermes_cli.config.load_config", return_value={
+            "auxiliary": {"compression": {"provider": "main", "model": "gpt-5.4-mini"}}
+        }):
+            provider, model, *_ = _resolve_task_provider_model(
+                "compression",
+                main_runtime={"provider": "openai-codex", "model": "gpt-5.4"},
+            )
+
+        assert provider == "main"
+        assert model == "gpt-5.4-mini"
+
+    def test_get_text_auxiliary_client_passes_main_runtime_through_resolution(self):
+        runtime = {"provider": "openai-codex", "model": "gpt-5.4"}
+        with (
+            patch(
+                "agent.auxiliary_client._resolve_task_provider_model",
+                return_value=("main", "gpt-5.4", None, None, None),
+            ) as mock_resolve,
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(MagicMock(), "gpt-5.4"),
+            ),
+        ):
+            get_text_auxiliary_client("compression", main_runtime=runtime)
+
+        assert mock_resolve.call_args.args[0] == "compression"
+        assert mock_resolve.call_args.kwargs["main_runtime"] == runtime
+
+    def test_call_llm_passes_main_runtime_through_resolution(self):
+        runtime = {"provider": "openai-codex", "model": "gpt-5.4"}
+        client = MagicMock()
+        client.base_url = "https://chatgpt.com/backend-api/codex"
+        client.chat.completions.create.return_value = {"ok": True}
+        with (
+            patch(
+                "agent.auxiliary_client._resolve_task_provider_model",
+                return_value=("main", "gpt-5.4", None, None, None),
+            ) as mock_resolve,
+            patch(
+                "agent.auxiliary_client._get_cached_client",
+                return_value=(client, "gpt-5.4"),
+            ),
+            patch(
+                "agent.auxiliary_client._validate_llm_response",
+                side_effect=lambda resp, _task: resp,
+            ),
+        ):
+            result = call_llm(
+                task="compression",
+                main_runtime=runtime,
+                messages=[{"role": "user", "content": "hi"}],
+            )
+
+        assert result == {"ok": True}
+        assert mock_resolve.call_args.kwargs["main_runtime"] == runtime
 
     def test_codex_pool_entry_takes_priority_over_auth_store(self):
         class _Entry:


### PR DESCRIPTION
## Summary
- make auxiliary `provider: main` inherit the live session model when no explicit task model is set
- thread `main_runtime` into auxiliary task resolution
- add regression tests for resolution precedence and `main_runtime` forwarding

## Problem
With config like:

```yaml
auxiliary:
  compression:
    provider: main
    model: ''
```

Hermes resolved the provider correctly but still fell through to provider-specific auxiliary defaults for the model. For Codex, that meant `gpt-5.2-codex` instead of the active session model, which produced misleading compression threshold auto-lowering warnings.

## Fix
- `get_text_auxiliary_client()` and `get_async_text_auxiliary_client()` now pass `main_runtime` into `_resolve_task_provider_model()`
- `call_llm()` now does the same for sync calls
- `_resolve_task_provider_model()` now inherits `main_runtime['model']` when:
  - no explicit task model is set, and
  - requested provider is `main`

## Tests
- added regression tests in `tests/agent/test_auxiliary_client.py`
- local run: `pytest -q tests/agent/test_auxiliary_client.py`

Closes #14306
