### PR TITLE
docs: add Exa web search backend setup guide (salvage #6697)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -374,6 +374,7 @@ AUTHOR_MAP = {
     "ibrahimozsarac@gmail.com": "iborazzi",
     "130149563+A-afflatus@users.noreply.github.com": "A-afflatus",
     "huangkwell@163.com": "huangke19",
+    "tanishq@exa.ai": "10ishq",
 }
 
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1200,6 +1200,8 @@ web:
 
 **Parallel search modes:** Set `PARALLEL_SEARCH_MODE` to control search behavior — `fast`, `one-shot`, or `agentic` (default: `agentic`).
 
+**Exa:** Set `EXA_API_KEY` in `~/.hermes/.env`. Supports `category` filtering (`company`, `research paper`, `news`, `people`, `personal site`, `pdf`) and domain/date filters.
+
 ## Browser
 
 Configure browser automation behavior:


### PR DESCRIPTION
Salvages #6697 by @10ishq onto current main.

Adds a one-line Exa-specific setup note to `website/docs/user-guide/configuration.md` next to the Parallel search-modes line — documents `EXA_API_KEY`, category filtering (company, research paper, news, people, personal site, pdf), and domain/date filters.

## Reapplied vs cherry-picked
@10ishq's original branch was ~6 months behind main and touched 1,456 unrelated files (deleted platforms, removed skills, stale test fixtures). Reapplied the net content addition onto current main with original authorship preserved via `--author=`.

Closes #6697.