### PR TITLE
chore: add .DS_Store to .gitignore (salvage #8999)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 /venv/
 /_pycache/
 *.pyc*

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -376,6 +376,7 @@ AUTHOR_MAP = {
     "huangkwell@163.com": "huangke19",
     "tanishq@exa.ai": "10ishq",
     "363708+christopherwoodall@users.noreply.github.com": "christopherwoodall",
+    "zhang9w0v5@qq.com": "zhang9w0v5",
 }
 
 


### PR DESCRIPTION
Salvages #8999 by @zhang9w0v5 onto current main.

Adds `.DS_Store` to `.gitignore` so macOS Finder metadata files don't get accidentally committed by contributors working on macOS.

Closes #8999. Author attribution preserved via cherry-pick.