### PR TITLE
fix: preserve proxy tool call history for Open WebUI sessions

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9018,17 +9018,37 @@ class GatewayRunner:
         # no history for this session yet, include what we have locally
         # so the first exchange has context.
         #
-        # We always include the current message.  For history, send a
-        # compact version (text-only user/assistant turns) — the remote
-        # handles tool replay and system prompts.
-        api_messages: List[Dict[str, str]] = []
+        # We always include the current message. For history, keep regular
+        # text turns plus the assistant/tool records needed to preserve
+        # multi-turn tool continuity on the remote session.
+        api_messages: List[Dict[str, Any]] = []
 
         if context_prompt:
             api_messages.append({"role": "system", "content": context_prompt})
 
         for msg in history:
             role = msg.get("role")
+            if not role or role in ("session_meta", "system"):
+                continue
+
             content = msg.get("content")
+            has_tool_calls = "tool_calls" in msg
+            has_tool_call_id = "tool_call_id" in msg
+            is_tool_message = role == "tool"
+
+            if has_tool_calls or has_tool_call_id or is_tool_message:
+                forwarded_msg: Dict[str, Any] = {"role": role}
+                if "content" in msg:
+                    forwarded_msg["content"] = content
+                if has_tool_calls:
+                    forwarded_msg["tool_calls"] = msg.get("tool_calls")
+                if has_tool_call_id:
+                    forwarded_msg["tool_call_id"] = msg.get("tool_call_id")
+                if msg.get("name"):
+                    forwarded_msg["name"] = msg.get("name")
+                api_messages.append(forwarded_msg)
+                continue
+
             if role in ("user", "assistant") and content:
                 api_messages.append({"role": role, "content": content})
 

--- a/tests/gateway/test_proxy_mode.py
+++ b/tests/gateway/test_proxy_mode.py
@@ -311,7 +311,7 @@ class TestRunAgentViaProxy:
         assert "Proxy connection error" in result["final_response"]
 
     @pytest.mark.asyncio
-    async def test_skips_tool_messages_in_history(self, monkeypatch):
+    async def test_preserves_tool_messages_in_history(self, monkeypatch):
         monkeypatch.setenv("GATEWAY_PROXY_URL", "http://host:8642")
         monkeypatch.delenv("GATEWAY_PROXY_KEY", raising=False)
         runner = _make_runner()
@@ -341,12 +341,14 @@ class TestRunAgentViaProxy:
                         session_id="test",
                     )
 
-        # Only user and assistant with content should be forwarded
         messages = session.captured_json["messages"]
-        roles = [m["role"] for m in messages]
-        assert "tool" not in roles
-        # assistant with None content should be skipped
-        assert all(m.get("content") for m in messages)
+        assert messages == [
+            {"role": "user", "content": "search for X"},
+            {"role": "assistant", "content": None, "tool_calls": [{"id": "tc1"}]},
+            {"role": "tool", "content": "search results...", "tool_call_id": "tc1"},
+            {"role": "assistant", "content": "Found results."},
+            {"role": "user", "content": "tell me more"},
+        ]
 
     @pytest.mark.asyncio
     async def test_result_shape_matches_run_agent(self, monkeypatch):


### PR DESCRIPTION
## Summary
- preserve assistant tool-call turns and tool result messages when gateway proxy mode forwards local history
- keep filtering out session metadata and system history, but stop collapsing proxy history to text-only turns
- update proxy-mode regression coverage to assert tool continuity is preserved

Fixes #14270

## Testing
- python3 -m pytest -o addopts='' tests/gateway/test_proxy_mode.py