### PR TITLE
security: add uv exclude-newer dependency cooldown to pyproject.toml (salvage #3472)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,3 +134,6 @@ markers = [
     "integration: marks tests requiring external services (API keys, Modal, etc.)",
 ]
 addopts = "-m 'not integration' -n auto"
+
+[tool.uv]
+exclude-newer = "7 days"

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -375,6 +375,7 @@ AUTHOR_MAP = {
     "130149563+A-afflatus@users.noreply.github.com": "A-afflatus",
     "huangkwell@163.com": "huangke19",
     "tanishq@exa.ai": "10ishq",
+    "363708+christopherwoodall@users.noreply.github.com": "christopherwoodall",
 }
 
 


### PR DESCRIPTION
Salvages #3472 by @christopherwoodall onto current main.

Adds `[tool.uv] exclude-newer = "7 days"` to pyproject.toml. This tells uv to ignore packages published within the last 7 days, providing defense-in-depth against the class of supply-chain attacks demonstrated by:
- **litellm 1.82.7/1.82.8** credential stealer (BerriAI/litellm#24512)
- **Trivy compromise** (March 2026)

Attackers exploit the narrow window between malicious package publication and community detection; a rolling 7-day cooldown closes most of it. Complements the existing lockfile-with-hashes posture without breaking legitimate dep bumps (just defers them 7 days).

Tests CI (`tests.yml`) runs `uv pip install -e ".[all,dev]"` against pyproject + lockfile-free resolution — unaffected by this change. Supply-chain-audit CI doesn't run `uv lock --check`.

Closes #3472. Author attribution preserved via cherry-pick.