### PR TITLE
feat(discord): add config option to disable slash commands (salvage #13130)

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -527,6 +527,7 @@ class DiscordAdapter(BasePlatformAdapter):
         # Reply threading mode: "off" (no replies), "first" (reply on first
         # chunk only, default), "all" (reply-reference on every chunk).
         self._reply_to_mode: str = getattr(config, 'reply_to_mode', 'first') or 'first'
+        self._slash_commands: bool = self.config.extra.get("slash_commands", True)
 
     async def connect(self) -> bool:
         """Connect to Discord and start receiving events."""
@@ -744,7 +745,8 @@ class DiscordAdapter(BasePlatformAdapter):
                     )
 
             # Register slash commands
-            self._register_slash_commands()
+            if self._slash_commands:
+                self._register_slash_commands()
 
             # Start the bot in background
             self._bot_task = asyncio.create_task(self._client.start(self.config.token))

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -377,6 +377,7 @@ AUTHOR_MAP = {
     "tanishq@exa.ai": "10ishq",
     "363708+christopherwoodall@users.noreply.github.com": "christopherwoodall",
     "zhang9w0v5@qq.com": "zhang9w0v5",
+    "fuleinist@outlook.com": "fuleinist",
 }
 
 


### PR DESCRIPTION
Salvages #13130 by @fuleinist onto current main.

Adds a `slash_commands` config flag under the Discord platform's `extra:` block, defaulting to `True` (current behavior). Users who don't want the bot to register slash commands (e.g., running multiple bot instances, existing slash-command conflicts) can set it to `false`:

```yaml
platforms:
  discord:
    extra:
      slash_commands: false
```

Uses the existing `config.extra.get(...)` pattern (same surface as `group_sessions_per_user`, `thread_sessions_per_user`, `require_mention`).

## One follow-up fix
The original commit had `or True` appended (`self.config.extra.get("slash_commands", True) or True`), which silently defeated the feature flag — it would always evaluate True. Corrected to just `self.config.extra.get("slash_commands", True)` before merging.

Closes #13130. Author attribution preserved via cherry-pick.